### PR TITLE
feat(actionpack): port ActionDispatch::Routing::RoutesProxy

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/index.ts
+++ b/packages/actionpack/src/action-dispatch/routing/index.ts
@@ -31,6 +31,13 @@ export {
 } from "./polymorphic-routes.js";
 export { Endpoint } from "./endpoint.js";
 export {
+  RoutesProxy,
+  mergeScriptNames,
+  type RoutesProxyHelpers,
+  type RoutesProxyInstance,
+  type ScriptNamer,
+} from "./routes-proxy.js";
+export {
   redirect,
   Redirect,
   PathRedirect,

--- a/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.test.ts
@@ -9,6 +9,8 @@ import {
   type PolymorphicHost,
   type PolymorphicMappingEntry,
 } from "./polymorphic-routes.js";
+import { RoutesProxy } from "./routes-proxy.js";
+import { urlOptions, type UrlForHost, type UrlForRoutes } from "./url-for.js";
 
 class Post {
   static readonly modelName = new ModelName("Post");
@@ -112,6 +114,35 @@ describe("polymorphicUrl/Path", () => {
     });
     expect(polymorphicPath.call(host, new Post(1))).toBe("/custom");
     expect(polymorphicUrl.call(host, new Post(1))).toBe("http://example.com/custom");
+  });
+});
+
+describe("polymorphic dispatch with leading RoutesProxy", () => {
+  test("invokes resolved helper on the proxy with merged options", () => {
+    const seen: unknown[][] = [];
+    const helpers = {
+      post_path: (...args: unknown[]) => {
+        seen.push(args);
+        return `/mounted/posts/${(args[0] as Post).id}`;
+      },
+    };
+    const routes: UrlForRoutes = { urlFor: () => "" };
+    const scope: UrlForHost = {
+      _routes: routes,
+      defaultUrlOptions: { locale: "en" },
+      urlOptions() {
+        return urlOptions.call(this);
+      },
+    };
+    const proxy = new RoutesProxy(routes, scope, helpers);
+
+    const host = makeHost();
+    const out = polymorphicPath.call(host, [proxy, new Post(7)]);
+    expect(out).toBe("/mounted/posts/7");
+    // helper invoked through proxy → merged options appended as last arg
+    expect(seen.length).toBe(1);
+    const finalArg = seen[0][seen[0].length - 1] as Record<string, unknown>;
+    expect(finalArg.locale).toBe("en");
   });
 });
 

--- a/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.ts
+++ b/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.ts
@@ -66,7 +66,7 @@ export type PolymorphicArg =
   | ModelClass
   | string
   | symbol
-  | ReadonlyArray<ToModel | ModelClass | string | symbol | null | undefined>
+  | ReadonlyArray<ToModel | ModelClass | string | symbol | RoutesProxy | null | undefined>
   // Hash form: { id: record, ...opts }
   | Record<string, unknown>;
 

--- a/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.ts
+++ b/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.ts
@@ -15,13 +15,15 @@
  *     polymorphicUrl([Symbol.for("admin"), post]) // admin_post_url(post)
  *     polymorphicUrl(Comment)                    // comments_url()
  *
- * `RoutesProxy` is not yet ported; the corresponding `record_or_hash_or_array.first
- * .is_a?(RoutesProxy)` branch in Rails is omitted here and will be wired when
- * `routes_proxy.rb` lands.
+ * When the first element of the array is a `RoutesProxy`, it becomes the
+ * recipient of the resolved helper call (mirroring Rails' `shift` in
+ * `HelperMethodBuilder.polymorphic_method`).
  */
 
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { ModelName } from "@blazetrails/activemodel";
+
+import { RoutesProxy } from "./routes-proxy.js";
 
 /** Record-shaped argument: anything with `toModel()`. */
 export interface ToModel {
@@ -285,12 +287,15 @@ export class HelperMethodBuilder {
 
     let method: string;
     let args: unknown[];
+    let target: PolymorphicHost = recipient;
     if (Array.isArray(recordOrHashOrArray)) {
       const compact = recordOrHashOrArray.filter((x) => x != null);
       if (compact.length === 0) {
         throw new ArgumentError("Nil location provided. Can't build URI.");
       }
-      // RoutesProxy branch omitted — not yet ported.
+      if (compact[0] instanceof RoutesProxy) {
+        target = compact.shift() as unknown as PolymorphicHost;
+      }
       [method, args] = builder.handleList(compact);
     } else if (typeof recordOrHashOrArray === "string") {
       [method, args] = builder.handleString(recordOrHashOrArray);
@@ -304,13 +309,13 @@ export class HelperMethodBuilder {
       [method, args] = builder.handleModel(recordOrHashOrArray as ToModel);
     }
 
-    const helper = recipient[method];
+    const helper = (target as unknown as Record<string, unknown>)[method];
     if (typeof helper !== "function") {
       throw new ArgumentError(`undefined route helper ${method}`);
     }
     return Object.keys(options).length === 0
-      ? (helper as (...a: unknown[]) => string).call(recipient, ...args)
-      : (helper as (...a: unknown[]) => string).call(recipient, ...args, options);
+      ? (helper as (...a: unknown[]) => string).call(target, ...args)
+      : (helper as (...a: unknown[]) => string).call(target, ...args, options);
   }
 
   readonly suffix: string;

--- a/packages/actionpack/src/action-dispatch/routing/routes-proxy.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/routes-proxy.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from "vitest";
+
+import { RoutesProxy, mergeScriptNames, type RoutesProxyInstance } from "./routes-proxy.js";
+import { urlOptions, type UrlForHost, type UrlForRoutes } from "./url-for.js";
+
+function makeRoutes(label = "R1"): UrlForRoutes {
+  return {
+    urlFor: () => `/${label}`,
+  };
+}
+
+function makeScope(routes: UrlForRoutes, extraOptions: Record<string, unknown> = {}): UrlForHost {
+  const scope: UrlForHost = {
+    _routes: routes,
+    defaultUrlOptions: { host: "example.com", ...extraOptions },
+    urlOptions() {
+      return { ...urlOptions.call(this), routesRef: this._routes };
+    },
+  };
+  return scope;
+}
+
+describe("RoutesProxy", () => {
+  it("exposes routes and _routes alias", () => {
+    const routes = makeRoutes();
+    const scope = makeScope(makeRoutes("OTHER"));
+    const proxy = new RoutesProxy(routes, scope, {});
+    expect(proxy.routes).toBe(routes);
+    expect(proxy._routes).toBe(routes);
+  });
+
+  it("urlOptions runs scope.urlOptions with _routes swapped to proxy routes", () => {
+    const proxyRoutes = makeRoutes("PROXY");
+    const scopeRoutes = makeRoutes("SCOPE");
+    const scope = makeScope(scopeRoutes);
+    const proxy = new RoutesProxy(proxyRoutes, scope, {});
+
+    const opts = proxy.urlOptions();
+    expect(opts.routesRef).toBe(proxyRoutes);
+    // restored after the call
+    expect(scope._routes).toBe(scopeRoutes);
+    expect(opts.host).toBe("example.com");
+  });
+
+  it("forwards helper calls with merged url_options", () => {
+    const seen: unknown[] = [];
+    const helpers = {
+      usersUrl(...args: unknown[]) {
+        seen.push(args);
+        return "/users";
+      },
+    };
+    const routes = makeRoutes();
+    const scope = makeScope(makeRoutes("SCOPE"));
+    const proxy = new RoutesProxy(routes, scope, helpers) as RoutesProxyInstance;
+
+    expect(proxy.usersUrl(1, { page: 2 })).toBe("/users");
+    const lastArg = (seen[0] as unknown[])[(seen[0] as unknown[]).length - 1] as Record<
+      string,
+      unknown
+    >;
+    expect(lastArg.host).toBe("example.com");
+    expect(lastArg.page).toBe(2);
+  });
+
+  it("appends merged options when no inline options were passed", () => {
+    const seen: unknown[][] = [];
+    const helpers = {
+      thingUrl(...args: unknown[]) {
+        seen.push(args);
+        return "/thing";
+      },
+    };
+    const proxy = new RoutesProxy(
+      makeRoutes(),
+      makeScope(makeRoutes()),
+      helpers,
+    ) as RoutesProxyInstance;
+    proxy.thingUrl(7);
+    expect(seen[0].length).toBe(2);
+    expect((seen[0][1] as Record<string, unknown>).host).toBe("example.com");
+  });
+
+  it("calls scriptNamer and merges via mergeScriptNames", () => {
+    const captured: Record<string, unknown>[] = [];
+    const helpers = {
+      thingUrl(...args: unknown[]) {
+        captured.push(args[args.length - 1] as Record<string, unknown>);
+        return "/x";
+      },
+    };
+    const scope = makeScope(makeRoutes());
+    const proxy = new RoutesProxy(
+      makeRoutes(),
+      scope,
+      helpers,
+      () => "/mounted",
+    ) as RoutesProxyInstance;
+
+    proxy.thingUrl({ script_name: "/ctx/old" });
+    expect(captured[0].script_name).toBe("/ctx/mounted");
+  });
+
+  it("throws on undefined helper when accessed directly", () => {
+    const proxy = new RoutesProxy(makeRoutes(), makeScope(makeRoutes()), {});
+    expect((proxy as RoutesProxyInstance).missingUrl).toBeUndefined();
+  });
+});
+
+describe("mergeScriptNames", () => {
+  it("returns newScriptName when previous is null", () => {
+    expect(mergeScriptNames(null, "/foo")).toBe("/foo");
+    expect(mergeScriptNames(undefined, "/foo")).toBe("/foo");
+  });
+
+  it("keeps context parts of previous and appends new", () => {
+    // previous "/ctx/old" has 2 slashes; new "/mounted" has 1; context = 2-1+1 = 2
+    // split("/").slice(0, 2) = ["", "ctx"] → "/ctx" + "/mounted"
+    expect(mergeScriptNames("/ctx/old", "/mounted")).toBe("/ctx/mounted");
+  });
+
+  it("handles deeper context", () => {
+    // previous "/a/b/old" (3 slashes), new "/mounted" (1) → context 3
+    // ["", "a", "b"] → "/a/b" + "/mounted"
+    expect(mergeScriptNames("/a/b/old", "/mounted")).toBe("/a/b/mounted");
+  });
+
+  it("handles new with multiple parts", () => {
+    // previous "/ctx/old" (2), new "/m/n" (2) → context 1 → [""] → "" + "/m/n"
+    expect(mergeScriptNames("/ctx/old", "/m/n")).toBe("/m/n");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
+++ b/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
@@ -12,7 +12,16 @@
  *
  * @see https://api.rubyonrails.org/classes/ActionDispatch/Routing/RoutesProxy.html
  */
-import { _withRoutes, type UrlForHost, type UrlForRoutes } from "./url-for.js";
+import {
+  _routesContext,
+  _withRoutes,
+  fullUrlFor,
+  optimizeRoutesGeneration,
+  routeFor,
+  urlFor,
+  type UrlForHost,
+  type UrlForRoutes,
+} from "./url-for.js";
 
 /** The minimal helpers-module surface RoutesProxy dispatches into. */
 export type RoutesProxyHelpers = Record<string, unknown>;
@@ -28,13 +37,30 @@ export type RoutesProxyInstance = RoutesProxy & {
   [helper: string]: any;
 };
 
-export class RoutesProxy {
+export class RoutesProxy implements UrlForHost {
   scope: UrlForHost;
   routes: UrlForRoutes;
+  /**
+   * UrlForHost field. Rails relies on `@_routes` set by `UrlFor#initialize`;
+   * here we expose it as a getter aliased to `routes` (mirrors the Ruby
+   * `alias :_routes :routes`).
+   */
+  defaultUrlOptions: Record<string, unknown> = {};
   /** @internal Rails: `@helpers` */
   private _helpers: RoutesProxyHelpers;
   /** @internal Rails: `@script_namer` */
   private _scriptNamer: ScriptNamer | null;
+
+  // UrlFor mixin (`include ActionDispatch::Routing::UrlFor` in Rails).
+  // Attached as `this`-typed functions per CLAUDE.md module-mixin pattern.
+  urlFor = urlFor;
+  fullUrlFor = fullUrlFor;
+  routeFor = routeFor;
+  optimizeRoutesGeneration = optimizeRoutesGeneration;
+  /** @internal Rails: `private def _with_routes` */
+  _withRoutes = _withRoutes;
+  /** @internal Rails: `private def _routes_context` */
+  _routesContext = _routesContext;
 
   constructor(
     routes: UrlForRoutes,
@@ -67,6 +93,9 @@ export class RoutesProxy {
   /** Rails: `alias :_routes :routes`. */
   get _routes(): UrlForRoutes {
     return this.routes;
+  }
+  set _routes(value: UrlForRoutes | null) {
+    if (value != null) this.routes = value;
   }
 
   urlOptions(): Record<string, unknown> {

--- a/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
+++ b/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
@@ -1,0 +1,140 @@
+/**
+ * ActionDispatch::Routing::RoutesProxy
+ *
+ * Mirrors `action_dispatch/routing/routes_proxy.rb`. A `RoutesProxy` wraps a
+ * `RouteSet` together with a host scope (typically the application's main
+ * `UrlFor` context) and forwards URL helper calls to a helpers module, with
+ * the scope's `urlOptions` mixed in and the `scriptName` resolved relative
+ * to the mount point.
+ *
+ * Rails uses `method_missing` to dispatch arbitrary helper calls; in TS we
+ * use a `Proxy` so callers can write `proxy.usersUrl(1)` directly.
+ *
+ * @see https://api.rubyonrails.org/classes/ActionDispatch/Routing/RoutesProxy.html
+ */
+import { _withRoutes, type UrlForHost, type UrlForRoutes } from "./url-for.js";
+
+/** The minimal helpers-module surface RoutesProxy dispatches into. */
+export type RoutesProxyHelpers = Record<string, unknown>;
+
+/** Rails: `script_namer` is a callable taking `options` and returning a string. */
+export type ScriptNamer = (options: Record<string, unknown>) => string;
+
+/**
+ * RoutesProxy instance shape. Indexed access surfaces forwarded helpers; the
+ * named members mirror `attr_accessor :scope, :routes` plus `urlOptions`.
+ */
+export type RoutesProxyInstance = RoutesProxy & {
+  [helper: string]: any;
+};
+
+export class RoutesProxy {
+  scope: UrlForHost;
+  routes: UrlForRoutes;
+  /** @internal Rails: `@helpers` */
+  private _helpers: RoutesProxyHelpers;
+  /** @internal Rails: `@script_namer` */
+  private _scriptNamer: ScriptNamer | null;
+
+  constructor(
+    routes: UrlForRoutes,
+    scope: UrlForHost,
+    helpers: RoutesProxyHelpers,
+    scriptNamer: ScriptNamer | null = null,
+  ) {
+    this.routes = routes;
+    this.scope = scope;
+    this._helpers = helpers;
+    this._scriptNamer = scriptNamer;
+
+    return new Proxy(this, {
+      get(target, prop, receiver) {
+        if (typeof prop === "string" && !(prop in target)) {
+          const fn = target._helpers[prop];
+          if (typeof fn === "function") {
+            return (...args: unknown[]) => target._dispatch(prop, args);
+          }
+        }
+        return Reflect.get(target, prop, receiver);
+      },
+      has(target, prop) {
+        if (typeof prop === "string" && prop in target._helpers) return true;
+        return Reflect.has(target, prop);
+      },
+    }) as RoutesProxy;
+  }
+
+  /** Rails: `alias :_routes :routes`. */
+  get _routes(): UrlForRoutes {
+    return this.routes;
+  }
+
+  urlOptions(): Record<string, unknown> {
+    return _withRoutes.call<
+      UrlForHost,
+      [UrlForRoutes, () => Record<string, unknown>],
+      Record<string, unknown>
+    >(this.scope, this.routes, () => this.scope.urlOptions());
+  }
+
+  /** @internal Rails: `method_missing(method, *args)` */
+  private _dispatch(method: string, args: unknown[]): unknown {
+    const fn = this._helpers[method];
+    if (typeof fn !== "function") {
+      throw new TypeError(`undefined helper '${method}' on RoutesProxy`);
+    }
+    const inlineOptions = extractOptions(args);
+    const options: Record<string, unknown> = { ...this.urlOptions(), ...inlineOptions };
+
+    if (this._scriptNamer) {
+      options["script_name"] = mergeScriptNames(
+        options["script_name"] as string | null | undefined,
+        this._scriptNamer(options),
+      );
+    }
+
+    args.push(options);
+    return (fn as (...a: unknown[]) => unknown).apply(this._helpers, args);
+  }
+}
+
+/**
+ * Keeps the part of the script name provided by the global context via
+ * `ENV["SCRIPT_NAME"]`, which `mount` doesn't know about since it depends on
+ * the specific request, but uses the script-name resolver for the mount-point
+ * dependent part.
+ *
+ * @internal Rails: `private def merge_script_names`
+ */
+export function mergeScriptNames(
+  previousScriptName: string | null | undefined,
+  newScriptName: string,
+): string {
+  if (previousScriptName == null) return newScriptName;
+
+  const resolvedParts = countSlashes(newScriptName);
+  const previousParts = countSlashes(previousScriptName);
+  const contextParts = previousParts - resolvedParts + 1;
+
+  return previousScriptName.split("/").slice(0, contextParts).join("/") + newScriptName;
+}
+
+/** @internal */
+function countSlashes(s: string): number {
+  let n = 0;
+  for (let i = 0; i < s.length; i++) if (s.charCodeAt(i) === 47) n++;
+  return n;
+}
+
+/** @internal Rails: `Array#extract_options!` — pops a trailing options hash. */
+function extractOptions(arr: unknown[]): Record<string, unknown> {
+  const last = arr[arr.length - 1];
+  if (last != null && typeof last === "object" && !Array.isArray(last)) {
+    const proto = Object.getPrototypeOf(last);
+    if (proto === null || proto === Object.prototype) {
+      arr.pop();
+      return last as Record<string, unknown>;
+    }
+  }
+  return {};
+}


### PR DESCRIPTION
## Summary

- Ports `action_dispatch/routing/routes_proxy.rb` to `routes-proxy.ts`. `RoutesProxy` wraps a `RouteSet` and a host scope (a `UrlFor` context), forwarding URL helper calls to a helpers module with the scope's `urlOptions` merged in and `scriptName` resolved relative to the mount point.
- Rails uses `method_missing` for dispatch; the TS port wraps the instance in a `Proxy` so callers can write `proxy.usersUrl(1)` directly.
- Wires the previously omitted `RoutesProxy` branch in `polymorphic-routes`' `HelperMethodBuilder.polymorphicMethod`: when the first element of an array is a `RoutesProxy`, it becomes the recipient of the resolved helper call (mirroring Rails' `record_or_hash_or_array.shift`).

Closes the last missing file in `actionpack/action_dispatch/routing/` per `docs/actionpack-100-percent.md`.

## Test plan
- [x] `pnpm vitest run` for `routes-proxy.test.ts`, `polymorphic-routes.test.ts`, `url-for.test.ts` — all pass
- [x] `pnpm lint`
- [x] `pnpm api:compare --package actionpack` — file recognized

## Follow-ups
- `direct(:name) { }` DSL on `polymorphic-routes` (was already on follow-up list).
- Widen `_routes` typing in polymorphic-routes when full `UrlFor` host wiring lands.