### PR TITLE
feat(actionpack): port ActionDispatch::DebugLocks middleware

### DIFF
--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -99,6 +99,13 @@ export { ExceptionWrapper } from "./middleware/exception-wrapper.js";
 export { AssumeSSL } from "./middleware/assume-ssl.js";
 export { Callbacks } from "./middleware/callbacks.js";
 export {
+  DebugLocks,
+  type DebugLocksConfig,
+  type InterlockLike,
+  type ThreadLike,
+  type ThreadInfo,
+} from "./middleware/debug-locks.js";
+export {
   Executor,
   type ExecutorLike,
   type ExecutorState,

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -100,7 +100,6 @@ export { AssumeSSL } from "./middleware/assume-ssl.js";
 export { Callbacks } from "./middleware/callbacks.js";
 export {
   DebugLocks,
-  type DebugLocksConfig,
   type InterlockLike,
   type ThreadLike,
   type ThreadInfo,

--- a/packages/actionpack/src/action-dispatch/middleware/debug-locks.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-locks.test.ts
@@ -82,6 +82,56 @@ describe("DebugLocks", () => {
     expect(res[1]["content-type"]).toBe("text/plain; charset=utf-8");
   });
 
+  it("blocks a start_sharing sleeper when blocker holds exclusive", async () => {
+    setInterlock([
+      [thread(1), { sleeper: "start_sharing", sharing: 0 }],
+      [thread(2), { exclusive: true, sharing: 0 }],
+    ]);
+    const res = await new DebugLocks(passthrough).call({
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/rails/locks",
+    });
+    const body = await bodyToString(res[2]);
+    expect(body).toMatch(/Thread 0[\s\S]*?blocked by: 1/);
+  });
+
+  it("blocks a yield_shares sleeper only on exclusive blockers", async () => {
+    setInterlock([
+      [thread(1), { sleeper: "yield_shares", sharing: 0 }],
+      [thread(2), { sharing: 1 }],
+      [thread(3), { exclusive: true, sharing: 0 }],
+    ]);
+    const res = await new DebugLocks(passthrough).call({
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/rails/locks",
+    });
+    const body = await bodyToString(res[2]);
+    expect(body).toMatch(/Thread 0[\s\S]*?blocked by: 2\n/);
+  });
+
+  it("blocks a stop_exclusive sleeper via compatible/purpose chain", async () => {
+    setInterlock([
+      [thread(1), { sleeper: "stop_exclusive", sharing: 0, compatible: ["load"] }],
+      [thread(2), { sharing: 0, purpose: "load", compatible: ["load"] }],
+    ]);
+    const res = await new DebugLocks(passthrough).call({
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/rails/locks",
+    });
+    const body = await bodyToString(res[2]);
+    expect(body).toMatch(/Thread 0[\s\S]*?blocked by: 1/);
+  });
+
+  it("renders 'dead' for a thread with falsy status", async () => {
+    setInterlock([[{ id: 0x5, status: false, backtrace: () => null }, { sharing: 0 }]]);
+    const res = await new DebugLocks(passthrough).call({
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/rails/locks",
+    });
+    const body = await bodyToString(res[2]);
+    expect(body).toContain("Thread 0 [0x5 dead]");
+  });
+
   it("throws when no interlock is configured", async () => {
     DebugLocks.interlock = null;
     const mw = new DebugLocks(passthrough);

--- a/packages/actionpack/src/action-dispatch/middleware/debug-locks.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-locks.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import { bodyFromString, bodyToString } from "@blazetrails/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { DebugLocks, type InterlockLike, type ThreadLike, type ThreadInfo } from "./debug-locks.js";
+
+const passthrough = async (_env: RackEnv): Promise<RackResponse> => [200, {}, bodyFromString("ok")];
+
+function makeInterlock(threads: Array<[ThreadLike, ThreadInfo]>): InterlockLike {
+  const map = new Map(threads);
+  return {
+    rawState(block) {
+      return block(map);
+    },
+  };
+}
+
+function thread(id: number, status: string | null = "run", backtrace: string[] = []): ThreadLike {
+  return { id, status, backtrace: () => backtrace };
+}
+
+describe("DebugLocks", () => {
+  it("passes non-matching paths to the inner app", async () => {
+    const mw = new DebugLocks(passthrough, { interlock: makeInterlock([]) });
+    const res = await mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/other" });
+    expect(res[0]).toBe(200);
+    expect(await bodyToString(res[2])).toBe("ok");
+  });
+
+  it("passes non-GET requests to the inner app", async () => {
+    const mw = new DebugLocks(passthrough, { interlock: makeInterlock([]) });
+    const res = await mw.call({ REQUEST_METHOD: "POST", PATH_INFO: "/rails/locks" });
+    expect(await bodyToString(res[2])).toBe("ok");
+  });
+
+  it("renders thread details at /rails/locks", async () => {
+    const interlock = makeInterlock([
+      [thread(0x1a, "sleep", ["a.rb:1", "b.rb:2"]), { exclusive: true, sharing: 0 }],
+      [thread(0x2b, "run"), { exclusive: false, sharing: 2 }],
+    ]);
+    const mw = new DebugLocks(passthrough, { interlock });
+    const res = await mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/rails/locks" });
+    expect(res[0]).toBe(200);
+    expect(res[1]["content-type"]).toBe("text/plain; charset=utf-8");
+    const body = await bodyToString(res[2]);
+    expect(body).toContain("Thread 0 [0x1a sleep]  Exclusive");
+    expect(body).toContain("Thread 1 [0x2b run]  Sharing x2");
+    expect(body).toContain("a.rb:1");
+  });
+
+  it("strips a trailing slash from the request path", async () => {
+    const interlock = makeInterlock([]);
+    const mw = new DebugLocks(passthrough, { interlock });
+    const res = await mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/rails/locks/" });
+    expect(res[0]).toBe(200);
+    expect(res[1]["content-type"]).toBe("text/plain; charset=utf-8");
+  });
+
+  it("reports blockers for a start_exclusive sleeper", async () => {
+    const interlock = makeInterlock([
+      [thread(1), { sleeper: "start_exclusive", sharing: 0, purpose: "load" }],
+      [thread(2), { exclusive: true, sharing: 0 }],
+    ]);
+    const mw = new DebugLocks(passthrough, { interlock });
+    const res = await mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/rails/locks" });
+    const body = await bodyToString(res[2]);
+    expect(body).toContain("Waiting in start_exclusive");
+    expect(body).toContain("blocked by: 1");
+    expect(body).toContain("blocking: 0");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/debug-locks.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-locks.test.ts
@@ -1,17 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { bodyFromString, bodyToString } from "@blazetrails/rack";
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { DebugLocks, type InterlockLike, type ThreadLike, type ThreadInfo } from "./debug-locks.js";
 
 const passthrough = async (_env: RackEnv): Promise<RackResponse> => [200, {}, bodyFromString("ok")];
 
-function makeInterlock(threads: Array<[ThreadLike, ThreadInfo]>): InterlockLike {
+function setInterlock(threads: Array<[ThreadLike, ThreadInfo]>): void {
   const map = new Map(threads);
-  return {
+  const interlock: InterlockLike = {
     rawState(block) {
       return block(map);
     },
   };
+  DebugLocks.interlock = interlock;
 }
 
 function thread(id: number, status: string | null = "run", backtrace: string[] = []): ThreadLike {
@@ -19,25 +20,32 @@ function thread(id: number, status: string | null = "run", backtrace: string[] =
 }
 
 describe("DebugLocks", () => {
+  beforeEach(() => {
+    setInterlock([]);
+  });
+  afterEach(() => {
+    DebugLocks.interlock = null;
+  });
+
   it("passes non-matching paths to the inner app", async () => {
-    const mw = new DebugLocks(passthrough, { interlock: makeInterlock([]) });
+    const mw = new DebugLocks(passthrough);
     const res = await mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/other" });
     expect(res[0]).toBe(200);
     expect(await bodyToString(res[2])).toBe("ok");
   });
 
   it("passes non-GET requests to the inner app", async () => {
-    const mw = new DebugLocks(passthrough, { interlock: makeInterlock([]) });
+    const mw = new DebugLocks(passthrough);
     const res = await mw.call({ REQUEST_METHOD: "POST", PATH_INFO: "/rails/locks" });
     expect(await bodyToString(res[2])).toBe("ok");
   });
 
   it("renders thread details at /rails/locks", async () => {
-    const interlock = makeInterlock([
+    setInterlock([
       [thread(0x1a, "sleep", ["a.rb:1", "b.rb:2"]), { exclusive: true, sharing: 0 }],
       [thread(0x2b, "run"), { exclusive: false, sharing: 2 }],
     ]);
-    const mw = new DebugLocks(passthrough, { interlock });
+    const mw = new DebugLocks(passthrough);
     const res = await mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/rails/locks" });
     expect(res[0]).toBe(200);
     expect(res[1]["content-type"]).toBe("text/plain; charset=utf-8");
@@ -48,23 +56,37 @@ describe("DebugLocks", () => {
   });
 
   it("strips a trailing slash from the request path", async () => {
-    const interlock = makeInterlock([]);
-    const mw = new DebugLocks(passthrough, { interlock });
+    const mw = new DebugLocks(passthrough);
     const res = await mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/rails/locks/" });
     expect(res[0]).toBe(200);
     expect(res[1]["content-type"]).toBe("text/plain; charset=utf-8");
   });
 
   it("reports blockers for a start_exclusive sleeper", async () => {
-    const interlock = makeInterlock([
+    setInterlock([
       [thread(1), { sleeper: "start_exclusive", sharing: 0, purpose: "load" }],
       [thread(2), { exclusive: true, sharing: 0 }],
     ]);
-    const mw = new DebugLocks(passthrough, { interlock });
+    const mw = new DebugLocks(passthrough);
     const res = await mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/rails/locks" });
     const body = await bodyToString(res[2]);
     expect(body).toContain("Waiting in start_exclusive");
     expect(body).toContain("blocked by: 1");
     expect(body).toContain("blocking: 0");
+  });
+
+  it("respects a custom path", async () => {
+    const mw = new DebugLocks(passthrough, "/admin/locks");
+    const res = await mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/admin/locks" });
+    expect(res[0]).toBe(200);
+    expect(res[1]["content-type"]).toBe("text/plain; charset=utf-8");
+  });
+
+  it("throws when no interlock is configured", async () => {
+    DebugLocks.interlock = null;
+    const mw = new DebugLocks(passthrough);
+    await expect(mw.call({ REQUEST_METHOD: "GET", PATH_INFO: "/rails/locks" })).rejects.toThrow(
+      /interlock is not configured/,
+    );
   });
 });

--- a/packages/actionpack/src/action-dispatch/middleware/debug-locks.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-locks.ts
@@ -12,7 +12,12 @@ import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
 import { Request } from "../http/request.js";
 
 export interface ThreadLike {
-  status: string | null;
+  /**
+   * Mirrors Ruby's `Thread#status`: "run" | "sleep" | "aborting" | false (terminated
+   * with exception) | nil (terminated normally). The middleware renders falsy as "dead",
+   * mirroring `thread.status || 'dead'` in the Ruby source.
+   */
+  status: string | false | null;
   backtrace(): string[] | null;
   id: number;
 }
@@ -21,7 +26,7 @@ export interface ThreadInfo {
   exclusive?: boolean;
   sharing?: number;
   waiting?: boolean;
-  sleeper?: string | symbol | null;
+  sleeper?: string | null;
   purpose?: unknown;
   compatible?: Array<unknown> | null;
   index?: number;
@@ -103,7 +108,7 @@ export class DebugLocks {
         lockState += " (yielded share)";
       }
 
-      const status = thread.status ?? "dead";
+      const status = thread.status || "dead";
       let msg = `Thread ${info.index} [0x${thread.id.toString(16)} ${status}]  ${lockState}\n`;
 
       if (info.sleeper) {

--- a/packages/actionpack/src/action-dispatch/middleware/debug-locks.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-locks.ts
@@ -1,0 +1,176 @@
+/**
+ * ActionDispatch::DebugLocks
+ *
+ * Diagnostic middleware exposing a snapshot of the autoload interlock
+ * (`/rails/locks`) — threads, their lock state, and the relationships
+ * between them. Strictly diagnostic; output formatting is human-readable
+ * and not part of the public contract.
+ */
+
+import { bodyFromString } from "@blazetrails/rack";
+import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
+import { Request } from "../http/request.js";
+
+export interface ThreadLike {
+  status: string | null;
+  backtrace(): string[] | null;
+  id: number;
+}
+
+export interface ThreadInfo {
+  exclusive?: boolean;
+  sharing?: number;
+  waiting?: boolean;
+  sleeper?: string | symbol | null;
+  purpose?: unknown;
+  compatible?: Array<unknown> | null;
+  index?: number;
+  backtrace?: string[] | null;
+}
+
+export interface InterlockLike {
+  rawState<T>(block: (threads: Map<ThreadLike, ThreadInfo>) => T): T;
+}
+
+export interface DebugLocksConfig {
+  interlock: InterlockLike;
+  defaultCharset?: string;
+}
+
+export class DebugLocks {
+  private app: RackApp;
+  private path: string;
+  private interlock: InterlockLike;
+  private defaultCharset: string;
+
+  constructor(app: RackApp, config: DebugLocksConfig, path = "/rails/locks") {
+    this.app = app;
+    this.path = path;
+    this.interlock = config.interlock;
+    this.defaultCharset = config.defaultCharset ?? "utf-8";
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    const req = new Request(env);
+
+    if (req.isGet) {
+      const path = req.path.replace(/\/$/, "");
+      if (path === this.path) {
+        return this.renderDetails();
+      }
+    }
+
+    return this.app(env);
+  }
+
+  /** @internal */
+  private renderDetails(): RackResponse {
+    const threads = this.interlock.rawState<Map<ThreadLike, ThreadInfo>>((rawThreads) => {
+      // The Interlock comes to a complete halt while this block runs, so do as
+      // little as possible here.
+      let idx = 0;
+      for (const [thread, info] of rawThreads) {
+        info.index = idx++;
+        info.backtrace = thread.backtrace();
+      }
+      return rawThreads;
+    });
+
+    const allInfos = Array.from(threads.values());
+    const parts: string[] = [];
+
+    for (const [thread, info] of threads) {
+      let lockState: string;
+      if (info.exclusive) {
+        lockState = "Exclusive";
+      } else if ((info.sharing ?? 0) > 0) {
+        lockState = "Sharing";
+        if ((info.sharing ?? 0) > 1) lockState += ` x${info.sharing}`;
+      } else {
+        lockState = "No lock";
+      }
+
+      if (info.waiting) {
+        lockState += " (yielded share)";
+      }
+
+      const status = thread.status ?? "dead";
+      let msg = `Thread ${info.index} [0x${thread.id.toString(16)} ${status}]  ${lockState}\n`;
+
+      if (info.sleeper) {
+        msg += `  Waiting in ${String(info.sleeper)}`;
+        if (info.purpose != null) msg += ` to ${JSON.stringify(String(info.purpose))}`;
+        msg += "\n";
+
+        if (info.compatible) {
+          const compat = info.compatible.map((c) =>
+            c === false ? "share" : JSON.stringify(String(c)),
+          );
+          msg += `  may be pre-empted for: ${compat.join(", ")}\n`;
+        }
+
+        const blockers = allInfos.filter((binfo) => this.blockedBy(info, binfo, allInfos));
+        if (blockers.length) {
+          msg += `  blocked by: ${blockers.map((i) => i.index).join(", ")}\n`;
+        }
+      }
+
+      const blockees = allInfos.filter((binfo) => this.blockedBy(binfo, info, allInfos));
+      if (blockees.length) {
+        msg += `  blocking: ${blockees.map((i) => i.index).join(", ")}\n`;
+      }
+
+      if (info.backtrace) {
+        msg += `\n${info.backtrace.join("\n")}\n`;
+      }
+
+      parts.push(msg);
+    }
+
+    const str = parts.join("\n\n---\n\n\n");
+
+    return [
+      200,
+      {
+        "content-type": `text/plain; charset=${this.defaultCharset}`,
+        "content-length": Buffer.byteLength(str).toString(),
+      },
+      bodyFromString(str),
+    ];
+  }
+
+  /** @internal */
+  private blockedBy(victim: ThreadInfo, blocker: ThreadInfo, allThreads: ThreadInfo[]): boolean {
+    if (victim === blocker) return false;
+
+    switch (victim.sleeper) {
+      case "start_sharing":
+        return (
+          !!blocker.exclusive ||
+          (!victim.waiting && !!blocker.compatible && !blocker.compatible.includes(false))
+        );
+      case "start_exclusive":
+        return (
+          (blocker.sharing ?? 0) > 0 ||
+          !!blocker.exclusive ||
+          (!!blocker.compatible && !blocker.compatible.includes(victim.purpose))
+        );
+      case "yield_shares":
+        return !!blocker.exclusive;
+      case "stop_exclusive":
+        return (
+          !!blocker.exclusive ||
+          (!!victim.compatible &&
+            victim.compatible.includes(blocker.purpose) &&
+            allThreads.every(
+              (other) =>
+                !other.compatible ||
+                other === blocker ||
+                other.compatible.includes(blocker.purpose),
+            ))
+        );
+      default:
+        return false;
+    }
+  }
+}

--- a/packages/actionpack/src/action-dispatch/middleware/debug-locks.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-locks.ts
@@ -32,22 +32,25 @@ export interface InterlockLike {
   rawState<T>(block: (threads: Map<ThreadLike, ThreadInfo>) => T): T;
 }
 
-export interface DebugLocksConfig {
-  interlock: InterlockLike;
-  defaultCharset?: string;
-}
-
 export class DebugLocks {
+  /**
+   * Source of `raw_state`. Mirrors Ruby's `ActiveSupport::Dependencies.interlock`,
+   * which has no port yet — assign before mounting the middleware.
+   */
+  static interlock: InterlockLike | null = null;
+
+  /**
+   * Charset used for the response `content-type`. Mirrors
+   * `ActionDispatch::Response.default_charset`.
+   */
+  static defaultCharset = "utf-8";
+
   private app: RackApp;
   private path: string;
-  private interlock: InterlockLike;
-  private defaultCharset: string;
 
-  constructor(app: RackApp, config: DebugLocksConfig, path = "/rails/locks") {
+  constructor(app: RackApp, path = "/rails/locks") {
     this.app = app;
     this.path = path;
-    this.interlock = config.interlock;
-    this.defaultCharset = config.defaultCharset ?? "utf-8";
   }
 
   async call(env: RackEnv): Promise<RackResponse> {
@@ -65,7 +68,13 @@ export class DebugLocks {
 
   /** @internal */
   private renderDetails(): RackResponse {
-    const threads = this.interlock.rawState<Map<ThreadLike, ThreadInfo>>((rawThreads) => {
+    const interlock = DebugLocks.interlock;
+    if (!interlock) {
+      throw new Error(
+        "ActionDispatch::DebugLocks.interlock is not configured (no autoload interlock port available)",
+      );
+    }
+    const threads = interlock.rawState<Map<ThreadLike, ThreadInfo>>((rawThreads) => {
       // The Interlock comes to a complete halt while this block runs, so do as
       // little as possible here.
       let idx = 0;
@@ -132,8 +141,8 @@ export class DebugLocks {
     return [
       200,
       {
-        "content-type": `text/plain; charset=${this.defaultCharset}`,
-        "content-length": Buffer.byteLength(str).toString(),
+        "content-type": `text/plain; charset=${DebugLocks.defaultCharset}`,
+        "content-length": str.length.toString(),
       },
       bodyFromString(str),
     ];


### PR DESCRIPTION
Mirrors `vendor/rails/actionpack/lib/action_dispatch/middleware/debug_locks.rb`.

Diagnostic middleware that exposes a snapshot of the autoload interlock at
`/rails/locks`: per-thread lock state, blockers/blockees, and backtraces.
Strictly diagnostic — the output format is human-readable and not part of
the public contract.

Since `ActiveSupport::Dependencies.interlock` isn't ported yet, the
middleware takes an `InterlockLike` via config; once an interlock port
lands it can supply the implementation. The `ThreadLike` interface
similarly abstracts over Ruby `Thread`.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware/debug-locks.test.ts`