### PR TITLE
test(activerecord): Batch 17 — autosave indexed-error I18n translation

### DIFF
--- a/packages/activemodel/src/error.test.ts
+++ b/packages/activemodel/src/error.test.ts
@@ -291,7 +291,7 @@ describe("ErrorTest", () => {
   // Rails error.rb:51-55: strip array notation, then pass full dotted attribute
   // to human_attribute_name with `attribute.tr(".", "_").humanize` as the default —
   // so the prefix segment is preserved when no translation matches.
-  it("fullMessage strips array notation but preserves dotted prefix in humanized default", () => {
+  it("fullMessage strips array notation from attribute", () => {
     const e = new Errors(null);
     e.add("items[0].name", "blank");
     const msg = e.fullMessages[0];
@@ -299,7 +299,7 @@ describe("ErrorTest", () => {
     expect(msg).not.toContain("[0]");
   });
 
-  it("fullMessage humanizes the full dotted attribute when no translation matches", () => {
+  it("fullMessage uses last segment of dotted attribute", () => {
     const e = new Errors(null);
     e.add("profile.bio", "blank");
     const msg = e.fullMessages[0];

--- a/packages/activemodel/src/error.test.ts
+++ b/packages/activemodel/src/error.test.ts
@@ -288,23 +288,22 @@ describe("ErrorTest", () => {
     expect(e.get("name")).toEqual(["tooShort"]);
   });
 
-  // P10: fullMessage strips array notation from attribute
-  it("fullMessage strips array notation from attribute", () => {
+  // Rails error.rb:51-55: strip array notation, then pass full dotted attribute
+  // to human_attribute_name with `attribute.tr(".", "_").humanize` as the default —
+  // so the prefix segment is preserved when no translation matches.
+  it("fullMessage strips array notation but preserves dotted prefix in humanized default", () => {
     const e = new Errors(null);
     e.add("items[0].name", "blank");
     const msg = e.fullMessages[0];
-    // Should humanize "name" not "items[0].name"
-    expect(msg).toBe("Name can't be blank");
+    expect(msg).toBe("Items name can't be blank");
     expect(msg).not.toContain("[0]");
   });
 
-  // P10: fullMessage uses last segment of dotted attribute
-  it("fullMessage uses last segment of dotted attribute", () => {
+  it("fullMessage humanizes the full dotted attribute when no translation matches", () => {
     const e = new Errors(null);
     e.add("profile.bio", "blank");
     const msg = e.fullMessages[0];
-    expect(msg).toBe("Bio can't be blank");
-    expect(msg).not.toContain("Profile");
+    expect(msg).toBe("Profile bio can't be blank");
   });
 
   // P10: fullMessage non-nested regression guard

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -9,7 +9,7 @@ interface ModelClass {
   name?: string;
   i18nScope?: string;
   modelName?: { i18nKey?: string };
-  humanAttributeName?: (attr: string) => string;
+  humanAttributeName?: (attr: string, options?: { default?: string }) => string;
   lookupAncestors?: () => ModelClass[];
 }
 
@@ -156,8 +156,17 @@ export class Error {
     const attrName = parts[parts.length - 1];
     const namespace = parts.length > 1 ? parts.slice(0, -1).join("/") : undefined;
 
+    // Rails passes the full dotted attribute (post array-strip) to
+    // human_attribute_name plus a humanized-from-underscored default so
+    // nested-association keys like "reference.job_id" resolve via the
+    // nested translation path and fall back to "Reference job".
+    const humanLookup = parts.length > 1 ? stripped : attrName;
+    const humanDefault = parts.length > 1 ? humanize(stripped.replace(/\./g, "_")) : undefined;
     const humanAttr = modelClass?.humanAttributeName
-      ? modelClass.humanAttributeName(attrName)
+      ? modelClass.humanAttributeName(
+          humanLookup,
+          humanDefault ? { default: humanDefault } : undefined,
+        )
       : humanize(attrName);
 
     let format: string;

--- a/packages/activemodel/src/error.ts
+++ b/packages/activemodel/src/error.ts
@@ -156,18 +156,15 @@ export class Error {
     const attrName = parts[parts.length - 1];
     const namespace = parts.length > 1 ? parts.slice(0, -1).join("/") : undefined;
 
-    // Rails passes the full dotted attribute (post array-strip) to
-    // human_attribute_name plus a humanized-from-underscored default so
-    // nested-association keys like "reference.job_id" resolve via the
-    // nested translation path and fall back to "Reference job".
-    const humanLookup = parts.length > 1 ? stripped : attrName;
-    const humanDefault = parts.length > 1 ? humanize(stripped.replace(/\./g, "_")) : undefined;
+    // Rails error.rb:51-55: pass the full dotted attribute (post array-strip)
+    // to human_attribute_name with `default: attribute.remove(/\.base\z/).tr(".", "_").humanize`
+    // so nested-association keys like "reference.job_id" resolve via the
+    // nested translation path and fall back to "Reference job"; the `.base`
+    // trailing strip means "reference.base" defaults to "Reference".
+    const humanDefault = humanize(stripped.replace(/\.base$/, "").replace(/\./g, "_"));
     const humanAttr = modelClass?.humanAttributeName
-      ? modelClass.humanAttributeName(
-          humanLookup,
-          humanDefault ? { default: humanDefault } : undefined,
-        )
-      : humanize(attrName);
+      ? modelClass.humanAttributeName(stripped, { default: humanDefault })
+      : humanDefault;
 
     let format: string;
     if (Error.i18nCustomizeFullMessage) {

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -3,6 +3,7 @@
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
 import { describe, it, expect, beforeEach } from "vitest";
+import { I18n, Error as ModelError } from "@blazetrails/activemodel";
 import {
   Base,
   registerModel,
@@ -2170,39 +2171,111 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
     expect(parent.errors.details.get("kids[1].base")?.length ?? 0).toBeGreaterThan(0);
   });
   it("indexed errors should be properly translated", () => {
-    const { Parent, Child } = makeIndexedHasMany({ indexErrors: true });
-    const parent = new Parent({ name: "p" });
-    cacheAssoc(parent, "children", [new Child({ name: "ok" }), new Child({ name: "" })]);
-    expect(parent.isValid()).toBe(false);
-    expect(parent.errors.where("children[1].name")).toHaveLength(1);
-    expect(parent.errors.where("children.name")).toHaveLength(0);
+    const oldCustomize = ModelError.i18nCustomizeFullMessage;
+    ModelError.i18nCustomizeFullMessage = true;
+    I18n.storeTranslations("en", {
+      activerecord: {
+        errors: {
+          models: {
+            "person/references": { format: "%{message}" },
+          },
+        },
+      },
+    });
+    try {
+      class Reference extends Base {
+        static {
+          this.attribute("favorite", "boolean");
+          this.attribute("job_id", "integer");
+          this.attribute("person_id", "integer");
+          this.validate(function (record: any) {
+            if (!record.favorite) record.errors.add("base", "should be favorite");
+          });
+          this.validates("job_id", { presence: true });
+        }
+      }
+      class Person extends Base {
+        static {
+          this.attribute("name", "string");
+        }
+      }
+      Person.adapter = adapter;
+      Reference.adapter = adapter;
+      registerModel("Person", Person);
+      registerModel("Reference", Reference);
+      Associations.hasMany.call(Person, "references", {
+        autosave: true,
+        indexErrors: true,
+        className: "Reference",
+        foreignKey: "person_id",
+      });
+
+      const refValid = new Reference({ favorite: true, job_id: 1 });
+      const refInvalid = new Reference({ favorite: false });
+      const p = new Person({});
+      cacheAssoc(p, "references", [refValid, refInvalid]);
+
+      expect(refValid.isValid()).toBe(true);
+      expect(refInvalid.isValid()).toBe(false);
+      expect(p.isValid()).toBe(false);
+      expect(p.errors.fullMessages).toEqual(["should be favorite", "can't be blank"]);
+    } finally {
+      ModelError.i18nCustomizeFullMessage = oldCustomize;
+      I18n.reset();
+    }
   });
   it("indexed errors on base attribute should be properly translated", () => {
-    class O extends Base {
-      static {
-        this.attribute("name", "string");
-      }
-    }
-    class Pt extends Base {
-      static {
-        this.attribute("name", "string");
-        this.attribute("o_id", "integer");
-        this.validates("name", { presence: true });
-      }
-    }
-    O.adapter = adapter;
-    Pt.adapter = adapter;
-    registerModel("OwnerHO", O);
-    registerModel("PetHO", Pt);
-    Associations.hasOne.call(O, "pet", {
-      autosave: true,
-      foreignKey: "o_id",
-      className: "PetHO",
+    I18n.storeTranslations("en", {
+      activerecord: {
+        attributes: {
+          person: { reference: "Super reference" },
+          reference: { base: "" },
+        },
+      },
     });
-    const owner = new O({ name: "Alice" });
-    cacheAssoc(owner, "pet", new Pt({ name: "" }));
-    expect(owner.isValid()).toBe(false);
-    expect(owner.errors.include("pet.name")).toBe(true);
+    try {
+      class Reference extends Base {
+        static {
+          this.attribute("favorite", "boolean");
+          this.attribute("job_id", "integer");
+          this.attribute("person_id", "integer");
+          this.validate(function (record: any) {
+            if (!record.favorite) record.errors.add("base", "should be favorite");
+          });
+          this.validates("job_id", { presence: true });
+        }
+      }
+      class Person extends Base {
+        static {
+          this.attribute("name", "string");
+          this.validates("reference", { presence: true });
+        }
+      }
+      Person.adapter = adapter;
+      Reference.adapter = adapter;
+      registerModel("Person", Person);
+      registerModel("Reference", Reference);
+      Associations.hasOne.call(Person, "reference", {
+        autosave: true,
+        className: "Reference",
+        foreignKey: "person_id",
+      });
+
+      const p = new Person({});
+      expect(p.isValid()).toBe(false);
+      expect(p.errors.fullMessages).toEqual(["Super reference can't be blank"]);
+
+      const refInvalid = new Reference({ favorite: false });
+      cacheAssoc(p, "reference", refInvalid);
+      expect(refInvalid.isValid()).toBe(false);
+      expect(p.isValid()).toBe(false);
+      expect(p.errors.fullMessages).toEqual([
+        " should be favorite",
+        "Reference job can't be blank",
+      ]);
+    } finally {
+      I18n.reset();
+    }
   });
   it("errors details should be indexed when global flag is set", () => {
     const old = indexNestedAttributeErrors;


### PR DESCRIPTION
## Summary

Batch 17 from docs/activerecord-100-plan.md — the two "indexed errors should be properly translated" tests in `autosave-association.test.ts` are rewritten against a real I18n backend (i18nCustomizeFullMessage wiring is already in place).

- Test bodies mirror Rails `test_indexed_errors_should_be_properly_translated` and `test_indexed_errors_on_base_attribute_should_be_properly_translated` verbatim: store translations, enable `i18nCustomizeFullMessage`, assert `errors.fullMessages`.
- `Error.fullMessage` (activemodel) now passes the full dotted attribute (post array-strip) to `humanAttributeName` plus a humanized-from-underscored default, matching Rails `error.rb` — so `reference.job_id` resolves to `Reference job` via the nested-attribute translation path instead of bare `Job`.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts -t "indexed errors"` — both rewrites pass
- [x] Regression: error.test.ts, errors.test.ts, translation.test.ts, i18n.test.ts, validations.test.ts, autosave-association.test.ts, nested-error.test.ts all green