### PR TITLE
feat(actionpack): port ActionDispatch::DebugView

### DIFF
--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -116,6 +116,7 @@ export {
 } from "./middleware/executor.js";
 export { Reloader } from "./middleware/reloader.js";
 export { PublicExceptions } from "./middleware/public-exceptions.js";
+export { DebugView } from "./middleware/debug-view.js";
 export {
   RemoteIp,
   GetIp,

--- a/packages/actionpack/src/action-dispatch/middleware/debug-view.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-view.test.ts
@@ -5,7 +5,8 @@
  */
 
 import { describe, it, expect } from "vitest";
-import { DebugView, BadRequest } from "./debug-view.js";
+import { DebugView } from "./debug-view.js";
+import { BadRequest } from "../../action-controller/metal/exceptions.js";
 
 describe("DebugView", () => {
   it("RESCUES_TEMPLATE_PATHS resolves alongside the source file", () => {

--- a/packages/actionpack/src/action-dispatch/middleware/debug-view.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-view.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Smoke tests for ActionDispatch::DebugView. Full Rails-mirrored cases
+ * (actionpack/test/dispatch/debug_exceptions_test.rb) follow up once
+ * ActionView::Base is ported.
+ */
+
+import { describe, it, expect } from "vitest";
+import { DebugView, BadRequest } from "./debug-view.js";
+
+describe("DebugView", () => {
+  it("RESCUES_TEMPLATE_PATHS resolves alongside the source file", () => {
+    expect(DebugView.RESCUES_TEMPLATE_PATHS).toHaveLength(1);
+    expect(DebugView.RESCUES_TEMPLATE_PATHS[0]).toMatch(/templates$/);
+    expect(DebugView.RESCUES_TEMPLATE_PATHS[0]).toMatch(/^(file:|https?:)/);
+  });
+
+  describe("debugParams", () => {
+    it("strips action and controller", () => {
+      const view = new DebugView({});
+      expect(view.debugParams({ action: "show", controller: "users", id: 1 })).toContain("id");
+      expect(view.debugParams({ action: "show", controller: "users", id: 1 })).not.toContain(
+        "action",
+      );
+    });
+
+    it("returns 'None' when only action/controller present", () => {
+      const view = new DebugView({});
+      expect(view.debugParams({ action: "show", controller: "users" })).toBe("None");
+    });
+  });
+
+  describe("debugHeaders", () => {
+    it("returns 'None' for empty headers", () => {
+      const view = new DebugView({});
+      expect(view.debugHeaders({})).toBe("None");
+      expect(view.debugHeaders(null)).toBe("None");
+    });
+
+    it("inspects and wraps commas with newlines", () => {
+      const view = new DebugView({});
+      const out = view.debugHeaders({ a: "1", b: "2" });
+      expect(out).toContain("\n");
+    });
+  });
+
+  describe("debugHash", () => {
+    it("sorts keys and inspects values", () => {
+      const view = new DebugView({});
+      const out = view.debugHash({ b: 2, a: 1 });
+      expect(out.indexOf("a:")).toBeLessThan(out.indexOf("b:"));
+    });
+
+    it("uses toHash() when available", () => {
+      const view = new DebugView({});
+      const out = view.debugHash({ toHash: () => ({ x: "y" }) });
+      expect(out).toBe('x: "y"');
+    });
+  });
+
+  it("protectAgainstForgery returns false", () => {
+    expect(new DebugView({}).protectAgainstForgery()).toBe(false);
+  });
+
+  describe("paramsValid", () => {
+    it("returns false when request parameter access throws BadRequest", () => {
+      const view = new DebugView({
+        request: {
+          get parameters() {
+            throw new BadRequest();
+          },
+        },
+      });
+      expect(view.paramsValid()).toBe(false);
+    });
+
+    it("returns true when parameters are accessible", () => {
+      const view = new DebugView({ request: { parameters: { id: 1 } } });
+      expect(view.paramsValid()).toBe(true);
+    });
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/debug-view.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-view.ts
@@ -7,12 +7,11 @@
  * DebugExceptions to render error pages. ActionView::Base is not yet
  * ported in trails, so this port provides the DebugView helper surface
  * (debugParams / debugHeaders / debugHash / paramsValid /
- * protectAgainstForgery) as a standalone class. Once ActionView::Base
- * lands, DebugView should be re-derived from it and the LookupContext
- * wiring filled in.
+ * protectAgainstForgery / compiledMethodContainer) as a standalone
+ * class. Once ActionView::Base lands, DebugView should be re-derived
+ * from it and its `render` (logger-silence wrapper around super)
+ * ported alongside.
  */
-
-import { LookupContext } from "@blazetrails/actionview";
 
 const TEMPLATES_URL = new URL("./templates", import.meta.url).href;
 
@@ -32,14 +31,11 @@ export class DebugView {
   static readonly RESCUES_TEMPLATE_PATHS: readonly string[] = [TEMPLATES_URL];
 
   /** @internal */
-  protected readonly lookupContext: LookupContext;
-  /** @internal */
   protected readonly assigns: Record<string, unknown>;
   /** @internal */
   protected readonly _request: ParamsRequestLike | undefined;
 
   constructor(assigns: Record<string, unknown>) {
-    this.lookupContext = new LookupContext();
     this.assigns = assigns;
     this._request = assigns["request"] as ParamsRequestLike | undefined;
   }
@@ -84,17 +80,6 @@ export class DebugView {
         return `${k}: ${valueInspected}`;
       })
       .join("\n");
-  }
-
-  /**
-   * Rails wraps `super` with `logger.silence` if available; trails does
-   * not yet have ActionView::Base#render, so this is a placeholder that
-   * callers can override or that will be filled in when ActionView::Base
-   * is ported.
-   * @internal
-   */
-  render(..._args: unknown[]): string {
-    throw new Error("DebugView#render requires ActionView::Base (not yet ported)");
   }
 
   protectAgainstForgery(): boolean {

--- a/packages/actionpack/src/action-dispatch/middleware/debug-view.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-view.ts
@@ -13,18 +13,12 @@
  * ported alongside.
  */
 
+import { BadRequest } from "../../action-controller/metal/exceptions.js";
+
 const TEMPLATES_URL = new URL("./templates", import.meta.url).href;
 
 interface ParamsRequestLike {
   parameters: unknown;
-}
-
-/** @internal */
-export class BadRequest extends Error {
-  constructor(message = "Bad Request") {
-    super(message);
-    this.name = "BadRequest";
-  }
 }
 
 export class DebugView {

--- a/packages/actionpack/src/action-dispatch/middleware/debug-view.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-view.ts
@@ -1,0 +1,135 @@
+/**
+ * ActionDispatch::DebugView
+ *
+ * Mirrors Rails `action_dispatch/middleware/debug_view.rb`.
+ *
+ * In Rails, DebugView extends ActionView::Base and is used by
+ * DebugExceptions to render error pages. ActionView::Base is not yet
+ * ported in trails, so this port provides the DebugView helper surface
+ * (debugParams / debugHeaders / debugHash / paramsValid /
+ * protectAgainstForgery) as a standalone class. Once ActionView::Base
+ * lands, DebugView should be re-derived from it and the LookupContext
+ * wiring filled in.
+ */
+
+import { LookupContext } from "@blazetrails/actionview";
+
+const TEMPLATES_URL = new URL("./templates", import.meta.url).href;
+
+interface ParamsRequestLike {
+  parameters: unknown;
+}
+
+/** @internal */
+export class BadRequest extends Error {
+  constructor(message = "Bad Request") {
+    super(message);
+    this.name = "BadRequest";
+  }
+}
+
+export class DebugView {
+  static readonly RESCUES_TEMPLATE_PATHS: readonly string[] = [TEMPLATES_URL];
+
+  /** @internal */
+  protected readonly lookupContext: LookupContext;
+  /** @internal */
+  protected readonly assigns: Record<string, unknown>;
+  /** @internal */
+  protected readonly _request: ParamsRequestLike | undefined;
+
+  constructor(assigns: Record<string, unknown>) {
+    this.lookupContext = new LookupContext();
+    this.assigns = assigns;
+    this._request = assigns["request"] as ParamsRequestLike | undefined;
+  }
+
+  /** @internal */
+  compiledMethodContainer(): typeof DebugView {
+    return this.constructor as typeof DebugView;
+  }
+
+  debugParams(params: Record<string, unknown>): string {
+    const cleanParams = { ...params };
+    delete cleanParams["action"];
+    delete cleanParams["controller"];
+
+    if (Object.keys(cleanParams).length === 0) {
+      return "None";
+    }
+    return prettyPrint(cleanParams, 200);
+  }
+
+  debugHeaders(headers: Record<string, unknown> | null | undefined): string {
+    if (headers && Object.keys(headers).length > 0) {
+      return inspect(headers).replace(/,/g, ",\n");
+    }
+    return "None";
+  }
+
+  debugHash(object: { toHash?: () => Record<string, unknown> } | Record<string, unknown>): string {
+    const hash =
+      typeof (object as { toHash?: () => Record<string, unknown> }).toHash === "function"
+        ? (object as { toHash: () => Record<string, unknown> }).toHash()
+        : (object as Record<string, unknown>);
+    const keys = Object.keys(hash).sort();
+    return keys
+      .map((k) => {
+        let valueInspected: string;
+        try {
+          valueInspected = inspect(hash[k]);
+        } catch (e) {
+          valueInspected = (e as Error).message;
+        }
+        return `${k}: ${valueInspected}`;
+      })
+      .join("\n");
+  }
+
+  /**
+   * Rails wraps `super` with `logger.silence` if available; trails does
+   * not yet have ActionView::Base#render, so this is a placeholder that
+   * callers can override or that will be filled in when ActionView::Base
+   * is ported.
+   * @internal
+   */
+  render(..._args: unknown[]): string {
+    throw new Error("DebugView#render requires ActionView::Base (not yet ported)");
+  }
+
+  protectAgainstForgery(): boolean {
+    return false;
+  }
+
+  paramsValid(): boolean {
+    try {
+      return Boolean(this._request?.parameters);
+    } catch (e) {
+      if (e instanceof BadRequest) return false;
+      throw e;
+    }
+  }
+}
+
+/** @internal */
+function inspect(value: unknown): string {
+  if (value === null) return "nil";
+  if (value === undefined) return "nil";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  if (Array.isArray(value)) return `[${value.map(inspect).join(", ")}]`;
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>).map(
+      ([k, v]) => `${JSON.stringify(k)}=>${inspect(v)}`,
+    );
+    return `{${entries.join(", ")}}`;
+  }
+  return String(value);
+}
+
+/** @internal */
+function prettyPrint(value: unknown, width: number): string {
+  const single = inspect(value);
+  if (single.length <= width) return single;
+  return JSON.stringify(value, null, 2);
+}


### PR DESCRIPTION
## Summary

Ports `action_dispatch/middleware/debug_view.rb` (Rails 1:1).

`DebugView` provides the helper surface used by `DebugExceptions` to render error pages: `debugParams`, `debugHeaders`, `debugHash`, `paramsValid`, `protectAgainstForgery`, `compiledMethodContainer`, plus the `RESCUES_TEMPLATE_PATHS` constant.

## Notes

- `ActionView::Base` is not yet ported, so `DebugView` is a standalone class instead of subclassing it.
- Rails' `render` is a logger-silencing wrapper around `super` (i.e. `ActionView::Base#render`). With no `super` to delegate to, it would be a pure stub — omitted here and called out as a follow-up.
- `RESCUES_TEMPLATE_PATHS` is exposed as a `file://` URL computed from `import.meta.url` (avoiding the `no-node-builtins` lint rule).
- `BadRequest` is exported alongside as the trigger for `paramsValid` returning false, mirroring Rails' `rescue ActionController::BadRequest`.

## api:compare

- `middleware/debug_view.rb` → `middleware/debug-view.ts`: 7/8 (88%). `render` deferred until `ActionView::Base` lands.

## Follow-ups

- Re-derive `DebugView` from `ActionView::Base` once ported; restore `render` with logger-silence semantics.
- Wire `DebugView` into `DebugExceptions` when Base + templates are ready.

## Test plan

- [x] Smoke tests for each helper method
- [x] `pnpm typecheck`
- [x] `pnpm api:compare` (positive delta — new file)
- [x] `pnpm test:compare` (no regression on `dispatch/debug_exceptions_test.rb`)