### PR TITLE
refactor(activerecord): remove dead createReflection helper

### DIFF
--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1734,44 +1734,6 @@ function reflectionClassFor(
 }
 
 /**
- * Create a reflection from an association definition.
- * Returns ThroughReflection wrapper for :through associations.
- */
-export function createReflection(
-  assocDef: { name: string; type: string; options: Record<string, unknown> },
-  ownerClass: typeof Base,
-): AssociationReflection | ThroughReflection {
-  const normalizedType =
-    assocDef.type === "hasManyThrough"
-      ? "hasMany"
-      : assocDef.type === "hasOneThrough"
-        ? "hasOne"
-        : assocDef.type;
-
-  const ReflectionClass = reflectionClassFor(normalizedType);
-  const { scope: assocScope, ...restOptions } = assocDef.options as {
-    scope?: (...args: any[]) => any;
-  } & Record<string, unknown>;
-  const reflection = new ReflectionClass(
-    assocDef.name,
-    assocScope ?? null,
-    restOptions,
-    ownerClass,
-  );
-
-  if (
-    assocDef.type !== "hasAndBelongsToMany" &&
-    (assocDef.options.through ||
-      assocDef.type === "hasManyThrough" ||
-      assocDef.type === "hasOneThrough")
-  ) {
-    return new ThroughReflection(reflection);
-  }
-
-  return reflection;
-}
-
-/**
  * Mirrors: ActiveRecord::Reflection.create
  */
 export function create(


### PR DESCRIPTION
## Summary

Batch 18 — Reflection residual cleanup (per `docs/activerecord-100-plan.md:54`).

Deletes the dead `createReflection` factory in `reflection.ts`. It had no callers; `Reflection.create` is the live Rails-mirrored factory used by `associations/builder/association.ts`. Removes a stale asymmetric helper.

The plan's second item ("deeply nested through-association resolution in `_buildThroughScope`") was folded into Batch 29.

## Test plan

- [x] `pnpm --filter activerecord exec tsc --noEmit` — no new errors in non-test sources
- [ ] CI green