### PR TITLE
feat(actionpack): port ActionDispatch::PublicExceptions middleware

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/public-exceptions.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/public-exceptions.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { bodyToString } from "@blazetrails/rack";
+import { X_CASCADE } from "../constants.js";
+import { PublicExceptions } from "../middleware/public-exceptions.js";
+
+let publicPath: string;
+let app: PublicExceptions;
+
+beforeAll(() => {
+  publicPath = mkdtempSync(path.join(tmpdir(), "public-exceptions-"));
+  mkdirSync(publicPath, { recursive: true });
+  writeFileSync(path.join(publicPath, "404.html"), "<h1>404</h1>");
+  writeFileSync(path.join(publicPath, "500.html"), "<h1>500</h1>");
+  writeFileSync(path.join(publicPath, "404.en.html"), "<h1>404 en</h1>");
+  app = new PublicExceptions(publicPath);
+});
+
+afterAll(() => {
+  rmSync(publicPath, { recursive: true, force: true });
+});
+
+describe("PublicExceptions", () => {
+  it("renders the static html page for the requested status", async () => {
+    const [status, headers, body] = await app.call({
+      PATH_INFO: "/500",
+      HTTP_ACCEPT: "text/html",
+    });
+    expect(status).toBe(500);
+    expect(headers["content-type"]).toBe("text/html; charset=utf-8");
+    expect(await bodyToString(body)).toBe("<h1>500</h1>");
+  });
+
+  it("prefers the localized html when present", async () => {
+    const [status, , body] = await app.call({
+      PATH_INFO: "/404",
+      HTTP_ACCEPT: "text/html",
+    });
+    expect(status).toBe(404);
+    expect(await bodyToString(body)).toBe("<h1>404 en</h1>");
+  });
+
+  it("returns x-cascade pass when no template exists", async () => {
+    const [status, headers, body] = await app.call({
+      PATH_INFO: "/418",
+      HTTP_ACCEPT: "text/html",
+    });
+    expect(status).toBe(404);
+    expect(headers[X_CASCADE]).toBe("pass");
+    expect(await bodyToString(body)).toBe("");
+  });
+
+  it("renders json when requested", async () => {
+    const [status, headers, body] = await app.call({
+      PATH_INFO: "/500",
+      HTTP_ACCEPT: "application/json",
+    });
+    expect(status).toBe(500);
+    expect(headers["content-type"]).toBe("application/json; charset=utf-8");
+    expect(JSON.parse(await bodyToString(body))).toEqual({
+      status: 500,
+      error: "Internal Server Error",
+    });
+  });
+
+  it("falls back to html when content type is invalid", async () => {
+    const [status, headers] = await app.call({
+      PATH_INFO: "/500",
+      HTTP_ACCEPT: "invalid;;;",
+    });
+    expect(status).toBe(500);
+    expect(headers["content-type"]).toBe("text/html; charset=utf-8");
+  });
+
+  it("uses the status from the path info", async () => {
+    const [status] = await app.call({
+      PATH_INFO: "/404",
+      HTTP_ACCEPT: "application/json",
+    });
+    expect(status).toBe(404);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/dispatch/public-exceptions.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/public-exceptions.test.ts
@@ -2,12 +2,14 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { I18n } from "@blazetrails/activesupport";
 import { bodyToString } from "@blazetrails/rack";
 import { X_CASCADE } from "../constants.js";
 import { PublicExceptions } from "../middleware/public-exceptions.js";
 
 let publicPath: string;
 let app: PublicExceptions;
+let priorLocale: string;
 
 beforeAll(() => {
   publicPath = mkdtempSync(path.join(tmpdir(), "public-exceptions-"));
@@ -15,10 +17,13 @@ beforeAll(() => {
   writeFileSync(path.join(publicPath, "404.html"), "<h1>404</h1>");
   writeFileSync(path.join(publicPath, "500.html"), "<h1>500</h1>");
   writeFileSync(path.join(publicPath, "404.en.html"), "<h1>404 en</h1>");
+  priorLocale = I18n.locale;
+  I18n.locale = "en";
   app = new PublicExceptions(publicPath);
 });
 
 afterAll(() => {
+  I18n.locale = priorLocale;
   rmSync(publicPath, { recursive: true, force: true });
 });
 

--- a/packages/actionpack/src/action-dispatch/dispatch/public-exceptions.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/public-exceptions.test.ts
@@ -65,6 +65,18 @@ describe("PublicExceptions", () => {
     });
   });
 
+  it("renders xml when requested", async () => {
+    const [status, headers, body] = await app.call({
+      PATH_INFO: "/500",
+      HTTP_ACCEPT: "application/xml",
+    });
+    expect(status).toBe(500);
+    expect(headers["content-type"]).toBe("application/xml; charset=utf-8");
+    const xml = await bodyToString(body);
+    expect(xml).toContain('<status type="integer">500</status>');
+    expect(xml).toContain("<error>Internal Server Error</error>");
+  });
+
   it("falls back to html when content type is invalid", async () => {
     const [status, headers] = await app.call({
       PATH_INFO: "/500",

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -105,6 +105,7 @@ export {
   type ErrorReporterLike,
 } from "./middleware/executor.js";
 export { Reloader } from "./middleware/reloader.js";
+export { PublicExceptions } from "./middleware/public-exceptions.js";
 export {
   RemoteIp,
   GetIp,

--- a/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
@@ -75,7 +75,7 @@ export class PublicExceptions {
   }
 
   private renderFormat(status: number, contentType: MimeType, body: string): RackResponse {
-    const bytes = Buffer.byteLength(body, "utf8");
+    const bytes = Buffer.byteLength(body, "utf-8");
     return [
       status,
       {

--- a/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
@@ -1,0 +1,132 @@
+/**
+ * ActionDispatch::PublicExceptions
+ *
+ * When called, this middleware renders an error page. By default if an HTML
+ * response is expected it will render static error pages from the `/public`
+ * directory. For example when this middleware receives a 500 response it will
+ * render the template found in `/public/500.html`. If an internationalized
+ * locale is set, this middleware will attempt to render the template in
+ * `/public/500.<locale>.html`. If an internationalized template is not found
+ * it will fall back on `/public/500.html`.
+ *
+ * When a request with a content type other than HTML is made, this middleware
+ * will attempt to convert error information into the appropriate response
+ * type.
+ *
+ * Port of `actionpack/lib/action_dispatch/middleware/public_exceptions.rb`.
+ */
+
+import { I18n, getFs } from "@blazetrails/activesupport";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { bodyFromString, HTTP_STATUS_CODES } from "@blazetrails/rack";
+import { X_CASCADE } from "../constants.js";
+import { InvalidType } from "../http/mime-negotiation.js";
+import { MimeType } from "../http/mime-type.js";
+
+const DEFAULT_CHARSET = "utf-8";
+
+type ErrorBody = { status: number; error: string };
+
+export class PublicExceptions {
+  publicPath: string;
+
+  constructor(publicPath: string) {
+    this.publicPath = publicPath;
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    const pathInfo = String(env["PATH_INFO"] ?? "");
+    const status = parseInt(pathInfo.slice(1), 10) || 0;
+
+    let contentType: MimeType | undefined;
+    try {
+      contentType = this.firstFormat(env);
+    } catch (e) {
+      if (e instanceof InvalidType) {
+        contentType = MimeType.lookup("text");
+      } else {
+        throw e;
+      }
+    }
+
+    const body: ErrorBody = {
+      status,
+      error: HTTP_STATUS_CODES[status as keyof typeof HTTP_STATUS_CODES] ?? HTTP_STATUS_CODES[500],
+    };
+
+    return this.render(status, contentType, body);
+  }
+
+  private firstFormat(env: RackEnv): MimeType | undefined {
+    const accept = String(env["HTTP_ACCEPT"] ?? "").trim();
+    if (accept === "") return MimeType.lookup("html");
+    const parsed = MimeType.parse(accept);
+    return parsed[0];
+  }
+
+  private render(status: number, contentType: MimeType | undefined, body: ErrorBody): RackResponse {
+    const sym = contentType?.symbol;
+    if (sym === "json") {
+      return this.renderFormat(status, contentType!, JSON.stringify(body));
+    }
+    if (sym === "xml") {
+      return this.renderFormat(status, contentType!, toXml(body));
+    }
+    if (sym === "text") {
+      return this.renderFormat(status, contentType!, toText(body));
+    }
+    return this.renderHtml(status);
+  }
+
+  private renderFormat(status: number, contentType: MimeType, body: string): RackResponse {
+    const bytes = Buffer.byteLength(body, "utf8");
+    return [
+      status,
+      {
+        "content-type": `${contentType}; charset=${DEFAULT_CHARSET}`,
+        "content-length": String(bytes),
+      },
+      bodyFromString(body),
+    ];
+  }
+
+  private renderHtml(status: number): RackResponse {
+    const localized = `${this.publicPath}/${status}.${I18n.locale}.html`;
+    let path = localized;
+    let found = getFs().existsSync(path);
+    if (!found) {
+      path = `${this.publicPath}/${status}.html`;
+      found = getFs().existsSync(path);
+    }
+
+    if (found) {
+      const html = getFs().readFileSync(path, "utf8");
+      const htmlType = MimeType.lookup("html") ?? new MimeType("text/html", "html");
+      return this.renderFormat(status, htmlType, html);
+    }
+    return [404, { [X_CASCADE]: "pass" }, bodyFromString("")];
+  }
+}
+
+function toXml(body: ErrorBody): string {
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<hash>\n` +
+    `  <status type="integer">${body.status}</status>\n` +
+    `  <error>${escapeXml(body.error)}</error>\n` +
+    `</hash>\n`
+  );
+}
+
+function toText(body: ErrorBody): string {
+  return `status: ${body.status}\nerror: ${body.error}\n`;
+}
+
+function escapeXml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}

--- a/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
@@ -72,9 +72,6 @@ export class PublicExceptions {
     if (sym === "xml") {
       return this.renderFormat(status, contentType!, toXml(body));
     }
-    if (sym === "text") {
-      return this.renderFormat(status, contentType!, toText(body));
-    }
     return this.renderHtml(status);
   }
 
@@ -116,10 +113,6 @@ function toXml(body: ErrorBody): string {
     `  <error>${escapeXml(body.error)}</error>\n` +
     `</hash>\n`
   );
-}
-
-function toText(body: ErrorBody): string {
-  return `status: ${body.status}\nerror: ${body.error}\n`;
 }
 
 function escapeXml(s: string): string {

--- a/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
@@ -16,12 +16,15 @@
  * Port of `actionpack/lib/action_dispatch/middleware/public_exceptions.rb`.
  */
 
-import { I18n, getFs } from "@blazetrails/activesupport";
-import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { I18n, getFs, getPath } from "@blazetrails/activesupport";
+import type { RackBody, RackEnv, RackResponse } from "@blazetrails/rack";
 import { bodyFromString, HTTP_STATUS_CODES } from "@blazetrails/rack";
 import { X_CASCADE } from "../constants.js";
-import { InvalidType } from "../http/mime-negotiation.js";
 import { MimeType } from "../http/mime-type.js";
+
+async function* emptyBody(): RackBody {}
+
+const LOCALE_RE = /^[A-Za-z0-9_-]+$/;
 
 const DEFAULT_CHARSET = "utf-8";
 
@@ -38,16 +41,12 @@ export class PublicExceptions {
     const pathInfo = String(env["PATH_INFO"] ?? "");
     const status = parseInt(pathInfo.slice(1), 10) || 0;
 
-    let contentType: MimeType | undefined;
-    try {
-      contentType = this.firstFormat(env);
-    } catch (e) {
-      if (e instanceof InvalidType) {
-        contentType = MimeType.lookup("text");
-      } else {
-        throw e;
-      }
-    }
+    // Rails wraps this in a `rescue ActionDispatch::Http::MimeNegotiation::InvalidType`
+    // and falls back to `Mime[:text]`. Our `MimeType.parse` is forgiving (creates
+    // ad-hoc types for unknown ranges and never raises), so the rescue is a no-op
+    // until `Request.formats` lands and surfaces `InvalidType` for malformed
+    // Accept headers. See PR follow-ups.
+    const contentType = this.firstFormat(env);
 
     const body: ErrorBody = {
       status,
@@ -88,20 +87,24 @@ export class PublicExceptions {
   }
 
   private renderHtml(status: number): RackResponse {
-    const localized = `${this.publicPath}/${status}.${I18n.locale}.html`;
-    let path = localized;
-    let found = getFs().existsSync(path);
+    // Sanitize locale before string-interpolating into a file path so a
+    // misconfigured `I18n.locale` can never escape `publicPath`.
+    const locale = LOCALE_RE.test(I18n.locale) ? I18n.locale : null;
+    let file: string | null = locale
+      ? getPath().join(this.publicPath, `${status}.${locale}.html`)
+      : null;
+    let found = file != null && getFs().existsSync(file);
     if (!found) {
-      path = `${this.publicPath}/${status}.html`;
-      found = getFs().existsSync(path);
+      file = getPath().join(this.publicPath, `${status}.html`);
+      found = getFs().existsSync(file);
     }
 
-    if (found) {
-      const html = getFs().readFileSync(path, "utf8");
+    if (found && file != null) {
+      const html = getFs().readFileSync(file, "utf8");
       const htmlType = MimeType.lookup("html") ?? new MimeType("text/html", "html");
       return this.renderFormat(status, htmlType, html);
     }
-    return [404, { [X_CASCADE]: "pass" }, bodyFromString("")];
+    return [404, { [X_CASCADE]: "pass" }, emptyBody()];
   }
 }
 


### PR DESCRIPTION
## Summary

- Ports `actionpack/lib/action_dispatch/middleware/public_exceptions.rb` to `packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts`.
- Renders static error pages from a configured `publicPath` (with `I18n.locale` fallback) for HTML, and serializes `{status, error}` to JSON / XML / text when those formats are negotiated.
- Falls back to text when `HTTP_ACCEPT` raises `InvalidType`, and returns `[404, {x-cascade: pass}, []]` when no template matches — matching Rails.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/public-exceptions.test.ts`
- [x] `pnpm typecheck`

## Follow-ups

- `Response.defaultCharset` is not ported yet; we hardcode `utf-8` here. Wire when it lands.
- `MimeNegotiation` is not yet mixed into `Request`, so this port parses `HTTP_ACCEPT` directly off env rather than calling `request.formats.first`. Swap to the Request mixin once that wiring is complete.