### PR TITLE
test(activerecord): batch 21 — polymorphic belongs_to query_constraints

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -2660,10 +2660,31 @@ describe("AssociationsTest", () => {
       parent_id: parent.id,
       parent_type: "PbtBlogPost",
     });
-    const loaded = await loadBelongsTo(child, "parent", { polymorphic: true });
+    const capturedSql: string[] = [];
+    const origExecute = adapter.execute.bind(adapter);
+    const spy = vi
+      .spyOn(adapter, "execute")
+      .mockImplementation(async (sql: string, binds?: unknown[]) => {
+        capturedSql.push(sql);
+        return origExecute(sql, binds);
+      });
+    let loaded: Base | null;
+    try {
+      loaded = await loadBelongsTo(child, "parent", { polymorphic: true });
+    } finally {
+      spy.mockRestore();
+    }
     expect(loaded).not.toBeNull();
     expect(loaded!.id).toBe(parent.id);
     expect((loaded as any).title).toBe("Parent");
+    // The composite query-constraints key must surface in the emitted SQL —
+    // proves blog_id participates in the lookup, not just parent_id.
+    const selectSql = capturedSql.find(
+      (s) => /SELECT/i.test(s) && /pbt_blog_posts/.test(s) && /WHERE/i.test(s),
+    );
+    expect(selectSql).toBeDefined();
+    expect(selectSql).toMatch(/blog_id/);
+    expect(selectSql).toMatch(/\bid\b/);
   });
   it("preloads model with query constraints by explicitly configured fk and pk", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -2645,6 +2645,11 @@ describe("AssociationsTest", () => {
         this.attribute("title", "string");
         this.attribute("parent_id", "integer");
         this.attribute("parent_type", "string");
+        // Match Rails sharded_blog_posts: single auto-increment PK; the
+        // composite key is enforced at the model layer via query_constraints
+        // only. derive_fk_query_constraints in Rails reflection.rb:865-868
+        // depends on primary_key being a string for the first_key/last_key
+        // comparison, so an array PK would break the FK derivation entirely.
         this.adapter = adapter;
         (this as any)._queryConstraintsList = ["blog_id", "id"];
         (this as any)._hasQueryConstraints = true;
@@ -2660,31 +2665,22 @@ describe("AssociationsTest", () => {
       parent_id: parent.id,
       parent_type: "PbtBlogPost",
     });
-    const capturedSql: string[] = [];
-    const origExecute = adapter.execute.bind(adapter);
-    const spy = vi
-      .spyOn(adapter, "execute")
-      .mockImplementation(async (sql: string, binds?: unknown[]) => {
-        capturedSql.push(sql);
-        return origExecute(sql, binds);
-      });
-    let loaded: Base | null;
-    try {
-      loaded = await loadBelongsTo(child, "parent", { polymorphic: true });
-    } finally {
-      spy.mockRestore();
-    }
+    const loaded = await loadBelongsTo(child, "parent", { polymorphic: true });
     expect(loaded).not.toBeNull();
     expect(loaded!.id).toBe(parent.id);
     expect((loaded as any).title).toBe("Parent");
-    // The composite query-constraints key must surface in the emitted SQL —
-    // proves blog_id participates in the lookup, not just parent_id.
-    const selectSql = capturedSql.find(
-      (s) => /SELECT/i.test(s) && /pbt_blog_posts/.test(s) && /WHERE/i.test(s),
-    );
-    expect(selectSql).toBeDefined();
-    expect(selectSql).toMatch(/blog_id/);
-    expect(selectSql).toMatch(/\bid\b/);
+    // Cross-tenant negative case: a child in blog 2 pointing at parent_id=10
+    // must NOT resolve to the blog-1 parent — proves blog_id participates
+    // (a buggy lookup using only parent_id would return the blog-1 parent).
+    const fakeChild = await PbtBlogPost.create({
+      blog_id: 2,
+      id: 12,
+      title: "WrongTenant",
+      parent_id: parent.id,
+      parent_type: "PbtBlogPost",
+    });
+    const wrong = await loadBelongsTo(fakeChild, "parent", { polymorphic: true });
+    expect(wrong).toBeNull();
   });
   it("preloads model with query constraints by explicitly configured fk and pk", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -2668,7 +2668,7 @@ describe("AssociationsTest", () => {
     const loaded = await loadBelongsTo(child, "parent", { polymorphic: true });
     expect(loaded).not.toBeNull();
     expect(loaded!.id).toBe(parent.id);
-    expect((loaded as any).title).toBe("Parent");
+    expect(loaded!.title).toBe("Parent");
     // Cross-tenant negative case: a child in blog 2 pointing at parent_id=10
     // must NOT resolve to the blog-1 parent — proves blog_id participates
     // (a buggy lookup using only parent_id would return the blog-1 parent).

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -2664,15 +2664,6 @@ describe("AssociationsTest", () => {
     expect(loaded).not.toBeNull();
     expect(loaded!.id).toBe(parent.id);
     expect((loaded as any).title).toBe("Parent");
-    // A sibling row sharing the parent_id but with a different blog_id must NOT
-    // match — proves the blog_id constraint participates in the lookup.
-    await PbtBlogPost.create({
-      blog_id: 2,
-      id: 99,
-      title: "Decoy",
-    });
-    const loaded2 = await loadBelongsTo(child, "parent", { polymorphic: true });
-    expect((loaded2 as any).title).toBe("Parent");
   });
   it("preloads model with query constraints by explicitly configured fk and pk", async () => {
     const adapter = freshAdapter();

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -2631,11 +2631,48 @@ describe("AssociationsTest", () => {
     expect(loaded).not.toBeNull();
     expect(loaded!.title).toBe("Following best practices");
   });
-  it.skip("polymorphic belongs to uses parent query constraints", () => {
-    // BLOCKED: associations — collection/singular feature gap
-    // ROOT-CAUSE: associations/associations.ts or preloader.ts missing collection/singular semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in associations.test.ts
-    /* needs composite key / query constraints support */
+  it("polymorphic belongs to uses parent query constraints", async () => {
+    // Rails: test_polymorphic_belongs_to_uses_parent_query_constraints (associations_test.rb:279).
+    // Owner has query_constraints :blog_id, :id. Polymorphic belongs_to :parent must derive
+    // the composite FK [blog_id, parent_id] and resolve against the target's
+    // [blog_id, id] query-constraints key — not just scalar parent_id.
+    const adapter = freshAdapter();
+    class PbtBlogPost extends Base {
+      static {
+        this._tableName = "pbt_blog_posts";
+        this.attribute("blog_id", "integer");
+        this.attribute("id", "integer");
+        this.attribute("title", "string");
+        this.attribute("parent_id", "integer");
+        this.attribute("parent_type", "string");
+        this.adapter = adapter;
+        (this as any)._queryConstraintsList = ["blog_id", "id"];
+        (this as any)._hasQueryConstraints = true;
+      }
+    }
+    registerModel("PbtBlogPost", PbtBlogPost);
+    Associations.belongsTo.call(PbtBlogPost, "parent", { polymorphic: true });
+    const parent = await PbtBlogPost.create({ blog_id: 1, id: 10, title: "Parent" });
+    const child = await PbtBlogPost.create({
+      blog_id: 1,
+      id: 11,
+      title: "Child",
+      parent_id: parent.id,
+      parent_type: "PbtBlogPost",
+    });
+    const loaded = await loadBelongsTo(child, "parent", { polymorphic: true });
+    expect(loaded).not.toBeNull();
+    expect(loaded!.id).toBe(parent.id);
+    expect((loaded as any).title).toBe("Parent");
+    // A sibling row sharing the parent_id but with a different blog_id must NOT
+    // match — proves the blog_id constraint participates in the lookup.
+    await PbtBlogPost.create({
+      blog_id: 2,
+      id: 99,
+      title: "Decoy",
+    });
+    const loaded2 = await loadBelongsTo(child, "parent", { polymorphic: true });
+    expect((loaded2 as any).title).toBe("Parent");
   });
   it("preloads model with query constraints by explicitly configured fk and pk", async () => {
     const adapter = freshAdapter();


### PR DESCRIPTION
## Summary

Un-skips the lone remaining test from Batch 21 — `polymorphic belongs to uses parent query constraints` (Rails: `test_polymorphic_belongs_to_uses_parent_query_constraints` in `associations_test.rb:279`).

Owner has `query_constraints :blog_id, :id` and a polymorphic `belongs_to :parent`. The composite FK `[blog_id, parent_id]` must resolve against the target's composite query-constraints key `[blog_id, id]`, not just scalar `parent_id`. A decoy row with the same `parent_id` but a different `blog_id` proves the `blog_id` constraint participates in the lookup.

## Other Batch 21 items — already shipped

While auditing the batch I verified the remaining items already work end-to-end and have passing tests; no impl changes were needed in this PR:

- **Preload HMT with composite query_constraints** (`associations.test.ts:9008`) — passing.
- **`AssociationQueryValue` Relation + composite FK** (`queries()` array-FK branch) — supported via the per-column `reselect(pk[i])` subquery path in `association-query-value.ts:42-93`.
- **`AssociationQueryValue.convertToId` array-PK branch** — handled in `association-query-value.ts:152-170`. The two "querying by whole/single associated records using query constraints" tests at `:2356` and `:2394` are passing.

The polymorphic test was the only un-shipped piece — the infrastructure (`computeForeignKey` → `deriveFkQueryConstraints` for FK, `associationPrimaryKeyFor(klass)` for PK via `joinPrimaryKeyFor` in `_lastChainScope`) already drives the polymorphic+QC path correctly; the test body was the missing artifact.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts -t "polymorphic belongs to uses parent query constraints"` passes
- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts -t "querying by whole associated records using query constraints"` passes
- [x] `pnpm vitest run packages/activerecord/src/associations.test.ts -t "preload has many through association with composite query constraints"` passes