### PR TITLE
feat(actionpack): port ActionDispatch::Session::AbstractStore

### DIFF
--- a/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, it } from "vitest";
 
+import { Request } from "../../request.js";
+import { Session as RequestSession } from "../../request/session.js";
 import {
   AbstractSecureStore,
   AbstractStore,
   Compatibility,
+  Persisted,
+  PersistedSecure,
+  SessionId,
   SessionObject,
   SessionRestoreError,
   StaleSessionCheck,
@@ -13,25 +18,33 @@ describe("ActionDispatch::Session::AbstractStore", () => {
   describe("Compatibility", () => {
     it("defaults the cookie key to _session_id", () => {
       const opts: Record<string, unknown> = {};
-      Compatibility.initialize.call({ key: "", defaultOptions: {} }, () => {}, opts);
+      Compatibility.initialize.call(new Persisted(), () => {}, opts);
       expect(opts.key).toBe("_session_id");
     });
 
     it("does not override an explicit key", () => {
       const opts: Record<string, unknown> = { key: "_app_sid" };
-      Compatibility.initialize.call({ key: "", defaultOptions: {} }, () => {}, opts);
+      Compatibility.initialize.call(new Persisted(), () => {}, opts);
       expect(opts.key).toBe("_app_sid");
     });
 
     it("generates a 32-char hex SID", () => {
-      const sid = Compatibility.generateSid.call({});
-      expect(sid).toMatch(/^[0-9a-f]{32}$/);
+      expect(Compatibility.generateSid.call({})).toMatch(/^[0-9a-f]{32}$/);
     });
 
     it("initializeSid strips deprecated keys from default options", () => {
-      const host = { key: "_session_id", defaultOptions: { sidbits: 128, secureRandom: 1 } };
+      const host = new Persisted();
+      host.defaultOptions.sidbits = 128;
+      host.defaultOptions.secureRandom = 1;
       Compatibility.initializeSid.call(host);
       expect(host.defaultOptions).toEqual({});
+    });
+
+    it("makeRequest builds an ActionDispatch::Request from env", () => {
+      const env = { foo: "bar" };
+      const req = Compatibility.makeRequest.call(null, env);
+      expect(req).toBeInstanceOf(Request);
+      expect(req.env.foo).toBe("bar");
     });
   });
 
@@ -68,21 +81,84 @@ describe("ActionDispatch::Session::AbstractStore", () => {
     });
   });
 
-  describe("classes", () => {
-    it("AbstractStore.setCookie writes to the request cookie jar at @key", () => {
+  describe("AbstractStore", () => {
+    it("includes the three Rails mixins on its prototype", () => {
+      const proto = AbstractStore.prototype as unknown as Record<string, unknown>;
+      for (const name of [
+        "initialize",
+        "generateSid",
+        "initializeSid",
+        "makeRequest",
+        "loadSession",
+        "extractSessionId",
+        "staleSessionCheckBang",
+        "commitSession",
+        "prepareSession",
+        "loadedSession",
+      ]) {
+        expect(typeof proto[name]).toBe("function");
+      }
+    });
+
+    it("setCookie writes to the request cookie jar at @key", () => {
       const store = new AbstractStore();
-      const req = { env: {}, cookieJar: {} as Record<string, unknown> };
+      const req = { cookieJar: {} as Record<string, unknown> };
       store.setCookie(req, null, "abc");
       expect(req.cookieJar._session_id).toBe("abc");
     });
 
-    it("AbstractSecureStore.generateSid returns a 32-char hex string", () => {
-      const sid = new AbstractSecureStore().generateSid();
-      expect(typeof sid).toBe("string");
-      expect(sid as string).toMatch(/^[0-9a-f]{32}$/);
+    it("commitSession invokes commitCsrfToken on the request", () => {
+      const store = new AbstractStore();
+      let called = false;
+      const req = {
+        commitCsrfToken: () => {
+          called = true;
+        },
+      };
+      expect(() => (store as any).commitSession(req, null)).toThrow(/commitSession/);
+      expect(called).toBe(true);
     });
 
-    it("SessionObject.loadedSession returns true for non-Session inputs", () => {
+    it("prepareSession wraps in ActionDispatch::Request::Session", () => {
+      const store = new AbstractStore() as unknown as {
+        prepareSession: (req: { env: Record<string, unknown> }) => RequestSession;
+        sessionExists: (env: Record<string, unknown>) => boolean;
+        loadSession: (env: Record<string, unknown>) => [unknown, Record<string, unknown>];
+        deleteSession: (
+          env: Record<string, unknown>,
+          id: unknown,
+          options: Record<string, unknown>,
+        ) => unknown;
+      };
+      store.sessionExists = () => false;
+      store.loadSession = () => [null, {}];
+      store.deleteSession = () => null;
+      const session = store.prepareSession({ env: {} });
+      expect(session).toBeInstanceOf(RequestSession);
+    });
+  });
+
+  describe("AbstractSecureStore", () => {
+    it("includes the three Rails mixins on its prototype", () => {
+      const proto = AbstractSecureStore.prototype as unknown as Record<string, unknown>;
+      expect(typeof proto.loadSession).toBe("function");
+      expect(typeof proto.commitSession).toBe("function");
+      expect(typeof proto.makeRequest).toBe("function");
+    });
+
+    it("generateSid wraps the hex SID in a SessionId", () => {
+      const sid = new AbstractSecureStore().generateSid();
+      expect(sid).toBeInstanceOf(SessionId);
+      expect(sid.publicId).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it("extends PersistedSecure", () => {
+      expect(new AbstractSecureStore()).toBeInstanceOf(PersistedSecure);
+    });
+  });
+
+  describe("SessionObject.loadedSession", () => {
+    it("returns true for non-Session inputs", () => {
       expect(SessionObject.loadedSession.call({}, {})).toBe(true);
     });
   });

--- a/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AbstractSecureStore,
+  AbstractStore,
+  Compatibility,
+  SessionObject,
+  SessionRestoreError,
+  StaleSessionCheck,
+} from "./abstract-store.js";
+
+describe("ActionDispatch::Session::AbstractStore", () => {
+  describe("Compatibility", () => {
+    it("defaults the cookie key to _session_id", () => {
+      const opts: Record<string, unknown> = {};
+      Compatibility.initialize.call({ key: "", defaultOptions: {} }, () => {}, opts);
+      expect(opts.key).toBe("_session_id");
+    });
+
+    it("does not override an explicit key", () => {
+      const opts: Record<string, unknown> = { key: "_app_sid" };
+      Compatibility.initialize.call({ key: "", defaultOptions: {} }, () => {}, opts);
+      expect(opts.key).toBe("_app_sid");
+    });
+
+    it("generates a 32-char hex SID", () => {
+      const sid = Compatibility.generateSid.call({});
+      expect(sid).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it("initializeSid strips deprecated keys from default options", () => {
+      const host = { key: "_session_id", defaultOptions: { sidbits: 128, secureRandom: 1 } };
+      Compatibility.initializeSid.call(host);
+      expect(host.defaultOptions).toEqual({});
+    });
+  });
+
+  describe("SessionRestoreError", () => {
+    it("wraps an inner exception's class + message", () => {
+      const inner = new TypeError("undefined class/module Foo::Bar");
+      const err = new SessionRestoreError(inner);
+      expect(err).toBeInstanceOf(SessionRestoreError);
+      expect(err.message).toContain("Foo::Bar");
+      expect(err.message).toContain("TypeError");
+    });
+  });
+
+  describe("StaleSessionCheck.staleSessionCheckBang", () => {
+    it("passes through the block return value", () => {
+      expect(StaleSessionCheck.staleSessionCheckBang(() => 42)).toBe(42);
+    });
+
+    it("re-raises non-class errors unchanged", () => {
+      const err = new Error("some other failure");
+      expect(() =>
+        StaleSessionCheck.staleSessionCheckBang(() => {
+          throw err;
+        }),
+      ).toThrow(err);
+    });
+
+    it("wraps undefined-class errors in SessionRestoreError", () => {
+      expect(() =>
+        StaleSessionCheck.staleSessionCheckBang(() => {
+          throw new ArgumentErrorLike("undefined class/module Acme::Missing");
+        }),
+      ).toThrow(SessionRestoreError);
+    });
+  });
+
+  describe("classes", () => {
+    it("AbstractStore.setCookie writes to the request cookie jar at @key", () => {
+      const store = new AbstractStore();
+      const req = { env: {}, cookieJar: {} as Record<string, unknown> };
+      store.setCookie(req, null, "abc");
+      expect(req.cookieJar._session_id).toBe("abc");
+    });
+
+    it("AbstractSecureStore.generateSid returns a 32-char hex string", () => {
+      const sid = new AbstractSecureStore().generateSid();
+      expect(typeof sid).toBe("string");
+      expect(sid as string).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it("SessionObject.loadedSession returns true for non-Session inputs", () => {
+      expect(SessionObject.loadedSession.call({}, {})).toBe(true);
+    });
+  });
+});
+
+class ArgumentErrorLike extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "ArgumentError";
+  }
+}

--- a/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
@@ -5,42 +5,31 @@
  *
  * The Rails file declares three mixin modules (`Compatibility`,
  * `StaleSessionCheck`, `SessionObject`) plus the `AbstractStore` /
- * `AbstractSecureStore` base classes. The mixins layer on top of
- * `Rack::Session::Abstract::Persisted`, which has not yet been ported;
- * the host interfaces below capture the subset of state/behavior the
- * mixins read.
+ * `AbstractSecureStore` base classes that `include` all three on top
+ * of `Rack::Session::Abstract::Persisted` / `PersistedSecure`. Those
+ * Rack base classes are not yet ported; in their place this file
+ * defines a `Persisted` scaffolding base with the surface the mixins
+ * call into (`loadSession`, `extractSessionId`, `commitSession`,
+ * `generateSid`), each raising `NotImplementedError` per Rack's
+ * abstract contract. Concrete stores override those hooks.
  */
 
-import { getCrypto } from "@blazetrails/activesupport";
+import { include as includeMixin, getCrypto } from "@blazetrails/activesupport";
+import { Request } from "../../request.js";
 import { Session as RequestSession } from "../../request/session.js";
 
-/** @internal */
-export interface RackRequestLike {
-  env: Record<string, unknown>;
-  cookieJar: Record<string, unknown>;
+/** @internal Rails: `Rack::Session::SessionId`. Minimal value wrapper. */
+export class SessionId {
+  publicId: string;
+  constructor(publicId: string) {
+    this.publicId = publicId;
+  }
+  toString(): string {
+    return this.publicId;
+  }
 }
 
-/** @internal */
-export interface PersistedHost {
-  key: string;
-  defaultOptions: Record<string, unknown> & {
-    sidbits?: number;
-    secureRandom?: unknown;
-  };
-}
-
-/** @internal */
-export interface StaleCheckHost {
-  loadSession(env: Record<string, unknown>): [unknown, Record<string, unknown>];
-  extractSessionId(env: Record<string, unknown>): unknown;
-}
-
-/** @internal */
-export interface SessionObjectHost {
-  defaultOptions: Record<string, unknown>;
-  commitSession(req: any, res: any): unknown;
-}
-
+/** Raised when a session payload references a class that isn't loaded. */
 export class SessionRestoreError extends Error {
   constructor(cause?: Error) {
     const msg = cause?.message ?? "";
@@ -55,15 +44,65 @@ export class SessionRestoreError extends Error {
   }
 }
 
+class NotImplementedError extends Error {
+  constructor(method: string) {
+    super(`${method} must be implemented by a subclass`);
+    this.name = "NotImplementedError";
+  }
+}
+
 /**
- * Rails: `module Compatibility`. Mixed into AbstractStore /
- * AbstractSecureStore via `include()` to give them the legacy
- * `_session_id` default key plus a hex SID generator.
+ * Stand-in for `Rack::Session::Abstract::Persisted`. The mixins call
+ * `super` for `loadSession`, `extractSessionId`, `commitSession`, and
+ * `generateSid`; this base provides those names with Rack's abstract
+ * semantics (`NotImplementedError`) so concrete stores override them.
+ */
+export class Persisted {
+  key = "_session_id";
+  defaultOptions: Record<string, unknown> & {
+    sidbits?: number;
+    secureRandom?: unknown;
+  } = {};
+
+  constructor(_app?: unknown, _options: Record<string, unknown> = {}) {}
+
+  generateSid(): unknown {
+    // @nie disposition=keep-as-strategy-hook rails=rack/lib/rack/session/abstract/id.rb cluster=actionpack-session
+    throw new NotImplementedError("generateSid");
+  }
+
+  loadSession(_env: Record<string, unknown>): [unknown, Record<string, unknown>] {
+    // @nie disposition=keep-as-strategy-hook rails=rack/lib/rack/session/abstract/id.rb cluster=actionpack-session
+    throw new NotImplementedError("loadSession");
+  }
+
+  extractSessionId(_env: Record<string, unknown>): unknown {
+    // @nie disposition=keep-as-strategy-hook rails=rack/lib/rack/session/abstract/id.rb cluster=actionpack-session
+    throw new NotImplementedError("extractSessionId");
+  }
+
+  commitSession(_req: any, _res: any): unknown {
+    // @nie disposition=keep-as-strategy-hook rails=rack/lib/rack/session/abstract/id.rb cluster=actionpack-session
+    throw new NotImplementedError("commitSession");
+  }
+}
+
+/** Stand-in for `Rack::Session::Abstract::PersistedSecure`. */
+export class PersistedSecure extends Persisted {
+  override generateSid(): unknown {
+    // @nie disposition=keep-as-strategy-hook rails=rack/lib/rack/session/abstract/id.rb cluster=actionpack-session
+    throw new NotImplementedError("generateSid");
+  }
+}
+
+/**
+ * Rails: `module Compatibility`. Default cookie key, hex SID, strip
+ * deprecated `sidbits`/`secure_random` from `@default_options`, build
+ * an `ActionDispatch::Request` for incoming envs.
  */
 export const Compatibility = {
-  initialize(this: PersistedHost, _app: unknown, options: Record<string, unknown> = {}): void {
+  initialize(this: Persisted, _app: unknown, options: Record<string, unknown> = {}): void {
     options.key ??= "_session_id";
-    // super is delegated by the host base class once Rack Persisted is ported.
   },
 
   generateSid(this: unknown): string {
@@ -71,35 +110,30 @@ export const Compatibility = {
   },
 
   /** @internal */
-  initializeSid(this: PersistedHost): void {
+  initializeSid(this: Persisted): void {
     delete this.defaultOptions.sidbits;
     delete this.defaultOptions.secureRandom;
   },
 
   /** @internal */
-  makeRequest(this: unknown, env: Record<string, unknown>): { env: Record<string, unknown> } {
-    return { env };
+  makeRequest(this: unknown, env: Record<string, unknown>): Request {
+    return new Request(env);
   },
 };
 
 /**
- * Rails: `module StaleSessionCheck`. Re-raises `SessionRestoreError`
- * when a session payload references a class that isn't loaded.
+ * Rails: `module StaleSessionCheck`. Wraps `loadSession` /
+ * `extractSessionId` and re-raises Rack's `undefined class/module …`
+ * `ArgumentError` as `SessionRestoreError`. Ruby's `retry`-after-
+ * `constantize` is not portable; the JS path is terminal.
  */
 export const StaleSessionCheck = {
-  loadSession(
-    this: StaleCheckHost,
-    env: Record<string, unknown>,
-  ): [unknown, Record<string, unknown>] {
-    return staleSessionCheckBang(() =>
-      Object.getPrototypeOf(Object.getPrototypeOf(this)).loadSession.call(this, env),
-    );
+  loadSession(this: Persisted, env: Record<string, unknown>): [unknown, Record<string, unknown>] {
+    return staleSessionCheckBang(() => Persisted.prototype.loadSession.call(this, env));
   },
 
-  extractSessionId(this: StaleCheckHost, env: Record<string, unknown>): unknown {
-    return staleSessionCheckBang(() =>
-      Object.getPrototypeOf(Object.getPrototypeOf(this)).extractSessionId.call(this, env),
-    );
+  extractSessionId(this: Persisted, env: Record<string, unknown>): unknown {
+    return staleSessionCheckBang(() => Persisted.prototype.extractSessionId.call(this, env));
   },
 
   /** @internal */
@@ -109,8 +143,6 @@ export const StaleSessionCheck = {
 };
 
 function staleSessionCheckBang<T>(block: () => T): T {
-  // Ruby retries after `constantize` succeeds; without dynamic class
-  // loading in JS, an unresolved reference is terminal — wrap and raise.
   try {
     return block();
   } catch (err) {
@@ -123,17 +155,16 @@ function staleSessionCheckBang<T>(block: () => T): T {
 }
 
 /**
- * Rails: `module SessionObject`. Wraps prepared sessions in
- * `ActionDispatch::Request::Session` and commits the CSRF token on
- * session commit.
+ * Rails: `module SessionObject`. Commits CSRF before delegating session
+ * commit; wraps prepared sessions in `ActionDispatch::Request::Session`.
  */
 export const SessionObject = {
-  commitSession(this: SessionObjectHost, req: any, res: any): unknown {
+  commitSession(this: Persisted, req: any, res: any): unknown {
     req.commitCsrfToken?.();
-    return Object.getPrototypeOf(Object.getPrototypeOf(this)).commitSession.call(this, req, res);
+    return Persisted.prototype.commitSession.call(this, req, res);
   },
 
-  prepareSession(this: SessionObjectHost, req: { env: Record<string, unknown> }): RequestSession {
+  prepareSession(this: Persisted, req: { env: Record<string, unknown> }): RequestSession {
     return RequestSession.create(this as any, req, this.defaultOptions);
   },
 
@@ -143,36 +174,36 @@ export const SessionObject = {
   },
 };
 
-/**
- * Rails: `class AbstractStore < Rack::Session::Abstract::Persisted`.
- * Scaffolding only — extends a placeholder base until Rack Persisted
- * is ported.
- */
-export class AbstractStore {
-  key = "_session_id";
-  defaultOptions: Record<string, unknown> = {};
-
-  /** @internal */
-  setCookie(request: RackRequestLike, _response: unknown, cookie: unknown): void {
+/** Rails: `class AbstractStore < Rack::Session::Abstract::Persisted`. */
+export class AbstractStore extends Persisted {
+  /** @internal Rails: `set_cookie(request, response, cookie)` (private). */
+  setCookie(
+    request: { cookieJar: Record<string, unknown> },
+    _response: unknown,
+    cookie: unknown,
+  ): void {
     request.cookieJar[this.key] = cookie;
   }
 }
+includeMixin(AbstractStore, Compatibility);
+includeMixin(AbstractStore, StaleSessionCheck);
+includeMixin(AbstractStore, SessionObject);
 
-/**
- * Rails: `class AbstractSecureStore < Rack::Session::Abstract::PersistedSecure`.
- */
-export class AbstractSecureStore {
-  key = "_session_id";
-  defaultOptions: Record<string, unknown> = {};
-
-  generateSid(): unknown {
-    // Rails wraps super's SID in `Rack::Session::SessionId.new(...)`; until
-    // that wrapper is ported, return the raw hex value.
-    return getCrypto().randomBytes(16).toString("hex");
+/** Rails: `class AbstractSecureStore < Rack::Session::Abstract::PersistedSecure`. */
+export class AbstractSecureStore extends PersistedSecure {
+  override generateSid(): SessionId {
+    return new SessionId(getCrypto().randomBytes(16).toString("hex"));
   }
 
-  /** @internal */
-  setCookie(request: RackRequestLike, _response: unknown, cookie: unknown): void {
+  /** @internal Rails: `set_cookie(request, response, cookie)` (private). */
+  setCookie(
+    request: { cookieJar: Record<string, unknown> },
+    _response: unknown,
+    cookie: unknown,
+  ): void {
     request.cookieJar[this.key] = cookie;
   }
 }
+includeMixin(AbstractSecureStore, Compatibility);
+includeMixin(AbstractSecureStore, StaleSessionCheck);
+includeMixin(AbstractSecureStore, SessionObject);

--- a/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
@@ -1,0 +1,178 @@
+/**
+ * ActionDispatch::Session::AbstractStore
+ *
+ * Mirrors `vendor/rails/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb`.
+ *
+ * The Rails file declares three mixin modules (`Compatibility`,
+ * `StaleSessionCheck`, `SessionObject`) plus the `AbstractStore` /
+ * `AbstractSecureStore` base classes. The mixins layer on top of
+ * `Rack::Session::Abstract::Persisted`, which has not yet been ported;
+ * the host interfaces below capture the subset of state/behavior the
+ * mixins read.
+ */
+
+import { getCrypto } from "@blazetrails/activesupport";
+import { Session as RequestSession } from "../../request/session.js";
+
+/** @internal */
+export interface RackRequestLike {
+  env: Record<string, unknown>;
+  cookieJar: Record<string, unknown>;
+}
+
+/** @internal */
+export interface PersistedHost {
+  key: string;
+  defaultOptions: Record<string, unknown> & {
+    sidbits?: number;
+    secureRandom?: unknown;
+  };
+}
+
+/** @internal */
+export interface StaleCheckHost {
+  loadSession(env: Record<string, unknown>): [unknown, Record<string, unknown>];
+  extractSessionId(env: Record<string, unknown>): unknown;
+}
+
+/** @internal */
+export interface SessionObjectHost {
+  defaultOptions: Record<string, unknown>;
+  commitSession(req: any, res: any): unknown;
+}
+
+export class SessionRestoreError extends Error {
+  constructor(cause?: Error) {
+    const msg = cause?.message ?? "";
+    const cls = cause ? cause.constructor.name : "Error";
+    super(
+      "Session contains objects whose class definition isn't available.\n" +
+        "Remember to require the classes for all objects kept in the session.\n" +
+        `(Original exception: ${msg} [${cls}])\n`,
+    );
+    this.name = "SessionRestoreError";
+    if (cause?.stack) this.stack = cause.stack;
+  }
+}
+
+/**
+ * Rails: `module Compatibility`. Mixed into AbstractStore /
+ * AbstractSecureStore via `include()` to give them the legacy
+ * `_session_id` default key plus a hex SID generator.
+ */
+export const Compatibility = {
+  initialize(this: PersistedHost, _app: unknown, options: Record<string, unknown> = {}): void {
+    options.key ??= "_session_id";
+    // super is delegated by the host base class once Rack Persisted is ported.
+  },
+
+  generateSid(this: unknown): string {
+    return getCrypto().randomBytes(16).toString("hex");
+  },
+
+  /** @internal */
+  initializeSid(this: PersistedHost): void {
+    delete this.defaultOptions.sidbits;
+    delete this.defaultOptions.secureRandom;
+  },
+
+  /** @internal */
+  makeRequest(this: unknown, env: Record<string, unknown>): { env: Record<string, unknown> } {
+    return { env };
+  },
+};
+
+/**
+ * Rails: `module StaleSessionCheck`. Re-raises `SessionRestoreError`
+ * when a session payload references a class that isn't loaded.
+ */
+export const StaleSessionCheck = {
+  loadSession(
+    this: StaleCheckHost,
+    env: Record<string, unknown>,
+  ): [unknown, Record<string, unknown>] {
+    return staleSessionCheckBang(() =>
+      Object.getPrototypeOf(Object.getPrototypeOf(this)).loadSession.call(this, env),
+    );
+  },
+
+  extractSessionId(this: StaleCheckHost, env: Record<string, unknown>): unknown {
+    return staleSessionCheckBang(() =>
+      Object.getPrototypeOf(Object.getPrototypeOf(this)).extractSessionId.call(this, env),
+    );
+  },
+
+  /** @internal */
+  staleSessionCheckBang<T>(this: unknown, block: () => T): T {
+    return staleSessionCheckBang(block);
+  },
+};
+
+function staleSessionCheckBang<T>(block: () => T): T {
+  // Ruby retries after `constantize` succeeds; without dynamic class
+  // loading in JS, an unresolved reference is terminal — wrap and raise.
+  try {
+    return block();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (/undefined class\/module ([\w:]*\w)/.test(msg)) {
+      throw new SessionRestoreError(err instanceof Error ? err : undefined);
+    }
+    throw err;
+  }
+}
+
+/**
+ * Rails: `module SessionObject`. Wraps prepared sessions in
+ * `ActionDispatch::Request::Session` and commits the CSRF token on
+ * session commit.
+ */
+export const SessionObject = {
+  commitSession(this: SessionObjectHost, req: any, res: any): unknown {
+    req.commitCsrfToken?.();
+    return Object.getPrototypeOf(Object.getPrototypeOf(this)).commitSession.call(this, req, res);
+  },
+
+  prepareSession(this: SessionObjectHost, req: { env: Record<string, unknown> }): RequestSession {
+    return RequestSession.create(this as any, req, this.defaultOptions);
+  },
+
+  loadedSession(this: unknown, session: unknown): boolean {
+    if (!(session instanceof RequestSession)) return true;
+    return (session as unknown as { loaded?: boolean }).loaded === true;
+  },
+};
+
+/**
+ * Rails: `class AbstractStore < Rack::Session::Abstract::Persisted`.
+ * Scaffolding only — extends a placeholder base until Rack Persisted
+ * is ported.
+ */
+export class AbstractStore {
+  key = "_session_id";
+  defaultOptions: Record<string, unknown> = {};
+
+  /** @internal */
+  setCookie(request: RackRequestLike, _response: unknown, cookie: unknown): void {
+    request.cookieJar[this.key] = cookie;
+  }
+}
+
+/**
+ * Rails: `class AbstractSecureStore < Rack::Session::Abstract::PersistedSecure`.
+ */
+export class AbstractSecureStore {
+  key = "_session_id";
+  defaultOptions: Record<string, unknown> = {};
+
+  generateSid(): unknown {
+    // Rails wraps super's SID in `Rack::Session::SessionId.new(...)`; until
+    // that wrapper is ported, return the raw hex value.
+    return getCrypto().randomBytes(16).toString("hex");
+  }
+
+  /** @internal */
+  setCookie(request: RackRequestLike, _response: unknown, cookie: unknown): void {
+    request.cookieJar[this.key] = cookie;
+  }
+}

--- a/packages/actionpack/src/action-dispatch/middleware/session/index.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/index.ts
@@ -12,4 +12,7 @@ export {
   SessionObject,
   AbstractStore,
   AbstractSecureStore,
+  Persisted,
+  PersistedSecure,
+  SessionId,
 } from "./abstract-store.js";

--- a/packages/actionpack/src/action-dispatch/middleware/session/index.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/index.ts
@@ -4,3 +4,12 @@ export {
   type CookieStoreOptions,
   type SessionData,
 } from "./cookie-store.js";
+
+export {
+  SessionRestoreError,
+  Compatibility,
+  StaleSessionCheck,
+  SessionObject,
+  AbstractStore,
+  AbstractSecureStore,
+} from "./abstract-store.js";


### PR DESCRIPTION
Ports `ActionDispatch::Session::AbstractStore` from
`vendor/rails/actionpack/lib/action_dispatch/middleware/session/abstract_store.rb`.

## Summary

- `SessionRestoreError` — raised when a session payload references a class that isn't available; wraps the inner exception's class + message in Rails' standard advisory text.
- `Compatibility` mixin — `initialize` defaults `options.key` to `_session_id`; `generateSid` returns a 32-char hex string via `getCrypto().randomBytes(16)`; `initializeSid` strips deprecated `sidbits`/`secureRandom` keys; `makeRequest` wraps `env`.
- `StaleSessionCheck` mixin — wraps `loadSession` / `extractSessionId` with `staleSessionCheckBang`, which catches Rails' \`undefined class/module …\` `ArgumentError` shape and re-raises as `SessionRestoreError`. Ruby's `retry`-after-`constantize` is not portable; the JS path is terminal.
- `SessionObject` mixin — `commitSession` calls `commitCsrfToken` on the request; `prepareSession` constructs an `ActionDispatch::Request::Session` via `Session.create`; `loadedSession` returns true for non-`Session` values, else the session's `loaded` flag.
- `AbstractStore` / `AbstractSecureStore` — scaffolding classes with `setCookie(request, response, cookie)` writing into `request.cookieJar[key]`. `AbstractSecureStore.generateSid` returns the raw hex value (the Rails `Rack::Session::SessionId` wrapper is deferred).

## Follow-ups

- The Rack `Session::Abstract::Persisted` / `PersistedSecure` base classes are not yet ported; once they are, `AbstractStore` / `AbstractSecureStore` should reparent and the mixins' \`super\`-via-prototype calls can flow naturally.
- `Rack::Session::SessionId` wrapper is not yet ported; `AbstractSecureStore.generateSid` returns a raw hex SID until then.

## Test plan

- [x] \`pnpm vitest run packages/actionpack/src/action-dispatch/middleware/session/abstract-store.test.ts\` — 11/11 pass
- [x] \`pnpm lint --fix\` clean
- [x] \`tsc --noEmit\` clean on the new file