### PR TITLE
feat(actionpack): port ActionDispatch::TestProcess

### DIFF
--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -55,6 +55,21 @@ export class CookieJar implements Iterable<[string, string]> {
     this._options = options;
   }
 
+  /**
+   * Build a CookieJar seeded with `cookies` from a request. Mirrors
+   * `Cookies::CookieJar.build(request, cookies)` used by
+   * `ActionDispatch::TestProcess#cookies`.
+   *
+   * @internal
+   */
+  static build(_request: unknown, cookies: Record<string, string>): CookieJar {
+    const jar = new CookieJar();
+    for (const [k, v] of Object.entries(cookies ?? {})) {
+      jar._cookies.set(k, v);
+    }
+    return jar;
+  }
+
   // --- Read ---
 
   get(key: string): string | undefined {

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -62,8 +62,15 @@ export class CookieJar implements Iterable<[string, string]> {
    *
    * @internal
    */
-  static build(_request: unknown, cookies: Record<string, string>): CookieJar {
-    const jar = new CookieJar();
+  static build(
+    request: { cookiesAppOptions?: CookieJarOptions } | null | undefined,
+    cookies: Record<string, string>,
+  ): CookieJar {
+    // Rails: `jar = new(req); jar.update(cookies); jar` — the request stores
+    // the options used by signed/encrypted jars. We forward
+    // `request.cookiesAppOptions` if the host exposes it so signed/encrypted
+    // accessors can find their secrets in test setups.
+    const jar = new CookieJar(request?.cookiesAppOptions ?? {});
     for (const [k, v] of Object.entries(cookies ?? {})) {
       jar._cookies.set(k, v);
     }

--- a/packages/actionpack/src/action-dispatch/testing/index.ts
+++ b/packages/actionpack/src/action-dispatch/testing/index.ts
@@ -14,3 +14,17 @@ export {
   type AssertionResponseHost,
   type AssertionResponseLike,
 } from "./assertions.js";
+export {
+  TestProcess,
+  FixtureFile,
+  fileFixtureUpload,
+  fixtureFileUpload,
+  assigns,
+  session,
+  flash,
+  cookies,
+  redirectToUrl,
+  type TestProcessHost,
+  type TestProcessRequest,
+  type TestProcessResponse,
+} from "./test-process.js";

--- a/packages/actionpack/src/action-dispatch/testing/test-process.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/test-process.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { FlashHash } from "../middleware/flash.js";
+import { CookieJar } from "../middleware/cookies.js";
+import {
+  TestProcess,
+  cookies,
+  flash,
+  redirectToUrl,
+  session,
+  assigns,
+  fileFixtureUpload,
+  type TestProcessHost,
+} from "./test-process.js";
+
+function makeHost(overrides: Partial<TestProcessHost> = {}): TestProcessHost {
+  return {
+    request: { session: { user: 1 }, flash: new FlashHash(), cookies: { a: "1" } },
+    response: { redirectUrl: "/somewhere" },
+    constructor: { fileFixturePath: null },
+    ...overrides,
+  };
+}
+
+describe("TestProcess", () => {
+  it("exposes a Rails-shaped module of helpers", () => {
+    expect(Object.keys(TestProcess).sort()).toEqual(
+      [
+        "assigns",
+        "cookies",
+        "fileFixtureUpload",
+        "fixtureFileUpload",
+        "flash",
+        "redirectToUrl",
+        "session",
+      ].sort(),
+    );
+  });
+
+  it("session/flash/redirectToUrl delegate to request/response", () => {
+    const host = makeHost();
+    expect(session.call(host)).toEqual({ user: 1 });
+    expect(flash.call(host)).toBeInstanceOf(FlashHash);
+    expect(redirectToUrl.call(host)).toBe("/somewhere");
+  });
+
+  it("cookies memoizes a CookieJar built from request cookies", () => {
+    const host = makeHost();
+    const jar = cookies.call(host);
+    expect(jar).toBeInstanceOf(CookieJar);
+    expect(jar.get("a")).toBe("1");
+    expect(cookies.call(host)).toBe(jar);
+  });
+
+  it("assigns raises the extracted-gem error", () => {
+    expect(() => assigns.call(makeHost())).toThrow(/extracted to a gem/);
+  });
+
+  it("fileFixtureUpload returns an UploadedFile with the given mime type", () => {
+    const host = makeHost();
+    const upload = fileFixtureUpload.call(host, "/etc/hostname", "text/plain");
+    expect(upload.contentType).toBe("text/plain");
+    expect(upload.originalFilename).toBe("hostname");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/testing/test-process.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/test-process.test.ts
@@ -1,3 +1,4 @@
+import { getFs, getOs, getPath } from "@blazetrails/activesupport";
 import { describe, expect, it } from "vitest";
 
 import { FlashHash } from "../middleware/flash.js";
@@ -57,9 +58,12 @@ describe("TestProcess", () => {
   });
 
   it("fileFixtureUpload returns an UploadedFile with the given mime type", () => {
+    const dir = getFs().mkdtempSync!(getPath().join(getOs().tmpdir(), "trails-tp-"));
+    const file = getPath().join(dir, "david.png");
+    getFs().writeFileSync(file, "x");
     const host = makeHost();
-    const upload = fileFixtureUpload.call(host, "/etc/hostname", "text/plain");
-    expect(upload.contentType).toBe("text/plain");
-    expect(upload.originalFilename).toBe("hostname");
+    const upload = fileFixtureUpload.call(host, file, "image/png");
+    expect(upload.contentType).toBe("image/png");
+    expect(upload.originalFilename).toBe("david.png");
   });
 });

--- a/packages/actionpack/src/action-dispatch/testing/test-process.ts
+++ b/packages/actionpack/src/action-dispatch/testing/test-process.ts
@@ -1,0 +1,140 @@
+/**
+ * Port of `ActionDispatch::TestProcess`.
+ *
+ * Rails source: actionpack/lib/action_dispatch/testing/test_process.rb
+ *
+ * A mixin of helpers exposed on integration-test hosts that expose
+ * `@request` / `@response`. Use the `this`-typed function pattern from
+ * CLAUDE.md so the helpers live in this file (matching Rails layout) and
+ * type-check against a host interface.
+ */
+
+import { getFs } from "@blazetrails/activesupport";
+
+import { CookieJar } from "../middleware/cookies.js";
+import type { FlashHash } from "../middleware/flash.js";
+import { UploadedFile } from "../http/upload.js";
+
+/**
+ * Minimal request shape the TestProcess helpers depend on.
+ *
+ * @internal
+ */
+export interface TestProcessRequest {
+  session: Record<string, unknown>;
+  flash: FlashHash;
+  cookies: Record<string, string>;
+}
+
+/**
+ * Minimal response shape the TestProcess helpers depend on.
+ *
+ * @internal
+ */
+export interface TestProcessResponse {
+  redirectUrl?: string;
+}
+
+/**
+ * Host interface for `TestProcess` and the nested `FixtureFile` mixin.
+ *
+ * @internal
+ */
+export interface TestProcessHost {
+  request: TestProcessRequest;
+  response: TestProcessResponse;
+  _cookieJar?: CookieJar;
+  /** ActiveSupport::Testing::FileFixtures hook. */
+  fileFixture?(path: string): string;
+  constructor: {
+    fileFixturePath?: string | null;
+  };
+}
+
+/**
+ * Shortcut for `Rack::Test::UploadedFile.new(File.join(file_fixture_path, path), type)`.
+ *
+ *     post(:change_avatar, { params: { avatar: fileFixtureUpload("david.png", "image/png") } });
+ *
+ * Default fixture files location is `test/fixtures/files`.
+ *
+ * Pass `true` as the third parameter to upload binary files.
+ */
+export function fileFixtureUpload(
+  this: TestProcessHost,
+  path: string,
+  mimeType?: string | null,
+  binary: boolean = false,
+): UploadedFile {
+  const fs = getFs();
+  let resolved = path;
+  if (this.constructor.fileFixturePath && !fs.existsSync(path)) {
+    if (!this.fileFixture) {
+      throw new Error(
+        "TestProcess#fileFixtureUpload: host does not implement fileFixture(); include ActiveSupport::Testing::FileFixtures.",
+      );
+    }
+    resolved = this.fileFixture(path);
+  }
+  const filename = resolved.split("/").pop() ?? resolved;
+  return new UploadedFile({
+    filename,
+    type: mimeType ?? undefined,
+    tempfile: resolved,
+    head: binary ? "Content-Transfer-Encoding: binary" : undefined,
+  });
+}
+
+/** Alias of {@link fileFixtureUpload}. */
+export const fixtureFileUpload = fileFixtureUpload;
+
+/**
+ * `assigns` has been extracted to a gem in Rails. Mirror the error so tests
+ * relying on the legacy helper get the same message.
+ */
+export function assigns(this: TestProcessHost, _key?: string | symbol): never {
+  throw new Error(
+    'NoMethodError: assigns has been extracted to a gem. To continue using it, add `gem "rails-controller-testing"` to your Gemfile.',
+  );
+}
+
+export function session(this: TestProcessHost): Record<string, unknown> {
+  return this.request.session;
+}
+
+export function flash(this: TestProcessHost): FlashHash {
+  return this.request.flash;
+}
+
+export function cookies(this: TestProcessHost): CookieJar {
+  if (!this._cookieJar) {
+    this._cookieJar = CookieJar.build(this.request, this.request.cookies);
+  }
+  return this._cookieJar;
+}
+
+export function redirectToUrl(this: TestProcessHost): string | undefined {
+  return this.response.redirectUrl;
+}
+
+/**
+ * Namespace object mirroring Rails' `ActionDispatch::TestProcess` module so
+ * that `api:compare` can locate the ported methods at the expected layout.
+ */
+export const TestProcess = {
+  fileFixtureUpload,
+  fixtureFileUpload,
+  assigns,
+  session,
+  flash,
+  cookies,
+  redirectToUrl,
+};
+
+/**
+ * Nested `ActionDispatch::TestProcess::FixtureFile` module.
+ */
+export const FixtureFile = {
+  fileFixtureUpload,
+  fixtureFileUpload,
+};

--- a/packages/actionpack/src/action-dispatch/testing/test-process.ts
+++ b/packages/actionpack/src/action-dispatch/testing/test-process.ts
@@ -9,9 +9,9 @@
  * type-check against a host interface.
  */
 
-import { getFs } from "@blazetrails/activesupport";
+import { getFs, getPath } from "@blazetrails/activesupport";
 
-import { CookieJar } from "../middleware/cookies.js";
+import { CookieJar, type CookieJarOptions } from "../middleware/cookies.js";
 import type { FlashHash } from "../middleware/flash.js";
 import { UploadedFile } from "../http/upload.js";
 
@@ -24,6 +24,8 @@ export interface TestProcessRequest {
   session: Record<string, unknown>;
   flash: FlashHash;
   cookies: Record<string, string>;
+  /** Forwarded to {@link CookieJar.build} for signed/encrypted jars. */
+  cookiesAppOptions?: CookieJarOptions;
 }
 
 /**
@@ -46,6 +48,12 @@ export interface TestProcessHost {
   _cookieJar?: CookieJar;
   /** ActiveSupport::Testing::FileFixtures hook. */
   fileFixture?(path: string): string;
+  /**
+   * Instance-level mirror of Rails' `self.class.file_fixture_path` class
+   * attribute — checked first so plain-object hosts (tests) and real class
+   * instances can both opt in. Falls back to `constructor.fileFixturePath`.
+   */
+  fileFixturePath?: string | null;
   constructor: {
     fileFixturePath?: string | null;
   };
@@ -67,8 +75,9 @@ export function fileFixtureUpload(
   binary: boolean = false,
 ): UploadedFile {
   const fs = getFs();
+  const fixturePath = this.fileFixturePath ?? this.constructor.fileFixturePath;
   let resolved = path;
-  if (this.constructor.fileFixturePath && !fs.existsSync(path)) {
+  if (fixturePath && !fs.existsSync(path)) {
     if (!this.fileFixture) {
       throw new Error(
         "TestProcess#fileFixtureUpload: host does not implement fileFixture(); include ActiveSupport::Testing::FileFixtures.",
@@ -76,9 +85,12 @@ export function fileFixtureUpload(
     }
     resolved = this.fileFixture(path);
   }
-  const filename = resolved.split("/").pop() ?? resolved;
+  // NOTE: Rails uses Rack::Test::UploadedFile which opens the tempfile with
+  // binary encoding when `binary` is true. trails wraps ActionDispatch's
+  // UploadedFile, whose read path already returns a Buffer (binary by
+  // default), so the flag is reflected in the part headers only.
   return new UploadedFile({
-    filename,
+    filename: getPath().basename(resolved),
     type: mimeType ?? undefined,
     tempfile: resolved,
     head: binary ? "Content-Transfer-Encoding: binary" : undefined,


### PR DESCRIPTION
## Summary

Ports `actionpack/lib/action_dispatch/testing/test_process.rb` 1:1.

- New `testing/test-process.ts` exposing the mixin helpers as \`this\`-typed
  functions (per CLAUDE.md module-mixin pattern): \`assigns\`, \`session\`,
  \`flash\`, \`cookies\`, \`redirectToUrl\`, plus the nested \`FixtureFile\`
  module (\`fileFixtureUpload\` / \`fixtureFileUpload\`).
- Adds \`CookieJar.build(request, cookies)\` static factory to mirror
  \`Cookies::CookieJar.build\` referenced by Rails' \`#cookies\` helper.
- Re-exports from \`testing/index.ts\`.

The helpers are decoupled from \`IntegrationTest\` (which has its own
session/flash/cookies wiring) — they target hosts that follow the Rails
shape and can be mixed in later without disturbing existing tests.

## Test plan

- [x] \`pnpm vitest run packages/actionpack/src/action-dispatch/testing/test-process.test.ts\`
- [x] \`pnpm --filter actionpack build\`