### PR TITLE
feat(activerecord): cross-cutting applyAssociationScope helper (Batch 32)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -602,12 +602,18 @@ export function applyAssociationScope<R>(
 ): R {
   if (!scope) return rel;
   if (reflectionScope !== undefined && scope === reflectionScope) return rel;
-  // Match the Rails `instance_exec` arity/`this`-binding pattern used by
-  // the head-scope path in `association-scope.ts:583-589`: 0-arg scope →
-  // `this=rel`; 1+-arg → `(rel, owner)` with `this=rel`. Arrow scopes
-  // (the common shape in this codebase) ignore both the `this` binding
-  // and the second arg, so this is additive for existing callers and
-  // unlocks Rails-faithful `function (owner) { this.where(...) }` shapes.
+  // Match the head-scope dispatch in `association-scope.ts:583-589`:
+  // 0-arg scope → `fn.call(rel)` (`this=rel`); 1+-arg → `fn.call(rel,
+  // rel, owner)` (`this=rel`, positional `(rel, owner)`).
+  //
+  // Caveat re: Rails parity: Rails' `instance_exec(owner, &scope)` makes
+  // a 1-arg Ruby block `->(owner) { ... }` receive OWNER as the sole
+  // positional. This codebase's convention is different — every scope
+  // call site is `(rel) => rel.where(...)`, so a 1-arg lambda must
+  // receive the RELATION. We preserve that convention here for symmetry
+  // with `association-scope.ts`. Function-keyword scopes that want
+  // owner access can either declare arity-2 `function (rel, owner)` or
+  // close over `this` (set to rel via `.call`).
   //
   // `|| rel` (not `??`) mirrors Ruby's `instance_exec(owner, &scope) ||
   // relation` — truthiness-based, so a scope returning `false` (idiomatic

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -570,6 +570,42 @@ function _scopeForAssociation(model: typeof Base): Relation<Base> {
 }
 
 /**
+ * Apply a caller-supplied association `scope:` lambda to a built relation.
+ *
+ * Mirrors Rails' `AssociationScope#eval_scope`
+ * (`activerecord/lib/active_record/associations/association_scope.rb:169-172`):
+ *
+ *   relation.instance_exec(owner, &scope) || relation
+ *
+ * The owner is passed as a positional arg so JS scopes can declare
+ * `(rel, owner) => rel.where({user_id: owner.id})` — arity-0/1 scopes
+ * (the common `(rel) => rel.where(...)` shape used throughout this
+ * codebase) silently ignore the extra argument. A falsy return falls
+ * back to the input relation, matching Rails' `|| relation` so scopes
+ * with conditional bodies (`if owner.foo then rel.where(...); end`)
+ * don't accidentally null out the chain.
+ *
+ * When `reflectionScope` is provided, skip application if `scope` is
+ * the exact same function reference. AssociationScope already merges
+ * `reflection.scope` (the macro-time lambda) via `scopeFor`; re-applying
+ * would double-merge. Callers that synthesize a NEW lambda (e.g.
+ * `loadHasManyThrough` wrapping with `sourceType` filtering) pass a
+ * different reference and still run.
+ *
+ * @internal
+ */
+export function applyAssociationScope<R>(
+  rel: R,
+  scope: ((rel: R, owner: Base) => R | null | undefined) | null | undefined,
+  owner: Base,
+  reflectionScope?: unknown,
+): R {
+  if (!scope) return rel;
+  if (reflectionScope !== undefined && scope === reflectionScope) return rel;
+  return (scope(rel, owner) ?? rel) as R;
+}
+
+/**
  * Build (or return cached) base AssociationScope. When the owner has
  * a registered `Association` instance for this name, route through
  * its `associationScope()` so calls hit Rails' `@association_scope`-
@@ -676,13 +712,10 @@ async function _loadThroughViaDisableJoinsScope(
     klass,
   });
   // Apply caller-supplied `options.scope` when it differs from the
-  // reflection's own scope — same rule the JOIN-based loaders use
-  // (line 488 etc.). Skipping when equal avoids double-application
-  // since DJAS already consumed the reflection's scope via constraints.
-  const reflScope = reflection.scope;
-  if (options?.scope && options.scope !== reflScope) {
-    rel = options.scope(rel as never);
-  }
+  // reflection's own scope — same rule the JOIN-based loaders use.
+  // Skipping when equal avoids double-application since DJAS already
+  // consumed the reflection's scope via constraints.
+  rel = applyAssociationScope(rel as never, options?.scope, record, reflection.scope);
   return (rel as { toArray: () => Promise<Base[]> }).toArray();
 }
 
@@ -811,9 +844,7 @@ export async function loadBelongsTo(
     const built = _builtAssociationScope(record, assocName, reflection, targetModel);
     const baseRelation = _scopeForAssociation(targetModel);
     let rel = baseRelation.merge(built);
-    if (options.scope && options.scope !== reflection.scope) {
-      rel = options.scope(rel);
-    }
+    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
     result = await rel.first();
   } else {
     // Inline fallback: no reflection registered.
@@ -941,9 +972,7 @@ export async function loadHasOne(
     const built = _builtAssociationScope(record, assocName, reflection, targetModel);
     const baseRelation = _scopeForAssociation(targetModel);
     let rel = baseRelation.merge(built);
-    if (options.scope && options.scope !== reflection.scope) {
-      rel = options.scope(rel);
-    }
+    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
     result = await rel.first();
   } else {
     // Inline fallback: no reflection registered.
@@ -967,7 +996,7 @@ export async function loadHasOne(
       let rel = targetModel
         .all()
         .where({ [foreignKey as string]: record._readAttribute(primaryKey as string) });
-      rel = options.scope(rel);
+      rel = applyAssociationScope(rel, options.scope, record);
       result = await rel.first();
     } else {
       result = await targetModel.findBy({
@@ -1155,9 +1184,7 @@ export async function loadHasMany(
     const built = _builtAssociationScope(record, assocName, reflection, targetModel);
     const baseRelation = _scopeForAssociation(targetModel);
     rel = baseRelation.merge(built);
-    if (options.scope && options.scope !== reflection.scope) {
-      rel = options.scope(rel);
-    }
+    rel = applyAssociationScope(rel, options.scope, record, reflection.scope);
   } else {
     // Inline fallback: no reflection (lower-level test helpers).
     if (Array.isArray(foreignKey)) {
@@ -1181,7 +1208,7 @@ export async function loadHasMany(
         .all()
         .where({ [foreignKey as string]: record._readAttribute(primaryKey as string) });
     }
-    if (options.scope) rel = options.scope(rel);
+    rel = applyAssociationScope(rel, options.scope, record);
   }
   const results: Base[] = await rel.toArray();
 
@@ -1277,7 +1304,7 @@ export function buildHasManyRelation(
   const className = options.className ?? camelize(singularize(assocName));
   const targetModel = resolveAssocClass(record, assocName, className);
   let rel = targetModel.all().where(conditions);
-  if (options.scope) rel = options.scope(rel);
+  rel = applyAssociationScope(rel, options.scope, record);
   return rel;
 }
 
@@ -1393,7 +1420,7 @@ export async function loadHasManyThrough(
       .filter((v) => v !== null && v !== undefined);
     if (targetIds.length === 0) return [];
     let rel = targetModel.all().where({ [targetModel.primaryKey as string]: targetIds });
-    if (options.scope) rel = options.scope(rel);
+    rel = applyAssociationScope(rel, options.scope, record);
     return rel.toArray();
   } else {
     // Source is has_many/has_one: target has FK pointing back to through record
@@ -1410,7 +1437,7 @@ export async function loadHasManyThrough(
     const whereConditions: Record<string, unknown> = { [sourceFk as string]: throughIds };
     if (sourceAsName) whereConditions[`${underscore(sourceAsName)}_type`] = throughClassName;
     let rel2 = targetModel.all().where(whereConditions);
-    if (options.scope) rel2 = options.scope(rel2);
+    rel2 = applyAssociationScope(rel2, options.scope, record);
     return rel2.toArray();
   }
 }
@@ -1632,7 +1659,7 @@ export async function loadHabtm(
   // filter and the caller-supplied scope lambda for query-method
   // composition (where/order/select/group/having/unscope).
   let rel: any = _scopeForAssociation(targetModel).where(inNode);
-  if (options.scope) rel = options.scope(rel);
+  rel = applyAssociationScope(rel, options.scope, record);
 
   return rel.toArray();
 }

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -602,7 +602,11 @@ export function applyAssociationScope<R>(
 ): R {
   if (!scope) return rel;
   if (reflectionScope !== undefined && scope === reflectionScope) return rel;
-  return (scope(rel, owner) ?? rel) as R;
+  // Rails' `instance_exec(owner, &scope) || relation` is truthiness-based
+  // (`||`), not nullish — a scope like `cond && rel.where(...)` that
+  // short-circuits to `false` must still fall back to the input relation.
+  // Mirror with `||`, not `??`.
+  return (scope(rel, owner) || rel) as R;
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -596,7 +596,7 @@ function _scopeForAssociation(model: typeof Base): Relation<Base> {
  */
 export function applyAssociationScope<R>(
   rel: R,
-  scope: ((this: R, rel: R, owner: Base) => unknown) | null | undefined,
+  scope: ((this: R, rel: R, owner: Base) => R | false | null | undefined) | null | undefined,
   owner: Base,
   reflectionScope?: unknown,
 ): R {
@@ -620,9 +620,9 @@ export function applyAssociationScope<R>(
   // JS `cond && rel.where(...)` short-circuit) falls back to the input.
   const result =
     scope.length === 0
-      ? (scope as unknown as (this: R) => unknown).call(rel)
+      ? (scope as unknown as (this: R) => R | false | null | undefined).call(rel)
       : scope.call(rel, rel, owner);
-  return (result || rel) as R;
+  return result || rel;
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -596,17 +596,27 @@ function _scopeForAssociation(model: typeof Base): Relation<Base> {
  */
 export function applyAssociationScope<R>(
   rel: R,
-  scope: ((rel: R, owner: Base) => R | null | undefined) | null | undefined,
+  scope: ((this: R, rel: R, owner: Base) => unknown) | null | undefined,
   owner: Base,
   reflectionScope?: unknown,
 ): R {
   if (!scope) return rel;
   if (reflectionScope !== undefined && scope === reflectionScope) return rel;
-  // Rails' `instance_exec(owner, &scope) || relation` is truthiness-based
-  // (`||`), not nullish — a scope like `cond && rel.where(...)` that
-  // short-circuits to `false` must still fall back to the input relation.
-  // Mirror with `||`, not `??`.
-  return (scope(rel, owner) || rel) as R;
+  // Match the Rails `instance_exec` arity/`this`-binding pattern used by
+  // the head-scope path in `association-scope.ts:583-589`: 0-arg scope →
+  // `this=rel`; 1+-arg → `(rel, owner)` with `this=rel`. Arrow scopes
+  // (the common shape in this codebase) ignore both the `this` binding
+  // and the second arg, so this is additive for existing callers and
+  // unlocks Rails-faithful `function (owner) { this.where(...) }` shapes.
+  //
+  // `|| rel` (not `??`) mirrors Ruby's `instance_exec(owner, &scope) ||
+  // relation` — truthiness-based, so a scope returning `false` (idiomatic
+  // JS `cond && rel.where(...)` short-circuit) falls back to the input.
+  const result =
+    scope.length === 0
+      ? (scope as unknown as (this: R) => unknown).call(rel)
+      : scope.call(rel, rel, owner);
+  return (result || rel) as R;
 }
 
 /**

--- a/packages/activerecord/src/associations/apply-association-scope.test.ts
+++ b/packages/activerecord/src/associations/apply-association-scope.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Unit tests for the cross-cutting `applyAssociationScope` helper.
+ *
+ * Mirrors Rails' `AssociationScope#eval_scope`
+ * (`activerecord/lib/active_record/associations/association_scope.rb:169-172`):
+ *
+ *   relation.instance_exec(owner, &scope) || relation
+ *
+ * The TS helper consolidates the equivalent post-merge step shared by
+ * `loadBelongsTo`, `loadHasOne`, `loadHasMany`, `loadHasManyThrough` (×3),
+ * `loadHabtm`, `buildHasManyRelation`, and the DJAS-routed through loader.
+ */
+import { describe, it, expect } from "vitest";
+import { applyAssociationScope, Base } from "../index.js";
+
+describe("applyAssociationScope", () => {
+  // Use a bare Base instance as the `owner` placeholder; the helper only
+  // forwards it positionally to the scope lambda.
+  const owner = Object.create(Base.prototype) as Base;
+
+  it("returns rel unchanged when scope is null/undefined", () => {
+    const rel = { tag: "rel" };
+    expect(applyAssociationScope(rel, null, owner)).toBe(rel);
+    expect(applyAssociationScope(rel, undefined, owner)).toBe(rel);
+  });
+
+  it("invokes the scope and returns its result", () => {
+    const rel = { tag: "rel" };
+    const next = { tag: "next" };
+    const out = applyAssociationScope(rel, () => next, owner);
+    expect(out).toBe(next);
+  });
+
+  it("falls back to rel when the scope returns falsy (Rails `|| relation`)", () => {
+    const rel = { tag: "rel" };
+    // Arrow `() => null` — mirrors a conditional Ruby block that returns nil.
+    expect(applyAssociationScope(rel, () => null, owner)).toBe(rel);
+    expect(applyAssociationScope(rel, () => undefined, owner)).toBe(rel);
+  });
+
+  it("passes the owner as the second positional arg", () => {
+    let captured: Base | undefined;
+    const rel = { tag: "rel" };
+    applyAssociationScope(
+      rel,
+      (r, o) => {
+        captured = o;
+        return r;
+      },
+      owner,
+    );
+    expect(captured).toBe(owner);
+  });
+
+  it("skips application when scope === reflectionScope (avoids double-merge)", () => {
+    const rel = { tag: "rel" };
+    let calls = 0;
+    const refScope = (r: typeof rel) => {
+      calls++;
+      return r;
+    };
+    const out = applyAssociationScope(rel, refScope, owner, refScope);
+    expect(calls).toBe(0);
+    expect(out).toBe(rel);
+  });
+
+  it("runs application when scope !== reflectionScope (synthesized wrapper)", () => {
+    const rel = { tag: "rel" };
+    const refScope = (r: typeof rel) => r;
+    const wrapper = (r: typeof rel) => ({ ...r, wrapped: true }) as typeof rel;
+    const out = applyAssociationScope(rel, wrapper, owner, refScope);
+    expect(out).toEqual({ tag: "rel", wrapped: true });
+  });
+
+  it("works with arity-0/1 scopes that ignore the owner arg", () => {
+    const rel = { tag: "rel", n: 0 };
+    // Arity-1 (typical in this codebase): `(rel) => rel.where(...)` shape.
+    const out = applyAssociationScope(rel, (r) => ({ ...r, n: r.n + 1 }), owner);
+    expect(out).toEqual({ tag: "rel", n: 1 });
+  });
+});

--- a/packages/activerecord/src/associations/apply-association-scope.test.ts
+++ b/packages/activerecord/src/associations/apply-association-scope.test.ts
@@ -39,9 +39,9 @@ describe("applyAssociationScope", () => {
     // short-circuit), and `0`/`""` for completeness.
     expect(applyAssociationScope(rel, () => null, owner)).toBe(rel);
     expect(applyAssociationScope(rel, () => undefined, owner)).toBe(rel);
-    expect(applyAssociationScope(rel, () => false as never, owner)).toBe(rel);
-    expect(applyAssociationScope(rel, () => 0 as never, owner)).toBe(rel);
-    expect(applyAssociationScope(rel, () => "" as never, owner)).toBe(rel);
+    expect(applyAssociationScope(rel, () => false, owner)).toBe(rel);
+    expect(applyAssociationScope(rel, () => 0, owner)).toBe(rel);
+    expect(applyAssociationScope(rel, () => "", owner)).toBe(rel);
   });
 
   it("passes the owner as the second positional arg", () => {
@@ -76,6 +76,22 @@ describe("applyAssociationScope", () => {
     const wrapper = (r: typeof rel) => ({ ...r, wrapped: true }) as typeof rel;
     const out = applyAssociationScope(rel, wrapper, owner, refScope);
     expect(out).toEqual({ tag: "rel", wrapped: true });
+  });
+
+  it("binds `this` to rel for arity-0 function-keyword scopes (Rails `instance_exec`)", () => {
+    // Mirrors the head-scope dispatch in `association-scope.ts:583-589`:
+    // `fn.length === 0 ? fn.call(scope) : fn.call(scope, scope, owner)`.
+    const rel = { tag: "rel", marked: false };
+    const out = applyAssociationScope(
+      rel,
+      function () {
+        // `this` is the relation; mutate-and-return mirrors Ruby's
+        // `instance_exec` self-binding for 0-arg scopes.
+        return { ...this, marked: true };
+      },
+      owner,
+    );
+    expect(out).toEqual({ tag: "rel", marked: true });
   });
 
   it("works with arity-0/1 scopes that ignore the owner arg", () => {

--- a/packages/activerecord/src/associations/apply-association-scope.test.ts
+++ b/packages/activerecord/src/associations/apply-association-scope.test.ts
@@ -7,8 +7,9 @@
  *   relation.instance_exec(owner, &scope) || relation
  *
  * The TS helper consolidates the equivalent post-merge step shared by
- * `loadBelongsTo`, `loadHasOne`, `loadHasMany`, `loadHasManyThrough` (×3),
- * `loadHabtm`, `buildHasManyRelation`, and the DJAS-routed through loader.
+ * `loadBelongsTo`, `loadHasOne` (×2 — reflection path + inline fallback),
+ * `loadHasMany` (×2), `loadHasManyThrough` (×2), `loadHabtm`,
+ * `buildHasManyRelation`, and the DJAS-routed `_loadThroughViaDisableJoinsScope`.
  */
 import { describe, it, expect } from "vitest";
 import { applyAssociationScope, Base } from "../index.js";
@@ -33,9 +34,14 @@ describe("applyAssociationScope", () => {
 
   it("falls back to rel when the scope returns falsy (Rails `|| relation`)", () => {
     const rel = { tag: "rel" };
-    // Arrow `() => null` — mirrors a conditional Ruby block that returns nil.
+    // Truthiness-based — mirrors Ruby's `|| relation`. Covers nil
+    // (`null`/`undefined`), `false` (idiomatic `cond && rel.where(...)`
+    // short-circuit), and `0`/`""` for completeness.
     expect(applyAssociationScope(rel, () => null, owner)).toBe(rel);
     expect(applyAssociationScope(rel, () => undefined, owner)).toBe(rel);
+    expect(applyAssociationScope(rel, () => false as never, owner)).toBe(rel);
+    expect(applyAssociationScope(rel, () => 0 as never, owner)).toBe(rel);
+    expect(applyAssociationScope(rel, () => "" as never, owner)).toBe(rel);
   });
 
   it("passes the owner as the second positional arg", () => {

--- a/packages/activerecord/src/associations/apply-association-scope.test.ts
+++ b/packages/activerecord/src/associations/apply-association-scope.test.ts
@@ -12,7 +12,11 @@
  * `buildHasManyRelation`, and the DJAS-routed `_loadThroughViaDisableJoinsScope`.
  */
 import { describe, it, expect } from "vitest";
-import { applyAssociationScope, Base } from "../index.js";
+import { Base } from "../index.js";
+// `applyAssociationScope` is `@internal` — imported directly from
+// `associations.ts` rather than re-exported through the package entry,
+// so it stays out of the public API surface.
+import { applyAssociationScope } from "../associations.js";
 
 describe("applyAssociationScope", () => {
   // Use a bare Base instance as the `owner` placeholder; the helper only
@@ -34,14 +38,13 @@ describe("applyAssociationScope", () => {
 
   it("falls back to rel when the scope returns falsy (Rails `|| relation`)", () => {
     const rel = { tag: "rel" };
-    // Truthiness-based — mirrors Ruby's `|| relation`. Covers nil
-    // (`null`/`undefined`), `false` (idiomatic `cond && rel.where(...)`
-    // short-circuit), and `0`/`""` for completeness.
+    // Truthiness-based — mirrors Ruby's `|| relation`. The scope type
+    // `R | false | null | undefined` covers all three legitimate falsy
+    // returns: `null`/`undefined` (Ruby `nil`) and `false` (idiomatic
+    // JS `cond && rel.where(...)` short-circuit).
     expect(applyAssociationScope(rel, () => null, owner)).toBe(rel);
     expect(applyAssociationScope(rel, () => undefined, owner)).toBe(rel);
     expect(applyAssociationScope(rel, () => false, owner)).toBe(rel);
-    expect(applyAssociationScope(rel, () => 0, owner)).toBe(rel);
-    expect(applyAssociationScope(rel, () => "", owner)).toBe(rel);
   });
 
   it("passes the owner as the second positional arg", () => {

--- a/packages/activerecord/src/associations/apply-association-scope.test.ts
+++ b/packages/activerecord/src/associations/apply-association-scope.test.ts
@@ -92,7 +92,7 @@ describe("applyAssociationScope", () => {
     const rel = { tag: "rel", marked: false };
     const out = applyAssociationScope(
       rel,
-      function () {
+      function (this: typeof rel) {
         // `this` is the relation; mutate-and-return mirrors Ruby's
         // `instance_exec` self-binding for 0-arg scopes.
         return { ...this, marked: true };

--- a/packages/activerecord/src/associations/apply-association-scope.test.ts
+++ b/packages/activerecord/src/associations/apply-association-scope.test.ts
@@ -13,9 +13,14 @@
  */
 import { describe, it, expect } from "vitest";
 import { Base } from "../index.js";
-// `applyAssociationScope` is `@internal` — imported directly from
-// `associations.ts` rather than re-exported through the package entry,
-// so it stays out of the public API surface.
+// `applyAssociationScope` is `@internal`. It's imported from
+// `associations.ts` directly (not re-exported through the package
+// entry) so it stays out of generated TypeDoc / index types — the
+// repo-wide pattern for Rails-private helpers (see CLAUDE.md's
+// `@internal` policy + the `blazetrails/rails-private-jsdoc` lint
+// rule). The `exports` map's `./*` subpath still allows reach via
+// `@blazetrails/activerecord/associations.js`; encapsulation here is
+// the same convention every other `_`-prefixed helper relies on.
 import { applyAssociationScope } from "../associations.js";
 
 describe("applyAssociationScope", () => {

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -55,7 +55,6 @@ export {
   association,
   isAssociationCached,
   loadHabtm,
-  applyAssociationScope,
   updateCounterCaches,
   touchBelongsToParents,
   eagerLoadBang,

--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -55,6 +55,7 @@ export {
   association,
   isAssociationCached,
   loadHabtm,
+  applyAssociationScope,
   updateCounterCaches,
   touchBelongsToParents,
   eagerLoadBang,


### PR DESCRIPTION
## Summary

Batch 32 — Slot B+C cross-cutting scope helper. Consolidates the post-merge `options.scope(rel)` step shared by every association loader behind a single Rails-faithful helper, `applyAssociationScope(rel, scope, owner, reflectionScope?)`.

Mirrors Rails' `AssociationScope#eval_scope` (`activerecord/lib/active_record/associations/association_scope.rb:169-172`):

```ruby
relation.instance_exec(owner, &scope) || relation
```

The helper:
- forwards `owner` positionally so scopes can declare `(rel, owner) => ...`; existing `(rel) => ...` callers silently ignore the extra arg
- falls back to the input relation on a falsy return (Rails' `|| relation`) so conditional-body scopes don't accidentally null the chain
- skips application when `scope === reflectionScope` (the macro-time lambda `AssociationScope` already merged via `scopeFor`); synthesized wrappers (e.g. `loadHasManyThrough`'s `sourceType` wrap) pass a different reference and still run

Swaps 10 call sites: `_loadThroughViaDisableJoinsScope`, `loadBelongsTo`, `loadHasOne` (×2 — reflection path + inline fallback), `loadHasMany` (×2), `buildHasManyRelation`, `loadHasManyThrough` (×2), `loadHabtm`.

## Follow-ups (deferred from original Batch 32 plan)

These items from the plan turned out to be already in place or out of scope; noting here so triage can reconcile:

- HABTM builder-time `scope:` is already captured into the reflection + `habtmOptions` (builder/has-and-belongs-to-many.ts) and `loadHabtm` auto-applies via the helper.
- HABTM join inserts already route through `throughModel.create(joinAttrs)` (collection-proxy.ts), not the `insertAll([joinAttrs])` validation-bypass shape the plan referenced.
- `_associationIds` invalidation sweep on `destroyAll` / explicit `clear()` — pure verification, deferred.

## Test plan

- [x] new `apply-association-scope.test.ts` covers: null/undefined scope, value pass-through, falsy fallback, owner forwarding, `scope === reflectionScope` skip, synthesized-wrapper run, arity-0/1 ignore-owner shape (7 tests)
- [x] `association-scope.test.ts` (27 tests) — green
- [x] `has-and-belongs-to-many-associations.test.ts` (98 / 24 skipped) — green
- [x] full local typecheck