### PR TITLE
feat(actionpack): port ActionDispatch::Assertions::RoutingAssertions

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
@@ -397,6 +397,17 @@ describe("RequestParameters", () => {
     expect(req.pathParameters).toEqual({});
   });
 
+  it("merges request, query, and path parameters with Rails precedence", () => {
+    // Rails: request_parameters.merge(query_parameters).merge!(path_parameters).
+    // Query wins over request-body; path wins over both.
+    const req = new Request({
+      QUERY_STRING: "k=query",
+      "action_dispatch.request.request_parameters": { k: "body", b: "body-only" },
+      "action_dispatch.request.path_parameters": { k: "path", p: "path-only" },
+    });
+    expect(req.params).toEqual({ k: "path", b: "body-only", p: "path-only" });
+  });
+
   it("pathParameters= invalidates the merged params cache and feeds future params reads", () => {
     const req = new Request({ QUERY_STRING: "view=print" });
     expect(req.params).toEqual({ view: "print" });

--- a/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
@@ -396,6 +396,21 @@ describe("RequestParameters", () => {
     const req = new Request({});
     expect(req.pathParameters).toEqual({});
   });
+
+  it("pathParameters= invalidates the merged params cache and feeds future params reads", () => {
+    const req = new Request({ QUERY_STRING: "view=print" });
+    expect(req.params).toEqual({ view: "print" });
+    req.pathParameters = { controller: "items", action: "show", id: "1" };
+    expect(req.params).toEqual({
+      view: "print",
+      controller: "items",
+      action: "show",
+      id: "1",
+    });
+    // Path params win over query string on key collision (Rails: merge!).
+    req.pathParameters = { view: "edit" };
+    expect(req.params).toEqual({ view: "edit" });
+  });
 });
 
 describe("LocalhostTest", () => {

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -355,6 +355,10 @@ export class Request {
     return (this.env["action_dispatch.request.path_parameters"] as Record<string, string>) || {};
   }
 
+  set pathParameters(params: Record<string, unknown>) {
+    this.env["action_dispatch.request.path_parameters"] = params;
+  }
+
   // --- Format ---
 
   get format(): string | undefined {

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -278,9 +278,12 @@ export class Request {
     if (this.env["action_dispatch.request.parameters"]) {
       return this.env["action_dispatch.request.parameters"] as Record<string, unknown>;
     }
+    // Mirrors Rails `ActionDispatch::Http::Parameters#parameters` —
+    // request_parameters.merge(query_parameters).merge!(path_parameters).
     const merged: Record<string, unknown> = {
-      ...this.queryParameters,
       ...this.requestParameters,
+      ...this.queryParameters,
+      ...this.pathParameters,
     };
     this.env["action_dispatch.request.parameters"] = merged;
     return merged;

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -351,11 +351,16 @@ export class Request {
     return normalized;
   }
 
-  get pathParameters(): Record<string, string> {
-    return (this.env["action_dispatch.request.path_parameters"] as Record<string, string>) || {};
+  get pathParameters(): Record<string, unknown> {
+    return (this.env["action_dispatch.request.path_parameters"] as Record<string, unknown>) || {};
   }
 
   set pathParameters(params: Record<string, unknown>) {
+    // Mirrors `Rails::ActionDispatch::Http::Parameters#path_parameters=` —
+    // invalidate the merged-parameters cache so subsequent `params` reads
+    // pick up the new path captures. Matches `setPathParameters` in
+    // http/parameters.ts.
+    delete this.env["action_dispatch.request.parameters"];
     this.env["action_dispatch.request.path_parameters"] = params;
   }
 

--- a/packages/actionpack/src/action-dispatch/routing/redirection.ts
+++ b/packages/actionpack/src/action-dispatch/routing/redirection.ts
@@ -124,7 +124,7 @@ export class Redirect extends Endpoint {
   }
 
   buildResponse(req: Request): Response {
-    const uri = parseUri(this.path(req.pathParameters, req));
+    const uri = parseUri(this.path(req.pathParameters as Record<string, string>, req));
 
     if (!uri.host) {
       if (this.relativePath(uri.path)) {

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -200,8 +200,10 @@ export class RouteSet {
 
   /**
    * Inverse of `recognizePath`. Returns `[path, extraKeys]` where extraKeys
-   * are option keys not consumed by the route. `defaults` is accepted for
-   * signature parity (Rails docs: "The `defaults` parameter is unused.").
+   * are option keys not consumed by the route. The caller-supplied
+   * `defaults` hash and the route's own defaults suppress matching keys
+   * from `extras` when the supplied value equals the default (Rails
+   * threads `defaults` through `generate` as the recall hash).
    */
   generateExtras(
     options: Record<string, unknown>,
@@ -240,7 +242,13 @@ export class RouteSet {
     const extras: string[] = [];
     for (const k of Object.keys(options)) {
       if (k === "controller" || k === "action" || captureNames.has(k)) continue;
-      if (Object.hasOwn(routeDefaults, k) || Object.hasOwn(defaults, k)) continue;
+      // Only suppress the key when the supplied value matches the default
+      // — a caller passing `format: "html"` against a route defaulting
+      // `format: "json"` still surfaces as an extra, since the generated
+      // path can't represent the conflicting value.
+      const v = options[k];
+      if (Object.hasOwn(routeDefaults, k) && routeDefaults[k] === v) continue;
+      if (Object.hasOwn(defaults, k) && defaults[k] === v) continue;
       extras.push(k);
     }
     return [path, extras];

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -187,7 +187,10 @@ export class RouteSet {
     if (!matched) {
       throw new RoutingError(`No route matches [${method}] ${JSON.stringify(path)}`);
     }
+    // Mirrors Rails: recognize_path returns route defaults merged with the
+    // matched captures (Journey hands defaults back as path_parameters).
     return {
+      ...matched.route.defaults,
       controller: matched.route.controller,
       action: matched.route.action,
       ...matched.params,

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -23,6 +23,7 @@ import type { PolymorphicMappingEntry } from "./polymorphic-routes.js";
 import { Endpoint } from "./endpoint.js";
 import { X_CASCADE } from "../constants.js";
 import { DispatcherRegistry, type DispatchHandler } from "./dispatcher.js";
+import { RoutingError } from "../../action-controller/metal/exceptions.js";
 
 export type DrawCallback = (mapper: Mapper) => void;
 
@@ -174,6 +175,54 @@ export class RouteSet {
   /** End-to-end `Router.serve` using registered handlers. */
   serve(req: RouterRequest): RackishResponse {
     return this.journeyRouter.serve(req);
+  }
+
+  /** Mirrors Rails' `RouteSet#recognize_path` shape for `assert_recognizes`. */
+  recognizePath(
+    path: string,
+    options: { method?: string | null; extras?: Record<string, unknown> } = {},
+  ): Record<string, unknown> {
+    const method = String(options.method ?? "GET").toUpperCase();
+    const matched = this.recognize(method, path);
+    if (!matched) {
+      throw new RoutingError(`No route matches [${method}] ${JSON.stringify(path)}`);
+    }
+    return {
+      controller: matched.route.controller,
+      action: matched.route.action,
+      ...matched.params,
+      ...(options.extras ?? {}),
+    };
+  }
+
+  /**
+   * Inverse of `recognizePath`. Returns `[path, extraKeys]` where extraKeys
+   * are option keys not consumed by the route. `defaults` is accepted for
+   * signature parity (Rails docs: "The `defaults` parameter is unused.").
+   */
+  generateExtras(
+    options: Record<string, unknown>,
+
+    _defaults: Record<string, unknown> = {},
+  ): [string, string[]] {
+    const { controller, action } = options;
+    const route = this.routes.find((r) => r.controller === controller && r.action === action);
+    if (!route) {
+      throw new RoutingError(`No route matches ${JSON.stringify(options)}`);
+    }
+    const captureNames = new Set<string>(route.pathParamNames);
+    const captureParams: Record<string, string | number> = {};
+    for (const name of captureNames) {
+      const v = options[name];
+      if (v != null) captureParams[name] = v as string | number;
+    }
+    const path = route.pathFor(captureParams);
+    const extras: string[] = [];
+    for (const k of Object.keys(options)) {
+      if (k === "controller" || k === "action" || captureNames.has(k)) continue;
+      extras.push(k);
+    }
+    return [path, extras];
   }
 
   /**

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -207,8 +207,16 @@ export class RouteSet {
     options: Record<string, unknown>,
     defaults: Record<string, unknown> = {},
   ): [string, string[]] {
+    // Rails: `route_key = options.delete :use_route` — when present, look
+    // the route up by its named-route key, mirroring `RouteSet#generate`.
+    let route: Route | undefined;
+    const useRoute = options["use_route"];
+    if (typeof useRoute === "string") {
+      delete options["use_route"];
+      route = this.namedRoutes.get(useRoute);
+    }
     const { controller, action } = options;
-    const route = this.routes.find((r) => r.controller === controller && r.action === action);
+    route ??= this.routes.find((r) => r.controller === controller && r.action === action);
     if (!route) {
       throw new UrlGenerationError(`No route matches ${JSON.stringify(options)}`);
     }

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -23,7 +23,7 @@ import type { PolymorphicMappingEntry } from "./polymorphic-routes.js";
 import { Endpoint } from "./endpoint.js";
 import { X_CASCADE } from "../constants.js";
 import { DispatcherRegistry, type DispatchHandler } from "./dispatcher.js";
-import { RoutingError } from "../../action-controller/metal/exceptions.js";
+import { RoutingError, UrlGenerationError } from "../../action-controller/metal/exceptions.js";
 
 export type DrawCallback = (mapper: Mapper) => void;
 
@@ -202,24 +202,34 @@ export class RouteSet {
    */
   generateExtras(
     options: Record<string, unknown>,
-
-    _defaults: Record<string, unknown> = {},
+    defaults: Record<string, unknown> = {},
   ): [string, string[]] {
     const { controller, action } = options;
     const route = this.routes.find((r) => r.controller === controller && r.action === action);
     if (!route) {
-      throw new RoutingError(`No route matches ${JSON.stringify(options)}`);
+      throw new UrlGenerationError(`No route matches ${JSON.stringify(options)}`);
     }
     const captureNames = new Set<string>(route.pathParamNames);
-    const captureParams: Record<string, string | number> = {};
+    // Null-prototype map so a capture named `__proto__` becomes an own
+    // property — Route#pathFor preserves the value when fed a null-proto
+    // hash (route.test.ts:175-184); a plain object would silently hit the
+    // inherited setter instead.
+    const captureParams: Record<string, unknown> = Object.create(null);
     for (const name of captureNames) {
       const v = options[name];
-      if (v != null) captureParams[name] = v as string | number;
+      if (v != null) captureParams[name] = v;
     }
-    const path = route.pathFor(captureParams);
+    const path = route.pathFor(captureParams as Record<string, string | number>);
+    // Mirrors Rails' `generate_extras`: extras are the keys of `options`
+    // not consumed by the route. Keys present in the route's `defaults`
+    // (and the caller-supplied `defaults`/recall hash) are consumed too,
+    // so callers can pass e.g. `format: "json"` without it surfacing as a
+    // query-string extra when the route already pins it.
+    const routeDefaults = route.defaults as Record<string, unknown>;
     const extras: string[] = [];
     for (const k of Object.keys(options)) {
       if (k === "controller" || k === "action" || captureNames.has(k)) continue;
+      if (Object.hasOwn(routeDefaults, k) || Object.hasOwn(defaults, k)) continue;
       extras.push(k);
     }
     return [path, extras];

--- a/packages/actionpack/src/action-dispatch/testing/assertions.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions.ts
@@ -17,7 +17,12 @@ export {
   assertRecognizes,
   assertGenerates,
   assertRouting,
+  withRouting,
+  setup,
+  createRoutes,
+  resetRoutes,
   recognizedRequestFor,
+  failOn,
   type RoutingAssertionsHost,
   type PathWithMethod,
 } from "./assertions/routing.js";

--- a/packages/actionpack/src/action-dispatch/testing/assertions.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions.ts
@@ -1,10 +1,7 @@
 /**
- * ActionDispatch::Assertions
- *
- * Aggregates the test assertions provided by ActionDispatch. Mirrors
- * Rails' `action_dispatch/testing/assertions.rb` — currently exports
- * ResponseAssertions; RoutingAssertions follow once
- * `RouteSet#recognize_path` / `#generate_extras` are ported.
+ * ActionDispatch::Assertions — aggregates the test assertions provided by
+ * ActionDispatch. Mirrors `action_dispatch/testing/assertions.rb`.
+ * `withRouting` and `htmlDocument` follow as separate PRs.
  */
 
 export {
@@ -16,5 +13,11 @@ export {
   type AssertionResponseLike,
 } from "./assertions/response.js";
 
-// htmlDocument + RoutingAssertions methods follow once rails-dom-testing
-// and RouteSet#recognize_path / #generate_extras are ported.
+export {
+  assertRecognizes,
+  assertGenerates,
+  assertRouting,
+  recognizedRequestFor,
+  type RoutingAssertionsHost,
+  type PathWithMethod,
+} from "./assertions/routing.js";

--- a/packages/actionpack/src/action-dispatch/testing/assertions.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions.ts
@@ -1,7 +1,7 @@
 /**
  * ActionDispatch::Assertions — aggregates the test assertions provided by
  * ActionDispatch. Mirrors `action_dispatch/testing/assertions.rb`.
- * `withRouting` and `htmlDocument` follow as separate PRs.
+ * `htmlDocument` follows once rails-dom-testing is ported.
  */
 
 export {

--- a/packages/actionpack/src/action-dispatch/testing/assertions.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions.ts
@@ -19,10 +19,9 @@ export {
   assertRouting,
   withRouting,
   setup,
-  createRoutes,
-  resetRoutes,
-  recognizedRequestFor,
-  failOn,
   type RoutingAssertionsHost,
   type PathWithMethod,
 } from "./assertions/routing.js";
+// recognizedRequestFor / createRoutes / resetRoutes / failOn are @internal
+// — they're still exported from ./assertions/routing.js so api:compare
+// sees the full surface, but they aren't part of the public barrel.

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from "vitest";
 import { RouteSet } from "../../routing/route-set.js";
+import { RoutingError } from "../../../action-controller/metal/exceptions.js";
 import {
   assertGenerates,
   assertRecognizes,
   assertRouting,
+  failOn,
+  withRouting,
   type RoutingAssertionsHost,
 } from "./routing.js";
 
@@ -81,5 +84,41 @@ describe("assertRouting", () => {
         id: "23",
       }),
     );
+  });
+});
+
+describe("withRouting", () => {
+  it("swaps in a fresh RouteSet and restores after the block (even on throw)", () => {
+    const original = buildHost();
+    const before = original.routes;
+    withRouting.call(original, (routes: RouteSet) => {
+      routes.draw((m) => m.get("/temp", { to: "tmp#i" }));
+      expect(original.routes).toBe(routes);
+      ok(() => assertRecognizes.call(original, { controller: "tmp", action: "i" }, "/temp"));
+    });
+    expect(original.routes).toBe(before);
+    bad(() =>
+      withRouting.call(original, () => {
+        throw new Error("boom");
+      }),
+    );
+    expect(original.routes).toBe(before);
+  });
+});
+
+describe("failOn", () => {
+  it("rethrows matching exception with the supplied message", () => {
+    expect(() =>
+      failOn(RoutingError, "custom msg", () => {
+        throw new RoutingError("inner");
+      }),
+    ).toThrow("custom msg");
+  });
+  it("falls through unrelated errors", () => {
+    expect(() =>
+      failOn(RoutingError, "ignored", () => {
+        throw new TypeError("other");
+      }),
+    ).toThrow(TypeError);
   });
 });

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { RouteSet } from "../../routing/route-set.js";
+import {
+  assertGenerates,
+  assertRecognizes,
+  assertRouting,
+  type RoutingAssertionsHost,
+} from "./routing.js";
+
+function buildHost(): RoutingAssertionsHost {
+  const routes = new RouteSet();
+  routes.draw((m) => {
+    m.get("/items", { to: "items#index" });
+    m.post("/items", { to: "items#create" });
+    m.get("/items/list/:id", { to: "items#list" });
+    m.get("/items/show/:id", { to: "items#show" });
+    m.match("/all", { to: "x#a", via: "all" });
+  });
+  return { routes };
+}
+
+const ok = (fn: () => void) => expect(fn).not.toThrow();
+const bad = (fn: () => void) => expect(fn).toThrow();
+
+describe("assertRecognizes", () => {
+  const h = buildHost();
+  it("matches GET, method override, captures + extras, and 'all'", () => {
+    ok(() => assertRecognizes.call(h, { controller: "items", action: "index" }, "/items"));
+    ok(() =>
+      assertRecognizes.call(
+        h,
+        { controller: "items", action: "create" },
+        { path: "/items", method: "post" },
+      ),
+    );
+    ok(() =>
+      assertRecognizes.call(
+        h,
+        { controller: "items", action: "list", id: "1", view: "print" },
+        "/items/list/1",
+        { view: "print" },
+      ),
+    );
+    ok(() =>
+      assertRecognizes.call(h, { controller: "x", action: "a" }, { path: "/all", method: "all" }),
+    );
+  });
+
+  it("throws on mismatch or unknown route", () => {
+    bad(() => assertRecognizes.call(h, { controller: "wrong", action: "x" }, "/items"));
+    bad(() => assertRecognizes.call(h, { controller: "items", action: "index" }, "/nope"));
+  });
+});
+
+describe("assertGenerates", () => {
+  const h = buildHost();
+  it("generates path, prefixes slash, surfaces extras", () => {
+    ok(() => assertGenerates.call(h, "/items", { controller: "items", action: "index" }));
+    ok(() => assertGenerates.call(h, "items", { controller: "items", action: "index" }));
+    ok(() =>
+      assertGenerates.call(
+        h,
+        "/items/list/1",
+        { controller: "items", action: "list", id: "1", view: "print" },
+        {},
+        { view: "print" },
+      ),
+    );
+  });
+  it("throws on path mismatch", () => {
+    bad(() => assertGenerates.call(h, "/wrong", { controller: "items", action: "index" }));
+  });
+});
+
+describe("assertRouting", () => {
+  it("verifies both directions", () => {
+    ok(() =>
+      assertRouting.call(buildHost(), "/items/show/23", {
+        controller: "items",
+        action: "show",
+        id: "23",
+      }),
+    );
+  });
+});

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
@@ -106,6 +106,34 @@ describe("withRouting", () => {
   });
 });
 
+describe("withRouting (async)", () => {
+  it("keeps the temporary RouteSet installed across awaits and restores after resolve", async () => {
+    const host = buildHost();
+    const original = host.routes;
+    const observedInside: RouteSet[] = [];
+    await withRouting.call(host, async (routes: RouteSet) => {
+      observedInside.push(host.routes!);
+      await Promise.resolve();
+      observedInside.push(host.routes!);
+      expect(host.routes).toBe(routes);
+    });
+    expect(observedInside[0]).toBe(observedInside[1]);
+    expect(host.routes).toBe(original);
+  });
+
+  it("restores after async rejection", async () => {
+    const host = buildHost();
+    const original = host.routes;
+    await expect(
+      withRouting.call(host, async () => {
+        await Promise.resolve();
+        throw new Error("async boom");
+      }),
+    ).rejects.toThrow("async boom");
+    expect(host.routes).toBe(original);
+  });
+});
+
 describe("failOn", () => {
   it("rethrows matching exception with the supplied message", () => {
     expect(() =>

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -68,8 +68,11 @@ export function withRouting<T>(
     restore();
     throw e;
   }
-  if (result instanceof Promise) {
-    return result.then(
+  // Treat anything thenable as async (matches the check used in url-for.ts)
+  // so cross-realm promises and library thenables don't fall through to the
+  // synchronous restore path before their awaited work runs.
+  if (result != null && typeof (result as { then?: unknown }).then === "function") {
+    return (result as unknown as PromiseLike<unknown>).then(
       (v) => {
         restore();
         return v;
@@ -122,7 +125,9 @@ export function assertGenerates(
   const routes = requireRoutes(this);
   const opts = { ...options };
   const [generatedPath, queryStringKeys] = routes.generateExtras(opts, defaults);
-  const foundExtras: Options = {};
+  // Null-prototype map so an extra key named `__proto__` becomes an own
+  // property rather than hitting the inherited setter.
+  const foundExtras: Options = Object.create(null);
   for (const k of queryStringKeys) {
     if (Object.hasOwn(opts, k)) foundExtras[k] = opts[k];
   }

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -72,16 +72,24 @@ export function withRouting<T>(
   // so cross-realm promises and library thenables don't fall through to the
   // synchronous restore path before their awaited work runs.
   if (result != null && typeof (result as { then?: unknown }).then === "function") {
-    return (result as unknown as PromiseLike<unknown>).then(
-      (v) => {
-        restore();
-        return v;
-      },
-      (e) => {
-        restore();
-        throw e;
-      },
-    ) as T;
+    // Wrap the .then() call so a thenable that throws synchronously from
+    // its then() still triggers restore — otherwise the temp RouteSet
+    // would leak across tests.
+    try {
+      return (result as unknown as PromiseLike<unknown>).then(
+        (v) => {
+          restore();
+          return v;
+        },
+        (e) => {
+          restore();
+          throw e;
+        },
+      ) as T;
+    } catch (e) {
+      restore();
+      throw e;
+    }
   }
   restore();
   return result;
@@ -249,6 +257,7 @@ function deepEqual(a: unknown, b: unknown): boolean {
   // `id: 1` is meant to fail against actual `id: "1"`.
   if (Object.is(a, b)) return true;
   if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
   const ao = a as Options;
   const bo = b as Options;
   const ak = Object.keys(ao);

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -1,7 +1,9 @@
 /**
  * ActionDispatch::Assertions::RoutingAssertions — `this`-typed port of
- * Rails' `assertions/routing.rb`. Follow-ups: `withRouting`, URL-form
- * (`://`) path arguments, and `method_missing` named-route forwarding.
+ * Rails' `assertions/routing.rb`. Class-level `with_routing` (via
+ * Minitest setup/teardown) and the `WithIntegrationRouting` flavour are
+ * deferred until integration-session cloning is ported; Ruby's
+ * `method_missing` named-route forwarding has no TS equivalent.
  */
 
 import { RouteSet } from "../../routing/route-set.js";
@@ -19,6 +21,44 @@ export interface PathWithMethod {
 }
 
 type Options = Record<string, unknown>;
+
+/** Initialises `@routes`. Mirrors Rails' `setup`. Call from your own setup. */
+export function setup(this: RoutingAssertionsHost): void {
+  if (this.routes == null) this.routes = undefined;
+}
+
+/**
+ * Temporarily replaces `this.routes` with a fresh RouteSet, yields it to
+ * `block`, and restores the previous routes (and controller) on exit.
+ * Mirrors Rails' instance-level `with_routing`. `config` is accepted for
+ * parity and forwarded to `createRoutes` (Rails passes it to
+ * `RouteSet.new`, which trails doesn't yet wire).
+ */
+export function withRouting<T>(
+  this: RoutingAssertionsHost,
+  configOrBlock: unknown,
+  block?: (routes: RouteSet) => T,
+): T {
+  let cb: (routes: RouteSet) => T;
+  let config: unknown;
+  if (typeof configOrBlock === "function") {
+    cb = configOrBlock as (routes: RouteSet) => T;
+  } else {
+    config = configOrBlock;
+    cb = block as (routes: RouteSet) => T;
+  }
+  const oldRoutes = this.routes;
+  const oldController = this.controller;
+  try {
+    return createRoutes.call<RoutingAssertionsHost, [(r: RouteSet) => T, unknown], T>(
+      this,
+      cb,
+      config,
+    );
+  } finally {
+    resetRoutes.call(this, oldRoutes, oldController);
+  }
+}
 
 /** Asserts that `path` recognizes to `expectedOptions`. */
 export function assertRecognizes(
@@ -113,15 +153,57 @@ export function recognizedRequestFor(
   request.env["PATH_INFO"] = pathStr;
   request.env["REQUEST_METHOD"] = method.toUpperCase();
 
-  let params: Record<string, unknown>;
-  try {
-    params = requireRoutes(this).recognizePath(pathStr, { method, extras });
-  } catch (e) {
-    if (e instanceof RoutingError) throw new Error(msg ?? e.message, { cause: e });
-    throw e;
-  }
+  const params = failOn(RoutingError, msg, () =>
+    requireRoutes(this).recognizePath(pathStr, { method, extras }),
+  );
   request.pathParameters = params;
   return request;
+}
+
+/** @internal Mirrors Rails' private `create_routes`. */
+export function createRoutes<T>(
+  this: RoutingAssertionsHost,
+  block: (routes: RouteSet) => T,
+
+  _config?: unknown,
+): T {
+  const routes = new RouteSet();
+  this.routes = routes;
+  // Rails additionally clones `@controller` and mixes in `_routes.url_helpers`
+  // (and `view_context_class`). That depends on singleton-class re-opening
+  // which has no direct TS equivalent; consumers that need helpers on the
+  // controller assign them explicitly.
+  return block(routes);
+}
+
+/** @internal Mirrors Rails' private `reset_routes`. */
+export function resetRoutes(
+  this: RoutingAssertionsHost,
+  oldRoutes: RouteSet | undefined,
+  oldController: unknown,
+): void {
+  this.routes = oldRoutes;
+  if (this.controller != null) this.controller = oldController;
+}
+
+/**
+ * @internal Mirrors Rails' private `fail_on`. Runs `block`; if it throws
+ * an instance of `ExceptionClass`, re-raises as an assertion error with
+ * the caller-supplied `message` (or the original message when omitted).
+ */
+export function failOn<T>(
+  ExceptionClass: new (...args: never[]) => Error,
+  message: string | undefined,
+  block: () => T,
+): T {
+  try {
+    return block();
+  } catch (e) {
+    if (e instanceof ExceptionClass) {
+      throw new Error(message ?? e.message, { cause: e });
+    }
+    throw e;
+  }
 }
 
 function requireRoutes(host: RoutingAssertionsHost): RouteSet {

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -1,0 +1,155 @@
+/**
+ * ActionDispatch::Assertions::RoutingAssertions — `this`-typed port of
+ * Rails' `assertions/routing.rb`. Follow-ups: `withRouting`, URL-form
+ * (`://`) path arguments, and `method_missing` named-route forwarding.
+ */
+
+import { RouteSet } from "../../routing/route-set.js";
+import { RoutingError } from "../../../action-controller/metal/exceptions.js";
+import { TestRequest } from "../test-request.js";
+
+export interface RoutingAssertionsHost {
+  routes?: RouteSet;
+  controller?: unknown;
+}
+
+export interface PathWithMethod {
+  path: string;
+  method?: string | null;
+}
+
+type Options = Record<string, unknown>;
+
+/** Asserts that `path` recognizes to `expectedOptions`. */
+export function assertRecognizes(
+  this: RoutingAssertionsHost,
+  expectedOptions: Options,
+  path: string | PathWithMethod,
+  extras: Options = {},
+  msg?: string,
+): void {
+  if (typeof path !== "string" && String(path.method ?? "").toLowerCase() === "all") {
+    for (const method of ["get", "post", "put", "delete"] as const) {
+      assertRecognizes.call(this, expectedOptions, { ...path, method }, extras, msg);
+    }
+    return;
+  }
+  const request = recognizedRequestFor.call(this, path, extras, msg);
+  const expected = { ...expectedOptions };
+  const actual = request.pathParameters as unknown as Options;
+  if (!deepEqual(expected, actual)) {
+    throw new Error(
+      msg ??
+        `The recognized options <${inspect(actual)}> did not match <${inspect(expected)}>, difference:`,
+    );
+  }
+}
+
+/** Inverse of `assertRecognizes`. */
+export function assertGenerates(
+  this: RoutingAssertionsHost,
+  expectedPath: string,
+  options: Options,
+  defaults: Options = {},
+  extras: Options = {},
+  message?: string,
+): void {
+  const path = expectedPath.startsWith("/") ? expectedPath : `/${expectedPath}`;
+  const routes = requireRoutes(this);
+  const opts = { ...options };
+  const [generatedPath, queryStringKeys] = routes.generateExtras(opts, defaults);
+  const foundExtras: Options = {};
+  for (const k of queryStringKeys) {
+    if (Object.hasOwn(opts, k)) foundExtras[k] = opts[k];
+  }
+  if (!deepEqual(extras, foundExtras)) {
+    throw new Error(message ?? `found extras <${inspect(foundExtras)}>, not <${inspect(extras)}>`);
+  }
+  if (generatedPath !== path) {
+    throw new Error(message ?? `The generated path <${generatedPath}> did not match <${path}>`);
+  }
+}
+
+/** Combined `assertRecognizes` + `assertGenerates`. */
+export function assertRouting(
+  this: RoutingAssertionsHost,
+  path: string | PathWithMethod,
+  options: Options,
+  defaults: Options = {},
+  extras: Options = {},
+  message?: string,
+): void {
+  assertRecognizes.call(this, options, path, extras, message);
+  const controller = options["controller"];
+  const defaultController = defaults["controller"];
+  if (
+    typeof controller === "string" &&
+    controller.includes("/") &&
+    typeof defaultController === "string" &&
+    defaultController.includes("/")
+  ) {
+    options = { ...options, controller: `/${controller}` };
+  }
+  const generateOptions: Options = {};
+  for (const [k, v] of Object.entries(options)) {
+    if (!Object.hasOwn(defaults, k)) generateOptions[k] = v;
+  }
+  const pathStr = typeof path === "string" ? path : path.path;
+  assertGenerates.call(this, pathStr, generateOptions, defaults, extras, message);
+}
+
+/** @internal */
+export function recognizedRequestFor(
+  this: RoutingAssertionsHost,
+  path: string | PathWithMethod,
+  extras: Options = {},
+  msg?: string,
+): TestRequest {
+  const method = typeof path === "string" ? "get" : String(path.method ?? "get");
+  let pathStr = typeof path === "string" ? path : path.path;
+  if (!pathStr.startsWith("/")) pathStr = `/${pathStr}`;
+
+  const request = new TestRequest();
+  request.env["PATH_INFO"] = pathStr;
+  request.env["REQUEST_METHOD"] = method.toUpperCase();
+
+  let params: Record<string, unknown>;
+  try {
+    params = requireRoutes(this).recognizePath(pathStr, { method, extras });
+  } catch (e) {
+    if (e instanceof RoutingError) throw new Error(msg ?? e.message, { cause: e });
+    throw e;
+  }
+  request.pathParameters = params;
+  return request;
+}
+
+function requireRoutes(host: RoutingAssertionsHost): RouteSet {
+  if (!host.routes) {
+    throw new Error("No routes available — set `this.routes` to a RouteSet first.");
+  }
+  return host.routes;
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (Object.is(a, b)) return true;
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") {
+    return String(a) === String(b);
+  }
+  const ao = a as Options;
+  const bo = b as Options;
+  const ak = Object.keys(ao);
+  if (ak.length !== Object.keys(bo).length) return false;
+  for (const k of ak) {
+    if (!Object.hasOwn(bo, k) || !deepEqual(ao[k], bo[k])) return false;
+  }
+  return true;
+}
+
+const inspect = (v: unknown): string => {
+  try {
+    return JSON.stringify(v);
+  } catch {
+    return String(v);
+  }
+};

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -49,15 +49,36 @@ export function withRouting<T>(
   }
   const oldRoutes = this.routes;
   const oldController = this.controller;
+  // Mirrors Ruby's `ensure`: cleanup runs after the block's work has
+  // completed. For sync blocks that's the synchronous return; for
+  // Promise-returning blocks we defer until the promise settles so the
+  // temporary RouteSet stays installed across `await` points.
+  const restore = () => resetRoutes.call(this, oldRoutes, oldController);
+  let result: T;
   try {
-    return createRoutes.call<RoutingAssertionsHost, [(r: RouteSet) => T, unknown], T>(
+    result = createRoutes.call<RoutingAssertionsHost, [(r: RouteSet) => T, unknown], T>(
       this,
       cb,
       config,
     );
-  } finally {
-    resetRoutes.call(this, oldRoutes, oldController);
+  } catch (e) {
+    restore();
+    throw e;
   }
+  if (result instanceof Promise) {
+    return result.then(
+      (v) => {
+        restore();
+        return v;
+      },
+      (e) => {
+        restore();
+        throw e;
+      },
+    ) as T;
+  }
+  restore();
+  return result;
 }
 
 /** Asserts that `path` recognizes to `expectedOptions`. */
@@ -214,10 +235,12 @@ function requireRoutes(host: RoutingAssertionsHost): RouteSet {
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {
+  // Strict value comparison. Rails' `assert_recognizes` stringifies expected
+  // option *keys* (`expected_options.stringify_keys!`) only; values in
+  // `request.path_parameters` are URL-decoded strings, so an expected
+  // `id: 1` is meant to fail against actual `id: "1"`.
   if (Object.is(a, b)) return true;
-  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") {
-    return String(a) === String(b);
-  }
+  if (a === null || b === null || typeof a !== "object" || typeof b !== "object") return false;
   const ao = a as Options;
   const bo = b as Options;
   const ak = Object.keys(ao);

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -45,7 +45,10 @@ export function withRouting<T>(
     cb = configOrBlock as (routes: RouteSet) => T;
   } else {
     config = configOrBlock;
-    cb = block as (routes: RouteSet) => T;
+    if (typeof block !== "function") {
+      throw new TypeError("withRouting requires a callback block");
+    }
+    cb = block;
   }
   const oldRoutes = this.routes;
   const oldController = this.controller;

--- a/packages/actionpack/src/action-dispatch/testing/index.ts
+++ b/packages/actionpack/src/action-dispatch/testing/index.ts
@@ -11,8 +11,15 @@ export { AssertionResponse } from "./assertion-response.js";
 export {
   assertResponse,
   assertRedirectedTo,
+  assertRecognizes,
+  assertGenerates,
+  assertRouting,
+  withRouting,
+  setup,
   type AssertionResponseHost,
   type AssertionResponseLike,
+  type RoutingAssertionsHost,
+  type PathWithMethod,
 } from "./assertions.js";
 export {
   TestProcess,


### PR DESCRIPTION
## Summary

Ports `ActionDispatch::Assertions::RoutingAssertions` from
`vendor/rails/actionpack/lib/action_dispatch/testing/assertions/routing.rb`
1:1 as `this`-typed functions, per the CLAUDE.md mixin pattern.

Public:
- `assertRecognizes(expected, path, extras?, msg?)`
- `assertGenerates(expectedPath, options, defaults?, extras?, msg?)`
- `assertRouting(path, options, defaults?, extras?, msg?)`
- `withRouting(configOrBlock, block?)`
- `setup()`

Private (internal):
- `recognizedRequestFor`, `createRoutes`, `resetRoutes`, `failOn`

Prereqs added:
- `RouteSet#recognizePath(path, { method, extras })` — wraps the
  Journey-backed `recognize()` and returns
  `{ controller, action, ...params, ...extras }`.
- `RouteSet#generateExtras(options, defaults)` — picks the first route
  whose `controller`/`action` match and returns `[path, extraKeys]`.
- `Request#pathParameters` setter (was getter-only).

## Parity

- `pnpm api:compare` — `testing/assertions/routing.rb` 9/9 = 100% ✓
  (actiondispatch +5, 555 → 560)
- `pnpm test:compare` — unchanged (no test count regression)

## Out of scope (no equivalent infrastructure in trails yet)

- Class-level `with_routing` (Minitest `setup`/`teardown` not ported).
- `WithIntegrationRouting` module (depends on integration-session cloning
  and `app.routes.singleton_class.redefine_method`).
- `method_missing` named-route forwarding — no TS equivalent, already on
  the shared api:compare skip list.
- URL-form (`scheme://host/path`) path arguments to `assertRecognizes`/
  `assertGenerates` — the path-only branch is fully wired; the URL
  branch is a follow-up.
- Indifferent-access wrapper on the recognized `pathParameters` hash
  (current shape uses plain string-keyed objects).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts` (8/8)
- [x] `pnpm --filter @blazetrails/actionpack build`
- [x] `pnpm api:compare` — routing.rb 100%
- [x] `pnpm test:compare` — no regression