### PR TITLE
feat(actionpack): port ActionDispatch::Http mime_types.rb

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/mime-type.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-type.ts
@@ -2,6 +2,8 @@
  * Mime::Type — MIME type registry and parsing.
  */
 
+import { registerDefaultMimeTypes } from "./mime-types.js";
+
 export class MimeType {
   /** @internal */
   readonly string: string;
@@ -57,7 +59,9 @@ export class MimeType {
     for (const syn of synonyms) {
       MimeType.registry.set(syn, type);
     }
-    for (const ext of extensions) {
+    // Rails registers `[symbol.to_s] + extension_synonyms` into
+    // EXTENSION_LOOKUP, so the symbol itself is always a valid extension key.
+    for (const ext of [symbol, ...extensions]) {
       MimeType.extensionMap.set(ext, type);
     }
     for (const cb of MimeType.callbacks) {
@@ -155,61 +159,88 @@ export class MimeType {
   }
 
   // --- Built-in types ---
+  //
+  // Default registrations live in `./mime-types.ts` (Rails: `mime_types.rb`).
+  // The constants below resolve through the registry, so each access returns
+  // the singleton registered by that file.
 
-  static readonly HTML = MimeType.register(
-    "text/html",
-    "html",
-    ["application/xhtml+xml"],
-    ["html", "htm"],
-  );
-  static readonly TEXT = MimeType.register("text/plain", "text", [], ["txt"]);
-  static readonly JS = MimeType.register(
-    "text/javascript",
-    "js",
-    ["application/javascript"],
-    ["js"],
-  );
-  static readonly CSS = MimeType.register("text/css", "css", [], ["css"]);
-  static readonly ICS = MimeType.register("text/calendar", "ics", [], ["ics"]);
-  static readonly CSV = MimeType.register("text/csv", "csv", [], ["csv"]);
-  static readonly VCF = MimeType.register("text/vcard", "vcf", [], ["vcf"]);
-
-  static readonly PNG = MimeType.register("image/png", "png", [], ["png"]);
-  static readonly GIF = MimeType.register("image/gif", "gif", [], ["gif"]);
-  static readonly BMP = MimeType.register("image/bmp", "bmp", [], ["bmp"]);
-  static readonly TIFF = MimeType.register("image/tiff", "tiff", [], ["tif", "tiff"]);
-  static readonly SVG = MimeType.register("image/svg+xml", "svg", [], ["svg"]);
-  static readonly WEBP = MimeType.register("image/webp", "webp", [], ["webp"]);
-
-  static readonly MPEG = MimeType.register("video/mpeg", "mpeg", [], ["mpeg", "mpg"]);
-
-  static readonly XML = MimeType.register("application/xml", "xml", ["text/xml"], ["xml"]);
-  static readonly RSS = MimeType.register("application/rss+xml", "rss", [], ["rss"]);
-  static readonly ATOM = MimeType.register("application/atom+xml", "atom", [], ["atom"]);
-  static readonly YAML = MimeType.register(
-    "application/x-yaml",
-    "yaml",
-    ["text/yaml"],
-    ["yml", "yaml"],
-  );
-
-  static readonly MULTIPART_FORM = MimeType.register(
-    "multipart/form-data",
-    "multipart_form",
-    [],
-    [],
-  );
-  static readonly URL_ENCODED_FORM = MimeType.register(
-    "application/x-www-form-urlencoded",
-    "url_encoded_form",
-    [],
-    [],
-  );
-
-  static readonly JSON = MimeType.register("application/json", "json", ["text/x-json"], ["json"]);
-  static readonly PDF = MimeType.register("application/pdf", "pdf", [], ["pdf"]);
-  static readonly ZIP = MimeType.register("application/zip", "zip", [], ["zip"]);
-  static readonly GZIP = MimeType.register("application/gzip", "gzip", [], ["gz"]);
+  static get HTML(): MimeType {
+    return MimeType.lookup("html")!;
+  }
+  static get TEXT(): MimeType {
+    return MimeType.lookup("text")!;
+  }
+  static get JS(): MimeType {
+    return MimeType.lookup("js")!;
+  }
+  static get CSS(): MimeType {
+    return MimeType.lookup("css")!;
+  }
+  static get ICS(): MimeType {
+    return MimeType.lookup("ics")!;
+  }
+  static get CSV(): MimeType {
+    return MimeType.lookup("csv")!;
+  }
+  static get VCF(): MimeType {
+    return MimeType.lookup("vcf")!;
+  }
+  static get PNG(): MimeType {
+    return MimeType.lookup("png")!;
+  }
+  static get JPEG(): MimeType {
+    return MimeType.lookup("jpeg")!;
+  }
+  static get GIF(): MimeType {
+    return MimeType.lookup("gif")!;
+  }
+  static get BMP(): MimeType {
+    return MimeType.lookup("bmp")!;
+  }
+  static get TIFF(): MimeType {
+    return MimeType.lookup("tiff")!;
+  }
+  static get SVG(): MimeType {
+    return MimeType.lookup("svg")!;
+  }
+  static get WEBP(): MimeType {
+    return MimeType.lookup("webp")!;
+  }
+  static get MPEG(): MimeType {
+    return MimeType.lookup("mpeg")!;
+  }
+  static get XML(): MimeType {
+    return MimeType.lookup("xml")!;
+  }
+  static get RSS(): MimeType {
+    return MimeType.lookup("rss")!;
+  }
+  static get ATOM(): MimeType {
+    return MimeType.lookup("atom")!;
+  }
+  static get YAML(): MimeType {
+    return MimeType.lookup("yaml")!;
+  }
+  static get MULTIPART_FORM(): MimeType {
+    return MimeType.lookup("multipart_form")!;
+  }
+  static get URL_ENCODED_FORM(): MimeType {
+    return MimeType.lookup("url_encoded_form")!;
+  }
+  static get JSON(): MimeType {
+    return MimeType.lookup("json")!;
+  }
+  static get PDF(): MimeType {
+    return MimeType.lookup("pdf")!;
+  }
+  static get ZIP(): MimeType {
+    return MimeType.lookup("zip")!;
+  }
+  static get GZIP(): MimeType {
+    return MimeType.lookup("gzip")!;
+  }
 
   static readonly ALL = new MimeType("*/*", "all");
 }
+
+registerDefaultMimeTypes(MimeType);

--- a/packages/actionpack/src/action-dispatch/http/mime-types.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-types.ts
@@ -1,0 +1,69 @@
+// Build list of Mime types for HTTP responses
+// https://www.iana.org/assignments/media-types/
+//
+// Mirrors `actionpack/lib/action_dispatch/http/mime_types.rb`. The Ruby file
+// runs `Mime::Type.register` at load time; here we expose the same data as a
+// function so `mime-type.ts` can invoke it after defining the class (avoids
+// a circular import).
+
+interface MimeTypeRegistrar {
+  register(string: string, symbol: string, synonyms?: string[], extensions?: string[]): unknown;
+}
+
+/** @internal */
+export function registerDefaultMimeTypes(MimeType: MimeTypeRegistrar): void {
+  MimeType.register("text/html", "html", ["application/xhtml+xml"], ["xhtml"]);
+  MimeType.register("text/plain", "text", [], ["txt"]);
+  MimeType.register("text/javascript", "js", [
+    "application/javascript",
+    "application/x-javascript",
+  ]);
+  MimeType.register("text/css", "css");
+  MimeType.register("text/calendar", "ics");
+  MimeType.register("text/csv", "csv");
+  MimeType.register("text/vcard", "vcf");
+  MimeType.register("text/vtt", "vtt", [], ["vtt"]);
+
+  MimeType.register("image/png", "png", [], ["png"]);
+  MimeType.register("image/jpeg", "jpeg", [], ["jpg", "jpeg", "jpe", "pjpeg"]);
+  MimeType.register("image/gif", "gif", [], ["gif"]);
+  MimeType.register("image/bmp", "bmp", [], ["bmp"]);
+  MimeType.register("image/tiff", "tiff", [], ["tif", "tiff"]);
+  MimeType.register("image/svg+xml", "svg");
+  MimeType.register("image/webp", "webp", [], ["webp"]);
+
+  MimeType.register("video/mpeg", "mpeg", [], ["mpg", "mpeg", "mpe"]);
+
+  MimeType.register("audio/mpeg", "mp3", [], ["mp1", "mp2", "mp3"]);
+  MimeType.register("audio/ogg", "ogg", [], ["oga", "ogg", "spx", "opus"]);
+  MimeType.register("audio/aac", "m4a", ["audio/mp4"], ["m4a", "mpg4", "aac"]);
+
+  MimeType.register("video/webm", "webm", [], ["webm"]);
+  MimeType.register("video/mp4", "mp4", [], ["mp4", "m4v"]);
+
+  MimeType.register("font/otf", "otf", [], ["otf"]);
+  MimeType.register("font/ttf", "ttf", [], ["ttf"]);
+  MimeType.register("font/woff", "woff", [], ["woff"]);
+  MimeType.register("font/woff2", "woff2", [], ["woff2"]);
+
+  MimeType.register("application/xml", "xml", ["text/xml", "application/x-xml"]);
+  MimeType.register("application/rss+xml", "rss");
+  MimeType.register("application/atom+xml", "atom");
+  MimeType.register("application/x-yaml", "yaml", ["text/yaml"], ["yml", "yaml"]);
+
+  MimeType.register("multipart/form-data", "multipart_form");
+  MimeType.register("application/x-www-form-urlencoded", "url_encoded_form");
+
+  // https://www.ietf.org/rfc/rfc4627.txt
+  // http://www.json.org/JSONRequest.html
+  // https://www.ietf.org/rfc/rfc7807.txt
+  MimeType.register("application/json", "json", [
+    "text/x-json",
+    "application/jsonrequest",
+    "application/problem+json",
+  ]);
+
+  MimeType.register("application/pdf", "pdf", [], ["pdf"]);
+  MimeType.register("application/zip", "zip", [], ["zip"]);
+  MimeType.register("application/gzip", "gzip", ["application/x-gzip"], ["gz"]);
+}

--- a/packages/actionpack/src/action-dispatch/http/mime-types.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-types.ts
@@ -22,7 +22,8 @@ export function registerDefaultMimeTypes(MimeType: MimeTypeRegistrar): void {
   MimeType.register("text/calendar", "ics");
   MimeType.register("text/csv", "csv");
   MimeType.register("text/vcard", "vcf");
-  MimeType.register("text/vtt", "vtt", [], ["vtt"]);
+  // Rails passes %w(vtt) in the synonyms slot (not extensions); mirror 1:1.
+  MimeType.register("text/vtt", "vtt", ["vtt"]);
 
   MimeType.register("image/png", "png", [], ["png"]);
   MimeType.register("image/jpeg", "jpeg", [], ["jpg", "jpeg", "jpe", "pjpeg"]);


### PR DESCRIPTION
## Summary

- Ports `actionpack/lib/action_dispatch/http/mime_types.rb` 1:1 into a new `packages/actionpack/src/action-dispatch/http/mime-types.ts`. The Rails file is pure side-effect registration data; here it's a `registerDefaultMimeTypes(MimeType)` function invoked from `mime-type.ts` after the class is defined (avoids the circular-import trap of a bottom-of-file side-effect `import`).
- Replaces the inline `static readonly HTML = MimeType.register(...)` block on `MimeType` with getters that resolve through the registry, so all defaults now flow through `mime-types.ts`. Adds the audio/video/font/etc. types Rails ships that we were missing (`jpeg`, `mp3`, `ogg`, `m4a`, `mp4`, `webm`, `otf`, `ttf`, `woff`, `woff2`, `vtt`) plus extra JSON/XML synonyms (`application/jsonrequest`, `application/problem+json`, `application/x-xml`, `application/x-javascript`).
- `MimeType.register` now mirrors Rails' `EXTENSION_LOOKUP` rule of `[symbol.to_s] + extension_synonyms` — the symbol itself is always a valid extension key, so `lookupByExtension("html"|"json"|"xml"|...)` keeps working without explicit `extensions` args in registrations.

## Test plan

- [x] `pnpm vitest run` for `dispatch/mime-type.test.ts`, `abstract-controller/collector.test.ts`, `action-dispatch/http/parameters.test.ts` — all 66 pass.
- [x] `pnpm lint` — clean.
- [x] `pnpm test:types` — clean.