### PR TITLE
feat(activerecord): align HABTM primary_key + through-table aliasing

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1570,9 +1570,19 @@ function singleFk(fk: string | string[] | undefined, fallback: string): string {
   return fk ?? fallback;
 }
 
-/** Resolve the owner primary key column for HABTM, respecting options.primaryKey. */
-function habtmOwnerPk(options: AssociationOptions, ctor: typeof Base): string {
-  const pk = options.primaryKey ?? ctor.primaryKey;
+/**
+ * Resolve the owner primary key column for HABTM.
+ *
+ * Rails' `Builder::HasAndBelongsToMany` does not forward `:primary_key`
+ * to the generated middle `has_many :through` or to the rhs `belongs_to`
+ * (see `middle_options` / `belongs_to_options` —
+ * activerecord/lib/active_record/associations/builder/has_and_belongs_to_many.rb).
+ * The owner-side join always resolves to the model's primary key.
+ *
+ * @internal
+ */
+function habtmOwnerPk(_options: AssociationOptions, ctor: typeof Base): string {
+  const pk = ctor.primaryKey;
   if (Array.isArray(pk)) {
     throw new ConfigurationError("HABTM associations do not support composite primary keys");
   }

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -257,11 +257,15 @@ export class HasAndBelongsToMany {
     // Rails' `hm_options` allowlist for the generated `has_many :through`
     // is the canonical set: before/after_add/remove, autosave, validate,
     // join_table, class_name, extend, strict_loading (associations.rb:1899).
-    // We additionally retain `foreignKey`/`primaryKey` because our public
-    // HABTM reflection plays the dual role Rails splits between
+    // We additionally retain `foreignKey` because our public HABTM
+    // reflection plays the dual role Rails splits between
     // `habtm_reflection` (which keeps the full options) and the generated
     // through-`has_many` — join-key resolution (`_resolveHabtmJoin`,
-    // `loadHabtm`) reads these directly off the public reflection.
+    // `loadHabtm`) reads this directly off the public reflection.
+    // `primaryKey` is intentionally NOT forwarded: Rails'
+    // `Builder::HasAndBelongsToMany` does not pass `:primary_key` to the
+    // middle has_many or rhs belongs_to, so the owner join always uses
+    // the model's primary key.
     // Spreading `...options` previously leaked `readonly`/`dependent`
     // into through-hasMany semantics — Rails drops those. `inverseOf` IS
     // retained because Rails' `habtm_reflection` is constructed with the
@@ -278,7 +282,6 @@ export class HasAndBelongsToMany {
       "extend",
       "strictLoading",
       "foreignKey",
-      "primaryKey",
       "inverseOf",
       "indexErrors",
       "associationForeignKey",

--- a/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
@@ -1,0 +1,83 @@
+/**
+ * Covers the real-table-name reuse in JoinDependency#_addThroughAssociation.
+ *
+ * Mirrors AliasTracker behavior (`activerecord/lib/active_record/table_metadata.rb`
+ * / `alias_tracker.rb`): a joined table uses its real name when not already
+ * in use, falling back to a tN alias only on collision. Previously
+ * `_addThroughAssociation` hard-coded `tN` aliases for both the through
+ * and target tables regardless of collisions, diverging from the
+ * single-step `addAssociation` path.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { Base, registerModel } from "../index.js";
+import { createTestAdapter } from "../test-adapter.js";
+import { Associations } from "../associations.js";
+import { JoinDependency } from "./join-dependency.js";
+
+describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
+  class JdtAuthor extends Base {
+    static {
+      this.attribute("name", "string");
+    }
+  }
+  class JdtPost extends Base {
+    static {
+      this.attribute("author_id", "integer");
+      this.attribute("title", "string");
+    }
+  }
+  class JdtComment extends Base {
+    static {
+      this.attribute("post_id", "integer");
+      this.attribute("body", "string");
+    }
+  }
+
+  beforeEach(() => {
+    const adapter = createTestAdapter();
+    for (const m of [JdtAuthor, JdtPost, JdtComment]) {
+      m.adapter = adapter;
+      (m as any)._associations = [];
+      registerModel(m);
+    }
+    Associations.hasMany.call(JdtAuthor, "jdtPosts", {
+      className: "JdtPost",
+      foreignKey: "author_id",
+    });
+    Associations.hasMany.call(JdtPost, "jdtComments", {
+      className: "JdtComment",
+      foreignKey: "post_id",
+    });
+    Associations.hasMany.call(JdtAuthor, "jdtComments", {
+      through: "jdtPosts",
+      source: "jdtComments",
+      className: "JdtComment",
+    });
+  });
+
+  it("uses real table names for through+target when no collision", () => {
+    const jd = new JoinDependency(JdtAuthor);
+    const node = jd.addAssociation("jdtComments");
+    expect(node).not.toBeNull();
+    // Through table joined by real name (jdt_posts), not t1
+    expect(node!.joinSql).toContain(`LEFT OUTER JOIN "jdt_posts"`);
+    expect(node!.joinSql).not.toContain(`"jdt_posts" "t`);
+    // Target table joined by real name (jdt_comments)
+    expect(node!.joinSql).toContain(`LEFT OUTER JOIN "jdt_comments"`);
+    expect(node!.joinSql).not.toContain(`"jdt_comments" "t`);
+    expect(node!.effectiveSqlName).toBe("jdt_comments");
+  });
+
+  it("falls back to tN alias when the real name collides", () => {
+    const jd = new JoinDependency(JdtAuthor);
+    // First, occupy "jdt_posts" via the direct join so the through table collides.
+    jd.addAssociation("jdtPosts");
+    const node = jd.addAssociation("jdtComments");
+    expect(node).not.toBeNull();
+    // Through table now aliased to tN because jdt_posts already used.
+    expect(node!.joinSql).toMatch(/LEFT OUTER JOIN "jdt_posts" "t\d+"/);
+    // Target still uses real name (first use).
+    expect(node!.joinSql).toContain(`LEFT OUTER JOIN "jdt_comments"`);
+    expect(node!.joinSql).not.toContain(`"jdt_comments" "t`);
+  });
+});

--- a/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-through-aliasing.test.ts
@@ -68,6 +68,22 @@ describe("JoinDependency#_addThroughAssociation real-table-name reuse", () => {
     expect(node!.effectiveSqlName).toBe("jdt_comments");
   });
 
+  it("falls back to tN alias when the target real name collides", () => {
+    const jd = new JoinDependency(JdtAuthor);
+    // Pre-occupy "jdt_comments" via a sibling direct hasMany on the author.
+    Associations.hasMany.call(JdtAuthor, "directComments", {
+      className: "JdtComment",
+      foreignKey: "post_id",
+    });
+    jd.addAssociation("directComments");
+    const node = jd.addAssociation("jdtComments");
+    expect(node).not.toBeNull();
+    // Through table still uses real name; target now aliased to tN.
+    expect(node!.joinSql).toContain(`LEFT OUTER JOIN "jdt_posts"`);
+    expect(node!.joinSql).toMatch(/LEFT OUTER JOIN "jdt_comments" "t\d+"/);
+    expect(node!.effectiveSqlName).toMatch(/^t\d+$/);
+  });
+
   it("falls back to tN alias when the real name collides", () => {
     const jd = new JoinDependency(JdtAuthor);
     // First, occupy "jdt_posts" via the direct join so the through table collides.

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -648,9 +648,10 @@ export class JoinDependency {
 
     // Mirror addAssociation collision-check (Rails AliasTracker): use the
     // real table name unless it's already in use, in which case fall back
-    // to the sequential tN alias.
+    // to the sequential tN alias. The mutation of `_usedTableNames` is
+    // deferred to the commit points below so failure paths don't pollute
+    // the set with tables we never actually joined.
     const throughEffective = this._usedTableNames.has(throughTable) ? throughAlias : throughTable;
-    this._usedTableNames.add(throughTable);
 
     let throughJoinOn = `"${throughEffective}"."${throughFk}" = "${sourceAlias}"."${sourcePk}"`;
     if (throughAssocDef.options.as) {
@@ -698,6 +699,11 @@ export class JoinDependency {
         });
       }
 
+      // Commit-point: the through-node push below is the first
+      // observable side-effect that depends on the alias decision.
+      const throughTableWasNew = !this._usedTableNames.has(throughTable);
+      this._usedTableNames.add(throughTable);
+
       const throughNodeName = parentAssocName
         ? `${parentAssocName}._through_${assocDef.options.through}`
         : `_through_${assocDef.options.through}`;
@@ -727,6 +733,7 @@ export class JoinDependency {
         this._nodes.length = snapshotNodes;
         this._aliases.length = snapshotAliases;
         this._nextTableIndex = snapshotNextIndex;
+        if (throughTableWasNew) this._usedTableNames.delete(throughTable);
         return null;
       }
 
@@ -779,8 +786,9 @@ export class JoinDependency {
     }
 
     // Mirror addAssociation collision-check for the target table too.
+    // Read-only here; the commit-point below pushes the resolved name
+    // into `_usedTableNames` after all failure guards have passed.
     const targetEffective = this._usedTableNames.has(targetTable) ? targetAlias : targetTable;
-    this._usedTableNames.add(targetTable);
     targetJoinOn = targetJoinOn.replaceAll("TARGET_PLACEHOLDER", targetEffective);
 
     // Apply association scope
@@ -802,6 +810,12 @@ export class JoinDependency {
     // Guard against composite PK on target
     const targetModelPk = (targetModel as any).primaryKey ?? "id";
     if (Array.isArray(targetModelPk)) return null;
+
+    // Commit-point for the non-recursive path: all failure guards have
+    // passed, so register both joined tables for AliasTracker collision
+    // checks by later joins.
+    this._usedTableNames.add(throughTable);
+    this._usedTableNames.add(targetTable);
 
     const targetColumns = getModelColumns(targetModel);
 

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -646,12 +646,22 @@ export class JoinDependency {
       : (throughAssocDef.options.foreignKey ?? `${_toUnderscore(modelClass.name)}_id`);
     if (Array.isArray(throughFk)) return null;
 
-    let throughJoinOn = `"${throughAlias}"."${throughFk}" = "${sourceAlias}"."${sourcePk}"`;
+    // Mirror addAssociation collision-check (Rails AliasTracker): use the
+    // real table name unless it's already in use, in which case fall back
+    // to the sequential tN alias.
+    const throughEffective = this._usedTableNames.has(throughTable) ? throughAlias : throughTable;
+    this._usedTableNames.add(throughTable);
+
+    let throughJoinOn = `"${throughEffective}"."${throughFk}" = "${sourceAlias}"."${sourcePk}"`;
     if (throughAssocDef.options.as) {
       const typeCol = `${_toUnderscore(throughAssocDef.options.as)}_type`;
-      throughJoinOn += ` AND "${throughAlias}"."${typeCol}" = '${modelClass.name}'`;
+      throughJoinOn += ` AND "${throughEffective}"."${typeCol}" = '${modelClass.name}'`;
     }
-    const throughJoinSql = `LEFT OUTER JOIN "${throughTable}" "${throughAlias}" ON ${throughJoinOn}`;
+    const throughJoinTableExpr =
+      throughEffective === throughTable
+        ? `"${throughTable}"`
+        : `"${throughTable}" "${throughEffective}"`;
+    const throughJoinSql = `LEFT OUTER JOIN ${throughJoinTableExpr} ON ${throughJoinOn}`;
 
     const sourceName = assocDef.options.source ?? _singularize(assocDef.name);
     const throughAssocs: any[] = (throughModel as any)._associations ?? [];
@@ -695,7 +705,7 @@ export class JoinDependency {
         tableIndex: throughTableIndex,
         tableAlias: throughAlias,
         tableName: throughTable,
-        effectiveSqlName: throughAlias,
+        effectiveSqlName: throughEffective,
         modelClass: throughModel as typeof Base,
         columns: throughColumns,
         assocName: throughNodeName,
@@ -708,7 +718,7 @@ export class JoinDependency {
       // Now recursively add the source association from the through model
       const recursiveNode = this.addAssociation(sourceName, {
         fromModel: throughModel,
-        fromAlias: throughAlias,
+        fromAlias: throughEffective,
         parentAssocName: parentAssocName,
       });
 
@@ -747,13 +757,13 @@ export class JoinDependency {
       targetTable = (targetModel as any).tableName;
       const targetPk = sourceAssocDef.options.primaryKey ?? (targetModel as any).primaryKey ?? "id";
       if (Array.isArray(targetPk)) return null;
-      targetJoinOn = `"${targetAlias}"."${targetPk}" = "${throughAlias}"."${targetFk}"`;
+      targetJoinOn = `"TARGET_PLACEHOLDER"."${targetPk}" = "${throughEffective}"."${targetFk}"`;
       if (isPoly) {
         // Mirrors Rails ThroughReflection / BelongsToReflection: the
         // polymorphic type column is `foreign_type` (options[:foreign_type]
         // || "#{name}_type"), and the value is the literal :source_type.
         const typeCol = sourceAssocDef.options.foreignType ?? `${_toUnderscore(sourceName)}_type`;
-        targetJoinOn += ` AND "${throughAlias}"."${typeCol}" = ${this._quoteString(String(assocDef.options.sourceType))}`;
+        targetJoinOn += ` AND "${throughEffective}"."${typeCol}" = ${this._quoteString(String(assocDef.options.sourceType))}`;
       }
     } else {
       const className = sourceAssocDef?.options?.className ?? _camelize(_singularize(sourceName));
@@ -765,8 +775,13 @@ export class JoinDependency {
       if (Array.isArray(targetFk)) return null;
       const throughPk = (throughModel as any).primaryKey ?? "id";
       if (Array.isArray(throughPk)) return null;
-      targetJoinOn = `"${targetAlias}"."${targetFk}" = "${throughAlias}"."${throughPk}"`;
+      targetJoinOn = `"TARGET_PLACEHOLDER"."${targetFk}" = "${throughEffective}"."${throughPk}"`;
     }
+
+    // Mirror addAssociation collision-check for the target table too.
+    const targetEffective = this._usedTableNames.has(targetTable) ? targetAlias : targetTable;
+    this._usedTableNames.add(targetTable);
+    targetJoinOn = targetJoinOn.replaceAll("TARGET_PLACEHOLDER", targetEffective);
 
     // Apply association scope
     if (assocDef.options.scope && typeof assocDef.options.scope === "function") {
@@ -775,14 +790,14 @@ export class JoinDependency {
       if (scopeSql) {
         const whereMatch = scopeSql.match(/\bWHERE\s+(.+?)(?:\s+ORDER|\s+LIMIT|\s*$)/i);
         if (whereMatch) {
-          const scopeWhere = whereMatch[1].replaceAll(`"${targetTable}"`, `"${targetAlias}"`);
+          const scopeWhere = whereMatch[1].replaceAll(`"${targetTable}"`, `"${targetEffective}"`);
           targetJoinOn += ` AND ${scopeWhere}`;
         }
       }
     }
 
     // Add STI type constraint on target
-    targetJoinOn = this._addStiConstraint(targetJoinOn, targetModel, targetAlias);
+    targetJoinOn = this._addStiConstraint(targetJoinOn, targetModel, targetEffective);
 
     // Guard against composite PK on target
     const targetModelPk = (targetModel as any).primaryKey ?? "id";
@@ -801,10 +816,14 @@ export class JoinDependency {
 
     const fullAssocName = parentAssocName ? `${parentAssocName}.${assocDef.name}` : assocDef.name;
 
+    const targetJoinTableExpr =
+      targetEffective === targetTable
+        ? `"${targetTable}"`
+        : `"${targetTable}" "${targetEffective}"`;
     const node: JoinNode = {
       tableIndex: targetTableIndex,
       tableAlias: targetAlias,
-      effectiveSqlName: targetAlias,
+      effectiveSqlName: targetEffective,
       tableName: targetTable,
       modelClass: targetModel,
       columns: targetColumns,
@@ -812,7 +831,7 @@ export class JoinDependency {
       immediateAssocName: assocDef.name,
       parentPath: parentAssocName ?? null,
       assocType: assocDef.type === "hasAndBelongsToMany" ? "hasMany" : assocDef.type,
-      joinSql: `${throughJoinSql} LEFT OUTER JOIN "${targetTable}" "${targetAlias}" ON ${targetJoinOn}`,
+      joinSql: `${throughJoinSql} LEFT OUTER JOIN ${targetJoinTableExpr} ON ${targetJoinOn}`,
     };
 
     this._nodes.push(node);

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -683,10 +683,15 @@ export class JoinDependency {
       // We already consumed a table index for the target, give it back
       this._nextTableIndex--;
 
-      // Snapshot state for rollback if recursive call fails
+      // Snapshot state for rollback if recursive call fails. Includes a
+      // copy of `_usedTableNames` because the recursive `addAssociation`
+      // (and any nested `_addThroughAssociation`) can mutate it before
+      // returning null on its own failure guards (e.g. composite-PK on
+      // a deeper target).
       const snapshotNodes = this._nodes.length;
       const snapshotAliases = this._aliases.length;
       const snapshotNextIndex = this._nextTableIndex;
+      const snapshotUsedTableNames = new Set(this._usedTableNames);
 
       // Add the through table JOIN as a standalone node (intermediate)
       const throughColumns = getModelColumns(throughModel);
@@ -701,7 +706,7 @@ export class JoinDependency {
 
       // Commit-point: the through-node push below is the first
       // observable side-effect that depends on the alias decision.
-      const throughTableWasNew = !this._usedTableNames.has(throughTable);
+      // The pre-recursion snapshot above covers rollback of this add.
       this._usedTableNames.add(throughTable);
 
       const throughNodeName = parentAssocName
@@ -729,11 +734,14 @@ export class JoinDependency {
       });
 
       if (!recursiveNode) {
-        // Roll back intermediate state
+        // Roll back intermediate state. Restore `_usedTableNames` from
+        // the pre-recursion snapshot so any mutation by the recursive
+        // call (including its own through additions) is undone — the
+        // `throughTableWasNew` delete alone wouldn't cover that.
         this._nodes.length = snapshotNodes;
         this._aliases.length = snapshotAliases;
         this._nextTableIndex = snapshotNextIndex;
-        if (throughTableWasNew) this._usedTableNames.delete(throughTable);
+        this._usedTableNames = snapshotUsedTableNames;
         return null;
       }
 

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -656,7 +656,7 @@ export class JoinDependency {
     let throughJoinOn = `"${throughEffective}"."${throughFk}" = "${sourceAlias}"."${sourcePk}"`;
     if (throughAssocDef.options.as) {
       const typeCol = `${_toUnderscore(throughAssocDef.options.as)}_type`;
-      throughJoinOn += ` AND "${throughEffective}"."${typeCol}" = '${modelClass.name}'`;
+      throughJoinOn += ` AND "${throughEffective}"."${typeCol}" = ${this._quoteString(String(modelClass.name))}`;
     }
     const throughJoinTableExpr =
       throughEffective === throughTable
@@ -788,7 +788,11 @@ export class JoinDependency {
     // Mirror addAssociation collision-check for the target table too.
     // Read-only here; the commit-point below pushes the resolved name
     // into `_usedTableNames` after all failure guards have passed.
-    const targetEffective = this._usedTableNames.has(targetTable) ? targetAlias : targetTable;
+    // Treat the pending through-table join as already occupying its name
+    // so a self-through (target table == through table) is forced to a
+    // tN alias rather than colliding on the same unaliased identifier.
+    const targetCollides = this._usedTableNames.has(targetTable) || targetTable === throughTable;
+    const targetEffective = targetCollides ? targetAlias : targetTable;
     targetJoinOn = targetJoinOn.replaceAll("TARGET_PLACEHOLDER", targetEffective);
 
     // Apply association scope

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1573,7 +1573,10 @@ export class Relation<T extends Base> {
     modelClass: any,
     assocDef: any,
   ): Array<{ table: string; on: string }> | null {
-    const sourcePkOption = assocDef.options.primaryKey ?? modelClass.primaryKey ?? "id";
+    // Rails' HABTM macro does not forward `:primary_key` to the generated
+    // through-`has_many` (Builder::HasAndBelongsToMany#middle_options); the
+    // owner-side join always resolves to the model's primary key.
+    const sourcePkOption = modelClass.primaryKey ?? "id";
     if (Array.isArray(sourcePkOption)) return null;
     const sourcePk: string = sourcePkOption;
     const sourceTable = modelClass.tableName;


### PR DESCRIPTION
## Summary

Batch 35 — HABTM Slot F (items 1 & 2 of 3, per `docs/activerecord-100-plan.md:138`).

- **Drop HABTM `primaryKey` override.** Rails' `Builder::HasAndBelongsToMany` (`middle_options` / `belongs_to_options`) does not forward `:primary_key` to the generated middle has_many or rhs belongs_to; the owner-side join always resolves to the model's primary key. Removed from `HABTM_FORWARDED_KEYS`, `habtmOwnerPk`, and `_resolveHabtmJoin`.
- **Real-table-name reuse in `_addThroughAssociation`.** Mirror the AliasTracker-style collision check from `addAssociation` for both the through and target tables: use the real table name when not already in use, fall back to a `tN` alias only on collision. Closes the divergence between the single-step join path and the through path. Added `join-dependency-through-aliasing.test.ts`.

## Follow-ups

- Item 3 of Batch 35 — schema-qualified HABTM tables (`"schema.table"` → `"schema"."table"`) in `_addThroughAssociation` — deferred. `loadHabtm` / `_resolveHabtmJoin` already get this for free via Arel's `splitSchemaQualifiedName`; the join-dependency path needs a small helper. Tracked for next slot.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/{join-dependency-quoting,join-dependency-through-aliasing,has-and-belongs-to-many-associations,has-many-through-associations,nested-through-associations,eager,left-outer-join-association,inner-join-association}.test.ts`
- [x] `pnpm typecheck`