### PR TITLE
refactor(activerecord): abstract addIndex → buildCreateIndexDefinition

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -264,26 +264,13 @@ export class SchemaStatements {
     columns: string | string[],
     options: AddIndexOptions = {},
   ): Promise<void> {
-    const cols = Array.isArray(columns) ? columns : [columns];
-    const indexName = options.name ?? this.indexName(tableName, { column: cols });
-    this._validateIndexLength(tableName, indexName);
-    const indexDef = new IndexDefinition(tableName, indexName, options.unique ?? false, cols, {
-      where: options.where,
-      orders: options.order ?? {},
-      lengths: options.length ?? {},
-      opclasses: options.opclass ?? {},
-      using: options.using,
-      type: options.type,
-      comment: options.comment,
-      include: options.include,
-      nullsNotDistinct: options.nullsNotDistinct,
-    });
-    const createDef = new CreateIndexDefinition(
-      indexDef,
-      options.ifNotExists ?? false,
-      this.indexAlgorithm(options.algorithm),
+    const createIndex = await this.buildCreateIndexDefinition(
+      tableName,
+      columns,
+      options as Record<string, unknown>,
     );
-    await this.adapter.executeMutation(this.schemaCreation.accept(createDef));
+    if (!createIndex) return;
+    await this.adapter.executeMutation(this.schemaCreation.accept(createIndex));
   }
 
   async removeIndex(
@@ -1186,21 +1173,8 @@ export class SchemaStatements {
       [key: string]: unknown;
     } = {},
   ): CreateIndexDefinition {
-    const columnNames = Array.isArray(columnName) ? columnName : [columnName];
-    const indexName = options.name ?? this.indexName(tableName, { column: columnNames });
-    this._validateIndexLength(tableName, indexName);
-    const idx = new IndexDefinition(tableName, indexName, !!options.unique, columnNames, {
-      where: options.where as string | undefined,
-      orders: (options.order ?? {}) as Record<string, string>,
-      lengths: (options.length ?? {}) as Record<string, number>,
-      opclasses: (options.opclass ?? {}) as Record<string, string>,
-      type: options.type as string | undefined,
-      using: options.using as string | undefined,
-      include: options.include as string[] | undefined,
-      nullsNotDistinct: options.nullsNotDistinct as boolean | undefined,
-      comment: options.comment as string | undefined,
-    });
-    return new CreateIndexDefinition(idx, !!options.ifNotExists, options.algorithm);
+    const [idx, algorithm, ifNotExists] = this.addIndexOptions(tableName, columnName, options);
+    return new CreateIndexDefinition(idx, ifNotExists, algorithm);
   }
 
   async isIndexNameExists(tableName: string, indexName: string): Promise<boolean> {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -264,12 +264,11 @@ export class SchemaStatements {
     columns: string | string[],
     options: AddIndexOptions = {},
   ): Promise<void> {
-    const createIndex = await this.buildCreateIndexDefinition(
+    const createIndex = this.buildCreateIndexDefinition(
       tableName,
       columns,
       options as Record<string, unknown>,
     );
-    if (!createIndex) return;
     await this.adapter.executeMutation(this.schemaCreation.accept(createIndex));
   }
 


### PR DESCRIPTION
## Summary

Refactors `SchemaStatements#addIndex` to delegate to
`buildCreateIndexDefinition`, mirroring Rails' `AbstractAdapter#add_index`
(`abstract/schema_statements.rb:915`). `buildCreateIndexDefinition` in
turn delegates to `addIndexOptions` instead of reimplementing the index
definition / algorithm extraction inline.

Three near-duplicate option-shape pipelines (`addIndex`,
`buildCreateIndexDefinition`, `addIndexOptions`) collapse into one.

Behavior unchanged. Covered by existing migration / schema /
schema-introspection / invertible-migration suites.

Part of Batch 48 (MySQL active-schema Slot D).

## Batch 48 follow-ups

The plan section lists four items. This PR addresses the
`addIndex`/`buildCreateIndexDefinition` Rails-parity refactor (item 4).
Remaining items, deferred:

- **CommandRecorder#changeTable bulk inversion** — already supported
  end-to-end (`invertChangeTable` reverses captured `subCommands`;
  command-recorder tests cover this). The plan note appears stale.
- **MariaDB CI timestamps verification** — verification-only, not a code
  change.
- **Extract MySQL `buildCreateIndexDefinition` pre-flight helper** — the
  shared pipeline is now `addIndexOptions`; the only remaining
  MySQL-specific step is the `ifNotExists` short-circuit, which has a
  single consumer (`AbstractMysqlAdapter`). Skipping the helper avoids a
  one-call abstraction.

## Test plan

- [x] `pnpm build`
- [x] `pnpm vitest run packages/activerecord/src/migration.test.ts packages/activerecord/src/connection-adapters/abstract/ packages/activerecord/src/schema-introspection.test.ts packages/activerecord/src/invertible-migration.test.ts`
- [ ] CI green