### PR TITLE
feat(actionpack): port ActionDispatch::Session::CacheStore

### DIFF
--- a/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
@@ -24,6 +24,14 @@ export class SessionId {
   constructor(publicId: string) {
     this.publicId = publicId;
   }
+  /**
+   * Rails: `Rack::Session::SessionId#private_id`. SHA256 hex of the
+   * public id; used as the cache lookup key by `AbstractSecureStore`
+   * subclasses so the raw cookie value never reaches the cache backend.
+   */
+  get privateId(): string {
+    return getCrypto().createHash("sha256").update(this.publicId).digest("hex");
+  }
   toString(): string {
     return this.publicId;
   }

--- a/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/abstract-store.ts
@@ -21,6 +21,8 @@ import { Session as RequestSession } from "../../request/session.js";
 /** @internal Rails: `Rack::Session::SessionId`. Minimal value wrapper. */
 export class SessionId {
   publicId: string;
+  /** @internal Memoized to mirror Rails' `@private_id ||= ...`. */
+  private _privateId?: string;
   constructor(publicId: string) {
     this.publicId = publicId;
   }
@@ -30,7 +32,8 @@ export class SessionId {
    * subclasses so the raw cookie value never reaches the cache backend.
    */
   get privateId(): string {
-    return getCrypto().createHash("sha256").update(this.publicId).digest("hex");
+    this._privateId ??= getCrypto().createHash("sha256").update(this.publicId).digest("hex");
+    return this._privateId;
   }
   toString(): string {
     return this.publicId;

--- a/packages/actionpack/src/action-dispatch/middleware/session/cache-store.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/cache-store.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { MemoryStore } from "@blazetrails/activesupport";
+import { CacheStore } from "./cache-store.js";
+import { SessionId } from "./abstract-store.js";
+
+function makeStore(opts: { expireAfter?: number } = {}): {
+  store: CacheStore;
+  cache: MemoryStore;
+} {
+  const cache = new MemoryStore();
+  const store = new CacheStore(() => undefined, { cache, ...opts });
+  return { store, cache };
+}
+
+describe("ActionDispatch::Session::CacheStore", () => {
+  it("requires a cache option", () => {
+    expect(() => new CacheStore(() => undefined, {})).toThrow(/cache/);
+  });
+
+  describe("findSession", () => {
+    it("returns a new sid and empty hash when sid is null", () => {
+      const { store } = makeStore();
+      const [sid, session] = store.findSession({}, null);
+      expect(sid).toBeInstanceOf(SessionId);
+      expect(sid.publicId).toMatch(/^[0-9a-f]{32}$/);
+      expect(sid.privateId).toMatch(/^[0-9a-f]{64}$/);
+      expect(session).toEqual({});
+    });
+
+    it("returns the stored session when found by privateId", () => {
+      const { store, cache } = makeStore();
+      const sid = new SessionId("a".repeat(32));
+      cache.write(`_session_id:${sid.privateId}`, { user: 1 });
+      const [returned, session] = store.findSession({}, sid);
+      expect(returned).toBe(sid);
+      expect(session).toEqual({ user: 1 });
+    });
+
+    it("falls back to publicId lookup", () => {
+      const { store, cache } = makeStore();
+      const sid = new SessionId("b".repeat(32));
+      cache.write(`_session_id:${sid.publicId}`, { user: 2 });
+      const [, session] = store.findSession({}, sid);
+      expect(session).toEqual({ user: 2 });
+    });
+
+    it("returns new sid when stored session is missing", () => {
+      const { store } = makeStore();
+      const sid = new SessionId("c".repeat(32));
+      const [returned, session] = store.findSession({}, sid);
+      expect(returned).not.toBe(sid);
+      expect(session).toEqual({});
+    });
+  });
+
+  describe("writeSession", () => {
+    it("writes session under the privateId key", () => {
+      const { store, cache } = makeStore();
+      const sid = new SessionId("d".repeat(32));
+      store.writeSession({}, sid, { user: 3 }, { expireAfter: 60 });
+      expect(cache.read(`_session_id:${sid.privateId}`)).toEqual({ user: 3 });
+    });
+
+    it("deletes the cache entry when session is null", () => {
+      const { store, cache } = makeStore();
+      const sid = new SessionId("e".repeat(32));
+      cache.write(`_session_id:${sid.privateId}`, { user: 4 });
+      store.writeSession({}, sid, null, {});
+      expect(cache.read(`_session_id:${sid.privateId}`)).toBeNull();
+    });
+  });
+
+  describe("deleteSession", () => {
+    it("removes both privateId and publicId entries and returns a fresh sid", () => {
+      const { store, cache } = makeStore();
+      const sid = new SessionId("f".repeat(32));
+      cache.write(`_session_id:${sid.privateId}`, { user: 5 });
+      cache.write(`_session_id:${sid.publicId}`, { user: 5 });
+      const fresh = store.deleteSession({}, sid, {});
+      expect(cache.read(`_session_id:${sid.privateId}`)).toBeNull();
+      expect(cache.read(`_session_id:${sid.publicId}`)).toBeNull();
+      expect(fresh.publicId).not.toBe(sid.publicId);
+    });
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/session/cache-store.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/cache-store.ts
@@ -1,0 +1,117 @@
+/**
+ * ActionDispatch::Session::CacheStore
+ *
+ * Mirrors `vendor/rails/actionpack/lib/action_dispatch/middleware/session/cache_store.rb`.
+ *
+ * A session store that uses an `ActiveSupport::Cache::Store` to store the
+ * sessions. Most useful when sessions hold non-critical data and need not
+ * live for extended periods of time.
+ *
+ * Options:
+ * - `cache`        — the cache to use. If not specified, the framework
+ *   cache (Rails: `Rails.cache`) is used.
+ * - `expireAfter`  — the length of time (in seconds) a session is stored
+ *   before automatically expiring. Rails defaults this to the cache's
+ *   `expires_in`; the bundled `@blazetrails/activesupport` stores don't
+ *   yet expose their constructor options, so in practice this default
+ *   is dormant until those stores grow an `options` accessor.
+ */
+
+import type { CacheStore as CacheStoreLike } from "@blazetrails/activesupport";
+import { AbstractSecureStore, SessionId } from "./abstract-store.js";
+
+export interface CacheStoreSessionOptions {
+  cache?: CacheStoreLike;
+  expireAfter?: number;
+  [key: string]: unknown;
+}
+
+/** Rails: `class CacheStore < AbstractSecureStore`. */
+export class CacheStore extends AbstractSecureStore {
+  /** @internal */
+  private readonly cache: CacheStoreLike;
+  /** @internal */
+  readonly options: CacheStoreSessionOptions;
+
+  constructor(app: unknown, options: CacheStoreSessionOptions = {}) {
+    super(app, options);
+    const cache = options.cache;
+    if (!cache) {
+      throw new Error(
+        "ActionDispatch::Session::CacheStore requires a `cache` option until Rails.cache is wired.",
+      );
+    }
+    this.cache = cache;
+    // Rails: `options[:expire_after] ||= @cache.options[:expires_in]`. The
+    // caller's options hash is mutated in place to match Rails semantics.
+    // Rails stores `expires_in` in seconds; @blazetrails/activesupport uses
+    // milliseconds, so convert when bridging.
+    const cacheExpiresInMs = (cache as { options?: { expiresIn?: number } }).options?.expiresIn;
+    if (options.expireAfter == null && cacheExpiresInMs != null) {
+      options.expireAfter = Math.floor(cacheExpiresInMs / 1000);
+    }
+    this.options = options;
+  }
+
+  /** Get a session from the cache. */
+  findSession(
+    _env: unknown,
+    sid: SessionId | null | undefined,
+  ): [SessionId, Record<string, unknown>] {
+    let session: Record<string, unknown> | undefined;
+    if (sid) {
+      session = this.getSessionWithFallback(sid);
+    }
+    if (!sid || !session) {
+      return [this.generateSid(), {}];
+    }
+    return [sid, session];
+  }
+
+  /** Set a session in the cache. */
+  writeSession(
+    _env: unknown,
+    sid: SessionId,
+    session: Record<string, unknown> | null,
+    options: { expireAfter?: number } = {},
+  ): SessionId {
+    const key = this.cacheKey(sid.privateId);
+    if (session) {
+      // Rails: `expires_in: options[:expire_after]` (seconds). The activesupport
+      // CacheStore takes milliseconds, so convert at the boundary.
+      const expiresIn = options.expireAfter != null ? options.expireAfter * 1000 : undefined;
+      this.cache.write(key, session, { expiresIn });
+    } else {
+      this.cache.delete(key);
+    }
+    return sid;
+  }
+
+  /** Remove a session from the cache. */
+  deleteSession(_env: unknown, sid: SessionId, _options: Record<string, unknown> = {}): SessionId {
+    this.cache.delete(this.cacheKey(sid.privateId));
+    this.cache.delete(this.cacheKey(sid.publicId));
+    return this.generateSid();
+  }
+
+  /**
+   * Turn the session id into a cache key.
+   * @internal
+   */
+  private cacheKey(id: string): string {
+    return `_session_id:${id}`;
+  }
+
+  /** @internal */
+  private getSessionWithFallback(sid: SessionId): Record<string, unknown> | undefined {
+    const fromPrivate = this.cache.read(this.cacheKey(sid.privateId));
+    if (fromPrivate) return fromPrivate as Record<string, unknown>;
+    const fromPublic = this.cache.read(this.cacheKey(sid.publicId));
+    return fromPublic ? (fromPublic as Record<string, unknown>) : undefined;
+  }
+
+  /** Narrowed return type. Rails: `AbstractSecureStore#generate_sid`. */
+  override generateSid(): SessionId {
+    return super.generateSid() as SessionId;
+  }
+}

--- a/packages/actionpack/src/action-dispatch/middleware/session/index.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/index.ts
@@ -16,3 +16,5 @@ export {
   PersistedSecure,
   SessionId,
 } from "./abstract-store.js";
+
+export { CacheStore, type CacheStoreSessionOptions } from "./cache-store.js";


### PR DESCRIPTION
## Summary

- Ports `vendor/rails/actionpack/lib/action_dispatch/middleware/session/cache_store.rb` to `packages/actionpack/src/action-dispatch/middleware/session/cache-store.ts`.
- `CacheStore` extends `AbstractSecureStore` (merged from slot `a`) and exposes the Rails `findSession` / `writeSession` / `deleteSession` surface, keyed by `SessionId.privateId` with `publicId` fallback (`get_session_with_fallback`).
- Adds a memoized `privateId` getter to `SessionId` (Rails' `Rack::Session::SessionId#private_id`, SHA256 hex of `publicId`) — the first `AbstractSecureStore` consumer that needed it.

## Notes

- `expireAfter` is in seconds (Rails parity) and converted to milliseconds at the `@blazetrails/activesupport` cache boundary.
- The constructor mutates the caller's `options` hash for the `expireAfter` default, mirroring Rails' `options[:expire_after] ||= ...` semantics.
- A `cache` option is required until `Rails.cache` is wired (no framework default available yet).

## Follow-ups

- Wire `Rails.cache` so the constructor can default `options.cache`.
- Expose `options` / `expiresIn` on the bundled activesupport cache stores so the dormant `@cache.options[:expires_in]` default in the constructor activates.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware/session/cache-store.test.ts` (8 tests)
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware/session/abstract-store.test.ts` (17 tests, unaffected by SessionId memoization)