### PR TITLE
test(activerecord): TM phase 5 — defineSchema for belongs-to-associations (4 small describes)

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 // -- Helpers --
@@ -22,8 +23,16 @@ function freshAdapter(): DatabaseAdapter {
 }
 
 describe("BelongsToWithForeignKeyTest", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string" },
+    });
+  });
+
   it("destroy linked models", async () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -40,8 +49,12 @@ describe("BelongsToWithForeignKeyTest", () => {
 describe("touch on belongs_to", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string", updated_at: "datetime" },
+      comments: { body: "string", post_id: "integer" },
+    });
   });
 
   it("touches parent updated_at when child is saved", async () => {
@@ -3740,8 +3753,12 @@ describe("BelongsToAssociationsTest", () => {
 
 describe("AsyncBelongsToAssociationsTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      albt_companies: { name: "string" },
+      albt_accounts: { company_id: "integer" },
+    });
   });
 
   it("async load belongs to", async () => {
@@ -3772,8 +3789,14 @@ describe("AsyncBelongsToAssociationsTest", () => {
 
 describe("BelongsToAssociationsTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      bt_companies: { name: "string" },
+      bt_accounts: { company_id: "integer", credit_limit: "integer" },
+      pk_firms: { name: "string", firm_name: "string" },
+      pk_clients: { firm_name: "string" },
+    });
   });
 
   it("belongs to", async () => {


### PR DESCRIPTION
## Summary

Migrates the four small describe blocks in
`packages/activerecord/src/associations/belongs-to-associations.test.ts`
to the per-describe `beforeEach` `defineSchema` pattern (the same shape
as `calculations.test.ts` / `inverse-associations.test.ts`), so the
file is no longer flagged by `scripts/audit-define-schema.ts`.

Covered describes:

- `BelongsToWithForeignKeyTest` (1 test) — `posts`
- `touch on belongs_to` (1 test) — `posts`, `comments`
- `AsyncBelongsToAssociationsTest` (1 test) — `albt_companies`, `albt_accounts`
- second `BelongsToAssociationsTest` (lines 3773–3847, 2 tests + 1 skip) —
  `bt_companies`, `bt_accounts`, `pk_firms`, `pk_clients`

The file's main `BelongsToAssociationsTest` describe at line 81 spans
~146 tests across dozens of unique tables and is too large for one
~300-LOC PR per `CLAUDE.md`. It is deferred to follow-up PRs.

## Verification

- `pnpm vitest run packages/activerecord/src/associations/belongs-to-associations.test.ts` —
  152 passed / 1 skipped (no regression in normal mode).
- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run ... -t 'destroy linked models|touches parent updated_at when child is saved|async load belongs to|belongs to with primary key'` —
  4 targeted tests pass (2 substring-collisions from the big describe still fail; covered by follow-ups).
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags this file.

## Test plan

- [x] Targeted small-describe tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] Full file passes in normal mode
- [x] No test names renamed
- [x] Audit script clean for this file
- [ ] CI green across PG / MySQL / SQLite

## Follow-ups

The line-81 `BelongsToAssociationsTest` describe (~146 tests, ~3660
LOC of source) needs migration in several incremental PRs — each test
inlines its own model classes with unique table names (Company,
BtcCompany, CcCompany, CustomCcCompany, Tag, etc.), so the schema set
is large. Split by adjacent test clusters per the
`inverse-associations` precedent (#1752 → #1839).