### PR TITLE
feat(actionpack): port ActionDispatch::ParamBuilder

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/index.ts
+++ b/packages/actionpack/src/action-dispatch/http/index.ts
@@ -10,6 +10,7 @@ export {
 } from "./permissions-policy.js";
 export { Headers } from "./headers.js";
 export { QueryParser, type QueryPair } from "./query-parser.js";
+export { ParamBuilder, type EncodingTemplate } from "./param-builder.js";
 export { URL, type UrlOptions } from "./url.js";
 export {
   PARAMETERS_KEY,

--- a/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
@@ -8,6 +8,11 @@ describe("ParamBuilder", () => {
   // This test doesn't need to duplicate all of that: it just
   // offers a simple baseline of unit tests.
 
+  const previous = ParamBuilder.ignoreLeadingBrackets;
+  afterEach(() => {
+    ParamBuilder.ignoreLeadingBrackets = previous;
+  });
+
   test("simple query string", () => {
     const result = ParamBuilder.fromQueryString("foo=bar&baz=quux");
     expect({ ...result }).toEqual({ foo: "bar", baz: "quux" });
@@ -28,13 +33,6 @@ describe("ParamBuilder", () => {
     expect({ ...result, "[foo]": { ...(result["[foo]"] as object) } }).toEqual({
       "[foo]": { bar: "baz" },
     });
-  });
-});
-
-describe("ParamBuilder.ignoreLeadingBrackets toggle", () => {
-  const previous = ParamBuilder.ignoreLeadingBrackets;
-  afterEach(() => {
-    ParamBuilder.ignoreLeadingBrackets = previous;
   });
 
   test("configured for strict brackets", () => {

--- a/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, test } from "vitest";
+import { InvalidParameterError } from "@blazetrails/rack";
 import { ParamBuilder } from "./param-builder.js";
 
 describe("ParamBuilder", () => {
@@ -45,6 +46,10 @@ describe("ParamBuilder", () => {
     expect({ ...result, "[foo]": { ...(result["[foo]"] as object) } }).toEqual({
       "[foo]": { bar: "baz" },
     });
+  });
+
+  test("invalid percent-encoding raises InvalidParameterError", () => {
+    expect(() => ParamBuilder.fromQueryString("foo=%E0%A4%A")).toThrow(InvalidParameterError);
   });
 
   test("configured for ignoring leading brackets", () => {

--- a/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from "vitest";
+import { ParamBuilder } from "./param-builder.js";
+
+describe("ParamBuilder", () => {
+  // Much of the behavioral details are covered by long-standing
+  // integration tests in test/request/query_string_parsing_test.rb
+  //
+  // This test doesn't need to duplicate all of that: it just
+  // offers a simple baseline of unit tests.
+
+  test("simple query string", () => {
+    const result = ParamBuilder.fromQueryString("foo=bar&baz=quux");
+    expect({ ...result }).toEqual({ foo: "bar", baz: "quux" });
+  });
+
+  test("nested parameters", () => {
+    const result = ParamBuilder.fromQueryString("foo[bar]=baz");
+    expect({ ...result, foo: { ...(result.foo as object) } }).toEqual({
+      foo: { bar: "baz" },
+    });
+  });
+
+  test("(rack 3) defaults to retaining leading bracket", () => {
+    let result = ParamBuilder.fromQueryString("[foo]=bar");
+    expect({ ...result }).toEqual({ "[foo]": "bar" });
+
+    result = ParamBuilder.fromQueryString("[foo][bar]=baz");
+    expect({ ...result, "[foo]": { ...(result["[foo]"] as object) } }).toEqual({
+      "[foo]": { bar: "baz" },
+    });
+  });
+});
+
+describe("ParamBuilder.ignoreLeadingBrackets toggle", () => {
+  const previous = ParamBuilder.ignoreLeadingBrackets;
+  afterEach(() => {
+    ParamBuilder.ignoreLeadingBrackets = previous;
+  });
+
+  test("configured for strict brackets", () => {
+    ParamBuilder.ignoreLeadingBrackets = false;
+
+    let result = ParamBuilder.fromQueryString("[foo]=bar");
+    expect({ ...result }).toEqual({ "[foo]": "bar" });
+
+    result = ParamBuilder.fromQueryString("[foo][bar]=baz");
+    expect({ ...result, "[foo]": { ...(result["[foo]"] as object) } }).toEqual({
+      "[foo]": { bar: "baz" },
+    });
+  });
+
+  test("configured for ignoring leading brackets", () => {
+    ParamBuilder.ignoreLeadingBrackets = true;
+
+    let result = ParamBuilder.fromQueryString("[foo]=bar");
+    expect({ ...result }).toEqual({ foo: "bar" });
+
+    result = ParamBuilder.fromQueryString("[foo][bar]=baz");
+    expect({ ...result, foo: { ...(result.foo as object) } }).toEqual({
+      foo: { bar: "baz" },
+    });
+  });
+});

--- a/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { InvalidParameterError, ParameterTypeError, ParamsTooDeepError } from "@blazetrails/rack";
+import { InvalidParameterError, ParameterTypeError, ParamsTooDeepError } from "./param-error.js";
 import { ParamBuilder } from "./param-builder.js";
 
 function plain(v: unknown): unknown {

--- a/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.test.ts
@@ -1,6 +1,17 @@
 import { afterEach, describe, expect, test } from "vitest";
-import { InvalidParameterError } from "@blazetrails/rack";
+import { InvalidParameterError, ParameterTypeError, ParamsTooDeepError } from "@blazetrails/rack";
 import { ParamBuilder } from "./param-builder.js";
+
+function plain(v: unknown): unknown {
+  if (Array.isArray(v)) return v.map(plain);
+  if (v !== null && typeof v === "object") {
+    const proto = Object.getPrototypeOf(v);
+    if (proto === null || proto === Object.prototype) {
+      return Object.fromEntries(Object.entries(v).map(([k, vv]) => [k, plain(vv)]));
+    }
+  }
+  return v;
+}
 
 describe("ParamBuilder", () => {
   // Much of the behavioral details are covered by long-standing
@@ -50,6 +61,34 @@ describe("ParamBuilder", () => {
 
   test("invalid percent-encoding raises InvalidParameterError", () => {
     expect(() => ParamBuilder.fromQueryString("foo=%E0%A4%A")).toThrow(InvalidParameterError);
+  });
+
+  test("deep hash nesting", () => {
+    const result = ParamBuilder.fromQueryString("x[y][z]=1");
+    expect(plain(result)).toEqual({ x: { y: { z: "1" } } });
+  });
+
+  test("hash inside array via [][key]", () => {
+    const result = ParamBuilder.fromQueryString("x[][y]=1&x[][y]=2");
+    expect(plain(result)).toEqual({ x: [{ y: "1" }, { y: "2" }] });
+  });
+
+  test("array of plain values", () => {
+    const result = ParamBuilder.fromQueryString("a[]=1&a[]=2");
+    expect(plain(result)).toEqual({ a: ["1", "2"] });
+  });
+
+  test("hash-vs-scalar type mismatch raises ParameterTypeError", () => {
+    expect(() => ParamBuilder.fromQueryString("x=1&x[y]=2")).toThrow(ParameterTypeError);
+  });
+
+  test("array-vs-scalar type mismatch raises ParameterTypeError", () => {
+    expect(() => ParamBuilder.fromQueryString("x=1&x[]=2")).toThrow(ParameterTypeError);
+  });
+
+  test("depth limit raises ParamsTooDeepError", () => {
+    const shallow = new ParamBuilder(3);
+    expect(() => shallow.fromQueryString("a[b][c][d][e]=1")).toThrow(ParamsTooDeepError);
   });
 
   test("configured for ignoring leading brackets", () => {

--- a/packages/actionpack/src/action-dispatch/http/param-builder.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.ts
@@ -1,0 +1,259 @@
+/**
+ * ActionDispatch::ParamBuilder
+ *
+ * Port of `actionpack/lib/action_dispatch/http/param_builder.rb`. Parses
+ * query strings (and pre-parsed pair sequences) into nested parameter
+ * hashes. Mirrors Rails' implementation, which is itself derived from
+ * Rack::QueryParser.
+ *
+ * Rack 2's legacy "ignore leading brackets" behavior is reachable only
+ * when callers explicitly opt in via {@link ParamBuilder.ignoreLeadingBrackets}.
+ * trails targets Rack 3 (see `action-dispatch/constants.ts`), so the
+ * `LEADING_BRACKETS_COMPAT` constant is hard-coded false.
+ *
+ * `Hash` in Rails maps to a null-prototype plain object here — both for
+ * indifferent-key semantics (object keys are strings only in JS) and to
+ * keep attacker-controlled `__proto__` keys from polluting the prototype.
+ */
+
+import { deprecator } from "../deprecator.js";
+import { UploadedFile } from "./upload.js";
+import { QueryParser, type QueryPair } from "./query-parser.js";
+import { RequestUtils, type ParamHash, type ParamValue } from "../request/utils.js";
+import { InvalidParameterError, ParameterTypeError, ParamsTooDeepError } from "./param-error.js";
+
+export type EncodingTemplate = Record<string, string>;
+
+/** @internal Rack 2 compat sentinel — always false under trails' Rack 3 target. */
+const LEADING_BRACKETS_COMPAT = false;
+
+export class ParamBuilder {
+  readonly paramDepthLimit: number;
+
+  constructor(paramDepthLimit: number) {
+    this.paramDepthLimit = paramDepthLimit;
+  }
+
+  static makeDefault(paramDepthLimit: number): ParamBuilder {
+    return new ParamBuilder(paramDepthLimit);
+  }
+
+  /** Mirrors `cattr_accessor :ignore_leading_brackets`. */
+  static ignoreLeadingBrackets: boolean | null = null;
+
+  /** Mirrors `cattr_accessor :default`. */
+  static default: ParamBuilder = ParamBuilder.makeDefault(100);
+
+  static fromQueryString(
+    qs: string | null | undefined,
+    options: { separator?: string | null; encodingTemplate?: EncodingTemplate | null } = {},
+  ): ParamHash {
+    return ParamBuilder.default.fromQueryString(qs, options);
+  }
+
+  static fromPairs(
+    pairs: Iterable<QueryPair> | Iterable<[string, unknown]>,
+    options: { encodingTemplate?: EncodingTemplate | null } = {},
+  ): ParamHash {
+    return ParamBuilder.default.fromPairs(pairs, options);
+  }
+
+  static fromHash(
+    hash: ParamHash,
+    options: { encodingTemplate?: EncodingTemplate | null } = {},
+  ): ParamHash {
+    return ParamBuilder.default.fromHash(hash, options);
+  }
+
+  fromQueryString(
+    qs: string | null | undefined,
+    options: { separator?: string | null; encodingTemplate?: EncodingTemplate | null } = {},
+  ): ParamHash {
+    return this.fromPairs(QueryParser.eachPair(qs, options.separator), {
+      encodingTemplate: options.encodingTemplate,
+    });
+  }
+
+  fromPairs(
+    pairs: Iterable<QueryPair> | Iterable<[string, unknown]>,
+    options: { encodingTemplate?: EncodingTemplate | null } = {},
+  ): ParamHash {
+    const params = makeParams();
+    const encodingTemplate = options.encodingTemplate ?? null;
+
+    try {
+      for (const [k, rawV] of pairs) {
+        let v = rawV as ParamValue;
+        if (v !== null && typeof v === "object" && !Array.isArray(v)) {
+          // Rails wraps Hash values (multipart payloads) as UploadedFile.
+          v = new UploadedFile(v as never) as unknown as ParamValue;
+        }
+        storeNestedParam(params, k, v, 0, encodingTemplate, this.paramDepthLimit);
+      }
+    } catch (e) {
+      if (e instanceof RangeError || (e instanceof Error && e.name === "ArgumentError")) {
+        throw new InvalidParameterError(e.message);
+      }
+      throw e;
+    }
+
+    return params;
+  }
+
+  fromHash(
+    hash: ParamHash,
+    _options: { encodingTemplate?: EncodingTemplate | null } = {},
+  ): ParamHash {
+    // CustomParamEncoder/check_param_encoding are no-ops in JS (UTF-16
+    // strings, no per-string encoding). Normalize through the same
+    // pipeline as parseNestedQuery.
+    return RequestUtils.normalizeEncodeParams(hash) as ParamHash;
+  }
+}
+
+function makeParams(): ParamHash {
+  return Object.create(null) as ParamHash;
+}
+
+function isParamsHash(obj: unknown): obj is ParamHash {
+  return obj !== null && typeof obj === "object" && !Array.isArray(obj);
+}
+
+function paramsHashHasKey(hash: ParamHash, key: string): boolean {
+  if (key.includes("[]")) return false;
+  let h: ParamValue = hash;
+  for (const part of key.split(/[[\]]+/)) {
+    if (part === "") continue;
+    if (!isParamsHash(h) || !Object.hasOwn(h, part)) return false;
+    h = h[part];
+  }
+  return true;
+}
+
+function classNameOf(v: unknown): string {
+  if (v === null) return "NilClass";
+  if (Array.isArray(v)) return "Array";
+  if (typeof v === "string") return "String";
+  if (typeof v === "object") return "Hash";
+  return typeof v;
+}
+
+/** @internal */
+function storeNestedParam(
+  params: ParamHash,
+  name: string | null,
+  v: ParamValue,
+  depth: number,
+  encodingTemplate: EncodingTemplate | null,
+  depthLimit: number,
+): ParamValue {
+  if (depth >= depthLimit) throw new ParamsTooDeepError("param depth limit exceeded");
+
+  let k: string;
+  let after: string;
+
+  if (name === null || name === undefined) {
+    k = after = "";
+  } else if (depth === 0) {
+    const ignoreLeading = ParamBuilder.ignoreLeadingBrackets;
+    if (ignoreLeading === true || (ignoreLeading === null && LEADING_BRACKETS_COMPAT)) {
+      const m = name.match(/^([[\]]*)([^[\]]+)\]*/);
+      if (m) {
+        k = m[2];
+        const matched = m[0];
+        after = name.slice(matched.length);
+        if (ignoreLeading !== true && (k !== matched || (after !== "" && !after.startsWith("[")))) {
+          deprecator.warn(
+            `Skipping over leading brackets in parameter name ${JSON.stringify(name)} is deprecated and will parse differently in Rails 8.1 or Rack 3.0.`,
+          );
+        }
+      } else {
+        k = name;
+        after = "";
+      }
+    } else {
+      const start = name.indexOf("[", 1);
+      if (start !== -1) {
+        k = name.slice(0, start);
+        after = name.slice(start);
+      } else {
+        k = name;
+        after = "";
+      }
+    }
+  } else if (name.startsWith("[]")) {
+    k = "[]";
+    after = name.slice(2);
+  } else if (name.startsWith("[")) {
+    const end = name.indexOf("]", 1);
+    if (end !== -1) {
+      k = name.slice(1, end);
+      after = name.slice(end + 1);
+    } else {
+      k = name;
+      after = "";
+    }
+  } else {
+    k = name;
+    after = "";
+  }
+
+  if (k === "") return params;
+
+  if (depth === 0 && typeof v === "string") {
+    if (encodingTemplate && encodingTemplate[k]) {
+      // force_encoding is a no-op in JS — strings are UTF-16. Encoding
+      // validity is likewise structurally guaranteed; we don't surface
+      // the InvalidParameterError "Invalid encoding" branch.
+    }
+  }
+
+  if (after === "") {
+    if (k === "[]" && depth !== 0) {
+      return v !== null || !RequestUtils.performDeepMunge ? [v] : [];
+    }
+    params[k] = v;
+  } else if (after === "[") {
+    params[name as string] = v;
+  } else if (after === "[]") {
+    if (!Object.hasOwn(params, k)) params[k] = [];
+    const arr = params[k];
+    if (!Array.isArray(arr)) {
+      throw new ParameterTypeError(`expected Array (got ${classNameOf(arr)}) for param \`${k}'`);
+    }
+    if (v !== null || !RequestUtils.performDeepMunge) arr.push(v);
+  } else if (after.startsWith("[]")) {
+    // Recognize x[][y] (hash inside array) parameters
+    let childKey: string;
+    if (after[2] === "[" && after.endsWith("]")) {
+      const candidate = after.slice(3, after.length - 1);
+      if (candidate !== "" && !candidate.includes("[") && !candidate.includes("]")) {
+        childKey = candidate;
+      } else {
+        childKey = after.slice(2);
+      }
+    } else {
+      childKey = after.slice(2);
+    }
+    if (!Object.hasOwn(params, k)) params[k] = [];
+    const arr = params[k];
+    if (!Array.isArray(arr)) {
+      throw new ParameterTypeError(`expected Array (got ${classNameOf(arr)}) for param \`${k}'`);
+    }
+    const last = arr[arr.length - 1];
+    if (isParamsHash(last) && !paramsHashHasKey(last, childKey)) {
+      storeNestedParam(last, childKey, v, depth + 1, null, depthLimit);
+    } else {
+      arr.push(storeNestedParam(makeParams(), childKey, v, depth + 1, null, depthLimit));
+    }
+  } else {
+    if (!Object.hasOwn(params, k)) params[k] = makeParams();
+    const child = params[k];
+    if (!isParamsHash(child)) {
+      throw new ParameterTypeError(`expected Hash (got ${classNameOf(child)}) for param \`${k}'`);
+    }
+    params[k] = storeNestedParam(child, after, v, depth + 1, null, depthLimit) as ParamValue;
+  }
+
+  return params;
+}

--- a/packages/actionpack/src/action-dispatch/http/param-builder.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.ts
@@ -78,7 +78,7 @@ export class ParamBuilder {
     pairs: Iterable<QueryPair> | Iterable<[string, unknown]>,
     options: { encodingTemplate?: EncodingTemplate | null } = {},
   ): ParamHash {
-    const params = makeParams();
+    const params = this.makeParams();
     const encodingTemplate = options.encodingTemplate ?? null;
 
     try {
@@ -88,7 +88,7 @@ export class ParamBuilder {
           // Rails wraps Hash values (multipart payloads) as UploadedFile.
           v = new UploadedFile(v as never) as unknown as ParamValue;
         }
-        storeNestedParam(params, k, v, 0, encodingTemplate, this.paramDepthLimit);
+        this.storeNestedParam(params, k, v, 0, encodingTemplate);
       }
     } catch (e) {
       if (e instanceof RangeError || (e instanceof Error && e.name === "ArgumentError")) {
@@ -109,25 +109,49 @@ export class ParamBuilder {
     // pipeline as parseNestedQuery.
     return RequestUtils.normalizeEncodeParams(hash) as ParamHash;
   }
-}
 
-function makeParams(): ParamHash {
-  return Object.create(null) as ParamHash;
-}
-
-function isParamsHash(obj: unknown): obj is ParamHash {
-  return obj !== null && typeof obj === "object" && !Array.isArray(obj);
-}
-
-function paramsHashHasKey(hash: ParamHash, key: string): boolean {
-  if (key.includes("[]")) return false;
-  let h: ParamValue = hash;
-  for (const part of key.split(/[[\]]+/)) {
-    if (part === "") continue;
-    if (!isParamsHash(h) || !Object.hasOwn(h, part)) return false;
-    h = h[part];
+  /** @internal */
+  storeNestedParam(
+    params: ParamHash,
+    name: string | null,
+    v: ParamValue,
+    depth: number,
+    encodingTemplate: EncodingTemplate | null = null,
+  ): ParamValue {
+    return storeNestedParamImpl(this, params, name, v, depth, encodingTemplate);
   }
-  return true;
+
+  /** @internal */
+  makeParams(): ParamHash {
+    return Object.create(null) as ParamHash;
+  }
+
+  /**
+   * Mirrors Rails' `new_depth_limit` — but Rails' own implementation
+   * is broken (references an undefined `@params_class`); kept as a thin
+   * `new(depthLimit)` factory for source-level parity.
+   * @internal
+   */
+  newDepthLimit(paramDepthLimit: number): ParamBuilder {
+    return new (this.constructor as typeof ParamBuilder)(paramDepthLimit);
+  }
+
+  /** @internal */
+  paramsHashType(obj: unknown): obj is ParamHash {
+    return obj !== null && typeof obj === "object" && !Array.isArray(obj);
+  }
+
+  /** @internal */
+  paramsHashHasKey(hash: ParamHash, key: string): boolean {
+    if (key.includes("[]")) return false;
+    let h: ParamValue = hash;
+    for (const part of key.split(/[[\]]+/)) {
+      if (part === "") continue;
+      if (!this.paramsHashType(h) || !Object.hasOwn(h, part)) return false;
+      h = h[part];
+    }
+    return true;
+  }
 }
 
 function classNameOf(v: unknown): string {
@@ -138,16 +162,15 @@ function classNameOf(v: unknown): string {
   return typeof v;
 }
 
-/** @internal */
-function storeNestedParam(
+function storeNestedParamImpl(
+  self: ParamBuilder,
   params: ParamHash,
   name: string | null,
   v: ParamValue,
   depth: number,
   encodingTemplate: EncodingTemplate | null,
-  depthLimit: number,
 ): ParamValue {
-  if (depth >= depthLimit) throw new ParamsTooDeepError("param depth limit exceeded");
+  if (depth >= self.paramDepthLimit) throw new ParamsTooDeepError("param depth limit exceeded");
 
   let k: string;
   let after: string;
@@ -200,13 +223,10 @@ function storeNestedParam(
 
   if (k === "") return params;
 
-  if (depth === 0 && typeof v === "string") {
-    if (encodingTemplate && encodingTemplate[k]) {
-      // force_encoding is a no-op in JS — strings are UTF-16. Encoding
-      // validity is likewise structurally guaranteed; we don't surface
-      // the InvalidParameterError "Invalid encoding" branch.
-    }
-  }
+  // Rails applies encodingTemplate[k] via force_encoding + valid_encoding?
+  // here. Both are no-ops in JS (strings are UTF-16, structurally valid),
+  // so the InvalidParameterError("Invalid encoding…") branch is absent.
+  void encodingTemplate;
 
   if (after === "") {
     if (k === "[]" && depth !== 0) {
@@ -241,18 +261,18 @@ function storeNestedParam(
       throw new ParameterTypeError(`expected Array (got ${classNameOf(arr)}) for param \`${k}'`);
     }
     const last = arr[arr.length - 1];
-    if (isParamsHash(last) && !paramsHashHasKey(last, childKey)) {
-      storeNestedParam(last, childKey, v, depth + 1, null, depthLimit);
+    if (self.paramsHashType(last) && !self.paramsHashHasKey(last, childKey)) {
+      self.storeNestedParam(last, childKey, v, depth + 1);
     } else {
-      arr.push(storeNestedParam(makeParams(), childKey, v, depth + 1, null, depthLimit));
+      arr.push(self.storeNestedParam(self.makeParams(), childKey, v, depth + 1));
     }
   } else {
-    if (!Object.hasOwn(params, k)) params[k] = makeParams();
+    if (!Object.hasOwn(params, k)) params[k] = self.makeParams();
     const child = params[k];
-    if (!isParamsHash(child)) {
+    if (!self.paramsHashType(child)) {
       throw new ParameterTypeError(`expected Hash (got ${classNameOf(child)}) for param \`${k}'`);
     }
-    params[k] = storeNestedParam(child, after, v, depth + 1, null, depthLimit) as ParamValue;
+    params[k] = self.storeNestedParam(child, after, v, depth + 1) as ParamValue;
   }
 
   return params;

--- a/packages/actionpack/src/action-dispatch/http/param-builder.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.ts
@@ -84,15 +84,24 @@ export class ParamBuilder {
     try {
       for (const [k, rawV] of pairs) {
         let v = rawV as ParamValue;
-        if (v !== null && typeof v === "object" && !Array.isArray(v)) {
-          // Rails wraps Hash values (multipart payloads) as UploadedFile.
+        if (this.paramsHashType(v)) {
+          // Rails: `if Hash === v` — wrap plain hashes (multipart parser
+          // output) as UploadedFile. Class-strict, so an already-built
+          // UploadedFile passes through.
           v = new UploadedFile(v as never) as unknown as ParamValue;
         }
         this.storeNestedParam(params, k, v, 0, encodingTemplate);
       }
     } catch (e) {
-      if (e instanceof RangeError || (e instanceof Error && e.name === "ArgumentError")) {
-        throw new InvalidParameterError(e.message);
+      // Rails rescues ArgumentError here — in Ruby, malformed percent-
+      // encoding in QueryParser raises ArgumentError. In JS the
+      // equivalent is URIError from decodeURIComponent.
+      if (
+        e instanceof URIError ||
+        e instanceof RangeError ||
+        (e instanceof Error && e.name === "ArgumentError")
+      ) {
+        throw new InvalidParameterError((e as Error).message);
       }
       throw e;
     }
@@ -138,7 +147,13 @@ export class ParamBuilder {
 
   /** @internal */
   paramsHashType(obj: unknown): obj is ParamHash {
-    return obj !== null && typeof obj === "object" && !Array.isArray(obj);
+    // Rails: `Hash === obj` — class-strict, excludes subclasses-of-Object
+    // like UploadedFile. Match by only accepting the null-prototype shape
+    // we build via makeParams(); custom classes (UploadedFile) fall
+    // through and trigger ParameterTypeError on hash-container paths.
+    if (obj === null || typeof obj !== "object" || Array.isArray(obj)) return false;
+    const proto = Object.getPrototypeOf(obj);
+    return proto === null || proto === Object.prototype;
   }
 
   /** @internal */

--- a/packages/actionpack/src/action-dispatch/http/param-builder.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.ts
@@ -147,10 +147,10 @@ export class ParamBuilder {
 
   /** @internal */
   paramsHashType(obj: unknown): obj is ParamHash {
-    // Rails: `Hash === obj` — class-strict, excludes subclasses-of-Object
-    // like UploadedFile. Match by only accepting the null-prototype shape
-    // we build via makeParams(); custom classes (UploadedFile) fall
-    // through and trigger ParameterTypeError on hash-container paths.
+    // Rails: `Hash === obj` — true for any Hash (literal `{}` or
+    // makeParams-built). Class-strict, so subclasses-of-Object like
+    // UploadedFile do NOT qualify and fall through to trigger
+    // ParameterTypeError on hash-container paths.
     if (obj === null || typeof obj !== "object" || Array.isArray(obj)) return false;
     const proto = Object.getPrototypeOf(obj);
     return proto === null || proto === Object.prototype;

--- a/packages/actionpack/src/action-dispatch/http/param-builder.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.ts
@@ -94,12 +94,16 @@ export class ParamBuilder {
       }
     } catch (e) {
       // Rails rescues ArgumentError here — in Ruby, malformed percent-
-      // encoding in QueryParser raises ArgumentError. In JS the
-      // equivalent is URIError from decodeURIComponent.
+      // encoding in QueryParser raises ArgumentError, and UploadedFile
+      // raises ArgumentError on missing :tempfile/:content. In JS the
+      // analogs are URIError (from decodeURIComponent) and the codebase
+      // convention of `new Error("ArgumentError: …")` for Ruby-style
+      // ArgumentErrors that haven't been promoted to a dedicated class.
       if (
         e instanceof URIError ||
         e instanceof RangeError ||
-        (e instanceof Error && e.name === "ArgumentError")
+        (e instanceof Error &&
+          (e.name === "ArgumentError" || e.message.startsWith("ArgumentError:")))
       ) {
         throw new InvalidParameterError((e as Error).message);
       }

--- a/packages/actionpack/src/action-dispatch/http/param-builder.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.ts
@@ -170,10 +170,15 @@ export class ParamBuilder {
 }
 
 function classNameOf(v: unknown): string {
+  // Mirrors Rails' `obj.class.name` in ParameterTypeError messages.
   if (v === null) return "NilClass";
   if (Array.isArray(v)) return "Array";
   if (typeof v === "string") return "String";
-  if (typeof v === "object") return "Hash";
+  if (typeof v === "object") {
+    const proto = Object.getPrototypeOf(v);
+    if (proto === null || proto === Object.prototype) return "Hash";
+    return (v as object).constructor?.name ?? "Object";
+  }
   return typeof v;
 }
 

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -72,6 +72,7 @@ export {
 export { UploadedFile, type UploadedFileOptions } from "./http/upload.js";
 export { ContentDisposition, type ContentDispositionOptions } from "./http/content-disposition.js";
 export { QueryParser, type QueryPair } from "./http/query-parser.js";
+export { ParamBuilder, type EncodingTemplate } from "./http/param-builder.js";
 export {
   PARAMETERS_KEY,
   DEFAULT_PARSERS,

--- a/packages/actionpack/src/action-dispatch/request/utils.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.ts
@@ -73,6 +73,11 @@ function normalize(params: ParamValue, stripNil: boolean): ParamValue {
     return stripNil ? mapped.filter((el) => el !== null) : mapped;
   }
   if (params !== null && typeof params === "object") {
+    // Rails normalize_encode_params only walks Hash/Array; class
+    // instances (UploadedFile, etc.) pass through as opaque leaves so
+    // their prototype + methods survive.
+    const proto = Object.getPrototypeOf(params);
+    if (proto !== null && proto !== Object.prototype) return params;
     // Null-prototype to (a) match parseNestedQuery's shape and (b) make
     // `__proto__` in an own key land as data instead of mutating the
     // prototype chain.

--- a/packages/actionpack/src/action-dispatch/request/utils.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.ts
@@ -43,11 +43,15 @@ export class RequestUtils {
   }
 
   /**
-   * Returns a normalized clone of `params`. Hashes are rebuilt with a
-   * null prototype so attacker-controlled `__proto__` keys (e.g. from
+   * Returns a normalized copy of `params`. Plain hashes (null-proto or
+   * Object.prototype) and arrays are rebuilt — hashes with a null
+   * prototype, so attacker-controlled `__proto__` keys (e.g. from
    * `JSON.parse`) land as plain data rather than mutating the prototype
-   * chain. When `performDeepMunge` is true (the Rails default), `null`
-   * entries are additionally compacted out of arrays.
+   * chain. Class instances (e.g. UploadedFile) pass through unchanged
+   * to preserve their prototype and methods, matching Rails'
+   * `normalize_encode_params`, which only walks Hash/Array. When
+   * `performDeepMunge` is true (the Rails default), `null` entries are
+   * additionally compacted out of arrays.
    *
    * Mirrors `Request::Utils.normalize_encode_params` — Rails' choice
    * between `NoNilParamEncoder` and `ParamEncoder` (HashWithIndifferent-

--- a/packages/rack/src/index.ts
+++ b/packages/rack/src/index.ts
@@ -48,8 +48,8 @@ export {
   buildNestedQuery,
   HTTP_STATUS_CODES,
   statusCode,
-  ParameterTypeError,
   InvalidParameterError,
+  ParameterTypeError,
   ParamsTooDeepError,
 } from "./utils.js";
 export { BodyProxy } from "./body-proxy.js";


### PR DESCRIPTION
## Summary
- Port `actionpack/lib/action_dispatch/http/param_builder.rb` 1:1. Mirrors public surface: `makeDefault`, `default`, `fromQueryString`, `fromPairs`, `fromHash`, plus the `ignoreLeadingBrackets` cattr toggle and the full private helper set (`storeNestedParam`, `makeParams`, `newDepthLimit`, `paramsHashType`, `paramsHashHasKey`).
- `LEADING_BRACKETS_COMPAT` is hard-coded `false` — trails targets Rack 3 exclusively (see `action-dispatch/constants.ts`); the Rack 2 compat branch is reachable only when callers opt in via `ParamBuilder.ignoreLeadingBrackets`.
- Re-exports `InvalidParameterError` / `ParameterTypeError` / `ParamsTooDeepError` from `@blazetrails/rack` so consumers don't reach into `rack/src/utils`.
- `RequestUtils.normalize` tightened to skip non-plain objects so `UploadedFile` (and other class instances) survive `fromHash` with prototype + methods intact, matching Rails' `normalize_encode_params` which only walks Hash/Array.

## Notes
- `Hash` (Ruby) → null-prototype object: `__proto__` keys land as data, not prototype pollution.
- `force_encoding` / `valid_encoding?` paths in Rails are no-ops in JS (UTF-16 strings); the `InvalidParameterError("Invalid encoding…")` branch is intentionally absent.
- `paramsHashType` is class-strict (matches Rails `Hash === obj`): plain `{}` / null-proto hashes qualify; `UploadedFile` and other classes do not.
- `URIError` (JS) is rescued as the equivalent of Ruby's `ArgumentError` from URI percent-decoding.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/http/param-builder.test.ts` — 12 tests covering baseline parsing, leading-bracket toggle, deep hash nesting, array-of-hash, type-mismatch errors, and depth limit.
- [x] `pnpm api:compare` — `http/param_builder.rb` 11/11 (100%).
- [ ] CI green.