### PR TITLE
refactor(activerecord): dedup scope-lambda arity dispatch + invalidate _associationIds (Batch 158)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -60,7 +60,7 @@ import {
   CompositePrimaryKeyMismatchError,
 } from "./associations/errors.js";
 import { ForeignAssociation } from "./associations/foreign-association.js";
-import { AssociationScope } from "./associations/association-scope.js";
+import { AssociationScope, invokeScopeLambda } from "./associations/association-scope.js";
 import type { Association as AssociationInstance } from "./associations/association.js";
 import { validateThroughReflection } from "./associations/validate-through-reflection.js";
 import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
@@ -602,27 +602,12 @@ export function applyAssociationScope<R>(
 ): R {
   if (!scope) return rel;
   if (reflectionScope !== undefined && scope === reflectionScope) return rel;
-  // Match the head-scope dispatch in `association-scope.ts:583-589`:
-  // 0-arg scope → `fn.call(rel)` (`this=rel`); 1+-arg → `fn.call(rel,
-  // rel, owner)` (`this=rel`, positional `(rel, owner)`).
-  //
-  // Caveat re: Rails parity: Rails' `instance_exec(owner, &scope)` makes
-  // a 1-arg Ruby block `->(owner) { ... }` receive OWNER as the sole
-  // positional. This codebase's convention is different — every scope
-  // call site is `(rel) => rel.where(...)`, so a 1-arg lambda must
-  // receive the RELATION. We preserve that convention here for symmetry
-  // with `association-scope.ts`. Function-keyword scopes that want
-  // owner access can either declare arity-2 `function (rel, owner)` or
-  // close over `this` (set to rel via `.call`).
-  //
-  // `|| rel` (not `??`) mirrors Ruby's `instance_exec(owner, &scope) ||
-  // relation` — truthiness-based, so a scope returning `false` (idiomatic
-  // JS `cond && rel.where(...)` short-circuit) falls back to the input.
-  const result =
-    scope.length === 0
-      ? (scope as unknown as (this: R) => R | false | null | undefined).call(rel)
-      : scope.call(rel, rel, owner);
-  return result || rel;
+  // See `invokeScopeLambda` in association-scope.ts for the arity /
+  // `this`-binding contract. `|| rel` (not `??`) mirrors Ruby's
+  // `instance_exec(owner, &scope) || relation` — truthiness-based, so a
+  // scope returning `false` (idiomatic JS `cond && rel.where(...)`
+  // short-circuit) falls back to the input.
+  return invokeScopeLambda(scope, rel, owner) || rel;
 }
 
 /**

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -38,18 +38,16 @@ export type ValueTransformation<T = unknown> = (v: T) => unknown;
  *
  * @internal
  */
+export type ScopeLambda<R> = (this: R, rel: R, owner: Base) => R | false | null | undefined;
+
 export function invokeScopeLambda<R>(
-  fn: (this: R, ...args: never[]) => R | false | null | undefined,
+  fn: ScopeLambda<R>,
   rel: R,
   owner: Base,
 ): R | false | null | undefined {
   return fn.length === 0
-    ? (fn as unknown as (this: R) => R | false | null | undefined).call(rel)
-    : (fn as unknown as (this: R, rel: R, owner: Base) => R | false | null | undefined).call(
-        rel,
-        rel,
-        owner,
-      );
+    ? (fn as (this: R) => ReturnType<ScopeLambda<R>>).call(rel)
+    : fn.call(rel, rel, owner);
 }
 
 /**
@@ -612,11 +610,7 @@ export class AssociationScope {
     if (!isThrough && typeof head.scopeFor === "function") {
       scope = head.scopeFor.call(head, scope, owner);
     } else if (typeof head.scope === "function") {
-      const result = invokeScopeLambda(
-        head.scope as (this: unknown, ...args: never[]) => unknown,
-        scope,
-        owner,
-      );
+      const result = invokeScopeLambda(head.scope as ScopeLambda<unknown>, scope, owner);
       if (result) scope = result;
     }
     return scope;

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -40,6 +40,7 @@ export type ValueTransformation<T = unknown> = (v: T) => unknown;
  */
 export type ScopeLambda<R> = (this: R, rel: R, owner: Base) => R | false | null | undefined;
 
+/** @internal */
 export function invokeScopeLambda<R>(
   fn: ScopeLambda<R>,
   rel: R,

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -21,6 +21,29 @@ import type { Quoting } from "../connection-adapters/abstract/quoting-interface.
 export type ValueTransformation<T = unknown> = (v: T) => unknown;
 
 /**
+ * Invoke a scope lambda with Rails' `instance_exec(owner, &scope)` arity
+ * semantics: 0-arg lambdas get `this=rel` with no positional args;
+ * 1+-arg lambdas get `this=rel` with positional `(rel, owner)`. Returns
+ * the raw lambda result; callers apply `|| rel` if they want Ruby-style
+ * `instance_exec(owner, &scope) || relation` truthy-fallback semantics.
+ *
+ * @internal
+ */
+export function invokeScopeLambda<R>(
+  fn: (this: R, ...args: never[]) => R | false | null | undefined,
+  rel: R,
+  owner: Base,
+): R | false | null | undefined {
+  return fn.length === 0
+    ? (fn as unknown as (this: R) => R | false | null | undefined).call(rel)
+    : (fn as unknown as (this: R, rel: R, owner: Base) => R | false | null | undefined).call(
+        rel,
+        rel,
+        owner,
+      );
+}
+
+/**
  * Minimum shape `AssociationScope.scope` needs from its argument. Rails
  * passes a concrete `Association` instance (see
  * `activerecord/lib/active_record/associations/association.rb`); we
@@ -580,11 +603,11 @@ export class AssociationScope {
     if (!isThrough && typeof head.scopeFor === "function") {
       scope = head.scopeFor.call(head, scope, owner);
     } else if (typeof head.scope === "function") {
-      // Match Rails instance_exec arity: 0-arg scope → this=scope;
-      // 1+-arg → (scope, owner).
-      const fn = head.scope;
-      const result =
-        fn.length === 0 ? (fn as () => unknown).call(scope) : fn.call(scope, scope, owner);
+      const result = invokeScopeLambda(
+        head.scope as (this: unknown, ...args: never[]) => unknown,
+        scope,
+        owner,
+      );
       if (result) scope = result;
     }
     return scope;

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -21,11 +21,20 @@ import type { Quoting } from "../connection-adapters/abstract/quoting-interface.
 export type ValueTransformation<T = unknown> = (v: T) => unknown;
 
 /**
- * Invoke a scope lambda with Rails' `instance_exec(owner, &scope)` arity
- * semantics: 0-arg lambdas get `this=rel` with no positional args;
- * 1+-arg lambdas get `this=rel` with positional `(rel, owner)`. Returns
- * the raw lambda result; callers apply `|| rel` if they want Ruby-style
- * `instance_exec(owner, &scope) || relation` truthy-fallback semantics.
+ * Invoke a scope lambda using this port's calling convention:
+ * 0-arg lambdas → `fn.call(rel)` (`this=rel`, no positional args);
+ * 1+-arg lambdas → `fn.call(rel, rel, owner)` (`this=rel`, positional
+ * `(rel, owner)`). Returns the raw lambda result; callers apply `|| rel`
+ * if they want Ruby-style `instance_exec(owner, &scope) || relation`
+ * truthy-fallback semantics.
+ *
+ * NOT a 1:1 port of Rails' `relation.instance_exec(owner, &scope)`
+ * (reflection.rb:449), which passes `owner` as the sole positional
+ * arg. Every call site in this codebase writes scopes as
+ * `(rel) => rel.where(...)`, so a 1-arg lambda here receives the
+ * relation; arity-2 declarations can opt into `(rel, owner)`. The
+ * `this`-binding only applies to `function`-keyword scopes — arrow
+ * functions have lexical `this` and ignore `.call`.
  *
  * @internal
  */

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -322,4 +322,26 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(reader.target.length).toBe(1);
     expect(reader[0]?.title).toBe("z");
   });
+
+  it("clear() invalidates the cached _associationIds (Batch 158 / B32)", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    const instance = (
+      blog as unknown as { _associationInstances: Map<string, unknown> }
+    )._associationInstances.get("apPosts") as { _associationIds: unknown[] | null };
+    instance._associationIds = [1, 2, 3];
+    await proxy.clear();
+    expect(instance._associationIds).toBeNull();
+  });
+
+  it("destroyAll() invalidates the cached _associationIds (Batch 158 / B32)", async () => {
+    const blog = await blogWithPosts();
+    const proxy = association<ApPost>(blog, "apPosts");
+    const instance = (
+      blog as unknown as { _associationInstances: Map<string, unknown> }
+    )._associationInstances.get("apPosts") as { _associationIds: unknown[] | null };
+    instance._associationIds = [1, 2, 3];
+    await proxy.destroyAll();
+    expect(instance._associationIds).toBeNull();
+  });
 });

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1599,6 +1599,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       if (unsaved.length > 0) {
         this._removeFromTarget(unsaved);
       }
+      this._invalidateAssociationIds();
     });
   }
 
@@ -1842,6 +1843,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   async destroyAll(): Promise<T[]> {
     const records = await this.toArray();
     await this.destroy(...records);
+    this._invalidateAssociationIds();
     return records;
   }
 


### PR DESCRIPTION
## Summary

Followup from #1865 (Batch 158 / B32, ~50 LOC).

- Extract `invokeScopeLambda` helper in `association-scope.ts` for the Rails `instance_exec(owner, &scope)` arity / `this`-binding contract (0-arg → `this=rel`; 1+-arg → `this=rel`, positional `(rel, owner)`). Used by both the head-scope dispatch in `AssociationScope#scope` and `applyAssociationScope` in `associations.ts`.
- Invalidate the `_associationIds` cache from `CollectionProxy#clear` and `CollectionProxy#destroyAll`. The existing `_invalidateAssociationIds` helper was only fired from `push`/`replace` paths; bulk removals left the cached `ids` array stale after the underlying rows were gone.

## Test plan

- [x] `pnpm build` clean
- [x] `apply-association-scope.test.ts` + `association-scope.test.ts` pass (35 tests)
- [x] `collection-proxy.test.ts` passes
- [ ] CI green