### PR TITLE
feat(actionpack): port ActionDispatch::ParamError hierarchy

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/index.ts
+++ b/packages/actionpack/src/action-dispatch/http/index.ts
@@ -63,6 +63,12 @@ export {
   type MimeNegotiationHost,
 } from "./mime-negotiation.js";
 export {
+  ParamError,
+  ParameterTypeError,
+  InvalidParameterError,
+  ParamsTooDeepError,
+} from "./param-error.js";
+export {
   FILTERED,
   filteredLocation,
   locationFilters,

--- a/packages/actionpack/src/action-dispatch/http/param-error.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-error.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  ParameterTypeError as RackParameterTypeError,
+  InvalidParameterError as RackInvalidParameterError,
+  ParamsTooDeepError as RackParamsTooDeepError,
+} from "@blazetrails/rack";
+
+import { ParseError } from "./parameters.js";
+import {
+  ParamError,
+  ParameterTypeError,
+  InvalidParameterError,
+  ParamsTooDeepError,
+} from "./param-error.js";
+
+describe("ActionDispatch::ParamError", () => {
+  it("is a subclass of ParseError", () => {
+    expect(new ParamError()).toBeInstanceOf(ParseError);
+  });
+
+  it("preserves the message", () => {
+    expect(new ParamError("bad").message).toBe("bad");
+  });
+
+  it("ParameterTypeError, InvalidParameterError, ParamsTooDeepError descend from ParamError", () => {
+    expect(new ParameterTypeError()).toBeInstanceOf(ParamError);
+    expect(new InvalidParameterError()).toBeInstanceOf(ParamError);
+    expect(new ParamsTooDeepError()).toBeInstanceOf(ParamError);
+  });
+
+  describe(".matches", () => {
+    it("returns true for ParamError instances", () => {
+      expect(ParamError.matches(new ParamError())).toBe(true);
+      expect(ParamError.matches(new ParameterTypeError())).toBe(true);
+    });
+
+    it("returns true for Rack parameter exceptions", () => {
+      expect(ParamError.matches(new RackParameterTypeError("x"))).toBe(true);
+      expect(ParamError.matches(new RackInvalidParameterError("x"))).toBe(true);
+      expect(ParamError.matches(new RackParamsTooDeepError("x"))).toBe(true);
+    });
+
+    it("returns false for unrelated errors", () => {
+      expect(ParamError.matches(new Error("nope"))).toBe(false);
+      expect(ParamError.matches("not an error")).toBe(false);
+    });
+  });
+});

--- a/packages/actionpack/src/action-dispatch/http/param-error.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-error.test.ts
@@ -45,5 +45,15 @@ describe("ActionDispatch::ParamError", () => {
     it("subclass instanceof check still resolves the default chain", () => {
       expect(new ParameterTypeError() instanceof ParameterTypeError).toBe(true);
     });
+
+    it("Rack errors do not match individual ActionDispatch subclasses", () => {
+      // Rails only overrides `self.===` on ParamError; subclasses retain
+      // default semantics, so an unrelated Rack error must not be caught
+      // by a `rescueFrom(InvalidParameterError)`.
+      expect(new RackParameterTypeError("x") instanceof InvalidParameterError).toBe(false);
+      expect(new RackParameterTypeError("x") instanceof ParameterTypeError).toBe(false);
+      expect(new RackInvalidParameterError("x") instanceof ParameterTypeError).toBe(false);
+      expect(new RackParamsTooDeepError("x") instanceof ParamsTooDeepError).toBe(false);
+    });
   });
 });

--- a/packages/actionpack/src/action-dispatch/http/param-error.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-error.test.ts
@@ -29,21 +29,21 @@ describe("ActionDispatch::ParamError", () => {
     expect(new ParamsTooDeepError()).toBeInstanceOf(ParamError);
   });
 
-  describe(".matches", () => {
-    it("returns true for ParamError instances", () => {
-      expect(ParamError.matches(new ParamError())).toBe(true);
-      expect(ParamError.matches(new ParameterTypeError())).toBe(true);
+  describe("instanceof (Symbol.hasInstance override mirrors Rails' self.===)", () => {
+    it("matches Rack parameter exceptions", () => {
+      expect(new RackParameterTypeError("x") instanceof ParamError).toBe(true);
+      expect(new RackInvalidParameterError("x") instanceof ParamError).toBe(true);
+      expect(new RackParamsTooDeepError("x") instanceof ParamError).toBe(true);
     });
 
-    it("returns true for Rack parameter exceptions", () => {
-      expect(ParamError.matches(new RackParameterTypeError("x"))).toBe(true);
-      expect(ParamError.matches(new RackInvalidParameterError("x"))).toBe(true);
-      expect(ParamError.matches(new RackParamsTooDeepError("x"))).toBe(true);
+    it("returns false for unrelated errors and non-objects", () => {
+      expect(new Error("nope") instanceof ParamError).toBe(false);
+      expect((null as unknown) instanceof ParamError).toBe(false);
+      expect((undefined as unknown) instanceof ParamError).toBe(false);
     });
 
-    it("returns false for unrelated errors", () => {
-      expect(ParamError.matches(new Error("nope"))).toBe(false);
-      expect(ParamError.matches("not an error")).toBe(false);
+    it("subclass instanceof check still resolves the default chain", () => {
+      expect(new ParameterTypeError() instanceof ParameterTypeError).toBe(true);
     });
   });
 });

--- a/packages/actionpack/src/action-dispatch/http/param-error.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-error.ts
@@ -29,12 +29,17 @@ export class ParamError extends ParseError {
   }
 
   static [Symbol.hasInstance](other: unknown): boolean {
-    if (
-      other instanceof RackParameterTypeError ||
-      other instanceof RackInvalidParameterError ||
-      other instanceof RackParamsTooDeepError
-    ) {
-      return true;
+    // Rails only overrides `self.===` on `ParamError`; subclasses fall back
+    // to the default semantics. Mirror that — only ParamError itself should
+    // claim Rack's parallel exceptions.
+    if (this === ParamError) {
+      if (
+        other instanceof RackParameterTypeError ||
+        other instanceof RackInvalidParameterError ||
+        other instanceof RackParamsTooDeepError
+      ) {
+        return true;
+      }
     }
     // Walk the prototype chain looking for ParamError.prototype, mirroring
     // the default `instanceof` semantics that this override replaces.

--- a/packages/actionpack/src/action-dispatch/http/param-error.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-error.ts
@@ -1,0 +1,57 @@
+/**
+ * ActionDispatch::ParamError
+ *
+ * Port of `actionpack/lib/action_dispatch/http/param_error.rb`. Defines the
+ * `ParamError` hierarchy raised when request parameters cannot be parsed or
+ * have an unexpected shape, plus a {@link ParamError.matches} helper that
+ * mirrors Rails' `def self.===(other)` override — Rails uses `===` so a
+ * `rescue ParamError` catches Rack's parallel exception classes
+ * (`Rack::Utils::ParameterTypeError`, `Rack::Utils::InvalidParameterError`,
+ * `Rack::QueryParser::ParamsTooDeepError`). JavaScript's `instanceof` cannot
+ * be overridden the same way, so consumers call `ParamError.matches(err)`.
+ */
+
+import {
+  ParameterTypeError as RackParameterTypeError,
+  InvalidParameterError as RackInvalidParameterError,
+  ParamsTooDeepError as RackParamsTooDeepError,
+} from "@blazetrails/rack";
+
+import { ParseError } from "./parameters.js";
+
+export class ParamError extends ParseError {
+  constructor(message?: string) {
+    super(message);
+    this.name = "ActionDispatch::ParamError";
+  }
+
+  static matches(other: unknown): boolean {
+    return (
+      other instanceof ParamError ||
+      other instanceof RackParameterTypeError ||
+      other instanceof RackInvalidParameterError ||
+      other instanceof RackParamsTooDeepError
+    );
+  }
+}
+
+export class ParameterTypeError extends ParamError {
+  constructor(message?: string) {
+    super(message);
+    this.name = "ActionDispatch::ParameterTypeError";
+  }
+}
+
+export class InvalidParameterError extends ParamError {
+  constructor(message?: string) {
+    super(message);
+    this.name = "ActionDispatch::InvalidParameterError";
+  }
+}
+
+export class ParamsTooDeepError extends ParamError {
+  constructor(message?: string) {
+    super(message);
+    this.name = "ActionDispatch::ParamsTooDeepError";
+  }
+}

--- a/packages/actionpack/src/action-dispatch/http/param-error.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-error.ts
@@ -3,12 +3,15 @@
  *
  * Port of `actionpack/lib/action_dispatch/http/param_error.rb`. Defines the
  * `ParamError` hierarchy raised when request parameters cannot be parsed or
- * have an unexpected shape, plus a {@link ParamError.matches} helper that
- * mirrors Rails' `def self.===(other)` override — Rails uses `===` so a
- * `rescue ParamError` catches Rack's parallel exception classes
- * (`Rack::Utils::ParameterTypeError`, `Rack::Utils::InvalidParameterError`,
- * `Rack::QueryParser::ParamsTooDeepError`). JavaScript's `instanceof` cannot
- * be overridden the same way, so consumers call `ParamError.matches(err)`.
+ * have an unexpected shape.
+ *
+ * Rails overrides `self.===` on `ParamError` so a `rescue ParamError` also
+ * catches the parallel Rack exception classes (`Rack::Utils::ParameterTypeError`,
+ * `Rack::Utils::InvalidParameterError`, `Rack::QueryParser::ParamsTooDeepError`).
+ * JavaScript exposes the same dispatch hook via `Symbol.hasInstance`: defining
+ * it on `ParamError` makes `err instanceof ParamError` return true for those
+ * Rack errors too, so `rescueFrom(ParamError)` (which uses `instanceof`) works
+ * the same as Rails' `rescue ParamError`.
  */
 
 import {
@@ -25,13 +28,22 @@ export class ParamError extends ParseError {
     this.name = "ActionDispatch::ParamError";
   }
 
-  static matches(other: unknown): boolean {
-    return (
-      other instanceof ParamError ||
+  static [Symbol.hasInstance](other: unknown): boolean {
+    if (
       other instanceof RackParameterTypeError ||
       other instanceof RackInvalidParameterError ||
       other instanceof RackParamsTooDeepError
-    );
+    ) {
+      return true;
+    }
+    // Walk the prototype chain looking for ParamError.prototype, mirroring
+    // the default `instanceof` semantics that this override replaces.
+    let proto: object | null = other == null ? null : Object.getPrototypeOf(other);
+    while (proto !== null) {
+      if (proto === this.prototype) return true;
+      proto = Object.getPrototypeOf(proto);
+    }
+    return false;
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -88,6 +88,12 @@ export {
   type ParameterParsers,
   type ParametersHost,
 } from "./http/parameters.js";
+export {
+  ParamError,
+  ParameterTypeError,
+  InvalidParameterError,
+  ParamsTooDeepError,
+} from "./http/param-error.js";
 export { RequestId, type RequestIdOptions } from "./middleware/request-id.js";
 export {
   BasicAuth,

--- a/packages/rack/src/index.ts
+++ b/packages/rack/src/index.ts
@@ -43,5 +43,13 @@ export async function bodyToString(body: RackBody): Promise<string> {
   return chunks.join("");
 }
 
-export { parseNestedQuery, buildNestedQuery, HTTP_STATUS_CODES, statusCode } from "./utils.js";
+export {
+  parseNestedQuery,
+  buildNestedQuery,
+  HTTP_STATUS_CODES,
+  statusCode,
+  ParameterTypeError,
+  InvalidParameterError,
+  ParamsTooDeepError,
+} from "./utils.js";
 export { BodyProxy } from "./body-proxy.js";


### PR DESCRIPTION
## Summary
- Ports `actionpack/lib/action_dispatch/http/param_error.rb` to `packages/actionpack/src/action-dispatch/http/param-error.ts`.
- `ParamError extends ParseError`, plus `ParameterTypeError`, `InvalidParameterError`, `ParamsTooDeepError`.
- Rails overrides `self.===` on `ParamError` so `rescue ParamError` also catches the parallel Rack exceptions (`Rack::Utils::ParameterTypeError`, `Rack::Utils::InvalidParameterError`, `Rack::QueryParser::ParamsTooDeepError`). JS exposes the same hook via `Symbol.hasInstance`; this override is scoped to `ParamError` itself (subclasses retain default `instanceof` semantics, matching Rails).
- Re-exports the three Rack parameter exception classes from `@blazetrails/rack`, and the new ActionDispatch hierarchy from the `action-dispatch` barrel.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/http/param-error.test.ts`
- [x] `pnpm typecheck`
- [x] `pnpm lint`