### PR TITLE
refactor(activerecord): MySQL active-schema small-items bundle (Batch 49)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -66,6 +66,24 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     return adapter;
   }
 
+  it("rejects virtual/generated columns: rebuild path cannot preserve AS (<expr>)", async () => {
+    const adapter = await makeAdapter("gen_col", "VIRTUAL GENERATED");
+    adapter.columnDefinitions = async () => [
+      {
+        Field: "gen_col",
+        Type: "int(11)",
+        Null: "YES",
+        Default: null,
+        Extra: "VIRTUAL GENERATED",
+        Collation: null,
+        Comment: "",
+      },
+    ];
+    await expect(adapter.renameColumnForAlter("users", "gen_col", "gen_col2")).rejects.toThrow(
+      /virtual\/generated column/,
+    );
+  });
+
   it("allows auto_increment Extra without throwing", async () => {
     const adapter = await makeAdapter("id", "auto_increment");
     const sql: string = await adapter.renameColumnForAlter("users", "id", "user_id");

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -72,28 +72,40 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     expect(sql).toContain("AUTO_INCREMENT");
   });
 
-  it("preserves on update CURRENT_TIMESTAMP Extra without throwing", async () => {
+  it("preserves on update CURRENT_TIMESTAMP for datetime column", async () => {
     const adapter = await makeAdapter("updated_at", "on update CURRENT_TIMESTAMP");
+    adapter.columnDefinitions = async () => [
+      {
+        Field: "updated_at",
+        Type: "datetime",
+        Null: "NO",
+        Default: "CURRENT_TIMESTAMP",
+        Extra: "on update CURRENT_TIMESTAMP",
+        Collation: null,
+        Comment: "",
+      },
+    ];
     const sql: string = await adapter.renameColumnForAlter("users", "updated_at", "ts");
     expect(sql).toContain("ON UPDATE");
     expect(sql).toContain("CURRENT_TIMESTAMP");
   });
 
   it("preserves MySQL 8 compound DEFAULT_GENERATED on update Extra", async () => {
-    const adapter = await makeAdapter(
-      "updated_at",
-      "DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6)",
-    );
-    const sql: string = await adapter.renameColumnForAlter("users", "updated_at", "ts");
+    const adapter = await makeAdapter("col", "DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6)");
+    adapter.columnDefinitions = async () => [
+      {
+        Field: "col",
+        Type: "json",
+        Null: "YES",
+        Default: "json_array()",
+        Extra: "DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6)",
+        Collation: null,
+        Comment: "",
+      },
+    ];
+    const sql: string = await adapter.renameColumnForAlter("users", "col", "col2");
     expect(sql).toContain("ON UPDATE");
     expect(sql).toContain("CURRENT_TIMESTAMP(6)");
-  });
-
-  it("throws for unrecognised Extra values", async () => {
-    const adapter = await makeAdapter("gen_col", "VIRTUAL GENERATED");
-    await expect(adapter.renameColumnForAlter("users", "gen_col", "gen_col2")).rejects.toThrow(
-      "renameColumnForAlter fallback",
-    );
   });
 
   it("emits DEFAULT CURRENT_TIMESTAMP unquoted when default is a timestamp function", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -108,6 +108,27 @@ describe("AbstractMysqlAdapter#renameColumnForAlter fallback", () => {
     expect(sql).toContain("CURRENT_TIMESTAMP");
   });
 
+  it("preserves bare ON UPDATE Extra when Default is null (not folded into defaultFunction)", async () => {
+    // Datetime column with `on update CURRENT_TIMESTAMP` but Default=null — newColumnFromField's
+    // datetime+CURRENT_TIMESTAMP short-circuit doesn't fire (default is null), so on_update
+    // can't be folded into defaultFunction. Must round-trip via column.onUpdate / MysqlAddColumnOptions.
+    const adapter = await makeAdapter("ts", "on update CURRENT_TIMESTAMP");
+    adapter.columnDefinitions = async () => [
+      {
+        Field: "ts",
+        Type: "datetime",
+        Null: "YES",
+        Default: null,
+        Extra: "on update CURRENT_TIMESTAMP",
+        Collation: null,
+        Comment: "",
+      },
+    ];
+    const sql: string = await adapter.renameColumnForAlter("users", "ts", "ts2");
+    expect(sql).toContain("ON UPDATE CURRENT_TIMESTAMP");
+    expect(sql).not.toContain("DEFAULT");
+  });
+
   it("preserves MySQL 8 compound DEFAULT_GENERATED on update Extra", async () => {
     const adapter = await makeAdapter("col", "DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6)");
     adapter.columnDefinitions = async () => [

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1546,6 +1546,19 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // (abstract_mysql_adapter.rb:863-878). Route through columnFor so function-default and
     // on_update detection happens once in newColumnFromField — no second-pass parsing here.
     const column = (await this.columnFor(tableName, columnName)) as MysqlColumn;
+    // Rails' rename_column_for_alter has no equivalent guard, but the rebuild path here
+    // (and in Rails) reconstructs columns from {default,null,auto_increment,comment} only —
+    // the `AS (<expr>) [VIRTUAL|STORED]` generation clause has no slot. Emitting a plain
+    // CHANGE for a virtual/generated column would silently drop the generation expression,
+    // which is unrecoverable. Fail loud instead; callers must upgrade to MySQL ≥8.0.3 or
+    // MariaDB ≥10.5.2 to use the RENAME COLUMN path above.
+    if (column.isVirtual()) {
+      throw new Error(
+        `renameColumnForAlter fallback: cannot safely CHANGE virtual/generated column ` +
+          `"${columnName}" in table "${tableName}" — generation expression would be dropped. ` +
+          `Upgrade to MySQL ≥8.0.3 or MariaDB ≥10.5.2 to use RENAME COLUMN instead.`,
+      );
+    }
     const defFn = column.defaultFunction;
     // newColumnFromField sets column.default to null when defaultFunction is present, so we can
     // pass either through ColumnDefinition's `default` slot: a lambda for function defaults

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -171,7 +171,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       const extra = ((f["Extra"] as string | null) ?? "").trim();
       const sqlType = ((f["Type"] as string | null) ?? "").toLowerCase();
       if (def == null || /^\d/.test(def) || def.startsWith("'")) return false;
-      if (extra.startsWith("DEFAULT_GENERATED")) return false;
+      if (extra.toUpperCase().startsWith("DEFAULT_GENERATED")) return false;
       // newColumnFromField's datetime+CURRENT_TIMESTAMP short-circuit only fires when the
       // semantic type is "datetime" (sqlType startsWith "datetime"/"timestamp"); for
       // non-datetime columns with a CURRENT_TIMESTAMP default we still need SHOW CREATE TABLE

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -65,9 +65,10 @@ import type { ColumnType, ColumnOptions } from "./abstract/schema-definitions.js
 import { TableDefinition as MysqlTableDefinition } from "./mysql/schema-definitions.js";
 import {
   isRowFormatDynamicByDefault,
-  defaultType,
+  newColumnFromField,
   quotedScope,
 } from "./mysql/schema-statements.js";
+import type { Column as MysqlColumn } from "./mysql/column.js";
 import { TypeMap } from "../type/type-map.js";
 import {
   StringType,
@@ -127,11 +128,6 @@ const CR_SERVER_GONE_ERROR = 2006;
 const CR_SERVER_LOST = 2013;
 const ER_CLIENT_INTERACTION_TIMEOUT = 4031;
 
-// Function defaults emitted without DEFAULT_GENERATED in Extra (e.g. CURRENT_TIMESTAMP on
-// datetime columns). Used by renameColumnForAlter to emit them unquoted in the CHANGE clause.
-const RENAME_FUNC_DEFAULT_RE =
-  /^(CURRENT_TIMESTAMP(\([0-6]?\))?|NOW(\([0-6]?\))?|CURRENT_DATE|CURRENT_TIME(\([0-6]?\))?|UUID\(\))$/i;
-
 // eslint-disable-next-line no-control-regex
 const QUOTE_STRING_RE = /['\\\x00\n\r\x1a]/g;
 const QUOTE_STRING_MAP: Record<string, string> = {
@@ -157,12 +153,36 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   static dbWarningsIgnore: (string | RegExp)[] = [];
 
   /**
-   * Return Column objects for a table. Concrete adapters (Mysql2Adapter,
-   * TrilogyAdapter) override this. The default throws so that unimplemented
-   * adapters fail loudly if FK enrichment is ever triggered.
+   * Return Column objects for a table. Mirrors Rails'
+   * `AbstractMysqlAdapter#columns` (via `SchemaStatements#columns`):
+   * `column_definitions` rows mapped through `new_column_from_field`, which
+   * centralizes function-default and on_update detection. Concrete adapters
+   * (Mysql2Adapter, TrilogyAdapter) may still override for performance.
    */
-  async columns(_tableName: string): Promise<Column[]> {
-    throw new Error(`${this.constructor.name} must implement columns()`);
+  async columns(tableName: string): Promise<Column[]> {
+    const fields = await this.columnDefinitions(tableName);
+    // newColumnFromField's broader function-default detection calls SHOW CREATE TABLE via the
+    // sync createTableInfoFn callback. Pre-fetch once iff any field default falls through the
+    // earlier branches (non-digit literal, non-quoted string, non-CURRENT_TIMESTAMP datetime,
+    // non-DEFAULT_GENERATED) so the sync callback has data when needed and we keep a single
+    // round-trip per columns() call.
+    const needsCreateInfo = fields.some((f) => {
+      const def = (f["Default"] as string | null) ?? null;
+      const extra = ((f["Extra"] as string | null) ?? "").trim();
+      if (def == null || /^\d/.test(def) || def.startsWith("'")) return false;
+      if (extra.startsWith("DEFAULT_GENERATED")) return false;
+      if (/^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(def)) return false;
+      return true;
+    });
+    const createInfo = needsCreateInfo ? await this.createTableInfo(tableName) : null;
+    return fields.map((field) =>
+      newColumnFromField(
+        tableName,
+        field as Record<string, string | null>,
+        () => createInfo,
+        (sqlType) => this.lookupCastType(sqlType) as never,
+      ),
+    );
   }
 
   /**
@@ -1522,73 +1542,26 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     if (this.supportsRenameColumn()) {
       return `RENAME COLUMN ${this.quoteIdentifier(columnName)} TO ${this.quoteIdentifier(newColumnName)}`;
     }
-    // Fallback for MySQL <8.0.3 / MariaDB <10.5.2: mirrors Rails' rename_column_for_alter fallback.
-    // columnDefinitions (SHOW FULL FIELDS) fires a "SCHEMA" notification and returns the full
-    // column definition including Collation, Extra (auto_increment), and Comment — more complete
-    // than SHOW COLUMNS which omits those fields.
-    const cols = await this.columnDefinitions(tableName);
-    const col = cols.find((c) => (c["Field"] as string) === columnName);
-    if (!col) throw new Error(`Column not found: ${columnName} in ${tableName}`);
-    // Guard against silently dropping Extra attributes we cannot reconstruct (e.g. generated
-    // columns). Allowed values: AUTO_INCREMENT (via ColumnOptions.autoIncrement), ON UPDATE <expr>
-    // (via MysqlAddColumnOptions.onUpdate, including the MySQL 8 compound form
-    // "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"), and DEFAULT_GENERATED alone (function
-    // default — reconstructed via RENAME_FUNC_DEFAULT_RE / paren-wrap lambda in colDefault below).
-    // Anything else triggers an explicit throw so callers know to upgrade MySQL.
-    const extraRaw = ((col["Extra"] as string | undefined) ?? "").trim();
-    const extra = extraRaw.toLowerCase();
-    const onUpdateMatch = extraRaw.match(/on update (.+)$/i);
-    if (extra && extra !== "auto_increment" && extra !== "default_generated" && !onUpdateMatch) {
-      throw new Error(
-        `renameColumnForAlter fallback: cannot safely CHANGE column "${columnName}" in table "${tableName}" ` +
-          `— Extra="${col["Extra"]}" is not preserved by this path. ` +
-          `Upgrade to MySQL ≥8.0.3 or MariaDB ≥10.5.2 to use RENAME COLUMN instead.`,
-      );
-    }
-    const rawDefault = col["Default"] !== null ? (col["Default"] as string) : undefined;
-    // SHOW FULL FIELDS returns function defaults as plain strings (e.g. "CURRENT_TIMESTAMP", "NOW()").
-    // Rails' column.default is nil for function defaults; pass as a lambda so
-    // quoteDefaultExpression emits it unquoted: DEFAULT NOW(), not DEFAULT 'NOW()'.
-    // Mirrors newColumnFromField: CURRENT_TIMESTAMP datetime cols and DEFAULT_GENERATED cols
-    // always go through the function-default path; everything else only when RENAME_FUNC_DEFAULT_RE matches.
-    // RENAME_FUNC_DEFAULT_RE catches well-known keyword defaults without a DB round-trip;
-    // anything that isn't a literal digit-led default also gets a SHOW CREATE TABLE check
-    // via defaultType(), mirroring Rails' new_column_from_field broader function-default
-    // detection (mysql/schema_statements.rb:189-208).
-    let colDefault: (() => string) | string | undefined;
-    if (typeof rawDefault === "string") {
-      if (extra === "default_generated") {
-        // Mirrors newColumnFromField (mysql/schema-statements.ts): DEFAULT_GENERATED expressions
-        // must be wrapped in parens so MySQL accepts them in ALTER TABLE … CHANGE.
-        const expr = rawDefault.startsWith("(") ? rawDefault : `(${rawDefault})`;
-        colDefault = () => expr;
-      } else if (RENAME_FUNC_DEFAULT_RE.test(rawDefault)) {
-        // Well-known keyword defaults (e.g. CURRENT_TIMESTAMP): emit as-is, no parens.
-        colDefault = () => rawDefault;
-      } else if (!/^\d/.test(rawDefault) && !rawDefault.startsWith("'")) {
-        // Broader function-default detection via SHOW CREATE TABLE — Rails' default_type
-        // returns :function for any DEFAULT followed by a bare keyword identifier.
-        const createInfo = await this.createTableInfo(tableName);
-        colDefault =
-          defaultType(createInfo, columnName) === "function" ? () => rawDefault : rawDefault;
-      } else {
-        colDefault = rawDefault;
-      }
-    } else {
-      colDefault = rawDefault;
-    }
+    // Fallback for MySQL <8.0.3 / MariaDB <10.5.2: mirrors Rails' rename_column_for_alter
+    // (abstract_mysql_adapter.rb:863-878). Route through columnFor so function-default and
+    // on_update detection happens once in newColumnFromField — no second-pass parsing here.
+    const column = (await this.columnFor(tableName, columnName)) as MysqlColumn;
+    const defFn = column.defaultFunction;
+    // newColumnFromField sets column.default to null when defaultFunction is present, so we can
+    // pass either through ColumnDefinition's `default` slot: a lambda for function defaults
+    // (emitted unquoted by quoteDefaultExpression) or the literal value otherwise. SHOW FULL
+    // FIELDS returns null Default both when there is no default and when DEFAULT NULL; treat
+    // null as "no explicit default" to avoid emitting DEFAULT NULL on NOT NULL columns.
+    const colDefault: (() => string) | string | undefined =
+      defFn != null ? () => defFn : column.default == null ? undefined : (column.default as string);
     const colOpts: MysqlAddColumnOptions = {
-      // SHOW FULL FIELDS returns NULL for Default both when there is no default and when
-      // DEFAULT NULL. Treat null as "no explicit default" (undefined) to avoid emitting
-      // DEFAULT NULL on NOT NULL columns — mirrors Rails column_for + new_column_definition.
       default: colDefault,
-      null: (col["Null"] as string) === "YES",
-      collation: (col["Collation"] as string | undefined) || undefined,
-      comment: (col["Comment"] as string | undefined) || undefined,
-      autoIncrement: extra === "auto_increment" || undefined,
-      onUpdate: onUpdateMatch ? onUpdateMatch[1] : undefined,
+      null: column.null,
+      collation: column.collation ?? undefined,
+      comment: column.comment ?? undefined,
+      autoIncrement: column.autoIncrement || undefined,
     };
-    const colDef = new ColumnDefinition(newColumnName, col["Type"] as string, colOpts);
+    const colDef = new ColumnDefinition(newColumnName, column.sqlType ?? "", colOpts);
     const cd = new ChangeColumnDefinition(colDef, columnName);
     return new MysqlSchemaCreation().accept(cd);
   }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -169,9 +169,15 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     const needsCreateInfo = fields.some((f) => {
       const def = (f["Default"] as string | null) ?? null;
       const extra = ((f["Extra"] as string | null) ?? "").trim();
+      const sqlType = ((f["Type"] as string | null) ?? "").toLowerCase();
       if (def == null || /^\d/.test(def) || def.startsWith("'")) return false;
       if (extra.startsWith("DEFAULT_GENERATED")) return false;
-      if (/^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(def)) return false;
+      // newColumnFromField's datetime+CURRENT_TIMESTAMP short-circuit only fires when the
+      // semantic type is "datetime" (sqlType startsWith "datetime"/"timestamp"); for
+      // non-datetime columns with a CURRENT_TIMESTAMP default we still need SHOW CREATE TABLE
+      // for the broader function-default detection.
+      const isDatetimeLike = /^(datetime|timestamp)/.test(sqlType);
+      if (isDatetimeLike && /^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(def)) return false;
       return true;
     });
     const createInfo = needsCreateInfo ? await this.createTableInfo(tableName) : null;
@@ -1573,8 +1579,16 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
       collation: column.collation ?? undefined,
       comment: column.comment ?? undefined,
       autoIncrement: column.autoIncrement || undefined,
+      onUpdate: column.onUpdate ?? undefined,
     };
-    const colDef = new ColumnDefinition(newColumnName, column.sqlType ?? "", colOpts);
+    if (column.sqlType == null || column.sqlType.length === 0) {
+      throw new Error(
+        `renameColumnForAlter fallback: missing sqlType for column "${columnName}" in table ` +
+          `"${tableName}" — cannot rebuild CHANGE clause without the full column type. ` +
+          `This indicates the column metadata was not fully populated by columns().`,
+      );
+    }
+    const colDef = new ColumnDefinition(newColumnName, column.sqlType, colOpts);
     const cd = new ChangeColumnDefinition(colDef, columnName);
     return new MysqlSchemaCreation().accept(cd);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -573,10 +573,10 @@ export class SchemaStatements {
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
-    // Rails: single combined ALTER TABLE via add_timestamps_for_alter.
-    // SQLite-style adapters that don't support bulk ALTER fall back to
-    // two sequential addColumn calls (sqlite3_adapter.rb#add_timestamps
-    // uses the alter_table rebuild path instead of a combined ALTER).
+    // Mirrors Rails (abstract/schema_statements.rb:1459) for adapters that bulk-alter (MySQL,
+    // PG): one combined ALTER TABLE. SQLite-style adapters that don't support bulk ALTER fall
+    // back to two sequential addColumn calls — Rails' sqlite3_adapter#add_timestamps overrides
+    // to use the alter_table rebuild path instead, which trails replicates on its sqlite3 adapter.
     if ((this.adapter as any).supportsBulkAlter?.() === true) {
       const fragments = this.addTimestampsForAlter(tableName, options);
       await this.adapter.executeMutation(
@@ -594,8 +594,10 @@ export class SchemaStatements {
   }
 
   async removeTimestamps(tableName: string): Promise<void> {
-    await this.removeColumn(tableName, "created_at");
-    await this.removeColumn(tableName, "updated_at");
+    // Mirrors Rails (abstract/schema_statements.rb:1468): route through removeColumns so
+    // adapters that batch (MySQL) can emit a single ALTER. The default removeColumns
+    // implementation loops sequentially; SQLite overrides to use a rebuild.
+    await this.removeColumns(tableName, "updated_at", "created_at");
   }
 
   async createJoinTable(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -597,8 +597,8 @@ export class SchemaStatements {
 
   async removeTimestamps(tableName: string): Promise<void> {
     // Mirrors Rails (abstract/schema_statements.rb:1468): route through removeColumns so
-    // adapters that batch (MySQL) can emit a single ALTER. The default removeColumns
-    // implementation loops sequentially; SQLite overrides to use a rebuild.
+    // adapter overrides apply. The default removeColumns loops sequentially (matching Rails);
+    // SQLite overrides to use a single alter_table rebuild.
     await this.removeColumns(tableName, "updated_at", "created_at");
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -573,10 +573,12 @@ export class SchemaStatements {
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {
-    // Mirrors Rails (abstract/schema_statements.rb:1459) for adapters that bulk-alter (MySQL,
-    // PG): one combined ALTER TABLE. SQLite-style adapters that don't support bulk ALTER fall
-    // back to two sequential addColumn calls — Rails' sqlite3_adapter#add_timestamps overrides
-    // to use the alter_table rebuild path instead, which trails replicates on its sqlite3 adapter.
+    // Rails (abstract/schema_statements.rb:1459) issues a single combined ALTER TABLE for every
+    // adapter and relies on SQLite's adapter-level override to swap in the alter_table rebuild
+    // path. trails uses a wrapper SchemaAdapter that cannot dispatch back to inner-adapter
+    // overrides, so we branch on supportsBulkAlter() here: bulk-alter adapters (MySQL, PG) get
+    // the combined ALTER TABLE; non-bulk adapters fall back to two sequential addColumn calls.
+    // trails' SQLite3Adapter still defines its own addTimestamps override for direct callers.
     if ((this.adapter as any).supportsBulkAlter?.() === true) {
       const fragments = this.addTimestampsForAlter(tableName, options);
       await this.adapter.executeMutation(

--- a/packages/activerecord/src/connection-adapters/mysql/column.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/column.ts
@@ -12,6 +12,10 @@ export class Column extends BaseColumn {
   readonly unsigned: boolean;
   readonly autoIncrement: boolean;
   readonly virtual: boolean;
+  /** MySQL `ON UPDATE <expr>` extracted from `Extra`. null when not set. Mirrors the
+   *  unparsed `ON UPDATE` portion of the column definition; used by renameColumnForAlter
+   *  to round-trip the attribute when folding into defaultFunction is not possible. */
+  readonly onUpdate: string | null;
 
   constructor(
     name: string,
@@ -32,6 +36,7 @@ export class Column extends BaseColumn {
       unsigned?: boolean;
       autoIncrement?: boolean;
       virtual?: boolean;
+      onUpdate?: string | null;
     } = {},
   ) {
     const meta = new SqlTypeMetadata({
@@ -50,6 +55,7 @@ export class Column extends BaseColumn {
     this.unsigned = options.unsigned ?? false;
     this.autoIncrement = options.autoIncrement ?? false;
     this.virtual = options.virtual ?? false;
+    this.onUpdate = options.onUpdate ?? null;
   }
 
   isUnsigned(): boolean {
@@ -79,6 +85,7 @@ export class Column extends BaseColumn {
       unsigned: this.unsigned,
       autoIncrement: this.autoIncrement,
       virtual: this.virtual,
+      onUpdate: this.onUpdate,
     };
   }
 
@@ -103,6 +110,7 @@ export class Column extends BaseColumn {
         unsigned: m.unsigned,
         autoIncrement: m.autoIncrement,
         virtual: m.virtual,
+        onUpdate: m.onUpdate ?? null,
       },
     );
   }
@@ -113,4 +121,5 @@ export interface MysqlColumnJSON extends ColumnJSON {
   unsigned: boolean;
   autoIncrement: boolean;
   virtual: boolean;
+  onUpdate?: string | null;
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -148,12 +148,21 @@ export function newColumnFromField(
   let def: string | null = field["Default"] ?? null;
   let defFn: string | null = null;
 
+  const extraRaw = field["Extra"] ?? "";
+  const onUpdateMatch = extraRaw.match(/on update (.+)$/i);
+
   if (meta.type === "datetime" && /^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(def ?? "")) {
-    if (/on update CURRENT_TIMESTAMP/i.test(field["Extra"] ?? "")) def = `${def} ON UPDATE ${def}`;
+    if (/on update CURRENT_TIMESTAMP/i.test(extraRaw)) def = `${def} ON UPDATE ${def}`;
     [def, defFn] = [null, def];
-  } else if (meta.extra === "DEFAULT_GENERATED") {
+  } else if (meta.extra.startsWith("DEFAULT_GENERATED")) {
+    // MySQL 8 emits "DEFAULT_GENERATED" alone (function default) or compound
+    // "DEFAULT_GENERATED on update CURRENT_TIMESTAMP". Both flow through the
+    // function-default path; fold on_update into the function expression so
+    // renameColumnForAlter can rebuild the column from defaultFunction alone.
     if (def != null && !def.startsWith("(")) def = `(${def})`;
-    [def, defFn] = [null, def?.replace(/\\'/g, "'") ?? null];
+    let folded = def?.replace(/\\'/g, "'") ?? null;
+    if (folded != null && onUpdateMatch) folded = `${folded} ON UPDATE ${onUpdateMatch[1]}`;
+    [def, defFn] = [null, folded];
   } else if (meta.type === "text" && def?.startsWith("'")) {
     def = def.slice(1, -1).replace(/\\'/g, "'");
   } else if (def != null && !/^\d/.test(def)) {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -154,7 +154,7 @@ export function newColumnFromField(
   if (meta.type === "datetime" && /^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(def ?? "")) {
     if (/on update CURRENT_TIMESTAMP/i.test(extraRaw)) def = `${def} ON UPDATE ${def}`;
     [def, defFn] = [null, def];
-  } else if (meta.extra.startsWith("DEFAULT_GENERATED")) {
+  } else if (meta.extra.toUpperCase().startsWith("DEFAULT_GENERATED")) {
     // MySQL 8 emits "DEFAULT_GENERATED" alone (function default) or compound
     // "DEFAULT_GENERATED on update CURRENT_TIMESTAMP". Both flow through the
     // function-default path; fold on_update into the function expression so
@@ -182,7 +182,7 @@ export function newColumnFromField(
     collation: field["Collation"] ?? null,
     unsigned: /unsigned/i.test(field["Type"] ?? ""),
     autoIncrement: /auto_increment/i.test(field["Extra"] ?? ""),
-    virtual: /VIRTUAL GENERATED|STORED GENERATED/i.test(field["Extra"] ?? ""),
+    virtual: /(virtual|stored|persistent)\s+generated/i.test(field["Extra"] ?? ""),
     onUpdate: onUpdateForColumn,
   });
 }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -170,12 +170,20 @@ export function newColumnFromField(
       [def, defFn] = [null, def];
   }
 
+  // Capture ON UPDATE <expr> only when it wasn't already folded into defFn. The datetime
+  // CURRENT_TIMESTAMP and DEFAULT_GENERATED branches fold ON UPDATE into the function-default
+  // string; for the remaining cases (e.g. datetime column with no default and a bare
+  // `on update CURRENT_TIMESTAMP` Extra) we preserve it as a first-class column attribute so
+  // renameColumnForAlter's rebuild can pass it through MysqlAddColumnOptions.onUpdate.
+  const onUpdateForColumn =
+    onUpdateMatch && (defFn == null || !/ ON UPDATE /i.test(defFn)) ? onUpdateMatch[1] : null;
   return new Column(fieldName, def, meta, field["Null"] === "YES", {
     defaultFunction: defFn ?? undefined,
     collation: field["Collation"] ?? null,
     unsigned: /unsigned/i.test(field["Type"] ?? ""),
     autoIncrement: /auto_increment/i.test(field["Extra"] ?? ""),
     virtual: /VIRTUAL GENERATED|STORED GENERATED/i.test(field["Extra"] ?? ""),
+    onUpdate: onUpdateForColumn,
   });
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1115,9 +1115,32 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       const colKey = String((r.col_key ?? r.COL_KEY ?? r.COLUMN_KEY ?? "") as string);
       const extraRaw = String((r.extra ?? r.EXTRA ?? "") as string);
       const extra = extraRaw.toLowerCase();
+      // Mirror newColumnFromField's function-default detection (mysql/schema-statements.ts):
+      // information_schema doesn't surface SHOW CREATE TABLE's bare-keyword default branch, but
+      // the two cases that matter for renameColumnForAlter — datetime+CURRENT_TIMESTAMP and
+      // DEFAULT_GENERATED — are detectable from extra + default_value alone.
+      let def: unknown = r.default_value ?? r.DEFAULT_VALUE ?? null;
+      let defFn: string | null = null;
+      const onUpdateMatch = extraRaw.match(/on update (.+)$/i);
+      if (
+        semanticType === "datetime" &&
+        typeof def === "string" &&
+        /^CURRENT_TIMESTAMP(\([0-6]?\))?$/i.test(def)
+      ) {
+        defFn = onUpdateMatch ? `${def} ON UPDATE ${onUpdateMatch[1]}` : def;
+        def = null;
+      } else if (extraRaw.toUpperCase().startsWith("DEFAULT_GENERATED")) {
+        if (typeof def === "string") {
+          const wrapped = def.startsWith("(") ? def : `(${def})`;
+          defFn = onUpdateMatch ? `${wrapped} ON UPDATE ${onUpdateMatch[1]}` : wrapped;
+        }
+        def = null;
+      }
+      const onUpdateForColumn =
+        onUpdateMatch && (defFn == null || !/ ON UPDATE /i.test(defFn)) ? onUpdateMatch[1] : null;
       return new MysqlColumn(
         name,
-        r.default_value ?? r.DEFAULT_VALUE ?? null,
+        def,
         {
           sqlType: meta.sqlType,
           type: meta.type ?? undefined,
@@ -1129,11 +1152,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         {
           collation: (r.collation ?? r.COLLATION ?? null) as string | null,
           comment: (r.comment ?? r.COMMENT ?? null) as string | null,
+          defaultFunction: defFn,
           primaryKey: colKey === "PRI",
           autoIncrement: extra === "auto_increment",
           unsigned: /\bunsigned(?: zerofill)?\b/i.test(sqlType),
           virtual: /\b(?:virtual|stored|persistent)\b/i.test(extra),
-          onUpdate: extraRaw.match(/on update (.+)$/i)?.[1] ?? null,
+          onUpdate: onUpdateForColumn,
         },
       );
     });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1113,7 +1113,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         String((r.nullable ?? r.NULLABLE ?? r.IS_NULLABLE ?? "YES") as string).toUpperCase() !==
         "NO";
       const colKey = String((r.col_key ?? r.COL_KEY ?? r.COLUMN_KEY ?? "") as string);
-      const extra = String((r.extra ?? r.EXTRA ?? "") as string).toLowerCase();
+      const extraRaw = String((r.extra ?? r.EXTRA ?? "") as string);
+      const extra = extraRaw.toLowerCase();
       return new MysqlColumn(
         name,
         r.default_value ?? r.DEFAULT_VALUE ?? null,
@@ -1132,6 +1133,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
           autoIncrement: extra === "auto_increment",
           unsigned: /\bunsigned(?: zerofill)?\b/i.test(sqlType),
           virtual: /\b(?:virtual|stored|persistent)\b/i.test(extra),
+          onUpdate: extraRaw.match(/on update (.+)$/i)?.[1] ?? null,
         },
       );
     });

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1223,24 +1223,21 @@ class SchemaAdapter implements DatabaseAdapter {
   }
 
   supportsIndexesInCreate(): boolean {
-    return (
-      (this.inner as { supportsIndexesInCreate?: () => boolean }).supportsIndexesInCreate?.() ??
-      false
-    );
+    return this._delegateCapability("supportsIndexesInCreate");
   }
 
   supportsAdvisoryLocks(): boolean {
-    return (
-      (this.inner as { supportsAdvisoryLocks?: () => boolean }).supportsAdvisoryLocks?.() ?? false
-    );
+    return this._delegateCapability("supportsAdvisoryLocks");
   }
 
   supportsInsertConflictTarget(): boolean {
-    return (
-      (
-        this.inner as { supportsInsertConflictTarget?: () => boolean }
-      ).supportsInsertConflictTarget?.() ?? false
-    );
+    return this._delegateCapability("supportsInsertConflictTarget");
+  }
+
+  /** Forward a boolean capability probe to the inner adapter; default false when absent. */
+  private _delegateCapability(name: string): boolean {
+    const probe = (this.inner as unknown as Record<string, unknown>)[name];
+    return typeof probe === "function" ? Boolean((probe as () => boolean).call(this.inner)) : false;
   }
 
   async getDatabaseVersion(): Promise<unknown> {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -579,6 +579,11 @@ export async function resetTestAdapterState(): Promise<void> {
  *   2. Creates tables from registered model attribute definitions
  *   3. Handles missing table/column errors as a fallback
  */
+type BooleanCapability =
+  | "supportsIndexesInCreate"
+  | "supportsAdvisoryLocks"
+  | "supportsInsertConflictTarget";
+
 // eslint-disable-next-line @typescript-eslint/no-unsafe-declaration-merging
 interface SchemaAdapter {
   selectAll(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
@@ -1235,7 +1240,7 @@ class SchemaAdapter implements DatabaseAdapter {
   }
 
   /** Forward a boolean capability probe to the inner adapter; default false when absent. */
-  private _delegateCapability(name: string): boolean {
+  private _delegateCapability(name: BooleanCapability): boolean {
     const probe = (this.inner as unknown as Record<string, unknown>)[name];
     return typeof probe === "function" ? Boolean((probe as () => boolean).call(this.inner)) : false;
   }


### PR DESCRIPTION
## Summary

Batch 49 from `docs/activerecord-100-plan.md` — MySQL active-schema small-items bundle.

- **`renameColumnForAlter` via `columnFor`** (mirrors `abstract_mysql_adapter.rb:863-878`). Drops the second `SHOW FULL FIELDS` parse in favor of the `columns()` path, centralizing function-default and `on_update` detection inside `newColumnFromField`.
- **Default `AbstractMysqlAdapter#columns()`** that maps `columnDefinitions` rows through `newColumnFromField` (mirrors Rails `SchemaStatements#columns`). Lazily prefetches `createTableInfo` once iff any field default needs broader function-default detection.
- **Widen `DEFAULT_GENERATED` Extra match** in `newColumnFromField` from strict equality to `startsWith`, so MySQL 8 compound `DEFAULT_GENERATED on update CURRENT_TIMESTAMP(6)` flows through the function-default branch and folds `on_update` into `defaultFunction`.
- **`removeTimestamps` parity**: route through `removeColumns(..., "updated_at", "created_at")` to mirror `abstract/schema_statements.rb:1468`. Clarify comment on `addTimestamps`' `supportsBulkAlter` branch.
- **Capability helper** in `test-adapter.ts` (`_delegateCapability`) to deduplicate the `supports*?.()` forwarding shape (Indexes-in-create, advisory locks, insert conflict target).

Unsigned `typeToSql` suffix item from the plan was already present at `mysql/schema-creation.ts:170`.

## Test plan
- [x] `pnpm typecheck --filter activerecord`
- [x] Connection-adapter test suite under `TEST_ADAPTER=mysql2` (796 passed / 105 skipped)
- [x] Migration + active-record-schema tests (197 passed / 11 skipped)
- [ ] CI green