### PR TITLE
test(activerecord): TM phase 5 — defineSchema for has-many-through-disable-joins-associations.test.ts

### DIFF
--- a/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
@@ -7,6 +7,31 @@ import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import { Associations, association, loadHasMany } from "../associations.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+
+const TEST_SCHEMA: Schema = {
+  dj_authors: { name: "string" },
+  dj_posts: {
+    dj_author_id: "integer",
+    title: "string",
+    body: "string",
+  },
+  dj_comments: {
+    dj_post_id: "integer",
+    body: "string",
+    origin_id: "integer",
+    origin_type: "string",
+  },
+  dj_ratings: {
+    dj_comment_id: "integer",
+    value: "integer",
+  },
+  dj_members: {
+    name: "string",
+    dj_member_type_id: "integer",
+  },
+  dj_member_types: { name: "string" },
+};
 
 /**
  * Build a DJAS scope for `assocName` on `owner`. Returns the deferred
@@ -27,8 +52,10 @@ function djasScope(owner: Base, assocName: string): any {
   });
 }
 
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
 }
 
 describe("HasManyThroughDisableJoinsAssociationsTest", () => {
@@ -83,8 +110,8 @@ describe("HasManyThroughDisableJoinsAssociationsTest", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     DjAuthor.adapter = adapter;
     DjPost.adapter = adapter;
     DjComment.adapter = adapter;


### PR DESCRIPTION
## Summary

Continues TM unification Phase 5. Migrates `has-many-through-disable-joins-associations.test.ts` to pass under `AR_NO_AUTO_SCHEMA=1` by seeding the test adapter via `defineSchema()` from an async `freshAdapter()`.

- `TEST_SCHEMA` covers all six tables the suite touches: `dj_authors`, `dj_posts`, `dj_comments`, `dj_ratings`, `dj_members`, `dj_member_types`.
- `freshAdapter()` promoted to `async`; `beforeEach` promoted to `async`.
- No test names changed.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts` → 32 passed
- `pnpm vitest run packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts` → 32 passed
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags this file

## Test plan

- [x] AR_NO_AUTO_SCHEMA=1 green
- [x] Normal mode green
- [x] No test names renamed
- [x] Audit clean
- [ ] CI green across PG / MySQL / SQLite