### PR TITLE
test(activerecord): TM phase 5 — defineSchema for left-outer-join-association.test.ts

### DIFF
--- a/packages/activerecord/src/associations/left-outer-join-association.test.ts
+++ b/packages/activerecord/src/associations/left-outer-join-association.test.ts
@@ -8,16 +8,26 @@ import { Associations } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+const TEST_SCHEMA: Schema = {
+  authors: { name: "string" },
+  posts: { title: "string", author_id: "integer" },
+  comments: { body: "string", post_id: "integer" },
+  l_posts: { title: "string" },
+  l_comments: { body: "string", type: "string", post_id: "integer" },
+};
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
 }
 
 describe("LeftOuterJoinAssociationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   function makeModels() {
@@ -164,7 +174,7 @@ describe("LeftOuterJoinAssociationTest", () => {
   });
 
   it("find with sti join", async () => {
-    const a = createTestAdapter();
+    const a = await freshAdapter();
     class LComment extends Base {
       static {
         this.attribute("body", "string");


### PR DESCRIPTION
## Summary

Continues TM unification Phase 5. Migrates `left-outer-join-association.test.ts` to pass under `AR_NO_AUTO_SCHEMA=1` by seeding the test adapter via `defineSchema()` from an async `freshAdapter()`.

- `TEST_SCHEMA` covers `authors` / `posts` / `comments` plus `l_posts` / `l_comments` (the STI cluster used by *find with sti join*).
- `freshAdapter()` now returns `Promise<DatabaseAdapter>`; `beforeEach` and the inner `createTestAdapter()` callsite in *find with sti join* now `await` it.
- No test names changed.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/associations/left-outer-join-association.test.ts` → 16 passed / 3 skipped
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags this file

## Test plan

- [x] `AR_NO_AUTO_SCHEMA=1` green
- [x] No test names renamed
- [x] Audit clean
- [ ] CI green across PG / MySQL / SQLite