### PR TITLE
test(activerecord): TM phase 5 — defineSchema for autosave-association.test.ts (cluster A)

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -16,6 +16,7 @@ import {
 import { Associations, setBelongsTo, association, loadHasManyThrough } from "./associations.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import {
   markForDestruction,
@@ -40,8 +41,16 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      pirates: { catchphrase: "string" },
+      ships: { name: "string", pirate_id: "integer" },
+      birds: { name: "string", pirate_id: "integer" },
+      parts: { name: "string", ship_id: "integer" },
+      parrots: { name: "string" },
+      parrots_pirates: { pirate_id: "integer", parrot_id: "integer" },
+    });
   });
 
   function makePirateShip() {


### PR DESCRIPTION
## Summary

Migrates the `TestDestroyAsPartOfAutosaveAssociation` describe block in
`packages/activerecord/src/autosave-association.test.ts` to the per-describe
`beforeEach` `defineSchema` pattern (same shape as #1873 / #1885), so the
file is no longer flagged by `scripts/audit-define-schema.ts`.

Cluster A covers describe 1 only (30 tests, lines 37–492). Tables:
`pirates`, `ships`, `birds`, `parts`, `parrots`, `parrots_pirates`.

The file is ~4637 LOC with 26 describe blocks. Each test inlines its own
model classes with distinct table names (firms/accounts, authors/posts,
polymorphic `*able_id`, CPK shop/order pairs, etc.), so the full migration
needs multiple incremental PRs per the CLAUDE.md PR-size ceiling.

## Verification

- `pnpm vitest run packages/activerecord/src/autosave-association.test.ts -t TestDestroyAsPartOfAutosaveAssociation` — 30 passed (normal mode).
- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/autosave-association.test.ts -t TestDestroyAsPartOfAutosaveAssociation` — 30 passed (strict mode).
- `pnpm vitest run packages/activerecord/src/autosave-association.test.ts` — 193 passed / 15 skipped (no regression in normal mode).
- `pnpm tsx scripts/audit-define-schema.ts` — file no longer flagged.

## Test plan

- [x] Cluster A tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] Full file passes in normal mode
- [x] No test names renamed
- [x] Audit script no longer flags this file
- [ ] CI green across PG / MySQL / SQLite

## Follow-ups

25 describes remain (~4145 LOC), to be migrated as `<base>b`, `<base>c`, …
Adjacent same-cluster bundling per the `belongs-to-associations` /
`inverse-associations` precedent:

- `TestDefaultAutosaveAssociationOnAHasManyAssociation` (lines 494–837) — `companies`, `clients`, `unvalidated_clients`, CPK `cpk_orders` / `cpk_books`, `aid_firms` / `aid_contracts` / `aid_developers`
- `TestDefaultAutosaveAssociationOnAHasOneAssociation` (lines 838–1309) — `firms` / `accounts`, `p_firms` / `p_accounts`, `loose_accounts`, `cb_firms` / `cb_accounts`, `cu_firms` / `cu_accounts`, `cs_firms` / `cs_accounts`, `cb_parents` / `cb_children`, `poly_parents` / `poly_children`, `cb_owners` / `cb_pets`, `poly_as_parents` / `poly_as_children`
- `TestAutosaveAssociationOnAHasOneAssociation` (lines 1310–1633) — pirate/ship variants (Dual*, Flex*, Deep*, Cc*, Swap*)
- … and 22 more describes