### PR TITLE
test(activerecord): TM phase 5 — defineSchema for time-precision + date-time-precision

### DIFF
--- a/packages/activerecord/src/date-time-precision.test.ts
+++ b/packages/activerecord/src/date-time-precision.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instantToS } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
-import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter } from "./test-adapter.js";
 import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./schema-dumper.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 
 function nsec(v: Temporal.Instant): number {
   let ns = v.epochNanoseconds % 1_000_000_000n;
@@ -13,18 +15,22 @@ function nsec(v: Temporal.Instant): number {
   return Number(ns);
 }
 
+// See time-precision.test.ts — placeholder schema; tests recreate `foos` per-test
+// with the precision under test via `ctx.createTable("foos", { force: true }, ...)`.
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, { foos: { name: "string" } });
+  return adapter;
+}
+
 describe("DateTimePrecisionTest", () => {
-  let adapter: SQLite3Adapter;
+  let adapter: DatabaseAdapter;
   let ctx: MigrationContext;
 
-  beforeEach(() => {
-    adapter = new SQLite3Adapter(":memory:");
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     ctx = new MigrationContext(adapter);
   });
-  afterEach(async () => {
-    await adapter.close();
-  });
-
   function makeFoo() {
     class Foo extends Base {
       static override tableName = "foos";

--- a/packages/activerecord/src/time-precision.test.ts
+++ b/packages/activerecord/src/time-precision.test.ts
@@ -1,27 +1,35 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
-import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter } from "./test-adapter.js";
 import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./schema-dumper.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 
 function nsecTime(v: Temporal.PlainTime): number {
   return v.millisecond * 1_000_000 + v.microsecond * 1_000 + v.nanosecond;
 }
 
+// Tests recreate `foos` per-test via `ctx.createTable("foos", { force: true }, ...)`
+// with varying precision options, so the schema seeded here is a placeholder that
+// satisfies AR_NO_AUTO_SCHEMA=1's "schema must be declared up front" requirement;
+// the `force: true` migrations drop and rebuild it with the precision under test.
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, { foos: { name: "string" } });
+  return adapter;
+}
+
 describe("TimePrecisionTest", () => {
-  let adapter: SQLite3Adapter;
+  let adapter: DatabaseAdapter;
   let ctx: MigrationContext;
 
-  beforeEach(() => {
-    adapter = new SQLite3Adapter(":memory:");
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     ctx = new MigrationContext(adapter);
   });
-  afterEach(async () => {
-    await adapter.close();
-  });
-
   function makeFoo() {
     class Foo extends Base {
       static override tableName = "foos";


### PR DESCRIPTION
## Summary

Migrates `time-precision.test.ts` (8 tests) and `date-time-precision.test.ts` (18 tests) to use `defineSchema()` + `createTestAdapter()` so both pass under `AR_NO_AUTO_SCHEMA=1` and clear `scripts/audit-define-schema.ts`.

Both files exercise migration mechanics directly — `ctx.createTable("foos", { force: true }, ...)` with varying precision options per test, plus schema-dump assertions. The seeded schema is a single `foos: { name: "string" }` placeholder per file; the per-test `force: true` migrations drop and rebuild it with the precision under test.

- `freshAdapter()` is async, returns `DatabaseAdapter`, seeds the placeholder via `defineSchema()` before returning.
- `beforeEach` is async; `ctx` is built from the seeded adapter.
- `afterEach(adapter.close())` removed — `createTestAdapter()`'s wrapper has no `close()` and the shared pool is managed by the test harness (matches `timestamp.test.ts`, etc.).
- No test names changed.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/time-precision.test.ts packages/activerecord/src/date-time-precision.test.ts` → 26 passed.
- `pnpm vitest run packages/activerecord/src/time-precision.test.ts packages/activerecord/src/date-time-precision.test.ts` → 26 passed.
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags either file.

## Test plan

- [x] Tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] Tests pass without `AR_NO_AUTO_SCHEMA`
- [x] No test names renamed
- [x] Audit script clean for these files
- [ ] CI green across PG / MySQL / SQLite