### PR TITLE
test(activerecord): TM phase 5 — defineSchema for reflection.test.ts

### DIFF
--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -31,17 +31,194 @@ import { createTestAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { UnknownPrimaryKey } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
+import { defineSchema, type Schema } from "./test-helpers/define-schema.js";
+
+// All tables referenced by tests in this file. Tests declare ad-hoc model
+// classes per-test, so under AR_NO_AUTO_SCHEMA=1 the schema must be
+// materialized up front rather than auto-derived by the test adapter.
+const TEST_SCHEMA: Schema = {
+  addresses: { street: "string" },
+  admin_users: { name: "string" },
+  appointments: { doctor_id: "integer", patient_id: "integer" },
+  articles: { title: "string", body_text: "string", views: "integer" },
+  authors: { name: "string" },
+  blog_posts: { title: "string", blog_id: "integer" },
+  bookmarks: { author_name: "string" },
+  books: { title: "string", author_id: "integer" },
+  bulbs: { car_id: "integer" },
+  cars: {},
+  cat_categories: { name: "string" },
+  catalog_categories: { name: "string" },
+  catalog_products: { name: "string" },
+  categories: { name: "string" },
+  chapters: { title: "string", book_id: "integer" },
+  chefs: { department_id: "integer", name: "string" },
+  children: { parent_id: "integer" },
+  clients: { name: "string" },
+  comments: { post_id: "integer", blog_post_id: "integer" },
+  companies: {},
+  company2s: {},
+  content_pages: { name: "string" },
+  contract2s: { company2_id: "integer" },
+  contracts: { company_id: "integer" },
+  crews: { ship_id: "integer" },
+  customers: {
+    balance_amount: "integer",
+    balance_currency: "string",
+    address_street: "string",
+    address_city: "string",
+  },
+  departments: { hotel_id: "integer", name: "string" },
+  developers: { name: "string" },
+  doctors: {},
+  essay_authors: { name: "string" },
+  essay_cats: { name: "string" },
+  essay_models: {
+    name: "string",
+    writer_id: "integer",
+    writer_type: "string",
+    category_id: "integer",
+  },
+  firms: { name: "string" },
+  habtm_posts: { title: "string" },
+  host_as: { name: "string" },
+  hot_accounts: { hot_owner_id: "integer" },
+  hot_owners: { name: "string" },
+  hot_profiles: { hot_account_id: "integer" },
+  hotels: { name: "string" },
+  items: { tenant_id: "integer" },
+  jt_categories: { name: "string" },
+  jt_products: { name: "string" },
+  libraries: { name: "string" },
+  line_items: { order_id: "integer", shop_id: "integer" },
+  magazines: { publisher_id: "integer" },
+  ms_departments: { hotel_id: "integer" },
+  ms_hotels: { name: "string" },
+  n_authors: { name: "string" },
+  n_categories: { name: "string" },
+  n_comments: { post_id: "integer" },
+  n_posts: { author_id: "integer" },
+  n_taggings: { post_id: "integer", tag_id: "integer" },
+  n_tags: { name: "string" },
+  nested_nested_users: { name: "string" },
+  nested_users: { name: "string" },
+  no_pk_models: {},
+  no_pk_owners: {},
+  ns_admin_users: { name: "string" },
+  ns_billing_accounts: { firm_id: "integer" },
+  ns_billing_firms: { name: "string" },
+  ns_billing_nested_firms: { name: "string" },
+  ns_biz_clients: { name: "string", firm_id: "integer" },
+  ns_biz_firms: { name: "string" },
+  ns_post_bs: { name: "string" },
+  ns_posts: { name: "string" },
+  ns_tag_bs: { name: "string" },
+  ns_tags: { name: "string" },
+  orders: {},
+  orgs: {},
+  orphan2s: { name: "string" },
+  orphans: { name: "string" },
+  owners: { no_pk_model_id: "integer", name: "string" },
+  parents: { name: "string" },
+  parts: { ship_id: "integer" },
+  patients: {},
+  people: { name: "string", age: "integer", active: "boolean" },
+  pets: { owner_id: "integer" },
+  post_tags: { post_id: "integer", tag_id: "integer" },
+  posts: {
+    writer_id: "integer",
+    author_id: "integer",
+    title: "string",
+    user_id: "integer",
+  },
+  profiles: { user_id: "integer" },
+  projects: { name: "string" },
+  publishers: {},
+  ratings: { comment_id: "integer" },
+  refl_authors: { name: "string" },
+  refl_categories: { name: "string" },
+  refl_essays: {
+    name: "string",
+    writer_id: "integer",
+    writer_type: "string",
+    category_id: "integer",
+  },
+  refl_organizations: { name: "string" },
+  rooms: { owner_id: "integer" },
+  sc2_chef_lists: {
+    employable_list_id: "integer",
+    employable_list_type: "string",
+    employable_id: "integer",
+    employable_type: "string",
+  },
+  sc2_hotels: { name: "string" },
+  sc2_mocktails: {},
+  sc3_authors: { name: "string" },
+  sc3_books: {
+    author_id: "integer",
+    format_record_id: "integer",
+    format_record_type: "string",
+  },
+  sc3_hardbacks: {},
+  sc4_chefs: {
+    department_id: "integer",
+    employable_id: "integer",
+    employable_type: "string",
+  },
+  sc4_depts: { hotel_id: "integer" },
+  sc4_drinks: {},
+  sc4_hotels: { name: "string" },
+  sc4_recipes: { chef_id: "integer", hotel_id: "integer" },
+  sc_cakes: {},
+  sc_chefs: {
+    department_id: "integer",
+    employable_id: "integer",
+    employable_type: "string",
+  },
+  sc_depts: { hotel_id: "integer" },
+  sc_drinks: {},
+  sc_hotels: { name: "string" },
+  ships: { name: "string" },
+  special_books: { isbn: "string", author_id: "integer" },
+  sponsors: {
+    sponsorable_id: "integer",
+    sponsorable_type: "string",
+    sponsor_club_id: "integer",
+  },
+  standalones: { name: "string" },
+  sub_books: { title: "string" },
+  subscribers: { name: "string" },
+  subscriptions: { subscriber_id: "integer", book_id: "integer" },
+  taggings: { taggable_id: "integer", taggable_type: "string" },
+  tags: { taggable_id: "integer", taggable_type: "string", name: "string" },
+  target_as: { name: "string" },
+  targets: {},
+  tasks: { title: "string" },
+  teams: {},
+  tenants: { tenant_id: "integer" },
+  top_users: { name: "string" },
+  topic2s: { title: "string" },
+  topics: {
+    title: "string",
+    author_name: "string",
+    body: "string",
+    category_id: "integer",
+  },
+  users: { name: "string", email: "string" },
+};
 
 // -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
 }
 
 describe("ReflectionTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   function makeModels() {
@@ -1033,8 +1210,8 @@ describe("ReflectionTest", () => {
     expect(type.cast(object)).toBe(object);
     expect(type.serialize(object)).toBe(object);
   });
-  it("reflection klass for nested class name", () => {
-    const adp = freshAdapter();
+  it("reflection klass for nested class name", async () => {
+    const adp = await freshAdapter();
     class Author extends Base {
       static {
         this.attribute("name", "string");
@@ -1054,8 +1231,8 @@ describe("ReflectionTest", () => {
     expect(ref).not.toBeNull();
     expect(ref!.klass).toBe(Book);
   });
-  it("irregular reflection class name", () => {
-    const adp = freshAdapter();
+  it("irregular reflection class name", async () => {
+    const adp = await freshAdapter();
     class Person extends Base {
       static {
         this.attribute("name", "string");
@@ -1074,8 +1251,8 @@ describe("ReflectionTest", () => {
     const ref = reflectOnAssociation(Person, "addresses");
     expect(ref!.klass).toBe(Address);
   });
-  it("reflection klass with same demodularized different modularized name", () => {
-    const adp = freshAdapter();
+  it("reflection klass with same demodularized different modularized name", async () => {
+    const adp = await freshAdapter();
     class NestedUser extends Base {
       static {
         this.attribute("name", "string");
@@ -1094,8 +1271,8 @@ describe("ReflectionTest", () => {
     const ref = reflectOnAssociation(AdminUser, "user");
     expect(ref!.klass).toBe(NestedUser);
   });
-  it("reflection klass with same modularized name", () => {
-    const adp = freshAdapter();
+  it("reflection klass with same modularized name", async () => {
+    const adp = await freshAdapter();
     class NestedNestedUser extends Base {
       static {
         this.attribute("name", "string");
@@ -2189,8 +2366,8 @@ describe("ReflectionTest", () => {
     }
   });
 
-  it("reflection klass with same demodularized name", () => {
-    const adp = freshAdapter();
+  it("reflection klass with same demodularized name", async () => {
+    const adp = await freshAdapter();
     class Project extends Base {
       static {
         this.attribute("name", "string");
@@ -2210,10 +2387,10 @@ describe("ReflectionTest", () => {
     expect(ref!.klass).toBe(Task);
   });
 
-  it("reflection klass demodulize top-level-first resolution", () => {
+  it("reflection klass demodulize top-level-first resolution", async () => {
     // Rails _klass: when demodulize(activeRecord.name) == className,
     // top-level ::ClassName is tried before namespace-relative lookup.
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class TopUser extends Base {
       static {
         this.attribute("name", "string");
@@ -2268,8 +2445,8 @@ describe("ReflectionTest", () => {
     expect(addr.city).toBe("Springfield");
   });
 
-  it("association reflection in modules", () => {
-    const adp = freshAdapter();
+  it("association reflection in modules", async () => {
+    const adp = await freshAdapter();
     class NsBizFirm extends Base {
       static {
         this.attribute("name", "string");
@@ -2684,8 +2861,8 @@ describe("ReflectionTest", () => {
     expect(ref!.className).toBe("Author");
   });
 
-  it("reflects on all associations", () => {
-    const adapter = freshAdapter();
+  it("reflects on all associations", async () => {
+    const adapter = await freshAdapter();
     class Post extends Base {
       static _tableName = "posts";
     }
@@ -2707,8 +2884,8 @@ describe("ReflectionTest", () => {
 describe("ReflectionTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   // Rails: test "columns"


### PR DESCRIPTION
## Summary

Migrates `reflection.test.ts` to use `defineSchema()` so it passes under
`AR_NO_AUTO_SCHEMA=1`.

- Adds `TEST_SCHEMA` covering the 122 ad-hoc tables derived from
  per-test class declarations (default name-inferred tables + the
  explicit `_tableName` overrides for `users`/`authors`/`books`/`posts`/`people`).
- `freshAdapter()` is now async — creates the adapter and seeds
  `TEST_SCHEMA` before returning. The two `beforeEach` hooks are promoted
  to async; the in-body `freshAdapter()` call sites are awaited and
  their surrounding `it()` callbacks marked async.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/reflection.test.ts` → 132 passed, 14 skipped.
- `pnpm vitest run packages/activerecord/src/reflection.test.ts` → 132 passed, 14 skipped.
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags this file.

## Test plan

- [x] Tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] Tests pass without `AR_NO_AUTO_SCHEMA`
- [x] No test names renamed
- [x] Audit script clean for this file
- [ ] CI green across PG / MySQL / SQLite

## Note on size

221 LOC, mostly the mechanical `TEST_SCHEMA` literal. Splitting the
schema dump by table subset isn't meaningful — `defineSchema()` must
contain every table the file references for the test to run.