### PR TITLE
test(activerecord): TM phase 5 — defineSchema for belongs-to-associations (cluster B, ~30 tests)

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -96,11 +96,12 @@ describe("BelongsToAssociationsTest", () => {
 
   beforeEach(async () => {
     adapter = freshAdapter();
-    // Schema covers the first ~30 tests in this describe: base
-    // Company/Account, counter-cache (Btc/Btcas/Cc/CustomCc/Btcau),
-    // polymorphic Post/Comment + Tag (incl. wp_cpk_tags), and Record/Entry
-    // families. Remaining tests inline unique table families and are
-    // deferred to follow-up cluster PRs.
+    // Schema covers the base Company/Account, counter-cache
+    // (Btc/Btcas/Cc/CustomCc/Btcau), polymorphic Post/Comment + Tag
+    // (incl. wp_cpk_tags), and Record/Entry table families. Later tests
+    // in this describe that reuse these tables also benefit; tests that
+    // inline additional unique table families remain uncovered under
+    // AR_NO_AUTO_SCHEMA=1 and are deferred to follow-up cluster PRs.
     await defineSchema(adapter, {
       companies: {
         name: "string",

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -94,8 +94,38 @@ describe("touch on belongs_to", () => {
 describe("BelongsToAssociationsTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    // Schema covers the first ~30 tests (lines 101-1190): the base
+    // Company/Account tests plus the counter-cache (Btc/Btcas/Cc/CustomCc/
+    // Btcau), polymorphic Post/Comment + Tag (incl. wp_cpk_tags), and
+    // Record/Entry families. Remaining tests in this describe inline more
+    // unique table families and are deferred to follow-up cluster PRs.
+    await defineSchema(adapter, {
+      companies: {
+        name: "string",
+        accounts_count: "integer",
+        active: "boolean",
+        updated_at: "datetime",
+      },
+      accounts: { company_id: "integer", credit_limit: "integer" },
+      btc_companies: { name: "string", accounts_count: "integer" },
+      btc_accounts: { company_id: "integer" },
+      btcas_companies: { name: "string", accounts_count: "integer" },
+      btcas_accounts: { company_id: "integer" },
+      cc_companies: { name: "string", accounts_count: "integer" },
+      cc_accounts: { company_id: "integer" },
+      custom_cc_companies: { name: "string", custom_count: "integer" },
+      custom_cc_accounts: { company_id: "integer" },
+      btcau_companies: { name: "string", accounts_count: "integer" },
+      btcau_accounts: { company_id: "integer", credit_limit: "integer" },
+      tags: { taggable_id: "integer", taggable_type: "string" },
+      wp_cpk_tags: { taggable_id: "integer", taggable_type: "string", name: "string" },
+      posts: { title: "string" },
+      comments: { commentable_id: "integer", commentable_type: "string" },
+      records: { name: "string" },
+      entries: { record_id: "integer" },
+    });
   });
 
   it("natural assignment", async () => {

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -96,11 +96,11 @@ describe("BelongsToAssociationsTest", () => {
 
   beforeEach(async () => {
     adapter = freshAdapter();
-    // Schema covers the first ~30 tests (lines 101-1190): the base
-    // Company/Account tests plus the counter-cache (Btc/Btcas/Cc/CustomCc/
-    // Btcau), polymorphic Post/Comment + Tag (incl. wp_cpk_tags), and
-    // Record/Entry families. Remaining tests in this describe inline more
-    // unique table families and are deferred to follow-up cluster PRs.
+    // Schema covers the first ~30 tests in this describe: base
+    // Company/Account, counter-cache (Btc/Btcas/Cc/CustomCc/Btcau),
+    // polymorphic Post/Comment + Tag (incl. wp_cpk_tags), and Record/Entry
+    // families. Remaining tests inline unique table families and are
+    // deferred to follow-up cluster PRs.
     await defineSchema(adapter, {
       companies: {
         name: "string",


### PR DESCRIPTION
## Summary

Cluster B follow-up to #1873. Extends the outer `BelongsToAssociationsTest`
describe's `beforeEach` with a `defineSchema` covering the table families
used by the first ~30 contiguous tests (lines 101-1190):

- Base `Company` / `Account`
- Counter-cache: `Btc` / `Btcas` / `Cc` / `CustomCc` / `Btcau`
- Polymorphic: `Post` / `Comment` + `Tag` (incl. `wp_cpk_tags`)
- `Record` / `Entry`

Follows the `inverse-associations.test.ts` precedent (#1752 / #1839):
a single describe-level schema rather than nested describes, to avoid
the ~700 LOC indentation churn of wrapping ~146 tests. Schema is
purely additive — later cluster PRs extend the table union for the
next slice of tests.

## Verification

- `pnpm vitest run packages/activerecord/src/associations/belongs-to-associations.test.ts`
  — 152 passed / 1 skipped (no regression in normal mode).
- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run ...` — **93 passed** / 59 failed
  / 1 skipped (up from ~5 passing pre-PR; remaining 59 failures are
  deferred clusters with unique table families).
- No test names renamed.
- Diff: 31 insertions, 1 deletion (1 file).

## Test plan

- [x] Full file passes in normal mode
- [x] First-cluster tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] No test names renamed
- [ ] CI green across PG / MySQL / SQLite

## Follow-ups

~115 tests remain across many unique table families: `Article`,
`AsgPkAccount`, `BidAccount`, `BpjAccount`, `BtAccount`,
`BuildPkCompany`, `Cat*`, `CcAsg*`, `Cccd*`, `Ccdd*`, `Cpk*`,
`Cpkm*`, `Cpko*`, `CreateBangCompany`, `Dc*`, `Dcn*`, `Dd*`, `Dh*`,
`Dpc*`, `EagerPk*`, `EagerSym*`, `Ecpk*`, `Elm*`, `FailCompany`,
`Fbcpk*`, `Icpk*`, `Ma*`, `Mcc*`, `NatNil*`, `NatPk*`, `Ncc*`,
`NoOrd*`, `NsCc*`, `Opt*`, `Pac*`, … — to be migrated in successive
cluster PRs (cluster C, D, …).