### PR TITLE
test(activerecord): TM phase 5 — defineSchema for relations.test.ts (cluster A)

### DIFF
--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { Base, Relation, Range, RecordNotFound, SoleRecordExceeded } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { sql as arelSql } from "@blazetrails/arel";
 
@@ -33,6 +34,17 @@ class Post extends Base {
 async function seedPosts() {
   adapter = freshAdapter();
   Post.adapter = adapter;
+  await defineSchema(adapter, {
+    posts: {
+      title: "string",
+      body: "string",
+      author: "string",
+      status: "string",
+      views: "integer",
+      category: "string",
+      published: "boolean",
+    },
+  });
   await Post.create({
     title: "First",
     body: "body1",
@@ -1087,6 +1099,14 @@ describe("RelationTest", () => {
   beforeEach(async () => {
     adapter = freshAdapter();
     Article.adapter = adapter;
+    await defineSchema(adapter, {
+      articles: {
+        title: "string",
+        status: "string",
+        author: "string",
+        views: "integer",
+      },
+    });
     // Clear scopes between tests
     if (Object.prototype.hasOwnProperty.call(Article, "_scopes")) {
       Article._scopes = new Map();
@@ -1213,6 +1233,13 @@ describe("RelationTest", () => {
   beforeEach(async () => {
     adapter = freshAdapter();
     Item.adapter = adapter;
+    await defineSchema(adapter, {
+      items: {
+        name: "string",
+        price: "integer",
+        category: "string",
+      },
+    });
     await Item.create({ name: "Apple", price: 1, category: "fruit" });
     await Item.create({ name: "Banana", price: 2, category: "fruit" });
     await Item.create({ name: "Carrot", price: 3, category: "vegetable" });
@@ -1970,6 +1997,14 @@ describe("RelationTest", () => {
   beforeEach(async () => {
     adapter = freshAdapter();
     Widget.adapter = adapter;
+    await defineSchema(adapter, {
+      widgets: {
+        name: "string",
+        color: "string",
+        weight: "integer",
+        active: { type: "boolean", default: true },
+      },
+    });
     await Widget.create({ name: "A", color: "red", weight: 10, active: true });
     await Widget.create({ name: "B", color: "blue", weight: 20, active: true });
     await Widget.create({ name: "C", color: "red", weight: 30, active: false });


### PR DESCRIPTION
## Summary

Migrates the first 5 `RelationTest` describes in
`packages/activerecord/src/relations.test.ts` to the per-describe
`beforeEach` `defineSchema` pattern (same shape as #1873 / #1887), so
those describes pass under `AR_NO_AUTO_SCHEMA=1`.

Cluster A covers:

- `seedPosts` helper (used by `describe("RelationTest")` at line 87 and
  at line 795) — table `posts`
- `Article` describe (line 1075) — table `articles`
- `Item` describe (line 1214) — table `items`
- `Widget` describe (line 1970) — table `widgets`

`+35` LOC. The file is ~6987 LOC with many more `RelationTest`
describes (each inlining its own model), so the full migration needs
multiple incremental PRs per the CLAUDE.md PR-size ceiling.

## Verification

- `pnpm vitest run packages/activerecord/src/relations.test.ts` —
  673 passed / 9 skipped (no regression in normal mode).
- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run
  packages/activerecord/src/relations.test.ts -t "filters by a single
  condition|finds a single record by id|defines a named scope callable
  from the class|all returns all records|select returns records with
  projected columns in SQL"` — representative tests from each cluster-A
  describe pass under strict mode.

## Follow-ups

Remaining describes (lines ~2148–6987) each define their own inline
models with distinct table names, to be migrated as `<base>b`,
`<base>c`, … e.g.:

- describes around line 2148 (Order, many User variants)
- the `items` / `users` `_tableName`-pinned blocks (2713–3578)
- the second `RelationTest` block at 4074 (Post variants)
- references / eager-loading blocks (3805+)
- final describes around 4232+

## Test plan

- [x] Cluster A tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] Full file passes in normal mode (no rename of test names)
- [ ] CI green across PG / MySQL / SQLite