### PR TITLE
test(activerecord): TM phase 5 — defineSchema for sqlite3-adapter.test.ts

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
@@ -9,6 +9,7 @@ import {
   loadBelongsTo,
   loadHasMany,
 } from "../index.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 
 describe("SqliteAdapter", () => {
   let adapter: SQLite3Adapter;
@@ -127,15 +128,10 @@ describe("SqliteAdapter", () => {
       }
     }
 
-    beforeEach(() => {
-      adapter.exec(`
-        CREATE TABLE "users" (
-          "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-          "name" TEXT,
-          "email" TEXT,
-          "age" INTEGER
-        )
-      `);
+    beforeEach(async () => {
+      await defineSchema(adapter, {
+        users: { name: "string", email: "string", age: "integer" },
+      });
       User.adapter = adapter;
     });
 
@@ -240,14 +236,9 @@ describe("SqliteAdapter", () => {
     }
 
     beforeEach(async () => {
-      adapter.exec(`
-        CREATE TABLE "products" (
-          "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-          "name" TEXT,
-          "price" INTEGER,
-          "category" TEXT
-        )
-      `);
+      await defineSchema(adapter, {
+        products: { name: "string", price: "integer", category: "string" },
+      });
       Product.adapter = adapter;
       await Product.create({ name: "Apple", price: 1, category: "fruit" });
       await Product.create({ name: "Banana", price: 2, category: "fruit" });
@@ -416,14 +407,13 @@ describe("SqliteAdapter", () => {
       }
     }
 
-    beforeEach(() => {
-      adapter.exec(`
-        CREATE TABLE "accounts" (
-          "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-          "name" TEXT,
-          "balance" INTEGER DEFAULT 0
-        )
-      `);
+    beforeEach(async () => {
+      await defineSchema(adapter, {
+        accounts: {
+          name: "string",
+          balance: { type: "integer", default: 0 },
+        },
+      });
       Account.adapter = adapter;
     });
 
@@ -493,20 +483,11 @@ describe("SqliteAdapter", () => {
       }
     }
 
-    beforeEach(() => {
-      adapter.exec(`
-        CREATE TABLE "authors" (
-          "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-          "name" TEXT
-        )
-      `);
-      adapter.exec(`
-        CREATE TABLE "books" (
-          "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-          "title" TEXT,
-          "author_id" INTEGER
-        )
-      `);
+    beforeEach(async () => {
+      await defineSchema(adapter, {
+        authors: { name: "string" },
+        books: { title: "string", author_id: "integer" },
+      });
       Author.adapter = adapter;
       Book.adapter = adapter;
       registerModel(Author);


### PR DESCRIPTION
## Summary

Migrates `packages/activerecord/src/adapters/sqlite3-adapter.test.ts`
off the audit's offenders list by replacing the four
`adapter.exec(CREATE TABLE ...)` blocks in the integration describes
(Base / Relation / transaction / associations) with `defineSchema()`
calls.

The two raw-SQL describes (\"raw SQL execution\", \"transactions\") and
the Migration integration describe intentionally keep their inline DDL —
they exercise the raw adapter and the Migration DSL directly, so
delegating to `defineSchema` would erase what the tests are covering.

This file already passed under `AR_NO_AUTO_SCHEMA=1` (it creates its own
tables in-band), so this PR is purely about getting the audit clean — no
behavior change.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/adapters/sqlite3-adapter.test.ts` → 49 passed
- `pnpm vitest run packages/activerecord/src/adapters/sqlite3-adapter.test.ts` → 49 passed
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags this file (34 → 33 offenders)

## Test plan

- [x] Tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] Tests pass without `AR_NO_AUTO_SCHEMA`
- [x] No test names renamed
- [x] Audit script clean for this file
- [ ] CI green across PG / MySQL / SQLite