### PR TITLE
test(activerecord): TM phase 5 — defineSchema for associations.test.ts (cluster A)

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -20,6 +20,7 @@ import {
   touchBelongsToParents,
 } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import {
   Associations,
@@ -62,12 +63,23 @@ describe("BelongsToAssociations", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
     Company.adapter = adapter;
     Account.adapter = adapter;
     registerModel(Company);
     registerModel(Account);
+    await defineSchema(adapter, {
+      companies: { name: "string" },
+      accounts: { company_id: "integer", credit_limit: "integer" },
+      firms: { name: "string", uuid: "string" },
+      clients: { firm_uuid: "string" },
+      sponsors: { sponsor_club_id: "integer" },
+      posts: { title: "string" },
+      comments: { body: "string", commentable_id: "integer", commentable_type: "string" },
+      authors: { name: "string" },
+      books: { author_id: "integer" },
+    });
   });
 
   // Rails: test_belongs_to
@@ -279,12 +291,18 @@ describe("HasOneAssociations", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
     Firm.adapter = adapter;
     AccountDetail.adapter = adapter;
     registerModel("Firm", Firm);
     registerModel("AccountDetail", AccountDetail);
+    await defineSchema(adapter, {
+      firms: { name: "string" },
+      account_details: { firm_id: "integer", credit_limit: "integer" },
+      profiles: { owner_id: "integer", firm_id: "integer", bio: "string" },
+      images: { imageable_id: "integer", imageable_type: "string", url: "string" },
+    });
   });
 
   // Rails: test_has_one
@@ -387,12 +405,19 @@ describe("HasManyAssociations", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
     Author.adapter = adapter;
     Post.adapter = adapter;
     registerModel(Author);
     registerModel(Post);
+    await defineSchema(adapter, {
+      authors: { name: "string" },
+      posts: { title: "string", author_id: "integer" },
+      articles: { writer_id: "integer", title: "string" },
+      blog_entries: { author_id: "integer", title: "string" },
+      taggings: { taggable_id: "integer", taggable_type: "string", tag: "string" },
+    });
   });
 
   // Rails: test_has_many
@@ -532,7 +557,7 @@ describe("HasManyThroughAssociations", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
     Doctor.adapter = adapter;
     Appointment.adapter = adapter;
@@ -540,6 +565,12 @@ describe("HasManyThroughAssociations", () => {
     registerModel(Doctor);
     registerModel(Appointment);
     registerModel(Patient);
+    await defineSchema(adapter, {
+      doctors: { name: "string" },
+      appointments: { doctor_id: "integer", patient_id: "integer" },
+      patients: { name: "string" },
+      orphans: { name: "string" },
+    });
 
     Associations.hasMany.call(Doctor, "appointments", { className: "Appointment" });
 
@@ -633,12 +664,16 @@ describe("CollectionProxy", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
     Team.adapter = adapter;
     Player.adapter = adapter;
     registerModel(Team);
     registerModel(Player);
+    await defineSchema(adapter, {
+      teams: { name: "string" },
+      players: { name: "string", team_id: "integer" },
+    });
     Associations.hasMany.call(Team, "players", { className: "Player", foreignKey: "team_id" });
   });
 


### PR DESCRIPTION
## Summary

Migrates the first 5 describes (BelongsToAssociations, HasOneAssociations, HasManyAssociations, HasManyThroughAssociations, CollectionProxy; lines 49–849) in `packages/activerecord/src/associations.test.ts` to the per-describe `beforeEach` `defineSchema` pattern (same shape as #1873 / #1887), so this slice passes under `AR_NO_AUTO_SCHEMA=1`.

The file is ~9998 LOC with many describes spanning belongs/has-one/has-many/through/proxy/dependent/strict-loading/reflection/HABTM/counter-cache/touch and large free-form blocks. Cluster A is the head-of-file group only; remaining clusters will ship as `<base>b/c/d/e` per the CLAUDE.md PR-size ceiling. `scripts/audit-define-schema.ts` will continue to flag the file until all describes migrate.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/associations.test.ts -t '<cluster-A test names>'` — 50 passed.
- `pnpm vitest run packages/activerecord/src/associations.test.ts` — 391 passed / 8 skipped (no regression, normal mode).
- No test names renamed.

## Follow-ups

Remaining describes to migrate in subsequent PRs (`<base>b`, `<base>c`, …):

- `DependentAssociations` (~lines 855–1113)
- `StrictLoading` (~1114–1200)
- `AssociationDefinitions` + `AssociationReflection` (~1201–1438)
- `HasAndBelongsToManyAssociations` (~1439–1539)
- `CounterCache` + `TouchBelongsToParents` (~1540–1725)
- `Rails-guided: association features` (~1726–1976)
- `AssociationsTest` mega-block (~1977 onward, hundreds of inline-class tests)
- `BelongsToAssociationsTest`, `HasManyAssociationsTest`, `AssociationProxyTest`, `PreloaderTest`, `inverse_of`, `Association Scopes`, and the trailing describes through ~9998

## Test plan

- [x] Cluster A passes under `AR_NO_AUTO_SCHEMA=1`
- [x] Full file passes in normal mode
- [x] No test names renamed
- [ ] CI green across PG / MySQL / SQLite