### PR TITLE
fix(activerecord): read datetime/time precision from MySQL column_type

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1476,6 +1476,16 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /** @internal */
   static override initializeTypeMap(this: typeof AbstractMysqlAdapter, m: TypeMap): void {
+    /**
+     * Mirrors: abstract_mysql_adapter.rb#extract_precision — for the
+     * `(date)?time(stamp)?` family, a missing `(N)` modifier resolves to 0
+     * (TIME ≡ TIME(0) on MySQL/MariaDB), not nil.
+     */
+    function extractMysqlTimePrecision(sqlType: string): number {
+      const m = sqlType.match(/\((\d+)\)/);
+      return m ? Number(m[1]) : 0;
+    }
+
     // Base types (mirrors AbstractAdapter#initialize_type_map via super)
     m.registerType(/^boolean/i, undefined, () => new BooleanType());
     m.registerType(/^char/i, undefined, () => new StringType());
@@ -1485,8 +1495,16 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     m.registerType(/^binary/i, undefined, () => new BinaryType());
     m.registerType(/^varbinary/i, undefined, () => new BinaryType());
     m.registerType(/^date$/i, new DateType());
-    m.registerType(/^time\b/i, undefined, () => new TimeType());
-    m.registerType(/^datetime/i, undefined, () => new MysqlDateTimeType());
+    m.registerType(
+      /^time\b/i,
+      undefined,
+      (sqlType) => new TimeType({ precision: extractMysqlTimePrecision(sqlType) }),
+    );
+    m.registerType(
+      /^datetime/i,
+      undefined,
+      (sqlType) => new MysqlDateTimeType({ precision: extractMysqlTimePrecision(sqlType) }),
+    );
     m.registerType(/decimal/i, undefined, () => new DecimalType());
     m.registerType(/numeric/i, undefined, () => new DecimalType());
     m.registerType("json", new JsonType());
@@ -1509,7 +1527,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     this.registerIntegerType(m, /^tinyint/i, { limit: 1 });
     m.registerType(/^year/i, undefined, () => new IntegerType());
     m.registerType(/^bit/i, undefined, () => new BinaryType());
-    m.registerType(/^timestamp/i, undefined, () => new MysqlDateTimeType());
+    m.registerType(
+      /^timestamp/i,
+      undefined,
+      (sqlType) => new MysqlDateTimeType({ precision: extractMysqlTimePrecision(sqlType) }),
+    );
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1104,12 +1104,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       const semanticType = (castName === "value" ? baseType : castName).toLowerCase();
       // information_schema.numeric_precision is NULL for date/time/datetime/timestamp.
       // MariaDB/MySQL encode fractional-seconds precision in the column_type string
-      // (e.g. "time(3)", "datetime(6)", "timestamp(0)") — parse it directly so
-      // precision: 0 is preserved instead of being read as NULL.
+      // (e.g. "time(3)", "datetime(6)", "timestamp(0)") — parse it directly. Mirrors
+      // abstract_mysql_adapter.rb#extract_precision: for `(date)?time(stamp)?` types,
+      // a missing `(N)` defaults to 0 (TIME ≡ TIME(0) on MySQL/MariaDB), not null.
       let precision: number | null = numPrec != null ? Number(numPrec) : null;
-      if (precision == null && /^(?:datetime|timestamp|time)/i.test(baseType)) {
+      if (precision == null && /^(?:datetime|timestamp|time)\b/i.test(baseType)) {
         const m = sqlType.match(/^(?:datetime|timestamp|time)\((\d+)\)/i);
-        if (m) precision = Number(m[1]);
+        precision = m ? Number(m[1]) : 0;
       }
       const meta = new SqlTypeMetadata({
         sqlType,

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1102,11 +1102,20 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       // MysqlDateTimeType.name is "datetime" for both "datetime" and "timestamp" DATA_TYPEs.
       const castName = castType.name;
       const semanticType = (castName === "value" ? baseType : castName).toLowerCase();
+      // information_schema.numeric_precision is NULL for date/time/datetime/timestamp.
+      // MariaDB/MySQL encode fractional-seconds precision in the column_type string
+      // (e.g. "time(3)", "datetime(6)", "timestamp(0)") — parse it directly so
+      // precision: 0 is preserved instead of being read as NULL.
+      let precision: number | null = numPrec != null ? Number(numPrec) : null;
+      if (precision == null && /^(?:datetime|timestamp|time)/i.test(baseType)) {
+        const m = sqlType.match(/^(?:datetime|timestamp|time)\((\d+)\)/i);
+        if (m) precision = Number(m[1]);
+      }
       const meta = new SqlTypeMetadata({
         sqlType,
         type: semanticType,
         limit: charLimitVal ?? typeMapLimit,
-        precision: numPrec != null ? Number(numPrec) : null,
+        precision,
         scale: numScale != null ? Number(numScale) : null,
       });
       const nullable =

--- a/packages/activerecord/src/time-precision.test.ts
+++ b/packages/activerecord/src/time-precision.test.ts
@@ -3,7 +3,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
 import type { DatabaseAdapter } from "./adapter.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, adapterType } from "./test-adapter.js";
 import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./schema-dumper.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
@@ -71,7 +71,10 @@ describe("TimePrecisionTest", () => {
     expect(nsecTime((foo as any).finish)).toBe(123456000);
   });
 
-  it("no time precision isnt truncated on assignment", async () => {
+  // Rails skips this on Mysql2Adapter/TrilogyAdapter: a `TIME` column without
+  // explicit precision is `TIME(0)` on MySQL/MariaDB, so the assignment does
+  // truncate. See vendor/rails/activerecord/test/cases/time_precision_test.rb.
+  it.skipIf(adapterType === "mysql")("no time precision isnt truncated on assignment", async () => {
     await ctx.createTable("foos", { force: true }, () => {});
     await ctx.addColumn("foos", "start", "time");
     await ctx.addColumn("foos", "finish", "time", { precision: 6 });


### PR DESCRIPTION
## Summary

CI on `main` (after #1888 migrated `time-precision.test.ts` + `date-time-precision.test.ts` to `createTestAdapter()`) surfaced MariaDB failures for time/datetime precision tests: assignments to `precision: 0` / `precision: 6` columns weren't being truncated, and `Foo.columnsHash()["start"].precision` came back `null`.

Root cause: `Mysql2Adapter#columns` reads `information_schema.numeric_precision`, but `numeric_precision` is `NULL` for date/time/datetime/timestamp columns. MySQL/MariaDB encode fractional-seconds precision in `column_type` (`time(3)`, `datetime(6)`, `timestamp(0)`). With `precision: null` reaching the cast types, no truncation happened on assignment.

Fix: when `num_precision` is `NULL` and the base type is `datetime`/`timestamp`/`time`, parse `(N)` from the column_type string.

Also mirrors Rails' `unless current_adapter?(:Mysql2Adapter, :TrilogyAdapter)` guard on `test_no_time_precision_isnt_truncated_on_assignment` — a `TIME` column without explicit precision is `TIME(0)` on MySQL/MariaDB.

## Verification

- `pnpm vitest run packages/activerecord/src/{time,date-time}-precision.test.ts` (sqlite) → 26 passed.
- No local MariaDB; CI matrix will verify.

## Test plan

- [ ] MariaDB Tests job green for `time-precision.test.ts` + `date-time-precision.test.ts`
- [ ] No regression on SQLite / PostgreSQL / MySQL