### PR TITLE
test(activerecord): TM phase 5 — defineSchema for has-and-belongs-to-many-associations.test.ts

### DIFF
--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -6,6 +6,7 @@ import { Base, registerModel, AssociationTypeMismatch } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import { Associations, loadHasMany, loadHabtm, association } from "../associations.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 
 function freshAdapter(): DatabaseAdapter {
   return createTestAdapter();
@@ -41,8 +42,19 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    // Schema covers the shared Developer/Project/DeveloperProject family
+    // used by the majority of tests in this describe. Tests further down
+    // that build their own `createTestAdapter()` adapter and declare
+    // inline classes (RichPerson/Treasure, CjDeveloper/CjProject, etc.)
+    // remain uncovered under AR_NO_AUTO_SCHEMA=1 and are deferred to
+    // follow-up cluster PRs.
+    await defineSchema(adapter, {
+      developers: { name: "string", salary: "integer" },
+      projects: { name: "string", approved: "boolean", featured: "boolean" },
+      developer_projects: { developer_id: "integer", project_id: "integer" },
+    });
     Developer.adapter = adapter;
     Project.adapter = adapter;
     DeveloperProject.adapter = adapter;
@@ -1176,6 +1188,11 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("association with validate false does not run associated validation callbacks on update", async () => {
     const a2 = createTestAdapter();
+    await defineSchema(a2, {
+      rich_person2s: { first_name: "string" },
+      treasure2s: { name: "string" },
+      treasures_rich_people2: { rich_person2_id: "integer", treasure2_id: "integer" },
+    });
     class RichPerson2 extends Base {
       static {
         this.attribute("first_name", "string");
@@ -1211,6 +1228,11 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   it("custom join table", async () => {
     // Use a differently-named join table model but with conventional FK columns
     const a2 = createTestAdapter();
+    await defineSchema(a2, {
+      cj_developers: { name: "string" },
+      cj_projects: { name: "string" },
+      custom_joins: { cj_developer_id: "integer", cj_project_id: "integer" },
+    });
     class CjDeveloper extends Base {
       static {
         this.attribute("name", "string");
@@ -1314,6 +1336,11 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   it("association name is the same as join table name", async () => {
     // Use a join table model whose name matches the association name
     const a2 = createTestAdapter();
+    await defineSchema(a2, {
+      same_devs: { name: "string" },
+      same_projs: { name: "string" },
+      same_joins: { same_dev_id: "integer", same_proj_id: "integer" },
+    });
     class SameDev extends Base {
       static {
         this.attribute("name", "string");
@@ -1454,6 +1481,13 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("layers destroyAssociations chain for multiple HABTMs on one class", async () => {
     const a2 = createTestAdapter();
+    await defineSchema(a2, {
+      multi_owners: { name: "string" },
+      tag_as: { name: "string" },
+      tag_bs: { name: "string" },
+      multi_owners_tag_as: { multi_owner_id: "integer", tag_a_id: "integer" },
+      multi_owners_tag_bs: { multi_owner_id: "integer", tag_b_id: "integer" },
+    });
     class MultiOwner extends Base {
       static {
         this.attribute("name", "string");
@@ -1508,6 +1542,12 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("subclass HABTM extends destroyAssociations chain via super", async () => {
     const a2 = createTestAdapter();
+    await defineSchema(a2, {
+      parent_owners: { name: "string" },
+      child_owners: { name: "string" },
+      parent_owners_p_tags: { parent_owner_id: "integer", tag_a_id: "integer" },
+      child_owners_c_tags: { child_owner_id: "integer", tag_b_id: "integer" },
+    });
     class ParentOwner extends Base {
       static {
         this.attribute("name", "string");

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -47,9 +47,8 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     // Schema covers the shared Developer/Project/DeveloperProject family
     // used by the majority of tests in this describe. Tests further down
     // that build their own `createTestAdapter()` adapter and declare
-    // inline classes (RichPerson/Treasure, CjDeveloper/CjProject, etc.)
-    // remain uncovered under AR_NO_AUTO_SCHEMA=1 and are deferred to
-    // follow-up cluster PRs.
+    // inline classes seed their own schema inline next to the adapter
+    // construction.
     await defineSchema(adapter, {
       developers: { name: "string", salary: "integer" },
       projects: { name: "string", approved: "boolean", featured: "boolean" },


### PR DESCRIPTION
## Summary

Migrates `has-and-belongs-to-many-associations.test.ts` to the
`defineSchema()` + `freshAdapter()` pattern so it passes under
`AR_NO_AUTO_SCHEMA=1` (TM phase 5, pattern from #1633 / #1697 / #1749 /
#1873 / #1888 / #1891 / #1894).

- Outer `HasAndBelongsToManyAssociationsTest` `beforeEach` becomes
  `async` and now calls `defineSchema(adapter, …)` for the shared
  `developers` / `projects` / `developer_projects` tables used by the
  bulk of tests in the describe.
- Five tests in this describe that build their own `createTestAdapter()`
  with inline class declarations now also call `defineSchema(a2, …)`
  for their unique table families:
  - `RichPerson2` / `Treasure2` / `treasures_rich_people2`
  - `CjDeveloper` / `CjProject` / `CustomJoin`
  - `SameDev` / `SameProj` / `SameJoin`
  - `MultiOwner` / `TagA` / `TagB` (+ join tables)
  - `ParentOwner` / `ChildOwner` (+ join tables)

## Verification

- `pnpm vitest run …has-and-belongs-to-many-associations.test.ts` —
  **74 passed / 24 skipped** (no regression in normal mode).
- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run …` — **74 passed / 24 skipped**
  (up from 6 passing pre-PR).
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags this file.
- No test names renamed.
- Diff: 41 insertions, 1 deletion (1 file).

## Test plan

- [x] Full file passes in normal mode
- [x] Full file passes under `AR_NO_AUTO_SCHEMA=1`
- [x] Audit clean
- [x] No test names renamed
- [ ] CI green across PG / MySQL / SQLite