### PR TITLE
test(activerecord): TM phase 5 — defineSchema for inner-join + extension + sqlite3/json bundle

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SQLite3Adapter } from "../../connection-adapters/sqlite3-adapter.js";
 import { Base } from "../../index.js";
+import { defineSchema } from "../../test-helpers/define-schema.js";
 
 let adapter: SQLite3Adapter;
 
@@ -17,9 +18,9 @@ afterEach(() => {
 
 describe("SQLite3JSONTest", () => {
   it("json string cast round-trip", async () => {
-    await adapter.exec(
-      `CREATE TABLE "json_string_cast" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "data" JSON)`,
-    );
+    await defineSchema(adapter, {
+      json_string_cast: { data: "json" },
+    });
     class JsonStringCast extends Base {
       static {
         this.tableName = "json_string_cast";
@@ -35,11 +36,12 @@ describe("SQLite3JSONTest", () => {
   });
 
   it("test_default", async () => {
-    adapter.exec(`CREATE TABLE "json_data_type" (
-      "id" INTEGER PRIMARY KEY AUTOINCREMENT,
-      "payload" JSON DEFAULT '{}',
-      "settings" JSON
-    )`);
+    await defineSchema(adapter, {
+      json_data_type: {
+        payload: { type: "json", default: "{}" },
+        settings: "json",
+      },
+    });
 
     const defaultVal = { users: "read", posts: ["read", "write"] };
     await adapter.addColumn("json_data_type", "permissions", "json", {

--- a/packages/activerecord/src/associations/extension.test.ts
+++ b/packages/activerecord/src/associations/extension.test.ts
@@ -8,17 +8,36 @@ import { Associations } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+const TEST_SCHEMA: Schema = {
+  ext_posts: { title: "string" },
+  ext_comments: { body: "string", ext_post_id: "integer" },
+  h_projects: { name: "string" },
+  h_developers: { name: "string" },
+  h_developers_h_projects: { h_developer_id: "integer", h_project_id: "integer" },
+  n_projects: { name: "string" },
+  n_developers: { name: "string" },
+  n_developers_n_projects: { n_developer_id: "integer", n_project_id: "integer" },
+  t2_projects: { name: "string" },
+  t2_developers: { name: "string" },
+  t2_developers_t2_projects: { t2_developer_id: "integer", t2_project_id: "integer" },
+  nb_projects: { name: "string" },
+  nb_developers: { name: "string" },
+  nb_developers_nb_projects: { nb_developer_id: "integer", nb_project_id: "integer" },
+};
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
 }
 
 describe("AssociationsExtensionsTest", () => {
   let extAdapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    extAdapter = freshAdapter();
+  beforeEach(async () => {
+    extAdapter = await freshAdapter();
   });
 
   function setupExtModels() {

--- a/packages/activerecord/src/associations/inner-join-association.test.ts
+++ b/packages/activerecord/src/associations/inner-join-association.test.ts
@@ -8,16 +8,31 @@ import { Associations } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+const TEST_SCHEMA: Schema = {
+  authors: { name: "string" },
+  posts: { title: "string", author_id: "integer" },
+  comments: { body: "string", type: "string", post_id: "integer" },
+  thr_authors: { name: "string" },
+  thr_posts: { title: "string", thr_author_id: "integer" },
+  thr_taggings: { thr_post_id: "integer", thr_tag_id: "integer" },
+  thr_tags: { name: "string" },
+  habtm_posts: { title: "string" },
+  habtm_tags: { name: "string" },
+  habtm_posts_habtm_tags: { habtm_post_id: "integer", habtm_tag_id: "integer" },
+};
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
 }
 
 describe("InnerJoinAssociationTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   function makeModels() {
@@ -210,7 +225,7 @@ describe("InnerJoinAssociationTest", () => {
   });
 
   it("find with sti join", async () => {
-    const a = createTestAdapter();
+    const a = await freshAdapter();
     class Comment extends Base {
       static {
         this.attribute("body", "string");


### PR DESCRIPTION
## Summary

Continues TM unification Phase 5. Migrates three test files to pass under `AR_NO_AUTO_SCHEMA=1` by seeding the test adapter via `defineSchema()`.

- `associations/inner-join-association.test.ts`: shared `TEST_SCHEMA` covers authors/posts/comments (with `type` for STI), `thr_*` (through), and `habtm_*` (has_and_belongs_to_many). `freshAdapter()` is now async; the inner *find with sti join* callsite `await`s it.
- `associations/extension.test.ts`: shared `TEST_SCHEMA` covers `ext_*`, `h_*`, `n_*`, `t2_*`, `nb_*` (habtm join tables included).
- `adapters/sqlite3/json.test.ts`: per-test `defineSchema()` replaces inline `CREATE TABLE`; `addColumn` for permissions retained.

No test names changed.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run` per file — all green (30/2 skipped, 8/4 skipped, 2 passed).
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags any of them.

## Test plan

- [x] `AR_NO_AUTO_SCHEMA=1` green
- [x] No test names renamed
- [x] Audit clean
- [ ] CI green across PG / MySQL / SQLite