### PR TITLE
test(activerecord): TM phase 5 — defineSchema for polymorphic-sti-through + nested-through-advanced

### DIFF
--- a/packages/activerecord/src/associations/nested-through-advanced.test.ts
+++ b/packages/activerecord/src/associations/nested-through-advanced.test.ts
@@ -11,6 +11,32 @@ import { Base, registerModel } from "../index.js";
 import { Associations, loadHasManyThrough } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+
+const TEST_SCHEMA: Schema = {
+  nta_authors: { name: "string" },
+  nta_posts: { nta_author_id: "integer", title: "string" },
+  nta_taggings: {
+    taggable_id: "integer",
+    taggable_type: "string",
+    nta_tag_id: "integer",
+  },
+  nta_tags: { name: "string" },
+  nse_hotels: { name: "string" },
+  nse_chefs: {
+    nse_hotel_id: "integer",
+    employable_id: "integer",
+    employable_type: "string",
+  },
+  nse_cake_designers: { name: "string" },
+  nse_drink_designers: { name: "string" },
+};
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
+}
 
 describe("HMT Slot E — nested-through advanced", () => {
   let adapter: DatabaseAdapter;
@@ -43,8 +69,8 @@ describe("HMT Slot E — nested-through advanced", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     NtaAuthor.adapter = adapter;
     NtaPost.adapter = adapter;
     NtaTagging.adapter = adapter;

--- a/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
+++ b/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
@@ -37,6 +37,25 @@ import { Base, registerModel, registerSubclass, enableSti } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+
+const TEST_SCHEMA: Schema = {
+  ps_hotels: { name: "string" },
+  ps_departments: { ps_hotel_id: "integer", name: "string" },
+  ps_chefs: {
+    ps_department_id: "integer",
+    employable_id: "integer",
+    employable_type: "string",
+  },
+  ps_cake_designers: { name: "string", type: "string" },
+  ps_drink_designers: { name: "string" },
+};
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
+}
 
 describe("HABTM Slot E — polymorphic + STI through", () => {
   let adapter: DatabaseAdapter;
@@ -82,8 +101,8 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
   enableSti(PsCakeDesigner);
   registerSubclass(PsSpecialCakeDesigner);
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     PsHotel.adapter = adapter;
     PsDepartment.adapter = adapter;
     PsChef.adapter = adapter;


### PR DESCRIPTION
## Summary

- Migrates `polymorphic-sti-through.test.ts` and `nested-through-advanced.test.ts` to `defineSchema()` + async `freshAdapter()` per `beforeEach`.
- Both files now pass under `AR_NO_AUTO_SCHEMA=1`.
- Pattern follows #1633 / #1697 / #1749 / #1888.

## Test plan
- [x] `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/associations/polymorphic-sti-through.test.ts packages/activerecord/src/associations/nested-through-advanced.test.ts` — 13/13 pass