### PR TITLE
test(activerecord): TM phase 5 — defineSchema for collection-proxy + cascaded-eager-loading

### DIFF
--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -7,11 +7,14 @@ import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
 import { Associations } from "../associations.js";
 
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema, type TableSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 // -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+async function freshAdapter(schema?: Record<string, TableSchema>): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  if (schema) await defineSchema(adapter, schema);
+  return adapter;
 }
 
 describe("CascadedEagerLoadingTest", () => {
@@ -64,7 +67,10 @@ describe("CascadedEagerLoadingTest", () => {
     /* fixture-dependent */
   });
   it("eager association loading with nil associations", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter({
+      en_parents: { name: "string" },
+      en_children: { value: "string", en_parent_id: "integer" },
+    });
     class ENParent extends Base {
       static {
         this._tableName = "en_parents";
@@ -118,7 +124,9 @@ describe("CascadedEagerLoadingTest", () => {
     /* fixture-dependent */
   });
   it("eager association loading with has many sti", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter({
+      sti_topics: { title: "string", type: "string", parent_id: "integer" },
+    });
     class StiTopic extends Base {
       static {
         this.attribute("title", "string");
@@ -159,7 +167,9 @@ describe("CascadedEagerLoadingTest", () => {
     expect(t2Replies).toHaveLength(0);
   });
   it("eager association loading with has many sti and subclasses", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter({
+      sti_topics2: { title: "string", type: "string", parent_id: "integer" },
+    });
     class StiTopic2 extends Base {
       static {
         this.attribute("title", "string");
@@ -201,7 +211,9 @@ describe("CascadedEagerLoadingTest", () => {
     expect(replies).toHaveLength(2);
   });
   it("eager association loading with belongs to sti", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter({
+      sti_topics3: { title: "string", type: "string", parent_id: "integer" },
+    });
     class StiTopic3 extends Base {
       static {
         this.attribute("title", "string");
@@ -241,7 +253,10 @@ describe("CascadedEagerLoadingTest", () => {
     /* fixture-dependent */
   });
   it("eager association loading where first level returns nil", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter({
+      ef_parents: { name: "string" },
+      ef_children: { value: "string", ef_parent_id: "integer" },
+    });
     class EFParent extends Base {
       static {
         this._tableName = "ef_parents";
@@ -271,7 +286,10 @@ describe("CascadedEagerLoadingTest", () => {
   });
 
   it("preload through missing records", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter({
+      pm_authors: { name: "string" },
+      pm_posts: { title: "string", pm_author_id: "integer" },
+    });
     class PMAuthor extends Base {
       static {
         this._tableName = "pm_authors";
@@ -302,7 +320,10 @@ describe("CascadedEagerLoadingTest", () => {
   });
 
   it("eager association loading with missing first record", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter({
+      em_authors: { name: "string" },
+      em_posts: { title: "string", em_author_id: "integer" },
+    });
     class EMAuthor extends Base {
       static {
         this._tableName = "em_authors";
@@ -353,7 +374,10 @@ describe("CascadedEagerLoadingTest", () => {
     /* fixture-dependent */
   });
   it("preloaded records are not duplicated", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter({
+      pd_authors: { name: "string" },
+      pd_posts: { title: "string", pd_author_id: "integer" },
+    });
     class PDAuthor extends Base {
       static {
         this._tableName = "pd_authors";

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, association, registerModel } from "../index.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("CollectionProxy — array-likeness (Phase R.1)", () => {
@@ -36,12 +37,16 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   // can find ApPost in the model registry.
   ApBlog.hasMany("apPosts", { className: "ApPost" });
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = createTestAdapter();
     ApBlog.adapter = adapter;
     ApPost.adapter = adapter;
     registerModel(ApBlog);
     registerModel(ApPost);
+    await defineSchema(adapter, {
+      ap_blogs: { name: "string" },
+      ap_posts: { title: "string", ap_blog_id: "integer" },
+    });
   });
 
   async function blogWithPosts(): Promise<ApBlog> {


### PR DESCRIPTION
## Summary

- Migrates `packages/activerecord/src/associations/collection-proxy.test.ts` and `packages/activerecord/src/associations/cascaded-eager-loading.test.ts` to the `defineSchema()` pattern (same shape as #1888 / #1893 / #1897).
- `collection-proxy.test.ts` has a single describe; its `beforeEach` now awaits `defineSchema` for `ap_blogs` / `ap_posts`.
- `cascaded-eager-loading.test.ts` constructs a fresh adapter per test (no shared `beforeEach`), so `freshAdapter()` now accepts an optional schema arg and is awaited per call site, with each non-skipped test passing only the tables it touches.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/associations/collection-proxy.test.ts packages/activerecord/src/associations/cascaded-eager-loading.test.ts` — 36 passed / 18 skipped.
- `pnpm vitest run` same files (normal mode) — 36 passed / 18 skipped (no regression).
- No test names renamed.

## Test plan

- [x] Both files pass under `AR_NO_AUTO_SCHEMA=1`
- [x] Both files pass in normal mode
- [x] No test names renamed
- [ ] CI green across PG / MySQL / SQLite