### PR TITLE
test(activerecord): TM phase 5 — defineSchema for readonly + instrumentation

### DIFF
--- a/packages/activerecord/src/instrumentation.test.ts
+++ b/packages/activerecord/src/instrumentation.test.ts
@@ -7,11 +7,19 @@ import { describe, it, expect, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
+const TEST_SCHEMA = {
+  books: { name: "string", type: "string" },
+  authors: { name: "string" },
+} as const;
+
 // -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
 }
 
 describe("InstrumentationTest", () => {
@@ -87,7 +95,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload name on load", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -103,7 +111,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload name on create", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -119,7 +127,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload name on update", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -136,7 +144,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload name on update all", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -153,7 +161,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload name on destroy", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -170,7 +178,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload name on delete all", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -187,7 +195,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload name on pluck", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -204,7 +212,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload name on count", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -221,7 +229,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload name on grouped count", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -240,7 +248,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload row count on select all", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -261,7 +269,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload row count on pluck", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -296,7 +304,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("payload connection with query cache disabled", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -321,7 +329,7 @@ describe("InstrumentationTest", () => {
   });
 
   it("no instantiation notification when no records", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Author extends Base {
       static {
         this.attribute("name", "string");
@@ -344,7 +352,7 @@ describe("TransactionInSqlActiveRecordPayloadTest", () => {
   });
 
   it("payload without an open transaction", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");
@@ -373,7 +381,7 @@ describe("TransactionInSqlActiveRecordPayloadNonTransactionalTest", () => {
   });
 
   it("payload without an open transaction", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Book extends Base {
       static {
         this.attribute("name", "string");

--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -196,7 +196,7 @@ describe("ReadonlyTest", () => {
     class Dev extends Base {
       static {
         this.attribute("name", "string");
-        this.attribute("updated_at", "string");
+        this.attribute("updated_at", "datetime");
         this.adapter = adapter;
       }
     }

--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -7,17 +7,28 @@ import { Base, ReadOnlyRecord } from "./index.js";
 import { ReadonlyAttributeError } from "./readonly-attributes.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
+const TEST_SCHEMA = {
+  posts: { title: "string" },
+  devs: { name: "string", updated_at: "datetime" },
+  users: { name: "string" },
+  items: { name: "string" },
+  products: { sku: "string", name: "string" },
+} as const;
+
 // -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
 }
 
 describe("ReadonlyTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   function makeModel() {
@@ -167,8 +178,8 @@ describe("ReadonlyTest", () => {
 
 describe("ReadonlyTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   function makeModel() {
@@ -212,8 +223,8 @@ describe("ReadonlyTest", () => {
 describe("ReadonlyTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   it("cant save readonly record", async () => {
@@ -248,8 +259,8 @@ describe("ReadonlyTest", () => {
 
 describe("ReadonlyTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   it("marks loaded records as readonly", async () => {
@@ -269,7 +280,7 @@ describe("ReadonlyTest", () => {
 
 describe("ReadonlyTest", () => {
   it("allows setting readonly attributes on create", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Product extends Base {
       static _tableName = "products";
     }
@@ -288,7 +299,7 @@ describe("ReadonlyTest", () => {
     // on a persisted-record write to an attr_readonly column (readonly_attributes.rb
     // line 49). The Rails test by this name in newer Rails asserts that
     // behavior — the "ignores" wording pre-dates the raise being added.
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     class Product extends Base {
       static _tableName = "products";
     }
@@ -311,8 +322,8 @@ describe("ReadonlyTest", () => {
     expect(product.name).toBe("Updated Widget");
   });
 
-  it("exposes readonlyAttributes list", () => {
-    const adapter = freshAdapter();
+  it("exposes readonlyAttributes list", async () => {
+    const adapter = await freshAdapter();
     class Product extends Base {
       static _tableName = "products";
     }
@@ -327,8 +338,8 @@ describe("ReadonlyTest", () => {
 
 describe("ReadonlyTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   it("readonly records cannot be saved", async () => {
@@ -349,8 +360,8 @@ describe("ReadonlyTest", () => {
 describe("ReadonlyTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   // Rails: test "readonly record cannot be saved"


### PR DESCRIPTION
## Summary

Migrates `packages/activerecord/src/readonly.test.ts` (32 tests) and `packages/activerecord/src/instrumentation.test.ts` (26 tests) to the per-test `defineSchema()` + async `freshAdapter()` pattern (same shape as #1633 / #1697 / #1749 / #1888), so both pass under `AR_NO_AUTO_SCHEMA=1` and clear `scripts/audit-define-schema.ts`.

- `freshAdapter()` is now async, returns `Promise<DatabaseAdapter>`, and seeds a shared `TEST_SCHEMA` via `defineSchema()` before returning.
- `readonly.test.ts` seeds `posts/devs/users/items/products`; all describe-scoped `beforeEach` are async, plus the inline per-test `freshAdapter()` callers awaited.
- `instrumentation.test.ts` seeds `books/authors`; all per-test `freshAdapter()` calls awaited.
- No test names changed.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/readonly.test.ts` → 25 passed / 7 skipped.
- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/instrumentation.test.ts` → 21 passed / 5 skipped.
- Normal mode (both files) → 46 passed / 12 skipped.
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags either file.

## Test plan

- [x] Tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] Tests pass without `AR_NO_AUTO_SCHEMA`
- [x] No test names renamed
- [x] Audit script clean for these files
- [ ] CI green across PG / MySQL / SQLite