### PR TITLE
feat(actionpack): port ActionDispatch::Session::MemCacheStore

### DIFF
--- a/docs/actionpack-100-percent.md
+++ b/docs/actionpack-100-percent.md
@@ -25,7 +25,7 @@ Current (2026-05-18): actiondispatch 628/1351 methods (46.5%), files 72/83.
 
 - **system_testing/** (5 files), **system_test_case.rb**, **testing/test_helpers/page_dump_helper.rb** — defer indefinitely; trails will use Playwright / Vitest browser mode, not Capybara/Selenium.
 - **http/rack_cache.rb** — intentional skip (Rack-specific).
-- **middleware/session/cache_store.rb**, **middleware/session/mem_cache_store.rb** — defer pending memcached integration.
+- ~~**middleware/session/cache_store.rb**, **middleware/session/mem_cache_store.rb**~~ — `cache_store.rb` ported in #1872; `mem_cache_store.rb` ported as a `CacheStore` subclass (real `@blazetrails/activesupport` MemCacheStore still pending).
 - **deprecator.rb** — 0/18; small port, no blockers.
 
 Everything else has a TS file; gaps are method-level.

--- a/packages/actionpack/src/action-dispatch/middleware/session/index.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/index.ts
@@ -18,3 +18,5 @@ export {
 } from "./abstract-store.js";
 
 export { CacheStore, type CacheStoreSessionOptions } from "./cache-store.js";
+
+export { MemCacheStore, type MemCacheStoreSessionOptions } from "./mem-cache-store.js";

--- a/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { MemoryStore } from "@blazetrails/activesupport";
+import { MemCacheStore } from "./mem-cache-store.js";
+import { SessionId } from "./abstract-store.js";
+
+describe("ActionDispatch::Session::MemCacheStore", () => {
+  it("aliases :expires to :expire_after", () => {
+    const cache = new MemoryStore();
+    const store = new MemCacheStore(() => undefined, { cache, expires: 600 });
+    expect(store.options.expireAfter).toBe(600);
+  });
+
+  it("keeps :expire_after when both are given", () => {
+    const cache = new MemoryStore();
+    const store = new MemCacheStore(() => undefined, {
+      cache,
+      expires: 600,
+      expireAfter: 900,
+    });
+    expect(store.options.expireAfter).toBe(900);
+  });
+
+  it("inherits CacheStore session behavior", () => {
+    const cache = new MemoryStore();
+    const store = new MemCacheStore(() => undefined, { cache });
+    const [sid, session] = store.findSession({}, null);
+    expect(sid).toBeInstanceOf(SessionId);
+    expect(session).toEqual({});
+  });
+
+  it("requires a cache option", () => {
+    expect(() => new MemCacheStore(() => undefined, {})).toThrow(/cache/);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.ts
@@ -1,0 +1,35 @@
+/**
+ * ActionDispatch::Session::MemCacheStore
+ *
+ * Mirrors `vendor/rails/actionpack/lib/action_dispatch/middleware/session/mem_cache_store.rb`.
+ *
+ * A session store that uses MemCache (Dalli) to implement storage. In Rails
+ * this subclasses `Rack::Session::Dalli`; trails does not yet have a Dalli
+ * port, so this mirrors the Rails class shape by subclassing `CacheStore`
+ * and typing `cache` as a memcache-backed `ActiveSupport::Cache::Store`.
+ * Wire a real memcached cache once `@blazetrails/activesupport`'s
+ * `MemCacheStore` ships.
+ *
+ * Options:
+ * - `expireAfter` — the length of time a session will be stored before
+ *   automatically expiring. Falls back to `expires` (Rails alias).
+ */
+
+import { CacheStore, type CacheStoreSessionOptions } from "./cache-store.js";
+
+export interface MemCacheStoreSessionOptions extends CacheStoreSessionOptions {
+  /** Rails: `options[:expire_after] ||= options[:expires]`. */
+  expires?: number;
+}
+
+/** Rails: `class MemCacheStore < Rack::Session::Dalli`. */
+export class MemCacheStore extends CacheStore {
+  constructor(app: unknown, options: MemCacheStoreSessionOptions = {}) {
+    // Rails: `options[:expire_after] ||= options[:expires]`. The caller's
+    // options hash is mutated in place to match Rails semantics.
+    if (options.expireAfter == null && options.expires != null) {
+      options.expireAfter = options.expires;
+    }
+    super(app, options);
+  }
+}


### PR DESCRIPTION
## Summary

Ports `vendor/rails/actionpack/lib/action_dispatch/middleware/session/mem_cache_store.rb` to `packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.ts`.

Rails subclasses `Rack::Session::Dalli`; trails has no Dalli port yet, so this subclasses our existing `CacheStore` (it already implements the AbstractSecureStore protocol) and adds the `:expires` → `:expire_after` aliasing the Rails constructor performs. A real memcached-backed cache can be slotted in once `@blazetrails/activesupport`'s `MemCacheStore` ships — for now any `CacheStoreLike` works.

Updated `docs/actionpack-100-percent.md` to reflect that the port is no longer deferred (with the remaining memcached-cache caveat noted).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.test.ts` (4 tests pass)
- [x] Pre-commit `pnpm build` + `pnpm typecheck` clean