### PR TITLE
test(activerecord): TM phase 5 — defineSchema for secure-password.test.ts

### DIFF
--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -4,12 +4,26 @@ import { Base } from "./index.js";
 import { hasSecurePassword } from "./secure-password.js";
 import { setTokenForSecret } from "./generates-token-for.js";
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 // -- Helpers --
 
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+// Union of every column referenced by tests in this file; per-test attribute
+// differences are immaterial (sqlite ignores unread columns).
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, {
+    users: {
+      name: "string",
+      token: "string",
+      email: "string",
+      password_digest: "string",
+      auth_token_digest: "string",
+      recovery_password_digest: "string",
+    },
+  });
+  return adapter;
 }
 
 // -- Phase 2000: Core --
@@ -17,8 +31,8 @@ function freshAdapter(): DatabaseAdapter {
 describe("secure_password", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   it("hashes password on save and authenticates", async () => {
@@ -86,8 +100,8 @@ describe("secure_password", () => {
 describe("SecurePassword (Rails-guided)", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   // Rails: test "authenticate with correct password"
@@ -169,8 +183,8 @@ describe("SecurePassword (Rails-guided)", () => {
 describe("password reset token", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     setTokenForSecret("test-reset-token-secret");
   });
 
@@ -295,8 +309,8 @@ describe("password reset token", () => {
 describe("SecurePasswordTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   // Builds a User class with the union of attributes used across these tests.
@@ -478,8 +492,8 @@ describe("SecurePasswordTest", () => {
 
 describe("hasSecurePassword — per-attribute confirmation, challenge, and salt", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
   });
 
   const makeModel = () => {


### PR DESCRIPTION
## Summary

Migrates `secure-password.test.ts` (37 tests) to `defineSchema()` + async `freshAdapter()` so it passes under `AR_NO_AUTO_SCHEMA=1` and clears `scripts/audit-define-schema.ts`.

The seeded `users` table covers the union of columns referenced across all describes (`id` PK auto, `name`, `token`, `email`, `password_digest`, `auth_token_digest`, `recovery_password_digest`); per-test `attribute()` declarations remain unchanged.

- `freshAdapter()` is async, seeds via `defineSchema()` before returning.
- All `beforeEach` hooks now async; the password-reset-token describe swapped its direct `createTestAdapter()` call for `freshAdapter()`.
- No test names changed.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/secure-password.test.ts` → 37 passed.
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags this file.

## Test plan

- [x] Tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] No test names renamed
- [x] Audit script clean for this file
- [ ] CI green across PG / MySQL / SQLite