### PR TITLE
test(activerecord): TM phase 5 — defineSchema for strict-loading.test.ts (cluster A)

### DIFF
--- a/docs/tm-unification-plan.md
+++ b/docs/tm-unification-plan.md
@@ -125,6 +125,7 @@ the TM stack — the TM stack is the truth.
 - `attribute-methods/{query,read,write,time-zone-conversion}.test.ts` — already pass under `AR_NO_AUTO_SCHEMA=1` (in-memory only). No migration needed.
 - `associations/inverse-associations.test.ts` — see Batch 122a/b for remainder describes.
 - `batches.test.ts` / `counter-cache.test.ts` — see Batch 129a/b.
+- `strict-loading.test.ts` — cluster A migrated in #1909 (first `StrictLoadingTest` describe). Remaining: second `StrictLoadingTest` describe (~lines 437–1291, ~30 `it()` blocks) and `StrictLoadingFixturesTest` + `strict_loading` + `strictLoadingByDefault` tail (~lines 1292–end). Audit script no longer flags this file (it's per-file, not per-describe) — track here.
 
 **Pattern note from #1697:** `core.test.ts` async-freshAdapter pattern (shared `TEST_SCHEMA` constant, helper async, sed-replace, flip sync `it()` to async) reusable for `enum.test.ts`. `calculations.test.ts` has too many distinct tables for one shared schema — per-describe `beforeEach` `defineSchema` (the pattern from `callbacks.test.ts`).
 

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./associations.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 // -- Helpers --
@@ -26,8 +27,16 @@ function freshAdapter(): DatabaseAdapter {
 describe("StrictLoadingTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      authors: { name: "string" },
+      books: { title: "string", author_id: "integer", publisher_id: "integer" },
+      profiles: { bio: "string", author_id: "integer" },
+      publishers: { name: "string" },
+      tags: { name: "string", taggable_id: "integer", taggable_type: "string" },
+      animals: { name: "string" },
+    });
   });
 
   // Rails: test_raises_on_lazy_loading_a_strict_loading_has_many_relation


### PR DESCRIPTION
## Summary

Migrates the first describe (`StrictLoadingTest`, lines 26–434, 18 `it()` blocks) in `packages/activerecord/src/strict-loading.test.ts` to the per-describe `beforeEach` `defineSchema` pattern (same shape as #1633 / #1697 / #1749 / #1887 / #1897), so this slice passes under `AR_NO_AUTO_SCHEMA=1`.

The file is 1404 LOC with five top-level describes. Cluster A is the head-of-file block only; remaining clusters will ship as `<base>b/c` per the CLAUDE.md PR-size ceiling.

`scripts/audit-define-schema.ts` is per-file (greps for any `defineSchema(` occurrence), so once this PR lands the file no longer surfaces in audit output even though clusters B/C remain. Remainder is tracked in `docs/tm-unification-plan.md` under "Phase 5 remainder" so it doesn't get lost.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/strict-loading.test.ts` — 23 passed / 41 skipped / 32 failed (baseline pre-PR: 12 passed / 43 failed). Remaining failures are clusters B/C still on auto-schema.
- `pnpm vitest run packages/activerecord/src/strict-loading.test.ts` — 55 passed / 41 skipped (no regression, normal mode).
- No test names renamed.

## Follow-ups

Remaining describes to migrate in subsequent PRs (`<base>b`, `<base>c`):

- Second `StrictLoadingTest` describe (~lines 437–1291, ~30 `it()` blocks) — largest cluster, may need its own PR or split further
- `StrictLoadingFixturesTest` + `strict_loading` + `strictLoadingByDefault` (~lines 1292–end)

## Test plan

- [x] Cluster A passes under `AR_NO_AUTO_SCHEMA=1`
- [x] Full file passes in normal mode
- [x] No test names renamed
- [x] Phase 5 remainder tracked in `docs/tm-unification-plan.md`
- [ ] CI green across PG / MySQL / SQLite