### PR TITLE
test(activerecord): TM phase 5 — defineSchema for disable-joins bundle (4 files)

### DIFF
--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -6,6 +6,19 @@ import type { DatabaseAdapter } from "../adapter.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+
+const TEST_SCHEMA: Schema = {
+  djs_authors: { name: "string" },
+  djs_posts: { djs_author_id: "integer", title: "string" },
+  djs_comments: { djs_post_id: "integer", body: "string" },
+};
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
+}
 
 describe("DisableJoinsAssociationScope", () => {
   let adapter: DatabaseAdapter;
@@ -31,8 +44,8 @@ describe("DisableJoinsAssociationScope", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     DjsAuthor.adapter = adapter;
     DjsPost.adapter = adapter;
     DjsComment.adapter = adapter;

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -21,6 +21,30 @@ import { Associations, loadHasMany } from "../associations.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+
+const TEST_SCHEMA: Schema = {
+  ck_shops: { name: "string" },
+  ck_orders: {
+    columns: {
+      shop_id: "integer",
+      order_number: "integer",
+      name: "string",
+    },
+    primaryKey: ["shop_id", "order_number"],
+  },
+  ck_line_items: {
+    ck_order_shop_id: "integer",
+    ck_order_number: "integer",
+    sku: "string",
+  },
+};
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
+}
 
 describe("DJAS — composite key support", () => {
   let adapter: DatabaseAdapter;
@@ -52,8 +76,8 @@ describe("DJAS — composite key support", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     CkShop.adapter = adapter;
     CkOrder.adapter = adapter;
     CkLineItem.adapter = adapter;

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -31,6 +31,31 @@ import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+
+const TEST_SCHEMA: Schema = {
+  ck_shops: { name: "string" },
+  ck_orders: {
+    columns: {
+      shop_id: "integer",
+      order_number: "integer",
+      label: "string",
+    },
+    primaryKey: ["shop_id", "order_number"],
+  },
+  ck_line_items: {
+    ck_order_shop_id: "integer",
+    ck_order_number: "integer",
+    sku: "string",
+  },
+  ck_tags: { ck_line_item_id: "integer", value: "string" },
+};
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
+}
 
 describe("DJAS composite-key + nested-through", () => {
   let adapter: DatabaseAdapter;
@@ -66,8 +91,8 @@ describe("DJAS composite-key + nested-through", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     CkShop.adapter = adapter;
     CkOrder.adapter = adapter;
     CkLineItem.adapter = adapter;

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
@@ -31,6 +31,30 @@ import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
+import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+
+const TEST_SCHEMA: Schema = {
+  dp_authors: { name: "string" },
+  dp_galleries: {
+    dp_author_id: "integer",
+    imageable_uuid: "string",
+    imageable_type: "string",
+  },
+  dp_non_id_photos: {
+    columns: { uuid: "string", title: "string" },
+    primaryKey: ["uuid"],
+  },
+  dp_non_id_articles: {
+    columns: { slug: "string", headline: "string" },
+    primaryKey: ["slug"],
+  },
+};
+
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, TEST_SCHEMA);
+  return adapter;
+}
 
 describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
   let adapter: DatabaseAdapter;
@@ -66,8 +90,8 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapter();
     DpAuthor.adapter = adapter;
     DpGallery.adapter = adapter;
     DpNonIdPhoto.adapter = adapter;


### PR DESCRIPTION
## Summary

Continues TM unification Phase 5. Migrates the disable-joins cluster
(4 test files) to seed the test adapter via `defineSchema()` from an
async `freshAdapter()`, so the suite passes under `AR_NO_AUTO_SCHEMA=1`.

Files:
- `associations/disable-joins-association-scope.test.ts`
- `associations/disable-joins-composite-key.test.ts`
- `associations/disable-joins-composite-nested.test.ts`
- `associations/disable-joins-polymorphic-nonid-pk.test.ts`

Each file gets a `TEST_SCHEMA` covering the tables its models touch,
plus a promoted async `freshAdapter()` and async `beforeEach`.
Composite PKs (`ck_orders`) and non-id PKs (`dp_non_id_photos.uuid`,
`dp_non_id_articles.slug`) use the wrapper schema form.

No test names changed.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run <4 files>` → 21 passed
- `pnpm vitest run <4 files>` → 21 passed

## Test plan

- [x] AR_NO_AUTO_SCHEMA=1 green
- [x] Normal mode green
- [x] No test names renamed
- [ ] CI green across PG / MySQL / SQLite