### PR TITLE
test(activerecord): TM phase 5 — defineSchema for association-scope-alias-tracker + source-type-validation

### DIFF
--- a/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
+++ b/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
@@ -27,7 +27,12 @@ import { Associations } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
 import { AliasTracker } from "./alias-tracker.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
+
+function freshAdapter(): DatabaseAdapter {
+  return createTestAdapter();
+}
 
 describe("AssociationScope — AliasTracker aliases repeated tables", () => {
   let adapter: DatabaseAdapter;
@@ -40,8 +45,11 @@ describe("AssociationScope — AliasTracker aliases repeated tables", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      at_users: { parent_id: "integer", name: "string" },
+    });
     AtUser.adapter = adapter;
     registerModel("AtUser", AtUser);
     (AtUser as any)._associations = [];

--- a/packages/activerecord/src/associations/source-type-validation.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.test.ts
@@ -33,7 +33,12 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations, association, loadHasMany } from "../associations.js";
 import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
+
+function freshAdapter(): DatabaseAdapter {
+  return createTestAdapter();
+}
 
 describe("ThroughReflection — checkValidityBang at first use", () => {
   let adapter: DatabaseAdapter;
@@ -65,8 +70,18 @@ describe("ThroughReflection — checkValidityBang at first use", () => {
     }
   }
 
-  beforeEach(() => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      stv_authors: { name: "string" },
+      stv_comments: {
+        stv_author_id: "integer",
+        origin_id: "integer",
+        origin_type: "string",
+      },
+      stv_posts: { stv_author_id: "integer" },
+      stv_members: { name: "string" },
+    });
     StvAuthor.adapter = adapter;
     StvComment.adapter = adapter;
     StvPost.adapter = adapter;


### PR DESCRIPTION
## Summary

Migrates two association test files to the `defineSchema()` + `freshAdapter()` pattern so they pass under `AR_NO_AUTO_SCHEMA=1` (TM phase 5; pattern from #1633 / #1697 / #1749 / #1888).

- `association-scope-alias-tracker.test.ts`: outer `beforeEach` becomes `async`; seeds the `at_users` table.
- `source-type-validation.test.ts`: outer `beforeEach` becomes `async`; seeds `stv_authors` / `stv_comments` / `stv_posts` / `stv_members`.

## Verification

- `pnpm vitest run …alias-tracker.test.ts …source-type-validation.test.ts` — **9 passed** (no regression).
- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run …` — **9 passed** (source-type-validation: 7 failed → 7 passed).
- No test names renamed.
- Diff: 27 insertions, 4 deletions (2 files).

## Test plan

- [x] Both files pass in normal mode
- [x] Both files pass under `AR_NO_AUTO_SCHEMA=1`
- [x] No test names renamed
- [ ] CI green across PG / MySQL / SQLite