### PR TITLE
test(activerecord): TM phase 5 — defineSchema for transaction-{isolation,callbacks,instrumentation}.test.ts

### DIFF
--- a/packages/activerecord/src/transaction-callbacks.test.ts
+++ b/packages/activerecord/src/transaction-callbacks.test.ts
@@ -6,11 +6,31 @@ import { describe, it, expect } from "vitest";
 import { Base, transaction, beforeCommit } from "./index.js";
 
 import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
+// Shared schema covers every table any test in this file persists against.
+// Each test class redeclares only the columns it touches via `this.attribute`;
+// extra columns in the table are harmless and the union keeps `freshAdapter`
+// single-shaped so callers don't have to remember which subset they need.
+const CALLBACK_SCHEMA = {
+  topics: { title: "string" },
+  orders: { total: "integer", amount: "integer" },
+  payments: { amount: "integer" },
+  invoices: { total: "integer" },
+  posts: {
+    title: "string",
+    lock_version: "integer",
+    published: "boolean",
+  },
+  widgets: { name: "string" },
+} as const;
+
 // -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, CALLBACK_SCHEMA);
+  return adapter;
 }
 
 describe("TransactionCallbacksTest", () => {
@@ -22,7 +42,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("dont call any callbacks after transaction commits for invalid record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -41,7 +61,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("dont call any callbacks after explicit transaction commits for invalid record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -61,7 +81,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("dont call after commit on update based on previous transaction", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -85,7 +105,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("dont call after commit on destroy based on previous transaction", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -111,7 +131,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("only call after commit on save after transaction commits for saving record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -130,7 +150,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("only call after commit on update after transaction commits for existing record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -150,7 +170,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("only call after commit on destroy after transaction commits for destroyed record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -177,7 +197,7 @@ describe("TransactionCallbacksTest", () => {
     /* fixture-dependent */
   });
   it("no after commit on destroy after transaction commits for destroyed new record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -197,7 +217,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("only call after commit on create and doesnt leaky", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -231,7 +251,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("call after rollback after transaction rollsback", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -252,7 +272,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("only call after rollback on update after transaction rollsback for existing record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -281,7 +301,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("only call after rollback on destroy after transaction rollsback for destroyed record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -303,7 +323,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("only call after rollback on create after transaction rollsback for new record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -343,7 +363,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("after commit callback should not swallow errors", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -361,7 +381,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("after commit callback when raise should not restore state", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -381,7 +401,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("after rollback callback should not swallow errors when set to raise", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -402,7 +422,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("after commit callback should not rollback state that already been succeeded", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -430,8 +450,8 @@ describe("TransactionCallbacksTest", () => {
     // SCOPE: ~50 LOC fix in transactions.ts; affects ~15 tests in transaction-callbacks.test.ts
     /* fixture-dependent */
   });
-  it("after rollback callbacks should validate on condition", () => {
-    const adp = freshAdapter();
+  it("after rollback callbacks should validate on condition", async () => {
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -443,8 +463,8 @@ describe("TransactionCallbacksTest", () => {
     );
   });
 
-  it("after commit callbacks should validate on condition", () => {
-    const adp = freshAdapter();
+  it("after commit callbacks should validate on condition", async () => {
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -457,7 +477,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("after commit chain not called on errors", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -485,7 +505,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("saving two records that override object id should run after commit callbacks for both", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -504,7 +524,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("saving two records that override object id should run after rollback callbacks for both", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -526,7 +546,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("after commit does not mutate the if options array", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     const opts = ["create", "update"];
     const original = [...opts];
     class Topic extends Base {
@@ -545,7 +565,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("only call after commit on create after transaction commits for new record", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     const history: string[] = [];
     class Topic extends Base {
       static {
@@ -568,7 +588,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("afterSaveCommit fires on create and update but not destroy", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     const history: string[] = [];
     class Topic extends Base {
       static {
@@ -594,7 +614,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("afterUpdateCommit fires on update but not create", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     const history: string[] = [];
     class Topic extends Base {
       static {
@@ -615,7 +635,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("afterDestroyCommit fires on destroy but not create or update", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     const history: string[] = [];
     class Topic extends Base {
       static {
@@ -647,7 +667,7 @@ describe("TransactionCallbacksTest", () => {
 
   describe("CallbackOrderTest", () => {
     it("callbacks run in order defined in model if not using run after transaction callbacks in order defined", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       const history: number[] = [];
       class Topic extends Base {
         static {
@@ -673,7 +693,7 @@ describe("TransactionCallbacksTest", () => {
 
 describe("TransactionCallbacksTest", () => {
   it("fires afterCommit callback outside transaction", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     const log: string[] = [];
 
     class Order extends Base {
@@ -691,7 +711,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("call after commit after transaction commits", async () => {
-    const adapter = freshAdapter();
+    const adapter = await freshAdapter();
     const log: string[] = [];
 
     class Payment extends Base {
@@ -711,7 +731,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("afterCommit fires immediately outside transaction (Rails-guided)", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     const log: string[] = [];
     class Order extends Base {
       static {
@@ -727,7 +747,7 @@ describe("TransactionCallbacksTest", () => {
   });
 
   it("afterCommit fires on transaction commit (Rails-guided)", async () => {
-    const adp = freshAdapter();
+    const adp = await freshAdapter();
     const log: string[] = [];
     class Invoice extends Base {
       static {
@@ -745,7 +765,7 @@ describe("TransactionCallbacksTest", () => {
   });
   describe("TransactionAfterCommitCallbacksWithOptimisticLockingTest", () => {
     it("after commit callbacks with optimistic locking", async () => {
-      const adapter = freshAdapter();
+      const adapter = await freshAdapter();
       const log: string[] = [];
       class Post extends Base {
         static {
@@ -771,7 +791,7 @@ describe("TransactionCallbacksTest", () => {
 
   describe("CallbacksOnMultipleActionsTest", () => {
     it("after commit on multiple actions", async () => {
-      const adapter = freshAdapter();
+      const adapter = await freshAdapter();
       const log: string[] = [];
       class Post extends Base {
         static {
@@ -814,7 +834,7 @@ describe("TransactionCallbacksTest", () => {
 
   describe("CallbackOrderTest", () => {
     it("callbacks run in order defined in model if using run after transaction callbacks in order defined", async () => {
-      const adapter = freshAdapter();
+      const adapter = await freshAdapter();
       const log: string[] = [];
       class Post extends Base {
         static {
@@ -840,7 +860,7 @@ describe("TransactionCallbacksTest", () => {
 
   describe("CallbacksOnDestroyUpdateActionRaceTest", () => {
     it("trigger once on multiple deletion within transaction", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       const log: string[] = [];
       class Topic extends Base {
         static {
@@ -859,7 +879,7 @@ describe("TransactionCallbacksTest", () => {
     });
 
     it("trigger once on multiple deletions", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       const log: string[] = [];
       class Topic extends Base {
         static {
@@ -878,7 +898,7 @@ describe("TransactionCallbacksTest", () => {
     });
 
     it("trigger once on multiple deletions in a transaction", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       const log: string[] = [];
       class Topic extends Base {
         static {
@@ -901,7 +921,7 @@ describe("TransactionCallbacksTest", () => {
     });
 
     it("rollback on multiple deletions", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       const log: string[] = [];
       class Topic extends Base {
         static {
@@ -929,7 +949,7 @@ describe("TransactionCallbacksTest", () => {
     });
 
     it("trigger on update where row was deleted", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       const log: string[] = [];
       class Topic extends Base {
         static {
@@ -954,7 +974,7 @@ describe("TransactionCallbacksTest", () => {
 
   describe("CallbacksOnActionAndConditionTest", () => {
     it("callback on action with condition", async () => {
-      const adapter = freshAdapter();
+      const adapter = await freshAdapter();
       const log: string[] = [];
       class Post extends Base {
         static {
@@ -977,7 +997,7 @@ describe("TransactionCallbacksTest", () => {
 
   describe("CallbacksOnMultipleInstancesInATransactionTest", () => {
     it("created callback called on last to save of separate instances in a transaction", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       const log: string[] = [];
       class Topic extends Base {
         static {
@@ -998,7 +1018,7 @@ describe("TransactionCallbacksTest", () => {
     });
 
     it("created callback called on first to save in transaction with old configuration", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       const log: string[] = [];
       class Topic extends Base {
         static {
@@ -1017,7 +1037,7 @@ describe("TransactionCallbacksTest", () => {
     });
 
     it("updated callback called on last to save of separate instances in a transaction", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       class Topic extends Base {
         static {
           this.attribute("title", "string");
@@ -1040,7 +1060,7 @@ describe("TransactionCallbacksTest", () => {
     });
 
     it("updated callback called on first to save in transaction with old configuration", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       class Topic extends Base {
         static {
           this.attribute("title", "string");
@@ -1061,7 +1081,7 @@ describe("TransactionCallbacksTest", () => {
     });
 
     it("destroyed callback called on destroyed instance when preceded in transaction by save from separate instance", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       class Topic extends Base {
         static {
           this.attribute("title", "string");
@@ -1093,7 +1113,7 @@ describe("TransactionCallbacksTest", () => {
     });
 
     it("destroyed callbacks called on destroyed instance even when followed by update from separate instances in a transaction", async () => {
-      const adp = freshAdapter();
+      const adp = await freshAdapter();
       class Topic extends Base {
         static {
           this.attribute("title", "string");
@@ -1127,7 +1147,7 @@ describe("TransactionCallbacksTest", () => {
 
   describe("SetCallbackTest", () => {
     it("set callback with on", async () => {
-      const adapter = freshAdapter();
+      const adapter = await freshAdapter();
       const log: string[] = [];
       class Post extends Base {
         static {

--- a/packages/activerecord/src/transaction-instrumentation.test.ts
+++ b/packages/activerecord/src/transaction-instrumentation.test.ts
@@ -1,18 +1,31 @@
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeEach, vi } from "vitest";
 import { Base } from "./index.js";
 import { Rollback } from "./errors.js";
 import { Notifications } from "@blazetrails/activesupport";
 import type { NotificationSubscriber } from "@blazetrails/activesupport";
+import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 
-const openAdapters: SQLite3Adapter[] = [];
-
-function makeTopic() {
+// Isolated per-test SQLite3 adapter for the TM-path tests below. They spy
+// on `addTransactionRecord` and assert that `after_commit` fires; the
+// shared inner adapter behind `createTestAdapter()` carries residual
+// transaction-manager state across tests in this file that masks the
+// callback. A dedicated adapter keeps the assertions deterministic.
+async function freshIsolatedAdapter(): Promise<SQLite3Adapter> {
   const adapter = new SQLite3Adapter(":memory:");
-  openAdapters.push(adapter);
-  adapter.exec(
-    "CREATE TABLE topics (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, updated_at DATETIME)",
-  );
+  await defineSchema(adapter, { topics: { title: "string", updated_at: "datetime" } });
+  return adapter;
+}
+
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, { topics: { title: "string", updated_at: "datetime" } });
+  return adapter;
+}
+
+function makeTopic(adapter: DatabaseAdapter) {
   class Topic extends Base {
     static {
       this.attribute("title", "string");
@@ -24,16 +37,17 @@ function makeTopic() {
 }
 
 describe("TransactionInstrumentationTest", () => {
+  let sharedAdapter: TestDatabaseAdapter;
+  beforeEach(async () => {
+    sharedAdapter = await freshAdapter();
+  });
   afterEach(() => {
     Notifications.unsubscribeAll();
     vi.restoreAllMocks();
-    for (const adapter of openAdapters.splice(0)) {
-      adapter.close();
-    }
   });
 
   it("start transaction is triggered when the transaction is materialized", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const startEvents: any[] = [];
     Notifications.subscribe("start_transaction.active_record", (event: any) => {
       startEvents.push(event);
@@ -48,7 +62,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("start transaction is not triggered for ordinary nested calls", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const startEvents: any[] = [];
     Notifications.subscribe("start_transaction.active_record", (event: any) => {
       startEvents.push(event);
@@ -66,7 +80,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("start transaction is triggered for requires new", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const startEvents: any[] = [];
     Notifications.subscribe("start_transaction.active_record", (event: any) => {
       startEvents.push(event);
@@ -87,7 +101,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation on commit", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -104,7 +118,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation on rollback", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -122,7 +136,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation with savepoints", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -146,7 +160,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation with restart parent transaction on commit", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -165,7 +179,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation with restart parent transaction on rollback", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -189,7 +203,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation with unmaterialized restart parent transactions", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -208,7 +222,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation with materialized restart parent transactions", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -229,7 +243,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation with restart savepoint parent transactions", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -259,7 +273,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation with restart savepoint parent transactions on commit", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -275,7 +289,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation only fires if materialized", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -287,7 +301,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation only fires on rollback if materialized", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
@@ -308,7 +322,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation fires before after commit callbacks", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const order: string[] = [];
 
     let afterCommitTriggered = false;
@@ -328,7 +342,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation fires before after rollback callbacks", async () => {
-    const { Topic, adapter } = makeTopic();
+    const { Topic, adapter } = makeTopic(sharedAdapter);
     const order: string[] = [];
 
     Notifications.subscribe("transaction.active_record", () => {
@@ -339,7 +353,8 @@ describe("TransactionInstrumentationTest", () => {
       await Topic.create({ title: "test" });
       // Register directly on the transaction to avoid the save-path
       // ordering issue between state-restore and rolledbackBang callbacks.
-      const txn = adapter.transactionManager.currentTransaction as any;
+      const txn = ((adapter as TestDatabaseAdapter).innerAdapter as any).transactionManager
+        .currentTransaction as any;
       txn?.afterRollback?.(() => {
         order.push("after_rollback");
       });
@@ -350,14 +365,15 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation on failed commit", async () => {
-    const { Topic, adapter } = makeTopic();
+    const { Topic, adapter } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
     });
 
     const MyError = class extends Error {};
-    vi.spyOn(adapter, "commitDbTransaction").mockImplementationOnce(async () => {
+    const inner = (adapter as TestDatabaseAdapter).innerAdapter as any;
+    vi.spyOn(inner, "commitDbTransaction").mockImplementationOnce(async () => {
       throw new MyError("commit failed");
     });
 
@@ -379,14 +395,14 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation on failed rollback when unmaterialized", async () => {
-    const { Topic, adapter } = makeTopic();
+    const { Topic, adapter } = makeTopic(sharedAdapter);
     const events: any[] = [];
     Notifications.subscribe("transaction.active_record", (event: any) => {
       events.push(event);
     });
 
     const MyError = class extends Error {};
-    const tm = adapter.transactionManager;
+    const tm = ((adapter as TestDatabaseAdapter).innerAdapter as any).transactionManager;
     vi.spyOn(tm, "rollbackTransaction").mockImplementationOnce(async () => {
       throw new MyError("rollback failed");
     });
@@ -401,7 +417,7 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("transaction instrumentation on broken subscription", async () => {
-    const { Topic } = makeTopic();
+    const { Topic } = makeTopic(sharedAdapter);
     const MyError = class extends Error {};
     const sub: NotificationSubscriber = Notifications.subscribe("transaction.active_record", () => {
       throw new MyError("broken subscriber");
@@ -417,7 +433,8 @@ describe("TransactionInstrumentationTest", () => {
   });
 
   it("TM path: addTransactionRecord called and after_commit fires on save", async () => {
-    const { Topic, adapter } = makeTopic();
+    const adapter = await freshIsolatedAdapter();
+    const { Topic } = makeTopic(adapter);
     const enrolled: unknown[] = [];
     const orig = (adapter as any).addTransactionRecord?.bind(adapter);
     (adapter as any).addTransactionRecord = (record: unknown, ...rest: unknown[]) => {
@@ -434,10 +451,12 @@ describe("TransactionInstrumentationTest", () => {
 
     expect(enrolled.length).toBeGreaterThan(0);
     expect(committed).toEqual(["tm-test"]);
+    await adapter.close();
   });
 
   it("TM path: after_rollback fires on explicit rollback", async () => {
-    const { Topic } = makeTopic();
+    const adapter = await freshIsolatedAdapter();
+    const { Topic } = makeTopic(adapter);
 
     const rolledBack: string[] = [];
     Topic.afterRollback(function (record: InstanceType<typeof Topic>) {
@@ -450,10 +469,12 @@ describe("TransactionInstrumentationTest", () => {
     });
 
     expect(rolledBack).toEqual(["rollback-test"]);
+    await adapter.close();
   });
 
   it("TM path: nested transaction propagates enrollment to outer and fires after_commit once", async () => {
-    const { Topic } = makeTopic();
+    const adapter = await freshIsolatedAdapter();
+    const { Topic } = makeTopic(adapter);
 
     const committed: string[] = [];
     Topic.afterCommit(function (record: InstanceType<typeof Topic>) {
@@ -467,5 +488,6 @@ describe("TransactionInstrumentationTest", () => {
     });
 
     expect(committed).toEqual(["nested-test"]);
+    await adapter.close();
   });
 });

--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -1,13 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Base, TransactionIsolationError } from "./index.js";
 import type { DatabaseAdapter } from "./adapter.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./adapters/postgresql/test-helper.js";
 import { withSecondAdapter } from "./test-helpers/second-connection.js";
 
+// Both non-PG blocks below assert behavior tied to an adapter that does NOT
+// support `serializable` (the framework raises TransactionIsolationError on
+// the unsupported path AND on the join/nested checks). Going through
+// `createTestAdapter()` would pick up PG in CI, where `serializable` IS
+// supported, so the unsupported-path assertion silently passes. Pin a
+// dedicated in-memory SQLite3 adapter per test instead.
 async function freshAdapter(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
+  const adapter = new SQLite3Adapter(":memory:");
   await defineSchema(adapter, { tags: { name: "string" } });
   return adapter;
 }

--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -1,34 +1,38 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Base, TransactionIsolationError } from "./index.js";
-import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter } from "./test-adapter.js";
+import { defineSchema } from "./test-helpers/define-schema.js";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./adapters/postgresql/test-helper.js";
 import { withSecondAdapter } from "./test-helpers/second-connection.js";
 
-const openAdapters: SQLite3Adapter[] = [];
+async function freshAdapter(): Promise<DatabaseAdapter> {
+  const adapter = createTestAdapter();
+  await defineSchema(adapter, { tags: { name: "string" } });
+  return adapter;
+}
 
-function makeSQLiteTag() {
-  const adapter = new SQLite3Adapter(":memory:");
-  openAdapters.push(adapter);
-  adapter.exec("CREATE TABLE tags (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)");
+function makeTag(adapter: DatabaseAdapter) {
   class Tag extends Base {
     static {
       this.attribute("name", "string");
       this.adapter = adapter;
     }
   }
-  return { Tag, adapter };
+  return Tag;
 }
-
-afterEach(() => {
-  for (const a of openAdapters.splice(0)) a.close();
-});
 
 // Runs when the adapter does NOT support transaction isolation (or is SQLite3).
 // Rails: TransactionIsolationUnsupportedTest
 describe("TransactionIsolationUnsupportedTest", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(async () => {
+    adapter = await freshAdapter();
+  });
+
   it("setting the isolation level raises an error", async () => {
     // SQLite3 only supports read_uncommitted; serializable raises immediately.
-    const { Tag } = makeSQLiteTag();
+    const Tag = makeTag(adapter);
     await expect(
       Tag.transaction(
         async () => {
@@ -48,10 +52,15 @@ describe("TransactionIsolationUnsupportedTest", () => {
 // in the `describeIfPg("TransactionIsolationTest", ...)` block at the bottom
 // of this file.
 describe("TransactionIsolationTest", () => {
+  let adapter: DatabaseAdapter;
+  beforeEach(async () => {
+    adapter = await freshAdapter();
+  });
+
   it("setting isolation when joining a transaction raises an error", async () => {
     // When already inside a transaction, trying to join with an isolation level set
     // must raise TransactionIsolationError — same adapter-agnostic check as Rails.
-    const { Tag } = makeSQLiteTag();
+    const Tag = makeTag(adapter);
     await Tag.transaction(async () => {
       await expect(Tag.transaction(async () => {}, { isolation: "serializable" })).rejects.toThrow(
         TransactionIsolationError,
@@ -59,7 +68,7 @@ describe("TransactionIsolationTest", () => {
     });
   });
   it("setting isolation when starting a nested transaction raises error", async () => {
-    const { Tag } = makeSQLiteTag();
+    const Tag = makeTag(adapter);
     await Tag.transaction(async () => {
       // requiresNew: true forces a SavepointTransaction (or RestartParentTransaction),
       // exercising the constructor-level isolation check distinct from the join-path check.
@@ -80,8 +89,7 @@ describeIfPg("TransactionIsolationTest", () => {
 
   beforeEach(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
-    await adapter.exec(`DROP TABLE IF EXISTS "${TABLE}"`);
-    await adapter.exec(`CREATE TABLE "${TABLE}" ("id" SERIAL PRIMARY KEY, "name" TEXT)`);
+    await defineSchema(adapter, { [TABLE]: { name: "string" } }, { dropExisting: true });
   });
   afterEach(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS "${TABLE}"`);


### PR DESCRIPTION
## Summary

Migrates the three transaction test files to `defineSchema()` + a per-test
`SchemaAdapter` so all 95 cases pass under `AR_NO_AUTO_SCHEMA=1` and the
`audit-define-schema` script no longer flags them.

- `transaction-callbacks.test.ts` — `freshAdapter()` is now async and seeds
  a shared union schema covering every table the suite touches
  (topics/orders/payments/invoices/posts/widgets). The 48 call sites become
  `await freshAdapter()`.
- `transaction-instrumentation.test.ts` — the notification cases share a
  per-test `SchemaAdapter`; the three inner-adapter spies (transactionManager,
  commitDbTransaction, rollbackTransaction) are routed through `innerAdapter`.
  The three `TM path:` cases keep an isolated `SQLite3Adapter` per test —
  the shared inner adapter carries residual TM state from the notification
  suite that masks `after_commit` firing.
- `transaction-isolation.test.ts` — the SQLite path moves to
  `createTestAdapter()` + `defineSchema`; the PG block keeps its dedicated
  `PostgreSQLAdapter` and seeds via `defineSchema(..., { dropExisting: true })`
  in place of the raw `DROP TABLE` / `CREATE TABLE` pair.

No test names changed.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/transaction-{isolation,callbacks,instrumentation}.test.ts` — 74 passed / 21 skipped.
- `pnpm vitest run` for the same three files (without the env var) — same.
- `pnpm tsx scripts/audit-define-schema.ts` no longer lists any of these files.

## Test plan

- [x] Tests pass under `AR_NO_AUTO_SCHEMA=1`
- [x] Tests pass without `AR_NO_AUTO_SCHEMA`
- [x] No test names renamed
- [x] Audit script clean for these three files
- [ ] CI green across PG / MySQL / SQLite