### PR TITLE
test(activerecord): TM phase 5 — defineSchema for postgresql/foreign-table.test.ts

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { defineSchema } from "../../test-helpers/define-schema.js";
 
 const url = new URL(PG_TEST_URL);
 const fdwHost = url.hostname || "localhost";
@@ -36,9 +37,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       ctx.skip();
       return;
     }
-    await adapter.exec(
-      `CREATE TABLE professors (id serial primary key, name character varying NOT NULL)`,
-    );
+    await defineSchema(adapter, {
+      professors: { name: { type: "string", null: false } },
+    });
     await adapter.exec(
       `CREATE SERVER foreign_server FOREIGN DATA WRAPPER postgres_fdw ` +
         `OPTIONS (host ${quoteLit(fdwHost)}, port ${quoteLit(fdwPort)}, dbname ${quoteLit(fdwDb)})`,


### PR DESCRIPTION
## Summary

Migrates `packages/activerecord/src/adapters/postgresql/foreign-table.test.ts` off the Phase 5 audit's offenders list by replacing the raw `CREATE TABLE professors` block in `beforeEach` with a `defineSchema()` call.

The FDW infrastructure (`CREATE SERVER foreign_server`, `CREATE FOREIGN TABLE foreign_professors`, `CREATE USER MAPPING`) intentionally stays as raw DDL — `defineSchema` has no foreign-table primitive, and those statements are the actual surface the test exercises.

## Verification

- `pnpm tsx scripts/audit-define-schema.ts` — offender count 7 → 6 (this file no longer listed)
- `TEST_ADAPTER=postgresql AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/adapters/postgresql/foreign-table.test.ts` — 10/10 skipped (no local PG; gated by `describeIfPg`). CI's PG job exercises the real path.
- No test names renamed.

## Test plan

- [x] Audit clean for this file
- [x] Local typecheck + build green
- [ ] CI PG job green