### PR TITLE
test(activerecord): TM phase 5 — defineSchema for encryptable-record-message-pack-serialized

### DIFF
--- a/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
@@ -5,10 +5,9 @@ import {
   snapshotEncryptionConfig,
   restoreEncryptionConfig,
   makeEncryptedBookWithBinaryMessagePackSerialized,
+  makeMsgPackTextBook,
   assertEncryptedAttribute,
-  Base,
 } from "./test-helpers.js";
-import { MessagePackMessageSerializer } from "./message-pack-message-serializer.js";
 import { Encoding as EncodingError } from "./errors.js";
 
 describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest", () => {
@@ -42,15 +41,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest",
   });
 
   it("text columns cannot be serialized with message pack", async () => {
-    const adapter = await freshAdapter();
-    const MsgPackTextBook = class extends Base {
-      static {
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.adapter = adapter;
-        this.encrypts("name", { messageSerializer: new MessagePackMessageSerializer() });
-      }
-    } as any;
+    const MsgPackTextBook = makeMsgPackTextBook(await freshAdapter());
     await expect(MsgPackTextBook.create({ name: "Dune" })).rejects.toThrow(EncodingError);
   });
 });

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -175,7 +175,6 @@ const ENCRYPTION_SCHEMA: Schema = {
   encrypted_book_with_serialized_first_binaries: { logo: "text" },
   encrypted_book_with_serialized_second_binaries: { logo: "text" },
   encrypted_book_with_binary_message_pack_serializeds: { logo: "text" },
-  msg_pack_text_books: { name: { type: "string", limit: 1024 } },
 };
 
 export async function installEncryptionSchema(adapter: DatabaseAdapter): Promise<void> {
@@ -429,6 +428,7 @@ export function makeEncryptedBookWithBinaryMessagePackSerialized(adapter: Databa
 export function makeMsgPackTextBook(adapter: DatabaseAdapter) {
   return class MsgPackTextBook extends Base {
     static {
+      this._tableName = "encrypted_books";
       this.attribute("id", "integer");
       this.attribute("name", "string");
       this.adapter = adapter;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -175,6 +175,7 @@ const ENCRYPTION_SCHEMA: Schema = {
   encrypted_book_with_serialized_first_binaries: { logo: "text" },
   encrypted_book_with_serialized_second_binaries: { logo: "text" },
   encrypted_book_with_binary_message_pack_serializeds: { logo: "text" },
+  msg_pack_text_books: { name: { type: "string", limit: 1024 } },
 };
 
 export async function installEncryptionSchema(adapter: DatabaseAdapter): Promise<void> {
@@ -416,6 +417,22 @@ export function makeEncryptedBookWithBinaryMessagePackSerialized(adapter: Databa
       this.attribute("logo", "binary");
       this.adapter = adapter;
       this.encrypts("logo", { messageSerializer: new MessagePackMessageSerializer() });
+    }
+  } as any;
+}
+
+/**
+ * MsgPackTextBook: a string `name` column encrypted with a MessagePack
+ * serializer. Used to assert that text columns reject MessagePack encoding
+ * (encrypted_record_message_pack_serialized_test.rb).
+ */
+export function makeMsgPackTextBook(adapter: DatabaseAdapter) {
+  return class MsgPackTextBook extends Base {
+    static {
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.adapter = adapter;
+      this.encrypts("name", { messageSerializer: new MessagePackMessageSerializer() });
     }
   } as any;
 }


### PR DESCRIPTION
## Summary

Migrates `encryptable-record-message-pack-serialized.test.ts` (3 tests) so it clears `scripts/audit-define-schema.ts` and passes under `AR_NO_AUTO_SCHEMA=1`.

The file already routed binary fixtures through `freshAdapter()` (which seeds via `defineSchema`), but it still declared an inline anonymous `class extends Base` for the text-column case — the audit pattern matches that and flagged the file.

- Extract the inline class into a `makeMsgPackTextBook(adapter)` factory in `encryption/test-helpers.ts`, alongside the other `makeEncrypted*` helpers.
- The factory pins `_tableName = "encrypted_books"`, matching Rails (`vendor/rails/activerecord/test/cases/encryption/encryptable_record_message_pack_serialized_test.rb:28-29` — `self.table_name = "encrypted_books"`). The shared `encrypted_books` schema entry already covers the `name` column, so no new schema row is needed.
- Test names unchanged.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts` → 3 passed.
- `pnpm tsx scripts/audit-define-schema.ts` no longer flags this file.

## Test plan

- [x] AR_NO_AUTO_SCHEMA=1 vitest passes
- [x] audit-define-schema clears