### PR TITLE
test(activerecord): TM phase 5 — defineSchema for autosave-association.test.ts (cluster B)

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -506,8 +506,21 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      companies: { name: "string" },
+      clients: { name: "string", company_id: "integer" },
+      unvalidated_clients: { name: "string", company_id: "integer" },
+      cpk_order_pks: {
+        columns: { shop_id: "integer", id: "integer", status: "string" },
+        primaryKey: ["shop_id", "id"],
+      },
+      cpk_book_fks: { order_id: "integer", title: "string" },
+      aid_firms: { name: "string" },
+      aid_contracts: { aid_firm_id: "integer", aid_developer_id: "integer" },
+      aid_developers: { name: "string" },
+    });
   });
 
   function makeModels() {


### PR DESCRIPTION
## Summary

Cluster B of the `autosave-association.test.ts` Phase 5 migration
(follows #1887 cluster A). Migrates the
`TestDefaultAutosaveAssociationOnAHasManyAssociation` describe (lines
503–845, ~30 tests) to the per-describe `beforeEach` `defineSchema`
pattern.

Tables declared: `companies`, `clients`, `unvalidated_clients`,
`cpk_order_pks` (composite PK `[shop_id, id]`), `cpk_book_fks`,
`aid_firms`, `aid_contracts`, `aid_developers`.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/autosave-association.test.ts -t TestDefaultAutosaveAssociationOnAHasManyAssociation` — 27 passed in the target describe (the 6 unrelated failures are in the still-unmigrated `*WithAcceptsNestedAttributes` describes that the `-t` regex also matches; they're scheduled for a later cluster).
- `pnpm vitest run packages/activerecord/src/autosave-association.test.ts` — 193 passed / 15 skipped (no regression).

## Test plan

- [x] Cluster B describe passes under `AR_NO_AUTO_SCHEMA=1`
- [x] Full file passes in normal mode
- [x] No test names renamed
- [ ] CI green across PG / MySQL / SQLite

## Follow-ups

24 describes remain (~3800 LOC). Next likely cluster: describe 3
(`TestDefaultAutosaveAssociationOnAHasOneAssociation`, lines 847–1318)
which uses firms/accounts variants (p_, loose_, cb_, cu_, cs_) plus
poly_parents / poly_children / cb_owners / cb_pets / poly_as_*.