### PR TITLE
test(activerecord): TM phase 5 — defineSchema for associations.test.ts (cluster B)

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -890,8 +890,16 @@ describe("CollectionProxy", () => {
 describe("DependentAssociations", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string" },
+      comments: { body: "string", post_id: "integer" },
+      items: { name: "string" },
+      tags: { name: "string", item_id: "integer" },
+      users: { name: "string" },
+      profiles: { user_id: "integer", bio: "string" },
+    });
   });
 
   // Rails: test_dependent_destroy
@@ -1169,7 +1177,7 @@ describe("StrictLoading", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
     Author.adapter = adapter;
     Book.adapter = adapter;
@@ -1177,6 +1185,11 @@ describe("StrictLoading", () => {
     registerModel(Author);
     registerModel(Book);
     registerModel(Profile);
+    await defineSchema(adapter, {
+      authors: { name: "string" },
+      books: { title: "string", author_id: "integer" },
+      profiles: { bio: "string", author_id: "integer" },
+    });
   });
 
   // Rails: test_strict_loading_on_belongs_to
@@ -1474,8 +1487,12 @@ describe("AssociationReflection", () => {
 describe("HasAndBelongsToManyAssociations", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      developers: { name: "string" },
+      projects: { name: "string" },
+    });
   });
 
   // Rails: test_habtm


### PR DESCRIPTION
## Summary

Continues #1897 (cluster A). Migrates the next 3 schema-touching describes in `packages/activerecord/src/associations.test.ts` to the per-describe `beforeEach` `defineSchema` pattern so the slice passes under `AR_NO_AUTO_SCHEMA=1`:

- `DependentAssociations` (~890–1148)
- `StrictLoading` (~1149–1230)
- `HasAndBelongsToManyAssociations` (~1474–1569)

`AssociationDefinitions` (~1236–1301) and `AssociationReflection` (~1307–1468) fall inside this contiguous range but exercise only macro storage / reflection lookups — no `create()` or other persistence — so they need no `defineSchema` and are intentionally left alone.

## Verification

- `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/associations.test.ts -t '<cluster-B names>'` — 34 passed.
- `pnpm vitest run packages/activerecord/src/associations.test.ts` — 391 passed / 8 skipped.
- No test names renamed.

## Follow-ups

Remaining describes for later clusters (`<base>c`, …):

- `CounterCache` + `TouchBelongsToParents` (~1575–1760)
- `Rails-guided: association features` (~1761–2011)
- `AssociationsTest` mega-block (~2012 onward)
- `BelongsToAssociationsTest`, `HasManyAssociationsTest`, `AssociationProxyTest`, `PreloaderTest`, `inverse_of`, `Association Scopes`, and the trailing describes through ~10033

## Test plan

- [x] Cluster B passes under `AR_NO_AUTO_SCHEMA=1`
- [x] Full file passes in normal mode
- [x] No test names renamed
- [ ] CI green across PG / MySQL / SQLite