### PR TITLE
feat(activerecord): defineSchema useTransactionalTests opt-out (B6.2)

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -128,6 +128,35 @@ export function shouldSkipGlobalReset(): boolean {
   return _skipGlobalResetDepth > 0;
 }
 
+// Per-adapter opt-out for the Phase 6.3 global BEGIN/ROLLBACK wrap.
+// Mirrors Rails' `self.use_transactional_tests = false` (per-test-class
+// in Rails; per-adapter here since adapters are the per-test-file unit
+// in trails). Written by `defineSchema(..., { useTransactionalTests })`,
+// read by the global `beforeEach` in `test-setup-ar.ts` (B6.3) and by
+// any future helper that needs to know whether transactional fixtures
+// are active. A WeakMap keeps the flag off the adapter's public surface
+// (it's purely a test concern) and avoids leaking adapters across
+// test files.
+const _useTransactionalTests = new WeakMap<object, boolean>();
+
+/** @internal */
+export function setUseTransactionalTests(adapter: object, value: boolean): void {
+  _useTransactionalTests.set(adapter, value);
+}
+
+/**
+ * Read the per-adapter opt-out for transactional fixtures. Defaults to
+ * `true` when the adapter has never been seen — the Phase 6.3 wrap is
+ * on-by-default, and `defineSchema` always records an explicit value
+ * before any DDL runs, so an unseen adapter means the file never called
+ * `defineSchema` (e.g. test-helper unit tests) and the wrap is harmless.
+ *
+ * @internal
+ */
+export function getUseTransactionalTests(adapter: object): boolean {
+  return _useTransactionalTests.get(adapter) ?? true;
+}
+
 /** Map ActiveModel type names to SQL column types. */
 function sqlType(typeName: string): string {
   switch (typeName) {

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, getUseTransactionalTests } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import { defineSchema, type ColumnSpec } from "./define-schema.js";
 
@@ -333,5 +333,43 @@ describe("defineSchema", () => {
 
     const rows = await adapter.execute(`SELECT * FROM "items"`);
     expect(rows).toHaveLength(0);
+  });
+
+  describe("useTransactionalTests flag", () => {
+    it("defaults to true when option omitted", async () => {
+      await defineSchema(adapter, { t1: { name: "string" } });
+      expect(getUseTransactionalTests(adapter)).toBe(true);
+    });
+
+    it("defaults to true when explicitly set to true", async () => {
+      await defineSchema(adapter, { t1: { name: "string" } }, { useTransactionalTests: true });
+      expect(getUseTransactionalTests(adapter)).toBe(true);
+    });
+
+    it("records false when explicitly opted out", async () => {
+      await defineSchema(adapter, { t1: { name: "string" } }, { useTransactionalTests: false });
+      expect(getUseTransactionalTests(adapter)).toBe(false);
+    });
+
+    it("is per-adapter: opting out one does not affect another", async () => {
+      const other = createTestAdapter();
+      await defineSchema(adapter, { t1: { name: "string" } }, { useTransactionalTests: false });
+      await defineSchema(other, { t2: { name: "string" } });
+      expect(getUseTransactionalTests(adapter)).toBe(false);
+      expect(getUseTransactionalTests(other)).toBe(true);
+    });
+
+    it("re-running defineSchema with a new flag overrides the prior value", async () => {
+      await defineSchema(adapter, { t1: { name: "string" } }, { useTransactionalTests: false });
+      expect(getUseTransactionalTests(adapter)).toBe(false);
+
+      await defineSchema(adapter, { t1: { name: "string" } }, { dropExisting: true });
+      expect(getUseTransactionalTests(adapter)).toBe(true);
+    });
+
+    it("defaults to true for an adapter that never called defineSchema", () => {
+      const fresh = createTestAdapter();
+      expect(getUseTransactionalTests(fresh)).toBe(true);
+    });
   });
 });

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -1,5 +1,6 @@
 import type { DatabaseAdapter } from "../adapter.js";
 import { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
+import { setUseTransactionalTests } from "../test-adapter.js";
 
 export type PrimitiveColumnSpec =
   | "string"
@@ -64,6 +65,15 @@ export type Schema = Record<string, TableSchema>;
 
 export interface DefineSchemaOpts {
   dropExisting?: boolean;
+  /**
+   * Mirror of Rails' `self.use_transactional_tests = false`. When `false`,
+   * the global per-test `BEGIN`/`ROLLBACK` wrap (Phase 6.3) is bypassed for
+   * tests using this adapter. Required for tests that mutate schema
+   * mid-body (migration tests, schema-dump tests, DDL tests) — DDL inside a
+   * transaction either commits implicitly (MySQL) or breaks rollback
+   * semantics (PG/SQLite savepoint interactions). Defaults to `true`.
+   */
+  useTransactionalTests?: boolean;
 }
 
 /** @internal */
@@ -261,6 +271,12 @@ export async function defineSchema(
 
   const cache = getCache(adapter);
   const known = adapterKnownTables(adapter);
+
+  // Record the per-adapter opt-out flag *before* any DDL runs. Phase 6.3's
+  // global `beforeEach` will read this via `getUseTransactionalTests()` to
+  // decide whether to wrap the test in BEGIN/ROLLBACK. Default is true; only
+  // an explicit `false` opts out.
+  setUseTransactionalTests(adapter, opts?.useTransactionalTests !== false);
 
   if (opts?.dropExisting) {
     for (const table of [...order].reverse()) {


### PR DESCRIPTION
## Summary

Phase 6 prep for the transactional-fixtures unification. See [docs/tm-unification-plan.md Phase 6](docs/tm-unification-plan.md) + [docs/activerecord-100-plan.md Batch B6.2](docs/activerecord-100-plan.md).

Adds the `useTransactionalTests` opt-out flag on `defineSchema`, mirroring Rails' per-test-class `self.use_transactional_tests = false`. Pure plumbing — no behavior change yet. B6.3 will read this flag from the global `beforeEach` to decide whether to wrap each test in `BEGIN`/`ROLLBACK`.

- `defineSchema(adapter, schema, { useTransactionalTests?: boolean })`, default `true`.
- Storage: `WeakMap<adapter, boolean>` in `test-adapter.ts` with `setUseTransactionalTests` / `getUseTransactionalTests` accessors (`@internal`). Keeps the flag off the adapter's public surface since it's a test concern, and avoids leaks across files.
- `defineSchema` records the flag *before* DDL runs so a later B6.3 wrap will see it on the first test.

## Candidate opt-out files (for B6.3 / B6.4)

Tests that mutate schema mid-body (create/drop tables, run migrations) and will need `useTransactionalTests: false` once B6.3 lands:

- `src/migration.test.ts`, `src/migrator.test.ts`, `src/invertible-migration.test.ts`, `src/multi-db-migrator.test.ts`
- `src/active-record-schema.test.ts`, `src/schema-dumper.test.ts`, `src/schema-introspection.test.ts`, `src/schema-columns-dump.test.ts`
- `src/connection-adapters/postgresql/schema-statements.test.ts` + `.../schema-statements-class.test.ts`
- `src/connection-adapters/mysql/schema-statements.test.ts`
- `src/adapters/postgresql/{schema,virtual-column,partitions,invertible-migration,range,uuid}.test.ts`
- `src/adapters/abstract-mysql-adapter/{schema,schema-migrations,table-options,active-schema,charset-collation}.test.ts`
- `src/adapters/sqlite3-adapter.test.ts`
- `src/connection-adapters/abstract-mysql-adapter.test.ts`
- `src/date-time-precision.test.ts`, `src/time-precision.test.ts`, `src/timestamp.test.ts`
- `src/query-cache.test.ts`, `src/insert-all.test.ts`, `src/calculations.test.ts`

(B6.3 will land the wiring; this PR only adds the flag.)

## Test plan

- [x] New tests in `define-schema.test.ts`: default true, explicit true, explicit false, per-adapter isolation, override on re-run, unseen-adapter default.
- [x] `pnpm lint` clean.
- [x] `pnpm typecheck` clean.
- [x] `pnpm vitest run packages/activerecord/src/test-helpers/define-schema.test.ts` — 22/22 pass.