### PR TITLE
feat(activerecord): make defineSchema idempotent (Phase 6 prep)

### DIFF
--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -248,6 +248,83 @@ describe("defineSchema", () => {
     });
   });
 
+  describe("idempotency", () => {
+    function ddlCounts(sqls: string[]): { creates: number; drops: number } {
+      return {
+        creates: sqls.filter((s) => /CREATE TABLE/i.test(s)).length,
+        drops: sqls.filter((s) => /DROP TABLE/i.test(s)).length,
+      };
+    }
+
+    it("re-running with the same schema emits no DDL", async () => {
+      await defineSchema(adapter, {
+        widgets: { name: "string", count: "integer" },
+      });
+
+      const spy = vi.spyOn(adapter, "executeMutation");
+      await defineSchema(adapter, {
+        widgets: { name: "string", count: "integer" },
+      });
+
+      const { creates, drops } = ddlCounts(spy.mock.calls.map((c) => c[0] as string));
+      expect(creates).toBe(0);
+      expect(drops).toBe(0);
+    });
+
+    it("changed column type drops + recreates only the changed table", async () => {
+      await defineSchema(adapter, {
+        a: { name: "string" },
+        b: { count: "integer" },
+        c: { ratio: "float" },
+      });
+
+      const spy = vi.spyOn(adapter, "executeMutation");
+      await defineSchema(adapter, {
+        a: { name: "string" },
+        b: { count: "string" }, // type changed
+        c: { ratio: "float" },
+      });
+
+      const sqls = spy.mock.calls.map((c) => c[0] as string);
+      const creates = sqls.filter((s) => /CREATE TABLE/i.test(s));
+      const drops = sqls.filter((s) => /DROP TABLE/i.test(s));
+      expect(drops).toHaveLength(1);
+      expect(drops[0]).toMatch(/\bb\b/);
+      expect(creates).toHaveLength(1);
+      expect(creates[0]).toMatch(/\bb\b/);
+    });
+
+    it("adding a column to one table leaves siblings alone", async () => {
+      await defineSchema(adapter, {
+        p: { title: "string" },
+        q: { label: "string" },
+      });
+
+      const spy = vi.spyOn(adapter, "executeMutation");
+      await defineSchema(adapter, {
+        p: { title: "string", extra: "integer" }, // column added
+        q: { label: "string" },
+      });
+
+      const sqls = spy.mock.calls.map((c) => c[0] as string);
+      const touchedQ = sqls.some((s) => /\bq\b/.test(s) && /(CREATE|DROP) TABLE/i.test(s));
+      expect(touchedQ).toBe(false);
+      const createsP = sqls.filter((s) => /CREATE TABLE/i.test(s) && /\bp\b/.test(s));
+      expect(createsP).toHaveLength(1);
+    });
+
+    it("dropExisting forces full drop+recreate even when schemas match", async () => {
+      await defineSchema(adapter, { items: { name: "string" } });
+
+      const spy = vi.spyOn(adapter, "executeMutation");
+      await defineSchema(adapter, { items: { name: "string" } }, { dropExisting: true });
+
+      const { creates, drops } = ddlCounts(spy.mock.calls.map((c) => c[0] as string));
+      expect(creates).toBeGreaterThanOrEqual(1);
+      expect(drops).toBeGreaterThanOrEqual(1);
+    });
+  });
+
   it("dropExisting drops first then creates", async () => {
     await defineSchema(adapter, { items: { name: "string" } });
     await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('old')`);

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -202,6 +202,49 @@ const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
   datetime: "string",
 };
 
+/**
+ * Per-adapter cache of the last-applied normalized table signatures. Lets
+ * `defineSchema` skip DDL when an identical schema is requested again —
+ * the Phase 6 hoist (`defineSchema` in `beforeAll` instead of `beforeEach`)
+ * relies on this being a no-op when nothing changed.
+ *
+ * @internal
+ */
+const _appliedSchemaSignatures = new WeakMap<DatabaseAdapter, Map<string, string>>();
+
+/** @internal */
+function getCache(adapter: DatabaseAdapter): Map<string, string> {
+  let cache = _appliedSchemaSignatures.get(adapter);
+  if (!cache) {
+    cache = new Map();
+    _appliedSchemaSignatures.set(adapter, cache);
+  }
+  return cache;
+}
+
+/** @internal */
+function tableSignature(table: TableSchema): string {
+  const columns = columnsOf(table);
+  const pk = primaryKeyOf(table);
+  const sortedCols: Record<string, ColumnSpec> = {};
+  for (const k of Object.keys(columns).sort()) sortedCols[k] = columns[k];
+  return JSON.stringify({ columns: sortedCols, primaryKey: pk ?? null });
+}
+
+/**
+ * Some adapters (notably the test adapter) expose the set of currently
+ * created tables. When available, use it to invalidate stale cache entries
+ * — e.g. when an external `resetTestAdapterState` dropped tables out from
+ * under us. Returns `null` when the adapter doesn't expose this signal, in
+ * which case we trust the cache alone.
+ *
+ * @internal
+ */
+function adapterKnownTables(adapter: DatabaseAdapter): Set<string> | null {
+  const candidate = (adapter as unknown as { tables?: unknown }).tables;
+  return candidate instanceof Set ? (candidate as Set<string>) : null;
+}
+
 export async function defineSchema(
   adapter: DatabaseAdapter,
   schema: Schema,
@@ -216,14 +259,32 @@ export async function defineSchema(
         ? COLUMN_TYPE_MAP_MYSQL
         : COLUMN_TYPE_MAP_SQLITE;
 
+  const cache = getCache(adapter);
+  const known = adapterKnownTables(adapter);
+
   if (opts?.dropExisting) {
     for (const table of [...order].reverse()) {
       await ss.dropTable(table, { ifExists: true });
+      cache.delete(table);
     }
   }
 
   for (const table of order) {
     const raw = schema[table];
+    const newSig = tableSignature(raw);
+    const cachedSig = cache.get(table);
+    const stillExists = known ? known.has(table) : cachedSig !== undefined;
+    if (cachedSig === newSig && stillExists) {
+      continue;
+    }
+    if (stillExists) {
+      await ss.dropTable(table, { ifExists: true });
+    } else if (cachedSig !== undefined) {
+      // Cache says we created it, but the adapter no longer reports it as
+      // present (e.g. resetTestAdapterState wiped state). Forget the stale
+      // entry and create fresh.
+      cache.delete(table);
+    }
     const columns = columnsOf(raw);
     const pk = primaryKeyOf(raw);
     const createOpts: { id?: boolean; primaryKey?: string[] } = {};
@@ -277,5 +338,6 @@ export async function defineSchema(
         t.column(colName, arType, options);
       }
     });
+    cache.set(table, newSig);
   }
 }


### PR DESCRIPTION
## Summary

- Cache the last-applied normalized table signature per adapter (WeakMap keyed by `DatabaseAdapter`).
- On re-entry, skip DDL for tables whose signature is unchanged; drop+recreate only the tables that differ.
- Cross-check against the adapter's exposed \`tables\` set when available (test adapter), so external state resets invalidate stale cache entries.
- \`dropExisting\` continues to force a full drop+recreate.

This unblocks Phase 6 of \`docs/tm-unification-plan.md\` — hoisting \`defineSchema\` from \`beforeEach\` to \`beforeAll\` becomes safe because re-invocation across files is a no-op when nothing changed.

## Test plan

- [x] \`pnpm vitest run packages/activerecord/src/test-helpers/define-schema.test.ts\` — all 20 pass (16 existing + 4 new)
- [x] New cases: same schema twice → 0 DDL; changed column type → drop+recreate only that one table; added column to one table → siblings untouched; \`dropExisting\` still forces full drop+recreate.