### PR TITLE
ci: split actionpack into its own no-DB tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,17 +222,11 @@ jobs:
     name: Action Pack Tests
     needs: changes
     if: needs.changes.outputs.docs_only != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10.27.0
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
+      - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm vitest run packages/actionpack
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,10 +214,27 @@ jobs:
           packages/activemodel
           packages/activesupport
           packages/rack
-          packages/actionpack
           packages/actionview
           packages/trailties
           scripts/guides-typecheck
+
+  actionpack-tests:
+    name: Action Pack Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.27.0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm vitest run packages/actionpack
 
   sqlite-tests:
     name: SQLite Tests
@@ -651,6 +668,7 @@ jobs:
       - dx-type-tests
       - virtualized-dx-type-tests
       - unit-tests
+      - actionpack-tests
       - sqlite-tests
       - postgres-tests
       - mariadb-tests


### PR DESCRIPTION
## Summary

Implements the Wave 1.5 CI split from `docs/ci-improvement-plan.md`:
moves `packages/actionpack` out of the shared `unit-tests` pnpm vitest
invocation into a dedicated `actionpack-tests` no-DB job.

- Zero AR coupling under `packages/actionpack/src` (re-verified via
  `grep -rln "@blazetrails/activerecord" packages/actionpack/src` → 0
  matches), so the split is drop-in — no env-var gating, no test
  relocations.
- New `actionpack-tests` job mirrors `unit-tests` setup (checkout +
  pnpm/action-setup@v4 + setup-node@v4 with pnpm cache + frozen install)
  and runs `pnpm vitest run packages/actionpack`.
- Added to the `ci` aggregate's `needs:` list so the gate blocks on it.
- `scripts/guides-typecheck` stays in `unit-tests` — typecheck pass,
  not actionpack-related.

Composite setup action dedup (`.github/actions/setup`) is intentionally
out of scope per the plan; new job should adopt it once it exists.

## Test plan

- [ ] CI runs the new `Action Pack Tests` job
- [ ] `unit-tests` no longer runs `packages/actionpack`
- [ ] `CI` aggregate gates on `actionpack-tests`