### PR TITLE
ci: split actionview into its own no-DB tests job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,7 +214,6 @@ jobs:
           packages/activemodel
           packages/activesupport
           packages/rack
-          packages/actionview
           packages/trailties
           scripts/guides-typecheck
 
@@ -229,6 +228,18 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm vitest run packages/actionpack
+
+  actionview-tests:
+    name: Action View Tests
+    needs: changes
+    if: needs.changes.outputs.docs_only != 'true'
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm vitest run packages/actionview
 
   sqlite-tests:
     name: SQLite Tests
@@ -663,6 +674,7 @@ jobs:
       - virtualized-dx-type-tests
       - unit-tests
       - actionpack-tests
+      - actionview-tests
       - sqlite-tests
       - postgres-tests
       - mariadb-tests


### PR DESCRIPTION
## Summary

- Extract `packages/actionview` from the shared `unit-tests` pnpm vitest invocation into a dedicated `actionview-tests` job.
- Mirrors the actionpack split pattern from `docs/ci-improvement-plan.md` (companion PR #1924).
- Adds `actionview-tests` to the `ci` aggregate `needs:` list so unexpected skips fail the gate.

Zero AR coupling under `packages/actionview/src` verified (\`grep -rln \"@blazetrails/activerecord\" packages/actionview/src\` → 0). Prepares for the .tse compiler / trails-tsc phase work tracked in \`docs/actionview-100-percent.md\`.

Coordinates with #1924 — if that lands first, this rebases trivially (both edits target distinct lines).

## Test plan

- [ ] CI run shows new \`Action View Tests\` job green
- [ ] \`unit-tests\` job no longer runs actionview tests
- [ ] \`CI\` aggregate gate passes