### PR TITLE
feat(actionpack): dispatch redirects through Redirect endpoints

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/url.ts
+++ b/packages/actionpack/src/action-dispatch/http/url.ts
@@ -9,7 +9,7 @@
  */
 
 import { toParam, toQuery } from "@blazetrails/activesupport";
-import { escapeFragment } from "../journey/router/utils.js";
+import { escapeFragment, rackEscape } from "../journey/router/utils.js";
 
 const IP_HOST_REGEXP = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/;
 const HOST_REGEXP = /(^[^:]+:\/\/)?(\[[^\]]+\]|[^:]+)(?::(\d+$))?/;
@@ -30,10 +30,6 @@ export interface UrlOptions {
   tldLength?: number;
   subdomain?: string | boolean | { toParam(): string };
   domain?: string;
-}
-
-function rackEscape(value: string): string {
-  return encodeURIComponent(value).replace(/%20/g, "+");
 }
 
 function isBlank(s: string): boolean {

--- a/packages/actionpack/src/action-dispatch/journey/router/utils.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router/utils.ts
@@ -54,6 +54,20 @@ export function escapeFragment(fragment: string): string {
   return escapeWith(fragment, UNSAFE_FRAGMENT);
 }
 
+/**
+ * Form-component percent-encoding, matching Ruby's
+ * `Rack::Utils.escape` / `URI.encode_www_form_component`.
+ *
+ * Encodes every byte except `*-._0-9A-Za-z`; space becomes `+`. JS's
+ * `encodeURIComponent` leaves `!'()~` unencoded (RFC 3986 unreserved),
+ * so we manually pct-encode those single-byte chars to match Rack.
+ */
+export function rackEscape(value: string): string {
+  return encodeURIComponent(value)
+    .replace(/[!'()~]/g, (c) => "%" + c.charCodeAt(0).toString(16).toUpperCase())
+    .replace(/%20/g, "+");
+}
+
 export function unescapeUri(uri: string): string {
   const bytes: number[] = [];
   const encoder = new TextEncoder();

--- a/packages/actionpack/src/action-dispatch/routing/redirection.ts
+++ b/packages/actionpack/src/action-dispatch/routing/redirection.ts
@@ -12,6 +12,7 @@ import { URL as UrlHelpers, type UrlOptions } from "../http/url.js";
 import {
   escapeFragment as journeyEscapeFragment,
   escapePath as journeyEscapePath,
+  rackEscape,
 } from "../journey/router/utils.js";
 import { Endpoint } from "./endpoint.js";
 import type { RackEnv } from "@blazetrails/rack";
@@ -73,11 +74,6 @@ function uriToString(uri: ParsedUri): string {
   if (uri.query !== null) out += `?${uri.query}`;
   if (uri.fragment !== null) out += `#${uri.fragment}`;
   return out;
-}
-
-/** Rack::Utils.escape — form-encoded value (space → +). */
-function rackEscape(value: string): string {
-  return encodeURIComponent(value).replace(/%20/g, "+");
 }
 
 function transformValues(

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -352,19 +352,21 @@ export class RouteSet {
 
     const { route, params } = matched;
 
-    // Handle redirect routes
-    if (route.isRedirect) {
-      const host = (env["HTTP_HOST"] as string) ?? "www.example.com";
-      const { url, status } = route.resolveRedirect(params, {
-        method,
-        path,
-        host,
-      });
-      return [
-        status,
-        { location: url, "content-type": "text/html" },
-        bodyFromString(`<html><body>You are being <a href="${url}">redirected</a>.</body></html>`),
-      ];
+    // Handle redirect routes by dispatching through the Redirect endpoint
+    // (PathRedirect / OptionRedirect / Redirect). Path captures are surfaced
+    // to the endpoint via `path_parameters` on the env, matching how Rails'
+    // routing layer hands captures to ActionDispatch::Routing::Redirect.
+    const redirectEndpoint = route.redirectEndpoint;
+    if (redirectEndpoint) {
+      env["action_dispatch.request.path_parameters"] = {
+        controller: route.controller,
+        action: route.action,
+        ...params,
+      };
+      const [status, headers, bodyArr] = redirectEndpoint.call(env);
+      const lowerHeaders: Record<string, string> = {};
+      for (const [k, v] of Object.entries(headers)) lowerHeaders[k.toLowerCase()] = v;
+      return [status, lowerHeaders, bodyFromString(bodyArr.join(""))];
     }
 
     // Merge route params into the env (like Rails does with request.params)

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -9,6 +9,8 @@ import type { Format } from "../journey/visitors.js";
 import { normalizePath as journeyNormalizePath } from "../journey/router/utils.js";
 import { buildJourneyRouter, journeyRecognize } from "./journey-bridge.js";
 import type { Router as JourneyRouter } from "../journey/router.js";
+import { OptionRedirect, PathRedirect, Redirect, type RedirectBlock } from "./redirection.js";
+import type { Request } from "../http/request.js";
 
 const PATHFOR_SEPARATORS = "/.?";
 
@@ -107,6 +109,39 @@ export class Route {
   get isRedirect(): boolean {
     return this.redirectTarget !== undefined;
   }
+
+  /**
+   * The {@link Redirect} endpoint built from {@link redirectTarget}, used by
+   * `RouteSet#call` as the production redirect dispatch path. Lazy so the
+   * `Redirect` classes (which pull in `Request`/`Response`) aren't constructed
+   * for non-redirect routes.
+   */
+  get redirectEndpoint(): Redirect | undefined {
+    if (this._redirectEndpoint !== undefined) return this._redirectEndpoint ?? undefined;
+    const target = this.redirectTarget;
+    if (target === undefined) {
+      this._redirectEndpoint = null;
+      return undefined;
+    }
+    let endpoint: Redirect;
+    if (typeof target === "function") {
+      const fn = target;
+      const block: RedirectBlock = (params, request: Request) =>
+        fn(params, { method: request.method, path: request.path });
+      endpoint = new Redirect(301, block);
+    } else if (typeof target === "string") {
+      endpoint = new PathRedirect(301, target);
+    } else {
+      const status = target.status ?? 301;
+      const { status: _s, ...opts } = target;
+      endpoint = new OptionRedirect(status, opts);
+    }
+    this._redirectEndpoint = endpoint;
+    return endpoint;
+  }
+
+  /** @internal */
+  private _redirectEndpoint: Redirect | null | undefined = undefined;
 
   /**
    * Returns the path-capture (dynamic/glob) parameter names declared by


### PR DESCRIPTION
## Summary

- Wire `ActionDispatch::Routing::Redirect` / `PathRedirect` / `OptionRedirect` into the production routing dispatch path. `Route` now lazily builds a `Redirect` endpoint from its `redirectTarget`; `RouteSet#call` dispatches via the endpoint's `call(env)` instead of the legacy `Route#resolveRedirect` (kept untouched so the direct-API callers in `dispatch/routing.test.ts` still pass).
- Extract `rackEscape` from `http/url.ts` into `journey/router/utils.ts` so it's shared with `routing/redirection.ts`, and fix `Rack::Utils.escape` parity — JS `encodeURIComponent` leaves `!'()~` unencoded (RFC 3986 unreserved), but `URI.encode_www_form_component` percent-encodes them.

Follows up #1827 (Tier 2 routing/redirection in `docs/actionpack-100-percent.md`).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/routing/ packages/actionpack/src/action-dispatch/http/url.test.ts packages/actionpack/src/action-dispatch/dispatch/routing.test.ts` — 420/420 pass