### PR TITLE
feat(actionpack): wire Cache::Request mixin onto Request + strict RFC 1123 parseHttpDate

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/cache.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.test.ts
@@ -5,6 +5,7 @@ import {
   fresh,
   generateStrongEtag,
   generateWeakEtag,
+  getLastModified,
   handleConditionalGet,
   isWeakEtag,
   mergeAndNormalizeCacheControl,
@@ -65,6 +66,37 @@ describe("Cache::Request", () => {
 });
 
 describe("Cache::Response", () => {
+  it("last_modified parses strict RFC 1123 (Time.httpdate parity)", () => {
+    expect(getLastModified.call(res({ "Last-Modified": "Sun, 06 Nov 1994 08:49:37 GMT" }))).toEqual(
+      new Date("1994-11-06T08:49:37Z"),
+    );
+  });
+
+  it("last_modified rejects RFC 850 / asctime / numeric-zone forms (httpdate is strict)", () => {
+    // RFC 850 form
+    expect(
+      getLastModified.call(res({ "Last-Modified": "Sunday, 06-Nov-94 08:49:37 GMT" })),
+    ).toBeUndefined();
+    // asctime form
+    expect(
+      getLastModified.call(res({ "Last-Modified": "Sun Nov  6 08:49:37 1994" })),
+    ).toBeUndefined();
+    // Numeric zone offset — valid RFC 2822 but rejected by Time.httpdate
+    expect(
+      getLastModified.call(res({ "Last-Modified": "Sun, 06 Nov 1994 08:49:37 -0500" })),
+    ).toBeUndefined();
+  });
+
+  it("last_modified rejects out-of-range and impossible-calendar values", () => {
+    expect(
+      getLastModified.call(res({ "Last-Modified": "Sun, 99 Nov 1994 08:49:37 GMT" })),
+    ).toBeUndefined();
+    // 31 Feb — Date.UTC would silently roll into March
+    expect(
+      getLastModified.call(res({ "Last-Modified": "Tue, 31 Feb 2015 08:49:37 GMT" })),
+    ).toBeUndefined();
+  });
+
   it("etag= sets weak validator", () => {
     const h: Record<string, string> = {};
     setEtag.call(res(h), "foo");

--- a/packages/actionpack/src/action-dispatch/http/cache.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.test.ts
@@ -30,6 +30,19 @@ describe("Cache::Request", () => {
     expect(notModified.call(r, new Date("1994-11-06T08:49:38Z"))).toBe(false);
   });
 
+  it("if_modified_since parses RFC 2822 numeric zone offsets (Time.rfc2822 parity)", () => {
+    const r = req({ "If-Modified-Since": "Sun, 06 Nov 1994 03:49:37 -0500" });
+    // Same instant as "Sun, 06 Nov 1994 08:49:37 GMT"
+    expect(notModified.call(r, new Date("1994-11-06T08:49:36Z"))).toBe(true);
+  });
+
+  it("if_modified_since rejects malformed values (no permissive Date.parse fallback)", () => {
+    const r = req({ "If-None-Match": '"abc"', "If-Modified-Since": "yesterday" });
+    expect(fresh.call(r, { etag: '"abc"' })).toBe(true); // etag still matches
+    // not_modified? returns false because the date is unparseable
+    expect(notModified.call(r, new Date("1994-11-06T08:49:36Z"))).toBe(false);
+  });
+
   it("etag_matches? handles list and wildcard", () => {
     expect(etagMatches.call(req({ "If-None-Match": '"a", "b"' }), '"a"')).toBe(true);
     expect(etagMatches.call(req({ "If-None-Match": "*" }), '"x"')).toBe(true);

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -38,11 +38,7 @@ export interface CacheResponseLike {
 }
 
 export function ifModifiedSince(this: RequestCacheHost): Date | undefined {
-  const since = this.getHeader(HTTP_IF_MODIFIED_SINCE);
-  if (!since) return undefined;
-  const t = Date.parse(since);
-  // boundary: HTTP-date wire-format header value parsed as JS Date.
-  return Number.isNaN(t) ? undefined : new Date(t);
+  return parseHttpDate(this.getHeader(HTTP_IF_MODIFIED_SINCE));
 }
 
 export function ifNoneMatch(this: RequestCacheHost): string | undefined {
@@ -92,9 +88,38 @@ function hdrSet(host: ResponseCacheHost, key: string): boolean {
   return host.hasHeader ? host.hasHeader(key) : host.getHeader(key) !== undefined;
 }
 
-function parseHttpDate(s: string | undefined): Date | undefined {
+const RFC1123_RE =
+  /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{4}) (\d{2}):(\d{2}):(\d{2}) GMT$/;
+const MONTHS: Record<string, number> = {
+  Jan: 0,
+  Feb: 1,
+  Mar: 2,
+  Apr: 3,
+  May: 4,
+  Jun: 5,
+  Jul: 6,
+  Aug: 7,
+  Sep: 8,
+  Oct: 9,
+  Nov: 10,
+  Dec: 11,
+};
+
+/**
+ * Parse an HTTP-date header value, strict RFC 1123 (IMF-fixdate) per RFC 9110.
+ * Returns undefined for any non-conforming value — including the obsolete
+ * RFC 850 and asctime forms, and any locale-sensitive `Date.parse` interpretations.
+ *
+ * Rails' `Time.httpdate` is similarly strict (accepts only RFC 1123 / RFC 2616).
+ *
+ * @internal
+ */
+export function parseHttpDate(s: string | undefined): Date | undefined {
   if (!s) return undefined;
-  const t = Date.parse(s);
+  const m = RFC1123_RE.exec(s);
+  if (!m) return undefined;
+  const [, day, mon, year, hh, mm, ss] = m;
+  const t = Date.UTC(Number(year), MONTHS[mon], Number(day), Number(hh), Number(mm), Number(ss));
   // boundary: HTTP-date wire-format header value parsed as JS Date.
   return Number.isNaN(t) ? undefined : new Date(t);
 }

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -124,13 +124,22 @@ export function parseRfc2822Date(s: string | undefined): Date | undefined {
   if (!m) return undefined;
   const [, day, mon, yr, hh, mm, ss, zone] = m;
   if (!RFC2822_ZONE_RE.test(zone)) return undefined;
+  const d = Number(day),
+    h = Number(hh),
+    mi = Number(mm),
+    s2 = Number(ss);
+  // Rails' Time.rfc2822 raises ArgumentError on out-of-range components.
+  if (d < 1 || d > 31 || h > 23 || mi > 59 || s2 > 60) return undefined;
   let year = Number(yr);
   if (year < 50) year += 2000;
   else if (year < 1000) year += 1900;
   let offsetMin = 0;
   if (/^[+-]\d{4}$/.test(zone)) {
+    const oh = Number(zone.slice(1, 3));
+    const om = Number(zone.slice(3, 5));
+    if (oh > 23 || om > 59) return undefined;
     const sign = zone[0] === "-" ? -1 : 1;
-    offsetMin = sign * (Number(zone.slice(1, 3)) * 60 + Number(zone.slice(3, 5)));
+    offsetMin = sign * (oh * 60 + om);
   } else if (zone === "EDT") offsetMin = -4 * 60;
   else if (zone === "EST" || zone === "CDT") offsetMin = -5 * 60;
   else if (zone === "CST" || zone === "MDT") offsetMin = -6 * 60;
@@ -156,7 +165,13 @@ export function parseHttpDate(s: string | undefined): Date | undefined {
   const m = RFC1123_RE.exec(s);
   if (!m) return undefined;
   const [, day, mon, year, hh, mm, ss] = m;
-  const t = Date.UTC(Number(year), MONTHS[mon], Number(day), Number(hh), Number(mm), Number(ss));
+  const d = Number(day),
+    h = Number(hh),
+    mi = Number(mm),
+    s2 = Number(ss);
+  // Rails' Time.httpdate raises ArgumentError on out-of-range components.
+  if (d < 1 || d > 31 || h > 23 || mi > 59 || s2 > 60) return undefined;
+  const t = Date.UTC(Number(year), MONTHS[mon], d, h, mi, s2);
   // boundary: HTTP-date wire-format header value parsed as JS Date.
   return Number.isNaN(t) ? undefined : new Date(t);
 }

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -133,6 +133,10 @@ export function parseRfc2822Date(s: string | undefined): Date | undefined {
   let year = Number(yr);
   if (year < 50) year += 2000;
   else if (year < 1000) year += 1900;
+  // Round-trip-validate calendar day (rejects 31 Feb, 30 Feb, etc.).
+  // boundary: probe Date used only to read normalized UTC components.
+  const probe = new Date(Date.UTC(year, MONTHS[mon], d));
+  if (probe.getUTCMonth() !== MONTHS[mon] || probe.getUTCDate() !== d) return undefined;
   let offsetMin = 0;
   if (/^[+-]\d{4}$/.test(zone)) {
     const oh = Number(zone.slice(1, 3));
@@ -171,7 +175,12 @@ export function parseHttpDate(s: string | undefined): Date | undefined {
     s2 = Number(ss);
   // Rails' Time.httpdate raises ArgumentError on out-of-range components.
   if (d < 1 || d > 31 || h > 23 || mi > 59 || s2 > 60) return undefined;
-  const t = Date.UTC(Number(year), MONTHS[mon], d, h, mi, s2);
+  const yr = Number(year);
+  // Round-trip-validate calendar day (rejects 31 Feb, 30 Feb, etc.).
+  // boundary: probe Date used only to read normalized UTC components.
+  const probe = new Date(Date.UTC(yr, MONTHS[mon], d));
+  if (probe.getUTCMonth() !== MONTHS[mon] || probe.getUTCDate() !== d) return undefined;
+  const t = Date.UTC(yr, MONTHS[mon], d, h, mi, s2);
   // boundary: HTTP-date wire-format header value parsed as JS Date.
   return Number.isNaN(t) ? undefined : new Date(t);
 }

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -38,7 +38,7 @@ export interface CacheResponseLike {
 }
 
 export function ifModifiedSince(this: RequestCacheHost): Date | undefined {
-  return parseHttpDate(this.getHeader(HTTP_IF_MODIFIED_SINCE));
+  return parseRfc2822Date(this.getHeader(HTTP_IF_MODIFIED_SINCE));
 }
 
 export function ifNoneMatch(this: RequestCacheHost): string | undefined {
@@ -104,6 +104,43 @@ const MONTHS: Record<string, number> = {
   Nov: 10,
   Dec: 11,
 };
+
+const RFC2822_ZONE_RE = /^(?:GMT|UT|UTC|Z|[+-]\d{4}|EDT|EST|CDT|CST|MDT|MST|PDT|PST)$/;
+
+/**
+ * Parse an RFC 2822 date — Rails' `Time.rfc2822` is used by
+ * `ActionDispatch::Http::Cache::Request#if_modified_since`. Accepts numeric
+ * zone offsets (`+0000`, `-0500`) and the obsolete zone names from RFC 2822
+ * §4.3, plus `GMT` which is what real-world HTTP clients send.
+ *
+ * @internal
+ */
+export function parseRfc2822Date(s: string | undefined): Date | undefined {
+  if (!s) return undefined;
+  const m =
+    /^(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), (\d{1,2}) (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (\d{2,4}) (\d{2}):(\d{2}):(\d{2}) (\S+)$/.exec(
+      s,
+    );
+  if (!m) return undefined;
+  const [, day, mon, yr, hh, mm, ss, zone] = m;
+  if (!RFC2822_ZONE_RE.test(zone)) return undefined;
+  let year = Number(yr);
+  if (year < 50) year += 2000;
+  else if (year < 1000) year += 1900;
+  let offsetMin = 0;
+  if (/^[+-]\d{4}$/.test(zone)) {
+    const sign = zone[0] === "-" ? -1 : 1;
+    offsetMin = sign * (Number(zone.slice(1, 3)) * 60 + Number(zone.slice(3, 5)));
+  } else if (zone === "EDT") offsetMin = -4 * 60;
+  else if (zone === "EST" || zone === "CDT") offsetMin = -5 * 60;
+  else if (zone === "CST" || zone === "MDT") offsetMin = -6 * 60;
+  else if (zone === "MST" || zone === "PDT") offsetMin = -7 * 60;
+  else if (zone === "PST") offsetMin = -8 * 60;
+  const t = Date.UTC(year, MONTHS[mon], Number(day), Number(hh), Number(mm), Number(ss));
+  if (Number.isNaN(t)) return undefined;
+  // boundary: HTTP-date wire-format header value parsed as JS Date.
+  return new Date(t - offsetMin * 60_000);
+}
 
 /**
  * Parse an HTTP-date header value, strict RFC 1123 (IMF-fixdate) per RFC 9110.

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -7,6 +7,15 @@
 
 import type { RackEnv } from "@blazetrails/rack";
 import { parseNestedQuery } from "@blazetrails/rack";
+import {
+  etagMatches as _etagMatches,
+  fresh as _fresh,
+  ifModifiedSince as _ifModifiedSince,
+  ifNoneMatch as _ifNoneMatch,
+  ifNoneMatchEtags as _ifNoneMatchEtags,
+  notModified as _notModified,
+  type CacheResponseLike,
+} from "./cache.js";
 import { RequestUtils, type ParamValue } from "../request/utils.js";
 
 export class Request {
@@ -213,18 +222,14 @@ export class Request {
     return (this.env["HTTP_ACCEPT"] as string) || "";
   }
 
-  get ifNoneMatch(): string | undefined {
-    return this.env["HTTP_IF_NONE_MATCH"] as string | undefined;
-  }
-
-  get ifNoneMatchEtags(): string[] {
-    const header = this.ifNoneMatch;
-    if (!header) return [];
-    return header
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-  }
+  // --- Conditional-GET (ActionDispatch::Http::Cache::Request) ---
+  // Mixed in onto Request.prototype below; declared here for typing.
+  declare ifModifiedSince: Date | undefined;
+  declare ifNoneMatch: string | undefined;
+  declare ifNoneMatchEtags: string[];
+  declare notModified: (modifiedAt: Date | undefined) => boolean;
+  declare etagMatches: (etag: string | undefined) => boolean;
+  declare fresh: (response: CacheResponseLike) => boolean;
 
   // --- Request type checks ---
 
@@ -444,3 +449,28 @@ export class Request {
     return new Request(env);
   }
 }
+
+// Mix in ActionDispatch::Http::Cache::Request. Property-style helpers
+// (Rails: no-arg methods) are wired as getters for parity with the existing
+// Request surface; methods that take arguments are wired as prototype methods.
+Object.defineProperty(Request.prototype, "ifModifiedSince", {
+  get(this: Request) {
+    return _ifModifiedSince.call(this);
+  },
+  configurable: true,
+});
+Object.defineProperty(Request.prototype, "ifNoneMatch", {
+  get(this: Request) {
+    return _ifNoneMatch.call(this);
+  },
+  configurable: true,
+});
+Object.defineProperty(Request.prototype, "ifNoneMatchEtags", {
+  get(this: Request) {
+    return _ifNoneMatchEtags.call(this);
+  },
+  configurable: true,
+});
+Request.prototype.notModified = _notModified;
+Request.prototype.etagMatches = _etagMatches;
+Request.prototype.fresh = _fresh;

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -224,9 +224,9 @@ export class Request {
 
   // --- Conditional-GET (ActionDispatch::Http::Cache::Request) ---
   // Mixed in onto Request.prototype below; declared here for typing.
-  declare ifModifiedSince: Date | undefined;
-  declare ifNoneMatch: string | undefined;
-  declare ifNoneMatchEtags: string[];
+  declare readonly ifModifiedSince: Date | undefined;
+  declare readonly ifNoneMatch: string | undefined;
+  declare readonly ifNoneMatchEtags: string[];
   declare notModified: (modifiedAt: Date | undefined) => boolean;
   declare etagMatches: (etag: string | undefined) => boolean;
   declare fresh: (response: CacheResponseLike) => boolean;


### PR DESCRIPTION
## Summary

- Mixes `ifModifiedSince` / `ifNoneMatch` / `ifNoneMatchEtags` / `notModified` / `etagMatches` / `fresh` from `action-dispatch/http/cache.ts` onto `Request.prototype`. Replaces the hand-rolled `ifNoneMatch` / `ifNoneMatchEtags` getters that lived directly on the class. Property-style helpers (no Rails args) stay as getters via `Object.defineProperty`; arg-taking helpers are wired as prototype methods.
- Tightens `parseHttpDate` to strict RFC 1123 (IMF-fixdate) per RFC 9110 — Rails' `Time.httpdate` is similarly strict and rejects the obsolete RFC 850 / asctime forms plus any locale-sensitive `Date.parse` interpretations. The header reader now returns `undefined` for non-conforming values rather than silently coercing.

## Follow-ups

- **Cache::Response mixin wiring** — `Response` ships its own string-valued `cacheControl` / `etag` / `weakEtag` / `strongEtag` accessors that conflict with Rails' `cache_control` (parsed hash) and weak/strong-etag-setter API. Wiring this in requires migrating `dispatch/response.test.ts` plus any other string-API callers. Left as a dedicated PR.
- **`params` getter** — the doc-listed concern about overlaying `pathParameters` is already correct in `request.ts:283-289` (the spread already matches Rails' `request_parameters.merge(query_parameters).merge!(path_parameters)`). No change needed here.

## Test plan

- [x] `vitest run packages/actionpack/src/action-dispatch/http/cache.test.ts packages/actionpack/src/action-dispatch/dispatch/request.test.ts` — 88 tests pass
- [x] No type regressions in touched files (existing unrelated `Cannot find module '@blazetrails/...'` errors are pre-existing build-order noise)