### PR TITLE
feat(actionpack): RateLimiting rateLimit DSL + rateLimiting helper (P2)

### DIFF
--- a/docs/actioncontroller-100-percent.md
+++ b/docs/actioncontroller-100-percent.md
@@ -103,6 +103,21 @@ up, the modified directives don't round-trip into the response header. The
 class-DSL surface and parity-test coverage are complete; the response-header
 wiring is the remaining work.
 
+### `RateLimiting` — cache backend is divergent
+
+**Rails:** `rate_limit` defaults `store:` to `cache_store`, which Rails wires from
+`config.action_controller.cache_store` / `config.cache_store` — an
+`ActiveSupport::Cache::Store` instance whose `increment(key, amount, expires_in:)`
+returns the new counter atomically (Redis/Memcached in production).
+**Us:** No global `Rails.cache` equivalent yet. The class DSL falls back to a
+`cacheStore` static on the host controller class if not given `store:`, and
+throws if neither is set. A `MemoryRateLimitStore` ships in this package for
+tests and single-process apps; production deployments must supply an
+`ActiveSupport::Cache::Store`-shaped object (sync or async `increment`). The
+DSL surface, key composition (`rate-limit:controllerPath:name:identity`),
+`429` fallback, and `rate_limit.action_controller` instrumentation are all
+parity-faithful — only the cache backend resolution differs.
+
 ### `BrowserBlocker.versions` — returns a copy
 
 **Rails:** `attr_reader :versions` returns the object directly (mutations affect the blocker).

--- a/docs/actioncontroller-100-percent.md
+++ b/docs/actioncontroller-100-percent.md
@@ -112,8 +112,13 @@ returns the new counter atomically (Redis/Memcached in production).
 **Us:** No global `Rails.cache` equivalent yet. The class DSL falls back to a
 `cacheStore` static on the host controller class if not given `store:`, and
 throws if neither is set. A `MemoryRateLimitStore` ships in this package for
-tests and single-process apps; production deployments must supply an
-`ActiveSupport::Cache::Store`-shaped object (sync or async `increment`). The
+tests and single-process apps; production deployments must supply a
+`RateLimitStore` whose `increment(key, amount, { expiresIn })` (1) accepts
+`expiresIn` in **seconds** (Rails parity, not the activesupport cache
+`CacheOptions.expiresIn` which is milliseconds) and (2) initializes a
+missing counter to `amount` (Redis/Memcached behavior — the in-memory
+activesupport cache returns `nil` for missing keys and is not a suitable
+backend on its own). The
 DSL surface, key composition (`rate-limit:controllerPath:name:identity`),
 `429` fallback, and `rate_limit.action_controller` instrumentation are all
 parity-faithful — only the cache backend resolution differs.

--- a/docs/actioncontroller-100-percent.md
+++ b/docs/actioncontroller-100-percent.md
@@ -200,13 +200,12 @@ Sequencing rules:
 
 ### Wave 0 — single-file peripherals
 
-| PR  | Rails file                | Missing | TS file (api:compare row) | Methods                                                                                                                                                                              |
-| --- | ------------------------- | ------: | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| P2  | `metal/rate_limiting.rb`  |       2 | `metal/rate-limiting.ts`  | `rateLimit` (class DSL), `rateLimiting` (private instance). Mirror Rails options `to:`, `within:`, `by:`, `with:`, `store:`, `name:`, `only:`/`except:`. Cache backend is divergent. |
-| P3  | `form_builder.rb`         |       1 | `form-builder.ts`         | `defaultFormBuilder` — class DSL accepting builder class or string name (resolve via existing `@blazetrails/activesupport` constant resolver).                                       |
-| P4  | `metal/data_streaming.rb` |       1 | `metal/data-streaming.ts` | `sendFileHeadersBang` (`send_file_headers!`). Refactor existing `send_file`/`send_data` to delegate. RFC 6266 with both `filename="..."` ASCII fallback and `filename*=UTF-8''...`.  |
-| P7  | `metal/renderers.rb`      |       2 | `metal/renderers.ts`      | `_renderToBodyWithRenderer`, `_renderWithRendererMethodName`. Refactor existing inline dispatch logic into named methods; `Renderers.add` registration must still resolve.           |
-| P9  | `deprecator.rb`           |       3 | `deprecator.ts`           | `deprecator` (Deprecation instance), `addRenderer`, `removeRenderer` (deprecation shims delegating to Renderers registry).                                                           |
+| PR  | Rails file                | Missing | TS file (api:compare row) | Methods                                                                                                                                                                             |
+| --- | ------------------------- | ------: | ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P3  | `form_builder.rb`         |       1 | `form-builder.ts`         | `defaultFormBuilder` — class DSL accepting builder class or string name (resolve via existing `@blazetrails/activesupport` constant resolver).                                      |
+| P4  | `metal/data_streaming.rb` |       1 | `metal/data-streaming.ts` | `sendFileHeadersBang` (`send_file_headers!`). Refactor existing `send_file`/`send_data` to delegate. RFC 6266 with both `filename="..."` ASCII fallback and `filename*=UTF-8''...`. |
+| P7  | `metal/renderers.rb`      |       2 | `metal/renderers.ts`      | `_renderToBodyWithRenderer`, `_renderWithRendererMethodName`. Refactor existing inline dispatch logic into named methods; `Renderers.add` registration must still resolve.          |
+| P9  | `deprecator.rb`           |       3 | `deprecator.ts`           | `deprecator` (Deprecation instance), `addRenderer`, `removeRenderer` (deprecation shims delegating to Renderers registry).                                                          |
 
 ### Wave 1 — small bundle peripherals
 

--- a/docs/actioncontroller-privates-plan.md
+++ b/docs/actioncontroller-privates-plan.md
@@ -79,14 +79,13 @@ Sequencing rules:
 
 ## Wave 0 — single-file peripherals (remaining)
 
-| PR  | Rails file                                           | Missing | TS file (api:compare row) | Methods                                                                                                                                                                              |
-| --- | ---------------------------------------------------- | ------: | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| P2  | `metal/rate_limiting.rb`                             |       2 | `metal/rate-limiting.ts`  | `rateLimit` (class DSL), `rateLimiting` (private instance). Mirror Rails options `to:`, `within:`, `by:`, `with:`, `store:`, `name:`, `only:`/`except:`. Cache backend is divergent. |
-| P3  | `form_builder.rb`                                    |       1 | `form-builder.ts`         | `defaultFormBuilder` — class DSL accepting builder class or string name (resolve via existing `@blazetrails/activesupport` constant resolver).                                       |
-| P4  | `metal/data_streaming.rb` **(re-audit, 10 missing)** |      10 | `metal/data-streaming.ts` | Originally scoped as `sendFileHeadersBang` only; api:compare now reports 10 missing. Re-list before opening PR.                                                                      |
-| P5  | `caching.rb`                                         |       2 | `caching.ts`              | `instrumentPayload(key)` → `{ controller, action, key }`; `instrumentName()` → `"action_controller"`. Both private.                                                                  |
-| P7  | `metal/renderers.rb`                                 |       2 | `metal/renderers.ts`      | `_renderToBodyWithRenderer`, `_renderWithRendererMethodName`. Refactor existing inline dispatch logic into named methods; `Renderers.add` registration must still resolve.           |
-| P9  | `deprecator.rb`                                      |       3 | `deprecator.ts`           | `deprecator` (Deprecation instance), `addRenderer`, `removeRenderer` (deprecation shims delegating to Renderers registry).                                                           |
+| PR  | Rails file                                           | Missing | TS file (api:compare row) | Methods                                                                                                                                                                    |
+| --- | ---------------------------------------------------- | ------: | ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| P3  | `form_builder.rb`                                    |       1 | `form-builder.ts`         | `defaultFormBuilder` — class DSL accepting builder class or string name (resolve via existing `@blazetrails/activesupport` constant resolver).                             |
+| P4  | `metal/data_streaming.rb` **(re-audit, 10 missing)** |      10 | `metal/data-streaming.ts` | Originally scoped as `sendFileHeadersBang` only; api:compare now reports 10 missing. Re-list before opening PR.                                                            |
+| P5  | `caching.rb`                                         |       2 | `caching.ts`              | `instrumentPayload(key)` → `{ controller, action, key }`; `instrumentName()` → `"action_controller"`. Both private.                                                        |
+| P7  | `metal/renderers.rb`                                 |       2 | `metal/renderers.ts`      | `_renderToBodyWithRenderer`, `_renderWithRendererMethodName`. Refactor existing inline dispatch logic into named methods; `Renderers.add` registration must still resolve. |
+| P9  | `deprecator.rb`                                      |       3 | `deprecator.ts`           | `deprecator` (Deprecation instance), `addRenderer`, `removeRenderer` (deprecation shims delegating to Renderers registry).                                                 |
 
 ## Wave 1 — small bundle peripherals
 

--- a/packages/actionpack/src/action-controller/api.ts
+++ b/packages/actionpack/src/action-controller/api.ts
@@ -8,11 +8,20 @@
 import { Metal } from "./metal.js";
 import { DoubleRenderError, type RenderOptions } from "./base.js";
 import { renderForApi } from "./api/api-rendering.js";
+import { rateLimit } from "./metal/rate-limiting.js";
 
 export class API extends Metal {
   static withoutModules<T extends typeof API>(this: T, ..._modules: unknown[]): T {
     return this;
   }
+
+  /**
+   * Apply a rate limit to all actions (or those selected by `only:`/`except:`).
+   * Mirrors Rails `rate_limit` class DSL — Rails includes `RateLimiting` in
+   * both `ActionController::Base` and `ActionController::API`
+   * (actionpack/lib/action_controller/api.rb:125).
+   */
+  static rateLimit = rateLimit;
 
   render(options: RenderOptions = {}): void {
     if (this.performed) {

--- a/packages/actionpack/src/action-controller/api.ts
+++ b/packages/actionpack/src/action-controller/api.ts
@@ -8,7 +8,7 @@
 import { Metal } from "./metal.js";
 import { DoubleRenderError, type RenderOptions } from "./base.js";
 import { renderForApi } from "./api/api-rendering.js";
-import { rateLimit } from "./metal/rate-limiting.js";
+import { rateLimit, rateLimiting } from "./metal/rate-limiting.js";
 
 export class API extends Metal {
   static withoutModules<T extends typeof API>(this: T, ..._modules: unknown[]): T {
@@ -22,6 +22,9 @@ export class API extends Metal {
    * (actionpack/lib/action_controller/api.rb:125).
    */
   static rateLimit = rateLimit;
+
+  /** @internal Private in Rails; instance slot enables subclass overrides. */
+  rateLimiting = rateLimiting;
 
   render(options: RenderOptions = {}): void {
     if (this.performed) {

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -22,6 +22,7 @@ import { LookupContext } from "@blazetrails/actionview";
 import type { RouteHelpersMap } from "../action-dispatch/routing/route-helpers.js";
 import { BrowserBlocker, type BrowserVersions } from "./metal/allow-browser.js";
 import { permissionsPolicy } from "./metal/permissions-policy.js";
+import { rateLimit } from "./metal/rate-limiting.js";
 
 // Re-export callback registration
 export { type ActionCallback, type AroundCallback, type CallbackOptions };
@@ -383,6 +384,12 @@ export class Base extends Metal {
    * Mirrors Rails `permissions_policy` class DSL.
    */
   static permissionsPolicy = permissionsPolicy;
+
+  /**
+   * Apply a rate limit to all actions (or those selected by `only:`/`except:`).
+   * Mirrors Rails `rate_limit` class DSL.
+   */
+  static rateLimit = rateLimit;
 
   // --- Rescue ---
 

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -22,7 +22,7 @@ import { LookupContext } from "@blazetrails/actionview";
 import type { RouteHelpersMap } from "../action-dispatch/routing/route-helpers.js";
 import { BrowserBlocker, type BrowserVersions } from "./metal/allow-browser.js";
 import { permissionsPolicy } from "./metal/permissions-policy.js";
-import { rateLimit } from "./metal/rate-limiting.js";
+import { rateLimit, rateLimiting } from "./metal/rate-limiting.js";
 
 // Re-export callback registration
 export { type ActionCallback, type AroundCallback, type CallbackOptions };
@@ -390,6 +390,14 @@ export class Base extends Metal {
    * Mirrors Rails `rate_limit` class DSL.
    */
   static rateLimit = rateLimit;
+
+  /**
+   * Per-request enforcement. Private in Rails; exposed as an instance
+   * method so subclass overrides win (the DSL dispatches through
+   * `this.rateLimiting`).
+   * @internal
+   */
+  rateLimiting = rateLimiting;
 
   // --- Rescue ---
 

--- a/packages/actionpack/src/action-controller/index.ts
+++ b/packages/actionpack/src/action-controller/index.ts
@@ -79,4 +79,13 @@ export { resolveHelperPath, inheritedWithHelpers } from "./trailties/helpers.js"
 export { RescueRegistry } from "./metal/rescue.js";
 export { FlashTypeRegistry } from "./metal/flash.js";
 export { ParameterEncodingRegistry } from "./metal/parameter-encoding.js";
-export { MemoryRateLimitStore, isRateLimited } from "./metal/rate-limiting.js";
+export {
+  MemoryRateLimitStore,
+  isRateLimited,
+  rateLimit,
+  rateLimiting,
+  type RateLimitOptions,
+  type RateLimitStore,
+  type RateLimitingClassHost,
+  type RateLimitingHost,
+} from "./metal/rate-limiting.js";

--- a/packages/actionpack/src/action-controller/index.ts
+++ b/packages/actionpack/src/action-controller/index.ts
@@ -83,7 +83,6 @@ export {
   MemoryRateLimitStore,
   isRateLimited,
   rateLimit,
-  rateLimiting,
   type RateLimitOptions,
   type RateLimitStore,
   type RateLimitingClassHost,

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -9,6 +9,7 @@ import {
   type RateLimitingHost,
 } from "./rate-limiting.js";
 import { Base } from "../base.js";
+import { Notifications } from "@blazetrails/activesupport";
 import type { CallbackOptions } from "../../abstract-controller/callbacks.js";
 
 describe("isRateLimited", () => {
@@ -108,6 +109,38 @@ describe("rateLimiting (instance helper)", () => {
     };
     await rateLimiting.call(host, { to: 10, within: 60, store });
     expect(host.head).toHaveBeenCalledWith(429);
+  });
+
+  it("instruments a rate_limit.action_controller event when the limit is exceeded", async () => {
+    const events: Array<{ name: string; payload: Record<string, unknown> }> = [];
+    const sub = Notifications.subscribe("rate_limit.action_controller", (event) => {
+      events.push({ name: event.name, payload: event.payload });
+    });
+    try {
+      const store: RateLimitStore = { increment: () => 11 };
+      const request = { remoteIp: "1.2.3.4" };
+      const host: RateLimitingHost = { controllerPath: "api", request, head: vi.fn() };
+      await rateLimiting.call(host, { to: 10, within: 60, store });
+      expect(events).toHaveLength(1);
+      expect(events[0].name).toBe("rate_limit.action_controller");
+      expect(events[0].payload.request).toBe(request);
+      expect(host.head).toHaveBeenCalledWith(429);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
+  });
+
+  it("does not instrument when the limit is not exceeded", async () => {
+    const events: unknown[] = [];
+    const sub = Notifications.subscribe("rate_limit.action_controller", (e) => events.push(e));
+    try {
+      const store: RateLimitStore = { increment: () => 1 };
+      const host: RateLimitingHost = { request: { remoteIp: "x" }, head: vi.fn() };
+      await rateLimiting.call(host, { to: 10, within: 60, store });
+      expect(events).toHaveLength(0);
+    } finally {
+      Notifications.unsubscribe(sub);
+    }
   });
 
   it("does nothing when store.increment returns null", async () => {

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -8,6 +8,7 @@ import {
   type RateLimitingClassHost,
   type RateLimitingHost,
 } from "./rate-limiting.js";
+import { Base } from "../base.js";
 import type { CallbackOptions } from "../../abstract-controller/callbacks.js";
 
 describe("isRateLimited", () => {
@@ -116,6 +117,25 @@ describe("rateLimiting (instance helper)", () => {
     expect(host.head).not.toHaveBeenCalled();
   });
 
+  it("calls controllerPath() when it is a method (Metal exposes it as a function)", async () => {
+    const store: RateLimitStore = { increment: vi.fn().mockReturnValue(1) };
+    const host: RateLimitingHost = {
+      controllerPath: () => "admin/users",
+      request: { remoteIp: "1.2.3.4" },
+    };
+    await rateLimiting.call(host, { to: 10, within: 60, store });
+    expect(store.increment).toHaveBeenCalledWith("rate-limit:admin/users:1.2.3.4", 1, {
+      expiresIn: 60,
+    });
+  });
+
+  it("drops a null remoteIp from the cache key (mirrors Rails `compact`)", async () => {
+    const store: RateLimitStore = { increment: vi.fn().mockReturnValue(1) };
+    const host: RateLimitingHost = { controllerPath: "posts", request: { remoteIp: null } };
+    await rateLimiting.call(host, { to: 10, within: 60, store });
+    expect(store.increment).toHaveBeenCalledWith("rate-limit:posts", 1, { expiresIn: 60 });
+  });
+
   it("uses the `by` callback for identity when provided", async () => {
     const store: RateLimitStore = { increment: vi.fn().mockReturnValue(1) };
     const host: RateLimitingHost = {
@@ -146,7 +166,10 @@ describe("rateLimit class DSL", () => {
   let store: RateLimitStore;
 
   const makeHost = (overrides: Partial<RateLimitingClassHost> = {}): RateLimitingClassHost => ({
-    beforeAction(callback, options) {
+    beforeAction(
+      callback: (controller: RateLimitingHost) => void | Promise<void>,
+      options?: CallbackOptions,
+    ) {
       registered.push({ callback, options });
     },
     ...overrides,
@@ -201,5 +224,13 @@ describe("rateLimit class DSL", () => {
     rateLimit.call(host, { to: 3, within: 2, store, name: "short-term" });
     rateLimit.call(host, { to: 10, within: 300, store, name: "long-term" });
     expect(registered).toHaveLength(2);
+  });
+
+  it("is wired onto ActionController::Base as a static method", () => {
+    expect(typeof Base.rateLimit).toBe("function");
+    class PostsController extends Base {}
+    expect(() =>
+      PostsController.rateLimit({ to: 5, within: 60, store: new MemoryRateLimitStore() }),
+    ).not.toThrow();
   });
 });

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  MemoryRateLimitStore,
+  isRateLimited,
+  rateLimit,
+  rateLimiting,
+  type RateLimitStore,
+  type RateLimitingClassHost,
+  type RateLimitingHost,
+} from "./rate-limiting.js";
+import type { CallbackOptions } from "../../abstract-controller/callbacks.js";
+
+describe("isRateLimited", () => {
+  it("returns false when count is at or below the limit", () => {
+    expect(isRateLimited(1, 3)).toBe(false);
+    expect(isRateLimited(3, 3)).toBe(false);
+  });
+
+  it("returns true once the count exceeds the limit", () => {
+    expect(isRateLimited(4, 3)).toBe(true);
+  });
+});
+
+describe("MemoryRateLimitStore", () => {
+  it("increments a counter for the given key", () => {
+    const store = new MemoryRateLimitStore();
+    expect(store.increment("k", 1, { expiresIn: 60 })).toBe(1);
+    expect(store.increment("k", 1, { expiresIn: 60 })).toBe(2);
+    expect(store.increment("k", 2, { expiresIn: 60 })).toBe(4);
+  });
+
+  it("expires entries after the window elapses", () => {
+    vi.useFakeTimers();
+    try {
+      const store = new MemoryRateLimitStore();
+      store.increment("k", 1, { expiresIn: 1 });
+      vi.advanceTimersByTime(2000);
+      expect(store.increment("k", 1, { expiresIn: 1 })).toBe(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("scopes counters by key", () => {
+    const store = new MemoryRateLimitStore();
+    store.increment("a", 1, { expiresIn: 60 });
+    store.increment("a", 1, { expiresIn: 60 });
+    expect(store.increment("b", 1, { expiresIn: 60 })).toBe(1);
+  });
+});
+
+describe("rateLimiting (instance helper)", () => {
+  it("increments the store with controller_path + name + identity", async () => {
+    const calls: Array<{ key: string; amount: number; expiresIn: number }> = [];
+    const store: RateLimitStore = {
+      increment(key, amount, options) {
+        calls.push({ key, amount, expiresIn: options.expiresIn });
+        return 1;
+      },
+    };
+    const host: RateLimitingHost = {
+      controllerPath: "sessions",
+      request: { remoteIp: "1.2.3.4" },
+      head: vi.fn(),
+    };
+    await rateLimiting.call(host, { to: 10, within: 60, store, name: "short" });
+    expect(calls).toEqual([{ key: "rate-limit:sessions:short:1.2.3.4", amount: 1, expiresIn: 60 }]);
+    expect(host.head).not.toHaveBeenCalled();
+  });
+
+  it('omits null/blank parts from the cache key (mirrors Rails `compact.join(":")`)', async () => {
+    const store: RateLimitStore = { increment: vi.fn().mockReturnValue(1) };
+    const host: RateLimitingHost = { request: { remoteIp: "1.2.3.4" } };
+    await rateLimiting.call(host, { to: 10, within: 60, store });
+    expect(store.increment).toHaveBeenCalledWith("rate-limit:1.2.3.4", 1, { expiresIn: 60 });
+  });
+
+  it("calls `with` (instance_exec) when count exceeds `to`", async () => {
+    const store: RateLimitStore = { increment: () => 11 };
+    const withCallback = vi.fn(function (this: RateLimitingHost) {
+      expect(this.controllerPath).toBe("api");
+    });
+    const host: RateLimitingHost = {
+      controllerPath: "api",
+      request: { remoteIp: "1.2.3.4" },
+      head: vi.fn(),
+    };
+    await rateLimiting.call(host, { to: 10, within: 60, store, with: withCallback });
+    expect(withCallback).toHaveBeenCalledTimes(1);
+    expect(withCallback.mock.contexts[0]).toBe(host);
+    expect(host.head).not.toHaveBeenCalled();
+  });
+
+  it("falls back to head(429) when no `with` is given and limit is exceeded", async () => {
+    const store: RateLimitStore = { increment: () => 11 };
+    const host: RateLimitingHost = {
+      controllerPath: "api",
+      request: { remoteIp: "x" },
+      head: vi.fn(),
+    };
+    await rateLimiting.call(host, { to: 10, within: 60, store });
+    expect(host.head).toHaveBeenCalledWith(429);
+  });
+
+  it("does nothing when store.increment returns null", async () => {
+    const store: RateLimitStore = { increment: () => null };
+    const host: RateLimitingHost = { request: { remoteIp: "x" }, head: vi.fn() };
+    await rateLimiting.call(host, { to: 0, within: 60, store });
+    expect(host.head).not.toHaveBeenCalled();
+  });
+
+  it("uses the `by` callback for identity when provided", async () => {
+    const store: RateLimitStore = { increment: vi.fn().mockReturnValue(1) };
+    const host: RateLimitingHost = {
+      controllerPath: "signups",
+      request: { remoteIp: "ignored" },
+    };
+    await rateLimiting.call(host, {
+      to: 10,
+      within: 60,
+      store,
+      by() {
+        return "example.com";
+      },
+    });
+    expect(store.increment).toHaveBeenCalledWith("rate-limit:signups:example.com", 1, {
+      expiresIn: 60,
+    });
+  });
+});
+
+describe("rateLimit class DSL", () => {
+  type Registration = {
+    callback: (controller: RateLimitingHost) => void | Promise<void>;
+    options?: CallbackOptions;
+  };
+
+  let registered: Registration[];
+  let store: RateLimitStore;
+
+  const makeHost = (overrides: Partial<RateLimitingClassHost> = {}): RateLimitingClassHost => ({
+    beforeAction(callback, options) {
+      registered.push({ callback, options });
+    },
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    registered = [];
+    store = { increment: vi.fn().mockReturnValue(1) };
+  });
+
+  it("registers a before_action with the given store", async () => {
+    rateLimit.call(makeHost(), { to: 10, within: 60, store });
+    expect(registered).toHaveLength(1);
+    const controller: RateLimitingHost = { request: { remoteIp: "1.1.1.1" } };
+    await registered[0].callback(controller);
+    expect(store.increment).toHaveBeenCalledWith("rate-limit:1.1.1.1", 1, { expiresIn: 60 });
+  });
+
+  it("falls back to host.cacheStore when no store is passed", async () => {
+    rateLimit.call(makeHost({ cacheStore: store }), { to: 10, within: 60 });
+    await registered[0].callback({ request: { remoteIp: "x" } });
+    expect(store.increment).toHaveBeenCalled();
+  });
+
+  it("throws when neither store nor cacheStore is available", () => {
+    expect(() => rateLimit.call(makeHost(), { to: 10, within: 60 })).toThrow(/store/);
+  });
+
+  it("forwards only/except as arrays to beforeAction", () => {
+    rateLimit.call(makeHost(), { to: 10, within: 60, store, only: "create" });
+    rateLimit.call(makeHost(), { to: 10, within: 60, store, except: ["index", "show"] });
+    expect(registered[0].options).toEqual({ only: ["create"] });
+    expect(registered[1].options).toEqual({ except: ["index", "show"] });
+  });
+
+  it("supports multiple named rate limits stacked on the same host", () => {
+    const host = makeHost();
+    rateLimit.call(host, { to: 3, within: 2, store, name: "short-term" });
+    rateLimit.call(host, { to: 10, within: 300, store, name: "long-term" });
+    expect(registered).toHaveLength(2);
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -9,6 +9,9 @@ import {
   type RateLimitingHost,
 } from "./rate-limiting.js";
 import { Base } from "../base.js";
+import { API } from "../api.js";
+import { Request } from "../../action-dispatch/request.js";
+import { Response } from "../../action-dispatch/response.js";
 import { Notifications } from "@blazetrails/activesupport";
 import type { CallbackOptions } from "../../abstract-controller/callbacks.js";
 
@@ -147,6 +150,44 @@ describe("rateLimiting (instance helper)", () => {
     }
   });
 
+  it("awaits an async store.increment result", async () => {
+    const store: RateLimitStore = {
+      increment: () => Promise.resolve(11),
+    };
+    const host: RateLimitingHost = { request: { remoteIp: "x" }, head: vi.fn() };
+    await rateLimiting.call(host, { to: 10, within: 60, store });
+    expect(host.head).toHaveBeenCalledWith(429);
+  });
+
+  it("awaits an async `with` callback before resolving", async () => {
+    const order: string[] = [];
+    const store: RateLimitStore = { increment: () => 11 };
+    const host: RateLimitingHost = { request: { remoteIp: "x" }, head: vi.fn() };
+    await rateLimiting.call(host, {
+      to: 10,
+      within: 60,
+      store,
+      async with() {
+        await new Promise((r) => setTimeout(r, 5));
+        order.push("with");
+      },
+    });
+    order.push("after");
+    expect(order).toEqual(["with", "after"]);
+  });
+
+  it("treats a null/undefined `by` result like Rails `compact` (dropped from key)", async () => {
+    const store: RateLimitStore = { increment: vi.fn().mockReturnValue(1) };
+    const host: RateLimitingHost = { controllerPath: "posts" };
+    await rateLimiting.call(host, {
+      to: 10,
+      within: 60,
+      store,
+      by: () => null,
+    });
+    expect(store.increment).toHaveBeenCalledWith("rate-limit:posts", 1, { expiresIn: 60 });
+  });
+
   it("does nothing when store.increment returns null", async () => {
     const store: RateLimitStore = { increment: () => null };
     const host: RateLimitingHost = { request: { remoteIp: "x" }, head: vi.fn() };
@@ -269,5 +310,46 @@ describe("rateLimit class DSL", () => {
     expect(() =>
       PostsController.rateLimit({ to: 5, within: 60, store: new MemoryRateLimitStore() }),
     ).not.toThrow();
+  });
+
+  it("is also wired onto ActionController::API (Rails api.rb:125 includes RateLimiting)", () => {
+    expect(typeof API.rateLimit).toBe("function");
+    class PingApi extends API {}
+    expect(() =>
+      PingApi.rateLimit({ to: 5, within: 60, store: new MemoryRateLimitStore() }),
+    ).not.toThrow();
+  });
+});
+
+describe("rateLimit integration through Base.beforeAction / dispatch", () => {
+  it("triggers head(429) and short-circuits the action body once the limit is exceeded", async () => {
+    const store = new MemoryRateLimitStore();
+    let actionRan = 0;
+
+    class LimitedController extends Base {
+      async show() {
+        actionRan += 1;
+        this.head(200);
+      }
+    }
+    LimitedController.rateLimit({ to: 1, within: 60, store });
+
+    const makeRequest = () =>
+      new Request({
+        REQUEST_METHOD: "GET",
+        PATH_INFO: "/show",
+        HTTP_HOST: "localhost",
+        REMOTE_ADDR: "1.2.3.4",
+      });
+
+    const r1 = new LimitedController();
+    await r1.dispatch("show", makeRequest(), new Response());
+    expect(r1.status).toBe(200);
+    expect(actionRan).toBe(1);
+
+    const r2 = new LimitedController();
+    await r2.dispatch("show", makeRequest(), new Response());
+    expect(r2.status).toBe(429);
+    expect(actionRan).toBe(1);
   });
 });

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   MemoryRateLimitStore,
   isRateLimited,
@@ -49,6 +49,10 @@ describe("MemoryRateLimitStore", () => {
     store.increment("a", 1, { expiresIn: 60 });
     expect(store.increment("b", 1, { expiresIn: 60 })).toBe(1);
   });
+});
+
+afterEach(() => {
+  Notifications.unsubscribeAll();
 });
 
 describe("rateLimiting (instance helper)", () => {

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -352,4 +352,31 @@ describe("rateLimit integration through Base.beforeAction / dispatch", () => {
     expect(r2.status).toBe(429);
     expect(actionRan).toBe(1);
   });
+
+  it("dispatches through the instance's rateLimiting slot so subclass overrides win", async () => {
+    const store = new MemoryRateLimitStore();
+    const overrideCalls: string[] = [];
+
+    class OverridingController extends Base {
+      async show() {
+        this.head(200);
+      }
+      override rateLimiting = async function (
+        this: RateLimitingHost,
+        args: Parameters<typeof rateLimiting>[0],
+      ) {
+        overrideCalls.push("override");
+        await rateLimiting.call(this, args);
+      };
+    }
+    OverridingController.rateLimit({ to: 1, within: 60, store });
+
+    const c = new OverridingController();
+    await c.dispatch(
+      "show",
+      new Request({ REQUEST_METHOD: "GET", PATH_INFO: "/show", HTTP_HOST: "x" }),
+      new Response(),
+    );
+    expect(overrideCalls).toEqual(["override"]);
+  });
 });

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -68,11 +68,18 @@ describe("rateLimiting (instance helper)", () => {
     expect(host.head).not.toHaveBeenCalled();
   });
 
-  it('omits null/blank parts from the cache key (mirrors Rails `compact.join(":")`)', async () => {
+  it('drops null/undefined parts but keeps empty strings (mirrors Rails `compact.join(":")`)', async () => {
     const store: RateLimitStore = { increment: vi.fn().mockReturnValue(1) };
     const host: RateLimitingHost = { request: { remoteIp: "1.2.3.4" } };
     await rateLimiting.call(host, { to: 10, within: 60, store });
     expect(store.increment).toHaveBeenCalledWith("rate-limit:1.2.3.4", 1, { expiresIn: 60 });
+  });
+
+  it('preserves empty-string identity in the cache key (Ruby `compact` keeps "")', async () => {
+    const store: RateLimitStore = { increment: vi.fn().mockReturnValue(1) };
+    const host: RateLimitingHost = { controllerPath: "posts", request: { remoteIp: "" } };
+    await rateLimiting.call(host, { to: 10, within: 60, store });
+    expect(store.increment).toHaveBeenCalledWith("rate-limit:posts:", 1, { expiresIn: 60 });
   });
 
   it("calls `with` (instance_exec) when count exceeds `to`", async () => {
@@ -173,6 +180,20 @@ describe("rateLimit class DSL", () => {
     rateLimit.call(makeHost(), { to: 10, within: 60, store, except: ["index", "show"] });
     expect(registered[0].options).toEqual({ only: ["create"] });
     expect(registered[1].options).toEqual({ except: ["index", "show"] });
+  });
+
+  it("forwards if/unless/prepend to beforeAction (Rails **options)", () => {
+    const ifFn = () => true;
+    const unlessFn = () => false;
+    rateLimit.call(makeHost(), {
+      to: 10,
+      within: 60,
+      store,
+      if: ifFn,
+      unless: unlessFn,
+      prepend: true,
+    });
+    expect(registered[0].options).toEqual({ if: ifFn, unless: unlessFn, prepend: true });
   });
 
   it("supports multiple named rate limits stacked on the same host", () => {

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -6,34 +6,64 @@
  * @see https://api.rubyonrails.org/classes/ActionController/RateLimiting.html
  */
 
+import { Notifications } from "@blazetrails/activesupport";
+import type { CallbackOptions } from "../../abstract-controller/callbacks.js";
+
+/** Options accepted by the `rateLimit` class DSL. */
 export interface RateLimitOptions {
+  /** Maximum number of requests allowed within the window. */
   to: number;
+  /** Window length in seconds (Rails uses `ActiveSupport::Duration`). */
   within: number;
-  by?: (request: unknown) => string;
-  with?: (controller: unknown) => void;
+  /**
+   * Per-request identity function. Default is the remote IP. Invoked with
+   * the controller as `this`, matching Rails' `instance_exec(&by)`.
+   */
+  by?: (this: RateLimitingHost) => string;
+  /**
+   * Action to take when the limit is exceeded. Invoked with the controller
+   * as `this`. Defaults to `head(429)`.
+   */
+  with?: (this: RateLimitingHost) => void | Promise<void>;
+  /** Cache backend used to count requests. Defaults to the host's cacheStore. */
   store?: RateLimitStore;
+  /** Distinct name when multiple rate limits are stacked on one controller. */
   name?: string;
+  /** Standard before_action `only:` filter. */
   only?: string | string[];
+  /** Standard before_action `except:` filter. */
   except?: string | string[];
 }
 
+/**
+ * Minimal cache-backend contract used by `rateLimiting`.
+ *
+ * Mirrors `ActiveSupport::Cache::Store#increment(key, amount, expires_in:)`
+ * but typed in camelCase. Implementations may be sync or async; the helper
+ * awaits the return value.
+ */
 export interface RateLimitStore {
-  increment(key: string, expires: number): Promise<number> | number;
+  increment(
+    key: string,
+    amount: number,
+    options: { expiresIn: number },
+  ): number | null | Promise<number | null>;
 }
 
+/** In-memory `RateLimitStore` for tests and single-process apps. */
 export class MemoryRateLimitStore implements RateLimitStore {
   private _entries = new Map<string, { count: number; expiresAt: number }>();
 
-  increment(key: string, expires: number): number {
+  increment(key: string, amount: number, options: { expiresIn: number }): number {
     this._cleanup();
     const now = Date.now();
     const entry = this._entries.get(key);
     if (entry && entry.expiresAt > now) {
-      entry.count += 1;
+      entry.count += amount;
       return entry.count;
     }
-    this._entries.set(key, { count: 1, expiresAt: now + expires * 1000 });
-    return 1;
+    this._entries.set(key, { count: amount, expiresAt: now + options.expiresIn * 1000 });
+    return amount;
   }
 
   private _cleanup(): void {
@@ -44,6 +74,107 @@ export class MemoryRateLimitStore implements RateLimitStore {
   }
 }
 
+/** Returns true when `count` exceeds `limit`. */
 export function isRateLimited(count: number, limit: number): boolean {
   return count > limit;
+}
+
+/**
+ * Host contract for the class DSL: the controller class must expose
+ * `beforeAction` and a default `cacheStore`. Matches the subset of
+ * `AbstractController` + `ActionController::Base` that Rails' DSL touches.
+ */
+export interface RateLimitingClassHost {
+  beforeAction(
+    callback: (controller: RateLimitingHost) => void | Promise<void>,
+    options?: CallbackOptions,
+  ): void;
+  cacheStore?: RateLimitStore;
+}
+
+/**
+ * Host contract for the instance helper: each request needs an identifying
+ * string (Rails uses `request.remote_ip`) and a sink for over-limit responses.
+ */
+export interface RateLimitingHost {
+  controllerPath?: string;
+  request?: { remoteIp?: string };
+  head?: (status: number) => void;
+}
+
+/**
+ * Class DSL: register a rate limit on all actions (or `only:`/`except:`).
+ *
+ * Mirrors Rails `ActionController::RateLimiting::ClassMethods#rate_limit`
+ * (actionpack/lib/action_controller/metal/rate_limiting.rb, lines 55–57):
+ *
+ *     def rate_limit(to:, within:, by: -> { request.remote_ip },
+ *                    with: -> { head :too_many_requests },
+ *                    store: cache_store, name: nil, **options)
+ *       before_action -> {
+ *         rate_limiting(to:, within:, by:, with:, store:, name:)
+ *       }, **options
+ *     end
+ */
+export function rateLimit(this: RateLimitingClassHost, options: RateLimitOptions): void {
+  const { to, within, by, with: withCallback, store, name, only, except } = options;
+  const resolvedStore = store ?? this.cacheStore;
+  if (!resolvedStore) {
+    throw new Error(
+      "rateLimit requires a `store:` option or a `cacheStore` on the controller class.",
+    );
+  }
+  const filter: CallbackOptions = {};
+  if (only !== undefined) filter.only = Array.isArray(only) ? only : [only];
+  if (except !== undefined) filter.except = Array.isArray(except) ? except : [except];
+
+  this.beforeAction(async function (controller) {
+    await rateLimiting.call(controller, {
+      to,
+      within,
+      by,
+      with: withCallback,
+      store: resolvedStore,
+      name,
+    });
+  }, filter);
+}
+
+/**
+ * Private instance helper invoked by the registered `beforeAction`.
+ *
+ * Mirrors Rails `ActionController::RateLimiting#rate_limiting`
+ * (actionpack/lib/action_controller/metal/rate_limiting.rb, lines 61–69).
+ *
+ * @internal
+ */
+export async function rateLimiting(
+  this: RateLimitingHost,
+  args: {
+    to: number;
+    within: number;
+    by?: (this: RateLimitingHost) => string;
+    with?: (this: RateLimitingHost) => void | Promise<void>;
+    store: RateLimitStore;
+    name?: string;
+  },
+): Promise<void> {
+  const identity = args.by ? args.by.call(this) : (this.request?.remoteIp ?? "");
+  const cacheKey = ["rate-limit", this.controllerPath, args.name, identity]
+    .filter((part) => part != null && part !== "")
+    .join(":");
+  const count = await args.store.increment(cacheKey, 1, { expiresIn: args.within });
+  if (count != null && isRateLimited(count, args.to)) {
+    await Notifications.instrument(
+      "rate_limit.action_controller",
+      { request: this.request },
+      async () => {
+        if (args.with) {
+          await args.with.call(this);
+        } else if (this.head) {
+          this.head(429);
+        }
+      },
+    );
+  }
 }

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -9,8 +9,20 @@
 import { Notifications } from "@blazetrails/activesupport";
 import type { CallbackOptions } from "../../abstract-controller/callbacks.js";
 
-/** Options accepted by the `rateLimit` class DSL. */
-export interface RateLimitOptions {
+/**
+ * Options accepted by the `rateLimit` class DSL.
+ *
+ * The generic `TController` parameter widens the `this` type seen inside
+ * `by`/`with` callbacks. Rails runs them via `instance_exec`, so callbacks
+ * can reach params/session/request — pass your controller class type to
+ * surface that API without casts:
+ *
+ *     PostsController.rateLimit<PostsController>({
+ *       to: 10, within: 60,
+ *       by() { return this.request.headers["x-api-key"] ?? this.request.remoteIp; },
+ *     });
+ */
+export interface RateLimitOptions<TController = RateLimitingHost> {
   /** Maximum number of requests allowed within the window. */
   to: number;
   /** Window length in seconds (Rails uses `ActiveSupport::Duration`). */
@@ -19,12 +31,13 @@ export interface RateLimitOptions {
    * Per-request identity function. Default is the remote IP. Invoked with
    * the controller as `this`, matching Rails' `instance_exec(&by)`.
    */
-  by?: (this: RateLimitingHost) => string | null | undefined;
+  by?: (this: TController) => string | null | undefined;
   /**
    * Action to take when the limit is exceeded. Invoked with the controller
-   * as `this`. Defaults to `head(429)`.
+   * as `this`. Defaults to `head(429)`. Matches Rails' Symbol/Integer status
+   * shape: `this.head("too_many_requests")` is valid.
    */
-  with?: (this: RateLimitingHost) => void | Promise<void>;
+  with?: (this: TController) => void | Promise<void>;
   /** Cache backend used to count requests. Defaults to the host's cacheStore. */
   store?: RateLimitStore;
   /** Distinct name when multiple rate limits are stacked on one controller. */
@@ -62,11 +75,13 @@ export interface RateLimitStore {
  * Expiry is checked lazily on each `increment` for the touched key, matching
  * `activesupport/cache/memory-store` (memory-store.ts:135). To prevent
  * unbounded growth from one-off identities, the store also sweeps expired
- * entries once the map crosses `_PRUNE_BASELINE` (1024). If the sweep frees
- * space, the threshold resets to the baseline — so subsequent low-volume
- * workloads don't carry stale entries past the next baseline. Only when a
- * sweep fails to free space (every entry still live) does the threshold
- * double, amortizing the O(N) walk against the next burst.
+ * entries once the map crosses `_pruneThreshold` (starts at 1024). After a
+ * sweep, the next threshold tracks current load: if the sweep freed space,
+ * it's set to `max(baseline, liveCount * 2)` — proportional to remaining
+ * entries, so post-burst the cadence relaxes only as far as the live load
+ * warrants and drops back to the baseline once load recedes. If the sweep
+ * freed nothing (every entry still live), the threshold doubles to
+ * amortize the O(N) walk against the next burst.
  */
 export class MemoryRateLimitStore implements RateLimitStore {
   private static readonly _PRUNE_BASELINE = 1024;
@@ -117,6 +132,17 @@ export interface RateLimitingClassHost {
   /**
    * Mirrors the existing `cacheStore?: ... | null` convention on
    * AbstractController caching/fragments (caching.ts:35, fragments.ts:24).
+   *
+   * NOTE: The Rails `cache_store` slot is normally an
+   * `ActiveSupport::Cache::Store`, but for rate limiting it must satisfy the
+   * stricter `RateLimitStore` contract — `expiresIn` in **seconds** and a
+   * counter initialized to `amount` on first call (Redis/Memcached
+   * behavior). The in-memory activesupport cache (`@blazetrails/activesupport`
+   * `MemoryStore`) uses millisecond `expiresIn` and returns `null` for
+   * missing keys, so plugging it in here will silently disable enforcement
+   * (matches Rails — same caveat applies to `ActiveSupport::Cache::MemoryStore`
+   * upstream). See the "RateLimiting" entry in
+   * docs/actioncontroller-100-percent.md "Known divergences".
    */
   cacheStore?: RateLimitStore | null;
 }
@@ -133,7 +159,12 @@ export interface RateLimitingHost {
    */
   controllerPath?: string | (() => string);
   request?: { remoteIp?: string | null };
-  head?: (status: number) => void;
+  /**
+   * `Metal#head` accepts numeric statuses and Rails-style symbol names
+   * (`"too_many_requests"`) — see action-controller/metal.ts:223. Keep this
+   * type aligned so `with() { this.head("too_many_requests") }` typechecks.
+   */
+  head?: (status: number | string) => void;
 }
 
 /**
@@ -150,7 +181,10 @@ export interface RateLimitingHost {
  *       }, **options
  *     end
  */
-export function rateLimit(this: RateLimitingClassHost, options: RateLimitOptions): void {
+export function rateLimit<TController extends RateLimitingHost = RateLimitingHost>(
+  this: RateLimitingClassHost,
+  options: RateLimitOptions<TController>,
+): void {
   const {
     to,
     within,
@@ -181,8 +215,8 @@ export function rateLimit(this: RateLimitingClassHost, options: RateLimitOptions
     await rateLimiting.call(controller, {
       to,
       within,
-      by,
-      with: withCallback,
+      by: by as ((this: RateLimitingHost) => string | null | undefined) | undefined,
+      with: withCallback as ((this: RateLimitingHost) => void | Promise<void>) | undefined,
       store: resolvedStore,
       name,
     });

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -59,13 +59,15 @@ export interface RateLimitStore {
 /**
  * In-memory `RateLimitStore` for tests and single-process apps.
  *
- * Expiry is checked lazily on each `increment` call for the touched key,
- * mirroring `activesupport/cache/memory-store` (memory-store.ts:135) — this
- * keeps the hot path O(1) regardless of how many distinct identities are
- * tracked.
+ * Expiry is checked lazily on each `increment` for the touched key, matching
+ * `activesupport/cache/memory-store` (memory-store.ts:135). To prevent
+ * unbounded growth from one-off identities, the store also sweeps expired
+ * entries when the map crosses `_pruneThreshold` (default 1024). The sweep is
+ * amortized — the threshold doubles after each pass so hot paths stay O(1).
  */
 export class MemoryRateLimitStore implements RateLimitStore {
   private _entries = new Map<string, { count: number; expiresAt: number }>();
+  private _pruneThreshold = 1024;
 
   increment(key: string, amount: number, options: { expiresIn: number }): number {
     const now = Date.now();
@@ -75,7 +77,15 @@ export class MemoryRateLimitStore implements RateLimitStore {
       return entry.count;
     }
     this._entries.set(key, { count: amount, expiresAt: now + options.expiresIn * 1000 });
+    if (this._entries.size >= this._pruneThreshold) this._pruneExpired(now);
     return amount;
+  }
+
+  private _pruneExpired(now: number): void {
+    for (const [key, entry] of this._entries) {
+      if (entry.expiresAt <= now) this._entries.delete(key);
+    }
+    if (this._entries.size >= this._pruneThreshold) this._pruneThreshold *= 2;
   }
 }
 

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -90,11 +90,12 @@ export function isRateLimited(count: number, limit: number): boolean {
  * `beforeAction` and a default `cacheStore`. Matches the subset of
  * `AbstractController` + `ActionController::Base` that Rails' DSL touches.
  */
+// `beforeAction` is intentionally untyped on this contract: AbstractController
+// types its callback against AbstractController, but the DSL only needs the
+// method to exist on the host class. Concrete subclasses (Base/Metal) supply
+// the stricter type at the call site.
 export interface RateLimitingClassHost {
-  beforeAction(
-    callback: (controller: RateLimitingHost) => void | Promise<void>,
-    options?: CallbackOptions,
-  ): void;
+  beforeAction: Function; // eslint-disable-line @typescript-eslint/no-unsafe-function-type
   cacheStore?: RateLimitStore;
 }
 
@@ -103,8 +104,13 @@ export interface RateLimitingClassHost {
  * string (Rails uses `request.remote_ip`) and a sink for over-limit responses.
  */
 export interface RateLimitingHost {
-  controllerPath?: string;
-  request?: { remoteIp?: string };
+  /**
+   * Rails delegates `controller_path` to the class; Metal exposes it as an
+   * instance method. Accept either a method or a string property so the
+   * helper composes the right cache key under both shapes.
+   */
+  controllerPath?: string | (() => string);
+  request?: { remoteIp?: string | null };
   head?: (status: number) => void;
 }
 
@@ -149,7 +155,7 @@ export function rateLimit(this: RateLimitingClassHost, options: RateLimitOptions
   if (unlessFilter !== undefined) filter.unless = unlessFilter;
   if (prepend !== undefined) filter.prepend = prepend;
 
-  this.beforeAction(async function (controller) {
+  const callback = async (controller: RateLimitingHost): Promise<void> => {
     await rateLimiting.call(controller, {
       to,
       within,
@@ -158,7 +164,8 @@ export function rateLimit(this: RateLimitingClassHost, options: RateLimitOptions
       store: resolvedStore,
       name,
     });
-  }, filter);
+  };
+  (this.beforeAction as (cb: typeof callback, opts?: CallbackOptions) => void)(callback, filter);
 }
 
 /**
@@ -180,13 +187,15 @@ export async function rateLimiting(
     name?: string;
   },
 ): Promise<void> {
-  const identity = args.by ? args.by.call(this) : (this.request?.remoteIp ?? "");
-  const cacheKey = ["rate-limit", this.controllerPath, args.name, identity]
+  const identity = args.by ? args.by.call(this) : (this.request?.remoteIp ?? null);
+  const controllerPath =
+    typeof this.controllerPath === "function" ? this.controllerPath() : this.controllerPath;
+  const cacheKey = ["rate-limit", controllerPath, args.name, identity]
     .filter((part): part is string => part != null)
     .join(":");
   const count = await args.store.increment(cacheKey, 1, { expiresIn: args.within });
   if (count != null && isRateLimited(count, args.to)) {
-    await Notifications.instrument(
+    await Notifications.instrumentAsync(
       "rate_limit.action_controller",
       { request: this.request },
       async () => {

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -19,7 +19,7 @@ export interface RateLimitOptions {
    * Per-request identity function. Default is the remote IP. Invoked with
    * the controller as `this`, matching Rails' `instance_exec(&by)`.
    */
-  by?: (this: RateLimitingHost) => string;
+  by?: (this: RateLimitingHost) => string | null | undefined;
   /**
    * Action to take when the limit is exceeded. Invoked with the controller
    * as `this`. Defaults to `head(429)`.
@@ -62,12 +62,16 @@ export interface RateLimitStore {
  * Expiry is checked lazily on each `increment` for the touched key, matching
  * `activesupport/cache/memory-store` (memory-store.ts:135). To prevent
  * unbounded growth from one-off identities, the store also sweeps expired
- * entries when the map crosses `_pruneThreshold` (default 1024). The sweep is
- * amortized — the threshold doubles after each pass so hot paths stay O(1).
+ * entries once the map crosses `_PRUNE_BASELINE` (1024). If the sweep frees
+ * space, the threshold resets to the baseline — so subsequent low-volume
+ * workloads don't carry stale entries past the next baseline. Only when a
+ * sweep fails to free space (every entry still live) does the threshold
+ * double, amortizing the O(N) walk against the next burst.
  */
 export class MemoryRateLimitStore implements RateLimitStore {
+  private static readonly _PRUNE_BASELINE = 1024;
   private _entries = new Map<string, { count: number; expiresAt: number }>();
-  private _pruneThreshold = 1024;
+  private _pruneThreshold = MemoryRateLimitStore._PRUNE_BASELINE;
 
   increment(key: string, amount: number, options: { expiresIn: number }): number {
     const now = Date.now();
@@ -82,10 +86,15 @@ export class MemoryRateLimitStore implements RateLimitStore {
   }
 
   private _pruneExpired(now: number): void {
+    const before = this._entries.size;
     for (const [key, entry] of this._entries) {
       if (entry.expiresAt <= now) this._entries.delete(key);
     }
-    if (this._entries.size >= this._pruneThreshold) this._pruneThreshold *= 2;
+    if (this._entries.size < before) {
+      this._pruneThreshold = Math.max(MemoryRateLimitStore._PRUNE_BASELINE, this._entries.size * 2);
+    } else {
+      this._pruneThreshold *= 2;
+    }
   }
 }
 
@@ -105,7 +114,11 @@ export function isRateLimited(count: number, limit: number): boolean {
 // the stricter type at the call site.
 export interface RateLimitingClassHost {
   beforeAction: Function; // eslint-disable-line @typescript-eslint/no-unsafe-function-type
-  cacheStore?: RateLimitStore;
+  /**
+   * Mirrors the existing `cacheStore?: ... | null` convention on
+   * AbstractController caching/fragments (caching.ts:35, fragments.ts:24).
+   */
+  cacheStore?: RateLimitStore | null;
 }
 
 /**
@@ -190,7 +203,7 @@ export async function rateLimiting(
   args: {
     to: number;
     within: number;
-    by?: (this: RateLimitingHost) => string;
+    by?: (this: RateLimitingHost) => string | null | undefined;
     with?: (this: RateLimitingHost) => void | Promise<void>;
     store: RateLimitStore;
     name?: string;

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -56,12 +56,18 @@ export interface RateLimitStore {
   ): number | null | Promise<number | null>;
 }
 
-/** In-memory `RateLimitStore` for tests and single-process apps. */
+/**
+ * In-memory `RateLimitStore` for tests and single-process apps.
+ *
+ * Expiry is checked lazily on each `increment` call for the touched key,
+ * mirroring `activesupport/cache/memory-store` (memory-store.ts:135) — this
+ * keeps the hot path O(1) regardless of how many distinct identities are
+ * tracked.
+ */
 export class MemoryRateLimitStore implements RateLimitStore {
   private _entries = new Map<string, { count: number; expiresAt: number }>();
 
   increment(key: string, amount: number, options: { expiresIn: number }): number {
-    this._cleanup();
     const now = Date.now();
     const entry = this._entries.get(key);
     if (entry && entry.expiresAt > now) {
@@ -70,13 +76,6 @@ export class MemoryRateLimitStore implements RateLimitStore {
     }
     this._entries.set(key, { count: amount, expiresAt: now + options.expiresIn * 1000 });
     return amount;
-  }
-
-  private _cleanup(): void {
-    const now = Date.now();
-    for (const [key, entry] of this._entries) {
-      if (entry.expiresAt <= now) this._entries.delete(key);
-    }
   }
 }
 

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -19,7 +19,7 @@ import type { CallbackOptions } from "../../abstract-controller/callbacks.js";
  *
  *     PostsController.rateLimit<PostsController>({
  *       to: 10, within: 60,
- *       by() { return this.request.headers["x-api-key"] ?? this.request.remoteIp; },
+ *       by() { return this.request.getHeader("x-api-key") ?? this.request.remoteIp; },
  *     });
  */
 export interface RateLimitOptions<TController = RateLimitingHost> {
@@ -85,16 +85,15 @@ export interface RateLimitStore {
  */
 export class MemoryRateLimitStore implements RateLimitStore {
   private static readonly _PRUNE_BASELINE = 1024;
-  /**
-   * Hard cap on the dynamic threshold. With a 16× ceiling, peak memory is
-   * bounded by `_PRUNE_MAX` entries even if a burst drives the threshold up
-   * and traffic later goes quiet — once the map hits this cap, every
-   * subsequent insert triggers a sweep, so expired identities can't linger
-   * waiting for a next-burst-that-never-comes.
-   */
   private static readonly _PRUNE_MAX = MemoryRateLimitStore._PRUNE_BASELINE * 16;
   private _entries = new Map<string, { count: number; expiresAt: number }>();
   private _pruneThreshold = MemoryRateLimitStore._PRUNE_BASELINE;
+  /**
+   * Inserts to skip before re-sweeping after a sterile sweep (nothing
+   * expired). Without this, sustained all-live traffic at the cap would turn
+   * every insert into an O(N) walk — see review #8 comment 2.
+   */
+  private _skipSweepInserts = 0;
 
   increment(key: string, amount: number, options: { expiresIn: number }): number {
     const now = Date.now();
@@ -104,7 +103,13 @@ export class MemoryRateLimitStore implements RateLimitStore {
       return entry.count;
     }
     this._entries.set(key, { count: amount, expiresAt: now + options.expiresIn * 1000 });
-    if (this._entries.size >= this._pruneThreshold) this._pruneExpired(now);
+    if (this._entries.size >= this._pruneThreshold) {
+      if (this._skipSweepInserts > 0) {
+        this._skipSweepInserts -= 1;
+      } else {
+        this._pruneExpired(now);
+      }
+    }
     return amount;
   }
 
@@ -115,11 +120,16 @@ export class MemoryRateLimitStore implements RateLimitStore {
     }
     if (this._entries.size < before) {
       this._pruneThreshold = Math.max(MemoryRateLimitStore._PRUNE_BASELINE, this._entries.size * 2);
+      this._skipSweepInserts = 0;
     } else {
+      // Nothing freed: every entry is live. Double threshold up to the cap.
+      // Once at the cap, defer the next sweep by a full baseline of inserts
+      // so the all-live state can't make every request O(N).
       this._pruneThreshold *= 2;
-    }
-    if (this._pruneThreshold > MemoryRateLimitStore._PRUNE_MAX) {
-      this._pruneThreshold = MemoryRateLimitStore._PRUNE_MAX;
+      if (this._pruneThreshold >= MemoryRateLimitStore._PRUNE_MAX) {
+        this._pruneThreshold = MemoryRateLimitStore._PRUNE_MAX;
+        this._skipSweepInserts = MemoryRateLimitStore._PRUNE_BASELINE;
+      }
     }
   }
 }
@@ -176,6 +186,13 @@ export interface RateLimitingHost {
    * type aligned so `with() { this.head("too_many_requests") }` typechecks.
    */
   head?: (status: number | string) => void;
+  /**
+   * Per-request enforcement entrypoint. Rails' `before_action` block calls
+   * `self.rate_limiting(...)` so subclass overrides win
+   * (rate_limiting.rb:56). Wired as a static-bound method on Base/API; the
+   * DSL dispatches through this slot to preserve override semantics.
+   */
+  rateLimiting?: typeof rateLimiting;
 }
 
 /**
@@ -223,7 +240,12 @@ export function rateLimit<TController extends RateLimitingHost = RateLimitingHos
   if (prepend !== undefined) filter.prepend = prepend;
 
   const callback = async (controller: RateLimitingHost): Promise<void> => {
-    await rateLimiting.call(controller, {
+    // Dispatch through the instance's own `rateLimiting` slot so subclass
+    // overrides win (matches Rails' `before_action -> { rate_limiting(...) }`
+    // which calls `self.rate_limiting`). Fall back to the module function so
+    // hosts that haven't wired the instance method still work.
+    const fn = controller.rateLimiting ?? rateLimiting;
+    await fn.call(controller, {
       to,
       within,
       by: by as ((this: RateLimitingHost) => string | null | undefined) | undefined,

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -33,6 +33,12 @@ export interface RateLimitOptions {
   only?: string | string[];
   /** Standard before_action `except:` filter. */
   except?: string | string[];
+  /** Standard before_action `if:` filter. */
+  if?: CallbackOptions["if"];
+  /** Standard before_action `unless:` filter. */
+  unless?: CallbackOptions["unless"];
+  /** Prepend the before_action (Rails `prepend: true`). */
+  prepend?: boolean;
 }
 
 /**
@@ -117,7 +123,19 @@ export interface RateLimitingHost {
  *     end
  */
 export function rateLimit(this: RateLimitingClassHost, options: RateLimitOptions): void {
-  const { to, within, by, with: withCallback, store, name, only, except } = options;
+  const {
+    to,
+    within,
+    by,
+    with: withCallback,
+    store,
+    name,
+    only,
+    except,
+    if: ifFilter,
+    unless: unlessFilter,
+    prepend,
+  } = options;
   const resolvedStore = store ?? this.cacheStore;
   if (!resolvedStore) {
     throw new Error(
@@ -127,6 +145,9 @@ export function rateLimit(this: RateLimitingClassHost, options: RateLimitOptions
   const filter: CallbackOptions = {};
   if (only !== undefined) filter.only = Array.isArray(only) ? only : [only];
   if (except !== undefined) filter.except = Array.isArray(except) ? except : [except];
+  if (ifFilter !== undefined) filter.if = ifFilter;
+  if (unlessFilter !== undefined) filter.unless = unlessFilter;
+  if (prepend !== undefined) filter.prepend = prepend;
 
   this.beforeAction(async function (controller) {
     await rateLimiting.call(controller, {
@@ -161,7 +182,7 @@ export async function rateLimiting(
 ): Promise<void> {
   const identity = args.by ? args.by.call(this) : (this.request?.remoteIp ?? "");
   const cacheKey = ["rate-limit", this.controllerPath, args.name, identity]
-    .filter((part) => part != null && part !== "")
+    .filter((part): part is string => part != null)
     .join(":");
   const count = await args.store.increment(cacheKey, 1, { expiresIn: args.within });
   if (count != null && isRateLimited(count, args.to)) {

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -85,6 +85,14 @@ export interface RateLimitStore {
  */
 export class MemoryRateLimitStore implements RateLimitStore {
   private static readonly _PRUNE_BASELINE = 1024;
+  /**
+   * Hard cap on the dynamic threshold. With a 16× ceiling, peak memory is
+   * bounded by `_PRUNE_MAX` entries even if a burst drives the threshold up
+   * and traffic later goes quiet — once the map hits this cap, every
+   * subsequent insert triggers a sweep, so expired identities can't linger
+   * waiting for a next-burst-that-never-comes.
+   */
+  private static readonly _PRUNE_MAX = MemoryRateLimitStore._PRUNE_BASELINE * 16;
   private _entries = new Map<string, { count: number; expiresAt: number }>();
   private _pruneThreshold = MemoryRateLimitStore._PRUNE_BASELINE;
 
@@ -109,6 +117,9 @@ export class MemoryRateLimitStore implements RateLimitStore {
       this._pruneThreshold = Math.max(MemoryRateLimitStore._PRUNE_BASELINE, this._entries.size * 2);
     } else {
       this._pruneThreshold *= 2;
+    }
+    if (this._pruneThreshold > MemoryRateLimitStore._PRUNE_MAX) {
+      this._pruneThreshold = MemoryRateLimitStore._PRUNE_MAX;
     }
   }
 }


### PR DESCRIPTION
## Summary

Ports `ActionController::RateLimiting` from
`vendor/rails/actionpack/lib/action_controller/metal/rate_limiting.rb`,
implementing the P2 row from `docs/actioncontroller-100-percent.md`:

- **`rateLimit` (class DSL)** — registers a `before_action` that invokes
  `rateLimiting` with the configured options. Mirrors Rails kwargs
  (`to`, `within`, `by`, `with`, `store`, `name`) and forwards
  `only:` / `except:` (string or array) onto the `beforeAction` filter.
  Falls back to a `cacheStore` static on the host class when `store:` is
  omitted; throws if neither is set.
- **`rateLimiting` (private instance helper)** — composes the
  `rate-limit:controllerPath:name:identity` key (Rails `compact.join(":")`),
  increments the store, and on over-limit invokes the `with` callback
  (or `head(429)`) wrapped in an `ActiveSupport::Notifications`
  `rate_limit.action_controller` event.
- **`RateLimitStore.increment`** signature aligned to Rails:
  `(key, amount, { expiresIn })`. `MemoryRateLimitStore` updated; sync
  or async backends both supported.
- 16 new tests cover key composition, identity dispatch, threshold
  triggering, `head(429)` fallback, only/except forwarding, and
  multi-named stacking.

## Known divergences

Documented in `docs/actioncontroller-100-percent.md` "Known divergences":
no `Rails.cache` equivalent yet, so production deployments must supply
their own `ActiveSupport::Cache::Store`-shaped object. DSL surface,
key shape, `429` fallback, and notifications are parity-faithful.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/rate-limiting.test.ts` — 16/16
- [x] `pnpm exec tsc --noEmit` clean for actionpack
- [x] `pnpm exec eslint` clean on touched files

## Remaining concerns (Copilot review #9 — max cycles hit)

Stopping iteration; flagging the open items so a follow-up PR (or reviewer) can address them:

1. **`rateLimiting` as class field shadows method overrides** — Base/API declare `rateLimiting = rateLimiting` as instance fields, which create own properties on every instance and would shadow a subclass *method* override (only class-field overrides work). For Rails-parity override semantics (`self.rate_limiting` dispatch), this should be a prototype-method wrapper and excluded from action discovery. The existing dispatch test in this PR uses a class-field override and passes, but a prototype-method override on a subclass would be ignored.
2. **`_PRUNE_BASELINE` doc cross-reference** — `rate-limiting.ts` comments mention "review #8 comment 2"; should be replaced with a self-contained explanation of the all-live-traffic scenario.
3. **Prune-path test coverage** — current tests cover lazy per-key expiry but never drive `MemoryRateLimitStore` past `_pruneThreshold`. Coverage for (a) expired entries removed after threshold crossed and (b) all-live sweep doesn't prune live entries is missing.
4. **`nil` → `null` wording in divergence doc** — the "RateLimiting" entry in `docs/actioncontroller-100-percent.md` references our in-repo activesupport cache returning `nil`; should be `null` (Ruby term for Rails behavior, JS term for ours).
