### PR TITLE
refactor(activerecord): centralize AnyClass + typed RawReflection (B18)

### DIFF
--- a/packages/activerecord/src/attribute-methods/composite-primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/composite-primary-key.ts
@@ -4,11 +4,13 @@
  * Mirrors: ActiveRecord::AttributeMethods::CompositePrimaryKey
  */
 
+import type { AnyClass } from "../internal/any-class.js";
+
 interface CompositePKRecord {
   id: unknown;
   readAttribute(name: string): unknown;
   _readAttribute(name: string): unknown;
-  constructor: (abstract new (...args: any[]) => any) & {
+  constructor: AnyClass & {
     primaryKey: string | string[];
     compositePrimaryKey: boolean;
   };

--- a/packages/activerecord/src/internal/any-class.ts
+++ b/packages/activerecord/src/internal/any-class.ts
@@ -1,0 +1,8 @@
+/**
+ * Internal alias for "any class constructor" used as a Map/Set key throughout
+ * ActiveRecord internals (Suppressor, NoTouching, Delegation). Centralized to
+ * keep the four duplicate declarations in sync.
+ *
+ * @internal
+ */
+export type AnyClass = abstract new (...args: any[]) => any;

--- a/packages/activerecord/src/no-touching.ts
+++ b/packages/activerecord/src/no-touching.ts
@@ -4,7 +4,7 @@
  * Mirrors: ActiveRecord::NoTouching
  */
 
-type AnyClass = abstract new (...args: any[]) => any;
+import type { AnyClass } from "./internal/any-class.js";
 
 const _noTouchingDepth = new Map<AnyClass, number>();
 

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1800,6 +1800,18 @@ export function reflections(
   return normalizedReflections(modelClass);
 }
 
+/**
+ * Minimal shape of values stored in `Base._reflections`. They are always
+ * `AssociationReflection | ThroughReflection`, but `normalizedReflections`
+ * only consumes the `name` and `parentReflection` fields — captured here so
+ * the lookup loop stays free of `as any` casts.
+ *
+ * @internal
+ */
+type RawReflection = (AssociationReflection | ThroughReflection) & {
+  readonly parentReflection?: AssociationReflection | ThroughReflection | null;
+};
+
 const _normalizedReflectionsCache = new WeakMap<
   typeof Base,
   Readonly<Record<string, AssociationReflection | ThroughReflection>>
@@ -1811,10 +1823,10 @@ export function normalizedReflections(
   const cached = _normalizedReflectionsCache.get(modelClass);
   if (cached) return cached;
 
-  const rawReflections: Record<string, unknown> = (modelClass as any)._reflections ?? {};
-  const result: Record<string, unknown> = {};
-  for (const [name, rawRef] of Object.entries(rawReflections)) {
-    const ref = rawRef as any;
+  const rawReflections: Record<string, RawReflection> =
+    (modelClass as { _reflections?: Record<string, RawReflection> })._reflections ?? {};
+  const result: Record<string, AssociationReflection | ThroughReflection> = {};
+  for (const [name, ref] of Object.entries(rawReflections)) {
     const parent = ref.parentReflection;
     if (parent) {
       result[parent.name] = parent;

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -11,14 +11,15 @@
 
 import type { Base } from "../base.js";
 import { Delegation as ASDelegation } from "@blazetrails/activesupport";
+import type { AnyClass } from "../internal/any-class.js";
+
+type AnyCallable = (...args: any[]) => any;
 
 /**
  * The Delegation module interface.
  *
  * Mirrors: ActiveRecord::Delegation
  */
-type AnyClass = abstract new (...args: any[]) => any;
-type AnyCallable = (...args: any[]) => any;
 
 export interface Delegation {
   delegatedClasses: Set<AnyClass>;

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -7,6 +7,7 @@
 
 import { getAsyncContext } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
+import type { AnyClass } from "./internal/any-class.js";
 
 /**
  * The suppressor registry: a map from class name → `true` when that
@@ -61,8 +62,6 @@ export function registry(): Record<string, true | undefined> {
  *
  * Mirrors: ActiveRecord::Suppressor.suppress
  */
-type AnyClass = abstract new (...args: any[]) => any;
-
 export async function suppress<R>(modelClass: AnyClass, fn: () => R | Promise<R>): Promise<R> {
   const name = modelClass.name;
   if (!name) {


### PR DESCRIPTION
## Summary

Batch 18 — Reflection fidelity sweep. Most items in the bundle turned out
to be audit-only no-ops; the remaining concrete cleanups are:

- Centralize the duplicated `AnyClass = abstract new (...args: any[]) => any`
  declaration (no-touching, suppressor, relation/delegation,
  attribute-methods/composite-primary-key) into a single
  `internal/any-class.ts` alias.
- Define an internal `RawReflection` type for values stored in
  `Base._reflections` so `normalizedReflections` no longer needs
  `rawRef as any`.

## Batch 18 audit notes (no-ops)

- **`createReflection` residual cleanup** — Already deleted in a prior PR;
  no match in `reflection.ts` today.
- **Sweep C `isPolymorphic` for `options.as`** — Rails `polymorphic?`
  (reflection.rb:721) returns only `options[:polymorphic]`. The existing
  `!!options.polymorphic` is the faithful mirror; re-applying the Sweep C
  attempt would re-break `HasOneAssociationPolymorphicThroughError`.
- **B21 array `primaryKey` in `deriveFkQueryConstraints`** — Rails'
  `primary_query_constraints.include?(owner_pk)` with array `owner_pk`
  hits Array#include? element-equality and returns false, so Rails throws
  the same `ArgumentError`. Our `ConfigurationError` matches Rails — no
  divergence to fix.
- **`_throughOwnerCols` `options.queryConstraints` branch** — reachable
  via the `Array.isArray(opts.foreignKey)` rewrite at reflection.ts:512
  (foreignKey arrays are promoted into `options.queryConstraints`); not
  dead.

## Test plan

- [x] `vitest run packages/activerecord/src/reflection.test.ts packages/activerecord/src/suppressor.test.ts` — green
- [x] `pnpm --filter activerecord tsc --noEmit` shows no new errors in touched files