### PR TITLE
test(activerecord): sharpen BLOCKED tags in adapter.test.ts

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -2,371 +2,231 @@ import { describe, it } from "vitest";
 
 describe("AdapterTest", () => {
   it.skip("update prepared statement", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs Book model + integration DB to round-trip null bytes through prepared statements
   });
   it.skip("create record with pk as zero", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs Book model + Book.find(0)/Book.destroy(0) integration round-trip
   });
   it.skip("valid column", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: schema — adapter#validType?(type) not implemented (iterates nativeDatabaseTypes keys)
   });
   it.skip("invalid column", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: schema — adapter#validType?(type) not implemented (must return false for unknown types)
   });
   it.skip("table exists?", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs accounts table from test schema for adapter#tableExists round-trip
   });
   it.skip("data sources", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs accounts/authors/tasks/topics fixtures for adapter#dataSources iteration
   });
   it.skip("indexes", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs accounts table; exercises addIndex/indexes/removeIndex round-trip
   });
   it.skip("returns empty indexes for non existing table", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: schema — adapter#indexes("nonexistingtable") must return [] rather than throw
   });
   it.skip("remove index when name and wrong column name specified", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: schema — removeIndex must raise ArgumentError when name + wrong column specified
   });
   it.skip("remove index when name and wrong column name specified positional argument", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: schema — removeIndex positional column form must raise ArgumentError on mismatch
   });
   it.skip("#exec_query queries with no result set return an empty ActiveRecord::Result", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs subscribers table for INSERT round-trip via execQuery
   });
   it.skip("#exec_query queries with an empty result set still return the columns", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs subscribers table for SELECT-with-empty-result column metadata
   });
   it.skip("charset", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: adapter-mysql — MySQL/Trilogy-only test; charset/show_variable wiring
   });
   it.skip("show nonexistent variable returns nil", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: adapter-mysql — MySQL/Trilogy-only test; showVariable("foo_bar_baz") returns null
   });
   it.skip("not specifying database name for cross database selects", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: adapter-mysql — MySQL/Trilogy-only test; cross-DB select via configurations
   });
   it.skip("disable prepared statements", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — ActiveRecord.disable_prepared_statements config + establishConnection wiring
   });
   it.skip("table alias", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: schema — Ruby per-instance method override (def @connection.test_table_alias_length) has no TS equivalent
   });
   it.skip("uniqueness violations are translated to specific exception", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs subscribers table; exercises RecordNotUnique translation from raw INSERT
   });
   it.skip("not null violations are translated to specific exception", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs Post model; exercises NotNullViolation translation
   });
   it.skip("value limit violations are translated to specific exception", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs Event model with limited title column; ValueTooLong translation
   });
   it.skip("numeric value out of ranges are translated to specific exception", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs Book model; RangeError translation on out-of-range bigint
   });
   it.skip("exceptions from notifications are not translated", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs posts table + ActiveSupport::Notifications.subscribe equivalent
   });
   it.skip("database related exceptions are translated to statement invalid", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: schema — adapter#execute must translate raw-SQL parse errors into StatementInvalid
   });
   it.skip("select all always return activerecord result", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs posts table; exercises selectAll returning Result instance
   });
   it.skip("select all insert update delete with casted binds", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs Event model + Arel::Nodes::BindParam round-trip through insert/update/delete/selectAll
   });
   it.skip("select all insert update delete with binds", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs Event model + Relation::QueryAttribute bind through insert/update/delete/selectAll
   });
   it.skip("select methods passing a association relation", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs Author/Post fixtures + association relation passed to selectOne/All/Value/Values
   });
   it.skip("select methods passing a relation", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs Post fixture + relation passed to selectOne/All/Value/Values
   });
   it.skip("type_to_sql returns a String for unmapped types", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: schema — sqlite3 typeToSql uppercases unknown types; Rails preserves the original symbol-as-string
   });
   it.skip("current database", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: adapter-mysql — currentDatabase only on MySQL/PG adapters; SQLite branch skips
   });
 });
 
 describe("AdapterForeignKeyTest", () => {
   it.skip("disable referential integrity", async () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs fk_test_has_pk/has_fk tables for disableReferentialIntegrity block
   });
   it.skip("foreign key violations are translated to specific exception with validate false", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs fk_test_has_fk table; InvalidForeignKey translation on save(validate: false)
   });
   it.skip("foreign key violations on insert are translated to specific exception", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs fk_test_has_fk table; InvalidForeignKey translation on raw INSERT
   });
   it.skip("foreign key violations on delete are translated to specific exception", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs fk_test_has_pk table; InvalidForeignKey translation on raw DELETE
   });
 });
 
 describe("AdapterTestWithoutTransaction", () => {
   it.skip("create with query cache", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: query-cache — needs Post fixture + enableQueryCache!/create round-trip with cache invalidation
   });
   it.skip("truncate", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: fixture — needs posts fixture + adapter#truncate("posts") integration
   });
   it.skip("truncate with query cache", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: query-cache — truncate must invalidate query cache after enableQueryCache!
   });
   it.skip("truncate tables with query cache", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: query-cache — truncateTables must invalidate query cache across multiple tables
   });
   it.skip("reset empty table with custom pk", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: adapter-pg — resetPkSequence! is PG-only; needs Movie fixture
   });
   it.skip("reset table with non integer pk", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: adapter-pg — resetPkSequence! is PG-only; needs Subscriber (nick PK) fixture
   });
 });
 
 describe("AdapterConnectionTest", () => {
   it.skip("reconnect after a disconnect", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — adapter#disconnect!/reconnect!/active? lifecycle wiring
   });
   it.skip("materialized transaction state is reset after a reconnect", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — materializeTransactions + reconnect! must reset open-transaction state
   });
   it.skip("materialized transaction state can be restored after a reconnect", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — reconnect!(restoreTransactions: true) option not implemented
   });
   it.skip("materialized transaction state is reset after a disconnect", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — disconnect! must clear materialized transaction state
   });
   it.skip("unmaterialized transaction state is reset after a reconnect", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — unmaterialized (lazy) transaction reset after reconnect!
   });
   it.skip("unmaterialized transaction state can be restored after a reconnect", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — reconnect!(restoreTransactions: true) for unmaterialized state
   });
   it.skip("unmaterialized transaction state is reset after a disconnect", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — disconnect! must clear unmaterialized transaction state
   });
   it.skip("active? detects remote disconnection", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — adapter#active? must detect remote disconnection (MySQL/PG-only test)
   });
   it.skip("verify! restores after remote disconnection", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — adapter#verify! reconnect-on-failure path
   });
   it.skip("reconnect! restores after remote disconnection", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — adapter#reconnect! after remote disconnect
   });
   it.skip("querying a 'clean' long-failed connection restores and succeeds", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — clean! + last_activity backdating + auto-verify-before-query
   });
   it.skip("querying a 'clean' recently-used but now-failed connection skips verification", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — clean! must skip verify on recently-used connection; surface AdapterError
   });
   it.skip("quoting a string on a 'clean' failed connection will not prevent reconnecting", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — quoteString must not verify; subsequent query reconnects
   });
   it.skip("querying after a failed non-retryable query restores and succeeds", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — non-retryable execute raises ConnectionFailed; next idempotent query reconnects
   });
   it.skip("idempotent SELECT queries are retried and result in a reconnect", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — idempotent SELECT auto-retry on ConnectionFailed
   });
   it.skip("#find and #find_by queries with known attributes are retried and result in a reconnect", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — find/findBy with known attrs marked retryable on ConnectionFailed
   });
   it.skip("queries containing SQL fragments are not retried", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — raw-SQL where/select/find_by must NOT be marked retryable
   });
   it.skip("queries containing SQL functions are not retried", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — Arel NamedFunction in WHERE must NOT be marked retryable
   });
   it.skip("transaction restores after remote disconnection", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — outer transaction must reconnect when raw connection died pre-open
   });
   it.skip("active transaction is restored after remote disconnection", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — materializeTransactions + remote disconnect + verify! within outer transaction
   });
   it.skip("dirty transaction cannot be restored after remote disconnection", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — dirty (post-write) transaction must raise ConnectionFailed and not retry block
   });
   it.skip("can reconnect and retry queries under limit when retry deadline is set", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — withRawConnection allowRetry + retryDeadline knob not implemented
   });
   it.skip("does not reconnect and retry queries when retries are disabled", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — withRawConnection default (allowRetry: false) must surface ConnectionFailed
   });
   it.skip("does not reconnect and retry queries that exceed retry deadline", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — retryDeadline expiration must surface ConnectionFailed
   });
   it.skip("#execute is retryable", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — adapter#execute with allowRetry: true must reconnect on remote kill
   });
   it.skip("disconnect and recover on #configure_connection failure", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: connection-pool — configureConnection failure recovery via pool.new_connection
   });
 });
 
 describe("AdapterThreadSafetyTest", () => {
   it.skip("#active? is synchronized", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: GVL — Ruby Thread.new/Thread.pass concurrency test; no JS thread equivalent
   });
   it.skip("#verify! is synchronized", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: GVL — Ruby Thread.new/Thread.pass concurrency test; no JS thread equivalent
   });
 });
 
 describe("AdvisoryLocksEnabledTest", () => {
   it.skip("advisory locks enabled?", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: adapter-pg — advisoryLocksEnabled? + establishConnection(advisory_locks:) is PG-only
   });
 });
 
 describe("InvalidateTransactionTest", () => {
   it.skip("invalidates transaction on rollback error", () => {
-    // BLOCKED: schema — abstract adapter schema introspection / query execution gap
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableExists/indexes/dataSources or abstract-adapter.ts#execQuery not fully implemented
-    // SCOPE: ~100 LOC across abstract/schema-statements.ts + abstract-adapter.ts; affects ~70 tests in adapter.test.ts
+    // BLOCKED: transactions — currentTransaction#invalidated? after Deadlocked inside withRawConnection
   });
 });

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -78,7 +78,7 @@ describe("AdapterTest", () => {
   });
   it.skip("disable prepared statements", () => {
     // BLOCKED: connection-pool
-    // ROOT-CAUSE: core/configurations: ActiveRecord.disablePreparedStatements global + establishConnection(prepared_statements:) merge not wired
+    // ROOT-CAUSE: core.ts#preparedStatements + connection-handling.ts#establishConnection: global ActiveRecord.disablePreparedStatements override of per-config prepared_statements:true not wired
     // SCOPE: ~25 LOC; affects ~1 test
   });
   it.skip("table alias", () => {
@@ -148,7 +148,7 @@ describe("AdapterTest", () => {
   });
   it.skip("current database", () => {
     // BLOCKED: adapter-mysql
-    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts#currentDatabase + postgresql-adapter.ts#currentDatabase: needs MySQL/PG test context (Rails respond_to? gate skips on SQLite) + ARTest.test_configuration_hashes wiring
+    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts#currentDatabase + postgresql-adapter.ts#currentDatabase: needs MySQL/PG test context (Rails respond_to? gate skips on SQLite); test-adapter.ts only exposes PG_TEST_URL/MYSQL_TEST_URL env, no per-config "database" name lookup
     // SCOPE: ~15 LOC port; affects ~1 test
   });
 });
@@ -344,14 +344,10 @@ describe("AdapterConnectionTest", () => {
 
 describe("AdapterThreadSafetyTest", () => {
   it.skip("#active? is synchronized", () => {
-    // BLOCKED: GVL
-    // ROOT-CAUSE: Ruby Thread.new/Thread.pass concurrency test; no JS thread equivalent — likely permanent
-    // SCOPE: candidate for unported-files.ts; affects ~2 tests
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — gvl
   });
   it.skip("#verify! is synchronized", () => {
-    // BLOCKED: GVL
-    // ROOT-CAUSE: Ruby Thread.new/Thread.pass concurrency test; no JS thread equivalent — likely permanent
-    // SCOPE: candidate for unported-files.ts; affects ~2 tests
+    // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — gvl
   });
 });
 

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -2,231 +2,371 @@ import { describe, it } from "vitest";
 
 describe("AdapterTest", () => {
   it.skip("update prepared statement", () => {
-    // BLOCKED: fixture — needs Book model + integration DB to round-trip null bytes through prepared statements
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures/books.ts: no Book model + integration round-trip for null bytes through prepared statements
+    // SCOPE: ~30 LOC port + Book fixture; affects ~1 test
   });
   it.skip("create record with pk as zero", () => {
-    // BLOCKED: fixture — needs Book model + Book.find(0)/Book.destroy(0) integration round-trip
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures/books.ts: needs Book.find(0)/Book.destroy(0) integration round-trip
+    // SCOPE: ~20 LOC port; affects ~1 test
   });
   it.skip("valid column", () => {
-    // BLOCKED: schema — adapter#validType?(type) not implemented (iterates nativeDatabaseTypes keys)
+    // BLOCKED: schema
+    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts: validType?(type) not implemented (must iterate nativeDatabaseTypes keys)
+    // SCOPE: ~10 LOC + nativeDatabaseTypes fix; affects ~2 tests
   });
   it.skip("invalid column", () => {
-    // BLOCKED: schema — adapter#validType?(type) not implemented (must return false for unknown types)
+    // BLOCKED: schema
+    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts: validType?(type) not implemented (must return false for unknown types)
+    // SCOPE: ~10 LOC; affects ~2 tests
   });
   it.skip("table exists?", () => {
-    // BLOCKED: fixture — needs accounts table from test schema for adapter#tableExists round-trip
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs accounts table for tableExists round-trip across coercions
+    // SCOPE: ~15 LOC port; affects ~1 test
   });
   it.skip("data sources", () => {
-    // BLOCKED: fixture — needs accounts/authors/tasks/topics fixtures for adapter#dataSources iteration
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs accounts/authors/tasks/topics fixtures for dataSources enumeration
+    // SCOPE: ~10 LOC port; affects ~2 tests
   });
   it.skip("indexes", () => {
-    // BLOCKED: fixture — needs accounts table; exercises addIndex/indexes/removeIndex round-trip
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs accounts table for addIndex/indexes/removeIndex round-trip
+    // SCOPE: ~25 LOC port; affects ~3 tests
   });
   it.skip("returns empty indexes for non existing table", () => {
-    // BLOCKED: schema — adapter#indexes("nonexistingtable") must return [] rather than throw
+    // BLOCKED: schema
+    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#indexes: must return [] for unknown tables rather than throw
+    // SCOPE: ~5 LOC; affects ~1 test
   });
   it.skip("remove index when name and wrong column name specified", () => {
-    // BLOCKED: schema — removeIndex must raise ArgumentError when name + wrong column specified
+    // BLOCKED: schema
+    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#removeIndex: must raise ArgumentError on name + wrong-column mismatch
+    // SCOPE: ~15 LOC + fixture; affects ~2 tests
   });
   it.skip("remove index when name and wrong column name specified positional argument", () => {
-    // BLOCKED: schema — removeIndex positional column form must raise ArgumentError on mismatch
+    // BLOCKED: schema
+    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#removeIndex: positional column form must raise ArgumentError on mismatch
+    // SCOPE: ~15 LOC + fixture; affects ~2 tests
   });
   it.skip("#exec_query queries with no result set return an empty ActiveRecord::Result", () => {
-    // BLOCKED: fixture — needs subscribers table for INSERT round-trip via execQuery
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs subscribers table for execQuery INSERT round-trip + empty-result assertions
+    // SCOPE: ~15 LOC port; affects ~2 tests
   });
   it.skip("#exec_query queries with an empty result set still return the columns", () => {
-    // BLOCKED: fixture — needs subscribers table for SELECT-with-empty-result column metadata
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs subscribers table for SELECT-with-empty-result column-metadata assertion
+    // SCOPE: ~15 LOC port; affects ~2 tests
   });
   it.skip("charset", () => {
-    // BLOCKED: adapter-mysql — MySQL/Trilogy-only test; charset/show_variable wiring
+    // BLOCKED: adapter-mysql
+    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts#charset: MySQL/Trilogy-only; needs MYSQL_TEST_URL test context
+    // SCOPE: ~10 LOC port; affects ~3 tests
   });
   it.skip("show nonexistent variable returns nil", () => {
-    // BLOCKED: adapter-mysql — MySQL/Trilogy-only test; showVariable("foo_bar_baz") returns null
+    // BLOCKED: adapter-mysql
+    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts#showVariable: MySQL/Trilogy-only; needs MYSQL_TEST_URL test context
+    // SCOPE: ~5 LOC port; affects ~1 test
   });
   it.skip("not specifying database name for cross database selects", () => {
-    // BLOCKED: adapter-mysql — MySQL/Trilogy-only test; cross-DB select via configurations
+    // BLOCKED: adapter-mysql
+    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts: MySQL-only cross-DB select via establishConnection + configurations.configsFor
+    // SCOPE: ~25 LOC port + ARTest config wiring; affects ~1 test
   });
   it.skip("disable prepared statements", () => {
-    // BLOCKED: connection-pool — ActiveRecord.disable_prepared_statements config + establishConnection wiring
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: core/configurations: ActiveRecord.disablePreparedStatements global + establishConnection(prepared_statements:) merge not wired
+    // SCOPE: ~25 LOC; affects ~1 test
   });
   it.skip("table alias", () => {
-    // BLOCKED: schema — Ruby per-instance method override (def @connection.test_table_alias_length) has no TS equivalent
+    // BLOCKED: schema
+    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts#tableAliasFor: Ruby per-instance method override (def @connection.test_table_alias_length) has no TS equivalent; needs subclass-based port
+    // SCOPE: ~15 LOC port via TestAdapter subclass; affects ~1 test
   });
   it.skip("uniqueness violations are translated to specific exception", () => {
-    // BLOCKED: fixture — needs subscribers table; exercises RecordNotUnique translation from raw INSERT
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs subscribers table; exercises RecordNotUnique translation from raw INSERT
+    // SCOPE: ~15 LOC port; affects ~1 test
   });
   it.skip("not null violations are translated to specific exception", () => {
-    // BLOCKED: fixture — needs Post model; exercises NotNullViolation translation
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs Post model with NOT NULL constraints for NotNullViolation translation
+    // SCOPE: ~10 LOC port; affects ~1 test
   });
   it.skip("value limit violations are translated to specific exception", () => {
-    // BLOCKED: fixture — needs Event model with limited title column; ValueTooLong translation
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs Event model with limited title column for ValueTooLong translation (non-SQLite only)
+    // SCOPE: ~10 LOC port + Event fixture; affects ~1 test
   });
   it.skip("numeric value out of ranges are translated to specific exception", () => {
-    // BLOCKED: fixture — needs Book model; RangeError translation on out-of-range bigint
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs Book model; exercises RangeError translation on out-of-range bigint (non-SQLite only)
+    // SCOPE: ~10 LOC port; affects ~1 test
   });
   it.skip("exceptions from notifications are not translated", () => {
-    // BLOCKED: fixture — needs posts table + ActiveSupport::Notifications.subscribe equivalent
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs posts table + ActiveSupport::Notifications.subscribe equivalent for sql.active_record event
+    // SCOPE: ~20 LOC port; affects ~1 test
   });
   it.skip("database related exceptions are translated to statement invalid", () => {
-    // BLOCKED: schema — adapter#execute must translate raw-SQL parse errors into StatementInvalid
+    // BLOCKED: schema
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#execute: must translate raw-SQL parse errors into StatementInvalid
+    // SCOPE: ~10 LOC + error-translator wiring; affects ~1 test
   });
   it.skip("select all always return activerecord result", () => {
-    // BLOCKED: fixture — needs posts table; exercises selectAll returning Result instance
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs posts table; exercises selectAll returning Result instance
+    // SCOPE: ~10 LOC port; affects ~1 test
   });
   it.skip("select all insert update delete with casted binds", () => {
-    // BLOCKED: fixture — needs Event model + Arel::Nodes::BindParam round-trip through insert/update/delete/selectAll
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs Event model + Arel::Nodes::BindParam round-trip through insert/update/delete/selectAll
+    // SCOPE: ~30 LOC port; affects ~2 tests
   });
   it.skip("select all insert update delete with binds", () => {
-    // BLOCKED: fixture — needs Event model + Relation::QueryAttribute bind through insert/update/delete/selectAll
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs Event model + Relation::QueryAttribute bind through insert/update/delete/selectAll
+    // SCOPE: ~30 LOC port; affects ~2 tests
   });
   it.skip("select methods passing a association relation", () => {
-    // BLOCKED: fixture — needs Author/Post fixtures + association relation passed to selectOne/All/Value/Values
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs Author/Post fixtures + association relation passed to selectOne/All/Value/Values
+    // SCOPE: ~20 LOC port; affects ~2 tests
   });
   it.skip("select methods passing a relation", () => {
-    // BLOCKED: fixture — needs Post fixture + relation passed to selectOne/All/Value/Values
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs Post fixture + relation passed to selectOne/All/Value/Values
+    // SCOPE: ~20 LOC port; affects ~2 tests
   });
   it.skip("type_to_sql returns a String for unmapped types", () => {
-    // BLOCKED: schema — sqlite3 typeToSql uppercases unknown types; Rails preserves the original symbol-as-string
+    // BLOCKED: schema
+    // ROOT-CAUSE: connection-adapters/abstract/schema-creation.ts#typeToSql default branch uppercases unknown types; Rails preserves the original symbol-as-string
+    // SCOPE: ~5 LOC fix in default branch; affects ~1 test
   });
   it.skip("current database", () => {
-    // BLOCKED: fixture — needs MySQL/PG adapter context (Rails skips on adapters without currentDatabase) + ARTest configurations wiring
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers: needs MySQL/PG adapter context (Rails skips on adapters without currentDatabase) + ARTest.test_configuration_hashes wiring
+    // SCOPE: ~15 LOC port; affects ~1 test
   });
 });
 
 describe("AdapterForeignKeyTest", () => {
   it.skip("disable referential integrity", async () => {
-    // BLOCKED: fixture — needs fk_test_has_pk/has_fk tables for disableReferentialIntegrity block
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs fk_test_has_pk/has_fk tables for disableReferentialIntegrity block
+    // SCOPE: ~20 LOC port + fk_test fixtures; affects ~4 tests
   });
   it.skip("foreign key violations are translated to specific exception with validate false", () => {
-    // BLOCKED: fixture — needs fk_test_has_fk table; InvalidForeignKey translation on save(validate: false)
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs fk_test_has_fk table; InvalidForeignKey translation on save(validate: false)
+    // SCOPE: ~15 LOC port; affects ~4 tests
   });
   it.skip("foreign key violations on insert are translated to specific exception", () => {
-    // BLOCKED: fixture — needs fk_test_has_fk table; InvalidForeignKey translation on raw INSERT
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs fk_test_has_fk table; InvalidForeignKey translation on raw INSERT
+    // SCOPE: ~15 LOC port; affects ~4 tests
   });
   it.skip("foreign key violations on delete are translated to specific exception", () => {
-    // BLOCKED: fixture — needs fk_test_has_pk table; InvalidForeignKey translation on raw DELETE
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs fk_test_has_pk table; InvalidForeignKey translation on raw DELETE
+    // SCOPE: ~15 LOC port; affects ~4 tests
   });
 });
 
 describe("AdapterTestWithoutTransaction", () => {
   it.skip("create with query cache", () => {
-    // BLOCKED: query-cache — needs Post fixture + enableQueryCache!/create round-trip with cache invalidation
+    // BLOCKED: query-cache
+    // ROOT-CAUSE: connection-adapters/abstract/query-cache.ts: enableQueryCache!/create cache-invalidation interplay
+    // SCOPE: ~20 LOC + posts fixture; affects ~3 tests
   });
   it.skip("truncate", () => {
-    // BLOCKED: fixture — needs posts fixture + adapter#truncate("posts") integration
+    // BLOCKED: fixture
+    // ROOT-CAUSE: test-helpers/fixtures: needs posts fixture for adapter#truncate("posts") integration
+    // SCOPE: ~15 LOC port; affects ~1 test
   });
   it.skip("truncate with query cache", () => {
-    // BLOCKED: query-cache — truncate must invalidate query cache after enableQueryCache!
+    // BLOCKED: query-cache
+    // ROOT-CAUSE: connection-adapters/abstract/query-cache.ts: truncate must invalidate query cache after enableQueryCache!
+    // SCOPE: ~15 LOC + posts fixture; affects ~3 tests
   });
   it.skip("truncate tables with query cache", () => {
-    // BLOCKED: query-cache — truncateTables must invalidate query cache across multiple tables
+    // BLOCKED: query-cache
+    // ROOT-CAUSE: connection-adapters/abstract/query-cache.ts: truncateTables must invalidate query cache across multiple tables
+    // SCOPE: ~15 LOC + posts/authors/author_addresses fixtures; affects ~3 tests
   });
   it.skip("reset empty table with custom pk", () => {
-    // BLOCKED: adapter-pg — resetPkSequence! is PG-only; needs Movie fixture
+    // BLOCKED: adapter-pg
+    // ROOT-CAUSE: connection-adapters/postgresql-adapter.ts#resetPkSequence!: PG-only; needs Movie fixture
+    // SCOPE: ~15 LOC port + Movie fixture; affects ~2 tests
   });
   it.skip("reset table with non integer pk", () => {
-    // BLOCKED: adapter-pg — resetPkSequence! is PG-only; needs Subscriber (nick PK) fixture
+    // BLOCKED: adapter-pg
+    // ROOT-CAUSE: connection-adapters/postgresql-adapter.ts#resetPkSequence!: PG-only; needs Subscriber (nick PK) fixture
+    // SCOPE: ~15 LOC port + Subscriber fixture; affects ~2 tests
   });
 });
 
 describe("AdapterConnectionTest", () => {
   it.skip("reconnect after a disconnect", () => {
-    // BLOCKED: connection-pool — adapter#disconnect!/reconnect!/active? lifecycle wiring
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts: disconnect!/reconnect!/active? lifecycle wiring
+    // SCOPE: ~20 LOC; affects ~17 tests
   });
   it.skip("materialized transaction state is reset after a reconnect", () => {
-    // BLOCKED: transactions — materializeTransactions + reconnect! must reset open-transaction state
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract/transaction.ts: materializeTransactions + reconnect! must reset open-transaction state
+    // SCOPE: ~25 LOC; affects ~7 tests
   });
   it.skip("materialized transaction state can be restored after a reconnect", () => {
-    // BLOCKED: transactions — reconnect!(restoreTransactions: true) option not implemented
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#reconnect!: restoreTransactions: true option not implemented
+    // SCOPE: ~25 LOC; affects ~2 tests
   });
   it.skip("materialized transaction state is reset after a disconnect", () => {
-    // BLOCKED: transactions — disconnect! must clear materialized transaction state
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#disconnect!: must clear materialized transaction state
+    // SCOPE: ~15 LOC; affects ~7 tests
   });
   it.skip("unmaterialized transaction state is reset after a reconnect", () => {
-    // BLOCKED: transactions — unmaterialized (lazy) transaction reset after reconnect!
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract/transaction.ts: unmaterialized (lazy) transaction reset after reconnect!
+    // SCOPE: ~15 LOC; affects ~7 tests
   });
   it.skip("unmaterialized transaction state can be restored after a reconnect", () => {
-    // BLOCKED: transactions — reconnect!(restoreTransactions: true) for unmaterialized state
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#reconnect!: restoreTransactions: true for unmaterialized state
+    // SCOPE: ~15 LOC; affects ~2 tests
   });
   it.skip("unmaterialized transaction state is reset after a disconnect", () => {
-    // BLOCKED: transactions — disconnect! must clear unmaterialized transaction state
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#disconnect!: must clear unmaterialized transaction state
+    // SCOPE: ~10 LOC; affects ~7 tests
   });
   it.skip("active? detects remote disconnection", () => {
-    // BLOCKED: connection-pool — adapter#active? must detect remote disconnection (MySQL/PG-only test)
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#active?: must detect remote disconnection (MySQL/PG-only test)
+    // SCOPE: ~15 LOC; affects ~17 tests
   });
   it.skip("verify! restores after remote disconnection", () => {
-    // BLOCKED: connection-pool — adapter#verify! reconnect-on-failure path
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#verify!: reconnect-on-failure path
+    // SCOPE: ~15 LOC; affects ~17 tests
   });
   it.skip("reconnect! restores after remote disconnection", () => {
-    // BLOCKED: connection-pool — adapter#reconnect! after remote disconnect
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#reconnect!: after remote disconnect path
+    // SCOPE: ~10 LOC; affects ~17 tests
   });
   it.skip("querying a 'clean' long-failed connection restores and succeeds", () => {
-    // BLOCKED: connection-pool — clean! + last_activity backdating + auto-verify-before-query
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts: clean! + @last_activity backdating + auto-verify-before-query not implemented
+    // SCOPE: ~30 LOC; affects ~3 tests
   });
   it.skip("querying a 'clean' recently-used but now-failed connection skips verification", () => {
-    // BLOCKED: connection-pool — clean! must skip verify on recently-used connection; surface AdapterError
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#clean!: must skip verify on recently-used connection; surface AdapterError
+    // SCOPE: ~20 LOC; affects ~3 tests
   });
   it.skip("quoting a string on a 'clean' failed connection will not prevent reconnecting", () => {
-    // BLOCKED: connection-pool — quoteString must not verify; subsequent query reconnects
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#quoteString: must not verify; subsequent query reconnects
+    // SCOPE: ~15 LOC; affects ~3 tests
   });
   it.skip("querying after a failed non-retryable query restores and succeeds", () => {
-    // BLOCKED: connection-pool — non-retryable execute raises ConnectionFailed; next idempotent query reconnects
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts: non-retryable execute raises ConnectionFailed; next idempotent query reconnects
+    // SCOPE: ~20 LOC; affects ~5 tests
   });
   it.skip("idempotent SELECT queries are retried and result in a reconnect", () => {
-    // BLOCKED: connection-pool — idempotent SELECT auto-retry on ConnectionFailed
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts: idempotent SELECT auto-retry on ConnectionFailed not implemented
+    // SCOPE: ~25 LOC; affects ~5 tests
   });
   it.skip("#find and #find_by queries with known attributes are retried and result in a reconnect", () => {
-    // BLOCKED: connection-pool — find/findBy with known attrs marked retryable on ConnectionFailed
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: relation/finder-methods.ts: find/findBy with known attrs marked retryable on ConnectionFailed
+    // SCOPE: ~15 LOC; affects ~5 tests
   });
   it.skip("queries containing SQL fragments are not retried", () => {
-    // BLOCKED: connection-pool — raw-SQL where/select/find_by must NOT be marked retryable
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: relation/query-methods.ts: raw-SQL where/select/find_by must NOT be marked retryable
+    // SCOPE: ~15 LOC; affects ~5 tests
   });
   it.skip("queries containing SQL functions are not retried", () => {
-    // BLOCKED: connection-pool — Arel NamedFunction in WHERE must NOT be marked retryable
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: relation/query-methods.ts: Arel NamedFunction in WHERE must NOT be marked retryable
+    // SCOPE: ~10 LOC; affects ~5 tests
   });
   it.skip("transaction restores after remote disconnection", () => {
-    // BLOCKED: transactions — outer transaction must reconnect when raw connection died pre-open
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract/transaction.ts: outer transaction must reconnect when raw connection died pre-open
+    // SCOPE: ~20 LOC; affects ~3 tests
   });
   it.skip("active transaction is restored after remote disconnection", () => {
-    // BLOCKED: transactions — materializeTransactions + remote disconnect + verify! within outer transaction
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract/transaction.ts: materializeTransactions + remote disconnect + verify! within outer transaction
+    // SCOPE: ~25 LOC; affects ~3 tests
   });
   it.skip("dirty transaction cannot be restored after remote disconnection", () => {
-    // BLOCKED: transactions — dirty (post-write) transaction must raise ConnectionFailed and not retry block
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract/transaction.ts: dirty (post-write) transaction must raise ConnectionFailed and not retry block
+    // SCOPE: ~20 LOC; affects ~3 tests
   });
   it.skip("can reconnect and retry queries under limit when retry deadline is set", () => {
-    // BLOCKED: connection-pool — withRawConnection allowRetry + retryDeadline knob not implemented
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#withRawConnection: allowRetry + retryDeadline knob not implemented
+    // SCOPE: ~25 LOC; affects ~3 tests
   });
   it.skip("does not reconnect and retry queries when retries are disabled", () => {
-    // BLOCKED: connection-pool — withRawConnection default (allowRetry: false) must surface ConnectionFailed
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#withRawConnection: default (allowRetry: false) must surface ConnectionFailed
+    // SCOPE: ~10 LOC; affects ~3 tests
   });
   it.skip("does not reconnect and retry queries that exceed retry deadline", () => {
-    // BLOCKED: connection-pool — retryDeadline expiration must surface ConnectionFailed
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#withRawConnection: retryDeadline expiration must surface ConnectionFailed
+    // SCOPE: ~15 LOC; affects ~3 tests
   });
   it.skip("#execute is retryable", () => {
-    // BLOCKED: connection-pool — adapter#execute with allowRetry: true must reconnect on remote kill
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#execute: allowRetry: true must reconnect on remote kill
+    // SCOPE: ~20 LOC; affects ~5 tests
   });
   it.skip("disconnect and recover on #configure_connection failure", () => {
-    // BLOCKED: connection-pool — configureConnection failure recovery via pool.new_connection
+    // BLOCKED: connection-pool
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#configureConnection: failure recovery via pool.new_connection
+    // SCOPE: ~25 LOC; affects ~1 test
   });
 });
 
 describe("AdapterThreadSafetyTest", () => {
   it.skip("#active? is synchronized", () => {
-    // BLOCKED: GVL — Ruby Thread.new/Thread.pass concurrency test; no JS thread equivalent
+    // BLOCKED: GVL
+    // ROOT-CAUSE: Ruby Thread.new/Thread.pass concurrency test; no JS thread equivalent — likely permanent
+    // SCOPE: candidate for unported-files.ts; affects ~2 tests
   });
   it.skip("#verify! is synchronized", () => {
-    // BLOCKED: GVL — Ruby Thread.new/Thread.pass concurrency test; no JS thread equivalent
+    // BLOCKED: GVL
+    // ROOT-CAUSE: Ruby Thread.new/Thread.pass concurrency test; no JS thread equivalent — likely permanent
+    // SCOPE: candidate for unported-files.ts; affects ~2 tests
   });
 });
 
 describe("AdvisoryLocksEnabledTest", () => {
   it.skip("advisory locks enabled?", () => {
-    // BLOCKED: adapter-pg — advisoryLocksEnabled? + establishConnection(advisory_locks:) is PG-only
+    // BLOCKED: adapter-pg
+    // ROOT-CAUSE: connection-adapters/postgresql-adapter.ts: advisoryLocksEnabled? + establishConnection(advisory_locks:) is PG-only
+    // SCOPE: ~15 LOC port; affects ~1 test
   });
 });
 
 describe("InvalidateTransactionTest", () => {
   it.skip("invalidates transaction on rollback error", () => {
-    // BLOCKED: transactions — currentTransaction#invalidated? after Deadlocked inside withRawConnection
+    // BLOCKED: transactions
+    // ROOT-CAUSE: connection-adapters/abstract/transaction.ts: currentTransaction#invalidated? after Deadlocked inside withRawConnection
+    // SCOPE: ~15 LOC; affects ~1 test
   });
 });

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -78,7 +78,7 @@ describe("AdapterTest", () => {
   });
   it.skip("disable prepared statements", () => {
     // BLOCKED: connection-pool
-    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#preparedStatements (getter/setter at L608) + connection-handling.ts#establishConnection: no global ActiveRecord.disablePreparedStatements toggle exists to override the per-config prepared_statements:true on (re-)establishConnection
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#preparedStatements getter/setter + connection-handling.ts#establishConnection: no global ActiveRecord.disablePreparedStatements toggle exists to override the per-config prepared_statements:true on (re-)establishConnection
     // SCOPE: ~25 LOC; affects ~1 test
   });
   it.skip("table alias", () => {

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -3,13 +3,13 @@ import { describe, it } from "vitest";
 describe("AdapterTest", () => {
   it.skip("update prepared statement", () => {
     // BLOCKED: fixture
-    // ROOT-CAUSE: test-helpers/fixtures/books.ts: no Book model + integration round-trip for null bytes through prepared statements
-    // SCOPE: ~30 LOC port + Book fixture; affects ~1 test
+    // ROOT-CAUSE: adapter.test.ts has no createTestAdapter/defineSchema setup; Book model (test-fixtures.ts) is defined but not wired here, and null-byte prepared-statement round-trip needs a live DB
+    // SCOPE: ~30 LOC port (Book wiring + setup); affects ~1 test
   });
   it.skip("create record with pk as zero", () => {
     // BLOCKED: fixture
-    // ROOT-CAUSE: test-helpers/fixtures/books.ts: needs Book.find(0)/Book.destroy(0) integration round-trip
-    // SCOPE: ~20 LOC port; affects ~1 test
+    // ROOT-CAUSE: adapter.test.ts has no createTestAdapter/defineSchema setup; Book (test-fixtures.ts) is defined but not wired here
+    // SCOPE: ~20 LOC port (Book wiring + setup); affects ~1 test
   });
   it.skip("valid column", () => {
     // BLOCKED: schema

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -13,12 +13,12 @@ describe("AdapterTest", () => {
   });
   it.skip("valid column", () => {
     // BLOCKED: schema
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts: validType?(type) not implemented (must iterate nativeDatabaseTypes keys)
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#isValidType: stub returns true for any non-empty string; must consult nativeDatabaseTypes()
     // SCOPE: ~10 LOC + nativeDatabaseTypes fix; affects ~2 tests
   });
   it.skip("invalid column", () => {
     // BLOCKED: schema
-    // ROOT-CAUSE: connection-adapters/abstract/schema-statements.ts: validType?(type) not implemented (must return false for unknown types)
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#isValidType: stub returns true for any non-empty string; must return false for types not in nativeDatabaseTypes()
     // SCOPE: ~10 LOC; affects ~2 tests
   });
   it.skip("table exists?", () => {
@@ -78,7 +78,7 @@ describe("AdapterTest", () => {
   });
   it.skip("disable prepared statements", () => {
     // BLOCKED: connection-pool
-    // ROOT-CAUSE: core.ts#preparedStatements + connection-handling.ts#establishConnection: global ActiveRecord.disablePreparedStatements override of per-config prepared_statements:true not wired
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#preparedStatements (getter/setter at L608) + connection-handling.ts#establishConnection: no global ActiveRecord.disablePreparedStatements toggle exists to override the per-config prepared_statements:true on (re-)establishConnection
     // SCOPE: ~25 LOC; affects ~1 test
   });
   it.skip("table alias", () => {
@@ -354,7 +354,7 @@ describe("AdapterThreadSafetyTest", () => {
 describe("AdvisoryLocksEnabledTest", () => {
   it.skip("advisory locks enabled?", () => {
     // BLOCKED: adapter-pg
-    // ROOT-CAUSE: connection-adapters/postgresql-adapter.ts: advisoryLocksEnabled? + establishConnection(advisory_locks:) is PG-only
+    // ROOT-CAUSE: connection-adapters/abstract-adapter.ts#isAdvisoryLocksEnabled (currently hardcoded false): PG override + establishConnection(advisory_locks:) config plumbing not wired
     // SCOPE: ~15 LOC port; affects ~1 test
   });
 });

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -147,8 +147,8 @@ describe("AdapterTest", () => {
     // SCOPE: ~5 LOC fix in default branch; affects ~1 test
   });
   it.skip("current database", () => {
-    // BLOCKED: fixture
-    // ROOT-CAUSE: test-helpers: needs MySQL/PG adapter context (Rails skips on adapters without currentDatabase) + ARTest.test_configuration_hashes wiring
+    // BLOCKED: adapter-mysql
+    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts#currentDatabase + postgresql-adapter.ts#currentDatabase: needs MySQL/PG test context (Rails respond_to? gate skips on SQLite) + ARTest.test_configuration_hashes wiring
     // SCOPE: ~15 LOC port; affects ~1 test
   });
 });

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -89,7 +89,7 @@ describe("AdapterTest", () => {
     // BLOCKED: schema — sqlite3 typeToSql uppercases unknown types; Rails preserves the original symbol-as-string
   });
   it.skip("current database", () => {
-    // BLOCKED: adapter-mysql — currentDatabase only on MySQL/PG adapters; SQLite branch skips
+    // BLOCKED: fixture — needs MySQL/PG adapter context (Rails skips on adapters without currentDatabase) + ARTest configurations wiring
   });
 });
 

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -169,6 +169,18 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "Tests class reloading via ActiveSupport::Dependencies / Zeitwerk in a forked process. " +
       "No Node.js equivalent; ES modules are cached for the process lifetime.",
   },
+  {
+    testFile: "adapter_test.rb",
+    className: "AdapterThreadSafetyTest",
+    tests: ["#active? is synchronized", "#verify! is synchronized"],
+    reason:
+      "AdapterThreadSafetyTest exercises Ruby Thread.new/Thread.pass concurrency " +
+      "on a single shared connection, asserting mutex-style serialization of " +
+      "#active?/#verify!/#disconnect! under the GVL. Node Worker threads use " +
+      "isolated heaps and structured-clone message passing, not the " +
+      "shared-memory Thread.new model this test relies on, so the GVL interleaving " +
+      "this test pins has no equivalent in our runtime target.",
+  },
   // --- Permanently not-portable: Rake tasks / dbconsole PTY ---
   {
     testFile: "adapters/postgresql/postgresql_rake_test.rb",
@@ -474,18 +486,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "test cares about (urlsafe encoding, no +/=/ chars) is covered by " +
       "packages/globalid/src/verifier.test.ts asserting char-class absence " +
       "rather than exact bytes.",
-  },
-  {
-    testFile: "adapter_test.rb",
-    className: "AdapterThreadSafetyTest",
-    tests: ["#active? is synchronized", "#verify! is synchronized"],
-    reason:
-      "AdapterThreadSafetyTest exercises Ruby Thread.new/Thread.pass concurrency " +
-      "on a single shared connection, asserting mutex-style serialization of " +
-      "#active?/#verify!/#disconnect! under the GVL. Node Worker threads use " +
-      "isolated heaps and structured-clone message passing, not the " +
-      "shared-memory Thread.new model this test relies on, so the GVL interleaving " +
-      "this test pins has no equivalent in our runtime target.",
   },
 ];
 

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -481,9 +481,10 @@ export const UNPORTED_FILES: UnportedFile[] = [
     reason:
       "AdapterThreadSafetyTest exercises Ruby Thread.new/Thread.pass concurrency " +
       "on a single shared connection, asserting mutex-style serialization of " +
-      "#active?/#verify!/#disconnect! under the GVL. JavaScript has no native " +
-      "threads — async/await on a single event-loop cannot reproduce the GVL " +
-      "interleaving that this test pins.",
+      "#active?/#verify!/#disconnect! under the GVL. Node Worker threads use " +
+      "isolated heaps and structured-clone message passing, not the shared- " +
+      "memory Thread.new model this test relies on, so the GVL interleaving " +
+      "this test pins has no equivalent in our runtime target.",
   },
 ];
 

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -483,8 +483,8 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "AdapterThreadSafetyTest exercises Ruby Thread.new/Thread.pass concurrency " +
       "on a single shared connection, asserting mutex-style serialization of " +
       "#active?/#verify!/#disconnect! under the GVL. Node Worker threads use " +
-      "isolated heaps and structured-clone message passing, not the shared- " +
-      "memory Thread.new model this test relies on, so the GVL interleaving " +
+      "isolated heaps and structured-clone message passing, not the " +
+      "shared-memory Thread.new model this test relies on, so the GVL interleaving " +
       "this test pins has no equivalent in our runtime target.",
   },
 ];

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -476,7 +476,8 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "rather than exact bytes.",
   },
   {
-    testFile: "adapter_test.rb",
+    testFile: "cases/adapter_test.rb",
+    className: "AdapterThreadSafetyTest",
     tests: ["#active? is synchronized", "#verify! is synchronized"],
     reason:
       "AdapterThreadSafetyTest exercises Ruby Thread.new/Thread.pass concurrency " +

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -475,6 +475,16 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "packages/globalid/src/verifier.test.ts asserting char-class absence " +
       "rather than exact bytes.",
   },
+  {
+    testFile: "adapter_test.rb",
+    tests: ["#active? is synchronized", "#verify! is synchronized"],
+    reason:
+      "AdapterThreadSafetyTest exercises Ruby Thread.new/Thread.pass concurrency " +
+      "on a single shared connection, asserting mutex-style serialization of " +
+      "#active?/#verify!/#disconnect! under the GVL. JavaScript has no native " +
+      "threads — async/await on a single event-loop cannot reproduce the GVL " +
+      "interleaving that this test pins.",
+  },
 ];
 
 export function isSourceUnported(file: string): boolean {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -476,7 +476,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "rather than exact bytes.",
   },
   {
-    testFile: "cases/adapter_test.rb",
+    testFile: "adapter_test.rb",
     className: "AdapterThreadSafetyTest",
     tests: ["#active? is synchronized", "#verify! is synchronized"],
     reason:


### PR DESCRIPTION
## Summary

The 70 skips in `packages/activerecord/src/adapter.test.ts` were all annotated with the same catch-all tag:

> `BLOCKED: schema — abstract adapter schema introspection / query execution gap`

But the underlying Rails tests in `vendor/rails/activerecord/test/cases/adapter_test.rb` actually fall into several distinct gap categories. Replace the blanket tag with accurate per-test categories from the `BLOCKED:` vocabulary in `docs/test-compare-100-plan.md` so triage agents can route the work into the right sized slots.

Resulting distribution:

- **fixture** — needs Book / Post / Author / Event / fk_test_* / subscribers tables (~20 tests)
- **connection-pool** — disconnect/reconnect/verify lifecycle, retryability, configureConnection recovery (~17 tests)
- **transactions** — materialize/restore semantics around reconnect/disconnect, dirty-tx behavior, invalidation (~10 tests)
- **schema** — `validType?`, `removeIndex` arg validation, `indexes` empty-on-missing, default-branch type_to_sql preservation, exec/StatementInvalid translation (~7 tests)
- **adapter-mysql** — charset/collation/show_variable/cross-DB/currentDatabase (~4 tests)
- **adapter-pg** — advisory_locks, resetPkSequence! (~3 tests)
- **query-cache** — create/truncate cache invalidation (~3 tests)
- **GVL** — thread-safety tests (~2 tests; likely permanent)

Tests remain skipped; test names and counts unchanged (70 skipped, 0 missing). This is a triage-grade re-annotation; the actual un-skip work for each cluster falls out into separate slots.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/adapter.test.ts` — 70 skipped, 0 failures
- [x] `pnpm test:compare --cached --package activerecord` — adapter_test.rb still 4 matched / 70 skipped (no name drift)
- [x] `pnpm eslint packages/activerecord/src/adapter.test.ts` clean