### PR TITLE
refactor(activerecord): tighten AnyClass to typeof Base (B18b)

### DIFF
--- a/packages/activerecord/src/attribute-methods/composite-primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/composite-primary-key.ts
@@ -4,16 +4,13 @@
  * Mirrors: ActiveRecord::AttributeMethods::CompositePrimaryKey
  */
 
-import type { AnyClass } from "../internal/any-class.js";
+import type { Base } from "../base.js";
 
 interface CompositePKRecord {
   id: unknown;
   readAttribute(name: string): unknown;
   _readAttribute(name: string): unknown;
-  constructor: AnyClass & {
-    primaryKey: string | string[];
-    compositePrimaryKey: boolean;
-  };
+  constructor: typeof Base;
 }
 
 /**

--- a/packages/activerecord/src/internal/any-class.ts
+++ b/packages/activerecord/src/internal/any-class.ts
@@ -1,8 +1,0 @@
-/**
- * Internal alias for "any class constructor" used as a Map/Set key throughout
- * ActiveRecord internals (Suppressor, NoTouching, Delegation). Centralized to
- * keep the four duplicate declarations in sync.
- *
- * @internal
- */
-export type AnyClass = abstract new (...args: any[]) => any;

--- a/packages/activerecord/src/no-touching.ts
+++ b/packages/activerecord/src/no-touching.ts
@@ -4,9 +4,9 @@
  * Mirrors: ActiveRecord::NoTouching
  */
 
-import type { AnyClass } from "./internal/any-class.js";
+import type { Base } from "./base.js";
 
-const _noTouchingDepth = new Map<AnyClass, number>();
+const _noTouchingDepth = new Map<typeof Base, number>();
 
 /**
  * Execute a block with touch callbacks suppressed for the given model class.
@@ -14,7 +14,7 @@ const _noTouchingDepth = new Map<AnyClass, number>();
  *
  * Mirrors: ActiveRecord::NoTouching.no_touching
  */
-export async function noTouching<R>(modelClass: AnyClass, fn: () => R | Promise<R>): Promise<R> {
+export async function noTouching<R>(modelClass: typeof Base, fn: () => R | Promise<R>): Promise<R> {
   const depth = _noTouchingDepth.get(modelClass) ?? 0;
   _noTouchingDepth.set(modelClass, depth + 1);
   try {
@@ -34,10 +34,10 @@ export async function noTouching<R>(modelClass: AnyClass, fn: () => R | Promise<
  *
  * Mirrors: ActiveRecord::NoTouching.applied_to?
  */
-export function isAppliedTo(modelClass: AnyClass): boolean {
-  let current: unknown = modelClass;
+export function isAppliedTo(modelClass: typeof Base): boolean {
+  let current: typeof Base | null = modelClass;
   while (current && typeof current === "function") {
-    if ((_noTouchingDepth.get(current as AnyClass) ?? 0) > 0) return true;
+    if ((_noTouchingDepth.get(current) ?? 0) > 0) return true;
     current = Object.getPrototypeOf(current);
   }
   return false;

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -11,7 +11,6 @@
 
 import type { Base } from "../base.js";
 import { Delegation as ASDelegation } from "@blazetrails/activesupport";
-import type { AnyClass } from "../internal/any-class.js";
 
 type AnyCallable = (...args: any[]) => any;
 
@@ -22,7 +21,7 @@ type AnyCallable = (...args: any[]) => any;
  */
 
 export interface Delegation {
-  delegatedClasses: Set<AnyClass>;
+  delegatedClasses: Set<typeof Base>;
 }
 
 /**
@@ -69,19 +68,19 @@ export class GeneratedRelationMethods {
  * Mirrors: ActiveRecord::Delegation::DelegateCache
  */
 export class DelegateCache {
-  private _cache: Map<AnyClass, Set<string>> = new Map();
+  private _cache: Map<typeof Base, Set<string>> = new Map();
 
-  initialize(modelClass: AnyClass): void {
+  initialize(modelClass: typeof Base): void {
     if (!this._cache.has(modelClass)) {
       this._cache.set(modelClass, new Set());
     }
   }
 
-  hasDelegated(modelClass: AnyClass, method: string): boolean {
+  hasDelegated(modelClass: typeof Base, method: string): boolean {
     return this._cache.get(modelClass)?.has(method) ?? false;
   }
 
-  register(modelClass: AnyClass, method: string): void {
+  register(modelClass: typeof Base, method: string): void {
     this.initialize(modelClass);
     this._cache.get(modelClass)!.add(method);
   }
@@ -94,11 +93,11 @@ export class DelegateCache {
  * Constrained to `object` because Relation._modelClass is private;
  * internal access uses `any` casts.
  */
-const _delegatedClasses = new Set<AnyClass>();
+const _delegatedClasses = new Set<typeof Base>();
 const _uncacheableMethods = new Set<string>(["to_a", "to_ary", "records", "inspect"]);
 const _delegateCache = new DelegateCache();
 
-export function delegatedClasses(): Set<AnyClass> {
+export function delegatedClasses(): Set<typeof Base> {
   return _delegatedClasses;
 }
 
@@ -106,23 +105,25 @@ export function uncacheableMethods(): Set<string> {
   return _uncacheableMethods;
 }
 
-export function delegateBaseMethods(klass: AnyClass): void {
+export function delegateBaseMethods(klass: typeof Base): void {
   _delegatedClasses.add(klass);
   _delegateCache.initialize(klass);
 }
 
-export function relationDelegateClass(klass: AnyClass): AnyClass {
+export function relationDelegateClass(klass: typeof Base): typeof Base {
   _delegatedClasses.add(klass);
   return klass;
 }
 
 export function initializeRelationDelegateCache(): void {
-  _delegateCache.initialize(Object);
+  for (const klass of _delegatedClasses) {
+    _delegateCache.initialize(klass);
+  }
 }
 
-const _generatedMethodsByModel = new WeakMap<AnyClass, GeneratedRelationMethods>();
+const _generatedMethodsByModel = new WeakMap<typeof Base, GeneratedRelationMethods>();
 
-function generatedMethodsFor(modelClass: AnyClass): GeneratedRelationMethods {
+function generatedMethodsFor(modelClass: typeof Base): GeneratedRelationMethods {
   let methods = _generatedMethodsByModel.get(modelClass);
   if (!methods) {
     methods = new GeneratedRelationMethods();
@@ -131,7 +132,11 @@ function generatedMethodsFor(modelClass: AnyClass): GeneratedRelationMethods {
   return methods;
 }
 
-export function generateRelationMethod(modelClass: AnyClass, name: string, fn: AnyCallable): void {
+export function generateRelationMethod(
+  modelClass: typeof Base,
+  name: string,
+  fn: AnyCallable,
+): void {
   generatedMethodsFor(modelClass).generate(name, fn);
 }
 
@@ -183,7 +188,7 @@ export function wrapWithScopeProxy<T extends object>(rel: T): T {
 }
 
 /** @internal */
-function relationClassFor(klass: AnyClass): typeof GeneratedRelationMethods {
+function relationClassFor(klass: typeof Base): typeof GeneratedRelationMethods {
   return GeneratedRelationMethods;
 }
 
@@ -195,6 +200,6 @@ function includeRelationMethods(target: object, methods: GeneratedRelationMethod
 }
 
 /** @internal */
-function generatedRelationMethods(modelClass: AnyClass): GeneratedRelationMethods {
+function generatedRelationMethods(modelClass: typeof Base): GeneratedRelationMethods {
   return _generatedMethodsByModel.get(modelClass) ?? new GeneratedRelationMethods();
 }

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -7,7 +7,7 @@
 
 import { getAsyncContext } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
-import type { AnyClass } from "./internal/any-class.js";
+import type { Base } from "./base.js";
 
 /**
  * The suppressor registry: a map from class name → `true` when that
@@ -62,7 +62,7 @@ export function registry(): Record<string, true | undefined> {
  *
  * Mirrors: ActiveRecord::Suppressor.suppress
  */
-export async function suppress<R>(modelClass: AnyClass, fn: () => R | Promise<R>): Promise<R> {
+export async function suppress<R>(modelClass: typeof Base, fn: () => R | Promise<R>): Promise<R> {
   const name = modelClass.name;
   if (!name) {
     // Anonymous classes can't participate in the name-keyed registry
@@ -82,11 +82,11 @@ export async function suppress<R>(modelClass: AnyClass, fn: () => R | Promise<R>
  * Check if the given model class (or any ancestor) is currently
  * suppressed in the active scope.
  */
-export function isSuppressed(modelClass: AnyClass): boolean {
+export function isSuppressed(modelClass: typeof Base): boolean {
   const reg = currentRegistry();
-  let current: unknown = modelClass;
+  let current: typeof Base | null = modelClass;
   while (current && typeof current === "function") {
-    const klassName = (current as AnyClass).name;
+    const klassName = current.name;
     if (klassName && reg[klassName]) return true;
     current = Object.getPrototypeOf(current);
   }


### PR DESCRIPTION
## Summary

Follow-up to #1931. The four sites that consumed `AnyClass` only ever
receive `Base` subclass constructors at runtime, so `typeof Base` is
the faithful type:

- `no-touching.ts`: drops the `current as AnyClass` cast in
  `isAppliedTo`'s prototype-chain walk.
- `suppressor.ts`: drops the `current as AnyClass` cast in
  `isSuppressed`'s prototype-chain walk.
- `relation/delegation.ts`: drops the loose alias entirely; also rewrites
  `initializeRelationDelegateCache` to mirror Rails'
  `DelegateCache#initialize_relation_delegate_cache`
  (relation/delegation.rb:32-45), which iterates
  `Delegation.delegated_classes` rather than seeding the cache with a
  meaningless `Object` key.
- `attribute-methods/composite-primary-key.ts`: collapses the
  `AnyClass & { primaryKey, compositePrimaryKey }` intersection on
  `CompositePKRecord.constructor` to `typeof Base` (both members
  already live on `typeof Base`).

Deletes `packages/activerecord/src/internal/any-class.ts` (added by
#1931) since no consumers remain.

## Rails parity

- `initializeRelationDelegateCache` now mirrors Rails'
  `DelegateCache#initialize_relation_delegate_cache`
  (vendor/rails/.../relation/delegation.rb:32-45) — iterates
  `delegated_classes` and registers each. Previously seeded the cache
  with a non-Rails `Object` sentinel.

## Test plan

- [x] `pnpm typecheck` — clean
- [x] `vitest run packages/activerecord/src/reflection.test.ts packages/activerecord/src/suppressor.test.ts` — green