### PR TITLE
feat(actionpack): wire Request to Http::Parameters mixin + static parameterParsers

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/parameters.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.test.ts
@@ -148,6 +148,25 @@ describe("parameterParsers registry", () => {
     expect(paramsParsers.call(host)).toEqual({ xml });
   });
 
+  it("stream-backed rack.input is drained once and cached under RAW_POST_DATA", () => {
+    let reads = 0;
+    const input = {
+      read() {
+        reads += 1;
+        return '{"a":1}';
+      },
+    };
+    const req = new Request({
+      REQUEST_METHOD: "POST",
+      CONTENT_TYPE: "application/json",
+      "rack.input": input,
+    });
+    expect(req.rawPost).toBe('{"a":1}');
+    expect(req.rawPost).toBe('{"a":1}');
+    expect(req.params).toMatchObject({ a: 1 });
+    expect(reads).toBe(1);
+  });
+
   it("Request.parameterParsers static accessor drives Request#requestParameters", () => {
     const xml: ParameterParser = (raw) => ({ parsed: raw });
     Request.parameterParsers = { ...DEFAULT_PARSERS, xml };

--- a/packages/actionpack/src/action-dispatch/http/parameters.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.test.ts
@@ -214,6 +214,15 @@ describe("parseFormattedParameters", () => {
     });
   });
 
+  it("yields when rawPost is empty even if content-length is absent", () => {
+    const host = makeHost({
+      contentLength: undefined,
+      contentMimeType: MimeType.JSON,
+      rawPost: "",
+    });
+    expect(parseFormattedParameters.call(host, DEFAULT_PARSERS, () => ({}))).toEqual({});
+  });
+
   it("yields when no parser registered for the MIME type", () => {
     const host = makeHost({ contentLength: 1, contentMimeType: MimeType.HTML, rawPost: "x" });
     const out = parseFormattedParameters.call(host, DEFAULT_PARSERS, () => ({ y: 1 }));

--- a/packages/actionpack/src/action-dispatch/http/parameters.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.test.ts
@@ -170,6 +170,17 @@ describe("parseFormattedParameters", () => {
     expect(out).toEqual({ y: 1 });
   });
 
+  it("parses when content-length is absent but a body is present (Rails content_length.zero? parity)", () => {
+    const host = makeHost({
+      contentLength: undefined,
+      contentMimeType: MimeType.JSON,
+      rawPost: '{"a":1}',
+    });
+    expect(parseFormattedParameters.call(host, DEFAULT_PARSERS, () => ({ y: 1 }))).toEqual({
+      a: 1,
+    });
+  });
+
   it("yields when no parser registered for the MIME type", () => {
     const host = makeHost({ contentLength: 1, contentMimeType: MimeType.HTML, rawPost: "x" });
     const out = parseFormattedParameters.call(host, DEFAULT_PARSERS, () => ({ y: 1 }));

--- a/packages/actionpack/src/action-dispatch/http/parameters.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from "vitest";
 import { MimeType } from "./mime-type.js";
+import { Request } from "./request.js";
 import {
   DEFAULT_PARSERS,
   PARAMETERS_KEY,
@@ -145,6 +146,19 @@ describe("parameterParsers registry", () => {
     setParameterParsers({ xml });
     const host = makeHost();
     expect(paramsParsers.call(host)).toEqual({ xml });
+  });
+
+  it("Request.parameterParsers static accessor drives Request#requestParameters", () => {
+    const xml: ParameterParser = (raw) => ({ parsed: raw });
+    Request.parameterParsers = { ...DEFAULT_PARSERS, xml };
+    expect(Request.parameterParsers).toMatchObject({ xml });
+    const req = new Request({
+      REQUEST_METHOD: "POST",
+      CONTENT_TYPE: "application/xml",
+      "rack.input": "<root/>",
+    });
+    expect(req.requestParameters).toEqual({ parsed: "<root/>" });
+    expect(req.params).toMatchObject({ parsed: "<root/>" });
   });
 });
 

--- a/packages/actionpack/src/action-dispatch/http/parameters.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.ts
@@ -156,7 +156,12 @@ export function parseFormattedParameters(
   parsers: ParameterParsers,
   fallback: () => Record<string, unknown>,
 ): Record<string, unknown> {
-  if (this.contentLength === 0 || this.contentMimeType === null) {
+  // Rails: `content_length.zero? || content_mime_type.nil?` → yield. Our
+  // `contentLength` returns `undefined` when the header is absent, so also
+  // treat an empty `rawPost` as no body — otherwise JSON requests without a
+  // `CONTENT_LENGTH` header would feed `""` to `JSON.parse` and raise
+  // `ParseError` instead of returning the documented empty-body `{}`.
+  if (this.contentLength === 0 || this.contentMimeType === null || !this.rawPost) {
     return fallback();
   }
   const strategy = parsers[this.contentMimeType.symbol];

--- a/packages/actionpack/src/action-dispatch/http/parameters.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.ts
@@ -172,8 +172,10 @@ export function parseFormattedParameters(
 
 /**
  * Logs the parse failure exactly once per request. Mirrors Rails'
- * `log_parse_error_once`; the once-per-request guard lives on the host as
- * `_parseErrorLogged` (Rails uses `@parse_error_logged`).
+ * `log_parse_error_once`; the guard is persisted on the env under
+ * `action_dispatch.request.parse_error_logged` so it survives across
+ * throwaway host adapters (Rails uses `@parse_error_logged` on the
+ * Request instance directly).
  *
  * @internal
  */

--- a/packages/actionpack/src/action-dispatch/http/parameters.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.ts
@@ -178,12 +178,16 @@ export function parseFormattedParameters(
  * @internal
  */
 export function logParseErrorOnce(this: ParametersHost): void {
-  const host = this as ParametersHost & { _parseErrorLogged?: boolean };
-  if (host._parseErrorLogged) return;
-  host._parseErrorLogged = true;
+  // Rails stores `@parse_error_logged` on the Request instance. The trails
+  // host adapter on `Request` can be a throwaway object created per access,
+  // so persist the guard on the env via getHeader/setHeader instead.
+  if (this.getHeader(PARSE_ERROR_LOGGED_KEY)) return;
+  this.setHeader(PARSE_ERROR_LOGGED_KEY, true);
   const logger = this.logger ?? new Logger({ write: (s) => stderr.write(s) });
   logger.debug(`Error occurred while parsing request parameters.\nContents:\n\n${this.rawPost}`);
 }
+
+const PARSE_ERROR_LOGGED_KEY = "action_dispatch.request.parse_error_logged";
 
 /**
  * Returns the currently-registered parameter parsers. Mirrors Rails'

--- a/packages/actionpack/src/action-dispatch/http/parameters.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.ts
@@ -185,8 +185,19 @@ export function logParseErrorOnce(this: ParametersHost): void {
   // so persist the guard on the env via getHeader/setHeader instead.
   if (this.getHeader(PARSE_ERROR_LOGGED_KEY)) return;
   this.setHeader(PARSE_ERROR_LOGGED_KEY, true);
-  const logger = this.logger ?? new Logger({ write: (s) => stderr.write(s) });
-  logger.debug(`Error occurred while parsing request parameters.\nContents:\n\n${this.rawPost}`);
+  const msg = `Error occurred while parsing request parameters.\nContents:\n\n${this.rawPost}`;
+  if (this.logger) {
+    this.logger.debug(msg);
+    return;
+  }
+  // Rails uses `ActiveSupport::Logger.new($stderr)` as the fallback; in
+  // browser hosts no process adapter is registered, so guard the write so
+  // the log attempt never replaces the caller's `ParseError`.
+  try {
+    new Logger({ write: (s) => stderr.write(s) }).debug(msg);
+  } catch {
+    // no-op: log is informational, the ParseError remains the real signal.
+  }
 }
 
 const PARSE_ERROR_LOGGED_KEY = "action_dispatch.request.parse_error_logged";

--- a/packages/actionpack/src/action-dispatch/http/parameters.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.ts
@@ -12,6 +12,8 @@
  * assigned directly onto the host class.
  */
 
+import { Logger } from "@blazetrails/activesupport";
+import { stderr } from "@blazetrails/activesupport/process-adapter";
 import { MimeType } from "./mime-type.js";
 
 export const PARAMETERS_KEY = "action_dispatch.request.path_parameters";
@@ -154,7 +156,7 @@ export function parseFormattedParameters(
   parsers: ParameterParsers,
   fallback: () => Record<string, unknown>,
 ): Record<string, unknown> {
-  if (!this.contentLength || this.contentMimeType === null) {
+  if (this.contentLength === 0 || this.contentMimeType === null) {
     return fallback();
   }
   const strategy = parsers[this.contentMimeType.symbol];
@@ -179,7 +181,7 @@ export function logParseErrorOnce(this: ParametersHost): void {
   const host = this as ParametersHost & { _parseErrorLogged?: boolean };
   if (host._parseErrorLogged) return;
   host._parseErrorLogged = true;
-  const logger = this.logger ?? { debug: (m: string) => console.error(m) };
+  const logger = this.logger ?? new Logger({ write: (s) => stderr.write(s) });
   logger.debug(`Error occurred while parsing request parameters.\nContents:\n\n${this.rawPost}`);
 }
 

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -422,6 +422,10 @@ export class Request {
       get rawPost() {
         return req.rawPost;
       },
+      get logger() {
+        const l = req.env["action_dispatch.logger"] ?? req.env["rack.logger"];
+        return (l as { debug(m: string): void } | null | undefined) ?? null;
+      },
     };
   }
 

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -32,6 +32,19 @@ import {
 } from "./mime-negotiation.js";
 import type { MimeType } from "./mime-type.js";
 import { RequestUtils, type ParamValue } from "../request/utils.js";
+import { MimeType } from "./mime-type.js";
+import {
+  parameters as _parameters,
+  parameterParsers as _parameterParsers,
+  paramsParsers as _paramsParsers,
+  parseFormattedParameters as _parseFormattedParameters,
+  pathParameters as _pathParameters,
+  setParameterParsers as _setParameterParsers,
+  setPathParameters as _setPathParameters,
+  type ParameterParser,
+  type ParameterParsers,
+  type ParametersHost,
+} from "./parameters.js";
 
 export class Request {
   readonly env: RackEnv;
@@ -229,6 +242,11 @@ export class Request {
     return isNaN(n) ? undefined : n;
   }
 
+  get contentMimeType(): MimeType | null {
+    const ct = this.contentType;
+    return ct ? (MimeType.lookup(ct) ?? null) : null;
+  }
+
   get userAgent(): string {
     return (this.env["HTTP_USER_AGENT"] as string) || "";
   }
@@ -316,18 +334,7 @@ export class Request {
   // --- Parameters ---
 
   get params(): Record<string, unknown> {
-    if (this.env["action_dispatch.request.parameters"]) {
-      return this.env["action_dispatch.request.parameters"] as Record<string, unknown>;
-    }
-    // Mirrors Rails `ActionDispatch::Http::Parameters#parameters` —
-    // request_parameters.merge(query_parameters).merge!(path_parameters).
-    const merged: Record<string, unknown> = {
-      ...this.requestParameters,
-      ...this.queryParameters,
-      ...this.pathParameters,
-    };
-    this.env["action_dispatch.request.parameters"] = merged;
-    return merged;
+    return _parameters.call(this._paramsHost);
   }
 
   get queryParameters(): Record<string, unknown> {
@@ -345,47 +352,10 @@ export class Request {
       return cached as Record<string, unknown>;
     }
 
-    const raw = this.env["rack.input"];
-    if (!raw) {
-      this.env["action_dispatch.request.request_parameters"] = {};
-      return {};
-    }
-
-    let input: string | null;
-    if (typeof raw === "string") {
-      input = raw;
-    } else if (typeof (raw as any).read === "function") {
-      input = (raw as any).read();
-      if (typeof (raw as any).rewind === "function") {
-        try {
-          (raw as any).rewind();
-        } catch {
-          // ignore rewind errors
-        }
-      }
-    } else {
-      input = null;
-    }
-
-    if (!input || typeof input !== "string") {
-      this.env["action_dispatch.request.request_parameters"] = {};
-      return {};
-    }
-
-    let params: Record<string, unknown> = {};
-    const ct = ((this.env["CONTENT_TYPE"] as string) || "").toLowerCase();
-    if (ct.includes("application/json")) {
-      try {
-        const parsed = JSON.parse(input);
-        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-          params = parsed;
-        }
-      } catch {
-        // ignore
-      }
-    } else if (ct.includes("application/x-www-form-urlencoded")) {
-      params = parseNestedQuery(input);
-    }
+    const host = this._paramsHost;
+    const params = _parseFormattedParameters.call(host, _paramsParsers.call(host), () =>
+      this._fallbackRequestParameters(),
+    );
 
     const normalized = RequestUtils.normalizeEncodeParams(params as ParamValue) as Record<
       string,
@@ -396,16 +366,74 @@ export class Request {
   }
 
   get pathParameters(): Record<string, unknown> {
-    return (this.env["action_dispatch.request.path_parameters"] as Record<string, unknown>) || {};
+    return _pathParameters.call(this._paramsHost);
   }
 
   set pathParameters(params: Record<string, unknown>) {
-    // Mirrors `Rails::ActionDispatch::Http::Parameters#path_parameters=` —
-    // invalidate the merged-parameters cache so subsequent `params` reads
-    // pick up the new path captures. Matches `setPathParameters` in
-    // http/parameters.ts.
-    delete this.env["action_dispatch.request.parameters"];
-    this.env["action_dispatch.request.path_parameters"] = params;
+    _setPathParameters.call(this._paramsHost, params);
+  }
+
+  /** Class-level parameter parser registry. Mirrors Rails `Request.parameter_parsers`. */
+  static get parameterParsers(): ParameterParsers {
+    return _parameterParsers();
+  }
+
+  static set parameterParsers(parsers: Record<string | symbol, ParameterParser>) {
+    _setParameterParsers(parsers);
+  }
+
+  /** @internal */
+  private get _paramsHost(): ParametersHost {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const req = this;
+    return {
+      getHeader: (k) => req.env[k],
+      setHeader: (k, v) => ((req.env[k] = v), v),
+      deleteHeader: (k) => void delete req.env[k],
+      get queryParameters() {
+        return req.queryParameters;
+      },
+      get requestParameters() {
+        return req.requestParameters;
+      },
+      get contentLength() {
+        return req.contentLength;
+      },
+      get contentMimeType() {
+        return req.contentMimeType;
+      },
+      get rawPost() {
+        return req.rawPost;
+      },
+    };
+  }
+
+  /** @internal */
+  private _fallbackRequestParameters(): Record<string, unknown> {
+    const raw = this.env["rack.input"];
+    if (!raw) return {};
+    let input: string | null;
+    if (typeof raw === "string") {
+      input = raw;
+    } else if (typeof (raw as { read?: unknown }).read === "function") {
+      input = (raw as { read(): string }).read();
+      const rewind = (raw as { rewind?: unknown }).rewind;
+      if (typeof rewind === "function") {
+        try {
+          (rewind as () => void).call(raw);
+        } catch {
+          // ignore
+        }
+      }
+    } else {
+      input = null;
+    }
+    if (!input || typeof input !== "string") return {};
+    const ct = ((this.env["CONTENT_TYPE"] as string) || "").toLowerCase();
+    if (ct.includes("application/x-www-form-urlencoded")) {
+      return parseNestedQuery(input);
+    }
+    return {};
   }
 
   // --- Format ---

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -32,7 +32,6 @@ import {
 } from "./mime-negotiation.js";
 import type { MimeType } from "./mime-type.js";
 import { RequestUtils, type ParamValue } from "../request/utils.js";
-import { MimeType } from "./mime-type.js";
 import {
   parameters as _parameters,
   parameterParsers as _parameterParsers,
@@ -240,11 +239,6 @@ export class Request {
     if (!cl) return undefined;
     const n = parseInt(cl, 10);
     return isNaN(n) ? undefined : n;
-  }
-
-  get contentMimeType(): MimeType | null {
-    const ct = this.contentType;
-    return ct ? (MimeType.lookup(ct.toLowerCase()) ?? null) : null;
   }
 
   get userAgent(): string {

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -244,7 +244,7 @@ export class Request {
 
   get contentMimeType(): MimeType | null {
     const ct = this.contentType;
-    return ct ? (MimeType.lookup(ct) ?? null) : null;
+    return ct ? (MimeType.lookup(ct.toLowerCase()) ?? null) : null;
   }
 
   get userAgent(): string {
@@ -321,14 +321,29 @@ export class Request {
   get body(): string {
     const input = this.env["rack.input"];
     if (typeof input === "string") return input;
+    if (input && typeof (input as { read?: unknown }).read === "function") {
+      const buf = (input as { read(): string }).read();
+      const rewind = (input as { rewind?: unknown }).rewind;
+      if (typeof rewind === "function") {
+        try {
+          (rewind as () => void).call(input);
+        } catch {
+          // ignore
+        }
+      }
+      return typeof buf === "string" ? buf : "";
+    }
     return "";
   }
 
   get rawPost(): string {
-    if (this.env["RAW_POST_DATA"]) {
-      return String(this.env["RAW_POST_DATA"]);
-    }
-    return this.body;
+    const cached = this.env["RAW_POST_DATA"];
+    if (cached != null) return String(cached);
+    // Rails caches raw_post under RAW_POST_DATA so repeated reads of a
+    // stream-backed rack.input don't yield "" after the first drain.
+    const body = this.body;
+    this.env["RAW_POST_DATA"] = body;
+    return body;
   }
 
   // --- Parameters ---
@@ -378,7 +393,9 @@ export class Request {
     return _parameterParsers();
   }
 
-  static set parameterParsers(parsers: Record<string | symbol, ParameterParser>) {
+  static set parameterParsers(
+    parsers: Record<string | symbol, ParameterParser> | Map<unknown, ParameterParser>,
+  ) {
     _setParameterParsers(parsers);
   }
 
@@ -410,25 +427,8 @@ export class Request {
 
   /** @internal */
   private _fallbackRequestParameters(): Record<string, unknown> {
-    const raw = this.env["rack.input"];
-    if (!raw) return {};
-    let input: string | null;
-    if (typeof raw === "string") {
-      input = raw;
-    } else if (typeof (raw as { read?: unknown }).read === "function") {
-      input = (raw as { read(): string }).read();
-      const rewind = (raw as { rewind?: unknown }).rewind;
-      if (typeof rewind === "function") {
-        try {
-          (rewind as () => void).call(raw);
-        } catch {
-          // ignore
-        }
-      }
-    } else {
-      input = null;
-    }
-    if (!input || typeof input !== "string") return {};
+    const input = this.rawPost;
+    if (!input) return {};
     const ct = ((this.env["CONTENT_TYPE"] as string) || "").toLowerCase();
     if (ct.includes("application/x-www-form-urlencoded")) {
       return parseNestedQuery(input);


### PR DESCRIPTION
## Summary

Follow-up to #1832. `Request` now delegates `params`, `pathParameters`,
`setPathParameters`, and `requestParameters` to the
`ActionDispatch::Http::Parameters` mixin in `http/parameters.ts` instead of
carrying an inline implementation. As a result:

- Custom MIME parsers registered via the new
  `Request.parameterParsers` static getter/setter (mirrors Rails
  `ActionDispatch::Request.parameter_parsers`) actually drive request-body
  parsing — previously the registry was unreachable from a real `Request`.
- `parseFormattedParameters` now skips parsing only when
  `contentLength === 0` (Rails `content_length.zero?`), not when the header
  is merely absent. Test requests that ship a body without `CONTENT_LENGTH`
  now parse correctly.
- `logParseErrorOnce` falls back to a real `ActiveSupport::Logger` writing
  to stderr (via the `process-adapter`) instead of `console.error`.
- Added `Request#contentMimeType` getter that resolves `CONTENT_TYPE`
  through `MimeType.lookup`.

## Test plan

- [x] `pnpm vitest run packages/actionpack` — 2573 passed (23 skipped)
- [x] `pnpm exec eslint` clean on both touched files
- [x] `pnpm build` clean