### PR TITLE
feat(actionpack): wire FilterParameters + FilterRedirect mixins

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
@@ -606,3 +606,61 @@ describe("RequestCookie", () => {
     expect(req.env["HTTP_COOKIE"]).toBe("foo=bar; baz=qux");
   });
 });
+
+describe("RequestHeaderEnvAccess", () => {
+  it("hasHeader/setHeader/deleteHeader/fetchHeader operate on env for non-HTTP keys", () => {
+    const req = new Request({});
+    expect(req.hasHeader("action_dispatch.parameter_filter")).toBe(false);
+    req.setHeader("action_dispatch.parameter_filter", ["password"]);
+    expect(req.hasHeader("action_dispatch.parameter_filter")).toBe(true);
+    expect(req.env["action_dispatch.parameter_filter"]).toEqual(["password"]);
+    expect(req.fetchHeader("action_dispatch.parameter_filter")).toEqual(["password"]);
+    req.deleteHeader("action_dispatch.parameter_filter");
+    expect(req.hasHeader("action_dispatch.parameter_filter")).toBe(false);
+  });
+
+  it("fetchHeader invokes fallback on miss", () => {
+    const req = new Request({});
+    expect(req.fetchHeader("missing", () => "fallback")).toBe("fallback");
+  });
+
+  it("getHeader maps HTTP-style names to HTTP_* env keys", () => {
+    const req = new Request({ HTTP_IF_NONE_MATCH: '"abc"' });
+    expect(req.getHeader("If-None-Match")).toBe('"abc"');
+  });
+
+  it("getHeader maps CGI-variable names without HTTP_ prefix", () => {
+    const req = new Request({ CONTENT_TYPE: "text/html" });
+    expect(req.getHeader("Content-Type")).toBe("text/html");
+  });
+});
+
+describe("RequestFilterParameters", () => {
+  it("filteredParameters replaces sensitive params with [FILTERED]", () => {
+    const req = new Request({
+      "action_dispatch.request.parameters": { password: "hunter2", name: "alice" },
+      "action_dispatch.parameter_filter": ["password"],
+    });
+    expect(req.filteredParameters()).toEqual({ password: "[FILTERED]", name: "alice" });
+  });
+
+  it("filteredPath replaces sensitive query params", () => {
+    const req = new Request({
+      PATH_INFO: "/users",
+      QUERY_STRING: "password=hunter2&name=alice",
+      "action_dispatch.parameter_filter": ["password"],
+    });
+    expect(req.filteredPath()).toBe("/users?password=[FILTERED]&name=alice");
+  });
+
+  it("filteredEnv strips RAW_POST_DATA by default", () => {
+    const req = new Request({ RAW_POST_DATA: "secret" });
+    expect(req.filteredEnv()["RAW_POST_DATA"]).toBe("[FILTERED]");
+  });
+
+  it("parameterFilter returns NULL_PARAM_FILTER when no header is configured", () => {
+    const req = new Request({});
+    // No filter list set → identity-style filter.
+    expect(req.parameterFilter().filter({ password: "x" })).toEqual({ password: "x" });
+  });
+});

--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -351,7 +351,7 @@ describe("ResponseFilterRedirect", () => {
     const res = new Response();
     res.location = "https://example.com/foo";
     expect(res.location).toBe("https://example.com/foo");
-    expect(res.headers["Location"]).toBe("https://example.com/foo");
+    expect(res.headers["location"]).toBe("https://example.com/foo");
   });
 
   it("filteredLocation strips sensitive query params using the request filter", () => {

--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Request } from "../request.js";
 import { Response } from "../response.js";
 
 describe("ResponseTest", () => {
@@ -342,5 +343,47 @@ describe("ResponseTest", () => {
 
   it("inspect for redirect", () => {
     expect(new Response(302).inspect()).toBe("#<ActionDispatch::Response 302 Found>");
+  });
+});
+
+describe("ResponseFilterRedirect", () => {
+  it("location getter/setter round-trips through the Location header", () => {
+    const res = new Response();
+    res.location = "https://example.com/foo";
+    expect(res.location).toBe("https://example.com/foo");
+    expect(res.headers["Location"]).toBe("https://example.com/foo");
+  });
+
+  it("filteredLocation strips sensitive query params using the request filter", () => {
+    const req = new Request({
+      "action_dispatch.parameter_filter": ["token"],
+    });
+    const res = new Response();
+    res.request = req;
+    res.location = "https://example.com/foo?token=secret&name=alice";
+    // WHATWG URL parser may URL-encode the brackets; check key behaviour
+    // (the `secret` value must be filtered).
+    const filtered = res.filteredLocation();
+    expect(filtered).toContain("name=alice");
+    expect(filtered).not.toContain("secret");
+    expect(filtered).toContain("token=");
+  });
+
+  it("filteredLocation replaces the entire location when redirect_filter matches", () => {
+    const req = new Request({
+      "action_dispatch.redirect_filter": [/secret/],
+    });
+    const res = new Response();
+    res.request = req;
+    res.location = "https://example.com/secret/path";
+    expect(res.filteredLocation()).toBe("[FILTERED]");
+  });
+
+  it("filteredLocation returns the unmodified location when no filters are configured", () => {
+    const req = new Request({});
+    const res = new Response();
+    res.request = req;
+    res.location = "https://example.com/foo";
+    expect(res.filteredLocation()).toBe("https://example.com/foo");
   });
 });

--- a/packages/actionpack/src/action-dispatch/http/filter-parameters.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/filter-parameters.test.ts
@@ -35,7 +35,7 @@ function makeHost(overrides: Partial<FilterParametersHost> = {}): FilterParamete
     env,
     path: "/",
     queryString: "",
-    parameters: () => ({}),
+    params: {},
     ...overrides,
   };
 }
@@ -48,9 +48,7 @@ describe("ENV_MATCH", () => {
 
 describe("filteredParameters", () => {
   it("returns parameters filtered by the configured filter list", () => {
-    const host = makeHost({
-      parameters: () => ({ password: "secret", username: "alice" }),
-    });
+    const host = makeHost({ params: { password: "secret", username: "alice" } });
     host.setHeader("action_dispatch.parameter_filter", ["password"]);
     expect(filteredParameters.call(host)).toEqual({
       password: "[FILTERED]",
@@ -58,9 +56,10 @@ describe("filteredParameters", () => {
     });
   });
 
-  it("returns an empty hash when parameters() throws ParseError", () => {
-    const host = makeHost({
-      parameters: () => {
+  it("returns an empty hash when reading params throws ParseError", () => {
+    const host = makeHost();
+    Object.defineProperty(host, "params", {
+      get() {
         throw new ParseError("bad");
       },
     });
@@ -68,8 +67,9 @@ describe("filteredParameters", () => {
   });
 
   it("rethrows non-ParseError exceptions", () => {
-    const host = makeHost({
-      parameters: () => {
+    const host = makeHost();
+    Object.defineProperty(host, "params", {
+      get() {
         throw new TypeError("boom");
       },
     });
@@ -78,8 +78,9 @@ describe("filteredParameters", () => {
 
   it("memoizes the filtered hash", () => {
     let calls = 0;
-    const host = makeHost({
-      parameters: () => {
+    const host = makeHost();
+    Object.defineProperty(host, "params", {
+      get() {
         calls++;
         return {};
       },

--- a/packages/actionpack/src/action-dispatch/http/filter-parameters.ts
+++ b/packages/actionpack/src/action-dispatch/http/filter-parameters.ts
@@ -35,7 +35,12 @@ export interface FilterParametersHost extends ParametersHost {
   env: Record<string, unknown>;
   path: string;
   queryString: string;
-  parameters(): Record<string, unknown>;
+  /**
+   * The merged parameter hash. Rails calls this `parameters`; trails exposes
+   * the same value via the `params` getter on `Request`, so the mixin reads
+   * from `params` to keep wiring onto `Request` collision-free.
+   */
+  params: Record<string, unknown>;
 }
 
 interface CachedState {
@@ -50,7 +55,7 @@ export function filteredParameters(this: FilterParametersHost): Record<string, u
   const host = this as FilterParametersHost & CachedState;
   if (host._filteredParameters !== undefined) return host._filteredParameters;
   try {
-    host._filteredParameters = parameterFilter.call(this).filter(this.parameters());
+    host._filteredParameters = parameterFilter.call(this).filter(this.params);
   } catch (e) {
     if (e instanceof ParseError) {
       host._filteredParameters = {};

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -31,7 +31,44 @@ import {
   type NullType,
 } from "./mime-negotiation.js";
 import type { MimeType } from "./mime-type.js";
+import {
+  filteredEnv as _filteredEnv,
+  filteredParameters as _filteredParameters,
+  filteredPath as _filteredPath,
+  parameterFilter as _parameterFilter,
+} from "./filter-parameters.js";
+import type { ParameterFilter } from "@blazetrails/activesupport";
 import { RequestUtils, type ParamValue } from "../request/utils.js";
+
+const HTTP_HEADER_NAME = /^[A-Za-z0-9-]+$/;
+const CGI_VARIABLES: ReadonlySet<string> = new Set([
+  "AUTH_TYPE",
+  "CONTENT_LENGTH",
+  "CONTENT_TYPE",
+  "GATEWAY_INTERFACE",
+  "HTTPS",
+  "PATH_INFO",
+  "PATH_TRANSLATED",
+  "QUERY_STRING",
+  "REMOTE_ADDR",
+  "REMOTE_HOST",
+  "REMOTE_IDENT",
+  "REMOTE_USER",
+  "REQUEST_METHOD",
+  "SCRIPT_NAME",
+  "SERVER_NAME",
+  "SERVER_PORT",
+  "SERVER_PROTOCOL",
+  "SERVER_SOFTWARE",
+]);
+
+function envName(key: string): string {
+  if (HTTP_HEADER_NAME.test(key)) {
+    const upper = key.toUpperCase().replace(/-/g, "_");
+    return CGI_VARIABLES.has(upper) ? upper : `HTTP_${upper}`;
+  }
+  return key;
+}
 
 export class Request {
   readonly env: RackEnv;
@@ -267,6 +304,13 @@ export class Request {
     _setIgnoreAcceptHeader(value);
   }
 
+  // --- Filter Parameters (ActionDispatch::Http::FilterParameters) ---
+  declare filteredParameters: () => Record<string, unknown>;
+  declare filteredEnv: () => Record<string, unknown>;
+  declare filteredPath: () => string;
+  declare parameterFilter: () => ParameterFilter;
+
+
   // --- Request type checks ---
 
   get isXmlHttpRequest(): boolean {
@@ -460,11 +504,45 @@ export class Request {
 
   // --- Header access ---
 
-  /** Get an HTTP header value by name (case-insensitive). */
+  /**
+   * Returns the value for the given key mapped to the env. HTTP-header-style
+   * names (alphanumerics + dashes) are converted to their CGI/Rack env name —
+   * `"Content-Type" → "CONTENT_TYPE"`, `"If-None-Match" → "HTTP_IF_NONE_MATCH"`
+   * — to mirror `ActionDispatch::Http::Headers#[]`. Keys that don't match the
+   * pattern (e.g. `"action_dispatch.parameter_filter"`) pass through to the
+   * env unchanged, mirroring `Request#get_header`.
+   */
   getHeader(name: string): string | undefined {
-    // Rack convention: HTTP headers are stored as HTTP_UPPER_SNAKE
-    const key = "HTTP_" + name.toUpperCase().replace(/-/g, "_");
-    return this.env[key] as string | undefined;
+    return this.env[envName(name)] as string | undefined;
+  }
+
+  /** Returns true if the env has a value for `name`. Mirrors `has_header?`. */
+  hasHeader(name: string): boolean {
+    return Object.prototype.hasOwnProperty.call(this.env, envName(name));
+  }
+
+  /** Sets `name` on the env. Returns the assigned value. Mirrors `set_header`. */
+  setHeader(name: string, value: unknown): unknown {
+    this.env[envName(name)] = value;
+    return value;
+  }
+
+  /** Deletes `name` from the env. Mirrors `delete_header`. */
+  deleteHeader(name: string): void {
+    delete this.env[envName(name)];
+  }
+
+  /**
+   * Returns the value for `name`, or invokes `fallback` with the key when
+   * absent. Mirrors `fetch_header`, which yields the key on miss.
+   */
+  fetchHeader<T = unknown>(name: string): unknown;
+  fetchHeader<T>(name: string, fallback: (key: string) => T): unknown | T;
+  fetchHeader<T>(name: string, fallback?: (key: string) => T): unknown | T {
+    const key = envName(name);
+    if (Object.prototype.hasOwnProperty.call(this.env, key)) return this.env[key];
+    if (fallback) return fallback(key);
+    throw new Error(`key not found: ${name}`);
   }
 
   // --- Inspect ---
@@ -575,3 +653,10 @@ Request.prototype.setFormat = function (this: Request, extension: unknown) {
 Request.prototype.setFormats = function (this: Request, extensions: unknown[]) {
   _setFormats.call(mimeHost(this), extensions);
 };
+
+// Mix in ActionDispatch::Http::FilterParameters. The mixin reads the merged
+// param hash via the host's `params` getter (already defined on `Request`).
+Request.prototype.filteredParameters = _filteredParameters;
+Request.prototype.filteredEnv = _filteredEnv;
+Request.prototype.filteredPath = _filteredPath;
+Request.prototype.parameterFilter = _parameterFilter;

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -516,33 +516,38 @@ export class Request {
     return this.env[envName(name)] as string | undefined;
   }
 
-  /** Returns true if the env has a value for `name`. Mirrors `has_header?`. */
-  hasHeader(name: string): boolean {
-    return Object.prototype.hasOwnProperty.call(this.env, envName(name));
+  /**
+   * Returns true if the env has a value for `key`. Mirrors Rails'
+   * `Rack::Request::Env#has_header?` — raw env access, no HTTP-name
+   * conversion. Callers passing HTTP-style names (e.g. `"Content-Type"`)
+   * should reach for `headers[]` (or `getHeader`, which applies the
+   * `Headers#env_name` mapping).
+   */
+  hasHeader(key: string): boolean {
+    return Object.prototype.hasOwnProperty.call(this.env, key);
   }
 
-  /** Sets `name` on the env. Returns the assigned value. Mirrors `set_header`. */
-  setHeader(name: string, value: unknown): unknown {
-    this.env[envName(name)] = value;
+  /** Sets `key` on the env. Returns the assigned value. Mirrors `set_header`. */
+  setHeader(key: string, value: unknown): unknown {
+    this.env[key] = value;
     return value;
   }
 
-  /** Deletes `name` from the env. Mirrors `delete_header`. */
-  deleteHeader(name: string): void {
-    delete this.env[envName(name)];
+  /** Deletes `key` from the env. Mirrors `delete_header`. */
+  deleteHeader(key: string): void {
+    delete this.env[key];
   }
 
   /**
-   * Returns the value for `name`, or invokes `fallback` with the key when
+   * Returns the value for `key`, or invokes `fallback` with `key` when
    * absent. Mirrors `fetch_header`, which yields the key on miss.
    */
-  fetchHeader<T = unknown>(name: string): unknown;
-  fetchHeader<T>(name: string, fallback: (key: string) => T): unknown | T;
-  fetchHeader<T>(name: string, fallback?: (key: string) => T): unknown | T {
-    const key = envName(name);
+  fetchHeader<T = unknown>(key: string): unknown;
+  fetchHeader<T>(key: string, fallback: (key: string) => T): unknown | T;
+  fetchHeader<T>(key: string, fallback?: (key: string) => T): unknown | T {
     if (Object.prototype.hasOwnProperty.call(this.env, key)) return this.env[key];
     if (fallback) return fallback(key);
-    throw new Error(`key not found: ${name}`);
+    throw new Error(`key not found: ${key}`);
   }
 
   // --- Inspect ---

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -310,7 +310,6 @@ export class Request {
   declare filteredPath: () => string;
   declare parameterFilter: () => ParameterFilter;
 
-
   // --- Request type checks ---
 
   get isXmlHttpRequest(): boolean {
@@ -542,7 +541,7 @@ export class Request {
    * Returns the value for `key`, or invokes `fallback` with `key` when
    * absent. Mirrors `fetch_header`, which yields the key on miss.
    */
-  fetchHeader<T = unknown>(key: string): unknown;
+  fetchHeader(key: string): unknown;
   fetchHeader<T>(key: string, fallback: (key: string) => T): unknown | T;
   fetchHeader<T>(key: string, fallback?: (key: string) => T): unknown | T {
     if (Object.prototype.hasOwnProperty.call(this.env, key)) return this.env[key];

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -5,6 +5,8 @@
  */
 
 import type { CookieExpires } from "../middleware/cookies.js";
+import type { Request } from "./request.js";
+import { filteredLocation as _filteredLocation } from "./filter-redirect.js";
 
 export class Response {
   private _status: number;
@@ -14,7 +16,7 @@ export class Response {
   private _charset: string | undefined;
   private _cookies: Map<string, CookieValue> = new Map();
   private _sending = false;
-  request: { host?: string; method?: string; path?: string } | null = null;
+  request: Request | null = null;
 
   constructor(status = 200, headers: Record<string, string> = {}, body: string[] = []) {
     this._status = status;
@@ -125,6 +127,25 @@ export class Response {
 
   get committed(): boolean {
     return this._committed;
+  }
+
+  // --- Location ---
+
+  /** The value of the `Location` header. Mirrors `Response#location`. */
+  get location(): string {
+    return this._headers["Location"] ?? this._headers["location"] ?? "";
+  }
+
+  set location(url: string) {
+    this._headers["Location"] = url;
+  }
+
+  /**
+   * Returns the redirect location with sensitive query parameters filtered
+   * out. See `ActionDispatch::Http::FilterRedirect`.
+   */
+  filteredLocation(): string {
+    return _filteredLocation.call(this);
   }
 
   // --- Cookies ---

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -133,11 +133,11 @@ export class Response {
 
   /** The value of the `Location` header. Mirrors `Response#location`. */
   get location(): string {
-    return this._headers["Location"] ?? this._headers["location"] ?? "";
+    return this._headers["location"] ?? this._headers["Location"] ?? "";
   }
 
   set location(url: string) {
-    this._headers["Location"] = url;
+    this._headers["location"] = url;
   }
 
   /**

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -137,6 +137,7 @@ export class Response {
   }
 
   set location(url: string) {
+    delete this._headers["Location"];
     this._headers["location"] = url;
   }
 


### PR DESCRIPTION
## Summary

- Wire the previously-dead `ActionDispatch::Http::FilterParameters` mixin onto `Request` (`filteredParameters`, `filteredEnv`, `filteredPath`, `parameterFilter`).
- Wire `Http::FilterRedirect` onto `Response` via a new `filteredLocation()` method, plus a `Response#location` accessor and widened `Response#request: Request | null`.
- Add Rails-parity `hasHeader`/`setHeader`/`deleteHeader`/`fetchHeader` on `Request` (raw env access) and upgrade `Request.getHeader` to use `Headers#env_name` conversion so dotted env keys (e.g. `action_dispatch.parameter_filter`) pass through unchanged while HTTP-style names continue to map to `HTTP_*`/CGI vars.

Closes the http/filter-parameters + filter-redirect entry in \`docs/actionpack-100-percent.md\` (Tier 2).

## Notes

- `FilterParametersHost` now reads the merged param hash via \`params\` rather than \`parameters()\`. trails uses \`params\` for what Rails calls \`parameters\`, and the existing controller dispatch path treats \`(request as any).parameters\` as a Parameters pre-population marker, so collision avoidance matters.
- WHATWG URL parser used in \`parameterFilteredLocation\` may diverge from Ruby \`URI.parse\` for byte-for-byte log output (e.g. percent-encoding of special characters). The set of *which* params get filtered is preserved.

## Test plan

- [x] \`pnpm vitest run packages/actionpack/src/action-dispatch/http/{filter-parameters,filter-redirect}.test.ts\`
- [x] \`pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/{request,response}.test.ts\` (new integration tests added)
- [x] \`pnpm vitest run packages/actionpack/src/action-controller/\` (no regressions in 860 controller tests; verified \`params.get(...)\` dispatch path)
- [x] \`pnpm --filter @blazetrails/actionpack build\` + \`pnpm lint\`