### PR TITLE
fix(activerecord): seed _createdColumns from CREATE TABLE body (B6.3b)

### DIFF
--- a/packages/activerecord/src/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/bigint-roundtrip.test.ts
@@ -5,26 +5,21 @@
  * JSON.stringify, where) with big_integer attributes. Runs on SQLite3
  * by default (no DB); runs on PG/MySQL when *_TEST_URL env vars are set.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 const BIG = 2n ** 62n; // 4611686018427387904 — above Number.MAX_SAFE_INTEGER
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
   await defineSchema(adapter, { metrics: { score: "big_integer", label: "string" } });
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
-});
+withTransactionalFixtures(() => adapter);
 
 describe("bigint model round-trip (all adapters)", () => {
   function makeModel() {

--- a/packages/activerecord/src/boolean.test.ts
+++ b/packages/activerecord/src/boolean.test.ts
@@ -2,25 +2,20 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
   await defineSchema(adapter, { topics: { title: "string", approved: "boolean" } });
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
-});
+withTransactionalFixtures(() => adapter);
 
 describe("BooleanTest", () => {
   function makeModel() {

--- a/packages/activerecord/src/custom-locking.test.ts
+++ b/packages/activerecord/src/custom-locking.test.ts
@@ -1,23 +1,18 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
   await defineSchema(adapter, {
     posts: { title: "string", lock_version: "integer" },
   });
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
-});
+withTransactionalFixtures(() => adapter);
 
 describe("CustomLockingTest", () => {
   it("custom lock", async () => {

--- a/packages/activerecord/src/date.test.ts
+++ b/packages/activerecord/src/date.test.ts
@@ -1,22 +1,17 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "./index.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
   await defineSchema(adapter, { events: { start_date: "date" } });
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
-});
+withTransactionalFixtures(() => adapter);
 
 describe("DateTest", () => {
   it("date with time value", async () => {

--- a/packages/activerecord/src/finder-respond-to.test.ts
+++ b/packages/activerecord/src/finder-respond-to.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, RecordNotFound } from "./index.js";
 import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
@@ -15,6 +15,12 @@ beforeAll(async () => {
   await defineSchema(adapter, {
     topics: { title: "string", author_name: "string", status: "string" },
   });
+});
+withTransactionalFixtures(() => adapter);
+
+// Recreate the model per test so a test that mutates the class (adds an
+// attribute, primes a finder cache, etc.) can't leak into later tests.
+beforeEach(() => {
   Topic = class extends Base {
     static {
       this.attribute("title", "string");
@@ -23,7 +29,6 @@ beforeAll(async () => {
     }
   };
 });
-withTransactionalFixtures(() => adapter);
 
 describe("FinderRespondToTest", () => {
   it("should preserve normal respond to behavior on base", () => {

--- a/packages/activerecord/src/finder-respond-to.test.ts
+++ b/packages/activerecord/src/finder-respond-to.test.ts
@@ -1,18 +1,20 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, RecordNotFound } from "./index.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 let Topic: typeof Base;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
-  await defineSchema(adapter, { topics: { title: "string", author_name: "string" } });
+  // `status` is added dynamically by one test below; declare it up front so
+  // a later test's INSERT doesn't trigger ALTER ADD COLUMN inside the
+  // transactional fixture (MariaDB implicit-commits on DDL).
+  await defineSchema(adapter, {
+    topics: { title: "string", author_name: "string", status: "string" },
+  });
   Topic = class extends Base {
     static {
       this.attribute("title", "string");
@@ -21,9 +23,7 @@ beforeEach(async () => {
     }
   };
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
-});
+withTransactionalFixtures(() => adapter);
 
 describe("FinderRespondToTest", () => {
   it("should preserve normal respond to behavior on base", () => {

--- a/packages/activerecord/src/habtm-destroy-order.test.ts
+++ b/packages/activerecord/src/habtm-destroy-order.test.ts
@@ -1,26 +1,21 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, association, registerModel } from "./index.js";
 import { Associations, loadHabtm } from "./associations.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
   await defineSchema(adapter, {
     students: { name: "string" },
     lessons: { name: "string" },
     lessons_students: { lesson_id: "integer", student_id: "integer" },
   });
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
-});
+withTransactionalFixtures(() => adapter);
 
 describe("HabtmDestroyOrderTest", () => {
   function makeModels() {

--- a/packages/activerecord/src/inherited.test.ts
+++ b/packages/activerecord/src/inherited.test.ts
@@ -1,24 +1,19 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
   await defineSchema(adapter, {
     parents: { name: "string" },
     children: { name: "string" },
   });
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
-});
+withTransactionalFixtures(() => adapter);
 
 describe("InheritedTest", () => {
   it("super before filter attributes", async () => {

--- a/packages/activerecord/src/test-adapter.test.ts
+++ b/packages/activerecord/src/test-adapter.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from "vitest";
+import { parseCreateTableColumns } from "./test-adapter.js";
+
+describe("parseCreateTableColumns", () => {
+  it("extracts simple columns from a MySQL CREATE TABLE", () => {
+    const sql =
+      "CREATE TABLE IF NOT EXISTS `metrics` " +
+      "(`id` bigint NOT NULL AUTO_INCREMENT PRIMARY KEY, `score` bigint, `label` varchar(255))";
+    expect([...parseCreateTableColumns(sql)]).toEqual(["id", "score", "label"]);
+  });
+
+  it("extracts columns from a PG CREATE TABLE", () => {
+    const sql =
+      'CREATE TABLE "metrics" ' +
+      '("id" SERIAL PRIMARY KEY, "score" bigint, "label" text, "score_2" numeric(10,2))';
+    expect([...parseCreateTableColumns(sql)]).toEqual(["id", "score", "label", "score_2"]);
+  });
+
+  it("ignores commas inside nested type parentheses", () => {
+    const sql = 'CREATE TABLE "t" ("id" SERIAL, "amount" DECIMAL(10,2), "name" VARCHAR(50))';
+    expect([...parseCreateTableColumns(sql)]).toEqual(["id", "amount", "name"]);
+  });
+
+  it("skips table-level constraints", () => {
+    const sql =
+      'CREATE TABLE "t" ("id" int, "name" text, ' +
+      'PRIMARY KEY ("id"), UNIQUE ("name"), ' +
+      'FOREIGN KEY ("other_id") REFERENCES "u" ("id"), ' +
+      'CONSTRAINT chk CHECK ("id" > 0))';
+    expect([...parseCreateTableColumns(sql)]).toEqual(["id", "name"]);
+  });
+
+  it("handles a single-quoted DEFAULT containing a close paren", () => {
+    const sql = "CREATE TABLE `t` (`id` int, `label` varchar(10) DEFAULT ')(', `n` int)";
+    expect([...parseCreateTableColumns(sql)]).toEqual(["id", "label", "n"]);
+  });
+
+  it("handles doubled single-quote escape inside a DEFAULT", () => {
+    const sql = "CREATE TABLE `t` (`id` int, `label` varchar(10) DEFAULT 'it''s )', `n` int)";
+    expect([...parseCreateTableColumns(sql)]).toEqual(["id", "label", "n"]);
+  });
+
+  it("falls back to {id} when there is no parenthesized body", () => {
+    expect([...parseCreateTableColumns("CREATE TABLE `t`")]).toEqual(["id"]);
+  });
+
+  it("falls back to {id} when the SQL is unrelated", () => {
+    expect([...parseCreateTableColumns("INSERT INTO t VALUES (1)")]).toEqual(["id"]);
+  });
+
+  it("falls back to {id} when the body never closes", () => {
+    expect([...parseCreateTableColumns("CREATE TABLE `t` (`id` int")]).toEqual(["id"]);
+  });
+
+  it("accepts unquoted identifiers", () => {
+    const sql = "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT, status TEXT)";
+    expect([...parseCreateTableColumns(sql)]).toEqual(["id", "name", "status"]);
+  });
+});

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -422,16 +422,50 @@ async function processPendingModels(inner: any): Promise<void> {
  *
  * Tracks paren depth so a nested type like `DECIMAL(10,2)` doesn't count
  * as a top-level comma; identifiers may be quoted with `"`, `` ` ``, or
- * unquoted. Returns `Set(["id"])` if no body is found.
+ * unquoted. Skips quoted SQL literals so a default like `DEFAULT ')'`
+ * doesn't close the column list. Returns `Set(["id"])` if no body is found.
+ *
+ * @internal exported for unit testing.
  */
-function parseCreateTableColumns(sql: string): Set<string> {
+export function parseCreateTableColumns(sql: string): Set<string> {
   const m = sql.match(/CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+["`]?\w+["`]?\s*\(/i);
   if (!m) return new Set(["id"]);
   const start = m.index! + m[0].length;
+
+  // Walk the body tracking paren depth, but skip over quoted literals so a
+  // `DEFAULT ')'` in a column definition doesn't close the column list.
+  // Supports single-quoted SQL strings (with `''` escape), double/backtick-
+  // quoted identifiers (which may legitimately contain parens), and MySQL's
+  // `\)` escape inside single-quoted strings.
+  const skipQuoted = (i: number, quote: string): number => {
+    i++;
+    while (i < sql.length) {
+      const ch = sql[i];
+      if (quote === "'" && ch === "\\" && i + 1 < sql.length) {
+        i += 2;
+        continue;
+      }
+      if (ch === quote) {
+        if (quote === "'" && sql[i + 1] === "'") {
+          i += 2;
+          continue;
+        }
+        return i + 1;
+      }
+      i++;
+    }
+    return i;
+  };
+
   let depth = 1;
   let end = -1;
-  for (let i = start; i < sql.length; i++) {
+  let i = start;
+  while (i < sql.length) {
     const ch = sql[i];
+    if (ch === "'" || ch === '"' || ch === "`") {
+      i = skipQuoted(i, ch);
+      continue;
+    }
     if (ch === "(") depth++;
     else if (ch === ")") {
       depth--;
@@ -440,6 +474,7 @@ function parseCreateTableColumns(sql: string): Set<string> {
         break;
       }
     }
+    i++;
   }
   if (end < 0) return new Set(["id"]);
 
@@ -457,15 +492,24 @@ function parseCreateTableColumns(sql: string): Set<string> {
     const colMatch = piece.match(/^(?:["`](\w+)["`]|(\w+))/);
     if (colMatch) cols.add(colMatch[1] ?? colMatch[2]);
   };
-  for (let i = 0; i < body.length; i++) {
-    const ch = body[i];
+  let j = 0;
+  while (j < body.length) {
+    const ch = body[j];
+    if (ch === "'" || ch === '"' || ch === "`") {
+      const next = skipQuoted(start + j, ch) - start;
+      part += body.slice(j, next);
+      j = next;
+      continue;
+    }
     if (ch === "(") pd++;
     else if (ch === ")") pd--;
     if (ch === "," && pd === 0) {
       flush();
+      j++;
       continue;
     }
     part += ch;
+    j++;
   }
   flush();
   if (cols.size === 0) cols.add("id");

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -413,6 +413,65 @@ async function processPendingModels(inner: any): Promise<void> {
   _pendingCpk.clear();
 }
 
+/**
+ * Extract the top-level column names from a `CREATE TABLE ... (...)` body.
+ * Used to seed `_createdColumns` so `processPendingModels()` skips an
+ * ALTER ADD on a column the CREATE TABLE just defined — important on
+ * MariaDB, where ALTER inside a transaction implicit-commits the BEGIN
+ * and breaks `withTransactionalFixtures` isolation.
+ *
+ * Tracks paren depth so a nested type like `DECIMAL(10,2)` doesn't count
+ * as a top-level comma; identifiers may be quoted with `"`, `` ` ``, or
+ * unquoted. Returns `Set(["id"])` if no body is found.
+ */
+function parseCreateTableColumns(sql: string): Set<string> {
+  const m = sql.match(/CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+["`]?\w+["`]?\s*\(/i);
+  if (!m) return new Set(["id"]);
+  const start = m.index! + m[0].length;
+  let depth = 1;
+  let end = -1;
+  for (let i = start; i < sql.length; i++) {
+    const ch = sql[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+  }
+  if (end < 0) return new Set(["id"]);
+
+  const cols = new Set<string>();
+  const body = sql.slice(start, end);
+  let part = "";
+  let pd = 0;
+  const flush = () => {
+    const piece = part.trim();
+    part = "";
+    if (!piece) return;
+    // Skip table-level constraints: PRIMARY KEY (...), FOREIGN KEY, UNIQUE, INDEX, KEY, CHECK, CONSTRAINT.
+    if (/^(PRIMARY\s+KEY|FOREIGN\s+KEY|UNIQUE\b|INDEX\b|KEY\b|CHECK\b|CONSTRAINT\b)/i.test(piece))
+      return;
+    const colMatch = piece.match(/^(?:["`](\w+)["`]|(\w+))/);
+    if (colMatch) cols.add(colMatch[1] ?? colMatch[2]);
+  };
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === "(") pd++;
+    else if (ch === ")") pd--;
+    if (ch === "," && pd === 0) {
+      flush();
+      continue;
+    }
+    part += ch;
+  }
+  flush();
+  if (cols.size === 0) cols.add("id");
+  return cols;
+}
+
 let _ddlSpCounter = 0;
 
 /**
@@ -863,8 +922,12 @@ class SchemaAdapter implements DatabaseAdapter {
         if (useSp) await this.inner.releaseSavepoint(sp);
         if (createMatch) {
           _createdTables.add(createMatch[1]);
+          // Parse the column list from the CREATE TABLE body so subsequent
+          // processPendingModels() doesn't try to ALTER ADD an already-present
+          // column. On MariaDB ALTER causes an implicit commit that breaks
+          // any enclosing BEGIN/ROLLBACK (transactional fixtures rely on this).
           if (!_createdColumns.has(createMatch[1])) {
-            _createdColumns.set(createMatch[1], new Set(["id"]));
+            _createdColumns.set(createMatch[1], parseCreateTableColumns(sql));
           }
         }
         if (dropMatch) {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -516,6 +516,41 @@ export function parseCreateTableColumns(sql: string): Set<string> {
   return cols;
 }
 
+/**
+ * Update `_createdTables`/`_createdColumns` after a CREATE TABLE or DROP TABLE
+ * has successfully executed. Shared between {@link SchemaAdapter.executeMutation}
+ * and {@link SchemaAdapter.exec} so both schema-setup paths keep tracking in
+ * sync — otherwise tests that issue raw DDL via `adapter.exec(...)` would
+ * leave the recovery path to add columns via ALTER inside a per-test
+ * transactional fixture (MariaDB implicit-commits on ALTER and breaks the
+ * fixture's BEGIN/ROLLBACK).
+ *
+ * For CREATE: when the table was already tracked, the CREATE was likely
+ * `IF NOT EXISTS` against a pre-existing table whose real column set may
+ * differ from the SQL we're parsing — fall back to `{id}` (mirroring the
+ * pre-#1938 behavior) rather than recording columns that might not exist.
+ *
+ * @internal
+ */
+function recordDdlTracking(
+  sql: string,
+  createMatch: RegExpMatchArray | null,
+  dropMatch: RegExpMatchArray | null,
+): void {
+  if (createMatch) {
+    const table = createMatch[1];
+    const wasTracked = _createdTables.has(table);
+    _createdTables.add(table);
+    if (!_createdColumns.has(table)) {
+      _createdColumns.set(table, wasTracked ? new Set(["id"]) : parseCreateTableColumns(sql));
+    }
+  }
+  if (dropMatch) {
+    _createdTables.delete(dropMatch[1]);
+    _createdColumns.delete(dropMatch[1]);
+  }
+}
+
 let _ddlSpCounter = 0;
 
 /**
@@ -964,20 +999,7 @@ class SchemaAdapter implements DatabaseAdapter {
         if (useSp) await this.inner.createSavepoint(sp);
         const result = await this.inner.executeMutation(sql, binds, name);
         if (useSp) await this.inner.releaseSavepoint(sp);
-        if (createMatch) {
-          _createdTables.add(createMatch[1]);
-          // Parse the column list from the CREATE TABLE body so subsequent
-          // processPendingModels() doesn't try to ALTER ADD an already-present
-          // column. On MariaDB ALTER causes an implicit commit that breaks
-          // any enclosing BEGIN/ROLLBACK (transactional fixtures rely on this).
-          if (!_createdColumns.has(createMatch[1])) {
-            _createdColumns.set(createMatch[1], parseCreateTableColumns(sql));
-          }
-        }
-        if (dropMatch) {
-          _createdTables.delete(dropMatch[1]);
-          _createdColumns.delete(dropMatch[1]);
-        }
+        recordDdlTracking(sql, createMatch, dropMatch);
         return result;
       } catch (e: any) {
         lastError = e;
@@ -1231,6 +1253,8 @@ class SchemaAdapter implements DatabaseAdapter {
 
   async exec(sql: string): Promise<void> {
     await this.setup();
+    const createMatch = sql.match(/CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+["`](\w+)["`]/i);
+    const dropMatch = sql.match(/DROP\s+TABLE(?:\s+IF\s+EXISTS)?\s+["`](\w+)["`]/i);
     // Auto-add IF NOT EXISTS / IF EXISTS
     if (/CREATE\s+TABLE\s+(?!IF)/i.test(sql)) {
       sql = sql.replace(/CREATE\s+TABLE\s+/i, "CREATE TABLE IF NOT EXISTS ");
@@ -1238,7 +1262,8 @@ class SchemaAdapter implements DatabaseAdapter {
     if (/DROP\s+TABLE\s+(?!IF)/i.test(sql)) {
       sql = sql.replace(/DROP\s+TABLE\s+/i, "DROP TABLE IF EXISTS ");
     }
-    return execDdlWithSavepoint(this.inner, sql);
+    await execDdlWithSavepoint(this.inner, sql);
+    recordDdlTracking(sql, createMatch, dropMatch);
   }
 
   async explain(

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -538,7 +538,8 @@ function recordDdlTracking(
   dropMatch: RegExpMatchArray | null,
 ): void {
   if (createMatch) {
-    const table = createMatch[1];
+    // `["`](\w+)["`]` lives in group 1, bare `\w+` in group 2.
+    const table = createMatch[1] ?? createMatch[2];
     const wasTracked = _createdTables.has(table);
     _createdTables.add(table);
     if (!_createdColumns.has(table)) {
@@ -546,8 +547,9 @@ function recordDdlTracking(
     }
   }
   if (dropMatch) {
-    _createdTables.delete(dropMatch[1]);
-    _createdColumns.delete(dropMatch[1]);
+    const table = dropMatch[1] ?? dropMatch[2];
+    _createdTables.delete(table);
+    _createdColumns.delete(table);
   }
 }
 
@@ -978,8 +980,10 @@ class SchemaAdapter implements DatabaseAdapter {
     // Detect DDL shape ahead of time. We record table tracking only AFTER the
     // SQL succeeds — recording up front poisons _createdTables when the SQL
     // fails, which then makes handleMissingSchemaError refuse to recover.
-    const createMatch = sql.match(/CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+["`](\w+)["`]/i);
-    const dropMatch = sql.match(/DROP\s+TABLE(?:\s+IF\s+EXISTS)?\s+["`](\w+)["`]/i);
+    const createMatch = sql.match(
+      /CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+(?:["`](\w+)["`]|(\w+))/i,
+    );
+    const dropMatch = sql.match(/DROP\s+TABLE(?:\s+IF\s+EXISTS)?\s+(?:["`](\w+)["`]|(\w+))/i);
 
     // Auto-add IF NOT EXISTS to CREATE TABLE to prevent "already exists" errors
     if (/CREATE\s+TABLE\s+(?!IF)/i.test(sql)) {
@@ -1253,8 +1257,10 @@ class SchemaAdapter implements DatabaseAdapter {
 
   async exec(sql: string): Promise<void> {
     await this.setup();
-    const createMatch = sql.match(/CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+["`](\w+)["`]/i);
-    const dropMatch = sql.match(/DROP\s+TABLE(?:\s+IF\s+EXISTS)?\s+["`](\w+)["`]/i);
+    const createMatch = sql.match(
+      /CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+(?:["`](\w+)["`]|(\w+))/i,
+    );
+    const dropMatch = sql.match(/DROP\s+TABLE(?:\s+IF\s+EXISTS)?\s+(?:["`](\w+)["`]|(\w+))/i);
     // Auto-add IF NOT EXISTS / IF EXISTS
     if (/CREATE\s+TABLE\s+(?!IF)/i.test(sql)) {
       sql = sql.replace(/CREATE\s+TABLE\s+/i, "CREATE TABLE IF NOT EXISTS ");

--- a/packages/activerecord/src/validations/absence-validation.test.ts
+++ b/packages/activerecord/src/validations/absence-validation.test.ts
@@ -2,25 +2,20 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("AbsenceValidationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeAll(() => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = createTestAdapter();
-  });
-  beforeEach(async () => {
     await defineSchema(adapter, { topics: { title: "string", body: "string" } });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
   function makeModel() {
     class Topic extends Base {
       static {

--- a/packages/activerecord/src/validations/length-validation.test.ts
+++ b/packages/activerecord/src/validations/length-validation.test.ts
@@ -2,25 +2,20 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("LengthValidationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeAll(() => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = createTestAdapter();
-  });
-  beforeEach(async () => {
     await defineSchema(adapter, { topics: { title: "string" } });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
   function makeModel() {
     class Topic extends Base {
       static {

--- a/packages/activerecord/src/validations/presence-validation.test.ts
+++ b/packages/activerecord/src/validations/presence-validation.test.ts
@@ -2,25 +2,20 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("PresenceValidationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeAll(() => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = createTestAdapter();
-  });
-  beforeEach(async () => {
     await defineSchema(adapter, { topics: { title: "string", body: "string" } });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   function makeModel() {
     class Topic extends Base {

--- a/packages/activerecord/src/validations/validations.test.ts
+++ b/packages/activerecord/src/validations/validations.test.ts
@@ -1,24 +1,19 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("Validation Contexts (Rails-guided)", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
-  });
-  beforeEach(async () => {
     await defineSchema(adapter, {
       users: { name: "string", terms: "string", change_reason: "string" },
     });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   // Rails: test "validation on: :create"
   it("valid uses create context when new", async () => {


### PR DESCRIPTION
## Summary

Re-applies the 11 transactional-fixture pilot files reverted in #1933 and fixes the underlying MariaDB failure. The PR description in #1933 attributed the breakage to a missing \`pool.pin_connection!\` equivalent, but the diagnosis was wrong — empirical query tracing on MariaDB reveals a different root cause.

## Diagnosis

Patched the mysql2 driver pool to log every query during \`bigint-roundtrip.test.ts\` with the pilot re-applied:

\`\`\`
BEGIN
ALTER TABLE \`metrics\` ADD COLUMN \`score\` BIGINT      <- DDL inside BEGIN
ALTER TABLE \`metrics\` ADD COLUMN \`label\` TEXT        <- DDL inside BEGIN
SAVEPOINT \`active_record_1\`
INSERT INTO \`metrics\` ...
RELEASE SAVEPOINT \`active_record_1\`
ROLLBACK TO SAVEPOINT \`active_record_1\`               <- ER 1305: doesn't exist
\`\`\`

MariaDB implicit-commits on every ALTER TABLE. The fixture's BEGIN is gone after the first ALTER, the SAVEPOINT opens in a new auto-committed statement, the INSERT auto-commits (rows persist across tests), and the post-commit rollback hits an already-released savepoint.

## Root cause

\`SchemaAdapter.executeMutation\` records only \`{id}\` in \`_createdColumns\` after a successful CREATE TABLE (test-adapter.ts:867). When the test then registers a model whose attributes match the columns just CREATE'd, \`processPendingModels()\` reads stale tracking, decides the columns are missing, and ALTERs to add them — inside the fixture's BEGIN.

## Fix

Parse the column list from the CREATE TABLE body and seed \`_createdColumns\` with the full set. \`parseCreateTableColumns()\` tracks paren depth so \`DECIMAL(10,2)\` and table-level constraints (\`PRIMARY KEY (...)\`, \`UNIQUE\`, \`CHECK\`, \`FOREIGN KEY\`, etc.) are handled correctly.

\`finder-respond-to.test.ts\` declares \`status\` in \`defineSchema\` because one test adds the attribute dynamically; without it the next INSERT would still trigger ALTER-inside-BEGIN even with the seeding fix.

## On the original task description

\`ConnectionPool#pinConnectionBang\` / \`unpinConnectionBang\` are already implemented (connection-pool.ts:499–569) and remain unused by \`withTransactionalFixtures\` because the test infra wraps a single bare adapter rather than going through a real ConnectionPool. Routing test-adapter through ConnectionPool is a follow-up but is no longer blocking Phase 6 — the pilots are green without it.

## Test plan

- [x] 11 pilot files on MariaDB (\`MYSQL_TEST_URL\`) — 46 passed, 5 skipped
- [x] 11 pilot files on PostgreSQL (\`PG_TEST_URL\`) — 46 passed, 5 skipped
- [x] 11 pilot files on SQLite (default) — 46 passed, 5 skipped
- [x] \`test-adapter\` + \`test-helpers/\` (100 tests) — green
- [x] Size: 252 LOC (under 300 ceiling)
- [ ] CI green across all adapters