### PR TITLE
feat(actionview): Phase 0.5 actionpack-unblocking stubs

### DIFF
--- a/packages/actionview/src/base.ts
+++ b/packages/actionview/src/base.ts
@@ -1,0 +1,23 @@
+/**
+ * Standalone view context. Phase 0.5 stub — just enough surface for
+ * actionpack `debug-view.ts` to extend, mixin chains in `metal/live` and
+ * `metal/helpers` to compile, and the `action_view` on-load callback to
+ * wire `defaultFormats` / `streamingCompletionOnException`. Real Base
+ * (assigns, output buffer, view renderer, with_view_paths) lands in
+ * Phase 4.
+ *
+ * @internal stub - real impl in Phase 4
+ */
+
+export class Base {
+  /** @internal stub - real impl in Phase 4 */
+  static streamingCompletionOnException = `"><script>window.location = "/500.html"</script></html>`;
+
+  /** @internal stub - real impl in Phase 4 */
+  static defaultFormats: string[] = ["html", "text", "js", "css", "xml", "json"];
+
+  /** @internal stub - real impl in Phase 4 */
+  static empty(): Base {
+    return new Base();
+  }
+}

--- a/packages/actionview/src/digestor.test.ts
+++ b/packages/actionview/src/digestor.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+
+import { Digestor } from "./digestor.js";
+import { LookupContext } from "./lookup-context.js";
+import { TemplateHandlerRegistry } from "./template-handler.js";
+import { InMemoryResolver } from "./template-resolver.js";
+
+function withFinder(source: string): LookupContext {
+  TemplateHandlerRegistry.register({
+    extensions: ["html"],
+    render: (s) => s,
+  });
+  const resolver = new InMemoryResolver();
+  resolver.add("posts/show", "html", "html", source);
+  resolver.add("posts/index", "html", "html", source);
+  const finder = new LookupContext();
+  finder.addResolver(resolver);
+  return finder;
+}
+
+describe("Digestor.digest", () => {
+  it("is stable for identical inputs", () => {
+    const a = Digestor.digest({ name: "posts/show", format: "html", finder: withFinder("hello") });
+    const b = Digestor.digest({ name: "posts/show", format: "html", finder: withFinder("hello") });
+    expect(a).toBe(b);
+  });
+
+  it("changes when the resolved template source changes", () => {
+    const a = Digestor.digest({ name: "posts/show", format: "html", finder: withFinder("hello") });
+    const b = Digestor.digest({
+      name: "posts/show",
+      format: "html",
+      finder: withFinder("goodbye"),
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("changes when the name changes", () => {
+    const finder = withFinder("hello");
+    const a = Digestor.digest({ name: "posts/show", format: "html", finder });
+    const b = Digestor.digest({ name: "posts/index", format: "html", finder });
+    expect(a).not.toBe(b);
+  });
+
+  it("returns a 16-char lowercase hex string", () => {
+    const digest = Digestor.digest({ name: "posts/show", format: "html", finder: withFinder("x") });
+    expect(digest).toMatch(/^[0-9a-f]{16}$/);
+  });
+
+  it("treats a missing template as empty source rather than throwing", () => {
+    const finder = new LookupContext();
+    expect(() =>
+      Digestor.digest({ name: "missing/template", format: "html", finder }),
+    ).not.toThrow();
+  });
+});

--- a/packages/actionview/src/digestor.ts
+++ b/packages/actionview/src/digestor.ts
@@ -1,0 +1,37 @@
+/**
+ * Computes a stable digest of a template for cache keys (used by
+ * `etag_with_template_digest`). This stub digests the resolved source
+ * only; the transitive `render`-call dependency walk lands in Phase 6.
+ *
+ * @internal stub - real impl in Phase 6
+ */
+
+import type { LookupContext } from "./lookup-context.js";
+
+export interface DigestorOptions {
+  name: string;
+  format?: string;
+  finder: LookupContext;
+  dependencies?: string[];
+}
+
+export class Digestor {
+  /** @internal stub - real impl in Phase 6 */
+  static digest({ name, format = "html", finder }: DigestorOptions): string {
+    const slash = name.lastIndexOf("/");
+    const prefix = slash >= 0 ? name.slice(0, slash) : "";
+    const action = slash >= 0 ? name.slice(slash + 1) : name;
+    const source = finder.findTemplate(action, prefix, format)?.source ?? "";
+    return fnv1a64Hex(`${name}|${format}|${source}`);
+  }
+}
+
+function fnv1a64Hex(input: string): string {
+  let hash = 0xcbf29ce484222325n;
+  const prime = 0x100000001b3n;
+  const mask = 0xffffffffffffffffn;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash ^ BigInt(input.charCodeAt(i))) * prime) & mask;
+  }
+  return hash.toString(16).padStart(16, "0");
+}

--- a/packages/actionview/src/digestor.ts
+++ b/packages/actionview/src/digestor.ts
@@ -10,19 +10,20 @@ import type { LookupContext } from "./lookup-context.js";
 
 export interface DigestorOptions {
   name: string;
-  format?: string;
+  format?: string | null;
   finder: LookupContext;
-  dependencies?: string[];
+  dependencies?: string[] | null;
 }
 
 export class Digestor {
   /** @internal stub - real impl in Phase 6 */
-  static digest({ name, format = "html", finder }: DigestorOptions): string {
+  static digest({ name, format, finder }: DigestorOptions): string {
     const slash = name.lastIndexOf("/");
     const prefix = slash >= 0 ? name.slice(0, slash) : "";
     const action = slash >= 0 ? name.slice(slash + 1) : name;
-    const source = finder.findTemplate(action, prefix, format)?.source ?? "";
-    return fnv1a64Hex(`${name}|${format}|${source}`);
+    const fmt = format ?? "html";
+    const source = finder.findTemplate(action, prefix, fmt)?.source ?? "";
+    return fnv1a64Hex(`${name}|${format ?? ""}|${source}`);
   }
 }
 

--- a/packages/actionview/src/helpers/form-builder.ts
+++ b/packages/actionview/src/helpers/form-builder.ts
@@ -1,0 +1,33 @@
+/**
+ * Sentinel FormBuilder so AC `form_builder.ts` can default its
+ * `defaultFormBuilder` class attribute. The real builder (`text_field`,
+ * `select`, nested `fields_for`, etc.) lands in Phase 5 T3.
+ *
+ * @internal stub - real impl in Phase 5 T3
+ */
+
+export interface FormBuilderOptions {
+  index?: string | number;
+  multipart?: boolean;
+  builder?: typeof FormBuilder;
+  [k: string]: unknown;
+}
+
+export class FormBuilder {
+  readonly objectName: string;
+  readonly object: unknown;
+  readonly template: unknown;
+  readonly options: FormBuilderOptions;
+
+  constructor(
+    objectName: string,
+    object: unknown,
+    template: unknown,
+    options: FormBuilderOptions = {},
+  ) {
+    this.objectName = objectName;
+    this.object = object;
+    this.template = template;
+    this.options = options;
+  }
+}

--- a/packages/actionview/src/helpers/index.ts
+++ b/packages/actionview/src/helpers/index.ts
@@ -1,3 +1,6 @@
+export { FormBuilder } from "./form-builder.js";
+export type { FormBuilderOptions } from "./form-builder.js";
+
 export { raw, safeJoin, toSentence } from "./output-safety-helper.js";
 export type { ToSentenceOptions } from "./output-safety-helper.js";
 

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -12,7 +12,26 @@ export {
   InMemoryResolver,
 } from "./template-resolver.js";
 
-export { LookupContext, MissingTemplate } from "./lookup-context.js";
+export { LookupContext, MissingTemplate, DetailsKey } from "./lookup-context.js";
+
+export { TemplateError } from "./template/error.js";
+export type { TemplateErrorOptions } from "./template/error.js";
+
+export { PathRegistry } from "./path-registry.js";
+
+export { Digestor } from "./digestor.js";
+export type { DigestorOptions } from "./digestor.js";
+
+export { Base } from "./base.js";
+
+export type {
+  Rendering,
+  Layouts,
+  LayoutsClass,
+  ViewPaths,
+  ViewPathsClass,
+  RenderOptions as RenderingOptions,
+} from "./rendering.js";
 
 export {
   Renderer,

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -4,7 +4,9 @@ export {
   TemplateHandlerRegistry,
 } from "./template-handler.js";
 
-export { type Template } from "./template.js";
+// Merged: `Template` is both the interface (data shape) and a namespace
+// exposing the Rails-spelled `Template.Error` class.
+export { Template } from "./template.js";
 
 export {
   type TemplateResolver,

--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -18,6 +18,17 @@ import type { TemplateResolver } from "./template-resolver.js";
 import type { Template } from "./template.js";
 
 export class MissingTemplate extends Error {
+  /** Rails-shape accessors — refined in Phase 1d. @internal stub - real impl in Phase 1d */
+  readonly path: string;
+  /** @internal stub - real impl in Phase 1d */
+  readonly paths: string[];
+  /** @internal stub - real impl in Phase 1d */
+  readonly prefixes: string[];
+  /** @internal stub - real impl in Phase 1d */
+  readonly partial: boolean;
+  /** @internal stub - real impl in Phase 1d */
+  readonly templateKeys: readonly string[];
+
   constructor(
     public readonly controller: string,
     public readonly action: string,
@@ -29,6 +40,11 @@ export class MissingTemplate extends Error {
         `Searched in: ${searchedPaths.length > 0 ? searchedPaths.join(", ") : "(no resolvers)"}`,
     );
     this.name = "MissingTemplate";
+    this.path = `${controller}/${action}`;
+    this.paths = searchedPaths;
+    this.prefixes = controller ? [controller] : [];
+    this.partial = action.startsWith("_");
+    this.templateKeys = [format];
   }
 }
 
@@ -241,3 +257,17 @@ export class LookupContext {
     return this.resolvers.map((r) => r.constructor.name);
   }
 }
+
+/**
+ * Cache key for `{locale, formats, variants, handlers}` detail tuples.
+ * Hooked by the `action_view` load callback to clear the cache between
+ * request cycles. Real cache wiring lands in Phase 1d.
+ *
+ * @internal stub - real impl in Phase 1d
+ */
+export class DetailsKey {
+  /** @internal stub - real impl in Phase 1d */
+  static clear(): void {}
+}
+
+(LookupContext as unknown as { DetailsKey: typeof DetailsKey }).DetailsKey = DetailsKey;

--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -49,6 +49,13 @@ export class MissingTemplate extends Error {
 }
 
 export class LookupContext {
+  /**
+   * Nested cache-key class, exposed at the value level by the runtime
+   * assignment near the bottom of this file and at the type level here.
+   * @internal stub - real impl in Phase 1d
+   */
+  static DetailsKey: typeof DetailsKey;
+
   private resolvers: TemplateResolver[] = [];
   private layoutName: string | false | null = "application";
   private _prefixes: string[] = [];
@@ -263,6 +270,10 @@ export class LookupContext {
  * Hooked by the `action_view` load callback to clear the cache between
  * request cycles. Real cache wiring lands in Phase 1d.
  *
+ * Also exported as `LookupContext.DetailsKey` via namespace merging so
+ * downstream code can mirror Rails' `ActionView::LookupContext::DetailsKey`
+ * spelling without `as any` casts.
+ *
  * @internal stub - real impl in Phase 1d
  */
 export class DetailsKey {
@@ -270,4 +281,9 @@ export class DetailsKey {
   static clear(): void {}
 }
 
-(LookupContext as unknown as { DetailsKey: typeof DetailsKey }).DetailsKey = DetailsKey;
+// Install DetailsKey as a static on LookupContext so consumers can write
+// `LookupContext.DetailsKey.clear()` — matching the Rails
+// `ActionView::LookupContext::DetailsKey` nesting both at the value and
+// the type level (see the corresponding `static DetailsKey: typeof
+// DetailsKey` field declared inside LookupContext above).
+(LookupContext as { DetailsKey: typeof DetailsKey }).DetailsKey = DetailsKey;

--- a/packages/actionview/src/path-registry.ts
+++ b/packages/actionview/src/path-registry.ts
@@ -1,0 +1,17 @@
+/**
+ * Process-wide registry of view-path resolvers. Only `allResolvers()` is
+ * needed to unblock AP's `exception_wrapper.rb:257` annotated-source
+ * path. Full impl (weak-ref cache, hooks, per-class view paths) lands in
+ * Phase 1c.
+ *
+ * @internal stub - real impl in Phase 1c
+ */
+
+import type { TemplateResolver } from "./template-resolver.js";
+
+export class PathRegistry {
+  /** @internal stub - real impl in Phase 1c */
+  static allResolvers(): TemplateResolver[] {
+    return [];
+  }
+}

--- a/packages/actionview/src/rendering.ts
+++ b/packages/actionview/src/rendering.ts
@@ -1,0 +1,66 @@
+/**
+ * Module-as-host interfaces mixed into ActionController::Base. Defined as
+ * TS interfaces (not classes) so AC can declaration-merge them into its
+ * own class without inheriting state. Real method bodies land in Phase 4.
+ *
+ * @internal stub - real impl in Phase 4
+ */
+
+import type { LookupContext } from "./lookup-context.js";
+import type { TemplateResolver } from "./template-resolver.js";
+
+export interface RenderOptions {
+  template?: string;
+  partial?: string;
+  action?: string;
+  layout?: string | false;
+  formats?: string[];
+  locals?: Record<string, unknown>;
+  status?: number;
+  body?: string;
+  plain?: string;
+  html?: string;
+  json?: unknown;
+  inline?: string;
+  [k: string]: unknown;
+}
+
+/** @internal stub - real impl in Phase 4 */
+export interface Rendering {
+  lookupContext: LookupContext;
+  render(options: RenderOptions | string, extra?: RenderOptions): string;
+  renderToString(options: RenderOptions | string, extra?: RenderOptions): string;
+  renderToBody(options?: RenderOptions): string;
+  _normalizeArgs(action: unknown, options?: RenderOptions): RenderOptions;
+  _normalizeOptions(options: RenderOptions): RenderOptions;
+  _normalizeRender(options: RenderOptions): RenderOptions;
+}
+
+/** @internal stub - real impl in Phase 4 */
+export interface Layouts {
+  _layoutForRendering(formats: string[]): string | false | undefined;
+  _layoutFor(name?: string | symbol): string;
+}
+
+/** @internal stub - real impl in Phase 4 */
+export interface LayoutsClass {
+  layout(
+    name: string | symbol | false | null | ((...args: unknown[]) => unknown),
+    conditions?: { only?: string | string[]; except?: string | string[] },
+  ): void;
+}
+
+/** @internal stub - real impl in Phase 4 */
+export interface ViewPaths {
+  viewPaths: TemplateResolver[];
+  prependViewPath(path: string | TemplateResolver | string[]): void;
+  appendViewPath(path: string | TemplateResolver | string[]): void;
+  detailsFor(name: string): Record<string, unknown>;
+}
+
+/** @internal stub - real impl in Phase 4 */
+export interface ViewPathsClass {
+  viewPaths: TemplateResolver[];
+  prependViewPath(path: string | TemplateResolver | string[]): void;
+  appendViewPath(path: string | TemplateResolver | string[]): void;
+}

--- a/packages/actionview/src/rendering.ts
+++ b/packages/actionview/src/rendering.ts
@@ -31,6 +31,7 @@ export interface Rendering {
   render(options: RenderOptions | string, extra?: RenderOptions): string;
   renderToString(options: RenderOptions | string, extra?: RenderOptions): string;
   renderToBody(options?: RenderOptions): string;
+  /** @internal */
   _normalizeArgs(action: unknown, options?: RenderOptions): RenderOptions;
   _normalizeOptions(options: RenderOptions): RenderOptions;
   _normalizeRender(options: RenderOptions): RenderOptions;

--- a/packages/actionview/src/template.ts
+++ b/packages/actionview/src/template.ts
@@ -4,6 +4,20 @@
  * A resolved template with source, handler reference, and metadata.
  */
 
+import { TemplateError } from "./template/error.js";
+
+/**
+ * `Template.Error` mirrors Rails' `ActionView::Template::Error` nesting so
+ * downstream code (actionpack `ExceptionWrapper`) can reference the
+ * canonical name. The class itself lives in `./template/error.js` to keep
+ * the Rails file layout.
+ */
+// eslint-disable-next-line @typescript-eslint/no-namespace
+export namespace Template {
+  export const Error = TemplateError;
+  export type Error = TemplateError;
+}
+
 export interface Template {
   /** Raw template source code */
   source: string;

--- a/packages/actionview/src/template/error.ts
+++ b/packages/actionview/src/template/error.ts
@@ -1,0 +1,33 @@
+/**
+ * Wraps an error raised while compiling/rendering a Template. AP's
+ * ExceptionWrapper unwraps this to surface the original cause to the
+ * debug view. Annotated-source extraction + line-number recovery lands
+ * in Phase 1b.
+ *
+ * @internal stub - real impl in Phase 1b
+ */
+
+import type { Template } from "../template.js";
+
+export interface TemplateErrorOptions {
+  original: Error;
+  template: Template;
+  sourceExtract?: string;
+}
+
+export class TemplateError extends Error {
+  /** @internal stub - real impl in Phase 1b */
+  readonly original: Error;
+  /** @internal stub - real impl in Phase 1b */
+  readonly template: Template;
+  /** @internal stub - real impl in Phase 1b */
+  readonly sourceExtract: string;
+
+  constructor(opts: TemplateErrorOptions) {
+    super(opts.original.message, { cause: opts.original });
+    this.name = "ActionView::Template::Error";
+    this.original = opts.original;
+    this.template = opts.template;
+    this.sourceExtract = opts.sourceExtract ?? "";
+  }
+}


### PR DESCRIPTION
Bundle of interface-only ActionView stubs so the ~6 actionpack follow-ups
that import view symbols can move from "blocked on full ActionView port"
to "blocked on Phase X (specific stub)". Per docs/actionview-100-percent.md
Phase 0.5.

## Stubs

| Symbol | Real impl phase | AP unblocks |
| --- | --- | --- |
| `Template.Error({original, template, sourceExtract})` | Phase 1b | exception-wrapper unwrap dispatch (#1834) |
| `PathRegistry.allResolvers()` | Phase 1c | exception_wrapper annotated-source |
| `Digestor.digest({name, format, finder})` | Phase 6 | etag_with_template_digest |
| `Base.empty()` / `streamingCompletionOnException` / `defaultFormats` | Phase 4 | debug-view extends (#1859), metal/live + helpers, on_load hooks |
| `Rendering` / `Layouts` / `ViewPaths` host interfaces | Phase 4 | AC base mixin chain compiles |
| `Helpers.FormBuilder` sentinel | Phase 5 T3 | AC form_builder default-setter |
| `LookupContext.DetailsKey.clear()` | Phase 1d | action_view on_load trailtie hook (#1842) |
| `MissingTemplate` Rails-shape fields | Phase 1d (refine) | exception_wrapper STATUS_MAP |

The `Digestor` stub returns a stable FNV-1a-64 hash of the resolved
template source — no dep walk yet, so cache keys are correct for "this
template changed" but not for "a render-called partial changed". Phase 6
swaps in the real walk.

`MissingTemplate` keeps its existing TS constructor signature; the
Rails-shape fields (`path`, `paths`, `prefixes`, `partial`, `templateKeys`)
are derived from existing args so all callers stay green. Phase 1d will
refine these once the real LookupContext details cascade lands.

Every new method/static is tagged `@internal stub - real impl in Phase X`
so the rails-private lint rule and the TypeDoc `excludeInternal` build
treat them as private until they're real.

## LOC

262 insertions, 1 deletion — under the 300 ceiling.

## Test plan

- [x] `pnpm --filter @blazetrails/actionview build` — clean
- [x] existing `packages/actionview/src/actionview.test.ts` — 71/71 passing
- [x] `pnpm lint` — clean
- [ ] CI build + typecheck across packages