### PR TITLE
feat(actionpack): wire PolymorphicRoutes onto RoutesProxy + UrlFor (#1855 follow-up)

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.test.ts
@@ -109,7 +109,7 @@ describe("polymorphicUrl/Path", () => {
 
   test("polymorphic_mappings shortcut wins over RESTful dispatch", () => {
     const host = makeHost();
-    host._routes.polymorphicMappings.set("Post", {
+    host._routes.polymorphicMappings!.set("Post", {
       call: (_h, _args, onlyPath) => (onlyPath ? "/custom" : "http://example.com/custom"),
     });
     expect(polymorphicPath.call(host, new Post(1))).toBe("/custom");

--- a/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.ts
+++ b/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.ts
@@ -46,9 +46,16 @@ export interface PolymorphicMappingEntry {
   call(host: PolymorphicHost, args: unknown[], onlyPath: boolean): string;
 }
 
-/** Surface the host's `_routes` must expose for polymorphic dispatch. */
+/**
+ * Surface the host's `_routes` must expose for polymorphic dispatch.
+ *
+ * Optional because not every RouteSet-shaped object has been wired with the
+ * `direct(:name) { ... }` registry yet; {@link polymorphicMapping} treats a
+ * missing map as "no custom direct routes" so test doubles and partial
+ * implementations don't trip a `TypeError` on the first polymorphic call.
+ */
 export interface PolymorphicRoutesAccessor {
-  polymorphicMappings: Map<string, PolymorphicMappingEntry>;
+  polymorphicMappings?: Map<string, PolymorphicMappingEntry>;
 }
 
 /**
@@ -211,12 +218,14 @@ export function polymorphicMapping(
   host: PolymorphicHost,
   record: unknown,
 ): PolymorphicMappingEntry | undefined {
+  const mappings = host._routes.polymorphicMappings;
+  if (!mappings) return undefined;
   if (isToModel(record)) {
-    return host._routes.polymorphicMappings.get(record.toModel().modelName.name);
+    return mappings.get(record.toModel().modelName.name);
   }
   const ctor = (record as { constructor?: { name?: string } })?.constructor;
   const key = ctor?.name ?? "";
-  return host._routes.polymorphicMappings.get(key);
+  return mappings.get(key);
 }
 
 type KeyStrategy = (name: ModelName) => string;

--- a/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
+++ b/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
@@ -31,6 +31,7 @@ import {
   type UrlForHost,
   type UrlForRoutes,
 } from "./url-for.js";
+import type { PolymorphicHost } from "./polymorphic-routes.js";
 
 /** The minimal helpers-module surface RoutesProxy dispatches into. */
 export type RoutesProxyHelpers = Record<string, unknown>;
@@ -86,7 +87,8 @@ export class RoutesProxy implements UrlForHost {
   /** @internal Rails-private helper. */
   polymorphicPathForAction = polymorphicPathForAction;
   /** @internal Rails-private helper. */
-  polymorphicMapping = (record: unknown) => polymorphicMapping(this as never, record);
+  polymorphicMapping = (record: unknown) =>
+    polymorphicMapping(this as unknown as PolymorphicHost, record);
 
   constructor(
     routes: UrlForRoutes,

--- a/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
+++ b/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
@@ -15,8 +15,17 @@
 import {
   _routesContext,
   _withRoutes,
+  editPolymorphicPath,
+  editPolymorphicUrl,
   fullUrlFor,
+  newPolymorphicPath,
+  newPolymorphicUrl,
   optimizeRoutesGeneration,
+  polymorphicMapping,
+  polymorphicPath,
+  polymorphicPathForAction,
+  polymorphicUrl,
+  polymorphicUrlForAction,
   routeFor,
   urlFor,
   type UrlForHost,
@@ -40,12 +49,6 @@ export type RoutesProxyInstance = RoutesProxy & {
 export class RoutesProxy implements UrlForHost {
   scope: UrlForHost;
   routes: UrlForRoutes;
-  /**
-   * UrlForHost field. Rails relies on `@_routes` set by `UrlFor#initialize`;
-   * here we expose it as a getter aliased to `routes` (mirrors the Ruby
-   * `alias :_routes :routes`).
-   */
-  defaultUrlOptions: Record<string, unknown> = {};
   /** @internal Rails: `@helpers` */
   private _helpers: RoutesProxyHelpers;
   /** @internal Rails: `@script_namer` */
@@ -61,6 +64,22 @@ export class RoutesProxy implements UrlForHost {
   _withRoutes = _withRoutes;
   /** @internal Rails: `private def _routes_context` */
   _routesContext = _routesContext;
+
+  // PolymorphicRoutes mixin — Rails `UrlFor` `include`s it, so it's
+  // transitively present on RoutesProxy. Attaching here makes the methods
+  // visible on the instance for `api:compare` and direct callers.
+  polymorphicUrl = polymorphicUrl;
+  polymorphicPath = polymorphicPath;
+  editPolymorphicUrl = editPolymorphicUrl;
+  editPolymorphicPath = editPolymorphicPath;
+  newPolymorphicUrl = newPolymorphicUrl;
+  newPolymorphicPath = newPolymorphicPath;
+  /** @internal Rails-private helper. */
+  polymorphicUrlForAction = polymorphicUrlForAction;
+  /** @internal Rails-private helper. */
+  polymorphicPathForAction = polymorphicPathForAction;
+  /** @internal Rails-private helper. */
+  polymorphicMapping = (record: unknown) => polymorphicMapping(this as never, record);
 
   constructor(
     routes: UrlForRoutes,
@@ -96,6 +115,15 @@ export class RoutesProxy implements UrlForHost {
   }
   set _routes(value: UrlForRoutes | null) {
     if (value != null) this.routes = value;
+  }
+
+  /**
+   * Rails: RoutesProxy doesn't own `default_url_options` — it's inherited
+   * from `UrlFor`, which delegates through to the wrapped scope. Mirror that
+   * by reading off `scope` so callers see one source of truth.
+   */
+  get defaultUrlOptions(): Record<string, unknown> {
+    return this.scope.defaultUrlOptions;
   }
 
   urlOptions(): Record<string, unknown> {

--- a/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
+++ b/packages/actionpack/src/action-dispatch/routing/routes-proxy.ts
@@ -49,6 +49,13 @@ export type RoutesProxyInstance = RoutesProxy & {
 export class RoutesProxy implements UrlForHost {
   scope: UrlForHost;
   routes: UrlForRoutes;
+  /**
+   * Rails: `UrlFor` declares `class_attribute :default_url_options` and
+   * initializes it to `{}` in its `included` block. RoutesProxy inherits
+   * that writable accessor — callers may set `proxy.defaultUrlOptions =
+   * { host: "..." }` per-instance.
+   */
+  defaultUrlOptions: Record<string, unknown> = {};
   /** @internal Rails: `@helpers` */
   private _helpers: RoutesProxyHelpers;
   /** @internal Rails: `@script_namer` */
@@ -115,15 +122,6 @@ export class RoutesProxy implements UrlForHost {
   }
   set _routes(value: UrlForRoutes | null) {
     if (value != null) this.routes = value;
-  }
-
-  /**
-   * Rails: RoutesProxy doesn't own `default_url_options` — it's inherited
-   * from `UrlFor`, which delegates through to the wrapped scope. Mirror that
-   * by reading off `scope` so callers see one source of truth.
-   */
-  get defaultUrlOptions(): Record<string, unknown> {
-    return this.scope.defaultUrlOptions;
   }
 
   urlOptions(): Record<string, unknown> {

--- a/packages/actionpack/src/action-dispatch/routing/url-for.ts
+++ b/packages/actionpack/src/action-dispatch/routing/url-for.ts
@@ -11,6 +11,22 @@
 
 import { NO_ROUTES_MESSAGE } from "../../abstract-controller/url-for.js";
 import { Parameters } from "../../action-controller/metal/strong-parameters.js";
+import type { PolymorphicMappingEntry } from "./polymorphic-routes.js";
+
+// Re-export the PolymorphicRoutes mixin functions. Rails: `module UrlFor;
+// include PolymorphicRoutes`. The functions are `this`-typed and hosts attach
+// them via the module-mixin pattern (see routes-proxy.ts).
+export {
+  polymorphicUrl,
+  polymorphicPath,
+  editPolymorphicUrl,
+  editPolymorphicPath,
+  newPolymorphicUrl,
+  newPolymorphicPath,
+  polymorphicUrlForAction,
+  polymorphicPathForAction,
+  polymorphicMapping,
+} from "./polymorphic-routes.js";
 
 /**
  * The minimal RouteSet surface UrlFor calls into. Matches Rails'
@@ -23,6 +39,13 @@ import { Parameters } from "../../action-controller/metal/strong-parameters.js";
 export interface UrlForRoutes {
   urlFor(options: Record<string, unknown>, routeName?: string | null): string;
   optimizeRoutesGeneration?(): boolean;
+  /**
+   * Rails' UrlFor includes PolymorphicRoutes, whose helpers read
+   * `_routes.polymorphic_mappings`. Optional here so existing test doubles
+   * keep working; `polymorphicUrl`/`polymorphicPath` treat a missing map as
+   * "no custom direct routes".
+   */
+  polymorphicMappings?: Map<string, PolymorphicMappingEntry>;
 }
 
 export interface UrlForHost {


### PR DESCRIPTION
## Summary

Rails `ActionDispatch::Routing::UrlFor` does `include PolymorphicRoutes`,
so `polymorphic_url`/`polymorphic_path`/`edit_`/`new_` variants and the
private `*_for_action`/`mapping` helpers are transitively present on
every host that mixes `UrlFor` in — including `RoutesProxy`. The port had
the standalone `polymorphic-routes.ts` mixin but never wired it through
`url-for.ts` / `routes-proxy.ts`.

- Re-export the 9 polymorphic functions from `routing/url-for.ts` so
  `api:compare` sees them on the module surface (Rails-include parity).
- Attach them as `this`-typed class fields on `RoutesProxy` per the
  CLAUDE.md module-mixin pattern. `polymorphicMapping` wraps in an arrow
  to match Rails' 1-arg `(record)` signature against the trails helper's
  factored `(host, record)` shape.
- Make `PolymorphicRoutesAccessor.polymorphicMappings` optional and have
  `polymorphicMapping()` short-circuit when it's absent; widen
  `UrlForRoutes` with the same optional field so the `direct(:name)`
  registry can live on `_routes` without breaking test doubles.

### api:compare delta

| File | Before | After |
|---|---|---|
| `routing/routes_proxy.rb` | 13/18 (72%) | 18/18 (100%) ✓ |
| `routing/url_for.rb` | 9/13 (69%) | 13/13 (100%) ✓ |

## Test plan

- [x] `routes-proxy.test.ts`, `url-for.test.ts`,
      `polymorphic-routes.test.ts` all pass
- [x] `pnpm api:compare --package actiondispatch` shows both files at 100%
- [x] Full actionpack build/typecheck green