### PR TITLE
feat(actionview): port OutputBuffer / RawOutputBuffer (Phase 0b)

### DIFF
--- a/packages/actionview/src/buffers.test.ts
+++ b/packages/actionview/src/buffers.test.ts
@@ -45,6 +45,25 @@ describe("OutputBuffer", () => {
     expect(buf.toStr()).toBe("<b>unsafe</b>");
   });
 
+  it("safeConcat throws on nil (Rails parity)", () => {
+    expect(() => new OutputBuffer().safeConcat(null)).toThrow(TypeError);
+    expect(() => new OutputBuffer().safeConcat(undefined)).toThrow(TypeError);
+  });
+
+  it("safeExprAppend skips nil and appends raw otherwise", () => {
+    const buf = new OutputBuffer("x");
+    buf.safeExprAppend(null);
+    buf.safeExprAppend(undefined);
+    expect(buf.toStr()).toBe("x");
+    buf.safeExprAppend("<b>");
+    expect(buf.toStr()).toBe("x<b>");
+  });
+
+  it("rawBuffer getter exposes underlying string", () => {
+    const buf = new OutputBuffer("hello");
+    expect(buf.rawBuffer).toBe("hello");
+  });
+
   it("toString returns a SafeBuffer", () => {
     const buf = new OutputBuffer("hi");
     const s = buf.toString();

--- a/packages/actionview/src/buffers.test.ts
+++ b/packages/actionview/src/buffers.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { htmlSafe, SafeBuffer } from "@blazetrails/activesupport";
+import { OutputBuffer, RawOutputBuffer } from "./buffers.js";
+
+describe("OutputBuffer", () => {
+  it("initializes from a string", () => {
+    const buf = new OutputBuffer("hello");
+    expect(buf.toStr()).toBe("hello");
+    expect(buf.length).toBe(5);
+  });
+
+  it("initializes from a SafeBuffer", () => {
+    const buf = new OutputBuffer(htmlSafe("<b>hi</b>"));
+    expect(buf.toStr()).toBe("<b>hi</b>");
+  });
+
+  it("calls toString on values via concat (number example from Rails docs)", () => {
+    const buf = new OutputBuffer("hello");
+    buf.concat(5);
+    expect(buf.toStr()).toBe("hello5");
+  });
+
+  it("escapes unsafe strings on concat", () => {
+    const buf = new OutputBuffer();
+    buf.concat("<script>");
+    expect(buf.toStr()).toBe("&lt;script&gt;");
+  });
+
+  it("does not escape SafeBuffer values on concat", () => {
+    const buf = new OutputBuffer();
+    buf.concat(htmlSafe("<b>bold</b>"));
+    expect(buf.toStr()).toBe("<b>bold</b>");
+  });
+
+  it("skips nil/undefined on concat", () => {
+    const buf = new OutputBuffer("x");
+    buf.concat(null);
+    buf.concat(undefined);
+    expect(buf.toStr()).toBe("x");
+  });
+
+  it("safeConcat bypasses escaping", () => {
+    const buf = new OutputBuffer();
+    buf.safeConcat("<b>unsafe</b>");
+    expect(buf.toStr()).toBe("<b>unsafe</b>");
+  });
+
+  it("toString returns a SafeBuffer", () => {
+    const buf = new OutputBuffer("hi");
+    const s = buf.toString();
+    expect(s).toBeInstanceOf(SafeBuffer);
+    expect(s.htmlSafe).toBe(true);
+    expect(s.toString()).toBe("hi");
+  });
+
+  it("isHtmlSafe always returns true", () => {
+    expect(new OutputBuffer().isHtmlSafe()).toBe(true);
+  });
+
+  it("isEmpty/isBlank reflect underlying buffer", () => {
+    expect(new OutputBuffer().isEmpty()).toBe(true);
+    expect(new OutputBuffer("   ").isBlank()).toBe(true);
+    expect(new OutputBuffer("x").isBlank()).toBe(false);
+  });
+
+  it("capture swaps the buffer and restores it", () => {
+    const buf = new OutputBuffer("before-");
+    const captured = buf.capture(() => {
+      buf.concat("inside");
+    });
+    expect(captured.toString()).toBe("inside");
+    expect(captured.htmlSafe).toBe(true);
+    expect(buf.toStr()).toBe("before-");
+  });
+
+  it("capture restores the buffer when the callback throws", () => {
+    const buf = new OutputBuffer("kept");
+    expect(() =>
+      buf.capture(() => {
+        buf.concat("lost");
+        throw new Error("boom");
+      }),
+    ).toThrow("boom");
+    expect(buf.toStr()).toBe("kept");
+  });
+
+  it("equals compares raw contents and type", () => {
+    expect(new OutputBuffer("a").equals(new OutputBuffer("a"))).toBe(true);
+    expect(new OutputBuffer("a").equals(new OutputBuffer("b"))).toBe(false);
+    expect(new OutputBuffer("a").equals("a")).toBe(false);
+  });
+});
+
+describe("RawOutputBuffer", () => {
+  it("appends to the wrapped buffer without escaping", () => {
+    const buf = new OutputBuffer();
+    const raw = buf.raw();
+    expect(raw).toBeInstanceOf(RawOutputBuffer);
+    raw.concat("<unsafe>");
+    expect(buf.toStr()).toBe("<unsafe>");
+  });
+
+  it("skips nil values", () => {
+    const buf = new OutputBuffer("x");
+    buf.raw().concat(null);
+    expect(buf.toStr()).toBe("x");
+  });
+
+  it("raw() returns self", () => {
+    const raw = new OutputBuffer().raw();
+    expect(raw.raw()).toBe(raw);
+  });
+});

--- a/packages/actionview/src/buffers.ts
+++ b/packages/actionview/src/buffers.ts
@@ -1,0 +1,123 @@
+import { SafeBuffer, htmlEscape, htmlSafe, isHtmlSafe } from "@blazetrails/activesupport";
+
+/**
+ * OutputBuffer — wraps a string with `<<`-collecting semantics for ERB-style templates.
+ *
+ * Mirrors ActionView::OutputBuffer. Difference vs SafeBuffer: `<<` / `concat`
+ * call `.toString()` on the input (so non-string values like numbers stringify
+ * naturally) and skip nil/undefined values entirely.
+ */
+export class OutputBuffer {
+  private _raw: string;
+
+  constructor(buffer: string | SafeBuffer = "") {
+    this._raw = buffer instanceof SafeBuffer ? buffer.toString() : String(buffer);
+  }
+
+  get length(): number {
+    return this._raw.length;
+  }
+
+  isEmpty(): boolean {
+    return this._raw.length === 0;
+  }
+
+  isBlank(): boolean {
+    return /^\s*$/.test(this._raw);
+  }
+
+  toString(): SafeBuffer {
+    return htmlSafe(this._raw);
+  }
+
+  /** Returns the raw, unescaped string. Mirrors Rails `to_str`. */
+  toStr(): string {
+    return this._raw;
+  }
+
+  htmlSafe(): SafeBuffer {
+    return this.toString();
+  }
+
+  isHtmlSafe(): boolean {
+    return true;
+  }
+
+  /** Append a value, escaping if not html-safe. Nil values are skipped. */
+  concat(value: unknown): this {
+    if (value === null || value === undefined) return this;
+    if (isHtmlSafe(value)) {
+      this._raw += (value as SafeBuffer).toString();
+    } else if (value instanceof OutputBuffer) {
+      this._raw += value.toStr();
+    } else {
+      this._raw += htmlEscape(value).toString();
+    }
+    return this;
+  }
+
+  /** Append without escaping. Mirrors Rails `safe_concat` / `safe_append=`. */
+  safeConcat(value: unknown): this {
+    if (value === null || value === undefined) return this;
+    this._raw += value instanceof SafeBuffer ? value.toString() : String(value);
+    return this;
+  }
+
+  /** Mirrors Rails `safe_expr_append=` — like safe_concat but skips nil. */
+  safeExprAppend(value: unknown): this {
+    if (value === null || value === undefined) return this;
+    this._raw += value instanceof SafeBuffer ? value.toString() : String(value);
+    return this;
+  }
+
+  /**
+   * Capture — swaps the buffer for the duration of `fn`, returns what was
+   * appended as an HTML-safe string. Mirrors Rails `capture(*args, &block)`.
+   */
+  capture<TArgs extends unknown[]>(fn: (...args: TArgs) => void, ...args: TArgs): SafeBuffer {
+    const previous = this._raw;
+    this._raw = "";
+    try {
+      fn(...args);
+      return htmlSafe(this._raw);
+    } finally {
+      this._raw = previous;
+    }
+  }
+
+  equals(other: unknown): boolean {
+    return other instanceof OutputBuffer && other.toStr() === this._raw;
+  }
+
+  raw(): RawOutputBuffer {
+    return new RawOutputBuffer(this);
+  }
+
+  /** @internal Direct access to the underlying string, used by RawOutputBuffer. */
+  get rawBuffer(): string {
+    return this._raw;
+  }
+
+  /** @internal Used by RawOutputBuffer to append without escaping. */
+  appendRaw(value: string): void {
+    this._raw += value;
+  }
+}
+
+/**
+ * RawOutputBuffer — bypasses escaping when appending to an OutputBuffer.
+ * Used by the template compiler for `<%== %>` raw-output expressions.
+ */
+export class RawOutputBuffer {
+  constructor(private readonly buffer: OutputBuffer) {}
+
+  concat(value: unknown): this {
+    if (value === null || value === undefined) return this;
+    this.buffer.appendRaw(value instanceof SafeBuffer ? value.toString() : String(value));
+    return this;
+  }
+
+  raw(): this {
+    return this;
+  }
+}

--- a/packages/actionview/src/buffers.ts
+++ b/packages/actionview/src/buffers.ts
@@ -56,9 +56,15 @@ export class OutputBuffer {
     return this;
   }
 
-  /** Append without escaping. Mirrors Rails `safe_concat` / `safe_append=`. */
+  /**
+   * Append without escaping. Mirrors Rails `safe_concat` / `safe_append=`.
+   * Unlike `safeExprAppend`, this does NOT skip nil — Rails raises TypeError
+   * on `String#<<(nil)`, so we throw to match.
+   */
   safeConcat(value: unknown): this {
-    if (value === null || value === undefined) return this;
+    if (value === null || value === undefined) {
+      throw new TypeError("no implicit conversion of nil into String");
+    }
     this._raw += value instanceof SafeBuffer ? value.toString() : String(value);
     return this;
   }

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -22,4 +22,6 @@ export {
 
 export { EjsHandler } from "./ejs-handler.js";
 
+export { OutputBuffer, RawOutputBuffer } from "./buffers.js";
+
 export * from "./helpers/index.js";


### PR DESCRIPTION
## Summary

Phase 0b from `docs/actionview-100-percent.md`: port `ActionView::OutputBuffer`
and its `RawOutputBuffer` sibling.

`ActiveSupport::SafeBuffer` already exists in `@blazetrails/activesupport`, so
this PR only adds the buffers.rb pair.

- `OutputBuffer.concat(value)` — calls `.toString()` on the value, skips nil, escapes if not html-safe (the docstring example `obuf << 5  # => "hello5"` is covered).
- `safeConcat` / `safeExprAppend` — bypass escaping; the latter additionally skips nil.
- `toString()` returns a `SafeBuffer`; `toStr()` returns the raw string.
- `capture(fn, ...args)` — swaps the underlying buffer for the duration of the callback (try/finally so a throw still restores it) and returns what was appended as an HTML-safe string.
- `raw()` returns a `RawOutputBuffer` that appends to the wrapped buffer without escaping.

`StreamingBuffer` / `RawStreamingBuffer` are deferred until streaming
rendering lands in a later phase.

## Test plan

- [x] `pnpm vitest run packages/actionview/src/buffers.test.ts` — 16/16 pass
- [x] `pnpm --filter @blazetrails/actionview exec tsc --noEmit` clean