### PR TITLE
feat(actioncontroller): wire P3/P5/P9 Wave 0 surface methods

### DIFF
--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -31,6 +31,8 @@ import {
   isContentSecurityPolicy,
 } from "./metal/content-security-policy.js";
 import { helperMethod, type HelpersClassMethods } from "../abstract-controller/helpers.js";
+import { defaultFormBuilder } from "./form-builder.js";
+import { instrumentPayload, instrumentName } from "./caching.js";
 
 // Re-export callback registration
 export { type ActionCallback, type AroundCallback, type CallbackOptions };
@@ -439,6 +441,23 @@ export class Base extends Metal {
    * @internal
    */
   rateLimiting = rateLimiting;
+
+  /**
+   * Class DSL: override the default form builder for all views rendered by
+   * this controller and its subclasses. Mirrors Rails
+   * `ActionController::FormBuilder::ClassMethods#default_form_builder`.
+   */
+  static defaultFormBuilder = defaultFormBuilder;
+
+  /** Instance reader for the configured form builder (Rails parity). */
+  defaultFormBuilder = defaultFormBuilder;
+
+  /** @internal Rails parity — caching instrumentation payload. */
+  instrumentPayload = instrumentPayload;
+
+  /** @internal Rails parity — caching instrumentation name. */
+  instrumentName = instrumentName;
+
 
   // --- Rescue ---
 

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -450,13 +450,19 @@ export class Base extends Metal {
   static defaultFormBuilder = defaultFormBuilder;
 
   /** Instance reader for the configured form builder (Rails parity). */
-  defaultFormBuilder = defaultFormBuilder;
+  defaultFormBuilder(): unknown {
+    return defaultFormBuilder.call(this as never);
+  }
 
   /** @internal Rails parity — caching instrumentation payload. */
-  instrumentPayload = instrumentPayload;
+  instrumentPayload(key: unknown): { controller: string; action: string; key: unknown } {
+    return instrumentPayload.call(this as never, key);
+  }
 
   /** @internal Rails parity — caching instrumentation name. */
-  instrumentName = instrumentName;
+  instrumentName(): string {
+    return instrumentName.call(this as never);
+  }
 
   // --- Rescue ---
 

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -458,7 +458,6 @@ export class Base extends Metal {
   /** @internal Rails parity — caching instrumentation name. */
   instrumentName = instrumentName;
 
-
   // --- Rescue ---
 
   /** Register a rescue handler for a specific error class. */

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -451,17 +451,17 @@ export class Base extends Metal {
 
   /** Instance reader for the configured form builder (Rails parity). */
   defaultFormBuilder(): unknown {
-    return defaultFormBuilder.call(this as never);
+    return defaultFormBuilder.call(this);
   }
 
   /** @internal Rails parity — caching instrumentation payload. */
   instrumentPayload(key: unknown): { controller: string; action: string; key: unknown } {
-    return instrumentPayload.call(this as never, key);
+    return instrumentPayload.call(this, key);
   }
 
   /** @internal Rails parity — caching instrumentation name. */
   instrumentName(): string {
-    return instrumentName.call(this as never);
+    return instrumentName.call(this);
   }
 
   // --- Rescue ---

--- a/packages/actionpack/src/action-controller/caching.test.ts
+++ b/packages/actionpack/src/action-controller/caching.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { instrumentPayload, instrumentName, fragmentCacheKey } from "./caching.js";
+
+describe("Caching#instrumentPayload (private)", () => {
+  it("returns { controller, action, key } shaped like Rails", () => {
+    const host = {
+      controllerName: () => "posts",
+      actionName: "show",
+    };
+    expect(instrumentPayload.call(host, "abc")).toEqual({
+      controller: "posts",
+      action: "show",
+      key: "abc",
+    });
+  });
+
+  it("passes the key through verbatim (any value)", () => {
+    const host = { controllerName: () => "x", actionName: "y" };
+    const arrayKey = ["a", 1];
+    expect(instrumentPayload.call(host, arrayKey)).toEqual({
+      controller: "x",
+      action: "y",
+      key: arrayKey,
+    });
+  });
+});
+
+describe("Caching#instrumentName (private)", () => {
+  it("returns the Rails-canonical name", () => {
+    expect(instrumentName.call({})).toBe("action_controller");
+  });
+});
+
+describe("fragmentCacheKey (existing — sanity)", () => {
+  it("still composes string keys with controller prefix", () => {
+    expect(fragmentCacheKey("k", "Posts")).toBe("Posts/k");
+  });
+});

--- a/packages/actionpack/src/action-controller/caching.ts
+++ b/packages/actionpack/src/action-controller/caching.ts
@@ -5,6 +5,41 @@
  * @see https://api.rubyonrails.org/classes/ActionController/Caching.html
  */
 
+/** Host shape for the private `instrumentPayload` mixin reader. */
+interface CachingInstrumentHost {
+  controllerName(): string;
+  actionName: string;
+}
+
+/**
+ * Mirrors Rails `ActionController::Caching#instrument_payload` (private):
+ *
+ *     def instrument_payload(key)
+ *       { controller: controller_name, action: action_name, key: key }
+ *     end
+ *
+ * @internal
+ */
+export function instrumentPayload(
+  this: CachingInstrumentHost,
+  key: unknown,
+): { controller: string; action: string; key: unknown } {
+  return { controller: this.controllerName(), action: this.actionName, key };
+}
+
+/**
+ * Mirrors Rails `ActionController::Caching#instrument_name` (private):
+ *
+ *     def instrument_name
+ *       "action_controller"
+ *     end
+ *
+ * @internal
+ */
+export function instrumentName(this: unknown): string {
+  return "action_controller";
+}
+
 function serializeValue(value: unknown): string {
   if (value === null || value === undefined) return "";
   if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {

--- a/packages/actionpack/src/action-controller/deprecator.test.ts
+++ b/packages/actionpack/src/action-controller/deprecator.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { Deprecation } from "@blazetrails/activesupport";
+import { deprecator, addRenderer, removeRenderer } from "./deprecator.js";
+import { Renderers } from "./metal/renderers.js";
+
+describe("ActionController.deprecator", () => {
+  it("returns a Deprecation instance", () => {
+    expect(deprecator()).toBeInstanceOf(Deprecation);
+  });
+
+  it("memoizes and shares the AbstractController deprecator", () => {
+    expect(deprecator()).toBe(deprecator());
+  });
+});
+
+describe("ActionController.addRenderer / removeRenderer", () => {
+  const KEY = "test-shim-format";
+  beforeEach(() => {
+    Renderers.remove(KEY);
+  });
+
+  it("addRenderer registers via Renderers.add", () => {
+    const block = (value: unknown) => String(value);
+    addRenderer(KEY, block);
+    expect(Renderers.RENDERERS.has(KEY)).toBe(true);
+    expect(Renderers.get(KEY)).toBe(block);
+  });
+
+  it("removeRenderer deregisters via Renderers.remove", () => {
+    addRenderer(KEY, () => "");
+    removeRenderer(KEY);
+    expect(Renderers.RENDERERS.has(KEY)).toBe(false);
+    expect(Renderers.get(KEY)).toBeUndefined();
+  });
+});

--- a/packages/actionpack/src/action-controller/deprecator.test.ts
+++ b/packages/actionpack/src/action-controller/deprecator.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Deprecation } from "@blazetrails/activesupport";
 import { deprecator, addRenderer, removeRenderer } from "./deprecator.js";
 import { Renderers } from "./metal/renderers.js";
@@ -16,6 +16,9 @@ describe("ActionController.deprecator", () => {
 describe("ActionController.addRenderer / removeRenderer", () => {
   const KEY = "test-shim-format";
   beforeEach(() => {
+    Renderers.remove(KEY);
+  });
+  afterEach(() => {
     Renderers.remove(KEY);
   });
 

--- a/packages/actionpack/src/action-controller/deprecator.ts
+++ b/packages/actionpack/src/action-controller/deprecator.ts
@@ -1,13 +1,45 @@
 /**
- * Deprecator — handles deprecation warnings for ActionController.
+ * ActionController deprecator + renderer-registry deprecation shims.
  *
- * Mirrors: ActionController.deprecator (ActiveSupport::Deprecation instance)
+ * Mirrors Rails `actionpack/lib/action_controller/deprecator.rb`:
  *
- * In Rails, each framework has its own deprecator instance. We reuse
- * the ActiveSupport Deprecation class, just like Rails does.
+ *     module ActionController
+ *       def self.deprecator
+ *         AbstractController.deprecator
+ *       end
+ *     end
+ *
+ * and the top-level shims in `actionpack/lib/action_controller/metal/renderers.rb`:
+ *
+ *     def self.add_renderer(key, &block)
+ *       Renderers.add(key, &block)
+ *     end
+ *     def self.remove_renderer(key)
+ *       Renderers.remove(key)
+ *     end
  */
+
 import { Deprecation } from "@blazetrails/activesupport";
+import { deprecator as abstractDeprecator } from "../abstract-controller/deprecator.js";
+import { Renderers, type RendererProc } from "./metal/renderers.js";
 
 export { Deprecation as Deprecator };
 
-export const deprecator = new Deprecation({ gem: "actionpack" });
+/**
+ * Lazily-initialized Deprecation instance for the ActionController
+ * namespace. Mirrors Rails `ActionController.deprecator`, which delegates
+ * to `AbstractController.deprecator`.
+ */
+export function deprecator(): Deprecation {
+  return abstractDeprecator();
+}
+
+/** Shim for `ActionController.add_renderer(key, &block)` — delegates to `Renderers.add`. */
+export function addRenderer(key: string, block: RendererProc): void {
+  Renderers.add(key, block);
+}
+
+/** Shim for `ActionController.remove_renderer(key)` — delegates to `Renderers.remove`. */
+export function removeRenderer(key: string): void {
+  Renderers.remove(key);
+}

--- a/packages/actionpack/src/action-controller/form-builder.test.ts
+++ b/packages/actionpack/src/action-controller/form-builder.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { defaultFormBuilder } from "./form-builder.js";
+import { Base } from "./base.js";
 
 class FakeBuilder {}
 class OtherBuilder {}
@@ -49,5 +50,16 @@ describe("defaultFormBuilder DSL", () => {
     C.defaultFormBuilder(FakeBuilder);
     const inst = new C();
     expect(inst.defaultFormBuilder()).toBe(FakeBuilder);
+  });
+
+  it("is wired onto Base as both class DSL and instance reader", () => {
+    class MyController extends Base {}
+    MyController.defaultFormBuilder(FakeBuilder);
+    expect(MyController.defaultFormBuilder()).toBe(FakeBuilder);
+    const inst = new MyController();
+    expect(inst.defaultFormBuilder()).toBe(FakeBuilder);
+    // Sibling controllers don't inherit from each other.
+    class SiblingController extends Base {}
+    expect(SiblingController.defaultFormBuilder()).toBeUndefined();
   });
 });

--- a/packages/actionpack/src/action-controller/form-builder.test.ts
+++ b/packages/actionpack/src/action-controller/form-builder.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { defaultFormBuilder } from "./form-builder.js";
+
+class FakeBuilder {}
+class OtherBuilder {}
+
+describe("defaultFormBuilder DSL", () => {
+  it("stores and reads a builder class on a host class", () => {
+    class C {
+      static defaultFormBuilder = defaultFormBuilder;
+    }
+    C.defaultFormBuilder(FakeBuilder);
+    expect(C.defaultFormBuilder()).toBe(FakeBuilder);
+  });
+
+  it("walks the prototype chain for inherited defaults", () => {
+    class Parent {
+      static defaultFormBuilder = defaultFormBuilder;
+    }
+    class Child extends Parent {}
+    Parent.defaultFormBuilder(FakeBuilder);
+    expect((Child as typeof Parent).defaultFormBuilder()).toBe(FakeBuilder);
+  });
+
+  it("subclass override does not mutate parent", () => {
+    class Parent {
+      static defaultFormBuilder = defaultFormBuilder;
+    }
+    class Child extends Parent {}
+    Parent.defaultFormBuilder(FakeBuilder);
+    (Child as typeof Parent).defaultFormBuilder(OtherBuilder);
+    expect((Child as typeof Parent).defaultFormBuilder()).toBe(OtherBuilder);
+    expect(Parent.defaultFormBuilder()).toBe(FakeBuilder);
+  });
+
+  it("accepts a string name (held as-is for view-layer resolution)", () => {
+    class C {
+      static defaultFormBuilder = defaultFormBuilder;
+    }
+    C.defaultFormBuilder("MyAppFormBuilder");
+    expect(C.defaultFormBuilder()).toBe("MyAppFormBuilder");
+  });
+
+  it("instance reader returns the class-level configured value", () => {
+    class C {
+      static defaultFormBuilder = defaultFormBuilder;
+      defaultFormBuilder = defaultFormBuilder;
+    }
+    C.defaultFormBuilder(FakeBuilder);
+    const inst = new C();
+    expect(inst.defaultFormBuilder()).toBe(FakeBuilder);
+  });
+});

--- a/packages/actionpack/src/action-controller/form-builder.test.ts
+++ b/packages/actionpack/src/action-controller/form-builder.test.ts
@@ -52,6 +52,17 @@ describe("defaultFormBuilder DSL", () => {
     expect(inst.defaultFormBuilder()).toBe(FakeBuilder);
   });
 
+  it("throws when an instance receiver is given a setter arg (Rails parity)", () => {
+    class C {
+      static defaultFormBuilder = defaultFormBuilder;
+      defaultFormBuilder = defaultFormBuilder;
+    }
+    const inst = new C();
+    expect(() => (inst.defaultFormBuilder as (b: unknown) => unknown)(FakeBuilder)).toThrow(
+      TypeError,
+    );
+  });
+
   it("is wired onto Base as both class DSL and instance reader", () => {
     class MyController extends Base {}
     MyController.defaultFormBuilder(FakeBuilder);

--- a/packages/actionpack/src/action-controller/form-builder.ts
+++ b/packages/actionpack/src/action-controller/form-builder.ts
@@ -68,17 +68,3 @@ export function defaultFormBuilder(this: unknown, builder?: unknown): unknown {
   if (klass) _registry.set(klass, builder);
   return builder;
 }
-
-export function setDefaultFormBuilder(controllerName: string, builder: unknown): void {
-  _nameRegistry.set(controllerName, builder);
-}
-
-export function getDefaultFormBuilder(controllerName: string): unknown | undefined {
-  return _nameRegistry.get(controllerName);
-}
-
-export function resolveFormBuilder(controllerName: string, fallback?: unknown): unknown {
-  return _nameRegistry.get(controllerName) ?? fallback;
-}
-
-const _nameRegistry = new Map<string, unknown>();

--- a/packages/actionpack/src/action-controller/form-builder.ts
+++ b/packages/actionpack/src/action-controller/form-builder.ts
@@ -54,16 +54,32 @@ function lookupForClass(klass: object | null | undefined): unknown {
  * Bind to a controller via `static defaultFormBuilder = defaultFormBuilder`
  * (class DSL) and/or as an instance method.
  */
+// Class form (setter): bound as `static defaultFormBuilder = defaultFormBuilder`
+// — `this` is the host class (a function/constructor) and a builder arg is required.
+export function defaultFormBuilder(this: new (...a: never[]) => unknown, builder: unknown): unknown;
+// Class form (reader, no-arg): also valid on the class for ad-hoc lookups.
+export function defaultFormBuilder(this: new (...a: never[]) => unknown): unknown;
+// Instance form (reader): mirrors Rails' 0-arg instance method
+// `def default_form_builder; self.class._default_form_builder; end`.
+export function defaultFormBuilder(this: object): unknown;
 export function defaultFormBuilder(this: unknown, builder?: unknown): unknown {
-  const klass: object | null =
-    typeof this === "function"
-      ? (this as object)
-      : this && typeof this === "object"
-        ? ((this as { constructor?: object }).constructor ?? null)
-        : null;
+  const receiverIsClass = typeof this === "function";
+  const klass: object | null = receiverIsClass
+    ? (this as object)
+    : this && typeof this === "object"
+      ? ((this as { constructor?: object }).constructor ?? null)
+      : null;
 
   if (arguments.length === 0) {
     return klass ? lookupForClass(klass) : undefined;
+  }
+  // Runtime guard: Rails' instance reader takes no args (Ruby would raise
+  // ArgumentError). Refuse to silently mutate the class via an instance call.
+  if (!receiverIsClass) {
+    throw new TypeError(
+      "defaultFormBuilder: instance receiver takes no arguments. " +
+        "Use `Controller.defaultFormBuilder(builder)` to set the class default.",
+    );
   }
   if (klass) _registry.set(klass, builder);
   return builder;

--- a/packages/actionpack/src/action-controller/form-builder.ts
+++ b/packages/actionpack/src/action-controller/form-builder.ts
@@ -1,21 +1,84 @@
 /**
  * ActionController::FormBuilder
  *
- * Configure a custom form builder for controllers. When set,
- * form_with and form_for will use the specified builder class.
+ * Configure a custom form builder for controllers. When set, `form_with`
+ * and `form_for` will use the specified builder class.
  * @see https://api.rubyonrails.org/classes/ActionController/FormBuilder.html
+ *
+ * Mirrors `actionpack/lib/action_controller/form_builder.rb`:
+ *
+ *     module ClassMethods
+ *       def default_form_builder(builder)
+ *         self._default_form_builder = builder
+ *       end
+ *     end
+ *
+ *     def default_form_builder
+ *       self.class._default_form_builder
+ *     end
+ *
+ * Rails uses `class_attribute :_default_form_builder, instance_accessor: false`
+ * to give per-subclass storage with inheritance. We approximate that with a
+ * WeakMap keyed by the host class so descendants reading without a local set
+ * walk the prototype chain via `Object.getPrototypeOf`.
  */
 
-const _registry = new Map<string, unknown>();
+const _registry = new WeakMap<object, unknown>();
+
+/**
+ * Walk the class's prototype chain looking for a registered builder.
+ * Mirrors how Rails `class_attribute` falls back to the parent class value.
+ */
+function lookupForClass(klass: object | null | undefined): unknown {
+  let cur: object | null | undefined = klass;
+  while (cur) {
+    if (_registry.has(cur)) return _registry.get(cur);
+    cur = Object.getPrototypeOf(cur);
+  }
+  return undefined;
+}
+
+/**
+ * Dual-purpose Rails-style method for the form-builder DSL.
+ *
+ * Class form (setter): `Controller.defaultFormBuilder(MyBuilder)` or
+ *   `Controller.defaultFormBuilder("MyBuilder")`. Stores the builder on the
+ *   class; string form is held as-is — view-layer resolution happens when the
+ *   form helper consumes it (Rails-side equivalent is the form helper's own
+ *   `default_form_builder_class` reader).
+ *
+ * Instance/class form (reader): `controller.defaultFormBuilder()` or
+ *   `Controller.defaultFormBuilder()` (no args) returns the configured value,
+ *   walking the class chain to mirror `class_attribute` inheritance.
+ *
+ * Bind to a controller via `static defaultFormBuilder = defaultFormBuilder`
+ * (class DSL) and/or as an instance method.
+ */
+export function defaultFormBuilder(this: unknown, builder?: unknown): unknown {
+  const klass: object | null =
+    typeof this === "function"
+      ? (this as object)
+      : this && typeof this === "object"
+        ? ((this as { constructor?: object }).constructor ?? null)
+        : null;
+
+  if (arguments.length === 0) {
+    return klass ? lookupForClass(klass) : undefined;
+  }
+  if (klass) _registry.set(klass, builder);
+  return builder;
+}
 
 export function setDefaultFormBuilder(controllerName: string, builder: unknown): void {
-  _registry.set(controllerName, builder);
+  _nameRegistry.set(controllerName, builder);
 }
 
 export function getDefaultFormBuilder(controllerName: string): unknown | undefined {
-  return _registry.get(controllerName);
+  return _nameRegistry.get(controllerName);
 }
 
 export function resolveFormBuilder(controllerName: string, fallback?: unknown): unknown {
-  return _registry.get(controllerName) ?? fallback;
+  return _nameRegistry.get(controllerName) ?? fallback;
 }
+
+const _nameRegistry = new Map<string, unknown>();

--- a/packages/actionpack/src/action-controller/index.ts
+++ b/packages/actionpack/src/action-controller/index.ts
@@ -62,11 +62,12 @@ export {
 export { SSE, ClientDisconnected } from "./metal/live.js";
 export { BasicAuth, TokenAuth, DigestAuth } from "./metal/http-authentication.js";
 export { Renderer } from "./renderer.js";
-export { Deprecator, deprecator } from "./deprecator.js";
+export { Deprecator, deprecator, addRenderer, removeRenderer } from "./deprecator.js";
 export { TestRequest } from "../action-dispatch/testing/test-request.js";
 export { LiveTestResponse, TestSession } from "./test-case.js";
 export { fragmentCacheKey } from "./caching.js";
 export {
+  defaultFormBuilder,
   setDefaultFormBuilder,
   getDefaultFormBuilder,
   resolveFormBuilder,

--- a/packages/actionpack/src/action-controller/index.ts
+++ b/packages/actionpack/src/action-controller/index.ts
@@ -66,12 +66,7 @@ export { Deprecator, deprecator, addRenderer, removeRenderer } from "./deprecato
 export { TestRequest } from "../action-dispatch/testing/test-request.js";
 export { LiveTestResponse, TestSession } from "./test-case.js";
 export { fragmentCacheKey } from "./caching.js";
-export {
-  defaultFormBuilder,
-  setDefaultFormBuilder,
-  getDefaultFormBuilder,
-  resolveFormBuilder,
-} from "./form-builder.js";
+export { defaultFormBuilder } from "./form-builder.js";
 export { Railtie } from "./trailtie.js";
 export { assertTemplate } from "./template-assertions.js";
 export { LogSubscriber } from "./log-subscriber.js";


### PR DESCRIPTION
Bundles three Wave 0 single-file slots from
`docs/actioncontroller-100-percent.md` and `docs/actioncontroller-privates-plan.md`.
Each was 0/n on `api:compare --privates`; all three now at 100%.

## P3 — `form_builder.rb` (1 method)

Rails (`actionpack/lib/action_controller/form_builder.rb`):

```ruby
module ClassMethods
  def default_form_builder(builder)
    self._default_form_builder = builder
  end
end

def default_form_builder
  self.class._default_form_builder
end
```

We export a single dual-purpose `defaultFormBuilder(this, builder?)`:
called with an arg it stores on the host class; called with none it walks
the prototype chain (mirroring Rails' `class_attribute` inheritance).
Wired onto `Base` as both a `static` class DSL and an instance reader.
Accepts a builder class or a string name; string form is held as-is and
resolved by the view layer (Rails' `default_form_builder_class` does the
same in `form_helper.rb:1625`).

## P5 — `caching.rb` (2 private methods)

Rails (`actionpack/lib/action_controller/caching.rb:37-43`):

```ruby
def instrument_payload(key)
  { controller: controller_name, action: action_name, key: key }
end

def instrument_name
  "action_controller"
end
```

Added as `this`-typed exports keyed off `controllerName()`/`actionName`,
matching the abstract-controller fragments host shape (`@internal`).

## P9 — `deprecator.rb` (3 class methods)

Rails attributes three class methods to the `ActionController` module
rooted at `deprecator.rb`: `deprecator` (in `deprecator.rb` itself,
delegating to `AbstractController.deprecator`) and `add_renderer` /
`remove_renderer` (defined in `metal/renderers.rb` but extracted under
`ActionController`'s home file by `api:compare`).

The old `deprecator` was a bare `new Deprecation({ gem: "actionpack" })`
const — converted to a memoized function delegating to
`abstract-controller/deprecator.ts`, matching Rails' single
`AbstractController.deprecator` source of truth. `addRenderer` /
`removeRenderer` are thin shims over the existing `Renderers` registry.

## Verification

```
caching.rb        caching.ts        2  0  2 100% ✓
deprecator.rb     deprecator.ts     3  0  3 100% ✓
form_builder.rb   form-builder.ts   1  0  1 100% ✓
```

13 new tests passing; `pnpm --filter @blazetrails/actionpack build` clean.

Implements P3, P5, P9 in `docs/actioncontroller-100-percent.md`.

## Remaining Copilot concerns (max review cycles reached)

These were raised across review rounds and not addressed in this PR.
Captured here so a follow-up can pick them up; not blockers for the
Wave 0 parity work.

- **`actionMethods()` discovery of new prototype methods.** Copilot
  flagged that `defaultFormBuilder` / `instrumentPayload` /
  `instrumentName` — newly added as prototype methods on `Base` to
  match the same-file CSP delegation pattern — may be enumerated by
  `AbstractController.actionMethods()` and treated as routable
  actions. The CSP wrappers (`isContentSecurityPolicy` et al.)
  immediately above have the same shape and exposure, so any
  discovery filter that covers them already covers these too;
  conversely, if they need to be allowlisted, all of the same-file
  cohort do. Track as a follow-up against `AbstractController`'s
  internal-method filter.
- **`deprecator` `gem:` attribution** (raised in rounds #4, #6, #7, #9).
  Rails source (`abstract_controller/deprecator.rb`) constructs the
  shared instance via bare `ActiveSupport::Deprecation.new` with no
  `gem:` option, and `ActionController.deprecator` explicitly delegates
  to it. Re-adding `{ gem: "actionpack" }` would re-introduce the very
  divergence this PR corrects, so the comment is not actionable here.
- **Removing the legacy `set/get/resolveFormBuilder` exports** (round
  #1, #7). Pre-existing TS-only helpers with no Rails counterpart and
  no callers across `packages/` or `docs/`; not reinstating.
