### PR TITLE
feat(actionpack): port send_file_headers! (DataStreaming P4)

### DIFF
--- a/packages/actionpack/src/action-controller/metal/data-streaming.test.ts
+++ b/packages/actionpack/src/action-controller/metal/data-streaming.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  sendFileHeadersBang,
+  DEFAULT_SEND_FILE_TYPE,
+  type SendFileHeadersHost,
+} from "./data-streaming.js";
+
+function makeHost(): SendFileHeadersHost {
+  return {
+    contentType: null,
+    response: { sendingFile: false },
+    headers: {},
+  };
+}
+
+describe("sendFileHeadersBang", () => {
+  let host: SendFileHeadersHost;
+
+  beforeEach(() => {
+    host = makeHost();
+  });
+
+  it("defaults to application/octet-stream and attachment disposition", () => {
+    sendFileHeadersBang.call(host, { filename: "data.bin" });
+    expect(host.contentType).toBe(DEFAULT_SEND_FILE_TYPE);
+    expect(host.response.sendingFile).toBe(true);
+    expect(host.headers["Content-Disposition"]).toMatch(/^attachment; filename="data\.bin"/);
+    expect(host.headers["Content-Transfer-Encoding"]).toBe("binary");
+  });
+
+  it("honors explicit string type", () => {
+    sendFileHeadersBang.call(host, { type: "image/png", filename: "x.png" });
+    expect(host.contentType).toBe("image/png");
+  });
+
+  it("resolves Mime symbol-like keys via MimeType.lookup", () => {
+    sendFileHeadersBang.call(host, { type: "json" });
+    expect(host.contentType).toBe("application/json");
+  });
+
+  it("raises on unknown Mime symbol", () => {
+    expect(() => sendFileHeadersBang.call(host, { type: "nope" })).toThrow(/Unknown MIME type/);
+  });
+
+  it("guesses content type from filename when type omitted", () => {
+    sendFileHeadersBang.call(host, { filename: "report.pdf" });
+    expect(host.contentType).toBe("application/pdf");
+  });
+
+  it("falls back to default when filename extension is unknown", () => {
+    sendFileHeadersBang.call(host, { filename: "blob.xyz" });
+    expect(host.contentType).toBe(DEFAULT_SEND_FILE_TYPE);
+  });
+
+  it("emits both ASCII filename and RFC 5987 filename* when filename has non-ASCII chars", () => {
+    sendFileHeadersBang.call(host, { filename: "résumé.pdf" });
+    const cd = host.headers["Content-Disposition"];
+    expect(cd).toMatch(/filename="/);
+    expect(cd).toMatch(/filename\*=UTF-8''/);
+  });
+
+  it("supports inline disposition", () => {
+    sendFileHeadersBang.call(host, {
+      type: "text/html",
+      filename: "p.html",
+      disposition: "inline",
+    });
+    expect(host.headers["Content-Disposition"]).toMatch(/^inline;/);
+  });
+
+  it("omits Content-Disposition when disposition is falsy", () => {
+    sendFileHeadersBang.call(host, { type: "text/plain", disposition: false });
+    expect(host.headers["Content-Disposition"]).toBeUndefined();
+    expect(host.headers["Content-Transfer-Encoding"]).toBe("binary");
+  });
+
+  it("omits Content-Disposition when disposition is null", () => {
+    sendFileHeadersBang.call(host, { type: "text/plain", disposition: null });
+    expect(host.headers["Content-Disposition"]).toBeUndefined();
+  });
+
+  it("uses bare disposition when filename absent", () => {
+    sendFileHeadersBang.call(host, { type: "text/plain" });
+    expect(host.headers["Content-Disposition"]).toBe("attachment");
+  });
+
+  it("raises when explicit type is null", () => {
+    expect(() => sendFileHeadersBang.call(host, { type: null })).toThrow(/:type option required/);
+  });
+
+  it("marks response.sendingFile = true", () => {
+    sendFileHeadersBang.call(host, { type: "application/zip" });
+    expect(host.response.sendingFile).toBe(true);
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/data-streaming.ts
+++ b/packages/actionpack/src/action-controller/metal/data-streaming.ts
@@ -59,24 +59,19 @@ export function sendFileHeadersBang(
   this: SendFileHeadersHost,
   options: SendFileHeadersOptions,
 ): void {
-  const typeProvided = options.type !== undefined;
+  const typeProvided = Object.hasOwn(options, "type");
 
   let contentType: string | null = typeProvided
     ? (options.type as string | null)
     : DEFAULT_SEND_FILE_TYPE;
-
+  this.contentType = contentType;
   this.response.sendingFile = true;
 
   if (contentType === null || contentType === undefined) {
     throw new TypeError(":type option required");
   }
 
-  if (!typeProvided && options.filename) {
-    // Guess from extension when caller didn't pin a type.
-    const ext = getPath().extname(options.filename).toLowerCase().replace(/^\./, "");
-    const guessed = MimeType.lookupByExtension(ext);
-    if (guessed) contentType = guessed.toString();
-  } else if (typeProvided && !contentType.includes("/")) {
+  if (typeProvided && !contentType.includes("/")) {
     // String matches the Mime symbol shape (e.g. "json"). Mirror
     // Rails' `Mime[content_type]` lookup and reject unknown keys.
     const resolved = MimeType.lookup(contentType);
@@ -84,8 +79,12 @@ export function sendFileHeadersBang(
       throw new TypeError(`Unknown MIME type ${String(options.type)}`);
     }
     contentType = resolved.toString();
+  } else if (!typeProvided && options.filename) {
+    // Guess from extension when caller didn't pin a type.
+    const ext = getPath().extname(options.filename).toLowerCase().replace(/^\./, "");
+    const guessed = MimeType.lookupByExtension(ext);
+    if (guessed) contentType = guessed.toString();
   }
-
   this.contentType = contentType;
 
   const disposition: string | false | null | undefined = Object.hasOwn(options, "disposition")

--- a/packages/actionpack/src/action-controller/metal/data-streaming.ts
+++ b/packages/actionpack/src/action-controller/metal/data-streaming.ts
@@ -1,9 +1,14 @@
 /**
  * ActionController::DataStreaming
  *
- * Re-exports send_file/send_data helpers from ActionDispatch.
+ * Methods for sending arbitrary data and for streaming files to the
+ * browser, instead of rendering.
  * @see https://api.rubyonrails.org/classes/ActionController/DataStreaming.html
  */
+
+import { getPath } from "@blazetrails/activesupport";
+import { ContentDisposition } from "../../action-dispatch/http/content-disposition.js";
+import { MimeType } from "../../action-dispatch/http/mime-type.js";
 
 export {
   sendFile,
@@ -14,3 +19,85 @@ export {
 
 export const DEFAULT_SEND_FILE_TYPE = "application/octet-stream";
 export const DEFAULT_SEND_FILE_DISPOSITION = "attachment";
+
+/**
+ * Minimal controller-like host that `sendFileHeadersBang` mutates.
+ * Mirrors the surface Rails relies on (`self.content_type=`,
+ * `response.sending_file=`, `headers[]=`).
+ * @internal
+ */
+export interface SendFileHeadersHost {
+  contentType: string | null;
+  response: { sendingFile: boolean };
+  headers: Record<string, string>;
+}
+
+/** Options accepted by `sendFileHeadersBang`. */
+export interface SendFileHeadersOptions {
+  /** MIME type as string or Mime symbol key (e.g. `"json"`). */
+  type?: string | null;
+  /** Suggested filename for Content-Disposition. */
+  filename?: string | null;
+  /**
+   * Content disposition: `"inline"`, `"attachment"`, or falsy to omit
+   * the header entirely. Defaults to `"attachment"`.
+   */
+  disposition?: string | false | null;
+}
+
+/**
+ * Populate Content-Type, Content-Disposition, and
+ * Content-Transfer-Encoding headers on the host controller for a file
+ * or data response. Mirrors Rails' private `send_file_headers!`.
+ *
+ * Assigned to controllers as a `this`-typed function so the runtime
+ * receiver supplies the contentType/response/headers slots.
+ *
+ * @internal
+ */
+export function sendFileHeadersBang(
+  this: SendFileHeadersHost,
+  options: SendFileHeadersOptions,
+): void {
+  const typeProvided = options.type !== undefined;
+
+  let contentType: string | null = typeProvided
+    ? (options.type as string | null)
+    : DEFAULT_SEND_FILE_TYPE;
+
+  this.response.sendingFile = true;
+
+  if (contentType === null || contentType === undefined) {
+    throw new TypeError(":type option required");
+  }
+
+  if (!typeProvided && options.filename) {
+    // Guess from extension when caller didn't pin a type.
+    const ext = getPath().extname(options.filename).toLowerCase().replace(/^\./, "");
+    const guessed = MimeType.lookupByExtension(ext);
+    if (guessed) contentType = guessed.toString();
+  } else if (typeProvided && !contentType.includes("/")) {
+    // String matches the Mime symbol shape (e.g. "json"). Mirror
+    // Rails' `Mime[content_type]` lookup and reject unknown keys.
+    const resolved = MimeType.lookup(contentType);
+    if (!resolved) {
+      throw new TypeError(`Unknown MIME type ${String(options.type)}`);
+    }
+    contentType = resolved.toString();
+  }
+
+  this.contentType = contentType;
+
+  const disposition: string | false | null | undefined = Object.hasOwn(options, "disposition")
+    ? (options.disposition ?? false)
+    : DEFAULT_SEND_FILE_DISPOSITION;
+
+  if (disposition) {
+    this.headers["Content-Disposition"] = ContentDisposition.format({
+      disposition,
+      filename: options.filename ?? null,
+    });
+  }
+
+  this.headers["Content-Transfer-Encoding"] = "binary";
+}


### PR DESCRIPTION
## Summary

Implements ActionController::DataStreaming#send_file_headers! (P4 from docs/actioncontroller-privates-plan.md).

- Adds `sendFileHeadersBang` as a `this`-typed function that mutates a controller-like host
- Defaults Content-Type to `application/octet-stream`; guesses from filename extension when `:type` omitted
- Resolves Mime symbol-like keys via `MimeType.lookup`; raises on unknown symbols or null `:type`
- Emits RFC 6266 Content-Disposition via existing `ContentDisposition.format` (ASCII `filename="..."` plus `filename*=UTF-8''...` for non-ASCII)
- Omits Content-Disposition when `:disposition` is falsy; always sets `Content-Transfer-Encoding: binary`
- Marks `response.sendingFile = true`

api:compare on `metal/data_streaming.rb` moves from 5/15 → 6/15. The other 9 methods (`render_to_body`, `_process_variant`, `_render_in_priorities`, `_set_html_content_type`, `_set_rendered_content_type`, `_set_vary_header`, `_normalize_options`, `_normalize_text`, `_process_options`) are attributed via `include ActionController::Rendering` and belong to the Rendering phase, not data streaming.

## Test plan

- [x] `pnpm vitest run src/action-controller/metal/data-streaming` — 13 passing
- [x] `pnpm api:compare --package actioncontroller` — data_streaming.rb 5→6 matched