### PR TITLE
feat(actionpack): Renderers _renderToBodyWithRenderer + _renderWithRendererMethodName (P7)

### DIFF
--- a/packages/actionpack/src/action-controller/metal/renderers.test.ts
+++ b/packages/actionpack/src/action-controller/metal/renderers.test.ts
@@ -11,9 +11,13 @@ describe("Renderers", () => {
 
   test("_renderWithRendererMethodName uses Rails convention", () => {
     expect(Renderers._renderWithRendererMethodName("csv")).toBe("_render_with_renderer_csv");
-    expect(Renderers._renderWithRendererMethodName(Symbol("json"))).toBe(
-      "_render_with_renderer_json",
-    );
+    expect(Renderers._renderWithRendererMethodName("json")).toBe("_render_with_renderer_json");
+  });
+
+  test("_renderToBodyWithRenderer ignores prototype keys (Hash#key? semantics)", () => {
+    keysToCleanup.push("toString");
+    Renderers.add("toString", () => "should-not-run");
+    expect(Renderers._renderToBodyWithRenderer({})).toBeNull();
   });
 
   test("add registers a renderer that dispatches by key", () => {

--- a/packages/actionpack/src/action-controller/metal/renderers.test.ts
+++ b/packages/actionpack/src/action-controller/metal/renderers.test.ts
@@ -12,7 +12,7 @@ describe("Renderers", () => {
   test("_renderWithRendererMethodName uses Rails convention", () => {
     expect(Renderers._renderWithRendererMethodName("csv")).toBe("_render_with_renderer_csv");
     expect(Renderers._renderWithRendererMethodName(Symbol("json"))).toBe(
-      "_render_with_renderer_Symbol(json)",
+      "_render_with_renderer_json",
     );
   });
 

--- a/packages/actionpack/src/action-controller/metal/renderers.test.ts
+++ b/packages/actionpack/src/action-controller/metal/renderers.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, test } from "vitest";
+
+import { Renderers } from "./renderers.js";
+
+describe("Renderers", () => {
+  const keysToCleanup: string[] = [];
+
+  afterEach(() => {
+    while (keysToCleanup.length) Renderers.remove(keysToCleanup.pop()!);
+  });
+
+  test("_renderWithRendererMethodName uses Rails convention", () => {
+    expect(Renderers._renderWithRendererMethodName("csv")).toBe("_render_with_renderer_csv");
+    expect(Renderers._renderWithRendererMethodName(Symbol("json"))).toBe(
+      "_render_with_renderer_Symbol(json)",
+    );
+  });
+
+  test("add registers a renderer that dispatches by key", () => {
+    keysToCleanup.push("csv");
+    Renderers.add("csv", (value) => `csv:${String(value)}`);
+
+    expect(Renderers.RENDERERS.has("csv")).toBe(true);
+    expect(Renderers.get("csv")).toBeDefined();
+  });
+
+  test("_renderToBodyWithRenderer dispatches to the matching renderer", () => {
+    keysToCleanup.push("csv");
+    Renderers.add("csv", (value, opts) => `csv:${String(value)}:${String(opts.filename)}`);
+
+    const result = Renderers._renderToBodyWithRenderer({ csv: "data", filename: "out" });
+    expect(result).toBe("csv:data:out");
+  });
+
+  test("_renderToBodyWithRenderer returns null when no key matches", () => {
+    expect(Renderers._renderToBodyWithRenderer({ html: "x" })).toBeNull();
+  });
+
+  test("remove deregisters both the key and the dispatch method", () => {
+    Renderers.add("xyz", () => "x");
+    Renderers.remove("xyz");
+
+    expect(Renderers.RENDERERS.has("xyz")).toBe(false);
+    expect(Renderers.get("xyz")).toBeUndefined();
+    expect(Renderers._renderToBodyWithRenderer({ xyz: "v" })).toBeNull();
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/renderers.ts
+++ b/packages/actionpack/src/action-controller/metal/renderers.ts
@@ -23,28 +23,48 @@ export class Renderers {
     return new Set(RENDERERS);
   }
 
+  /**
+   * Mirrors Rails `Renderers._render_with_renderer_method_name(key)`.
+   * Returns the conventional dispatch method name for a renderer key.
+   */
+  static _renderWithRendererMethodName(key: string | symbol): string {
+    return `_render_with_renderer_${String(key)}`;
+  }
+
   static add(key: string, block: RendererProc): void {
     RENDERERS.add(key);
-    this._registry.set(key, block);
+    this._registry.set(this._renderWithRendererMethodName(key), block);
   }
 
   static remove(key: string): void {
     RENDERERS.delete(key);
-    this._registry.delete(key);
+    this._registry.delete(this._renderWithRendererMethodName(key));
   }
 
   static get(key: string): RendererProc | undefined {
-    return this._registry.get(key);
+    return this._registry.get(this._renderWithRendererMethodName(key));
   }
 
-  static renderToBody(options: Record<string, unknown>): string | null {
+  /**
+   * Mirrors Rails `_render_to_body_with_renderer(options)`. Iterates the
+   * registered renderer names, and for the first key present in `options`
+   * dispatches to the renderer proc by its conventional method name.
+   * Returns `null` when no registered renderer key matches.
+   */
+  static _renderToBodyWithRenderer(options: Record<string, unknown>): string | null {
     for (const name of RENDERERS) {
       if (name in options) {
-        const renderer = this._registry.get(name);
+        const methodName = this._renderWithRendererMethodName(name);
+        const renderer = this._registry.get(methodName);
         if (renderer) return renderer(options[name], options);
       }
     }
     return null;
+  }
+
+  /** @deprecated use {@link _renderToBodyWithRenderer} */
+  static renderToBody(options: Record<string, unknown>): string | null {
+    return this._renderToBodyWithRenderer(options);
   }
 
   static useRenderers(...renderers: string[]): void {

--- a/packages/actionpack/src/action-controller/metal/renderers.ts
+++ b/packages/actionpack/src/action-controller/metal/renderers.ts
@@ -27,9 +27,8 @@ export class Renderers {
    * Mirrors Rails `Renderers._render_with_renderer_method_name(key)`.
    * Returns the conventional dispatch method name for a renderer key.
    */
-  static _renderWithRendererMethodName(key: string | symbol): string {
-    const suffix = typeof key === "symbol" ? (key.description ?? "") : key;
-    return `_render_with_renderer_${suffix}`;
+  static _renderWithRendererMethodName(key: string): string {
+    return `_render_with_renderer_${key}`;
   }
 
   static add(key: string, block: RendererProc): void {
@@ -54,7 +53,7 @@ export class Renderers {
    */
   static _renderToBodyWithRenderer(options: Record<string, unknown>): string | null {
     for (const name of RENDERERS) {
-      if (name in options) {
+      if (Object.hasOwn(options, name)) {
         const methodName = this._renderWithRendererMethodName(name);
         const renderer = this._registry.get(methodName);
         if (renderer) return renderer(options[name], options);

--- a/packages/actionpack/src/action-controller/metal/renderers.ts
+++ b/packages/actionpack/src/action-controller/metal/renderers.ts
@@ -28,7 +28,8 @@ export class Renderers {
    * Returns the conventional dispatch method name for a renderer key.
    */
   static _renderWithRendererMethodName(key: string | symbol): string {
-    return `_render_with_renderer_${String(key)}`;
+    const suffix = typeof key === "symbol" ? (key.description ?? "") : key;
+    return `_render_with_renderer_${suffix}`;
   }
 
   static add(key: string, block: RendererProc): void {


### PR DESCRIPTION
## Summary

Implements P7 from `docs/actioncontroller-100-percent.md` for `metal/renderers.rb`.

- Adds `Renderers._renderWithRendererMethodName(key)` — builds the conventional `_render_with_renderer_<key>` dispatch name (Rails parity).
- Adds `Renderers._renderToBodyWithRenderer(options)` — iterates registered renderer names, finds the first key present in `options`, and dispatches through the registry by method name. Returns `null` when no key matches.
- `Renderers.add` / `remove` / `get` now key the registry by the conventional method name, so existing registrations resolve unchanged.
- Old `Renderers.renderToBody` kept as a one-line shim that delegates to the new method.

Rails source: `vendor/rails/actionpack/lib/action_controller/metal/renderers.rb`.

## Test plan

- [x] `pnpm vitest run --project other packages/actionpack/src/action-controller/metal/renderers.test.ts` — 5 new tests cover name helper, add/remove, dispatch, and miss → null.
- [x] `pnpm build` + `pnpm typecheck`.