### PR TITLE
feat(actioncontroller): metal/allow_browser privates (P13)

### DIFF
--- a/packages/actionpack/src/action-controller/metal/allow-browser.test.ts
+++ b/packages/actionpack/src/action-controller/metal/allow-browser.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect } from "vitest";
+import { BrowserBlocker } from "./allow-browser.js";
+
+const CHROME_118 =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/118 Safari/537.36";
+const CHROME_120 =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36";
+const IE_11 = "Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko";
+const GOOGLE_BOT =
+  "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 5X Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/W.X.Y.Z Mobile Safari/537.36 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)";
+
+describe("BrowserBlocker", () => {
+  describe("expandedVersions", () => {
+    it("resolves the :modern named set", () => {
+      const b = new BrowserBlocker(CHROME_120, "modern");
+      expect(b.expandedVersions()).toEqual({
+        safari: "17.2",
+        chrome: "120",
+        firefox: "121",
+        opera: "106",
+        ie: false,
+      });
+    });
+
+    it("returns an empty map for an unknown named set", () => {
+      const b = new BrowserBlocker(CHROME_120, "unknown" as "modern");
+      expect(b.expandedVersions()).toEqual({});
+    });
+
+    it("returns a hash directly when given one", () => {
+      const b = new BrowserBlocker(CHROME_120, { chrome: "119" });
+      expect(b.expandedVersions()).toEqual({ chrome: "119" });
+    });
+
+    it("memoizes the result", () => {
+      const b = new BrowserBlocker(CHROME_120, "modern");
+      expect(b.expandedVersions()).toBe(b.expandedVersions());
+    });
+  });
+
+  describe("normalizedBrowserName", () => {
+    it("normalizes 'internet explorer' to 'ie'", () => {
+      const b = new BrowserBlocker(IE_11, {});
+      expect(b.normalizedBrowserName()).toBe("ie");
+    });
+
+    it("lowercases the browser name", () => {
+      const b = new BrowserBlocker(CHROME_120, {});
+      expect(b.normalizedBrowserName()).toBe("chrome");
+    });
+  });
+
+  describe("isBot", () => {
+    it("returns true for a Googlebot user agent", () => {
+      const b = new BrowserBlocker(GOOGLE_BOT, "modern");
+      expect(b.isBot()).toBe(true);
+    });
+
+    it("returns false for a regular browser", () => {
+      const b = new BrowserBlocker(CHROME_120, "modern");
+      expect(b.isBot()).toBe(false);
+    });
+  });
+
+  describe("isUserAgentVersionReported", () => {
+    it("returns false when the user-agent header is empty", () => {
+      const b = new BrowserBlocker("", "modern");
+      expect(b.isUserAgentVersionReported()).toBe(false);
+    });
+
+    it("returns true when the parsed version is present", () => {
+      const b = new BrowserBlocker(CHROME_120, "modern");
+      expect(b.isUserAgentVersionReported()).toBe(true);
+    });
+  });
+
+  describe("minimumBrowserVersionForBrowser", () => {
+    it("looks up by normalized browser name", () => {
+      const b = new BrowserBlocker(CHROME_120, { chrome: "119" });
+      expect(b.minimumBrowserVersionForBrowser()).toBe("119");
+    });
+
+    it("returns false when the browser is explicitly disallowed", () => {
+      const b = new BrowserBlocker(IE_11, { ie: false });
+      expect(b.minimumBrowserVersionForBrowser()).toBe(false);
+    });
+
+    it("returns undefined when the browser is not listed", () => {
+      const b = new BrowserBlocker(CHROME_120, { firefox: "120" });
+      expect(b.minimumBrowserVersionForBrowser()).toBeUndefined();
+    });
+  });
+
+  describe("isVersionGuardedBrowser", () => {
+    it("is true when an entry exists (including false)", () => {
+      expect(new BrowserBlocker(IE_11, { ie: false }).isVersionGuardedBrowser()).toBe(true);
+      expect(new BrowserBlocker(CHROME_120, { chrome: "119" }).isVersionGuardedBrowser()).toBe(
+        true,
+      );
+    });
+
+    it("is false when the browser is not listed", () => {
+      expect(new BrowserBlocker(CHROME_120, { firefox: "120" }).isVersionGuardedBrowser()).toBe(
+        false,
+      );
+    });
+  });
+
+  describe("isVersionBelowMinimumRequired", () => {
+    it("is true when the parsed version is below the minimum", () => {
+      const b = new BrowserBlocker(CHROME_118, { chrome: "119" });
+      expect(b.isVersionBelowMinimumRequired()).toBe(true);
+    });
+
+    it("is false when the parsed version meets the minimum", () => {
+      const b = new BrowserBlocker(CHROME_120, { chrome: "119" });
+      expect(b.isVersionBelowMinimumRequired()).toBe(false);
+    });
+
+    it("is true when the minimum is false (browser disallowed)", () => {
+      const b = new BrowserBlocker(IE_11, { ie: false });
+      expect(b.isVersionBelowMinimumRequired()).toBe(true);
+    });
+  });
+
+  describe("isUnsupportedBrowser", () => {
+    it("blocks an old guarded browser that isn't a bot", () => {
+      const b = new BrowserBlocker(CHROME_118, "modern");
+      expect(b.isUnsupportedBrowser()).toBe(true);
+    });
+
+    it("does not block a bot even when guarded and below minimum", () => {
+      const b = new BrowserBlocker(GOOGLE_BOT, "modern");
+      expect(b.isUnsupportedBrowser()).toBe(false);
+    });
+
+    it("does not block an unguarded browser", () => {
+      const b = new BrowserBlocker(CHROME_120, { firefox: "200" });
+      expect(b.isUnsupportedBrowser()).toBe(false);
+    });
+  });
+
+  describe("blocked", () => {
+    it("is true when version is reported and the browser is unsupported", () => {
+      expect(new BrowserBlocker(CHROME_118, "modern").blocked).toBe(true);
+    });
+
+    it("is false when no user-agent is sent", () => {
+      expect(new BrowserBlocker("", "modern").blocked).toBe(false);
+    });
+
+    it("is false when the browser meets the minimum", () => {
+      expect(new BrowserBlocker(CHROME_120, "modern").blocked).toBe(false);
+    });
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/allow-browser.ts
+++ b/packages/actionpack/src/action-controller/metal/allow-browser.ts
@@ -11,68 +11,98 @@ import { UAParser } from "ua-parser-js";
 export type BrowserVersions = "modern" | Record<string, string | false>;
 
 const SETS: Record<string, Record<string, string | false>> = {
-  modern: { safari: "17.2", chrome: "120", firefox: "121", opera: "106" },
+  modern: { safari: "17.2", chrome: "120", firefox: "121", opera: "106", ie: false },
 };
 
 export class BrowserBlocker {
-  private _versions: Record<string, string | false>;
   private _userAgent: string;
-  private _parser?: UAParser;
+  private _versions: BrowserVersions;
+  private _parsed?: UAParser;
+  private _expanded?: Record<string, string | false>;
 
   constructor(userAgentString: string, versions: BrowserVersions) {
     this._userAgent = userAgentString;
-    this._versions = typeof versions === "string" ? (SETS[versions] ?? {}) : versions;
-  }
-
-  private get parser(): UAParser {
-    this._parser ??= new UAParser(this._userAgent);
-    return this._parser;
+    this._versions = versions;
   }
 
   get versions(): Record<string, string | false> {
-    return { ...this._versions };
+    return { ...this.expandedVersions() };
   }
 
   get blocked(): boolean {
-    if (!this._userAgent) return false;
-    if (this._bot()) return false;
-
-    const minimum = this._minimumVersionForBrowser();
-    if (minimum === undefined) return false;
-    if (minimum === false) return true;
-
-    const browser = this.parser.getBrowser();
-    if (!browser.version) return false;
-    return this._compareVersions(browser.version, minimum) < 0;
+    return this.isUserAgentVersionReported() && this.isUnsupportedBrowser();
   }
 
-  private _bot(): boolean {
+  /** @internal */
+  parsedUserAgent(): UAParser {
+    this._parsed ??= new UAParser(this._userAgent);
+    return this._parsed;
+  }
+
+  /** @internal */
+  isUserAgentVersionReported(): boolean {
+    if (!this._userAgent) return false;
+    const version = this.parsedUserAgent().getBrowser().version ?? "";
+    return version.length > 0;
+  }
+
+  /** @internal */
+  isUnsupportedBrowser(): boolean {
+    return this.isVersionGuardedBrowser() && this.isVersionBelowMinimumRequired() && !this.isBot();
+  }
+
+  /** @internal */
+  isVersionGuardedBrowser(): boolean {
+    return this.minimumBrowserVersionForBrowser() !== undefined;
+  }
+
+  /** @internal */
+  isBot(): boolean {
     return /bot|crawl|spider|slurp/i.test(this._userAgent);
   }
 
-  private _minimumVersionForBrowser(): string | false | undefined {
-    return this._versions[this._normalizedBrowserName()];
+  /** @internal */
+  isVersionBelowMinimumRequired(): boolean {
+    const minimum = this.minimumBrowserVersionForBrowser();
+    if (minimum === undefined) return true;
+    if (minimum === false) return true;
+    const version = this.parsedUserAgent().getBrowser().version ?? "";
+    return compareVersions(version, minimum) < 0;
   }
 
-  private _normalizedBrowserName(): string {
-    const browser = this.parser.getBrowser();
-    const name = (browser.name ?? "").toLowerCase();
+  /** @internal */
+  minimumBrowserVersionForBrowser(): string | false | undefined {
+    return this.expandedVersions()[this.normalizedBrowserName()];
+  }
+
+  /** @internal */
+  expandedVersions(): Record<string, string | false> {
+    if (!this._expanded) {
+      const v = this._versions;
+      this._expanded = typeof v === "string" ? (SETS[v] ?? {}) : v;
+    }
+    return this._expanded;
+  }
+
+  /** @internal */
+  normalizedBrowserName(): string {
+    const name = (this.parsedUserAgent().getBrowser().name ?? "").toLowerCase();
     if (name === "internet explorer" || name === "ie") return "ie";
     if (name === "mobile chrome") return "chrome";
     if (name === "mobile safari") return "safari";
     if (name === "mobile firefox") return "firefox";
     return name;
   }
+}
 
-  private _compareVersions(a: string, b: string): number {
-    const pa = a.split(".").map(Number);
-    const pb = b.split(".").map(Number);
-    const len = Math.max(pa.length, pb.length);
-    for (let i = 0; i < len; i++) {
-      const na = pa[i] ?? 0;
-      const nb = pb[i] ?? 0;
-      if (na !== nb) return na - nb;
-    }
-    return 0;
+function compareVersions(a: string, b: string): number {
+  const pa = a.split(".").map(Number);
+  const pb = b.split(".").map(Number);
+  const len = Math.max(pa.length, pb.length);
+  for (let i = 0; i < len; i++) {
+    const na = pa[i] ?? 0;
+    const nb = pb[i] ?? 0;
+    if (na !== nb) return na - nb;
   }
+  return 0;
 }


### PR DESCRIPTION
Implements **P13** from `docs/actioncontroller-privates-plan.md`.

Refactors `BrowserBlocker` (`metal/allow-browser.ts`) to expose the 9
Rails-named private helpers so they match the layout in
`vendor/rails/actionpack/lib/action_controller/metal/allow_browser.rb`:

- `parsedUserAgent` — memoized `UAParser` for the request UA.
- `isUserAgentVersionReported` — `request.user_agent.present? && parsed_user_agent.version.to_s.present?`
- `isUnsupportedBrowser` — `version_guarded_browser? && version_below_minimum_required? && !bot?`
- `isVersionGuardedBrowser` — `minimum_browser_version_for_browser != nil`
- `isBot` — `parsed_user_agent.bot?`
- `isVersionBelowMinimumRequired` — compares parsed version to minimum.
- `minimumBrowserVersionForBrowser` — `expanded_versions[normalized_browser_name]`
- `expandedVersions` — memoized `SETS[versions] || versions`.
- `normalizedBrowserName` — `"internet explorer" => "ie"` (also handles mobile-* aliases).

`blocked` is now derived as `isUserAgentVersionReported() && isUnsupportedBrowser()`,
mirroring Rails:

```ruby
def blocked?
  user_agent_version_reported? && unsupported_browser?
end
```

The `:modern` SET now includes `ie: false`, matching:

```ruby
SETS = {
  modern: { safari: 17.2, chrome: 120, firefox: 121, opera: 106, ie: false }
}
```

`api:compare --package actioncontroller --privates` for `metal/allow_browser.rb`:
**5/14 → 14/14 (100%)**.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/controller/allow-browser.test.ts` — 7 pass
- [x] `pnpm build` clean
- [x] `pnpm api:compare --package actioncontroller --privates` shows allow_browser at 100%