### PR TITLE
feat(actionpack): ContentSecurityPolicy class DSL + helpers (P10)

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -78,6 +78,9 @@ export class AbstractController {
     "inspect",
     "controllerPath",
     "controllerName",
+    "isContentSecurityPolicy",
+    "contentSecurityPolicyNonce",
+    "currentContentSecurityPolicy",
   ]);
 
   private static _actionMethodCache?: Set<string>;

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -406,14 +406,24 @@ export class Base extends Metal {
    */
   static contentSecurityPolicyReportOnly = contentSecurityPolicyReportOnly;
 
+  /**
+   * Defined as prototype methods (not instance fields) so subclasses can
+   * override via the normal class-method syntax — the DSL dispatches through
+   * `this.currentContentSecurityPolicy` (content-security-policy.ts:80) for
+   * Rails parity (content_security_policy.rb:42 resolves via `self`).
+   */
   /** @internal Private in Rails; exposed for parity coverage. */
-  isContentSecurityPolicy = isContentSecurityPolicy;
-
+  isContentSecurityPolicy(): boolean {
+    return isContentSecurityPolicy.call(this as never);
+  }
   /** @internal Private in Rails; exposed for parity coverage. */
-  contentSecurityPolicyNonce = contentSecurityPolicyNonce;
-
+  contentSecurityPolicyNonce(): string | null {
+    return contentSecurityPolicyNonce.call(this as never);
+  }
   /** @internal Private in Rails; exposed for parity coverage. */
-  currentContentSecurityPolicy = currentContentSecurityPolicy;
+  currentContentSecurityPolicy(): ReturnType<typeof currentContentSecurityPolicy> {
+    return currentContentSecurityPolicy.call(this as never);
+  }
 
   /**
    * Apply a rate limit to all actions (or those selected by `only:`/`except:`).

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -23,6 +23,13 @@ import type { RouteHelpersMap } from "../action-dispatch/routing/route-helpers.j
 import { BrowserBlocker, type BrowserVersions } from "./metal/allow-browser.js";
 import { permissionsPolicy } from "./metal/permissions-policy.js";
 import { rateLimit, rateLimiting } from "./metal/rate-limiting.js";
+import {
+  contentSecurityPolicy,
+  contentSecurityPolicyNonce,
+  contentSecurityPolicyReportOnly,
+  currentContentSecurityPolicy,
+  isContentSecurityPolicy,
+} from "./metal/content-security-policy.js";
 
 // Re-export callback registration
 export { type ActionCallback, type AroundCallback, type CallbackOptions };
@@ -384,6 +391,29 @@ export class Base extends Metal {
    * Mirrors Rails `permissions_policy` class DSL.
    */
   static permissionsPolicy = permissionsPolicy;
+
+  // --- Content Security Policy ---
+
+  /**
+   * Override the globally configured Content-Security-Policy on a
+   * per-action basis. Mirrors Rails `content_security_policy` class DSL.
+   */
+  static contentSecurityPolicy = contentSecurityPolicy;
+
+  /**
+   * Override the globally configured Content-Security-Policy-Report-Only
+   * header. Mirrors Rails `content_security_policy_report_only` class DSL.
+   */
+  static contentSecurityPolicyReportOnly = contentSecurityPolicyReportOnly;
+
+  /** @internal Private in Rails; exposed for parity coverage. */
+  isContentSecurityPolicy = isContentSecurityPolicy;
+
+  /** @internal Private in Rails; exposed for parity coverage. */
+  contentSecurityPolicyNonce = contentSecurityPolicyNonce;
+
+  /** @internal Private in Rails; exposed for parity coverage. */
+  currentContentSecurityPolicy = currentContentSecurityPolicy;
 
   /**
    * Apply a rate limit to all actions (or those selected by `only:`/`except:`).

--- a/packages/actionpack/src/action-controller/metal/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-controller/metal/content-security-policy.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  contentSecurityPolicy,
+  contentSecurityPolicyNonce,
+  contentSecurityPolicyReportOnly,
+  currentContentSecurityPolicy,
+  isContentSecurityPolicy,
+  type ContentSecurityPolicyBlock,
+} from "./content-security-policy.js";
+import { ContentSecurityPolicy as Policy } from "../../action-dispatch/http/content-security-policy.js";
+import type { CallbackOptions } from "../../abstract-controller/callbacks.js";
+
+type Registration = {
+  callback: (controller: unknown) => void | boolean | Promise<void | boolean>;
+  options?: CallbackOptions;
+};
+
+function makeHost() {
+  const registered: Registration[] = [];
+  const host = {
+    beforeAction(
+      callback: (controller: unknown) => void | boolean | Promise<void | boolean>,
+      options?: CallbackOptions,
+    ) {
+      registered.push({ callback, options });
+    },
+  };
+  return { host, registered };
+}
+
+function makeController(initial: Policy | null = null) {
+  return { request: { contentSecurityPolicy: initial } };
+}
+
+describe("contentSecurityPolicy class DSL", () => {
+  let host: ReturnType<typeof makeHost>["host"];
+  let registered: Registration[];
+
+  beforeEach(() => {
+    ({ host, registered } = makeHost());
+  });
+
+  it("registers a before_action and yields a cloned current policy to the block", async () => {
+    const existing = new Policy((p) => p.defaultSrc(":self"));
+    const controller = makeController(existing);
+    let yielded: Policy | undefined;
+    const block: ContentSecurityPolicyBlock = function (policy) {
+      yielded = policy;
+      policy.scriptSrc(":self");
+    };
+    contentSecurityPolicy.call(host, true, { only: ["show"] }, block);
+
+    expect(registered).toHaveLength(1);
+    expect(registered[0].options).toEqual({ only: ["show"] });
+
+    await registered[0].callback(controller);
+    expect(yielded).toBeInstanceOf(Policy);
+    expect(yielded).not.toBe(existing);
+    expect(controller.request.contentSecurityPolicy).toBe(yielded);
+  });
+
+  it("starts from a fresh policy when the request has none", async () => {
+    const controller = makeController(null);
+    contentSecurityPolicy.call(host, true, {}, function (policy) {
+      policy.defaultSrc(":self");
+    });
+    await registered[0].callback(controller);
+    expect(controller.request.contentSecurityPolicy).toBeInstanceOf(Policy);
+  });
+
+  it("nils the request CSP when disabled", async () => {
+    const controller = makeController(new Policy());
+    contentSecurityPolicy.call(host, false, { only: ["index"] });
+    await registered[0].callback(controller);
+    expect(controller.request.contentSecurityPolicy).toBeNull();
+  });
+
+  it("treats a first-positional options object as enabled=true (Rails kwargs shape)", async () => {
+    const controller = makeController(null);
+    contentSecurityPolicy.call(
+      host,
+      { only: ["show"] },
+      undefined as unknown as CallbackOptions,
+      function (policy) {
+        policy.defaultSrc(":self");
+      },
+    );
+    expect(registered[0].options).toEqual({ only: ["show"] });
+    await registered[0].callback(controller);
+    expect(controller.request.contentSecurityPolicy).toBeInstanceOf(Policy);
+  });
+});
+
+describe("contentSecurityPolicyReportOnly class DSL", () => {
+  let host: ReturnType<typeof makeHost>["host"];
+  let registered: Registration[];
+
+  beforeEach(() => {
+    ({ host, registered } = makeHost());
+  });
+
+  it("registers a before_action that sets request.contentSecurityPolicyReportOnly", async () => {
+    const controller: { request: { contentSecurityPolicyReportOnly?: boolean | Policy | null } } = {
+      request: {},
+    };
+    contentSecurityPolicyReportOnly.call(host, true, { only: ["show"] });
+    expect(registered[0].options).toEqual({ only: ["show"] });
+    await registered[0].callback(controller);
+    expect(controller.request.contentSecurityPolicyReportOnly).toBe(true);
+  });
+
+  it("clears the report-only header when passed false", async () => {
+    const controller: { request: { contentSecurityPolicyReportOnly?: boolean | Policy | null } } = {
+      request: { contentSecurityPolicyReportOnly: true },
+    };
+    contentSecurityPolicyReportOnly.call(host, false);
+    await registered[0].callback(controller);
+    expect(controller.request.contentSecurityPolicyReportOnly).toBe(false);
+  });
+
+  it("treats a first-positional options object as reportOnly=true", async () => {
+    const controller: { request: { contentSecurityPolicyReportOnly?: boolean | Policy | null } } = {
+      request: {},
+    };
+    contentSecurityPolicyReportOnly.call(host, { except: ["index"] });
+    expect(registered[0].options).toEqual({ except: ["index"] });
+    await registered[0].callback(controller);
+    expect(controller.request.contentSecurityPolicyReportOnly).toBe(true);
+  });
+});
+
+describe("private instance helpers", () => {
+  it("isContentSecurityPolicy reflects request.contentSecurityPolicy presence", () => {
+    expect(isContentSecurityPolicy.call({ request: { contentSecurityPolicy: null } })).toBe(false);
+    expect(isContentSecurityPolicy.call({ request: { contentSecurityPolicy: new Policy() } })).toBe(
+      true,
+    );
+  });
+
+  it("contentSecurityPolicyNonce returns the request nonce or null", () => {
+    expect(contentSecurityPolicyNonce.call({ request: {} })).toBeNull();
+    expect(
+      contentSecurityPolicyNonce.call({ request: { contentSecurityPolicyNonce: "abc" } }),
+    ).toBe("abc");
+  });
+
+  it("currentContentSecurityPolicy dups the request policy", () => {
+    const existing = new Policy((p) => p.defaultSrc(":self"));
+    const dup = currentContentSecurityPolicy.call({
+      request: { contentSecurityPolicy: existing },
+    });
+    expect(dup).toBeInstanceOf(Policy);
+    expect(dup).not.toBe(existing);
+  });
+
+  it("currentContentSecurityPolicy returns a fresh policy when none is set", () => {
+    const fresh = currentContentSecurityPolicy.call({ request: { contentSecurityPolicy: null } });
+    expect(fresh).toBeInstanceOf(Policy);
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-controller/metal/content-security-policy.test.ts
@@ -75,17 +75,24 @@ describe("contentSecurityPolicy class DSL", () => {
     expect(controller.request.contentSecurityPolicy).toBeNull();
   });
 
-  it("treats a first-positional options object as enabled=true (Rails kwargs shape)", async () => {
+  it("treats a first-positional options object as enabled=true and accepts a block in arg 2 (Rails kwargs shape)", async () => {
     const controller = makeController(null);
-    contentSecurityPolicy.call(
-      host,
-      { only: ["show"] },
-      undefined as unknown as CallbackOptions,
-      function (policy) {
-        policy.defaultSrc(":self");
-      },
-    );
+    let blockRan = false;
+    contentSecurityPolicy.call(host, { only: ["show"] }, function (policy) {
+      blockRan = true;
+      policy.defaultSrc(":self");
+    });
     expect(registered[0].options).toEqual({ only: ["show"] });
+    await registered[0].callback(controller);
+    expect(blockRan).toBe(true);
+    expect(controller.request.contentSecurityPolicy).toBeInstanceOf(Policy);
+  });
+
+  it("accepts a block-only form (no enabled, no options)", async () => {
+    const controller = makeController(null);
+    contentSecurityPolicy.call(host, function (policy) {
+      policy.defaultSrc(":self");
+    });
     await registered[0].callback(controller);
     expect(controller.request.contentSecurityPolicy).toBeInstanceOf(Policy);
   });

--- a/packages/actionpack/src/action-controller/metal/content-security-policy.ts
+++ b/packages/actionpack/src/action-controller/metal/content-security-policy.ts
@@ -65,25 +65,35 @@ interface ContentSecurityPolicyInstanceHost {
  */
 export function contentSecurityPolicy(
   this: ContentSecurityPolicyClassHost,
-  enabled: boolean | CallbackOptions = true,
-  options: CallbackOptions = {},
+  enabled: boolean | CallbackOptions | ContentSecurityPolicyBlock = true,
+  options: CallbackOptions | ContentSecurityPolicyBlock = {},
   block?: ContentSecurityPolicyBlock,
 ): void {
   let resolvedEnabled: boolean;
   let resolvedOptions: CallbackOptions;
+  let resolvedBlock: ContentSecurityPolicyBlock | undefined;
   if (typeof enabled === "boolean") {
+    // (enabled, options, block) — Rails canonical positional form
     resolvedEnabled = enabled;
-    resolvedOptions = options;
+    resolvedOptions = typeof options === "function" ? {} : options;
+    resolvedBlock = typeof options === "function" ? options : block;
+  } else if (typeof enabled === "function") {
+    // (block) — block-only form
+    resolvedEnabled = true;
+    resolvedOptions = {};
+    resolvedBlock = enabled;
   } else {
+    // (options, block) — Rails kwargs-leading form, e.g. `content_security_policy(only: :index) do ... end`
     resolvedEnabled = true;
     resolvedOptions = enabled;
+    resolvedBlock = typeof options === "function" ? options : block;
   }
   this.beforeAction(function (controller: unknown) {
     const host = controller as ContentSecurityPolicyInstanceHost;
-    if (block) {
+    if (resolvedBlock) {
       const resolveCurrent = host.currentContentSecurityPolicy ?? currentContentSecurityPolicy;
       const policy = resolveCurrent.call(host);
-      block.call(controller, policy);
+      resolvedBlock.call(controller, policy);
       host.request.contentSecurityPolicy = policy;
     }
     if (!resolvedEnabled) {

--- a/packages/actionpack/src/action-controller/metal/content-security-policy.ts
+++ b/packages/actionpack/src/action-controller/metal/content-security-policy.ts
@@ -1,31 +1,158 @@
 /**
  * ActionController::ContentSecurityPolicy
  *
- * Overrides or disables the globally configured Content-Security-Policy
- * header on a per-controller or per-action basis.
+ * Overrides or disables the globally configured Content-Security-Policy and
+ * Content-Security-Policy-Report-Only headers on a per-controller or
+ * per-action basis.
  * @see https://api.rubyonrails.org/classes/ActionController/ContentSecurityPolicy.html
  */
 
-import { getCrypto } from "@blazetrails/activesupport";
-import { deleteHeaderCaseInsensitive } from "./header-utils.js";
+import type { CallbackOptions } from "../../abstract-controller/callbacks.js";
+import { ContentSecurityPolicy as Policy } from "../../action-dispatch/http/content-security-policy.js";
 
-/** @internal */
-export function contentSecurityPolicyNonce(): string {
-  return getCrypto().randomBytes(16).toString("base64");
+/**
+ * Block invoked with the per-request CSP. Mutate `policy` to override or
+ * extend the globally configured Content-Security-Policy.
+ */
+export type ContentSecurityPolicyBlock = (this: unknown, policy: Policy) => void;
+
+/**
+ * Subset of the request shape this DSL touches. Rails reads/writes
+ * `request.content_security_policy` and the report-only counterpart; downstream
+ * middleware materializes the values into response headers.
+ */
+interface CspRequest {
+  contentSecurityPolicy?: Policy | null;
+  contentSecurityPolicyReportOnly?: Policy | boolean | null;
+  contentSecurityPolicyNonce?: string | null;
 }
 
-export function hasContentSecurityPolicy(response: {
-  getHeader(name: string): string | undefined;
-}): boolean {
-  return response.getHeader("content-security-policy") !== undefined;
+interface ContentSecurityPolicyClassHost {
+  beforeAction(
+    callback: (controller: unknown) => void | boolean | Promise<void | boolean>,
+    options?: CallbackOptions,
+  ): void;
 }
 
-export function applyContentSecurityPolicy(
-  headers: Record<string, string>,
-  policy: string | false,
+interface ContentSecurityPolicyInstanceHost {
+  request: CspRequest;
+}
+
+/**
+ * Class DSL: register a per-controller Content-Security-Policy override.
+ *
+ * Mirrors Rails `ActionController::ContentSecurityPolicy::ClassMethods#content_security_policy`
+ * (actionpack/lib/action_controller/metal/content_security_policy.rb, lines 38–49):
+ *
+ *     def content_security_policy(enabled = true, **options, &block)
+ *       before_action(options) do
+ *         if block_given?
+ *           policy = current_content_security_policy
+ *           instance_exec(policy, &block)
+ *           request.content_security_policy = policy
+ *         end
+ *         unless enabled
+ *           request.content_security_policy = nil
+ *         end
+ *       end
+ *     end
+ */
+export function contentSecurityPolicy(
+  this: ContentSecurityPolicyClassHost,
+  enabled: boolean | CallbackOptions = true,
+  options: CallbackOptions = {},
+  block?: ContentSecurityPolicyBlock,
 ): void {
-  deleteHeaderCaseInsensitive(headers, "content-security-policy");
-  if (policy !== false) {
-    headers["content-security-policy"] = policy;
+  let resolvedEnabled: boolean;
+  let resolvedOptions: CallbackOptions;
+  if (typeof enabled === "boolean") {
+    resolvedEnabled = enabled;
+    resolvedOptions = options;
+  } else {
+    resolvedEnabled = true;
+    resolvedOptions = enabled;
   }
+  this.beforeAction(function (controller: unknown) {
+    const host = controller as ContentSecurityPolicyInstanceHost;
+    if (block) {
+      const policy = currentContentSecurityPolicy.call(host);
+      block.call(controller, policy);
+      host.request.contentSecurityPolicy = policy;
+    }
+    if (!resolvedEnabled) {
+      host.request.contentSecurityPolicy = null;
+    }
+  }, resolvedOptions);
+}
+
+/**
+ * Class DSL: override the Content-Security-Policy-Report-Only header.
+ *
+ * Mirrors Rails `ActionController::ContentSecurityPolicy::ClassMethods#content_security_policy_report_only`
+ * (actionpack/lib/action_controller/metal/content_security_policy.rb, lines 63–67):
+ *
+ *     def content_security_policy_report_only(report_only = true, **options)
+ *       before_action(options) do
+ *         request.content_security_policy_report_only = report_only
+ *       end
+ *     end
+ */
+export function contentSecurityPolicyReportOnly(
+  this: ContentSecurityPolicyClassHost,
+  reportOnly: boolean | CallbackOptions = true,
+  options: CallbackOptions = {},
+): void {
+  let resolvedReportOnly: boolean;
+  let resolvedOptions: CallbackOptions;
+  if (typeof reportOnly === "boolean") {
+    resolvedReportOnly = reportOnly;
+    resolvedOptions = options;
+  } else {
+    resolvedReportOnly = true;
+    resolvedOptions = reportOnly;
+  }
+  this.beforeAction(function (controller: unknown) {
+    const host = controller as ContentSecurityPolicyInstanceHost;
+    host.request.contentSecurityPolicyReportOnly = resolvedReportOnly;
+  }, resolvedOptions);
+}
+
+/**
+ * Private instance helper: truthy when a CSP is set on the current request.
+ *
+ * Mirrors Rails `ActionController::ContentSecurityPolicy#content_security_policy?`
+ * (actionpack/lib/action_controller/metal/content_security_policy.rb, lines 72–74).
+ *
+ * @internal
+ */
+export function isContentSecurityPolicy(this: ContentSecurityPolicyInstanceHost): boolean {
+  return this.request.contentSecurityPolicy != null;
+}
+
+/**
+ * Private instance helper: returns the per-request nonce.
+ *
+ * Mirrors Rails `ActionController::ContentSecurityPolicy#content_security_policy_nonce`
+ * (actionpack/lib/action_controller/metal/content_security_policy.rb, lines 76–78).
+ *
+ * @internal
+ */
+export function contentSecurityPolicyNonce(this: ContentSecurityPolicyInstanceHost): string | null {
+  return this.request.contentSecurityPolicyNonce ?? null;
+}
+
+/**
+ * Private instance helper: returns a duplicate of the request's current CSP
+ * (so block mutations don't leak across requests), or a fresh empty policy.
+ *
+ * Mirrors Rails `ActionController::ContentSecurityPolicy#current_content_security_policy`
+ * (actionpack/lib/action_controller/metal/content_security_policy.rb, lines 80–82):
+ *
+ *     request.content_security_policy&.clone || ActionDispatch::ContentSecurityPolicy.new
+ *
+ * @internal
+ */
+export function currentContentSecurityPolicy(this: ContentSecurityPolicyInstanceHost): Policy {
+  const current = this.request.contentSecurityPolicy;
+  return current ? current.dup() : new Policy();
 }

--- a/packages/actionpack/src/action-controller/metal/content-security-policy.ts
+++ b/packages/actionpack/src/action-controller/metal/content-security-policy.ts
@@ -36,6 +36,12 @@ interface ContentSecurityPolicyClassHost {
 
 interface ContentSecurityPolicyInstanceHost {
   request: CspRequest;
+  /**
+   * Rails resolves `current_content_security_policy` via `self`, so subclass
+   * overrides win (content_security_policy.rb:42). Wired as an instance slot
+   * on Base; the DSL dispatches through it to preserve that semantics.
+   */
+  currentContentSecurityPolicy?: typeof currentContentSecurityPolicy;
 }
 
 /**
@@ -75,7 +81,8 @@ export function contentSecurityPolicy(
   this.beforeAction(function (controller: unknown) {
     const host = controller as ContentSecurityPolicyInstanceHost;
     if (block) {
-      const policy = currentContentSecurityPolicy.call(host);
+      const resolveCurrent = host.currentContentSecurityPolicy ?? currentContentSecurityPolicy;
+      const policy = resolveCurrent.call(host);
       block.call(controller, policy);
       host.request.contentSecurityPolicy = policy;
     }


### PR DESCRIPTION
## Summary
- Implements P10 from `docs/actioncontroller-100-percent.md` — `metal/content_security_policy.rb`
- Class DSL: `contentSecurityPolicy(enabled, options, block)`, `contentSecurityPolicyReportOnly(reportOnly, options)` — both accept either `(boolean, options, block)` or a leading options object (Rails kwargs shape)
- Private instance helpers: `isContentSecurityPolicy`, `currentContentSecurityPolicy`, `contentSecurityPolicyNonce`
- Wired onto `ActionController::Base`. Rails does not include this module in `ActionController::API` (base.rb:292), so API is intentionally unchanged
- Replaces the previous unused, non-Rails-mirroring helpers (`applyContentSecurityPolicy`, `hasContentSecurityPolicy`, parameterless `contentSecurityPolicyNonce`) — no in-tree callers

## Divergence
Until middleware materializes `request.contentSecurityPolicy` into the response header, the DSL writes the request slot but no header is emitted — same parity gap as `permissionsPolicy` (documented under "Known divergences" in `docs/action-controller-100-percent.md`).

## Size
~336 LOC additions, ~17 deletions (slightly above the 300 LOC soft ceiling; ~160 of the additions are the focused test file, which the splitting heuristics don't naturally bisect here — DSL impl + helpers + wiring are one cohesive Rails source file).

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/content-security-policy.test.ts` — 11 passing
- [x] `pnpm vitest run packages/actionpack/src/action-controller/` — 906 passing (no regressions)
- [x] `pnpm tsc --build` clean