### PR TITLE
feat(actioncontroller): Redirecting privates (P14)

### DIFF
--- a/packages/actionpack/src/action-controller/metal/redirecting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/redirecting.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect } from "vitest";
+import {
+  UnsafeRedirectError,
+  _allowOtherHost,
+  _computeRedirectToLocation,
+  _ensureUrlIsHttpHeaderSafe,
+  _enforceOpenRedirectProtection,
+  _extractRedirectToStatus,
+  _urlHostAllowed,
+} from "./redirecting.js";
+
+const host = (overrides: Record<string, unknown> = {}) =>
+  ({
+    request: { host: "example.com", protocol: "http://", hostWithPort: "example.com" },
+    redirectTo: () => {},
+    ...overrides,
+  }) as never;
+
+describe("_computeRedirectToLocation", () => {
+  const req = { protocol: "http://", hostWithPort: "example.com" };
+
+  it("passes scheme-qualified strings through", () => {
+    expect(_computeRedirectToLocation.call(undefined, req, "https://foo.test/x")).toBe(
+      "https://foo.test/x",
+    );
+  });
+
+  it("passes protocol-relative strings through", () => {
+    expect(_computeRedirectToLocation.call(undefined, req, "//foo.test/x")).toBe("//foo.test/x");
+  });
+
+  it("prepends protocol+host for plain paths", () => {
+    expect(_computeRedirectToLocation.call(undefined, req, "/posts")).toBe(
+      "http://example.com/posts",
+    );
+  });
+
+  it("strips null, CR, LF from the result", () => {
+    expect(_computeRedirectToLocation.call(undefined, req, "https://x.test/a\r\nb\0c")).toBe(
+      "https://x.test/abc",
+    );
+  });
+
+  it("recurses through a Proc-like function", () => {
+    const fn = () => "/inner";
+    expect(_computeRedirectToLocation.call(host(), req, fn)).toBe("http://example.com/inner");
+  });
+
+  it("delegates non-string options to urlFor", () => {
+    const ctx = host({ urlFor: (o: { id: number }) => `/posts/${o.id}` });
+    expect(_computeRedirectToLocation.call(ctx, req, { id: 5 })).toBe("/posts/5");
+  });
+});
+
+describe("_allowOtherHost", () => {
+  it("returns true when raiseOnOpenRedirects is falsy", () => {
+    expect(_allowOtherHost.call({ raiseOnOpenRedirects: false } as never)).toBe(true);
+    expect(_allowOtherHost.call({} as never)).toBe(true);
+  });
+
+  it("returns false when raiseOnOpenRedirects is true", () => {
+    expect(_allowOtherHost.call({ raiseOnOpenRedirects: true } as never)).toBe(false);
+  });
+});
+
+describe("_extractRedirectToStatus", () => {
+  it("drains :status from a hash and resolves symbols", () => {
+    const opts: Record<string, unknown> = { status: "see_other", id: 1 };
+    expect(_extractRedirectToStatus.call(undefined, opts, {})).toBe(303);
+    expect(opts).toEqual({ id: 1 });
+  });
+
+  it("falls back to responseOptions[:status]", () => {
+    expect(_extractRedirectToStatus.call(undefined, "https://x.test", { status: 301 })).toBe(301);
+  });
+
+  it("defaults to 302", () => {
+    expect(_extractRedirectToStatus.call(undefined, "https://x.test", {})).toBe(302);
+  });
+});
+
+describe("_urlHostAllowed", () => {
+  it("allows same-host absolute URLs", () => {
+    expect(_urlHostAllowed.call(host(), "https://example.com/x")).toBe(true);
+  });
+
+  it("rejects other-host absolute URLs", () => {
+    expect(_urlHostAllowed.call(host(), "https://evil.test/x")).toBe(false);
+  });
+
+  it("rejects protocol-relative URLs to other hosts", () => {
+    expect(_urlHostAllowed.call(host(), "//evil.test/x")).toBe(false);
+  });
+
+  it("allows single-leading-slash paths", () => {
+    expect(_urlHostAllowed.call(host(), "/profile")).toBe(true);
+  });
+
+  it("rejects non-rooted paths", () => {
+    expect(_urlHostAllowed.call(host(), "profile")).toBe(false);
+  });
+});
+
+describe("_enforceOpenRedirectProtection", () => {
+  it("returns the location when allowOtherHost is true", () => {
+    expect(
+      _enforceOpenRedirectProtection.call(host(), "https://evil.test/x", { allowOtherHost: true }),
+    ).toBe("https://evil.test/x");
+  });
+
+  it("returns the location when same-host", () => {
+    expect(_enforceOpenRedirectProtection.call(host(), "/safe", { allowOtherHost: false })).toBe(
+      "/safe",
+    );
+  });
+
+  it("raises UnsafeRedirectError for cross-host without allowOtherHost", () => {
+    expect(() =>
+      _enforceOpenRedirectProtection.call(host(), "https://evil.test/x", {
+        allowOtherHost: false,
+      }),
+    ).toThrow(UnsafeRedirectError);
+  });
+});
+
+describe("_ensureUrlIsHttpHeaderSafe", () => {
+  it("accepts safe ASCII URLs", () => {
+    expect(() => _ensureUrlIsHttpHeaderSafe.call(undefined, "https://x.test/a")).not.toThrow();
+  });
+
+  it("rejects URLs with embedded CR/LF/NUL", () => {
+    expect(() => _ensureUrlIsHttpHeaderSafe.call(undefined, "https://x.test/a\nfoo")).toThrow(
+      UnsafeRedirectError,
+    );
+    expect(() => _ensureUrlIsHttpHeaderSafe.call(undefined, "https://x.test/a\0foo")).toThrow(
+      UnsafeRedirectError,
+    );
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/redirecting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/redirecting.test.ts
@@ -92,6 +92,17 @@ describe("_urlHostAllowed", () => {
     expect(_urlHostAllowed.call(host(), "//evil.test/x")).toBe(false);
   });
 
+  // Open-redirect guard: Rails' `URI("//foo").host` is nil, so the bare
+  // `//`-prefix is unconditionally rejected even when the post-`//`
+  // authority happens to match `request.host`.
+  it("rejects protocol-relative URLs even when the authority matches request.host", () => {
+    expect(_urlHostAllowed.call(host(), "//example.com/x")).toBe(false);
+  });
+
+  it("rejects malformed scheme-prefixed URLs", () => {
+    expect(_urlHostAllowed.call(host(), "http://[::1")).toBe(false);
+  });
+
   it("allows single-leading-slash paths", () => {
     expect(_urlHostAllowed.call(host(), "/profile")).toBe(true);
   });

--- a/packages/actionpack/src/action-controller/metal/redirecting.ts
+++ b/packages/actionpack/src/action-controller/metal/redirecting.ts
@@ -6,6 +6,18 @@
  * @see https://api.rubyonrails.org/classes/ActionController/Redirecting.html
  */
 
+import { Metal } from "../metal.js";
+import { urlOptions as _urlOptions, type UrlForHost } from "./url-for.js";
+
+/**
+ * Re-export of {@link UrlFor#urlOptions}; Rails' `Redirecting` module
+ * includes `UrlFor`, so this method is part of the Redirecting host
+ * surface.
+ */
+export function urlOptions(this: UrlForHost): Record<string, unknown> {
+  return _urlOptions.call(this);
+}
+
 export class UnsafeRedirectError extends Error {
   constructor(message?: string) {
     super(message ?? "Unsafe redirect");
@@ -13,9 +25,18 @@ export class UnsafeRedirectError extends Error {
   }
 }
 
+// eslint-disable-next-line no-control-regex -- mirrors Rails' ILLEGAL_HEADER_VALUE_REGEX
+const ILLEGAL_HEADER_VALUE_REGEX = /[\x00-\x08\x0A-\x1F]/;
+const SCHEME_OR_PROTOCOL_RELATIVE_RE = /^([a-z][a-z\d\-+.]*:|\/\/).*/i;
+
 export interface RedirectingHost {
-  request: { referer?: string | null; host?: string };
+  request: { referer?: string | null; host?: string; protocol?: string; hostWithPort?: string };
   redirectTo(url: string, options?: Record<string, unknown>): void;
+  urlFor?(options: unknown): string;
+}
+
+interface PrivateHost extends RedirectingHost {
+  raiseOnOpenRedirects?: boolean;
 }
 
 export function redirectBackOrTo(
@@ -23,9 +44,11 @@ export function redirectBackOrTo(
   fallbackLocation: string,
   options: { allowOtherHost?: boolean } & Record<string, unknown> = {},
 ): void {
-  const { allowOtherHost = true, ...redirectOptions } = options;
+  const allowOtherHost = options.allowOtherHost ?? _allowOtherHost.call(this as PrivateHost);
+  const { allowOtherHost: _ignored, ...redirectOptions } = options;
+  void _ignored;
   const referer = this.request.referer;
-  if (referer && (allowOtherHost || urlHostAllowed(referer, this.request.host ?? ""))) {
+  if (referer && (allowOtherHost || _urlHostAllowed.call(this, referer))) {
     this.redirectTo(referer, { allowOtherHost, ...redirectOptions });
   } else {
     this.redirectTo(fallbackLocation, redirectOptions);
@@ -34,20 +57,129 @@ export function redirectBackOrTo(
 
 export function urlFrom(this: RedirectingHost, location: string | null | undefined): string | null {
   if (!location || location.trim() === "") return null;
-  return urlHostAllowed(location, this.request.host ?? "") ? location : null;
+  return _urlHostAllowed.call(this, location) ? location : null;
 }
 
-function urlHostAllowed(location: string, requestHost: string): boolean {
-  try {
-    const url = new URL(location, "http://placeholder");
-    const host = url.hostname === "placeholder" ? null : url.hostname;
+/**
+ * @internal Rails-private. Compute the redirect URL from `redirect_to`'s polymorphic options.
+ * Mirrors `_compute_redirect_to_location(request, options)` in
+ * `actionpack/lib/action_controller/metal/redirecting.rb`.
+ */
+export function _computeRedirectToLocation(
+  this: RedirectingHost | void,
+  request: { protocol?: string; hostWithPort?: string },
+  options: unknown,
+): string {
+  let result: string;
+  if (typeof options === "string") {
+    if (SCHEME_OR_PROTOCOL_RELATIVE_RE.test(options)) {
+      result = options;
+    } else {
+      result = `${request.protocol ?? ""}${request.hostWithPort ?? ""}${options}`;
+    }
+  } else if (typeof options === "function") {
+    const self = this as RedirectingHost | undefined;
+    const resolved = (options as (this: unknown) => unknown).call(self);
+    return _computeRedirectToLocation.call(self as RedirectingHost, request, resolved);
+  } else {
+    const self = this as RedirectingHost | undefined;
+    if (self && typeof self.urlFor === "function") {
+      result = self.urlFor(options);
+    } else {
+      throw new TypeError(
+        `_computeRedirectToLocation: cannot resolve options of type ${typeof options} without a urlFor() host`,
+      );
+    }
+  }
+  return result.replace(/[\0\r\n]/g, "");
+}
 
-    if (host === requestHost) return true;
-    if (host !== null) return false;
-    if (!location.startsWith("/")) return false;
-    if (location.startsWith("//")) return false;
-    return true;
+/**
+ * @internal Rails-private. Default for the `allow_other_host` keyword on `redirect_to` —
+ * inverse of `raise_on_open_redirects`.
+ */
+export function _allowOtherHost(this: PrivateHost): boolean {
+  return !this.raiseOnOpenRedirects;
+}
+
+/**
+ * @internal Rails-private. Resolve the redirect status, draining `:status` from `options`
+ * (when a Hash) then `responseOptions`, defaulting to 302.
+ */
+export function _extractRedirectToStatus(
+  this: unknown,
+  options: unknown,
+  responseOptions: Record<string, unknown>,
+): number {
+  if (
+    options !== null &&
+    typeof options === "object" &&
+    Object.hasOwn(options as object, "status")
+  ) {
+    const opts = options as Record<string, unknown>;
+    const status = opts.status;
+    delete opts.status;
+    return Metal.resolveStatus(status as number | string);
+  }
+  if (Object.hasOwn(responseOptions, "status")) {
+    return Metal.resolveStatus(responseOptions.status as number | string);
+  }
+  return 302;
+}
+
+/**
+ * @internal Rails-private. Returns `location` when allowed; otherwise raises
+ * `UnsafeRedirectError` describing the blocked URL.
+ */
+export function _enforceOpenRedirectProtection(
+  this: RedirectingHost,
+  location: string,
+  { allowOtherHost }: { allowOtherHost: boolean },
+): string {
+  if (allowOtherHost || _urlHostAllowed.call(this, location)) {
+    return location;
+  }
+  const truncated = location.length > 100 ? `${location.slice(0, 97)}...` : location;
+  throw new UnsafeRedirectError(
+    `Unsafe redirect to ${JSON.stringify(truncated)}, pass allow_other_host: true to redirect anyway.`,
+  );
+}
+
+/**
+ * @internal Rails-private. Mirrors `_url_host_allowed?`. Internal URLs must share the
+ * request host or be a same-origin path (single leading slash).
+ */
+export function _urlHostAllowed(this: RedirectingHost, url: unknown): boolean {
+  const raw = url == null ? "" : String(url);
+  let host: string | null;
+  try {
+    if (raw.startsWith("//")) {
+      const parsed = new URL(`http:${raw}`);
+      host = parsed.hostname;
+    } else if (/^[a-z][a-z\d\-+.]*:/i.test(raw)) {
+      const parsed = new URL(raw);
+      host = parsed.hostname;
+    } else {
+      host = null;
+    }
   } catch {
     return false;
+  }
+  if (host === (this.request.host ?? "")) return true;
+  if (host !== null) return false;
+  if (!raw.startsWith("/")) return false;
+  return !raw.startsWith("//");
+}
+
+/**
+ * @internal Rails-private. Raises if `url` contains any character forbidden in an HTTP
+ * header value per RFC 7230 §3.2.6.
+ */
+export function _ensureUrlIsHttpHeaderSafe(this: unknown, url: string): void {
+  if (ILLEGAL_HEADER_VALUE_REGEX.test(url)) {
+    throw new UnsafeRedirectError(
+      `The redirect URL ${url} contains one or more illegal HTTP header field character. ` +
+        `Set of legal characters defined in https://datatracker.ietf.org/doc/html/rfc7230#section-3.2.6`,
+    );
   }
 }

--- a/packages/actionpack/src/action-controller/metal/redirecting.ts
+++ b/packages/actionpack/src/action-controller/metal/redirecting.ts
@@ -44,9 +44,8 @@ export function redirectBackOrTo(
   fallbackLocation: string,
   options: { allowOtherHost?: boolean } & Record<string, unknown> = {},
 ): void {
-  const allowOtherHost = options.allowOtherHost ?? _allowOtherHost.call(this as PrivateHost);
-  const { allowOtherHost: _ignored, ...redirectOptions } = options;
-  void _ignored;
+  const { allowOtherHost: explicitAllow, ...redirectOptions } = options;
+  const allowOtherHost = explicitAllow ?? _allowOtherHost.call(this as PrivateHost);
   const referer = this.request.referer;
   if (referer && (allowOtherHost || _urlHostAllowed.call(this, referer))) {
     this.redirectTo(referer, { allowOtherHost, ...redirectOptions });
@@ -114,6 +113,7 @@ export function _extractRedirectToStatus(
   if (
     options !== null &&
     typeof options === "object" &&
+    !Array.isArray(options) &&
     Object.hasOwn(options as object, "status")
   ) {
     const opts = options as Record<string, unknown>;
@@ -151,22 +151,21 @@ export function _enforceOpenRedirectProtection(
  */
 export function _urlHostAllowed(this: RedirectingHost, url: unknown): boolean {
   const raw = url == null ? "" : String(url);
-  let host: string | null;
-  try {
-    if (raw.startsWith("//")) {
-      const parsed = new URL(`http:${raw}`);
-      host = parsed.hostname;
-    } else if (/^[a-z][a-z\d\-+.]*:/i.test(raw)) {
-      const parsed = new URL(raw);
-      host = parsed.hostname;
-    } else {
-      host = null;
+  // Mirrors Ruby's `URI(url).host`, which is nil for any input without an
+  // explicit scheme — protocol-relative `//foo` URLs included. That's the
+  // load-bearing piece of the open-redirect guard: every `//`-prefixed URL
+  // falls through to the trailing `!raw.startsWith("//")` rejection,
+  // regardless of whether the post-`//` authority happens to match
+  // `request.host`.
+  let host: string | null = null;
+  if (/^[a-z][a-z\d\-+.]*:/i.test(raw)) {
+    try {
+      host = new URL(raw).hostname || null;
+    } catch {
+      return false;
     }
-  } catch {
-    return false;
   }
-  if (host === (this.request.host ?? "")) return true;
-  if (host !== null) return false;
+  if (host !== null) return host === (this.request.host ?? "");
   if (!raw.startsWith("/")) return false;
   return !raw.startsWith("//");
 }


### PR DESCRIPTION
Implements **P14** from `docs/actioncontroller-privates-plan.md` — the
seven `metal/redirecting.rb` privates (re-audit: was 6, api:compare reported 7).

## Mirrored from Rails

`actionpack/lib/action_controller/metal/redirecting.rb`:

```ruby
def _compute_redirect_to_location(request, options) # :nodoc:
  case options
  when /\A([a-z][a-z\d\-+.]*:|\/\/).*/i then options.to_str
  when String then request.protocol + request.host_with_port + options
  when Proc   then _compute_redirect_to_location request, instance_eval(&options)
  else url_for(options)
  end.delete("\0\r\n")
end

def _allow_other_host = !raise_on_open_redirects

def _extract_redirect_to_status(options, response_options)
  if options.is_a?(Hash) && options.key?(:status)
    Rack::Utils.status_code(options.delete(:status))
  elsif response_options.key?(:status)
    Rack::Utils.status_code(response_options[:status])
  else 302 end
end

def _enforce_open_redirect_protection(location, allow_other_host:)
  if allow_other_host || _url_host_allowed?(location) then location
  else raise UnsafeRedirectError, "Unsafe redirect to #{location.truncate(100).inspect}, …"
  end
end

def _url_host_allowed?(url)
  host = URI(url.to_s).host
  return true if host == request.host
  return false unless host.nil?
  return false unless url.to_s.start_with?("/")
  !url.to_s.start_with?("//")
rescue ArgumentError, URI::Error
  false
end

def _ensure_url_is_http_header_safe(url)
  if url.match?(ILLEGAL_HEADER_VALUE_REGEX)
    raise UnsafeRedirectError, "The redirect URL #{url} contains …"
  end
end
```

## Implementation

- 6 new module-scope `this`-typed functions in
  `packages/actionpack/src/action-controller/metal/redirecting.ts`
  (CLAUDE.md mixin pattern).
- Re-export of `urlOptions` (mirrors `include ActionController::UrlFor`
  in the Concern — the api:compare row counts inherited methods against
  the including file).
- Existing `redirectBackOrTo` / `urlFrom` rewired through the new
  `_allowOtherHost` / `_urlHostAllowed` so the dispatch matches Rails.
- Per-method `@internal` JSDoc; `no-control-regex` disabled with a
  comment on the `ILLEGAL_HEADER_VALUE_REGEX` constant.

## Verification

- `pnpm api:compare --package actioncontroller --privates` →
  `metal/redirecting.rb` **12/12 (100%) ✓** (was 5/12, 42%).
- `pnpm vitest run packages/actionpack/src/action-controller/metal/redirecting.test.ts`
  → 21 passing.
- `pnpm build` clean; `pnpm lint` clean.

LOC: 145+/13− impl + 139 new test = 297 LOC, under the 300 ceiling.

## Notes / follow-ups

- `redirect_to` / `redirect_back` themselves still live on `Base` and
  haven't yet been refactored to call into the new privates — that's a
  larger reshape into `base.ts` and is left for a follow-up so this PR
  stays focused on the private surface.