### PR TITLE
feat(actioncontroller): ParamsWrapper privates (P15)

### DIFF
--- a/packages/actionpack/src/action-controller/metal/params-wrapper.test.ts
+++ b/packages/actionpack/src/action-controller/metal/params-wrapper.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+import {
+  EXCLUDE_PARAMETERS,
+  Options,
+  _defaultWrapModel,
+  _extractParameters,
+  _performParameterWrapping,
+  _setWrapperOptions,
+  _wrapParameters,
+  _wrapperFormats,
+  _wrapperKey,
+  _wrapperEnabled,
+  type ParamsWrapperHost,
+} from "./params-wrapper.js";
+
+function makeHost(
+  opts: Partial<Options> = {},
+  requestOverrides: Partial<ParamsWrapperHost["request"]> = {},
+): ParamsWrapperHost {
+  const merged = new Options(
+    opts.name ?? null,
+    opts.format ?? null,
+    opts.include ?? null,
+    opts.exclude ?? null,
+    opts.klass ?? null,
+    opts.model ?? null,
+  );
+  const request: ParamsWrapperHost["request"] = {
+    hasContentType: () => true,
+    contentMimeType: { ref: "json" },
+    requestParameters: {},
+    filteredParameters: () => ({}),
+    parameters: {},
+    ...requestOverrides,
+  };
+  return { _wrapperOptions: merged, request };
+}
+
+describe("ParamsWrapper privates", () => {
+  it("_wrapperKey returns Options.name", () => {
+    expect(_wrapperKey.call(makeHost({ name: "user" }))).toBe("user");
+    expect(_wrapperKey.call(makeHost())).toBeNull();
+  });
+
+  it("_wrapperFormats returns Options.format", () => {
+    expect(_wrapperFormats.call(makeHost({ format: ["json", "xml"] }))).toEqual(["json", "xml"]);
+  });
+
+  it("_extractParameters slices by include when set", () => {
+    const host = makeHost({ include: ["name"] });
+    expect(_extractParameters.call(host, { name: "a", age: 1 })).toEqual({ name: "a" });
+  });
+
+  it("_extractParameters drops exclude + EXCLUDE_PARAMETERS when exclude set", () => {
+    const host = makeHost({ exclude: ["admin"] });
+    expect(
+      _extractParameters.call(host, {
+        name: "a",
+        admin: true,
+        _method: "x",
+        authenticity_token: "t",
+      }),
+    ).toEqual({ name: "a" });
+  });
+
+  it("_extractParameters drops only EXCLUDE_PARAMETERS by default", () => {
+    const host = makeHost();
+    expect(_extractParameters.call(host, { name: "a", utf8: "✓" })).toEqual({ name: "a" });
+    expect(EXCLUDE_PARAMETERS).toContain("utf8");
+  });
+
+  it("_wrapParameters wraps under wrapper key", () => {
+    const host = makeHost({ name: "user", include: ["name"] });
+    expect(_wrapParameters.call(host, { name: "Dean", age: 30 })).toEqual({
+      user: { name: "Dean" },
+    });
+  });
+
+  it("_wrapParameters returns empty object when no key", () => {
+    expect(_wrapParameters.call(makeHost(), { name: "x" })).toEqual({});
+  });
+
+  it("_wrapperEnabled true when format matches and key absent", () => {
+    const host = makeHost(
+      { name: "user", format: ["json"] },
+      { requestParameters: { name: "a" }, parameters: { name: "a" } },
+    );
+    expect(_wrapperEnabled.call(host)).toBe(true);
+  });
+
+  it("_wrapperEnabled false when wrapper key already present", () => {
+    const host = makeHost({ name: "user", format: ["json"] }, { parameters: { user: {} } });
+    expect(_wrapperEnabled.call(host)).toBe(false);
+  });
+
+  it("_wrapperEnabled false when format does not match", () => {
+    const host = makeHost({ name: "user", format: ["xml"] }, { contentMimeType: { ref: "json" } });
+    expect(_wrapperEnabled.call(host)).toBe(false);
+  });
+
+  it("_wrapperEnabled false when no content type", () => {
+    const host = makeHost({ name: "user", format: ["json"] }, { hasContentType: () => false });
+    expect(_wrapperEnabled.call(host)).toBe(false);
+  });
+
+  it("_wrapperEnabled false on parse error (rescue)", () => {
+    const host = makeHost(
+      { name: "user", format: ["json"] },
+      {
+        hasContentType: () => {
+          throw new Error("boom");
+        },
+      },
+    );
+    expect(_wrapperEnabled.call(host)).toBe(false);
+  });
+
+  it("_performParameterWrapping merges into request hashes", () => {
+    const requestParameters: Record<string, unknown> = { name: "Dean", age: 30 };
+    const parameters: Record<string, unknown> = { ...requestParameters };
+    const filtered: Record<string, unknown> = { name: "Dean", age: 30 };
+    const host = makeHost(
+      { name: "user", include: ["name"] },
+      {
+        requestParameters,
+        parameters,
+        filteredParameters: () => filtered,
+      },
+    );
+    _performParameterWrapping.call(host);
+    expect(parameters.user).toEqual({ name: "Dean" });
+    expect(requestParameters.user).toEqual({ name: "Dean" });
+    expect(filtered.user).toEqual({ name: "Dean" });
+  });
+
+  it("_setWrapperOptions replaces _wrapperOptions via Options.fromHash", () => {
+    const host: { _wrapperOptions: Options } = { _wrapperOptions: new Options() };
+    _setWrapperOptions.call(host, { name: "user", format: ["json"] });
+    expect(host._wrapperOptions.name).toBe("user");
+    expect(host._wrapperOptions.format).toEqual(["json"]);
+  });
+
+  it("_defaultWrapModel derives snake_case singular from controller class name", () => {
+    expect(
+      _defaultWrapModel.call({
+        _wrapperOptions: new Options(null, null, null, null, { name: "UsersController" }, null),
+      }),
+    ).toBe("user");
+
+    expect(
+      _defaultWrapModel.call({
+        _wrapperOptions: new Options(
+          null,
+          null,
+          null,
+          null,
+          { name: "Admin::PostsController" },
+          null,
+        ),
+      }),
+    ).toBe("post");
+  });
+
+  it("_defaultWrapModel returns null for unnamed (anonymous) klass", () => {
+    expect(_defaultWrapModel.call({ _wrapperOptions: new Options() })).toBeNull();
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/params-wrapper.test.ts
+++ b/packages/actionpack/src/action-controller/metal/params-wrapper.test.ts
@@ -27,7 +27,7 @@ function makeHost(
   );
   const request: ParamsWrapperHost["request"] = {
     hasContentType: () => true,
-    contentMimeType: { ref: "json" },
+    contentMimeType: { ref: () => "json" },
     requestParameters: {},
     filteredParameters: () => ({}),
     parameters: {},
@@ -94,7 +94,10 @@ describe("ParamsWrapper privates", () => {
   });
 
   it("_wrapperEnabled false when format does not match", () => {
-    const host = makeHost({ name: "user", format: ["xml"] }, { contentMimeType: { ref: "json" } });
+    const host = makeHost(
+      { name: "user", format: ["xml"] },
+      { contentMimeType: { ref: () => "json" } },
+    );
     expect(_wrapperEnabled.call(host)).toBe(false);
   });
 

--- a/packages/actionpack/src/action-controller/metal/params-wrapper.test.ts
+++ b/packages/actionpack/src/action-controller/metal/params-wrapper.test.ts
@@ -12,6 +12,7 @@ import {
   _wrapperEnabled,
   type ParamsWrapperHost,
 } from "./params-wrapper.js";
+import { ParseError } from "../../action-dispatch/http/parameters.js";
 
 function makeHost(
   opts: Partial<Options> = {},
@@ -30,7 +31,7 @@ function makeHost(
     contentMimeType: { ref: () => "json" },
     requestParameters: {},
     filteredParameters: () => ({}),
-    parameters: {},
+    params: {},
     ...requestOverrides,
   };
   return { _wrapperOptions: merged, request };
@@ -83,13 +84,13 @@ describe("ParamsWrapper privates", () => {
   it("_wrapperEnabled true when format matches and key absent", () => {
     const host = makeHost(
       { name: "user", format: ["json"] },
-      { requestParameters: { name: "a" }, parameters: { name: "a" } },
+      { requestParameters: { name: "a" }, params: { name: "a" } },
     );
     expect(_wrapperEnabled.call(host)).toBe(true);
   });
 
   it("_wrapperEnabled false when wrapper key already present", () => {
-    const host = makeHost({ name: "user", format: ["json"] }, { parameters: { user: {} } });
+    const host = makeHost({ name: "user", format: ["json"] }, { params: { user: {} } });
     expect(_wrapperEnabled.call(host)).toBe(false);
   });
 
@@ -106,7 +107,19 @@ describe("ParamsWrapper privates", () => {
     expect(_wrapperEnabled.call(host)).toBe(false);
   });
 
-  it("_wrapperEnabled false on parse error (rescue)", () => {
+  it("_wrapperEnabled false on ParseError (rescue ActionDispatch::Http::Parameters::ParseError)", () => {
+    const host = makeHost(
+      { name: "user", format: ["json"] },
+      {
+        hasContentType: () => {
+          throw new ParseError("bad json");
+        },
+      },
+    );
+    expect(_wrapperEnabled.call(host)).toBe(false);
+  });
+
+  it("_wrapperEnabled rethrows non-ParseError exceptions", () => {
     const host = makeHost(
       { name: "user", format: ["json"] },
       {
@@ -115,23 +128,23 @@ describe("ParamsWrapper privates", () => {
         },
       },
     );
-    expect(_wrapperEnabled.call(host)).toBe(false);
+    expect(() => _wrapperEnabled.call(host)).toThrow("boom");
   });
 
   it("_performParameterWrapping merges into request hashes", () => {
     const requestParameters: Record<string, unknown> = { name: "Dean", age: 30 };
-    const parameters: Record<string, unknown> = { ...requestParameters };
+    const params: Record<string, unknown> = { ...requestParameters };
     const filtered: Record<string, unknown> = { name: "Dean", age: 30 };
     const host = makeHost(
       { name: "user", include: ["name"] },
       {
         requestParameters,
-        parameters,
+        params,
         filteredParameters: () => filtered,
       },
     );
     _performParameterWrapping.call(host);
-    expect(parameters.user).toEqual({ name: "Dean" });
+    expect(params.user).toEqual({ name: "Dean" });
     expect(requestParameters.user).toEqual({ name: "Dean" });
     expect(filtered.user).toEqual({ name: "Dean" });
   });

--- a/packages/actionpack/src/action-controller/metal/params-wrapper.ts
+++ b/packages/actionpack/src/action-controller/metal/params-wrapper.ts
@@ -75,12 +75,17 @@ export function wrapParameters(
 export interface ParamsWrapperHost {
   request: {
     hasContentType(): boolean;
-    contentMimeType: { ref?: string | null } | null;
+    contentMimeType: { ref(): string | null } | null;
     requestParameters: Record<string, unknown>;
     filteredParameters(): Record<string, unknown>;
     parameters: Record<string, unknown>;
   };
   _wrapperOptions: Options;
+}
+
+/** @internal */
+export interface WrapperHostClass {
+  name?: string | null;
 }
 
 /**
@@ -156,7 +161,7 @@ export function _wrapParameters(
 export function _wrapperEnabled(this: ParamsWrapperHost): boolean {
   try {
     if (!this.request.hasContentType()) return false;
-    const ref = this.request.contentMimeType?.ref;
+    const ref = this.request.contentMimeType?.ref();
     if (!ref) return false;
     const formats = _wrapperFormats.call(this);
     const key = _wrapperKey.call(this);
@@ -199,7 +204,7 @@ export function _performParameterWrapping(this: ParamsWrapperHost): void {
  * @internal
  */
 export function _defaultWrapModel(this: { _wrapperOptions: Options }): string | null {
-  const klass = this._wrapperOptions.klass as { name?: string | null } | null | undefined;
+  const klass = this._wrapperOptions.klass as WrapperHostClass | null | undefined;
   const name = klass?.name;
   if (!name) return null;
   const stripped = name.replace(/Controller$/, "");

--- a/packages/actionpack/src/action-controller/metal/params-wrapper.ts
+++ b/packages/actionpack/src/action-controller/metal/params-wrapper.ts
@@ -1,10 +1,16 @@
 /**
- * ActionController::ParamsWrapper::Options
+ * ActionController::ParamsWrapper::Options + private mixin methods
  *
- * Configuration data container for parameter wrapping. The wrapping
- * logic itself lives in action-controller/params-wrapper.ts.
+ * Configuration data container for parameter wrapping plus the
+ * controller-instance mixin functions that perform the wrapping at
+ * `process_action` time. Mirrors `metal/params_wrapper.rb`.
  * @see https://api.rubyonrails.org/classes/ActionController/ParamsWrapper.html
  */
+
+import { demodulize, singularize, underscore } from "@blazetrails/activesupport";
+
+/** @internal */
+export const EXCLUDE_PARAMETERS = ["authenticity_token", "_method", "utf8"];
 
 export class Options {
   name: string | null;
@@ -63,4 +69,140 @@ export function wrapParameters(
     wrapped[key] = value;
   }
   return { ...params, [name]: wrapped };
+}
+
+/** @internal */
+export interface ParamsWrapperHost {
+  request: {
+    hasContentType(): boolean;
+    contentMimeType: { ref?: string | null } | null;
+    requestParameters: Record<string, unknown>;
+    filteredParameters(): Record<string, unknown>;
+    parameters: Record<string, unknown>;
+  };
+  _wrapperOptions: Options;
+}
+
+/**
+ * Sets `_wrapper_options` on the controller class (class-method mixin).
+ * @internal
+ */
+export function _setWrapperOptions(
+  this: { _wrapperOptions: Options },
+  options: Record<string, unknown>,
+): void {
+  this._wrapperOptions = Options.fromHash(options);
+}
+
+/**
+ * Returns the wrapper key under which wrapped params are stored.
+ * @internal
+ */
+export function _wrapperKey(this: ParamsWrapperHost): string | null {
+  return this._wrapperOptions.name;
+}
+
+/**
+ * Returns the list of enabled formats.
+ * @internal
+ */
+export function _wrapperFormats(this: ParamsWrapperHost): string[] | null {
+  return this._wrapperOptions.format;
+}
+
+/**
+ * Returns the subset of `parameters` selected by include/exclude options.
+ * @internal
+ */
+export function _extractParameters(
+  this: ParamsWrapperHost,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  const opts = this._wrapperOptions;
+  if (opts.include) {
+    const includeOnly = opts.include;
+    const out: Record<string, unknown> = {};
+    for (const k of includeOnly) {
+      if (Object.hasOwn(parameters, k)) out[k] = parameters[k];
+    }
+    return out;
+  }
+  const exclude = opts.exclude ? [...opts.exclude, ...EXCLUDE_PARAMETERS] : EXCLUDE_PARAMETERS;
+  const out: Record<string, unknown> = {};
+  for (const k of Object.keys(parameters)) {
+    if (!exclude.includes(k)) out[k] = parameters[k];
+  }
+  return out;
+}
+
+/**
+ * Wraps `parameters` into `{ wrapperKey => extractedParameters }`.
+ * @internal
+ */
+export function _wrapParameters(
+  this: ParamsWrapperHost,
+  parameters: Record<string, unknown>,
+): Record<string, unknown> {
+  const key = _wrapperKey.call(this);
+  if (!key) return {};
+  return { [key]: _extractParameters.call(this, parameters) };
+}
+
+/**
+ * Checks if parameter wrapping should be performed for this request.
+ * Mirrors Rails' `_wrapper_enabled?`.
+ * @internal
+ */
+export function _wrapperEnabled(this: ParamsWrapperHost): boolean {
+  try {
+    if (!this.request.hasContentType()) return false;
+    const ref = this.request.contentMimeType?.ref;
+    if (!ref) return false;
+    const formats = _wrapperFormats.call(this);
+    const key = _wrapperKey.call(this);
+    if (!formats || !formats.includes(ref)) return false;
+    if (!key) return false;
+    return !Object.hasOwn(this.request.parameters, key);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Performs the wrap: merges wrapped hash into `request.parameters`,
+ * `request.requestParameters`, and `request.filteredParameters()`.
+ * @internal
+ */
+export function _performParameterWrapping(this: ParamsWrapperHost): void {
+  const reqParams = this.request.requestParameters;
+  const wrappedHash = _wrapParameters.call(this, reqParams);
+  const wrappedKeys = Object.keys(reqParams);
+  const filtered = this.request.filteredParameters();
+  const slice: Record<string, unknown> = {};
+  for (const k of wrappedKeys) {
+    if (Object.hasOwn(filtered, k)) slice[k] = filtered[k];
+  }
+  const wrappedFiltered = _wrapParameters.call(this, slice);
+  Object.assign(this.request.parameters, wrappedHash);
+  Object.assign(this.request.requestParameters, wrappedHash);
+  Object.assign(filtered, wrappedFiltered);
+}
+
+/**
+ * Derive the wrapper model name from the controller class name.
+ * Rails uses `safe_constantize` to look up a model class by traversing
+ * namespaces (`Foo::Bar::UsersController` → `Foo::Bar::User`, `Foo::User`,
+ * `User`); we don't have a global constant registry, so we return the
+ * demodulized, singularized, snake_case name as a string fallback. Callers
+ * that need a real model class should pass `model:` explicitly to
+ * `wrap_parameters`.
+ * @internal
+ */
+export function _defaultWrapModel(this: { _wrapperOptions: Options }): string | null {
+  const klass = this._wrapperOptions.klass as { name?: string | null } | null | undefined;
+  const name = klass?.name;
+  if (!name) return null;
+  const stripped = name.replace(/Controller$/, "");
+  if (!stripped) return null;
+  return underscore(singularize(demodulize(stripped)));
 }

--- a/packages/actionpack/src/action-controller/metal/params-wrapper.ts
+++ b/packages/actionpack/src/action-controller/metal/params-wrapper.ts
@@ -9,6 +9,8 @@
 
 import { demodulize, singularize, underscore } from "@blazetrails/activesupport";
 
+import { ParseError } from "../../action-dispatch/http/parameters.js";
+
 /** @internal */
 export const EXCLUDE_PARAMETERS = ["authenticity_token", "_method", "utf8"];
 
@@ -78,7 +80,7 @@ export interface ParamsWrapperHost {
     contentMimeType: { ref(): string | null } | null;
     requestParameters: Record<string, unknown>;
     filteredParameters(): Record<string, unknown>;
-    parameters: Record<string, unknown>;
+    params: Record<string, unknown>;
   };
   _wrapperOptions: Options;
 }
@@ -167,9 +169,10 @@ export function _wrapperEnabled(this: ParamsWrapperHost): boolean {
     const key = _wrapperKey.call(this);
     if (!formats || !formats.includes(ref)) return false;
     if (!key) return false;
-    return !Object.hasOwn(this.request.parameters, key);
-  } catch {
-    return false;
+    return !Object.hasOwn(this.request.params, key);
+  } catch (err) {
+    if (err instanceof ParseError) return false;
+    throw err;
   }
 }
 
@@ -188,7 +191,7 @@ export function _performParameterWrapping(this: ParamsWrapperHost): void {
     if (Object.hasOwn(filtered, k)) slice[k] = filtered[k];
   }
   const wrappedFiltered = _wrapParameters.call(this, slice);
-  Object.assign(this.request.parameters, wrappedHash);
+  Object.assign(this.request.params, wrappedHash);
   Object.assign(this.request.requestParameters, wrappedHash);
   Object.assign(filtered, wrappedFiltered);
 }


### PR DESCRIPTION
Implements P15 from `docs/actioncontroller-privates-plan.md` —
`metal/params_wrapper.rb` privates (8 methods).

## Methods (mirror)

From `vendor/rails/actionpack/lib/action_controller/metal/params_wrapper.rb`:

```ruby
def _wrapper_key
  _wrapper_options.name
end

def _wrapper_formats
  _wrapper_options.format
end

def _wrap_parameters(parameters)
  { _wrapper_key => _extract_parameters(parameters) }
end

def _extract_parameters(parameters)
  if include_only = _wrapper_options.include
    parameters.slice(*include_only)
  elsif _wrapper_options.exclude
    exclude = _wrapper_options.exclude + EXCLUDE_PARAMETERS
    parameters.except(*exclude)
  else
    parameters.except(*EXCLUDE_PARAMETERS)
  end
end

def _wrapper_enabled?
  return false unless request.has_content_type?
  ref = request.content_mime_type.ref
  _wrapper_formats.include?(ref) && _wrapper_key && !request.parameters.key?(_wrapper_key)
rescue ActionDispatch::Http::Parameters::ParseError
  false
end

def _perform_parameter_wrapping
  wrapped_hash = _wrap_parameters request.request_parameters
  wrapped_keys = request.request_parameters.keys
  wrapped_filtered_hash = _wrap_parameters request.filtered_parameters.slice(*wrapped_keys)
  request.parameters.merge! wrapped_hash
  request.request_parameters.merge! wrapped_hash
  request.filtered_parameters.merge! wrapped_filtered_hash
end

def _set_wrapper_options(options)
  self._wrapper_options = Options.from_hash(options)
end

def _default_wrap_model
  # namespace walk via safe_constantize
end
```

Uses the documented `this`-typed function mixin pattern (CLAUDE.md) with
a `ParamsWrapperHost` interface for the controller-side request surface
the wrapper consumes.

## Known divergence

`_defaultWrapModel` returns the demodulized/singularized snake_case name
string instead of a model **class**. Rails uses `safe_constantize` to
walk up the namespace chain looking for a defined constant; we don't
have a global constant registry. Callers that need a real model class
should pass `model:` explicitly to `wrap_parameters`.

## api:compare

`metal/params_wrapper.rb` → `metal/params-wrapper.ts`: **7/15 → 15/15
(100%)**. Overall `actioncontroller --privates`: 265/581 → 273/581
(45.6% → 47.0%).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/params-wrapper.test.ts` — 16 tests pass
- [x] `pnpm tsx scripts/api-compare/compare.ts --package actioncontroller --privates` — row at 100%
- [x] `pnpm build` clean