### PR TITLE
feat(actioncontroller): metal/rendering privates (P16)

### DIFF
--- a/packages/actionpack/src/action-controller/metal/rendering.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.test.ts
@@ -41,7 +41,7 @@ describe("_normalizeOptions", () => {
       status: "not_found",
       plain: { toText: () => "<plain>" },
     });
-    expect(out.html).toBe("&lt;b&gt;&amp;&quot;&#39;&lt;/b&gt;");
+    expect(String(out.html)).toBe("&lt;b&gt;&amp;&quot;&#39;&lt;/b&gt;");
     expect(out.status).toBe(404);
     expect(out.plain).toBe("<plain>");
   });

--- a/packages/actionpack/src/action-controller/metal/rendering.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+import {
+  _normalizeOptions,
+  _normalizeText,
+  _processOptions,
+  _processVariant,
+  _renderInPriorities,
+  _setHtmlContentType,
+  _setRenderedContentType,
+  _setVaryHeader,
+  RENDER_FORMATS_IN_PRIORITY,
+} from "./rendering.js";
+
+describe("_renderInPriorities", () => {
+  test("returns first present priority key, ignoring prototype chain", () => {
+    expect(_renderInPriorities({ body: "b", plain: "p", html: "h" })).toBe("b");
+    expect(_renderInPriorities({ plain: "p", html: "h" })).toBe("p");
+    expect(_renderInPriorities({ html: "h" })).toBe("h");
+    expect(_renderInPriorities({ json: "{}" })).toBeNull();
+    expect(_renderInPriorities(Object.create({ body: "inherited" }))).toBeNull();
+    expect([...RENDER_FORMATS_IN_PRIORITY]).toEqual(["body", "plain", "html"]);
+  });
+});
+
+describe("_normalizeText", () => {
+  test("calls toText() on priority option values that respond", () => {
+    const options: Record<string, unknown> = {
+      plain: { toText: () => "from-toText" },
+      html: 5,
+    };
+    _normalizeText(options);
+    expect(options.plain).toBe("from-toText");
+    expect(options.html).toBe(5);
+  });
+});
+
+describe("_normalizeOptions", () => {
+  test("html-escapes :html, resolves symbolic status, runs _normalize_text first", () => {
+    const out = _normalizeOptions({
+      html: "<b>&\"'</b>",
+      status: "not_found",
+      plain: { toText: () => "<plain>" },
+    });
+    expect(out.html).toBe("&lt;b&gt;&amp;&quot;&#39;&lt;/b&gt;");
+    expect(out.status).toBe(404);
+    expect(out.plain).toBe("<plain>");
+  });
+});
+
+describe("_processVariant", () => {
+  test("copies present variant onto options; ignores absent/empty", () => {
+    const opts: Record<string, unknown> = {};
+    _processVariant.call({ request: { variant: Symbol.for("mobile") } }, opts);
+    expect(opts.variant).toBe(Symbol.for("mobile"));
+
+    const opts2: Record<string, unknown> = {};
+    _processVariant.call({ request: { variant: undefined } }, opts2);
+    _processVariant.call({ request: { variant: [] } }, opts2);
+    _processVariant.call({}, opts2);
+    expect(opts2).toEqual({});
+  });
+});
+
+describe("_setHtmlContentType", () => {
+  test("assigns text/html to the host content type", () => {
+    const host = { contentType: null as string | null };
+    _setHtmlContentType.call(host);
+    expect(host.contentType).toBe("text/html");
+  });
+});
+
+describe("_setRenderedContentType", () => {
+  test("assigns format only when response has no media type and format is truthy", () => {
+    const host = (responseCt?: string) => ({
+      contentType: null as string | null,
+      response: { contentType: responseCt },
+    });
+
+    const a = host();
+    _setRenderedContentType.call(a, "text/csv");
+    expect(a.contentType).toBe("text/csv");
+
+    const b = host("application/json");
+    _setRenderedContentType.call(b, "text/csv");
+    expect(b.contentType).toBeNull();
+
+    const c = host();
+    _setRenderedContentType.call(c, null);
+    expect(c.contentType).toBeNull();
+  });
+});
+
+describe("_setVaryHeader", () => {
+  function makeHost(initial?: string, shouldApply = true) {
+    const headers = new Map<string, string>();
+    if (initial !== undefined) headers.set("vary", initial);
+    return {
+      headers,
+      host: {
+        request: { shouldApplyVaryHeader: () => shouldApply },
+        response: {
+          getHeader: (n: string) => headers.get(n.toLowerCase()),
+          setHeader: (n: string, v: string) => headers.set(n.toLowerCase(), v),
+        },
+      },
+    };
+  }
+
+  test("sets Vary: Accept when missing and request opts in; preserves existing or opt-out", () => {
+    const a = makeHost();
+    _setVaryHeader.call(a.host);
+    expect(a.headers.get("vary")).toBe("Accept");
+
+    const b = makeHost("Cookie");
+    _setVaryHeader.call(b.host);
+    expect(b.headers.get("vary")).toBe("Cookie");
+
+    const c = makeHost(undefined, false);
+    _setVaryHeader.call(c.host);
+    expect(c.headers.has("vary")).toBe(false);
+  });
+});
+
+describe("_processOptions", () => {
+  test("applies status / contentType / location, ignoring missing keys", () => {
+    const setHeaderCalls: Array<[string, string]> = [];
+    const host = {
+      status: 200,
+      contentType: null as string | null,
+      setHeader: (n: string, v: string) => setHeaderCalls.push([n, v]),
+      urlFor: (s: string) => `/url/${s}`,
+    };
+    _processOptions.call(host, {
+      status: "created",
+      contentType: "text/plain",
+      location: "post-1",
+    });
+    expect(host.status).toBe(201);
+    expect(host.contentType).toBe("text/plain");
+    expect(setHeaderCalls).toEqual([["Location", "/url/post-1"]]);
+
+    _processOptions.call(host, {});
+    expect(host.status).toBe(201);
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -6,6 +6,7 @@
  * @see https://api.rubyonrails.org/classes/ActionController/Rendering.html
  */
 
+import { htmlEscape, isPresent } from "@blazetrails/activesupport";
 import { Metal } from "../metal.js";
 import { Renderer } from "../renderer.js";
 
@@ -48,21 +49,12 @@ export function _normalizeText(options: Record<string, unknown>): void {
 export function _normalizeOptions(options: Record<string, unknown>): Record<string, unknown> {
   _normalizeText(options);
   if (options.html) {
-    options.html = htmlEscape(String(options.html));
+    options.html = htmlEscape(options.html);
   }
   if (options.status) {
     options.status = Metal.resolveStatus(options.status as number | string);
   }
   return options;
-}
-
-function htmlEscape(s: string): string {
-  return s
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;");
 }
 
 export interface RenderingHost {
@@ -92,9 +84,9 @@ export function _processVariant(
   options: Record<string, unknown>,
 ): void {
   const variant = this.request?.variant;
-  if (variant === undefined || variant === null) return;
-  if (Array.isArray(variant) && variant.length === 0) return;
-  options.variant = variant;
+  if (isPresent(variant)) {
+    options.variant = variant;
+  }
 }
 
 /**

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -1,8 +1,8 @@
 /**
  * ActionController::Rendering
  *
- * Render dispatch module mixed into controllers. Checks for double render
- * and processes render format priorities.
+ * Render dispatch module mixed into controllers. Mirrors the
+ * Rails-private helpers used by the rendering pipeline.
  * @see https://api.rubyonrails.org/classes/ActionController/Rendering.html
  */
 
@@ -11,40 +11,150 @@ import { Renderer } from "../renderer.js";
 
 export const RENDER_FORMATS_IN_PRIORITY = ["body", "plain", "html"] as const;
 
-export function renderInPriorities(options: Record<string, unknown>): unknown | null {
+/**
+ * Mirrors Rails `_render_in_priorities(options)` — returns the first
+ * present `:body`/`:plain`/`:html` value, or `null` when none is set.
+ * @internal
+ */
+export function _renderInPriorities(options: Record<string, unknown>): unknown {
   for (const format of RENDER_FORMATS_IN_PRIORITY) {
-    if (format in options) return options[format];
+    if (Object.hasOwn(options, format)) return options[format];
   }
   return null;
 }
 
-export function normalizeRenderOptions(options: Record<string, unknown>): Record<string, unknown> {
-  const normalized = { ...options };
-
-  if (normalized.status !== undefined && normalized.status !== null) {
-    normalized.status = Metal.resolveStatus(normalized.status as number | string);
+/**
+ * Mirrors Rails `_normalize_text(options)` — for each priority format
+ * key whose value responds to `to_text`, replace it with the result.
+ * @internal
+ */
+export function _normalizeText(options: Record<string, unknown>): void {
+  for (const format of RENDER_FORMATS_IN_PRIORITY) {
+    if (Object.hasOwn(options, format)) {
+      const v = options[format] as { toText?: () => unknown } | null;
+      if (v != null && typeof v === "object" && typeof v.toText === "function") {
+        options[format] = v.toText();
+      }
+    }
   }
-
-  return normalized;
 }
 
-export function processRenderOptions(options: Record<string, unknown>): {
-  status?: number;
-  contentType?: string;
-  location?: string;
-} {
-  const result: { status?: number; contentType?: string; location?: string } = {};
-  if (options.status !== undefined && options.status !== null) {
-    result.status = Metal.resolveStatus(options.status as number | string);
+/**
+ * Mirrors Rails `_normalize_options(options)` — normalizes text-form
+ * options, HTML-escapes `:html` strings, and resolves status names to
+ * numeric codes.
+ * @internal
+ */
+export function _normalizeOptions(options: Record<string, unknown>): Record<string, unknown> {
+  _normalizeText(options);
+  if (options.html) {
+    options.html = htmlEscape(String(options.html));
   }
-  if (options.contentType || options.content_type)
-    result.contentType = (options.contentType ?? options.content_type) as string;
-  if (options.location) result.location = options.location as string;
-  return result;
+  if (options.status) {
+    options.status = Metal.resolveStatus(options.status as number | string);
+  }
+  return options;
+}
+
+function htmlEscape(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export interface RenderingHost {
+  request?: {
+    variant?: unknown;
+    shouldApplyVaryHeader?: () => boolean;
+  };
+  response: {
+    contentType?: string;
+    getHeader(name: string): string | undefined;
+    setHeader(name: string, value: string): void;
+  };
+  contentType: string | null;
+  status: number;
+  setHeader(name: string, value: string): void;
+  urlFor(loc: string): string;
+}
+
+/**
+ * Mirrors Rails `_process_variant(options)`. When the current request
+ * declares a variant, copies it into the render options hash so the
+ * downstream lookup picks the variant-specific template.
+ * @internal
+ */
+export function _processVariant(
+  this: Pick<RenderingHost, "request">,
+  options: Record<string, unknown>,
+): void {
+  const variant = this.request?.variant;
+  if (variant === undefined || variant === null) return;
+  if (Array.isArray(variant) && variant.length === 0) return;
+  options.variant = variant;
+}
+
+/**
+ * Mirrors Rails `_set_html_content_type` — `self.content_type = Mime[:html].to_s`.
+ * @internal
+ */
+export function _setHtmlContentType(this: Pick<RenderingHost, "contentType">): void {
+  this.contentType = "text/html";
+}
+
+/**
+ * Mirrors Rails `_set_rendered_content_type(format)` — assigns the
+ * rendered format's MIME string when the response hasn't already
+ * committed a media type.
+ * @internal
+ */
+export function _setRenderedContentType(
+  this: { contentType: string | null; response: { contentType?: string } },
+  format: string | null | undefined,
+): void {
+  if (format && !this.response.contentType) {
+    this.contentType = String(format);
+  }
+}
+
+/**
+ * Mirrors Rails `_set_vary_header` — adds `Vary: Accept` when the
+ * response hasn't set one and the request indicates it should.
+ * @internal
+ */
+export function _setVaryHeader(this: Pick<RenderingHost, "request" | "response">): void {
+  const cur = this.response.getHeader("Vary") ?? this.response.getHeader("vary");
+  const blank = !cur || cur.trim() === "";
+  if (blank && this.request?.shouldApplyVaryHeader?.()) {
+    this.response.setHeader("Vary", "Accept");
+  }
+}
+
+/**
+ * Mirrors Rails `_process_options(options)` — applies controller-level
+ * options (`:status`, `:content_type`, `:location`) to the response.
+ * @internal
+ */
+export function _processOptions(
+  this: Pick<RenderingHost, "status" | "contentType" | "setHeader" | "urlFor">,
+  options: Record<string, unknown>,
+): void {
+  if (options.status) {
+    this.status = Metal.resolveStatus(options.status as number | string);
+  }
+  if (options.contentType) {
+    this.contentType = String(options.contentType);
+  }
+  if (options.location) {
+    this.setHeader("Location", this.urlFor(String(options.location)));
+  }
 }
 
 export function renderToBody(options: Record<string, unknown> = {}): string {
-  const body = renderInPriorities(options);
+  const body = _renderInPriorities(options);
   return body !== null ? String(body) : " ";
 }
 


### PR DESCRIPTION
Implements **P16** from `docs/actioncontroller-privates-plan.md`.

Adds the 8 Rails-named private helpers in
`packages/actionpack/src/action-controller/metal/rendering.ts` so they
mirror `vendor/rails/actionpack/lib/action_controller/metal/rendering.rb`:

| Method | Rails source |
| --- | --- |
| `_processVariant(options)` | `def _process_variant(options); options[:variant] = request.variant if … request.variant.present?; end` |
| `_renderInPriorities(options)` | `RENDER_FORMATS_IN_PRIORITY.each { \|f\| return options[f] if options.key?(f) }; nil` |
| `_setHtmlContentType` | `self.content_type = Mime[:html].to_s` |
| `_setRenderedContentType(format)` | `self.content_type = format.to_s if format && !response.media_type` |
| `_setVaryHeader` | `response.headers["Vary"] = "Accept" if response.headers["Vary"].blank? && request.should_apply_vary_header?` |
| `_normalizeOptions(options)` | `_normalize_text(options); options[:html] = ERB::Util.html_escape(...); options[:status] = Rack::Utils.status_code(...)` |
| `_normalizeText(options)` | `RENDER_FORMATS_IN_PRIORITY.each { \|f\| options[f] = options[f].to_text if options.key?(f) && options[f].respond_to?(:to_text) }` |
| `_processOptions(options)` | `self.status = … if status; self.content_type = … if content_type; headers["Location"] = url_for(location) if location` |

State-mutating helpers (`_processVariant`, `_setHtmlContentType`,
`_setRenderedContentType`, `_setVaryHeader`, `_processOptions`) use the
`this`-typed function pattern from CLAUDE.md so they can be mixed onto a
controller without an extra delegation wrapper. Pure helpers
(`_renderInPriorities`, `_normalizeOptions`, `_normalizeText`) remain
standalone exports. `_normalizeOptions` calls into
`@blazetrails/activesupport`'s `htmlEscape` (SafeBuffer-aware, matches
`ERB::Util.html_escape`) and `_processVariant` uses `isPresent` for
full Rails `present?` parity.

The previous `renderInPriorities` / `normalizeRenderOptions` /
`processRenderOptions` exports had no callers and were removed
(CLAUDE.md: no backwards-compat hacks).

`api:compare --package actioncontroller --privates` for
`metal/rendering.rb`: **6/14 → 14/14 (100%)**.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/rendering.test.ts` — 8 pass
- [x] `pnpm build` clean
- [x] `pnpm lint` clean
- [x] `pnpm api:compare --package actioncontroller --privates` shows `metal/rendering.rb` at 100%