### PR TITLE
feat(actionpack): register CSP helpers as view helper_methods (P10 follow-up)

### DIFF
--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -30,6 +30,7 @@ import {
   currentContentSecurityPolicy,
   isContentSecurityPolicy,
 } from "./metal/content-security-policy.js";
+import { helperMethod, type HelpersClassMethods } from "../abstract-controller/helpers.js";
 
 // Re-export callback registration
 export { type ActionCallback, type AroundCallback, type CallbackOptions };
@@ -663,6 +664,16 @@ export class Base extends Metal {
     return false;
   }
 }
+
+// Rails: `included do helper_method :content_security_policy?,
+// :content_security_policy_nonce end` (content_security_policy.rb:13).
+// Trails wires mixins onto Base explicitly, so register the helper-method
+// proxies here so templates can call these via the helpers module.
+helperMethod(
+  Base as unknown as HelpersClassMethods,
+  "isContentSecurityPolicy",
+  "contentSecurityPolicyNonce",
+);
 
 export class DoubleRenderError extends AbstractControllerError {
   constructor(message = "Render and/or redirect were called multiple times in this action.") {

--- a/packages/actionpack/src/action-controller/metal/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-controller/metal/content-security-policy.test.ts
@@ -165,3 +165,30 @@ describe("private instance helpers", () => {
     expect(fresh).toBeInstanceOf(Policy);
   });
 });
+
+describe("helper_method registration on Base", () => {
+  it("exposes isContentSecurityPolicy and contentSecurityPolicyNonce as view helpers", async () => {
+    const { Base } = await import("../base.js");
+    const cls = Base as unknown as { _helperMethods?: string[] };
+    expect(cls._helperMethods).toEqual(
+      expect.arrayContaining(["isContentSecurityPolicy", "contentSecurityPolicyNonce"]),
+    );
+  });
+
+  it("helper proxies forward to the controller instance", async () => {
+    const { Base } = await import("../base.js");
+    const cls = Base as unknown as {
+      _helpers?: Record<
+        string,
+        (this: { controller: Record<string, unknown> }, ...args: unknown[]) => unknown
+      >;
+    };
+    const controller = {
+      isContentSecurityPolicy: () => true,
+      contentSecurityPolicyNonce: () => "abc123",
+    };
+    const proxy = { controller };
+    expect(cls._helpers!.isContentSecurityPolicy.call(proxy)).toBe(true);
+    expect(cls._helpers!.contentSecurityPolicyNonce.call(proxy)).toBe("abc123");
+  });
+});


### PR DESCRIPTION
## Summary
P10 follow-up from PR #1948 post-merge findings. Rails' `included do` block in `content_security_policy.rb:13-14` registers `content_security_policy?` and `content_security_policy_nonce` as view helpers via `AbstractController::Helpers#helper_method`. Trails wires mixins explicitly rather than via `included do`, so this PR calls `helperMethod(Base, ...)` at module bottom in `action-controller/base.ts`.

The helpers-module proxy delegates lookups to `this.controller[name]`, so the existing prototype methods on `Base` (added in #1948) answer the calls — no duplicate implementation.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/content-security-policy.test.ts` — 14 passing (2 new)
- [x] `pnpm tsc --build` clean

~34 LOC.