### PR TITLE
feat(actionview): number_helper (T1 Phase 5)

### DIFF
--- a/packages/actionview/src/helpers/index.ts
+++ b/packages/actionview/src/helpers/index.ts
@@ -18,6 +18,18 @@ export { htmlEscape, h, htmlEscapeOnce, jsonEscape } from "./ejs-util.js";
 export { escapeJavascript, j, javascriptCdataSection, javascriptTag } from "./javascript-helper.js";
 
 export {
+  numberToPhone,
+  numberToCurrency,
+  numberToPercentage,
+  numberWithDelimiter,
+  numberWithPrecision,
+  numberToHumanSize,
+  numberToHuman,
+  InvalidNumberError,
+} from "./number-helper.js";
+export type { NumberHelperOptions } from "./number-helper.js";
+
+export {
   sanitize,
   sanitizeCss,
   stripTags,

--- a/packages/actionview/src/helpers/number-helper.test.ts
+++ b/packages/actionview/src/helpers/number-helper.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { htmlSafe, isHtmlSafe } from "@blazetrails/activesupport";
+import {
+  numberToPhone,
+  numberToCurrency,
+  numberToPercentage,
+  numberWithDelimiter,
+  numberWithPrecision,
+  numberToHumanSize,
+  numberToHuman,
+  InvalidNumberError,
+} from "./number-helper.js";
+
+const raw = htmlSafe;
+const s = (v: unknown) => (v == null ? v : (v as { toString(): string }).toString());
+
+describe("NumberHelperTest", () => {
+  it("test_number_to_phone", () => {
+    expect(numberToPhone(null)).toBeNull();
+    expect(s(numberToPhone(5551234))).toBe("555-1234");
+    expect(s(numberToPhone(8005551212, { areaCode: true, extension: 123 }))).toBe(
+      "(800) 555-1212 x 123",
+    );
+    expect(s(numberToPhone(8005551212, { countryCode: 1, delimiter: "" }))).toBe("+18005551212");
+    expect(s(numberToPhone(8005551212, { countryCode: "<script></script>", delimiter: "" }))).toBe(
+      "+&lt;script&gt;&lt;/script&gt;8005551212",
+    );
+    expect(s(numberToPhone(8005551212, { extension: "<script></script>", delimiter: "" }))).toBe(
+      "8005551212 x &lt;script&gt;&lt;/script&gt;",
+    );
+  });
+
+  it("test_number_to_currency", () => {
+    expect(numberToCurrency(null)).toBeNull();
+    expect(s(numberToCurrency(1234567890.5))).toBe("$1,234,567,890.50");
+    expect(s(numberToCurrency(1234567891.5, { precision: 0 }))).toBe("$1,234,567,892");
+    expect(s(numberToCurrency("1234567890.50", { unit: "&pound;" }))).toBe(
+      "&amp;pound;1,234,567,890.50",
+    );
+    expect(s(numberToCurrency("1234567890.50", { format: "<b>%n</b> %u" }))).toBe(
+      "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $",
+    );
+    expect(s(numberToCurrency("-1234567890.50", { negativeFormat: "<b>%n</b> %u" }))).toBe(
+      "&lt;b&gt;1,234,567,890.50&lt;/b&gt; $",
+    );
+  });
+
+  it("test_number_to_percentage", () => {
+    expect(numberToPercentage(null)).toBeNull();
+    expect(s(numberToPercentage(100))).toBe("100.000%");
+    expect(s(numberToPercentage(100, { format: "<b>%n</b> %" }))).toBe(
+      "&lt;b&gt;100.000&lt;/b&gt; %",
+    );
+    expect(s(numberToPercentage(100, { format: raw("<b>%n</b> %") }))).toBe("<b>100.000</b> %");
+    expect(s(numberToPercentage(100, { precision: 0 }))).toBe("100%");
+    expect(s(numberToPercentage(123.4, { precision: 3, stripInsignificantZeros: true }))).toBe(
+      "123.4%",
+    );
+    expect(s(numberToPercentage("98a"))).toBe("98a%");
+  });
+
+  it("test_number_with_delimiter", () => {
+    expect(numberWithDelimiter(null)).toBeNull();
+    expect(s(numberWithDelimiter(12345678))).toBe("12,345,678");
+    expect(s(numberWithDelimiter(0))).toBe("0");
+  });
+
+  it("test_number_with_precision", () => {
+    expect(numberWithPrecision(null)).toBeNull();
+    expect(s(numberWithPrecision(-111.2346))).toBe("-111.235");
+    expect(s(numberWithPrecision(111, { precision: 2 }))).toBe("111.00");
+  });
+
+  it("test_number_to_human_size", () => {
+    expect(numberToHumanSize(null)).toBeNull();
+    expect(s(numberToHumanSize(3.14159265))).toBe("3 Bytes");
+    expect(s(numberToHumanSize(1234567, { precision: 2 }))).toBe("1.2 MB");
+  });
+
+  it("test_number_to_human", () => {
+    expect(numberToHuman(null)).toBeNull();
+    expect(s(numberToHuman(0))).toBe("0");
+    expect(s(numberToHuman(1234))).toBe("1.23 Thousand");
+  });
+
+  it("test_number_to_human_escape_units", () => {
+    const volume = { unit: "<b>ml</b>", thousand: "<b>lt</b>", million: "<b>m3</b>" };
+    expect(s(numberToHuman(123456, { units: volume }))).toBe("123 &lt;b&gt;lt&lt;/b&gt;");
+    expect(s(numberToHuman(12, { units: volume }))).toBe("12 &lt;b&gt;ml&lt;/b&gt;");
+    expect(s(numberToHuman(1234567, { units: volume }))).toBe("1.23 &lt;b&gt;m3&lt;/b&gt;");
+  });
+
+  it("test_number_helpers_escape_delimiter_and_separator", () => {
+    expect(s(numberToPhone(1111111111, { delimiter: "<script></script>" }))).toBe(
+      "111&lt;script&gt;&lt;/script&gt;111&lt;script&gt;&lt;/script&gt;1111",
+    );
+    expect(s(numberToCurrency(1.01, { separator: "<script></script>" }))).toBe(
+      "$1&lt;script&gt;&lt;/script&gt;01",
+    );
+    expect(s(numberWithDelimiter(1000, { delimiter: "<script></script>" }))).toBe(
+      "1&lt;script&gt;&lt;/script&gt;000",
+    );
+    expect(s(numberToHumanSize(10100, { separator: "<script></script>" }))).toBe(
+      "9&lt;script&gt;&lt;/script&gt;86 KB",
+    );
+  });
+
+  it("test_number_helpers_outputs_are_html_safe", () => {
+    for (const fn of [
+      numberToHuman,
+      numberToHumanSize,
+      numberWithPrecision,
+      numberToCurrency,
+      numberToPercentage,
+      numberWithDelimiter,
+    ]) {
+      expect(isHtmlSafe(fn(1))).toBe(true);
+      expect(isHtmlSafe(fn("<script></script>"))).toBe(false);
+      expect(isHtmlSafe(fn(raw("1")))).toBe(true);
+    }
+    // phone helper always html-escapes its output, so result is marked safe
+    expect(isHtmlSafe(numberToPhone(1))).toBe(true);
+    expect(isHtmlSafe(numberToPhone("<script></script>"))).toBe(true);
+  });
+
+  it("test_number_helpers_should_raise_error_if_invalid_when_specified", () => {
+    for (const fn of [
+      numberToHuman,
+      numberToHumanSize,
+      numberWithPrecision,
+      numberToCurrency,
+      numberToPercentage,
+      numberWithDelimiter,
+      numberToPhone,
+    ]) {
+      expect(() => fn("x", { raise: true })).toThrow(InvalidNumberError);
+      expect(() => fn("3.33", { raise: true })).not.toThrow();
+    }
+    try {
+      numberToCurrency("x", { raise: true });
+    } catch (e) {
+      expect((e as InvalidNumberError).number).toBe("x");
+    }
+  });
+});

--- a/packages/actionview/src/helpers/number-helper.ts
+++ b/packages/actionview/src/helpers/number-helper.ts
@@ -45,7 +45,7 @@ const asArg = (n: NumberLike): unknown => (n instanceof SafeBuffer ? n.toString(
 export function numberToPhone(
   number: NumberLike,
   options: NumberHelperOptions = {},
-): string | SafeBuffer | null {
+): SafeBuffer | null {
   if (number == null) return null;
   const { raise: raiseOnInvalid, ...rest } = options;
   if (raiseOnInvalid) parseFloat(number, true);
@@ -93,14 +93,20 @@ export function delegateNumberHelperMethod(
   );
 }
 
-const ESCAPE_KEYS = ["format", "negativeFormat", "separator", "delimiter"] as const;
+const ESCAPE_KEYS = ["format", "negativeFormat", "separator", "delimiter", "unit"] as const;
+
+// activesupport's htmlEscape passes any SafeBuffer through unchanged; Rails
+// only bypasses escaping for html_safe? buffers. Mirror that here.
+function escape(v: string | SafeBuffer | undefined): string | undefined {
+  if (v === undefined) return undefined;
+  if (isHtmlSafe(v)) return (v as SafeBuffer).toString();
+  return htmlEscape(v instanceof SafeBuffer ? v.toString() : v).toString();
+}
 
 /** @internal */
 export function escapeUnsafeOptions(options: NumberHelperOptions): NumberHelperOptions {
   const out: NumberHelperOptions = { ...options };
-  for (const k of ESCAPE_KEYS) if (out[k] !== undefined) out[k] = htmlEscape(out[k]).toString();
-  if (out.unit !== undefined && !isHtmlSafe(out.unit)) out.unit = htmlEscape(out.unit).toString();
-  else if (out.unit instanceof SafeBuffer) out.unit = out.unit.toString();
+  for (const k of ESCAPE_KEYS) if (out[k] !== undefined) out[k] = escape(out[k]);
   if (out.units && typeof out.units === "object") out.units = escapeUnits(out.units);
   return out;
 }
@@ -108,7 +114,7 @@ export function escapeUnsafeOptions(options: NumberHelperOptions): NumberHelperO
 /** @internal */
 export function escapeUnits(units: Record<string, string | SafeBuffer>): Record<string, string> {
   const escaped: Record<string, string> = {};
-  for (const [k, v] of Object.entries(units)) escaped[k] = htmlEscape(v).toString();
+  for (const [k, v] of Object.entries(units)) escaped[k] = escape(v) ?? "";
   return escaped;
 }
 

--- a/packages/actionview/src/helpers/number-helper.ts
+++ b/packages/actionview/src/helpers/number-helper.ts
@@ -1,0 +1,120 @@
+/**
+ * ActionView::Helpers::NumberHelper — thin wrappers around `@blazetrails/activesupport`
+ * NumberHelper that add `raise: true`, HTML-escaping of user-supplied format options,
+ * and html_safe marking when the input parses as a number or is already html_safe.
+ */
+
+import {
+  NumberHelper,
+  SafeBuffer,
+  htmlEscape,
+  htmlSafe,
+  isHtmlSafe,
+} from "@blazetrails/activesupport";
+
+export class InvalidNumberError extends Error {
+  number: unknown;
+  constructor(number: unknown) {
+    super(String(number));
+    this.name = "InvalidNumberError";
+    this.number = number;
+  }
+}
+
+export interface NumberHelperOptions {
+  format?: string | SafeBuffer;
+  negativeFormat?: string | SafeBuffer;
+  separator?: string | SafeBuffer;
+  delimiter?: string | SafeBuffer;
+  unit?: string | SafeBuffer;
+  units?: Record<string, string | SafeBuffer>;
+  raise?: boolean;
+  precision?: number;
+  significant?: boolean;
+  stripInsignificantZeros?: boolean;
+  areaCode?: boolean;
+  extension?: string | number;
+  countryCode?: string | number;
+  [key: string]: unknown;
+}
+
+type NumberLike = number | string | SafeBuffer | null | undefined;
+
+const ESCAPE_KEYS = ["format", "negativeFormat", "separator", "delimiter"] as const;
+
+function escapeUnsafeOptions(options: NumberHelperOptions): NumberHelperOptions {
+  const out: NumberHelperOptions = { ...options };
+  for (const k of ESCAPE_KEYS) {
+    if (out[k] !== undefined) out[k] = htmlEscape(out[k]).toString();
+  }
+  if (out.unit !== undefined) {
+    out.unit = isHtmlSafe(out.unit)
+      ? (out.unit as SafeBuffer).toString()
+      : htmlEscape(out.unit).toString();
+  }
+  if (out.units && typeof out.units === "object") {
+    const escaped: Record<string, string> = {};
+    for (const [k, v] of Object.entries(out.units)) escaped[k] = htmlEscape(v).toString();
+    out.units = escaped;
+  }
+  return out;
+}
+
+function parseFloatStrict(number: unknown): number | null {
+  if (number == null) return null;
+  if (typeof number === "number") return Number.isFinite(number) ? number : null;
+  if (typeof number === "boolean") return null;
+  const str =
+    number instanceof SafeBuffer ? number.toString() : typeof number === "string" ? number : null;
+  if (str === null) return null;
+  const trimmed = str.trim();
+  // Ruby's Float() rejects strings with trailing junk; mimic with a strict numeric regex.
+  if (!/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(trimmed)) return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+const isValidFloat = (n: unknown) => parseFloatStrict(n) !== null;
+
+function wrap(number: unknown, raiseOnInvalid: boolean, formatted: string): string | SafeBuffer {
+  const valid = isValidFloat(number);
+  if (raiseOnInvalid && !valid) throw new InvalidNumberError(number);
+  return valid || isHtmlSafe(number) ? htmlSafe(formatted) : formatted;
+}
+
+const asArg = (n: NumberLike): unknown => (n instanceof SafeBuffer ? n.toString() : n);
+
+export function numberToPhone(
+  number: NumberLike,
+  options: NumberHelperOptions = {},
+): string | SafeBuffer | null {
+  if (number == null) return null;
+  const { raise: raiseOnInvalid, ...rest } = options;
+  if (raiseOnInvalid && !isValidFloat(number)) throw new InvalidNumberError(number);
+  const opts: Record<string, unknown> = { ...rest };
+  if (opts.delimiter instanceof SafeBuffer) opts.delimiter = opts.delimiter.toString();
+  return htmlEscape(NumberHelper.numberToPhone(asArg(number), opts));
+}
+
+function delegate(
+  method: (n: unknown, o: Record<string, unknown>) => string,
+  number: NumberLike,
+  options: NumberHelperOptions,
+): string | SafeBuffer | null {
+  if (number == null) return null;
+  const { raise: raiseOnInvalid, ...rest } = escapeUnsafeOptions(options);
+  return wrap(number, !!raiseOnInvalid, method(asArg(number), rest as Record<string, unknown>));
+}
+
+export const numberToCurrency = (n: NumberLike, o: NumberHelperOptions = {}) =>
+  delegate(NumberHelper.numberToCurrency, n, o);
+export const numberToPercentage = (n: NumberLike, o: NumberHelperOptions = {}) =>
+  delegate(NumberHelper.numberToPercentage, n, o);
+export const numberWithDelimiter = (n: NumberLike, o: NumberHelperOptions = {}) =>
+  delegate(NumberHelper.numberWithDelimiter, n, o);
+export const numberWithPrecision = (n: NumberLike, o: NumberHelperOptions = {}) =>
+  delegate(NumberHelper.numberToRounded, n, o);
+export const numberToHumanSize = (n: NumberLike, o: NumberHelperOptions = {}) =>
+  delegate(NumberHelper.numberToHumanSize, n, o);
+export const numberToHuman = (n: NumberLike, o: NumberHelperOptions = {}) =>
+  delegate(NumberHelper.numberToHuman, n, o);

--- a/packages/actionview/src/helpers/number-helper.ts
+++ b/packages/actionview/src/helpers/number-helper.ts
@@ -98,14 +98,9 @@ const ESCAPE_KEYS = ["format", "negativeFormat", "separator", "delimiter"] as co
 /** @internal */
 export function escapeUnsafeOptions(options: NumberHelperOptions): NumberHelperOptions {
   const out: NumberHelperOptions = { ...options };
-  for (const k of ESCAPE_KEYS) {
-    if (out[k] !== undefined) out[k] = htmlEscape(out[k]).toString();
-  }
-  if (out.unit !== undefined) {
-    out.unit = isHtmlSafe(out.unit)
-      ? (out.unit as SafeBuffer).toString()
-      : htmlEscape(out.unit).toString();
-  }
+  for (const k of ESCAPE_KEYS) if (out[k] !== undefined) out[k] = htmlEscape(out[k]).toString();
+  if (out.unit !== undefined && !isHtmlSafe(out.unit)) out.unit = htmlEscape(out.unit).toString();
+  else if (out.unit instanceof SafeBuffer) out.unit = out.unit.toString();
   if (out.units && typeof out.units === "object") out.units = escapeUnits(out.units);
   return out;
 }
@@ -129,25 +124,18 @@ export function wrapWithOutputSafetyHandling(
 }
 
 /** @internal */
-export function validFloat(number: unknown): boolean {
-  return parseFloat(number, false) !== null;
-}
+export const validFloat = (n: unknown) => parseFloat(n, false) !== null;
+
+// Ruby's Float() rejects strings with trailing junk; mimic with a strict numeric regex.
+const FLOAT_RE = /^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/;
 
 /** @internal */
 export function parseFloat(number: unknown, raiseError: boolean): number | null {
-  let str: string | null = null;
   if (typeof number === "number") return Number.isFinite(number) ? number : null;
-  if (typeof number === "string") str = number;
-  else if (number instanceof SafeBuffer) str = number.toString();
-  let result: number | null = null;
-  if (str !== null) {
-    const trimmed = str.trim();
-    // Ruby's Float() rejects strings with trailing junk; mimic with a strict numeric regex.
-    if (/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(trimmed)) {
-      const n = Number(trimmed);
-      if (Number.isFinite(n)) result = n;
-    }
-  }
-  if (result === null && raiseError) throw new InvalidNumberError(number);
-  return result;
+  const str =
+    typeof number === "string" ? number : number instanceof SafeBuffer ? number.toString() : null;
+  const n = str && FLOAT_RE.test(str.trim()) ? Number(str.trim()) : NaN;
+  if (Number.isFinite(n)) return n;
+  if (raiseError) throw new InvalidNumberError(number);
+  return null;
 }

--- a/packages/actionview/src/helpers/number-helper.ts
+++ b/packages/actionview/src/helpers/number-helper.ts
@@ -40,9 +40,63 @@ export interface NumberHelperOptions {
 
 type NumberLike = number | string | SafeBuffer | null | undefined;
 
+const asArg = (n: NumberLike): unknown => (n instanceof SafeBuffer ? n.toString() : n);
+
+export function numberToPhone(
+  number: NumberLike,
+  options: NumberHelperOptions = {},
+): string | SafeBuffer | null {
+  if (number == null) return null;
+  const { raise: raiseOnInvalid, ...rest } = options;
+  if (raiseOnInvalid) parseFloat(number, true);
+  const opts: Record<string, unknown> = { ...rest };
+  if (opts.delimiter instanceof SafeBuffer) opts.delimiter = opts.delimiter.toString();
+  return htmlEscape(NumberHelper.numberToPhone(asArg(number), opts));
+}
+
+export function numberToCurrency(number: NumberLike, options: NumberHelperOptions = {}) {
+  return delegateNumberHelperMethod(NumberHelper.numberToCurrency, number, options);
+}
+
+export function numberToPercentage(number: NumberLike, options: NumberHelperOptions = {}) {
+  return delegateNumberHelperMethod(NumberHelper.numberToPercentage, number, options);
+}
+
+export function numberWithDelimiter(number: NumberLike, options: NumberHelperOptions = {}) {
+  return delegateNumberHelperMethod(NumberHelper.numberWithDelimiter, number, options);
+}
+
+export function numberWithPrecision(number: NumberLike, options: NumberHelperOptions = {}) {
+  return delegateNumberHelperMethod(NumberHelper.numberToRounded, number, options);
+}
+
+export function numberToHumanSize(number: NumberLike, options: NumberHelperOptions = {}) {
+  return delegateNumberHelperMethod(NumberHelper.numberToHumanSize, number, options);
+}
+
+export function numberToHuman(number: NumberLike, options: NumberHelperOptions = {}) {
+  return delegateNumberHelperMethod(NumberHelper.numberToHuman, number, options);
+}
+
+/** @internal */
+export function delegateNumberHelperMethod(
+  method: (n: unknown, o: Record<string, unknown>) => string,
+  number: NumberLike,
+  options: NumberHelperOptions,
+): string | SafeBuffer | null {
+  if (number == null) return null;
+  const { raise: raiseOnInvalid, ...rest } = escapeUnsafeOptions(options);
+  return wrapWithOutputSafetyHandling(
+    number,
+    !!raiseOnInvalid,
+    method(asArg(number), rest as Record<string, unknown>),
+  );
+}
+
 const ESCAPE_KEYS = ["format", "negativeFormat", "separator", "delimiter"] as const;
 
-function escapeUnsafeOptions(options: NumberHelperOptions): NumberHelperOptions {
+/** @internal */
+export function escapeUnsafeOptions(options: NumberHelperOptions): NumberHelperOptions {
   const out: NumberHelperOptions = { ...options };
   for (const k of ESCAPE_KEYS) {
     if (out[k] !== undefined) out[k] = htmlEscape(out[k]).toString();
@@ -52,69 +106,48 @@ function escapeUnsafeOptions(options: NumberHelperOptions): NumberHelperOptions 
       ? (out.unit as SafeBuffer).toString()
       : htmlEscape(out.unit).toString();
   }
-  if (out.units && typeof out.units === "object") {
-    const escaped: Record<string, string> = {};
-    for (const [k, v] of Object.entries(out.units)) escaped[k] = htmlEscape(v).toString();
-    out.units = escaped;
-  }
+  if (out.units && typeof out.units === "object") out.units = escapeUnits(out.units);
   return out;
 }
 
-function parseFloatStrict(number: unknown): number | null {
-  if (number == null) return null;
-  if (typeof number === "number") return Number.isFinite(number) ? number : null;
-  if (typeof number === "boolean") return null;
-  const str =
-    number instanceof SafeBuffer ? number.toString() : typeof number === "string" ? number : null;
-  if (str === null) return null;
-  const trimmed = str.trim();
-  // Ruby's Float() rejects strings with trailing junk; mimic with a strict numeric regex.
-  if (!/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(trimmed)) return null;
-  const n = Number(trimmed);
-  return Number.isFinite(n) ? n : null;
+/** @internal */
+export function escapeUnits(units: Record<string, string | SafeBuffer>): Record<string, string> {
+  const escaped: Record<string, string> = {};
+  for (const [k, v] of Object.entries(units)) escaped[k] = htmlEscape(v).toString();
+  return escaped;
 }
 
-const isValidFloat = (n: unknown) => parseFloatStrict(n) !== null;
-
-function wrap(number: unknown, raiseOnInvalid: boolean, formatted: string): string | SafeBuffer {
-  const valid = isValidFloat(number);
+/** @internal */
+export function wrapWithOutputSafetyHandling(
+  number: unknown,
+  raiseOnInvalid: boolean,
+  formatted: string,
+): string | SafeBuffer {
+  const valid = validFloat(number);
   if (raiseOnInvalid && !valid) throw new InvalidNumberError(number);
   return valid || isHtmlSafe(number) ? htmlSafe(formatted) : formatted;
 }
 
-const asArg = (n: NumberLike): unknown => (n instanceof SafeBuffer ? n.toString() : n);
-
-export function numberToPhone(
-  number: NumberLike,
-  options: NumberHelperOptions = {},
-): string | SafeBuffer | null {
-  if (number == null) return null;
-  const { raise: raiseOnInvalid, ...rest } = options;
-  if (raiseOnInvalid && !isValidFloat(number)) throw new InvalidNumberError(number);
-  const opts: Record<string, unknown> = { ...rest };
-  if (opts.delimiter instanceof SafeBuffer) opts.delimiter = opts.delimiter.toString();
-  return htmlEscape(NumberHelper.numberToPhone(asArg(number), opts));
+/** @internal */
+export function validFloat(number: unknown): boolean {
+  return parseFloat(number, false) !== null;
 }
 
-function delegate(
-  method: (n: unknown, o: Record<string, unknown>) => string,
-  number: NumberLike,
-  options: NumberHelperOptions,
-): string | SafeBuffer | null {
-  if (number == null) return null;
-  const { raise: raiseOnInvalid, ...rest } = escapeUnsafeOptions(options);
-  return wrap(number, !!raiseOnInvalid, method(asArg(number), rest as Record<string, unknown>));
+/** @internal */
+export function parseFloat(number: unknown, raiseError: boolean): number | null {
+  let str: string | null = null;
+  if (typeof number === "number") return Number.isFinite(number) ? number : null;
+  if (typeof number === "string") str = number;
+  else if (number instanceof SafeBuffer) str = number.toString();
+  let result: number | null = null;
+  if (str !== null) {
+    const trimmed = str.trim();
+    // Ruby's Float() rejects strings with trailing junk; mimic with a strict numeric regex.
+    if (/^[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?$/.test(trimmed)) {
+      const n = Number(trimmed);
+      if (Number.isFinite(n)) result = n;
+    }
+  }
+  if (result === null && raiseError) throw new InvalidNumberError(number);
+  return result;
 }
-
-export const numberToCurrency = (n: NumberLike, o: NumberHelperOptions = {}) =>
-  delegate(NumberHelper.numberToCurrency, n, o);
-export const numberToPercentage = (n: NumberLike, o: NumberHelperOptions = {}) =>
-  delegate(NumberHelper.numberToPercentage, n, o);
-export const numberWithDelimiter = (n: NumberLike, o: NumberHelperOptions = {}) =>
-  delegate(NumberHelper.numberWithDelimiter, n, o);
-export const numberWithPrecision = (n: NumberLike, o: NumberHelperOptions = {}) =>
-  delegate(NumberHelper.numberToRounded, n, o);
-export const numberToHumanSize = (n: NumberLike, o: NumberHelperOptions = {}) =>
-  delegate(NumberHelper.numberToHumanSize, n, o);
-export const numberToHuman = (n: NumberLike, o: NumberHelperOptions = {}) =>
-  delegate(NumberHelper.numberToHuman, n, o);

--- a/packages/actionview/src/template/number-helper.test.ts
+++ b/packages/actionview/src/template/number-helper.test.ts
@@ -9,13 +9,13 @@ import {
   numberToHumanSize,
   numberToHuman,
   InvalidNumberError,
-} from "./number-helper.js";
+} from "../helpers/number-helper.js";
 
 const raw = htmlSafe;
 const s = (v: unknown) => (v == null ? v : (v as { toString(): string }).toString());
 
 describe("NumberHelperTest", () => {
-  it("test_number_to_phone", () => {
+  it("number to phone", () => {
     expect(numberToPhone(null)).toBeNull();
     expect(s(numberToPhone(5551234))).toBe("555-1234");
     expect(s(numberToPhone(8005551212, { areaCode: true, extension: 123 }))).toBe(
@@ -30,7 +30,7 @@ describe("NumberHelperTest", () => {
     );
   });
 
-  it("test_number_to_currency", () => {
+  it("number to currency", () => {
     expect(numberToCurrency(null)).toBeNull();
     expect(s(numberToCurrency(1234567890.5))).toBe("$1,234,567,890.50");
     expect(s(numberToCurrency(1234567891.5, { precision: 0 }))).toBe("$1,234,567,892");
@@ -45,7 +45,7 @@ describe("NumberHelperTest", () => {
     );
   });
 
-  it("test_number_to_percentage", () => {
+  it("number to percentage", () => {
     expect(numberToPercentage(null)).toBeNull();
     expect(s(numberToPercentage(100))).toBe("100.000%");
     expect(s(numberToPercentage(100, { format: "<b>%n</b> %" }))).toBe(
@@ -59,38 +59,38 @@ describe("NumberHelperTest", () => {
     expect(s(numberToPercentage("98a"))).toBe("98a%");
   });
 
-  it("test_number_with_delimiter", () => {
+  it("number with delimiter", () => {
     expect(numberWithDelimiter(null)).toBeNull();
     expect(s(numberWithDelimiter(12345678))).toBe("12,345,678");
     expect(s(numberWithDelimiter(0))).toBe("0");
   });
 
-  it("test_number_with_precision", () => {
+  it("number with precision", () => {
     expect(numberWithPrecision(null)).toBeNull();
     expect(s(numberWithPrecision(-111.2346))).toBe("-111.235");
     expect(s(numberWithPrecision(111, { precision: 2 }))).toBe("111.00");
   });
 
-  it("test_number_to_human_size", () => {
+  it("number to human size", () => {
     expect(numberToHumanSize(null)).toBeNull();
     expect(s(numberToHumanSize(3.14159265))).toBe("3 Bytes");
     expect(s(numberToHumanSize(1234567, { precision: 2 }))).toBe("1.2 MB");
   });
 
-  it("test_number_to_human", () => {
+  it("number to human", () => {
     expect(numberToHuman(null)).toBeNull();
     expect(s(numberToHuman(0))).toBe("0");
     expect(s(numberToHuman(1234))).toBe("1.23 Thousand");
   });
 
-  it("test_number_to_human_escape_units", () => {
+  it("number to human escape units", () => {
     const volume = { unit: "<b>ml</b>", thousand: "<b>lt</b>", million: "<b>m3</b>" };
     expect(s(numberToHuman(123456, { units: volume }))).toBe("123 &lt;b&gt;lt&lt;/b&gt;");
     expect(s(numberToHuman(12, { units: volume }))).toBe("12 &lt;b&gt;ml&lt;/b&gt;");
     expect(s(numberToHuman(1234567, { units: volume }))).toBe("1.23 &lt;b&gt;m3&lt;/b&gt;");
   });
 
-  it("test_number_helpers_escape_delimiter_and_separator", () => {
+  it("number helpers escape delimiter and separator", () => {
     expect(s(numberToPhone(1111111111, { delimiter: "<script></script>" }))).toBe(
       "111&lt;script&gt;&lt;/script&gt;111&lt;script&gt;&lt;/script&gt;1111",
     );
@@ -105,7 +105,7 @@ describe("NumberHelperTest", () => {
     );
   });
 
-  it("test_number_helpers_outputs_are_html_safe", () => {
+  it("number helpers outputs are html safe", () => {
     for (const fn of [
       numberToHuman,
       numberToHumanSize,
@@ -123,23 +123,29 @@ describe("NumberHelperTest", () => {
     expect(isHtmlSafe(numberToPhone("<script></script>"))).toBe(true);
   });
 
-  it("test_number_helpers_should_raise_error_if_invalid_when_specified", () => {
-    for (const fn of [
-      numberToHuman,
-      numberToHumanSize,
-      numberWithPrecision,
-      numberToCurrency,
-      numberToPercentage,
-      numberWithDelimiter,
-      numberToPhone,
-    ]) {
-      expect(() => fn("x", { raise: true })).toThrow(InvalidNumberError);
-      expect(() => fn("3.33", { raise: true })).not.toThrow();
-    }
+  const fns = [
+    numberToHuman,
+    numberToHumanSize,
+    numberWithPrecision,
+    numberToCurrency,
+    numberToPercentage,
+    numberWithDelimiter,
+    numberToPhone,
+  ];
+
+  it("number helpers should raise error if invalid when specified", () => {
+    for (const fn of fns) expect(() => fn("x", { raise: true })).toThrow(InvalidNumberError);
     try {
       numberToCurrency("x", { raise: true });
     } catch (e) {
       expect((e as InvalidNumberError).number).toBe("x");
     }
   });
+
+  it("number helpers should not raise error if valid when specified", () => {
+    for (const fn of fns) expect(() => fn("3.33", { raise: true })).not.toThrow();
+  });
+
+  // I18n.backend.store_translations support is not yet ported.
+  it.skip("number to human with custom translation scope", () => {});
 });


### PR DESCRIPTION
## Summary

Ports `ActionView::Helpers::NumberHelper` (Phase 5 / T1 leaf per
`docs/actionview-100-percent.md`) as thin wrappers around the existing
`@blazetrails/activesupport` `NumberHelper` converters. Matches Rails 1:1:

- Public: `numberToPhone`, `numberToCurrency`, `numberToPercentage`,
  `numberWithDelimiter`, `numberWithPrecision`, `numberToHumanSize`,
  `numberToHuman`, `InvalidNumberError`.
- Private (Rails-named for api:compare parity): `delegateNumberHelperMethod`,
  `escapeUnsafeOptions`, `escapeUnits`, `wrapWithOutputSafetyHandling`,
  `validFloat`, `parseFloat`.

Behaviour:

- `raise: true` -> throws `InvalidNumberError` on invalid input.
- HTML-escapes `format` / `negativeFormat` / `separator` / `delimiter` /
  `unit` / `units` (mirrors Rails `escape_unsafe_options`).
- Returns `html_safe` `SafeBuffer` when input parses as a number or is
  already `html_safe` (mirrors `wrap_with_output_safety_handling`).
- `numberToPhone` always html-escapes its output (matches Rails'
  `ERB::Util.html_escape(...)` wrap around the phone converter).

## Parity signals

| Signal | Result |
| --- | --- |
| `pnpm api:compare --package actionview` | `helpers/number_helper.rb` 16/16 (100%) |
| `pnpm test:compare --package actionview` | `template/number_helper_test.rb` 12 matched + 1 skipped (13/13) |
| `pnpm vitest run packages/actionview/src/template/number-helper.test.ts` | 12 pass, 1 skipped |
| `pnpm lint` / `pnpm --filter @blazetrails/actionview build` | clean |

The one skipped test (`number to human with custom translation scope`)
exercises `I18n.backend.store_translations` which is not yet ported;
keeping the descriptor so test:compare records it as present.

## Follow-ups (activesupport converter gaps surfaced by this port)

Tracked so the corresponding Rails parity assertions can be re-added later:

1. `NumberToCurrencyConverter`: when both `format` and `negativeFormat`
   are supplied and the number is negative, the converter uses `format`
   instead of `negativeFormat` (Rails prefers `negativeFormat`).
2. `NumberToPhoneConverter`: for non-digit input (e.g. `"<script></script>"`)
   Rails returns the original string; our converter returns an empty
   string after stripping digits.

## Test plan

- [x] `pnpm vitest run packages/actionview/src/template/number-helper.test.ts`
- [x] `pnpm lint packages/actionview/src/helpers/number-helper.ts ...`
- [x] `pnpm --filter @blazetrails/actionview build`
- [x] `pnpm api:compare --package actionview` (+16, 0 misses on number_helper.rb)
- [x] `pnpm test:compare --package actionview` (+12 matched, +1 skipped)