### PR TITLE
feat(actionview): debug helper (T1)

### DIFF
--- a/packages/actionview/src/helpers/debug-helper.test.ts
+++ b/packages/actionview/src/helpers/debug-helper.test.ts
@@ -39,6 +39,17 @@ describe("DebugHelperTest", () => {
     expect(out).not.toContain("<pre");
   });
 
+  it("fallback inspect renders shared (non-cyclic) refs normally, not as Circular", () => {
+    vi.spyOn(yaml, "stringify").mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const shared = { id: 1 };
+    const out = debug({ a: shared, b: shared }).toString();
+    expect(out).not.toContain("[Circular]");
+    expect(out).toContain("a: { id: 1 }");
+    expect(out).toContain("b: { id: 1 }");
+  });
+
   it("fallback inspect renders circular references as [Circular]", () => {
     vi.spyOn(yaml, "stringify").mockImplementation(() => {
       throw new Error("boom");

--- a/packages/actionview/src/helpers/debug-helper.test.ts
+++ b/packages/actionview/src/helpers/debug-helper.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { SafeBuffer } from "@blazetrails/activesupport";
+import { debug } from "./debug-helper.js";
+
+describe("DebugHelperTest", () => {
+  it("test_debug", () => {
+    const obj = { name: "firebase", count: 42 };
+    const output = debug(obj).toString();
+    expect(output).toContain('<pre class="debug_dump">');
+    expect(output).toContain("name: firebase");
+    expect(output).toContain("count: 42");
+    expect(output).toContain("</pre>");
+  });
+
+  it("returns a SafeBuffer marked html_safe", () => {
+    const out = debug({ a: 1 });
+    expect(out).toBeInstanceOf(SafeBuffer);
+    expect(out.htmlSafe).toBe(true);
+  });
+
+  it("escapes HTML in YAML output", () => {
+    const out = debug({ html: "<script>alert(1)</script>" }).toString();
+    expect(out).not.toContain("<script>");
+    expect(out).toContain("&lt;script&gt;");
+  });
+
+  it("test_debug_with_marshal_error falls back to inspect inside code", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    const out = debug(circular).toString();
+    expect(out).toContain('class="debug_dump"');
+  });
+});

--- a/packages/actionview/src/helpers/debug-helper.test.ts
+++ b/packages/actionview/src/helpers/debug-helper.test.ts
@@ -1,6 +1,7 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { SafeBuffer } from "@blazetrails/activesupport";
 import { debug } from "./debug-helper.js";
+import * as yaml from "@blazetrails/activesupport/yaml";
 
 describe("DebugHelperTest", () => {
   it("test_debug", () => {
@@ -25,9 +26,16 @@ describe("DebugHelperTest", () => {
   });
 
   it("test_debug_with_marshal_error falls back to inspect inside code", () => {
-    const circular: Record<string, unknown> = {};
-    circular.self = circular;
-    const out = debug(circular).toString();
-    expect(out).toContain('class="debug_dump"');
+    const spy = vi.spyOn(yaml, "stringify").mockImplementation(() => {
+      throw new Error("boom");
+    });
+    try {
+      const out = debug({ html: "<b>x</b>" }).toString();
+      expect(out).toContain('<code class="debug_dump">');
+      expect(out).toContain("</code>");
+      expect(out).not.toContain("<pre");
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/packages/actionview/src/helpers/debug-helper.test.ts
+++ b/packages/actionview/src/helpers/debug-helper.test.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { SafeBuffer } from "@blazetrails/activesupport";
 import { debug } from "./debug-helper.js";
 import * as yaml from "@blazetrails/activesupport/yaml";
 
 describe("DebugHelperTest", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("test_debug", () => {
     const obj = { name: "firebase", count: 42 };
     const output = debug(obj).toString();
@@ -26,16 +30,23 @@ describe("DebugHelperTest", () => {
   });
 
   it("test_debug_with_marshal_error falls back to inspect inside code", () => {
-    const spy = vi.spyOn(yaml, "stringify").mockImplementation(() => {
+    vi.spyOn(yaml, "stringify").mockImplementation(() => {
       throw new Error("boom");
     });
-    try {
-      const out = debug({ html: "<b>x</b>" }).toString();
-      expect(out).toContain('<code class="debug_dump">');
-      expect(out).toContain("</code>");
-      expect(out).not.toContain("<pre");
-    } finally {
-      spy.mockRestore();
-    }
+    const out = debug({ html: "<b>x</b>" }).toString();
+    expect(out).toContain('<code class="debug_dump">');
+    expect(out).toContain("</code>");
+    expect(out).not.toContain("<pre");
+  });
+
+  it("fallback inspect renders circular references as [Circular]", () => {
+    vi.spyOn(yaml, "stringify").mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const circular: Record<string, unknown> = { name: "x" };
+    circular.self = circular;
+    const out = debug(circular).toString();
+    expect(out).toContain("[Circular]");
+    expect(out).toContain("name:");
   });
 });

--- a/packages/actionview/src/helpers/debug-helper.ts
+++ b/packages/actionview/src/helpers/debug-helper.ts
@@ -5,9 +5,10 @@ import { htmlEscape } from "./ejs-util.js";
 
 /**
  * debug — returns a YAML representation of `object` wrapped with `<pre>`.
- * Falls back to a best-effort JSON / `Object.prototype.toString` rendering
- * inside `<code>` if YAML serialization throws (e.g. circular references).
- * Mirrors `ActionView::Helpers::DebugHelper#debug`'s Marshal/YAML rescue path.
+ * Falls back to a recursive inspect-style rendering (objects as
+ * `{ key: value, … }`, arrays as `[v, …]`, cycles as `[Circular]`) inside
+ * `<code>` if YAML serialization throws. Mirrors
+ * `ActionView::Helpers::DebugHelper#debug`'s Marshal/YAML rescue path.
  */
 export function debug(object: unknown): SafeBuffer {
   try {
@@ -32,12 +33,15 @@ function inspect(value: unknown, seen: WeakSet<object> = new WeakSet()): string 
 
   if (seen.has(value as object)) return "[Circular]";
   seen.add(value as object);
-
-  if (Array.isArray(value)) {
-    return `[${value.map((v) => inspect(v, seen)).join(", ")}]`;
+  try {
+    if (Array.isArray(value)) {
+      return `[${value.map((v) => inspect(v, seen)).join(", ")}]`;
+    }
+    const entries = Object.entries(value as Record<string, unknown>).map(
+      ([k, v]) => `${k}: ${inspect(v, seen)}`,
+    );
+    return `{ ${entries.join(", ")} }`;
+  } finally {
+    seen.delete(value as object);
   }
-  const entries = Object.entries(value as Record<string, unknown>).map(
-    ([k, v]) => `${k}: ${inspect(v, seen)}`,
-  );
-  return `{ ${entries.join(", ")} }`;
 }

--- a/packages/actionview/src/helpers/debug-helper.ts
+++ b/packages/actionview/src/helpers/debug-helper.ts
@@ -1,0 +1,34 @@
+import { SafeBuffer } from "@blazetrails/activesupport";
+import { stringify } from "@blazetrails/activesupport/yaml";
+import { contentTag } from "./tag-helper.js";
+import { htmlEscape } from "./ejs-util.js";
+
+/**
+ * debug — returns a YAML representation of `object` wrapped with `<pre>`.
+ * Falls back to a Node.js `util.inspect`-style string inside `<code>` if YAML
+ * serialization throws (e.g. circular references).
+ */
+export function debug(object: unknown): SafeBuffer {
+  try {
+    const yaml = stringify(object);
+    return contentTag("pre", htmlEscape(yaml), { class: "debug_dump" });
+  } catch {
+    return contentTag("code", inspect(object), { class: "debug_dump" });
+  }
+}
+
+function inspect(value: unknown): string {
+  if (value === null) return "null";
+  if (value === undefined) return "undefined";
+  if (typeof value === "string") return JSON.stringify(value);
+  if (typeof value === "bigint") return `${value.toString()}n`;
+  if (typeof value === "function") return value.toString();
+  if (typeof value === "object") {
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return Object.prototype.toString.call(value);
+    }
+  }
+  return String(value);
+}

--- a/packages/actionview/src/helpers/debug-helper.ts
+++ b/packages/actionview/src/helpers/debug-helper.ts
@@ -5,8 +5,9 @@ import { htmlEscape } from "./ejs-util.js";
 
 /**
  * debug — returns a YAML representation of `object` wrapped with `<pre>`.
- * Falls back to a Node.js `util.inspect`-style string inside `<code>` if YAML
- * serialization throws (e.g. circular references).
+ * Falls back to a best-effort JSON / `Object.prototype.toString` rendering
+ * inside `<code>` if YAML serialization throws (e.g. circular references).
+ * Mirrors `ActionView::Helpers::DebugHelper#debug`'s Marshal/YAML rescue path.
  */
 export function debug(object: unknown): SafeBuffer {
   try {

--- a/packages/actionview/src/helpers/debug-helper.ts
+++ b/packages/actionview/src/helpers/debug-helper.ts
@@ -18,18 +18,26 @@ export function debug(object: unknown): SafeBuffer {
   }
 }
 
-function inspect(value: unknown): string {
+function inspect(value: unknown, seen: WeakSet<object> = new WeakSet()): string {
   if (value === null) return "null";
   if (value === undefined) return "undefined";
   if (typeof value === "string") return JSON.stringify(value);
   if (typeof value === "bigint") return `${value.toString()}n`;
-  if (typeof value === "function") return value.toString();
-  if (typeof value === "object") {
-    try {
-      return JSON.stringify(value);
-    } catch {
-      return Object.prototype.toString.call(value);
-    }
+  if (typeof value === "symbol") return value.toString();
+  if (typeof value === "function") {
+    const name = (value as { name?: string }).name;
+    return `[Function${name ? `: ${name}` : " (anonymous)"}]`;
   }
-  return String(value);
+  if (typeof value !== "object") return String(value);
+
+  if (seen.has(value as object)) return "[Circular]";
+  seen.add(value as object);
+
+  if (Array.isArray(value)) {
+    return `[${value.map((v) => inspect(v, seen)).join(", ")}]`;
+  }
+  const entries = Object.entries(value as Record<string, unknown>).map(
+    ([k, v]) => `${k}: ${inspect(v, seen)}`,
+  );
+  return `{ ${entries.join(", ")} }`;
 }

--- a/packages/actionview/src/helpers/index.ts
+++ b/packages/actionview/src/helpers/index.ts
@@ -1,6 +1,8 @@
 export { raw, safeJoin, toSentence } from "./output-safety-helper.js";
 export type { ToSentenceOptions } from "./output-safety-helper.js";
 
+export { debug } from "./debug-helper.js";
+
 export {
   tag,
   contentTag,


### PR DESCRIPTION
## Summary
- Adds `debug(object)` helper mirroring `ActionView::Helpers::DebugHelper#debug`.
- YAML-serializes via `@blazetrails/activesupport/yaml` and wraps the (HTML-escaped) output in `<pre class=\"debug_dump\">`.
- Falls back to a recursive inspect-style formatter inside `<code class=\"debug_dump\">` when serialization throws (objects as `{ key: value }`, arrays as `[v, …]`, true cycles as `[Circular]`). Mirrors Rails' Marshal/YAML rescue path.

## Scope
Bundle 2 Phase 5 T1 from \`docs/actionview-100-percent.md\`. The companion \`output_safety_helper.rb\` is already at 100% (3/3) on this branch — \`raw\`, \`safeJoin\`, \`toSentence\` — so this PR only adds \`debug_helper.rb\`.

\`SafeBuffer\` / \`htmlSafe\` already exist in activesupport (Phase 0b), so no temporary alias is needed.

## Parity
- \`pnpm api:compare --package actionview\` shows \`debug_helper.rb 1/18\` — the 17 missing are the inherited \`TagHelper\` methods (\`include TagHelper\`), not real new methods.

## Test plan
- [x] \`pnpm vitest run --project other packages/actionview/src/helpers/debug-helper.test.ts\` (6 tests pass)
- [x] \`pnpm api:compare --package actionview\`
- [x] \`pnpm --filter @blazetrails/actionview build\`