### PR TITLE
feat(activerecord): withTransactionalFixtures accepts raw adapters (B6.4)

### DIFF
--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -118,8 +118,8 @@ describe("withTransactionalFixtures (raw adapter)", () => {
     await defineSchema(adapter, { raw_fixture_users: { name: "string" } });
   });
 
-  afterAll(() => {
-    adapter.close();
+  afterAll(async () => {
+    await adapter.close();
   });
 
   withTransactionalFixtures(() => adapter);

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -1,9 +1,10 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
   createTestAdapter,
   shouldSkipGlobalReset,
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
+import { SQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
 import { defineSchema } from "./define-schema.js";
 import { withTransactionalFixtures } from "./with-transactional-fixtures.js";
 
@@ -100,5 +101,37 @@ describe("withTransactionalFixtures (useTransactionalTests=false opt-out)", () =
     // pushSkipGlobalReset — otherwise opted-out files would silently
     // bypass the global resetTestAdapterState beforeEach they rely on.
     expect(shouldSkipGlobalReset()).toBe(false);
+  });
+});
+
+// Adapter-cluster files (adapters/postgresql/*.test.ts, etc.) construct a
+// raw DatabaseAdapter directly instead of going through createTestAdapter().
+// The helper must accept that shape — `transactionManager` lives on the
+// adapter itself via AbstractAdapter, not behind an `innerAdapter` wrapper.
+describe("withTransactionalFixtures (raw adapter)", () => {
+  let adapter: SQLite3Adapter;
+  const exec = (sql: string) => adapter.exec(sql);
+  const query = (sql: string) => adapter.execute(sql);
+
+  beforeAll(async () => {
+    adapter = new SQLite3Adapter(":memory:");
+    await defineSchema(adapter, { raw_fixture_users: { name: "string" } });
+  });
+
+  afterAll(() => {
+    adapter.close();
+  });
+
+  withTransactionalFixtures(() => adapter);
+
+  it("rolls back inserts between tests (first run)", async () => {
+    await exec(`INSERT INTO raw_fixture_users (id, name) VALUES (1, 'alice')`);
+    const rows = await query(`SELECT * FROM raw_fixture_users`);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("sees zero rows because the previous insert rolled back", async () => {
+    const rows = await query(`SELECT * FROM raw_fixture_users`);
+    expect(rows).toHaveLength(0);
   });
 });

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -8,7 +8,7 @@ import {
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
 
-interface TxnAdapter {
+interface TxnHost {
   transactionManager: {
     beginTransaction: (opts: { joinable: boolean; _lazy: boolean }) => Promise<unknown>;
     rollbackTransaction: () => Promise<void>;
@@ -22,13 +22,16 @@ interface TxnAdapter {
  * `innerAdapter`) or a raw `DatabaseAdapter` constructed directly by a test
  * file (`new PostgreSQLAdapter(...)`, `new SQLite3Adapter(...)`, etc.) which
  * exposes `transactionManager` on itself via `AbstractAdapter`. Adapter-cluster
- * tests under `adapters/**` predominantly take the raw path.
+ * tests under `adapters/**` predominantly take the raw path. Not every
+ * `DatabaseAdapter` shape in the repo carries `transactionManager` (e.g. the
+ * `QueryCacheAdapter` wrapper in `query-cache.ts`), so the union narrows to
+ * adapters that do — type-checking matches runtime behavior.
  */
-export type TransactionalFixturesAdapter = TestDatabaseAdapter | DatabaseAdapter;
+export type TransactionalFixturesAdapter = TestDatabaseAdapter | (DatabaseAdapter & TxnHost);
 
-function tm(adapter: TransactionalFixturesAdapter): TxnAdapter["transactionManager"] {
+function tm(adapter: TransactionalFixturesAdapter): TxnHost["transactionManager"] {
   const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter;
-  const host = (wrapped ?? adapter) as unknown as Partial<TxnAdapter>;
+  const host = (wrapped ?? adapter) as unknown as Partial<TxnHost>;
   if (!host.transactionManager) {
     throw new Error(
       `withTransactionalFixtures: adapter ${(adapter as { adapterName?: string }).adapterName ?? "unknown"} ` +

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -1,4 +1,5 @@
 import { beforeAll, beforeEach, afterEach, afterAll } from "vitest";
+import type { DatabaseAdapter } from "../adapter.js";
 import {
   getUseTransactionalTests,
   popSkipGlobalReset,
@@ -15,15 +16,26 @@ interface TxnAdapter {
   };
 }
 
-function tm(adapter: TestDatabaseAdapter): TxnAdapter["transactionManager"] {
-  const inner = adapter.innerAdapter as unknown as Partial<TxnAdapter>;
-  if (!inner.transactionManager) {
+/**
+ * The helper accepts either the {@link TestDatabaseAdapter} produced by
+ * {@link createTestAdapter} (whose `transactionManager` lives on the wrapped
+ * `innerAdapter`) or a raw `DatabaseAdapter` constructed directly by a test
+ * file (`new PostgreSQLAdapter(...)`, `new SQLite3Adapter(...)`, etc.) which
+ * exposes `transactionManager` on itself via `AbstractAdapter`. Adapter-cluster
+ * tests under `adapters/**` predominantly take the raw path.
+ */
+export type TransactionalFixturesAdapter = TestDatabaseAdapter | DatabaseAdapter;
+
+function tm(adapter: TransactionalFixturesAdapter): TxnAdapter["transactionManager"] {
+  const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter;
+  const host = (wrapped ?? adapter) as unknown as Partial<TxnAdapter>;
+  if (!host.transactionManager) {
     throw new Error(
       `withTransactionalFixtures: adapter ${(adapter as { adapterName?: string }).adapterName ?? "unknown"} ` +
         `does not expose transactionManager`,
     );
   }
-  return inner.transactionManager;
+  return host.transactionManager;
 }
 
 /**
@@ -78,8 +90,16 @@ function tm(adapter: TestDatabaseAdapter): TxnAdapter["transactionManager"] {
  *   withTransactionalFixtures(() => adapter);
  *
  *   it("inserts a row", async () => { ... });  // rolled back in afterEach
+ *
+ * @example  // adapter-cluster file using a raw adapter directly
+ *   let adapter: PostgreSQLAdapter;
+ *   beforeAll(async () => {
+ *     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+ *     await defineSchema(adapter, { ... });
+ *   });
+ *   withTransactionalFixtures(() => adapter);
  */
-export function withTransactionalFixtures(getAdapter: () => TestDatabaseAdapter): void {
+export function withTransactionalFixtures(getAdapter: () => TransactionalFixturesAdapter): void {
   let active = true;
 
   beforeAll(() => {


### PR DESCRIPTION
## Summary

Unblocks B6.4b adapter-cluster promotion. The pilot files in #1938 all went through `createTestAdapter()`, which returns a `TestDatabaseAdapter` whose `transactionManager` lives behind an `innerAdapter` wrapper. The adapter-cluster files under `adapters/**` (e.g. `adapters/postgresql/bytea.test.ts`, `adapters/sqlite3/json.test.ts`) construct adapters directly — `new PostgreSQLAdapter(PG_TEST_URL)`, `new SQLite3Adapter(":memory:")`, etc. — and expose `transactionManager` on the adapter itself via `AbstractAdapter`.

The helper's `tm()` now falls back to the adapter itself when `innerAdapter` is absent, and the public signature widens to `TestDatabaseAdapter | DatabaseAdapter` (a new exported `TransactionalFixturesAdapter` union). No behavior change for the existing `TestDatabaseAdapter` path; both pre-existing test groups continue to pass.

This is intentionally infra-only so the cluster-file sweep stays a clean follow-up.

## Test plan

- [x] `with-transactional-fixtures.test.ts` — 8 tests pass (5 existing + new raw-`SQLite3Adapter` group covering rollback-between-tests)
- [x] Typecheck clean for the touched files
- [x] Size: 59 insertions / 6 deletions
- [ ] CI green

## Follow-up

- B6.4b proper: migrate the ~10 `adapters/**/*.test.ts` files that already use `defineSchema` to the `beforeAll` + `withTransactionalFixtures` pattern, now possible without casts. Some files have per-test DDL (`CREATE EXTENSION`, `DROP TABLE` in `beforeEach`) that needs to collapse into shared `beforeAll`; a few may need `useTransactionalTests: false` opt-out where they intentionally exercise committed DDL.