### PR TITLE
test(activerecord): migrate associations cluster to transactional fixtures (B6.4a)

### DIFF
--- a/packages/activerecord/src/associations/association-relation.test.ts
+++ b/packages/activerecord/src/associations/association-relation.test.ts
@@ -3,14 +3,14 @@
 // and loaded target stay wired up. Mirrors Rails'
 // ActiveRecord::AssociationRelation behavior.
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, association, registerModel, AssociationRelation } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("AssociationRelation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class ArBlog extends Base {
     declare name: string;
@@ -32,7 +32,7 @@ describe("AssociationRelation", () => {
 
   ArBlog.hasMany("arPosts", { className: "ArPost" });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       ar_blogs: { name: "string" },
@@ -49,6 +49,7 @@ describe("AssociationRelation", () => {
     registerModel(ArBlog);
     registerModel(ArPost);
   });
+  withTransactionalFixtures(() => adapter);
 
   async function freshBlog(): Promise<ArBlog> {
     const blog = new ArBlog({ name: "Dev" });

--- a/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
+++ b/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
@@ -21,21 +21,17 @@
  * cases like `has_many :grandparents, through: :parents, source:
  * :parent` where self-joins are common.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
 import { AliasTracker } from "./alias-tracker.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
-
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("AssociationScope — AliasTracker aliases repeated tables", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class AtUser extends Base {
     static {
@@ -45,8 +41,8 @@ describe("AssociationScope — AliasTracker aliases repeated tables", () => {
     }
   }
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       at_users: { parent_id: "integer", name: "string" },
     });
@@ -68,6 +64,7 @@ describe("AssociationScope — AliasTracker aliases repeated tables", () => {
       source: "children",
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("AliasTracker: bare table on first visit, aliased on repeat, thunk only invoked on repeat", () => {
     // Seed with an unrelated table so the first AtUser visit is

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -10,16 +10,16 @@
  *
  * Reset on init and on `reload()` via `reset_scope`.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("Association scope cache", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class CacheAuthor extends Base {
     static {
@@ -39,7 +39,7 @@ describe("Association scope cache", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       cache_authors: { name: "string" },
@@ -64,6 +64,7 @@ describe("Association scope cache", () => {
       foreignKey: "cache_post_id",
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   // Restore spies even if a test throws — leaked spies on
   // AssociationScope.scope can corrupt sibling tests in this file.

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -1,16 +1,16 @@
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
 import { Associations } from "../associations.js";
 import { AssociationScope, ReflectionProxy } from "./association-scope.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("AssociationScope", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       wr_authors: {},
@@ -50,6 +50,7 @@ describe("AssociationScope", () => {
       int_tags: { label: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);

--- a/packages/activerecord/src/associations/bidirectional-destroy-dependencies.test.ts
+++ b/packages/activerecord/src/associations/bidirectional-destroy-dependencies.test.ts
@@ -1,20 +1,21 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("BidirectionalDestroyDependenciesTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       contents: { title: "string" },
       content_positions: { content_id: "integer", position: "integer" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Content extends Base {

--- a/packages/activerecord/src/associations/collection-proxy-count.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy-count.test.ts
@@ -18,16 +18,16 @@
  * path. Nested-through and `disable_joins: true` through shapes
  * fall back to load-and-length — tracked in task #22.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("CollectionProxy#count — non-through fast path", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class CpcAuthor extends Base {
     static {
@@ -43,7 +43,7 @@ describe("CollectionProxy#count — non-through fast path", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       cpc_authors: { name: "string" },
@@ -61,6 +61,7 @@ describe("CollectionProxy#count — non-through fast path", () => {
       foreignKey: "cpc_author_id",
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterEach(() => Notifications.unsubscribeAll());
 

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -5,14 +5,14 @@
 // associations return today. No reader change yet — these methods
 // just exist on the proxy returned by `association(record, name)`.
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, association, registerModel } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("CollectionProxy — array-likeness (Phase R.1)", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class ApBlog extends Base {
     declare name: string;
@@ -37,7 +37,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   // can find ApPost in the model registry.
   ApBlog.hasMany("apPosts", { className: "ApPost" });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     ApBlog.adapter = adapter;
     ApPost.adapter = adapter;
@@ -48,6 +48,7 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
       ap_posts: { title: "string", ap_blog_id: "integer" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   async function blogWithPosts(): Promise<ApBlog> {
     const blog = new ApBlog({ name: "Dev" });

--- a/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
+++ b/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
@@ -5,15 +5,15 @@
  *   - HMT insert_record two-step alignment (super.insertRecord →
  *     save_through_record) for HABTM
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     b30_owners: { name: "string" },
@@ -27,6 +27,7 @@ beforeEach(async () => {
     b30_posts_b30_tags: { b30_post_id: "integer", b30_tag_id: "integer" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 
 describe("constructor-form association writer", () => {
   function makeHasManyModels() {

--- a/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
+++ b/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
@@ -18,16 +18,16 @@
  * DJAR materializes records to enforce the in-memory reorder.
  * We don't need to materialize for the count, so we emit COUNT.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("CollectionProxy#count — disable_joins through", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class CdAuthor extends Base {
     static {
@@ -50,7 +50,7 @@ describe("CollectionProxy#count — disable_joins through", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       cd_authors: { name: "string" },
@@ -86,6 +86,7 @@ describe("CollectionProxy#count — disable_joins through", () => {
       disableJoins: true,
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterEach(() => Notifications.unsubscribeAll());
 

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -1,12 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   djs_authors: { name: "string" },
@@ -14,14 +14,8 @@ const TEST_SCHEMA: Schema = {
   djs_comments: { djs_post_id: "integer", body: "string" },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
-  await defineSchema(adapter, TEST_SCHEMA);
-  return adapter;
-}
-
 describe("DisableJoinsAssociationScope", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class DjsAuthor extends Base {
     static {
@@ -44,8 +38,9 @@ describe("DisableJoinsAssociationScope", () => {
     }
   }
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
     DjsAuthor.adapter = adapter;
     DjsPost.adapter = adapter;
     DjsComment.adapter = adapter;
@@ -81,6 +76,7 @@ describe("DisableJoinsAssociationScope", () => {
       disableJoins: true,
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   // Backstop in case a test throws before reaching its in-test
   // unsubscribe — leaked sql.active_record subscribers can corrupt

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -14,14 +14,14 @@
  * joins through associations: tuple-style matching across the
  * intermediate records, no JOIN in the generated query shape.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   ck_shops: { name: "string" },
@@ -40,14 +40,8 @@ const TEST_SCHEMA: Schema = {
   },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
-  await defineSchema(adapter, TEST_SCHEMA);
-  return adapter;
-}
-
 describe("DJAS — composite key support", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   // Shopify-style composite-PK shape: (shop_id, order_number). We
   // avoid `id` as the second PK column because Base.id is an accessor
@@ -76,8 +70,9 @@ describe("DJAS — composite key support", () => {
     }
   }
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
     CkShop.adapter = adapter;
     CkOrder.adapter = adapter;
     CkLineItem.adapter = adapter;
@@ -104,6 +99,7 @@ describe("DJAS — composite key support", () => {
       disableJoins: true,
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   // Backstop in case a test throws before reaching its in-test
   // unsubscribe. Same pattern as instrumentation.test.ts.

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -25,13 +25,13 @@
  * line_item_tags) — the middle step emits an Arel OR-of-AND
  * composite predicate from PredicateBuilder.buildComposite.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   ck_shops: { name: "string" },
@@ -51,14 +51,8 @@ const TEST_SCHEMA: Schema = {
   ck_tags: { ck_line_item_id: "integer", value: "string" },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
-  await defineSchema(adapter, TEST_SCHEMA);
-  return adapter;
-}
-
 describe("DJAS composite-key + nested-through", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class CkShop extends Base {
     static {
@@ -91,8 +85,9 @@ describe("DJAS composite-key + nested-through", () => {
     }
   }
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
     CkShop.adapter = adapter;
     CkOrder.adapter = adapter;
     CkLineItem.adapter = adapter;
@@ -134,6 +129,7 @@ describe("DJAS composite-key + nested-through", () => {
       disableJoins: true,
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterEach(() => Notifications.unsubscribeAll());
 

--- a/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
@@ -19,16 +19,16 @@
  * the gate, or a change to `_getChain` that silently falls back,
  * gets caught.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("DJAS routing widening — nested-through", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   // Author → Post → Comment → Rating (4-level chain).
   // `noJoinsNtRatings` on the author is nested: it goes through
@@ -61,7 +61,7 @@ describe("DJAS routing widening — nested-through", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       nt_authors: { name: "string" },
@@ -112,6 +112,7 @@ describe("DJAS routing widening — nested-through", () => {
       disableJoins: true,
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterEach(() => {
     Notifications.unsubscribeAll();

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
@@ -25,13 +25,13 @@
  * (reflection.rb:968); our ReflectionProxy forwards it, and DJAS'
  * `_addConstraintsDj` threads it through the chain walk.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   dp_authors: { name: "string" },
@@ -50,14 +50,8 @@ const TEST_SCHEMA: Schema = {
   },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
-  await defineSchema(adapter, TEST_SCHEMA);
-  return adapter;
-}
-
 describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class DpAuthor extends Base {
     static {
@@ -90,8 +84,9 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
     }
   }
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
     DpAuthor.adapter = adapter;
     DpGallery.adapter = adapter;
     DpNonIdPhoto.adapter = adapter;
@@ -136,6 +131,7 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
       disableJoins: true,
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterEach(() => Notifications.unsubscribeAll());
 

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -18,16 +18,16 @@
  * that re-introduces the gate — or any future change that silently
  * falls back to AssociationScope — is caught.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel } from "../index.js";
 import { Associations, association, loadHasMany } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("DJAS routing widening — sourceType + polymorphic source", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class RwAuthor extends Base {
     static {
@@ -56,7 +56,7 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       rw_authors: { name: "string" },
@@ -110,6 +110,7 @@ describe("DJAS routing widening — sourceType + polymorphic source", () => {
       disableJoins: true,
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterEach(() => {
     Notifications.unsubscribeAll();


### PR DESCRIPTION
## Summary

Promotes 15 `associations/*.test.ts` files to the `beforeAll` + `withTransactionalFixtures`
pattern landed in the #1938 pilot. Schema is defined once per file; each test runs
inside a BEGIN/ROLLBACK pair so test data is isolated without paying for full schema
rebuilds on every `it()`.

The original pilot scope (#1933) was reverted after MariaDB CI failed; #1938 traced
the failure to `test-adapter._createdColumns` not being seeded from `CREATE TABLE`
bodies and fixed it. With that in place, the associations cluster migrates without
further changes.

## Files migrated

- `association-relation`, `association-scope`, `association-scope-alias-tracker`,
  `association-scope-cache`
- `bidirectional-destroy-dependencies`, `collection-proxy`, `collection-proxy-count`,
  `constructor-form-and-hmt-insert`
- `cp-count-disable-joins-through`, `disable-joins-association-scope`,
  `disable-joins-composite-key`, `disable-joins-composite-nested`,
  `disable-joins-nested-through`, `disable-joins-polymorphic-nonid-pk`,
  `disable-joins-routing-widening`

## Test plan

- [x] 15 files green on SQLite (default) — 110 passed, 1 skipped
- [ ] CI green across SQLite, PostgreSQL, MariaDB
- [x] Size: 207 LOC (under 300 ceiling)

## Follow-ups

There are ~20 more `associations/*.test.ts` files using `defineSchema` + `beforeEach`
that can be migrated in a subsequent batch. Files with multiple `beforeEach` blocks
(e.g. `callbacks.test.ts`, `belongs-to-associations.test.ts`,
`inverse-associations.test.ts`) need more careful per-describe migration and are not
included here.

Separately, `constructor-form-and-hmt-insert.test.ts` has a pre-existing failure
under `AR_NO_AUTO_SCHEMA=1` (HABTM derives join table `b30_posts_tags` while the
schema declares `b30_posts_b30_tags`). Reproduced against `main` — not introduced
by this PR.

## Test plan

- [ ] CI green across all adapters