### PR TITLE
test(activerecord): migrate readonly/secure-password/statement-cache to transactional fixtures (B6.4b)

### DIFF
--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -2,13 +2,13 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, ReadOnlyRecord } from "./index.js";
 import { ReadonlyAttributeError } from "./readonly-attributes.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA = {
   posts: { title: "string" },
@@ -19,17 +19,18 @@ const TEST_SCHEMA = {
 } as const;
 
 // -- Helpers --
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("ReadonlyTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModel() {
     class Post extends Base {
@@ -177,10 +178,11 @@ describe("ReadonlyTest", () => {
 });
 
 describe("ReadonlyTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModel() {
     class Post extends Base {
@@ -221,11 +223,12 @@ describe("ReadonlyTest", () => {
 });
 
 describe("ReadonlyTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("cant save readonly record", async () => {
     class Post extends Base {
@@ -258,10 +261,11 @@ describe("ReadonlyTest", () => {
 });
 
 describe("ReadonlyTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("marks loaded records as readonly", async () => {
     class Item extends Base {
@@ -337,10 +341,11 @@ describe("ReadonlyTest", () => {
 });
 
 describe("ReadonlyTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("readonly records cannot be saved", async () => {
     class User extends Base {
@@ -358,11 +363,12 @@ describe("ReadonlyTest", () => {
 });
 
 describe("ReadonlyTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   // Rails: test "readonly record cannot be saved"
   it("cant save readonly record", async () => {

--- a/packages/activerecord/src/readonly.test.ts
+++ b/packages/activerecord/src/readonly.test.ts
@@ -283,8 +283,13 @@ describe("ReadonlyTest", () => {
 });
 
 describe("ReadonlyTest", () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = await freshAdapter();
+  });
+  withTransactionalFixtures(() => adapter);
+
   it("allows setting readonly attributes on create", async () => {
-    const adapter = await freshAdapter();
     class Product extends Base {
       static _tableName = "products";
     }
@@ -303,7 +308,6 @@ describe("ReadonlyTest", () => {
     // on a persisted-record write to an attr_readonly column (readonly_attributes.rb
     // line 49). The Rails test by this name in newer Rails asserts that
     // behavior — the "ignores" wording pre-dates the raise being added.
-    const adapter = await freshAdapter();
     class Product extends Base {
       static _tableName = "products";
     }
@@ -327,7 +331,6 @@ describe("ReadonlyTest", () => {
   });
 
   it("exposes readonlyAttributes list", async () => {
-    const adapter = await freshAdapter();
     class Product extends Base {
       static _tableName = "products";
     }

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -1,17 +1,17 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { performance } from "node:perf_hooks";
 import { Base } from "./index.js";
 import { hasSecurePassword } from "./secure-password.js";
 import { setTokenForSecret } from "./generates-token-for.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 // -- Helpers --
 
 // Union of every column referenced by tests in this file; per-test attribute
 // differences are immaterial (sqlite ignores unread columns).
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, {
     users: {
@@ -29,11 +29,12 @@ async function freshAdapter(): Promise<DatabaseAdapter> {
 // -- Phase 2000: Core --
 
 describe("secure_password", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("hashes password on save and authenticates", async () => {
     class User extends Base {
@@ -98,11 +99,12 @@ describe("secure_password", () => {
 });
 
 describe("SecurePassword (Rails-guided)", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   // Rails: test "authenticate with correct password"
   it("authenticate returns the user on success", async () => {
@@ -181,10 +183,14 @@ describe("SecurePassword (Rails-guided)", () => {
 });
 
 describe("password reset token", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
+  });
+  withTransactionalFixtures(() => adapter);
+
+  beforeEach(() => {
     setTokenForSecret("test-reset-token-secret");
   });
 
@@ -307,11 +313,12 @@ describe("password reset token", () => {
 });
 
 describe("SecurePasswordTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   // Builds a User class with the union of attributes used across these tests.
   // Per-test attribute differences in Rails are immaterial for these tests
@@ -491,10 +498,11 @@ describe("SecurePasswordTest", () => {
 });
 
 describe("hasSecurePassword — per-attribute confirmation, challenge, and salt", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   const makeModel = () => {
     class User extends Base {

--- a/packages/activerecord/src/statement-cache.test.ts
+++ b/packages/activerecord/src/statement-cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Attribute, ValueType } from "@blazetrails/activemodel";
 import {
   StatementCache,
@@ -9,26 +9,22 @@ import {
   Params,
   BindMap,
 } from "./statement-cache.js";
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 describe("StatementCacheTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       books: { name: "string", title: "string" },
       authors: { name: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);


### PR DESCRIPTION
## Summary

Promotes three root `activerecord/src/*.test.ts` files to the `beforeAll` +
`withTransactionalFixtures` pattern landed in #1938 / #1957. Schema is
defined once per describe; each test runs inside a BEGIN/ROLLBACK pair,
eliminating per-test schema rebuilds.

## Files migrated

- `readonly.test.ts` (7 describes)
- `secure-password.test.ts` (5 describes; password-reset token stays in
  `beforeEach` so each test still gets a fresh secret)
- `statement-cache.test.ts` (outer describe migrated; inner round-trip
  blocks retain their own dedicated adapters)

## Test plan

- [x] 3 files green on SQLite (default) — 78 passed, 10 skipped
- [x] 3 files green under `AR_NO_AUTO_SCHEMA=1`
- [ ] CI green across SQLite, PostgreSQL, MariaDB
- [x] Size: 92 LOC (well under 300 ceiling)

## Follow-ups

Deferred for risk/complexity (suitable for subsequent B6.4 slots):

- **`transaction-callbacks`, `transaction-instrumentation`,
  `transaction-isolation`** — exercise commit/rollback/isolation semantics
  directly; an outer wrapper transaction would alter the very behavior
  under test. Likely need `useTransactionalTests: false` opt-out per
  describe.
- **`callbacks`, `autosave-association`, `nested-attributes`,
  `strict-loading`** — per-describe migration is mechanically simple but
  each file has many `beforeEach` blocks and warrants its own focused PR.
- **`instrumentation`, `query-cache`** — currently call `freshAdapter()`
  inline per `it()` rather than via a shared describe-scoped adapter;
  non-trivial restructure to share one adapter across the describe.