### PR TITLE
test(activerecord): migrate relation + validations cluster to transactional fixtures (B6.4c)

### DIFF
--- a/packages/activerecord/src/relation/and.test.ts
+++ b/packages/activerecord/src/relation/and.test.ts
@@ -2,21 +2,22 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
-beforeEach(async () => {
+let adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   adapter = createTestAdapter();
   await defineSchema(adapter, {
     posts: { title: "string", body: "string", author: "string" },
     users: { name: "string", role: "string", active: "boolean" },
   });
 });
+withTransactionalFixtures(() => adapter);
 
 // ==========================================================================
 // AndTest — targets relation/and_test.rb

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -10,14 +10,14 @@
  *
  * Mirrors: ActiveRecord predicate-builder composite-key handling.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("Relation#where — composite-key form", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class CompOrder extends Base {
     static {
@@ -29,7 +29,7 @@ describe("Relation#where — composite-key form", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       comp_orders: {
@@ -48,6 +48,7 @@ describe("Relation#where — composite-key form", () => {
     // registration also avoids the stale-entry leak across the
     // suite that registerModel would otherwise create.
   });
+  withTransactionalFixtures(() => adapter);
 
   it("compiles `where(['c1','c2'], [[v1a,v1b], [v2a,v2b]])` to OR-of-AND of column equalities", async () => {
     await CompOrder.create({ shop_id: 1, order_number: 100, name: "match-1" });

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -1,18 +1,19 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeEach(async () => {
+beforeAll(async () => {
   adapter = createTestAdapter();
   await defineSchema(adapter, {
     arel_posts: { title: "string" },
     posts: { title: "string" },
   });
 });
+withTransactionalFixtures(() => adapter);
 
 describe("DelegationTest", () => {
   it("not respond to arel method", () => {

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -2,21 +2,22 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("RelationMutationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       posts: { title: "string", author: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModel() {
     class Post extends Base {

--- a/packages/activerecord/src/relation/select-star-join-collision.test.ts
+++ b/packages/activerecord/src/relation/select-star-join-collision.test.ts
@@ -17,15 +17,15 @@
  * behavior); callers who want bare `*` there override with
  * `.select("*")`.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("SELECT * column collision in joined relations", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class SsjUser extends Base {
     static {
@@ -41,7 +41,7 @@ describe("SELECT * column collision in joined relations", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       ssj_users: { name: "string" },
@@ -70,6 +70,7 @@ describe("SELECT * column collision in joined relations", () => {
       source: "friend",
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("hydrates the target's columns, not the join table's, when ids collide", async () => {
     const a = await SsjUser.create({ name: "a" });

--- a/packages/activerecord/src/relation/structural-compatibility.test.ts
+++ b/packages/activerecord/src/relation/structural-compatibility.test.ts
@@ -2,22 +2,23 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeEach(async () => {
+beforeAll(async () => {
   adapter = createTestAdapter();
   await defineSchema(adapter, {
     posts: { title: "string", score: "integer" },
     users: { name: "string" },
   });
 });
+withTransactionalFixtures(() => adapter);
 
 // ==========================================================================
 // StructuralCompatibilityTest — targets relation/structural_compatibility_test.rb

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -2,15 +2,15 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: { title: "string", tags_count: "integer" },
@@ -21,7 +21,8 @@ beforeEach(async () => {
     ws_posts: { title: "string", tags_count: "integer" },
   });
 });
-function freshAdapter(): DatabaseAdapter {
+withTransactionalFixtures(() => _adapter);
+function freshAdapter(): TestDatabaseAdapter {
   return _adapter;
 }
 

--- a/packages/activerecord/src/validations/association-validation.test.ts
+++ b/packages/activerecord/src/validations/association-validation.test.ts
@@ -2,21 +2,18 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("AssociationValidationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeAll(() => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = createTestAdapter();
-  });
-  beforeEach(async () => {
     await defineSchema(adapter, {
       posts: { title: "string" },
       comments: { body: "string", post_id: "integer" },
@@ -32,9 +29,7 @@ describe("AssociationValidationTest", () => {
       reply_ctxs: { title: "string" },
     });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("validates associated many", async () => {
     let cidx = 0;

--- a/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
@@ -1,29 +1,23 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { Base } from "../index.js";
 import { I18n } from "@blazetrails/activemodel";
 import { RecordInvalid } from "../validations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 describe("I18nGenerateMessageValidationTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
-  });
-  beforeEach(async () => {
     await defineSchema(adapter, { topics: { title: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
   afterEach(() => {
     I18n.reset();
-  });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-    vi.unstubAllEnvs();
   });
 
   function makeTopic() {

--- a/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-generate-message-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from "vitest";
 import { Base } from "../index.js";
 import { I18n } from "@blazetrails/activemodel";
 import { RecordInvalid } from "../validations.js";
@@ -18,6 +18,9 @@ describe("I18nGenerateMessageValidationTest", () => {
   withTransactionalFixtures(() => adapter);
   afterEach(() => {
     I18n.reset();
+  });
+  afterAll(() => {
+    vi.unstubAllEnvs();
   });
 
   function makeTopic() {

--- a/packages/activerecord/src/validations/numericality-validation.test.ts
+++ b/packages/activerecord/src/validations/numericality-validation.test.ts
@@ -2,30 +2,25 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 import { NumericalityValidator } from "./numericality.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("NumericalityValidationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeAll(() => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = createTestAdapter();
-  });
-  beforeEach(async () => {
     await defineSchema(adapter, {
       widgets: { price: "float", quantity: "integer" },
       widget2s: { price: "float" },
       decimals: { amount: "decimal" },
     });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
   function makeModel() {
     class Widget extends Base {
       static {


### PR DESCRIPTION
## Summary

Promotes 10 `relation/*.test.ts` + `validations/*.test.ts` files to the `beforeAll` + `withTransactionalFixtures` pattern landed in the #1938 pilot and extended in #1956 / #1957 (B6.4 / B6.4a).

Schema is defined once per file; each test runs inside a BEGIN/ROLLBACK pair so test data is isolated without paying for full schema rebuilds on every `it()`.

## Files migrated

**relation/**
- `and`, `composite-where`, `delegation`, `mutation`, `select-star-join-collision`, `structural-compatibility`, `with`

**validations/**
- `association-validation`, `i18n-generate-message-validation`, `numericality-validation`

## Test plan

- [x] 10 files green on SQLite (default) — 112 passed / 3 skipped
- [x] 10 files green under `AR_NO_AUTO_SCHEMA=1`
- [ ] CI green across SQLite, PostgreSQL, MariaDB
- [x] Size: 131 LOC (under 300 ceiling)

## Follow-ups

- Encryption files (`encryptable-record`, `extended-deterministic-queries`) use per-test `freshAdapter()` helpers and need a deeper rework to migrate.
- Larger relation files with many per-describe `beforeEach` blocks (`or`, `where`, `merging`, `delete-all`, `select`, `update-all`, `where-chain`, `where-clause`, `annotations`, `order`, `predicate-builder`, `thenable`) need careful per-describe migration and are deferred.
- `uniqueness-validation` has multiple per-describe schemas and is deferred.