### PR TITLE
test(activerecord): migrate inverse + hmt associations to transactional fixtures (B6.4d1)

### DIFF
--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -1,10 +1,10 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/has_many_through_associations_test.rb
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Base, registerModel, enableSti, registerSubclass, RecordInvalid } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import {
   Associations,
   association,
@@ -536,18 +536,19 @@ const TEST_SCHEMA: Schema = {
   us_posts: { us_author_id: "integer" },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("HasManyThroughAssociationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it.skip("marshal dump", () => {
     // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — marshal

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/inverse_associations_test.rb
  */
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base, association, registerModel, InverseOfAssociationNotFoundError } from "../index.js";
 import {
   Associations,
@@ -13,19 +13,19 @@ import {
   setHasMany,
 } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 // -- Helpers --
-function freshAdapter(): DatabaseAdapter {
+function freshAdapter(): TestDatabaseAdapter {
   return createTestAdapter();
 }
 
 describe("InverseBelongsToTests", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       men: { name: "string" },
@@ -41,6 +41,7 @@ describe("InverseBelongsToTests", () => {
   afterAll(async () => {
     await dropAllTables(adapter);
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Man extends Base {
@@ -396,8 +397,8 @@ describe("InverseBelongsToTests", () => {
 });
 
 describe("InverseHasManyTests", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       men: { name: "string" },
@@ -423,6 +424,7 @@ describe("InverseHasManyTests", () => {
   afterAll(async () => {
     await dropAllTables(adapter);
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Man extends Base {
@@ -769,8 +771,8 @@ describe("InverseHasManyTests", () => {
 });
 
 describe("InverseMultipleHasManyInversesForSameModel", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       men: { name: "string" },
@@ -782,6 +784,7 @@ describe("InverseMultipleHasManyInversesForSameModel", () => {
   afterAll(async () => {
     await dropAllTables(adapter);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("that we can load associations that have the same reciprocal name from different models", async () => {
     class Man extends Base {
@@ -843,8 +846,8 @@ describe("InverseMultipleHasManyInversesForSameModel", () => {
 });
 
 describe("AutomaticInverseFindingTests", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       men: { name: "string" },
@@ -859,6 +862,7 @@ describe("AutomaticInverseFindingTests", () => {
   afterAll(async () => {
     await dropAllTables(adapter);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("has one and belongs to should find inverse automatically on multiple word name", () => {
     // Automatic inverse finding is not yet implemented; inverseOf must be explicit
@@ -1279,8 +1283,8 @@ describe("AutomaticInverseFindingTests", () => {
 });
 
 describe("InversePolymorphicBelongsToTests", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       men: { name: "string" },
@@ -1292,6 +1296,7 @@ describe("InversePolymorphicBelongsToTests", () => {
   afterAll(async () => {
     await dropAllTables(adapter);
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Man extends Base {
@@ -1504,8 +1509,8 @@ describe("InversePolymorphicBelongsToTests", () => {
 
 describe("InverseCachedPathTests", () => {
   // Tests for the _cachedAssociations / _preloadedAssociations fast-paths in loadBelongsTo.
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       cached_men: { name: "string" },
@@ -1518,6 +1523,7 @@ describe("InverseCachedPathTests", () => {
   afterAll(async () => {
     await dropAllTables(adapter);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("wires inverseOf on the cached-associations fast-path", async () => {
     class CachedFace extends Base {
@@ -1591,8 +1597,8 @@ describe("InverseCachedPathTests", () => {
 });
 
 describe("InverseAssociationTests", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       men: { name: "string" },
@@ -1605,6 +1611,7 @@ describe("InverseAssociationTests", () => {
   afterAll(async () => {
     await dropAllTables(adapter);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("should allow for inverse of options in associations", () => {
     class Man extends Base {
@@ -1710,8 +1717,8 @@ describe("InverseAssociationTests", () => {
 });
 
 describe("inverse_of", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       authors: { name: "string" },
@@ -1724,6 +1731,7 @@ describe("inverse_of", () => {
   afterAll(async () => {
     await dropAllTables(adapter);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("sets inverse reference on loaded belongs_to", async () => {
     class Author extends Base {
@@ -1785,8 +1793,8 @@ describe("inverse_of", () => {
 });
 
 describe("InverseHasOneTests", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       men: { name: "string" },
@@ -1798,6 +1806,7 @@ describe("InverseHasOneTests", () => {
   afterAll(async () => {
     await dropAllTables(adapter);
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Man extends Base {


### PR DESCRIPTION
## Summary

Promotes two more `associations/*.test.ts` files to the `beforeAll` +
`withTransactionalFixtures` pattern from #1957:

- `inverse-associations.test.ts` — 9 describe blocks
- `has-many-through-associations.test.ts` — 1 describe block

Each describe's `beforeEach(adapter = freshAdapter(); defineSchema(...))`
moves to `beforeAll`, with `withTransactionalFixtures(() => adapter)`
wrapping each test in BEGIN/ROLLBACK so data is isolated without
re-running DDL between tests. The adapter variable is retyped to
`TestDatabaseAdapter` to match the helper's expected shape.

## Test plan

- [x] Both files green on SQLite (default): 242 passed, 24 skipped
- [x] Both files green on SQLite with `AR_NO_AUTO_SCHEMA=1`
- [ ] CI green across SQLite, PostgreSQL, MariaDB
- [x] Size: 65 LOC (under 300 ceiling)

## Follow-ups (not in this PR)

- **`has-and-belongs-to-many-associations.test.ts`** cannot be migrated
  as-is: several tests call `createTestAdapter()` inline mid-body, which
  sets the module-level `_needsCleanup` flag and causes the next call to
  `adapter.setup()` to drop the shared describe's tables. The original
  per-test `beforeEach` masked this by recreating the schema each time.
  Migrating this file needs the inline-adapter tests rewritten to share
  the describe-level adapter, or a per-file opt-out.

- **`has-many-associations.test.ts`** mostly relies on auto-schema in
  its `beforeEach` blocks (no `defineSchema` call), so transactional
  fixtures would not help until those describes are first promoted to
  explicit `defineSchema`.

- **Big root-level files** (`persistence`, `calculations`, `attributes`)
  each have many `describe` blocks with their own `beforeEach`; they
  need to be split across smaller PRs to stay under the 300 LOC ceiling
  and individually verified — `attributes` in particular uses an inline
  `freshAdapter()` per `it()` and doesn't share an adapter at describe
  scope.