### PR TITLE
fix(actionpack): wire HelperMethodBuilder into urlFor symbol/class/model branches

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.ts
+++ b/packages/actionpack/src/action-dispatch/routing/polymorphic-routes.ts
@@ -83,7 +83,8 @@ export interface PolymorphicOptions {
   [key: string]: unknown;
 }
 
-function isModelClass(x: unknown): x is ModelClass {
+/** @internal */
+export function isModelClass(x: unknown): x is ModelClass {
   return typeof x === "function" && "modelName" in (x as object);
 }
 
@@ -103,7 +104,8 @@ function isHash(x: unknown): boolean {
   return proto === Object.prototype || proto === null;
 }
 
-function symbolToString(s: symbol): string {
+/** @internal */
+export function symbolToString(s: symbol): string {
   const name = s.description;
   if (!name) {
     throw new ArgumentError(

--- a/packages/actionpack/src/action-dispatch/routing/url-for.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/url-for.test.ts
@@ -78,6 +78,12 @@ describe("ActionDispatch::Routing::UrlFor", () => {
     expect(routes.calls[0]![1]).toBe("post");
   });
 
+  it("use_route Symbol() without description throws ArgumentError", () => {
+    expect(() => fullUrlFor.call(makeHost(), { use_route: Symbol() })).toThrow(
+      /description-less Symbol/,
+    );
+  });
+
   it("explicit option wins over urlOptions default", () => {
     const host = makeHost({ defaultUrlOptions: { host: "default.test" } });
     const routes = host._routes as ReturnType<typeof makeRoutes>;
@@ -85,8 +91,45 @@ describe("ActionDispatch::Routing::UrlFor", () => {
     expect(routes.calls[0]![0]).toEqual({ host: "override.test" });
   });
 
-  it("symbol options throw with HelperMethodBuilder reference", () => {
-    expect(() => fullUrlFor.call(makeHost(), Symbol("user"))).toThrow(/HelperMethodBuilder/);
+  it("symbol options delegate to HelperMethodBuilder.url().handleStringCall", () => {
+    const user_url = vi.fn(() => "/users");
+    const host = makeHost();
+    (host as unknown as Record<string, unknown>)["user_url"] = user_url;
+    const result = fullUrlFor.call(host, Symbol("user"));
+    expect(result).toBe("/users");
+    expect(user_url).toHaveBeenCalledOnce();
+  });
+
+  it("class options delegate to HelperMethodBuilder.url().handleClassCall", () => {
+    const users_url = vi.fn(() => "/users");
+    class User {
+      static modelName = {
+        name: "User",
+        singularRouteKey: "user",
+        routeKey: "users",
+      };
+    }
+    const host = makeHost();
+    (host as unknown as Record<string, unknown>)["users_url"] = users_url;
+    const result = fullUrlFor.call(host, User);
+    expect(result).toBe("/users");
+    expect(users_url).toHaveBeenCalledOnce();
+  });
+
+  it("model instance options delegate to HelperMethodBuilder.url().handleModelCall", () => {
+    const user_url = vi.fn(() => "/users/1");
+    const modelName = { name: "User", singularRouteKey: "user", routeKey: "users" };
+    class UserRecord {
+      toModel() {
+        return { modelName, persisted: () => true };
+      }
+    }
+    const user = new UserRecord();
+    const host = makeHost();
+    (host as unknown as Record<string, unknown>)["user_url"] = user_url;
+    const result = fullUrlFor.call(host, user);
+    expect(result).toBe("/users/1");
+    expect(user_url).toHaveBeenCalledOnce();
   });
 
   it("array options delegate to host.polymorphicUrl when present", () => {
@@ -140,14 +183,15 @@ describe("ActionDispatch::Routing::UrlFor", () => {
         return { id: 1 };
       }
     }
-    expect(() => fullUrlFor.call(makeHost(), new FakeParams())).toThrow(/HelperMethodBuilder/);
+    // No toModel() → handleModelCall TypeErrors on record.toModel().
+    expect(() => fullUrlFor.call(makeHost(), new FakeParams())).toThrow(TypeError);
   });
 
   it("class-instance options fall through to HelperMethodBuilder dispatch", () => {
     class Post {
       id = 1;
     }
-    expect(() => fullUrlFor.call(makeHost(), new Post())).toThrow(/HelperMethodBuilder/);
+    expect(() => fullUrlFor.call(makeHost(), new Post())).toThrow(TypeError);
   });
 
   it("optimizeRoutesGeneration requires empty defaultUrlOptions", () => {

--- a/packages/actionpack/src/action-dispatch/routing/url-for.ts
+++ b/packages/actionpack/src/action-dispatch/routing/url-for.ts
@@ -11,7 +11,15 @@
 
 import { NO_ROUTES_MESSAGE } from "../../abstract-controller/url-for.js";
 import { Parameters } from "../../action-controller/metal/strong-parameters.js";
-import type { PolymorphicMappingEntry } from "./polymorphic-routes.js";
+import {
+  HelperMethodBuilder,
+  isModelClass,
+  symbolToString,
+  type ModelClass,
+  type PolymorphicHost,
+  type PolymorphicMappingEntry,
+  type ToModel,
+} from "./polymorphic-routes.js";
 
 // Re-export the PolymorphicRoutes mixin functions. Rails: `module UrlFor;
 // include PolymorphicRoutes`. The functions are `this`-typed and hosts attach
@@ -128,16 +136,23 @@ export function fullUrlFor(this: UrlForHost, options?: UrlForOptions): string {
       rawRouteName == null
         ? null
         : typeof rawRouteName === "symbol"
-          ? (rawRouteName.description ?? null)
+          ? symbolToString(rawRouteName)
           : String(rawRouteName);
     return requireRoutes(this).urlFor(merged, routeName);
   }
-  // Symbol / Function / model — Rails delegates to HelperMethodBuilder.url
-  // (in route_set.rb), which is not yet ported. Mirror the dispatch shape
-  // so callers see the right surface area.
-  throw new Error(
-    `urlFor(${typeof options}) requires HelperMethodBuilder (not yet ported from route_set.rb)`,
-  );
+  // Rails: `case options when Symbol ... when Class ... else` delegates to
+  // `HelperMethodBuilder.url.{handle_string,_class,_model}_call`. The PolymorphicHost
+  // contract is what HelperMethodBuilder dispatches against; UrlForHost satisfies
+  // it (both expose `_routes` and host-side dynamic helper methods).
+  const builder = HelperMethodBuilder.url();
+  const target = this as unknown as PolymorphicHost;
+  if (typeof options === "symbol") {
+    return builder.handleStringCall(target, symbolToString(options));
+  }
+  if (isModelClass(options)) {
+    return builder.handleClassCall(target, options as ModelClass);
+  }
+  return builder.handleModelCall(target, options as ToModel);
 }
 
 /**


### PR DESCRIPTION
## Summary

Rails' `UrlFor#full_url_for` dispatches `Symbol`/`Class`/else to
`HelperMethodBuilder.url.handle_{string,class,model}_call`. The stubs
in `action-dispatch/routing/url-for.ts` still referenced "not yet ported"
wording, but `HelperMethodBuilder` landed in #1855. This wires the three
branches to live delegates.

Also throw on `use_route: Symbol()` with no `.description` via the shared
`symbolToString` helper (previously silently fell through to `null`),
matching the polymorphic-routes contract.

Plan doc entry: Tier 1 — `routing/url_for` (#1825) in `docs/actionpack-100-percent.md:70`.

## Changes

- `url-for.ts`: import `HelperMethodBuilder`/`isModelClass`/`symbolToString`; dispatch Symbol→`handleStringCall`, Class→`handleClassCall`, else→`handleModelCall`; route `use_route: Symbol` through `symbolToString` (throws on description-less symbols).
- `polymorphic-routes.ts`: export `isModelClass` and `symbolToString` as `@internal` helpers.
- Tests: replace the 3 "throws /HelperMethodBuilder/" assertions with live dispatch tests; add `use_route: Symbol()` description-less throw.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/routing/url-for.test.ts` — 27/27
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/routing/polymorphic-routes.test.ts`
- [x] `pnpm build` / `pnpm lint --fix`