### PR TITLE
feat(actionpack): port ContentSecurityPolicy::Middleware + Request nonce

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -6,6 +6,13 @@
 
 export type CSPSource = string | ((request?: unknown) => string);
 
+/**
+ * Rails' default nonce-eligible directives. Mirrors
+ * `DEFAULT_NONCE_DIRECTIVES = %w[script-src style-src]`
+ * (actionpack/lib/action_dispatch/http/content_security_policy.rb:174).
+ */
+export const DEFAULT_NONCE_DIRECTIVES = ["script-src", "style-src"] as const;
+
 const SCRIPT_DIRECTIVES = ["script_src", "script_src_attr", "script_src_elem"] as const;
 
 const STYLE_DIRECTIVES = ["style_src", "style_src_attr", "style_src_elem"] as const;
@@ -153,8 +160,9 @@ export class ContentSecurityPolicy {
 
   // --- Build ---
 
-  build(request?: unknown, nonce?: string): string {
+  build(request?: unknown, nonce?: string, nonceDirectives?: readonly string[]): string {
     const parts: string[] = [];
+    const nonceDirs = nonceDirectives ?? DEFAULT_NONCE_DIRECTIVES;
 
     for (const [directive, sources] of this.directives) {
       const resolved = sources.map((s) => {
@@ -172,9 +180,9 @@ export class ContentSecurityPolicy {
         if (val.includes(";")) throw new Error(`Invalid CSP source: contains semicolon`);
       }
 
-      // Add nonce to script/style sources
+      // Add nonce to nonce-eligible directives (Rails default: script-src, style-src)
       const allSources = [...resolved];
-      if (nonce && (directive.startsWith("script-src") || directive.startsWith("style-src"))) {
+      if (nonce && nonceDirs.includes(directive)) {
         allSources.push(`'nonce-${nonce}'`);
       }
 
@@ -207,4 +215,91 @@ export class ContentSecurityPolicy {
   hasDirective(name: string): boolean {
     return this.directives.has(name);
   }
+}
+
+// ---------------------------------------------------------------------------
+// ActionDispatch::ContentSecurityPolicy::Request mixin
+// ---------------------------------------------------------------------------
+
+/**
+ * Rack env keys read/written by the CSP middleware and per-request DSL.
+ * Mirrors the Rails `Request` module constants
+ * (actionpack/lib/action_dispatch/http/content_security_policy.rb:74-78).
+ */
+export const POLICY = "action_dispatch.content_security_policy";
+export const POLICY_REPORT_ONLY = "action_dispatch.content_security_policy_report_only";
+export const NONCE_GENERATOR = "action_dispatch.content_security_policy_nonce_generator";
+export const NONCE = "action_dispatch.content_security_policy_nonce";
+export const NONCE_DIRECTIVES = "action_dispatch.content_security_policy_nonce_directives";
+
+/** Minimal host shape — `Request` satisfies this via `getHeader`/`setHeader`. */
+export interface CspRequestHost {
+  getHeader(key: string): unknown;
+  setHeader(key: string, value: unknown): unknown;
+}
+
+/** @internal Per-request nonce generator: `(request) => string`. */
+export type NonceGenerator = (request: unknown) => string;
+
+export function contentSecurityPolicy(this: CspRequestHost): ContentSecurityPolicy | undefined {
+  return this.getHeader(POLICY) as ContentSecurityPolicy | undefined;
+}
+
+export function setContentSecurityPolicy(
+  this: CspRequestHost,
+  policy: ContentSecurityPolicy | null,
+): void {
+  this.setHeader(POLICY, policy);
+}
+
+export function contentSecurityPolicyReportOnly(this: CspRequestHost): boolean | undefined {
+  return this.getHeader(POLICY_REPORT_ONLY) as boolean | undefined;
+}
+
+export function setContentSecurityPolicyReportOnly(this: CspRequestHost, value: boolean): void {
+  this.setHeader(POLICY_REPORT_ONLY, value);
+}
+
+export function contentSecurityPolicyNonceGenerator(
+  this: CspRequestHost,
+): NonceGenerator | undefined {
+  return this.getHeader(NONCE_GENERATOR) as NonceGenerator | undefined;
+}
+
+export function setContentSecurityPolicyNonceGenerator(
+  this: CspRequestHost,
+  generator: NonceGenerator,
+): void {
+  this.setHeader(NONCE_GENERATOR, generator);
+}
+
+export function contentSecurityPolicyNonceDirectives(
+  this: CspRequestHost,
+): readonly string[] | undefined {
+  return this.getHeader(NONCE_DIRECTIVES) as readonly string[] | undefined;
+}
+
+export function setContentSecurityPolicyNonceDirectives(
+  this: CspRequestHost,
+  directives: readonly string[],
+): void {
+  this.setHeader(NONCE_DIRECTIVES, directives);
+}
+
+/**
+ * Per-request CSP nonce. Returns `undefined` unless a nonce generator is
+ * configured; otherwise lazily memoizes the generated nonce in the env so
+ * repeated reads return the same value (one nonce per request).
+ *
+ * Mirrors Rails `Request#content_security_policy_nonce`
+ * (actionpack/lib/action_dispatch/http/content_security_policy.rb:112-120).
+ */
+export function contentSecurityPolicyNonce(this: CspRequestHost): string | undefined {
+  const generator = contentSecurityPolicyNonceGenerator.call(this);
+  if (!generator) return undefined;
+  const existing = this.getHeader(NONCE) as string | undefined;
+  if (existing !== undefined) return existing;
+  const generated = generator(this);
+  this.setHeader(NONCE, generated);
+  return generated;
 }

--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -241,8 +241,10 @@ export interface CspRequestHost {
 /** @internal Per-request nonce generator: `(request) => string`. */
 export type NonceGenerator = (request: unknown) => string;
 
-export function contentSecurityPolicy(this: CspRequestHost): ContentSecurityPolicy | undefined {
-  return this.getHeader(POLICY) as ContentSecurityPolicy | undefined;
+export function contentSecurityPolicy(
+  this: CspRequestHost,
+): ContentSecurityPolicy | null | undefined {
+  return this.getHeader(POLICY) as ContentSecurityPolicy | null | undefined;
 }
 
 export function setContentSecurityPolicy(

--- a/packages/actionpack/src/action-dispatch/http/index.ts
+++ b/packages/actionpack/src/action-dispatch/http/index.ts
@@ -2,7 +2,7 @@ export { Request } from "./request.js";
 export { Response, type CookieOptions } from "./response.js";
 export { MimeType } from "./mime-type.js";
 export { UploadedFile, type UploadedFileOptions } from "./upload.js";
-export { ContentSecurityPolicy, type CSPSource } from "./content-security-policy.js";
+export * from "./content-security-policy.js";
 export {
   PermissionsPolicy,
   type PermissionSource,

--- a/packages/actionpack/src/action-dispatch/http/index.ts
+++ b/packages/actionpack/src/action-dispatch/http/index.ts
@@ -2,7 +2,22 @@ export { Request } from "./request.js";
 export { Response, type CookieOptions } from "./response.js";
 export { MimeType } from "./mime-type.js";
 export { UploadedFile, type UploadedFileOptions } from "./upload.js";
-export * from "./content-security-policy.js";
+export {
+  ContentSecurityPolicy,
+  DEFAULT_NONCE_DIRECTIVES,
+  contentSecurityPolicy,
+  setContentSecurityPolicy,
+  contentSecurityPolicyReportOnly,
+  setContentSecurityPolicyReportOnly,
+  contentSecurityPolicyNonceGenerator,
+  setContentSecurityPolicyNonceGenerator,
+  contentSecurityPolicyNonceDirectives,
+  setContentSecurityPolicyNonceDirectives,
+  contentSecurityPolicyNonce,
+  type CSPSource,
+  type CspRequestHost,
+  type NonceGenerator,
+} from "./content-security-policy.js";
 export {
   PermissionsPolicy,
   type PermissionSource,

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -54,6 +54,7 @@ export {
 export { MiddlewareStack } from "./middleware/stack.js";
 export { MimeType } from "./http/mime-type.js";
 export { ContentSecurityPolicy, type CSPSource } from "./http/content-security-policy.js";
+export { ContentSecurityPolicyMiddleware } from "./middleware/content-security-policy.js";
 export { redirectTo, redirectBack, type RedirectResult } from "./redirect.js";
 export { FlashHash } from "./middleware/flash.js";
 export { Static, type StaticOptions } from "./middleware/static.js";

--- a/packages/actionpack/src/action-dispatch/middleware/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/content-security-policy.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { bodyFromString } from "@blazetrails/rack";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { ContentSecurityPolicyMiddleware } from "./content-security-policy.js";
+import { ContentSecurityPolicy } from "../http/content-security-policy.js";
+import { CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY_REPORT_ONLY } from "../constants.js";
+
+const DEFAULT_CSP = "default-src 'self' https: http:";
+
+function buildEnv(overrides: Record<string, unknown> = {}): RackEnv {
+  const policy = new ContentSecurityPolicy();
+  policy.defaultSrc(() => "'self'");
+  return {
+    REQUEST_METHOD: "GET",
+    PATH_INFO: "/",
+    "action_dispatch.content_security_policy": policy,
+    "action_dispatch.content_security_policy_nonce_generator": () => "iyhD0Yc0W+c=",
+    "action_dispatch.content_security_policy_report_only": false,
+    ...overrides,
+  };
+}
+
+describe("ContentSecurityPolicyMiddleware", () => {
+  let env: RackEnv;
+
+  beforeEach(() => {
+    env = buildEnv();
+  });
+
+  it("writes CSP header from request policy", async () => {
+    const app = async (): Promise<RackResponse> => [200, {}, bodyFromString("")];
+    const mw = new ContentSecurityPolicyMiddleware(app);
+    const [, headers] = await mw.call(env);
+    expect(headers[CONTENT_SECURITY_POLICY]).toContain("default-src 'self'");
+  });
+
+  it("does not override existing app CSP header", async () => {
+    const app = async (): Promise<RackResponse> => [
+      200,
+      { [CONTENT_SECURITY_POLICY]: DEFAULT_CSP },
+      bodyFromString(""),
+    ];
+    const mw = new ContentSecurityPolicyMiddleware(app);
+    const [, headers] = await mw.call(env);
+    expect(headers[CONTENT_SECURITY_POLICY]).toBe(DEFAULT_CSP);
+  });
+
+  it("does not override existing app CSP report-only header", async () => {
+    env["action_dispatch.content_security_policy_report_only"] = true;
+    const app = async (): Promise<RackResponse> => [
+      200,
+      { [CONTENT_SECURITY_POLICY_REPORT_ONLY]: DEFAULT_CSP },
+      bodyFromString(""),
+    ];
+    const mw = new ContentSecurityPolicyMiddleware(app);
+    const [, headers] = await mw.call(env);
+    expect(headers[CONTENT_SECURITY_POLICY_REPORT_ONLY]).toBe(DEFAULT_CSP);
+  });
+
+  it("uses report-only header when configured", async () => {
+    env["action_dispatch.content_security_policy_report_only"] = true;
+    const app = async (): Promise<RackResponse> => [200, {}, bodyFromString("")];
+    const mw = new ContentSecurityPolicyMiddleware(app);
+    const [, headers] = await mw.call(env);
+    expect(headers[CONTENT_SECURITY_POLICY_REPORT_ONLY]).toBeDefined();
+    expect(headers[CONTENT_SECURITY_POLICY]).toBeUndefined();
+  });
+
+  it("skips CSP injection on 304 Not Modified", async () => {
+    const app = async (): Promise<RackResponse> => [304, {}, bodyFromString("")];
+    const mw = new ContentSecurityPolicyMiddleware(app);
+    const [, headers] = await mw.call(env);
+    expect(headers[CONTENT_SECURITY_POLICY]).toBeUndefined();
+  });
+
+  it("returns response unchanged when no policy is set", async () => {
+    const noPolicyEnv: RackEnv = { REQUEST_METHOD: "GET", PATH_INFO: "/" };
+    const app = async (): Promise<RackResponse> => [200, {}, bodyFromString("")];
+    const mw = new ContentSecurityPolicyMiddleware(app);
+    const [, headers] = await mw.call(noPolicyEnv);
+    expect(headers[CONTENT_SECURITY_POLICY]).toBeUndefined();
+  });
+
+  it("includes a nonce when generator is configured", async () => {
+    const policy = new ContentSecurityPolicy();
+    policy.scriptSrc("'self'");
+    env["action_dispatch.content_security_policy"] = policy;
+    const app = async (): Promise<RackResponse> => [200, {}, bodyFromString("")];
+    const mw = new ContentSecurityPolicyMiddleware(app);
+    const [, headers] = await mw.call(env);
+    expect(headers[CONTENT_SECURITY_POLICY]).toContain("'nonce-iyhD0Yc0W+c='");
+  });
+
+  it("memoizes the nonce across reads (one per request)", async () => {
+    let calls = 0;
+    env["action_dispatch.content_security_policy_nonce_generator"] = () => {
+      calls++;
+      return "abc";
+    };
+    const policy = new ContentSecurityPolicy();
+    policy.scriptSrc("'self'");
+    policy.styleSrc("'self'");
+    env["action_dispatch.content_security_policy"] = policy;
+    const app = async (): Promise<RackResponse> => [200, {}, bodyFromString("")];
+    await new ContentSecurityPolicyMiddleware(app).call(env);
+    expect(calls).toBe(1);
+  });
+
+  it("respects custom nonce-directives env override", async () => {
+    env["action_dispatch.content_security_policy_nonce_directives"] = ["script-src"];
+    const policy = new ContentSecurityPolicy();
+    policy.scriptSrc("'self'");
+    policy.styleSrc("'self'");
+    env["action_dispatch.content_security_policy"] = policy;
+    const app = async (): Promise<RackResponse> => [200, {}, bodyFromString("")];
+    const [, headers] = await new ContentSecurityPolicyMiddleware(app).call(env);
+    const header = headers[CONTENT_SECURITY_POLICY] as string;
+    expect(header).toMatch(/script-src 'self' 'nonce-/);
+    expect(header).not.toMatch(/style-src 'self' 'nonce-/);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/content-security-policy.test.ts
@@ -2,7 +2,11 @@ import { describe, it, expect, beforeEach } from "vitest";
 import { bodyFromString } from "@blazetrails/rack";
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { ContentSecurityPolicyMiddleware } from "./content-security-policy.js";
-import { ContentSecurityPolicy } from "../http/content-security-policy.js";
+import {
+  ContentSecurityPolicy,
+  contentSecurityPolicyNonce,
+} from "../http/content-security-policy.js";
+import { Request } from "../http/request.js";
 import { CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY_REPORT_ONLY } from "../constants.js";
 
 const DEFAULT_CSP = "default-src 'self' https: http:";
@@ -104,8 +108,6 @@ describe("ContentSecurityPolicyMiddleware", () => {
       calls++;
       return "abc";
     };
-    const { Request } = await import("../http/request.js");
-    const { contentSecurityPolicyNonce } = await import("../http/content-security-policy.js");
     const request = new Request(env);
     expect(contentSecurityPolicyNonce.call(request)).toBe("abc");
     expect(contentSecurityPolicyNonce.call(request)).toBe("abc");

--- a/packages/actionpack/src/action-dispatch/middleware/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/content-security-policy.test.ts
@@ -27,14 +27,16 @@ describe("ContentSecurityPolicyMiddleware", () => {
     env = buildEnv();
   });
 
-  it("writes CSP header from request policy", async () => {
+  // Rails: test_rack_lint — trails has no Rack::Lint, so we exercise the
+  // middleware end-to-end and assert it produces a CSP header without raising.
+  it("rack lint", async () => {
     const app = async (): Promise<RackResponse> => [200, {}, bodyFromString("")];
     const mw = new ContentSecurityPolicyMiddleware(app);
     const [, headers] = await mw.call(env);
     expect(headers[CONTENT_SECURITY_POLICY]).toContain("default-src 'self'");
   });
 
-  it("does not override existing app CSP header", async () => {
+  it("does not override app content security policy", async () => {
     const app = async (): Promise<RackResponse> => [
       200,
       { [CONTENT_SECURITY_POLICY]: DEFAULT_CSP },
@@ -45,7 +47,7 @@ describe("ContentSecurityPolicyMiddleware", () => {
     expect(headers[CONTENT_SECURITY_POLICY]).toBe(DEFAULT_CSP);
   });
 
-  it("does not override existing app CSP report-only header", async () => {
+  it("does not override app content security policy report only", async () => {
     env["action_dispatch.content_security_policy_report_only"] = true;
     const app = async (): Promise<RackResponse> => [
       200,

--- a/packages/actionpack/src/action-dispatch/middleware/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/content-security-policy.test.ts
@@ -94,17 +94,22 @@ describe("ContentSecurityPolicyMiddleware", () => {
   });
 
   it("memoizes the nonce across reads (one per request)", async () => {
+    // Mirrors Rails' "one nonce per request" invariant
+    // (content_security_policy.rb:112-120): repeated reads of
+    // content_security_policy_nonce return the cached env value rather than
+    // re-invoking the generator. We assert this directly on the Request mixin
+    // since the middleware itself only reads the nonce once per request.
     let calls = 0;
     env["action_dispatch.content_security_policy_nonce_generator"] = () => {
       calls++;
       return "abc";
     };
-    const policy = new ContentSecurityPolicy();
-    policy.scriptSrc("'self'");
-    policy.styleSrc("'self'");
-    env["action_dispatch.content_security_policy"] = policy;
-    const app = async (): Promise<RackResponse> => [200, {}, bodyFromString("")];
-    await new ContentSecurityPolicyMiddleware(app).call(env);
+    const { Request } = await import("../http/request.js");
+    const { contentSecurityPolicyNonce } = await import("../http/content-security-policy.js");
+    const request = new Request(env);
+    expect(contentSecurityPolicyNonce.call(request)).toBe("abc");
+    expect(contentSecurityPolicyNonce.call(request)).toBe("abc");
+    expect(contentSecurityPolicyNonce.call(request)).toBe("abc");
     expect(calls).toBe(1);
   });
 

--- a/packages/actionpack/src/action-dispatch/middleware/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/content-security-policy.ts
@@ -1,0 +1,64 @@
+/**
+ * ActionDispatch::ContentSecurityPolicy::Middleware
+ *
+ * Materializes a per-request `ActionDispatch::ContentSecurityPolicy` into the
+ * `Content-Security-Policy` (or `-Report-Only`) response header. Mirrors
+ * actionpack/lib/action_dispatch/http/content_security_policy.rb:32-71.
+ */
+
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import { CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY_REPORT_ONLY } from "../constants.js";
+import { Request } from "../http/request.js";
+import {
+  contentSecurityPolicy,
+  contentSecurityPolicyNonce,
+  contentSecurityPolicyNonceDirectives,
+  contentSecurityPolicyReportOnly,
+} from "../http/content-security-policy.js";
+
+type RackApp = (env: RackEnv) => Promise<RackResponse>;
+
+export class ContentSecurityPolicyMiddleware {
+  private app: RackApp;
+
+  constructor(app: RackApp) {
+    this.app = app;
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    const response = await this.app(env);
+    const [status, headers] = response;
+
+    // Returning CSP headers with a 304 Not Modified is harmful, since nonces
+    // in the new CSP headers might not match nonces in the cached HTML.
+    if (status === 304) return response;
+    if (this.policyPresent(headers)) return response;
+
+    const request = new Request(env);
+    const policy = contentSecurityPolicy.call(request);
+    if (!policy) return response;
+
+    const nonce = contentSecurityPolicyNonce.call(request);
+    const nonceDirectives = contentSecurityPolicyNonceDirectives.call(request);
+    const context =
+      (env["action_controller.instance"] as unknown) ??
+      (request as unknown as { controllerInstance?: unknown }).controllerInstance ??
+      request;
+
+    headers[this.headerName(request)] = policy.build(context, nonce, nonceDirectives);
+    return response;
+  }
+
+  private headerName(request: Request): string {
+    return contentSecurityPolicyReportOnly.call(request)
+      ? CONTENT_SECURITY_POLICY_REPORT_ONLY
+      : CONTENT_SECURITY_POLICY;
+  }
+
+  private policyPresent(headers: Record<string, unknown>): boolean {
+    return (
+      headers[CONTENT_SECURITY_POLICY] != null ||
+      headers[CONTENT_SECURITY_POLICY_REPORT_ONLY] != null
+    );
+  }
+}

--- a/packages/actionpack/src/action-dispatch/middleware/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/content-security-policy.ts
@@ -6,7 +6,7 @@
  * actionpack/lib/action_dispatch/http/content_security_policy.rb:32-71.
  */
 
-import type { RackEnv, RackResponse } from "@blazetrails/rack";
+import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
 import { CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY_REPORT_ONLY } from "../constants.js";
 import { Request } from "../http/request.js";
 import {
@@ -15,8 +15,6 @@ import {
   contentSecurityPolicyNonceDirectives,
   contentSecurityPolicyReportOnly,
 } from "../http/content-security-policy.js";
-
-type RackApp = (env: RackEnv) => Promise<RackResponse>;
 
 export class ContentSecurityPolicyMiddleware {
   private app: RackApp;
@@ -58,7 +56,7 @@ export class ContentSecurityPolicyMiddleware {
       : CONTENT_SECURITY_POLICY;
   }
 
-  private policyPresent(headers: Record<string, unknown>): boolean {
+  private policyPresent(headers: Record<string, string>): boolean {
     return (
       headers[CONTENT_SECURITY_POLICY] != null ||
       headers[CONTENT_SECURITY_POLICY_REPORT_ONLY] != null

--- a/packages/actionpack/src/action-dispatch/middleware/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/content-security-policy.ts
@@ -40,10 +40,13 @@ export class ContentSecurityPolicyMiddleware {
 
     const nonce = contentSecurityPolicyNonce.call(request);
     const nonceDirectives = contentSecurityPolicyNonceDirectives.call(request);
-    const context =
-      (env["action_controller.instance"] as unknown) ??
-      (request as unknown as { controllerInstance?: unknown }).controllerInstance ??
-      request;
+    // Rails: `context = request.controller_instance || request`
+    // (content_security_policy.rb:51). `controller_instance` reads the
+    // `action_controller.instance` env slot (http/request.rb:190-192). Until
+    // the trails metal sets that env slot consistently, the fallback to
+    // `request` is what gets exercised — but we keep the env lookup so that
+    // wiring lands without revisiting this file.
+    const context = env["action_controller.instance"] ?? request;
 
     headers[this.headerName(request)] = policy.build(context, nonce, nonceDirectives);
     return response;


### PR DESCRIPTION
## Summary

- Port `ActionDispatch::ContentSecurityPolicy::Middleware` — materializes a per-request CSP into the `Content-Security-Policy` (or `-Report-Only`) response header, with 304 passthrough and respect for app-supplied headers (mirrors `actionpack/lib/action_dispatch/http/content_security_policy.rb:32-71`).
- Port the `Request` mixin (`contentSecurityPolicy` / `Nonce` / `Generator` / `Directives`) as standalone functions reading/writing the rack env keys Rails uses. The nonce is lazily memoized on the env so the generator runs once per request.
- Extend `ContentSecurityPolicy.build()` with a `nonceDirectives` parameter (default = Rails' `DEFAULT_NONCE_DIRECTIVES = ["script-src", "style-src"]`), replacing the previous `startsWith`-based check so script-src-attr/elem no longer pick up nonces by default.

Follow-up to #1948. Helper-method registration for `isContentSecurityPolicy` / `contentSecurityPolicyNonce` on `ActionController::Base` already exists (`action-controller/base.ts:672-676`); this PR completes the dispatch side.

## Test plan
- [x] New middleware tests cover header injection, 304 passthrough, report-only branch, no-policy passthrough, nonce inclusion + per-request memoization, and custom `nonceDirectives` override
- [x] Existing CSP DSL + metal CSP tests still pass
- [x] `pnpm -w build` clean
- [x] PR size: 285 LOC (under 300 ceiling)