### PR TITLE
test(activerecord): defineSchema for has-many tail + warn on shared-adapter sharp edge

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -8037,10 +8037,17 @@ describe("HasManyAssociationsTest", () => {
   });
 });
 
+const TAIL_PRIMARY_KEYS_SCHEMA: Schema = {
+  cpk_authors: { name: "string" },
+  cpk_posts: { author_id: "integer", title: "string" },
+  cpk_asg_authors: { name: "string" },
+  cpk_asg_posts: { author_id: "integer", title: "string" },
+};
+
 describe("HasManyAssociationsTestPrimaryKeys", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapterWithSchema(TAIL_PRIMARY_KEYS_SCHEMA);
   });
 
   it("has many custom primary key", async () => {
@@ -8089,10 +8096,33 @@ describe("HasManyAssociationsTestPrimaryKeys", () => {
   });
 });
 
+const TAIL_HMT_SCHEMA: Schema = {
+  no_cb_authors: { name: "string" },
+  no_cb_posts: { author_id: "integer", title: "string" },
+  reset_authors: { name: "string" },
+  reset_posts: { author_id: "integer", title: "string" },
+  del_cc_authors: { name: "string", posts_count: "integer" },
+  del_cc_posts: { author_id: "integer", title: "string" },
+  dep_del_authors: { name: "string" },
+  dep_del_posts: { author_id: "integer", title: "string" },
+  null_authors: { name: "string" },
+  null_posts: { author_id: "integer", title: "string" },
+  one_authors: { name: "string" },
+  one_posts: { author_id: "integer", title: "string" },
+  abs_poly_comments: { body: "string", commentable_id: "integer", commentable_type: "string" },
+  abs_poly_posts: { title: "string" },
+  cust_poly_comments: { body: "string", taggable_id: "integer", taggable_type: "string" },
+  cust_poly_posts: { title: "string" },
+  no_raise_authors: { name: "string" },
+  no_raise_posts: { author_id: "integer", title: "string" },
+  preload_authors: { name: "string" },
+  preload_posts: { author_id: "integer", title: "string" },
+};
+
 describe("HasManyAssociationsTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapterWithSchema(TAIL_HMT_SCHEMA);
   });
 
   it("do not call callbacks for delete all", async () => {
@@ -8378,10 +8408,15 @@ describe("HasManyAssociationsTest", () => {
   });
 });
 
+const TAIL_ASYNC_SCHEMA: Schema = {
+  async_authors: { name: "string" },
+  async_posts: { author_id: "integer", title: "string" },
+};
+
 describe("AsyncHasManyAssociationsTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapterWithSchema(TAIL_ASYNC_SCHEMA);
   });
 
   it("async load has many", async () => {
@@ -8411,10 +8446,17 @@ describe("AsyncHasManyAssociationsTest", () => {
   });
 });
 
+const TAIL_HMT2_SCHEMA: Schema = {
+  cn_posts: { title: "string", my_comment_count: "integer" },
+  cn_comments: { body: "string", post_id: "integer" },
+  r_widgets: { name: "string", container_id: "integer" },
+  r_containers: { name: "string" },
+};
+
 describe("HasManyAssociationsTest", () => {
   let adapter: DatabaseAdapter;
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeEach(async () => {
+    adapter = await freshAdapterWithSchema(TAIL_HMT2_SCHEMA);
   });
 
   it("custom named counter cache", async () => {

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -659,10 +659,33 @@ export interface TestDatabaseAdapter extends DatabaseAdapter {
   readonly tables: Set<string>;
 }
 
+let _createTestAdapterWarned = false;
+
 /**
  * Create a fresh adapter for testing.
+ *
+ * SHARP EDGE — calling this **inside** a `withTransactionalFixtures` scope
+ * (i.e. mid-test, after `beforeAll` set up the shared adapter) sets the
+ * module-level `_needsCleanup` flag. The next `SchemaAdapter.setup()` call
+ * sees that flag and triggers `resetTestAdapterState()`, which **drops every
+ * table** — silently destroying the schema the surrounding describe just
+ * built. The symptom is "table not found" on subsequent tests in the same
+ * file. See follow-up notes on #1960 (`has-and-belongs-to-many-associations`
+ * still trips this). Migrations to transactional fixtures must rewrite any
+ * inline `createTestAdapter()` calls to reuse the describe-level adapter.
+ *
+ * Warn (once) when this happens so future migrations don't fail silently.
  */
 export function createTestAdapter(): TestDatabaseAdapter {
+  if (_skipGlobalResetDepth > 0 && !_createTestAdapterWarned) {
+    _createTestAdapterWarned = true;
+
+    console.warn(
+      "[trails] createTestAdapter() called inside withTransactionalFixtures — " +
+        "this sets _needsCleanup and will drop the shared describe's tables on " +
+        "the next setup(). Reuse the describe-level adapter instead.",
+    );
+  }
   _needsCleanup = true;
   return _factory();
 }


### PR DESCRIPTION
## Summary

Two-part prep for promoting `has-many-associations.test.ts` to
`withTransactionalFixtures` (B6.4 follow-up to #1960).

1. **Per-describe `defineSchema` for the 4 tail describes** in
   `has-many-associations.test.ts` (lines 8040, 8092, 8381, 8414). Each
   `beforeEach` now creates an adapter via `freshAdapterWithSchema(...)`
   so the file no longer depends on auto-schema for those blocks. The
   big head `HasManyAssociationsTest` describe (262-8038) still relies
   on auto-derived schemas — its ~7700 lines need a separate PR.

2. **Document + warn on the `createTestAdapter()` sharp edge** that bit
   #1960's habtm migration: calling `createTestAdapter()` inside a
   `withTransactionalFixtures` scope sets the module-level
   `_needsCleanup` flag, which makes the next `SchemaAdapter.setup()`
   call `resetTestAdapterState()` — silently dropping every table the
   surrounding describe just built. Adds a one-shot `console.warn` when
   this happens so future migrations don't fail silently, plus an
   explicit JSDoc block on the function describing the trap.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/has-many-associations.test.ts` — 309 passed / 1 skipped
- [x] Same file with `AR_NO_AUTO_SCHEMA=1` — the migrated tail describes pass; failures isolated to the big head block (expected, follow-up)
- [x] Size: 73 LOC (under 300 ceiling)

## Follow-ups (not in this PR)

- **Migrate the head `HasManyAssociationsTest` block (262-8038)** to
  `defineSchema`. ~100+ tables, multi-PR job — split per cluster.
- **Promote tail describes to `withTransactionalFixtures`** once head
  block is migrated; whole-file flip lands together.
- **`has-and-belongs-to-many-associations.test.ts`** — inline
  `createTestAdapter()` calls now warn instead of failing silently;
  rewrite those to reuse the describe-level adapter before flipping
  the file to transactional fixtures.