### PR TITLE
feat(activerecord): encryption test-helpers shared-adapter pattern (B1959)

### DIFF
--- a/packages/activerecord/src/encryption/concurrency.test.ts
+++ b/packages/activerecord/src/encryption/concurrency.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import {
   freshAdapter,
   configureEncryption,
@@ -6,9 +6,18 @@ import {
   restoreEncryptionConfig,
   makeEncryptedBook,
 } from "./test-helpers.js";
+import type { TestDatabaseAdapter } from "../test-adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("ActiveRecord::Encryption::ConcurrencyTest", () => {
+  let adapter: TestDatabaseAdapter;
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeAll(async () => {
+    adapter = await freshAdapter();
+  });
+
+  withTransactionalFixtures(() => adapter);
 
   beforeEach(() => {
     configSnapshot = snapshotEncryptionConfig();
@@ -22,7 +31,7 @@ describe("ActiveRecord::Encryption::ConcurrencyTest", () => {
   it("models can be encrypted and decrypted in different threads concurrently", async () => {
     // JS is single-threaded; this exercises concurrent async encrypt/decrypt operations
     // (multiple Promises in flight) to verify no shared-state corruption occurs.
-    const Book = makeEncryptedBook(await freshAdapter());
+    const Book = makeEncryptedBook(adapter);
     new Book();
 
     const names = Array.from({ length: 10 }, (_, i) => `Concurrent Book ${i}`);

--- a/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import {
   freshAdapter,
   configureEncryption,
@@ -8,10 +8,19 @@ import {
   makeMsgPackTextBook,
   assertEncryptedAttribute,
 } from "./test-helpers.js";
+import type { TestDatabaseAdapter } from "../test-adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { Encoding as EncodingError } from "./errors.js";
 
 describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest", () => {
+  let adapter: TestDatabaseAdapter;
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeAll(async () => {
+    adapter = await freshAdapter();
+  });
+
+  withTransactionalFixtures(() => adapter);
 
   beforeEach(() => {
     configSnapshot = snapshotEncryptionConfig();
@@ -23,14 +32,14 @@ describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest",
   });
 
   it("binary data can be serialized with message pack", async () => {
-    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(await freshAdapter());
+    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
     const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
     const book = await Book.create({ logo: allBytes });
     await assertEncryptedAttribute(book, "logo", allBytes);
   });
 
   it("binary data can be encrypted uncompressed and serialized with message pack", async () => {
-    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(await freshAdapter());
+    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
     // Rails: both ranges are 128 bytes (< 140 threshold) so neither is compressed.
     // TS note: highBytes (128–255) encoded as Latin-1 measures as 256 UTF-8 bytes so
     // it may be compressed; the round-trip is correct either way.
@@ -41,7 +50,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest",
   });
 
   it("text columns cannot be serialized with message pack", async () => {
-    const MsgPackTextBook = makeMsgPackTextBook(await freshAdapter());
+    const MsgPackTextBook = makeMsgPackTextBook(adapter);
     await expect(MsgPackTextBook.create({ name: "Dune" })).rejects.toThrow(EncodingError);
   });
 });

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -1,6 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
-import type { TestDatabaseAdapter } from "../test-adapter.js";
-import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Scheme } from "./scheme.js";
 import { Configurable } from "./configurable.js";
@@ -61,15 +59,8 @@ function makeType(
 }
 
 describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
-  let adapter: TestDatabaseAdapter;
   let savedSupportUnencryptedData: boolean;
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
-
-  beforeAll(async () => {
-    adapter = await freshAdapter();
-  });
-
-  withTransactionalFixtures(() => adapter);
 
   beforeEach(() => {
     savedSupportUnencryptedData = Configurable.config.supportUnencryptedData;
@@ -88,7 +79,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     // fails and the fallback path is actually exercised.
     const prevKeyProvider = makeKeyProvider("prev-key-for-schemes-test-32bytes!!");
     Configurable.config.previous = [{ keyProvider: prevKeyProvider }] as SchemeOptions[];
-    const Author = makeEncryptedAuthor(adapter);
+    const Author = makeEncryptedAuthor(await freshAdapter());
     new Author();
     const author = await Author.create({ name: "david" });
     const currentType = (Author as any).typeForAttribute("name") as EncryptedAttributeType;
@@ -112,7 +103,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     Configurable.config.previous = [
       { keyProvider: makeKeyProvider("prev-key-for-decryption-error-32b!") },
     ] as SchemeOptions[];
-    const Author = makeEncryptedAuthor(adapter);
+    const Author = makeEncryptedAuthor(await freshAdapter());
     new Author();
     const author = await withoutEncryption(() => Author.create({ name: "unencrypted author" }));
     const reloaded = await Author.find(author.id);
@@ -120,7 +111,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
   });
 
   it("use a custom encryptor", async () => {
-    const adp = adapter;
+    const adp = await freshAdapter();
     const EncryptedAuthor1 = await makeFreshModel(adp, { id: "integer", name: "string" });
     EncryptedAuthor1.encrypts("name", { encryptor: new TestEncryptor({ "1": "2" }) });
     new EncryptedAuthor1();
@@ -134,7 +125,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
 
   it("support previous contexts", async () => {
     Configurable.config.supportUnencryptedData = true;
-    const adp = adapter;
+    const adp = await freshAdapter();
     const EncryptedAuthor2 = await makeFreshModel(adp, { id: "integer", name: "string" });
     EncryptedAuthor2.encrypts("name", {
       encryptor: new TestEncryptor({ "2": "3" }),
@@ -333,7 +324,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
         { encryptor: prevEncryptor, deterministic: true } as SchemeOptions,
       ];
 
-      const adp = adapter;
+      const adp = await freshAdapter();
       const Author = await makeFreshModel(adp, { id: "integer", name: "string" });
       Author.encrypts("name", { encryptor: currentEncryptor, deterministic: true, fixed: false });
       new Author();

--- a/packages/activerecord/src/encryption/encryption-schemes.test.ts
+++ b/packages/activerecord/src/encryption/encryption-schemes.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
+import type { TestDatabaseAdapter } from "../test-adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Scheme } from "./scheme.js";
 import { Configurable } from "./configurable.js";
@@ -59,8 +61,15 @@ function makeType(
 }
 
 describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
+  let adapter: TestDatabaseAdapter;
   let savedSupportUnencryptedData: boolean;
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeAll(async () => {
+    adapter = await freshAdapter();
+  });
+
+  withTransactionalFixtures(() => adapter);
 
   beforeEach(() => {
     savedSupportUnencryptedData = Configurable.config.supportUnencryptedData;
@@ -79,7 +88,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     // fails and the fallback path is actually exercised.
     const prevKeyProvider = makeKeyProvider("prev-key-for-schemes-test-32bytes!!");
     Configurable.config.previous = [{ keyProvider: prevKeyProvider }] as SchemeOptions[];
-    const Author = makeEncryptedAuthor(await freshAdapter());
+    const Author = makeEncryptedAuthor(adapter);
     new Author();
     const author = await Author.create({ name: "david" });
     const currentType = (Author as any).typeForAttribute("name") as EncryptedAttributeType;
@@ -103,7 +112,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
     Configurable.config.previous = [
       { keyProvider: makeKeyProvider("prev-key-for-decryption-error-32b!") },
     ] as SchemeOptions[];
-    const Author = makeEncryptedAuthor(await freshAdapter());
+    const Author = makeEncryptedAuthor(adapter);
     new Author();
     const author = await withoutEncryption(() => Author.create({ name: "unencrypted author" }));
     const reloaded = await Author.find(author.id);
@@ -111,7 +120,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
   });
 
   it("use a custom encryptor", async () => {
-    const adp = await freshAdapter();
+    const adp = adapter;
     const EncryptedAuthor1 = await makeFreshModel(adp, { id: "integer", name: "string" });
     EncryptedAuthor1.encrypts("name", { encryptor: new TestEncryptor({ "1": "2" }) });
     new EncryptedAuthor1();
@@ -125,7 +134,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
 
   it("support previous contexts", async () => {
     Configurable.config.supportUnencryptedData = true;
-    const adp = await freshAdapter();
+    const adp = adapter;
     const EncryptedAuthor2 = await makeFreshModel(adp, { id: "integer", name: "string" });
     EncryptedAuthor2.encrypts("name", {
       encryptor: new TestEncryptor({ "2": "3" }),
@@ -324,7 +333,7 @@ describe("ActiveRecord::Encryption::EncryptionSchemesTest", () => {
         { encryptor: prevEncryptor, deterministic: true } as SchemeOptions,
       ];
 
-      const adp = await freshAdapter();
+      const adp = adapter;
       const Author = await makeFreshModel(adp, { id: "integer", name: "string" });
       Author.encrypts("name", { encryptor: currentEncryptor, deterministic: true, fixed: false });
       new Author();

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -6,7 +6,7 @@
  */
 
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
 import { Base } from "../index.js";
 import type { DatabaseAdapter } from "../adapter.js";
@@ -181,7 +181,28 @@ export async function installEncryptionSchema(adapter: DatabaseAdapter): Promise
   await defineSchema(adapter, ENCRYPTION_SCHEMA);
 }
 
-export async function freshAdapter(): Promise<DatabaseAdapter> {
+/**
+ * Creates a `TestDatabaseAdapter` with the shared encryption schema installed.
+ *
+ * Two usage patterns:
+ *
+ * 1. **Per-test (legacy):** call `await freshAdapter()` inside each `it()`.
+ *    Spins up a brand-new adapter+schema for every test — slow but isolated.
+ *
+ * 2. **Transactional fixtures (preferred, B6.4):** call once in `beforeAll`
+ *    and wrap with `withTransactionalFixtures(() => adapter)` so each test
+ *    runs inside a BEGIN/ROLLBACK pair:
+ *
+ *    ```ts
+ *    let adapter: TestDatabaseAdapter;
+ *    beforeAll(async () => { adapter = await freshAdapter(); });
+ *    withTransactionalFixtures(() => adapter);
+ *    ```
+ *
+ *    The returned type is `TestDatabaseAdapter` so it satisfies
+ *    {@link TransactionalFixturesAdapter} without an extra cast.
+ */
+export async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await installEncryptionSchema(adapter);
   return adapter;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -201,6 +201,12 @@ export async function installEncryptionSchema(adapter: DatabaseAdapter): Promise
  *
  *    The returned type is `TestDatabaseAdapter` so it satisfies
  *    {@link TransactionalFixturesAdapter} without an extra cast.
+ *
+ * Caveat: tests that call {@link makeFreshModel} from inside `it()` bodies
+ * cannot use pattern (2) on MySQL/MariaDB. `makeFreshModel` runs DDL
+ * (`CREATE TABLE`) which auto-commits on MySQL and breaks the outer
+ * BEGIN/ROLLBACK wrap — the next `ROLLBACK TO SAVEPOINT` then errors with
+ * `SAVEPOINT active_record_1 does not exist`. Keep such tests on pattern (1).
  */
 export async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();

--- a/packages/activerecord/src/encryption/unencrypted-attributes.test.ts
+++ b/packages/activerecord/src/encryption/unencrypted-attributes.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import {
   freshAdapter,
   configureEncryption,
@@ -8,11 +8,20 @@ import {
   assertEncryptedAttribute,
   withoutEncryption,
 } from "./test-helpers.js";
+import type { TestDatabaseAdapter } from "../test-adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { Configurable } from "./configurable.js";
 import { Decryption as DecryptionError } from "./errors.js";
 
 describe("ActiveRecord::Encryption::UnencryptedAttributesTest", () => {
+  let adapter: TestDatabaseAdapter;
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
+
+  beforeAll(async () => {
+    adapter = await freshAdapter();
+  });
+
+  withTransactionalFixtures(() => adapter);
 
   beforeEach(() => {
     configSnapshot = snapshotEncryptionConfig();
@@ -30,7 +39,7 @@ describe("ActiveRecord::Encryption::UnencryptedAttributesTest", () => {
     // the system IS tolerant of plaintext). supportUnencryptedData = true
     // enables the plaintext-fallback path.
     Configurable.config.supportUnencryptedData = true;
-    const Post = makeEncryptedPost(await freshAdapter());
+    const Post = makeEncryptedPost(adapter);
     new Post();
     const post = await withoutEncryption(() =>
       Post.create({ title: "The Starfleet is here!", body: "take cover!" }),
@@ -50,7 +59,7 @@ describe("ActiveRecord::Encryption::UnencryptedAttributesTest", () => {
     // supportUnencryptedData = false disables the plaintext fallback, so reading
     // an unencrypted column raises DecryptionError.
     Configurable.config.supportUnencryptedData = false;
-    const Post = makeEncryptedPost(await freshAdapter());
+    const Post = makeEncryptedPost(adapter);
     new Post();
     const post = await withoutEncryption(() =>
       Post.create({ title: "The Starfleet is here!", body: "take cover!" }),


### PR DESCRIPTION
## Summary

Prereq for Phase 6 B6.4 — unblocks migrating `encryption/*.test.ts` to `withTransactionalFixtures`.

- `freshAdapter()` now returns `TestDatabaseAdapter` (was `DatabaseAdapter`) so it satisfies `TransactionalFixturesAdapter` directly; JSDoc documents the legacy per-test pattern vs. the shared-adapter `beforeAll` + `withTransactionalFixtures(() => adapter)` pattern.
- Pilot-migrates 4 encryption test files to the shared-adapter pattern, proving the helper change is sufficient:
  - `concurrency.test.ts`
  - `unencrypted-attributes.test.ts`
  - `encryptable-record-message-pack-serialized.test.ts`
  - `encryption-schemes.test.ts` (first describe block; second is pure-unit, no DB)

No production-source changes; tests-only + helper retyping.

## Follow-ups (B6.4 cluster PRs)

Remaining `encryption/*.test.ts` files still using per-test `freshAdapter()`:
- `encryptable-record.test.ts` (59 calls — largest)
- `encryptable-record-api.test.ts` (19)
- `uniqueness-validations.test.ts` (6)
- `extended-deterministic-queries.test.ts`

## Test plan

- [x] 4 migrated files green locally (SQLite) — 21 tests pass
- [ ] CI green across SQLite, PostgreSQL, MariaDB
- [x] Size: 137 LOC under 300 ceiling