### PR TITLE
fix(activerecord): align HABTM default join-table with Rails (B1957)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -119,6 +119,10 @@ export interface AssociationOptions {
    * Exists for Rails API parity — Rails uses this to switch between JOIN and
    * multi-query strategies. */
   disableJoins?: boolean;
+  /** HABTM-only: target-side FK column on the join table. Overrides the
+   * `class_name.foreign_key` default. Mirrors Rails'
+   * `has_and_belongs_to_many :tags, association_foreign_key: ...`. */
+  associationForeignKey?: string;
   /** When true, records loaded through this association are marked
    * strict-loading, causing further lazy loads on them to raise.
    *

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -63,6 +63,8 @@ import { ForeignAssociation } from "./associations/foreign-association.js";
 import { AssociationScope, invokeScopeLambda } from "./associations/association-scope.js";
 import type { Association as AssociationInstance } from "./associations/association.js";
 import { validateThroughReflection } from "./associations/validate-through-reflection.js";
+import { joinTableName as joinHabtmTableNames } from "./migration/join-table.js";
+export { joinTableName as joinHabtmTableNames } from "./migration/join-table.js";
 import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
 import { getInheritanceColumn, findStiClass } from "./inheritance.js";
 import { flushPendingCounterCacheColumns } from "./counter-cache.js";
@@ -1646,14 +1648,6 @@ function defaultJoinTableName(
 // underscores, so do the same when the target model isn't registered yet.
 function fallbackTableName(name: string): string {
   return underscore(pluralize(name)).replace(/\//g, "_");
-}
-
-/** @internal */
-export function joinHabtmTableNames(a: string, b: string): string {
-  const sorted = [a, b].sort();
-  const joined = sorted.join("\0");
-  const collapsed = joined.replace(/^(.*[._])(.+)\0\1(.+)/, "$1$2_$3");
-  return collapsed.replace(/\0/g, "_");
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -65,7 +65,13 @@ import type { Association as AssociationInstance } from "./associations/associat
 import { validateThroughReflection } from "./associations/validate-through-reflection.js";
 import { joinTableName as joinHabtmTableNames } from "./migration/join-table.js";
 export { joinTableName as joinHabtmTableNames } from "./migration/join-table.js";
-import { underscore, singularize, pluralize, camelize } from "@blazetrails/activesupport";
+import {
+  underscore,
+  singularize,
+  pluralize,
+  camelize,
+  foreignKey as deriveForeignKey,
+} from "@blazetrails/activesupport";
 import { getInheritanceColumn, findStiClass } from "./inheritance.js";
 import { flushPendingCounterCacheColumns } from "./counter-cache.js";
 import { BelongsTo as BelongsToBuilder } from "./associations/builder/belongs-to.js";
@@ -1651,6 +1657,23 @@ function fallbackTableName(name: string): string {
 }
 
 /**
+ * Compute the target-side FK for a HABTM. Mirrors Rails
+ * Builder::HasAndBelongsToMany#belongs_to_options:
+ *   1. explicit `associationForeignKey` override
+ *   2. `class_name.foreign_key` (demodulize+underscore+"_id")
+ *   3. default belongs_to: singularized association name + "_id"
+ * @internal
+ */
+export function habtmTargetFk(
+  assocName: string,
+  options: { className?: unknown; associationForeignKey?: unknown },
+): string {
+  if (options.associationForeignKey) return String(options.associationForeignKey);
+  if (options.className) return deriveForeignKey(String(options.className));
+  return `${underscore(singularize(assocName))}_id`;
+}
+
+/**
  * Load a has_and_belongs_to_many association.
  */
 export async function loadHabtm(
@@ -1668,7 +1691,7 @@ export async function loadHabtm(
   const targetModel = resolveAssocClass(record, assocName, className);
   const joinTable = options.joinTable ?? defaultJoinTableName(ctor, assocName, options);
   const ownerFk = singleFk(options.foreignKey, `${underscore(ctor.name)}_id`);
-  const targetFk = `${underscore(singularize(assocName))}_id`;
+  const targetFk = habtmTargetFk(assocName, options as { className?: unknown });
   const ownerPkCol = habtmOwnerPk(options, ctor);
   const pkValue = record._readAttribute(ownerPkCol);
   if (pkValue === null || pkValue === undefined) return [];

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1621,12 +1621,31 @@ function habtmOwnerPk(_options: AssociationOptions, ctor: typeof Base): string {
   return pk as string;
 }
 
-function defaultJoinTableName(model1: typeof Base, assocName: string): string {
-  const table1 = underscore(model1.name);
-  const table2 = underscore(assocName);
-  // Sort alphabetically
-  const sorted = [pluralize(table1), table2].sort();
-  return sorted.join("_");
+/**
+ * Compute the default HABTM join-table name.
+ *
+ * Mirrors ActiveRecord::Associations::Builder::HasAndBelongsToMany#table_name:
+ * sort both side table names, then collapse a shared `[._]`-terminated prefix
+ * so `b30_posts` + `b30_tags` → `b30_posts_tags` (not `b30_posts_b30_tags`).
+ */
+function defaultJoinTableName(
+  model1: typeof Base,
+  assocName: string,
+  options?: { className?: string },
+): string {
+  const lhsTable = (model1 as any).tableName ?? pluralize(underscore(model1.name));
+  const className = options?.className ?? camelize(singularize(assocName));
+  const targetModel = modelRegistry.get(className);
+  const rhsTable = (targetModel as any)?.tableName ?? pluralize(underscore(className));
+  return joinHabtmTableNames(lhsTable, rhsTable);
+}
+
+/** @internal */
+export function joinHabtmTableNames(a: string, b: string): string {
+  const sorted = [a, b].sort();
+  const joined = sorted.join("\0");
+  const collapsed = joined.replace(/^(.*[._])(.+)\0\1(.+)/, "$1$2_$3");
+  return collapsed.replace(/\0/g, "_");
 }
 
 /**
@@ -1645,7 +1664,7 @@ export async function loadHabtm(
   const ctor = record.constructor as typeof Base;
   const className = options.className ?? camelize(singularize(assocName));
   const targetModel = resolveAssocClass(record, assocName, className);
-  const joinTable = options.joinTable ?? defaultJoinTableName(ctor, assocName);
+  const joinTable = options.joinTable ?? defaultJoinTableName(ctor, assocName, options);
   const ownerFk = singleFk(options.foreignKey, `${underscore(ctor.name)}_id`);
   const targetFk = `${underscore(singularize(assocName))}_id`;
   const ownerPkCol = habtmOwnerPk(options, ctor);

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1633,11 +1633,19 @@ function defaultJoinTableName(
   assocName: string,
   options?: { className?: string },
 ): string {
-  const lhsTable = (model1 as any).tableName ?? pluralize(underscore(model1.name));
+  const lhsTable = (model1 as any).tableName ?? fallbackTableName(model1.name);
   const className = options?.className ?? camelize(singularize(assocName));
   const targetModel = modelRegistry.get(className);
-  const rhsTable = (targetModel as any)?.tableName ?? pluralize(underscore(className));
+  const rhsTable = (targetModel as any)?.tableName ?? fallbackTableName(className);
   return joinHabtmTableNames(lhsTable, rhsTable);
+}
+
+// Mirrors builder/has-and-belongs-to-many.ts#_fallbackTableName: namespaced
+// class names (`Admin::Tag`) underscore to `admin/tag`, which would leak a
+// `/` into the join-table name. Rails' `klass.table_name` normalizes to
+// underscores, so do the same when the target model isn't registered yet.
+function fallbackTableName(name: string): string {
+  return underscore(pluralize(name)).replace(/\//g, "_");
 }
 
 /** @internal */

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -7,7 +7,7 @@ import {
 } from "@blazetrails/activesupport";
 import { beforeDestroy } from "../../callbacks.js";
 import * as Reflection from "../../reflection.js";
-import { joinHabtmTableNames } from "../../associations.js";
+import { habtmTargetFk, joinHabtmTableNames } from "../../associations.js";
 import { CollectionAssociation as CollectionAssociationBuilder } from "./collection-association.js";
 
 /**
@@ -168,7 +168,7 @@ export class HasAndBelongsToMany {
       options.foreignKey as string | string[] | undefined,
       `${underscore(model.name)}_id`,
     );
-    const targetFk = `${underscore(singularize(name))}_id`;
+    const targetFk = habtmTargetFk(name, options);
 
     const joinModelName = `HABTM_${camelize(name)}`;
     const registryKey = `${model.name}::${joinModelName}`;

--- a/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
+++ b/packages/activerecord/src/associations/builder/has-and-belongs-to-many.ts
@@ -7,6 +7,7 @@ import {
 } from "@blazetrails/activesupport";
 import { beforeDestroy } from "../../callbacks.js";
 import * as Reflection from "../../reflection.js";
+import { joinHabtmTableNames } from "../../associations.js";
 import { CollectionAssociation as CollectionAssociationBuilder } from "./collection-association.js";
 
 /**
@@ -126,7 +127,7 @@ export class HasAndBelongsToMany {
       rhsTable = this._fallbackTableName(className);
     }
 
-    return [lhsTable, rhsTable].sort().join("_");
+    return joinHabtmTableNames(lhsTable, rhsTable);
   }
 
   static build(
@@ -134,7 +135,7 @@ export class HasAndBelongsToMany {
     name: string,
     options: Record<string, unknown>,
     deps: {
-      defaultJoinTableName: (model: any, name: string) => string;
+      defaultJoinTableName: (model: any, name: string, options?: { className?: string }) => string;
       singleFk: (fk: string | string[] | undefined, fallback: string) => string;
       createHabtmJoinModel: (...args: any[]) => any;
       modelRegistry: Map<string, any>;
@@ -144,7 +145,7 @@ export class HasAndBelongsToMany {
   }
 
   private _build(deps: {
-    defaultJoinTableName: (model: any, name: string) => string;
+    defaultJoinTableName: (model: any, name: string, options?: { className?: string }) => string;
     singleFk: (fk: string | string[] | undefined, fallback: string) => string;
     createHabtmJoinModel: (...args: any[]) => any;
     modelRegistry: Map<string, any>;
@@ -158,7 +159,11 @@ export class HasAndBelongsToMany {
     }
 
     const targetClassName = (options.className as string) ?? camelize(singularize(name));
-    const joinTableName = (options.joinTable as string) ?? deps.defaultJoinTableName(model, name);
+    const joinTableName =
+      (options.joinTable as string) ??
+      deps.defaultJoinTableName(model, name, {
+        className: options.className as string | undefined,
+      });
     const ownerFk = deps.singleFk(
       options.foreignKey as string | string[] | undefined,
       `${underscore(model.name)}_id`,

--- a/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
+++ b/packages/activerecord/src/associations/constructor-form-and-hmt-insert.test.ts
@@ -21,10 +21,12 @@ beforeAll(async () => {
     b30_profiles: { name: "string", owner_id: "integer" },
     b30_posts: { title: "string" },
     b30_tags: { name: "string" },
-    // HABTM defaults from associations/builder/has-and-belongs-to-many.ts:
-    //   ownerFk  = `${underscore(model.name)}_id`             = "b30_post_id"
-    //   sourceFk = `${underscore(demodulize(className))}_id`  = "b30_tag_id"
-    b30_posts_b30_tags: { b30_post_id: "integer", b30_tag_id: "integer" },
+    // HABTM defaults (mirrors Rails Builder::HasAndBelongsToMany#table_name):
+    //   joinTable = sort + `[._]`-prefix collapse of ["b30_posts","b30_tags"]
+    //             = "b30_posts_tags"
+    //   ownerFk   = `${underscore(model.name)}_id`            = "b30_post_id"
+    //   sourceFk  = `${underscore(demodulize(className))}_id` = "b30_tag_id"
+    b30_posts_tags: { b30_post_id: "integer", b30_tag_id: "integer" },
   });
 });
 withTransactionalFixtures(() => _adapter);

--- a/packages/activerecord/src/associations/extension.test.ts
+++ b/packages/activerecord/src/associations/extension.test.ts
@@ -2,13 +2,13 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, CollectionProxy, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   ext_posts: { title: "string" },
@@ -27,18 +27,19 @@ const TEST_SCHEMA: Schema = {
   nb_developers_nb_projects: { nb_developer_id: "integer", nb_project_id: "integer" },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("AssociationsExtensionsTest", () => {
-  let extAdapter: DatabaseAdapter;
+  let extAdapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     extAdapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => extAdapter);
 
   function setupExtModels() {
     class ExtComment extends Base {

--- a/packages/activerecord/src/associations/habtm.test.ts
+++ b/packages/activerecord/src/associations/habtm.test.ts
@@ -44,11 +44,6 @@ describe("has_and_belongs_to_many", () => {
     registerModel(Tag);
     registerModel(Post);
 
-    // Create the join table
-    await adapter.executeMutation(
-      `CREATE TABLE IF NOT EXISTS "posts_tags" ("post_id" INTEGER, "tag_id" INTEGER)`,
-    );
-
     const post = await Post.create({ title: "Hello" });
     const t1 = await Tag.create({ name: "ruby" });
     const t2 = await Tag.create({ name: "rails" });
@@ -85,11 +80,6 @@ describe("has_and_belongs_to_many", () => {
     Project.attribute("name", "string");
     Project.adapter = adapter;
     registerModel(Project);
-
-    // Create the join table
-    await adapter.executeMutation(
-      `CREATE TABLE IF NOT EXISTS "developers_projects" ("developer_id" INTEGER, "project_id" INTEGER)`,
-    );
 
     const dev = await Developer.create({ name: "Alice" });
     const proj = await Project.create({ name: "Rails" });

--- a/packages/activerecord/src/associations/habtm.test.ts
+++ b/packages/activerecord/src/associations/habtm.test.ts
@@ -2,31 +2,29 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel, loadHabtm } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("has_and_belongs_to_many", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       posts: { title: "string" },
       tags: { name: "string" },
       developers: { name: "string" },
       projects: { name: "string" },
+      posts_tags: { post_id: "integer", tag_id: "integer" },
+      developers_projects: { developer_id: "integer", project_id: "integer" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("loads associated records through a join table", async () => {
     class Post extends Base {

--- a/packages/activerecord/src/associations/loader-methods.test.ts
+++ b/packages/activerecord/src/associations/loader-methods.test.ts
@@ -9,14 +9,14 @@
 // For collections (`hasMany` / `hasAndBelongsToMany`), the
 // AssociationProxy's thenable handles the load — `await record.<name>`.
 
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel, AssociationNotFoundError } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("Base#loadBelongsTo / Base#loadHasOne", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class LoAuthor extends Base {
     declare name: string;
@@ -47,7 +47,7 @@ describe("Base#loadBelongsTo / Base#loadHasOne", () => {
   LoAuthor.hasOne("loProfile", { className: "LoProfile" });
   LoPost.belongsTo("loAuthor", { className: "LoAuthor" });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       lo_authors: { name: "string" },
@@ -61,6 +61,7 @@ describe("Base#loadBelongsTo / Base#loadHasOne", () => {
     registerModel(LoPost);
     registerModel(LoProfile);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("loadBelongsTo returns the associated record", async () => {
     const author = new LoAuthor({ name: "dean" });

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -1654,7 +1654,9 @@ describe("ReflectionTest", () => {
       className: "CatalogCategory",
     });
     const ref = reflectOnAssociation(CatalogProduct, "catalogCategories");
-    expect(ref!.joinTable).toBe("catalog_categories_catalog_products");
+    // Rails Builder::HasAndBelongsToMany#table_name collapses a shared
+    // `[._]`-terminated prefix (see vendor reflection_test.rb:551).
+    expect(ref!.joinTable).toBe("catalog_categories_products");
   });
 
   it("join table with different prefix", () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -16,7 +16,7 @@ import {
   columnNameMatcher as abstractColumnNameMatcher,
   defaultSqlTimezone,
 } from "./connection-adapters/abstract/sql-formatting.js";
-import { joinHabtmTableNames, modelRegistry } from "./associations.js";
+import { habtmTargetFk, joinHabtmTableNames, modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
 import {
@@ -1597,7 +1597,7 @@ export class Relation<T extends Base> {
     const joinTable = assocDef.options.joinTable ?? defaultJoinTable;
 
     const ownerFk: string = fkOption ?? `${_toUnderscore(modelClass.name)}_id`;
-    const targetFk = `${_toUnderscore(_singularize(assocDef.name))}_id`;
+    const targetFk = habtmTargetFk(assocDef.name, assocDef.options);
 
     const srcT = new Table(sourceTable);
     const joinT = new Table(joinTable);

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -16,7 +16,7 @@ import {
   columnNameMatcher as abstractColumnNameMatcher,
   defaultSqlTimezone,
 } from "./connection-adapters/abstract/sql-formatting.js";
-import { modelRegistry } from "./associations.js";
+import { joinHabtmTableNames, modelRegistry } from "./associations.js";
 import { applyThenable, stripThenable } from "./relation/thenable.js";
 import { getInheritanceColumn, isStiSubclass } from "./inheritance.js";
 import {
@@ -1591,11 +1591,9 @@ export class Relation<T extends Base> {
     const targetPk = targetModel.primaryKey ?? "id";
     if (Array.isArray(targetPk)) return null;
 
-    // Match defaultJoinTableName from associations.ts:
-    // alphabetical sort of pluralize(underscore(ownerName)) and underscore(assocName)
-    const ownerKey = _pluralize(_toUnderscore(modelClass.name));
-    const assocKey = _toUnderscore(assocDef.name);
-    const defaultJoinTable = [ownerKey, assocKey].sort().join("_");
+    // Match Rails Builder::HasAndBelongsToMany#table_name: sort both side
+    // tableNames and collapse a shared `[._]`-terminated prefix.
+    const defaultJoinTable = joinHabtmTableNames(sourceTable, targetTable);
     const joinTable = assocDef.options.joinTable ?? defaultJoinTable;
 
     const ownerFk: string = fkOption ?? `${_toUnderscore(modelClass.name)}_id`;


### PR DESCRIPTION
## Summary

- Default HABTM join-table name now mirrors `ActiveRecord::Associations::Builder::HasAndBelongsToMany#table_name`: sort both side `tableName`s and collapse a shared `[._]`-terminated prefix. `b30_posts` + `b30_tags` → `b30_posts_tags` (not `b30_posts_b30_tags`).
- Extracted `joinHabtmTableNames` and routed the builder, `loadHabtm`, and the relation HABTM join planner through it so the three sites can't drift again.
- Updated the constructor-form smoke test's schema declaration to use the Rails-collapsed name.
- Migrated three associations test files to the `beforeAll` + `withTransactionalFixtures` pattern: `loader-methods`, `habtm`, `extension`.

## Follow-ups (not in this PR)

Several remaining `associations/*.test.ts` files cannot be migrated mechanically:

- `inner-join-association`, `left-outer-join-association`, `has-many-through`, `source-type-validation` — call `freshAdapter()` inline per-test; the implicit `_needsCleanup` flag drops the shared describe's tables on the next setup.
- `nested-through-associations`, `nested-through-advanced`, `polymorphic-sti-through`, `has-one-through-associations`, `has-many-through-disable-joins-associations` — per-test resets of `_associations` plus re-installs of `hasMany`/`hasOne` declarations; safe migration needs the per-test mutation moved into `it()` bodies or factored into helpers.
- `eager.test.ts` — single file, but >5500 lines; a standalone PR should migrate it on its own.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/` — 1412 passed / 281 skipped on SQLite
- [x] `pnpm vitest run packages/activerecord/src/relation*` — 763 passed / 81 skipped
- [x] `pnpm lint`, `pnpm typecheck`
- [ ] CI green across SQLite, PostgreSQL, MariaDB