### PR TITLE
ci: diff against merge-base in detect-changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
             echo "actionpack_affected=true" >> "$GITHUB_OUTPUT"
-          elif ! files=$(git diff --name-only "$base" "$head" 2>/dev/null); then
+          elif ! files=$(git diff --name-only "$base"..."$head" 2>/dev/null); then
             echo "git diff failed (base may be unreachable after force-push) — running full matrix"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,11 @@ jobs:
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
             echo "actionpack_affected=true" >> "$GITHUB_OUTPUT"
+          # Triple-dot: diff against the merge-base of $base and $head, not
+          # against the current tip of the base branch. Using `$base $head`
+          # would also include every commit merged to main since this branch
+          # diverged, inflating the changed-files list with unrelated paths
+          # and triggering gates that shouldn't fire.
           elif ! files=$(git diff --name-only "$base"..."$head" 2>/dev/null); then
             echo "git diff failed (base may be unreachable after force-push) — running full matrix"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- detect-changes was using `git diff $base $head` with `$base = pull_request.base.sha` (the current tip of the base branch). When main advances after the branch diverges, that diff includes every commit merged to main in between, inflating the changed-files list with unrelated paths and flipping gates that shouldn't fire — e.g. #1963, an actionpack-only PR, scheduled sqlite/postgres/mariadb because intervening main commits touched activerecord/activemodel/actionview.
- Switch to `$base...$head` so the diff is taken against the merge-base, matching the PR's actual file diff. Added an inline comment so the reason for the triple-dot is obvious.

## Test plan
- [ ] On this PR, `detect-changes` log lists only `.github/workflows/ci.yml` under "Changed files" (the full matrix still runs because that path matches `INFRA_RE`, which is correct).
- [ ] Future actionpack-only PRs targeting an older base no longer schedule sqlite/postgres/mariadb.