### PR TITLE
feat(actioncontroller): port HttpAuthentication::Basic (P17a)

### DIFF
--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -33,6 +33,13 @@ import {
 import { helperMethod, type HelpersClassMethods } from "../abstract-controller/helpers.js";
 import { defaultFormBuilder } from "./form-builder.js";
 import { instrumentPayload, instrumentName } from "./caching.js";
+import {
+  authenticateOrRequestWithHttpBasic,
+  authenticateWithHttpBasic,
+  httpBasicAuthenticateOrRequestWith,
+  httpBasicAuthenticateWith,
+  requestHttpBasicAuthentication,
+} from "./metal/http-authentication.js";
 
 // Re-export callback registration
 export { type ActionCallback, type AroundCallback, type CallbackOptions };
@@ -463,6 +470,15 @@ export class Base extends Metal {
   instrumentName(): string {
     return instrumentName.call(this);
   }
+
+  // --- HTTP Basic authentication (Rails parity, P17a) ---
+
+  /** Class DSL: `http_basic_authenticate_with name:, password:, realm:, **options`. */
+  static httpBasicAuthenticateWith = httpBasicAuthenticateWith;
+  httpBasicAuthenticateOrRequestWith = httpBasicAuthenticateOrRequestWith;
+  authenticateOrRequestWithHttpBasic = authenticateOrRequestWithHttpBasic;
+  authenticateWithHttpBasic = authenticateWithHttpBasic;
+  requestHttpBasicAuthentication = requestHttpBasicAuthentication;
 
   // --- Rescue ---
 

--- a/packages/actionpack/src/action-controller/metal/http-authentication.test.ts
+++ b/packages/actionpack/src/action-controller/metal/http-authentication.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  authenticate,
+  authenticationRequest,
+  authParam,
+  authScheme,
+  decodeCredentials,
+  encodeCredentials,
+  hasBasicCredentials,
+  userNameAndPassword,
+  authenticateOrRequestWithHttpBasic,
+  authenticateWithHttpBasic,
+  httpBasicAuthenticateOrRequestWith,
+  httpBasicAuthenticateWith,
+  requestHttpBasicAuthentication,
+  type BasicControllerHost,
+} from "./http-authentication.js";
+
+const req = (auth?: string) => ({ authorization: auth });
+const ctrl = (auth?: string): BasicControllerHost => ({
+  request: req(auth),
+  headers: {},
+  status: 200,
+  responseBody: null,
+});
+
+describe("HttpAuthentication::Basic", () => {
+  it("encode/decode round-trip, including colons in password", () => {
+    const header = encodeCredentials("admin", "se:cret");
+    expect(decodeCredentials(req(header))).toBe("admin:se:cret");
+    expect(userNameAndPassword(req(header))).toEqual(["admin", "se:cret"]);
+  });
+
+  it("authScheme + authParam mirror Ruby split(' ', 2) — ignores leading + collapses runs", () => {
+    expect([authScheme(req("Basic Zm9v")), authParam(req("Basic Zm9v"))]).toEqual([
+      "Basic",
+      "Zm9v",
+    ]);
+    expect(authParam(req("Bearer"))).toBeUndefined();
+    expect([authScheme(req("  Basic   Zm9v")), authParam(req("  Basic   Zm9v"))]).toEqual([
+      "Basic",
+      "Zm9v",
+    ]);
+  });
+
+  it("hasBasicCredentials is case-insensitive, rejects empty/whitespace/wrong scheme", () => {
+    expect(hasBasicCredentials(req("basic Zm9vOmJhcg=="))).toBe(true);
+    expect(hasBasicCredentials(req("Bearer abc"))).toBe(false);
+    expect(hasBasicCredentials(req())).toBe(false);
+    expect(hasBasicCredentials(req("   "))).toBe(false);
+  });
+
+  it("authenticate invokes login_procedure with decoded user+pass, else returns undefined", () => {
+    const verify = vi.fn((u: string, p: string) => `${u}/${p}`);
+    expect(authenticate(req(encodeCredentials("dhh", "secret")), verify)).toBe("dhh/secret");
+    expect(authenticate(req(), verify)).toBeUndefined();
+  });
+
+  it("authenticationRequest writes 401 + WWW-Authenticate and strips realm quotes", () => {
+    const c = { headers: {} as Record<string, string>, status: 200, responseBody: null };
+    authenticationRequest(c, 'Evil"Realm', null);
+    expect(c.headers["WWW-Authenticate"]).toBe('Basic realm="EvilRealm"');
+    expect(c.status).toBe(401);
+    expect(c.responseBody).toBe("HTTP Basic: Access denied.\n");
+  });
+});
+
+describe("HttpAuthentication::Basic::ControllerMethods", () => {
+  it("authenticateWithHttpBasic delegates to authenticate using this.request", () => {
+    const c = ctrl(encodeCredentials("u", "p"));
+    expect(authenticateWithHttpBasic.call(c, (u, p) => ({ u, p }))).toEqual({ u: "u", p: "p" });
+  });
+
+  it("authenticateOrRequestWithHttpBasic returns login result, else issues 401", () => {
+    const ok = ctrl(encodeCredentials("u", "p"));
+    expect(authenticateOrRequestWithHttpBasic.call(ok, null, null, () => "OK")).toBe("OK");
+    const fail = ctrl();
+    expect(authenticateOrRequestWithHttpBasic.call(fail, null, null, () => "OK")).toBe(false);
+    expect(fail.status).toBe(401);
+    expect(fail.headers["WWW-Authenticate"]).toBe('Basic realm="Application"');
+  });
+
+  it("requestHttpBasicAuthentication uses provided realm + message", () => {
+    const c = ctrl();
+    requestHttpBasicAuthentication.call(c, "Zone", "nope");
+    expect(c.headers["WWW-Authenticate"]).toBe('Basic realm="Zone"');
+    expect(c.responseBody).toBe("nope");
+  });
+
+  it("httpBasicAuthenticateOrRequestWith succeeds only on matching credentials", () => {
+    const ok = ctrl(encodeCredentials("dhh", "secret"));
+    expect(httpBasicAuthenticateOrRequestWith.call(ok, { name: "dhh", password: "secret" })).toBe(
+      true,
+    );
+    const bad = ctrl(encodeCredentials("dhh", "wrong"));
+    expect(httpBasicAuthenticateOrRequestWith.call(bad, { name: "dhh", password: "secret" })).toBe(
+      false,
+    );
+    expect(bad.status).toBe(401);
+  });
+});
+
+describe("HttpAuthentication::Basic::ControllerMethods::ClassMethods", () => {
+  it("httpBasicAuthenticateWith registers a beforeAction filter and forwards filter options", () => {
+    const beforeAction = vi.fn();
+    httpBasicAuthenticateWith.call({ beforeAction }, { name: "dhh", password: "s", only: "edit" });
+    const [cb, opts] = beforeAction.mock.calls[0];
+    expect(opts).toEqual({ only: "edit" });
+    expect(cb(ctrl(encodeCredentials("dhh", "s")))).toBe(true);
+  });
+
+  it("httpBasicAuthenticateWith rejects non-string name/password", () => {
+    const ba = vi.fn();
+    expect(() =>
+      httpBasicAuthenticateWith.call({ beforeAction: ba }, { name: 1 as never, password: "x" }),
+    ).toThrow(/Expected name/);
+    expect(() =>
+      httpBasicAuthenticateWith.call({ beforeAction: ba }, { name: "x", password: null as never }),
+    ).toThrow(/Expected password/);
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/http-authentication.ts
+++ b/packages/actionpack/src/action-controller/metal/http-authentication.ts
@@ -1,9 +1,8 @@
 /**
- * ActionController::HttpAuthentication
- *
- * Re-exports the HTTP Basic, Digest, and Token authentication helpers
- * from ActionDispatch.
- * @see https://api.rubyonrails.org/classes/ActionController/HttpAuthentication.html
+ * ActionController::HttpAuthentication — Rails-fidelity Basic auth helpers
+ * ported from `actionpack/lib/action_controller/metal/http_authentication.rb`.
+ * Digest + Token live under the `BasicAuth`/`TokenAuth`/`DigestAuth` re-exports
+ * pending P17b / P17c.
  */
 
 export {
@@ -14,3 +13,184 @@ export {
   type TokenAuthCredentials,
   type DigestAuthParams,
 } from "../../action-dispatch/http-authentication.js";
+
+// ============================================================================
+// HttpAuthentication::Basic
+// ============================================================================
+
+/** Mirrors Rails `request.authorization`. */
+export interface BasicAuthRequestLike {
+  authorization?: string | null;
+}
+
+/** Controller slice mutated by `authenticationRequest`. */
+export interface BasicAuthControllerLike {
+  headers: Record<string, string>;
+  status: number | string;
+  responseBody: string | string[] | Buffer | null | undefined;
+}
+
+// Ruby `String#split(" ", 2)`: split on the first whitespace run, ignoring
+// leading whitespace. Returns up to two pieces.
+function splitOnFirstWhitespace(s: string): [string, string?] {
+  const trimmed = s.replace(/^\s+/, "");
+  const m = /\s+/.exec(trimmed);
+  return m ? [trimmed.slice(0, m.index), trimmed.slice(m.index + m[0].length)] : [trimmed];
+}
+
+const reqAuth = (request: BasicAuthRequestLike): string =>
+  request.authorization == null ? "" : String(request.authorization);
+
+/** Mirrors `Basic#authenticate`. */
+export function authenticate<T>(
+  request: BasicAuthRequestLike,
+  loginProcedure: (userName: string, password: string) => T,
+): T | undefined {
+  if (!hasBasicCredentials(request)) return undefined;
+  const [user, pass] = userNameAndPassword(request);
+  return loginProcedure(user, pass);
+}
+
+/** Mirrors `Basic#has_basic_credentials?`. */
+export function hasBasicCredentials(request: BasicAuthRequestLike): boolean {
+  return reqAuth(request).trim().length > 0 && authScheme(request).toLowerCase() === "basic";
+}
+
+/** Mirrors `Basic#user_name_and_password`. */
+export function userNameAndPassword(request: BasicAuthRequestLike): [string, string] {
+  const decoded = decodeCredentials(request);
+  const idx = decoded.indexOf(":");
+  return idx === -1 ? [decoded, ""] : [decoded.slice(0, idx), decoded.slice(idx + 1)];
+}
+
+/** Mirrors `Basic#decode_credentials`. */
+export function decodeCredentials(request: BasicAuthRequestLike): string {
+  try {
+    return Buffer.from(authParam(request) ?? "", "base64").toString("utf-8");
+  } catch {
+    return "";
+  }
+}
+
+/** Mirrors `Basic#auth_scheme`. */
+export function authScheme(request: BasicAuthRequestLike): string {
+  return splitOnFirstWhitespace(reqAuth(request))[0];
+}
+
+/** Mirrors `Basic#auth_param`. `Array#second` returns `nil` when there's no
+ *  whitespace separator; we return `undefined`. */
+export function authParam(request: BasicAuthRequestLike): string | undefined {
+  return splitOnFirstWhitespace(reqAuth(request))[1];
+}
+
+/** Mirrors `Basic#encode_credentials`. */
+export function encodeCredentials(userName: string, password: string): string {
+  return `Basic ${Buffer.from(`${userName}:${password}`).toString("base64")}`;
+}
+
+/** Mirrors `Basic#authentication_request`. Mutates the controller in place. */
+export function authenticationRequest(
+  controller: BasicAuthControllerLike,
+  realm: string,
+  message: string | null | undefined,
+): void {
+  controller.headers["WWW-Authenticate"] = `Basic realm="${realm.replace(/"/g, "")}"`;
+  controller.status = 401;
+  controller.responseBody = message ?? "HTTP Basic: Access denied.\n";
+}
+
+// ============================================================================
+// HttpAuthentication::Basic::ControllerMethods
+// ============================================================================
+
+export interface BasicControllerHost extends BasicAuthControllerLike {
+  request: BasicAuthRequestLike;
+}
+
+/** Mirrors `Basic::ControllerMethods#http_basic_authenticate_or_request_with`.
+ *  Bitwise `&` ensures both `secureCompare` calls always run — Rails' length-
+ *  leak protection. */
+export function httpBasicAuthenticateOrRequestWith(
+  this: BasicControllerHost,
+  options: { name: string; password: string; realm?: string | null; message?: string | null },
+): boolean {
+  const { name, password, realm = null, message = null } = options;
+  return authenticateOrRequestWithHttpBasic.call(
+    this as BasicControllerHost,
+    realm,
+    message,
+    (givenName: string, givenPassword: string): boolean => {
+      const u = secureCompare(String(givenName ?? ""), name);
+      const p = secureCompare(String(givenPassword ?? ""), password);
+      return Boolean(u & p);
+    },
+  ) as boolean;
+}
+
+/** Mirrors `Basic::ControllerMethods#authenticate_or_request_with_http_basic`. */
+export function authenticateOrRequestWithHttpBasic<T>(
+  this: BasicControllerHost,
+  realm: string | null | undefined,
+  message: string | null | undefined,
+  loginProcedure: (userName: string, password: string) => T,
+): T | false {
+  const result = authenticateWithHttpBasic.call<
+    BasicControllerHost,
+    [typeof loginProcedure],
+    T | undefined
+  >(this, loginProcedure);
+  if (result) return result;
+  requestHttpBasicAuthentication.call(this, realm ?? "Application", message);
+  return false;
+}
+
+/** Mirrors `Basic::ControllerMethods#authenticate_with_http_basic`. */
+export function authenticateWithHttpBasic<T>(
+  this: BasicControllerHost,
+  loginProcedure: (userName: string, password: string) => T,
+): T | undefined {
+  return authenticate(this.request, loginProcedure);
+}
+
+/** Mirrors `Basic::ControllerMethods#request_http_basic_authentication`. */
+export function requestHttpBasicAuthentication(
+  this: BasicControllerHost,
+  realm: string = "Application",
+  message: string | null | undefined = null,
+): void {
+  authenticationRequest(this, realm, message);
+}
+
+// ============================================================================
+// HttpAuthentication::Basic::ControllerMethods::ClassMethods
+// ============================================================================
+
+export interface BasicClassDSLHost {
+  beforeAction(cb: (controller: BasicControllerHost) => unknown, options?: unknown): unknown;
+}
+
+/** Mirrors `Basic::ControllerMethods::ClassMethods#http_basic_authenticate_with`. */
+export function httpBasicAuthenticateWith(
+  this: BasicClassDSLHost,
+  options: { name: string; password: string; realm?: string | null; [filter: string]: unknown },
+): void {
+  if (typeof options.name !== "string") {
+    throw new TypeError(`Expected name: to be a String, got ${typeof options.name}`);
+  }
+  if (typeof options.password !== "string") {
+    throw new TypeError(`Expected password: to be a String, got ${typeof options.password}`);
+  }
+  const { name, password, realm = null, ...rest } = options;
+  this.beforeAction(function (controller) {
+    return httpBasicAuthenticateOrRequestWith.call(controller, { name, password, realm });
+  }, rest);
+}
+
+// Constant-time compare returning 0/1 — mirrors `SecurityUtils.secure_compare`.
+// Returns 0/1 so callers can `&` results without short-circuit.
+function secureCompare(a: string, b: string): 0 | 1 {
+  if (a.length !== b.length) return 0;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0 ? 1 : 0;
+}


### PR DESCRIPTION
## Summary

Implements **P17a** from `docs/actioncontroller-100-percent.md`: ports the
`Basic` submodule of `actionpack/lib/action_controller/metal/http_authentication.rb`
to Rails-fidelity exports in `metal/http-authentication.ts`. Digest (P17b) and
Token (P17c) remain.

The file previously only re-exported the legacy `BasicAuth`/`TokenAuth`/`DigestAuth`
helpers, so api-compare was 0/33. With this change it goes to **13/33** —
every Basic-module method present, including the 5 controller-side helpers
which are wired onto `Base` so the feature is actually usable.

## What's added (13 methods)

`Basic` (8): `authenticate`, `hasBasicCredentials`, `userNameAndPassword`,
`decodeCredentials`, `authScheme`, `authParam`, `encodeCredentials`,
`authenticationRequest`.

`Basic::ControllerMethods` (4): `httpBasicAuthenticateOrRequestWith`,
`authenticateOrRequestWithHttpBasic`, `authenticateWithHttpBasic`,
`requestHttpBasicAuthentication`. All wired onto `Base` as instance methods.

`Basic::ControllerMethods::ClassMethods` (1): `httpBasicAuthenticateWith`,
wired onto `Base` as a static class DSL.

## Fidelity notes

- `authScheme`/`authParam` use a custom split that mirrors Ruby's
  `String#split(" ", 2)` semantics (leading whitespace ignored, runs of
  whitespace collapsed) — JS's native `split(" ", 2)` differs and would
  break `"  Basic   Zm9v"` style inputs.
- `httpBasicAuthenticateOrRequestWith` uses bitwise `&` on two
  constant-time compares so both always run — preserves Rails' "doesn't
  short-circuit so length information isn't leaked" guarantee.
- `httpBasicAuthenticateWith` forwards the rest of its options to
  `beforeAction` (so `only:`/`except:` filters work) and rejects non-string
  `name`/`password` with `TypeError`, matching Rails' `ArgumentError`.

## Verification

```
$ pnpm tsx scripts/api-compare/compare.ts --package actioncontroller --files | grep http_auth
metal/http_authentication.rb   metal/http-authentication.ts   13   20   33  39%
```

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/http-authentication.test.ts` — 11/11 passing
- [x] `pnpm tsx scripts/api-compare/compare.ts --package actioncontroller --files` shows 13/33 (was 0/33)
- [x] Touched files type-check clean against the rest of the package
- [ ] CI green