### PR TITLE
feat(activerecord): wire DidYouMean corrections into HasManyThroughAssociationNotFoundError

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -622,7 +622,7 @@ describe("HasManyThroughAssociations", () => {
     const orphan = await Orphan.create({ name: "Lost" });
     await expect(
       loadHasManyThrough(orphan, "things", { through: "nonexistent", className: "Patient" }),
-    ).rejects.toThrow('Through association "nonexistent" not found');
+    ).rejects.toThrow(/Could not find the association :nonexistent/);
   });
 
   // Rails: test_has_many_through_only_returns_matching

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -52,6 +52,7 @@ export async function initializeAssociations(): Promise<void> {
   ]);
 }
 import { StrictLoadingViolationError, ConfigurationError, Rollback } from "./errors.js";
+import { HasManyThroughAssociationNotFoundError } from "./associations/errors.js";
 import {
   AssociationNotFoundError,
   DeleteRestrictionError,
@@ -311,7 +312,26 @@ function _wireInverseAssociation(owner: Base, child: Base, inverseName: string):
   child._cachedAssociations.set(inverseName, owner);
 }
 
-function levenshtein(a: string, b: string): number {
+/**
+ * @internal
+ * Builds a HasManyThroughAssociationNotFoundError with DidYouMean-style
+ * `corrections` derived from the owner's existing association names —
+ * mirrors `ActiveRecord::HasManyThroughAssociationNotFoundError#corrections`.
+ */
+export function _hmtNotFound(
+  ctor: typeof Base,
+  assocName: string,
+  through: string,
+): HasManyThroughAssociationNotFoundError {
+  const assocs: AssociationDefinition[] = ctor._associations ?? [];
+  const corrections = assocs
+    .map((a) => a.name)
+    .filter((n) => n !== assocName && levenshtein(n, through) <= 3);
+  return new HasManyThroughAssociationNotFoundError(ctor.name, through, assocName, corrections);
+}
+
+/** @internal */
+export function levenshtein(a: string, b: string): number {
   const m = a.length;
   const n = b.length;
   const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
@@ -1369,9 +1389,7 @@ export async function loadHasManyThrough(
   const associations: AssociationDefinition[] = ctor._associations ?? [];
   const throughAssoc = associations.find((a) => a.name === options.through);
   if (!throughAssoc) {
-    throw new ConfigurationError(
-      `Through association "${options.through}" not found on ${ctor.name}`,
-    );
+    throw _hmtNotFound(ctor, assocName, options.through!);
   }
 
   // Resolve the target model
@@ -1471,9 +1489,7 @@ export async function loadHasOneThrough(
   const associations: AssociationDefinition[] = ctor._associations ?? [];
   const throughAssoc = associations.find((a) => a.name === options.through);
   if (!throughAssoc) {
-    throw new ConfigurationError(
-      `Through association "${options.through}" not found on ${ctor.name}`,
-    );
+    throw _hmtNotFound(ctor, assocName, options.through!);
   }
 
   // Load the through record (could be has_one or belongs_to)

--- a/packages/activerecord/src/associations/errors.ts
+++ b/packages/activerecord/src/associations/errors.ts
@@ -65,12 +65,20 @@ export class InverseOfAssociationRecursiveError extends ActiveRecordError {
 export class HasManyThroughAssociationNotFoundError extends ActiveRecordError {
   readonly ownerClass: string;
   readonly reflection: string;
+  readonly corrections: string[];
 
-  constructor(owner: string, through: string, reflection: string = through) {
-    super(`Could not find the association :${through} in model ${owner}`);
+  constructor(
+    owner: string,
+    through: string,
+    reflection: string = through,
+    corrections: string[] = [],
+  ) {
+    const suggestion = corrections.length > 0 ? `\nDid you mean? ${corrections.join(", ")}` : "";
+    super(`Could not find the association :${through} in model ${owner}${suggestion}`);
     this.name = "HasManyThroughAssociationNotFoundError";
     this.ownerClass = owner;
     this.reflection = reflection;
+    this.corrections = corrections;
   }
 }
 

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -978,11 +978,34 @@ describe("AssociationsJoinModelTest", () => {
     ).rejects.toThrow(/Could not find the association :nonexistent/);
   });
 
-  it.skip("exceptions have suggestions for fix", () => {
-    // BLOCKED: associations — join-model feature gap
-    // ROOT-CAUSE: associations/join-model.ts or preloader.ts missing join-model semantics
-    // SCOPE: ~50–200 LOC fix in associations/ or preloader.ts; affects ~10–79 tests in join-model.test.ts
-    // Requires error message suggestions
+  it("exceptions have suggestions for fix", async () => {
+    const ad = freshAdapter();
+    class EhsAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = ad;
+      }
+    }
+    class EhsTagging extends Base {
+      static {
+        this.attribute("author_id", "integer");
+        this.adapter = ad;
+      }
+    }
+    await registerSchemaFor(ad, EhsAuthor, EhsTagging);
+    // Real reflection: taggings. Misspelled :through → "taggng" (lev 2).
+    Associations.hasMany.call(EhsAuthor, "taggings", {
+      className: "EhsTagging",
+      foreignKey: "author_id",
+    });
+    Associations.hasMany.call(EhsAuthor, "tags", {
+      through: "taggng",
+      className: "EhsTagging",
+    });
+    const author = await EhsAuthor.create({ name: "Spell" });
+    await expect(
+      loadHasManyThrough(author, "tags", { through: "taggng", className: "EhsTagging" }),
+    ).rejects.toThrow(/Did you mean\? taggings/);
   });
 
   it("has many through join model with conditions", async () => {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -10,7 +10,7 @@ import {
   foreignKey as deriveForeignKey,
 } from "@blazetrails/activesupport";
 import { Table } from "@blazetrails/arel";
-import { modelRegistry } from "./associations.js";
+import { modelRegistry, levenshtein } from "./associations.js";
 import {
   hasQueryConstraints,
   queryConstraintsList,
@@ -1442,6 +1442,7 @@ export class ThroughReflection extends AbstractReflection {
         this.activeRecord.name,
         this.through,
         this.name,
+        this._throughCorrections(),
       );
     }
 
@@ -1535,6 +1536,21 @@ export class ThroughReflection extends AbstractReflection {
   /** @internal */
   protected deriveClassName(): string {
     return (this.options.sourceType as string) || (this.sourceReflection as any)?.className || "";
+  }
+
+  /**
+   * @internal
+   * Mirrors ActiveRecord's DidYouMean-powered suggestions for
+   * HasManyThroughAssociationNotFoundError. Returns reflection names on
+   * the active_record that are within Levenshtein distance 3 of the
+   * misspelled `:through` name, excluding the failing reflection.
+   */
+  private _throughCorrections(): string[] {
+    const rawReflections: Record<string, unknown> =
+      (this.activeRecord as { _reflections?: Record<string, unknown> })._reflections ?? {};
+    const candidates = Object.keys(rawReflections).filter((k) => k !== this.name);
+    const target = this.through;
+    return candidates.filter((k) => levenshtein(k, target) <= 3);
   }
 
   /**


### PR DESCRIPTION
## Summary

Mirrors Rails' `DidYouMean::Correctable` behavior on `HasManyThroughAssociationNotFoundError`: when a `has_many :through` points at a missing reflection, the error now includes a `Did you mean? …` list of similarly-named associations on the owner.

Drives the `join_model_test` `exceptions have suggestions for fix` un-skip — `join-model.test.ts`: **61/41 → 62/40** (matched/skipped via `pnpm test:compare --cached`).

## Changes

- `associations/errors.ts`: `HasManyThroughAssociationNotFoundError` now accepts/exposes `corrections` and appends `\nDid you mean? …` to its message when non-empty (Rails parity).
- `reflection.ts`: `ThroughReflection#checkValidityBang` passes corrections derived from `_reflections` via Levenshtein distance ≤ 3.
- `associations.ts`: `loadHasManyThrough` / `loadHasOneThrough` replace the ad-hoc `ConfigurationError("Through association ... not found")` with the Rails-faithful error via a new `_hmtNotFound` helper; `levenshtein` is now exported as `@internal`.
- `associations.test.ts`: updates one existing message expectation to the new Rails wording (`Could not find the association :…`).
- `associations/join-model.test.ts`: un-skips `exceptions have suggestions for fix` with a ported body that defines a real `taggings` reflection and a bogus `through: "taggng"` to verify the suggestion fires.

## Scope note

The other 40 skipped tests in `join-model.test.ts` are tagged `BLOCKED` for substantive `associations/join-model.ts` / `preloader.ts` feature gaps (polymorphic-through, STI-through, piggyback selects, custom PKs on belongs-to source, counter caches, etc.) — each needs its own focused PR. This one ships only the suggestion path and its single matching test, well under the 300-LOC ceiling.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/join-model.test.ts packages/activerecord/src/associations.test.ts packages/activerecord/src/associations/errors.test.ts` — 459 passing
- [x] `pnpm test:compare --cached` shows `join_model_test.rb` at 62 matched / 40 skipped
- [x] `pnpm lint --fix`, `pnpm typecheck` clean