### PR TITLE
feat(actionview): port Template base class (Phase 1b)

### DIFF
--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -124,7 +124,7 @@ export class LookupContext {
       // Fallback: look in "layouts" prefix
       const template = resolver.find(name, "layouts", format, extensions);
       if (template) {
-        return { ...template, isLayout: true };
+        return template.asLayout();
       }
     }
     return null;

--- a/packages/actionview/src/template-resolver.ts
+++ b/packages/actionview/src/template-resolver.ts
@@ -14,7 +14,13 @@
  *     find(name, prefix, format, extensions) {
  *       const row = db.query("SELECT source, ext FROM templates WHERE ...");
  *       if (!row) return null;
- *       return { source: row.source, extension: row.ext, ... };
+ *       return new Template({
+ *         source: row.source,
+ *         extension: row.ext,
+ *         identifier: `${prefix}/${name}`,
+ *         virtualPath: `${prefix}/${name}`,
+ *         format,
+ *       });
  *     }
  *   }
  */

--- a/packages/actionview/src/template-resolver.ts
+++ b/packages/actionview/src/template-resolver.ts
@@ -20,7 +20,7 @@
  */
 
 import { getFs, getPath } from "@blazetrails/activesupport";
-import type { Template } from "./template.js";
+import { Template } from "./template.js";
 
 /**
  * A resolver knows how to find templates.
@@ -70,27 +70,29 @@ export class FileSystemResolver implements TemplateResolver {
       // Try format-specific first: index.html.ejs
       const formatPath = getPath().join(dir, `${name}.${format}.${ext}`);
       if (getFs().existsSync(formatPath)) {
-        return {
+        return new Template({
           source: getFs().readFileSync(formatPath, "utf-8"),
           extension: ext,
           identifier: `${prefix}/${name}`,
+          virtualPath: `${prefix}/${name}`,
           format,
           fullPath: formatPath,
           isPartial: name.startsWith("_"),
-        };
+        });
       }
 
       // Fallback: index.ejs
       const plainPath = getPath().join(dir, `${name}.${ext}`);
       if (getFs().existsSync(plainPath)) {
-        return {
+        return new Template({
           source: getFs().readFileSync(plainPath, "utf-8"),
           extension: ext,
           identifier: `${prefix}/${name}`,
+          virtualPath: `${prefix}/${name}`,
           format,
           fullPath: plainPath,
           isPartial: name.startsWith("_"),
-        };
+        });
       }
     }
 
@@ -101,7 +103,7 @@ export class FileSystemResolver implements TemplateResolver {
   findLayout(name: string, format: string, extensions: string[]): Template | null {
     const template = this.find(name, "layouts", format, extensions);
     if (template) {
-      return { ...template, isLayout: true };
+      return template.asLayout();
     }
     return null;
   }
@@ -127,23 +129,21 @@ export class InMemoryResolver implements TemplateResolver {
    */
   add(identifier: string, format: string, extension: string, source: string): void {
     const key = this.key(identifier, format);
-    this.templates.set(key, {
-      source,
-      extension,
-      identifier,
-      format,
-      isPartial: identifier.includes("/_") || identifier.startsWith("_"),
-    });
-    // Also store without format for fallback
-    const fallbackKey = `${identifier}:*`;
-    if (!this.templates.has(fallbackKey)) {
-      this.templates.set(fallbackKey, {
+    const isPartial = identifier.includes("/_") || identifier.startsWith("_");
+    const make = (): Template =>
+      new Template({
         source,
         extension,
         identifier,
+        virtualPath: identifier,
         format,
-        isPartial: identifier.includes("/_") || identifier.startsWith("_"),
+        isPartial,
       });
+    this.templates.set(key, make());
+    // Also store without format for fallback
+    const fallbackKey = `${identifier}:*`;
+    if (!this.templates.has(fallbackKey)) {
+      this.templates.set(fallbackKey, make());
     }
   }
 
@@ -200,7 +200,7 @@ export class InMemoryResolver implements TemplateResolver {
   findLayout(name: string, format: string, extensions: string[]): Template | null {
     const template = this.find(name, "layouts", format, extensions);
     if (template) {
-      return { ...template, isLayout: true };
+      return template.asLayout();
     }
     return null;
   }

--- a/packages/actionview/src/template.test.ts
+++ b/packages/actionview/src/template.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Template } from "./template.js";
+import { TemplateError } from "./template/error.js";
+import { TemplateHandlers, type TemplateHandler } from "./template/handlers.js";
+
+const echo: TemplateHandler = {
+  extensions: ["txt"],
+  render: (source, locals) => `${source}::${JSON.stringify(locals)}`,
+};
+
+describe("ActionView::Template (smoke)", () => {
+  afterEach(() => TemplateHandlers.clear());
+
+  it("stores Rails-named attrs and derives variable from virtualPath", () => {
+    const t = new Template({
+      source: "hi",
+      identifier: "posts/_form",
+      virtualPath: "posts/_form.html.ejs",
+      format: "html",
+      variant: "phone",
+      extension: "ejs",
+      locals: ["a"],
+    });
+    expect(t.identifier).toBe("posts/_form");
+    expect(t.format).toBe("html");
+    expect(t.variant).toBe("phone");
+    expect(t.variable).toBe("form");
+    expect(t.isPartial).toBe(true);
+    expect(t.locals).toEqual(["a"]);
+  });
+
+  it("strict_locals! strips the magic comment and memoizes the signature", () => {
+    const t = new Template({
+      source: "<%# locals: (headline:, alerts: []) %>\nbody",
+      identifier: "x",
+    });
+    expect(t.strictLocalsBang()).toBe("headline:, alerts: []");
+    expect(t.source).not.toMatch(/locals:/);
+    expect(t.strictLocalsQ()).toBe(true);
+    expect(t.locals).toBeNull();
+
+    const afterFirst = t.source;
+    expect(t.strictLocalsBang()).toBe("headline:, alerts: []");
+    expect(t.source).toBe(afterFirst);
+  });
+
+  it("render delegates to the handler and wraps non-TemplateError failures", async () => {
+    TemplateHandlers.registerTemplateHandler("txt", echo);
+    const t = new Template({ source: "hi", identifier: "x", extension: "txt" });
+    expect(await t.render({ name: "ada" })).toBe(`hi::${JSON.stringify({ name: "ada" })}`);
+
+    TemplateHandlers.clear();
+    TemplateHandlers.registerTemplateHandler("txt", {
+      extensions: ["txt"],
+      render: () => {
+        throw new Error("boom");
+      },
+    });
+    await expect(t.render()).rejects.toBeInstanceOf(TemplateError);
+  });
+
+  it("render throws a helpful error when no handler is registered", async () => {
+    const t = new Template({ source: "x", identifier: "x", extension: "nope" });
+    await expect(t.render()).rejects.toThrow(/No template handler registered for ".nope"/);
+  });
+
+  it("asLayout returns a copy with isLayout flipped on", () => {
+    const t = new Template({ source: "<html/>", identifier: "layouts/app", extension: "ejs" });
+    const wrapped = t.asLayout();
+    expect(wrapped.isLayout).toBe(true);
+    expect(t.isLayout).toBe(false);
+    expect(wrapped).not.toBe(t);
+  });
+
+  it("exposes Template.Error for the Rails-spelled nesting", () => {
+    expect(Template.Error).toBe(TemplateError);
+  });
+});

--- a/packages/actionview/src/template.ts
+++ b/packages/actionview/src/template.ts
@@ -1,36 +1,201 @@
 /**
- * ActionView::Template
+ * ActionView::Template — Rails mirror: `action_view/template.rb`.
  *
- * A resolved template with source, handler reference, and metadata.
+ * A single template file: source, handler, and metadata (identifier,
+ * format, variant, locals). The TS port collapses Rails' compile-then-
+ * `module_eval` step into a direct `handler.render(source, locals, ctx)`
+ * call — our handler interface already does the compile-and-execute in
+ * one shot (see `template/handlers.ts`).
  */
-
 import { TemplateError } from "./template/error.js";
+import { TemplateHandlers, type RenderContext, type TemplateHandler } from "./template/handlers.js";
 
-/**
- * `Template.Error` mirrors Rails' `ActionView::Template::Error` nesting so
- * downstream code (actionpack `ExceptionWrapper`) can reference the
- * canonical name. The class itself lives in `./template/error.js` to keep
- * the Rails file layout.
- */
-// eslint-disable-next-line @typescript-eslint/no-namespace
-export namespace Template {
-  export const Error = TemplateError;
-  export type Error = TemplateError;
+const STRICT_LOCALS_REGEX = /#\s+locals:\s+\((.*)\)/;
+const VARIABLE_FROM_BASENAME = /^_?(.*?)(?:\.\w+)*$/;
+const NONE = Symbol("Template::NONE");
+
+export interface TemplateOptions {
+  source: string;
+  identifier: string;
+  handler?: TemplateHandler | null;
+  locals?: readonly string[];
+  format?: string | null;
+  variant?: string | null;
+  virtualPath?: string | null;
+  /** File extension. Rails infers from `handler`; kept here for the
+   * resolver's "I just read this file off disk" shortcut. */
+  extension?: string;
+  fullPath?: string;
+  isLayout?: boolean;
+  /** Defaults to `basename(virtualPath ?? identifier).startsWith("_")`. */
+  isPartial?: boolean;
 }
 
-export interface Template {
-  /** Raw template source code */
-  source: string;
-  /** File extension determining which handler to use (e.g., "ejs") */
-  extension: string;
-  /** Logical path (e.g., "posts/index") */
-  identifier: string;
-  /** Response format (e.g., "html", "json", "text") */
-  format: string;
-  /** Full filesystem path (for error reporting), if available */
-  fullPath?: string;
-  /** Whether this is a layout template */
-  isLayout?: boolean;
-  /** Whether this is a partial template */
-  isPartial?: boolean;
+export class Template {
+  static Error = TemplateError;
+
+  readonly identifier: string;
+  readonly handler: TemplateHandler | null;
+  readonly variable: string | null;
+  readonly format: string | null;
+  readonly variant: string | null;
+  readonly virtualPath: string | null;
+  readonly extension: string;
+  readonly fullPath?: string;
+  /** Mutable so resolvers can flip a cached lookup without rebuilding. */
+  isLayout: boolean;
+  readonly isPartial: boolean;
+
+  private _source: string;
+  private readonly _locals: readonly string[];
+  private _strictLocals: string | null | typeof NONE = NONE;
+  /** @internal */
+  _strictLocalKeys: readonly string[] | null = null;
+  private _shortIdentifier?: string;
+
+  constructor(opts: TemplateOptions) {
+    this._source = opts.source;
+    this.identifier = opts.identifier;
+    this.handler = opts.handler ?? null;
+    this._locals = opts.locals ?? [];
+    this.virtualPath = opts.virtualPath ?? null;
+    this.format = opts.format ?? null;
+    this.variant = opts.variant ?? null;
+    this.extension = opts.extension ?? "";
+    this.fullPath = opts.fullPath;
+    this.isLayout = opts.isLayout ?? false;
+    this.isPartial =
+      opts.isPartial ?? basename(this.virtualPath ?? this.identifier).startsWith("_");
+    this.variable = deriveVariable(this.virtualPath);
+  }
+
+  get source(): string {
+    return this._source;
+  }
+
+  /** Null when the template declares strict locals via the magic comment. */
+  get locals(): readonly string[] | null {
+    return this.strictLocalsQ() ? null : this._locals;
+  }
+
+  /** MIME-type token. Returns the format string until `Mime::Type` lands. */
+  get type(): string | null {
+    return this.format;
+  }
+
+  /** Path with the project-root prefix stripped (no-op until trails has
+   * a project-root concept). */
+  get shortIdentifier(): string {
+    return (this._shortIdentifier ??= this.identifier);
+  }
+
+  /** Rails: `supports_streaming?` — true when the handler opts in. */
+  supportsStreaming(): boolean {
+    const h = this.resolveHandler();
+    return Boolean(
+      h && (h as { supportsStreaming?: () => boolean }).supportsStreaming?.() === true,
+    );
+  }
+
+  /**
+   * Rails: `Template#strict_locals!`. Lazily strips the
+   * `<%# locals: (...) %>` magic comment, memoizes the signature, and
+   * returns it. Returns null when the comment is absent.
+   */
+  strictLocalsBang(): string | null {
+    if (this._strictLocals === NONE) {
+      const m = STRICT_LOCALS_REGEX.exec(this._source);
+      if (m) {
+        this._source = this._source.replace(STRICT_LOCALS_REGEX, "");
+        const sig = m[1]!.trim();
+        this._strictLocals = sig === "" ? "**nil" : sig;
+      } else {
+        this._strictLocals = null;
+      }
+    }
+    return this._strictLocals;
+  }
+
+  /** Rails: `Template#strict_locals?`. */
+  strictLocalsQ(): boolean {
+    return this.strictLocalsBang() != null;
+  }
+
+  /** Render this template. Non-TemplateError failures from the handler
+   * are wrapped in {@link TemplateError} so AP's ExceptionWrapper can
+   * unwrap to the original cause. */
+  async render(
+    locals: Record<string, unknown> = {},
+    context: Partial<RenderContext> = {},
+  ): Promise<string> {
+    // Touch strict locals so the magic comment is stripped before the
+    // handler sees the source — matches Rails' compile order.
+    this.strictLocalsBang();
+
+    const handler = this.resolveHandler();
+    if (!handler) {
+      throw new Error(
+        `No template handler registered for ".${this.extension}". ` +
+          `Register one with TemplateHandlers.registerTemplateHandler(ext, handler).`,
+      );
+    }
+
+    try {
+      return await handler.render(this._source, locals, {
+        controller: context.controller ?? "",
+        action: context.action ?? "",
+        format: context.format ?? this.format ?? "",
+        yield: context.yield,
+        ...context,
+        templatePath: context.templatePath ?? this.fullPath ?? this.identifier,
+      });
+    } catch (e) {
+      if (e instanceof TemplateError) throw e;
+      throw new TemplateError({ original: e as Error, template: this });
+    }
+  }
+
+  inspect(): string {
+    const locals = this._locals.length > 0 ? `[:${this._locals.join(", :")}]` : "[]";
+    return `#<Template ${this.shortIdentifier} locals=${locals}>`;
+  }
+
+  toString(): string {
+    return this.inspect();
+  }
+
+  /** Shallow copy with `isLayout = true`. Resolvers use this when a
+   * cached lookup needs to be served as a layout wrapper. */
+  asLayout(): Template {
+    return new Template({
+      source: this._source,
+      identifier: this.identifier,
+      handler: this.handler,
+      locals: this._locals,
+      format: this.format,
+      variant: this.variant,
+      virtualPath: this.virtualPath,
+      extension: this.extension,
+      fullPath: this.fullPath,
+      isPartial: this.isPartial,
+      isLayout: true,
+    });
+  }
+
+  /** @internal */
+  private resolveHandler(): TemplateHandler | undefined {
+    return this.handler ?? TemplateHandlers.handlerForExtension(this.extension);
+  }
+}
+
+function deriveVariable(virtualPath: string | null): string | null {
+  if (!virtualPath) return null;
+  const base = virtualPath.endsWith("/") ? "" : basename(virtualPath);
+  const m = VARIABLE_FROM_BASENAME.exec(base);
+  return m?.[1] || null;
+}
+
+function basename(path: string): string {
+  const slash = path.lastIndexOf("/");
+  return slash === -1 ? path : path.slice(slash + 1);
 }

--- a/packages/actionview/src/template.ts
+++ b/packages/actionview/src/template.ts
@@ -151,7 +151,8 @@ export class Template {
       });
     } catch (e) {
       if (e instanceof TemplateError) throw e;
-      throw new TemplateError({ original: e as Error, template: this });
+      const original = e instanceof Error ? e : new Error(String(e));
+      throw new TemplateError({ original, template: this });
     }
   }
 

--- a/packages/actionview/src/template.ts
+++ b/packages/actionview/src/template.ts
@@ -142,11 +142,11 @@ export class Template {
 
     try {
       return await handler.render(this._source, locals, {
+        ...context,
         controller: context.controller ?? "",
         action: context.action ?? "",
         format: context.format ?? this.format ?? "",
         yield: context.yield,
-        ...context,
         templatePath: context.templatePath ?? this.fullPath ?? this.identifier,
       });
     } catch (e) {


### PR DESCRIPTION
## Summary

- Replaces the type-stub `Template` interface with a real `ActionView::Template` class (Rails mirror: `action_view/template.rb`).
- Carries Rails-spelled attrs (`identifier`, `handler`, `variable`, `format`, `variant`, `virtualPath`, `locals`), strict-locals magic-comment handling (`strictLocalsBang` / `strictLocalsQ`), and `Template#render` that delegates to the registered handler and wraps non-`TemplateError` failures so AP's `ExceptionWrapper` can unwrap to the original cause.
- Resolvers now produce `Template` instances; `lookup-context`'s `{ ...template, isLayout: true }` becomes `template.asLayout()` since the spread no longer carries methods.

Deviation from Rails: the TS port collapses Rails' `compile! → module_eval(compiled_source)` step into a direct `handler.render(source, locals, ctx)` call — our handler interface already does compile-and-execute in one shot (see `template/handlers.ts`). Encoding handling (`encode!`, `WrongEncodingError`) is omitted; JS strings are already UTF-16. `method_name`, `spot`, `translate_location`, `marshal_dump/load` are intentionally not ported.

Follow-ups (Phase 1bb):

- Full Rails-mirrored test coverage (`test/template/...`). This PR ships impl + smoke tests per the docs/actionview-100-percent.md `<base>` / `<base>b` split heuristic.
- Wire `Template#render` into `LookupContext#renderTemplate` so the context-level error wrapping flows through the instance.
- `type` returning a real `Mime::Type` once Phase 0b/Mime lands.
- Compiled-body caching (Rails' `@compiled` + mutex) once handlers separate compile from render.

## Test plan

- [x] `pnpm vitest run packages/actionview/` — 287 passed, 1 skipped (pre-existing).
- [x] Pre-commit `tsc --build` + `typecheck` clean.