### PR TITLE
test(activerecord): migrate uniqueness-validations + extended-deterministic-queries to transactional fixtures (B6.4)

### DIFF
--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -1,4 +1,6 @@
-import { describe, it, expect, beforeEach, beforeAll, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
+import type { TestDatabaseAdapter } from "../test-adapter.js";
 import {
   AdditionalValue,
   EncryptedQuery,
@@ -30,14 +32,11 @@ const TEST_KEY = Buffer.alloc(32, "x").toString("base64");
  * Mirrors Rails' `models/book_encrypted.rb`: one `books` table, five model
  * classes pointing at it with different encryption configurations.
  *
- * Config mutation and prototype patching are handled in the describe
- * block's beforeAll/afterAll; setupBooks() only builds fresh classes
- * and an adapter per test.
+ * Schema and classes are built once in beforeAll so transactional fixtures
+ * can wrap each test in BEGIN/ROLLBACK — DDL inside beforeEach would
+ * auto-commit on MariaDB and break the outer wrap.
  */
-async function setupBooks() {
-  const adapter = createTestAdapter();
-  await defineSchema(adapter, { books: { name: "string" } });
-
+function buildBooks(adapter: TestDatabaseAdapter) {
   class UnencryptedBook extends Base {
     static {
       this._tableName = "books";
@@ -84,7 +83,6 @@ async function setupBooks() {
   }
 
   return {
-    adapter,
     UnencryptedBook,
     EncryptedBook,
     EncryptedBookWithDowncaseName,
@@ -94,7 +92,8 @@ async function setupBooks() {
 }
 
 describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
-  let books: Awaited<ReturnType<typeof setupBooks>>;
+  let adapter: TestDatabaseAdapter;
+  let books: ReturnType<typeof buildBooks>;
 
   // Snapshot global state up front and restore it after the whole
   // block. Configurable.config and Relation/Base/EncryptedAttributeType
@@ -115,7 +114,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
     serialize?: (...args: any[]) => unknown;
   } = {};
 
-  beforeAll(() => {
+  beforeAll(async () => {
     Configurable.config.extendQueries = true;
     Configurable.config.supportUnencryptedData = true;
     Configurable.config.keyDerivationSalt = "test-salt";
@@ -129,7 +128,16 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
     savedMethods.serialize = EncryptedAttributeType.prototype.serialize;
 
     installExtendedQueriesIfConfigured();
+
+    adapter = createTestAdapter();
+    await defineSchema(adapter, { books: { name: "string" } });
+    books = buildBooks(adapter);
+    // Warm the books table so the first create in each test doesn't race
+    // with the test-adapter's regex-recovery schema path on MariaDB.
+    await books.EncryptedBook.where("1=1").toArray();
   });
+
+  withTransactionalFixtures(() => adapter);
 
   afterAll(() => {
     Relation.prototype.where = savedMethods.where as typeof Relation.prototype.where;
@@ -146,15 +154,6 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
     Configurable.config.keyDerivationSalt = savedConfig.keyDerivationSalt;
     Configurable.config.primaryKey = savedConfig.primaryKey;
     Configurable.config.deterministicKey = savedConfig.deterministicKey;
-  });
-
-  beforeEach(async () => {
-    books = await setupBooks();
-    // Warm the books table so the first create in each test doesn't race
-    // with the test-adapter's regex-recovery schema path on MariaDB,
-    // which can otherwise leave the create's INSERT torn from the
-    // subsequent SELECT (different pool connections, uncommitted state).
-    await books.EncryptedBook.where("1=1").toArray();
   });
 
   it("Finds records when data is unencrypted", async () => {

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -132,8 +132,9 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, { books: { name: "string" } });
     books = buildBooks(adapter);
-    // Warm the books table so the first create in each test doesn't race
-    // with the test-adapter's regex-recovery schema path on MariaDB.
+    // Warm the books table once before any test runs so the first create
+    // doesn't race with the test-adapter's regex-recovery schema path on
+    // MariaDB. Subsequent tests reuse the warmed schema cache.
     await books.EncryptedBook.where("1=1").toArray();
   });
 

--- a/packages/activerecord/src/encryption/uniqueness-validations.test.ts
+++ b/packages/activerecord/src/encryption/uniqueness-validations.test.ts
@@ -1,11 +1,10 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import {
   freshAdapter,
   configureEncryption,
   snapshotEncryptionConfig,
   restoreEncryptionConfig,
   makeEncryptedBookWithDowncaseName,
-  makeFreshModel,
   makeKeyProvider,
   makeEncryptedBook,
 } from "./test-helpers.js";
@@ -17,7 +16,28 @@ import { UniquenessValidator } from "../validations.js";
 import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Relation } from "../relation.js";
 import { Base } from "../index.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
+import type { TestDatabaseAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
+
+// Builds a fresh Base subclass bound to the shared `encrypted_books` table.
+// Each test gets its own class so `encrypts(...)` is called exactly once
+// (encrypts() is idempotent and would no-op on a reused class). DDL was
+// already executed in beforeAll, so no in-test ALTER TABLE — compatible
+// with transactional fixtures on MariaDB.
+function freshBook(adapter: DatabaseAdapter): any {
+  return class extends Base {
+    static {
+      this._tableName = "encrypted_books";
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.adapter = adapter;
+    }
+  } as any;
+}
+
 describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
+  let adapter: TestDatabaseAdapter;
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
   let savedExtendQueries: boolean;
   const savedMethods: {
@@ -27,6 +47,12 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
     findBy?: (...args: any[]) => unknown;
     serialize?: (...args: any[]) => unknown;
   } = {};
+
+  beforeAll(async () => {
+    adapter = await freshAdapter();
+  });
+
+  withTransactionalFixtures(() => adapter);
 
   beforeEach(() => {
     configSnapshot = snapshotEncryptionConfig();
@@ -61,7 +87,7 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
   });
 
   it("uniqueness validations work", async () => {
-    const Book = makeEncryptedBookWithDowncaseName(await freshAdapter());
+    const Book = makeEncryptedBookWithDowncaseName(adapter);
     Book.validatesUniqueness("name");
     new Book();
 
@@ -75,15 +101,13 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
     // previousTypes, so the uniqueness query also searches for the unencrypted value.
     Configurable.config.supportUnencryptedData = true;
 
-    const adp = await freshAdapter();
-    const Book = await makeFreshModel(adp, { id: "integer", name: "string" });
+    const Book = freshBook(adapter);
     Book.validatesUniqueness("name");
     Book.encrypts("name", { deterministic: true, downcase: true });
     new Book();
 
     // Insert unencrypted "dune" directly (simulates a row that leaked plain text).
-    const RawBook = await makeFreshModel(adp, { id: "integer", name: "string" });
-    RawBook._tableName = Book._tableName;
+    const RawBook = freshBook(adapter);
     new RawBook();
     await RawBook.create({ name: "dune" });
 
@@ -98,14 +122,12 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
     // supportUnencryptedData: false — so no plain-text fallback in previousTypes.
     Configurable.config.supportUnencryptedData = true;
 
-    const adp = await freshAdapter();
-    const Book = await makeFreshModel(adp, { id: "integer", name: "string" });
+    const Book = freshBook(adapter);
     Book.validatesUniqueness("name");
     Book.encrypts("name", { deterministic: true, downcase: true, supportUnencryptedData: false });
     new Book();
 
-    const RawBook = await makeFreshModel(adp, { id: "integer", name: "string" });
-    RawBook._tableName = Book._tableName;
+    const RawBook = freshBook(adapter);
     new RawBook();
     await RawBook.create({ name: "dune" });
 
@@ -120,14 +142,12 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
     // supportUnencryptedData: true — so the plain-text fallback IS included.
     Configurable.config.supportUnencryptedData = false;
 
-    const adp = await freshAdapter();
-    const Book = await makeFreshModel(adp, { id: "integer", name: "string" });
+    const Book = freshBook(adapter);
     Book.validatesUniqueness("name");
     Book.encrypts("name", { deterministic: true, downcase: true, supportUnencryptedData: true });
     new Book();
 
-    const RawBook = await makeFreshModel(adp, { id: "integer", name: "string" });
-    RawBook._tableName = Book._tableName;
+    const RawBook = freshBook(adapter);
     new RawBook();
     await RawBook.create({ name: "dune" });
 
@@ -141,7 +161,7 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
     Configurable.config.supportUnencryptedData = false;
     Configurable.config.previous = [{ downcase: true, deterministic: true }];
 
-    const OldBook = await makeFreshModel(await freshAdapter(), { id: "integer", name: "string" });
+    const OldBook = freshBook(adapter);
     OldBook.validatesUniqueness("name");
     OldBook.encrypts("name", { deterministic: true, downcase: false });
     new OldBook();
@@ -159,7 +179,7 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
     const prevKeyProvider = makeKeyProvider("prev-key-for-uniqueness-test-32b!!");
     Configurable.config.previous = [{ keyProvider: prevKeyProvider, deterministic: true }];
 
-    const Book = makeEncryptedBook(await freshAdapter()); // deterministic encrypted name
+    const Book = makeEncryptedBook(adapter); // deterministic encrypted name
     Book.validatesUniqueness("name");
     new Book();
 


### PR DESCRIPTION
## Summary

Phase 6 / B6.4 follow-up to #1967 (shared-adapter test-helper pattern). Migrates two encryption test files away from the per-test `freshAdapter()` + `makeFreshModel()` pattern so they can use `withTransactionalFixtures`. `makeFreshModel` runs `CREATE TABLE` inside `it()` bodies, which auto-commits on MariaDB and breaks the outer BEGIN/ROLLBACK wrap.

- `uniqueness-validations.test.ts` — 6 `makeFreshModel(...)` calls replaced with a local `freshBook(adapter)` helper that builds a Base subclass bound to the pre-existing `encrypted_books` table (already in the shared encryption schema). Adapter created once in `beforeAll`; tests run inside transactions.
- `extended-deterministic-queries.test.ts` — schema/class setup moved from `beforeEach` to `beforeAll`; `withTransactionalFixtures(() => adapter)` wired. The five Book classes are stateless and safe to share across tests.

No production-source changes; tests-only.

## Follow-ups (still call `makeFreshModel` inside `it()` bodies)

- `encryptable-record.test.ts` (59 calls — largest)
- `encryptable-record-api.test.ts` (19 calls)

## Test plan

- [x] Both files green on SQLite, PG, and MariaDB (individually and together)
- [x] `AR_NO_AUTO_SCHEMA=1` green
- [x] Size: 93 LOC (well under 300 ceiling)
- [ ] CI green across SQLite, PostgreSQL, MariaDB