### PR TITLE
test(activerecord): reuse describe-level adapter in HABTM tests (B1966)

### DIFF
--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -46,9 +46,9 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     adapter = freshAdapter();
     // Schema covers the shared Developer/Project/DeveloperProject family
     // used by the majority of tests in this describe. Tests further down
-    // that build their own `createTestAdapter()` adapter and declare
-    // inline classes seed their own schema inline next to the adapter
-    // construction.
+    // that declare their own inline classes reuse this per-test adapter
+    // and seed additional tables via `defineSchema` next to the class
+    // declarations.
     await defineSchema(adapter, {
       developers: { name: "string", salary: "integer" },
       projects: { name: "string", approved: "boolean", featured: "boolean" },
@@ -629,7 +629,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     // signature (vendor/rails/activerecord/lib/active_record/associations.rb:1870-1871):
     // the macro-time scope flows positionally into the reflection, not
     // into the options bag. This is the exact wire the PR adds.
-    const a5 = createTestAdapter();
+    const a5 = adapter;
     class ScDev extends Base {
       static {
         this.attribute("name", "string");
@@ -1152,7 +1152,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   });
 
   it("association with validate false does not run associated validation callbacks on create", async () => {
-    const a2 = createTestAdapter();
+    const a2 = adapter;
     class RichPerson extends Base {
       static {
         this.attribute("first_name", "string");
@@ -1186,7 +1186,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   });
 
   it("association with validate false does not run associated validation callbacks on update", async () => {
-    const a2 = createTestAdapter();
+    const a2 = adapter;
     await defineSchema(a2, {
       rich_person2s: { first_name: "string" },
       treasure2s: { name: "string" },
@@ -1226,7 +1226,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("custom join table", async () => {
     // Use a differently-named join table model but with conventional FK columns
-    const a2 = createTestAdapter();
+    const a2 = adapter;
     await defineSchema(a2, {
       cj_developers: { name: "string" },
       cj_projects: { name: "string" },
@@ -1334,7 +1334,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
 
   it("association name is the same as join table name", async () => {
     // Use a join table model whose name matches the association name
-    const a2 = createTestAdapter();
+    const a2 = adapter;
     await defineSchema(a2, {
       same_devs: { name: "string" },
       same_projs: { name: "string" },
@@ -1479,7 +1479,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   // ==========================================================================
 
   it("layers destroyAssociations chain for multiple HABTMs on one class", async () => {
-    const a2 = createTestAdapter();
+    const a2 = adapter;
     await defineSchema(a2, {
       multi_owners: { name: "string" },
       tag_as: { name: "string" },
@@ -1540,7 +1540,7 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
   });
 
   it("subclass HABTM extends destroyAssociations chain via super", async () => {
-    const a2 = createTestAdapter();
+    const a2 = adapter;
     await defineSchema(a2, {
       parent_owners: { name: "string" },
       child_owners: { name: "string" },

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -46,9 +46,10 @@ describe("HasAndBelongsToManyAssociationsTest", () => {
     adapter = freshAdapter();
     // Schema covers the shared Developer/Project/DeveloperProject family
     // used by the majority of tests in this describe. Tests further down
-    // that declare their own inline classes reuse this per-test adapter
-    // and seed additional tables via `defineSchema` next to the class
-    // declarations.
+    // that declare their own inline classes reuse this per-test adapter;
+    // those that hit the database also seed additional tables via
+    // `defineSchema` next to the class declarations, while reflection-
+    // or validation-only tests skip the schema step.
     await defineSchema(adapter, {
       developers: { name: "string", salary: "integer" },
       projects: { name: "string", approved: "boolean", featured: "boolean" },


### PR DESCRIPTION
## Summary

Follow-up to #1966. Replaces 7 inline `createTestAdapter()` calls inside `it()` blocks in `has-and-belongs-to-many-associations.test.ts` with the per-test `adapter` already built in `beforeEach`.

Eliminates the sharp-edge warning #1966 wired up: calling `createTestAdapter()` inside a describe whose `beforeEach` already built one set the module-level `_needsCleanup` flag and silently dropped the surrounding tables on the next `SchemaAdapter.setup()`.

Each `beforeEach` already builds a fresh adapter and seeds `developers/projects/developer_projects`. The 7 inline tests each declare unique table names, so they continue to seed their own `defineSchema` calls — just against the shared per-test adapter instead of an extra one. The one exception (`"association with validate false ... on create"`) makes no DB calls.

No flip to `withTransactionalFixtures` here — that follow-up needs schemas declared up front via `defineSchema` in `beforeAll`, which is its own migration.

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts --project activerecord` — 74 passed / 24 skipped
- [x] Size: 20 LOC under 300 ceiling
- [ ] CI green