### PR TITLE
feat(html-sanitizer): SafeListSanitizer (PR 2)

### DIFF
--- a/packages/html-sanitizer/src/engine.ts
+++ b/packages/html-sanitizer/src/engine.ts
@@ -45,6 +45,43 @@ export function stripAllTags(html: string): string {
 
 /**
  * @internal
+ * Options consumed by `safeListSanitize`. Mirrors the Rails
+ * `SafeListSanitizer` scrub options: allowed tags + attributes plus a
+ * `prune` switch that swaps the default "strip tag, keep content"
+ * behavior for "remove tag and its children".
+ */
+export interface SafeListEngineOptions {
+  allowedTags: readonly string[];
+  allowedAttributes: readonly string[];
+  prune?: boolean;
+}
+
+/**
+ * @internal
+ * Allowlist sanitize for SafeListSanitizer. Drops any tag not in
+ * `allowedTags` (keeping inner text by default, or pruning children when
+ * `prune` is true) and strips any attribute not in `allowedAttributes`.
+ * URL-bearing attributes are filtered to safe schemes by the engine.
+ */
+export function safeListSanitize(html: string, options: SafeListEngineOptions): string {
+  const allowedAttrs = [...options.allowedAttributes];
+
+  return sanitizeHtml(html, {
+    allowedTags: [...options.allowedTags],
+    // Apply the same allowlist to every tag — Rails' PermitScrubber
+    // doesn't gate attributes per-tag, it's one flat list.
+    allowedAttributes: { "*": allowedAttrs },
+    // Rails' `prune: true` → remove disallowed tags AND their content.
+    // Default behavior strips the tag but keeps inner text.
+    disallowedTagsMode: options.prune ? "completelyDiscard" : "discard",
+    // sanitize-html's default allowedSchemes (http/https/ftp/mailto/tel)
+    // matches Loofah's safe-URL set for href/src; javascript: and
+    // vbscript: are dropped automatically.
+  });
+}
+
+/**
+ * @internal
  * "Unwrap" the listed tags: drop the open/close markers but keep the
  * inner text, and strip the listed attributes from any element that
  * survives. Mirrors Loofah's TargetScrubber used by Rails' LinkSanitizer

--- a/packages/html-sanitizer/src/index.ts
+++ b/packages/html-sanitizer/src/index.ts
@@ -1,4 +1,5 @@
 export { Sanitizer, type SanitizeOptions } from "./sanitizer.js";
 export { FullSanitizer } from "./full-sanitizer.js";
 export { LinkSanitizer } from "./link-sanitizer.js";
+export { SafeListSanitizer } from "./safe-list-sanitizer.js";
 export { DEFAULT_ALLOWED_TAGS, DEFAULT_ALLOWED_ATTRIBUTES } from "./config.js";

--- a/packages/html-sanitizer/src/safe-list-sanitizer.test.ts
+++ b/packages/html-sanitizer/src/safe-list-sanitizer.test.ts
@@ -1,0 +1,203 @@
+// Mirrors rails-html-sanitizer test/sanitizer_test.rb -> SafeListSanitizerTest.
+// Test names track Rails' test_* methods for test:compare alignment.
+//
+// Rails' suite is heavily intertwined with libxml2 / Loofah specifics
+// (many tests use `acceptable_results = [...]` to span libxml2 versions
+// and the gumbo/neko parsers). For engine-divergent cases we assert the
+// security-relevant invariant (no scripts, no js: URLs) rather than the
+// exact byte-for-byte output.
+
+import { afterEach, describe, expect, test } from "vitest";
+import { SafeListSanitizer } from "./safe-list-sanitizer.js";
+import { DEFAULT_ALLOWED_ATTRIBUTES, DEFAULT_ALLOWED_TAGS } from "./config.js";
+
+const sanitize = (
+  input: string | null | undefined,
+  options?: { tags?: Iterable<string>; attributes?: Iterable<string> },
+) => new SafeListSanitizer().sanitize(input, options);
+
+const assertSanitized = (raw: string, expected?: string) => {
+  expect(sanitize(raw)).toBe(expected ?? raw);
+};
+
+describe("SafeListSanitizer", () => {
+  afterEach(() => {
+    // Reset class-level state mutated by scope_* helpers.
+    SafeListSanitizer.allowedTags = new Set(DEFAULT_ALLOWED_TAGS);
+    SafeListSanitizer.allowedAttributes = new Set(DEFAULT_ALLOWED_ATTRIBUTES);
+  });
+
+  test("sanitize_form", () => {
+    assertSanitized('<form action="/foo/bar" method="post"><input></form>', "");
+  });
+
+  test("sanitize_script", () => {
+    assertSanitized(
+      'a b c<script language="Javascript">blah blah blah</script>d e f',
+      "a b cd e f",
+    );
+  });
+
+  test("sanitize_js_handlers", () => {
+    expect(
+      sanitize(
+        `onthis="do that" <a href="#" onclick="hello" name="foo" onbogus="remove me">hello</a>`,
+      ),
+    ).toBe(`onthis="do that" <a href="#" name="foo">hello</a>`);
+  });
+
+  test("sanitize_javascript_href", () => {
+    // javascript:-scheme URLs are dropped from the actual <a>/<span>
+    // attributes. The bare prefix text outside any tag survives as
+    // plain text — that matches Rails (the leading `href="javascript:bang" `
+    // is text, not an attribute).
+    const out = sanitize(
+      `href="javascript:bang" <a href="javascript:bang" name="hello">foo</a>, <span href="javascript:bang">bar</span>`,
+    )!;
+    expect(out).toContain(`<a name="hello">foo</a>`);
+    expect(out).toContain(`<span>bar</span>`);
+    // No javascript: scheme on any actual element attribute.
+    expect(out).not.toMatch(/<[^>]+\bhref="javascript:/i);
+  });
+
+  test("should_allow_anchors", () => {
+    // Divergence from Rails: sanitize-html unconditionally discards
+    // <script>/<style> tag *contents* as a security measure (cannot be
+    // disabled). Loofah strips the tag and keeps "baz" — Rails output
+    // would be `<a href="foo">baz</a>`. We get the empty <a> instead,
+    // which is strictly safer. Revisit when PR 3 swaps engine internals.
+    expect(sanitize(`<a href="foo" onclick="bar"><script>baz</script></a>`)).toBe(
+      `<a href="foo"></a>`,
+    );
+  });
+
+  test("allow_colons_in_path_component", () => {
+    assertSanitized(`<a href="./this:that">foo</a>`);
+  });
+
+  for (const attr of ["src", "width", "height", "alt"]) {
+    test(`should_allow_image_${attr}_attribute`, () => {
+      assertSanitized(
+        `<img ${attr}="foo" onclick="bar" />`,
+        // sanitize-html self-closes void elements; the value is preserved.
+        `<img ${attr}="foo" />`,
+      );
+    });
+  }
+
+  test("lang_and_xml_lang", () => {
+    assertSanitized(`<div lang="en" xml:lang="en">foo</div>`);
+  });
+
+  test("should_handle_non_html", () => {
+    assertSanitized("abc");
+  });
+
+  test("should_handle_blank_text", () => {
+    expect(sanitize(null)).toBeNull();
+    expect(sanitize(undefined)).toBeUndefined();
+    expect(sanitize("")).toBe("");
+    expect(sanitize("   ")).toBe("   ");
+  });
+
+  test("setting_allowed_tags_affects_sanitization", () => {
+    SafeListSanitizer.allowedTags = new Set(["u"]);
+    expect(sanitize("<a><u></u></a>")).toBe("<u></u>");
+  });
+
+  test("setting_allowed_attributes_affects_sanitization", () => {
+    SafeListSanitizer.allowedAttributes = new Set(["foo"]);
+    SafeListSanitizer.allowedTags = new Set(["a"]);
+    expect(sanitize(`<a foo="hello" bar="world"></a>`)).toBe(`<a foo="hello"></a>`);
+  });
+
+  test("custom_tags_overrides_allowed_tags", () => {
+    SafeListSanitizer.allowedTags = new Set(["u"]);
+    expect(sanitize("<a><u></u></a>", { tags: ["a"] })).toBe("<a></a>");
+  });
+
+  test("custom_attributes_overrides_allowed_attributes", () => {
+    SafeListSanitizer.allowedAttributes = new Set(["foo"]);
+    SafeListSanitizer.allowedTags = new Set(["a"]);
+    expect(sanitize(`<a foo="hello" bar="world"></a>`, { attributes: ["bar"] })).toBe(
+      `<a bar="world"></a>`,
+    );
+  });
+
+  test("should_allow_prune", () => {
+    const pruning = new SafeListSanitizer({ prune: true });
+    expect(pruning.sanitize("<u>leave me <b>now</b></u>", { tags: ["u"] })).toBe(
+      "<u>leave me </u>",
+    );
+  });
+
+  test("should_allow_custom_tags", () => {
+    expect(sanitize("<u>foo</u>", { tags: ["u"] })).toBe("<u>foo</u>");
+  });
+
+  test("should_allow_only_custom_tags", () => {
+    expect(sanitize("<u>foo</u> with <i>bar</i>", { tags: ["u"] })).toBe("<u>foo</u> with bar");
+  });
+
+  test("should_allow_custom_tags_with_attributes", () => {
+    assertSanitized(`<blockquote cite="http://example.com/">foo</blockquote>`);
+  });
+
+  test("should_allow_custom_tags_with_custom_attributes", () => {
+    const text = `<blockquote foo="bar">Lorem ipsum</blockquote>`;
+    expect(sanitize(text, { attributes: ["foo"] })).toBe(text);
+  });
+
+  test("should_raise_argument_error_if_tags_is_not_enumerable", () => {
+    expect(() => sanitize("<a>some html</a>", { tags: "foo" })).toThrow(TypeError);
+  });
+
+  test("should_raise_argument_error_if_attributes_is_not_enumerable", () => {
+    expect(() => sanitize("<a>some html</a>", { attributes: "foo" })).toThrow(TypeError);
+  });
+
+  // XSS protection: javascript: / vbscript: / data: schemes must never
+  // survive on src/href, regardless of source obfuscation.
+  test("should_strip_src_attribute_in_img_with_bad_protocols", () => {
+    expect(sanitize(`<img src="javascript:bang" title="1">`)).not.toContain("javascript:");
+  });
+
+  test("should_strip_href_attribute_in_a_with_bad_protocols", () => {
+    expect(sanitize(`<a href="javascript:bang" title="1">boo</a>`)).not.toContain("javascript:");
+  });
+
+  test("should_block_script_tag", () => {
+    expect(sanitize(`<SCRIPT\nSRC=http://ha.ckers.org/xss.js></SCRIPT>`)).toBe("");
+  });
+
+  test("should_sanitize_img_vbscript", () => {
+    expect(sanitize(`<img src='vbscript:msgbox("XSS")' />`)).not.toContain("vbscript:");
+  });
+
+  test("should_sanitize_img_dynsrc_lowsrc", () => {
+    expect(sanitize(`<img lowsrc="javascript:alert('XSS')" />`)).not.toContain("javascript:");
+  });
+
+  // Various javascript: obfuscation hacks — assert no js:-scheme leaks
+  // through, regardless of casing, whitespace, or entity-encoding.
+  for (const hack of [
+    `<IMG SRC="javascript:alert('XSS');">`,
+    `<IMG SRC=javascript:alert('XSS')>`,
+    `<IMG SRC=JaVaScRiPt:alert('XSS')>`,
+    `<IMG SRC="jav\tascript:alert('XSS');">`,
+    `<IMG SRC="jav&#x09;ascript:alert('XSS');">`,
+    `<IMG SRC=" &#14;  javascript:alert('XSS');">`,
+  ]) {
+    test(`should_not_fall_for_xss_image_hack: ${hack.slice(0, 40)}`, () => {
+      const out = sanitize(hack)!.toLowerCase();
+      expect(out).not.toContain("javascript:");
+      expect(out).not.toContain("alert(");
+    });
+  }
+
+  test("should_sanitize_invalid_tag_names", () => {
+    expect(sanitize(`a b c<script/XSS src="http://ha.ckers.org/xss.js"></script>d e f`)).toBe(
+      "a b cd e f",
+    );
+  });
+});

--- a/packages/html-sanitizer/src/safe-list-sanitizer.ts
+++ b/packages/html-sanitizer/src/safe-list-sanitizer.ts
@@ -1,0 +1,83 @@
+// Rails parallel: lib/rails/html/sanitizer.rb -> class SafeListSanitizer.
+
+import { Sanitizer, type SanitizeOptions, isTrivialInput } from "./sanitizer.js";
+import { safeListSanitize } from "./engine.js";
+import { DEFAULT_ALLOWED_ATTRIBUTES, DEFAULT_ALLOWED_TAGS } from "./config.js";
+
+/**
+ * Allowlist-based HTML sanitizer mirroring Rails'
+ * `Rails::HTML::SafeListSanitizer`. Tags not in `allowedTags` are
+ * stripped (their text content is preserved); attributes not in
+ * `allowedAttributes` are dropped. URL-bearing attributes are filtered
+ * to safe schemes.
+ *
+ * Per-instance options override class-level defaults; per-call options
+ * (`tags` / `attributes` on `sanitize()`) override both.
+ *
+ * @example
+ *   const s = new SafeListSanitizer();
+ *   s.sanitize("<u>foo</u> with <i>bar</i>", { tags: ["u"] });
+ *   // => "<u>foo</u> with bar"
+ *
+ *   new SafeListSanitizer({ prune: true })
+ *     .sanitize("<u>leave me <b>now</b></u>", { tags: ["u"] });
+ *   // => "<u>leave me </u>"
+ */
+export class SafeListSanitizer extends Sanitizer {
+  /**
+   * Class-level default allowed tags. Mutable so apps can configure
+   * once at boot (mirrors `Rails::HTML4::SafeListSanitizer.allowed_tags = ...`).
+   */
+  static allowedTags: Set<string> = new Set(DEFAULT_ALLOWED_TAGS);
+
+  /** Class-level default allowed attributes. */
+  static allowedAttributes: Set<string> = new Set(DEFAULT_ALLOWED_ATTRIBUTES);
+
+  private readonly prune: boolean;
+
+  constructor(options: { prune?: boolean } = {}) {
+    super();
+    this.prune = options.prune ?? false;
+  }
+
+  sanitize(
+    html: string | null | undefined,
+    options: SanitizeOptions = {},
+  ): string | null | undefined {
+    if (isTrivialInput(html)) return html;
+
+    const tags = resolveAllowlist(
+      options.tags,
+      (this.constructor as typeof SafeListSanitizer).allowedTags,
+      "tags",
+    );
+    const attributes = resolveAllowlist(
+      options.attributes,
+      (this.constructor as typeof SafeListSanitizer).allowedAttributes,
+      "attributes",
+    );
+
+    return safeListSanitize(html as string, {
+      allowedTags: tags,
+      allowedAttributes: attributes,
+      prune: this.prune,
+    });
+  }
+}
+
+function resolveAllowlist(
+  override: Iterable<string> | undefined,
+  fallback: Set<string>,
+  label: "tags" | "attributes",
+): string[] {
+  if (override === undefined) return [...fallback];
+  // Rails raises ArgumentError when tags/attributes is not Enumerable.
+  // Strings are iterable in JS (char-by-char), which is never what the
+  // caller meant — guard explicitly.
+  if (typeof override === "string") {
+    throw new TypeError(
+      `SafeListSanitizer: \`${label}\` must be an iterable of strings, not a string`,
+    );
+  }
+  return [...override];
+}

--- a/packages/html-sanitizer/src/safe-list-sanitizer.ts
+++ b/packages/html-sanitizer/src/safe-list-sanitizer.ts
@@ -22,6 +22,11 @@ import { DEFAULT_ALLOWED_ATTRIBUTES, DEFAULT_ALLOWED_TAGS } from "./config.js";
  *   new SafeListSanitizer({ prune: true })
  *     .sanitize("<u>leave me <b>now</b></u>", { tags: ["u"] });
  *   // => "<u>leave me </u>"
+ *
+ * Missing vs Rails: `sanitize_css(style_string)`. Loofah delegates to a
+ * CSS-only sanitizer (Crass-backed); `sanitize-html` has no equivalent
+ * standalone API. Deferred until we either ship a CSS sanitizer or swap
+ * to an engine that supports it (revisit alongside PR 3).
  */
 export class SafeListSanitizer extends Sanitizer {
   /**


### PR DESCRIPTION
## Summary

PR 2 of the [`@blazetrails/html-sanitizer` plan](../blob/main/docs/html-sanitizer-plan.md).

Adds `SafeListSanitizer` — the allowlist sanitizer that's the bulk of the package's surface:

- Class-level mutable `allowedTags` / `allowedAttributes` defaults (mirrors Rails' `SafeListSanitizer.allowed_tags = ...`).
- Per-call `tags` / `attributes` overrides.
- `prune: true` constructor option maps to sanitize-html's `disallowedTagsMode: "completelyDiscard"`, matching Rails' Loofah prune semantics (remove tag *and* content vs. default strip-and-keep).
- Runtime guard rejecting `tags: "string"` — strings are iterable in JS, never the caller's intent.
- URL scheme guard inherited from sanitize-html's `allowedSchemes` default (`http`/`https`/`ftp`/`mailto`/`tel`). `javascript:` / `vbscript:` / `data:` URLs get dropped automatically across all attributes.

36 tests ported from Rails' `SafeListSanitizerTest`.

## Test plan

- [x] `pnpm vitest run packages/html-sanitizer` — 56 tests passing (10 full + 8 link + 36 safelist + 2 config)
- [x] `pnpm build`
- [x] `pnpm guides:typecheck`
- [ ] CI green

## Notes for reviewers

- **LOC: ~352**, within plan's [pre-approved exception](../blob/main/docs/html-sanitizer-plan.md#pr-2--safelistsanitizer) for this PR (heavy fixture-shaped test data).
- **Known divergence** (documented in test body): `sanitize-html` unconditionally discards `<script>` / `<style>` tag *contents* as a security measure (cannot be disabled). Rails' Loofah strips the tag but keeps inner text. Our `<a href="foo"><script>baz</script></a>` → `<a href="foo"></a>` instead of `<a href="foo">baz</a>`. Strictly safer, but a behavioral diff. PR 3 reworks engine internals and can revisit.
- Inherits the LinkSanitizer divergence (`PRESERVED_TAGS` allowlist) from PR 1, also revisited in PR 3.