### PR TITLE
test(activerecord): defineSchema + shared-adapter for dependent has-many head describes (B1966b)

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -440,6 +440,179 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
+  let adapter: TestDatabaseAdapter;
+
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      dep_authors: { name: "string" },
+      dep_posts: { author_id: "integer", title: "string" },
+      nullify_all_authors: { name: "string" },
+      nullify_all_posts: { author_id: "integer", title: "string" },
+      limited_del_authors: { name: "string" },
+      limited_del_posts: { author_id: "integer", title: "string" },
+      firms: { name: "string" },
+      dep_accounts: { firm_id: "integer", credit_limit: "integer" },
+      re_authors: { name: "string" },
+      re_posts: { author_id: "integer", title: "string" },
+    });
+  });
+  withTransactionalFixtures(() => adapter);
+
+  it("dependence", async () => {
+    class DepAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class DepPost extends Base {
+      static {
+        this.attribute("author_id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(DepAuthor);
+    registerModel(DepPost);
+    Associations.hasMany.call(DepAuthor, "dep_posts", {
+      className: "DepPost",
+      foreignKey: "author_id",
+      dependent: "destroy",
+    });
+    const author = await DepAuthor.create({ name: "Alice" });
+    await DepPost.create({ author_id: author.id, title: "A" });
+    await processDependentAssociations(author);
+    const remaining = await DepPost.where({ author_id: author.id }).toArray();
+    expect(remaining.length).toBe(0);
+  });
+
+  it("delete all with option nullify", async () => {
+    class NullifyAllAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class NullifyAllPost extends Base {
+      static {
+        this.attribute("author_id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(NullifyAllAuthor);
+    registerModel(NullifyAllPost);
+    Associations.hasMany.call(NullifyAllAuthor, "nullify_all_posts", {
+      className: "NullifyAllPost",
+      foreignKey: "author_id",
+      dependent: "nullify",
+    });
+    const author = await NullifyAllAuthor.create({ name: "Alice" });
+    const post = await NullifyAllPost.create({ author_id: author.id, title: "A" });
+    await processDependentAssociations(author);
+    const reloaded = await NullifyAllPost.find(post.id!);
+    expect((reloaded as any).author_id).toBeNull();
+  });
+
+  it("delete all accepts limited parameters", async () => {
+    class LimitedDelAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class LimitedDelPost extends Base {
+      static {
+        this.attribute("author_id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(LimitedDelAuthor);
+    registerModel(LimitedDelPost);
+    Associations.hasMany.call(LimitedDelAuthor, "limited_del_posts", {
+      className: "LimitedDelPost",
+      foreignKey: "author_id",
+      dependent: "delete",
+    });
+    const author = await LimitedDelAuthor.create({ name: "Alice" });
+    await LimitedDelPost.create({ author_id: author.id, title: "A" });
+    await LimitedDelPost.create({ author_id: author.id, title: "B" });
+    await processDependentAssociations(author);
+    const remaining = await loadHasMany(author, "limited_del_posts", {
+      className: "LimitedDelPost",
+      foreignKey: "author_id",
+    });
+    expect(remaining.length).toBe(0);
+  });
+
+  it("dependence on account", async () => {
+    class Firm extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class DepAccount extends Base {
+      static {
+        this.attribute("firm_id", "integer");
+        this.attribute("credit_limit", "integer");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(Firm);
+    registerModel(DepAccount);
+    Associations.hasMany.call(Firm, "dep_accounts", {
+      className: "DepAccount",
+      foreignKey: "firm_id",
+      dependent: "destroy",
+    });
+    const firm = await Firm.create({ name: "Acme" });
+    await DepAccount.create({ firm_id: firm.id, credit_limit: 100 });
+    await DepAccount.create({ firm_id: firm.id, credit_limit: 200 });
+    await processDependentAssociations(firm);
+    const remaining = await loadHasMany(firm, "dep_accounts", {
+      className: "DepAccount",
+      foreignKey: "firm_id",
+    });
+    expect(remaining.length).toBe(0);
+  });
+
+  it("restrict with error", async () => {
+    class ReAuthor extends Base {
+      static {
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class RePost extends Base {
+      static {
+        this.attribute("author_id", "integer");
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(ReAuthor);
+    registerModel(RePost);
+    Associations.hasMany.call(ReAuthor, "rePosts", {
+      className: "RePost",
+      foreignKey: "author_id",
+      dependent: "restrictWithError",
+    });
+    const author = await ReAuthor.create({ name: "Writer" });
+    await RePost.create({ author_id: author.id, title: "P" });
+    try {
+      await author.destroy();
+      const found = await ReAuthor.findBy({ id: author.id });
+      expect(found || true).toBeTruthy();
+    } catch (e: any) {
+      expect(e.message).toMatch(/restrict|cannot|delete/i);
+    }
+  });
+});
+
+describe("HasManyAssociationsTest", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(() => {
@@ -1435,34 +1608,6 @@ describe("HasManyAssociationsTest", () => {
   });
 
   // -- Dependence --
-
-  it("dependence", async () => {
-    class DepAuthor extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class DepPost extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(DepAuthor);
-    registerModel(DepPost);
-    Associations.hasMany.call(DepAuthor, "dep_posts", {
-      className: "DepPost",
-      foreignKey: "author_id",
-      dependent: "destroy",
-    });
-    const author = await DepAuthor.create({ name: "Alice" });
-    await DepPost.create({ author_id: author.id, title: "A" });
-    await processDependentAssociations(author);
-    const remaining = await DepPost.where({ author_id: author.id }).toArray();
-    expect(remaining.length).toBe(0);
-  });
 
   // -- Get/Set IDs --
 
@@ -4970,65 +5115,6 @@ describe("HasManyAssociationsTest", () => {
     const reloaded = await CcClrSymAuthor.find(author.id!);
     expect((reloaded as any).posts_count).toBe(0);
   });
-  it("delete all with option nullify", async () => {
-    class NullifyAllAuthor extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class NullifyAllPost extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(NullifyAllAuthor);
-    registerModel(NullifyAllPost);
-    Associations.hasMany.call(NullifyAllAuthor, "nullify_all_posts", {
-      className: "NullifyAllPost",
-      foreignKey: "author_id",
-      dependent: "nullify",
-    });
-    const author = await NullifyAllAuthor.create({ name: "Alice" });
-    const post = await NullifyAllPost.create({ author_id: author.id, title: "A" });
-    await processDependentAssociations(author);
-    const reloaded = await NullifyAllPost.find(post.id!);
-    expect((reloaded as any).author_id).toBeNull();
-  });
-  it("delete all accepts limited parameters", async () => {
-    class LimitedDelAuthor extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class LimitedDelPost extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(LimitedDelAuthor);
-    registerModel(LimitedDelPost);
-    Associations.hasMany.call(LimitedDelAuthor, "limited_del_posts", {
-      className: "LimitedDelPost",
-      foreignKey: "author_id",
-      dependent: "delete",
-    });
-    const author = await LimitedDelAuthor.create({ name: "Alice" });
-    await LimitedDelPost.create({ author_id: author.id, title: "A" });
-    await LimitedDelPost.create({ author_id: author.id, title: "B" });
-    await processDependentAssociations(author);
-    const remaining = await loadHasMany(author, "limited_del_posts", {
-      className: "LimitedDelPost",
-      foreignKey: "author_id",
-    });
-    expect(remaining.length).toBe(0);
-  });
-
   it("clearing an exclusively dependent association collection", async () => {
     class ExclDepAuthor extends Base {
       static {
@@ -5549,71 +5635,7 @@ describe("HasManyAssociationsTest", () => {
     });
     expect(remaining.length).toBe(0);
   });
-  it("dependence on account", async () => {
-    class Firm extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class DepAccount extends Base {
-      static {
-        this.attribute("firm_id", "integer");
-        this.attribute("credit_limit", "integer");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Firm);
-    registerModel(DepAccount);
-    Associations.hasMany.call(Firm, "dep_accounts", {
-      className: "DepAccount",
-      foreignKey: "firm_id",
-      dependent: "destroy",
-    });
-    const firm = await Firm.create({ name: "Acme" });
-    await DepAccount.create({ firm_id: firm.id, credit_limit: 100 });
-    await DepAccount.create({ firm_id: firm.id, credit_limit: 200 });
-    await processDependentAssociations(firm);
-    const remaining = await loadHasMany(firm, "dep_accounts", {
-      className: "DepAccount",
-      foreignKey: "firm_id",
-    });
-    expect(remaining.length).toBe(0);
-  });
-  it("restrict with error", async () => {
-    class ReAuthor extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class RePost extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(ReAuthor);
-    registerModel(RePost);
-    Associations.hasMany.call(ReAuthor, "rePosts", {
-      className: "RePost",
-      foreignKey: "author_id",
-      dependent: "restrictWithError",
-    });
-    const author = await ReAuthor.create({ name: "Writer" });
-    await RePost.create({ author_id: author.id, title: "P" });
-    // With restrict_with_error, destroying should fail when children exist
-    try {
-      await author.destroy();
-      // If destroy doesn't throw, check that the record still exists
-      const found = await ReAuthor.findBy({ id: author.id });
-      // Either the destroy was prevented, or the implementation doesn't enforce restrict yet
-      expect(found || true).toBeTruthy();
-    } catch (e: any) {
-      expect(e.message).toMatch(/restrict|cannot|delete/i);
-    }
-  });
+
   it("restrict with error with locale", async () => {
     class ReLocaleAuthor extends Base {
       static {


### PR DESCRIPTION
## Summary

Extracts 5 `dependent: :destroy/:delete_all/:nullify/:restrict_with_error` tests from the big head `HasManyAssociationsTest` describe into a new shared-adapter describe (pilot pattern from #1967, matches sibling B1966a polymorphic batch).

- `beforeAll` creates one `TestDatabaseAdapter` + `defineSchema(...)` for the 10 tables the block touches.
- `withTransactionalFixtures(() => adapter)` rolls each test back instead of rebuilding the adapter per test.

Tests moved (names unchanged for `test:compare` parity):
- dependence (destroy)
- delete all with option nullify (nullify)
- delete all accepts limited parameters (delete_all)
- dependence on account (destroy)
- restrict with error (restrict_with_error)

## Follow-ups

Adjacent dependent tests left in place for later batches:
- dependence with transaction support on failure
- clearing an exclusively dependent association collection
- restrict with error with locale
- three levels of dependence

Test-body tightening (separate from migration): the `restrict with error` test was copied verbatim and retains an `expect(found || true).toBeTruthy()` assertion that is always truthy. Rails' `test_restrict_with_error` asserts `firm.errors` is populated and the record still exists; aligning to Rails behavior (and to trails' `DeleteRestrictionError`) is a follow-up out of scope for this migration.

The remaining ~7600 lines of the head `HasManyAssociationsTest` block still rely on per-test `freshAdapter()` + auto-derived schema.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/has-many-associations.test.ts` — 309 passed, 1 skipped
- [x] Size: 330 LOC (176/154)
- [ ] CI green across SQLite, PostgreSQL, MariaDB