### PR TITLE
test(activerecord): migrate has-many building cluster to transactional fixtures (B1966e)

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import {
   SubclassNotFound,
@@ -24,9 +24,10 @@ import {
 import { DeleteRestrictionError } from "./errors.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -537,355 +538,6 @@ describe("HasManyAssociationsTest", () => {
     }
     expect(titles).toContain("A");
     expect(titles).toContain("B");
-  });
-
-  // -- Adding --
-
-  it("adding", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const post = await Post.create({ title: "New" });
-    // Setting the FK manually simulates adding
-    post.author_id = author.id;
-    await post.save();
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts.some((p: any) => p.id === post.id)).toBe(true);
-  });
-
-  it("adding a collection", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const p1 = await Post.create({ title: "X" });
-    const p2 = await Post.create({ title: "Y" });
-    for (const p of [p1, p2]) {
-      p.author_id = author.id;
-      await p.save();
-    }
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts.length).toBe(2);
-  });
-
-  it("adding using create", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "Created" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts.length).toBe(1);
-    expect((posts[0] as any).title).toBe("Created");
-  });
-
-  // -- Build --
-
-  it("build", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const post = Post.new({ author_id: author.id, title: "Built" });
-    expect(post.isNewRecord()).toBe(true);
-    expect((post as any).author_id).toBe(author.id);
-  });
-
-  it("build many", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const posts = [
-      Post.new({ author_id: author.id, title: "A" }),
-      Post.new({ author_id: author.id, title: "B" }),
-    ];
-    expect(posts.length).toBe(2);
-    expect(posts.every((p) => p.isNewRecord())).toBe(true);
-  });
-
-  it("collection size after building", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "Saved" });
-    const newPost = Post.new({ author_id: author.id, title: "Built" });
-    expect(newPost.isNewRecord()).toBe(true);
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts.length).toBe(1);
-  });
-
-  it("collection not empty after building", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "A" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts.length > 0).toBe(true);
-  });
-
-  it("build via block", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const post = Post.new({ author_id: author.id });
-    (post as any).title = "Via block";
-    expect((post as any).title).toBe("Via block");
-  });
-
-  it("new aliased to build", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const post = Post.new({ author_id: author.id, title: "Built" });
-    expect(post).toBeDefined();
-    expect(post.isNewRecord()).toBe(true);
-  });
-
-  // -- Create --
-
-  it("create", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const post = await Post.create({ author_id: author.id, title: "Created" });
-    expect(post.isNewRecord()).toBe(false);
-    expect(post.id).toBeDefined();
-  });
-
-  it("create many", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "A" });
-    await Post.create({ author_id: author.id, title: "B" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts.length).toBe(2);
-  });
-
-  it("create with bang on has many when parent is new raises", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = Author.new({ name: "Alice" });
-    expect(author.isNewRecord()).toBe(true);
-    // Creating a child before saving the parent should be handled carefully
-    // In our system, it doesn't auto-set FK from new parent's id
-    const post = Post.new({ title: "Test" });
-    expect(post.isNewRecord()).toBe(true);
-  });
-
-  it("create from association with nil values should work", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    // Creating with null title should still work
-    const post = await Post.create({ author_id: author.id });
-    expect(post.isNewRecord()).toBe(false);
-  });
-
-  it("has many build with options", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.attribute("published", "boolean");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const post = Post.new({ author_id: author.id, title: "Draft", published: false });
-    expect((post as any).title).toBe("Draft");
   });
 
   // -- Deleting --
@@ -1577,122 +1229,6 @@ describe("HasManyAssociationsTest", () => {
       foreignKey: "author_id",
     });
     expect(posts.length).toBe(0);
-  });
-
-  // -- Replace --
-
-  it("replace", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "Old" });
-    // Replace: nullify old, assign new
-    await processDependentAssociations(author);
-    const newPost = await Post.create({ author_id: author.id, title: "New" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts.some((p: any) => p.id === newPost.id)).toBe(true);
-  });
-
-  it("replace with less", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    await Post.create({ author_id: author.id, title: "A" });
-    await Post.create({ author_id: author.id, title: "B" });
-    // Remove one
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    await (posts[0] as any).destroy();
-    const remaining = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(remaining.length).toBe(1);
-  });
-
-  it("replace with new", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const oldPost = await Post.create({ author_id: author.id, title: "Old" });
-    await oldPost.destroy();
-    const newPost = await Post.create({ author_id: author.id, title: "New" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts.some((p: any) => p.id === newPost.id)).toBe(true);
-    expect(posts.some((p: any) => p.id === oldPost.id)).toBe(false);
-  });
-
-  it("replace with same content", async () => {
-    class Author extends Base {
-      static {
-        this.attribute("name", "string");
-        this.adapter = adapter;
-      }
-    }
-    class Post extends Base {
-      static {
-        this.attribute("author_id", "integer");
-        this.attribute("title", "string");
-        this.adapter = adapter;
-      }
-    }
-    registerModel(Author);
-    registerModel(Post);
-    const author = await Author.create({ name: "Alice" });
-    const post = await Post.create({ author_id: author.id, title: "Same" });
-    const posts = await loadHasMany(author, "posts", {
-      className: "Post",
-      foreignKey: "author_id",
-    });
-    expect(posts.length).toBe(1);
-    expect(posts[0].id).toBe(post.id);
   });
 
   // -- Has many on new record --
@@ -8034,6 +7570,231 @@ describe("HasManyAssociationsTest", () => {
       foreignKey: "author_id",
     });
     expect(remaining.length).toBe(0);
+  });
+});
+
+// Building cluster (adding `<<`, build, create, replace `=`) migrated to a
+// shared describe-level adapter with explicit defineSchema +
+// withTransactionalFixtures (Batch B1966e). Tests previously defined Author
+// and Post inside each `it()` block against an inline `freshAdapter()` from
+// the parent describe's `beforeEach`. Hoisting the classes and adapter to
+// `beforeAll` means schema DDL runs once per file and each test runs inside
+// BEGIN/ROLLBACK rather than rebuilding tables.
+describe("HasManyAssociationsTest", () => {
+  let adapter: TestDatabaseAdapter;
+
+  class Author extends Base {
+    declare name: string;
+  }
+  class Post extends Base {
+    declare author_id: number;
+    declare title: string;
+    declare published: boolean;
+  }
+
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      authors: { name: "string" },
+      posts: { author_id: "integer", title: "string", published: "boolean" },
+    });
+    Author.attribute("name", "string");
+    Author.adapter = adapter;
+    Post.attribute("author_id", "integer");
+    Post.attribute("title", "string");
+    Post.attribute("published", "boolean");
+    Post.adapter = adapter;
+    registerModel(Author);
+    registerModel(Post);
+  });
+  withTransactionalFixtures(() => adapter);
+
+  // -- Adding --
+
+  it("adding", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const post = await Post.create({ title: "New" });
+    post.author_id = author.id as number;
+    await post.save();
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(posts.some((p: any) => p.id === post.id)).toBe(true);
+  });
+
+  it("adding a collection", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const p1 = await Post.create({ title: "X" });
+    const p2 = await Post.create({ title: "Y" });
+    for (const p of [p1, p2]) {
+      p.author_id = author.id as number;
+      await p.save();
+    }
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(posts.length).toBe(2);
+  });
+
+  it("adding using create", async () => {
+    const author = await Author.create({ name: "Alice" });
+    await Post.create({ author_id: author.id, title: "Created" });
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(posts.length).toBe(1);
+    expect((posts[0] as any).title).toBe("Created");
+  });
+
+  // -- Build --
+
+  it("build", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const post = Post.new({ author_id: author.id, title: "Built" });
+    expect(post.isNewRecord()).toBe(true);
+    expect((post as any).author_id).toBe(author.id);
+  });
+
+  it("build many", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const posts = [
+      Post.new({ author_id: author.id, title: "A" }),
+      Post.new({ author_id: author.id, title: "B" }),
+    ];
+    expect(posts.length).toBe(2);
+    expect(posts.every((p) => p.isNewRecord())).toBe(true);
+  });
+
+  it("collection size after building", async () => {
+    const author = await Author.create({ name: "Alice" });
+    await Post.create({ author_id: author.id, title: "Saved" });
+    const newPost = Post.new({ author_id: author.id, title: "Built" });
+    expect(newPost.isNewRecord()).toBe(true);
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(posts.length).toBe(1);
+  });
+
+  it("collection not empty after building", async () => {
+    const author = await Author.create({ name: "Alice" });
+    await Post.create({ author_id: author.id, title: "A" });
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(posts.length > 0).toBe(true);
+  });
+
+  it("build via block", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const post = Post.new({ author_id: author.id });
+    (post as any).title = "Via block";
+    expect((post as any).title).toBe("Via block");
+  });
+
+  it("new aliased to build", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const post = Post.new({ author_id: author.id, title: "Built" });
+    expect(post).toBeDefined();
+    expect(post.isNewRecord()).toBe(true);
+  });
+
+  // -- Create --
+
+  it("create", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const post = await Post.create({ author_id: author.id, title: "Created" });
+    expect(post.isNewRecord()).toBe(false);
+    expect(post.id).toBeDefined();
+  });
+
+  it("create many", async () => {
+    const author = await Author.create({ name: "Alice" });
+    await Post.create({ author_id: author.id, title: "A" });
+    await Post.create({ author_id: author.id, title: "B" });
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(posts.length).toBe(2);
+  });
+
+  it("create with bang on has many when parent is new raises", async () => {
+    const author = Author.new({ name: "Alice" });
+    expect(author.isNewRecord()).toBe(true);
+    const post = Post.new({ title: "Test" });
+    expect(post.isNewRecord()).toBe(true);
+  });
+
+  it("create from association with nil values should work", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const post = await Post.create({ author_id: author.id });
+    expect(post.isNewRecord()).toBe(false);
+  });
+
+  it("has many build with options", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const post = Post.new({ author_id: author.id, title: "Draft", published: false });
+    expect((post as any).title).toBe("Draft");
+  });
+
+  // -- Replace --
+
+  it("replace", async () => {
+    const author = await Author.create({ name: "Alice" });
+    await Post.create({ author_id: author.id, title: "Old" });
+    await processDependentAssociations(author);
+    const newPost = await Post.create({ author_id: author.id, title: "New" });
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(posts.some((p: any) => p.id === newPost.id)).toBe(true);
+  });
+
+  it("replace with less", async () => {
+    const author = await Author.create({ name: "Alice" });
+    await Post.create({ author_id: author.id, title: "A" });
+    await Post.create({ author_id: author.id, title: "B" });
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    await (posts[0] as any).destroy();
+    const remaining = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(remaining.length).toBe(1);
+  });
+
+  it("replace with new", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const oldPost = await Post.create({ author_id: author.id, title: "Old" });
+    await oldPost.destroy();
+    const newPost = await Post.create({ author_id: author.id, title: "New" });
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(posts.some((p: any) => p.id === newPost.id)).toBe(true);
+    expect(posts.some((p: any) => p.id === oldPost.id)).toBe(false);
+  });
+
+  it("replace with same content", async () => {
+    const author = await Author.create({ name: "Alice" });
+    const post = await Post.create({ author_id: author.id, title: "Same" });
+    const posts = await loadHasMany(author, "posts", {
+      className: "Post",
+      foreignKey: "author_id",
+    });
+    expect(posts.length).toBe(1);
+    expect(posts[0].id).toBe(post.id);
   });
 });
 


### PR DESCRIPTION
## Summary

Continues the B6.4 migration begun in #1957 / #1960. Promotes the
**Adding / Build / Create / Replace** sections of
`has-many-associations.test.ts` — the `<<`, `build`, `create`, `=`,
`replace` cluster — from inline `freshAdapter()` + per-test class
definitions to a shared describe-level adapter with explicit
`defineSchema` and `withTransactionalFixtures` (#1938 pilot).

The follow-up note in #1960 flagged that this file relied on
auto-schema in its `beforeEach` blocks (no `defineSchema`), so
transactional fixtures couldn't help until at least one cluster was
promoted to explicit schema first. This PR is that promotion for the
building cluster — 18 tests total.

## Mechanics

- 18 tests moved out of the auto-schema `describe("HasManyAssociationsTest")` at the top of the file into a new sibling describe of the same name lower down. Vitest treats duplicate describe names as siblings, so test:compare paths are unaffected and the test names themselves are preserved verbatim.
- `Author` / `Post` classes were identical across all 18 tests — hoisted to describe scope and registered once in `beforeAll`. `Post` gains a `published: "boolean"` column to keep the `has many build with options` test working without per-test schema variation.
- `withTransactionalFixtures(() => adapter)` wraps each `it()` in BEGIN/ROLLBACK so DDL runs once for the file.

## Test plan

- [x] \`pnpm exec vitest run packages/activerecord/src/associations/has-many-associations.test.ts --project activerecord\` — 309 passed / 1 skipped
- [x] Size: 261 LOC (under 300 ceiling); net -239 lines
- [ ] CI green across SQLite, PostgreSQL, MariaDB

## Follow-ups

Remaining sections in the original auto-schema describe (Counting, Finding, Deleting, Destroying, Dependence, Get/Set IDs, Included in collection, Clearing, Counter cache, Has many on new record, Calling size/empty, Association definition, Scoped queries) can be migrated in subsequent batches following the same pattern. Each is independently sizable.