### PR TITLE
test(activerecord): un-skip relation-scoping 'find with annotation unscope'

### DIFF
--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -324,7 +324,7 @@ describe("RelationScopingTest", () => {
     expect(unscopedSql).toContain("SELECT");
   });
 
-  it("find with annotation unscope", () => {
+  it("find with annotation unscope", async () => {
     class AnnUnscopePost extends Base {
       static {
         this._tableName = "ann_posts";
@@ -332,11 +332,12 @@ describe("RelationScopingTest", () => {
         this.adapter = adapter;
       }
     }
-    const sql = AnnUnscopePost.annotate("unscope")
-      .where({ title: "x" })
-      .unscope("annotate")
-      .toSql();
-    expect(sql).not.toContain("/* unscope */");
+    await AnnUnscopePost.create({ title: "David" });
+    const rel = AnnUnscopePost.annotate("unscope").where({ title: "David" }).unscope("annotate");
+    expect(rel.toSql()).not.toContain("/* unscope */");
+    const post = (await rel.first()) as Base | null;
+    expect(post).not.toBeNull();
+    expect(post!.title).toBe("David");
   });
 
   it.skip("scoped find include", () => {

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -269,17 +269,13 @@ describe("RelationScopingTest", () => {
   });
 
   it.skip("scoped find select", () => {
-    // BLOCKED: relation — relation scoping feature gap
-    // ROOT-CAUSE: relation/scoping.ts#scopeFor or Relation#scoped missing Rails parity
-    // SCOPE: ~50 LOC in relation/scoping.ts; affects ~28 tests in relation-scoping.test.ts
-    /* needs scoping + select interaction */
+    // BLOCKED: select narrowing of loaded attributes — hasAttribute() does not
+    // reflect the projected column set; depends on attribute-set materialization
+    // from result rows rather than from the schema declaration.
   });
 
   it.skip("scope select concatenates", () => {
-    // BLOCKED: relation — relation scoping feature gap
-    // ROOT-CAUSE: relation/scoping.ts#scopeFor or Relation#scoped missing Rails parity
-    // SCOPE: ~50 LOC in relation/scoping.ts; affects ~28 tests in relation-scoping.test.ts
-    /* select overwrites instead of concatenating */
+    // BLOCKED: select narrowing of loaded attributes — see "scoped find select".
   });
 
   it("scoped count", async () => {
@@ -328,11 +324,19 @@ describe("RelationScopingTest", () => {
     expect(unscopedSql).toContain("SELECT");
   });
 
-  it.skip("find with annotation unscope", () => {
-    // BLOCKED: relation — relation scoping feature gap
-    // ROOT-CAUSE: relation/scoping.ts#scopeFor or Relation#scoped missing Rails parity
-    // SCOPE: ~50 LOC in relation/scoping.ts; affects ~28 tests in relation-scoping.test.ts
-    /* needs unscope(:annotate) */
+  it("find with annotation unscope", () => {
+    class AnnUnscopePost extends Base {
+      static {
+        this._tableName = "ann_posts";
+        this.attribute("title", "string");
+        this.adapter = adapter;
+      }
+    }
+    const sql = AnnUnscopePost.annotate("unscope")
+      .where({ title: "x" })
+      .unscope("annotate")
+      .toSql();
+    expect(sql).not.toContain("/* unscope */");
   });
 
   it.skip("scoped find include", () => {
@@ -486,10 +490,9 @@ describe("RelationScopingTest", () => {
   });
 
   it.skip("scoping respects sti constraint", () => {
-    // BLOCKED: relation — relation scoping feature gap
-    // ROOT-CAUSE: relation/scoping.ts#scopeFor or Relation#scoped missing Rails parity
-    // SCOPE: ~50 LOC in relation/scoping.ts; affects ~28 tests in relation-scoping.test.ts
-    /* needs STI + scoping interaction */
+    // BLOCKED: STI find — subclass `find(id)` does not enforce the type
+    // constraint at query time, so `SpecialComment.find(id_of_plain)` returns
+    // a record instead of raising RecordNotFound.
   });
 
   it("scoping with klass method works in the scope block", async () => {


### PR DESCRIPTION
## Summary
- Flips `it.skip("find with annotation unscope")` in `relation-scoping.test.ts` to a real port of the Rails test, exercising `annotate(...).where(...).unscope("annotate")`.
- Probed every other skip in the file; 27 remain blocked on real infra gaps. Two boilerplate gap-comments were rewritten to point at the actual cause:
  - `scoped find select` / `scope select concatenates` — `select()` does not narrow loaded attributes; `hasAttribute()` is still true for unselected columns.
  - `scoping respects sti constraint` — STI subclass `find(id)` does not enforce the type constraint at query time.

## Why so small
Most of the 28 skipped tests need infrastructure not yet present: associations + joins-on-associations, `includes()`, Arel-attribute input to `order()`, `reload()`, STI find filtering, the `scoping(all_queries: true)` option, and `select`-narrowed attribute sets. Honest gap notes beat fabricated bypasses.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/scoping/relation-scoping.test.ts` — 51 passed, 27 skipped (was 28).
- [x] `pnpm test:compare --cached` — `relation_scoping_test.rb` now reports 37 matched / 27 skipped (was 36 / 28).