### PR TITLE
feat(actionview): date helper — distanceOfTimeInWords + timeAgoInWords (Phase 5 T1)

### DIFF
--- a/packages/actionview/src/helpers/date-helper.test.ts
+++ b/packages/actionview/src/helpers/date-helper.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "vitest";
+import {
+  distanceOfTimeInWords,
+  distanceOfTimeInWordsToNow,
+  timeAgoInWords,
+} from "./date-helper.js";
+
+const SECOND = 1000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+function add(base: Date, ms: number): Date {
+  return new Date(base.getTime() + ms);
+}
+
+const from = new Date(Date.UTC(2004, 5, 6, 21, 45, 0));
+
+describe("DateHelperTest", () => {
+  it("test_distance_in_words", () => {
+    // include_seconds: true — sub-minute distances bucketed by seconds
+    expect(distanceOfTimeInWords(from, add(from, 0 * SECOND), { includeSeconds: true })).toBe(
+      "less than 5 seconds",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 4 * SECOND), { includeSeconds: true })).toBe(
+      "less than 5 seconds",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 5 * SECOND), { includeSeconds: true })).toBe(
+      "less than 10 seconds",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 9 * SECOND), { includeSeconds: true })).toBe(
+      "less than 10 seconds",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 10 * SECOND), { includeSeconds: true })).toBe(
+      "less than 20 seconds",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 19 * SECOND), { includeSeconds: true })).toBe(
+      "less than 20 seconds",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 20 * SECOND), { includeSeconds: true })).toBe(
+      "half a minute",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 39 * SECOND), { includeSeconds: true })).toBe(
+      "half a minute",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 40 * SECOND), { includeSeconds: true })).toBe(
+      "less than a minute",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 59 * SECOND), { includeSeconds: true })).toBe(
+      "less than a minute",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 60 * SECOND), { includeSeconds: true })).toBe(
+      "1 minute",
+    );
+
+    // include_seconds: false (default) — sub-30s rounds to 0 min
+    expect(distanceOfTimeInWords(from, add(from, 0 * SECOND))).toBe("less than a minute");
+    expect(distanceOfTimeInWords(from, add(from, 29 * SECOND))).toBe("less than a minute");
+    expect(distanceOfTimeInWords(from, add(from, 30 * SECOND))).toBe("1 minute");
+    expect(distanceOfTimeInWords(from, add(from, 1 * MINUTE + 29 * SECOND))).toBe("1 minute");
+    expect(distanceOfTimeInWords(from, add(from, 1 * MINUTE + 30 * SECOND))).toBe("2 minutes");
+    expect(distanceOfTimeInWords(from, add(from, 44 * MINUTE + 29 * SECOND))).toBe("44 minutes");
+    expect(distanceOfTimeInWords(from, add(from, 44 * MINUTE + 30 * SECOND))).toBe("about 1 hour");
+    expect(distanceOfTimeInWords(from, add(from, 89 * MINUTE + 29 * SECOND))).toBe("about 1 hour");
+    expect(distanceOfTimeInWords(from, add(from, 89 * MINUTE + 30 * SECOND))).toBe("about 2 hours");
+    expect(distanceOfTimeInWords(from, add(from, 23 * HOUR + 59 * MINUTE + 29 * SECOND))).toBe(
+      "about 24 hours",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 23 * HOUR + 59 * MINUTE + 30 * SECOND))).toBe(
+      "1 day",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 41 * HOUR + 59 * MINUTE + 30 * SECOND))).toBe(
+      "2 days",
+    );
+    expect(distanceOfTimeInWords(from, add(from, 2 * DAY + 12 * HOUR))).toBe("3 days");
+  });
+
+  it("test_distance_in_words_with_nil_input", () => {
+    expect(() => distanceOfTimeInWords(null as unknown as Date)).toThrow();
+    expect(() => distanceOfTimeInWords(0, null as unknown as Date)).toThrow();
+  });
+
+  it("test_distance_in_words_with_mixed_argument_types", () => {
+    expect(distanceOfTimeInWords(0, 60)).toBe("1 minute");
+    expect(distanceOfTimeInWords(600, 0)).toBe("10 minutes");
+  });
+
+  it("test_time_ago_in_words_passes_include_seconds", () => {
+    const past = new Date(Date.now() - 15 * SECOND);
+    expect(timeAgoInWords(past, { includeSeconds: true })).toBe("less than 20 seconds");
+    expect(timeAgoInWords(past, { includeSeconds: false })).toBe("less than a minute");
+  });
+
+  it("test_distance_in_words_with_dates", () => {
+    const startDate = new Date(Date.UTC(1975, 0, 31));
+    const endDate = new Date(Date.UTC(1977, 0, 31));
+    expect(distanceOfTimeInWords(startDate, endDate)).toBe("about 2 years");
+
+    const s2 = new Date(Date.UTC(1982, 11, 3));
+    const e2 = new Date(Date.UTC(2010, 10, 30));
+    expect(distanceOfTimeInWords(s2, e2)).toBe("almost 28 years");
+    expect(distanceOfTimeInWords(e2, s2)).toBe("almost 28 years");
+  });
+
+  it("test_distance_in_words_with_integers", () => {
+    expect(distanceOfTimeInWords(59)).toBe("1 minute");
+    expect(distanceOfTimeInWords(60 * 60)).toBe("about 1 hour");
+    expect(distanceOfTimeInWords(0, 59)).toBe("1 minute");
+    expect(distanceOfTimeInWords(60 * 60, 0)).toBe("about 1 hour");
+    expect(distanceOfTimeInWords(10 ** 8)).toBe("about 3 years");
+    expect(distanceOfTimeInWords(0, 10 ** 8)).toBe("about 3 years");
+  });
+
+  it("test_time_ago_in_words", () => {
+    const oneYearAndOneDayAgo = new Date(Date.now() - (365 * DAY + 1 * DAY));
+    expect(timeAgoInWords(oneYearAndOneDayAgo)).toBe("about 1 year");
+  });
+
+  it("aliases distance_of_time_in_words_to_now to time_ago_in_words", () => {
+    const past = new Date(Date.now() - 15 * SECOND);
+    expect(distanceOfTimeInWordsToNow(past, { includeSeconds: true })).toBe("less than 20 seconds");
+  });
+
+  it("supports custom scope via I18n lookup", () => {
+    // unknown scope falls back to defaults; non-default scope without
+    // backing translations still produces a sensible English result.
+    expect(distanceOfTimeInWords(0, 60, { scope: "datetime.distance_in_words" })).toBe("1 minute");
+  });
+});

--- a/packages/actionview/src/helpers/date-helper.ts
+++ b/packages/actionview/src/helpers/date-helper.ts
@@ -1,0 +1,163 @@
+import { I18n } from "@blazetrails/activesupport";
+
+/**
+ * ActionView::Helpers::DateHelper — formatting half.
+ *
+ * Implements `distanceOfTimeInWords`, `timeAgoInWords`, and the
+ * `distanceOfTimeInWordsToNow` alias. Date-select tag helpers are part of
+ * Phase 5 T3 and not included here.
+ */
+
+const MINUTES_IN_YEAR = 525600;
+const MINUTES_IN_QUARTER_YEAR = 131400;
+const MINUTES_IN_THREE_QUARTERS_YEAR = 394200;
+
+const DEFAULT_DISTANCE_IN_WORDS: Record<string, { one: string; other: string } | string> = {
+  half_a_minute: "half a minute",
+  less_than_x_seconds: { one: "less than 1 second", other: "less than %{count} seconds" },
+  x_seconds: { one: "1 second", other: "%{count} seconds" },
+  less_than_x_minutes: { one: "less than a minute", other: "less than %{count} minutes" },
+  x_minutes: { one: "1 minute", other: "%{count} minutes" },
+  about_x_hours: { one: "about 1 hour", other: "about %{count} hours" },
+  x_days: { one: "1 day", other: "%{count} days" },
+  about_x_months: { one: "about 1 month", other: "about %{count} months" },
+  x_months: { one: "1 month", other: "%{count} months" },
+  about_x_years: { one: "about 1 year", other: "about %{count} years" },
+  over_x_years: { one: "over 1 year", other: "over %{count} years" },
+  almost_x_years: { one: "almost 1 year", other: "almost %{count} years" },
+};
+
+export type DistanceOfTimeInput = Date | number | { toDate: () => Date } | { toTime: () => Date };
+
+export interface DistanceOfTimeOptions {
+  includeSeconds?: boolean;
+  scope?: string;
+  locale?: string;
+}
+
+/** @internal */
+function normalizeDistanceOfTimeArgumentToTime(value: DistanceOfTimeInput): Date {
+  // boundary: numeric input is seconds-since-epoch, matching Ruby Time.at(n).
+  if (typeof value === "number") return new Date(value * 1000);
+  // boundary: public API accepts JS Date as a primary input shape.
+  if (value instanceof Date) return value;
+  if (value && typeof (value as { toTime?: unknown }).toTime === "function") {
+    return (value as { toTime: () => Date }).toTime();
+  }
+  if (value && typeof (value as { toDate?: unknown }).toDate === "function") {
+    return (value as { toDate: () => Date }).toDate();
+  }
+  throw new TypeError(`${String(value)} can't be converted to a Time value`);
+}
+
+/** @internal */
+function lookupTranslation(
+  scope: string,
+  key: string,
+  locale: string | undefined,
+): { one?: string; other?: string } | string | undefined {
+  const result = I18n.translate(`${scope}.${key}`, { locale, default: null });
+  if (typeof result === "string") return result;
+  if (result && typeof result === "object" && !Array.isArray(result)) {
+    return result as { one?: string; other?: string };
+  }
+  return undefined;
+}
+
+/** @internal */
+function translateDistance(
+  key: string,
+  count: number,
+  scope: string,
+  locale: string | undefined,
+): string {
+  const looked = lookupTranslation(scope, key, locale) ?? DEFAULT_DISTANCE_IN_WORDS[key];
+  if (looked === undefined) return `[missing: ${scope}.${key}]`;
+  if (typeof looked === "string") return looked.replace(/%\{count\}/g, String(count));
+  const variant = count === 1 ? looked.one : looked.other;
+  const template = variant ?? looked.other ?? looked.one ?? "";
+  return template.replace(/%\{count\}/g, String(count));
+}
+
+/**
+ * Reports the approximate distance in time between two dates as a human
+ * phrase ("about 1 hour", "3 days", etc.). Mirrors Rails
+ * `ActionView::Helpers::DateHelper#distance_of_time_in_words`.
+ *
+ * - `toTime` defaults to 0 (epoch), matching Rails' default argument.
+ * - Numeric inputs are seconds since the Unix epoch (Rails `Time.at(n)`).
+ * - With `includeSeconds: true`, sub-minute differences resolve to
+ *   "less than N seconds" / "half a minute" / "1 minute".
+ */
+export function distanceOfTimeInWords(
+  fromTime: DistanceOfTimeInput,
+  toTime: DistanceOfTimeInput = 0,
+  options: DistanceOfTimeOptions = {},
+): string {
+  const scope = options.scope ?? "datetime.distance_in_words";
+  const locale = options.locale;
+
+  let from = normalizeDistanceOfTimeArgumentToTime(fromTime);
+  let to = normalizeDistanceOfTimeArgumentToTime(toTime);
+  if (from.getTime() > to.getTime()) {
+    [from, to] = [to, from];
+  }
+
+  const distanceInSeconds = Math.round((to.getTime() - from.getTime()) / 1000);
+  const distanceInMinutes = Math.round(distanceInSeconds / 60);
+
+  const t = (key: string, count = 1): string => translateDistance(key, count, scope, locale);
+
+  if (distanceInMinutes <= 1) {
+    if (!options.includeSeconds) {
+      return distanceInMinutes === 0
+        ? t("less_than_x_minutes", 1)
+        : t("x_minutes", distanceInMinutes);
+    }
+    if (distanceInSeconds <= 4) return t("less_than_x_seconds", 5);
+    if (distanceInSeconds <= 9) return t("less_than_x_seconds", 10);
+    if (distanceInSeconds <= 19) return t("less_than_x_seconds", 20);
+    if (distanceInSeconds <= 39) return t("half_a_minute");
+    if (distanceInSeconds <= 59) return t("less_than_x_minutes", 1);
+    return t("x_minutes", 1);
+  }
+  if (distanceInMinutes < 45) return t("x_minutes", distanceInMinutes);
+  if (distanceInMinutes < 90) return t("about_x_hours", 1);
+  if (distanceInMinutes < 1440) return t("about_x_hours", Math.round(distanceInMinutes / 60));
+  if (distanceInMinutes < 2520) return t("x_days", 1);
+  if (distanceInMinutes < 43200) return t("x_days", Math.round(distanceInMinutes / 1440));
+  if (distanceInMinutes < 86400) return t("about_x_months", Math.round(distanceInMinutes / 43200));
+  if (distanceInMinutes < 525600) return t("x_months", Math.round(distanceInMinutes / 43200));
+
+  let fromYear = from.getUTCFullYear();
+  if (from.getUTCMonth() + 1 >= 3) fromYear += 1;
+  let toYear = to.getUTCFullYear();
+  if (to.getUTCMonth() + 1 < 3) toYear -= 1;
+  let leapYears = 0;
+  if (fromYear <= toYear) {
+    for (let y = fromYear; y <= toYear; y++) {
+      if ((y % 4 === 0 && y % 100 !== 0) || y % 400 === 0) leapYears += 1;
+    }
+  }
+  const minutesWithOffset = distanceInMinutes - leapYears * 1440;
+  const remainder = ((minutesWithOffset % MINUTES_IN_YEAR) + MINUTES_IN_YEAR) % MINUTES_IN_YEAR;
+  const distanceInYears = Math.trunc(minutesWithOffset / MINUTES_IN_YEAR);
+  if (remainder < MINUTES_IN_QUARTER_YEAR) return t("about_x_years", distanceInYears);
+  if (remainder < MINUTES_IN_THREE_QUARTERS_YEAR) return t("over_x_years", distanceInYears);
+  return t("almost_x_years", distanceInYears + 1);
+}
+
+/**
+ * Like {@link distanceOfTimeInWords}, but with `toTime` fixed to the
+ * current time. Numeric inputs are not accepted, matching Rails.
+ */
+export function timeAgoInWords(
+  fromTime: Exclude<DistanceOfTimeInput, number>,
+  options: DistanceOfTimeOptions = {},
+): string {
+  // boundary: "now" sentinel — JS Date is the canonical wall-clock source here.
+  return distanceOfTimeInWords(fromTime, new Date(), options);
+}
+
+/** Alias of {@link timeAgoInWords}. */
+export const distanceOfTimeInWordsToNow = timeAgoInWords;

--- a/packages/actionview/src/helpers/index.ts
+++ b/packages/actionview/src/helpers/index.ts
@@ -52,6 +52,13 @@ export {
 } from "./sanitize-helper.js";
 export type { Sanitizer, SanitizerClass, SanitizerVendor } from "./sanitize-helper.js";
 
+export {
+  distanceOfTimeInWords,
+  timeAgoInWords,
+  distanceOfTimeInWordsToNow,
+} from "./date-helper.js";
+export type { DistanceOfTimeInput, DistanceOfTimeOptions } from "./date-helper.js";
+
 export { truncate, pluralize, wordWrap, simpleFormat } from "./text-helper.js";
 export type {
   TruncateOptions,

--- a/packages/actionview/src/template/date-helper.test.ts
+++ b/packages/actionview/src/template/date-helper.test.ts
@@ -3,7 +3,7 @@ import {
   distanceOfTimeInWords,
   distanceOfTimeInWordsToNow,
   timeAgoInWords,
-} from "./date-helper.js";
+} from "../helpers/date-helper.js";
 
 const SECOND = 1000;
 const MINUTE = 60 * SECOND;
@@ -17,7 +17,7 @@ function add(base: Date, ms: number): Date {
 const from = new Date(Date.UTC(2004, 5, 6, 21, 45, 0));
 
 describe("DateHelperTest", () => {
-  it("test_distance_in_words", () => {
+  it("distance in words", () => {
     // include_seconds: true — sub-minute distances bucketed by seconds
     expect(distanceOfTimeInWords(from, add(from, 0 * SECOND), { includeSeconds: true })).toBe(
       "less than 5 seconds",
@@ -75,23 +75,23 @@ describe("DateHelperTest", () => {
     expect(distanceOfTimeInWords(from, add(from, 2 * DAY + 12 * HOUR))).toBe("3 days");
   });
 
-  it("test_distance_in_words_with_nil_input", () => {
+  it("distance in words with nil input", () => {
     expect(() => distanceOfTimeInWords(null as unknown as Date)).toThrow();
     expect(() => distanceOfTimeInWords(0, null as unknown as Date)).toThrow();
   });
 
-  it("test_distance_in_words_with_mixed_argument_types", () => {
+  it("distance in words with mixed argument types", () => {
     expect(distanceOfTimeInWords(0, 60)).toBe("1 minute");
     expect(distanceOfTimeInWords(600, 0)).toBe("10 minutes");
   });
 
-  it("test_time_ago_in_words_passes_include_seconds", () => {
+  it("time ago in words passes include seconds", () => {
     const past = new Date(Date.now() - 15 * SECOND);
     expect(timeAgoInWords(past, { includeSeconds: true })).toBe("less than 20 seconds");
     expect(timeAgoInWords(past, { includeSeconds: false })).toBe("less than a minute");
   });
 
-  it("test_distance_in_words_with_dates", () => {
+  it("distance in words with dates", () => {
     const startDate = new Date(Date.UTC(1975, 0, 31));
     const endDate = new Date(Date.UTC(1977, 0, 31));
     expect(distanceOfTimeInWords(startDate, endDate)).toBe("about 2 years");
@@ -102,7 +102,7 @@ describe("DateHelperTest", () => {
     expect(distanceOfTimeInWords(e2, s2)).toBe("almost 28 years");
   });
 
-  it("test_distance_in_words_with_integers", () => {
+  it("distance in words with integers", () => {
     expect(distanceOfTimeInWords(59)).toBe("1 minute");
     expect(distanceOfTimeInWords(60 * 60)).toBe("about 1 hour");
     expect(distanceOfTimeInWords(0, 59)).toBe("1 minute");
@@ -111,7 +111,7 @@ describe("DateHelperTest", () => {
     expect(distanceOfTimeInWords(0, 10 ** 8)).toBe("about 3 years");
   });
 
-  it("test_time_ago_in_words", () => {
+  it("time ago in words", () => {
     const oneYearAndOneDayAgo = new Date(Date.now() - (365 * DAY + 1 * DAY));
     expect(timeAgoInWords(oneYearAndOneDayAgo)).toBe("about 1 year");
   });


### PR DESCRIPTION
## Summary

Implements the formatting half of `ActionView::Helpers::DateHelper` (Phase 5 T1):

- `distanceOfTimeInWords(from, to, options)` — full bucketed phrasing, `includeSeconds` branch, leap-year offset path
- `timeAgoInWords(from, options)` — wraps with `to = now`
- `distanceOfTimeInWordsToNow` — alias of `timeAgoInWords`

Mirrors Rails `vendor/rails/actionview/lib/action_view/helpers/date_helper.rb` (95–180). Date *select tag* helpers (`select_date`, `select_time`, etc.) are part of Phase 5 T3 and deliberately out of scope.

Notes:
- Translations honor `options.scope` / `options.locale` via `I18n.translate`, falling back to bundled English strings (sourced from `actionview/lib/action_view/locale/en.yml`).
- Numeric inputs are seconds-since-epoch, matching Ruby `Time.at(n)` — required by `test_distance_in_words_with_integers`.
- `// boundary:` annotated for the JS `Date` inputs/now sentinel.

## Test plan

- [x] `pnpm vitest run packages/actionview/src/helpers/date-helper.test.ts` — 9 passing, Rails test-name parity
- [x] `pnpm lint packages/actionview/src/helpers/date-helper.ts ...test.ts` — clean
- [ ] CI green