### PR TITLE
feat(actionpack): Live::Buffer producer/consumer queue (P18a)

### DIFF
--- a/packages/actionpack/src/action-controller/index.ts
+++ b/packages/actionpack/src/action-controller/index.ts
@@ -59,7 +59,12 @@ export {
   InvalidAuthenticityToken,
   InvalidCrossOriginRequest,
 } from "./metal/request-forgery-protection.js";
-export { SSE, ClientDisconnected } from "./metal/live.js";
+export {
+  SSE,
+  ClientDisconnected,
+  Buffer as LiveBuffer,
+  Response as LiveResponse,
+} from "./metal/live.js";
 export { BasicAuth, TokenAuth, DigestAuth } from "./metal/http-authentication.js";
 export { Renderer } from "./renderer.js";
 export { Deprecator, deprecator, addRenderer, removeRenderer } from "./deprecator.js";

--- a/packages/actionpack/src/action-controller/metal/live.test.ts
+++ b/packages/actionpack/src/action-controller/metal/live.test.ts
@@ -40,9 +40,21 @@ describe("ActionController::Live::Buffer", () => {
     buf.write("one");
     buf.write("two");
     buf.close();
-    buf.write("after-close-but-still-queued");
     expect([...buf.eachChunk()]).toEqual(["one", "two"]);
     expect(buf.closed).toBe(true);
+  });
+
+  it("write after close raises (matches Rails IOError-on-closed-stream)", () => {
+    const buf = new Buffer(makeResponse());
+    buf.close();
+    expect(() => buf.write("x")).toThrow(/closed stream/);
+  });
+
+  it("close commits the underlying response", () => {
+    const res = makeResponse();
+    const buf = new Buffer(res);
+    buf.close();
+    expect(res.committed).toBe(true);
   });
 
   it("abort clears the queue, isConnected flips to false", () => {
@@ -153,5 +165,22 @@ describe("ActionController::Live::Response", () => {
     res.stream.write("b");
     res.stream.close();
     expect([...res.stream.eachChunk()]).toEqual(["a", "b"]);
+  });
+
+  it("beforeCommitted (via close) flushes accumulated cookies into a set-cookie header", () => {
+    const res = new Response();
+    res.setCookie("session", "abc");
+    res.setCookie("flash", "hi");
+    res.stream.close();
+    expect(res.headers["set-cookie"]).toBe("session=abc\nflash=hi");
+    expect(res.committed).toBe(true);
+  });
+
+  it("beforeCommitted does not overwrite an explicit set-cookie header", () => {
+    const res = new Response();
+    res.setCookie("session", "abc");
+    res.setHeader("set-cookie", "manual=1");
+    res.stream.close();
+    expect(res.headers["set-cookie"]).toBe("manual=1");
   });
 });

--- a/packages/actionpack/src/action-controller/metal/live.test.ts
+++ b/packages/actionpack/src/action-controller/metal/live.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { Buffer, ClientDisconnected, Response, SSE } from "./live.js";
+
+function makeResponse() {
+  return new Response();
+}
+
+describe("ActionController::Live::Buffer", () => {
+  it("queueSize defaults to 10", () => {
+    expect(Buffer.queueSize).toBe(10);
+  });
+
+  it("write pushes chunks and sets Cache-Control/Content-Length on uncommitted response", () => {
+    const res = makeResponse();
+    res.setHeader("content-length", "42");
+    const buf = new Buffer(res);
+    buf.write("hello");
+    expect(res.headers["cache-control"]).toBe("no-cache");
+    expect(res.headers["content-length"]).toBeUndefined();
+  });
+
+  it("write does not touch headers once response is committed", () => {
+    const res = makeResponse();
+    res.close();
+    const buf = new Buffer(res);
+    buf.write("x");
+    expect(res.headers["cache-control"]).toBeUndefined();
+  });
+
+  it("writeln appends a newline only when missing", () => {
+    const buf = new Buffer(makeResponse());
+    buf.writeln("a");
+    buf.writeln("b\n");
+    expect([...buf.eachChunk()]).toEqual(["a\n", "b\n"]);
+  });
+
+  it("close pushes a null sentinel; eachChunk stops there", () => {
+    const buf = new Buffer(makeResponse());
+    buf.write("one");
+    buf.write("two");
+    buf.close();
+    buf.write("after-close-but-still-queued");
+    expect([...buf.eachChunk()]).toEqual(["one", "two"]);
+    expect(buf.closed).toBe(true);
+  });
+
+  it("abort clears the queue, isConnected flips to false", () => {
+    const buf = new Buffer(makeResponse());
+    buf.write("a");
+    buf.abort();
+    expect(buf.isConnected).toBe(false);
+    expect([...buf.eachChunk()]).toEqual([]);
+  });
+
+  it("write after abort raises ClientDisconnected by default", () => {
+    const buf = new Buffer(makeResponse());
+    buf.abort();
+    expect(() => buf.write("x")).toThrow(ClientDisconnected);
+  });
+
+  it("ignoreDisconnect=true silently swallows writes after abort", () => {
+    const buf = new Buffer(makeResponse());
+    buf.ignoreDisconnect = true;
+    buf.abort();
+    expect(() => buf.write("x")).not.toThrow();
+  });
+
+  it("onError + callOnError fires the registered callback", () => {
+    const buf = new Buffer(makeResponse());
+    const cb = vi.fn();
+    buf.onError(cb);
+    buf.callOnError();
+    expect(cb).toHaveBeenCalledOnce();
+  });
+
+  it("default error callback is a no-op", () => {
+    const buf = new Buffer(makeResponse());
+    expect(() => buf.callOnError()).not.toThrow();
+  });
+});
+
+describe("ActionController::Live::SSE", () => {
+  function captureStream() {
+    const writes: string[] = [];
+    let closed = false;
+    return {
+      stream: {
+        write: (s: string) => writes.push(s),
+        close: () => {
+          closed = true;
+        },
+      },
+      writes,
+      isClosed: () => closed,
+    };
+  }
+
+  it("writes a string payload with data: prefix", () => {
+    const cap = captureStream();
+    new SSE(cap.stream).write("hello");
+    expect(cap.writes.join("")).toBe("data: hello\n\n");
+  });
+
+  it("encodes objects as JSON", () => {
+    const cap = captureStream();
+    new SSE(cap.stream).write({ name: "John" });
+    expect(cap.writes.join("")).toBe(`data: ${JSON.stringify({ name: "John" })}\n\n`);
+  });
+
+  it("emits permitted options (event, id, retry) per write", () => {
+    const cap = captureStream();
+    new SSE(cap.stream).write("hi", { event: "x", id: "1", retry: 500 });
+    const joined = cap.writes.join("");
+    expect(joined).toContain("event: x\n");
+    expect(joined).toContain("id: 1\n");
+    expect(joined).toContain("retry: 500\n");
+    expect(joined.endsWith("data: hi\n\n")).toBe(true);
+  });
+
+  it("constructor options apply to every write unless overridden", () => {
+    const cap = captureStream();
+    const sse = new SSE(cap.stream, { event: "default", retry: 100 });
+    sse.write("a");
+    sse.write("b", { event: "override" });
+    const joined = cap.writes.join("");
+    expect(joined).toContain("event: default\n");
+    expect(joined).toContain("event: override\n");
+  });
+
+  it("splits embedded newlines into multiple data: lines", () => {
+    const cap = captureStream();
+    new SSE(cap.stream).write("line1\nline2");
+    expect(cap.writes.join("")).toBe("data: line1\ndata: line2\n\n");
+  });
+
+  it("close closes the underlying stream", () => {
+    const cap = captureStream();
+    new SSE(cap.stream).close();
+    expect(cap.isClosed()).toBe(true);
+  });
+});
+
+describe("ActionController::Live::Response", () => {
+  it("constructs a Buffer as its stream", () => {
+    const res = new Response();
+    expect(res.stream).toBeInstanceOf(Buffer);
+  });
+
+  it("stream writes flow through the live Buffer", () => {
+    const res = new Response();
+    res.stream.write("a");
+    res.stream.write("b");
+    res.stream.close();
+    expect([...res.stream.eachChunk()]).toEqual(["a", "b"]);
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/live.test.ts
+++ b/packages/actionpack/src/action-controller/metal/live.test.ts
@@ -140,6 +140,12 @@ describe("ActionController::Live::SSE", () => {
     expect(joined).toContain("event: override\n");
   });
 
+  it("emits an empty id: line when id is the empty string (Last-Event-ID reset)", () => {
+    const cap = captureStream();
+    new SSE(cap.stream).write("hi", { id: "" });
+    expect(cap.writes.join("")).toContain("id: \n");
+  });
+
   it("splits embedded newlines into multiple data: lines", () => {
     const cap = captureStream();
     new SSE(cap.stream).write("line1\nline2");
@@ -165,6 +171,14 @@ describe("ActionController::Live::Response", () => {
     res.stream.write("b");
     res.stream.close();
     expect([...res.stream.eachChunk()]).toEqual(["a", "b"]);
+  });
+
+  it("inherits DispatchResponse.create factory shape (status/headers/body args)", () => {
+    const res = new Response(201, { "x-test": "1" }, ["seed"]);
+    expect(res.status).toBe(201);
+    expect(res.headers["x-test"]).toBe("1");
+    expect(res.body).toBe("seed");
+    expect(res.stream).toBeInstanceOf(Buffer);
   });
 
   it("beforeCommitted (via close) flushes accumulated cookies into a set-cookie header", () => {

--- a/packages/actionpack/src/action-controller/metal/live.ts
+++ b/packages/actionpack/src/action-controller/metal/live.ts
@@ -19,6 +19,7 @@ interface LiveResponseLike {
   headers: Record<string, string>;
   setHeader(key: string, value: string): void;
   deleteHeader(key: string): void;
+  close?(): void;
 }
 
 type ErrorCallback = () => void;
@@ -63,6 +64,8 @@ export class Buffer {
   }
 
   write(string: string): void {
+    if (this._closed) throw new Error("closed stream");
+
     if (!this._response.committed) {
       if (!this._response.headers["cache-control"] && !this._response.headers["Cache-Control"]) {
         this._response.setHeader("cache-control", "no-cache");
@@ -93,6 +96,9 @@ export class Buffer {
    * @see {@link abort}
    */
   close(): void {
+    if (typeof (this._response as { close?: () => void }).close === "function") {
+      (this._response as { close: () => void }).close();
+    }
     this._closed = true;
     this._buf.push(null);
   }
@@ -220,16 +226,29 @@ export class Response extends DispatchResponse {
     this.stream = new Buffer(this);
   }
 
+  close(): void {
+    this.beforeCommitted();
+    super.close();
+  }
+
   /**
    * Hook invoked before the response is committed. Mirrors Rails'
-   * `before_committed`, which flushes cookies into the response. We don't
-   * carry a cookie jar on the request yet, so this is a no-op safe override
-   * point.
+   * `before_committed`, which flushes the request's cookie jar onto the
+   * response. We don't yet carry a `request.cookie_jar` collaborator, but
+   * any cookies set directly via `setCookie` on this response are flattened
+   * into a single `set-cookie` header here so they aren't lost.
    *
    * @internal
    */
   protected beforeCommitted(): void {
-    // Rails: jar = request.cookie_jar; jar.write(self) unless committed?
+    if (this.committed) return;
+    const cookies = this.cookies;
+    const names = Object.keys(cookies);
+    if (names.length === 0) return;
+    if (this.headers["set-cookie"] !== undefined || this.headers["Set-Cookie"] !== undefined) {
+      return;
+    }
+    this.setHeader("set-cookie", names.map((n) => `${n}=${cookies[n]}`).join("\n"));
   }
 
   /**

--- a/packages/actionpack/src/action-controller/metal/live.ts
+++ b/packages/actionpack/src/action-controller/metal/live.ts
@@ -5,69 +5,242 @@
  * @see https://api.rubyonrails.org/classes/ActionController/Live.html
  */
 
+import { Response as DispatchResponse } from "../../action-dispatch/http/response.js";
+
 export class ClientDisconnected extends Error {
   constructor(message?: string) {
-    super(message ?? "Client disconnected");
+    super(message ?? "client disconnected");
     this.name = "ClientDisconnected";
   }
 }
 
-export class Buffer {
-  private _data: string[] = [];
-  private _closed = false;
+interface LiveResponseLike {
+  committed: boolean;
+  headers: Record<string, string>;
+  setHeader(key: string, value: string): void;
+  deleteHeader(key: string): void;
+}
 
-  write(chunk: string): void {
-    if (this._closed) throw new ClientDisconnected();
-    this._data.push(chunk);
+type ErrorCallback = () => void;
+
+/**
+ * Action Controller Live Buffer.
+ *
+ * A producer/consumer queue that backs `response.stream` for live streaming
+ * controllers. Writes push chunks onto an internal queue; `eachChunk` drains
+ * it on the consumer side. Closing the stream pushes a sentinel `null`.
+ *
+ * Mirrors `ActionController::Live::Buffer`.
+ */
+export class Buffer {
+  /**
+   * Class-level cap on queued chunks. Rails defaults to 10; `null` means
+   * unbounded. We don't enforce backpressure (no SizedQueue in JS), but
+   * preserve the accessor so `Buffer.queueSize = n` is observable.
+   */
+  static queueSize: number | null = 10;
+
+  /**
+   * If `true`, writes after the client disconnects are silently dropped.
+   * If `false` (default), they raise {@link ClientDisconnected}.
+   */
+  ignoreDisconnect = false;
+
+  /** @internal */
+  protected _response: LiveResponseLike;
+  /** @internal */
+  protected _buf: Array<string | null>;
+  /** @internal */
+  protected _aborted = false;
+  /** @internal */
+  protected _closed = false;
+  /** @internal */
+  protected _errorCallback: ErrorCallback = () => {};
+
+  constructor(response: LiveResponseLike) {
+    this._response = response;
+    this._buf = this.buildQueue((this.constructor as typeof Buffer).queueSize);
   }
 
+  write(string: string): void {
+    if (!this._response.committed) {
+      if (!this._response.headers["cache-control"] && !this._response.headers["Cache-Control"]) {
+        this._response.setHeader("cache-control", "no-cache");
+      }
+      this._response.deleteHeader("content-length");
+      this._response.deleteHeader("Content-Length");
+    }
+
+    this._buf.push(string);
+
+    if (!this.isConnected) {
+      this._buf.length = 0;
+      if (!this.ignoreDisconnect) {
+        throw new ClientDisconnected("client disconnected");
+      }
+    }
+  }
+
+  /** Same as `write` but appends a newline if one isn't already present. */
+  writeln(string: string): void {
+    this.write(string.endsWith("\n") ? string : `${string}\n`);
+  }
+
+  /**
+   * Write a 'close' event to the buffer; the producer thread uses this to
+   * notify the consumer it's finished supplying content.
+   *
+   * @see {@link abort}
+   */
   close(): void {
     this._closed = true;
+    this._buf.push(null);
   }
 
   get closed(): boolean {
     return this._closed;
   }
-}
 
-export class SSE {
-  private _stream: Buffer;
-  private _retry?: number;
-  private _event?: string;
-
-  constructor(stream: Buffer, options: { retry?: number; event?: string } = {}) {
-    this._stream = stream;
-    this._retry = options.retry;
-    this._event = options.event;
+  /**
+   * Inform the producer that the client has disconnected; the consumer is no
+   * longer interested in any further content.
+   */
+  abort(): void {
+    this._aborted = true;
+    this._buf.length = 0;
   }
 
-  write(object: unknown, options: { event?: string; id?: string; retry?: number } = {}): void {
-    const event = options.event ?? this._event;
-    const retry = options.retry ?? this._retry;
-    const id = options.id;
+  /** Is the client still connected and waiting for content? */
+  get isConnected(): boolean {
+    return !this._aborted;
+  }
 
-    const data = typeof object === "string" ? object : (JSON.stringify(object) ?? "null");
+  /** Register a callback invoked if an error is raised while streaming. */
+  onError(block: ErrorCallback): void {
+    this._errorCallback = block;
+  }
 
-    let payload = "";
-    if (id !== undefined) payload += `id: ${id}\n`;
-    if (event !== undefined) payload += `event: ${event}\n`;
-    if (retry !== undefined) payload += `retry: ${retry}\n`;
+  callOnError(): void {
+    this._errorCallback();
+  }
 
-    for (const line of data.split(/\r?\n/)) {
-      payload += `data: ${line}\n`;
+  /**
+   * Drain the queue, yielding each non-null chunk in order. Stops at the
+   * sentinel `null` pushed by {@link close}.
+   *
+   * @internal
+   */
+  *eachChunk(): IterableIterator<string> {
+    while (this._buf.length > 0) {
+      const str = this._buf.shift();
+      if (str === null || str === undefined) break;
+      yield str;
     }
-    payload += "\n";
+  }
 
-    this._stream.write(payload);
+  /**
+   * Build the backing queue. Rails uses a SizedQueue when `queueSize` is set;
+   * we approximate with a plain array since JS has no thread-blocking queues.
+   *
+   * @internal
+   */
+  protected buildQueue(_queueSize: number | null): Array<string | null> {
+    return [];
+  }
+}
+
+/**
+ * Action Controller Live Server Sent Events.
+ *
+ * Writes Server-Sent Events to a {@link Buffer}-like stream. Accepts either a
+ * pre-encoded string or any value JSON-serializable via `JSON.stringify`.
+ *
+ * Mirrors `ActionController::Live::SSE`.
+ */
+export class SSE {
+  static readonly PERMITTED_OPTIONS = ["retry", "event", "id"] as const;
+
+  private _stream: { write(s: string): void; close(): void };
+  private _options: { retry?: number | string; event?: string; id?: string };
+
+  constructor(
+    stream: { write(s: string): void; close(): void },
+    options: { retry?: number | string; event?: string; id?: string } = {},
+  ) {
+    this._stream = stream;
+    this._options = options;
   }
 
   close(): void {
     this._stream.close();
   }
+
+  write(
+    object: unknown,
+    options: { retry?: number | string; event?: string; id?: string } = {},
+  ): void {
+    if (typeof object === "string") {
+      this.performWrite(object, options);
+    } else {
+      this.performWrite(JSON.stringify(object) ?? "null", options);
+    }
+  }
+
+  /** @internal */
+  private performWrite(
+    json: string,
+    options: { retry?: number | string; event?: string; id?: string },
+  ): void {
+    const current: Record<string, string | number | undefined> = {
+      ...this._options,
+      ...options,
+    };
+
+    for (const name of SSE.PERMITTED_OPTIONS) {
+      const value = current[name];
+      if (value !== undefined && value !== null && value !== "") {
+        this._stream.write(`${name}: ${value}\n`);
+      }
+    }
+
+    const message = json.replace(/\n/g, "\ndata: ");
+    this._stream.write(`data: ${message}\n\n`);
+  }
 }
 
-export class Response {
-  headers: Record<string, string> = {};
-  stream: Buffer = new Buffer();
-  status: number = 200;
+/**
+ * Live::Response — an {@link DispatchResponse} whose `stream` is a live
+ * {@link Buffer}. Mirrors `ActionController::Live::Response`.
+ */
+export class Response extends DispatchResponse {
+  stream: Buffer;
+
+  constructor() {
+    super();
+    this.stream = new Buffer(this);
+  }
+
+  /**
+   * Hook invoked before the response is committed. Mirrors Rails'
+   * `before_committed`, which flushes cookies into the response. We don't
+   * carry a cookie jar on the request yet, so this is a no-op safe override
+   * point.
+   *
+   * @internal
+   */
+  protected beforeCommitted(): void {
+    // Rails: jar = request.cookie_jar; jar.write(self) unless committed?
+  }
+
+  /**
+   * Wrap a synchronous body into a live Buffer by pushing each part. Mirrors
+   * Rails' `build_buffer`, used when assigning `response_body=` directly.
+   *
+   * @internal
+   */
+  protected buildBuffer(response: LiveResponseLike, body: Iterable<string>): Buffer {
+    const buf = new Buffer(response);
+    for (const part of body) buf.write(part);
+    return buf;
+  }
 }

--- a/packages/actionpack/src/action-controller/metal/live.ts
+++ b/packages/actionpack/src/action-controller/metal/live.ts
@@ -204,7 +204,9 @@ export class SSE {
 
     for (const name of SSE.PERMITTED_OPTIONS) {
       const value = current[name];
-      if (value !== undefined && value !== null && value !== "") {
+      // Match Ruby truthiness: `if option_value` is true for "" — an empty
+      // `id:` line resets the browser's Last-Event-ID, which is valid SSE.
+      if (value !== undefined && value !== null) {
         this._stream.write(`${name}: ${value}\n`);
       }
     }
@@ -221,8 +223,8 @@ export class SSE {
 export class Response extends DispatchResponse {
   stream: Buffer;
 
-  constructor() {
-    super();
+  constructor(status = 200, headers: Record<string, string> = {}, body: string[] = []) {
+    super(status, headers, body);
     this.stream = new Buffer(this);
   }
 


### PR DESCRIPTION
## Summary

Implements `ActionController::Live::Buffer` per the P18a row in
`docs/actioncontroller-100-percent.md`. Closes 12 missing methods on
`metal/live.rb`:

- **Buffer:** `queueSize` (class), `ignoreDisconnect`, `writeln`, `abort`,
  `isConnected`, `onError`, `callOnError`, `eachChunk`, `buildQueue`
- **SSE:** `performWrite` (private; previously inlined)
- **Live::Response:** `beforeCommitted`, `buildBuffer`

Buffer wraps an underlying dispatch `Response`: writes push chunks onto an
internal queue and (on an uncommitted response) lazily set
`Cache-Control: no-cache` + strip `Content-Length`. `close()` pushes a `null`
sentinel that `eachChunk` treats as end-of-stream. `abort()` drops the queue
and flips `isConnected` so subsequent writes raise `ClientDisconnected`
unless `ignoreDisconnect` is true.

Ruby's `MonitorMixin` / `SizedQueue` / `Concurrent::CachedThreadPool` have no
JS equivalents, so synchronization and backpressure are approximated with a
plain array — public surface stays faithful.

`api:compare`: `metal/live.rb` 5/27 → 17/27 (63%). Remaining 10 are the
`Live` mixin methods (`process`, `sendStream`, …) covered by **P18b**.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/live.test.ts` — 18 passing
- [x] `pnpm api:compare` — metal/live.rb at 63%
- [x] `pnpm lint --fix` clean