### PR TITLE
test(activerecord): port 10 database-tasks tests (remote-host + url config)

### DIFF
--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -172,17 +172,35 @@ describe("DatabaseTasksCreateAllTest", () => {
     expect(created).toHaveLength(0);
   });
 
-  it.skip("ignores remote databases", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
-    /* needs remote host detection */
+  it("ignores remote databases", async () => {
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
+    });
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await DatabaseTasks.createAll();
+      expect(created).toHaveLength(0);
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
-  it.skip("warning for remote databases", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
-    /* needs remote host detection */
+  it("warning for remote databases", async () => {
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
+    });
+    const writes: string[] = [];
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    try {
+      await DatabaseTasks.createAll();
+      expect(writes.join("")).toMatch(
+        /This task only modifies local databases\. dev\.db is on a remote host\./,
+      );
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 
   it("creates configurations with local ip", async () => {
@@ -222,6 +240,7 @@ describe("DatabaseTasksCreateCurrentTest", () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "sqlite3", database: "dev.db" },
       test: { adapter: "sqlite3", database: "test.db" },
+      production: { url: "sqlite3://prod-db-host/prod-db" },
     });
   });
   afterEach(() => {
@@ -236,11 +255,10 @@ describe("DatabaseTasksCreateCurrentTest", () => {
     expect(created).toContain("test:test.db");
   });
 
-  it.skip("creates current environment database with url", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
-    /* needs URL config */
+  it("creates current environment database with url", async () => {
+    DatabaseTasks.env = "production";
+    await DatabaseTasks.createCurrent("production");
+    expect(created).toContain("production:/prod-db");
   });
 
   it("creates test and development databases when env was not specified", async () => {
@@ -256,11 +274,18 @@ describe("DatabaseTasksCreateCurrentTest", () => {
     expect(created.length).toBe(2);
   });
 
-  it.skip("creates development database without test database when skip test database", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
-    /* needs skip_test_database config */
+  it("creates development database without test database when skip test database", async () => {
+    const prev = process.env.SKIP_TEST_DATABASE;
+    process.env.SKIP_TEST_DATABASE = "true";
+    try {
+      DatabaseTasks.env = "development";
+      await DatabaseTasks.createCurrent();
+      expect(created).toContain("development:dev.db");
+      expect(created.some((c) => c.startsWith("test:"))).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.SKIP_TEST_DATABASE;
+      else process.env.SKIP_TEST_DATABASE = prev;
+    }
   });
   it.skip("establishes connection for the given environments", () => {
     // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
@@ -287,6 +312,10 @@ describe("DatabaseTasksCreateCurrentThreeTierTest", () => {
       test: {
         primary: { adapter: "sqlite3", database: "test_primary.db" },
       },
+      production: {
+        primary: { url: "sqlite3://prod-db-host/prod-db" },
+        secondary: { url: "sqlite3://secondary-prod-db-host/secondary-prod-db" },
+      },
     });
   });
   afterEach(() => {
@@ -302,10 +331,11 @@ describe("DatabaseTasksCreateCurrentThreeTierTest", () => {
     expect(created[0]).toContain("test");
   });
 
-  it.skip("creates current environment database with url", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
+  it("creates current environment database with url", async () => {
+    DatabaseTasks.env = "production";
+    await DatabaseTasks.createCurrent("production");
+    expect(created).toContain("production:primary:/prod-db");
+    expect(created).toContain("production:secondary:/secondary-prod-db");
   });
 
   it("creates test and development databases when env was not specified", async () => {
@@ -351,15 +381,35 @@ describe("DatabaseTasksDropAllTest", () => {
     expect(dropped).toHaveLength(0);
   });
 
-  it.skip("ignores remote databases", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
+  it("ignores remote databases", async () => {
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
+    });
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    try {
+      await DatabaseTasks.dropAll();
+      expect(dropped).toHaveLength(0);
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
-  it.skip("warning for remote databases", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
+  it("warning for remote databases", async () => {
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
+    });
+    const writes: string[] = [];
+    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+      writes.push(String(chunk));
+      return true;
+    });
+    try {
+      await DatabaseTasks.dropAll();
+      expect(writes.join("")).toMatch(
+        /This task only modifies local databases\. dev\.db is on a remote host\./,
+      );
+    } finally {
+      writeSpy.mockRestore();
+    }
   });
 
   it("drops configurations with local ip", async () => {
@@ -399,6 +449,7 @@ describe("DatabaseTasksDropCurrentTest", () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "sqlite3", database: "dev.db" },
       test: { adapter: "sqlite3", database: "test.db" },
+      production: { url: "sqlite3://prod-db-host/prod-db" },
     });
   });
   afterEach(() => {
@@ -413,10 +464,17 @@ describe("DatabaseTasksDropCurrentTest", () => {
     expect(dropped).toContain("test:test.db");
   });
 
-  it.skip("drops current environment database with url", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
+  it("drops current environment database with url", async () => {
+    const prev = process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
+    process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = "1";
+    try {
+      DatabaseTasks.env = "production";
+      await DatabaseTasks.dropCurrent("production");
+      expect(dropped).toContain("production:/prod-db");
+    } finally {
+      if (prev === undefined) delete process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
+      else process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = prev;
+    }
   });
 
   it("drops test and development databases when env was not specified", async () => {
@@ -450,6 +508,10 @@ describe("DatabaseTasksDropCurrentThreeTierTest", () => {
       test: {
         primary: { adapter: "sqlite3", database: "test.db" },
       },
+      production: {
+        primary: { url: "sqlite3://prod-db-host/prod-db" },
+        secondary: { url: "sqlite3://secondary-prod-db-host/secondary-prod-db" },
+      },
     });
   });
   afterEach(() => {
@@ -464,10 +526,18 @@ describe("DatabaseTasksDropCurrentThreeTierTest", () => {
     expect(dropped).toHaveLength(1);
   });
 
-  it.skip("drops current environment database with url", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
+  it("drops current environment database with url", async () => {
+    const prev = process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
+    process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = "1";
+    try {
+      DatabaseTasks.env = "production";
+      await DatabaseTasks.dropCurrent("production");
+      expect(dropped).toContain("production:primary");
+      expect(dropped).toContain("production:secondary");
+    } finally {
+      if (prev === undefined) delete process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
+      else process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = prev;
+    }
   });
 
   it("drops test and development databases when env was not specified", async () => {
@@ -670,10 +740,23 @@ describe("DatabaseTasksTruncateAllWithMultipleDatabasesTest", () => {
     expect(truncated.length).toBe(2);
   });
 
-  it.skip("truncate all databases with url for environment", () => {
-    // BLOCKED: migration — DatabaseTasks feature gap in database-tasks
-    // ROOT-CAUSE: tasks/database-tasks.ts missing Rails parity for task lifecycle (create/drop/migrate/schema)
-    // SCOPE: ~50–100 LOC fix in tasks/database-tasks.ts; affects ~26 tests in database-tasks.test.ts
+  it("truncate all databases with url for environment", async () => {
+    DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
+      production: {
+        primary: { url: "sqlite3://prod-db-host/prod-db" },
+        secondary: { url: "sqlite3://secondary-prod-db-host/secondary-prod-db" },
+      },
+    });
+    const prev = process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
+    process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = "1";
+    try {
+      await DatabaseTasks.truncateAll("production");
+      expect(truncated).toContain("production:/prod-db");
+      expect(truncated).toContain("production:/secondary-prod-db");
+    } finally {
+      if (prev === undefined) delete process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK;
+      else process.env.DISABLE_DATABASE_ENVIRONMENT_CHECK = prev;
+    }
   });
 
   it("truncate all development databases when env is not specified", async () => {

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -162,6 +162,7 @@ describe("DatabaseTasksCreateAllTest", () => {
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
     DatabaseTasks.databaseConfiguration = null;
+    vi.restoreAllMocks();
   });
 
   it("ignores configurations without databases", async () => {
@@ -176,31 +177,23 @@ describe("DatabaseTasksCreateAllTest", () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
     });
-    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    try {
-      await DatabaseTasks.createAll();
-      expect(created).toHaveLength(0);
-    } finally {
-      writeSpy.mockRestore();
-    }
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    await DatabaseTasks.createAll();
+    expect(created).toHaveLength(0);
   });
   it("warning for remote databases", async () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
     });
     const writes: string[] = [];
-    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
       writes.push(String(chunk));
       return true;
     });
-    try {
-      await DatabaseTasks.createAll();
-      expect(writes.join("")).toMatch(
-        /This task only modifies local databases\. dev\.db is on a remote host\./,
-      );
-    } finally {
-      writeSpy.mockRestore();
-    }
+    await DatabaseTasks.createAll();
+    expect(writes.join("")).toMatch(
+      /This task only modifies local databases\. dev\.db is on a remote host\./,
+    );
   });
 
   it("creates configurations with local ip", async () => {
@@ -371,6 +364,7 @@ describe("DatabaseTasksDropAllTest", () => {
   afterEach(() => {
     DatabaseTasks.clearRegisteredTasks();
     DatabaseTasks.databaseConfiguration = null;
+    vi.restoreAllMocks();
   });
 
   it("ignores configurations without databases", async () => {
@@ -385,31 +379,23 @@ describe("DatabaseTasksDropAllTest", () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
     });
-    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation(() => true);
-    try {
-      await DatabaseTasks.dropAll();
-      expect(dropped).toHaveLength(0);
-    } finally {
-      writeSpy.mockRestore();
-    }
+    vi.spyOn(process.stderr, "write").mockImplementation(() => true);
+    await DatabaseTasks.dropAll();
+    expect(dropped).toHaveLength(0);
   });
   it("warning for remote databases", async () => {
     DatabaseTasks.databaseConfiguration = new DatabaseConfigurations({
       development: { adapter: "sqlite3", database: "dev.db", host: "my.server.tld" },
     });
     const writes: string[] = [];
-    const writeSpy = vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
+    vi.spyOn(process.stderr, "write").mockImplementation((chunk) => {
       writes.push(String(chunk));
       return true;
     });
-    try {
-      await DatabaseTasks.dropAll();
-      expect(writes.join("")).toMatch(
-        /This task only modifies local databases\. dev\.db is on a remote host\./,
-      );
-    } finally {
-      writeSpy.mockRestore();
-    }
+    await DatabaseTasks.dropAll();
+    expect(writes.join("")).toMatch(
+      /This task only modifies local databases\. dev\.db is on a remote host\./,
+    );
   });
 
   it("drops configurations with local ip", async () => {

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -499,9 +499,11 @@ export class DatabaseTasks {
   }
 
   // Mirrors Rails: LOCAL_HOSTS = ["127.0.0.1", "localhost"] + host.blank?
+  // (blank? treats whitespace-only strings as blank, so we trim before
+  // comparing.)
   /** @internal */
   static _localDatabase(c: DatabaseConfig): boolean {
-    const host = c.host;
+    const host = c.host?.trim();
     return !host || host === "localhost" || host === "127.0.0.1";
   }
 
@@ -1162,8 +1164,7 @@ export function eachCurrentEnvironment(environment: string): string[] {
 
 /** @internal */
 export function isLocalDatabase(dbConfig: DatabaseConfig): boolean {
-  const host = dbConfig.host;
-  return !host || host === "localhost" || host === "127.0.0.1" || host === "::1";
+  return DatabaseTasks._localDatabase(dbConfig);
 }
 
 /** @internal */

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -482,11 +482,26 @@ export class DatabaseTasks {
   /** @internal */
   static eachLocalConfiguration(): DatabaseConfig[] {
     if (!this.databaseConfiguration) return [];
-    return this.databaseConfiguration.configurations.filter((c) => {
-      if (!c.database) return false;
-      const host = c.host;
-      return !host || host === "localhost" || host === "127.0.0.1" || host === "::1";
-    });
+    const result: DatabaseConfig[] = [];
+    for (const c of this.databaseConfiguration.configurations) {
+      if (!c.database) continue;
+      if (this._localDatabase(c)) {
+        result.push(c);
+      } else {
+        const stderr = (globalThis as { process?: { stderr?: { write: (s: string) => unknown } } })
+          .process?.stderr;
+        stderr?.write?.(
+          `This task only modifies local databases. ${c.database} is on a remote host.\n`,
+        );
+      }
+    }
+    return result;
+  }
+
+  /** @internal */
+  static _localDatabase(c: DatabaseConfig): boolean {
+    const host = c.host;
+    return !host || host === "localhost" || host === "127.0.0.1" || host === "::1";
   }
 
   static cacheDumpFilename(

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -483,7 +483,7 @@ export class DatabaseTasks {
   static eachLocalConfiguration(): DatabaseConfig[] {
     if (!this.databaseConfiguration) return [];
     const result: DatabaseConfig[] = [];
-    for (const c of this.databaseConfiguration.configurations) {
+    for (const c of this.databaseConfiguration.configsFor()) {
       if (!c.database) continue;
       if (this._localDatabase(c)) {
         result.push(c);
@@ -498,10 +498,11 @@ export class DatabaseTasks {
     return result;
   }
 
+  // Mirrors Rails: LOCAL_HOSTS = ["127.0.0.1", "localhost"] + host.blank?
   /** @internal */
   static _localDatabase(c: DatabaseConfig): boolean {
     const host = c.host;
-    return !host || host === "localhost" || host === "127.0.0.1" || host === "::1";
+    return !host || host === "localhost" || host === "127.0.0.1";
   }
 
   static cacheDumpFilename(


### PR DESCRIPTION
## Summary

Un-skips 10 tests in `packages/activerecord/src/tasks/database-tasks.test.ts` (26 → 16 skipped) by porting the bodies from Rails' `vendor/rails/activerecord/test/cases/tasks/database_tasks_test.rb`.

Ported tests:
- `DatabaseTasksCreateAllTest` — `ignores remote databases`, `warning for remote databases`
- `DatabaseTasksDropAllTest` — `ignores remote databases`, `warning for remote databases`
- `DatabaseTasksCreateCurrentTest` — `creates current environment database with url`, `creates development database without test database when skip test database`
- `DatabaseTasksCreateCurrentThreeTierTest` — `creates current environment database with url`
- `DatabaseTasksDropCurrentTest` / `DatabaseTasksDropCurrentThreeTierTest` — `drops current environment database with url`
- `DatabaseTasksTruncateAllWithMultipleDatabasesTest` — `truncate all databases with url for environment`

`DatabaseTasks.eachLocalConfiguration` now emits the Rails-format `"This task only modifies local databases. <db> is on a remote host."` warning to `process.stderr` instead of silently dropping non-local configs. Local-host predicate factored out as `_localDatabase`.

## Follow-ups (remaining 16 skips)

Genuine infra gaps — out of scope here:
- schema cache (`dump_schema_cache`, `clear_schema_cache`, `migrate clears schema cache afterward`)
- migration tracking / status (`raises if no migrations have been made`, `migrate status table`, `migrate raise error on failed check target version`, `migrate using scope` x3)
- multi-database protected-env check (`with multiple databases`)
- `establishes connection` (needs `Base.establish_connection` stub plumbing)
- `dump_schema` filesystem tests (`ensure db dir`, `db dir ignored if included in schema dump`)
- `setting schema dump to nil` (needs `schemaDumpPath` to return `string | null` with cascading caller updates)
- TS-not-applicable: symbol env names

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/tasks/database-tasks.test.ts` — 107 passed, 16 skipped
- [x] Diff: 147 insertions, 49 deletions (under 250 LOC ceiling)