### PR TITLE
feat(actionpack): ParseError/ParamError family → 400 in ExceptionWrapper

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/exception-wrapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/exception-wrapper.test.ts
@@ -76,13 +76,6 @@ describe("ExceptionWrapperTest", () => {
     expect(ExceptionWrapper.statusCodeFor("ParamsTooDeepError")).toBe(400);
   });
 
-  it("inherits a parent's status via the prototype chain walk", () => {
-    class ParamError extends Error {}
-    class SubError extends ParamError {}
-    const wrapper = new ExceptionWrapper(new SubError("nested"));
-    expect(wrapper.statusCode).toBe(400);
-  });
-
   it("#rescue_response? returns false for an exception that's not in rescue_responses", () => {
     expect(ExceptionWrapper.rescueResponse("SomeRandomError")).toBe(false);
   });

--- a/packages/actionpack/src/action-dispatch/dispatch/exception-wrapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/exception-wrapper.test.ts
@@ -64,6 +64,25 @@ describe("ExceptionWrapperTest", () => {
     expect(ExceptionWrapper.statusCodeFor("ParameterTypeError")).toBe(400);
   });
 
+  it("#status_code returns 400 for the ActionDispatch ParseError/ParamError family", () => {
+    expect(ExceptionWrapper.statusCodeFor("ActionDispatch::Http::Parameters::ParseError")).toBe(
+      400,
+    );
+    expect(ExceptionWrapper.statusCodeFor("ActionDispatch::ParamError")).toBe(400);
+    expect(ExceptionWrapper.statusCodeFor("ActionDispatch::ParameterTypeError")).toBe(400);
+    expect(ExceptionWrapper.statusCodeFor("ActionDispatch::InvalidParameterError")).toBe(400);
+    expect(ExceptionWrapper.statusCodeFor("ActionDispatch::ParamsTooDeepError")).toBe(400);
+    expect(ExceptionWrapper.statusCodeFor("InvalidParameterError")).toBe(400);
+    expect(ExceptionWrapper.statusCodeFor("ParamsTooDeepError")).toBe(400);
+  });
+
+  it("inherits a parent's status via the prototype chain walk", () => {
+    class ParamError extends Error {}
+    class SubError extends ParamError {}
+    const wrapper = new ExceptionWrapper(new SubError("nested"));
+    expect(wrapper.statusCode).toBe(400);
+  });
+
   it("#rescue_response? returns false for an exception that's not in rescue_responses", () => {
     expect(ExceptionWrapper.rescueResponse("SomeRandomError")).toBe(false);
   });

--- a/packages/actionpack/src/action-dispatch/http/parameters.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.test.ts
@@ -248,4 +248,47 @@ describe("parseFormattedParameters", () => {
       ParseError,
     );
   });
+
+  it("rethrows Rack ParamError-family failures without wrapping", async () => {
+    const { ParameterTypeError, InvalidParameterError, ParamsTooDeepError } =
+      await import("@blazetrails/rack");
+    const { ParamError } = await import("./param-error.js");
+    const host = makeHost({
+      contentLength: 1,
+      contentMimeType: MimeType.JSON,
+      rawPost: "{}",
+    });
+    for (const Err of [ParameterTypeError, InvalidParameterError, ParamsTooDeepError]) {
+      const parsers = {
+        [MimeType.JSON.symbol]: () => {
+          throw new Err("boom");
+        },
+      };
+      let caught: unknown;
+      try {
+        parseFormattedParameters.call(host, parsers, () => ({}));
+      } catch (e) {
+        caught = e;
+      }
+      expect(caught).toBeInstanceOf(Err);
+      expect(caught).toBeInstanceOf(ParamError);
+    }
+  });
+
+  it("rethrows ActionDispatch ParseError subclasses without re-wrapping", async () => {
+    const { ParameterTypeError: AdParameterTypeError } = await import("./param-error.js");
+    const host = makeHost({
+      contentLength: 1,
+      contentMimeType: MimeType.JSON,
+      rawPost: "{}",
+    });
+    const parsers = {
+      [MimeType.JSON.symbol]: () => {
+        throw new AdParameterTypeError("nope");
+      },
+    };
+    expect(() => parseFormattedParameters.call(host, parsers, () => ({}))).toThrow(
+      AdParameterTypeError,
+    );
+  });
 });

--- a/packages/actionpack/src/action-dispatch/http/parameters.ts
+++ b/packages/actionpack/src/action-dispatch/http/parameters.ts
@@ -14,6 +14,11 @@
 
 import { Logger } from "@blazetrails/activesupport";
 import { stderr } from "@blazetrails/activesupport/process-adapter";
+import {
+  ParameterTypeError as RackParameterTypeError,
+  InvalidParameterError as RackInvalidParameterError,
+  ParamsTooDeepError as RackParamsTooDeepError,
+} from "@blazetrails/rack";
 import { MimeType } from "./mime-type.js";
 
 export const PARAMETERS_KEY = "action_dispatch.request.path_parameters";
@@ -169,7 +174,20 @@ export function parseFormattedParameters(
 
   try {
     return strategy(this.rawPost);
-  } catch {
+  } catch (e) {
+    // Pass ParamError-family failures (and already-wrapped ParseErrors)
+    // through untouched so callers can `rescueFrom(ParamError)` and see the
+    // specific subclass — mirrors Rails, where `ParamError.===` covers the
+    // parallel Rack exceptions. Everything else collapses to a generic
+    // ParseError so JSON / strategy bugs surface as a 400.
+    if (e instanceof ParseError) throw e;
+    if (
+      e instanceof RackParameterTypeError ||
+      e instanceof RackInvalidParameterError ||
+      e instanceof RackParamsTooDeepError
+    ) {
+      throw e;
+    }
     logParseErrorOnce.call(this);
     throw new ParseError("Error occurred while parsing request parameters");
   }

--- a/packages/actionpack/src/action-dispatch/middleware/exception-wrapper.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/exception-wrapper.ts
@@ -27,10 +27,6 @@ const STATUS_MAP: Record<string, number> = {
   "ActionDispatch::ParameterTypeError": 400,
   "ActionDispatch::InvalidParameterError": 400,
   "ActionDispatch::ParamsTooDeepError": 400,
-  // Unqualified TS class names so the prototype-chain walk in
-  // `computeStatusCode` can resolve subclasses by ancestor constructor name.
-  ParseError: 400,
-  ParamError: 400,
 };
 
 export class ExceptionWrapper {
@@ -144,23 +140,10 @@ export class ExceptionWrapper {
   }
 
   private computeStatusCode(): number {
-    // Direct lookup by exception name first, mirroring Rails'
-    // `@@rescue_responses[class_name]`. Fall back to a prototype-chain walk
-    // so subclasses inherit the parent's registered status (e.g. an
-    // unregistered `ParseError` subclass still maps to 400).
-    const direct = STATUS_MAP[this.exceptionName];
-    if (direct !== undefined) return direct;
-    let ctor: { name?: string; prototype?: object } | null = this.exception.constructor as {
-      name?: string;
-      prototype?: object;
-    } | null;
-    while (ctor && ctor.name && ctor.name !== "Error" && ctor.name !== "Object") {
-      const status = STATUS_MAP[ctor.name];
-      if (status !== undefined) return status;
-      const proto = ctor.prototype ? Object.getPrototypeOf(ctor.prototype) : null;
-      ctor = proto ? (proto.constructor as { name?: string; prototype?: object } | null) : null;
-    }
-    return 500;
+    // Direct lookup by exception name, mirroring Rails'
+    // `@@rescue_responses[class_name]` (no ancestor walk — Rails subclasses
+    // must register their own name to opt in).
+    return STATUS_MAP[this.exceptionName] ?? 500;
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/middleware/exception-wrapper.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/exception-wrapper.ts
@@ -16,7 +16,21 @@ const STATUS_MAP: Record<string, number> = {
   InvalidAuthenticityToken: 422,
   ParameterMissing: 400,
   ParameterTypeError: 400,
+  InvalidParameterError: 400,
+  ParamsTooDeepError: 400,
   UnpermittedParameters: 400,
+  // ActionDispatch ParseError/ParamError family — Rails' rescue_responses uses
+  // the fully-qualified class names that `param-error.ts` and `parameters.ts`
+  // assign via `this.name`. All map to 400 Bad Request, matching Rails.
+  "ActionDispatch::Http::Parameters::ParseError": 400,
+  "ActionDispatch::ParamError": 400,
+  "ActionDispatch::ParameterTypeError": 400,
+  "ActionDispatch::InvalidParameterError": 400,
+  "ActionDispatch::ParamsTooDeepError": 400,
+  // Unqualified TS class names so the prototype-chain walk in
+  // `computeStatusCode` can resolve subclasses by ancestor constructor name.
+  ParseError: 400,
+  ParamError: 400,
 };
 
 export class ExceptionWrapper {
@@ -130,8 +144,23 @@ export class ExceptionWrapper {
   }
 
   private computeStatusCode(): number {
-    const name = this.exceptionName;
-    return STATUS_MAP[name] ?? 500;
+    // Direct lookup by exception name first, mirroring Rails'
+    // `@@rescue_responses[class_name]`. Fall back to a prototype-chain walk
+    // so subclasses inherit the parent's registered status (e.g. an
+    // unregistered `ParseError` subclass still maps to 400).
+    const direct = STATUS_MAP[this.exceptionName];
+    if (direct !== undefined) return direct;
+    let ctor: { name?: string; prototype?: object } | null = this.exception.constructor as {
+      name?: string;
+      prototype?: object;
+    } | null;
+    while (ctor && ctor.name && ctor.name !== "Error" && ctor.name !== "Object") {
+      const status = STATUS_MAP[ctor.name];
+      if (status !== undefined) return status;
+      const proto = ctor.prototype ? Object.getPrototypeOf(ctor.prototype) : null;
+      ctor = proto ? (proto.constructor as { name?: string; prototype?: object } | null) : null;
+    }
+    return 500;
   }
 }
 


### PR DESCRIPTION
## Summary

- Register the ActionDispatch `ParseError` / `ParamError` family (and the Rack `ParameterTypeError` / `InvalidParameterError` / `ParamsTooDeepError` counterparts) in `ExceptionWrapper.STATUS_MAP` → **400 Bad Request**, matching Rails' `rescue_responses`.
- `computeStatusCode` stays a direct `STATUS_MAP[exceptionName]` lookup — matches Rails' `status_code_for_exception` (`exception_wrapper.rb:175`), which is a plain `@@rescue_responses[class_name]` index with no ancestor walk. Subclasses must register their own name to opt in.
- Tighten `parseFormattedParameters`: Rack `ParamError`-family failures and already-wrapped `ParseError`s propagate untouched so `rescueFrom(ParamError)` sees the specific subclass instead of a generic `ParseError`.

Refs `docs/actionpack-100-percent.md` Tier 1 — http/param_error (#1879).

## Test plan

- [x] `pnpm vitest run --project other packages/actionpack/src/action-dispatch/dispatch/exception-wrapper.test.ts packages/actionpack/src/action-dispatch/http/parameters.test.ts packages/actionpack/src/action-dispatch/http/param-error.test.ts`
- [x] `pnpm test:types`
- [x] api:compare / test:compare deltas non-negative (unchanged)
- [ ] CI green