### PR TITLE
feat(actionpack): CSRF verification predicates (P20a)

### DIFF
--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
@@ -140,15 +140,14 @@ describe("unverifiedRequestWarningMessage", () => {
 
 describe("isVerifiedRequest", () => {
   it("returns true when protection is disabled or method is GET/HEAD", () => {
-    expect(isVerifiedRequest(controller({ allowForgeryProtection: false }), () => false)).toBe(
-      true,
-    );
-    expect(isVerifiedRequest(controller({ request: { method: "GET" } }), () => false)).toBe(true);
-    expect(isVerifiedRequest(controller({ request: { method: "HEAD" } }), () => false)).toBe(true);
+    expect(isVerifiedRequest(controller({ allowForgeryProtection: false }))).toBe(true);
+    expect(isVerifiedRequest(controller({ request: { method: "GET" } }))).toBe(true);
+    expect(isVerifiedRequest(controller({ request: { method: "HEAD" } }))).toBe(true);
   });
   it("requires valid origin and token for POST", () => {
-    expect(isVerifiedRequest(controller(), () => true)).toBe(true);
-    expect(isVerifiedRequest(controller(), () => false)).toBe(false);
+    expect(isVerifiedRequest(controller({ isAnyAuthenticityTokenValid: () => true }))).toBe(true);
+    expect(isVerifiedRequest(controller({ isAnyAuthenticityTokenValid: () => false }))).toBe(false);
+    expect(isVerifiedRequest(controller())).toBe(false);
   });
 });
 

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
@@ -67,11 +67,11 @@ describe("isValidRequestOrigin", () => {
 
 describe("markForSameOriginVerificationBang / isMarkedForSameOriginVerification", () => {
   it("sets the flag based on GET", () => {
-    const get = controller({ request: { method: "GET" } });
+    const get = controller({ request: { method: "GET", baseUrl: "https://example.com" } });
     markForSameOriginVerificationBang(get);
     expect(isMarkedForSameOriginVerification(get)).toBe(true);
 
-    const post = controller({ request: { method: "POST" } });
+    const post = controller({ request: { method: "POST", baseUrl: "https://example.com" } });
     markForSameOriginVerificationBang(post);
     expect(isMarkedForSameOriginVerification(post)).toBe(false);
   });
@@ -84,19 +84,30 @@ describe("isNonXhrJavascriptResponse", () => {
   it("matches text/ and application/javascript when not xhr", () => {
     for (const mediaType of ["text/javascript", "application/javascript"]) {
       expect(
-        isNonXhrJavascriptResponse(controller({ request: { method: "GET", mediaType } })),
+        isNonXhrJavascriptResponse(
+          controller({ request: { method: "GET", baseUrl: "https://example.com", mediaType } }),
+        ),
       ).toBe(true);
     }
   });
   it("is false when xhr or non-js media type", () => {
     expect(
       isNonXhrJavascriptResponse(
-        controller({ request: { method: "GET", mediaType: "text/javascript", xhr: true } }),
+        controller({
+          request: {
+            method: "GET",
+            baseUrl: "https://example.com",
+            mediaType: "text/javascript",
+            xhr: true,
+          },
+        }),
       ),
     ).toBe(false);
     expect(
       isNonXhrJavascriptResponse(
-        controller({ request: { method: "GET", mediaType: "text/html" } }),
+        controller({
+          request: { method: "GET", baseUrl: "https://example.com", mediaType: "text/html" },
+        }),
       ),
     ).toBe(false);
   });
@@ -106,16 +117,46 @@ describe("verifySameOriginRequest", () => {
   it("raises when marked + non-xhr js response", () => {
     const c = controller({
       _markedForSameOriginVerification: true,
-      request: { method: "GET", mediaType: "text/javascript" },
+      request: { method: "GET", baseUrl: "https://example.com", mediaType: "text/javascript" },
     });
     expect(() => verifySameOriginRequest(c)).toThrow(InvalidCrossOriginRequest);
   });
   it("no-ops when not marked", () => {
     expect(() =>
       verifySameOriginRequest(
-        controller({ request: { method: "GET", mediaType: "text/javascript" } }),
+        controller({
+          request: {
+            method: "GET",
+            baseUrl: "https://example.com",
+            mediaType: "text/javascript",
+          },
+        }),
       ),
     ).not.toThrow();
+  });
+
+  it("warns via logger when raising", () => {
+    const calls: string[] = [];
+    const c = controller({
+      _markedForSameOriginVerification: true,
+      request: { method: "GET", baseUrl: "https://example.com", mediaType: "text/javascript" },
+      logger: { warn: (m) => calls.push(m) },
+    });
+    expect(() => verifySameOriginRequest(c)).toThrow(InvalidCrossOriginRequest);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatch(/Security warning/);
+  });
+
+  it("suppresses logger warning when logWarningOnCsrfFailure is false", () => {
+    const calls: string[] = [];
+    const c = controller({
+      _markedForSameOriginVerification: true,
+      request: { method: "GET", baseUrl: "https://example.com", mediaType: "text/javascript" },
+      logger: { warn: (m) => calls.push(m) },
+      logWarningOnCsrfFailure: false,
+    });
+    expect(() => verifySameOriginRequest(c)).toThrow(InvalidCrossOriginRequest);
+    expect(calls).toHaveLength(0);
   });
 });
 
@@ -141,8 +182,14 @@ describe("unverifiedRequestWarningMessage", () => {
 describe("isVerifiedRequest", () => {
   it("returns true when protection is disabled or method is GET/HEAD", () => {
     expect(isVerifiedRequest(controller({ allowForgeryProtection: false }))).toBe(true);
-    expect(isVerifiedRequest(controller({ request: { method: "GET" } }))).toBe(true);
-    expect(isVerifiedRequest(controller({ request: { method: "HEAD" } }))).toBe(true);
+    expect(
+      isVerifiedRequest(controller({ request: { method: "GET", baseUrl: "https://example.com" } })),
+    ).toBe(true);
+    expect(
+      isVerifiedRequest(
+        controller({ request: { method: "HEAD", baseUrl: "https://example.com" } }),
+      ),
+    ).toBe(true);
   });
   it("requires valid origin and token for POST", () => {
     expect(isVerifiedRequest(controller({ isAnyAuthenticityTokenValid: () => true }))).toBe(true);
@@ -158,6 +205,9 @@ describe("normalizeActionPath / normalizeRelativeActionPath", () => {
   });
   it("extracts path from full URL", () => {
     expect(normalizeActionPath("https://example.com/foo/", "/current")).toBe("/foo");
+  });
+  it("extracts path from protocol-relative URL", () => {
+    expect(normalizeActionPath("//example.com/foo/", "/current")).toBe("/foo");
   });
   it("joins relative paths onto request path and collapses /./", () => {
     expect(normalizeActionPath("bar", "/foo")).toBe("/foo/bar");

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import {
+  InvalidAuthenticityToken,
+  InvalidCrossOriginRequest,
+  isProtectAgainstForgery,
+  isValidRequestOrigin,
+  markForSameOriginVerificationBang,
+  isMarkedForSameOriginVerification,
+  isNonXhrJavascriptResponse,
+  verifySameOriginRequest,
+  unverifiedRequestWarningMessage,
+  isVerifiedRequest,
+  normalizeActionPath,
+  normalizeRelativeActionPath,
+  type CsrfController,
+} from "./request-forgery-protection.js";
+
+function controller(overrides: Partial<CsrfController> = {}): CsrfController {
+  return {
+    request: { method: "POST", origin: "https://example.com", baseUrl: "https://example.com" },
+    ...overrides,
+  };
+}
+
+describe("isProtectAgainstForgery", () => {
+  it("returns true by default", () => {
+    expect(isProtectAgainstForgery(controller())).toBe(true);
+  });
+  it("returns false when allowForgeryProtection is false", () => {
+    expect(isProtectAgainstForgery(controller({ allowForgeryProtection: false }))).toBe(false);
+  });
+  it("delegates to session.enabled()", () => {
+    expect(isProtectAgainstForgery(controller({ session: { enabled: () => false } }))).toBe(false);
+    expect(isProtectAgainstForgery(controller({ session: { enabled: () => true } }))).toBe(true);
+  });
+});
+
+describe("isValidRequestOrigin", () => {
+  it("is true when origin check is disabled", () => {
+    expect(isValidRequestOrigin(controller({ forgeryProtectionOriginCheck: false }))).toBe(true);
+  });
+  it("is true when origin matches base_url or is missing", () => {
+    expect(isValidRequestOrigin(controller())).toBe(true);
+    expect(
+      isValidRequestOrigin(
+        controller({ request: { method: "POST", baseUrl: "https://example.com" } }),
+      ),
+    ).toBe(true);
+  });
+  it("is false when origin differs", () => {
+    expect(
+      isValidRequestOrigin(
+        controller({
+          request: { method: "POST", origin: "https://evil.com", baseUrl: "https://example.com" },
+        }),
+      ),
+    ).toBe(false);
+  });
+  it("raises InvalidAuthenticityToken for 'null' origin", () => {
+    expect(() =>
+      isValidRequestOrigin(
+        controller({ request: { method: "POST", origin: "null", baseUrl: "https://example.com" } }),
+      ),
+    ).toThrow(InvalidAuthenticityToken);
+  });
+});
+
+describe("markForSameOriginVerificationBang / isMarkedForSameOriginVerification", () => {
+  it("sets the flag based on GET", () => {
+    const get = controller({ request: { method: "GET" } });
+    markForSameOriginVerificationBang(get);
+    expect(isMarkedForSameOriginVerification(get)).toBe(true);
+
+    const post = controller({ request: { method: "POST" } });
+    markForSameOriginVerificationBang(post);
+    expect(isMarkedForSameOriginVerification(post)).toBe(false);
+  });
+  it("defaults to false", () => {
+    expect(isMarkedForSameOriginVerification(controller())).toBe(false);
+  });
+});
+
+describe("isNonXhrJavascriptResponse", () => {
+  it("matches text/ and application/javascript when not xhr", () => {
+    for (const mediaType of ["text/javascript", "application/javascript"]) {
+      expect(
+        isNonXhrJavascriptResponse(controller({ request: { method: "GET", mediaType } })),
+      ).toBe(true);
+    }
+  });
+  it("is false when xhr or non-js media type", () => {
+    expect(
+      isNonXhrJavascriptResponse(
+        controller({ request: { method: "GET", mediaType: "text/javascript", xhr: true } }),
+      ),
+    ).toBe(false);
+    expect(
+      isNonXhrJavascriptResponse(
+        controller({ request: { method: "GET", mediaType: "text/html" } }),
+      ),
+    ).toBe(false);
+  });
+});
+
+describe("verifySameOriginRequest", () => {
+  it("raises when marked + non-xhr js response", () => {
+    const c = controller({
+      _markedForSameOriginVerification: true,
+      request: { method: "GET", mediaType: "text/javascript" },
+    });
+    expect(() => verifySameOriginRequest(c)).toThrow(InvalidCrossOriginRequest);
+  });
+  it("no-ops when not marked", () => {
+    expect(() =>
+      verifySameOriginRequest(
+        controller({ request: { method: "GET", mediaType: "text/javascript" } }),
+      ),
+    ).not.toThrow();
+  });
+});
+
+describe("unverifiedRequestWarningMessage", () => {
+  it("returns short message when origin is valid", () => {
+    expect(unverifiedRequestWarningMessage(controller())).toBe(
+      "Can't verify CSRF token authenticity.",
+    );
+  });
+  it("returns detailed message when origin mismatches", () => {
+    expect(
+      unverifiedRequestWarningMessage(
+        controller({
+          request: { method: "POST", origin: "https://evil.com", baseUrl: "https://example.com" },
+        }),
+      ),
+    ).toBe(
+      "HTTP Origin header (https://evil.com) didn't match request.base_url (https://example.com)",
+    );
+  });
+});
+
+describe("isVerifiedRequest", () => {
+  it("returns true when protection is disabled or method is GET/HEAD", () => {
+    expect(isVerifiedRequest(controller({ allowForgeryProtection: false }), () => false)).toBe(
+      true,
+    );
+    expect(isVerifiedRequest(controller({ request: { method: "GET" } }), () => false)).toBe(true);
+    expect(isVerifiedRequest(controller({ request: { method: "HEAD" } }), () => false)).toBe(true);
+  });
+  it("requires valid origin and token for POST", () => {
+    expect(isVerifiedRequest(controller(), () => true)).toBe(true);
+    expect(isVerifiedRequest(controller(), () => false)).toBe(false);
+  });
+});
+
+describe("normalizeActionPath / normalizeRelativeActionPath", () => {
+  it("strips trailing slash from absolute paths", () => {
+    expect(normalizeActionPath("/foo/bar/", "/current")).toBe("/foo/bar");
+    expect(normalizeActionPath("/foo/bar", "/current")).toBe("/foo/bar");
+  });
+  it("extracts path from full URL", () => {
+    expect(normalizeActionPath("https://example.com/foo/", "/current")).toBe("/foo");
+  });
+  it("joins relative paths onto request path and collapses /./", () => {
+    expect(normalizeActionPath("bar", "/foo")).toBe("/foo/bar");
+    expect(normalizeActionPath("./bar", "/foo")).toBe("/foo/bar");
+    expect(normalizeRelativeActionPath("bar/", "/foo")).toBe("/foo/bar");
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -214,6 +214,8 @@ export interface CsrfController {
   _markedForSameOriginVerification?: boolean;
   logger?: { warn(msg: string): void } | null;
   logWarningOnCsrfFailure?: boolean;
+  /** Supplied by P20c (token validation). */
+  isAnyAuthenticityTokenValid?: () => boolean;
 }
 
 const CROSS_ORIGIN_JAVASCRIPT_WARNING =
@@ -284,28 +286,17 @@ export function verifySameOriginRequest(controller: CsrfController): void {
 
 /** @internal */
 export function unverifiedRequestWarningMessage(controller: CsrfController): string {
-  try {
-    if (isValidRequestOrigin(controller)) {
-      return "Can't verify CSRF token authenticity.";
-    }
-  } catch {
-    // fall through — origin-check raised, treat as mismatch for messaging
+  if (isValidRequestOrigin(controller)) {
+    return "Can't verify CSRF token authenticity.";
   }
   return `HTTP Origin header (${controller.request.origin}) didn't match request.base_url (${controller.request.baseUrl})`;
 }
 
-/**
- * Caller supplies a token-validity check so this module stays free of crypto
- * concerns (those live in token-generation/validation PRs).
- * @internal
- */
-export function isVerifiedRequest(
-  controller: CsrfController,
-  anyAuthenticityTokenValid: () => boolean,
-): boolean {
+/** @internal */
+export function isVerifiedRequest(controller: CsrfController): boolean {
   if (!isProtectAgainstForgery(controller)) return true;
   if (isGetOrHead(controller.request.method)) return true;
-  return isValidRequestOrigin(controller) && anyAuthenticityTokenValid();
+  return isValidRequestOrigin(controller) && (controller.isAnyAuthenticityTokenValid?.() ?? false);
 }
 
 /** @internal */

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -198,7 +198,7 @@ export function skipForgeryProtection(
 export interface CsrfRequest {
   method: string;
   origin?: string | null;
-  baseUrl?: string | null;
+  baseUrl: string;
   path?: string;
   mediaType?: string | null;
   xhr?: boolean;
@@ -308,19 +308,21 @@ export function normalizeRelativeActionPath(relActionPath: string, requestPath: 
 
 /** @internal */
 export function normalizeActionPath(actionPath: string, requestPath: string): string {
+  // Mirrors Ruby's URI.parse: relative inputs without a leading "/" pass
+  // through unparsed; absolute paths, protocol-relative ("//host/x"), and
+  // absolute URLs all have their `.pathname` extracted (using a dummy base
+  // so the URL constructor accepts the schemeless cases).
+  if (actionPath === "" || !actionPath.startsWith("/")) {
+    const SCHEME_RE = /^[a-z][a-z0-9+.-]*:/i;
+    if (!SCHEME_RE.test(actionPath)) {
+      return normalizeRelativeActionPath(actionPath, requestPath);
+    }
+  }
   let parsedPath: string;
-  let isRelative: boolean;
   try {
-    const url = new URL(actionPath);
-    parsedPath = url.pathname;
-    isRelative = false;
+    parsedPath = new URL(actionPath, "http://_placeholder_").pathname;
   } catch {
     parsedPath = actionPath;
-    isRelative = true;
-  }
-
-  if (isRelative && (actionPath === "" || !actionPath.startsWith("/"))) {
-    return normalizeRelativeActionPath(parsedPath, requestPath);
   }
   return parsedPath.endsWith("/") && parsedPath.length > 1 ? parsedPath.slice(0, -1) : parsedPath;
 }

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -189,3 +189,147 @@ export function skipForgeryProtection(
   const merged = { raise: false, ...options };
   _controller.skipBeforeAction?.("verifyAuthenticityToken", merged);
 }
+
+// ---------------------------------------------------------------------------
+// Verification predicates (Rails: metal/request_forgery_protection.rb privates)
+// ---------------------------------------------------------------------------
+
+/** @internal */
+export interface CsrfRequest {
+  method: string;
+  origin?: string | null;
+  baseUrl?: string | null;
+  path?: string;
+  mediaType?: string | null;
+  xhr?: boolean;
+  xCsrfToken?: string | null;
+}
+
+/** @internal */
+export interface CsrfController {
+  request: CsrfRequest;
+  session?: { enabled?: () => boolean } | Record<string, unknown> | null;
+  allowForgeryProtection?: boolean;
+  forgeryProtectionOriginCheck?: boolean;
+  _markedForSameOriginVerification?: boolean;
+  logger?: { warn(msg: string): void } | null;
+  logWarningOnCsrfFailure?: boolean;
+}
+
+const CROSS_ORIGIN_JAVASCRIPT_WARNING =
+  "Security warning: an embedded <script> tag on another site requested " +
+  "protected JavaScript. If you know what you're doing, go ahead and disable " +
+  "forgery protection on this action to permit cross-origin JavaScript embedding.";
+
+const NULL_ORIGIN_MESSAGE =
+  "The browser returned a 'null' origin for a request with origin-based " +
+  "forgery protection turned on. This usually means you have the 'no-referrer' " +
+  "Referrer-Policy header enabled, or that the request came from a site that " +
+  "refused to give its origin. This makes it impossible for Rails to verify " +
+  "the source of the requests. Likely the best solution is to change your " +
+  "referrer policy to something less strict like same-origin or strict-origin. " +
+  "If you cannot change the referrer policy, you can disable origin checking " +
+  "with the Rails.application.config.action_controller.forgery_protection_origin_check setting.";
+
+function isGetOrHead(method: string): boolean {
+  const m = method.toUpperCase();
+  return m === "GET" || m === "HEAD";
+}
+
+/** @internal */
+export function isProtectAgainstForgery(controller: CsrfController): boolean {
+  if (controller.allowForgeryProtection === false) return false;
+  const session = controller.session;
+  if (session && typeof (session as { enabled?: unknown }).enabled === "function") {
+    return (session as { enabled: () => boolean }).enabled();
+  }
+  return true;
+}
+
+/** @internal */
+export function isValidRequestOrigin(controller: CsrfController): boolean {
+  if (controller.forgeryProtectionOriginCheck === false) return true;
+  const origin = controller.request.origin;
+  if (origin === "null") throw new InvalidAuthenticityToken(NULL_ORIGIN_MESSAGE);
+  return origin == null || origin === controller.request.baseUrl;
+}
+
+/** @internal */
+export function markForSameOriginVerificationBang(controller: CsrfController): boolean {
+  const value = controller.request.method.toUpperCase() === "GET";
+  controller._markedForSameOriginVerification = value;
+  return value;
+}
+
+/** @internal */
+export function isMarkedForSameOriginVerification(controller: CsrfController): boolean {
+  return controller._markedForSameOriginVerification ?? false;
+}
+
+/** @internal */
+export function isNonXhrJavascriptResponse(controller: CsrfController): boolean {
+  const mediaType = controller.request.mediaType ?? "";
+  return /^(?:text|application)\/javascript/.test(mediaType) && !controller.request.xhr;
+}
+
+/** @internal */
+export function verifySameOriginRequest(controller: CsrfController): void {
+  if (isMarkedForSameOriginVerification(controller) && isNonXhrJavascriptResponse(controller)) {
+    if (controller.logger && controller.logWarningOnCsrfFailure !== false) {
+      controller.logger.warn(CROSS_ORIGIN_JAVASCRIPT_WARNING);
+    }
+    throw new InvalidCrossOriginRequest(CROSS_ORIGIN_JAVASCRIPT_WARNING);
+  }
+}
+
+/** @internal */
+export function unverifiedRequestWarningMessage(controller: CsrfController): string {
+  try {
+    if (isValidRequestOrigin(controller)) {
+      return "Can't verify CSRF token authenticity.";
+    }
+  } catch {
+    // fall through — origin-check raised, treat as mismatch for messaging
+  }
+  return `HTTP Origin header (${controller.request.origin}) didn't match request.base_url (${controller.request.baseUrl})`;
+}
+
+/**
+ * Caller supplies a token-validity check so this module stays free of crypto
+ * concerns (those live in token-generation/validation PRs).
+ * @internal
+ */
+export function isVerifiedRequest(
+  controller: CsrfController,
+  anyAuthenticityTokenValid: () => boolean,
+): boolean {
+  if (!isProtectAgainstForgery(controller)) return true;
+  if (isGetOrHead(controller.request.method)) return true;
+  return isValidRequestOrigin(controller) && anyAuthenticityTokenValid();
+}
+
+/** @internal */
+export function normalizeRelativeActionPath(relActionPath: string, requestPath: string): string {
+  let path = requestPath + "/" + relActionPath;
+  path = path.replace(/\/\.\//g, "/");
+  return path.endsWith("/") && path.length > 1 ? path.slice(0, -1) : path;
+}
+
+/** @internal */
+export function normalizeActionPath(actionPath: string, requestPath: string): string {
+  let parsedPath: string;
+  let isRelative: boolean;
+  try {
+    const url = new URL(actionPath);
+    parsedPath = url.pathname;
+    isRelative = false;
+  } catch {
+    parsedPath = actionPath;
+    isRelative = true;
+  }
+
+  if (isRelative && (actionPath === "" || !actionPath.startsWith("/"))) {
+    return normalizeRelativeActionPath(parsedPath, requestPath);
+  }
+  return parsedPath.endsWith("/") && parsedPath.length > 1 ? parsedPath.slice(0, -1) : parsedPath;
+}


### PR DESCRIPTION
## Summary

Implements 10 Rails-named private helpers on
`metal/request-forgery-protection.ts` per `docs/actioncontroller-100-percent.md`
slot P20a:

- `isVerifiedRequest`, `verifySameOriginRequest`
- `markForSameOriginVerificationBang`, `isMarkedForSameOriginVerification`
- `isNonXhrJavascriptResponse`, `isValidRequestOrigin`
- `isProtectAgainstForgery`, `unverifiedRequestWarningMessage`
- `normalizeActionPath`, `normalizeRelativeActionPath`

All are standalone `this`-free functions taking an explicit `CsrfController`
shape (request + flags + optional logger). `isVerifiedRequest` calls
`controller.isAnyAuthenticityTokenValid?.()` — the optional controller
method that P20c (token validation + strategy plumbing) will populate.
Crypto-bearing token generation/encoding lands in P20b; full token
validation lands in P20c.

Brings `metal/request_forgery_protection.rb` from **17/48 (35%)** to
**27/48 (56%)** on `pnpm api:compare --package actioncontroller --privates`.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts` — 23 tests
- [x] `pnpm lint`
- [x] `pnpm api:compare --package actioncontroller --privates` confirms 10 methods closed