### PR TITLE
feat(actionview): tag-helper Phase 5 T2 — TagBuilder API surface

### DIFF
--- a/packages/actionview/src/helpers/tag-helper.ts
+++ b/packages/actionview/src/helpers/tag-helper.ts
@@ -5,7 +5,12 @@ import {
   htmlEscapeOnce,
   xmlNameEscape,
 } from "@blazetrails/activesupport";
-import { safeJoin } from "./output-safety-helper.js";
+import {
+  raw as _raw,
+  safeJoin as _safeJoin,
+  toSentence as _toSentence,
+  type ToSentenceOptions,
+} from "./output-safety-helper.js";
 
 /**
  * ActionView::Helpers::TagHelper
@@ -433,6 +438,13 @@ export function escapeOnce(html: string): SafeBuffer {
  * TagBuilder — modern HTML5 tag builder accessed via tag.div, tag.p, etc.
  */
 export class TagBuilder {
+  /** @internal */
+  viewContext: unknown;
+
+  constructor(viewContext?: unknown) {
+    this.viewContext = viewContext;
+  }
+
   /**
    * attributes() — transforms a hash into HTML attributes string.
    */
@@ -443,10 +455,82 @@ export class TagBuilder {
   }
 
   /**
+   * tagString() — low-level builder used by the dynamic dispatch methods.
+   * Mirrors `TagBuilder#tag_string`.
+   */
+  tagString(
+    name: string,
+    content: unknown,
+    options?: Record<string, unknown> | null,
+    opts?: { escape?: boolean; block?: (tagBuilder: TagBuilder) => unknown },
+  ): SafeBuffer {
+    const escape = opts?.escape !== false;
+    const actualContent = opts?.block ? opts.block(this) : content;
+    return contentTagString(name, actualContent, options ?? undefined, escape);
+  }
+
+  /**
+   * defineElement — registers a content-bearing element. Mirrors
+   * `TagBuilder.define_element`. The Proxy already dispatches arbitrary
+   * element names; calling this explicitly is only needed when a non-default
+   * tag name should be reachable through a different method name.
+   */
+  static defineElement(name: string, opts?: { methodName?: string }): void {
+    if (opts?.methodName && opts.methodName !== name) {
+      METHOD_TO_TAG_NAME[opts.methodName] = name;
+    }
+  }
+
+  /**
+   * defineVoidElement — registers a void element (no closing tag, no content).
+   */
+  static defineVoidElement(name: string, opts?: { methodName?: string }): void {
+    VOID_ELEMENTS.add(name);
+    if (opts?.methodName && opts.methodName !== name) {
+      METHOD_TO_TAG_NAME[opts.methodName] = name;
+    }
+  }
+
+  /**
+   * defineSelfClosingElement — registers a self-closing SVG-style element.
+   */
+  static defineSelfClosingElement(name: string, opts?: { methodName?: string }): void {
+    SELF_CLOSING_ELEMENTS.add(name);
+    if (opts?.methodName && opts.methodName !== name) {
+      METHOD_TO_TAG_NAME[opts.methodName] = name;
+    }
+  }
+
+  /**
    * Dynamic element methods are handled via Proxy
    */
 
   [key: string]: unknown;
+}
+
+/**
+ * tagBuilder() — returns the shared TagBuilder proxy. Mirrors the private
+ * `TagHelper#tag_builder` accessor.
+ *
+ * @internal
+ */
+export function tagBuilder(): TagBuilder {
+  return getTagBuilder();
+}
+
+/** Re-exported from output-safety-helper so Rails parity matches `TagHelper`'s `OutputSafetyHelper` include. */
+export function raw(stringish: unknown): SafeBuffer {
+  return _raw(stringish);
+}
+
+/** Re-exported from output-safety-helper so Rails parity matches `TagHelper`'s `OutputSafetyHelper` include. */
+export function safeJoin(array: unknown[], sep?: string | SafeBuffer | null): SafeBuffer {
+  return _safeJoin(array, sep);
+}
+
+/** Re-exported from output-safety-helper so Rails parity matches `TagHelper`'s `OutputSafetyHelper` include. */
+export function toSentence(array: unknown[], options?: ToSentenceOptions): SafeBuffer {
+  return _toSentence(array, options);
 }
 
 function createTagBuilderProxy(): TagBuilder {
@@ -466,6 +550,8 @@ function createTagBuilderProxy(): TagBuilder {
       // Known own properties
       if (
         prop === "attributes" ||
+        prop === "tagString" ||
+        prop === "viewContext" ||
         prop === "constructor" ||
         prop === "publicMethods" ||
         prop === "public_methods"

--- a/packages/actionview/src/helpers/tag-helper.ts
+++ b/packages/actionview/src/helpers/tag-helper.ts
@@ -465,7 +465,14 @@ export class TagBuilder {
     opts?: { escape?: boolean; block?: (tagBuilder: TagBuilder) => unknown },
   ): SafeBuffer {
     const escape = opts?.escape !== false;
-    const actualContent = opts?.block ? opts.block(this) : content;
+    let actualContent: unknown = content;
+    if (opts?.block) {
+      const vc = this.viewContext as { capture?: (b: TagBuilder, fn: () => unknown) => unknown };
+      actualContent =
+        vc && typeof vc.capture === "function"
+          ? vc.capture(this, () => opts.block!(this))
+          : opts.block(this);
+    }
     return contentTagString(name, actualContent, options ?? undefined, escape);
   }
 

--- a/packages/actionview/src/template/tag-helper.test.ts
+++ b/packages/actionview/src/template/tag-helper.test.ts
@@ -7,6 +7,10 @@ import {
   classNames,
   cdataSection,
   escapeOnce,
+  TagBuilder,
+  tagBuilder,
+  safeJoin,
+  toSentence,
 } from "../helpers/tag-helper.js";
 import { htmlSafe, SafeBuffer } from "@blazetrails/activesupport";
 import { raw } from "../helpers/output-safety-helper.js";
@@ -821,5 +825,56 @@ describe("TagHelperTest", () => {
   it("respond to", () => {
     const t = tag() as any;
     expect("any_tag" in t).toBe(true);
+  });
+
+  describe("TagBuilder", () => {
+    it("constructor stores view context", () => {
+      const ctx = { _outputBuffer: null };
+      const builder = new TagBuilder(ctx);
+      expect(builder.viewContext).toBe(ctx);
+    });
+
+    it("tagString builds a content tag", () => {
+      const builder = new TagBuilder();
+      expect(builder.tagString("p", "Hi").toString()).toBe("<p>Hi</p>");
+      expect(builder.tagString("p", null, { class: "x" }).toString()).toBe('<p class="x"></p>');
+      expect(builder.tagString("p", null, undefined, { block: () => "Yo" }).toString()).toBe(
+        "<p>Yo</p>",
+      );
+    });
+
+    it("defineVoidElement registers a void element", () => {
+      TagBuilder.defineVoidElement("custom-void");
+      const t = tag() as any;
+      expect(t["custom-void"]().toString()).toBe("<custom-void>");
+    });
+
+    it("defineSelfClosingElement registers a self-closing element", () => {
+      TagBuilder.defineSelfClosingElement("custom-selfclose");
+      const t = tag() as any;
+      expect(t["custom-selfclose"]().toString()).toBe("<custom-selfclose />");
+    });
+
+    it("defineElement with methodName aliases", () => {
+      TagBuilder.defineElement("my-elem", { methodName: "my_alias" });
+      const t = tag() as any;
+      expect(t.my_alias("x").toString()).toBe("<my-elem>x</my-elem>");
+    });
+  });
+
+  describe("tagBuilder()", () => {
+    it("returns the shared TagBuilder proxy", () => {
+      const b = tagBuilder() as any;
+      expect(b.span("hi").toString()).toBe("<span>hi</span>");
+    });
+  });
+
+  describe("OutputSafetyHelper re-exports", () => {
+    it("safeJoin", () => {
+      expect(safeJoin(["a", "b"], "-").toString()).toBe("a-b");
+    });
+    it("toSentence", () => {
+      expect(toSentence(["a", "b", "c"]).toString()).toBe("a, b, and c");
+    });
   });
 });


### PR DESCRIPTION
## Summary

Phase 5 T2 helper work from `docs/actionview-100-percent.md`: extends the existing `tag` / `contentTag` / `tag.div(...)` proxy with the Rails-mirrored `TagBuilder` API that downstream form / asset helpers will sit on top of.

- `TagBuilder` now has a `constructor(viewContext?)`, an instance `tagString(name, content, options?, { escape?, block? })` builder, and three static registrars: `defineElement`, `defineVoidElement`, `defineSelfClosingElement` (the dynamic proxy still handles dispatch — these just register non-default `name`/`methodName` pairs and toggle the void / self-closing sets).
- Adds `tagBuilder()` as the shared-proxy accessor (mirrors the private `TagHelper#tag_builder`).
- Adds delegating `raw`, `safeJoin`, `toSentence` exports so the `OutputSafetyHelper` include shows up under `tag_helper.rb` in `api:compare`.
- Tests added in `src/template/tag-helper.test.ts` (89 tests, all passing).

`api:compare` for `helpers/tag_helper.rb`: **15/29 → 24/29 (52% → 83%)**.

## Follow-ups (deferred)

The remaining 5 missing methods all belong to `CaptureHelper` and depend on a real view-context host with output-buffer state, which doesn't exist yet:

- `capture`, `contentFor`, `provide`, `isContentFor`, `withOutputBuffer`

These need to land alongside the `ViewContext` class — they're not unblocking T3 tag-builder work.

## Test plan

- [x] `pnpm vitest run packages/actionview/src/template/tag-helper.test.ts` — 89/89 pass
- [x] `pnpm api:compare --package actionview` — tag_helper.rb up to 24/29
- [x] PR size: 143 LOC (well under 300 ceiling)