### PR TITLE
feat(actionpack): wire Cache::Response onto Response (additive)

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -97,17 +97,18 @@ describe("ResponseTest", () => {
 
   it("read ETag and Cache-Control", () => {
     const res = new Response();
-    res.etag = "abc123";
-    res.cacheControl = "public, max-age=3600";
-    expect(res.etag).toBe('"abc123"');
-    expect(res.cacheControl).toBe("public, max-age=3600");
+    res.setWeakEtag("abc123");
+    res._cacheControl = "public, max-age=3600";
+    // Rails: `etag` reader returns the raw header set by weak_etag=.
+    expect(res.etag?.startsWith('W/"')).toBe(true);
+    expect(res._cacheControl).toBe("public, max-age=3600");
   });
 
   it("read strong ETag", () => {
     const res = new Response();
-    res.etag = '"strong-etag"';
-    expect(res.strongEtag).toBe(true);
-    expect(res.weakEtag).toBe(false);
+    res.setStrongEtag("strong-etag");
+    expect(res.isStrongEtag()).toBe(true);
+    expect(res.isWeakEtag()).toBe(false);
   });
 
   it("read charset and content type", () => {
@@ -119,14 +120,14 @@ describe("ResponseTest", () => {
 
   it("respect no-store cache-control", () => {
     const res = new Response();
-    res.cacheControl = "no-store";
-    expect(res.cacheControl).toBe("no-store");
+    res._cacheControl = "no-store";
+    expect(res._cacheControl).toBe("no-store");
   });
 
   it("respect private, no-store cache-control", () => {
     const res = new Response();
-    res.cacheControl = "private, no-store";
-    expect(res.cacheControl).toBe("private, no-store");
+    res._cacheControl = "private, no-store";
+    expect(res._cacheControl).toBe("private, no-store");
   });
 
   it("does not include Status header", () => {
@@ -222,8 +223,8 @@ describe("ResponseTest", () => {
   it("weak ETag detection", () => {
     const res = new Response();
     res.setHeader("etag", 'W/"abc"');
-    expect(res.weakEtag).toBe(true);
-    expect(res.strongEtag).toBe(false);
+    expect(res.isWeakEtag()).toBe(true);
+    expect(res.isStrongEtag()).toBe(false);
   });
 
   it("setting etag to undefined removes it", () => {
@@ -233,25 +234,20 @@ describe("ResponseTest", () => {
     expect(res.etag).toBeUndefined();
   });
 
-  it("etag auto-quotes unquoted value", () => {
+  it("etag= delegates to setWeakEtag (Rails parity)", () => {
     const res = new Response();
     res.etag = "abc";
-    expect(res.etag).toBe('"abc"');
-  });
-
-  it("etag preserves W/ prefix", () => {
-    const res = new Response();
-    res.etag = 'W/"weak"';
-    expect(res.etag).toBe('W/"weak"');
+    expect(res.etag?.startsWith('W/"')).toBe(true);
+    expect(res.isWeakEtag()).toBe(true);
   });
 
   // --- Cache-Control ---
 
-  it("setting cacheControl to undefined removes it", () => {
+  it("setting _cacheControl to undefined removes it", () => {
     const res = new Response();
-    res.cacheControl = "no-cache";
-    res.cacheControl = undefined;
-    expect(res.cacheControl).toBeUndefined();
+    res._cacheControl = "no-cache";
+    res._cacheControl = undefined;
+    expect(res._cacheControl).toBeUndefined();
   });
 
   // --- Content type ---
@@ -481,13 +477,22 @@ describe("Response Cache::Response wiring", () => {
     expect(res.isWeakEtag()).toBe(false);
   });
 
-  it("cacheControlHash returns a parsed directive hash", () => {
+  it("cacheControl returns a parsed directive hash", () => {
     const res = new Response();
     res.setHeader("Cache-Control", "max-age=600, public, foo=bar");
-    const hash = res.cacheControlHash;
+    const hash = res.cacheControl;
     expect(hash["max_age"]).toBe("600");
     expect(hash["public"]).toBe(true);
     expect(hash.extras).toEqual(["foo=bar"]);
+  });
+
+  it("mergeAndNormalizeCacheControl writes back the combined directive set", () => {
+    const res = new Response();
+    res._cacheControl = "no-cache";
+    res.mergeAndNormalizeCacheControl({ public: true, max_age: 30 });
+    const cc = res._cacheControl!;
+    expect(cc).toContain("max-age=30");
+    expect(cc).toContain("public");
   });
 
   it("handleConditionalGet sets a default Cache-Control when an ETag is present", () => {

--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -465,6 +465,9 @@ describe("Response Cache::Response wiring", () => {
     expect(res.isWeakEtag()).toBe(true);
     expect(res.isStrongEtag()).toBe(false);
     expect(res.hasEtag).toBe(true);
+    // Case-insensitive read: same value via any casing.
+    expect(res.getHeader("etag")).toBe(e);
+    expect(res.getHeader("ETAG")).toBe(e);
   });
 
   it("setStrongEtag writes an unprefixed digest", () => {
@@ -500,6 +503,23 @@ describe("Response Cache::Response wiring", () => {
     res.setWeakEtag("v1");
     res.handleConditionalGet();
     expect(res.getHeader("Cache-Control")).toBe("max-age=0, private, must-revalidate");
+    expect(res.getHeader("cache-control")).toBe("max-age=0, private, must-revalidate");
+  });
+
+  it("lastModified = undefined clears the Last-Modified header", () => {
+    const res = new Response();
+    res.lastModified = new Date("1994-11-06T08:49:37Z");
+    res.lastModified = undefined;
+    expect(res.hasLastModified).toBe(false);
+    expect(res.lastModified).toBeUndefined();
+  });
+
+  it("date = undefined clears the Date header", () => {
+    const res = new Response();
+    res.date = new Date("1994-11-06T08:49:37Z");
+    res.date = undefined;
+    expect(res.hasDate).toBe(false);
+    expect(res.date).toBeUndefined();
   });
 
   it("handleConditionalGet is a no-op when Cache-Control is already set", () => {

--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -436,3 +436,78 @@ describe("ResponseFilterRedirect", () => {
     expect(res.filteredLocation()).toBe("https://example.com/foo");
   });
 });
+
+describe("Response Cache::Response wiring", () => {
+  it("lastModified round-trips through Last-Modified header", () => {
+    const res = new Response();
+    const t = new Date("1994-11-06T08:49:37Z");
+    res.lastModified = t;
+    expect(res.hasLastModified).toBe(true);
+    expect(res.getHeader("Last-Modified")).toBe("Sun, 06 Nov 1994 08:49:37 GMT");
+    expect(res.lastModified?.getTime()).toBe(t.getTime());
+  });
+
+  it("lastModified returns undefined when absent", () => {
+    const res = new Response();
+    expect(res.hasLastModified).toBe(false);
+    expect(res.lastModified).toBeUndefined();
+  });
+
+  it("date round-trips through Date header", () => {
+    const res = new Response();
+    const t = new Date("1994-11-06T08:49:37Z");
+    res.date = t;
+    expect(res.hasDate).toBe(true);
+    expect(res.date?.getTime()).toBe(t.getTime());
+  });
+
+  it("setWeakEtag writes a W/-prefixed strong-form digest", () => {
+    const res = new Response();
+    res.setWeakEtag(["abc", 1]);
+    const e = res.getHeader("ETag")!;
+    expect(e.startsWith('W/"')).toBe(true);
+    expect(res.isWeakEtag()).toBe(true);
+    expect(res.isStrongEtag()).toBe(false);
+    expect(res.hasEtag).toBe(true);
+  });
+
+  it("setStrongEtag writes an unprefixed digest", () => {
+    const res = new Response();
+    res.setStrongEtag(["abc", 1]);
+    const e = res.getHeader("ETag")!;
+    expect(e.startsWith('"')).toBe(true);
+    expect(e.startsWith('W/"')).toBe(false);
+    expect(res.isStrongEtag()).toBe(true);
+    expect(res.isWeakEtag()).toBe(false);
+  });
+
+  it("cacheControlHash returns a parsed directive hash", () => {
+    const res = new Response();
+    res.setHeader("Cache-Control", "max-age=600, public, foo=bar");
+    const hash = res.cacheControlHash;
+    expect(hash["max_age"]).toBe("600");
+    expect(hash["public"]).toBe(true);
+    expect(hash.extras).toEqual(["foo=bar"]);
+  });
+
+  it("handleConditionalGet sets a default Cache-Control when an ETag is present", () => {
+    const res = new Response();
+    res.setWeakEtag("v1");
+    res.handleConditionalGet();
+    expect(res.getHeader("Cache-Control")).toBe("max-age=0, private, must-revalidate");
+  });
+
+  it("handleConditionalGet is a no-op when Cache-Control is already set", () => {
+    const res = new Response();
+    res.setWeakEtag("v1");
+    res.setHeader("Cache-Control", "public, max-age=60");
+    res.handleConditionalGet();
+    expect(res.getHeader("Cache-Control")).toBe("public, max-age=60");
+  });
+
+  it("handleConditionalGet is a no-op without ETag or Last-Modified", () => {
+    const res = new Response();
+    res.handleConditionalGet();
+    expect(res.getHeader("Cache-Control")).toBeUndefined();
+  });
+});

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -10,13 +10,13 @@ import {
   type CacheControlHash,
   cacheControl as _cacheControl,
   getDate as _getDate,
-  getEtag as _getEtag,
   getLastModified as _getLastModified,
   handleConditionalGet as _handleConditionalGet,
   hasDate as _hasDate,
   hasEtag as _hasEtag,
   hasLastModified as _hasLastModified,
   isStrongEtag as _isStrongEtag,
+  mergeAndNormalizeCacheControl as _mergeAndNormalizeCacheControl,
   isWeakEtag as _isWeakEtag,
   setDate as _setDate,
   setLastModified as _setLastModified,
@@ -98,11 +98,22 @@ export class Response {
   }
 
   setHeader(key: string, value: string): void {
+    // Headers are logically case-insensitive (Rack response semantics).
+    // Clear any other-case entry so reads through `getHeader` / accessors
+    // can't return a stale value written under a different case.
+    const lower = key.toLowerCase();
+    if (lower !== key && lower in this._headers) delete this._headers[lower];
+    for (const k of Object.keys(this._headers)) {
+      if (k !== key && k.toLowerCase() === lower) delete this._headers[k];
+    }
     this._headers[key] = value;
   }
 
   deleteHeader(key: string): void {
-    delete this._headers[key];
+    const lower = key.toLowerCase();
+    for (const k of Object.keys(this._headers)) {
+      if (k === key || k.toLowerCase() === lower) delete this._headers[k];
+    }
   }
 
   // --- Content type ---
@@ -220,13 +231,21 @@ export class Response {
     return result;
   }
 
-  // --- Cache-Control ---
+  // --- Cache-Control (raw string accessor; Rails aliases this as `_cache_control`) ---
 
-  get cacheControl(): string | undefined {
+  /**
+   * Raw `Cache-Control` header value. Mirrors Rails'
+   * `Response#_cache_control` alias (`Rack::Response::Helpers#cache_control`),
+   * which is the un-parsed header string. The parsed directive hash is
+   * exposed via {@link cacheControl} (wired below from `Cache::Response`).
+   *
+   * @internal
+   */
+  get _cacheControl(): string | undefined {
     return this._headers["cache-control"] ?? this._headers["Cache-Control"];
   }
 
-  set cacheControl(value: string | undefined) {
+  set _cacheControl(value: string | undefined) {
     if (value) {
       this._headers["cache-control"] = value;
     } else {
@@ -237,30 +256,23 @@ export class Response {
 
   // --- ETag ---
 
+  /** Mirrors Rails' `Cache::Response#etag` reader — returns the `ETag` header. */
   get etag(): string | undefined {
     return this._headers["etag"] ?? this._headers["ETag"];
   }
 
-  set etag(value: string | undefined) {
-    if (value) {
-      // Ensure proper quoting
-      if (!value.startsWith('"') && !value.startsWith('W/"')) {
-        value = `"${value}"`;
-      }
-      this._headers["etag"] = value;
-    } else {
+  /**
+   * Mirrors Rails' `Cache::Response#etag=` — delegates to
+   * {@link setWeakEtag}, which hashes `validators` into a weak validator
+   * (`W/"<md5>"`). Pass `undefined` to delete the header.
+   */
+  set etag(value: unknown) {
+    if (value === undefined) {
       delete this._headers["etag"];
       delete this._headers["ETag"];
+      return;
     }
-  }
-
-  get weakEtag(): boolean {
-    return this.etag?.startsWith('W/"') ?? false;
-  }
-
-  get strongEtag(): boolean {
-    const e = this.etag;
-    return e !== undefined && e.startsWith('"') && !e.startsWith('W/"');
+    this.setWeakEtag(value);
   }
 
   // --- Cache::Response wiring (declared here for typing; bound below) ---
@@ -274,12 +286,14 @@ export class Response {
   declare isWeakEtag: () => boolean;
   declare isStrongEtag: () => boolean;
   declare handleConditionalGet: () => void;
+  declare mergeAndNormalizeCacheControl: (cacheControl: CacheControlHash) => void;
   /**
    * Parsed `Cache-Control` directives as a hash, mirroring Rails'
-   * `Cache::Response#cache_control`. The raw header string remains available
-   * via the existing {@link cacheControl} string accessor.
+   * `Cache::Response#cache_control` (an `attr_reader` set by
+   * `prepare_cache_control!`). The raw header string is exposed via
+   * {@link _cacheControl}.
    */
-  declare readonly cacheControlHash: CacheControlHash;
+  declare readonly cacheControl: CacheControlHash;
 
   // --- Rack response ---
 
@@ -307,10 +321,9 @@ export class Response {
 
 // Mix in ActionDispatch::Http::Cache::Response. Property-style helpers
 // (Rails no-arg accessors) are wired as getters/setters; methods that take
-// arguments are wired as prototype methods. The existing `etag`/`cacheControl`
-// string accessors are intentionally retained — Rails-parity replacements
-// (etag= → weakEtag=, cacheControl as parsed hash) are tracked as a separate
-// follow-up since they break existing test expectations.
+// arguments are wired as prototype methods. The raw `Cache-Control` header
+// string is exposed via `_cacheControl` (Rails: aliased `_cache_control`),
+// and `cacheControl` (this wiring) is the parsed directive hash.
 Object.defineProperty(Response.prototype, "lastModified", {
   get(this: Response) {
     return _getLastModified.call(this);
@@ -347,7 +360,7 @@ Object.defineProperty(Response.prototype, "hasEtag", {
   },
   configurable: true,
 });
-Object.defineProperty(Response.prototype, "cacheControlHash", {
+Object.defineProperty(Response.prototype, "cacheControl", {
   get(this: Response) {
     return _cacheControl.call(this);
   },
@@ -368,11 +381,12 @@ Response.prototype.isStrongEtag = function (this: Response) {
 Response.prototype.handleConditionalGet = function (this: Response) {
   _handleConditionalGet.call(this);
 };
-// `_getEtag` mirrors Rails' `Cache::Response#etag` reader. The existing
-// `Response.etag` getter already returns the header value (case-insensitive),
-// so we don't re-wire it here. Reference the import to satisfy TS unused-import.
-void _getEtag;
-
+Response.prototype.mergeAndNormalizeCacheControl = function (
+  this: Response,
+  cacheControl: CacheControlHash,
+) {
+  _mergeAndNormalizeCacheControl.call(this, cacheControl);
+};
 export interface CookieOptions {
   value: string;
   path?: string;

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -94,7 +94,13 @@ export class Response {
   }
 
   getHeader(key: string): string | undefined {
-    return this._headers[key.toLowerCase()] ?? this._headers[key];
+    const direct = this._headers[key] ?? this._headers[key.toLowerCase()];
+    if (direct !== undefined) return direct;
+    const lower = key.toLowerCase();
+    for (const k of Object.keys(this._headers)) {
+      if (k.toLowerCase() === lower) return this._headers[k];
+    }
+    return undefined;
   }
 
   setHeader(key: string, value: string): void {
@@ -328,8 +334,9 @@ Object.defineProperty(Response.prototype, "lastModified", {
   get(this: Response) {
     return _getLastModified.call(this);
   },
-  set(this: Response, t: Date) {
-    _setLastModified.call(this, t);
+  set(this: Response, t: Date | undefined) {
+    if (t === undefined) this.deleteHeader("Last-Modified");
+    else _setLastModified.call(this, t);
   },
   configurable: true,
 });
@@ -343,8 +350,9 @@ Object.defineProperty(Response.prototype, "date", {
   get(this: Response) {
     return _getDate.call(this);
   },
-  set(this: Response, t: Date) {
-    _setDate.call(this, t);
+  set(this: Response, t: Date | undefined) {
+    if (t === undefined) this.deleteHeader("Date");
+    else _setDate.call(this, t);
   },
   configurable: true,
 });

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -6,6 +6,23 @@
 
 import type { CookieExpires } from "../middleware/cookies.js";
 import type { Request } from "./request.js";
+import {
+  type CacheControlHash,
+  cacheControl as _cacheControl,
+  getDate as _getDate,
+  getEtag as _getEtag,
+  getLastModified as _getLastModified,
+  handleConditionalGet as _handleConditionalGet,
+  hasDate as _hasDate,
+  hasEtag as _hasEtag,
+  hasLastModified as _hasLastModified,
+  isStrongEtag as _isStrongEtag,
+  isWeakEtag as _isWeakEtag,
+  setDate as _setDate,
+  setLastModified as _setLastModified,
+  setStrongEtag as _setStrongEtag,
+  setWeakEtag as _setWeakEtag,
+} from "./cache.js";
 import { filteredLocation as _filteredLocation } from "./filter-redirect.js";
 
 export class Response {
@@ -246,6 +263,24 @@ export class Response {
     return e !== undefined && e.startsWith('"') && !e.startsWith('W/"');
   }
 
+  // --- Cache::Response wiring (declared here for typing; bound below) ---
+  declare lastModified: Date | undefined;
+  declare date: Date | undefined;
+  declare readonly hasLastModified: boolean;
+  declare readonly hasDate: boolean;
+  declare readonly hasEtag: boolean;
+  declare setWeakEtag: (validators: unknown) => void;
+  declare setStrongEtag: (validators: unknown) => void;
+  declare isWeakEtag: () => boolean;
+  declare isStrongEtag: () => boolean;
+  declare handleConditionalGet: () => void;
+  /**
+   * Parsed `Cache-Control` directives as a hash, mirroring Rails'
+   * `Cache::Response#cache_control`. The raw header string remains available
+   * via the existing {@link cacheControl} string accessor.
+   */
+  declare readonly cacheControlHash: CacheControlHash;
+
   // --- Rack response ---
 
   toRack(): [number, Record<string, string>, string[]] {
@@ -269,6 +304,74 @@ export class Response {
     return new this(status, headers, body ? [body] : []) as InstanceType<T>;
   }
 }
+
+// Mix in ActionDispatch::Http::Cache::Response. Property-style helpers
+// (Rails no-arg accessors) are wired as getters/setters; methods that take
+// arguments are wired as prototype methods. The existing `etag`/`cacheControl`
+// string accessors are intentionally retained — Rails-parity replacements
+// (etag= → weakEtag=, cacheControl as parsed hash) are tracked as a separate
+// follow-up since they break existing test expectations.
+Object.defineProperty(Response.prototype, "lastModified", {
+  get(this: Response) {
+    return _getLastModified.call(this);
+  },
+  set(this: Response, t: Date) {
+    _setLastModified.call(this, t);
+  },
+  configurable: true,
+});
+Object.defineProperty(Response.prototype, "hasLastModified", {
+  get(this: Response) {
+    return _hasLastModified.call(this);
+  },
+  configurable: true,
+});
+Object.defineProperty(Response.prototype, "date", {
+  get(this: Response) {
+    return _getDate.call(this);
+  },
+  set(this: Response, t: Date) {
+    _setDate.call(this, t);
+  },
+  configurable: true,
+});
+Object.defineProperty(Response.prototype, "hasDate", {
+  get(this: Response) {
+    return _hasDate.call(this);
+  },
+  configurable: true,
+});
+Object.defineProperty(Response.prototype, "hasEtag", {
+  get(this: Response) {
+    return _hasEtag.call(this);
+  },
+  configurable: true,
+});
+Object.defineProperty(Response.prototype, "cacheControlHash", {
+  get(this: Response) {
+    return _cacheControl.call(this);
+  },
+  configurable: true,
+});
+Response.prototype.setWeakEtag = function (this: Response, v: unknown) {
+  _setWeakEtag.call(this, v);
+};
+Response.prototype.setStrongEtag = function (this: Response, v: unknown) {
+  _setStrongEtag.call(this, v);
+};
+Response.prototype.isWeakEtag = function (this: Response) {
+  return _isWeakEtag.call(this);
+};
+Response.prototype.isStrongEtag = function (this: Response) {
+  return _isStrongEtag.call(this);
+};
+Response.prototype.handleConditionalGet = function (this: Response) {
+  _handleConditionalGet.call(this);
+};
+// `_getEtag` mirrors Rails' `Cache::Response#etag` reader. The existing
+// `Response.etag` getter already returns the header value (case-insensitive),
+// so we don't re-wire it here. Reference the import to satisfy TS unused-import.
+void _getEtag;
 
 export interface CookieOptions {
   value: string;


### PR DESCRIPTION
## Summary

Followup to #1828 / #1927. Full Rails-parity wiring of
`ActionDispatch::Http::Cache::Response` onto `Response.prototype`.

### Public surface added / changed

- `lastModified` getter/setter, `hasLastModified` — Rails' `last_modified` / `last_modified=` / `last_modified?`
- `date` getter/setter, `hasDate` — Rails' `date` / `date=` / `date?`
- `etag` getter unchanged (reads `ETag` header)
- **`etag=` now delegates to `setWeakEtag`** — Rails' `def etag=(v); self.weak_etag = v; end`
- `setWeakEtag(v)`, `setStrongEtag(v)` — Rails' `weak_etag=` / `strong_etag=`
- `isWeakEtag()`, `isStrongEtag()`, `hasEtag` — Rails' `weak_etag?` / `strong_etag?` / `etag?`
- **`cacheControl` now returns the parsed directive hash** — Rails' `attr_reader :cache_control` on `Cache::Response`
- **`_cacheControl` is the raw header string accessor** — Rails' `alias :_cache_control :cache_control` from `Rack::Response::Helpers`
- `handleConditionalGet()`, `mergeAndNormalizeCacheControl(hash)` — Rails' `handle_conditional_get!` / `merge_and_normalize_cache_control!`

### Audit of the other named #1828 follow-ups

While picking this up I confirmed the three small follow-ups listed alongside
the cache wiring entry in `docs/actionpack-100-percent.md` are already shipped
and don't need any new code:

- **strict RFC 1123 `parseHttpDate`** — shipped in #1927 (`cache.ts:167-186` plus rejection tests at `cache.test.ts:75-98`).
- **`params` getter overlays `pathParameters`** — shipped in #1936 (`parameters.ts:115-116` merges `pathParameters` last, matching Rails `parameters.rb:52-64`).
- **`Request.getHeader` HTTP\_ normalization audit** — `request.ts:78-84`'s `envName` matches Rails `Headers#env_name` (same regex, same `CGI_VARIABLES` list). The intentional divergence is that our `Request#getHeader` performs the normalization itself rather than only on a `Headers` wrapper, because 20+ callers across actionpack pass HTTP-style names directly. No code change recommended.

### Implementation notes

- `Response.setHeader` / `Response.deleteHeader` now normalize header case so a write to `"Cache-Control"` and a write to `"cache-control"` don't shadow each other (required for `_cacheControl` ↔ `setHeader` round-trips through `mergeAndNormalizeCacheControl`).
- The non-Rails `weakEtag` / `strongEtag` boolean getters on `Response` are removed; callers use the `isWeakEtag()` / `isStrongEtag()` predicates wired from `cache.ts`.
- All Rails `Cache::Response` accessors mapped. No stubs.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/response.test.ts packages/actionpack/src/action-dispatch/http/cache.test.ts` — 82 / 82
- [x] `pnpm vitest run packages/actionpack/` — 2788 passed, 23 pre-existing skips
- [x] `pnpm lint --fix`
- [x] `pnpm api:compare` — actionpack not yet tracked (delta 0/0)
- [x] `pnpm test:compare` — actionpack not yet tracked (delta 0/0)