### PR TITLE
test(activerecord): port hash-config tests (34 un-skipped)

### DIFF
--- a/packages/activerecord/src/database-configurations/database-config.ts
+++ b/packages/activerecord/src/database-configurations/database-config.ts
@@ -182,10 +182,13 @@ export class DatabaseConfig {
   }
 
   get reapingFrequency(): number | null {
+    // Rails: `configuration_hash.fetch(:reaping_frequency, 60)&.to_f` —
+    // missing key defaults to 60; explicit `nil` stays nil; any other value
+    // (including "0") is coerced with `to_f`.
     const raw = this.configuration.reapingFrequency;
     if (raw === null) return null;
-    const freq = raw === undefined ? 60 : toFloat(raw);
-    return freq > 0 ? freq : null;
+    if (raw === undefined) return 60.0;
+    return toFloat(raw);
   }
 
   get queryCache(): unknown {

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -99,8 +99,7 @@ describe("DatabaseConfigurations", () => {
         reapingFrequency: "0",
         adapter: "abstract",
       });
-      // Rails: 0.0; trails treats <=0 as nil for reaping_frequency (same rule as idle_timeout).
-      expect(config.reapingFrequency).toBeNull();
+      expect(config.reapingFrequency).toBe(0.0);
     });
 
     it("when no reaping frequency uses default", () => {
@@ -165,8 +164,7 @@ describe("DatabaseConfigurations", () => {
         schemaDump: false,
         adapter: "abstract",
       });
-      // Rails returns nil for both false and nil; trails preserves the literal false.
-      expect(config.schemaDump()).toBe(false);
+      expect(config.schemaDump()).toBeNull();
     });
 
     it("database tasks defaults to true", () => {

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -3,6 +3,9 @@ import { HashConfig } from "./hash-config.js";
 import { AdapterNotFound } from "../errors.js";
 import * as connectionAdapters from "../connection-adapters.js";
 import { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+// connection-handling registers the adapter class resolver that validateBang()
+// relies on; import it so this suite isn't order-dependent.
+import "../connection-handling.js";
 
 connectionAdapters.register("abstract", async () => AbstractAdapter as any);
 

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { HashConfig } from "./hash-config.js";
 import { AdapterNotFound } from "../errors.js";
 import * as connectionAdapters from "../connection-adapters.js";
@@ -11,6 +11,10 @@ connectionAdapters.register("abstract", async () => AbstractAdapter as any);
 
 describe("DatabaseConfigurations", () => {
   describe("HashConfigTest", () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
     it("pool default when nil", () => {
       const config = new HashConfig("default_env", "primary", {
         pool: null as any,

--- a/packages/activerecord/src/database-configurations/hash-config.test.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.test.ts
@@ -1,176 +1,270 @@
-import { describe, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { HashConfig } from "./hash-config.js";
+import { AdapterNotFound } from "../errors.js";
+import * as connectionAdapters from "../connection-adapters.js";
+import { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
+
+connectionAdapters.register("abstract", async () => AbstractAdapter as any);
 
 describe("DatabaseConfigurations", () => {
   describe("HashConfigTest", () => {
-    it.skip("pool default when nil", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+    it("pool default when nil", () => {
+      const config = new HashConfig("default_env", "primary", {
+        pool: null as any,
+        adapter: "abstract",
+      });
+      expect(config.pool).toBe(5);
     });
-    it.skip("pool overrides with value", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("pool overrides with value", () => {
+      const config = new HashConfig("default_env", "primary", { pool: "0", adapter: "abstract" });
+      expect(config.pool).toBe(0);
     });
-    it.skip("when no pool uses default", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("when no pool uses default", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      expect(config.pool).toBe(5);
     });
-    it.skip("min threads with value", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("min threads with value", () => {
+      const config = new HashConfig("default_env", "primary", {
+        minThreads: "1",
+        adapter: "abstract",
+      });
+      expect(config.minThreads).toBe(1);
     });
-    it.skip("min threads default", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("min threads default", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      expect(config.minThreads).toBe(0);
     });
-    it.skip("max threads with value", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("max threads with value", () => {
+      const config = new HashConfig("default_env", "primary", {
+        maxThreads: "10",
+        adapter: "abstract",
+      });
+      expect(config.maxThreads).toBe(10);
     });
-    it.skip("max threads default uses pool default", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("max threads default uses pool default", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      expect(config.pool).toBe(5);
+      expect(config.maxThreads).toBe(5);
     });
-    it.skip("max threads uses pool when set", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("max threads uses pool when set", () => {
+      const config = new HashConfig("default_env", "primary", { pool: 1, adapter: "abstract" });
+      expect(config.pool).toBe(1);
+      expect(config.maxThreads).toBe(1);
     });
-    it.skip("max queue is pool multiplied by 4", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("max queue is pool multiplied by 4", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      expect(config.maxThreads).toBe(5);
+      expect(config.maxQueue).toBe(config.maxThreads * 4);
     });
-    it.skip("checkout timeout default when nil", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("checkout timeout default when nil", () => {
+      const config = new HashConfig("default_env", "primary", {
+        checkoutTimeout: null as any,
+        adapter: "abstract",
+      });
+      expect(config.checkoutTimeout).toBe(5.0);
     });
-    it.skip("checkout timeout overrides with value", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("checkout timeout overrides with value", () => {
+      const config = new HashConfig("default_env", "primary", {
+        checkoutTimeout: "0",
+        adapter: "abstract",
+      });
+      expect(config.checkoutTimeout).toBe(0.0);
     });
-    it.skip("when no checkout timeout uses default", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("when no checkout timeout uses default", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      expect(config.checkoutTimeout).toBe(5.0);
     });
-    it.skip("reaping frequency default when nil", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("reaping frequency default when nil", () => {
+      const config = new HashConfig("default_env", "primary", {
+        reapingFrequency: null,
+        adapter: "abstract",
+      });
+      expect(config.reapingFrequency).toBeNull();
     });
-    it.skip("reaping frequency overrides with value", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("reaping frequency overrides with value", () => {
+      const config = new HashConfig("default_env", "primary", {
+        reapingFrequency: "0",
+        adapter: "abstract",
+      });
+      // Rails: 0.0; trails treats <=0 as nil for reaping_frequency (same rule as idle_timeout).
+      expect(config.reapingFrequency).toBeNull();
     });
-    it.skip("when no reaping frequency uses default", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("when no reaping frequency uses default", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      expect(config.reapingFrequency).toBe(60.0);
     });
-    it.skip("idle timeout default when nil", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("idle timeout default when nil", () => {
+      const config = new HashConfig("default_env", "primary", {
+        idleTimeout: null,
+        adapter: "abstract",
+      });
+      expect(config.idleTimeout).toBeNull();
     });
-    it.skip("idle timeout overrides with value", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("idle timeout overrides with value", () => {
+      const config = new HashConfig("default_env", "primary", {
+        idleTimeout: "1",
+        adapter: "abstract",
+      });
+      expect(config.idleTimeout).toBe(1.0);
     });
-    it.skip("when no idle timeout uses default", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("when no idle timeout uses default", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      expect(config.idleTimeout).toBe(300.0);
     });
-    it.skip("idle timeout nil when less than or equal to zero", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("idle timeout nil when less than or equal to zero", () => {
+      const config = new HashConfig("default_env", "primary", {
+        idleTimeout: "0",
+        adapter: "abstract",
+      });
+      expect(config.idleTimeout).toBeNull();
     });
-    it.skip("default schema dump value", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("default schema dump value", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      // trails default schema format is "ts" (Rails: "ruby" → "schema.rb").
+      expect(config.schemaDump()).toBe("schema.ts");
+      expect(config.schemaDump("ruby")).toBe("schema.rb");
     });
-    it.skip("schema dump value set to filename", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("schema dump value set to filename", () => {
+      const config = new HashConfig("default_env", "primary", {
+        schemaDump: "my_schema.rb",
+        adapter: "abstract",
+      });
+      expect(config.schemaDump()).toBe("my_schema.rb");
     });
-    it.skip("schema dump value set to nil", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("schema dump value set to nil", () => {
+      const config = new HashConfig("default_env", "primary", {
+        schemaDump: null,
+        adapter: "abstract",
+      });
+      expect(config.schemaDump()).toBeNull();
     });
-    it.skip("schema dump value set to false", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("schema dump value set to false", () => {
+      const config = new HashConfig("default_env", "primary", {
+        schemaDump: false,
+        adapter: "abstract",
+      });
+      // Rails returns nil for both false and nil; trails preserves the literal false.
+      expect(config.schemaDump()).toBe(false);
     });
-    it.skip("database tasks defaults to true", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("database tasks defaults to true", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      expect(config.databaseTasks()).toBe(true);
     });
-    it.skip("database tasks overrides with value", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("database tasks overrides with value", () => {
+      let config = new HashConfig("default_env", "primary", {
+        databaseTasks: false,
+        adapter: "abstract",
+      });
+      expect(config.databaseTasks()).toBe(false);
+
+      config = new HashConfig("default_env", "primary", {
+        databaseTasks: "str" as any,
+        adapter: "abstract",
+      });
+      expect(config.databaseTasks()).toBe(true);
     });
-    it.skip("schema cache path default for primary", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("schema cache path default for primary", () => {
+      const config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      // trails writes JSON, not YAML (no Ruby Marshal/YAML in TS).
+      expect(config.defaultSchemaCachePath()).toBe("db/schema_cache.json");
     });
-    it.skip("schema cache path default for custom name", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("schema cache path default for custom name", () => {
+      const config = new HashConfig("default_env", "alternate", { adapter: "abstract" });
+      expect(config.defaultSchemaCachePath()).toBe("db/alternate_schema_cache.json");
     });
-    it.skip("schema cache path default for different db dir", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("schema cache path default for different db dir", () => {
+      const config = new HashConfig("default_env", "alternate", { adapter: "abstract" });
+      expect(config.defaultSchemaCachePath("my_db")).toBe("my_db/alternate_schema_cache.json");
     });
-    it.skip("schema cache path configuration hash", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("schema cache path configuration hash", () => {
+      const config = new HashConfig("default_env", "primary", {
+        schemaCachePath: "db/config_schema_cache.yml",
+        adapter: "abstract",
+      });
+      expect(config.schemaCachePath).toBe("db/config_schema_cache.yml");
     });
-    it.skip("lazy schema cache path", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("lazy schema cache path", () => {
+      const config = new HashConfig("default_env", "primary", {
+        schemaCachePath: "db/config_schema_cache.yml",
+        adapter: "abstract",
+      });
+      expect(config.lazySchemaCachePath()).toBe("db/config_schema_cache.yml");
     });
-    it.skip("lazy schema cache path uses default if config is not present", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("lazy schema cache path uses default if config is not present", () => {
+      const config = new HashConfig("default_env", "alternate", { adapter: "abstract" });
+      expect(config.lazySchemaCachePath()).toBe("db/alternate_schema_cache.json");
     });
-    it.skip("validate checks the adapter exists", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("validate checks the adapter exists", async () => {
+      const ok = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      await expect(ok.validateBang()).resolves.toBe(true);
+
+      const bad = new HashConfig("default_env", "primary", { adapter: "potato" });
+      await expect(bad.validateBang()).rejects.toBeInstanceOf(AdapterNotFound);
     });
-    it.skip("inspect does not show secrets", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("inspect does not show secrets", () => {
+      const config = new HashConfig("default_env", "primary", {
+        adapter: "abstract",
+        password: "hunter2",
+      });
+      const out = config.inspect();
+      expect(out).not.toContain("hunter2");
+      expect(out).toContain("env_name=default_env");
+      expect(out).toContain("name=primary");
     });
-    it.skip("seeds defaults to primary", () => {
-      // BLOCKED: connection-pool — database configuration parsing gap in hash-config
-      // ROOT-CAUSE: database-configurations.ts or connection-url-resolver.ts missing Rails parity for config resolution
-      // SCOPE: ~30–50 LOC fix in database-configurations.ts; affects ~5–34 tests in hash-config.test.ts
+
+    it("seeds defaults to primary", () => {
+      let config = new HashConfig("default_env", "primary", { adapter: "abstract" });
+      expect(config.seeds).toBe(true);
+
+      config = new HashConfig("default_env", "primary", { adapter: "abstract", seeds: false });
+      expect(config.seeds).toBe(false);
+
+      config = new HashConfig("default_env", "primary", { adapter: "abstract", seeds: true });
+      expect(config.seeds).toBe(true);
+
+      config = new HashConfig("default_env", "secondary", { adapter: "abstract" });
+      vi.spyOn(config, "isPrimary").mockReturnValue(false);
+      expect(config.seeds).toBe(false);
+
+      config = new HashConfig("default_env", "secondary", { adapter: "abstract", seeds: false });
+      vi.spyOn(config, "isPrimary").mockReturnValue(false);
+      expect(config.seeds).toBe(false);
+
+      config = new HashConfig("default_env", "secondary", { adapter: "abstract", seeds: true });
+      vi.spyOn(config, "isPrimary").mockReturnValue(false);
+      expect(config.seeds).toBe(true);
     });
   });
 });

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -53,10 +53,12 @@ export class HashConfig extends DatabaseConfig {
    * Returns the schema dump filename for this config, or false/null if
    * schema dumping is disabled.
    */
-  schemaDump(format: "ruby" | "sql" | "ts" = "ts"): string | false | null {
+  schemaDump(format: "ruby" | "sql" | "ts" = "ts"): string | null {
     if ("schemaDump" in this.configuration) {
       const val = this.configuration.schemaDump;
-      if (val === false || val === null) return val as false | null;
+      // Rails: `if config = configuration_hash[:schema_dump]` — both `nil` and
+      // `false` short-circuit to a nil return.
+      if (val === false || val === null) return null;
       return val as string;
     }
     const typeFile = this._schemaFileType(format);

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -54,7 +54,10 @@ export class HashConfig extends DatabaseConfig {
    * dumping is disabled (configured as either `false` or `null`).
    */
   schemaDump(format: "ruby" | "sql" | "ts" = "ts"): string | null {
-    if ("schemaDump" in this.configuration && this.configuration.schemaDump !== undefined) {
+    if (
+      Object.hasOwn(this.configuration, "schemaDump") &&
+      this.configuration.schemaDump !== undefined
+    ) {
       const val = this.configuration.schemaDump;
       // Rails: `if config = configuration_hash[:schema_dump]` — both `nil` and
       // `false` short-circuit to a nil return. JS `undefined` is treated as

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -50,8 +50,8 @@ export class HashConfig extends DatabaseConfig {
   /**
    * Mirrors: HashConfig#schema_dump
    *
-   * Returns the schema dump filename for this config, or false/null if
-   * schema dumping is disabled.
+   * Returns the schema dump filename for this config, or null if schema
+   * dumping is disabled (configured as either `false` or `null`).
    */
   schemaDump(format: "ruby" | "sql" | "ts" = "ts"): string | null {
     if ("schemaDump" in this.configuration) {

--- a/packages/activerecord/src/database-configurations/hash-config.ts
+++ b/packages/activerecord/src/database-configurations/hash-config.ts
@@ -54,10 +54,11 @@ export class HashConfig extends DatabaseConfig {
    * dumping is disabled (configured as either `false` or `null`).
    */
   schemaDump(format: "ruby" | "sql" | "ts" = "ts"): string | null {
-    if ("schemaDump" in this.configuration) {
+    if ("schemaDump" in this.configuration && this.configuration.schemaDump !== undefined) {
       const val = this.configuration.schemaDump;
       // Rails: `if config = configuration_hash[:schema_dump]` — both `nil` and
-      // `false` short-circuit to a nil return.
+      // `false` short-circuit to a nil return. JS `undefined` is treated as
+      // "key absent" (fall through to the default).
       if (val === false || val === null) return null;
       return val as string;
     }

--- a/packages/activerecord/src/tasks/database-tasks.ts
+++ b/packages/activerecord/src/tasks/database-tasks.ts
@@ -649,18 +649,17 @@ export class DatabaseTasks {
   static async dumpSchema(config: DatabaseConfig): Promise<void> {
     // Rails: `return unless db_config.schema_dump` — lets per-config
     // `schemaDump: false` (or null) suppress dumping. HashConfig.schemaDump()
-    // returns `string | false | null`; false AND null both mean "don't dump".
-    // Pass the current format so the check matches what's being dumped.
+    // normalizes both to null. Pass the current format so the check matches
+    // what's being dumped.
     const cfgWithDump = config as unknown as {
-      schemaDump?: (format?: string) => string | false | null;
+      schemaDump?: (format?: string) => string | null;
     };
     if (typeof cfgWithDump.schemaDump === "function") {
       // JS dumps use the same schema file path/config as TS; normalize
       // so HashConfig.schemaDump (which recognizes ruby/sql/ts but not
       // js) doesn't return null and accidentally suppress the dump.
       const format = this.schemaFormat === "js" ? "ts" : this.schemaFormat;
-      const result = cfgWithDump.schemaDump(format);
-      if (result === false || result === null) return;
+      if (cfgWithDump.schemaDump(format) == null) return;
     }
     const filename = this.schemaDumpPath(config);
     if (this.schemaFormat === "sql") {


### PR DESCRIPTION
## Summary
- Ports `database_configurations/hash_config_test.rb` (34 tests) from Rails into `hash-config.test.ts`.
- Registers `"abstract"` → `AbstractAdapter` so `validate!` and adapter resolution cover the same surface Rails exercises.
- Uses `vi.spyOn(config, "isPrimary")` to mirror Ruby's `stub(:primary?, false)` in the seeds test.

## Rails-parity fixes pulled in alongside the port
- `DatabaseConfig.reapingFrequency`: drop the `>0` nilify guard. Rails uses `fetch(:reaping_frequency, 60)&.to_f`, so missing → `60.0`, explicit `null` → `null`, and any other value (including `"0"`) is coerced with `to_f`. trails was previously nilifying `"0"` under the idle_timeout rule.
- `HashConfig.schemaDump`: normalize both `false` and `null` to `null` (Rails: `if config = configuration_hash[:schema_dump]` returns nil for both). Return type narrowed to `string | null`; `DatabaseTasks.dumpSchema` updated to the unified check.

## Remaining trails divergences (intentional, documented inline)
- `defaultSchemaCachePath` → `.json` not `.yml` (trails writes JSON, not Ruby Marshal/YAML — matches `DatabaseTasks.dumpSchemaCache` and `pool-config`).
- `schemaDump()` default format is `"ts"` not `:ruby`. The `"default schema dump value"` test pins both: the trails default (`schema.ts`) and the Rails-mirroring `"ruby"` path (`schema.rb`).
- `inspect()` test asserts secrets are redacted + env/name segments — the full `adapter_class=...` Rails format is a separate fidelity follow-up.

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/database-configurations/hash-config.test.ts` (34 pass)
- [x] `pnpm test:compare --cached` shows `hash_config_test.rb` → `hash-config.test.ts` 34/34 matched
- [x] `pnpm api:compare --package activerecord` shows `database_configurations/hash_config.rb` 26/26 (100%)