### PR TITLE
feat(actionview): LookupContext Phase 1d — details cascade + DetailsKey

### DIFF
--- a/packages/actionview/src/actionview.test.ts
+++ b/packages/actionview/src/actionview.test.ts
@@ -535,6 +535,14 @@ describe("ActionView::LookupContext", () => {
       expect(a.detailsKey()).toBe(b.detailsKey());
     });
 
+    it("does not collide on detail values containing : , |", () => {
+      const c1 = new LookupContext();
+      const c2 = new LookupContext();
+      c1.variants = ["a", "b"];
+      c2.variants = ["a,s:b|"];
+      expect(c1.detailsKey()).not.toBe(c2.detailsKey());
+    });
+
     it("distinguishes non-global Symbols by identity in the details key", () => {
       const c1 = new LookupContext();
       const c2 = new LookupContext();

--- a/packages/actionview/src/actionview.test.ts
+++ b/packages/actionview/src/actionview.test.ts
@@ -535,6 +535,27 @@ describe("ActionView::LookupContext", () => {
       expect(a.detailsKey()).toBe(b.detailsKey());
     });
 
+    it("canonicalizes invalid formats before computing the cache key", () => {
+      LookupContext.DetailsKey.clear();
+      const c1 = new LookupContext();
+      const c2 = new LookupContext();
+      c1.formats = ["html"];
+      const k1 = c1.detailsKey();
+      // Build a details tuple that filters down to ["html"] and verify
+      // it hits the same cache entry.
+      const k2 = LookupContext.DetailsKey.detailsCacheKey({
+        ...(c2 as unknown as { _details: Record<string, string[]> })._details,
+        formats: ["html"],
+      });
+      expect(k1).toBe(k2);
+    });
+
+    it("isAny produces a Requested with variants:'any' so any variant matches", () => {
+      const c = new LookupContext();
+      const [, key] = c.detailArgsForAny();
+      expect((key as unknown as { variantsIdx: unknown }).variantsIdx).toBe("any");
+    });
+
     it("does not collide on detail values containing : , |", () => {
       const c1 = new LookupContext();
       const c2 = new LookupContext();

--- a/packages/actionview/src/actionview.test.ts
+++ b/packages/actionview/src/actionview.test.ts
@@ -473,6 +473,12 @@ describe("ActionView::LookupContext", () => {
       expect(Array.from(c.formats)).toEqual(["xml", "html", "text", "js", "css", "json"]);
     });
 
+    it("formats= removes every */* occurrence before expanding defaults", () => {
+      const c = new LookupContext();
+      c.formats = ["*/*", "xml", "*/*"];
+      expect(Array.from(c.formats)).toEqual(["xml", "html", "text", "js", "css", "json"]);
+    });
+
     it("formats= adds html fallback when only :js is requested", () => {
       const c = new LookupContext();
       c.formats = ["js"];
@@ -527,6 +533,14 @@ describe("ActionView::LookupContext", () => {
       const a = new LookupContext();
       const b = new LookupContext();
       expect(a.detailsKey()).toBe(b.detailsKey());
+    });
+
+    it("distinguishes non-global Symbols by identity in the details key", () => {
+      const c1 = new LookupContext();
+      const c2 = new LookupContext();
+      c1.variants = [Symbol("mobile")];
+      c2.variants = [Symbol("mobile")];
+      expect(c1.detailsKey()).not.toBe(c2.detailsKey());
     });
 
     it("digestCache is per-tuple and persists across instances", () => {

--- a/packages/actionview/src/actionview.test.ts
+++ b/packages/actionview/src/actionview.test.ts
@@ -543,6 +543,81 @@ describe("ActionView::LookupContext", () => {
       expect(LookupContext.DetailsKey.digestCaches()).toEqual([]);
     });
   });
+
+  describe("ViewPaths protocol (Phase 1d)", () => {
+    const stubResolver = () => {
+      const r = {
+        templates: [] as Array<{ name: string; prefix: string; partial: boolean; t: unknown }>,
+        findAll(name: string, prefix: string, partial: boolean): unknown[] {
+          return this.templates
+            .filter((x) => x.name === name && x.prefix === prefix && x.partial === partial)
+            .map((x) => x.t);
+        },
+      };
+      return r;
+    };
+
+    it("constructor accepts an array of resolvers and exposes viewPaths", () => {
+      const r = stubResolver();
+      const c = new LookupContext([r]);
+      expect(c.viewPaths.size).toBe(1);
+      expect(c.viewPaths.at(0)).toBe(r);
+    });
+
+    it("find / findAll delegate to viewPaths with normalized prefixes", () => {
+      const r = stubResolver();
+      r.templates.push({ name: "show", prefix: "users", partial: false, t: { id: 1 } });
+      const c = new LookupContext([r]);
+      expect(c.findAll("users/show", [], false)).toEqual([{ id: 1 }]);
+      expect(c.find("users/show", [], false)).toEqual({ id: 1 });
+    });
+
+    it("isExists returns true/false based on viewPaths matches", () => {
+      const r = stubResolver();
+      r.templates.push({ name: "form", prefix: "users", partial: true, t: { p: 1 } });
+      const c = new LookupContext([r]);
+      expect(c.isExists("form", ["users"], true)).toBe(true);
+      expect(c.isExists("missing", ["users"], true)).toBe(false);
+    });
+
+    it("isAny uses default details and ignores format constraints", () => {
+      const r = stubResolver();
+      r.templates.push({ name: "index", prefix: "posts", partial: false, t: { p: 1 } });
+      const c = new LookupContext([r]);
+      expect(c.isAny("index", ["posts"], false)).toBe(true);
+    });
+
+    it("appendViewPaths / prependViewPaths rebuild the PathSet", () => {
+      const a = stubResolver();
+      const b = stubResolver();
+      const c = new LookupContext([a]);
+      c.appendViewPaths([b]);
+      expect(c.viewPaths.at(1)).toBe(b);
+      c.prependViewPaths([b]);
+      expect(c.viewPaths.at(0)).toBe(b);
+    });
+
+    it("withPrependedFormats returns sibling with overridden formats", () => {
+      const c = new LookupContext();
+      const next = c.withPrependedFormats(["json"]);
+      expect(Array.from(next.formats)).toEqual(["json"]);
+      expect(Array.from(c.formats)).not.toEqual(["json"]);
+    });
+
+    it("detailArgsFor returns memoized details when options is empty", () => {
+      const c = new LookupContext();
+      const [d1] = c.detailArgsFor({});
+      const [d2] = c.detailArgsFor({});
+      expect(d1).toBe(d2);
+    });
+
+    it("detailArgsFor merges options without mutating instance details", () => {
+      const c = new LookupContext();
+      const [details] = c.detailArgsFor({ formats: ["json"] });
+      expect(Array.from(details.formats)).toEqual(["json"]);
+      expect(Array.from(c.formats)).not.toEqual(["json"]);
+    });
+  });
 });
 
 // ==========================================================================

--- a/packages/actionview/src/actionview.test.ts
+++ b/packages/actionview/src/actionview.test.ts
@@ -457,6 +457,92 @@ describe("ActionView::LookupContext", () => {
       expect(output).toBe("content");
     });
   });
+
+  describe("details cascade (Phase 1d)", () => {
+    it("seeds default details from registered procs", () => {
+      const c = new LookupContext();
+      expect(c.locale).toBe("en");
+      expect(Array.from(c.formats)).toEqual(["html", "text", "js", "css", "xml", "json"]);
+      expect(Array.from(c.variants)).toEqual([]);
+      expect(Array.from(c.handlers)).toContain("ejs");
+    });
+
+    it("formats= expands */* using defaults and dedupes", () => {
+      const c = new LookupContext();
+      c.formats = ["xml", "*/*"];
+      expect(Array.from(c.formats)).toEqual(["xml", "html", "text", "js", "css", "json"]);
+    });
+
+    it("formats= adds html fallback when only :js is requested", () => {
+      const c = new LookupContext();
+      c.formats = ["js"];
+      expect(Array.from(c.formats)).toEqual(["js", "html"]);
+      expect(c.htmlFallbackForJs).toBe(true);
+    });
+
+    it("formats= rejects unknown formats", () => {
+      const c = new LookupContext();
+      expect(() => {
+        c.formats = ["nope"];
+      }).toThrow(/Invalid formats/);
+    });
+
+    it("locale getter returns first locale; setter replaces it", () => {
+      const c = new LookupContext();
+      c.locale = "fr";
+      expect(c.locale).toBe("fr");
+    });
+
+    it("setting details invalidates the cached details key", () => {
+      const c = new LookupContext();
+      const first = c.detailsKey();
+      c.formats = ["html"];
+      const second = c.detailsKey();
+      expect(first).not.toBe(second);
+    });
+  });
+
+  describe("DetailsKey + cache (Phase 1d)", () => {
+    beforeEach(() => {
+      LookupContext.DetailsKey.clear();
+    });
+
+    it("returns null detailsKey when cache is disabled", () => {
+      const c = new LookupContext();
+      c.cache = false;
+      expect(c.detailsKey()).toBeNull();
+    });
+
+    it("disableCache yields without cache and restores prior value", () => {
+      const c = new LookupContext();
+      let inner: unknown;
+      c.disableCache(() => {
+        inner = c.detailsKey();
+      });
+      expect(inner).toBeNull();
+      expect(c.detailsKey()).not.toBeNull();
+    });
+
+    it("DetailsKey.detailsCacheKey returns the same Requested for equal details", () => {
+      const a = new LookupContext();
+      const b = new LookupContext();
+      expect(a.detailsKey()).toBe(b.detailsKey());
+    });
+
+    it("digestCache is per-tuple and persists across instances", () => {
+      const a = new LookupContext();
+      const b = new LookupContext();
+      a.digestCache().set("k", "v");
+      expect(b.digestCache().get("k")).toBe("v");
+    });
+
+    it("DetailsKey.clear wipes details + digest caches", () => {
+      const c = new LookupContext();
+      c.digestCache().set("k", "v");
+      LookupContext.DetailsKey.clear();
+      expect(LookupContext.DetailsKey.digestCaches()).toEqual([]);
+    });
+  });
 });
 
 // ==========================================================================

--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -157,28 +157,30 @@ export class DetailsKey {
   /** @internal Per-symbol identity tag, so two non-global Symbols with
    * the same description don't collide in `_stableKey`. Mirrors Ruby's
    * symbol interning (where `:foo == :foo` is always true) by giving
-   * each non-interned Symbol a stable per-process numeric id. */
-  private static _symbolIds = new Map<symbol, number>();
+   * each non-interned Symbol a stable per-process numeric id. Stored
+   * in a WeakMap so unreferenced symbols can be GC'd. */
+  private static _symbolIds: WeakMap<WeakKey, number> = new WeakMap();
   private static _nextSymbolId = 0;
   private static _tagSymbol(s: symbol): string {
     const keyed = Symbol.keyFor(s);
     if (keyed !== undefined) return `S@${keyed}`;
-    let id = DetailsKey._symbolIds.get(s);
+    let id = DetailsKey._symbolIds.get(s as unknown as WeakKey);
     if (id === undefined) {
       id = ++DetailsKey._nextSymbolId;
-      DetailsKey._symbolIds.set(s, id);
+      DetailsKey._symbolIds.set(s as unknown as WeakKey, id);
     }
     return `s#${id}`;
   }
 
-  /** @internal Stable key for a details tuple. */
+  /** @internal Unambiguous key for a details tuple — JSON encoding so
+   * raw `:`, `,`, or `|` inside a detail value can't collide. */
   private static _stableKey(details: DetailsMap): string {
-    return REGISTERED_DETAILS.map(
-      (k) =>
-        `${k}:${(details[k] ?? [])
-          .map((v) => (typeof v === "symbol" ? DetailsKey._tagSymbol(v) : `s:${String(v)}`))
-          .join(",")}`,
-    ).join("|");
+    return JSON.stringify(
+      REGISTERED_DETAILS.map((k) => [
+        k,
+        (details[k] ?? []).map((v) => (typeof v === "symbol" ? DetailsKey._tagSymbol(v) : v)),
+      ]),
+    );
   }
 }
 

--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -105,20 +105,21 @@ export class DetailsKey {
 
   /** Canonical Requested object for a given detail tuple. */
   static detailsCacheKey(details: DetailsMap): Requested {
-    const key = DetailsKey._stableKey(details);
-    let req = DetailsKey._detailsKeys.get(key);
-    if (req) return req;
     let formats = details.formats;
     if (formats && !formats.every((f) => typeof f === "string" && VALID_FORMAT_SYMBOLS.has(f))) {
       formats = formats.filter(
         (f) => typeof f === "string" && VALID_FORMAT_SYMBOLS.has(f),
       ) as DetailValue;
     }
+    const normalized: DetailsMap = { ...details, formats: formats ?? [] };
+    const key = DetailsKey._stableKey(normalized);
+    let req = DetailsKey._detailsKeys.get(key);
+    if (req) return req;
     req = new Requested({
-      locale: details.locale ?? [],
-      handlers: details.handlers ?? [],
-      formats: formats ?? [],
-      variants: details.variants ?? [],
+      locale: normalized.locale ?? [],
+      handlers: normalized.handlers ?? [],
+      formats: normalized.formats ?? [],
+      variants: normalized.variants ?? [],
     });
     DetailsKey._detailsKeys.set(key, req);
     return req;
@@ -450,9 +451,21 @@ export class LookupContext {
     if (this._detailArgsForAny) return this._detailArgsForAny;
     const details: DetailsMap = {};
     for (const k of REGISTERED_DETAILS) {
-      details[k] = k === "variants" ? ["*"] : DEFAULT_PROCS[k]();
+      details[k] = DEFAULT_PROCS[k]();
     }
-    const key = this._detailsCache ? DetailsKey.detailsCacheKey(details) : null;
+    // Rails passes `variants: :any` here; the canonical Requested uses
+    // a sentinel-array branch ("any") that matches every variant. We
+    // bypass DetailsKey._detailsKeys for this special form since
+    // `Requested.variantsIdx === "any"` is not representable in the
+    // DetailsMap.
+    const key = this._detailsCache
+      ? new Requested({
+          locale: details.locale,
+          handlers: details.handlers,
+          formats: details.formats,
+          variants: "any",
+        })
+      : null;
     this._detailArgsForAny = [details, key];
     return this._detailArgsForAny;
   }

--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -10,12 +10,55 @@
  *   ctx.addResolver(new InMemoryResolver()); // fallback
  *
  *   const output = await ctx.render("posts", "index", "html", { posts: [...] });
+ *
+ * Phase 1d fleshes out the registered-details cascade (locale, formats,
+ * variants, handlers) and a real `DetailsKey` cache mirroring
+ * `action_view/lookup_context.rb`.
  */
 
 import type { RenderContext } from "./template/handlers.js";
 import { TemplateHandlerRegistry } from "./template/handlers.js";
 import type { TemplateResolver } from "./template-resolver.js";
 import type { Template } from "./template.js";
+import { PathRegistry } from "./path-registry.js";
+import { Requested } from "./template-details.js";
+
+type DetailValue = ReadonlyArray<string | symbol>;
+type DetailsMap = Record<string, DetailValue>;
+type DefaultProc = () => DetailValue;
+
+const DEFAULT_PROCS: Record<string, DefaultProc> = {};
+const REGISTERED_DETAILS: string[] = [];
+
+function registerDetail(name: string, proc: DefaultProc): void {
+  if (!REGISTERED_DETAILS.includes(name)) REGISTERED_DETAILS.push(name);
+  DEFAULT_PROCS[name] = proc;
+}
+
+// I18n is not yet ported; fall back to a single "en" locale.
+registerDetail("locale", () => ["en"]);
+registerDetail("formats", () => ["html", "text", "js", "css", "xml", "json"]);
+registerDetail("variants", () => []);
+registerDetail("handlers", () => TemplateHandlerRegistry.extensions as DetailValue);
+
+/** Whitelist of format symbols recognized by `formats=`. */
+const VALID_FORMAT_SYMBOLS: ReadonlySet<string> = new Set([
+  "html",
+  "text",
+  "js",
+  "css",
+  "xml",
+  "json",
+  "rss",
+  "atom",
+  "yaml",
+  "multipart_form",
+  "url_encoded_form",
+  "ics",
+  "csv",
+  "vcf",
+  "tsx",
+]);
 
 export class MissingTemplate extends Error {
   /** Rails-shape accessors — refined in Phase 1d. @internal stub - real impl in Phase 1d */
@@ -48,17 +91,210 @@ export class MissingTemplate extends Error {
   }
 }
 
+/**
+ * Per-process cache of `{locale, formats, variants, handlers}` detail
+ * tuples + their associated digest caches. Mirrors
+ * `ActionView::LookupContext::DetailsKey`.
+ */
+export class DetailsKey {
+  /** @internal */
+  static _detailsKeys = new Map<string, Requested>();
+  /** @internal */
+  static _digestCache = new Map<Requested, Map<string, string>>();
+
+  /** Canonical Requested object for a given detail tuple. */
+  static detailsCacheKey(details: DetailsMap): Requested {
+    const key = DetailsKey._stableKey(details);
+    let req = DetailsKey._detailsKeys.get(key);
+    if (req) return req;
+    let formats = details.formats;
+    if (formats && !formats.every((f) => typeof f === "string" && VALID_FORMAT_SYMBOLS.has(f))) {
+      formats = formats.filter(
+        (f) => typeof f === "string" && VALID_FORMAT_SYMBOLS.has(f),
+      ) as DetailValue;
+    }
+    req = new Requested({
+      locale: details.locale ?? [],
+      handlers: details.handlers ?? [],
+      formats: formats ?? [],
+      variants: details.variants ?? [],
+    });
+    DetailsKey._detailsKeys.set(key, req);
+    return req;
+  }
+
+  /** Digest cache scoped to a given detail tuple. */
+  static digestCache(details: DetailsMap): Map<string, string> {
+    const req = DetailsKey.detailsCacheKey(details);
+    let cache = DetailsKey._digestCache.get(req);
+    if (!cache) {
+      cache = new Map();
+      DetailsKey._digestCache.set(req, cache);
+    }
+    return cache;
+  }
+
+  static digestCaches(): Array<Map<string, string>> {
+    return Array.from(DetailsKey._digestCache.values());
+  }
+
+  /** Clear every resolver cache, plus the details and digest caches. */
+  static clear(): void {
+    for (const resolver of PathRegistry.allResolvers()) {
+      const r = resolver as TemplateResolver & { clearCache?: () => void };
+      r.clearCache?.();
+    }
+    DetailsKey._detailsKeys.clear();
+    DetailsKey._digestCache.clear();
+  }
+
+  /** @internal Stable JSON-ish key for a details tuple. */
+  private static _stableKey(details: DetailsMap): string {
+    return REGISTERED_DETAILS.map(
+      (k) => `${k}:${(details[k] ?? []).map((v) => String(v)).join(",")}`,
+    ).join("|");
+  }
+}
+
 export class LookupContext {
-  /**
-   * Nested cache-key class, exposed at the value level by the runtime
-   * assignment near the bottom of this file and at the type level here.
-   * @internal stub - real impl in Phase 1d
-   */
   static DetailsKey: typeof DetailsKey;
 
+  /** Names of detail facets registered process-wide. */
+  static get registeredDetails(): ReadonlyArray<string> {
+    return REGISTERED_DETAILS;
+  }
+
+  /** @internal Register a new detail facet (used by extensions). */
+  static registerDetail(name: string, proc: DefaultProc): void {
+    registerDetail(name, proc);
+  }
+
+  /** @internal */
+  static _defaultProcs(): Record<string, DefaultProc> {
+    return DEFAULT_PROCS;
+  }
+
+  // --- Existing high-level renderer state (kept for AC integration) ---
   private resolvers: TemplateResolver[] = [];
   private layoutName: string | false | null = "application";
-  private _prefixes: string[] = [];
+
+  // --- Rails-faithful state ---
+  private _details: DetailsMap;
+  private _prefixes: string[];
+  private _detailsKey: Requested | null = null;
+  private _detailsCache = true;
+  private _htmlFallbackForJs = false;
+
+  constructor(details: DetailsMap = {}, prefixes: string[] = []) {
+    this._prefixes = prefixes;
+    this._details = {};
+    for (const k of REGISTERED_DETAILS) {
+      this._details[k] = details[k] ?? DEFAULT_PROCS[k]();
+    }
+  }
+
+  // --- prefixes ---
+  get prefixes(): string[] {
+    return this._prefixes;
+  }
+  set prefixes(value: string[]) {
+    this._prefixes = value;
+  }
+
+  // --- details accessors ---
+  get locale(): string | symbol | null {
+    return this._details.locale[0] ?? null;
+  }
+  set locale(value: string | symbol | null) {
+    this._setDetail("locale", value == null ? DEFAULT_PROCS.locale() : [value]);
+  }
+
+  get formats(): DetailValue {
+    return this._details.formats;
+  }
+  set formats(values: DetailValue | null | undefined) {
+    if (!values) {
+      this._setDetail("formats", DEFAULT_PROCS.formats());
+      return;
+    }
+    let arr = [...values];
+    const wildIdx = arr.indexOf("*/*");
+    if (wildIdx >= 0) {
+      arr.splice(wildIdx, 1);
+      arr = arr.concat(DEFAULT_PROCS.formats());
+    }
+    arr = Array.from(new Set(arr));
+    const invalid = arr.filter((f) => typeof f !== "string" || !VALID_FORMAT_SYMBOLS.has(f));
+    if (invalid.length > 0) {
+      throw new Error(`Invalid formats: ${invalid.map((v) => String(v)).join(", ")}`);
+    }
+    if (arr.length === 1 && arr[0] === "js") {
+      arr.push("html");
+      this._htmlFallbackForJs = true;
+    }
+    this._setDetail("formats", arr);
+  }
+  get htmlFallbackForJs(): boolean {
+    return this._htmlFallbackForJs;
+  }
+
+  get variants(): DetailValue {
+    return this._details.variants;
+  }
+  set variants(values: DetailValue | null | undefined) {
+    this._setDetail(
+      "variants",
+      values && values.length > 0 ? [...values] : DEFAULT_PROCS.variants(),
+    );
+  }
+
+  get handlers(): DetailValue {
+    return this._details.handlers;
+  }
+  set handlers(values: DetailValue | null | undefined) {
+    this._setDetail(
+      "handlers",
+      values && values.length > 0 ? [...values] : DEFAULT_PROCS.handlers(),
+    );
+  }
+
+  /** @internal */
+  private _setDetail(key: string, value: DetailValue): void {
+    if (this._details[key] === value) return;
+    this._detailsKey = null;
+    this._details = { ...this._details, [key]: value };
+  }
+
+  // --- cache controls (DetailsCache module) ---
+  get cache(): boolean {
+    return this._detailsCache;
+  }
+  set cache(value: boolean) {
+    this._detailsCache = value;
+  }
+
+  /** Cache key for the current details tuple (null when cache is off). */
+  detailsKey(): Requested | null {
+    if (!this._detailsCache) return null;
+    if (!this._detailsKey) this._detailsKey = DetailsKey.detailsCacheKey(this._details);
+    return this._detailsKey;
+  }
+
+  /** Run `block` with the details cache disabled. */
+  disableCache<T>(block: () => T): T {
+    const prev = this._detailsCache;
+    this._detailsCache = false;
+    try {
+      return block();
+    } finally {
+      this._detailsCache = prev;
+    }
+  }
+
+  /** Digest cache scoped to the current details tuple. */
+  digestCache(): Map<string, string> {
+    return DetailsKey.digestCache(this._details);
+  }
 
   /** Add a resolver to the lookup chain. First added = highest priority. */
   addResolver(resolver: TemplateResolver): void {
@@ -73,15 +309,6 @@ export class LookupContext {
   /** Get the current layout name. */
   getLayout(): string | false | null {
     return this.layoutName;
-  }
-
-  /** Set view prefixes (for controller inheritance lookup). */
-  set prefixes(value: string[]) {
-    this._prefixes = value;
-  }
-
-  get prefixes(): string[] {
-    return this._prefixes;
   }
 
   /**
@@ -265,25 +492,4 @@ export class LookupContext {
   }
 }
 
-/**
- * Cache key for `{locale, formats, variants, handlers}` detail tuples.
- * Hooked by the `action_view` load callback to clear the cache between
- * request cycles. Real cache wiring lands in Phase 1d.
- *
- * Also exported as `LookupContext.DetailsKey` via namespace merging so
- * downstream code can mirror Rails' `ActionView::LookupContext::DetailsKey`
- * spelling without `as any` casts.
- *
- * @internal stub - real impl in Phase 1d
- */
-export class DetailsKey {
-  /** @internal stub - real impl in Phase 1d */
-  static clear(): void {}
-}
-
-// Install DetailsKey as a static on LookupContext so consumers can write
-// `LookupContext.DetailsKey.clear()` — matching the Rails
-// `ActionView::LookupContext::DetailsKey` nesting both at the value and
-// the type level (see the corresponding `static DetailsKey: typeof
-// DetailsKey` field declared inside LookupContext above).
 (LookupContext as { DetailsKey: typeof DetailsKey }).DetailsKey = DetailsKey;

--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -388,7 +388,7 @@ export class LookupContext {
   ): unknown {
     const [base, pfxs] = this.normalizeName(name, prefixes);
     const [details, key] = this.detailArgsFor(options);
-    return this._viewPaths.find(base, pfxs, partial, details as never, key, keys);
+    return this._viewPaths.find(base, pfxs, partial, details, key, keys);
   }
 
   /** Rails-shape `find_all`. */
@@ -401,7 +401,7 @@ export class LookupContext {
   ): unknown[] {
     const [base, pfxs] = this.normalizeName(name, prefixes);
     const [details, key] = this.detailArgsFor(options);
-    return this._viewPaths.findAll(base, pfxs, partial, details as never, key, keys);
+    return this._viewPaths.findAll(base, pfxs, partial, details, key, keys);
   }
 
   /** Rails-shape `exists?` / `template_exists?`. */
@@ -414,7 +414,7 @@ export class LookupContext {
   ): boolean {
     const [base, pfxs] = this.normalizeName(name, prefixes);
     const [details, key] = this.detailArgsFor(options);
-    return this._viewPaths.exists(base, pfxs, partial, details as never, key, keys);
+    return this._viewPaths.exists(base, pfxs, partial, details, key, keys);
   }
 
   /**
@@ -424,7 +424,7 @@ export class LookupContext {
   isAny(name: string, prefixes: ReadonlyArray<string> = [], partial = false): boolean {
     const [base, pfxs] = this.normalizeName(name, prefixes);
     const [details, key] = this.detailArgsForAny();
-    return this._viewPaths.exists(base, pfxs, partial, details as never, key, []);
+    return this._viewPaths.exists(base, pfxs, partial, details, key, []);
   }
 
   /**

--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -21,6 +21,7 @@ import { TemplateHandlerRegistry } from "./template/handlers.js";
 import type { TemplateResolver } from "./template-resolver.js";
 import type { Template } from "./template.js";
 import { PathRegistry } from "./path-registry.js";
+import { PathSet, type PathSetResolver } from "./path-set.js";
 import { Requested } from "./template-details.js";
 
 type DetailValue = ReadonlyArray<string | symbol>;
@@ -184,13 +185,30 @@ export class LookupContext {
   private _detailsKey: Requested | null = null;
   private _detailsCache = true;
   private _htmlFallbackForJs = false;
+  private _viewPaths: PathSet;
+  private _detailArgsForAny: [DetailsMap, Requested | null] | null = null;
 
-  constructor(details: DetailsMap = {}, prefixes: string[] = []) {
+  constructor(
+    viewPaths: PathSet | ReadonlyArray<PathSetResolver> | null = null,
+    details: DetailsMap = {},
+    prefixes: string[] = [],
+  ) {
     this._prefixes = prefixes;
-    this._details = {};
+    this._details = this.initializeDetails({}, details);
+    this._viewPaths = this.buildViewPaths(viewPaths);
+  }
+
+  /**
+   * @internal
+   * Populate `target` with the registered detail facets, falling back to
+   * each facet's default proc when `details` doesn't supply a value.
+   * Mirrors `LookupContext#initialize_details`.
+   */
+  initializeDetails(target: DetailsMap, details: DetailsMap): DetailsMap {
     for (const k of REGISTERED_DETAILS) {
-      this._details[k] = details[k] ?? DEFAULT_PROCS[k]();
+      target[k] = details[k] ?? DEFAULT_PROCS[k]();
     }
+    return target;
   }
 
   // --- prefixes ---
@@ -294,6 +312,138 @@ export class LookupContext {
   /** Digest cache scoped to the current details tuple. */
   digestCache(): Map<string, string> {
     return DetailsKey.digestCache(this._details);
+  }
+
+  /**
+   * Return a sibling `LookupContext` whose `formats` detail is replaced
+   * with the given list. Mirrors `LookupContext#with_prepended_formats`.
+   */
+  withPrependedFormats(formats: DetailValue): LookupContext {
+    const details = { ...this._details, formats };
+    return new LookupContext(this._viewPaths, details, this._prefixes);
+  }
+
+  // --- ViewPaths module ---
+  /** Frozen `PathSet` of resolvers used for Rails-shape lookups. */
+  get viewPaths(): PathSet {
+    return this._viewPaths;
+  }
+
+  /**
+   * @internal
+   * Whenever setting view paths, make a copy so we can manipulate them
+   * per-instance without aliasing. Mirrors
+   * `ViewPaths#build_view_paths` (the `String`/`Pathname` wrapping there
+   * is deferred to the resolver port).
+   */
+  buildViewPaths(paths: PathSet | ReadonlyArray<PathSetResolver> | null): PathSet {
+    if (paths instanceof PathSet) return paths;
+    return new PathSet(paths ?? []);
+  }
+
+  /** Append `paths` to the current view-path set. */
+  appendViewPaths(paths: ReadonlyArray<PathSetResolver>): void {
+    this._viewPaths = this.buildViewPaths([...this._viewPaths.toArray(), ...paths]);
+  }
+
+  /** Prepend `paths` to the current view-path set. */
+  prependViewPaths(paths: ReadonlyArray<PathSetResolver>): void {
+    this._viewPaths = this.buildViewPaths([...paths, ...this._viewPaths.toArray()]);
+  }
+
+  /**
+   * Find one matching template (Rails-shape signature). Aliased as
+   * `findTemplate` for the existing 3-arg call sites.
+   */
+  find(
+    name: string,
+    prefixes: ReadonlyArray<string> = [],
+    partial = false,
+    keys: ReadonlyArray<string> = [],
+    options: Record<string, DetailValue> = {},
+  ): unknown {
+    const [base, pfxs] = this.normalizeName(name, prefixes);
+    const [details, key] = this.detailArgsFor(options);
+    return this._viewPaths.find(base, pfxs, partial, details as never, key, keys);
+  }
+
+  /** Rails-shape `find_all`. */
+  findAll(
+    name: string,
+    prefixes: ReadonlyArray<string> = [],
+    partial = false,
+    keys: ReadonlyArray<string> = [],
+    options: Record<string, DetailValue> = {},
+  ): unknown[] {
+    const [base, pfxs] = this.normalizeName(name, prefixes);
+    const [details, key] = this.detailArgsFor(options);
+    return this._viewPaths.findAll(base, pfxs, partial, details as never, key, keys);
+  }
+
+  /** Rails-shape `exists?` / `template_exists?`. */
+  isExists(
+    name: string,
+    prefixes: ReadonlyArray<string> = [],
+    partial = false,
+    keys: ReadonlyArray<string> = [],
+    options: Record<string, DetailValue> = {},
+  ): boolean {
+    const [base, pfxs] = this.normalizeName(name, prefixes);
+    const [details, key] = this.detailArgsFor(options);
+    return this._viewPaths.exists(base, pfxs, partial, details as never, key, keys);
+  }
+
+  /**
+   * Rails-shape `any?` / `any_templates?` — ignores format/locale/variant
+   * constraints by using `detail_args_for_any`.
+   */
+  isAny(name: string, prefixes: ReadonlyArray<string> = [], partial = false): boolean {
+    const [base, pfxs] = this.normalizeName(name, prefixes);
+    const [details, key] = this.detailArgsForAny();
+    return this._viewPaths.exists(base, pfxs, partial, details as never, key, []);
+  }
+
+  /**
+   * @internal
+   * Compute the (details, detailsKey) pair for a lookup. Returns the
+   * memoized request details when `options` is empty (the hot path).
+   */
+  detailArgsFor(options: Record<string, DetailValue>): [DetailsMap, Requested | null] {
+    if (Object.keys(options).length === 0) return [this._details, this.detailsKey()];
+    const userDetails = { ...this._details, ...options };
+    const key = this._detailsCache ? DetailsKey.detailsCacheKey(userDetails) : null;
+    return [userDetails, key];
+  }
+
+  /**
+   * @internal
+   * Details tuple for `any?` lookups — every facet at its default except
+   * `variants`, which is wildcarded.
+   */
+  detailArgsForAny(): [DetailsMap, Requested | null] {
+    if (this._detailArgsForAny) return this._detailArgsForAny;
+    const details: DetailsMap = {};
+    for (const k of REGISTERED_DETAILS) {
+      details[k] = k === "variants" ? ["*"] : DEFAULT_PROCS[k]();
+    }
+    const key = this._detailsCache ? DetailsKey.detailsCacheKey(details) : null;
+    this._detailArgsForAny = [details, key];
+    return this._detailArgsForAny;
+  }
+
+  /**
+   * @internal
+   * Splits a possibly-namespaced template name (`"admin/users/show"`)
+   * into `(name, prefixes)`. Mirrors `ViewPaths#normalize_name`.
+   */
+  normalizeName(name: string, prefixes: ReadonlyArray<string>): [string, ReadonlyArray<string>] {
+    const idx = name.lastIndexOf("/");
+    if (idx < 0) return [name, prefixes.length > 0 ? prefixes : [""]];
+    let pathPrefix = name.slice(0, idx);
+    if (pathPrefix.startsWith("/")) pathPrefix = pathPrefix.slice(1);
+    const base = name.slice(idx + 1);
+    const pfxs = prefixes.length === 0 ? [pathPrefix] : prefixes.map((p) => `${p}/${pathPrefix}`);
+    return [base, pfxs];
   }
 
   /** Add a resolver to the lookup chain. First added = highest priority. */

--- a/packages/actionview/src/lookup-context.ts
+++ b/packages/actionview/src/lookup-context.ts
@@ -139,7 +139,12 @@ export class DetailsKey {
     return Array.from(DetailsKey._digestCache.values());
   }
 
-  /** Clear every resolver cache, plus the details and digest caches. */
+  /**
+   * Clear the details and digest caches, plus any resolver caches
+   * advertised by `PathRegistry`. Until the resolver port (Phase 1c)
+   * wires real entries into `PathRegistry`, the resolver loop is a
+   * no-op.
+   */
   static clear(): void {
     for (const resolver of PathRegistry.allResolvers()) {
       const r = resolver as TemplateResolver & { clearCache?: () => void };
@@ -149,10 +154,30 @@ export class DetailsKey {
     DetailsKey._digestCache.clear();
   }
 
-  /** @internal Stable JSON-ish key for a details tuple. */
+  /** @internal Per-symbol identity tag, so two non-global Symbols with
+   * the same description don't collide in `_stableKey`. Mirrors Ruby's
+   * symbol interning (where `:foo == :foo` is always true) by giving
+   * each non-interned Symbol a stable per-process numeric id. */
+  private static _symbolIds = new Map<symbol, number>();
+  private static _nextSymbolId = 0;
+  private static _tagSymbol(s: symbol): string {
+    const keyed = Symbol.keyFor(s);
+    if (keyed !== undefined) return `S@${keyed}`;
+    let id = DetailsKey._symbolIds.get(s);
+    if (id === undefined) {
+      id = ++DetailsKey._nextSymbolId;
+      DetailsKey._symbolIds.set(s, id);
+    }
+    return `s#${id}`;
+  }
+
+  /** @internal Stable key for a details tuple. */
   private static _stableKey(details: DetailsMap): string {
     return REGISTERED_DETAILS.map(
-      (k) => `${k}:${(details[k] ?? []).map((v) => String(v)).join(",")}`,
+      (k) =>
+        `${k}:${(details[k] ?? [])
+          .map((v) => (typeof v === "symbol" ? DetailsKey._tagSymbol(v) : `s:${String(v)}`))
+          .join(",")}`,
     ).join("|");
   }
 }
@@ -236,10 +261,9 @@ export class LookupContext {
       return;
     }
     let arr = [...values];
-    const wildIdx = arr.indexOf("*/*");
-    if (wildIdx >= 0) {
-      arr.splice(wildIdx, 1);
-      arr = arr.concat(DEFAULT_PROCS.formats());
+    const hadWildcard = arr.includes("*/*");
+    if (hadWildcard) {
+      arr = arr.filter((v) => v !== "*/*").concat(DEFAULT_PROCS.formats());
     }
     arr = Array.from(new Set(arr));
     const invalid = arr.filter((f) => typeof f !== "string" || !VALID_FORMAT_SYMBOLS.has(f));

--- a/packages/actionview/src/path-set.ts
+++ b/packages/actionview/src/path-set.ts
@@ -14,12 +14,23 @@
 import type { Requested, TemplateDetails } from "./template-details.js";
 import type { TemplatePath } from "./template-path.js";
 
+/**
+ * Argument shape for the `details` parameter of resolver lookups. Rails
+ * passes the raw details hash here (see `view_paths.rb#find`); the
+ * `TemplateDetails`/`Requested` cases are accepted for resolvers that
+ * already work in canonical-key form.
+ */
+export type LookupDetails =
+  | TemplateDetails
+  | Requested
+  | Readonly<Record<string, ReadonlyArray<string | symbol>>>;
+
 export interface PathSetResolver {
   findAll(
     path: TemplatePath | string,
     prefix: string,
     partial: boolean,
-    details: TemplateDetails | Requested,
+    details: LookupDetails,
     detailsKey: unknown,
     locals: ReadonlyArray<string>,
   ): unknown[];
@@ -83,7 +94,7 @@ export class PathSet implements Iterable<PathSetResolver> {
     path: TemplatePath | string,
     prefixes: string | ReadonlyArray<string>,
     partial: boolean,
-    details: TemplateDetails | Requested,
+    details: LookupDetails,
     detailsKey: unknown,
     locals: ReadonlyArray<string>,
   ): unknown {
@@ -97,7 +108,7 @@ export class PathSet implements Iterable<PathSetResolver> {
     path: TemplatePath | string,
     prefixes: string | ReadonlyArray<string>,
     partial: boolean,
-    details: TemplateDetails | Requested,
+    details: LookupDetails,
     detailsKey: unknown,
     locals: ReadonlyArray<string>,
   ): unknown[] {
@@ -149,7 +160,7 @@ export class PathSet implements Iterable<PathSetResolver> {
     path: TemplatePath | string,
     prefixes: string | ReadonlyArray<string>,
     partial: boolean,
-    details: TemplateDetails | Requested,
+    details: LookupDetails,
     detailsKey: unknown,
     locals: ReadonlyArray<string>,
   ): boolean {


### PR DESCRIPTION
## Summary

`LookupContext` ported to mirror `action_view/lookup_context.rb` 1:1
(29/29 methods via `api:compare`).

**Details cascade**
- Registered details (`locale`, `formats`, `variants`, `handlers`) with
  a per-process default-proc registry and per-instance details map.
- `initializeDetails`, `_setDetail` (invalidates cached key on change).
- Locale getter returns the first locale (Rails-style); setter replaces.
- `formats=` expands `*/*`, dedupes, adds an html fallback when only
  `:js` is set (exposed via `htmlFallbackForJs`), rejects unknown
  symbols.
- `withPrependedFormats(formats)` returns a sibling LookupContext with
  the formats detail replaced.

**DetailsKey cache**
- Canonical `Requested` per detail tuple via `detailsCacheKey`.
- Per-tuple digest cache via `digestCache` + `digestCaches()`.
- `clear()` wipes both maps and calls `clearCache` on every resolver in
  `PathRegistry`.
- `cache` accessor + `disableCache(block)` scope guard.
- `detailsKey()` lazily builds and memoizes the request key.
- `digestCache()` instance method returns the per-tuple digest map.

**ViewPaths module**
- Constructor takes `(viewPaths, details, prefixes)`; existing no-arg
  construction still works.
- `viewPaths` getter exposes the frozen `PathSet`.
- `buildViewPaths`, `appendViewPaths`, `prependViewPaths`.
- `find` / `findAll` / `isExists` / `isAny` normalize the name, build
  `(details, detailsKey)` via `detailArgsFor` / `detailArgsForAny`, and
  delegate to `PathSet#find` / `findAll` / `exists`.
- `normalizeName` splits namespaced names (`"admin/users/show"`).
- `detailArgsFor` memoizes the hot path (empty options) and merges
  without mutating the instance details map.

Existing high-level `render` / `renderPartial` / `renderCollection`
helpers (used by ActionController) are preserved verbatim.

Source reference: `vendor/rails/actionview/lib/action_view/lookup_context.rb`.

## Coverage

- `api:compare` — `lookup_context.rb`: **29/29 (100%)**, up from 16/29.
- `test:compare` — no regressions (delta = 0).

## Test plan

- [x] `pnpm vitest run packages/actionview/src/actionview.test.ts` — 90 pass (24 new)
- [x] `pnpm tsc --build`
- [x] `pnpm api:compare --package actionview` — lookup_context.rb 100%