### PR TITLE
test(activerecord): defineSchema for has-many counting/finding/deleting cluster (B1966-main-a)

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -613,11 +613,16 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      authors: { name: "string" },
+      posts: { author_id: "integer", title: "string" },
+    });
   });
+  withTransactionalFixtures(() => adapter);
 
   // -- Counting --
 
@@ -1006,6 +1011,14 @@ describe("HasManyAssociationsTest", () => {
       foreignKey: "author_id",
     });
     expect(posts.length).toBe(1);
+  });
+});
+
+describe("HasManyAssociationsTest", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(() => {
+    adapter = freshAdapter();
   });
 
   // -- Destroying --


### PR DESCRIPTION
## Summary

First slice of the B1966-main cluster, splitting the legacy `beforeEach freshAdapter()` describe at the top of `has-many-associations.test.ts` so the Counting, Finding, and Deleting sections (14 tests, all on `authors` + `posts`) now use `createTestAdapter` + `defineSchema` + `withTransactionalFixtures`. The Destroying section onwards continues on the legacy adapter pattern in a second describe.

Net diff is small (~16 lines) because the test bodies stay in place — only the surrounding describe wrappers move.

## Follow-ups

The B1966-main work is multi-PR; this is slice (a). Remaining sections still on the legacy `freshAdapter()` beforeEach (and seven standalone `freshAdapter()` callsites elsewhere in the file) need migrating before the no-schema variant can be dropped in B1966-finale:

- Destroying / Dependence / Get-Set IDs / Included-in-collection / Clearing
- Has-many on new record / size-empty-many-none
- Association definition through to end of main describe (~hundreds of tests)
- Standalone `freshAdapter()` callsites at lines 251, 2082 (sti subselect count, needs schema), and the five STI `building the associated object` tests around 2388–2530 (no-DB, can switch to `createTestAdapter` directly)

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/has-many-associations.test.ts` — 309 passed / 1 skipped
- [x] `pnpm lint --fix`
- [x] `pnpm typecheck`