### PR TITLE
fix(actionpack): default Request#domain to HttpURL.tldLength

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -247,19 +247,20 @@ export class Request {
   // --- Domain / subdomains ---
 
   // Rails: `Request#{domain,subdomains,subdomain}` delegate to
-  // `ActionDispatch::Http::URL.extract_*` (`url.rb:320-340`). Keeping these
-  // as thin pass-throughs means the negative-`slice` clamp added in
-  // url.ts#extractSubdomainsFrom applies here too.
+  // `ActionDispatch::Http::URL.extract_*` (`url.rb:320-340`) and default the
+  // `tld_length` arg to the class-level `@@tld_length` so railtie config
+  // (`URL.tldLength = N`) flows through. `domain` returns `nil` for IP /
+  // unnamed hosts; we mirror that with `string | null`.
 
-  domain(tldLength = 1): string {
-    return HttpURL.extractDomain(this.host, tldLength) ?? "";
+  domain(tldLength: number = HttpURL.tldLength): string | null {
+    return HttpURL.extractDomain(this.host, tldLength);
   }
 
-  subdomains(tldLength = 1): string[] {
+  subdomains(tldLength: number = HttpURL.tldLength): string[] {
     return HttpURL.extractSubdomains(this.host, tldLength);
   }
 
-  subdomain(tldLength = 1): string {
+  subdomain(tldLength: number = HttpURL.tldLength): string {
     return HttpURL.extractSubdomain(this.host, tldLength);
   }
 


### PR DESCRIPTION
## Summary

- Default `Request#{domain,subdomains,subdomain}` `tldLength` arg to `HttpURL.tldLength` so railtie config (`URL.tldLength = N`) flows through, matching Rails (`url.rb:324-340`). `url.ts#fullUrlFor` already read from `URL.tldLength`; the per-method helpers were hardcoded to `1`.
- Widen `Request#domain` return to `string | null` so `HttpURL.extractDomain`'s `null` for IP / unnamed hosts passes through (Rails returns `nil` there; previously coerced to `""`).

Tier 1 followup from #1953. Doc note in `docs/actionpack-100-percent.md` Tier 1 leaves; adjacent items were already merged so this lands as a focused fidelity fix.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/request.test.ts packages/actionpack/src/action-dispatch/http/url.test.ts` — 120 passed
- [ ] CI green