### PR TITLE
test(activerecord): defineSchema for has-many destroying/clearing cluster (B1966-main-b)

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -1015,11 +1015,30 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      authors: { name: "string" },
+      posts: { author_id: "integer", title: "string" },
+      destroy_all_authors: { name: "string" },
+      destroy_all_posts: { author_id: "integer", title: "string" },
+      delete_all_unloaded_authors: { name: "string" },
+      delete_all_unloaded_posts: { author_id: "integer", title: "string" },
+      nullify_authors: { name: "string" },
+      nullify_posts: { author_id: "integer", title: "string" },
+      cpk_authors: { name: "string" },
+      cpk_posts: { tenant_id: "integer", author_id: "integer", title: "string" },
+      cache_authors: { name: "string" },
+      cache_posts: { cache_author_id: "integer" },
+      clear_authors: { name: "string" },
+      clear_posts: { author_id: "integer", title: "string" },
+      clear_dep_authors: { name: "string" },
+      clear_dep_posts: { author_id: "integer", title: "string" },
+    });
   });
+  withTransactionalFixtures(() => adapter);
 
   // -- Destroying --
 
@@ -1497,6 +1516,14 @@ describe("HasManyAssociationsTest", () => {
     expect(author.isNewRecord()).toBe(true);
     // New records have no id; any query would return 0 results
     expect(author.id == null).toBe(true);
+  });
+});
+
+describe("HasManyAssociationsTest", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(() => {
+    adapter = freshAdapter();
   });
 
   // -- Calling size/empty --


### PR DESCRIPTION
## Summary

Second slice of B1966-main. Migrates the Destroying, Get/Set IDs, Included-in-collection, Clearing, and Has-many-on-new-record sections (~21 tests) from legacy `freshAdapter()` beforeEach to `createTestAdapter` + `defineSchema` + `withTransactionalFixtures`. Same shape as B1966-main-a — test bodies unchanged, only the surrounding describe wrapper moves.

Schema covers the 16 distinct tables referenced by these tests (Author/Post plus per-test prefixes like \`destroy_all_\`, \`nullify_\`, \`cpk_\`, \`cache_\`, \`clear_\`, \`clear_dep_\`).

## Follow-ups

Remaining B1966-main slices before the no-schema \`freshAdapter()\` variant can be dropped:

- B1966-main-c: Calling size/empty section (~lines 1502–1772).
- B1966-main-d: Association definition / Scoped queries (~lines 1772–7457). Likely needs further sub-slicing.
- B1966-main-standalone: 7 bare \`freshAdapter()\` callsites outside the main \`beforeEach\` (\`.toSql()\` and 5 STI build-only tests can switch to \`createTestAdapter()\` directly; \`sti subselect count\` needs a small schema).

## Test plan

- [x] \`pnpm vitest run packages/activerecord/src/associations/has-many-associations.test.ts\` — 309 passed / 1 skipped
- [x] \`pnpm lint --fix\`
- [x] \`pnpm typecheck\`