### PR TITLE
feat(actionpack): MAPPINGS symbol-source table for CSP DSL

### DIFF
--- a/packages/actionpack/src/action-dispatch/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/content-security-policy.ts
@@ -1,1 +1,6 @@
-export { ContentSecurityPolicy, type CSPSource } from "./http/content-security-policy.js";
+export {
+  ContentSecurityPolicy,
+  MAPPINGS,
+  type CSPSource,
+  type CspSymbol,
+} from "./http/content-security-policy.js";

--- a/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { ContentSecurityPolicy } from "../content-security-policy.js";
+import { ContentSecurityPolicy, MAPPINGS } from "../content-security-policy.js";
 
 describe("ContentSecurityPolicyTest", () => {
   it("build", () => {
@@ -204,6 +204,37 @@ describe("ContentSecurityPolicyTest", () => {
     const policy = new ContentSecurityPolicy();
     policy.requireSriFor("script", "style");
     expect(policy.build()).toBe("require-sri-for script style");
+  });
+
+  it("symbol-source mappings", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.defaultSrc(":self", ":https");
+    policy.scriptSrc(":self", ":unsafe_eval", ":strict_dynamic");
+    policy.imgSrc(":self", ":data", ":blob");
+    policy.objectSrc(":none");
+    const header = policy.build();
+    expect(header).toContain("default-src 'self' https:");
+    expect(header).toContain("script-src 'self' 'unsafe-eval' 'strict-dynamic'");
+    expect(header).toContain("img-src 'self' data: blob:");
+    expect(header).toContain("object-src 'none'");
+  });
+
+  it("symbol-source mappings table", () => {
+    expect(MAPPINGS.self).toBe("'self'");
+    expect(MAPPINGS.https).toBe("https:");
+    expect(MAPPINGS.none).toBe("'none'");
+    expect(MAPPINGS.unsafe_inline).toBe("'unsafe-inline'");
+  });
+
+  it("unknown symbol-source raises", () => {
+    const policy = new ContentSecurityPolicy();
+    expect(() => policy.defaultSrc(":bogus")).toThrow(/Unknown content security policy source/);
+  });
+
+  it("non-symbol strings pass through unchanged", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.scriptSrc("https://cdn.example.com", "'sha256-abc123'");
+    expect(policy.build()).toBe("script-src https://cdn.example.com 'sha256-abc123'");
   });
 
   it("trusted types directive", () => {

--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -195,11 +195,10 @@ export class ContentSecurityPolicy {
    * keyword in [[MAPPINGS]] or throws.
    */
   private applyMapping(source: string): string {
-    const mapped = MAPPINGS[source as keyof typeof MAPPINGS] as string | undefined;
-    if (mapped === undefined) {
+    if (!Object.hasOwn(MAPPINGS, source)) {
       throw new TypeError(`Unknown content security policy source mapping: ${source}`);
     }
-    return mapped;
+    return MAPPINGS[source as keyof typeof MAPPINGS];
   }
 
   /**

--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -4,22 +4,17 @@
  * DSL for building Content-Security-Policy headers.
  */
 
-export type CSPSource = string | ((request?: unknown) => string | string[]);
-
 /**
- * Rails' default nonce-eligible directives. Mirrors
- * `DEFAULT_NONCE_DIRECTIVES = %w[script-src style-src]`
- * (actionpack/lib/action_dispatch/http/content_security_policy.rb:174).
+ * Symbol-source shorthands. Mirrors Rails' `MAPPINGS` constant
+ * (actionpack/lib/action_dispatch/http/content_security_policy.rb:128-147).
+ *
+ * Ruby's `policy.script_src :self, :https` becomes
+ * `policy.scriptSrc(":self", ":https")` in trails — a leading `:` marks the
+ * string as a symbol shorthand and resolves through this table. Strings
+ * without the `:` prefix pass through unchanged so literal sources like
+ * `"script"` (for `require-sri-for`) keep their plain-string meaning.
  */
-export const DEFAULT_NONCE_DIRECTIVES = ["script-src", "style-src"] as const;
-
-/**
- * @internal
- * Mirrors Rails' `MAPPINGS` constant — short-form keyword sources used by the
- * DSL (Symbols in Ruby, prefixed-`:`-strings here) expand to their CSP source
- * representation when passed to a directive setter.
- */
-const MAPPINGS: Record<string, string> = {
+export const MAPPINGS = {
   self: "'self'",
   unsafe_eval: "'unsafe-eval'",
   wasm_unsafe_eval: "'wasm-unsafe-eval'",
@@ -38,7 +33,19 @@ const MAPPINGS: Record<string, string> = {
   strict_dynamic: "'strict-dynamic'",
   ws: "ws:",
   wss: "wss:",
-};
+} as const;
+
+export type CspSymbol = `:${keyof typeof MAPPINGS}`;
+
+export type CSPSource = CspSymbol | (string & {}) | ((request?: unknown) => string | string[]);
+
+/**
+ * Rails' default nonce-eligible directives. Mirrors
+ * `DEFAULT_NONCE_DIRECTIVES = %w[script-src style-src]`
+ * (actionpack/lib/action_dispatch/http/content_security_policy.rb:174).
+ */
+export const DEFAULT_NONCE_DIRECTIVES = ["script-src", "style-src"] as const;
+
 
 type DirectiveName = string;
 
@@ -189,7 +196,7 @@ export class ContentSecurityPolicy {
    * keyword in [[MAPPINGS]] or throws.
    */
   private applyMapping(source: string): string {
-    const mapped = MAPPINGS[source];
+    const mapped = MAPPINGS[source as keyof typeof MAPPINGS] as string | undefined;
     if (mapped === undefined) {
       throw new TypeError(`Unknown content security policy source mapping: ${source}`);
     }

--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -46,7 +46,6 @@ export type CSPSource = CspSymbol | (string & {}) | ((request?: unknown) => stri
  */
 export const DEFAULT_NONCE_DIRECTIVES = ["script-src", "style-src"] as const;
 
-
 type DirectiveName = string;
 
 /**

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -53,7 +53,12 @@ export {
 } from "./middleware/host-authorization.js";
 export { MiddlewareStack } from "./middleware/stack.js";
 export { MimeType } from "./http/mime-type.js";
-export { ContentSecurityPolicy, type CSPSource } from "./http/content-security-policy.js";
+export {
+  ContentSecurityPolicy,
+  MAPPINGS,
+  type CSPSource,
+  type CspSymbol,
+} from "./http/content-security-policy.js";
 export { ContentSecurityPolicyMiddleware } from "./middleware/content-security-policy.js";
 export { redirectTo, redirectBack, type RedirectResult } from "./redirect.js";
 export { FlashHash } from "./middleware/flash.js";


### PR DESCRIPTION
## Summary

- Add `MAPPINGS` constant (Rails parity: `content_security_policy.rb:128-147`)
- Widen `CSPSource` to accept `:self`, `:https`, `:unsafe_inline`, etc. — leading `:` marks a symbol shorthand that resolves through the table
- `CspSymbol` is a template-literal type (`` `:${keyof typeof MAPPINGS}` ``) for autocomplete; unknown `:foo` throws at runtime like Rails' `ArgumentError`
- Strings without the `:` prefix pass through unchanged, so existing usage (URLs, hashes, the literal `"script"` for `require-sri-for`) is unaffected

Required before Rails integration tests using `policy.script_src :self, :https` can land.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts` (+3 new tests)
- [x] middleware + metal CSP suites still green
- [x] `tsc --build` clean