### PR TITLE
test(activerecord): defineSchema for has-many size/empty cluster (B1966-main-c)

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -1520,11 +1520,24 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(() => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      authors: { name: "string" },
+      posts: { author_id: "integer", title: "string" },
+      size_un_authors: { name: "string" },
+      size_un_posts: { author_id: "integer", title: "string" },
+      size_ld_authors: { name: "string" },
+      size_ld_posts: { author_id: "integer", title: "string" },
+      empty_un_authors: { name: "string" },
+      empty_un_posts: { author_id: "integer", title: "string" },
+      empty_ld_authors: { name: "string" },
+      empty_ld_posts: { author_id: "integer", title: "string" },
+    });
   });
+  withTransactionalFixtures(() => adapter);
 
   // -- Calling size/empty --
 


### PR DESCRIPTION
## Summary

Third slice of the B1966-main cluster. Migrates the **Calling size/empty** section of `has-many-associations.test.ts` (7 tests) from the legacy `freshAdapter()` beforeEach pattern to `createTestAdapter` + `defineSchema` + `withTransactionalFixtures`.

Splits the legacy `freshAdapter()` describe at the `// -- Calling size/empty --` boundary: the migrated describe covers size/empty + many/none tests; a new sibling legacy describe picks up at `// -- Association definition --` onward.

Stacked on #1997 (B1966-main-b).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/has-many-associations.test.ts` — 309 passed / 1 skipped