### PR TITLE
test(activerecord): defineSchema for has-many association definition cluster (B1966-main-d)

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -1740,6 +1740,19 @@ describe("HasManyAssociationsTest", () => {
     });
     expect(posts.length === 0).toBe(false);
   });
+});
+
+describe("HasManyAssociationsTest", () => {
+  let adapter: TestDatabaseAdapter;
+
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      authors: { name: "string" },
+      posts: { author_id: "integer", title: "string" },
+    });
+  });
+  withTransactionalFixtures(() => adapter);
 
   // -- Association definition --
 
@@ -1828,6 +1841,14 @@ describe("HasManyAssociationsTest", () => {
     });
     const found = posts.find((p: any) => p.id === post.id);
     expect(found).toBeDefined();
+  });
+});
+
+describe("HasManyAssociationsTest", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(() => {
+    adapter = freshAdapter();
   });
 
   // -- Scoped queries --


### PR DESCRIPTION
## Summary

Continues the B1966-main split of `has-many-associations.test.ts` (after #1995 / B1966-main-a). Splits the legacy `beforeEach freshAdapter()` describe at the `// -- Association definition --` boundary so the 4 tests in that section run under `createTestAdapter` + `defineSchema` + `withTransactionalFixtures` on the standard `authors`/`posts` schema. The Scoped queries section onwards continues in a new sibling describe on the legacy adapter pattern.

Net diff is small (21 added lines) — only the surrounding describe wrappers move.

## Follow-ups

Remaining sections still on the legacy `freshAdapter()` beforeEach (and standalone `freshAdapter()` callsites elsewhere) need migrating before the no-schema variant can be dropped in B1966-finale:

- Calling size / empty (parallel batch-b1966-main-c)
- Scoped queries through to end of main describe
- Standalone `freshAdapter()` callsites lower in the file

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/has-many-associations.test.ts` — 309 passed / 1 skipped
- [x] `pnpm lint --fix`
- [x] `pnpm typecheck`