### PR TITLE
feat(actioncontroller): CSRF validation + storage plumbing (P20b/P20c)

### DIFF
--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
@@ -227,7 +227,7 @@ describe("P20b/P20c smoke", () => {
         method: "POST",
         baseUrl: "https://example.com",
         path: "/posts",
-        env: { "action_dispatch.request.csrf_token": generateCsrfToken() },
+        env: { "action_controller.csrf_token": generateCsrfToken() },
       },
       ...overrides,
     };
@@ -268,7 +268,7 @@ describe("P20b/P20c smoke", () => {
         method: "POST",
         baseUrl: "https://example.com",
         path: "/posts/",
-        env: { "action_dispatch.request.csrf_token": generateCsrfToken() },
+        env: { "action_controller.csrf_token": generateCsrfToken() },
       },
     });
     expect(isValidPerFormCsrfToken(c, perFormCsrfToken(c, null, "/posts", "POST"))).toBe(true);

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
@@ -240,6 +240,14 @@ describe("P20b/P20c smoke", () => {
     expect(realCsrfToken(c).equals(realCsrfToken(c))).toBe(true);
   });
 
+  it("encode/decodeCsrfToken use urlsafe base64 without padding; reject garbage", () => {
+    const raw = Buffer.from("?".repeat(32));
+    const encoded = maskToken(raw);
+    expect(encoded).not.toMatch(/[+/=]/);
+    expect(unmaskToken(decodeCsrfToken(encoded)).equals(raw)).toBe(true);
+    expect(() => decodeCsrfToken("!!! not base64 !!!")).toThrow();
+  });
+
   it("isAnyAuthenticityTokenValid: masked global via param + X-CSRF; rejects empty", () => {
     const c = tokenC();
     const masked = maskToken(globalCsrfToken(c));

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts
@@ -1,18 +1,40 @@
 import { describe, it, expect } from "vitest";
 import {
+  Exception,
   InvalidAuthenticityToken,
   InvalidCrossOriginRequest,
-  isProtectAgainstForgery,
-  isValidRequestOrigin,
-  markForSameOriginVerificationBang,
+  NullSession,
+  ResetSession,
+  compareWithGlobalToken,
+  compareWithRealToken,
+  decodeCsrfToken,
+  formAuthenticityParam,
+  generateCsrfToken,
+  globalCsrfToken,
+  isAnyAuthenticityTokenValid,
   isMarkedForSameOriginVerification,
   isNonXhrJavascriptResponse,
-  verifySameOriginRequest,
-  unverifiedRequestWarningMessage,
+  isProtectAgainstForgery,
+  isStorageStrategy,
+  isValidAuthenticityToken,
+  isValidPerFormCsrfToken,
+  isValidRequestOrigin,
   isVerifiedRequest,
+  markForSameOriginVerificationBang,
+  maskToken,
+  maskedAuthenticityToken,
   normalizeActionPath,
   normalizeRelativeActionPath,
+  perFormCsrfToken,
+  protectionMethodClass,
+  realCsrfToken,
+  requestAuthenticityTokens,
+  storageStrategy,
+  unmaskToken,
+  unverifiedRequestWarningMessage,
+  verifySameOriginRequest,
   type CsrfController,
+  type CsrfTokenStorage,
 } from "./request-forgery-protection.js";
 
 function controller(overrides: Partial<CsrfController> = {}): CsrfController {
@@ -195,6 +217,82 @@ describe("isVerifiedRequest", () => {
     expect(isVerifiedRequest(controller({ isAnyAuthenticityTokenValid: () => true }))).toBe(true);
     expect(isVerifiedRequest(controller({ isAnyAuthenticityTokenValid: () => false }))).toBe(false);
     expect(isVerifiedRequest(controller())).toBe(false);
+  });
+});
+
+describe("P20b/P20c smoke", () => {
+  function tokenC(overrides: Partial<CsrfController> = {}): CsrfController {
+    return {
+      request: {
+        method: "POST",
+        baseUrl: "https://example.com",
+        path: "/posts",
+        env: { "action_dispatch.request.csrf_token": generateCsrfToken() },
+      },
+      ...overrides,
+    };
+  }
+
+  it("mask/unmask round-trips and realCsrfToken is stable per request", () => {
+    const raw = decodeCsrfToken(generateCsrfToken());
+    expect(unmaskToken(decodeCsrfToken(maskToken(raw))).equals(raw)).toBe(true);
+    const c = tokenC();
+    expect(realCsrfToken(c).equals(realCsrfToken(c))).toBe(true);
+  });
+
+  it("isAnyAuthenticityTokenValid: masked global via param + X-CSRF; rejects empty", () => {
+    const c = tokenC();
+    const masked = maskToken(globalCsrfToken(c));
+    expect(isAnyAuthenticityTokenValid({ ...c, params: { authenticity_token: masked } })).toBe(
+      true,
+    );
+    expect(
+      isAnyAuthenticityTokenValid({ ...c, request: { ...c.request, xCsrfToken: masked } }),
+    ).toBe(true);
+    expect(isAnyAuthenticityTokenValid(c)).toBe(false);
+    expect(isValidAuthenticityToken(c, null, "")).toBe(false);
+  });
+
+  it("isValidPerFormCsrfToken + compareWith{Global,Real}Token", () => {
+    const c = tokenC({
+      perFormCsrfTokens: true,
+      request: {
+        method: "POST",
+        baseUrl: "https://example.com",
+        path: "/posts/",
+        env: { "action_dispatch.request.csrf_token": generateCsrfToken() },
+      },
+    });
+    expect(isValidPerFormCsrfToken(c, perFormCsrfToken(c, null, "/posts", "POST"))).toBe(true);
+    expect(compareWithGlobalToken(c, globalCsrfToken(c))).toBe(true);
+    expect(compareWithRealToken(c, realCsrfToken(c))).toBe(true);
+    expect(maskedAuthenticityToken(c, { action: "/posts", method: "POST" })).toBeTruthy();
+  });
+
+  it("requestAuthenticityTokens + formAuthenticityParam honor custom token name", () => {
+    const c = tokenC({
+      params: { my: "p" },
+      requestForgeryProtectionToken: "my",
+      request: { ...tokenC().request, xCsrfToken: "x" },
+    });
+    expect(formAuthenticityParam(c)).toBe("p");
+    expect(requestAuthenticityTokens(c)).toEqual(["p", "x"]);
+  });
+
+  it("protectionMethodClass maps names + passes class through", () => {
+    expect(protectionMethodClass("null_session")).toBe(NullSession);
+    expect(protectionMethodClass("reset_session")).toBe(ResetSession);
+    expect(protectionMethodClass("exception")).toBe(Exception);
+    expect(() => protectionMethodClass("nope" as never)).toThrow();
+  });
+
+  it("isStorageStrategy + storageStrategy dispatch and reject junk", () => {
+    expect(isStorageStrategy({ fetch() {}, store() {}, reset() {} })).toBe(true);
+    expect(isStorageStrategy(storageStrategy("session"))).toBe(true);
+    expect(isStorageStrategy(storageStrategy("cookie"))).toBe(true);
+    const c: CsrfTokenStorage = { fetch: () => null, store() {}, reset() {} };
+    expect(storageStrategy(c)).toBe(c);
+    expect(() => storageStrategy("bogus" as never)).toThrow();
   });
 });
 

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -328,24 +328,21 @@ const GLOBAL_CSRF_TOKEN_IDENTIFIER = "!real_csrf_token";
 
 /** @internal */
 export function generateCsrfToken(): string {
-  return getCrypto()
-    .randomBytes(AUTHENTICITY_TOKEN_LENGTH)
-    .toString("base64")
-    .replace(/\+/g, "-")
-    .replace(/\//g, "_")
-    .replace(/=+$/, "");
+  // Rails: SecureRandom.urlsafe_base64(AUTHENTICITY_TOKEN_LENGTH).
+  return encodeCsrfToken(getCrypto().randomBytes(AUTHENTICITY_TOKEN_LENGTH));
 }
 
 /** @internal */
 export function encodeCsrfToken(rawToken: Buffer): string {
-  return rawToken.toString("base64");
+  // Rails: Base64.urlsafe_encode64(csrf_token, padding: false)
+  return rawToken.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 /** @internal */
 export function decodeCsrfToken(encodedToken: string): Buffer {
-  const buf = Buffer.from(encodedToken.replace(/-/g, "+").replace(/_/g, "/"), "base64");
-  if (buf.length === 0 && encodedToken.length !== 0) throw new TypeError("invalid base64");
-  return buf;
+  // Rails: Base64.urlsafe_decode64 — raises ArgumentError on invalid input.
+  if (!/^[A-Za-z0-9+/_-]*={0,2}$/.test(encodedToken)) throw new TypeError("invalid base64");
+  return Buffer.from(encodedToken.replace(/-/g, "+").replace(/_/g, "/"), "base64");
 }
 
 /** @internal */
@@ -453,7 +450,9 @@ export function isValidPerFormCsrfToken(
   session?: unknown,
 ): boolean {
   if (!c.perFormCsrfTokens) return false;
-  const path = (c.request.path ?? "/").replace(/\/+$/, "") || "/";
+  const rawPath = c.request.path ?? "/";
+  // Rails: request.path.chomp("/") — strips a single trailing slash only.
+  const path = rawPath.length > 1 && rawPath.endsWith("/") ? rawPath.slice(0, -1) : rawPath;
   const method = c.request.requestMethod ?? c.request.method;
   return compareBuffers(token, perFormCsrfToken(c, session, path, method));
 }

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -226,6 +226,8 @@ export interface CsrfController {
   perFormCsrfTokens?: boolean;
   requestForgeryProtectionToken?: string;
   csrfTokenStorageStrategy?: CsrfTokenStorage;
+  /** Cookie jar — required when `storageStrategy("cookie")` is configured. */
+  cookies?: Record<string, string>;
   _markedForSameOriginVerification?: boolean;
   logger?: { warn(msg: string): void } | null;
   logWarningOnCsrfFailure?: boolean;
@@ -344,7 +346,10 @@ export function encodeCsrfToken(rawToken: Buffer): string {
 export function decodeCsrfToken(encodedToken: string): Buffer {
   // Rails: Base64.urlsafe_decode64 — raises ArgumentError on invalid input.
   if (!/^[A-Za-z0-9+/_-]*={0,2}$/.test(encodedToken)) throw new TypeError("invalid base64");
-  return Buffer.from(encodedToken.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+  // Reject impossible base64 lengths (length % 4 === 1 cannot encode any bytes).
+  const stripped = encodedToken.replace(/=+$/, "");
+  if (stripped.length % 4 === 1) throw new TypeError("invalid base64 length");
+  return Buffer.from(stripped.replace(/-/g, "+").replace(/_/g, "/"), "base64");
 }
 
 /** @internal */
@@ -531,11 +536,10 @@ export function storageStrategy(name: "session" | "cookie" | CsrfTokenStorage): 
   }
   if (name === "cookie") {
     const k = new CookieStore("csrf_token");
-    type CC = { cookies?: Record<string, string> };
     return {
-      fetch: (c) => k.fetch((c as CC).cookies ?? {}),
-      store: (c, t) => k.write((c as CC).cookies ?? {}, t),
-      reset: (c) => k.reset((c as CC).cookies ?? {}),
+      fetch: (c) => k.fetch(c.cookies ?? {}),
+      store: (c, t) => k.write((c.cookies ??= {}), t),
+      reset: (c) => k.reset(c.cookies ?? {}),
     };
   }
   if (isStorageStrategy(name)) return name;

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -5,6 +5,7 @@
  * @see https://api.rubyonrails.org/classes/ActionController/RequestForgeryProtection.html
  */
 
+import { getCrypto } from "@blazetrails/activesupport";
 import { ActionControllerError } from "./exceptions.js";
 
 export class InvalidAuthenticityToken extends ActionControllerError {
@@ -200,21 +201,35 @@ export interface CsrfRequest {
   origin?: string | null;
   baseUrl: string;
   path?: string;
+  requestMethod?: string;
   mediaType?: string | null;
   xhr?: boolean;
   xCsrfToken?: string | null;
+  /** Per-request token cache (mirrors `request.env[CSRF_TOKEN]`). */
+  env?: Record<string, unknown>;
+}
+
+/** @internal */
+export interface CsrfTokenStorage {
+  fetch(controller: CsrfController): string | null | undefined;
+  store(controller: CsrfController, token: string): void;
+  reset(controller: CsrfController): void;
 }
 
 /** @internal */
 export interface CsrfController {
   request: CsrfRequest;
   session?: { enabled?: () => boolean } | Record<string, unknown> | null;
+  params?: Record<string, unknown>;
   allowForgeryProtection?: boolean;
   forgeryProtectionOriginCheck?: boolean;
+  perFormCsrfTokens?: boolean;
+  requestForgeryProtectionToken?: string;
+  csrfTokenStorageStrategy?: CsrfTokenStorage;
   _markedForSameOriginVerification?: boolean;
   logger?: { warn(msg: string): void } | null;
   logWarningOnCsrfFailure?: boolean;
-  /** Supplied by P20c (token validation). */
+  /** Optional override used by tests/legacy callers. */
   isAnyAuthenticityTokenValid?: () => boolean;
 }
 
@@ -296,7 +311,236 @@ export function unverifiedRequestWarningMessage(controller: CsrfController): str
 export function isVerifiedRequest(controller: CsrfController): boolean {
   if (!isProtectAgainstForgery(controller)) return true;
   if (isGetOrHead(controller.request.method)) return true;
-  return isValidRequestOrigin(controller) && (controller.isAnyAuthenticityTokenValid?.() ?? false);
+  const valid = controller.isAnyAuthenticityTokenValid
+    ? controller.isAnyAuthenticityTokenValid()
+    : isAnyAuthenticityTokenValid(controller);
+  return isValidRequestOrigin(controller) && valid;
+}
+
+// ---------------------------------------------------------------------------
+// Token primitives + P20c verification predicates + strategy plumbing
+// (Rails: request_forgery_protection.rb privates)
+// ---------------------------------------------------------------------------
+
+const AUTHENTICITY_TOKEN_LENGTH = 32;
+const CSRF_TOKEN_ENV_KEY = "action_dispatch.request.csrf_token";
+const GLOBAL_CSRF_TOKEN_IDENTIFIER = "!real_csrf_token";
+
+/** @internal */
+export function generateCsrfToken(): string {
+  return getCrypto()
+    .randomBytes(AUTHENTICITY_TOKEN_LENGTH)
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "");
+}
+
+/** @internal */
+export function encodeCsrfToken(rawToken: Buffer): string {
+  return rawToken.toString("base64");
+}
+
+/** @internal */
+export function decodeCsrfToken(encodedToken: string): Buffer {
+  const buf = Buffer.from(encodedToken.replace(/-/g, "+").replace(/_/g, "/"), "base64");
+  if (buf.length === 0 && encodedToken.length !== 0) throw new TypeError("invalid base64");
+  return buf;
+}
+
+/** @internal */
+export function xorByteStrings(s1: Buffer, s2: Buffer): Buffer {
+  const out = Buffer.alloc(s1.length);
+  for (let i = 0; i < s1.length; i++) out[i] = s1[i] ^ s2[i];
+  return out;
+}
+
+/** @internal */
+export function realCsrfToken(controller: CsrfController, _session?: unknown): Buffer {
+  const env = (controller.request.env ??= {});
+  let encoded = env[CSRF_TOKEN_ENV_KEY] as string | undefined;
+  if (encoded == null) {
+    encoded = controller.csrfTokenStorageStrategy?.fetch(controller) ?? generateCsrfToken();
+    env[CSRF_TOKEN_ENV_KEY] = encoded;
+  }
+  return decodeCsrfToken(encoded);
+}
+
+/** @internal */
+export function csrfTokenHmac(c: CsrfController, session: unknown, identifier: string): Buffer {
+  return getCrypto()
+    .createHmac("sha256", realCsrfToken(c, session))
+    .update(identifier)
+    .digest()
+    .subarray(0, AUTHENTICITY_TOKEN_LENGTH);
+}
+
+/** @internal */
+export function globalCsrfToken(c: CsrfController, session?: unknown): Buffer {
+  return csrfTokenHmac(c, session, GLOBAL_CSRF_TOKEN_IDENTIFIER);
+}
+
+/** @internal */
+export function perFormCsrfToken(
+  c: CsrfController,
+  session: unknown,
+  actionPath: string,
+  method: string,
+): Buffer {
+  return csrfTokenHmac(c, session, `${actionPath}#${method.toLowerCase()}`);
+}
+
+/** @internal */
+export function maskToken(rawToken: Buffer): string {
+  const otp = getCrypto().randomBytes(AUTHENTICITY_TOKEN_LENGTH);
+  return encodeCsrfToken(Buffer.concat([otp, xorByteStrings(otp, rawToken)]));
+}
+
+/** @internal */
+export function unmaskToken(masked: Buffer): Buffer {
+  return xorByteStrings(
+    masked.subarray(0, AUTHENTICITY_TOKEN_LENGTH),
+    masked.subarray(AUTHENTICITY_TOKEN_LENGTH),
+  );
+}
+
+/** @internal */
+export function maskedAuthenticityToken(
+  c: CsrfController,
+  formOptions: { action?: string; method?: string } = {},
+): string {
+  const { action, method } = formOptions;
+  const requestPath = c.request.path ?? "/";
+  const raw =
+    c.perFormCsrfTokens && action && method
+      ? perFormCsrfToken(c, null, normalizeActionPath(action, requestPath), method)
+      : globalCsrfToken(c);
+  return maskToken(raw);
+}
+
+/** @internal */
+export function formAuthenticityParam(c: CsrfController): unknown {
+  return c.params?.[c.requestForgeryProtectionToken ?? "authenticity_token"];
+}
+
+/** @internal */
+export function requestAuthenticityTokens(c: CsrfController): unknown[] {
+  return [formAuthenticityParam(c), c.request.xCsrfToken];
+}
+
+function compareBuffers(a: Buffer, b: Buffer): boolean {
+  return a.length === b.length && getCrypto().timingSafeEqual(a, b);
+}
+
+/** @internal */
+export function compareWithRealToken(c: CsrfController, token: Buffer, session?: unknown): boolean {
+  return compareBuffers(token, realCsrfToken(c, session));
+}
+
+/** @internal */
+export function compareWithGlobalToken(
+  c: CsrfController,
+  token: Buffer,
+  session?: unknown,
+): boolean {
+  return compareBuffers(token, globalCsrfToken(c, session));
+}
+
+/** @internal */
+export function isValidPerFormCsrfToken(
+  c: CsrfController,
+  token: Buffer,
+  session?: unknown,
+): boolean {
+  if (!c.perFormCsrfTokens) return false;
+  const path = (c.request.path ?? "/").replace(/\/+$/, "") || "/";
+  const method = c.request.requestMethod ?? c.request.method;
+  return compareBuffers(token, perFormCsrfToken(c, session, path, method));
+}
+
+/** @internal */
+export function isValidAuthenticityToken(
+  c: CsrfController,
+  session: unknown,
+  encoded: unknown,
+): boolean {
+  if (typeof encoded !== "string" || encoded.length === 0) return false;
+  let masked: Buffer;
+  try {
+    masked = decodeCsrfToken(encoded);
+  } catch {
+    return false;
+  }
+  if (masked.length === AUTHENTICITY_TOKEN_LENGTH) return compareWithRealToken(c, masked, session);
+  if (masked.length === AUTHENTICITY_TOKEN_LENGTH * 2) {
+    const csrfToken = unmaskToken(masked);
+    return (
+      compareWithGlobalToken(c, csrfToken, session) ||
+      compareWithRealToken(c, csrfToken, session) ||
+      isValidPerFormCsrfToken(c, csrfToken, session)
+    );
+  }
+  return false;
+}
+
+/** @internal */
+export function isAnyAuthenticityTokenValid(c: CsrfController): boolean {
+  for (const token of requestAuthenticityTokens(c)) {
+    if (isValidAuthenticityToken(c, c.session, token)) return true;
+  }
+  return false;
+}
+
+export type ProtectionMethodName = "null_session" | "reset_session" | "exception";
+type ProtectionMethodCtor = new (controller: Controller) => ProtectionMethods;
+
+/** @internal */
+export function protectionMethodClass(
+  name: ProtectionMethodName | ProtectionMethodCtor,
+): ProtectionMethodCtor {
+  if (typeof name === "function") return name;
+  if (name === "null_session") return NullSession;
+  if (name === "reset_session") return ResetSession;
+  if (name === "exception") return Exception;
+  throw new TypeError(
+    "Invalid request forgery protection method, use :null_session, :exception, :reset_session, or a custom forgery protection class.",
+  );
+}
+
+/** @internal */
+export function isStorageStrategy(o: unknown): o is CsrfTokenStorage {
+  const s = o as CsrfTokenStorage | null;
+  return (
+    !!s &&
+    typeof s.fetch === "function" &&
+    typeof s.store === "function" &&
+    typeof s.reset === "function"
+  );
+}
+
+/** @internal */
+export function storageStrategy(name: "session" | "cookie" | CsrfTokenStorage): CsrfTokenStorage {
+  if (name === "session") {
+    const s = new SessionStore();
+    return {
+      fetch: (c) => s.fetch((c.session as Record<string, unknown>) ?? {}),
+      store: (c, t) => s.write((c.session ??= {}) as Record<string, unknown>, t),
+      reset: (c) => s.reset((c.session as Record<string, unknown>) ?? {}),
+    };
+  }
+  if (name === "cookie") {
+    const k = new CookieStore("csrf_token");
+    type CC = { cookies?: Record<string, string> };
+    return {
+      fetch: (c) => k.fetch((c as CC).cookies ?? {}),
+      store: (c, t) => k.write((c as CC).cookies ?? {}, t),
+      reset: (c) => k.reset((c as CC).cookies ?? {}),
+    };
+  }
+  if (isStorageStrategy(name)) return name;
+  throw new TypeError(
+    "Invalid CSRF token storage strategy, use :session, :cookie, or a custom CSRF token storage class.",
+  );
 }
 
 /** @internal */

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -327,7 +327,8 @@ export function isVerifiedRequest(controller: CsrfController): boolean {
 // ---------------------------------------------------------------------------
 
 const AUTHENTICITY_TOKEN_LENGTH = 32;
-const CSRF_TOKEN_ENV_KEY = "action_dispatch.request.csrf_token";
+// Rails: CSRF_TOKEN = "action_controller.csrf_token" (request_forgery_protection.rb:64).
+const CSRF_TOKEN_ENV_KEY = "action_controller.csrf_token";
 const GLOBAL_CSRF_TOKEN_IDENTIFIER = "!real_csrf_token";
 
 /** @internal */

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -421,8 +421,11 @@ export function maskedAuthenticityToken(
 ): string {
   const { action, method } = formOptions;
   const requestPath = c.request.path ?? "/";
+  // Rails: `per_form_csrf_tokens && action && method` — Ruby `&&` only treats
+  // nil/false as falsy, so an empty-string action ("submit to current path")
+  // still triggers per-form generation.
   const raw =
-    c.perFormCsrfTokens && action && method
+    c.perFormCsrfTokens && action != null && method != null
       ? perFormCsrfToken(c, null, normalizeActionPath(action, requestPath), method)
       : globalCsrfToken(c);
   return maskToken(raw);

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -364,7 +364,12 @@ export function realCsrfToken(controller: CsrfController, _session?: unknown): B
   const env = (controller.request.env ??= {});
   let encoded = env[CSRF_TOKEN_ENV_KEY] as string | undefined;
   if (encoded == null) {
-    encoded = controller.csrfTokenStorageStrategy?.fetch(controller) ?? generateCsrfToken();
+    // Rails: csrf_token_storage_strategy defaults to SessionStore.new at the
+    // class level (line 100 of request_forgery_protection.rb); mirror that
+    // here so a session-backed controller without explicit config still
+    // verifies tokens against its session-stored real token.
+    const strategy = (controller.csrfTokenStorageStrategy ??= storageStrategy("session"));
+    encoded = strategy.fetch(controller) ?? generateCsrfToken();
     env[CSRF_TOKEN_ENV_KEY] = encoded;
   }
   return decodeCsrfToken(encoded);
@@ -457,9 +462,8 @@ export function isValidPerFormCsrfToken(
   session?: unknown,
 ): boolean {
   if (!c.perFormCsrfTokens) return false;
-  const rawPath = c.request.path ?? "/";
-  // Rails: request.path.chomp("/") — strips a single trailing slash only.
-  const path = rawPath.length > 1 && rawPath.endsWith("/") ? rawPath.slice(0, -1) : rawPath;
+  // Rails: request.path.chomp("/") — strips a single trailing slash, so "/" → "".
+  const path = (c.request.path ?? "").replace(/\/$/, "");
   const method = c.request.requestMethod ?? c.request.method;
   return compareBuffers(token, perFormCsrfToken(c, session, path, method));
 }
@@ -552,7 +556,8 @@ export function storageStrategy(name: "session" | "cookie" | CsrfTokenStorage): 
 export function normalizeRelativeActionPath(relActionPath: string, requestPath: string): string {
   let path = requestPath + "/" + relActionPath;
   path = path.replace(/\/\.\//g, "/");
-  return path.endsWith("/") && path.length > 1 ? path.slice(0, -1) : path;
+  // Rails: uri.path.chomp("/") — single trailing slash, so "/" → "".
+  return path.endsWith("/") ? path.slice(0, -1) : path;
 }
 
 /** @internal */
@@ -573,5 +578,6 @@ export function normalizeActionPath(actionPath: string, requestPath: string): st
   } catch {
     parsedPath = actionPath;
   }
-  return parsedPath.endsWith("/") && parsedPath.length > 1 ? parsedPath.slice(0, -1) : parsedPath;
+  // Rails: uri.path.chomp("/") — single trailing slash, so "/" → "".
+  return parsedPath.endsWith("/") ? parsedPath.slice(0, -1) : parsedPath;
 }

--- a/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
+++ b/packages/actionpack/src/action-controller/metal/request-forgery-protection.ts
@@ -311,10 +311,12 @@ export function unverifiedRequestWarningMessage(controller: CsrfController): str
 export function isVerifiedRequest(controller: CsrfController): boolean {
   if (!isProtectAgainstForgery(controller)) return true;
   if (isGetOrHead(controller.request.method)) return true;
-  const valid = controller.isAnyAuthenticityTokenValid
+  // Rails: valid_request_origin? && any_authenticity_token_valid? — origin
+  // check short-circuits so a bad origin never reaches token storage.
+  if (!isValidRequestOrigin(controller)) return false;
+  return controller.isAnyAuthenticityTokenValid
     ? controller.isAnyAuthenticityTokenValid()
     : isAnyAuthenticityTokenValid(controller);
-  return isValidRequestOrigin(controller) && valid;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds the Rails-mirrored private methods on
`metal/request-forgery-protection.ts` that the verification predicates
(P20a, #1988) consume:

**Token primitives (P20b)** — `generateCsrfToken`, `encodeCsrfToken`,
`decodeCsrfToken`, `xorByteStrings`, `realCsrfToken`, `csrfTokenHmac`,
`globalCsrfToken`, `perFormCsrfToken`, `maskToken`, `unmaskToken`,
`maskedAuthenticityToken`.

**Validation + plumbing (P20c)** — `isAnyAuthenticityTokenValid`,
`requestAuthenticityTokens`, `isValidAuthenticityToken`,
`isValidPerFormCsrfToken`, `compareWithRealToken`, `compareWithGlobalToken`,
`formAuthenticityParam`, `protectionMethodClass`, `storageStrategy`,
`isStorageStrategy`.

`isVerifiedRequest` now calls `isAnyAuthenticityTokenValid` directly;
`CsrfController.isAnyAuthenticityTokenValid` is kept as an optional
override for tests/legacy callers.

`api:compare` for `metal/request_forgery_protection.rb`: **27/48 → 48/48 (100%)**.

P20b primitives didn't exist in module form yet (only as a class in
`action-dispatch/request-forgery-protection.ts`), so they're bundled
here — the two clusters are tightly coupled and combined LOC stays
under target.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/request-forgery-protection.test.ts` — 29 pass
- [x] `pnpm vitest run packages/actionpack/src/action-controller/controller/request-forgery-protection.test.ts` — 56 pass (no regressions to the legacy class-based path)
- [x] `pnpm api:compare --package actioncontroller --privates` — `metal/request_forgery_protection.rb` 100%