### PR TITLE
feat(actionpack): port ActionController::Live mixin (P18b)

### DIFF
--- a/packages/actionpack/src/action-controller/metal/live.test.ts
+++ b/packages/actionpack/src/action-controller/metal/live.test.ts
@@ -14,7 +14,7 @@ import {
   originalNewControllerThread,
   process,
   sendStream,
-  setResponseBody,
+  responseBody,
 } from "./live.js";
 
 function makeResponse() {
@@ -255,7 +255,7 @@ describe("ActionController::Live#process", () => {
 describe("ActionController::Live#response_body=", () => {
   it("assigns the body and closes the response", () => {
     const host = makeHost();
-    setResponseBody.call(host, "payload");
+    responseBody.call(host, "payload");
     expect(host.response.body).toBe("payload");
     expect(host.response.committed).toBe(true);
   });

--- a/packages/actionpack/src/action-controller/metal/live.test.ts
+++ b/packages/actionpack/src/action-controller/metal/live.test.ts
@@ -326,17 +326,20 @@ describe("ActionController::Live private helpers", () => {
 });
 
 describe("ActionController::Live::ClassMethods#make_response!", () => {
+  type Req = Parameters<typeof makeResponseBang>[0];
+  function mkReq(protocol: string): Req {
+    return { getHeader: (n: string) => (n === "SERVER_PROTOCOL" ? protocol : undefined) } as Req;
+  }
+
   it("returns a Live::Response for HTTP/1.1+ requests", () => {
-    const req = { getHeader: (n: string) => (n === "SERVER_PROTOCOL" ? "HTTP/1.1" : undefined) };
-    const res = makeResponseBang(req, () => new Response());
+    const res = makeResponseBang(mkReq("HTTP/1.1"), () => new Response());
     expect(res).toBeInstanceOf(Response);
     expect((res as Response).stream).toBeInstanceOf(Buffer);
   });
 
   it("defers to the parent factory for HTTP/1.0 requests", () => {
-    const req = { getHeader: (n: string) => (n === "SERVER_PROTOCOL" ? "HTTP/1.0" : undefined) };
     const sentinel = new Response();
-    const res = makeResponseBang(req, () => sentinel);
+    const res = makeResponseBang(mkReq("HTTP/1.0"), () => sentinel);
     expect(res).toBe(sentinel);
   });
 });

--- a/packages/actionpack/src/action-controller/metal/live.test.ts
+++ b/packages/actionpack/src/action-controller/metal/live.test.ts
@@ -1,6 +1,21 @@
 import { describe, expect, it, vi } from "vitest";
 
-import { Buffer, ClientDisconnected, Response, SSE } from "./live.js";
+import {
+  Buffer,
+  ClientDisconnected,
+  Response,
+  SSE,
+  cleanUpThreadLocals,
+  liveThreadPoolExecutor,
+  logError,
+  makeResponseBang,
+  newControllerThread,
+  originalCleanUpThreadLocals,
+  originalNewControllerThread,
+  process,
+  sendStream,
+  setResponseBody,
+} from "./live.js";
 
 function makeResponse() {
   return new Response();
@@ -196,5 +211,132 @@ describe("ActionController::Live::Response", () => {
     res.setHeader("set-cookie", "manual=1");
     res.stream.close();
     expect(res.headers["set-cookie"]).toBe("manual=1");
+  });
+});
+
+function makeHost() {
+  return {
+    request: { getHeader: () => undefined as string | undefined },
+    response: new Response(),
+  };
+}
+
+describe("ActionController::Live#process", () => {
+  it("awaits the action and commits the response", async () => {
+    const host = makeHost();
+    const seen: string[] = [];
+    await process.call(host, "show", async (n) => {
+      seen.push(n);
+      host.response.stream.write("hi");
+    });
+    expect(seen).toEqual(["show"]);
+    expect(host.response.committed).toBe(true);
+  });
+
+  it("re-raises pre-commit errors; routes post-commit errors through onError", async () => {
+    await expect(
+      process.call(makeHost(), "show", () => {
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+
+    const host = makeHost();
+    const fired = vi.fn();
+    host.response.stream.onError(fired);
+    await process.call(host, "show", async () => {
+      host.response.stream.write("partial");
+      host.response.close();
+      throw new Error("post");
+    });
+    expect(fired).toHaveBeenCalledOnce();
+  });
+});
+
+describe("ActionController::Live#response_body=", () => {
+  it("assigns the body and closes the response", () => {
+    const host = makeHost();
+    setResponseBody.call(host, "payload");
+    expect(host.response.body).toBe("payload");
+    expect(host.response.committed).toBe(true);
+  });
+});
+
+describe("ActionController::Live#send_stream", () => {
+  it("sets headers from filename, yields the stream, falls back to octet-stream", async () => {
+    const a = makeHost();
+    await sendStream.call(a, { filename: "subscribers.csv" }, (s) => s.write("x\n"));
+    expect(a.response.headers["content-type"]).toMatch(/csv/);
+    expect(a.response.headers["content-disposition"]).toContain("subscribers.csv");
+    expect(a.response.headers["content-disposition"]).toContain("attachment");
+
+    const b = makeHost();
+    await sendStream.call(b, { filename: "blob.zzz" }, () => {});
+    expect(b.response.headers["content-type"]).toBe("application/octet-stream");
+  });
+
+  it("accepts an explicit type string", async () => {
+    const host = makeHost();
+    await sendStream.call(host, { filename: "data.bin", type: "application/x-foo" }, () => {});
+    expect(host.response.headers["content-type"]).toBe("application/x-foo");
+  });
+
+  it("closes the stream even when the block throws", async () => {
+    const host = makeHost();
+    await expect(
+      sendStream.call(host, { filename: "x.csv" }, () => {
+        throw new Error("write failed");
+      }),
+    ).rejects.toThrow("write failed");
+    expect(host.response.stream.closed).toBe(true);
+  });
+});
+
+describe("ActionController::Live private helpers", () => {
+  it("newControllerThread invokes the block on the next microtask", async () => {
+    const host = makeHost();
+    const order: string[] = [];
+    const p = newControllerThread.call(host, () => {
+      order.push("inside");
+    });
+    order.push("after-call");
+    await p;
+    expect(order).toEqual(["after-call", "inside"]);
+  });
+
+  it("cleanUpThreadLocals is a no-op; originals are reference-equal; pool is a singleton", () => {
+    expect(() => cleanUpThreadLocals.call(makeHost(), [], null)).not.toThrow();
+    expect(originalNewControllerThread).toBe(newControllerThread);
+    expect(originalCleanUpThreadLocals).toBe(cleanUpThreadLocals);
+    expect(liveThreadPoolExecutor()).toBe(liveThreadPoolExecutor());
+  });
+
+  it("logError writes via the controller logger at fatal", () => {
+    const fatal = vi.fn();
+    logError.call({ logger: { fatal } }, new Error("oops"));
+    expect(fatal).toHaveBeenCalledOnce();
+    const arg = fatal.mock.calls[0][0];
+    const rendered = typeof arg === "function" ? (arg as () => string)() : arg;
+    expect(rendered).toContain("Error");
+    expect(rendered).toContain("oops");
+  });
+
+  it("logError silently no-ops when no logger is configured", () => {
+    expect(() => logError.call({}, new Error("oops"))).not.toThrow();
+  });
+});
+
+describe("ActionController::Live::ClassMethods#make_response!", () => {
+  it("returns a Live::Response for HTTP/1.1+ requests", () => {
+    const req = { getHeader: (n: string) => (n === "SERVER_PROTOCOL" ? "HTTP/1.1" : undefined) };
+    const res = makeResponseBang(req, () => new Response());
+    expect(res).toBeInstanceOf(Response);
+    expect((res as Response).stream).toBeInstanceOf(Buffer);
+  });
+
+  it("defers to the parent factory for HTTP/1.0 requests", () => {
+    const req = { getHeader: (n: string) => (n === "SERVER_PROTOCOL" ? "HTTP/1.0" : undefined) };
+    const sentinel = new Response();
+    const res = makeResponseBang(req, () => sentinel);
+    expect(res).toBe(sentinel);
   });
 });

--- a/packages/actionpack/src/action-controller/metal/live.ts
+++ b/packages/actionpack/src/action-controller/metal/live.ts
@@ -7,6 +7,7 @@
 
 import { ContentDisposition } from "../../action-dispatch/http/content-disposition.js";
 import { MimeType } from "../../action-dispatch/http/mime-type.js";
+import type { Request } from "../../action-dispatch/http/request.js";
 import { Response as DispatchResponse } from "../../action-dispatch/http/response.js";
 
 export class ClientDisconnected extends Error {
@@ -291,6 +292,7 @@ export async function process(
   runAction: (n: string) => void | Promise<void>,
 ): Promise<void> {
   let error: unknown = undefined;
+  let errorSet = false;
   await newControllerThread.call(this, async () => {
     try {
       await runAction(name);
@@ -311,13 +313,14 @@ export async function process(
         }
       } else {
         error = e;
+        errorSet = true;
       }
     } finally {
       cleanUpThreadLocals.call(this, [], null);
       if (!this.response.committed) this.response.close();
     }
   });
-  if (error) throw error;
+  if (errorSet) throw error;
 }
 
 /** Mirrors `ActionController::Live#response_body=`. */
@@ -398,13 +401,13 @@ export function liveThreadPoolExecutor(): LiveExecutor {
 /** Mirrors `ActionController::Live::ClassMethods#make_response!`. HTTP/1.0
  *  has no chunked transfer encoding, so streaming defers to the parent factory. */
 export function makeResponseBang(
-  request: { getHeader?(name: string): string | undefined },
+  request: Request,
   superFactory: () => DispatchResponse,
 ): DispatchResponse {
-  const protocol = request.getHeader?.("SERVER_PROTOCOL") ?? request.getHeader?.("HTTP_VERSION");
+  const protocol = request.getHeader("SERVER_PROTOCOL") ?? request.getHeader("HTTP_VERSION");
   if (protocol === "HTTP/1.0") return superFactory();
   const res = new Response();
-  res.request = request as unknown as Response["request"];
+  res.request = request;
   return res;
 }
 

--- a/packages/actionpack/src/action-controller/metal/live.ts
+++ b/packages/actionpack/src/action-controller/metal/live.ts
@@ -321,7 +321,7 @@ export async function process(
 }
 
 /** Mirrors `ActionController::Live#response_body=`. */
-export function setResponseBody(this: LiveControllerHost, body: string): void {
+export function responseBody(this: LiveControllerHost, body: string): void {
   this.response.body = body;
   this.response.close();
 }

--- a/packages/actionpack/src/action-controller/metal/live.ts
+++ b/packages/actionpack/src/action-controller/metal/live.ts
@@ -5,6 +5,8 @@
  * @see https://api.rubyonrails.org/classes/ActionController/Live.html
  */
 
+import { ContentDisposition } from "../../action-dispatch/http/content-disposition.js";
+import { MimeType } from "../../action-dispatch/http/mime-type.js";
 import { Response as DispatchResponse } from "../../action-dispatch/http/response.js";
 
 export class ClientDisconnected extends Error {
@@ -264,4 +266,155 @@ export class Response extends DispatchResponse {
     for (const part of body) buf.write(part);
     return buf;
   }
+}
+
+// === ActionController::Live mixin ===
+// JS has no threads, so newControllerThread runs the block on the next
+// microtask. Pre-commit errors propagate; post-commit errors route through
+// Buffer.callOnError + logError, matching Rails' control flow.
+
+interface LoggerLike {
+  fatal(message: string | (() => string)): void;
+}
+
+export interface LiveControllerHost {
+  request: { getHeader?(name: string): string | undefined; format?: unknown };
+  response: Response;
+  logger?: LoggerLike;
+}
+
+/** Mirrors `ActionController::Live#process`. `runAction` stands in for
+ *  Rails' `super(name)`, since TS has no super for assigned methods. */
+export async function process(
+  this: LiveControllerHost,
+  name: string,
+  runAction: (n: string) => void | Promise<void>,
+): Promise<void> {
+  let error: unknown = undefined;
+  await newControllerThread.call(this, async () => {
+    try {
+      await runAction(name);
+    } catch (e) {
+      const resp = this.response;
+      if (resp?.committed) {
+        try {
+          resp.stream.callOnError();
+        } catch (inner) {
+          logError.call(this, inner);
+        } finally {
+          logError.call(this, e);
+          try {
+            resp.stream.close();
+          } catch {
+            /* already closed */
+          }
+        }
+      } else {
+        error = e;
+      }
+    } finally {
+      cleanUpThreadLocals.call(this, [], null);
+      if (!this.response.committed) this.response.close();
+    }
+  });
+  if (error) throw error;
+}
+
+/** Mirrors `ActionController::Live#response_body=`. */
+export function setResponseBody(this: LiveControllerHost, body: string): void {
+  this.response.body = body;
+  this.response.close();
+}
+
+export interface SendStreamOptions {
+  filename: string;
+  disposition?: string;
+  type?: string | symbol | null;
+}
+
+/** Mirrors `ActionController::Live#send_stream`. */
+export async function sendStream(
+  this: LiveControllerHost,
+  options: SendStreamOptions,
+  block: (stream: Buffer) => void | Promise<void>,
+): Promise<void> {
+  const { filename, type } = options;
+  const disposition = options.disposition ?? "attachment";
+
+  let resolved =
+    typeof type === "string"
+      ? type
+      : typeof type === "symbol"
+        ? (MimeType.lookup(type.description ?? "")?.toString() ?? null)
+        : null;
+  if (!resolved) {
+    const dot = filename.lastIndexOf(".");
+    const ext = dot >= 0 ? filename.slice(dot + 1).toLowerCase() : "";
+    resolved = (ext && MimeType.lookupByExtension(ext)?.toString()) || "application/octet-stream";
+  }
+
+  const res = this.response;
+  res.setHeader("content-type", resolved);
+  res.setHeader("content-disposition", ContentDisposition.format({ disposition, filename }));
+
+  try {
+    await block(res.stream);
+  } finally {
+    res.stream.close();
+  }
+}
+
+/** @internal */
+export async function newControllerThread(
+  this: LiveControllerHost,
+  block: () => void | Promise<void>,
+): Promise<void> {
+  await liveThreadPoolExecutor().post(block);
+}
+
+/** @internal No-op — Ruby clears copied thread-locals; JS shares one context. */
+export function cleanUpThreadLocals(this: LiveControllerHost, _l: unknown, _t: unknown): void {}
+
+/** Pre-test-override alias; Rails' test_case.rb re-aliases the public method
+ *  to run inline, so the originals stay available for parity. */
+export const originalNewControllerThread = newControllerThread;
+export const originalCleanUpThreadLocals = cleanUpThreadLocals;
+
+interface LiveExecutor {
+  post(fn: () => void | Promise<void>): Promise<void>;
+}
+let _liveExecutor: LiveExecutor | undefined;
+
+/** @internal */
+export function liveThreadPoolExecutor(): LiveExecutor {
+  return (_liveExecutor ??= {
+    post: async (fn) => {
+      await Promise.resolve();
+      await fn();
+    },
+  });
+}
+
+/** Mirrors `ActionController::Live::ClassMethods#make_response!`. HTTP/1.0
+ *  has no chunked transfer encoding, so streaming defers to the parent factory. */
+export function makeResponseBang(
+  request: { getHeader?(name: string): string | undefined },
+  superFactory: () => DispatchResponse,
+): DispatchResponse {
+  const protocol = request.getHeader?.("SERVER_PROTOCOL") ?? request.getHeader?.("HTTP_VERSION");
+  if (protocol === "HTTP/1.0") return superFactory();
+  const res = new Response();
+  res.request = request as unknown as Response["request"];
+  return res;
+}
+
+/** @internal Mirrors `ActionController::Live#log_error`. */
+export function logError(this: { logger?: LoggerLike }, exception: unknown): void {
+  const logger = this.logger;
+  if (!logger) return;
+  const err = exception as { name?: string; message?: string; stack?: string };
+  const name = err?.name ?? "Error";
+  const message = err?.message ?? String(exception);
+  const stack = err?.stack ?? "";
+  logger.fatal(() => `\n${name} (${message}):\n  ${stack}\n\n`);
 }


### PR DESCRIPTION
## Summary

Implements the 10 `ActionController::Live` mixin methods called out by
P18b in `docs/actioncontroller-100-percent.md`:

- `process`, `responseBody=` (`setResponseBody`), `sendStream`
- `newControllerThread`, `cleanUpThreadLocals`, `logError` (private)
- `originalNewControllerThread`, `originalCleanUpThreadLocals` (parity aliases)
- `liveThreadPoolExecutor` (process-wide executor)
- `makeResponseBang` (Live `ClassMethods#make_response!`)

Closes `metal/live.rb` 17/27 → 27/27.

## Design notes

JS has no threads, so `newControllerThread` posts the block onto the next
microtask via a process-wide `liveThreadPoolExecutor`. Rails' control flow
is preserved end-to-end: pre-commit errors propagate to the caller, while
post-commit errors flow through `Buffer#callOnError` followed by
`logError`. `cleanUpThreadLocals` is a documented no-op (JS shares a
single execution context).

`process` takes an explicit `runAction` parameter standing in for Rails'
`super(name)`, since TS has no `super` for functions assigned directly to
a class.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/live.test.ts` — 36 tests pass
- [x] `pnpm lint --fix` on the touched files clean
- [x] Diff is 299 LOC, under the 300 ceiling