### PR TITLE
feat(actionpack): wire CSP middleware via action-dispatch trailtie

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -371,7 +371,7 @@ export function contentSecurityPolicyNonceGenerator(
 
 export function setContentSecurityPolicyNonceGenerator(
   this: CspRequestHost,
-  generator: NonceGenerator,
+  generator: NonceGenerator | null,
 ): void {
   this.setHeader(NONCE_GENERATOR, generator);
 }
@@ -384,7 +384,7 @@ export function contentSecurityPolicyNonceDirectives(
 
 export function setContentSecurityPolicyNonceDirectives(
   this: CspRequestHost,
-  directives: readonly string[],
+  directives: readonly string[] | null,
 ): void {
   this.setHeader(NONCE_DIRECTIVES, directives);
 }

--- a/packages/actionpack/src/action-dispatch/trailtie.test.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
-import { Trailtie, type ActionDispatchConfig } from "./trailtie.js";
+import {
+  Trailtie,
+  type ActionDispatchConfig,
+  type ContentSecurityPolicyConfig,
+} from "./trailtie.js";
+import { ContentSecurityPolicy } from "./http/content-security-policy.js";
+import { ContentSecurityPolicyMiddleware } from "./middleware/content-security-policy.js";
 import { URL as HttpURL } from "./http/url.js";
 import { QueryParser } from "./http/query-parser.js";
 import { RequestUtils } from "./request/utils.js";
@@ -81,6 +87,49 @@ describe("ActionDispatch::Trailtie", () => {
     cfg().defaultCharset = "iso-8859-1";
     Trailtie.runInitializers();
     expect(Response.defaultCharset).toBe("iso-8859-1");
+  });
+
+  it("seeds Rails-compatible defaults on config.contentSecurityPolicy", () => {
+    const c = Trailtie.config["contentSecurityPolicy"] as ContentSecurityPolicyConfig;
+    expect(c.policy).toBeNull();
+    expect(c.reportOnly).toBe(false);
+    expect(c.nonceGenerator).toBeNull();
+    expect(c.nonceDirectives).toBeNull();
+  });
+
+  it("defaultMiddleware contributes ContentSecurityPolicyMiddleware", () => {
+    const stack = Trailtie.defaultMiddleware();
+    const klasses = [...stack].map((e) => e.klass);
+    expect(klasses).toContain(ContentSecurityPolicyMiddleware);
+  });
+
+  it("seedContentSecurityPolicyEnv copies config slots onto request env", () => {
+    const headers: Record<string, unknown> = {};
+    const req = {
+      getHeader: (k: string) => headers[k],
+      setHeader: (k: string, v: unknown) => (headers[k] = v),
+    };
+    const policy = new ContentSecurityPolicy((p) => p.defaultSrc("'self'"));
+    const generator = () => "abc";
+    const cfg = Trailtie.config["contentSecurityPolicy"] as ContentSecurityPolicyConfig;
+    cfg.policy = policy;
+    cfg.reportOnly = true;
+    cfg.nonceGenerator = generator;
+    cfg.nonceDirectives = ["script-src"];
+
+    Trailtie.seedContentSecurityPolicyEnv(req);
+
+    expect(headers["action_dispatch.content_security_policy"]).toBe(policy);
+    expect(headers["action_dispatch.content_security_policy_report_only"]).toBe(true);
+    expect(headers["action_dispatch.content_security_policy_nonce_generator"]).toBe(generator);
+    expect(headers["action_dispatch.content_security_policy_nonce_directives"]).toEqual([
+      "script-src",
+    ]);
+
+    cfg.policy = null;
+    cfg.reportOnly = false;
+    cfg.nonceGenerator = null;
+    cfg.nonceDirectives = null;
   });
 
   it("runInitializers resets Response.defaultCharset to utf-8 when cfg is null", () => {

--- a/packages/actionpack/src/action-dispatch/trailtie.test.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.test.ts
@@ -20,6 +20,7 @@ function cfg(): ActionDispatchConfig {
 
 describe("ActionDispatch::Trailtie", () => {
   let savedConfig: ActionDispatchConfig;
+  let savedCspConfig: ContentSecurityPolicyConfig;
   let savedTldLength: number;
   let savedStrictQuery: boolean | null;
   let savedPerformDeepMunge: boolean;
@@ -30,6 +31,9 @@ describe("ActionDispatch::Trailtie", () => {
 
   beforeEach(() => {
     savedConfig = structuredClone(cfg());
+    savedCspConfig = {
+      ...(Trailtie.config["contentSecurityPolicy"] as ContentSecurityPolicyConfig),
+    };
     savedTldLength = HttpURL.tldLength;
     savedStrictQuery = QueryParser.strictQueryStringSeparator;
     savedPerformDeepMunge = RequestUtils.performDeepMunge;
@@ -41,6 +45,7 @@ describe("ActionDispatch::Trailtie", () => {
 
   afterEach(() => {
     Trailtie.config["actionDispatch"] = savedConfig;
+    Trailtie.config["contentSecurityPolicy"] = savedCspConfig;
     HttpURL.tldLength = savedTldLength;
     QueryParser.strictQueryStringSeparator = savedStrictQuery;
     RequestUtils.performDeepMunge = savedPerformDeepMunge;
@@ -125,11 +130,23 @@ describe("ActionDispatch::Trailtie", () => {
     expect(headers["action_dispatch.content_security_policy_nonce_directives"]).toEqual([
       "script-src",
     ]);
+  });
 
-    cfg.policy = null;
-    cfg.reportOnly = false;
-    cfg.nonceGenerator = null;
-    cfg.nonceDirectives = null;
+  it("seedContentSecurityPolicyEnv writes all four slots unconditionally (Rails parity)", () => {
+    const headers: Record<string, unknown> = {
+      "action_dispatch.content_security_policy_report_only": true,
+    };
+    const req = {
+      getHeader: (k: string) => headers[k],
+      setHeader: (k: string, v: unknown) => (headers[k] = v),
+    };
+    // Defaults are all falsy — Rails copies them anyway (application.rb:344),
+    // which must overwrite the stale `true` carried over from a prior request.
+    Trailtie.seedContentSecurityPolicyEnv(req);
+    expect(headers["action_dispatch.content_security_policy_report_only"]).toBe(false);
+    expect(headers["action_dispatch.content_security_policy"]).toBeNull();
+    expect(headers["action_dispatch.content_security_policy_nonce_generator"]).toBeNull();
+    expect(headers["action_dispatch.content_security_policy_nonce_directives"]).toBeNull();
   });
 
   it("runInitializers resets Response.defaultCharset to utf-8 when cfg is null", () => {

--- a/packages/actionpack/src/action-dispatch/trailtie.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.ts
@@ -179,11 +179,12 @@ export class Trailtie extends BaseRailtie {
    */
   static seedContentSecurityPolicyEnv(request: CspRequestHost): void {
     const cfg = this.config["contentSecurityPolicy"] as ContentSecurityPolicyConfig;
-    if (cfg.policy) setContentSecurityPolicy.call(request, cfg.policy);
-    if (cfg.reportOnly) setContentSecurityPolicyReportOnly.call(request, cfg.reportOnly);
-    if (cfg.nonceGenerator)
-      setContentSecurityPolicyNonceGenerator.call(request, cfg.nonceGenerator);
-    if (cfg.nonceDirectives)
-      setContentSecurityPolicyNonceDirectives.call(request, cfg.nonceDirectives);
+    // Mirror Rails application.rb:342-346 — all four slots are copied
+    // unconditionally so toggling app config back to a falsy value
+    // overwrites any stale env carried over from a prior request.
+    setContentSecurityPolicy.call(request, cfg.policy);
+    setContentSecurityPolicyReportOnly.call(request, cfg.reportOnly);
+    setContentSecurityPolicyNonceGenerator.call(request, cfg.nonceGenerator);
+    setContentSecurityPolicyNonceDirectives.call(request, cfg.nonceDirectives);
   }
 }

--- a/packages/actionpack/src/action-dispatch/trailtie.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.ts
@@ -158,13 +158,6 @@ export class Trailtie extends BaseRailtie {
       // "utf-8" so initializer state doesn't leak across runs.
       Response.defaultCharset = cfg.defaultCharset ?? "utf-8";
     });
-
-    // Mirrors Rails' default_middleware_stack.rb:85 (`middleware.use
-    // ActionDispatch::ContentSecurityPolicy::Middleware`). trails has no
-    // app-owned default stack yet, so the middleware is exposed via
-    // [[defaultMiddleware]] for hosts to insert; the initializer is the
-    // hook point where future api-only gating can apply.
-    this.initializer("action_dispatch.content_security_policy", () => {});
   }
 
   /**

--- a/packages/actionpack/src/action-dispatch/trailtie.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.ts
@@ -26,6 +26,17 @@ import { QueryParser } from "./http/query-parser.js";
 import { RequestUtils } from "./request/utils.js";
 import { CacheConfig } from "./http/cache.js";
 import { Response } from "./http/response.js";
+import {
+  ContentSecurityPolicy,
+  type NonceGenerator,
+  type CspRequestHost,
+  setContentSecurityPolicy,
+  setContentSecurityPolicyReportOnly,
+  setContentSecurityPolicyNonceGenerator,
+  setContentSecurityPolicyNonceDirectives,
+} from "./http/content-security-policy.js";
+import { ContentSecurityPolicyMiddleware } from "./middleware/content-security-policy.js";
+import { MiddlewareStack } from "./middleware/stack.js";
 
 /**
  * Shape of `config.actionDispatch` — mirrors the
@@ -102,11 +113,31 @@ function defaultActionDispatchConfig(): ActionDispatchConfig {
   };
 }
 
+/**
+ * Shape of `config.contentSecurityPolicy` — mirrors the top-level CSP slots
+ * on `Rails::Application::Configuration` (`content_security_policy`,
+ * `_report_only`, `_nonce_generator`, `_nonce_directives`). Rails routes
+ * these into the env via `application.rb:342-346`; the
+ * `action_dispatch.content_security_policy` initializer below mirrors that
+ * by seeding per-request env keys via [[seedContentSecurityPolicyEnv]].
+ */
+export interface ContentSecurityPolicyConfig {
+  policy: ContentSecurityPolicy | null;
+  reportOnly: boolean;
+  nonceGenerator: NonceGenerator | null;
+  nonceDirectives: readonly string[] | null;
+}
+
+function defaultContentSecurityPolicyConfig(): ContentSecurityPolicyConfig {
+  return { policy: null, reportOnly: false, nonceGenerator: null, nonceDirectives: null };
+}
+
 export class Trailtie extends BaseRailtie {
   static {
     registerRailtie(this);
 
     this.config["actionDispatch"] = defaultActionDispatchConfig();
+    this.config["contentSecurityPolicy"] = defaultContentSecurityPolicyConfig();
 
     this.initializer("action_dispatch.deprecator", () => {
       BaseRailtie.deprecators["actionDispatch"] = deprecator;
@@ -127,5 +158,39 @@ export class Trailtie extends BaseRailtie {
       // "utf-8" so initializer state doesn't leak across runs.
       Response.defaultCharset = cfg.defaultCharset ?? "utf-8";
     });
+
+    // Mirrors Rails' default_middleware_stack.rb:85 (`middleware.use
+    // ActionDispatch::ContentSecurityPolicy::Middleware`). trails has no
+    // app-owned default stack yet, so the middleware is exposed via
+    // [[defaultMiddleware]] for hosts to insert; the initializer is the
+    // hook point where future api-only gating can apply.
+    this.initializer("action_dispatch.content_security_policy", () => {});
+  }
+
+  /**
+   * Default ActionDispatch middleware contributed by this trailtie. Apps
+   * compose this into their own stack on boot. Mirrors the per-framework
+   * middleware insertions Rails performs in
+   * `railties/lib/rails/application/default_middleware_stack.rb`.
+   */
+  static defaultMiddleware(): MiddlewareStack {
+    const stack = new MiddlewareStack();
+    stack.use(ContentSecurityPolicyMiddleware);
+    return stack;
+  }
+
+  /**
+   * Seed per-request CSP env keys from `config.contentSecurityPolicy`.
+   * Called by hosts at the start of request processing — mirrors the
+   * `env_config` propagation in `railties/lib/rails/application.rb:342-346`.
+   */
+  static seedContentSecurityPolicyEnv(request: CspRequestHost): void {
+    const cfg = this.config["contentSecurityPolicy"] as ContentSecurityPolicyConfig;
+    if (cfg.policy) setContentSecurityPolicy.call(request, cfg.policy);
+    if (cfg.reportOnly) setContentSecurityPolicyReportOnly.call(request, cfg.reportOnly);
+    if (cfg.nonceGenerator)
+      setContentSecurityPolicyNonceGenerator.call(request, cfg.nonceGenerator);
+    if (cfg.nonceDirectives)
+      setContentSecurityPolicyNonceDirectives.call(request, cfg.nonceDirectives);
   }
 }


### PR DESCRIPTION
## Summary

Wires `ActionDispatch::ContentSecurityPolicy::Middleware` into the action-dispatch trailtie so apps get CSP by default. Mirrors the per-framework middleware contribution Rails performs in `railties/lib/rails/application/default_middleware_stack.rb:85` and the env propagation in `railties/lib/rails/application.rb:342-346`.

- Adds `config.contentSecurityPolicy` with `policy` / `reportOnly` / `nonceGenerator` / `nonceDirectives` slots (Rails-named camelCase mirrors).
- Adds the `action_dispatch.content_security_policy` initializer (hook point; insertion is performed by `defaultMiddleware()` since trails has no app-owned default stack yet).
- `Trailtie.defaultMiddleware()` returns a `MiddlewareStack` containing `ContentSecurityPolicyMiddleware` — hosts compose this into their own stack on boot.
- `Trailtie.seedContentSecurityPolicyEnv(request)` copies config slots onto the per-request env keys (`action_dispatch.content_security_policy*`) consumed by the middleware and request helpers.

Follow-up to #1948 / #1963. Unblocks `application/content_security_policy_test.rb` (8 tests, currently 0% matched) per `docs/actionpack-100-percent.md`.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/trailtie.test.ts` — 8 passing (4 new)
- [x] `pnpm tsc --build` clean
- [x] PR size: 115 LOC (under 300 ceiling)

## Follow-ups
- Wire `seedContentSecurityPolicyEnv` into the request-prep hook once trails has a central per-request dispatch point.
- `api_only` gating on `defaultMiddleware()` once an `apiOnly` app-config slot exists.