### PR TITLE
test(activerecord): defineSchema for CounterCache associations cluster

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -1592,8 +1592,20 @@ describe("HasAndBelongsToManyAssociations", () => {
 describe("CounterCache", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      topics: {
+        title: "string",
+        replies_count: { type: "integer", default: 0 },
+      },
+      replies: { content: "string", topic_id: "integer" },
+      categories: {
+        name: "string",
+        num_products: { type: "integer", default: 0 },
+      },
+      products: { name: "string", category_id: "integer" },
+    });
   });
 
   // Rails: test_update_counter_cache_on_create


### PR DESCRIPTION
## Summary

- Migrate the `CounterCache` describe block in `packages/activerecord/src/associations.test.ts` to call `defineSchema(adapter, {...})` in `beforeEach` instead of relying on the test-adapter lazy auto-schema path.
- Tables declared: `topics`, `replies`, `categories`, `products`.

Part of Phase 5/7 of `docs/tm-unification-plan.md` — unblocks deletion of the auto-schema fallback by removing one of the named offender clusters.

## Test plan

- [x] \`AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/associations.test.ts -t "CounterCache"\` passes (4/4)
- [x] \`pnpm vitest run packages/activerecord/src/associations.test.ts -t "CounterCache"\` still passes