### PR TITLE
test(activerecord): unblock invertible-migration under AR_NO_AUTO_SCHEMA

### DIFF
--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -484,11 +484,20 @@ describe("Reversible Migrations", () => {
     // Table was dropped; selecting from it raises (auto-schema off) or
     // returns empty rows (auto-schema on, pre-Phase-7). Only swallow the
     // missing-table error so unrelated failures still surface.
-    const afterDrop = await adapter.execute(`SELECT * FROM "posts"`).catch((e: unknown) => {
-      const msg = String((e as Error)?.message ?? e);
-      if (/no such table|does not exist|doesn't exist/i.test(msg)) return [] as unknown[];
-      throw e;
-    });
+    const afterDrop = await adapter
+      .execute(`SELECT * FROM "posts"`)
+      .catch((e: unknown): Record<string, unknown>[] => {
+        const msg = String((e as Error)?.message ?? e);
+        // Mirrors the table-missing patterns in test-adapter.ts handleMissingSchemaError.
+        if (
+          /relation "\w+" does not exist|Table '(?:\w+\.)?\w+' doesn't exist|no such table:/i.test(
+            msg,
+          )
+        ) {
+          return [];
+        }
+        throw e;
+      });
     expect(afterDrop).toHaveLength(0);
   });
 });

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -481,8 +481,7 @@ describe("Reversible Migrations", () => {
 
     // Down — drops the table
     await migration.run(adapter, "down");
-    // Table was dropped; SchemaAdapter returns empty rows on a missing-table select.
-    const afterDrop = await adapter.execute(`SELECT * FROM "posts"`);
-    expect(afterDrop).toHaveLength(0);
+    // Table was dropped; selecting from it now raises.
+    await expect(adapter.execute(`SELECT * FROM "posts"`)).rejects.toThrow(/no such table|posts/);
   });
 });

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -482,8 +482,13 @@ describe("Reversible Migrations", () => {
     // Down — drops the table
     await migration.run(adapter, "down");
     // Table was dropped; selecting from it raises (auto-schema off) or
-    // returns empty rows (auto-schema on, pre-Phase-7).
-    const afterDrop = await adapter.execute(`SELECT * FROM "posts"`).catch(() => [] as unknown[]);
+    // returns empty rows (auto-schema on, pre-Phase-7). Only swallow the
+    // missing-table error so unrelated failures still surface.
+    const afterDrop = await adapter.execute(`SELECT * FROM "posts"`).catch((e: unknown) => {
+      const msg = String((e as Error)?.message ?? e);
+      if (/no such table|does not exist|doesn't exist/i.test(msg)) return [] as unknown[];
+      throw e;
+    });
     expect(afterDrop).toHaveLength(0);
   });
 });

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -481,7 +481,9 @@ describe("Reversible Migrations", () => {
 
     // Down — drops the table
     await migration.run(adapter, "down");
-    // Table was dropped; selecting from it now raises.
-    await expect(adapter.execute(`SELECT * FROM "posts"`)).rejects.toThrow(/no such table|posts/);
+    // Table was dropped; selecting from it raises (auto-schema off) or
+    // returns empty rows (auto-schema on, pre-Phase-7).
+    const afterDrop = await adapter.execute(`SELECT * FROM "posts"`).catch(() => [] as unknown[]);
+    expect(afterDrop).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## Summary

Phase 7 of `docs/tm-unification-plan.md` deletes `SchemaAdapter`'s auto-schema / missing-table recovery. This PR keeps three flagged test files green under `AR_NO_AUTO_SCHEMA=1` (the gate per plan line 156).

- **invertible-migration.test.ts** — `change method runs up and reverses on down` relied on `SchemaAdapter` returning empty rows for a `SELECT` against a dropped table. Replaced with a narrow catch that swallows only missing-table errors (`relation "x" does not exist` / `Table 'x' doesn't exist` / `no such table:` — mirroring `test-adapter.ts:1118-1121`) and rethrows anything else. Works under both auto-schema modes.
- **multiparameter-attributes.test.ts** — already passes; tests are pure in-memory `assignAttributes` (no DB persistence). No changes.
- **active-record-schema.test.ts** — already passes; tests run their own migrations via `Schema.define` / `Migration` subclasses. No changes.

## Test plan

- [x] `AR_NO_AUTO_SCHEMA=1 pnpm vitest run` against all three files
- [x] same three files pass without `AR_NO_AUTO_SCHEMA=1`