### PR TITLE
feat(actionpack): wire Base.prototype.sendFileHeadersBang

### DIFF
--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -40,6 +40,7 @@ import {
   httpBasicAuthenticateWith,
   requestHttpBasicAuthentication,
 } from "./metal/http-authentication.js";
+import { sendFileHeadersBang } from "./metal/data-streaming.js";
 
 // Re-export callback registration
 export { type ActionCallback, type AroundCallback, type CallbackOptions };
@@ -573,6 +574,9 @@ export class Base extends Metal {
 
   // --- Send File / Send Data ---
 
+  /** Mirrors Rails `send_file_headers!`; wired below via `Base.prototype`. */
+  declare sendFileHeadersBang: typeof sendFileHeadersBang;
+
   /** Send file content. */
   sendFile(
     filePath: string,
@@ -704,6 +708,10 @@ export class Base extends Metal {
     return false;
   }
 }
+
+// Rails: `ActionController::DataStreaming#send_file_headers!` mixed in via
+// `include DataStreaming`. Trails wires it onto Base.prototype explicitly.
+Base.prototype.sendFileHeadersBang = sendFileHeadersBang;
 
 // Rails: `included do helper_method :content_security_policy?,
 // :content_security_policy_nonce end` (content_security_policy.rb:13).

--- a/packages/actionpack/src/action-controller/controller/send-file.test.ts
+++ b/packages/actionpack/src/action-controller/controller/send-file.test.ts
@@ -344,4 +344,20 @@ describe("SendFileController", () => {
     await c.dispatch("action", makeRequest(), makeResponse());
     expect(c.contentType).toBe("image/png");
   });
+
+  // Guards the Base.prototype.sendFileHeadersBang wiring so a refactor
+  // that drops the prototype assignment trips this test.
+  it("sendFileHeadersBang is reachable on controllers and mutates response", async () => {
+    class C extends Base {
+      async action() {
+        this.sendFileHeadersBang({ type: "image/png", filename: "x.png" });
+      }
+    }
+    const c = new C();
+    await c.dispatch("action", makeRequest(), makeResponse());
+    expect(c.contentType).toBe("image/png");
+    expect(c.response.sendingFile).toBe(true);
+    expect(c.getHeader("Content-Disposition")).toMatch(/attachment;.*filename="x\.png"/);
+    expect(c.getHeader("Content-Transfer-Encoding")).toBe("binary");
+  });
 });

--- a/packages/actionpack/src/action-controller/metal/data-streaming.test.ts
+++ b/packages/actionpack/src/action-controller/metal/data-streaming.test.ts
@@ -5,16 +5,24 @@ import {
   type SendFileHeadersHost,
 } from "./data-streaming.js";
 
-function makeHost(): SendFileHeadersHost {
+interface TestHost extends SendFileHeadersHost {
+  headers: Record<string, string>;
+}
+
+function makeHost(): TestHost {
+  const headers: Record<string, string> = {};
   return {
     contentType: null,
     response: { sendingFile: false },
-    headers: {},
+    headers,
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+    },
   };
 }
 
 describe("sendFileHeadersBang", () => {
-  let host: SendFileHeadersHost;
+  let host: TestHost;
 
   beforeEach(() => {
     host = makeHost();

--- a/packages/actionpack/src/action-controller/metal/data-streaming.ts
+++ b/packages/actionpack/src/action-controller/metal/data-streaming.ts
@@ -29,7 +29,8 @@ export const DEFAULT_SEND_FILE_DISPOSITION = "attachment";
 export interface SendFileHeadersHost {
   contentType: string | null;
   response: { sendingFile: boolean };
-  headers: Record<string, string>;
+  setHeader(name: string, value: string): void;
+  removeHeader?(name: string): void;
 }
 
 /** Options accepted by `sendFileHeadersBang`. */
@@ -92,11 +93,14 @@ export function sendFileHeadersBang(
     : DEFAULT_SEND_FILE_DISPOSITION;
 
   if (disposition) {
-    this.headers["Content-Disposition"] = ContentDisposition.format({
-      disposition,
-      filename: options.filename ?? null,
-    });
+    this.setHeader(
+      "Content-Disposition",
+      ContentDisposition.format({
+        disposition,
+        filename: options.filename ?? null,
+      }),
+    );
   }
 
-  this.headers["Content-Transfer-Encoding"] = "binary";
+  this.setHeader("Content-Transfer-Encoding", "binary");
 }

--- a/packages/actionpack/src/action-controller/metal/data-streaming.ts
+++ b/packages/actionpack/src/action-controller/metal/data-streaming.ts
@@ -23,14 +23,14 @@ export const DEFAULT_SEND_FILE_DISPOSITION = "attachment";
 /**
  * Minimal controller-like host that `sendFileHeadersBang` mutates.
  * Mirrors the surface Rails relies on (`self.content_type=`,
- * `response.sending_file=`, `headers[]=`).
+ * `response.sending_file=`, `headers["..."]=` — surfaced here as
+ * `setHeader` to match `ActionController::Base`'s public API).
  * @internal
  */
 export interface SendFileHeadersHost {
   contentType: string | null;
   response: { sendingFile: boolean };
   setHeader(name: string, value: string): void;
-  removeHeader?(name: string): void;
 }
 
 /** Options accepted by `sendFileHeadersBang`. */

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -36,6 +36,8 @@ export class Response {
   private _charset: string | undefined;
   private _cookies: Map<string, CookieValue> = new Map();
   private _sending = false;
+  /** Rails: `response.sending_file = true` flag set by `send_file_headers!`. */
+  sendingFile = false;
   request: Request | null = null;
 
   constructor(status = 200, headers: Record<string, string> = {}, body: string[] = []) {


### PR DESCRIPTION
## Summary

- Wires `ActionController::DataStreaming#send_file_headers!` (Rails) onto `Base.prototype` as `sendFileHeadersBang`. The function existed in `metal/data-streaming.ts` but wasn't reachable from controllers.
- Adjusts `SendFileHeadersHost` to require `setHeader` so `Base` (which exposes `setHeader`/`getHeader`, not a raw `headers` object) satisfies the host interface. Function body now calls `this.setHeader(...)` instead of `this.headers[...] = ...`.
- Adds `Response.sendingFile = false` so the Rails `response.sending_file = true` slot has a home.

## Follow-ups

- Refactor `Base#sendFile` / `Base#sendData` to delegate to `sendFileHeadersBang`. Today they inline divergent header logic — notably `sendData` without options skips `Content-Disposition` whereas Rails defaults to `attachment`. Refactor will need to update the matching tests in `controller/send-file.test.ts` to pass `disposition: null` where the existing TS-only divergence is asserted.
- `api:compare` will still show `metal/data_streaming.rb` at 6/15: the 9 missing entries are Rendering privates that already live in `rendering.ts` (which is at 100%). The extractor's re-export resolver only handles classes/modules, not standalone functions, so `export { _processVariant, ... } from "./rendering.js"` does not register. Either extend the extractor or duplicate wrappers in a separate PR.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/data-streaming.test.ts`
- [x] `pnpm vitest run packages/actionpack/src/action-controller/controller/send-file.test.ts`
- [x] `pnpm -w build`