### PR TITLE
refactor(actionpack): tighten UrlForOptions; symbol use_route in routing assertions

### DIFF
--- a/docs/actionpack-100-percent.md
+++ b/docs/actionpack-100-percent.md
@@ -67,13 +67,17 @@ Sized in LOC; all unblocked. Bundle to PR-ceiling (~250 LOC) per
 - **http/url** (#1818) — clamp `extractSubdomainsFrom` end at `Math.max(0, parts.length - (tldLength+1))` (~5).
 - **http/mime-type** (#1848) — register `MimeType.ALL` (intern `parse("*/*")`) + identity compare in `negotiateMime` (~10); allow null symbol for ad-hoc types so `formats` filter isn't a no-op (~10); re-parent `InvalidType` onto `MimeType.InvalidMimeType` when base lands (~10); raise `InvalidType` on media ranges missing `/` (#1861).
 - **http/mime_negotiation** (#1848) — tighten `paramsReadable` catch to `[BadRequest, ParseError]` (~5).
-- **routing/url_for** (#1825) — fix stale "HelperMethodBuilder (not yet ported)" wording in 3 stub branches (~30); throw on `use_route: Symbol()` with no `.description` (~5).
+- ~~**routing/url_for** (#1825)~~ — wording fixed; `use_route: Symbol()` with no `.description` throws via `symbolToString`. `UrlForOptions` tightened to `string|symbol|object|null|undefined` (eslint pragma + dead `Function` arm dropped).
 - **routing/endpoint** (#1836) — `engine()` returns false; ~5 LOC once `Rails::Engine` lands.
 - **middleware/actionable_exceptions** (#1853) — prototype-chain walk in `ActionableError.action` (~15); warn on `_registry` collision (~10); switch endpoint to `cattrAccessor` (~5).
 - **middleware/remote-ip** (#1820) — relax `customProxies` check to `Symbol.iterator in Object(...)` (~10).
 - **middleware/public_exceptions** (#1861) — replace hardcoded `"utf-8"` with `Response.defaultCharset` (~10).
 - **middleware/session/abstract_store** (#1863) — `privateId` + comparison helpers on `SessionId` (~10); add `cookieJar` accessor to `Request` (~20).
-- **testing/assertions/routing** (#1866) — accept JS Symbol for `use_route` via `Symbol#description` (~5); URL-form path support in `assertRecognizes`/`assertGenerates` (~20).
+- **testing/assertions/routing** (#1866) — ~~accept JS Symbol for `use_route` via `Symbol#description`~~ (done — normalized via `symbolToString` in `assertGenerates`); URL-form path support in `assertRecognizes`/`assertGenerates` (~20).
+- **controller/allow_browser** (#1947) — known divergences from Rails (`useragent` gem):
+  - `isBot` uses a regex (`bot|crawl|spider|slurp`) rather than `useragent`'s curated bot list — may miss exotic crawler UAs.
+  - Mobile UAs fold into desktop families (`mobile chrome`/`mobile safari`/`mobile firefox` → `chrome`/`safari`/`firefox`); Rails distinguishes them and requires explicit `mobile_safari:` keys.
+  - `compareVersions` is a dot-segment numeric compare; semver prerelease tags (`120.0.0-beta`) parse to `NaN` and compare as `0` (Rails delegates to `useragent`'s `OperatingSystem::Version` which is also non-strict but handles tags).
 - **testing/test-response** (#1845) — port `successful`/`notFound`/`redirection`/`serverError`/`clientError` status predicates; unblocks skipped "helpers" test.
 - **http/param_error** (#1879) — extend `ExceptionWrapper.STATUS_MAP` for ParseError/ParamError family → 400, or switch to prototype-chain walk (~30); wire `ParamError` into `request.ts` parse rescue once that lands (~10).
 - **http/param_builder** (#1877) — relocate ParamBuilder + QueryParser test files from `http/` to `dispatch/` for Rails layout parity (~20).

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -19,7 +19,7 @@ import {
   type JourneyMatch,
 } from "./journey-bridge.js";
 import type { Router as JourneyRouter, RackishResponse, RouterRequest } from "../journey/router.js";
-import type { PolymorphicMappingEntry } from "./polymorphic-routes.js";
+import { symbolToString, type PolymorphicMappingEntry } from "./polymorphic-routes.js";
 import { Endpoint } from "./endpoint.js";
 import { X_CASCADE } from "../constants.js";
 import { DispatcherRegistry, type DispatchHandler } from "./dispatcher.js";
@@ -214,11 +214,15 @@ export class RouteSet {
   ): [string, string[]] {
     // Rails: `route_key = options.delete :use_route` — when present, look
     // the route up by its named-route key, mirroring `RouteSet#generate`.
+    // Rails route names are Symbols; we accept both strings and JS symbols
+    // (symbols carry their name in `.description` via `symbolToString`).
     let route: Route | undefined;
     const useRoute = options["use_route"];
-    if (typeof useRoute === "string") {
+    if (typeof useRoute === "string" || typeof useRoute === "symbol") {
       delete options["use_route"];
-      route = this.namedRoutes.get(useRoute);
+      route = this.namedRoutes.get(
+        typeof useRoute === "symbol" ? symbolToString(useRoute) : useRoute,
+      );
     }
     const { controller, action } = options;
     route ??= this.routes.find((r) => r.controller === controller && r.action === action);

--- a/packages/actionpack/src/action-dispatch/routing/url-for.ts
+++ b/packages/actionpack/src/action-dispatch/routing/url-for.ts
@@ -93,20 +93,11 @@ export function urlFor(this: UrlForHost, options?: UrlForOptions): string {
   return fullUrlFor.call(this, options);
 }
 
-export type UrlForOptions =
-  | null
-  | undefined
-  | string
-  | symbol
-  | unknown[]
-  | Record<string, unknown>
-  // Rails dispatch matches `Class` and arbitrary models in addition to the
-  // explicit `Hash`/`Array`/`String`/`Symbol` cases; widening to `object`
-  // and any function lets callers pass model instances and class refs
-  // without casting (the unsupported branches throw at runtime).
-  | object
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  | Function;
+// Rails dispatch matches `Class` and arbitrary models in addition to the
+// explicit `Hash`/`Array`/`String`/`Symbol` cases. `object` covers
+// `Record`, arrays, class refs, and model instances (TS treats functions
+// as `object`), so callers pass them without casting.
+export type UrlForOptions = null | undefined | string | symbol | object;
 
 /** @internal */
 export function fullUrlFor(this: UrlForHost, options?: UrlForOptions): string {

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
@@ -73,6 +73,17 @@ describe("assertGenerates", () => {
   it("throws on path mismatch", () => {
     bad(() => assertGenerates.call(h, "/wrong", { controller: "items", action: "index" }));
   });
+  it("accepts use_route: Symbol via Symbol#description (Rails parity)", () => {
+    const host: RoutingAssertionsHost = { routes: new RouteSet() };
+    host.routes!.draw((m) => m.get("/items", { to: "items#index", as: "items" }));
+    ok(() =>
+      assertGenerates.call(host, "/items", {
+        controller: "items",
+        action: "index",
+        use_route: Symbol("items"),
+      }),
+    );
+  });
 });
 
 describe("assertRouting", () => {

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -7,7 +7,6 @@
  */
 
 import { RouteSet } from "../../routing/route-set.js";
-import { symbolToString } from "../../routing/polymorphic-routes.js";
 import { RoutingError } from "../../../action-controller/metal/exceptions.js";
 import { TestRequest } from "../test-request.js";
 
@@ -133,10 +132,6 @@ export function assertGenerates(
   const path = expectedPath.startsWith("/") ? expectedPath : `/${expectedPath}`;
   const routes = requireRoutes(this);
   const opts = { ...options };
-  // Rails accepts `use_route: :name`; symbols carry their name in `.description`.
-  if (typeof opts["use_route"] === "symbol") {
-    opts["use_route"] = symbolToString(opts["use_route"]);
-  }
   const [generatedPath, queryStringKeys] = routes.generateExtras(opts, defaults);
   // Null-prototype map so an extra key named `__proto__` becomes an own
   // property rather than hitting the inherited setter.

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -7,6 +7,7 @@
  */
 
 import { RouteSet } from "../../routing/route-set.js";
+import { symbolToString } from "../../routing/polymorphic-routes.js";
 import { RoutingError } from "../../../action-controller/metal/exceptions.js";
 import { TestRequest } from "../test-request.js";
 
@@ -132,6 +133,10 @@ export function assertGenerates(
   const path = expectedPath.startsWith("/") ? expectedPath : `/${expectedPath}`;
   const routes = requireRoutes(this);
   const opts = { ...options };
+  // Rails accepts `use_route: :name`; symbols carry their name in `.description`.
+  if (typeof opts["use_route"] === "symbol") {
+    opts["use_route"] = symbolToString(opts["use_route"]);
+  }
   const [generatedPath, queryStringKeys] = routes.generateExtras(opts, defaults);
   // Null-prototype map so an extra key named `__proto__` becomes an own
   // property rather than hitting the inherited setter.


### PR DESCRIPTION
## Summary

- Drop dead `Function` arm and `eslint-disable-next-line @typescript-eslint/no-unsafe-function-type` pragma from `UrlForOptions`. Collapse the union to `string | symbol | object | null | undefined` — `object` already covers `Record<string, unknown>`, `unknown[]`, class references, and model instances (TS treats functions as `object`), so callers still pass models / class refs without casting.
- `assertGenerates` now accepts `use_route: Symbol` (Rails parity, #1866 leaf) by normalizing through the now-exported `symbolToString` helper from `polymorphic-routes.ts`. A description-less `Symbol()` propagates the existing `ArgumentError`.
- Docs (`actionpack-100-percent.md`):
  - Mark `routing/url_for` (#1825) follow-ups complete (the stub-wording fix and `use_route: Symbol()` ArgumentError already shipped with #1961; this PR additionally tightens the type).
  - Mark `testing/assertions/routing` Symbol bit (#1866) complete; the URL-form path support remains.
  - Document `controller/allow_browser` (#1947) known divergences from Rails' `useragent` gem: `isBot` regex vs the gem's curated list, mobile-UA fold-ins into desktop families, and the `compareVersions` semver-prerelease gap.

Per `docs/actionpack-100-percent.md` urlFor (#1961) and allow_browser (#1947) follow-ups.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts packages/actionpack/src/action-dispatch/routing/url-for.test.ts` (38 pass; new symbol-use_route case included)
- [ ] CI green