### PR TITLE
fix(api-compare): lint-deps matches subpath imports

### DIFF
--- a/scripts/api-compare/lint-deps.test.ts
+++ b/scripts/api-compare/lint-deps.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import * as ts from "typescript";
-import { methodUsesDepImport } from "./lint-deps.js";
+import { methodUsesDepImport, isImportFromPackage } from "./lint-deps.js";
 
 function makeSourceFile(source: string): ts.SourceFile {
   return ts.createSourceFile("virtual.ts", source, ts.ScriptTarget.Latest, true);
@@ -161,5 +161,24 @@ describe("methodUsesDepImport — lint-deps-ignore annotation", () => {
     expect(methodUsesDepImport(node, new Set(["Nodes"]), new Set(), "arel", sf, anchor)).toBe(
       false,
     );
+  });
+});
+
+describe("isImportFromPackage", () => {
+  const pkg = "@blazetrails/activesupport";
+  it("matches the package root exactly", () => {
+    expect(isImportFromPackage(pkg, pkg)).toBe(true);
+  });
+  it("matches subpath imports", () => {
+    expect(isImportFromPackage(`${pkg}/message-verifier`, pkg)).toBe(true);
+    expect(isImportFromPackage(`${pkg}/temporal`, pkg)).toBe(true);
+  });
+  it("does not match a different package with a shared prefix", () => {
+    expect(isImportFromPackage("@blazetrails/activesupporting", pkg)).toBe(false);
+    expect(isImportFromPackage("@blazetrails/activerecord", pkg)).toBe(false);
+  });
+  it("does not match unrelated specifiers", () => {
+    expect(isImportFromPackage("typescript", pkg)).toBe(false);
+    expect(isImportFromPackage("./local", pkg)).toBe(false);
   });
 });

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -166,7 +166,7 @@ function analyzeTsDepUsage(
     for (const stmt of sourceFile.statements) {
       if (!ts.isImportDeclaration(stmt)) continue;
       const specifier = (stmt.moduleSpecifier as ts.StringLiteral).text;
-      if (specifier !== tsImport && !specifier.startsWith(tsImport + "/")) continue;
+      if (!isImportFromPackage(specifier, tsImport)) continue;
       const clause = stmt.importClause;
       if (!clause) continue;
       if (clause.name) importedNames.add(clause.name.text);
@@ -253,6 +253,16 @@ function visitMethodDeclarations(
     ts.forEachChild(node, visit);
   };
   ts.forEachChild(sourceFile, visit);
+}
+
+/**
+ * Match an import specifier against a package root, including subpath
+ * imports (e.g. "@blazetrails/activesupport/message-verifier" matches
+ * tsImport "@blazetrails/activesupport"). Requires a "/" boundary so
+ * "@blazetrails/activesupporting" does not match "@blazetrails/activesupport".
+ */
+export function isImportFromPackage(specifier: string, tsImport: string): boolean {
+  return specifier === tsImport || specifier.startsWith(tsImport + "/");
 }
 
 export function isWithinTypeNode(node: ts.Node): boolean {

--- a/scripts/api-compare/lint-deps.ts
+++ b/scripts/api-compare/lint-deps.ts
@@ -166,7 +166,7 @@ function analyzeTsDepUsage(
     for (const stmt of sourceFile.statements) {
       if (!ts.isImportDeclaration(stmt)) continue;
       const specifier = (stmt.moduleSpecifier as ts.StringLiteral).text;
-      if (specifier !== tsImport) continue;
+      if (specifier !== tsImport && !specifier.startsWith(tsImport + "/")) continue;
       const clause = stmt.importClause;
       if (!clause) continue;
       if (clause.name) importedNames.add(clause.name.text);


### PR DESCRIPTION
## Summary

`lint-deps.ts` did an exact match on import specifiers, so subpath imports like `@blazetrails/activesupport/message-verifier` and `@blazetrails/activesupport/temporal` were ignored. Methods that genuinely used those imports were reported as violations.

Extracted `isImportFromPackage(specifier, tsImport)` that matches the package root or any `<root>/...` subpath (requires the `/` boundary so `@blazetrails/activesupporting` does not match `@blazetrails/activesupport`).

## Effect

`activerecord -> activesupport`: **22/59 (37.3%) -> 27/59 (45.8%)** compliant.

Five methods now correctly credited:
- `signed-id.ts:signedIdVerifier` — uses `MessageVerifier` from `@blazetrails/activesupport/message-verifier`
- `token-for.ts:findByTokenForBang` — same subpath
- `abstract-adapter.ts:quote / typeCast` and `mysql/quoting.ts:typeCast` — use `Temporal` from `@blazetrails/activesupport/temporal`

The remaining 32 violations are real gaps (IsolatedExecutionState, MessagePack, KeyGenerator, Benchmark, ExecutionContext, etc.) — not addressed here.

## Test plan

- [x] `pnpm vitest run scripts/api-compare/lint-deps.test.ts` — 19 pass (4 new for `isImportFromPackage`)
- [x] `pnpm tsx scripts/api-compare/lint-deps.ts --package activerecord --dep activesupport` — score climbs 37.3% -> 45.8%
- [ ] CI green