### PR TITLE
feat(actionpack): wire metal/rendering privates onto Metal + camelCase content_type

### DIFF
--- a/packages/actionpack/src/action-controller/api/api-rendering.test.ts
+++ b/packages/actionpack/src/action-controller/api/api-rendering.test.ts
@@ -1,0 +1,18 @@
+import { describe, test, expect } from "vitest";
+import { renderForApi } from "./api-rendering.js";
+
+describe("renderForApi — contentType contract", () => {
+  test("honors camelCase `contentType` over the format default", () => {
+    expect(renderForApi({ plain: "hi", contentType: "text/markdown" })).toEqual({
+      body: "hi",
+      contentType: "text/markdown",
+    });
+  });
+
+  test("ignores snake_case `content_type` (camelCase-only contract)", () => {
+    expect(renderForApi({ plain: "hi", content_type: "text/markdown" })).toEqual({
+      body: "hi",
+      contentType: "text/plain; charset=utf-8",
+    });
+  });
+});

--- a/packages/actionpack/src/action-controller/api/api-rendering.ts
+++ b/packages/actionpack/src/action-controller/api/api-rendering.ts
@@ -7,7 +7,7 @@
  */
 
 function resolveContentType(options: Record<string, unknown>, fallback: string): string {
-  return (options.contentType as string | undefined) ?? fallback;
+  return typeof options.contentType === "string" ? options.contentType : fallback;
 }
 
 export function renderForApi(options: Record<string, unknown>): {

--- a/packages/actionpack/src/action-controller/api/api-rendering.ts
+++ b/packages/actionpack/src/action-controller/api/api-rendering.ts
@@ -7,11 +7,7 @@
  */
 
 function resolveContentType(options: Record<string, unknown>, fallback: string): string {
-  return (
-    (options.contentType as string | undefined) ??
-    (options.content_type as string | undefined) ??
-    fallback
-  );
+  return (options.contentType as string | undefined) ?? fallback;
 }
 
 export function renderForApi(options: Record<string, unknown>): {

--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -17,6 +17,16 @@ import {
   type MiddlewareEntry,
 } from "../action-dispatch/middleware/stack.js";
 import { includeContent } from "./metal/head.js";
+import {
+  _normalizeOptions as _normalizeOptionsFn,
+  _normalizeText as _normalizeTextFn,
+  _processOptions as _processOptionsFn,
+  _processVariant as _processVariantFn,
+  _renderInPriorities as _renderInPrioritiesFn,
+  _setHtmlContentType as _setHtmlContentTypeFn,
+  _setRenderedContentType as _setRenderedContentTypeFn,
+  _setVaryHeader as _setVaryHeaderFn,
+} from "./metal/rendering.js";
 
 const STATUS_CODES: Record<string, number> = {
   ok: 200,
@@ -323,4 +333,36 @@ export class Metal extends AbstractController {
     if (typeof status === "number") return status;
     return STATUS_CODES[status] ?? 500;
   }
+
+  /**
+   * Mirrors Rails `ActionController::Rendering#render_to_body`:
+   *   super || _render_in_priorities(options) || " "
+   * Subclasses (template renderers) override and `super` falls back to
+   * this body-priority resolution.
+   * @internal
+   */
+  renderToBody(options: Record<string, unknown> = {}): unknown {
+    const body = _renderInPrioritiesFn(options);
+    return body ?? " ";
+  }
+
+  // Rails-private rendering helpers — wired onto the class so the
+  // `metal/rendering.rb` privates resolve as `Metal._foo` (api:compare
+  // surface) while keeping the implementation in `metal/rendering.ts`.
+  /** @internal */
+  static _normalizeOptions = _normalizeOptionsFn;
+  /** @internal */
+  static _normalizeText = _normalizeTextFn;
+  /** @internal */
+  static _processOptions = _processOptionsFn;
+  /** @internal */
+  static _processVariant = _processVariantFn;
+  /** @internal */
+  static _renderInPriorities = _renderInPrioritiesFn;
+  /** @internal */
+  static _setHtmlContentType = _setHtmlContentTypeFn;
+  /** @internal */
+  static _setRenderedContentType = _setRenderedContentTypeFn;
+  /** @internal */
+  static _setVaryHeader = _setVaryHeaderFn;
 }

--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -17,6 +17,7 @@ import {
   type MiddlewareEntry,
 } from "../action-dispatch/middleware/stack.js";
 import { includeContent } from "./metal/head.js";
+import { Renderers } from "./metal/renderers.js";
 import {
   _normalizeOptions as _normalizeOptionsFn,
   _normalizeText as _normalizeTextFn,
@@ -335,15 +336,21 @@ export class Metal extends AbstractController {
   }
 
   /**
-   * Mirrors Rails `ActionController::Rendering#render_to_body`:
-   *   super || _render_in_priorities(options) || " "
-   * Subclasses (template renderers) override and `super` falls back to
-   * this body-priority resolution.
+   * Composes the Rails `render_to_body` chain. With `ActionController::Base`'s
+   * include order, the effective chain is:
+   *
+   *   Rendering#render_to_body   → super || _render_in_priorities(options) || " "
+   *   Renderers#render_to_body   → _render_to_body_with_renderer(options) || super
+   *   AbstractController         → (nil — no-op base)
+   *
+   * Flattened: try the registered renderers first, then the
+   * `:body`/`:plain`/`:html` priority resolver, finally the
+   * single-space fallback. Subclasses that template-render override
+   * this and delegate back via `super`.
    * @internal
    */
   renderToBody(options: Record<string, unknown> = {}): unknown {
-    const body = _renderInPrioritiesFn(options);
-    return body ?? " ";
+    return Renderers._renderToBodyWithRenderer(options) ?? _renderInPrioritiesFn(options) ?? " ";
   }
 
   // Rails-private rendering helpers — wired onto the class so the

--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -18,6 +18,7 @@ import {
 } from "../action-dispatch/middleware/stack.js";
 import { includeContent } from "./metal/head.js";
 import { Renderers } from "./metal/renderers.js";
+import { STATUS_CODES, resolveStatus } from "./metal/status-codes.js";
 import {
   _normalizeOptions as _normalizeOptionsFn,
   _normalizeText as _normalizeTextFn,
@@ -28,31 +29,6 @@ import {
   _setRenderedContentType as _setRenderedContentTypeFn,
   _setVaryHeader as _setVaryHeaderFn,
 } from "./metal/rendering.js";
-
-const STATUS_CODES: Record<string, number> = {
-  ok: 200,
-  created: 201,
-  accepted: 202,
-  no_content: 204,
-  moved_permanently: 301,
-  found: 302,
-  see_other: 303,
-  not_modified: 304,
-  bad_request: 400,
-  unauthorized: 401,
-  forbidden: 403,
-  not_found: 404,
-  method_not_allowed: 405,
-  not_acceptable: 406,
-  conflict: 409,
-  gone: 410,
-  unprocessable_entity: 422,
-  too_many_requests: 429,
-  internal_server_error: 500,
-  not_implemented: 501,
-  bad_gateway: 502,
-  service_unavailable: 503,
-};
 
 export class MiddlewareStack extends DispatchMiddlewareStack {}
 
@@ -330,10 +306,7 @@ export class Metal extends AbstractController {
   }
 
   /** Resolve a status symbol to a number. */
-  static resolveStatus(status: number | string): number {
-    if (typeof status === "number") return status;
-    return STATUS_CODES[status] ?? 500;
-  }
+  static resolveStatus = resolveStatus;
 
   /**
    * Composes the Rails `render_to_body` chain. With `ActionController::Base`'s
@@ -350,7 +323,14 @@ export class Metal extends AbstractController {
    * @internal
    */
   renderToBody(options: Record<string, unknown> = {}): unknown {
-    return Renderers._renderToBodyWithRenderer(options) ?? _renderInPrioritiesFn(options) ?? " ";
+    // Match Ruby `||` short-circuit semantics: skip on `nil`/`false`,
+    // keep `""` and `0` (truthy in Ruby).
+    const truthy = (v: unknown): boolean => v != null && v !== false;
+    const renderer = Renderers._renderToBodyWithRenderer(options);
+    if (truthy(renderer)) return renderer;
+    const priority = _renderInPrioritiesFn(options);
+    if (truthy(priority)) return priority;
+    return " ";
   }
 
   // Rails-private rendering helpers — wired onto the class so the

--- a/packages/actionpack/src/action-controller/metal/rendering.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.test.ts
@@ -143,3 +143,27 @@ describe("_processOptions", () => {
     expect(host.status).toBe(201);
   });
 });
+
+describe("Metal wiring", () => {
+  test("exposes the rendering privates as static members", async () => {
+    const { Metal } = await import("../metal.js");
+    expect(Metal._renderInPriorities).toBe(_renderInPriorities);
+    expect(Metal._normalizeText).toBe(_normalizeText);
+    expect(Metal._normalizeOptions).toBe(_normalizeOptions);
+    expect(Metal._processVariant).toBe(_processVariant);
+    expect(Metal._setHtmlContentType).toBe(_setHtmlContentType);
+    expect(Metal._setRenderedContentType).toBe(_setRenderedContentType);
+    expect(Metal._setVaryHeader).toBe(_setVaryHeader);
+    expect(Metal._processOptions).toBe(_processOptions);
+  });
+
+  test("renderToBody routes through _renderInPriorities and falls back to ' '", async () => {
+    const { Metal } = await import("../metal.js");
+    const instance = Object.create(Metal.prototype) as InstanceType<typeof Metal>;
+    expect(instance.renderToBody({ body: "hi" })).toBe("hi");
+    expect(instance.renderToBody({ plain: "p", html: "h" })).toBe("p");
+    expect(instance.renderToBody({ html: "h" })).toBe("h");
+    expect(instance.renderToBody({})).toBe(" ");
+    expect(instance.renderToBody({ json: "{}" })).toBe(" ");
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/rendering.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.test.ts
@@ -166,4 +166,16 @@ describe("Metal wiring", () => {
     expect(instance.renderToBody({})).toBe(" ");
     expect(instance.renderToBody({ json: "{}" })).toBe(" ");
   });
+
+  test("renderToBody dispatches to a registered renderer before the priority resolver", async () => {
+    const { Metal } = await import("../metal.js");
+    const { Renderers } = await import("../metal/renderers.js");
+    Renderers.add("csvBody", (v) => `csv:${String(v)}`);
+    try {
+      const instance = Object.create(Metal.prototype) as InstanceType<typeof Metal>;
+      expect(instance.renderToBody({ csvBody: "a,b" })).toBe("csv:a,b");
+    } finally {
+      Renderers.remove("csvBody");
+    }
+  });
 });

--- a/packages/actionpack/src/action-controller/metal/rendering.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.test.ts
@@ -45,6 +45,17 @@ describe("_normalizeOptions", () => {
     expect(out.status).toBe(404);
     expect(out.plain).toBe("<plain>");
   });
+
+  test("Ruby-truthy gate: '' and 0 are processed, null/false skip", () => {
+    // `html: ""` is Ruby-truthy → html-escape runs and returns a SafeBuffer
+    // wrapping "" (still truthy / present, just escaped).
+    expect(String(_normalizeOptions({ html: "" }).html)).toBe("");
+    // `status: 0` is Ruby-truthy → resolveStatus passes the number through.
+    expect(_normalizeOptions({ status: 0 }).status).toBe(0);
+    // `null`/`false` skip → fields untouched.
+    expect(_normalizeOptions({ html: null }).html).toBeNull();
+    expect(_normalizeOptions({ status: false }).status).toBe(false);
+  });
 });
 
 describe("_processVariant", () => {
@@ -141,6 +152,24 @@ describe("_processOptions", () => {
 
     _processOptions.call(host, {});
     expect(host.status).toBe(201);
+  });
+
+  test("Ruby-truthy gate: '' / 0 are applied, null/false skip", () => {
+    const host = {
+      status: 200,
+      contentType: null as string | null,
+      setHeader: () => undefined,
+      urlFor: (s: string) => s,
+    };
+    _processOptions.call(host, { status: 0, contentType: "" });
+    expect(host.status).toBe(0);
+    expect(host.contentType).toBe("");
+
+    host.status = 200;
+    host.contentType = null;
+    _processOptions.call(host, { status: null, contentType: false });
+    expect(host.status).toBe(200);
+    expect(host.contentType).toBeNull();
   });
 });
 

--- a/packages/actionpack/src/action-controller/metal/rendering.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.test.ts
@@ -167,6 +167,19 @@ describe("Metal wiring", () => {
     expect(instance.renderToBody({ json: "{}" })).toBe(" ");
   });
 
+  test("renderToBody preserves '' / 0 (Ruby-truthy) and falls through on false/null", async () => {
+    const { Metal } = await import("../metal.js");
+    const instance = Object.create(Metal.prototype) as InstanceType<typeof Metal>;
+    // Ruby `""` and `0` are truthy; Rails `super || _render_in_priorities || " "`
+    // returns them as-is rather than falling through.
+    expect(instance.renderToBody({ body: "" })).toBe("");
+    expect(instance.renderToBody({ plain: 0 })).toBe(0);
+    // Ruby `false`/`nil` fall through; `_renderInPriorities` returns null
+    // when no key matches, so the " " fallback wins.
+    expect(instance.renderToBody({ body: false })).toBe(" ");
+    expect(instance.renderToBody({ body: null })).toBe(" ");
+  });
+
   test("renderToBody dispatches to a registered renderer before the priority resolver", async () => {
     const { Metal } = await import("../metal.js");
     const { Renderers } = await import("../metal/renderers.js");

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -48,10 +48,12 @@ export function _normalizeText(options: Record<string, unknown>): void {
  */
 export function _normalizeOptions(options: Record<string, unknown>): Record<string, unknown> {
   _normalizeText(options);
-  if (options.html) {
+  // Ruby `if options[:key]` — only `nil`/`false` skip; `""` and `0` are
+  // truthy and must still be processed.
+  if (options.html != null && options.html !== false) {
     options.html = htmlEscape(options.html);
   }
-  if (options.status) {
+  if (options.status != null && options.status !== false) {
     options.status = resolveStatus(options.status as number | string);
   }
   return options;
@@ -134,13 +136,15 @@ export function _processOptions(
   this: Pick<RenderingHost, "status" | "contentType" | "setHeader" | "urlFor">,
   options: Record<string, unknown>,
 ): void {
-  if (options.status) {
+  // Ruby `if options[:key]` — only `nil`/`false` skip; `""` and `0` are
+  // truthy and must still be applied.
+  if (options.status != null && options.status !== false) {
     this.status = resolveStatus(options.status as number | string);
   }
-  if (options.contentType) {
+  if (options.contentType != null && options.contentType !== false) {
     this.contentType = String(options.contentType);
   }
-  if (options.location) {
+  if (options.location != null && options.location !== false) {
     this.setHeader("Location", this.urlFor(String(options.location)));
   }
 }

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -7,8 +7,8 @@
  */
 
 import { htmlEscape, isPresent } from "@blazetrails/activesupport";
-import { Metal } from "../metal.js";
 import { Renderer } from "../renderer.js";
+import { resolveStatus } from "./status-codes.js";
 
 export const RENDER_FORMATS_IN_PRIORITY = ["body", "plain", "html"] as const;
 
@@ -52,7 +52,7 @@ export function _normalizeOptions(options: Record<string, unknown>): Record<stri
     options.html = htmlEscape(options.html);
   }
   if (options.status) {
-    options.status = Metal.resolveStatus(options.status as number | string);
+    options.status = resolveStatus(options.status as number | string);
   }
   return options;
 }
@@ -135,7 +135,7 @@ export function _processOptions(
   options: Record<string, unknown>,
 ): void {
   if (options.status) {
-    this.status = Metal.resolveStatus(options.status as number | string);
+    this.status = resolveStatus(options.status as number | string);
   }
   if (options.contentType) {
     this.contentType = String(options.contentType);

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -129,7 +129,10 @@ export function _setVaryHeader(this: Pick<RenderingHost, "request" | "response">
 
 /**
  * Mirrors Rails `_process_options(options)` — applies controller-level
- * options (`:status`, `:content_type`, `:location`) to the response.
+ * options (`:status`, `:content_type`, `:location` in Rails) to the
+ * response. Trails reads camelCase keys (`contentType`) per CLAUDE.md;
+ * the snake_case Ruby symbols are documented here only for cross-
+ * reference to the Rails source.
  * @internal
  */
 export function _processOptions(

--- a/packages/actionpack/src/action-controller/metal/status-codes.ts
+++ b/packages/actionpack/src/action-controller/metal/status-codes.ts
@@ -1,0 +1,40 @@
+/**
+ * Rack-style HTTP status name → numeric code lookup, shared by Metal,
+ * its rendering privates, and head(). Lives in its own module so the
+ * helpers in `metal/rendering.ts` can resolve status symbols without
+ * importing `Metal` (which would create an ESM cycle: `metal.ts` ↔
+ * `metal/rendering.ts`).
+ *
+ * @internal
+ */
+
+export const STATUS_CODES: Record<string, number> = {
+  ok: 200,
+  created: 201,
+  accepted: 202,
+  no_content: 204,
+  moved_permanently: 301,
+  found: 302,
+  see_other: 303,
+  not_modified: 304,
+  bad_request: 400,
+  unauthorized: 401,
+  forbidden: 403,
+  not_found: 404,
+  method_not_allowed: 405,
+  not_acceptable: 406,
+  conflict: 409,
+  gone: 410,
+  unprocessable_entity: 422,
+  too_many_requests: 429,
+  internal_server_error: 500,
+  not_implemented: 501,
+  bad_gateway: 502,
+  service_unavailable: 503,
+};
+
+/** @internal */
+export function resolveStatus(status: number | string): number {
+  if (typeof status === "number") return status;
+  return STATUS_CODES[status] ?? 500;
+}

--- a/packages/actionpack/src/action-controller/renderer.test.ts
+++ b/packages/actionpack/src/action-controller/renderer.test.ts
@@ -85,4 +85,18 @@ describe("Renderer", () => {
       ).toBe("http");
     });
   });
+
+  describe("render — contentType", () => {
+    it("honors camelCase `contentType` over the default for the rendered format", () => {
+      const r = new Renderer({}, null);
+      r.render({ plain: "hi", contentType: "text/markdown" });
+      expect(r.contentType).toBe("text/markdown");
+    });
+
+    it("ignores snake_case `content_type` (camelCase-only contract)", () => {
+      const r = new Renderer({}, null);
+      r.render({ plain: "hi", content_type: "text/markdown" });
+      expect(r.contentType).toBe("text/plain; charset=utf-8");
+    });
+  });
 });

--- a/packages/actionpack/src/action-controller/renderer.ts
+++ b/packages/actionpack/src/action-controller/renderer.ts
@@ -47,8 +47,7 @@ export class Renderer {
       merged.status !== undefined && merged.status !== null
         ? Metal.resolveStatus(merged.status as number | string)
         : 200;
-    const explicitContentType =
-      (merged.contentType as string | undefined) ?? (merged.content_type as string | undefined);
+    const explicitContentType = merged.contentType as string | undefined;
 
     if (merged.json !== undefined) {
       this._lastContentType = explicitContentType ?? "application/json; charset=utf-8";

--- a/packages/actionpack/src/action-controller/renderer.ts
+++ b/packages/actionpack/src/action-controller/renderer.ts
@@ -7,8 +7,8 @@
  * @see https://api.rubyonrails.org/classes/ActionController/Renderer.html
  */
 
-import { Metal } from "./metal.js";
 import type { RouteSetLike } from "../abstract-controller/url-for.js";
+import { resolveStatus } from "./metal/status-codes.js";
 
 export class Renderer {
   private _controller: unknown;
@@ -45,7 +45,7 @@ export class Renderer {
     const merged = { ...this._defaults, ...options };
     this._lastStatus =
       merged.status !== undefined && merged.status !== null
-        ? Metal.resolveStatus(merged.status as number | string)
+        ? resolveStatus(merged.status as number | string)
         : 200;
     const explicitContentType = merged.contentType as string | undefined;
 

--- a/packages/actionpack/src/action-controller/renderer.ts
+++ b/packages/actionpack/src/action-controller/renderer.ts
@@ -47,7 +47,8 @@ export class Renderer {
       merged.status !== undefined && merged.status !== null
         ? resolveStatus(merged.status as number | string)
         : 200;
-    const explicitContentType = merged.contentType as string | undefined;
+    const explicitContentType =
+      typeof merged.contentType === "string" ? merged.contentType : undefined;
 
     if (merged.json !== undefined) {
       this._lastContentType = explicitContentType ?? "application/json; charset=utf-8";


### PR DESCRIPTION
## Summary

Followup to #1951 (metal/rendering privates).

- Wires the eight Rails-named helpers from `metal/rendering.ts` as `static` members on `Metal` so they resolve via the class surface that api:compare and downstream callers expect: `_processVariant`, `_renderInPriorities`, `_setHtmlContentType`, `_setRenderedContentType`, `_setVaryHeader`, `_normalizeOptions`, `_normalizeText`, `_processOptions`.
- Adds an instance `Metal#renderToBody(options)` that mirrors Rails' `ActionController::Rendering#render_to_body`:

  ```ruby
  super || _render_in_priorities(options) || " "
  ```
- Drops the `merged.content_type` snake_case fallback from `Renderer#render` — per CLAUDE.md this project uses camelCase only, even for Rails payload keys.

Rails source: `vendor/rails/actionpack/lib/action_controller/metal/rendering.rb`.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/rendering.test.ts` (10 tests, +2 for the new wiring)
- [x] `pnpm vitest run packages/actionpack/src/action-controller/renderer.test.ts` + full `metal/` test dir green
- [x] `pnpm lint --fix` clean