### PR TITLE
feat(actionpack): wire rateLimiting as prototype method + prune tests

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -81,6 +81,7 @@ export class AbstractController {
     "isContentSecurityPolicy",
     "contentSecurityPolicyNonce",
     "currentContentSecurityPolicy",
+    "rateLimiting",
   ]);
 
   private static _actionMethodCache?: Set<string>;

--- a/packages/actionpack/src/action-controller/api.ts
+++ b/packages/actionpack/src/action-controller/api.ts
@@ -23,8 +23,10 @@ export class API extends Metal {
    */
   static rateLimit = rateLimit;
 
-  /** @internal Private in Rails; instance slot enables subclass overrides. */
-  rateLimiting = rateLimiting;
+  /** @internal Private in Rails; prototype slot enables subclass overrides. */
+  async rateLimiting(args: Parameters<typeof rateLimiting>[0]): Promise<void> {
+    return rateLimiting.call(this, args);
+  }
 
   render(options: RenderOptions = {}): void {
     if (this.performed) {

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -442,12 +442,15 @@ export class Base extends Metal {
   static rateLimit = rateLimit;
 
   /**
-   * Per-request enforcement. Private in Rails; exposed as an instance
+   * Per-request enforcement. Private in Rails; exposed as a prototype
    * method so subclass overrides win (the DSL dispatches through
-   * `this.rateLimiting`).
+   * `this.rateLimiting`). Listed in AbstractController._internalMethods
+   * so it isn't picked up as an action.
    * @internal
    */
-  rateLimiting = rateLimiting;
+  async rateLimiting(args: Parameters<typeof rateLimiting>[0]): Promise<void> {
+    return rateLimiting.call(this, args);
+  }
 
   /**
    * Class DSL: override the default form builder for all views rendered by

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -447,4 +447,34 @@ describe("rateLimit integration through Base.beforeAction / dispatch", () => {
     );
     expect(overrideCalls).toEqual(["override"]);
   });
+
+  it("a prototype-method override of rateLimiting wins through rateLimit/beforeAction dispatch", async () => {
+    const store = new MemoryRateLimitStore();
+    const overrideCalls: string[] = [];
+
+    class MethodOverrideController extends Base {
+      async show() {
+        this.head(200);
+      }
+      override async rateLimiting(args: Parameters<typeof rateLimiting>[0]): Promise<void> {
+        overrideCalls.push("method-override");
+        await rateLimiting.call(this, args);
+      }
+    }
+    MethodOverrideController.rateLimit({ to: 1, within: 60, store });
+
+    const c = new MethodOverrideController();
+    await c.dispatch(
+      "show",
+      new Request({ REQUEST_METHOD: "GET", PATH_INFO: "/show", HTTP_HOST: "x" }),
+      new Response(),
+    );
+    expect(overrideCalls).toEqual(["method-override"]);
+    // Sanity: the override lives on the subclass prototype (not as an own
+    // instance field), which is the override shape this PR is enabling.
+    expect(
+      Object.prototype.hasOwnProperty.call(MethodOverrideController.prototype, "rateLimiting"),
+    ).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(c, "rateLimiting")).toBe(false);
+  });
 });

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -52,6 +52,74 @@ describe("MemoryRateLimitStore", () => {
     store.increment("a", 1, { expiresIn: 60 });
     expect(store.increment("b", 1, { expiresIn: 60 })).toBe(1);
   });
+
+  describe("prune sweep", () => {
+    const BASELINE = 1024;
+    const PRUNE_MAX = BASELINE * 16;
+
+    type StoreInternals = {
+      _entries: Map<string, unknown>;
+      _pruneThreshold: number;
+      _skipSweepInserts: number;
+    };
+    const peek = (store: MemoryRateLimitStore): StoreInternals =>
+      store as unknown as StoreInternals;
+
+    it("sweeps expired entries once size crosses the threshold", () => {
+      vi.useFakeTimers();
+      try {
+        const store = new MemoryRateLimitStore();
+        for (let i = 0; i < BASELINE - 1; i += 1) {
+          store.increment(`old:${i}`, 1, { expiresIn: 1 });
+        }
+        vi.advanceTimersByTime(2000);
+        // Stays just under the threshold — no sweep yet.
+        expect(peek(store)._entries.size).toBe(BASELINE - 1);
+        store.increment("trigger", 1, { expiresIn: 60 });
+        // Crossing the threshold triggers a sweep that drops all expired keys.
+        expect(peek(store)._entries.size).toBe(1);
+        // Sweep freed space → threshold relaxes back to the baseline.
+        expect(peek(store)._pruneThreshold).toBe(BASELINE);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("doubles the threshold when an all-live sweep frees nothing", () => {
+      const store = new MemoryRateLimitStore();
+      for (let i = 0; i < BASELINE; i += 1) {
+        store.increment(`live:${i}`, 1, { expiresIn: 3600 });
+      }
+      // All entries are live, so the sweep freed nothing and the next
+      // threshold doubles.
+      expect(peek(store)._pruneThreshold).toBe(BASELINE * 2);
+      expect(peek(store)._skipSweepInserts).toBe(0);
+    });
+
+    it("saturates the threshold at _PRUNE_MAX and arms _skipSweepInserts", () => {
+      const store = new MemoryRateLimitStore();
+      // Enough inserts to double the threshold past the cap: each sterile
+      // sweep doubles 1024 → 2048 → 4096 → 8192 → 16384 (= _PRUNE_MAX).
+      // 8193 entries triggers the fourth sweep and saturates the cap.
+      for (let i = 0; i < BASELINE * 8 + 1; i += 1) {
+        store.increment(`live:${i}`, 1, { expiresIn: 3600 });
+      }
+      expect(peek(store)._pruneThreshold).toBe(PRUNE_MAX);
+      expect(peek(store)._skipSweepInserts).toBe(BASELINE);
+    });
+
+    it("decrements _skipSweepInserts on inserts past the saturated cap (no rescan)", () => {
+      const store = new MemoryRateLimitStore();
+      for (let i = 0; i < PRUNE_MAX; i += 1) {
+        store.increment(`live:${i}`, 1, { expiresIn: 3600 });
+      }
+      // size now == _PRUNE_MAX; the most recent insert hit the sweep block,
+      // saw the skip counter armed, and decremented it once rather than
+      // walking the whole map.
+      expect(peek(store)._pruneThreshold).toBe(PRUNE_MAX);
+      expect(peek(store)._skipSweepInserts).toBe(BASELINE - 1);
+    });
+  });
 });
 
 afterEach(() => {

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -54,9 +54,6 @@ describe("MemoryRateLimitStore", () => {
   });
 
   describe("prune sweep", () => {
-    const BASELINE = 1024;
-    const PRUNE_MAX = BASELINE * 16;
-
     type StoreInternals = {
       _entries: Map<string, unknown>;
       _pruneThreshold: number;
@@ -64,6 +61,14 @@ describe("MemoryRateLimitStore", () => {
     };
     const peek = (store: MemoryRateLimitStore): StoreInternals =>
       store as unknown as StoreInternals;
+    // Derive tuning constants from the implementation so these tests
+    // assert behavior, not specific numeric values.
+    const STATICS = MemoryRateLimitStore as unknown as {
+      _PRUNE_BASELINE: number;
+      _PRUNE_MAX: number;
+    };
+    const BASELINE = STATICS._PRUNE_BASELINE;
+    const PRUNE_MAX = STATICS._PRUNE_MAX;
 
     it("sweeps expired entries once size crosses the threshold", () => {
       vi.useFakeTimers();

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.test.ts
@@ -103,10 +103,13 @@ describe("MemoryRateLimitStore", () => {
 
     it("saturates the threshold at _PRUNE_MAX and arms _skipSweepInserts", () => {
       const store = new MemoryRateLimitStore();
-      // Enough inserts to double the threshold past the cap: each sterile
-      // sweep doubles 1024 → 2048 → 4096 → 8192 → 16384 (= _PRUNE_MAX).
-      // 8193 entries triggers the fourth sweep and saturates the cap.
-      for (let i = 0; i < BASELINE * 8 + 1; i += 1) {
+      // Each sterile (all-live) sweep doubles the threshold:
+      // BASELINE → 2·BASELINE → 4·BASELINE → … → PRUNE_MAX.
+      // The Nth all-live insert (where N == current threshold) trips the
+      // sweep, so the run that saturates at PRUNE_MAX happens once size
+      // reaches PRUNE_MAX/2 == BASELINE * 8 (when PRUNE_MAX = 16·BASELINE).
+      const saturatingInsertCount = PRUNE_MAX / 2;
+      for (let i = 0; i < saturatingInsertCount; i += 1) {
         store.increment(`live:${i}`, 1, { expiresIn: 3600 });
       }
       expect(peek(store)._pruneThreshold).toBe(PRUNE_MAX);

--- a/packages/actionpack/src/action-controller/metal/rate-limiting.ts
+++ b/packages/actionpack/src/action-controller/metal/rate-limiting.ts
@@ -89,9 +89,13 @@ export class MemoryRateLimitStore implements RateLimitStore {
   private _entries = new Map<string, { count: number; expiresAt: number }>();
   private _pruneThreshold = MemoryRateLimitStore._PRUNE_BASELINE;
   /**
-   * Inserts to skip before re-sweeping after a sterile sweep (nothing
-   * expired). Without this, sustained all-live traffic at the cap would turn
-   * every insert into an O(N) walk — see review #8 comment 2.
+   * Inserts to defer before re-sweeping after a sterile sweep at the cap
+   * (every entry still live; no space was reclaimed). Without this, once
+   * `_pruneThreshold` saturates at `_PRUNE_MAX` under sustained all-live
+   * traffic, every subsequent insert would re-trigger the O(N) walk because
+   * `size >= threshold` stays true. Counting down a baseline of inserts
+   * amortizes the next walk against another `_PRUNE_BASELINE` requests so
+   * the steady-state cost stays O(1) per increment.
    */
   private _skipSweepInserts = 0;
 


### PR DESCRIPTION
## Summary

Follow-up to RateLimiting (#1930) per `docs/actionpack-100-percent.md`.

- Move `rateLimiting` from a class field to a prototype method on `ActionController::Base` and `::API` so it lives where Rails' private helper does — on the class, reachable via the prototype chain and overridable by subclasses.
- Add `rateLimiting` to `AbstractController._internalMethods` so `actionMethods()` doesn't expose it as a controller action.
- Add prune-path tests for `MemoryRateLimitStore`:
  - past-threshold sweep frees expired entries and relaxes the threshold back to `_PRUNE_BASELINE`
  - all-live sweep doubles the threshold when nothing is freed
  - saturating sweeps cap the threshold at `_PRUNE_MAX` and arm `_skipSweepInserts`; subsequent over-cap inserts decrement the counter without rescanning
- Replace the "review #8 comment 2" reference on `_skipSweepInserts` with a self-contained explanation of why deferral is needed at the cap.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/rate-limiting.test.ts` — 33/33
- [x] `pnpm vitest run packages/actionpack/src` — 2865/2865 passed, 23 skipped
- [x] `pnpm lint` clean