### PR TITLE
feat(trailties): port Rails::Paths::Root and Paths::Path

### DIFF
--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -5,6 +5,8 @@
 export interface FsStatResult {
   isDirectory(): boolean;
   isFile(): boolean;
+  /** Only populated by lstat results (adapters may always return false from stat). */
+  isSymbolicLink?(): boolean;
   size: number;
   mtime: Date;
 }
@@ -46,6 +48,14 @@ export interface FsAdapter {
   cwd(): string;
   /** Async existence check — avoids requiring existsSync in async code paths. */
   exists(path: string): Promise<boolean>;
+  /**
+   * Async stat — async-only callers use this instead of statSync. Optional
+   * on the interface for backwards-compatibility, but async-only consumers
+   * (e.g. trailties) require it and will error if absent.
+   */
+  stat?(path: string): Promise<FsStatResult>;
+  /** Async lstat (no symlink follow). Optional; adapters without symlink support may omit. */
+  lstat?(path: string): Promise<FsStatResult>;
   /**
    * Create a unique temp directory (optional — not all filesystems support
    * atomic uniqueness). Only used by server-side database tasks; custom
@@ -111,8 +121,12 @@ function tryAutoRegisterNode(): boolean {
     const req = nodeModule.createRequire(
       typeof __filename !== "undefined" ? __filename : "file:///activesupport",
     );
-    const nodeFs = req("node:fs") as Omit<FsAdapter, "cwd" | "exists">;
-    const fsPromises = req("node:fs/promises") as { access(p: string): Promise<void> };
+    const nodeFs = req("node:fs") as Omit<FsAdapter, "cwd" | "exists" | "stat" | "lstat">;
+    const fsPromises = req("node:fs/promises") as {
+      access(p: string): Promise<void>;
+      stat(p: string): Promise<FsStatResult>;
+      lstat(p: string): Promise<FsStatResult>;
+    };
     const fs: FsAdapter = Object.assign({}, nodeFs, {
       cwd: () => globalThis.process.cwd(),
       exists: (p: string) =>
@@ -124,6 +138,8 @@ function tryAutoRegisterNode(): boolean {
             throw error;
           },
         ),
+      stat: (p: string) => fsPromises.stat(p),
+      lstat: (p: string) => fsPromises.lstat(p),
     }) as FsAdapter;
     const nodePath = req("node:path") as Required<Omit<PathAdapter, "pathToFileURL">>;
     const nodeUrl = req("node:url") as { pathToFileURL(p: string): URL };
@@ -153,9 +169,14 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
         if (typeof globalThis.process === "undefined" || !globalThis.process.versions?.node) {
           return false;
         }
-        const nodeFs = (await import("node:fs")) as unknown as Omit<FsAdapter, "cwd" | "exists">;
+        const nodeFs = (await import("node:fs")) as unknown as Omit<
+          FsAdapter,
+          "cwd" | "exists" | "stat" | "lstat"
+        >;
         const fsPromises = (await import("node:fs/promises")) as unknown as {
           access(p: string): Promise<void>;
+          stat(p: string): Promise<FsStatResult>;
+          lstat(p: string): Promise<FsStatResult>;
         };
         const fs: FsAdapter = Object.assign({}, nodeFs, {
           cwd: () => globalThis.process.cwd(),
@@ -164,6 +185,8 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
               () => true,
               () => false,
             ),
+          stat: (p: string) => fsPromises.stat(p),
+          lstat: (p: string) => fsPromises.lstat(p),
         }) as FsAdapter;
         const nodePath = (await import("node:path")) as unknown as Required<
           Omit<PathAdapter, "pathToFileURL">

--- a/packages/trailties/src/paths.test.ts
+++ b/packages/trailties/src/paths.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import {
+  fsAdapterConfig,
+  registerFsAdapter,
+  type FsAdapter,
+  type PathAdapter,
+} from "@blazetrails/activesupport";
+import { Root } from "./paths.js";
+
+const posixPath: PathAdapter = {
+  join: (...p) => p.join("/").replace(/\/+/g, "/"),
+  dirname: (p) => p.replace(/\/[^/]*$/, "") || "/",
+  basename: (p) => p.split("/").pop() ?? "",
+  resolve: (...p) =>
+    p
+      .reduce((o, x) => (!x ? o : x.startsWith("/") ? x : o ? `${o}/${x}` : x), "")
+      .replace(/\/+/g, "/"),
+  extname: (p) => (p.lastIndexOf(".") > 0 ? p.slice(p.lastIndexOf(".")) : ""),
+  isAbsolute: (p) => p.startsWith("/"),
+  sep: "/",
+};
+const stat = (d: boolean) => ({
+  isDirectory: () => d,
+  isFile: () => !d,
+  size: 0,
+  mtime: new Date(),
+});
+function install(isDir = false): void {
+  registerFsAdapter(
+    "test",
+    {
+      cwd: () => "/",
+      exists: async () => true,
+      stat: async () => stat(isDir),
+      statSync: () => stat(isDir),
+    } as unknown as FsAdapter,
+    posixPath,
+  );
+  fsAdapterConfig.adapter = "test";
+}
+
+const PREV = fsAdapterConfig.adapter;
+let root: Root;
+beforeEach(() => {
+  install(false);
+  root = new Root("/foo/bar");
+});
+afterEach(() => {
+  fsAdapterConfig.adapter = PREV;
+});
+
+describe("Rails::Paths", () => {
+  test("a paths object initialized with nil can be updated", async () => {
+    const r = new Root(null);
+    r.add("app");
+    r.path = "/root";
+    expect(r.get("app")!.toAry()).toEqual(["app"]);
+    expect(await r.get("app")!.toA()).toEqual(["/root/app"]);
+  });
+
+  test("creating a root level path", async () => {
+    root.add("app");
+    expect(await root.get("app")!.toA()).toEqual(["/foo/bar/app"]);
+  });
+
+  test("raises exception if root path never set", async () => {
+    const r = new Root(null);
+    r.add("app");
+    await expect(r.get("app")!.toA()).rejects.toThrow();
+  });
+
+  test("creating a child level path", async () => {
+    root.add("app");
+    root.add("app/models");
+    expect(await root.get("app/models")!.toA()).toEqual(["/foo/bar/app/models"]);
+  });
+
+  test("adding multiple physical paths as an array", async () => {
+    root.add("app", { with: ["/app", "/app2"] });
+    expect(await root.get("app")!.toA()).toEqual(["/app", "/app2"]);
+  });
+
+  test("adding multiple physical paths using #push", async () => {
+    root.add("app");
+    root.get("app")!.push("app2");
+    expect(await root.get("app")!.toA()).toEqual(["/foo/bar/app", "/foo/bar/app2"]);
+  });
+
+  test("a path can be added to the load path on creation", async () => {
+    install(true);
+    root = new Root("/foo/bar");
+    root.add("app", { with: "/app", loadPath: true });
+    expect(root.get("app")!.isLoadPath()).toBe(true);
+    expect(await root.loadPaths()).toEqual(["/app"]);
+  });
+
+  test("load paths does NOT include files", async () => {
+    root.add("app/README.md", { loadPath: true });
+    expect(await root.loadPaths()).toEqual([]);
+  });
+
+  test("A failed symlink is still a valid file", async () => {
+    registerFsAdapter(
+      "sym",
+      {
+        cwd: () => "/",
+        exists: async () => false,
+        stat: async () => stat(false),
+        statSync: () => stat(false),
+        lstat: async () => ({ ...stat(false), isSymbolicLink: () => true }),
+      } as unknown as FsAdapter,
+      posixPath,
+    );
+    fsAdapterConfig.adapter = "sym";
+    root = new Root("/foo");
+    root.add("bar.rb");
+    await expect(root.get("bar.rb")!.existent()).rejects.toThrow(/symlink/);
+  });
+});

--- a/packages/trailties/src/paths.ts
+++ b/packages/trailties/src/paths.ts
@@ -1,0 +1,149 @@
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import { glob as fsGlob } from "@blazetrails/activesupport/glob";
+
+export interface PathOptions {
+  with?: string | string[];
+  glob?: string;
+  loadPath?: boolean;
+}
+
+// Port of railties/lib/rails/paths.rb. Autoload / eager-load APIs are
+// intentionally omitted (ESM + bundlers cover those concerns); only
+// load_path / load_paths are kept.
+export class Root {
+  path: string | null;
+  _entries: Map<string, Path> = new Map();
+
+  constructor(path: string | null) {
+    this.path = path;
+  }
+
+  add(path: string, options: PathOptions = {}): Path {
+    const withVals =
+      options.with === undefined
+        ? [path]
+        : Array.isArray(options.with)
+          ? options.with
+          : [options.with];
+    const node = new Path(this, path, withVals, options);
+    this._entries.set(path, node);
+    return node;
+  }
+
+  get(path: string): Path | undefined {
+    return this._entries.get(path);
+  }
+
+  allPaths(): Path[] {
+    return Array.from(new Set(this._entries.values()));
+  }
+
+  async loadPaths(): Promise<string[]> {
+    const out: string[] = [];
+    for (const node of this.allPaths()) {
+      if (!node.isLoadPath()) continue;
+      const dirs = await node.existentDirectories();
+      const excluded = new Set<string>();
+      for (const child of node.children()) {
+        if (child.isLoadPath()) continue;
+        for (const d of await child.existentDirectories()) excluded.add(d);
+      }
+      for (const d of dirs) if (!excluded.has(d)) out.push(d);
+    }
+    return Array.from(new Set(out));
+  }
+}
+
+export class Path {
+  glob: string | undefined;
+  private _paths: string[];
+  private _current: string;
+  private _root: Root;
+  private _loadPath = false;
+
+  constructor(root: Root, current: string, paths: string[], options: PathOptions = {}) {
+    this._root = root;
+    this._current = current;
+    this._paths = [...paths];
+    this.glob = options.glob;
+    this._loadPath = !!options.loadPath;
+  }
+
+  children(): Path[] {
+    return [...this._root._entries.keys()]
+      .filter((k) => k.startsWith(this._current) && k !== this._current)
+      .sort()
+      .map((k) => this._root._entries.get(k)!);
+  }
+
+  loadPathBang(): void {
+    this._loadPath = true;
+  }
+  isLoadPath(): boolean {
+    return this._loadPath;
+  }
+
+  push(p: string): void {
+    this._paths.push(p);
+  }
+  toAry(): string[] {
+    return this._paths;
+  }
+  toA(): Promise<string[]> {
+    return this.expanded();
+  }
+
+  async expanded(): Promise<string[]> {
+    if (this._root.path === null) throw new Error("You need to set a path root");
+    const path = await getPathAsync();
+    const fs = await getFsAsync();
+    const out: string[] = [];
+    for (const raw of this._paths) {
+      const abs = path.resolve(this._root.path, raw);
+      if (this.glob && (await isDir(fs, abs))) {
+        const files = await fsGlob(this.glob, { cwd: abs });
+        out.push(...files.map((f) => path.join(abs, f)).sort());
+      } else {
+        out.push(abs);
+      }
+    }
+    return Array.from(new Set(out));
+  }
+
+  async existent(): Promise<string[]> {
+    const fs = await getFsAsync();
+    const out: string[] = [];
+    for (const f of await this.expanded()) {
+      if (await fs.exists(f)) {
+        out.push(f);
+      } else if (fs.lstat && (await isSymlink(fs, f))) {
+        throw new Error(`File "${f}" is a symlink that does not point to a valid file`);
+      }
+    }
+    return out;
+  }
+
+  async existentDirectories(): Promise<string[]> {
+    const fs = await getFsAsync();
+    const out: string[] = [];
+    for (const f of await this.expanded()) if (await isDir(fs, f)) out.push(f);
+    return out;
+  }
+}
+
+type Fs = Awaited<ReturnType<typeof getFsAsync>>;
+async function isDir(fs: Fs, p: string): Promise<boolean> {
+  if (!fs.stat) throw new Error("FsAdapter.stat() is required for trailties (async-only).");
+  try {
+    return (await fs.stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+async function isSymlink(fs: Fs, p: string): Promise<boolean> {
+  try {
+    return !!(await fs.lstat!(p)).isSymbolicLink?.();
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 PR 1.1 of `docs/trailties-plan.md`. Ports `railties/lib/rails/paths.rb`:

- **Root** — `add`, `get`, `allPaths`, `loadPaths`, `path` accessor.
- **Path** — `push`, `toAry`, `toA`/`expanded`, `existent`, `existentDirectories`, `children`, `loadPathBang`/`isLoadPath`, `glob` accessor.

Glob expansion delegates to `@blazetrails/activesupport/glob`. Async-only filesystem access; adds `stat`/`lstat` to `FsAdapter` so trailties keeps the async-only rule (`docs/trailties-plan.md` hard rule 3).

Total diff: **288 insertions / 3 deletions** (under the 300 LOC ceiling).

## Rails source

`railties/lib/rails/paths.rb` (Rails 8.0).

## Intentionally skipped (autoload / eager-load)

Per `docs/trailties-plan.md`:

- `Root#autoload_once`, `#eager_load` (collector), `#autoload_paths`
- `Path#autoload_once!`, `#skip_autoload_once!`, `#autoload_once?`
- `Path#eager_load!`, `#skip_eager_load!`, `#eager_load?`
- `Path#autoload!`, `#skip_autoload!`, `#autoload?`
- `filter_by` for non-load_path predicates

## Deferred to follow-up 1.1b (LOC ceiling)

The remaining Rails surface and verbatim-named tests are split out to keep this PR under 300 LOC:

- `Root#set` (Ruby `[]=`), `Root#values`, `Root#keys`, `Root#valuesAt`
- `Path#absoluteCurrent`, `#concat`, `#unshift`, `#skipLoadPathBang`, `#extensions`, `#first`, `#last`
- `exclude:` option on `add`
- Remaining ~14 Rails-named test cases from `vendor/rails/railties/test/paths_test.rb`

## Test plan

- [x] `pnpm vitest run packages/trailties/src/paths.test.ts` — 9 tests, verbatim Rails names where Rails has tests
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm -r build` clean (website pre-existing failure unrelated)
- [x] LOC under 300 ceiling
- [ ] PR 1.1b lands deferred surface + remaining tests

---

## Copilot review #1 responses

1. **`children()` boundary** — Kept. Rails uses `start_with?` verbatim (`vendor/rails/railties/lib/rails/paths.rb` L138). Fidelity rule wins; a regex/segment check would diverge from upstream.
2. **`glob` bypasses `FsAdapter`** — Out of scope here. `@blazetrails/activesupport/glob` already documents the Node-only limitation in its file header pending the browser-adapter PR; `Paths` correctly delegates to it.
3. **`isSymlink` unsafe cast** — Fixed. Added optional `isSymbolicLink()` to `FsStatResult`; cast removed.
4. **Glob expansion test coverage** — Deferred to 1.1b (LOC ceiling). Tracked in PR body.
5. **`FsAdapter.stat()` breaking change** — Fixed. `stat` is now optional with a `statSync` fallback at the call site.


---

## Copilot review #2 responses

1. **`isDir` `statSync` fallback** — Fixed. Removed the sync fallback; `isDir` now throws if `FsAdapter.stat` is missing, honoring trailties hard rule 3 (async fs only).
2. **`children()` boundary** — Kept (already addressed in review #1). Rails `vendor/rails/railties/lib/rails/paths.rb` L138 uses `start_with?` verbatim.
3. **Glob expansion test coverage** — Deferred to 1.1b (LOC ceiling).
4. **"A failed symlink is still a valid file" expects a throw** — Kept. Rails `paths.rb` L220–228 literally `raise`s when a path's `File.exist?` is false but `File.symlink?` is true; the upstream test name is itself a Rails quirk. The test asserts the Rails-source behavior verbatim.


---

## Copilot review #3 responses

1. **`FsAdapter.stat?` JSDoc misleading** — Fixed. Removed the inaccurate "fall back to `statSync`" wording; comment now states async-only consumers require it and will error if absent.
2. **Glob expansion test coverage** — Deferred to 1.1b (LOC ceiling), already tracked.
