### PR TITLE
test(activerecord): defineSchema for remaining calculations + persistence describes

### DIFF
--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -2847,8 +2847,69 @@ describe("CalculationsTest", () => {
 describe("CalculationsTest", () => {
   let adapter: DatabaseAdapter;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      accounts: { balance: "integer" },
+      authors: { name: "string" },
+      conversations: {
+        status: "integer",
+        comments_status: "integer",
+        question_type: "integer",
+      },
+      orders: { status: "string", total: "integer" },
+      people: { name: "string", age: "integer" },
+      posts: {
+        title: "string",
+        status: "string",
+        published: "boolean",
+        author_id: "integer",
+        body: "string",
+        comments_count: "integer",
+        likes_count: "integer",
+        views_count: "integer",
+        updated_at: "datetime",
+      },
+      products: { sku: "string", name: "string" },
+      rg_authors: { name: "string" },
+      rg_books: { rg_author_id: "integer", title: "string" },
+      rg_comments: { rg_post_id: "integer" },
+      rg_posts: { title: "string" },
+      rg_wa_authors: {},
+      rg_wa_posts: { rg_wa_author_id: "integer" },
+      rg_wm_authors: {},
+      rg_wm_posts: { rg_wm_author_id: "integer" },
+      sl_authors: { name: "string" },
+      sl_books: { sl_author_id: "integer", title: "string", name: "string" },
+      sl2_authors: { name: "string" },
+      sl2_books: { sl2_author_id: "integer" },
+      sl3_authors: { name: "string" },
+      sl3_books: { sl3_author_id: "integer" },
+      topics: {
+        title: "string",
+        status: "string",
+        body: "string",
+        updated_at: "datetime",
+        checked_at: "datetime",
+        approved: "boolean",
+        category: "string",
+        written_on: "datetime",
+        content: "string",
+        author_name: "string",
+      },
+      users: {
+        name: "string",
+        status: "string",
+        role: "string",
+        age: "integer",
+        email: "string",
+        updated_at: "datetime",
+        ssn: "string",
+        bio: "string",
+        active: "boolean",
+      },
+      vehicles: { name: "string", type: "string" },
+    });
   });
 
   // Rails: test "group count"
@@ -6240,8 +6301,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: attributeChanged?(from:, to:) — Active Model Dirty
   it("attributeChanged? supports from: and to: options (Active Model Dirty)", async () => {
-    const adapter = createTestAdapter();
-
     class Person extends Base {
       static {
         this._tableName = "people";
@@ -6273,7 +6332,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: optimizer_hints — add database query hints
   it("optimizerHints() adds hints to generated SQL", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6288,7 +6346,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: errors.full_messages_for — error messages for specific attribute
   it("errors.fullMessagesFor() returns messages for specific attribute", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6308,7 +6365,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: errors.of_kind? — check for specific error type
   it("errors.ofKind() checks for error type on attribute", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6326,7 +6382,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: column_for_attribute — attribute metadata
   it("columnForAttribute() returns type info for attribute", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6345,7 +6400,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: attributes_before_type_cast — raw attribute values
   it("attributesBeforeTypeCast returns raw values", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6361,7 +6415,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: encrypts — encrypted attributes
   it("encrypts() transparently encrypts and decrypts attributes", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6390,7 +6443,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: scope with extension block
   it("scope with extension block adds methods to the relation", () => {
-    const adapter = createTestAdapter();
     class Post extends Base {
       static {
         this._tableName = "posts";
@@ -6450,7 +6502,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: no_touching — suppress touch callbacks
   it("noTouching() suppresses touching during block", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6471,7 +6522,6 @@ describe("CalculationsTest", () => {
     const { generatesTokenFor, setTokenForSecret } = await import("./generates-token-for.js");
     setTokenForSecret("test-secret");
     try {
-      const adapter = createTestAdapter();
       class User extends Base {
         static {
           this._tableName = "users";
@@ -6493,7 +6543,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: Relation#readonly? — check readonly status
   it("Relation.isReadonly reflects readonly state", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6526,7 +6575,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: nullify_blanks — auto-nullify blank strings
   it("nullifyBlanks converts empty strings to null", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6544,7 +6592,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: prepend callbacks
   it("before_destroy with prepend: true runs first", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6569,7 +6616,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: suppress — skip persistence during block
   it("suppress() prevents database writes", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6607,7 +6653,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: to_xml — XML serialization
   it("toXml() serializes model to XML", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6627,7 +6672,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: from_json — JSON deserialization
   it("fromJson() sets attributes from JSON", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6643,7 +6687,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: from_json with root
   it("fromJson() supports include_root", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6659,7 +6702,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: persisted? — checks if record is saved
   it("isPersisted() returns false for new records, true after save", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6676,7 +6718,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: attribute_types — returns map of column types
   it("attributeTypes returns type objects per column", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6692,7 +6733,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: logger — set/get logger
   it("logger defaults to null and can be set", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6709,7 +6749,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: Relation#build — creates unsaved record with scope
   it("Relation#build creates unsaved record with scoped attributes", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6727,7 +6766,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: Relation#create — persists record with scope
   it("Relation#create persists record with scoped attributes", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6744,7 +6782,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: Relation#spawn — independent copy
   it("Relation#spawn returns an independent copy", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6760,7 +6797,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: invert_where — inverts where conditions
   it("invertWhere swaps where and whereNot", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6781,7 +6817,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: Relation#inspect — debug representation
   it("inspect() returns human-readable relation info", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6798,7 +6833,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: toModel returns self (ActiveModel::Conversion)
   it("toModel() returns self", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6813,7 +6847,6 @@ describe("CalculationsTest", () => {
   // Rails guide: i18nScope
   it("i18nScope returns 'activemodel' on Model", () => {
     // Base overrides Model's i18nScope to return "activerecord"
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6826,7 +6859,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: attribute_previously_changed?
   it("attributePreviouslyChanged checks last save changes", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6844,7 +6876,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: CollectionProxy#push
   it("CollectionProxy push adds records", async () => {
-    const adapter = createTestAdapter();
     class Author extends Base {
       static {
         this._tableName = "authors";
@@ -6874,7 +6905,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: CollectionProxy#isEmpty
   it("CollectionProxy isEmpty returns true when empty", async () => {
-    const adapter = createTestAdapter();
     class Author extends Base {
       static {
         this._tableName = "authors";
@@ -6901,7 +6931,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: load_async schedules background load
   it("loadAsync returns the relation for chaining", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6918,7 +6947,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: clone — shallow clone preserving id
   it("clone preserves id and persisted state", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6935,7 +6963,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: find_each with order: :desc (Rails 7.1)
   it("findEach supports order option", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6960,7 +6987,6 @@ describe("CalculationsTest", () => {
   it("toGid returns a GlobalID-like URI", async () => {
     setApp("TestApp");
     try {
-      const adapter = createTestAdapter();
       class User extends Base {
         static {
           this._tableName = "users";
@@ -6978,7 +7004,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: column_defaults
   it("columnDefaults returns default values", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -6992,7 +7017,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: find_by_attribute dynamic finder
   it("findByAttribute finds record by single column", async () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -7009,7 +7033,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: confirmation validator with caseSensitive: false
   it("confirmation validator supports case_sensitive: false", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -7026,7 +7049,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: extending with function
   it("extending accepts a function argument", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";
@@ -7043,7 +7065,6 @@ describe("CalculationsTest", () => {
 
   // Rails guide: attribute_method_prefix
   it("attributeMethodPrefix defines prefixed methods", () => {
-    const adapter = createTestAdapter();
     class User extends Base {
       static {
         this._tableName = "users";

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1156,8 +1156,34 @@ describe("PersistenceTest", () => {
 });
 
 describe("PersistenceTest", () => {
+  let adapter: DatabaseAdapter;
+
+  beforeEach(async () => {
+    adapter = freshAdapter();
+    await defineSchema(adapter, {
+      animals: { name: "string", type: "string" },
+      dogs: { name: "string", type: "string" },
+      minimals: {},
+      order_items: {
+        shop_id: "integer",
+        order_id: "integer",
+        item_name: "string",
+      },
+      other_topics: { title: "string" },
+      posts: { title: "string", created_at: "datetime" },
+      topics: {
+        title: "string",
+        lock_version: "integer",
+        body: "string",
+        updated_at: "datetime",
+        created_at: "datetime",
+        active: "boolean",
+        count: "integer",
+      },
+    });
+  });
+
   it("fills auto populated columns on creation", async () => {
-    const adapter = freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -1174,7 +1200,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update attribute does not invoke callbacks", async () => {
-    const adapter = freshAdapter();
     const log: string[] = [];
     class Topic extends Base {
       static {
@@ -1195,7 +1220,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update attribute does not autoincrement lock version", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1210,7 +1234,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update columns should not modify specific columns", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1229,7 +1252,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update columns changing id", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1253,7 +1275,6 @@ describe("PersistenceTest", () => {
   });
 
   it("create bang many with block", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1267,7 +1288,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1280,7 +1300,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update with block", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1294,7 +1313,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update association", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1308,7 +1326,6 @@ describe("PersistenceTest", () => {
   });
 
   it("becomes keeps the type column if an STI model", async () => {
-    const adapter = freshAdapter();
     class Animal extends Base {
       static {
         this.attribute("name", "string");
@@ -1330,7 +1347,6 @@ describe("PersistenceTest", () => {
   });
 
   it("becomes keeps errors", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1353,7 +1369,6 @@ describe("PersistenceTest", () => {
   });
 
   it("becomes should not change current class", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1373,7 +1388,6 @@ describe("PersistenceTest", () => {
   });
 
   it("becomes copies custom primary key", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1392,7 +1406,6 @@ describe("PersistenceTest", () => {
   });
 
   it("becomes! should copy attributes", async () => {
-    const adapter = freshAdapter();
     class Animal extends Base {
       static {
         this.attribute("name", "string");
@@ -1412,7 +1425,6 @@ describe("PersistenceTest", () => {
   });
 
   it("save update with dirty timestamp", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1427,7 +1439,6 @@ describe("PersistenceTest", () => {
   });
 
   it("save without N+1", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1442,7 +1453,6 @@ describe("PersistenceTest", () => {
   });
 
   it("create columns not equal to fields", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1456,7 +1466,6 @@ describe("PersistenceTest", () => {
   });
 
   it("instantiate creates a new record from the given hash", () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1469,7 +1478,6 @@ describe("PersistenceTest", () => {
   });
 
   it("delete returns number of affected rows", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1482,7 +1490,6 @@ describe("PersistenceTest", () => {
   });
 
   it("delete many returns number of affected rows", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1498,7 +1505,6 @@ describe("PersistenceTest", () => {
   });
 
   it("create with timestamps record timestamps", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1513,7 +1519,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update_attribute_vs_update_column", async () => {
-    const adapter = freshAdapter();
     const log: string[] = [];
     class Topic extends Base {
       static {
@@ -1538,7 +1543,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update_all with limit", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1552,7 +1556,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update_all with order", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1566,7 +1569,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update_all with offset", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1579,7 +1581,6 @@ describe("PersistenceTest", () => {
   });
 
   it("destroy with nil raises ActiveRecordError", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1590,7 +1591,6 @@ describe("PersistenceTest", () => {
   });
 
   it("reload refreshes the instance", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1604,7 +1604,6 @@ describe("PersistenceTest", () => {
   });
 
   it("reload does not forget the PK", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1618,7 +1617,6 @@ describe("PersistenceTest", () => {
   });
 
   it("reload returns self", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1631,7 +1629,6 @@ describe("PersistenceTest", () => {
   });
 
   it("save returns self", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1645,7 +1642,6 @@ describe("PersistenceTest", () => {
   });
 
   it("save bang should always save", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1658,7 +1654,6 @@ describe("PersistenceTest", () => {
   });
 
   it("save with duped frozen attribute", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1673,7 +1668,6 @@ describe("PersistenceTest", () => {
   });
 
   it("toggle!", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("active", "boolean", { default: false });
@@ -1688,7 +1682,6 @@ describe("PersistenceTest", () => {
   });
 
   it("increment!", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("count", "integer", { default: 0 });
@@ -1705,7 +1698,6 @@ describe("PersistenceTest", () => {
   // Rails' increment! emits an atomic UPDATE via update_counters, so
   // two concurrent calls both land instead of racing on a read-then-write.
   it("increment! applies concurrent increments atomically", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("count", "integer", { default: 0 });
@@ -1724,7 +1716,6 @@ describe("PersistenceTest", () => {
   // must no longer look dirty, otherwise a later save() would re-persist
   // the already-applied delta.
   it("increment! clears dirty tracking for the incremented attribute", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("count", "integer", { default: 0 });
@@ -1741,7 +1732,6 @@ describe("PersistenceTest", () => {
   // Rails: increment!(attribute, by, touch: :updated_at) updates the
   // timestamp in the same atomic statement.
   it("increment! with touch option updates the named timestamp column", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("count", "integer", { default: 0 });
@@ -1759,7 +1749,6 @@ describe("PersistenceTest", () => {
   });
 
   it("populates non primary key autoincremented column for a cpk model", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1771,7 +1760,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update many!", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1787,7 +1775,6 @@ describe("PersistenceTest", () => {
   });
 
   it("class level update without ids!", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1801,7 +1788,6 @@ describe("PersistenceTest", () => {
   });
 
   it("class level update is affected by scoping!", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1815,7 +1801,6 @@ describe("PersistenceTest", () => {
   });
 
   it("increment aliased attribute", () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("count", "integer", { default: 0 });
@@ -1828,7 +1813,6 @@ describe("PersistenceTest", () => {
   });
 
   it("increment nil attribute", () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("count", "integer");
@@ -1841,7 +1825,6 @@ describe("PersistenceTest", () => {
   });
 
   it("increment updates counter in db using offset", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("count", "integer", { default: 0 });
@@ -1855,7 +1838,6 @@ describe("PersistenceTest", () => {
   });
 
   it("increment with touch updates timestamps", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("count", "integer", { default: 0 });
@@ -1869,7 +1851,6 @@ describe("PersistenceTest", () => {
   });
 
   it("destroy many", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1883,7 +1864,6 @@ describe("PersistenceTest", () => {
   });
 
   it("destroy many with invalid id", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1896,7 +1876,6 @@ describe("PersistenceTest", () => {
   // Rails: Base.delete(ids[]) should delete every matching row — single-column
   // PK case routes through `where(pk: ids).delete_all` (delete_by semantics).
   it("delete with array of ids removes all matching rows", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1911,7 +1890,6 @@ describe("PersistenceTest", () => {
   });
 
   it("delete with nil / [] is a no-op returning 0", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -1931,7 +1909,6 @@ describe("PersistenceTest", () => {
   // — NOT a per-column IN cross-product (which would also match
   // [shop_id=2, order_id=10]).
   it("delete accepts an array of composite-PK tuples", async () => {
-    const adapter = freshAdapter();
     class OrderItem extends Base {
       static {
         this._tableName = "order_items";
@@ -1959,7 +1936,6 @@ describe("PersistenceTest", () => {
   // Rails: update(id, attrs) on a composite-PK model must treat a flat
   // tuple as ONE id (not parallel ids). Mirrors destroy's detection.
   it("update on composite PK treats a tuple as a single id", async () => {
-    const adapter = freshAdapter();
     class OrderItem extends Base {
       static {
         this._tableName = "order_items";
@@ -1980,7 +1956,6 @@ describe("PersistenceTest", () => {
   // Rails: destroy(id) on a composite-PK model with a single tuple must
   // destroy ONE record, not iterate the tuple as N ids.
   it("destroy on composite PK treats a tuple as a single id", async () => {
-    const adapter = freshAdapter();
     class OrderItem extends Base {
       static {
         this._tableName = "order_items";
@@ -2000,7 +1975,6 @@ describe("PersistenceTest", () => {
   });
 
   it("create prefetched pk", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2013,7 +1987,6 @@ describe("PersistenceTest", () => {
   });
 
   it("build many through factory with block", () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2026,7 +1999,6 @@ describe("PersistenceTest", () => {
   });
 
   it("save for record with only primary key that is provided", async () => {
-    const adapter = freshAdapter();
     class Minimal extends Base {
       static {
         this.adapter = adapter;
@@ -2039,7 +2011,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update columns not equal attributes", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2054,7 +2025,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update for record with only primary key", async () => {
-    const adapter = freshAdapter();
     class Minimal extends Base {
       static {
         this.adapter = adapter;
@@ -2066,7 +2036,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update attribute after update", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2080,7 +2049,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update attribute does not run sql if attribute is not changed", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2094,7 +2062,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update raises record not found exception", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2105,7 +2072,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update attribute with one updated", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2120,7 +2086,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update attribute for updated at on", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2136,7 +2101,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update attribute!", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2149,7 +2113,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update attribute for updated at on!", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2163,7 +2126,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update column for readonly attribute", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2177,7 +2139,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update column with one changed and one updated", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2194,7 +2155,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update column with default scope", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2208,7 +2168,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update columns should not use setter method", async () => {
-    const adapter = freshAdapter();
     const log: string[] = [];
     class Topic extends Base {
       static {
@@ -2226,7 +2185,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update columns should not leave the object dirty", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2241,7 +2199,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update columns with one readonly attribute", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2256,7 +2213,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update columns with one changed and one updated", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2272,7 +2228,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update columns returns boolean", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2286,7 +2241,6 @@ describe("PersistenceTest", () => {
   });
 
   it("class level destroy", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2299,7 +2253,6 @@ describe("PersistenceTest", () => {
   });
 
   it("class level destroy is affected by scoping", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2312,7 +2265,6 @@ describe("PersistenceTest", () => {
   });
 
   it("class level delete with invalid ids", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2325,7 +2277,6 @@ describe("PersistenceTest", () => {
   });
 
   it("class level delete is affected by scoping", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2338,7 +2289,6 @@ describe("PersistenceTest", () => {
   });
 
   it("update uses query constraints config", async () => {
-    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");
@@ -2353,7 +2303,6 @@ describe("PersistenceTest", () => {
 
   describe("QueryConstraintsTest", () => {
     it("primary key stays the same", async () => {
-      const adapter = freshAdapter();
       class Topic extends Base {
         static {
           this.attribute("title", "string");
@@ -3270,8 +3219,13 @@ describe("PersistenceTest", () => {
     }
   }
 
-  beforeEach(() => {
+  beforeEach(async () => {
     adapter = freshAdapter();
+    await defineSchema(adapter, {
+      posts: { title: "string", body: "string" },
+      requireds: { name: "string" },
+      trackeds: { name: "string" },
+    });
     Post.adapter = adapter;
   });
 


### PR DESCRIPTION
## Summary

Phase 7 of `docs/tm-unification-plan.md` deletes the auto-schema path in `test-adapter.ts`. This migrates the remaining unmigrated describes in two activerecord test files so they declare their schemas explicitly via `defineSchema()` and stay green under `AR_NO_AUTO_SCHEMA=1`.

- `packages/activerecord/src/calculations.test.ts`: the large mixed-fixture describe starting at line 2847 (Order/Topic/User/Post/etc. + `rg_*`, `sl_*`, `sl2_*`, `sl3_*` association fixtures). Adds a `defineSchema` to its `beforeEach` covering every table referenced inside, and drops 36 inline `const adapter = createTestAdapter()` shadowing lines so each `it` uses the describe-level adapter.
- `packages/activerecord/src/persistence.test.ts`: two describes migrated.
  - The freshAdapter-per-test describe at line 1158 (78 `const adapter = freshAdapter()` calls) — hoisted to a single describe-level `let adapter` + `beforeEach` with `defineSchema` for `topics / minimals / posts / animals / dogs / other_topics / order_items`.
  - The Post-class describe at line 3263 — its existing `beforeEach` now also calls `defineSchema` for `posts / requireds / trackeds`.

## Test plan

- [x] `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/calculations.test.ts` → 543 passed, 3 skipped
- [x] `AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/persistence.test.ts` → 389 passed
- [x] `pnpm vitest run` both files without the env var → 932 passed, 3 skipped

## Size

This PR is intentionally over the usual 300-LOC ceiling — explicit permission granted in the spawn prompt. Final shortstat: 2 files, +95 / −120 (net negative; additions+deletions = 215 LOC).