### PR TITLE
feat(trailties): port Rails::Initializable (PR 1.2)

### DIFF
--- a/packages/trailties/src/initializable.test.ts
+++ b/packages/trailties/src/initializable.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, test } from "vitest";
+import { Initializable } from "./initializable.js";
+
+let arr: number[] = [];
+let withArg: unknown = null;
+const push = (n: number) => () => void arr.push(n);
+
+class Foo extends Initializable {
+  foo?: number;
+  bar?: number;
+  static {
+    Foo.initializer("start", {}, function (this: Foo) {
+      this.foo = (this.foo ?? 0) + 1;
+    });
+  }
+}
+class Bar extends Foo {
+  static {
+    Bar.initializer("bar", {}, function (this: Bar) {
+      this.bar = (this.bar ?? 0) + 1;
+    });
+  }
+}
+
+class Parent extends Initializable {
+  static {
+    Parent.initializer("one", {}, push(1));
+    Parent.initializer("two", {}, push(2));
+  }
+}
+class Child extends Parent {
+  static {
+    Child.initializer("three", { before: "one" }, push(3));
+    Child.initializer("four", { after: "one", before: "two" }, push(4));
+  }
+}
+// Re-open Parent (the Rails fixture does this) to add :five.
+Parent.initializer("five", { before: "one" }, push(5));
+
+class Instance extends Initializable {
+  static {
+    Instance.initializer("one", { group: "assets" }, push(1));
+    Instance.initializer("two", {}, push(2));
+    Instance.initializer("three", { group: "all" }, push(3));
+    Instance.initializer("four", {}, push(4));
+  }
+}
+
+class WithArgs extends Initializable {
+  static {
+    WithArgs.initializer("foo", {}, (arg: unknown) => void (withArg = arg));
+  }
+}
+
+class MoreInitializers extends Initializable {
+  static {
+    MoreInitializers.initializer("startup", { before: "last" }, push(3));
+    MoreInitializers.initializer(
+      "terminate",
+      { after: "first", before: "startup" },
+      function (this: MoreInitializers) {
+        arr.push(this.two());
+      },
+    );
+  }
+  two(): number {
+    return 2;
+  }
+}
+class OverriddenInitializer extends Initializable {
+  static {
+    OverriddenInitializer.initializer("first", {}, push(1));
+    OverriddenInitializer.initializer("last", {}, push(4));
+  }
+  static override get initializers() {
+    return super.initializers.plus(new MoreInitializers().initializers);
+  }
+}
+
+class PluginA extends Initializable {
+  static {
+    PluginA.initializer("plugin_a.startup", {}, push(1));
+    PluginA.initializer("plugin_a.terminate", {}, push(4));
+  }
+}
+class PluginB extends Initializable {
+  static {
+    PluginB.initializer("plugin_b.startup", { after: "plugin_a.startup" }, push(2));
+    PluginB.initializer("plugin_b.terminate", { before: "plugin_a.terminate" }, push(3));
+  }
+}
+class InterdependentApplication extends Initializable {
+  static override get initializers() {
+    return PluginB.initializers.plus(PluginA.initializers);
+  }
+}
+
+describe("Basic", () => {
+  test("initializers run", () => {
+    const foo = new Foo();
+    foo.runInitializers();
+    expect(foo.foo).toBe(1);
+  });
+  test("initializers are inherited", () => {
+    const bar = new Bar();
+    bar.runInitializers();
+    expect([bar.foo, bar.bar]).toEqual([1, 1]);
+  });
+  test("initializers only get run once", () => {
+    const foo = new Foo();
+    foo.runInitializers();
+    foo.runInitializers();
+    expect(foo.foo).toBe(1);
+  });
+  test("creating initializer without a block raises an error", () => {
+    expect(() => {
+      class Bad extends Initializable {}
+      // @ts-expect-error testing runtime guard
+      Bad.initializer("foo", {});
+    }).toThrow(TypeError);
+  });
+  test("Initializer provides context's class name", () => {
+    const foo = new Foo();
+    expect(foo.initializers[0].contextClass).toBe(foo.constructor);
+  });
+});
+
+describe("BeforeAfter", () => {
+  test("running on parent", () => {
+    arr = [];
+    new Parent().runInitializers();
+    expect(arr).toEqual([5, 1, 2]);
+  });
+  test("running on child", () => {
+    arr = [];
+    new Child().runInitializers();
+    expect(arr).toEqual([5, 3, 1, 4, 2]);
+  });
+  test("handles dependencies introduced before all initializers are loaded", () => {
+    arr = [];
+    new InterdependentApplication().runInitializers();
+    expect(arr).toEqual([1, 2, 3, 4]);
+  });
+});
+
+describe("InstanceTest", () => {
+  test("running locals", () => {
+    arr = [];
+    new Instance().runInitializers();
+    expect(arr).toEqual([2, 3, 4]);
+  });
+  test("running locals with groups", () => {
+    arr = [];
+    new Instance().runInitializers("assets");
+    expect(arr).toEqual([1, 3]);
+  });
+});
+
+describe("WithArgsTest", () => {
+  test("running initializers with args", () => {
+    withArg = null;
+    new WithArgs().runInitializers("default", "foo");
+    expect(withArg).toBe("foo");
+  });
+});
+
+describe("OverriddenInitializerTest", () => {
+  test("merges in the initializers from the parent in the right order", () => {
+    arr = [];
+    new OverriddenInitializer().runInitializers();
+    expect(arr).toEqual([1, 2, 3, 4]);
+  });
+});

--- a/packages/trailties/src/initializable.test.ts
+++ b/packages/trailties/src/initializable.test.ts
@@ -112,6 +112,17 @@ describe("Basic", () => {
     foo.runInitializers();
     expect(foo.foo).toBe(1);
   });
+  test("opts is optional (Rails initializer(name, opts = {}, &blk))", () => {
+    class NoOpts extends Initializable {
+      static {
+        NoOpts.initializer("only", () => void arr.push(7));
+      }
+    }
+    arr = [];
+    new NoOpts().runInitializers();
+    expect(arr).toEqual([7]);
+  });
+
   test("creating initializer without a block raises an error", () => {
     expect(() => {
       class Bad extends Initializable {}

--- a/packages/trailties/src/initializable.ts
+++ b/packages/trailties/src/initializable.ts
@@ -23,7 +23,7 @@ export class Initializer<C = unknown> {
   ) {
     this.name = name;
     this._context = context;
-    this._options = { group: "default", ...options };
+    this._options = { ...options, group: options.group ?? "default" };
     this.block = block;
   }
 

--- a/packages/trailties/src/initializable.ts
+++ b/packages/trailties/src/initializable.ts
@@ -1,0 +1,163 @@
+// Port of `Rails::Initializable` from `railties/lib/rails/initializable.rb`.
+export type InitializerGroup = string;
+
+export interface InitializerOptions {
+  before?: string;
+  after?: string;
+  group?: InitializerGroup;
+}
+
+export type InitializerBlock<C = unknown> = (this: C, ...args: unknown[]) => unknown;
+
+export class Initializer<C = unknown> {
+  readonly name: string;
+  readonly block: InitializerBlock<C>;
+  private readonly _context: C | null;
+  private readonly _options: InitializerOptions;
+
+  constructor(
+    name: string,
+    context: C | null,
+    options: InitializerOptions,
+    block: InitializerBlock<C>,
+  ) {
+    this.name = name;
+    this._context = context;
+    this._options = { group: "default", ...options };
+    this.block = block;
+  }
+
+  get before(): string | undefined {
+    return this._options.before;
+  }
+  get after(): string | undefined {
+    return this._options.after;
+  }
+
+  belongsTo(group: InitializerGroup): boolean {
+    return this._options.group === group || this._options.group === "all";
+  }
+
+  run(...args: unknown[]): unknown {
+    return this.block.apply(this._context as C, args);
+  }
+
+  bind<T>(context: T): Initializer<T> {
+    if (this._context !== null) return this as unknown as Initializer<T>;
+    return new Initializer<T>(
+      this.name,
+      context,
+      this._options,
+      this.block as unknown as InitializerBlock<T>,
+    );
+  }
+
+  get contextClass(): unknown {
+    return (this._context as { constructor?: unknown } | null)?.constructor;
+  }
+}
+
+export class Collection extends Array<Initializer> {
+  plus(other: Initializer[]): Collection {
+    return new Collection(...this, ...other);
+  }
+
+  /** @internal Mirrors Rails `tsort_each_child`. */
+  tsortEachChild(node: Initializer): Initializer[] {
+    return this.filter((i) => i.before === node.name || i.name === node.after);
+  }
+
+  /** DFS post-order matching Ruby `TSort#tsort_each`. Stable on iteration order. */
+  tsort(): Initializer[] {
+    const out: Initializer[] = [];
+    const visited = new Set<Initializer>();
+    const visiting = new Set<Initializer>();
+    const visit = (n: Initializer): void => {
+      if (visited.has(n)) return;
+      if (visiting.has(n)) throw new Error(`Cyclic initializer dependency at "${n.name}"`);
+      visiting.add(n);
+      for (const child of this.tsortEachChild(n)) visit(child);
+      visiting.delete(n);
+      visited.add(n);
+      out.push(n);
+    };
+    for (const n of this) visit(n);
+    return out;
+  }
+}
+
+/** @internal Per-class own collections, keyed by constructor. */
+const OWN = new WeakMap<typeof Initializable, Collection>();
+
+export class Initializable {
+  private _initializers?: Collection;
+  private _ran?: boolean;
+
+  /** @internal Per-class collection — mirrors Rails' `@initializers ||= ...`. */
+  static _ownInitializers(): Collection {
+    let own = OWN.get(this);
+    if (!own) {
+      own = new Collection();
+      OWN.set(this, own);
+    }
+    return own;
+  }
+
+  /** Subclasses may override to splice in extra initializers. */
+  static get initializers(): Collection {
+    return this._ownInitializers();
+  }
+
+  static initializersChain(): Collection {
+    const classes: Array<typeof Initializable> = [this];
+    for (
+      let cursor: unknown = Object.getPrototypeOf(this);
+      cursor && cursor !== Function.prototype && cursor !== Object.prototype;
+      cursor = Object.getPrototypeOf(cursor)
+    ) {
+      classes.unshift(cursor as typeof Initializable);
+    }
+    let chain = new Collection();
+    for (const klass of classes) {
+      if (klass === Initializable || klass.prototype instanceof Initializable) {
+        chain = chain.plus(klass.initializers);
+      }
+    }
+    return chain;
+  }
+
+  static initializersFor(binding: unknown): Collection {
+    return new Collection(...this.initializersChain().map((i) => i.bind(binding)));
+  }
+
+  static initializer<C = unknown>(
+    name: string,
+    opts: InitializerOptions,
+    block: InitializerBlock<C>,
+  ): void {
+    if (typeof block !== "function") {
+      throw new TypeError("A block must be passed when defining an initializer");
+    }
+    const own = this._ownInitializers();
+    const referencedBefore = opts.before !== undefined && own.some((i) => i.name === opts.before);
+    if (own.length > 0 && !referencedBefore && opts.after === undefined) {
+      opts = { ...opts, after: own[own.length - 1].name };
+    }
+    own.push(new Initializer<C>(name, null, opts, block) as Initializer);
+  }
+
+  get initializers(): Collection {
+    if (!this._initializers) {
+      this._initializers = (this.constructor as typeof Initializable).initializersFor(this);
+    }
+    return this._initializers;
+  }
+
+  runInitializers(group: InitializerGroup = "default", ...args: unknown[]): void {
+    if (this._ran) return;
+    for (const init of this.initializers.tsort()) {
+      if (init.belongsTo(group)) init.run(...args);
+    }
+    this._ran = true;
+  }
+}

--- a/packages/trailties/src/initializable.ts
+++ b/packages/trailties/src/initializable.ts
@@ -39,7 +39,12 @@ export class Initializer<C = unknown> {
   }
 
   run(...args: unknown[]): unknown {
-    return this.block.apply(this._context as C, args);
+    if (this._context === null) {
+      throw new Error(
+        `Initializer "${this.name}" is unbound; call bind(context) (or run via runInitializers) first`,
+      );
+    }
+    return this.block.apply(this._context, args);
   }
 
   bind<T>(context: T): Initializer<T> {

--- a/packages/trailties/src/initializable.ts
+++ b/packages/trailties/src/initializable.ts
@@ -130,18 +130,26 @@ export class Initializable {
     return new Collection(...this.initializersChain().map((i) => i.bind(binding)));
   }
 
+  static initializer<C = unknown>(name: string, block: InitializerBlock<C>): void;
   static initializer<C = unknown>(
     name: string,
     opts: InitializerOptions,
     block: InitializerBlock<C>,
+  ): void;
+  static initializer<C = unknown>(
+    name: string,
+    optsOrBlock: InitializerOptions | InitializerBlock<C>,
+    maybeBlock?: InitializerBlock<C>,
   ): void {
+    const block = typeof optsOrBlock === "function" ? optsOrBlock : maybeBlock;
+    const opts: InitializerOptions = typeof optsOrBlock === "function" ? {} : { ...optsOrBlock };
     if (typeof block !== "function") {
       throw new TypeError("A block must be passed when defining an initializer");
     }
     const own = this._ownInitializers();
     const referencedBefore = opts.before !== undefined && own.some((i) => i.name === opts.before);
     if (own.length > 0 && !referencedBefore && opts.after === undefined) {
-      opts = { ...opts, after: own[own.length - 1].name };
+      opts.after = own[own.length - 1].name;
     }
     own.push(new Initializer<C>(name, null, opts, block) as Initializer);
   }


### PR DESCRIPTION
## Summary

Phase 1 leaf per `docs/trailties-plan.md` PR 1.2. Ports Rails `Initializable` — the ordered-initializer dependency graph that powers `Engine`/`Application` boot.

- `Initializer` — `name`, `before`/`after`, `group`, `bind(context)`, `run(...args)`, `contextClass`.
- `Collection extends Array<Initializer>` — `plus()`, `tsortEachChild()`, `tsort()` (DFS post-order matching Ruby TSort).
- `Initializable` — static `initializer()` macro (overloads for both `(name, block)` and `(name, opts, block)`, matching Rails' `initializer(name, opts = {}, &blk)`) with auto-`after` chaining; `initializers` getter (overridable per Rails fixture pattern); `initializersChain()` walks the prototype chain parent-first; per-instance memoized `initializers`; idempotent `runInitializers(group?, ...args)`.

Per-class own collections live in a module-scoped `WeakMap<typeof Initializable, Collection>` keyed by constructor, so subclasses don't share the parent's array and GC of unreferenced classes still works.

## Rails source

**Kept (full port):** `railties/lib/rails/initializable.rb` — `Initializer`, `Collection`, `tsort_each_node`, `tsort_each_child`, `run_initializers`, class-level `initializer` macro (incl. opts-optional), `initializers`, `initializers_chain`, `initializers_for`, inheritance merging.

**Skipped:** none. Plan doc lists no skips for this PR.

**Tests:** `railties/test/initializable_test.rb` mirrored verbatim — all 12 Rails tests across `Basic`, `BeforeAfter`, `InstanceTest`, `WithArgsTest`, `OverriddenInitializerTest`, plus one TS-specific test covering the opts-less overload.

## Notes

- No `node:*` imports (per trailties hard rule 1).
- Open question #1 from the plan (whether `Concern` supports class-side state): sidestepped — TS class inheritance + prototype-chain walk handles the merge directly, no `Concern` needed for this PR.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/initializable.test.ts --project other` — 13/13 green
- [x] `pnpm lint` clean on both files
- [x] `pnpm exec tsc --noEmit` clean
- [x] No `node:*` imports in new files