### PR TITLE
test(activerecord): add animals.active column for default-scoping inheritance test

### DIFF
--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -27,7 +27,7 @@ beforeEach(async () => {
       mentor_id: "integer",
       active: "boolean",
     },
-    animals: { name: "string", type: "string" },
+    animals: { name: "string", type: "string", active: "boolean" },
     dogs: { name: "string", type: "string", active: "boolean" },
     articles: {
       title: "string",


### PR DESCRIPTION
## Summary

The shared top-level `defineSchema` in `packages/activerecord/src/scoping/default-scoping.test.ts` was missing the `active:boolean` column on `animals`, which the `DefaultScopingTest > default scope with inheritance` case uses (`Animal` declares `active`, `Dog extends Animal` STI). Under `AR_NO_AUTO_SCHEMA=1` this surfaced as `table animals has no column named active`.

The file's describes were already migrated to the shared `_adapter`/defineSchema pattern; this is the only column gap. Unblocks Phase 7 of `docs/tm-unification-plan.md`.

## Verification

`AR_NO_AUTO_SCHEMA=1 pnpm vitest run packages/activerecord/src/scoping/default-scoping.test.ts` — 151 pass.

## Size

1 line.