### PR TITLE
ci(prettier): self-hosted cold/warm cache trial (DO NOT MERGE)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,7 @@ jobs:
   prettier:
     name: Prettier
     needs: changes
-    # TEMPORARY: hardcoded to self-hosted for the cold/warm cache trial in
+    # TEMPORARY: hardcoded to self-hosted for the cold/warm/warm2 cache trial in
     # docs/self-hosted-runner-restart-plan.md (Deliverable 3). Revert this
     # line to `${{ vars.RUNNER || 'ubuntu-latest' }}` before merge.
     runs-on: self-hosted

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,9 +191,9 @@ jobs:
   prettier:
     name: Prettier
     needs: changes
-    # TEMPORARY: hardcoded to self-hosted for the cold/warm cache trial
-    # described in docs/self-hosted-runner-restart-plan.md (Deliverable 3).
-    # Revert this line to `${{ vars.RUNNER || 'ubuntu-latest' }}` before merge.
+    # TEMPORARY: hardcoded to self-hosted for the cold/warm cache trial in
+    # docs/self-hosted-runner-restart-plan.md (Deliverable 3). Revert this
+    # line to `${{ vars.RUNNER || 'ubuntu-latest' }}` before merge.
     runs-on: self-hosted
     timeout-minutes: 30
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,7 +191,10 @@ jobs:
   prettier:
     name: Prettier
     needs: changes
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    # TEMPORARY: hardcoded to self-hosted for the cold/warm cache trial
+    # described in docs/self-hosted-runner-restart-plan.md (Deliverable 3).
+    # Revert this line to `${{ vars.RUNNER || 'ubuntu-latest' }}` before merge.
+    runs-on: self-hosted
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Hardcodes the `prettier` job to `runs-on: self-hosted` to measure cold-cache
  + warm-cache WAN egress on the home runner before flipping `vars.RUNNER`
  for everything (see [docs/self-hosted-runner-restart-plan.md](../blob/main/docs/self-hosted-runner-restart-plan.md)
  Deliverable 3).
- Every other job stays on hosted. Failure here is contained to formatting.
- **DO NOT MERGE.** Revert the hardcoded line before this branch is touched.

## Test plan

- [ ] Snapshot vnstat eth0 before first run
- [ ] First push → cold-cache run; record per-job WAN
- [ ] Second push (whitespace nudge, same lockfile) → warm-cache run; record WAN
- [ ] Warm run < 50 MB per plan target
- [ ] bandwidth-guard did not trip