### PR TITLE
feat(actionpack): wire ParamsWrapper into Base + reconcile EXCLUDE_PARAMETERS

### DIFF
--- a/packages/actionpack/src/action-controller/base-params-wrapper.test.ts
+++ b/packages/actionpack/src/action-controller/base-params-wrapper.test.ts
@@ -1,6 +1,8 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./base.js";
 import { Options as ParamsWrapperOptions } from "./metal/params-wrapper.js";
+import { Request } from "../action-dispatch/http/request.js";
+import { Response } from "../action-dispatch/http/response.js";
 
 describe("Base ParamsWrapper wiring", () => {
   it("has default _wrapperOptions with empty format array", () => {
@@ -69,5 +71,56 @@ describe("Base ParamsWrapper wiring", () => {
     F.wrapParameters("widget");
     const instance = Object.create(F.prototype) as F;
     expect(instance._wrapperOptions.name).toBe("widget");
+  });
+
+  it("processAction wraps request params and exposes them via this.params", async () => {
+    let seen: Record<string, unknown> | null = null;
+    class WidgetsController extends Base {
+      static actions = ["create"];
+      create(): void {
+        seen = this.params.toUnsafeHash();
+        this.head(204);
+      }
+    }
+    WidgetsController.wrapParameters({ format: ["json"], name: "widget" });
+    const request = new Request({
+      REQUEST_METHOD: "POST",
+      PATH_INFO: "/widgets",
+      HTTP_HOST: "localhost",
+      CONTENT_TYPE: "application/json",
+      "action_dispatch.request.request_parameters": { name: "alpha", color: "blue" },
+    });
+    const controller = new WidgetsController();
+    await controller.dispatch("create", request, new Response());
+    expect(seen).not.toBeNull();
+    expect((seen as unknown as Record<string, unknown>).widget).toEqual({
+      name: "alpha",
+      color: "blue",
+    });
+    expect((seen as unknown as Record<string, unknown>).name).toBe("alpha");
+  });
+
+  it("processAction does not wrap when format does not match request content-type", async () => {
+    let seen: Record<string, unknown> | null = null;
+    class ThingsController extends Base {
+      static actions = ["create"];
+      create(): void {
+        seen = this.params.toUnsafeHash();
+        this.head(204);
+      }
+    }
+    ThingsController.wrapParameters({ format: ["xml"], name: "thing" });
+    const request = new Request({
+      REQUEST_METHOD: "POST",
+      PATH_INFO: "/things",
+      HTTP_HOST: "localhost",
+      CONTENT_TYPE: "application/json",
+      "action_dispatch.request.request_parameters": { name: "beta" },
+    });
+    const controller = new ThingsController();
+    await controller.dispatch("create", request, new Response());
+    expect(seen).not.toBeNull();
+    expect((seen as unknown as Record<string, unknown>).thing).toBeUndefined();
+    expect((seen as unknown as Record<string, unknown>).name).toBe("beta");
   });
 });

--- a/packages/actionpack/src/action-controller/base-params-wrapper.test.ts
+++ b/packages/actionpack/src/action-controller/base-params-wrapper.test.ts
@@ -32,6 +32,13 @@ describe("Base ParamsWrapper wiring", () => {
     expect(B._wrapperOptions.include).toEqual(["x"]);
   });
 
+  it("wrapParameters derives default name from controller class when format enabled", () => {
+    class UsersController extends Base {}
+    UsersController.wrapParameters({ format: ["json"] });
+    expect(UsersController._wrapperOptions.name).toBe("user");
+    expect(UsersController._wrapperOptions.format).toEqual(["json"]);
+  });
+
   it("wrapParameters(false) disables wrapping by zeroing format", () => {
     class C extends Base {}
     C.wrapParameters({ format: ["json"] });

--- a/packages/actionpack/src/action-controller/base-params-wrapper.test.ts
+++ b/packages/actionpack/src/action-controller/base-params-wrapper.test.ts
@@ -66,6 +66,18 @@ describe("Base ParamsWrapper wiring", () => {
     expect(Parent._wrapperOptions.klass).toBe(Parent);
   });
 
+  it("inheritedParamsWrapper re-derives auto-derived name from subclass klass", () => {
+    class UsersController extends Base {}
+    UsersController.wrapParameters({ format: ["json"] });
+    expect(UsersController._wrapperOptions.name).toBe("user");
+    expect(UsersController._wrapperOptions.nameSet).toBe(false);
+    class AdminsController extends UsersController {}
+    AdminsController.inheritedParamsWrapper();
+    // Re-derived from AdminsController, not inherited "user"
+    expect(AdminsController._wrapperOptions.name).toBe("admin");
+    expect(AdminsController._wrapperOptions.klass).toBe(AdminsController);
+  });
+
   it("inheritedParamsWrapper is a no-op when format is empty", () => {
     class E extends Base {}
     const before = E._wrapperOptions;

--- a/packages/actionpack/src/action-controller/base-params-wrapper.test.ts
+++ b/packages/actionpack/src/action-controller/base-params-wrapper.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { Base } from "./base.js";
+import { Options as ParamsWrapperOptions } from "./metal/params-wrapper.js";
+
+describe("Base ParamsWrapper wiring", () => {
+  it("has default _wrapperOptions with empty format array", () => {
+    expect(Base._wrapperOptions).toBeInstanceOf(ParamsWrapperOptions);
+    expect(Base._wrapperOptions.format).toEqual([]);
+  });
+
+  it("wrapParameters with symbol/string sets name and binds klass", () => {
+    class UsersController extends Base {}
+    UsersController.wrapParameters("person", { include: ["name"] });
+    expect(UsersController._wrapperOptions.name).toBe("person");
+    expect(UsersController._wrapperOptions.include).toEqual(["name"]);
+    expect(UsersController._wrapperOptions.klass).toBe(UsersController);
+    // Parent unchanged
+    expect(Base._wrapperOptions.name).toBeNull();
+  });
+
+  it("wrapParameters with hash merges format from current", () => {
+    class A extends Base {}
+    A.wrapParameters({ format: ["json"] });
+    class B extends A {}
+    // No own format set yet; inherits A's [json]
+    expect(B._wrapperOptions.format).toEqual(["json"]);
+    // Adding more options preserves format from current
+    B.wrapParameters({ include: ["x"] });
+    expect(B._wrapperOptions.format).toEqual(["json"]);
+    expect(B._wrapperOptions.include).toEqual(["x"]);
+  });
+
+  it("wrapParameters(false) disables wrapping by zeroing format", () => {
+    class C extends Base {}
+    C.wrapParameters({ format: ["json"] });
+    C.wrapParameters(false);
+    expect(C._wrapperOptions.format).toEqual([]);
+  });
+
+  it("wrapParameters with class arg stores model", () => {
+    class Model {}
+    class D extends Base {}
+    D.wrapParameters(Model);
+    expect(D._wrapperOptions.model).toBe(Model);
+    expect(D._wrapperOptions.klass).toBe(D);
+  });
+
+  it("inheritedParamsWrapper rebinds klass when format is enabled", () => {
+    class Parent extends Base {}
+    Parent.wrapParameters({ format: ["json"], name: "parent" });
+    class Child extends Parent {}
+    Child.inheritedParamsWrapper();
+    expect(Child._wrapperOptions.klass).toBe(Child);
+    expect(Child._wrapperOptions.name).toBe("parent");
+    expect(Child._wrapperOptions.format).toEqual(["json"]);
+    // Parent's options unchanged
+    expect(Parent._wrapperOptions.klass).toBe(Parent);
+  });
+
+  it("inheritedParamsWrapper is a no-op when format is empty", () => {
+    class E extends Base {}
+    const before = E._wrapperOptions;
+    E.inheritedParamsWrapper();
+    expect(E._wrapperOptions).toBe(before);
+  });
+
+  it("instance _wrapperOptions reads from constructor", () => {
+    class F extends Base {}
+    F.wrapParameters("widget");
+    const instance = Object.create(F.prototype) as F;
+    expect(instance._wrapperOptions.name).toBe("widget");
+  });
+});

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -41,6 +41,12 @@ import {
   requestHttpBasicAuthentication,
 } from "./metal/http-authentication.js";
 import { sendFileHeadersBang } from "./metal/data-streaming.js";
+import {
+  Options as ParamsWrapperOptions,
+  _performParameterWrapping,
+  _wrapperEnabled,
+  type ParamsWrapperHost,
+} from "./metal/params-wrapper.js";
 
 // Re-export callback registration
 export { type ActionCallback, type AroundCallback, type CallbackOptions };
@@ -475,6 +481,83 @@ export class Base extends Metal {
     return instrumentName.call(this);
   }
 
+  // --- Params Wrapper ---
+
+  /**
+   * Class-level wrapper options. Mirrors Rails'
+   * `class_attribute :_wrapper_options, default: Options.from_hash(format: [])`.
+   * Statics are inherited through the class chain; `wrapParameters` assigns an
+   * own property on the calling subclass.
+   */
+  static _wrapperOptions: ParamsWrapperOptions = ParamsWrapperOptions.fromHash({ format: [] });
+
+  /** Instance accessor for the active wrapper options (reads from constructor). */
+  get _wrapperOptions(): ParamsWrapperOptions {
+    return (this.constructor as typeof Base)._wrapperOptions;
+  }
+
+  /**
+   * Class DSL: configure parameter wrapping. Mirrors Rails
+   * `ActionController::ParamsWrapper::ClassMethods#wrap_parameters`.
+   *
+   *     wrapParameters({ format: ["json"] })
+   *     wrapParameters("person", { include: ["name"] })
+   *     wrapParameters(false)                    // disable wrapping
+   *     wrapParameters(SomeModelClass)
+   */
+  static wrapParameters(
+    nameOrModelOrOptions:
+      | string
+      | false
+      | Record<string, unknown>
+      | (new (...args: never[]) => unknown),
+    options: Record<string, unknown> = {},
+  ): void {
+    let model: unknown = null;
+    let opts: Record<string, unknown> = options;
+    if (nameOrModelOrOptions === false) {
+      opts = { ...opts, format: [] };
+    } else if (typeof nameOrModelOrOptions === "string") {
+      opts = { ...opts, name: nameOrModelOrOptions };
+    } else if (
+      typeof nameOrModelOrOptions === "object" &&
+      nameOrModelOrOptions !== null &&
+      !Array.isArray(nameOrModelOrOptions)
+    ) {
+      opts = nameOrModelOrOptions as Record<string, unknown>;
+    } else {
+      model = nameOrModelOrOptions;
+    }
+    const current = this._wrapperOptions;
+    const merged = { format: current.format ?? [], ...opts };
+    const newOpts = ParamsWrapperOptions.fromHash(merged);
+    newOpts.model = model;
+    newOpts.klass = this;
+    this._wrapperOptions = newOpts;
+  }
+
+  /**
+   * Rails' ParamsWrapper `inherited` hook duplicates the parent's options
+   * and rebinds `klass` to the subclass when wrapping is enabled (format
+   * non-empty). JS class statics already inherit; this static method should
+   * be invoked explicitly by subclasses that need a per-subclass `klass`
+   * rebind for `_defaultWrapModel` to derive a name from the subclass.
+   * @internal
+   */
+  static inheritedParamsWrapper(): void {
+    const inherited = this._wrapperOptions;
+    if (!inherited.format || inherited.format.length === 0) return;
+    const dup = ParamsWrapperOptions.fromHash({
+      name: inherited.name,
+      format: inherited.format,
+      include: inherited.include,
+      exclude: inherited.exclude,
+    });
+    dup.model = inherited.model;
+    dup.klass = this;
+    this._wrapperOptions = dup;
+  }
+
   // --- HTTP Basic authentication (Rails parity, P17a) ---
 
   /** Class DSL: `http_basic_authenticate_with name:, password:, realm:, **options`. */
@@ -501,6 +584,9 @@ export class Base extends Metal {
    */
   async processAction(action: string, ...args: unknown[]): Promise<void> {
     try {
+      if (this.request && _wrapperEnabled.call(this as unknown as ParamsWrapperHost)) {
+        _performParameterWrapping.call(this as unknown as ParamsWrapperHost);
+      }
       await super.processAction(action, ...args);
 
       // Resolve any pending async renders (template/partial)

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -47,6 +47,7 @@ import {
   _wrapperEnabled,
   type ParamsWrapperHost,
 } from "./metal/params-wrapper.js";
+import { Parameters as StrongParameters } from "./metal/strong-parameters.js";
 
 // Re-export callback registration
 export { type ActionCallback, type AroundCallback, type CallbackOptions };
@@ -586,6 +587,15 @@ export class Base extends Metal {
     try {
       if (this.request && _wrapperEnabled.call(this as unknown as ParamsWrapperHost)) {
         _performParameterWrapping.call(this as unknown as ParamsWrapperHost);
+        // Rails' controller `params` is `request.parameters` by reference, so
+        // the merge in `_performParameterWrapping` is visible to actions. Our
+        // Metal.dispatch snapshots `request.params` into `this.params` before
+        // processAction runs, so we re-sync after wrapping to surface the
+        // wrapped root key to the action.
+        this.params = new StrongParameters({
+          ...this.request.params,
+          ...this.request.pathParameters,
+        });
       }
       await super.processAction(action, ...args);
 

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -540,7 +540,9 @@ export class Base extends Metal {
     // on first read. We store name eagerly, so assign the derived default
     // here when wrapping is enabled but no name was provided — otherwise
     // `_wrapperEnabled` would always return false for the common Rails form
-    // `wrap_parameters format: [...]`.
+    // `wrap_parameters format: [...]`. `nameSet` stays `false` in that
+    // case so subclasses re-derive from their own `klass` via
+    // `inheritedParamsWrapper`.
     if ((newOpts.format?.length ?? 0) > 0 && !newOpts.name) {
       newOpts.name = _defaultWrapModel.call({ _wrapperOptions: newOpts });
     }
@@ -558,18 +560,24 @@ export class Base extends Metal {
   static inheritedParamsWrapper(): void {
     const inherited = this._wrapperOptions;
     if (!inherited.format || inherited.format.length === 0) return;
+    // Mirrors Rails' `Options#dup` semantics: copy all fields including
+    // `nameSet`, then rebind `klass`. Pass `null` for name so fromHash's
+    // `nameSet` defaults to false, then assign explicitly below to
+    // preserve the parent's explicit-vs-derived state.
     const dup = ParamsWrapperOptions.fromHash({
-      name: inherited.name,
       format: inherited.format,
       include: inherited.include,
       exclude: inherited.exclude,
     });
     dup.model = inherited.model;
     dup.klass = this;
-    // Re-derive default name from the subclass `klass` when the parent's
-    // name was itself derived (matches Rails' lazy `name` semantics on
-    // `inherited`: each subclass derives from its own `controller_name`).
-    if (!dup.name) {
+    if (inherited.nameSet) {
+      // Parent's name was explicitly provided — inherit it as-is.
+      dup.name = inherited.name;
+      dup.nameSet = true;
+    } else {
+      // Parent's name (if any) was auto-derived; re-derive from the
+      // subclass `klass` so `Child < Parent` wraps under its own name.
       dup.name = _defaultWrapModel.call({ _wrapperOptions: dup });
     }
     this._wrapperOptions = dup;

--- a/packages/actionpack/src/action-controller/base.ts
+++ b/packages/actionpack/src/action-controller/base.ts
@@ -43,6 +43,7 @@ import {
 import { sendFileHeadersBang } from "./metal/data-streaming.js";
 import {
   Options as ParamsWrapperOptions,
+  _defaultWrapModel,
   _performParameterWrapping,
   _wrapperEnabled,
   type ParamsWrapperHost,
@@ -534,6 +535,15 @@ export class Base extends Metal {
     const newOpts = ParamsWrapperOptions.fromHash(merged);
     newOpts.model = model;
     newOpts.klass = this;
+    // Rails' `Options#name` is a lazy getter that derives a default from
+    // `klass.controller_name.singularize` (or `model.to_s.demodulize.underscore`)
+    // on first read. We store name eagerly, so assign the derived default
+    // here when wrapping is enabled but no name was provided — otherwise
+    // `_wrapperEnabled` would always return false for the common Rails form
+    // `wrap_parameters format: [...]`.
+    if ((newOpts.format?.length ?? 0) > 0 && !newOpts.name) {
+      newOpts.name = _defaultWrapModel.call({ _wrapperOptions: newOpts });
+    }
     this._wrapperOptions = newOpts;
   }
 
@@ -556,6 +566,12 @@ export class Base extends Metal {
     });
     dup.model = inherited.model;
     dup.klass = this;
+    // Re-derive default name from the subclass `klass` when the parent's
+    // name was itself derived (matches Rails' lazy `name` semantics on
+    // `inherited`: each subclass derives from its own `controller_name`).
+    if (!dup.name) {
+      dup.name = _defaultWrapModel.call({ _wrapperOptions: dup });
+    }
     this._wrapperOptions = dup;
   }
 

--- a/packages/actionpack/src/action-controller/metal/params-wrapper.ts
+++ b/packages/actionpack/src/action-controller/metal/params-wrapper.ts
@@ -21,6 +21,13 @@ export class Options {
   exclude: string[] | null;
   klass: unknown;
   model: unknown;
+  /**
+   * Tracks whether `name` was explicitly provided (mirrors Rails'
+   * `@name_set` mutex flag in `Options#initialize` — `@name_set = name`
+   * is truthy only when a name was passed in). Used by the `inherited`
+   * hook to decide whether to re-derive the default on subclass dup.
+   */
+  nameSet: boolean;
 
   constructor(
     name: string | null = null,
@@ -36,6 +43,7 @@ export class Options {
     this.exclude = exclude;
     this.klass = klass;
     this.model = model;
+    this.nameSet = name != null;
   }
 
   static fromHash(hash: Record<string, unknown>): Options {

--- a/packages/actionpack/src/action-controller/params-wrapper.ts
+++ b/packages/actionpack/src/action-controller/params-wrapper.ts
@@ -19,6 +19,7 @@
  */
 
 import { Parameters } from "./metal/strong-parameters.js";
+import { EXCLUDE_PARAMETERS as RAILS_EXCLUDE_PARAMETERS } from "./metal/params-wrapper.js";
 
 export interface WrapParametersOptions {
   /** Keys to include in the wrapped hash. If omitted, all non-framework keys are included. */
@@ -31,14 +32,18 @@ export interface WrapParametersOptions {
   name?: string;
 }
 
-/** Framework parameter keys that are never wrapped. */
+/**
+ * Framework parameter keys that are never wrapped. Composed of the
+ * Rails-faithful `EXCLUDE_PARAMETERS` (`authenticity_token`, `_method`,
+ * `utf8`) from `metal/params-wrapper.ts` plus the routing/form keys that
+ * this higher-level helper additionally strips (`controller`, `action`,
+ * `format`, `commit`).
+ */
 const EXCLUDE_PARAMETERS = new Set([
+  ...RAILS_EXCLUDE_PARAMETERS,
   "controller",
   "action",
   "format",
-  "_method",
-  "authenticity_token",
-  "utf8",
   "commit",
 ]);
 


### PR DESCRIPTION
## Summary

Wires the metal/params-wrapper privates onto `ActionController::Base` and reconciles the duplicated `EXCLUDE_PARAMETERS` constant. Followup to #1950.

### Base wiring (`action-controller/base.ts`)
- `_wrapperOptions` class attribute, defaulting to `Options.fromHash({ format: [] })` — mirrors Rails `class_attribute :_wrapper_options`.
- `wrapParameters` class DSL accepting the same five forms Rails handles: symbol/string (sets `name`), hash (sets options directly), `false` (disables), model class (binds `model`), and plain options on top of the current `format`.
- `inheritedParamsWrapper` static — JS class statics already inherit through the prototype chain, so this is an opt-in helper for subclasses that want a per-subclass `klass` rebind (so `_defaultWrapModel` can derive the wrapper name from the subclass). Matches Rails' `inherited` hook semantics without requiring a global hook.
- `processAction` calls `_wrapperEnabled` + `_performParameterWrapping` before `super.processAction` when a request is attached.
- Instance `_wrapperOptions` getter routes through `this.constructor` so the privates pick up the active class config.

### EXCLUDE_PARAMETERS reconciliation
- `metal/params-wrapper.ts` keeps the Rails-faithful 3-element set: `["authenticity_token", "_method", "utf8"]`.
- `action-controller/params-wrapper.ts` imports that set and composes it with the additional routing/form keys (`controller`, `action`, `format`, `commit`) it needs at the helper level.

### Tests
- `base-params-wrapper.test.ts` — 8 tests covering default options, the five DSL forms, the `inheritedParamsWrapper` rebind/no-op semantics, and the instance getter.
- Existing `metal/params-wrapper.test.ts` (17) and `controller/params-wrapper.test.ts` (23) still pass.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/base-params-wrapper.test.ts packages/actionpack/src/action-controller/metal/params-wrapper.test.ts packages/actionpack/src/action-controller/controller/params-wrapper.test.ts` (48 pass)
- [ ] CI green

## Size

3 files changed, 168 insertions(+), 4 deletions(-) — within the 300 LOC ceiling.