### PR TITLE
feat(activesupport): IsolatedExecutionState + wire 3 AR call sites

### DIFF
--- a/packages/activerecord/src/explain-registry.ts
+++ b/packages/activerecord/src/explain-registry.ts
@@ -16,8 +16,10 @@
  * scope has been opened so existing unit-level tests keep working.
  */
 
-import { getAsyncContext } from "@blazetrails/activesupport";
+import { IsolatedExecutionState, getAsyncContext } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
+
+const REGISTRY_KEY = "active_record_explain_registry";
 
 interface Slot {
   collect: boolean;
@@ -119,5 +121,5 @@ export class ExplainRegistry {
  * @internal
  */
 export function instance(): ExplainRegistry {
-  return new ExplainRegistry();
+  return IsolatedExecutionState.fetch(REGISTRY_KEY, () => new ExplainRegistry());
 }

--- a/packages/activerecord/src/scoping.ts
+++ b/packages/activerecord/src/scoping.ts
@@ -21,85 +21,87 @@ export class Scoping {
  * Mirrors: ActiveRecord::Scoping::ScopeRegistry
  */
 export class ScopeRegistry {
-  private static _currentScopes: WeakMap<object, any> = new WeakMap();
-  private static _ignoreDefaultScope: WeakMap<object, any> = new WeakMap();
-  private static _globalCurrentScope: WeakMap<object, any> = new WeakMap();
+  // Rails: `@current_scope = {}` etc on the instance — per-fiber-isolated
+  // because `instance()` itself is per-fiber via IsolatedExecutionState.
+  // We use WeakMap (model class as key) instead of Rails' string-keyed Hash
+  // (model.name) so anonymous classes work and model classes can be GC'd.
+  private readonly _currentScopes: WeakMap<object, any> = new WeakMap();
+  private readonly _ignoreDefaultScope: WeakMap<object, any> = new WeakMap();
+  private readonly _globalCurrentScope: WeakMap<object, any> = new WeakMap();
 
   static instance(): ScopeRegistry {
     return IsolatedExecutionState.fetch(SCOPE_REGISTRY_KEY, () => new ScopeRegistry());
   }
 
   currentScope(modelClass: object, skipInherited = false): any | null {
-    return ScopeRegistry.currentScope(modelClass, skipInherited);
+    return valueFor(this._currentScopes, modelClass, skipInherited);
   }
 
   setCurrentScope(modelClass: object, scope: any): void {
-    ScopeRegistry.setCurrentScope(modelClass, scope);
+    setValueFor(this._currentScopes, modelClass, scope);
   }
 
   ignoreDefaultScope(modelClass: object, skipInherited = false): any | null {
-    return ScopeRegistry.ignoreDefaultScope(modelClass, skipInherited);
+    return valueFor(this._ignoreDefaultScope, modelClass, skipInherited);
   }
 
   setIgnoreDefaultScope(modelClass: object, value: any): void {
-    ScopeRegistry.setIgnoreDefaultScope(modelClass, value);
+    setValueFor(this._ignoreDefaultScope, modelClass, value);
   }
 
   globalCurrentScope(modelClass: object, skipInherited = false): any | null {
-    return ScopeRegistry.globalCurrentScope(modelClass, skipInherited);
+    return valueFor(this._globalCurrentScope, modelClass, skipInherited);
   }
 
   setGlobalCurrentScope(modelClass: object, scope: any): void {
-    ScopeRegistry.setGlobalCurrentScope(modelClass, scope);
+    setValueFor(this._globalCurrentScope, modelClass, scope);
   }
 
+  // Class-method delegators — Rails uses `delegate :current_scope, …, to: :instance`.
   static currentScope(modelClass: object, skipInherited = false): any | null {
-    return this.valueFor(this._currentScopes, modelClass, skipInherited);
+    return this.instance().currentScope(modelClass, skipInherited);
   }
-
   static setCurrentScope(modelClass: object, scope: any): void {
-    this.setValueFor(this._currentScopes, modelClass, scope);
+    this.instance().setCurrentScope(modelClass, scope);
   }
-
   static ignoreDefaultScope(modelClass: object, skipInherited = false): any | null {
-    return this.valueFor(this._ignoreDefaultScope, modelClass, skipInherited);
+    return this.instance().ignoreDefaultScope(modelClass, skipInherited);
   }
-
   static setIgnoreDefaultScope(modelClass: object, value: any): void {
-    this.setValueFor(this._ignoreDefaultScope, modelClass, value);
+    this.instance().setIgnoreDefaultScope(modelClass, value);
   }
-
   static globalCurrentScope(modelClass: object, skipInherited = false): any | null {
-    return this.valueFor(this._globalCurrentScope, modelClass, skipInherited);
+    return this.instance().globalCurrentScope(modelClass, skipInherited);
   }
-
   static setGlobalCurrentScope(modelClass: object, scope: any): void {
-    this.setValueFor(this._globalCurrentScope, modelClass, scope);
+    this.instance().setGlobalCurrentScope(modelClass, scope);
   }
+}
 
-  // Rails: value_for(@registry, model, skip_inherited_scope)
-  // Walks up the prototype chain unless skipInherited is true.
-  private static valueFor(
-    map: WeakMap<object, any>,
-    modelClass: object,
-    skipInherited: boolean,
-  ): any | null {
-    const value = map.get(modelClass);
-    if (value !== undefined) return value;
-    if (skipInherited) return null;
-    const parent = Object.getPrototypeOf(modelClass);
-    if (typeof parent === "function" && parent !== modelClass) {
-      return this.valueFor(map, parent, false);
-    }
-    return null;
+// Rails: value_for(@registry, model, skip_inherited_scope).
+// Walks up the prototype chain unless skipInherited is true.
+/** @internal */
+function valueFor(
+  map: WeakMap<object, any>,
+  modelClass: object,
+  skipInherited: boolean,
+): any | null {
+  const value = map.get(modelClass);
+  if (value !== undefined) return value;
+  if (skipInherited) return null;
+  const parent = Object.getPrototypeOf(modelClass);
+  if (typeof parent === "function" && parent !== modelClass) {
+    return valueFor(map, parent, false);
   }
+  return null;
+}
 
-  private static setValueFor(map: WeakMap<object, any>, modelClass: object, value: any): void {
-    if (value === null) {
-      map.delete(modelClass);
-    } else {
-      map.set(modelClass, value);
-    }
+/** @internal */
+function setValueFor(map: WeakMap<object, any>, modelClass: object, value: any): void {
+  if (value === null) {
+    map.delete(modelClass);
+  } else {
+    map.set(modelClass, value);
   }
 }
 

--- a/packages/activerecord/src/scoping.ts
+++ b/packages/activerecord/src/scoping.ts
@@ -1,3 +1,7 @@
+import { IsolatedExecutionState } from "@blazetrails/activesupport";
+
+const SCOPE_REGISTRY_KEY = "active_record_scoped_methods";
+
 /**
  * Scoping module — manages current scope and scope registry.
  * Base delegates scoping operations to these classes.
@@ -21,11 +25,8 @@ export class ScopeRegistry {
   private static _ignoreDefaultScope: WeakMap<object, any> = new WeakMap();
   private static _globalCurrentScope: WeakMap<object, any> = new WeakMap();
 
-  private static _instance: ScopeRegistry | null = null;
-
   static instance(): ScopeRegistry {
-    if (!this._instance) this._instance = new ScopeRegistry();
-    return this._instance;
+    return IsolatedExecutionState.fetch(SCOPE_REGISTRY_KEY, () => new ScopeRegistry());
   }
 
   currentScope(modelClass: object, skipInherited = false): any | null {

--- a/packages/activerecord/src/scoping.ts
+++ b/packages/activerecord/src/scoping.ts
@@ -1,6 +1,6 @@
 import { IsolatedExecutionState } from "@blazetrails/activesupport";
 
-const SCOPE_REGISTRY_KEY = "active_record_scoped_methods";
+const SCOPE_REGISTRY_KEY = "active_record_scope_registry";
 
 /**
  * Scoping module — manages current scope and scope registry.

--- a/packages/activerecord/src/suppressor.ts
+++ b/packages/activerecord/src/suppressor.ts
@@ -5,41 +5,31 @@
  * Mirrors: ActiveRecord::Suppressor
  */
 
-import { getAsyncContext } from "@blazetrails/activesupport";
+import { IsolatedExecutionState, getAsyncContext } from "@blazetrails/activesupport";
 import type { AsyncContext } from "@blazetrails/activesupport";
 import type { Base } from "./base.js";
 
+const SUPPRESSOR_REGISTRY_KEY = "active_record_suppressor_registry";
+
 /**
- * The suppressor registry: a map from class name → `true` when that
- * class is currently suppressed. Mirrors Rails'
- * `Suppressor.registry[klass.name] = true` contract.
- *
- * Storage is async-context-scoped (matching `explain-registry.ts` and
- * Rails' `IsolatedExecutionState`/per-fiber semantics) so two
- * concurrent `suppress` blocks running under the same Promise.all
- * don't leak state into each other. Outside any active scope
- * (sequential code paths) we fall back to a process-global registry,
- * so existing direct mutations (`Base.registry[name] = true`)
- * still work.
+ * Per-async-scope override layer used by `suppress()` so concurrent
+ * `Promise.all` branches don't leak suppression state into each other.
+ * `registry()` returns the override if a scope is active, otherwise the
+ * per-context bag from `IsolatedExecutionState` (mirroring Rails'
+ * `Suppressor.registry`).
  *
  * `Object.create(null)` avoids `__proto__`/`constructor` foot-guns.
  */
-const _fallback: Record<string, true | undefined> = Object.create(null);
+let _scopeOverride: AsyncContext<Record<string, true | undefined>> | null = null;
+let _scopeAdapter: ReturnType<typeof getAsyncContext> | null = null;
 
-let _context: AsyncContext<Record<string, true | undefined>> | null = null;
-let _contextAdapter: ReturnType<typeof getAsyncContext> | null = null;
-
-function ctx(): AsyncContext<Record<string, true | undefined>> {
+function scopeOverride(): AsyncContext<Record<string, true | undefined>> {
   const adapter = getAsyncContext();
-  if (!_context || _contextAdapter !== adapter) {
-    _contextAdapter = adapter;
-    _context = adapter.create<Record<string, true | undefined>>();
+  if (!_scopeOverride || _scopeAdapter !== adapter) {
+    _scopeAdapter = adapter;
+    _scopeOverride = adapter.create<Record<string, true | undefined>>();
   }
-  return _context;
-}
-
-function currentRegistry(): Record<string, true | undefined> {
-  return ctx().getStore() ?? _fallback;
+  return _scopeOverride;
 }
 
 /**
@@ -51,7 +41,13 @@ function currentRegistry(): Record<string, true | undefined> {
  * Mirrors: ActiveRecord::Suppressor.registry
  */
 export function registry(): Record<string, true | undefined> {
-  return currentRegistry();
+  return (
+    scopeOverride().getStore() ??
+    IsolatedExecutionState.fetch(
+      SUPPRESSOR_REGISTRY_KEY,
+      () => Object.create(null) as Record<string, true | undefined>,
+    )
+  );
 }
 
 /**
@@ -69,13 +65,13 @@ export async function suppress<R>(modelClass: typeof Base, fn: () => R | Promise
     // (Rails has the same constraint); just run the block.
     return await fn();
   }
-  const parent = currentRegistry();
+  const parent = registry();
   // Null-prototype copy: keeps `Object.prototype` keys (toString,
   // constructor, …) from masquerading as suppressed class names.
   const child: Record<string, true | undefined> = Object.create(null);
   Object.assign(child, parent);
   child[name] = true;
-  return await ctx().run(child, fn);
+  return await scopeOverride().run(child, fn);
 }
 
 /**
@@ -83,7 +79,7 @@ export async function suppress<R>(modelClass: typeof Base, fn: () => R | Promise
  * suppressed in the active scope.
  */
 export function isSuppressed(modelClass: typeof Base): boolean {
-  const reg = currentRegistry();
+  const reg = registry();
   let current: typeof Base | null = modelClass;
   while (current && typeof current === "function") {
     const klassName = current.name;

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -34,6 +34,8 @@ export {
 } from "./async-context-adapter.js";
 export type { AsyncContext, AsyncContextAdapter } from "./async-context-adapter.js";
 
+export { IsolatedExecutionState } from "./isolated-execution-state.js";
+
 export {
   registerChildProcessAdapter,
   getChildProcess,

--- a/packages/activesupport/src/isolated-execution-state.test.ts
+++ b/packages/activesupport/src/isolated-execution-state.test.ts
@@ -1,8 +1,22 @@
 import { describe, expect, it, beforeEach } from "vitest";
 import { IsolatedExecutionState } from "./isolated-execution-state.js";
 
-describe("IsolatedExecutionState", () => {
+describe("IsolatedExecutionStateTest", () => {
   beforeEach(() => IsolatedExecutionState.clear());
+
+  // Rails parameterizes isolation as `:fiber` vs `:thread`. trails has no
+  // fiber/thread distinction (single-threaded Node + AsyncLocalStorage), so
+  // these three Rails tests are not portable; they stay skipped to preserve
+  // the test:compare mapping with the upstream file.
+  it.skip("#[] when isolation level is :fiber");
+
+  it.skip("#[] when isolation level is :thread");
+
+  it.skip("changing the isolation level clear the old store");
+
+  // ---------------------------------------------------------------------------
+  // trails-specific behavioral coverage (no Rails counterpart)
+  // ---------------------------------------------------------------------------
 
   it("get/set/has/delete on the fallback (no scope)", () => {
     expect(IsolatedExecutionState.has("k")).toBe(false);
@@ -19,6 +33,21 @@ describe("IsolatedExecutionState", () => {
     const b = IsolatedExecutionState.fetch("singleton", () => ++n);
     expect(a).toBe(1);
     expect(b).toBe(1);
+  });
+
+  it("fetch caches an explicit undefined", () => {
+    let n = 0;
+    const a = IsolatedExecutionState.fetch<undefined>("nullable", () => {
+      n++;
+      return undefined;
+    });
+    const b = IsolatedExecutionState.fetch<undefined>("nullable", () => {
+      n++;
+      return undefined;
+    });
+    expect(a).toBeUndefined();
+    expect(b).toBeUndefined();
+    expect(n).toBe(1);
   });
 
   it("run isolates state from outer context", async () => {

--- a/packages/activesupport/src/isolated-execution-state.test.ts
+++ b/packages/activesupport/src/isolated-execution-state.test.ts
@@ -1,9 +1,34 @@
-import { describe, it } from "vitest";
+import { describe, expect, it, beforeEach } from "vitest";
+import { IsolatedExecutionState } from "./isolated-execution-state.js";
 
-describe("IsolatedExecutionStateTest", () => {
-  it.skip("#[] when isolation level is :fiber");
+describe("IsolatedExecutionState", () => {
+  beforeEach(() => IsolatedExecutionState.clear());
 
-  it.skip("#[] when isolation level is :thread");
+  it("get/set/has/delete on the fallback (no scope)", () => {
+    expect(IsolatedExecutionState.has("k")).toBe(false);
+    IsolatedExecutionState.set("k", 1);
+    expect(IsolatedExecutionState.get<number>("k")).toBe(1);
+    expect(IsolatedExecutionState.has("k")).toBe(true);
+    IsolatedExecutionState.delete("k");
+    expect(IsolatedExecutionState.has("k")).toBe(false);
+  });
 
-  it.skip("changing the isolation level clear the old store");
+  it("fetch initializes once", () => {
+    let n = 0;
+    const a = IsolatedExecutionState.fetch("singleton", () => ++n);
+    const b = IsolatedExecutionState.fetch("singleton", () => ++n);
+    expect(a).toBe(1);
+    expect(b).toBe(1);
+  });
+
+  it("run isolates state from outer context", async () => {
+    IsolatedExecutionState.set("outer", "A");
+    await IsolatedExecutionState.run(async () => {
+      expect(IsolatedExecutionState.get("outer")).toBeUndefined();
+      IsolatedExecutionState.set("inner", "B");
+      expect(IsolatedExecutionState.get("inner")).toBe("B");
+    });
+    expect(IsolatedExecutionState.get("outer")).toBe("A");
+    expect(IsolatedExecutionState.get("inner")).toBeUndefined();
+  });
 });

--- a/packages/activesupport/src/isolated-execution-state.ts
+++ b/packages/activesupport/src/isolated-execution-state.ts
@@ -58,8 +58,9 @@ export const IsolatedExecutionState = {
    */
   fetch<T>(key: string | symbol, init: () => T): T {
     const s = store();
-    const existing = s.get(key);
-    if (existing !== undefined) return existing as T;
+    // `has`-then-`get` (rather than checking `get() !== undefined`) so a
+    // caller that intentionally cached `undefined` doesn't re-run `init()`.
+    if (s.has(key)) return s.get(key) as T;
     const value = init();
     s.set(key, value);
     return value;

--- a/packages/activesupport/src/isolated-execution-state.ts
+++ b/packages/activesupport/src/isolated-execution-state.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-execution-context key/value store, mirroring Rails'
+ * `ActiveSupport::IsolatedExecutionState`. Rails uses Thread/Fiber-local
+ * storage; the TS equivalent is AsyncLocalStorage (via
+ * {@link getAsyncContext}), which carries state through the `await` chain
+ * of a single logical task without bleeding into concurrent tasks.
+ *
+ * When no scope has been opened (e.g. at module top-level), reads/writes
+ * fall back to a process-global Map — matches the practical behavior of
+ * Rails' main thread before any request wrapper runs.
+ *
+ * Mirrors: ActiveSupport::IsolatedExecutionState
+ */
+
+import { getAsyncContext } from "./async-context-adapter.js";
+import type { AsyncContext, AsyncContextAdapter } from "./async-context-adapter.js";
+
+type Store = Map<string | symbol, unknown>;
+
+let _ctx: AsyncContext<Store> | null = null;
+let _adapter: AsyncContextAdapter | null = null;
+const _fallback: Store = new Map();
+
+function ctx(): AsyncContext<Store> {
+  const adapter = getAsyncContext();
+  if (!_ctx || _adapter !== adapter) {
+    _adapter = adapter;
+    _ctx = adapter.create<Store>();
+  }
+  return _ctx;
+}
+
+function store(): Store {
+  return ctx().getStore() ?? _fallback;
+}
+
+export const IsolatedExecutionState = {
+  get<T = unknown>(key: string | symbol): T | undefined {
+    return store().get(key) as T | undefined;
+  },
+  set<T>(key: string | symbol, value: T): T {
+    store().set(key, value);
+    return value;
+  },
+  has(key: string | symbol): boolean {
+    return store().has(key);
+  },
+  delete(key: string | symbol): boolean {
+    return store().delete(key);
+  },
+  clear(): void {
+    store().clear();
+  },
+  /**
+   * Read `key`; if absent, call `init()`, store the result, and return it.
+   * Mirrors Rails' `IsolatedExecutionState[key] ||= ...` idiom used for
+   * per-context singletons (ExplainRegistry, ScopeRegistry, etc.).
+   */
+  fetch<T>(key: string | symbol, init: () => T): T {
+    const s = store();
+    const existing = s.get(key);
+    if (existing !== undefined) return existing as T;
+    const value = init();
+    s.set(key, value);
+    return value;
+  },
+  /**
+   * Run `fn` inside a fresh, isolated state Map. State written inside is
+   * invisible to outer/parallel contexts. Used for per-request isolation.
+   */
+  run<R>(fn: () => R): R {
+    return ctx().run(new Map(), fn);
+  },
+};


### PR DESCRIPTION
## Summary

PR 1 of the `lint:deps` activerecord → activesupport push (37.3% → 59.3%).

- New `packages/activesupport/src/isolated-execution-state.ts` — per-async-context key/value store backed by `AsyncContext`, with a Map fallback when no scope is open. Mirrors Rails' `IsolatedExecutionState[key] ||= ...` idiom via `fetch(key, init)`.
- Wires three Rails-mirroring singletons through it:
  - `ExplainRegistry.instance`
  - `ScopeRegistry.instance`
  - `Suppressor.registry`

Closes 3 direct violations; lint:deps transitively cleared more via taint propagation, taking ar→as from 22/59 (37.3%) to 35/59 (59.3%).

## Test plan

- [x] `pnpm vitest run packages/activesupport/src/isolated-execution-state.test.ts`
- [x] `pnpm vitest run packages/activerecord/src/scoping/ packages/activerecord/src/explain.test.ts packages/activerecord/src/explain-subscriber.test.ts packages/activerecord/src/suppressor.test.ts`
- [x] `pnpm lint:deps` — ar→as 35/59 (59.3%)
- [x] `pnpm build` / `pnpm typecheck` (run by pre-commit hook)

## Follow-ups

PRs 2–5 in the plan will close the remaining 24 violations:
- PR 2: more IsolatedExecutionState wiring (core.ts, connection-handling.ts, abstract-adapter, connection-handler, connection-pool)
- PR 3: Notifications + Benchmark + ExecutionContext
- PR 4: KeyGenerator + MessagePack + MessageVerifier
- PR 5: CodeGenerator + lint-deps-ignore for `ActiveSupport::Dependencies` autoload refs