### PR TITLE
feat(actionpack): port AbstractController::Callbacks ActionFilter + option normalizers

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -6,13 +6,22 @@
  * @see https://api.rubyonrails.org/classes/AbstractController/Base.html
  */
 
-import type {
+import {
+  _insertCallbacks,
+  _normalizeCallbackOption,
+  _normalizeCallbackOptions,
+  type ActionCallback,
+  type AroundCallback,
+  type CallbackEntry,
+  type CallbackOptions,
+} from "./callbacks.js";
+export type {
   ActionCallback,
   AroundCallback,
   CallbackOptions,
-  CallbackEntry,
+  CallbackPredicateLike,
 } from "./callbacks.js";
-export type { ActionCallback, AroundCallback, CallbackOptions } from "./callbacks.js";
+export { ActionFilter } from "./callbacks.js";
 
 /** Raised when an action cannot be found for the given controller. */
 export class ActionNotFound extends Error {
@@ -121,8 +130,16 @@ export class AbstractController {
     return this._actionMethodCache!.has(action);
   }
 
+  /** @internal Rails-private callback option normalizer. */
+  static _normalizeCallbackOptions = _normalizeCallbackOptions;
+  /** @internal Rails-private single-key callback option normalizer. */
+  static _normalizeCallbackOption = _normalizeCallbackOption;
+  /** @internal Rails-private callback insertion helper. */
+  static _insertCallbacks = _insertCallbacks;
+
   /** Register a before_action callback. */
   static beforeAction(callback: ActionCallback, options: CallbackOptions = {}): void {
+    _normalizeCallbackOptions(options);
     const entry: CallbackEntry = { callback, type: "before", options };
     if (options.prepend) {
       this._ensureOwnCallbacks().unshift(entry);
@@ -133,6 +150,7 @@ export class AbstractController {
 
   /** Register an after_action callback. */
   static afterAction(callback: ActionCallback, options: CallbackOptions = {}): void {
+    _normalizeCallbackOptions(options);
     const entry: CallbackEntry = { callback, type: "after", options };
     if (options.prepend) {
       this._ensureOwnCallbacks().unshift(entry);
@@ -143,6 +161,7 @@ export class AbstractController {
 
   /** Register an around_action callback. */
   static aroundAction(callback: AroundCallback, options: CallbackOptions = {}): void {
+    _normalizeCallbackOptions(options);
     const entry: CallbackEntry = { callback, type: "around", options };
     if (options.prepend) {
       this._ensureOwnCallbacks().unshift(entry);
@@ -279,9 +298,23 @@ export class AbstractController {
     const opts = entry.options;
     if (opts.only && !opts.only.includes(action)) return false;
     if (opts.except && opts.except.includes(action)) return false;
-    if (opts.if && !opts.if(this)) return false;
-    if (opts.unless && opts.unless(this)) return false;
+    if (opts.if !== undefined && !this._evalPredicate(opts.if, true)) return false;
+    if (opts.unless !== undefined && this._evalPredicate(opts.unless, false)) return false;
     return true;
+  }
+
+  private _evalPredicate(pred: NonNullable<CallbackOptions["if"]>, requireAll: boolean): boolean {
+    if (typeof pred === "function") return pred(this);
+    if (requireAll) {
+      for (const p of pred) {
+        if (!(typeof p === "function" ? p(this) : p.isMatch(this))) return false;
+      }
+      return true;
+    }
+    for (const p of pred) {
+      if (typeof p === "function" ? p(this) : p.isMatch(this)) return true;
+    }
+    return false;
   }
 
   private static _ensureOwnCallbacks(): CallbackEntry[] {

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -224,8 +224,10 @@ export class AbstractController {
     const callbacks = allCallbacks.filter((entry) => {
       return !skipped.some((s) => {
         if (s.callback !== entry.callback) return false;
-        if (s.options.only && !_actionList(s.options.only).includes(action)) return false;
-        if (s.options.except && _actionList(s.options.except).includes(action)) return false;
+        if (s.options.only !== undefined && !_actionList(s.options.only).includes(action))
+          return false;
+        if (s.options.except !== undefined && _actionList(s.options.except).includes(action))
+          return false;
         return true;
       });
     });
@@ -300,8 +302,8 @@ export class AbstractController {
 
   private _shouldRun(entry: CallbackEntry, action: string): boolean {
     const opts = entry.options;
-    if (opts.only && !_actionList(opts.only).includes(action)) return false;
-    if (opts.except && _actionList(opts.except).includes(action)) return false;
+    if (opts.only !== undefined && !_actionList(opts.only).includes(action)) return false;
+    if (opts.except !== undefined && _actionList(opts.except).includes(action)) return false;
     if (opts.if !== undefined && !this._evalPredicate(opts.if, true)) return false;
     if (opts.unless !== undefined && this._evalPredicate(opts.unless, false)) return false;
     return true;

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -21,7 +21,6 @@ export type {
   CallbackOptions,
   CallbackPredicateLike,
 } from "./callbacks.js";
-export { ActionFilter } from "./callbacks.js";
 
 /** Raised when an action cannot be found for the given controller. */
 export class ActionNotFound extends Error {

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -31,6 +31,11 @@ export class ActionNotFound extends Error {
   }
 }
 
+/** Rails `Array(value)`: coerce scalar to single-element array. @internal */
+function _actionList(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
 export class AbstractController {
   /** The action currently being processed. */
   actionName: string = "";
@@ -220,8 +225,8 @@ export class AbstractController {
     const callbacks = allCallbacks.filter((entry) => {
       return !skipped.some((s) => {
         if (s.callback !== entry.callback) return false;
-        if (s.options.only && !s.options.only.includes(action)) return false;
-        if (s.options.except && s.options.except.includes(action)) return false;
+        if (s.options.only && !_actionList(s.options.only).includes(action)) return false;
+        if (s.options.except && _actionList(s.options.except).includes(action)) return false;
         return true;
       });
     });
@@ -296,8 +301,8 @@ export class AbstractController {
 
   private _shouldRun(entry: CallbackEntry, action: string): boolean {
     const opts = entry.options;
-    if (opts.only && !opts.only.includes(action)) return false;
-    if (opts.except && opts.except.includes(action)) return false;
+    if (opts.only && !_actionList(opts.only).includes(action)) return false;
+    if (opts.except && _actionList(opts.except).includes(action)) return false;
     if (opts.if !== undefined && !this._evalPredicate(opts.if, true)) return false;
     if (opts.unless !== undefined && this._evalPredicate(opts.unless, false)) return false;
     return true;

--- a/packages/actionpack/src/abstract-controller/callbacks.test.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.test.ts
@@ -1,5 +1,12 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { AbstractController, ActionNotFound } from "./base.js";
+import {
+  ActionFilter,
+  _insertCallbacks,
+  _normalizeCallbackOption,
+  _normalizeCallbackOptions,
+  type CallbackOptions,
+} from "./callbacks.js";
 
 // ==========================================================================
 // abstract/callbacks_test.rb
@@ -382,5 +389,103 @@ describe("AbstractController::Base — trails-only", () => {
   it("performed starts false", () => {
     const c = new (class extends AbstractController {})();
     expect(c.performed).toBe(false);
+  });
+});
+
+// ==========================================================================
+// trails-only coverage for ActionFilter + normalization helpers (Rails has
+// no public test for these; they're :nodoc: in callbacks.rb).
+// ==========================================================================
+describe("ActionFilter", () => {
+  it("matches when the controller's actionName is in the configured set", () => {
+    class C extends AbstractController {}
+    const c = new C();
+    c.actionName = "index";
+    const f = new ActionFilter([], "only", ["index", "show"]);
+    expect(f.isMatch(c)).toBe(true);
+    c.actionName = "destroy";
+    expect(f.isMatch(c)).toBe(false);
+  });
+
+  it("accepts a scalar action name", () => {
+    class C extends AbstractController {}
+    const c = new C();
+    c.actionName = "index";
+    expect(new ActionFilter([], "only", "index").isMatch(c)).toBe(true);
+  });
+});
+
+describe("_normalizeCallbackOption", () => {
+  it("converts :only into a prepended ActionFilter on :if", () => {
+    const opts: CallbackOptions = { only: ["index"] };
+    _normalizeCallbackOption(opts, "only", "if");
+    expect(opts.only).toBeUndefined();
+    expect(Array.isArray(opts.if)).toBe(true);
+    expect((opts.if as unknown[])[0]).toBeInstanceOf(ActionFilter);
+  });
+
+  it("converts :except into a prepended ActionFilter on :unless", () => {
+    const opts: CallbackOptions = { except: ["index"] };
+    _normalizeCallbackOption(opts, "except", "unless");
+    expect(opts.except).toBeUndefined();
+    expect((opts.unless as unknown[])[0]).toBeInstanceOf(ActionFilter);
+  });
+
+  it("is a no-op when the source key is absent", () => {
+    const opts: CallbackOptions = {};
+    _normalizeCallbackOption(opts, "only", "if");
+    expect(opts.if).toBeUndefined();
+  });
+
+  it("preserves an existing :if predicate by appending after the new filter", () => {
+    const existing = () => true;
+    const opts: CallbackOptions = { only: ["index"], if: existing };
+    _normalizeCallbackOption(opts, "only", "if");
+    const list = opts.if as unknown[];
+    expect(list).toHaveLength(2);
+    expect(list[0]).toBeInstanceOf(ActionFilter);
+    expect(list[1]).toBe(existing);
+  });
+});
+
+describe("_normalizeCallbackOptions", () => {
+  it("normalizes both :only and :except in a single pass", () => {
+    const opts: CallbackOptions = { only: ["a"], except: ["b"] };
+    _normalizeCallbackOptions(opts);
+    expect(opts.only).toBeUndefined();
+    expect(opts.except).toBeUndefined();
+    expect((opts.if as unknown[])[0]).toBeInstanceOf(ActionFilter);
+    expect((opts.unless as unknown[])[0]).toBeInstanceOf(ActionFilter);
+  });
+});
+
+describe("_insertCallbacks", () => {
+  it("yields each callback with the normalized options", () => {
+    const cb1 = () => {};
+    const cb2 = () => {};
+    const opts: CallbackOptions = { only: ["index"] };
+    const seen: Array<[unknown, CallbackOptions]> = [];
+    _insertCallbacks([cb1, cb2], opts, null, (cb, o) => seen.push([cb, o]));
+    expect(seen.map(([c]) => c)).toEqual([cb1, cb2]);
+    expect(opts.only).toBeUndefined();
+    expect((opts.if as unknown[])[0]).toBeInstanceOf(ActionFilter);
+    // `filters` is a transient bookkeeping key; should be removed post-yield.
+    expect(opts.filters).toBeUndefined();
+  });
+
+  it("appends the block to the callback list when provided", () => {
+    const block = () => {};
+    const opts: CallbackOptions = {};
+    const seen: unknown[] = [];
+    _insertCallbacks([], opts, block, (cb) => seen.push(cb));
+    expect(seen).toEqual([block]);
+  });
+});
+
+describe("AbstractController callback statics", () => {
+  it("exposes _normalizeCallbackOptions, _normalizeCallbackOption, _insertCallbacks", () => {
+    expect(AbstractController._normalizeCallbackOptions).toBe(_normalizeCallbackOptions);
+    expect(AbstractController._normalizeCallbackOption).toBe(_normalizeCallbackOption);
+    expect(AbstractController._insertCallbacks).toBe(_insertCallbacks);
   });
 });

--- a/packages/actionpack/src/abstract-controller/callbacks.test.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.test.ts
@@ -470,7 +470,7 @@ describe("_insertCallbacks", () => {
     expect(opts.only).toBeUndefined();
     expect((opts.if as unknown[])[0]).toBeInstanceOf(ActionFilter);
     // `filters` is a transient bookkeeping key; should be removed post-yield.
-    expect(opts.filters).toBeUndefined();
+    expect((opts as Record<string, unknown>).filters).toBeUndefined();
   });
 
   it("appends the block to the callback list when provided", () => {

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -35,9 +35,18 @@ export interface CallbackOptions {
     | ((controller: AbstractController) => boolean)
     | Array<((controller: AbstractController) => boolean) | CallbackPredicateLike>;
   prepend?: boolean;
-  /** @internal Used by _insertCallbacks to feed filter names into ActionFilter. */
-  filters?: Array<ActionCallback | AroundCallback>;
 }
+
+/**
+ * Internal extension of CallbackOptions used by _insertCallbacks /
+ * _normalizeCallbackOption to thread the registered callback list
+ * through to ActionFilter (mirrors Rails' `options[:filters]`).
+ *
+ * @internal
+ */
+export type CallbackOptionsWithFilters = CallbackOptions & {
+  filters?: Array<ActionCallback | AroundCallback>;
+};
 
 export interface CallbackEntry {
   callback: ActionCallback | AroundCallback;
@@ -129,7 +138,7 @@ export function _normalizeCallbackOption(
   if (fromValue === undefined) return;
   delete options[from];
 
-  const filters = options.filters ?? [];
+  const filters = (options as CallbackOptionsWithFilters).filters ?? [];
   const filter = new ActionFilter(filters, from, fromValue);
 
   const existing = options[to];
@@ -157,9 +166,10 @@ export function _insertCallbacks(
   yieldFn: (callback: ActionCallback | AroundCallback, options: CallbackOptions) => void,
 ): void {
   if (block) callbacks.push(block);
-  options.filters = callbacks;
+  const opts = options as CallbackOptionsWithFilters;
+  opts.filters = callbacks;
   _normalizeCallbackOptions(options);
-  delete options.filters;
+  delete opts.filters;
   for (const callback of callbacks) {
     yieldFn(callback, options);
   }

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -1,7 +1,8 @@
 /**
  * AbstractController::Callbacks
  *
- * Callback type definitions and options for AbstractController action lifecycle.
+ * Callback type definitions, options, and option-normalization helpers
+ * for AbstractController action lifecycle.
  * @see https://api.rubyonrails.org/classes/AbstractController/Callbacks.html
  */
 
@@ -16,16 +17,130 @@ export type AroundCallback = (
   next: () => Promise<void>,
 ) => void | Promise<void>;
 
+/**
+ * A predicate object stored on a callback's `if`/`unless` list after
+ * normalization, used to match the action name being processed.
+ */
+export interface CallbackPredicateLike {
+  isMatch(controller: AbstractController): boolean;
+}
+
 export interface CallbackOptions {
   only?: string[];
   except?: string[];
-  if?: (controller: AbstractController) => boolean;
-  unless?: (controller: AbstractController) => boolean;
+  if?:
+    | ((controller: AbstractController) => boolean)
+    | Array<((controller: AbstractController) => boolean) | CallbackPredicateLike>;
+  unless?:
+    | ((controller: AbstractController) => boolean)
+    | Array<((controller: AbstractController) => boolean) | CallbackPredicateLike>;
   prepend?: boolean;
+  /** @internal Used by _insertCallbacks to feed filter names into ActionFilter. */
+  filters?: Array<ActionCallback | AroundCallback>;
 }
 
 export interface CallbackEntry {
   callback: ActionCallback | AroundCallback;
   type: "before" | "after" | "around";
   options: CallbackOptions;
+}
+
+/**
+ * Matches the controller's current action name against a fixed set of
+ * action names. Stored on `if`/`unless` after `only`/`except` are
+ * normalized away. Mirrors AbstractController::Callbacks::ActionFilter.
+ *
+ * @internal
+ */
+export class ActionFilter implements CallbackPredicateLike {
+  private readonly _filters: ReadonlyArray<ActionCallback | AroundCallback>;
+  private readonly _conditionalKey: "only" | "except";
+  private readonly _actions: ReadonlySet<string>;
+
+  constructor(
+    filters: ReadonlyArray<ActionCallback | AroundCallback>,
+    conditionalKey: "only" | "except",
+    actions: string | string[],
+  ) {
+    this._filters = filters.slice();
+    this._conditionalKey = conditionalKey;
+    this._actions = new Set((Array.isArray(actions) ? actions : [actions]).map((a) => String(a)));
+  }
+
+  /** True iff the controller's current action is in the configured set. */
+  isMatch(controller: AbstractController): boolean {
+    return this._actions.has(controller.actionName);
+  }
+
+  /** @internal */
+  get filters(): ReadonlyArray<ActionCallback | AroundCallback> {
+    return this._filters;
+  }
+
+  /** @internal */
+  get conditionalKey(): "only" | "except" {
+    return this._conditionalKey;
+  }
+}
+
+/**
+ * If `:only` or `:except` are used, convert them into the `:if` and
+ * `:unless` options expected by the callback engine.
+ *
+ * @internal
+ */
+export function _normalizeCallbackOptions(options: CallbackOptions): void {
+  _normalizeCallbackOption(options, "only", "if");
+  _normalizeCallbackOption(options, "except", "unless");
+}
+
+/**
+ * Convert one of `:only`/`:except` on `options` into a prepended
+ * ActionFilter on the corresponding `:if`/`:unless` slot.
+ *
+ * @internal
+ */
+export function _normalizeCallbackOption(
+  options: CallbackOptions,
+  from: "only" | "except",
+  to: "if" | "unless",
+): void {
+  const fromValue = options[from];
+  if (fromValue === undefined) return;
+  delete options[from];
+
+  const filters = options.filters ?? [];
+  const filter = new ActionFilter(filters, from, fromValue);
+
+  const existing = options[to];
+  const list: Array<((controller: AbstractController) => boolean) | CallbackPredicateLike> =
+    existing === undefined ? [] : Array.isArray(existing) ? existing.slice() : [existing];
+  list.unshift(filter);
+  options[to] = list;
+}
+
+/**
+ * Take an array of callbacks (optionally followed by an options object)
+ * and an optional block, normalize the options, then invoke `yieldFn`
+ * for each callback. Mirrors Rails' `_insert_callbacks`.
+ *
+ * In Ruby this is `extract_options!` + `yield`. In TypeScript callers
+ * typically already split callbacks from options, so we accept an
+ * explicit `options` parameter and an optional `block`.
+ *
+ * @internal
+ */
+export function _insertCallbacks(
+  callbacks: Array<ActionCallback | AroundCallback>,
+  options: CallbackOptions,
+  block: ActionCallback | AroundCallback | null,
+  yieldFn: (callback: ActionCallback | AroundCallback, options: CallbackOptions) => void,
+): void {
+  if (block) callbacks.push(block);
+  options.filters = callbacks;
+  _normalizeCallbackOptions(options);
+  delete options.filters;
+  for (const callback of callbacks) {
+    yieldFn(callback, options);
+  }
 }

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -72,6 +72,26 @@ export class ActionFilter implements CallbackPredicateLike {
     return this._actions.has(controller.actionName);
   }
 
+  /**
+   * Rails aliases `after`/`before`/`around` to `match?` so the same
+   * filter object can be invoked by ActiveSupport::Callbacks for each
+   * callback kind. Mirrored here for fidelity even though our dispatch
+   * doesn't currently look them up by kind.
+   *
+   * @internal
+   */
+  after(controller: AbstractController): boolean {
+    return this.isMatch(controller);
+  }
+  /** @internal */
+  before(controller: AbstractController): boolean {
+    return this.isMatch(controller);
+  }
+  /** @internal */
+  around(controller: AbstractController): boolean {
+    return this.isMatch(controller);
+  }
+
   /** @internal */
   get filters(): ReadonlyArray<ActionCallback | AroundCallback> {
     return this._filters;

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -26,8 +26,8 @@ export interface CallbackPredicateLike {
 }
 
 export interface CallbackOptions {
-  only?: string[];
-  except?: string[];
+  only?: string | string[];
+  except?: string | string[];
   if?:
     | ((controller: AbstractController) => boolean)
     | Array<((controller: AbstractController) => boolean) | CallbackPredicateLike>;

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -44,7 +44,7 @@ export interface CallbackOptions {
  *
  * @internal
  */
-export type CallbackOptionsWithFilters = CallbackOptions & {
+type CallbackOptionsWithFilters = CallbackOptions & {
   filters?: Array<ActionCallback | AroundCallback>;
 };
 
@@ -165,12 +165,16 @@ export function _insertCallbacks(
   block: ActionCallback | AroundCallback | null,
   yieldFn: (callback: ActionCallback | AroundCallback, options: CallbackOptions) => void,
 ): void {
-  if (block) callbacks.push(block);
+  // Rails splats `*names` into a fresh array, so its in-place push is
+  // invisible to callers. JS callers own the array they pass in — copy
+  // to preserve that effective immutability.
+  const list = callbacks.slice();
+  if (block) list.push(block);
   const opts = options as CallbackOptionsWithFilters;
-  opts.filters = callbacks;
+  opts.filters = list;
   _normalizeCallbackOptions(options);
   delete opts.filters;
-  for (const callback of callbacks) {
+  for (const callback of list) {
     yieldFn(callback, options);
   }
 }


### PR DESCRIPTION
## Summary
- Ports the Rails-private machinery from `abstract_controller/callbacks.rb`: `ActionFilter` class plus `_normalizeCallbackOptions`, `_normalizeCallbackOption`, `_insertCallbacks`.
- Wires `_normalizeCallbackOptions` into `beforeAction` / `afterAction` / `aroundAction` so `:only`/`:except` get converted to prepended ActionFilter predicates on `:if`/`:unless` at registration, matching ActiveSupport::Callbacks semantics.
- Generalizes `_shouldRun` to resolve `if`/`unless` as either a function or an array of function/ActionFilter entries.

## api:compare
- `callbacks.rb`: 0/6 → 5/6 (83%)
- abstractcontroller overall: 48.8% → 54.9%

## Follow-ups
- `process_action` (private wrapper expected in `callbacks.ts`) still counts as a miss. Closing it would require relocating dispatch from `base.ts` into a callbacks-layered wrapper; deferred to keep this PR scoped.
- Named-callback dedup (the `name?: string` slot referenced by the skipped `TestCallbacks2 / TestCallbacksWithChangedConditions` tests) is unchanged here.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/abstract-controller/callbacks.test.ts` — 33 pass / 9 skip
- [x] `pnpm tsx scripts/api-compare/compare.ts --package abstractcontroller --privates`
- [x] `pnpm exec tsc --noEmit -p packages/actionpack` (no new errors in `abstract-controller/`)