### PR TITLE
feat(actionpack): rename http/cache helpers to Rails parity names

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -97,7 +97,7 @@ describe("ResponseTest", () => {
 
   it("read ETag and Cache-Control", () => {
     const res = new Response();
-    res.setWeakEtag("abc123");
+    res.weakEtag("abc123");
     res._cacheControl = "public, max-age=3600";
     // Rails: `etag` reader returns the raw header set by weak_etag=.
     expect(res.etag?.startsWith('W/"')).toBe(true);
@@ -106,7 +106,7 @@ describe("ResponseTest", () => {
 
   it("read strong ETag", () => {
     const res = new Response();
-    res.setStrongEtag("strong-etag");
+    res.strongEtag("strong-etag");
     expect(res.isStrongEtag()).toBe(true);
     expect(res.isWeakEtag()).toBe(false);
   });
@@ -459,7 +459,7 @@ describe("Response Cache::Response wiring", () => {
 
   it("setWeakEtag writes a W/-prefixed strong-form digest", () => {
     const res = new Response();
-    res.setWeakEtag(["abc", 1]);
+    res.weakEtag(["abc", 1]);
     const e = res.getHeader("ETag")!;
     expect(e.startsWith('W/"')).toBe(true);
     expect(res.isWeakEtag()).toBe(true);
@@ -472,7 +472,7 @@ describe("Response Cache::Response wiring", () => {
 
   it("setStrongEtag writes an unprefixed digest", () => {
     const res = new Response();
-    res.setStrongEtag(["abc", 1]);
+    res.strongEtag(["abc", 1]);
     const e = res.getHeader("ETag")!;
     expect(e.startsWith('"')).toBe(true);
     expect(e.startsWith('W/"')).toBe(false);
@@ -492,7 +492,7 @@ describe("Response Cache::Response wiring", () => {
   it("mergeAndNormalizeCacheControl writes back the combined directive set", () => {
     const res = new Response();
     res._cacheControl = "no-cache";
-    res.mergeAndNormalizeCacheControl({ public: true, max_age: 30 });
+    res.mergeAndNormalizeCacheControlBang({ public: true, max_age: 30 });
     const cc = res._cacheControl!;
     expect(cc).toContain("max-age=30");
     expect(cc).toContain("public");
@@ -500,8 +500,8 @@ describe("Response Cache::Response wiring", () => {
 
   it("handleConditionalGet sets a default Cache-Control when an ETag is present", () => {
     const res = new Response();
-    res.setWeakEtag("v1");
-    res.handleConditionalGet();
+    res.weakEtag("v1");
+    res.handleConditionalGetBang();
     expect(res.getHeader("Cache-Control")).toBe("max-age=0, private, must-revalidate");
     expect(res.getHeader("cache-control")).toBe("max-age=0, private, must-revalidate");
   });
@@ -524,15 +524,15 @@ describe("Response Cache::Response wiring", () => {
 
   it("handleConditionalGet is a no-op when Cache-Control is already set", () => {
     const res = new Response();
-    res.setWeakEtag("v1");
+    res.weakEtag("v1");
     res.setHeader("Cache-Control", "public, max-age=60");
-    res.handleConditionalGet();
+    res.handleConditionalGetBang();
     expect(res.getHeader("Cache-Control")).toBe("public, max-age=60");
   });
 
   it("handleConditionalGet is a no-op without ETag or Last-Modified", () => {
     const res = new Response();
-    res.handleConditionalGet();
+    res.handleConditionalGetBang();
     expect(res.getHeader("Cache-Control")).toBeUndefined();
   });
 });

--- a/packages/actionpack/src/action-dispatch/http/cache.test.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.test.ts
@@ -6,9 +6,9 @@ import {
   generateStrongEtag,
   generateWeakEtag,
   getLastModified,
-  handleConditionalGet,
+  handleConditionalGetBang,
   isWeakEtag,
-  mergeAndNormalizeCacheControl,
+  mergeAndNormalizeCacheControlBang,
   notModified,
   setEtag,
   setLastModified,
@@ -113,26 +113,26 @@ describe("Cache::Response", () => {
     const h: Record<string, string> = {};
     const r = res(h);
     setEtag.call(r, "x");
-    handleConditionalGet.call(r);
+    handleConditionalGetBang.call(r);
     expect(h["Cache-Control"]).toBe("max-age=0, private, must-revalidate");
 
     const h2: Record<string, string> = { "Cache-Control": "public" };
     setEtag.call(res(h2), "x");
-    handleConditionalGet.call(res(h2));
+    handleConditionalGetBang.call(res(h2));
     expect(h2["Cache-Control"]).toBe("public");
   });
 
   it("merge_and_normalize_cache_control! emits directives in Rails order", () => {
     const h: Record<string, string> = {};
-    mergeAndNormalizeCacheControl.call(res(h), { max_age: 60, public: true });
+    mergeAndNormalizeCacheControlBang.call(res(h), { max_age: 60, public: true });
     expect(h["Cache-Control"]).toBe("max-age=60, public");
 
     const h2: Record<string, string> = {};
-    mergeAndNormalizeCacheControl.call(res(h2), { no_store: true, private: true });
+    mergeAndNormalizeCacheControlBang.call(res(h2), { no_store: true, private: true });
     expect(h2["Cache-Control"]).toBe("private, no-store");
 
     const h3: Record<string, string> = { "Cache-Control": "no-cache, community=internal" };
-    mergeAndNormalizeCacheControl.call(res(h3), { max_age: 10, public: true });
+    mergeAndNormalizeCacheControlBang.call(res(h3), { max_age: 10, public: true });
     expect(h3["Cache-Control"]).toBe("max-age=10, public, community=internal");
   });
 

--- a/packages/actionpack/src/action-dispatch/http/cache.ts
+++ b/packages/actionpack/src/action-dispatch/http/cache.ts
@@ -205,12 +205,14 @@ export function setDate(this: R, t: Date) {
   this.setHeader(DATE, t.toUTCString());
 }
 export function setEtag(this: R, v: unknown) {
-  setWeakEtag.call(this, v);
+  weakEtag.call(this, v);
 }
-export function setWeakEtag(this: R, v: unknown) {
+/** Rails' `Cache::Response#weak_etag=`. */
+export function weakEtag(this: R, v: unknown) {
   this.setHeader(ETAG, generateWeakEtag(v));
 }
-export function setStrongEtag(this: R, v: unknown) {
+/** Rails' `Cache::Response#strong_etag=`. */
+export function strongEtag(this: R, v: unknown) {
   this.setHeader(ETAG, generateStrongEtag(v));
 }
 export function getEtag(this: R) {
@@ -279,18 +281,18 @@ export function cacheControl(this: ResponseCacheHost): CacheControlHash {
 }
 
 /** @internal */
-export function prepareCacheControl(this: ResponseCacheHost): CacheControlHash {
+export function prepareCacheControlBang(this: ResponseCacheHost): CacheControlHash {
   return cacheControlHeaders.call(this);
 }
 
-export function handleConditionalGet(this: ResponseCacheHost): void {
+export function handleConditionalGetBang(this: ResponseCacheHost): void {
   if ((hasEtag.call(this) || hasLastModified.call(this)) && !this.getHeader(CACHE_CONTROL)) {
     this.setHeader(CACHE_CONTROL, DEFAULT_CACHE_CONTROL);
   }
 }
 
 /** @internal */
-export function mergeAndNormalizeCacheControl(
+export function mergeAndNormalizeCacheControlBang(
   this: ResponseCacheHost,
   cacheControl: CacheControlHash,
 ): void {

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -11,17 +11,17 @@ import {
   cacheControl as _cacheControl,
   getDate as _getDate,
   getLastModified as _getLastModified,
-  handleConditionalGet as _handleConditionalGet,
+  handleConditionalGetBang as _handleConditionalGetBang,
   hasDate as _hasDate,
   hasEtag as _hasEtag,
   hasLastModified as _hasLastModified,
   isStrongEtag as _isStrongEtag,
-  mergeAndNormalizeCacheControl as _mergeAndNormalizeCacheControl,
+  mergeAndNormalizeCacheControlBang as _mergeAndNormalizeCacheControlBang,
   isWeakEtag as _isWeakEtag,
   setDate as _setDate,
   setLastModified as _setLastModified,
-  setStrongEtag as _setStrongEtag,
-  setWeakEtag as _setWeakEtag,
+  strongEtag as _strongEtag,
+  weakEtag as _weakEtag,
 } from "./cache.js";
 import { filteredLocation as _filteredLocation } from "./filter-redirect.js";
 
@@ -271,7 +271,7 @@ export class Response {
 
   /**
    * Mirrors Rails' `Cache::Response#etag=` — delegates to
-   * {@link setWeakEtag}, which hashes `validators` into a weak validator
+   * {@link weakEtag}, which hashes `validators` into a weak validator
    * (`W/"<md5>"`). Pass `undefined` to delete the header.
    */
   set etag(value: unknown) {
@@ -280,7 +280,7 @@ export class Response {
       delete this._headers["ETag"];
       return;
     }
-    this.setWeakEtag(value);
+    this.weakEtag(value);
   }
 
   // --- Cache::Response wiring (declared here for typing; bound below) ---
@@ -289,12 +289,12 @@ export class Response {
   declare readonly hasLastModified: boolean;
   declare readonly hasDate: boolean;
   declare readonly hasEtag: boolean;
-  declare setWeakEtag: (validators: unknown) => void;
-  declare setStrongEtag: (validators: unknown) => void;
+  declare weakEtag: (validators: unknown) => void;
+  declare strongEtag: (validators: unknown) => void;
   declare isWeakEtag: () => boolean;
   declare isStrongEtag: () => boolean;
-  declare handleConditionalGet: () => void;
-  declare mergeAndNormalizeCacheControl: (cacheControl: CacheControlHash) => void;
+  declare handleConditionalGetBang: () => void;
+  declare mergeAndNormalizeCacheControlBang: (cacheControl: CacheControlHash) => void;
   /**
    * Parsed `Cache-Control` directives as a hash, mirroring Rails'
    * `Cache::Response#cache_control` (an `attr_reader` set by
@@ -376,11 +376,11 @@ Object.defineProperty(Response.prototype, "cacheControl", {
   },
   configurable: true,
 });
-Response.prototype.setWeakEtag = function (this: Response, v: unknown) {
-  _setWeakEtag.call(this, v);
+Response.prototype.weakEtag = function (this: Response, v: unknown) {
+  _weakEtag.call(this, v);
 };
-Response.prototype.setStrongEtag = function (this: Response, v: unknown) {
-  _setStrongEtag.call(this, v);
+Response.prototype.strongEtag = function (this: Response, v: unknown) {
+  _strongEtag.call(this, v);
 };
 Response.prototype.isWeakEtag = function (this: Response) {
   return _isWeakEtag.call(this);
@@ -388,14 +388,14 @@ Response.prototype.isWeakEtag = function (this: Response) {
 Response.prototype.isStrongEtag = function (this: Response) {
   return _isStrongEtag.call(this);
 };
-Response.prototype.handleConditionalGet = function (this: Response) {
-  _handleConditionalGet.call(this);
+Response.prototype.handleConditionalGetBang = function (this: Response) {
+  _handleConditionalGetBang.call(this);
 };
-Response.prototype.mergeAndNormalizeCacheControl = function (
+Response.prototype.mergeAndNormalizeCacheControlBang = function (
   this: Response,
   cacheControl: CacheControlHash,
 ) {
-  _mergeAndNormalizeCacheControl.call(this, cacheControl);
+  _mergeAndNormalizeCacheControlBang.call(this, cacheControl);
 };
 export interface CookieOptions {
   value: string;


### PR DESCRIPTION
## Summary

Closes the last 5 method gaps for `action_dispatch/http/cache.rb` (81% → 100%, +9 toward the actiondispatch overall: 694 → 703 / 1351).

Pure renames so the api:compare canonical-name candidate (`weak_etag=` → `weakEtag`, `prepare_cache_control!` → `prepareCacheControlBang`, …) finds them:

- \`setWeakEtag\` → \`weakEtag\`
- \`setStrongEtag\` → \`strongEtag\`
- \`prepareCacheControl\` → \`prepareCacheControlBang\`
- \`handleConditionalGet\` → \`handleConditionalGetBang\`
- \`mergeAndNormalizeCacheControl\` → \`mergeAndNormalizeCacheControlBang\`

\`Response\` prototype wiring and the two affected test files (cache.test.ts, response.test.ts) were updated to call the new names. No behavioral change.

## Test plan

- [x] \`pnpm vitest run packages/actionpack/src/action-dispatch/http/cache.test.ts packages/actionpack/src/action-dispatch/dispatch/response.test.ts\` — 84 pass
- [x] \`pnpm api:compare --package actiondispatch --privates\` — http/cache.rb at 26/26 (100%)
- [x] \`pnpm lint --fix\` clean