### PR TITLE
docs(runner): document stop-timeout-seconds=1800

### DIFF
--- a/infra/runner/README.md
+++ b/infra/runner/README.md
@@ -49,12 +49,12 @@ dokku ps:set gh-runner restart-policy always
 #    forwards SIGTERM, waits `stop-timeout-seconds`, then SIGKILLs. Default
 #    is 30s — shorter than nearly every job. If a scale operation lands
 #    while a runner is mid-job, SIGKILL bypasses the entrypoint's EXIT
-#    trap, the GitHub-side runner record is not deregistered, and the
-#    stale `offline busy=true` registration holds the job slot for the
-#    workflow's `timeout-minutes` (30 here) before GitHub gives up. The
-#    re-dispatch loses ~30 minutes of CI per stale runner. 900s (15 min)
-#    is generous headroom vs current job lengths; raise if jobs ever
-#    exceed that.
+#    trap (infra/runner/entrypoint.sh), the GitHub-side runner record is
+#    not deregistered, and the stale `offline busy=true` registration
+#    holds the job slot for the workflow's `timeout-minutes` (set per-job
+#    in .github/workflows/ci.yml) before GitHub gives up and re-dispatches.
+#    900s (15 min) is generous headroom vs current job lengths; raise if
+#    jobs ever exceed that.
 dokku ps:set gh-runner stop-timeout-seconds 900
 
 # 6. Persistent pnpm store across ephemeral container lifetimes. CAS-safe
@@ -108,6 +108,16 @@ dokku logs gh-runner --tail 100
 **Crash-looping?** Most likely a bad `GH_PAT` (401 from token endpoint) or
 a revoked PAT. Check the entrypoint log line `→ Requesting registration
 token` followed by the response.
+
+**Stale `offline busy=true` runner blocking job dispatch?** Symptom: a job
+sits "in progress" for the full workflow `timeout-minutes` without ever
+emitting logs, and `gh api repos/<repo>/actions/runners` shows a runner
+with `status=offline` and `busy=true`. Cause: `docker stop` SIGKILLed an
+in-flight runner before the entrypoint's EXIT trap could deregister.
+Cancel the stuck workflow run (`gh run cancel`), wait for the registration
+to free, then `gh api -X DELETE .../runners/<id>`. Prevent recurrence by
+confirming `dokku ps:report gh-runner | grep stop-timeout` shows 900s —
+existing deploys must run setup step 5 once.
 
 **Updating the runner version:** bump `RUNNER_VERSION` in the Dockerfile
 and `git push dokku main`. Check

--- a/infra/runner/README.md
+++ b/infra/runner/README.md
@@ -45,17 +45,20 @@ dokku config:set --no-restart gh-runner \
 #    drains to zero after one CI run.
 dokku ps:set gh-runner restart-policy always
 
-# 5. Stop-timeout MUST be longer than the longest CI job. `docker stop`
-#    forwards SIGTERM, waits `stop-timeout-seconds`, then SIGKILLs. Default
-#    is 30s — shorter than nearly every job. If a scale operation lands
-#    while a runner is mid-job, SIGKILL bypasses the entrypoint's EXIT
-#    trap (infra/runner/entrypoint.sh), the GitHub-side runner record is
-#    not deregistered, and the stale `offline busy=true` registration
-#    holds the job slot for the workflow's `timeout-minutes` (set per-job
-#    in .github/workflows/ci.yml) before GitHub gives up and re-dispatches.
-#    900s (15 min) is generous headroom vs current job lengths; raise if
-#    jobs ever exceed that.
-dokku ps:set gh-runner stop-timeout-seconds 900
+# 5. Stop-timeout MUST be >= the workflow's `timeout-minutes` ceiling.
+#    `docker stop` forwards SIGTERM, waits `stop-timeout-seconds`, then
+#    SIGKILLs. Default is 30s — shorter than nearly every job. If a scale
+#    operation lands while a runner is mid-job, SIGKILL bypasses the
+#    entrypoint's EXIT trap (infra/runner/entrypoint.sh), the GitHub-side
+#    runner record is not deregistered, and the stale `offline busy=true`
+#    registration holds the job slot for the workflow's `timeout-minutes`
+#    before GitHub gives up and re-dispatches.
+#
+#    Workflow jobs in .github/workflows/ci.yml use `timeout-minutes: 30`,
+#    so 1800s is the matching upper bound — a job hitting its own timeout
+#    can still clean up. Raise this in lockstep if the workflow ceiling
+#    ever increases.
+dokku ps:set gh-runner stop-timeout-seconds 1800
 
 # 6. Persistent pnpm store across ephemeral container lifetimes. CAS-safe
 #    for concurrent replicas (pnpm uses content-addressed storage).
@@ -116,7 +119,7 @@ with `status=offline` and `busy=true`. Cause: `docker stop` SIGKILLed an
 in-flight runner before the entrypoint's EXIT trap could deregister.
 Cancel the stuck workflow run (`gh run cancel`), wait for the registration
 to free, then `gh api -X DELETE .../runners/<id>`. Prevent recurrence by
-confirming `dokku ps:report gh-runner | grep stop-timeout` shows 900s —
+confirming `dokku ps:report gh-runner | grep stop-timeout` shows 1800s —
 existing deploys must run setup step 5 once.
 
 **Updating the runner version:** bump `RUNNER_VERSION` in the Dockerfile

--- a/infra/runner/README.md
+++ b/infra/runner/README.md
@@ -45,7 +45,19 @@ dokku config:set --no-restart gh-runner \
 #    drains to zero after one CI run.
 dokku ps:set gh-runner restart-policy always
 
-# 5. Persistent pnpm store across ephemeral container lifetimes. CAS-safe
+# 5. Stop-timeout MUST be longer than the longest CI job. `docker stop`
+#    forwards SIGTERM, waits `stop-timeout-seconds`, then SIGKILLs. Default
+#    is 30s — shorter than nearly every job. If a scale operation lands
+#    while a runner is mid-job, SIGKILL bypasses the entrypoint's EXIT
+#    trap, the GitHub-side runner record is not deregistered, and the
+#    stale `offline busy=true` registration holds the job slot for the
+#    workflow's `timeout-minutes` (30 here) before GitHub gives up. The
+#    re-dispatch loses ~30 minutes of CI per stale runner. 900s (15 min)
+#    is generous headroom vs current job lengths; raise if jobs ever
+#    exceed that.
+dokku ps:set gh-runner stop-timeout-seconds 900
+
+# 6. Persistent pnpm store across ephemeral container lifetimes. CAS-safe
 #    for concurrent replicas (pnpm uses content-addressed storage).
 #    node_modules and dist remain per-container, never shared.
 sudo mkdir -p /var/lib/dokku/data/storage/gh-runner-pnpm

--- a/infra/runner/README.md
+++ b/infra/runner/README.md
@@ -118,7 +118,8 @@ emitting logs, and `gh api repos/<repo>/actions/runners` shows a runner
 with `status=offline` and `busy=true`. Cause: `docker stop` SIGKILLed an
 in-flight runner before the entrypoint's EXIT trap could deregister.
 Cancel the stuck workflow run (`gh run cancel`), wait for the registration
-to free, then `gh api -X DELETE .../runners/<id>`. Prevent recurrence by
+to free, then `gh api -X DELETE repos/<repo>/actions/runners/<id>`.
+Prevent recurrence by
 confirming `dokku ps:report gh-runner | grep stop-timeout` shows 1800s —
 existing deploys must run setup step 5 once.
 


### PR DESCRIPTION
## Summary

- Document the `dokku ps:set gh-runner stop-timeout-seconds 1800` step required during one-time setup.
- Without it (default 30s), `docker stop` SIGKILLs runners mid-job during scale operations, the entrypoint's EXIT trap is bypassed, and stale `offline busy=true` runner registrations hold job slots for the workflow's `timeout-minutes` (~30m) before re-dispatch.
- 1800s matches the workflow's `timeout-minutes: 30` ceiling so any in-spec job can finish + clean up before SIGKILL.
- Hit this today during the runner=1 → runner=2 scale-up — one Build & Type Check job stuck on a deleted container's registration, had to cancel the run manually. Server already updated; this PR just records the required step in the README.

## Test plan

- [x] Applied on the live `gh-runner` dokku app: `Stop timeout seconds: 1800`
- [x] README change is doc-only — no code/CI impact