### PR TITLE
test(activerecord): explicit defineSchema for encryption/uniqueness-validations

### DIFF
--- a/packages/activerecord/src/encryption/uniqueness-validations.test.ts
+++ b/packages/activerecord/src/encryption/uniqueness-validations.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import {
-  freshAdapter,
   configureEncryption,
   snapshotEncryptionConfig,
   restoreEncryptionConfig,
@@ -8,6 +7,8 @@ import {
   makeKeyProvider,
   makeEncryptedBook,
 } from "./test-helpers.js";
+import { createTestAdapter } from "../test-adapter.js";
+import { defineSchema } from "../test-helpers/define-schema.js";
 import { Configurable } from "./configurable.js";
 import { installExtendedQueriesIfConfigured } from "./install.js";
 import { ExtendedDeterministicUniquenessValidator } from "./extended-deterministic-uniqueness-validator.js";
@@ -49,7 +50,11 @@ describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
   } = {};
 
   beforeAll(async () => {
-    adapter = await freshAdapter();
+    adapter = createTestAdapter();
+    await defineSchema(adapter, {
+      encrypted_books: { name: { type: "string", limit: 1024, default: "<untitled>" } },
+      encrypted_book_with_downcase_names: { name: { type: "string", limit: 1024 } },
+    });
   });
 
   withTransactionalFixtures(() => adapter);


### PR DESCRIPTION
## Summary

- Last Phase 5 audit offender. `freshAdapter()` already installed the
  schema in `beforeAll`, but the audit only matches the literal
  `defineSchema(` token in-file.
- Inline the two tables this file uses (`encrypted_books`,
  `encrypted_book_with_downcase_names`) so schema setup is locally
  visible and `pnpm tsx scripts/audit-define-schema.ts` returns clean.
- Audit now reports zero offenders — unblocks Phase 6 (BEGIN/ROLLBACK
  in place of `dropAllTables` between tests).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/encryption/uniqueness-validations.test.ts` (6/6 pass)
- [x] `pnpm tsx scripts/audit-define-schema.ts` — OK