### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in relation/ cluster

### DIFF
--- a/packages/activerecord/src/relation/annotations.test.ts
+++ b/packages/activerecord/src/relation/annotations.test.ts
@@ -2,15 +2,16 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: { title: "string" },
@@ -18,6 +19,7 @@ beforeEach(async () => {
     users: { name: "string" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }

--- a/packages/activerecord/src/relation/delete-all.test.ts
+++ b/packages/activerecord/src/relation/delete-all.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 
 function epochMs(v: unknown): number {
@@ -14,12 +14,13 @@ function epochMs(v: unknown): number {
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany, processDependentAssociations } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: {
@@ -35,6 +36,7 @@ beforeEach(async () => {
     delete_all_posts: { title: "string", author_id: "integer" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }

--- a/packages/activerecord/src/relation/order.test.ts
+++ b/packages/activerecord/src/relation/order.test.ts
@@ -2,21 +2,23 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: { title: "string", score: "integer" },
     items: { name: "string", price: "integer" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -2,15 +2,16 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: { title: "string", body: "string", status: "string" },
@@ -20,6 +21,7 @@ beforeEach(async () => {
     users: { name: "string", email: "string", role: "string" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -11,20 +11,22 @@ function epochMs(v: unknown): number {
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: { title: "string", author: "string", views: "integer", updated_at: "datetime" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }

--- a/packages/activerecord/src/relation/where-clause.test.ts
+++ b/packages/activerecord/src/relation/where-clause.test.ts
@@ -2,20 +2,22 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: { title: "string", author: "string", status: "string" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }


### PR DESCRIPTION
## Summary

First Phase 6 PR (per `docs/tm-unification-plan.md`). Migrates six
`packages/activerecord/src/relation/` test files from per-test
`beforeEach(defineSchema)` to once-per-file `beforeAll(defineSchema)` +
`withTransactionalFixtures()`. Each test now wraps in a BEGIN/ROLLBACK
pair instead of dropping and recreating tables between tests.

Files: annotations, order, where-clause, update-all, select, delete-all.

This is the proof-of-pattern slice — the remaining `relation/` files
(merging, or, where-chain, where, thenable, predicate-builder) follow
in subsequent PRs.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/relation/{annotations,order,where-clause,update-all,select,delete-all}.test.ts` — 169 pass, 3 pre-existing skips