### PR TITLE
feat(actionpack): dedup callbacks by name in AbstractController hierarchy

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -188,6 +188,20 @@ export class AbstractController {
         chain.push(...(klass as any)._callbacks);
       }
     }
+    // Dedup by `options.name`: when a subclass registers a callback with
+    // the same name, drop the inherited entry. Mirrors AS::Callbacks
+    // identifying callbacks by symbol — `before_action :first, ...` in a
+    // child replaces the parent's `:first` registration.
+    const overriddenNames = new Set<string>();
+    for (let i = chain.length - 1; i >= 0; i--) {
+      const name = chain[i]!.options.name;
+      if (name === undefined) continue;
+      if (overriddenNames.has(name)) {
+        chain.splice(i, 1);
+      } else {
+        overriddenNames.add(name);
+      }
+    }
     return chain;
   }
 

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -188,18 +188,22 @@ export class AbstractController {
         chain.push(...(klass as any)._callbacks);
       }
     }
-    // Dedup by `options.name`: when a subclass registers a callback with
-    // the same name, drop the inherited entry. Mirrors AS::Callbacks
-    // identifying callbacks by symbol — `before_action :first, ...` in a
-    // child replaces the parent's `:first` registration.
-    const overriddenNames = new Set<string>();
+    // Dedup by (`options.name`, `type`): when a subclass registers a
+    // callback with the same name and kind, drop the inherited entry.
+    // Mirrors AS::Callbacks CallbackChain#remove_duplicates, which
+    // matches on Callback#duplicates? (same filter + same kind) — so
+    // `before_action :first` and `after_action :first` coexist, but a
+    // child's `before_action :first, except: :index` replaces the
+    // parent's `before_action :first`.
+    const seen = new Set<string>();
     for (let i = chain.length - 1; i >= 0; i--) {
-      const name = chain[i]!.options.name;
-      if (name === undefined) continue;
-      if (overriddenNames.has(name)) {
+      const entry = chain[i]!;
+      if (entry.options.name === undefined) continue;
+      const key = `${entry.type}\0${entry.options.name}`;
+      if (seen.has(key)) {
         chain.splice(i, 1);
       } else {
-        overriddenNames.add(name);
+        seen.add(key);
       }
     }
     return chain;

--- a/packages/actionpack/src/abstract-controller/callbacks.test.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.test.ts
@@ -49,7 +49,7 @@ class Callback2 extends AbstractController {
     this.responseBody = (this.text ?? "") as string;
   }
 }
-Callback2.beforeAction((c) => (c as Callback2).first());
+Callback2.beforeAction((c) => (c as Callback2).first(), { name: "first" });
 Callback2.afterAction((c) => (c as Callback2)._second());
 Callback2.aroundAction(async (c, next) => {
   const self = c as Callback2;
@@ -59,7 +59,10 @@ Callback2.aroundAction(async (c, next) => {
 });
 
 class Callback2Overwrite extends Callback2 {}
-Callback2Overwrite.beforeAction((c) => (c as Callback2).first(), { except: ["index"] });
+Callback2Overwrite.beforeAction((c) => (c as Callback2).first(), {
+  name: "first",
+  except: ["index"],
+});
 
 describe("TestCallbacks2", () => {
   let controller: Callback2;
@@ -82,14 +85,11 @@ describe("TestCallbacks2", () => {
     expect(controller.aroundz).toBe("FIRSTSECOND");
   });
 
-  // BLOCKED: Rails identifies callbacks by name (`:first` symbol), so
-  // `before_action :first, except: :index` in a subclass *replaces* the
-  // parent's unconditional `:first`. trails identifies callbacks by
-  // function reference — no named replacement — so the parent's
-  // unconditional callback still fires on :index. ~60 LOC follow-up to
-  // add a `name?: string` slot on CallbackOptions and dedup-by-name in
-  // the registry.
-  it.skip("before_action with overwritten condition", () => {});
+  it("before_action with overwritten condition", async () => {
+    const overwriteController = new Callback2Overwrite();
+    await overwriteController.processAction("index");
+    expect(overwriteController.responseBody).toBe("");
+  });
 });
 
 class Callback3 extends AbstractController {
@@ -267,7 +267,10 @@ class ChangedConditions extends Callback2 {
     this.responseBody = (this.text ?? "") as string;
   }
 }
-ChangedConditions.beforeAction((c) => (c as Callback2).first(), { only: ["index"] });
+ChangedConditions.beforeAction((c) => (c as Callback2).first(), {
+  name: "first",
+  only: ["index"],
+});
 
 describe("TestCallbacksWithChangedConditions", () => {
   let controller: ChangedConditions;
@@ -280,11 +283,10 @@ describe("TestCallbacksWithChangedConditions", () => {
     expect(controller.responseBody).toBe("Hello world");
   });
 
-  // BLOCKED: same named-callback-replacement gap as TestCallbacks2's
-  // "before_action with overwritten condition" — Rails dedups :first by
-  // symbol, trails doesn't dedup by function reference, so the parent's
-  // unconditional :first still fires on :not_index.
-  it.skip("when a callback is modified in a child with :only, it does not work for other actions", () => {});
+  it("when a callback is modified in a child with :only, it does not work for other actions", async () => {
+    await controller.processAction("not_index");
+    expect(controller.responseBody).toBe("");
+  });
 });
 
 class SetsResponseBody extends AbstractController {

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -26,6 +26,14 @@ export interface CallbackPredicateLike {
 }
 
 export interface CallbackOptions {
+  /**
+   * Symbolic name for the callback. When a subclass registers a callback
+   * with the same `name`, it replaces the inherited entry (Rails
+   * identifies callbacks by symbol in AS::Callbacks). Without `name`,
+   * callbacks are identified by function reference and don't dedup
+   * across the inheritance chain.
+   */
+  name?: string;
   only?: string | string[];
   except?: string | string[];
   if?:


### PR DESCRIPTION
## Summary
- Adds `name?: string` to `CallbackOptions`. When a subclass registers a callback with the same `name`, `getCallbacks()` drops the inherited entry — mirrors AS::Callbacks identifying callbacks by symbol, so `before_action :first, except: :index` in a child replaces the parent's unconditional `:first` registration.
- Un-skips 2 callbacks tests:
  - `TestCallbacks2 > before_action with overwritten condition`
  - `TestCallbacksWithChangedConditions > ... does not work for other actions`

Follow-up from #2036 (documented in the recent-merge followups list).

## Notes for reviewers
- The original task suggested bundling a process_action wrapper relocation + base.rb cluster fidelity sweep into ~250 LOC. Those are deferred to a follow-up slot:
  - **process_action wrapper relocation**: Rails has a private `process_action(...)` in `Callbacks` that wraps `super` with `run_callbacks(:process_action)`. trails' inline before/after/around dispatch in `base.ts#processAction` would need a real layered refactor (no `runCallbacks` infra yet), which is bigger than the bundling budget and orthogonal to the dedup behavior.
  - **base.rb fidelity sweep**: `pnpm api:compare --package actionpack` currently reports 0/0 — the package's tracked files don't surface here, so picking 4–6 base.rb misses from that signal isn't feasible in this slot. Worth a dedicated audit.

PR is intentionally tight (~40 insertions of impl) to keep review surface small.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/abstract-controller/callbacks.test.ts` — 35 passing, 7 skipped (two previously-skipped tests now passing)
- [x] `pnpm build` + `pnpm typecheck` clean (via lint-staged pre-commit)