### PR TITLE
feat(actionpack): process_action relocation + raise_on_missing_callback_actions + base.rb cluster

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -269,12 +269,16 @@ export class AbstractController {
     }
   }
 
-  /** Rails `Base#process` — public entry, sets state, dispatches via
-   * `processAction`. Raises `ActionNotFound` if the action is unknown. */
+  /**
+   * Rails `Base#process` — public entry. Validates the action via
+   * `_findActionName`, resets the response body, then delegates to
+   * `processAction` which handles the per-request `actionName` /
+   * `_performed` setup. Splitting state ownership this way (Rails-style
+   * single-setter is the goal, but trails has long-standing direct
+   * `processAction` callers in Metal and tests that need their state
+   * primed) avoids the double-assign that earlier iterations had.
+   */
   async process(action: string, ...args: unknown[]): Promise<void> {
-    this.actionName = action;
-    this._performed = false;
-    this._responseBody = null;
     if (!this._findActionName(action)) {
       throw new ActionNotFound(
         `The action '${action}' could not be found for ${this.constructor.name}`,
@@ -282,6 +286,7 @@ export class AbstractController {
         action,
       );
     }
+    this._responseBody = null;
     await this.processAction(action, ...args);
   }
 

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -188,6 +188,20 @@ export class AbstractController {
         chain.push(...(klass as any)._callbacks);
       }
     }
+    // Dedup by `options.name`: when a subclass registers a callback with
+    // the same name, drop the inherited entry. Mirrors AS::Callbacks
+    // identifying callbacks by symbol — `before_action :first, ...` in a
+    // child replaces the parent's `:first` registration.
+    const overriddenNames = new Set<string>();
+    for (let i = chain.length - 1; i >= 0; i--) {
+      const name = chain[i]!.options.name;
+      if (name === undefined) continue;
+      if (overriddenNames.has(name)) {
+        chain.splice(i, 1);
+      } else {
+        overriddenNames.add(name);
+      }
+    }
     return chain;
   }
 

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -27,6 +27,7 @@ export type {
 export class ActionNotFound extends Error {
   readonly controller: AbstractController | null;
   readonly action: string | null;
+  private _corrections?: string[];
 
   constructor(
     message: string,
@@ -39,10 +40,44 @@ export class ActionNotFound extends Error {
     this.action = action;
   }
 
-  /** Rails delegates to DidYouMean::SpellChecker; we return []. @internal */
+  /**
+   * "Did you mean" suggestions — the controller's action methods ranked by
+   * edit distance to the missing action. Mirrors Rails' DidYouMean
+   * integration (`DidYouMean::SpellChecker.new(dictionary: controller.class.action_methods).correct(action)`)
+   * using Levenshtein distance with a `≤ floor(name.length / 3) + 1`
+   * threshold, capped at 3 suggestions. Memoized.
+   */
   get corrections(): string[] {
-    return [];
+    if (this._corrections) return this._corrections;
+    if (!this.controller || !this.action) return (this._corrections = []);
+    const dictionary = (this.controller.constructor as typeof AbstractController).actionMethods();
+    const target = this.action;
+    const threshold = Math.floor(target.length / 3) + 1;
+    const scored = dictionary
+      .map((candidate) => ({ candidate, distance: _editDistance(target, candidate) }))
+      .filter(({ distance }) => distance <= threshold)
+      .sort((a, b) => a.distance - b.distance);
+    return (this._corrections = scored.slice(0, 3).map((s) => s.candidate));
   }
+}
+
+/** Levenshtein distance — iterative two-row implementation. @internal */
+function _editDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  let prev = new Array<number>(b.length + 1);
+  let curr = new Array<number>(b.length + 1);
+  for (let j = 0; j <= b.length; j++) prev[j] = j;
+  for (let i = 1; i <= a.length; i++) {
+    curr[0] = i;
+    for (let j = 1; j <= b.length; j++) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      curr[j] = Math.min(curr[j - 1]! + 1, prev[j]! + 1, prev[j - 1]! + cost);
+    }
+    [prev, curr] = [curr, prev];
+  }
+  return prev[b.length]!;
 }
 
 export class AbstractController {

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -188,18 +188,22 @@ export class AbstractController {
         chain.push(...(klass as any)._callbacks);
       }
     }
-    // Dedup by `options.name`: when a subclass registers a callback with
-    // the same name, drop the inherited entry. Mirrors AS::Callbacks
-    // identifying callbacks by symbol — `before_action :first, ...` in a
-    // child replaces the parent's `:first` registration.
-    const overriddenNames = new Set<string>();
+    // Dedup by (`options.name`, `type`): when a subclass registers a
+    // callback with the same name and kind, drop the inherited entry.
+    // Mirrors AS::Callbacks CallbackChain#remove_duplicates, which
+    // matches on Callback#duplicates? (same filter + same kind) — so
+    // `before_action :first` and `after_action :first` coexist, but a
+    // child's `before_action :first, except: :index` replaces the
+    // parent's `before_action :first`.
+    const seen = new Set<string>();
     for (let i = chain.length - 1; i >= 0; i--) {
-      const name = chain[i]!.options.name;
-      if (name === undefined) continue;
-      if (overriddenNames.has(name)) {
+      const entry = chain[i]!;
+      if (entry.options.name === undefined) continue;
+      const key = `${entry.type}\0${entry.options.name}`;
+      if (seen.has(key)) {
         chain.splice(i, 1);
       } else {
-        overriddenNames.add(name);
+        seen.add(key);
       }
     }
     return chain;

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -10,6 +10,7 @@ import {
   _insertCallbacks,
   _normalizeCallbackOption,
   _normalizeCallbackOptions,
+  processAction as _runProcessActionCallbacks,
   type ActionCallback,
   type AroundCallback,
   type CallbackEntry,
@@ -24,20 +25,33 @@ export type {
 
 /** Raised when an action cannot be found for the given controller. */
 export class ActionNotFound extends Error {
-  constructor(message: string) {
+  readonly controller: AbstractController | null;
+  readonly action: string | null;
+
+  constructor(
+    message: string,
+    controller: AbstractController | null = null,
+    action: string | null = null,
+  ) {
     super(message);
     this.name = "ActionNotFound";
+    this.controller = controller;
+    this.action = action;
   }
-}
 
-/** Rails `Array(value)`: coerce scalar to single-element array. @internal */
-function _actionList(value: string | string[]): string[] {
-  return Array.isArray(value) ? value : [value];
+  /** Rails delegates to DidYouMean::SpellChecker; we return []. @internal */
+  get corrections(): string[] {
+    return [];
+  }
 }
 
 export class AbstractController {
   /** The action currently being processed. */
   actionName: string = "";
+
+  /** When true, ActionFilter#isMatch raises if `:only`/`:except` references
+   * an action that doesn't exist on the controller. Rails 7.1 mattr_accessor. */
+  static raiseOnMissingCallbackActions: boolean = false;
 
   /** Internal storage for response body. Subclasses may override the
    * `responseBody` accessor (e.g. Metal writes through to the response). */
@@ -143,30 +157,33 @@ export class AbstractController {
 
   /** Register a before_action callback. */
   static beforeAction(callback: ActionCallback, options: CallbackOptions = {}): void {
-    _normalizeCallbackOptions(options);
-    const entry: CallbackEntry = { callback, type: "before", options };
-    if (options.prepend) {
-      this._ensureOwnCallbacks().unshift(entry);
-    } else {
-      this._ensureOwnCallbacks().push(entry);
-    }
+    this._registerActionCallback("before", callback, options);
   }
 
   /** Register an after_action callback. */
   static afterAction(callback: ActionCallback, options: CallbackOptions = {}): void {
-    _normalizeCallbackOptions(options);
-    const entry: CallbackEntry = { callback, type: "after", options };
-    if (options.prepend) {
-      this._ensureOwnCallbacks().unshift(entry);
-    } else {
-      this._ensureOwnCallbacks().push(entry);
-    }
+    this._registerActionCallback("after", callback, options);
   }
 
   /** Register an around_action callback. */
   static aroundAction(callback: AroundCallback, options: CallbackOptions = {}): void {
+    this._registerActionCallback("around", callback, options);
+  }
+
+  /** Pre-populates `options.filters` so ActionFilter retains the callback
+   * for diagnostic rendering. Mirrors `_insert_callbacks` filters wiring. @internal */
+  private static _registerActionCallback(
+    type: "before" | "after" | "around",
+    callback: ActionCallback | AroundCallback,
+    options: CallbackOptions,
+  ): void {
+    const opts = options as CallbackOptions & {
+      filters?: Array<ActionCallback | AroundCallback>;
+    };
+    opts.filters = [callback];
     _normalizeCallbackOptions(options);
-    const entry: CallbackEntry = { callback, type: "around", options };
+    delete opts.filters;
+    const entry: CallbackEntry = { callback, type, options };
     if (options.prepend) {
       this._ensureOwnCallbacks().unshift(entry);
     } else {
@@ -226,75 +243,89 @@ export class AbstractController {
   }
 
   /**
-   * Process an action by name. Runs callbacks around the action. Extra
-   * `args` are forwarded to the action method (mirrors Rails'
-   * `Controller#process(action, *args)`).
+   * Process an action by name. Delegates to the callbacks-wrapping
+   * dispatcher in `callbacks.ts`, which then invokes `_dispatchAction` as
+   * the inner step (mirrors Rails AC::Callbacks#process_action overriding
+   * Base#process_action with a `run_callbacks { super }` wrapper).
    */
   async processAction(action: string, ...args: unknown[]): Promise<void> {
     this.actionName = action;
     this._performed = false;
+    await _runProcessActionCallbacks(this, action, () => this._dispatchAction(action, ...args));
+  }
 
+  /** Rails `Base#send_action` — raw method dispatch with actionMissing
+   * fallback and ActionNotFound on no match. @internal */
+  async _dispatchAction(action: string, ...args: unknown[]): Promise<void> {
     const Constructor = this.constructor as typeof AbstractController;
-    const allCallbacks = Constructor.getCallbacks();
-    const skipped = Constructor.getSkipped();
-
-    // Filter out skipped callbacks
-    const callbacks = allCallbacks.filter((entry) => {
-      return !skipped.some((s) => {
-        if (s.callback !== entry.callback) return false;
-        if (s.options.only !== undefined && !_actionList(s.options.only).includes(action))
-          return false;
-        if (s.options.except !== undefined && _actionList(s.options.except).includes(action))
-          return false;
-        return true;
-      });
-    });
-
-    const befores = callbacks.filter((c) => c.type === "before" && this._shouldRun(c, action));
-    const afters = callbacks.filter((c) => c.type === "after" && this._shouldRun(c, action));
-    const arounds = callbacks.filter((c) => c.type === "around" && this._shouldRun(c, action));
-
-    // Build the around chain
-    const executeAction = async (): Promise<void> => {
-      // Run before callbacks
-      for (const entry of befores) {
-        if (this.performed) return;
-        const result = await (entry.callback as ActionCallback)(this);
-        if (result === false) return; // Halt chain
+    if (Constructor.hasAction(action)) {
+      const method = (this as any)[action];
+      if (typeof method === "function") {
+        await method.apply(this, args);
       }
-
-      if (this.performed) return;
-
-      // Execute the action (only if it's a recognized action method)
-      if (Constructor.hasAction(action)) {
-        const method = (this as any)[action];
-        if (typeof method === "function") {
-          await method.apply(this, args);
-        }
-      } else if (typeof (this as any).actionMissing === "function") {
-        await (this as any).actionMissing(action, ...args);
-      } else {
-        throw new ActionNotFound(
-          `The action '${action}' could not be found for ${this.constructor.name}`,
-        );
-      }
-
-      // Run after callbacks (in reverse order)
-      for (const entry of afters.reverse()) {
-        await (entry.callback as ActionCallback)(this);
-      }
-    };
-
-    // Wrap with around callbacks
-    let chain = executeAction;
-    for (const around of arounds.reverse()) {
-      const inner = chain;
-      chain = async () => {
-        await (around.callback as AroundCallback)(this, inner);
-      };
+    } else if (typeof (this as any).actionMissing === "function") {
+      await (this as any).actionMissing(action, ...args);
+    } else {
+      throw new ActionNotFound(
+        `The action '${action}' could not be found for ${this.constructor.name}`,
+        this,
+        action,
+      );
     }
+  }
 
-    await chain();
+  /** Rails `Base#process` — public entry, sets state, dispatches via
+   * `processAction`. Raises `ActionNotFound` if the action is unknown. */
+  async process(action: string, ...args: unknown[]): Promise<void> {
+    this.actionName = action;
+    this._performed = false;
+    this._responseBody = null;
+    if (!this._findActionName(action)) {
+      throw new ActionNotFound(
+        `The action '${action}' could not be found for ${this.constructor.name}`,
+        this,
+        action,
+      );
+    }
+    await this.processAction(action, ...args);
+  }
+
+  /** Rails `available_action?` — `action` is a real method or covered by
+   * `actionMissing`. */
+  isAvailableAction(action: string): boolean {
+    return this._findActionName(action) !== undefined;
+  }
+
+  /** @internal */
+  isActionMethod(name: string): boolean {
+    return (this.constructor as typeof AbstractController).hasAction(name);
+  }
+
+  /** @internal */
+  _handleActionMissing(...args: unknown[]): unknown {
+    return (this as any).actionMissing?.(this.actionName, ...args);
+  }
+
+  /** @internal */
+  _findActionName(name: string): string | undefined {
+    return this._validActionName(name) ? this.methodForAction(name) : undefined;
+  }
+
+  /** @internal */
+  methodForAction(name: string): string | undefined {
+    if (this.isActionMethod(name)) return name;
+    if (typeof (this as any).actionMissing === "function") return "_handleActionMissing";
+    return undefined;
+  }
+
+  /** @internal Rails `_valid_action_name?` — reject path-separator names. */
+  _validActionName(name: string): boolean {
+    return !name.includes("/");
+  }
+
+  /** Rails `Base.supports_path?` — whether this controller renders URL paths. */
+  static supportsPath(): boolean {
+    return true;
   }
 
   /**
@@ -316,29 +347,6 @@ export class AbstractController {
   /** Get available action names. */
   availableActions(): string[] {
     return (this.constructor as typeof AbstractController).actionMethods();
-  }
-
-  private _shouldRun(entry: CallbackEntry, action: string): boolean {
-    const opts = entry.options;
-    if (opts.only !== undefined && !_actionList(opts.only).includes(action)) return false;
-    if (opts.except !== undefined && _actionList(opts.except).includes(action)) return false;
-    if (opts.if !== undefined && !this._evalPredicate(opts.if, true)) return false;
-    if (opts.unless !== undefined && this._evalPredicate(opts.unless, false)) return false;
-    return true;
-  }
-
-  private _evalPredicate(pred: NonNullable<CallbackOptions["if"]>, requireAll: boolean): boolean {
-    if (typeof pred === "function") return pred(this);
-    if (requireAll) {
-      for (const p of pred) {
-        if (!(typeof p === "function" ? p(this) : p.isMatch(this))) return false;
-      }
-      return true;
-    }
-    for (const p of pred) {
-      if (typeof p === "function" ? p(this) : p.isMatch(this)) return true;
-    }
-    return false;
   }
 
   private static _ensureOwnCallbacks(): CallbackEntry[] {

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -27,7 +27,6 @@ export type {
 export class ActionNotFound extends Error {
   readonly controller: AbstractController | null;
   readonly action: string | null;
-  private _corrections?: string[];
 
   constructor(
     message: string,
@@ -39,45 +38,6 @@ export class ActionNotFound extends Error {
     this.controller = controller;
     this.action = action;
   }
-
-  /**
-   * "Did you mean" suggestions — the controller's action methods ranked by
-   * edit distance to the missing action. Mirrors Rails' DidYouMean
-   * integration (`DidYouMean::SpellChecker.new(dictionary: controller.class.action_methods).correct(action)`)
-   * using Levenshtein distance with a `≤ floor(name.length / 3) + 1`
-   * threshold, capped at 3 suggestions. Memoized.
-   */
-  get corrections(): string[] {
-    if (this._corrections) return this._corrections;
-    if (!this.controller || !this.action) return (this._corrections = []);
-    const dictionary = (this.controller.constructor as typeof AbstractController).actionMethods();
-    const target = this.action;
-    const threshold = Math.floor(target.length / 3) + 1;
-    const scored = dictionary
-      .map((candidate) => ({ candidate, distance: _editDistance(target, candidate) }))
-      .filter(({ distance }) => distance <= threshold)
-      .sort((a, b) => a.distance - b.distance);
-    return (this._corrections = scored.slice(0, 3).map((s) => s.candidate));
-  }
-}
-
-/** Levenshtein distance — iterative two-row implementation. @internal */
-function _editDistance(a: string, b: string): number {
-  if (a === b) return 0;
-  if (a.length === 0) return b.length;
-  if (b.length === 0) return a.length;
-  let prev = new Array<number>(b.length + 1);
-  let curr = new Array<number>(b.length + 1);
-  for (let j = 0; j <= b.length; j++) prev[j] = j;
-  for (let i = 1; i <= a.length; i++) {
-    curr[0] = i;
-    for (let j = 1; j <= b.length; j++) {
-      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
-      curr[j] = Math.min(curr[j - 1]! + 1, prev[j]! + 1, prev[j - 1]! + cost);
-    }
-    [prev, curr] = [curr, prev];
-  }
-  return prev[b.length]!;
 }
 
 export class AbstractController {

--- a/packages/actionpack/src/abstract-controller/callbacks.test.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.test.ts
@@ -327,18 +327,79 @@ describe("TestCallbacksWithArgs", () => {
 });
 
 describe("TestCallbacksWithMissingConditions", () => {
-  // BLOCKED: raise_on_missing_callback_actions class flag is not ported.
-  // The whole "callbacks reference an action that doesn't exist on the
-  // controller" diagnostic path is unimplemented (~80 LOC follow-up:
-  // validate :only / :except against availableActions at processAction
-  // time when the flag is set).
-  it.skip("callbacks raise exception when their 'only' condition is a missing action", () => {});
-  it.skip("callbacks raise exception when their 'only' array condition contains a missing action", () => {});
-  it.skip("callbacks raise exception when their 'except' condition is a missing action", () => {});
-  it.skip("callbacks raise exception when their 'except' array condition contains a missing action", () => {});
-  it.skip("raised exception message includes the names of callback actions and missing conditional action", () => {});
-  it.skip("raised exception message includes a block callback", () => {});
-  it.skip("callbacks with both :only and :except options raise an exception with the correct message", () => {});
+  function makeController(
+    register: (k: typeof AbstractController) => void,
+  ): typeof AbstractController {
+    class C extends AbstractController {
+      async index() {}
+      async show() {}
+    }
+    C.raiseOnMissingCallbackActions = true;
+    register(C);
+    return C;
+  }
+
+  async function runAndCatch(C: typeof AbstractController): Promise<Error> {
+    const c = new C();
+    try {
+      await c.processAction("index");
+    } catch (e) {
+      return e as Error;
+    }
+    throw new Error("expected processAction to throw");
+  }
+
+  it("callbacks raise exception when their 'only' condition is a missing action", async () => {
+    const C = makeController((k) => k.beforeAction(function callback() {}, { only: "showw" }));
+    expect(await runAndCatch(C)).toBeInstanceOf(ActionNotFound);
+  });
+
+  it("callbacks raise exception when their 'only' array condition contains a missing action", async () => {
+    const C = makeController((k) =>
+      k.beforeAction(function callback() {}, { only: ["index", "showw"] }),
+    );
+    expect(await runAndCatch(C)).toBeInstanceOf(ActionNotFound);
+  });
+
+  it("callbacks raise exception when their 'except' condition is a missing action", async () => {
+    const C = makeController((k) => k.beforeAction(function callback() {}, { except: "showw" }));
+    expect(await runAndCatch(C)).toBeInstanceOf(ActionNotFound);
+  });
+
+  it("callbacks raise exception when their 'except' array condition contains a missing action", async () => {
+    const C = makeController((k) =>
+      k.beforeAction(function callback() {}, { except: ["index", "showw"] }),
+    );
+    expect(await runAndCatch(C)).toBeInstanceOf(ActionNotFound);
+  });
+
+  it("raised exception message includes the names of callback actions and missing conditional action", async () => {
+    const C = makeController((k) => {
+      k.beforeAction(function callback1() {}, { only: "showw" });
+      k.beforeAction(function callback2() {}, { only: "showw" });
+      k.beforeAction(() => {}, { only: "showw" });
+    });
+    // trails' beforeAction takes one callback at a time, so each
+    // registration gets its own ActionFilter and the first one to fail
+    // surfaces in the message. We assert on that one + the shared bits
+    // (`only`, `showw`) — Rails groups all callbacks into one filter
+    // because `before_action :a, :b, :c, only: :showw` shares a list.
+    const err = await runAndCatch(C);
+    for (const s of [":callback1", "only", "showw"]) expect(err.message).toContain(s);
+  });
+
+  it("raised exception message includes a block callback", async () => {
+    const C = makeController((k) => k.beforeAction(() => {}, { only: "showw" }));
+    expect((await runAndCatch(C)).message).toContain("#<Proc:");
+  });
+
+  it("callbacks with both :only and :except options raise an exception with the correct message", async () => {
+    const C = makeController((k) =>
+      k.beforeAction(function callback() {}, { only: ["index", "show"], except: "showw" }),
+    );
+    const err = await runAndCatch(C);
+    for (const s of [":callback", "except", "showw"]) expect(err.message).toContain(s);
+  });
 });
 
 // ==========================================================================

--- a/packages/actionpack/src/abstract-controller/callbacks.test.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.test.ts
@@ -49,7 +49,7 @@ class Callback2 extends AbstractController {
     this.responseBody = (this.text ?? "") as string;
   }
 }
-Callback2.beforeAction((c) => (c as Callback2).first());
+Callback2.beforeAction((c) => (c as Callback2).first(), { name: "first" });
 Callback2.afterAction((c) => (c as Callback2)._second());
 Callback2.aroundAction(async (c, next) => {
   const self = c as Callback2;
@@ -59,7 +59,10 @@ Callback2.aroundAction(async (c, next) => {
 });
 
 class Callback2Overwrite extends Callback2 {}
-Callback2Overwrite.beforeAction((c) => (c as Callback2).first(), { except: ["index"] });
+Callback2Overwrite.beforeAction((c) => (c as Callback2).first(), {
+  name: "first",
+  except: ["index"],
+});
 
 describe("TestCallbacks2", () => {
   let controller: Callback2;
@@ -82,14 +85,11 @@ describe("TestCallbacks2", () => {
     expect(controller.aroundz).toBe("FIRSTSECOND");
   });
 
-  // BLOCKED: Rails identifies callbacks by name (`:first` symbol), so
-  // `before_action :first, except: :index` in a subclass *replaces* the
-  // parent's unconditional `:first`. trails identifies callbacks by
-  // function reference — no named replacement — so the parent's
-  // unconditional callback still fires on :index. ~60 LOC follow-up to
-  // add a `name?: string` slot on CallbackOptions and dedup-by-name in
-  // the registry.
-  it.skip("before_action with overwritten condition", () => {});
+  it("before_action with overwritten condition", async () => {
+    const overwriteController = new Callback2Overwrite();
+    await overwriteController.processAction("index");
+    expect(overwriteController.responseBody).toBe("");
+  });
 });
 
 class Callback3 extends AbstractController {
@@ -267,7 +267,10 @@ class ChangedConditions extends Callback2 {
     this.responseBody = (this.text ?? "") as string;
   }
 }
-ChangedConditions.beforeAction((c) => (c as Callback2).first(), { only: ["index"] });
+ChangedConditions.beforeAction((c) => (c as Callback2).first(), {
+  name: "first",
+  only: ["index"],
+});
 
 describe("TestCallbacksWithChangedConditions", () => {
   let controller: ChangedConditions;
@@ -280,11 +283,10 @@ describe("TestCallbacksWithChangedConditions", () => {
     expect(controller.responseBody).toBe("Hello world");
   });
 
-  // BLOCKED: same named-callback-replacement gap as TestCallbacks2's
-  // "before_action with overwritten condition" — Rails dedups :first by
-  // symbol, trails doesn't dedup by function reference, so the parent's
-  // unconditional :first still fires on :not_index.
-  it.skip("when a callback is modified in a child with :only, it does not work for other actions", () => {});
+  it("when a callback is modified in a child with :only, it does not work for other actions", async () => {
+    await controller.processAction("not_index");
+    expect(controller.responseBody).toBe("");
+  });
 });
 
 class SetsResponseBody extends AbstractController {

--- a/packages/actionpack/src/abstract-controller/callbacks.test.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.test.ts
@@ -430,6 +430,23 @@ describe("AbstractController::Base — trails-only", () => {
     await expect(c.processAction("missing")).rejects.toThrow(ActionNotFound);
   });
 
+  it("ActionNotFound.corrections suggests near-match action methods", async () => {
+    class SuggestController extends AbstractController {
+      async index() {}
+      async show() {}
+      async destroy() {}
+    }
+    const c = new SuggestController();
+    try {
+      await c.processAction("shw");
+    } catch (e) {
+      const err = e as ActionNotFound;
+      expect(err.controller).toBe(c);
+      expect(err.action).toBe("shw");
+      expect(err.corrections).toContain("show");
+    }
+  });
+
   it("available actions lists instance methods", () => {
     class MethodController extends AbstractController {
       async index() {}

--- a/packages/actionpack/src/abstract-controller/callbacks.test.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.test.ts
@@ -430,23 +430,6 @@ describe("AbstractController::Base — trails-only", () => {
     await expect(c.processAction("missing")).rejects.toThrow(ActionNotFound);
   });
 
-  it("ActionNotFound.corrections suggests near-match action methods", async () => {
-    class SuggestController extends AbstractController {
-      async index() {}
-      async show() {}
-      async destroy() {}
-    }
-    const c = new SuggestController();
-    try {
-      await c.processAction("shw");
-    } catch (e) {
-      const err = e as ActionNotFound;
-      expect(err.controller).toBe(c);
-      expect(err.action).toBe("shw");
-      expect(err.corrections).toContain("show");
-    }
-  });
-
   it("available actions lists instance methods", () => {
     class MethodController extends AbstractController {
       async index() {}

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -26,6 +26,14 @@ export interface CallbackPredicateLike {
 }
 
 export interface CallbackOptions {
+  /**
+   * Symbolic name for the callback. When a subclass registers a callback
+   * with the same `name`, it replaces the inherited entry (Rails
+   * identifies callbacks by symbol in AS::Callbacks). Without `name`,
+   * callbacks are identified by function reference and don't dedup
+   * across the inheritance chain.
+   */
+  name?: string;
   only?: string | string[];
   except?: string | string[];
   if?:

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -94,10 +94,14 @@ export class ActionFilter implements CallbackPredicateLike {
           this._filters.length === 1
             ? _inspectFilter(this._filters[0]!)
             : `[${this._filters.map(_inspectFilter).join(", ")}]`;
+        // Ruby `:key.inspect` renders as `:key`; preserve that for parity
+        // with Rails' error message format (the literal `:only` / `:except`).
         const message =
           `The ${missing} action could not be found for the ${names} ` +
           `callback on ${controller.constructor.name}, but it is listed in the controller's ` +
-          `${JSON.stringify(this._conditionalKey)} option.`;
+          `:${this._conditionalKey} option.\n\n` +
+          `Raising for missing callback actions is a new default in Rails 7.1; ` +
+          `set \`raiseOnMissingCallbackActions = false\` on the controller class to opt out.`;
         throw new ActionNotFound(message, controller, missing);
       }
     }

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -6,7 +6,7 @@
  * @see https://api.rubyonrails.org/classes/AbstractController/Callbacks.html
  */
 
-import type { AbstractController } from "./base.js";
+import { ActionNotFound, type AbstractController } from "./base.js";
 
 export type ActionCallback = (
   controller: AbstractController,
@@ -86,6 +86,21 @@ export class ActionFilter implements CallbackPredicateLike {
 
   /** True iff the controller's current action is in the configured set. */
   isMatch(controller: AbstractController): boolean {
+    const Constructor = controller.constructor as { raiseOnMissingCallbackActions?: boolean };
+    if (Constructor.raiseOnMissingCallbackActions) {
+      const missing = [...this._actions].find((a) => !controller.isAvailableAction(a));
+      if (missing !== undefined) {
+        const names =
+          this._filters.length === 1
+            ? _inspectFilter(this._filters[0]!)
+            : `[${this._filters.map(_inspectFilter).join(", ")}]`;
+        const message =
+          `The ${missing} action could not be found for the ${names} ` +
+          `callback on ${controller.constructor.name}, but it is listed in the controller's ` +
+          `${JSON.stringify(this._conditionalKey)} option.`;
+        throw new ActionNotFound(message, controller, missing);
+      }
+    }
     return this._actions.has(controller.actionName);
   }
 
@@ -185,4 +200,102 @@ export function _insertCallbacks(
   for (const callback of list) {
     yieldFn(callback, options);
   }
+}
+
+function _actionList(value: string | string[]): string[] {
+  return Array.isArray(value) ? value : [value];
+}
+
+/** Named fn → `:name`; anon → `#<Proc:…>` (Rails Proc#inspect parity). @internal */
+function _inspectFilter(filter: ActionCallback | AroundCallback): string {
+  const fn = filter as { name?: string };
+  return fn.name && fn.name.length > 0 ? `:${fn.name}` : "#<Proc:anonymous>";
+}
+
+function _shouldRun(controller: AbstractController, entry: CallbackEntry, action: string): boolean {
+  const opts = entry.options;
+  if (opts.only !== undefined && !_actionList(opts.only).includes(action)) return false;
+  if (opts.except !== undefined && _actionList(opts.except).includes(action)) return false;
+  if (opts.if !== undefined && !_evalPredicate(controller, opts.if, true)) return false;
+  if (opts.unless !== undefined && _evalPredicate(controller, opts.unless, false)) return false;
+  return true;
+}
+
+function _evalPredicate(
+  controller: AbstractController,
+  pred: NonNullable<CallbackOptions["if"]>,
+  requireAll: boolean,
+): boolean {
+  if (typeof pred === "function") return pred(controller);
+  if (requireAll) {
+    for (const p of pred) {
+      if (!(typeof p === "function" ? p(controller) : p.isMatch(controller))) return false;
+    }
+    return true;
+  }
+  for (const p of pred) {
+    if (typeof p === "function" ? p(controller) : p.isMatch(controller)) return true;
+  }
+  return false;
+}
+
+/**
+ * Rails `AC::Callbacks#process_action` — wraps the dispatch with the
+ * registered `:process_action` callbacks. Ruby uses a `run_callbacks { super }`
+ * override; here the wrapping lives in callbacks.ts and `Base#processAction`
+ * delegates to it so the file layout matches Rails.
+ * @internal
+ */
+export async function processAction(
+  controller: AbstractController,
+  action: string,
+  dispatch: () => Promise<void>,
+): Promise<void> {
+  const Constructor = controller.constructor as unknown as {
+    getCallbacks: () => CallbackEntry[];
+    getSkipped: () => Array<{
+      callback: ActionCallback | AroundCallback;
+      options: CallbackOptions;
+    }>;
+  };
+  const allCallbacks = Constructor.getCallbacks();
+  const skipped = Constructor.getSkipped();
+
+  const callbacks = allCallbacks.filter((entry) => {
+    return !skipped.some((s) => {
+      if (s.callback !== entry.callback) return false;
+      if (s.options.only !== undefined && !_actionList(s.options.only).includes(action))
+        return false;
+      if (s.options.except !== undefined && _actionList(s.options.except).includes(action))
+        return false;
+      return true;
+    });
+  });
+
+  const befores = callbacks.filter((c) => c.type === "before" && _shouldRun(controller, c, action));
+  const afters = callbacks.filter((c) => c.type === "after" && _shouldRun(controller, c, action));
+  const arounds = callbacks.filter((c) => c.type === "around" && _shouldRun(controller, c, action));
+
+  const executeAction = async (): Promise<void> => {
+    for (const entry of befores) {
+      if (controller.performed) return;
+      const result = await (entry.callback as ActionCallback)(controller);
+      if (result === false) return;
+    }
+    if (controller.performed) return;
+    await dispatch();
+    for (const entry of afters.reverse()) {
+      await (entry.callback as ActionCallback)(controller);
+    }
+  };
+
+  let chain = executeAction;
+  for (const around of arounds.reverse()) {
+    const inner = chain;
+    chain = async () => {
+      await (around.callback as AroundCallback)(controller, inner);
+    };
+  }
+
+  await chain();
 }


### PR DESCRIPTION
## Summary

Three bundled abstractcontroller followups from #2036, stacked on top of #2042 (named-callback dedup).

1. **`process_action` wrapper relocation** — moves the callback-wrapping logic from `base.ts` into `callbacks.ts`. `base.ts` retains the raw dispatch core as `_dispatchAction` (Rails `Base#send_action`); `callbacks.ts` owns the layered `processAction(controller, action, dispatch)` wrapper that builds the before/after/around chain around dispatch. Mirrors Rails' AC::Callbacks#process_action overriding Base#process_action with a `run_callbacks { super }` wrapper. Closes `callbacks.rb` 5/6 → 6/6.

2. **`raise_on_missing_callback_actions` diagnostic (Rails 7.1)** — `static raiseOnMissingCallbackActions: boolean = false` on `AbstractController`; when set, `ActionFilter#isMatch` validates each callback's `only`/`except` actions exist on the controller via `isAvailableAction()` and raises `ActionNotFound` with a message listing the filter identifiers and the missing action. `ActionNotFound` widened with `controller` / `action` readers. Unskips the 7 `TestCallbacksWithMissingConditions` tests.

   `ActionNotFound#corrections` (Rails' DidYouMean integration) is intentionally **not** added here — Rails only defines it `if defined?(DidYouMean::Correctable)`, and trails has no DidYouMean port yet. A separate planning PR for the SpellChecker port is in flight.

3. **base.rb cluster fidelity** — adds `process`, `isAvailableAction`, `isActionMethod`, `_findActionName`, `methodForAction`, `_validActionName`, `_handleActionMissing`, and static `supportsPath`. base.rb 4/23 → 14/23; abstractcontroller overall 54.9% → 68.3%.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/abstract-controller/callbacks.test.ts` — 42/42 pass (was 35 passing + 7 skipped).
- [x] Full actionpack suite — 1286/1286 pass.
- [x] `pnpm api:compare --package abstractcontroller` — callbacks.rb 6/6 ✓, base.rb 14/23, overall 56/82 (68.3%, up from 45/82).