### PR TITLE
fix(activesupport): align around-callback composition with Rails

### DIFF
--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -122,7 +122,7 @@ describe("Callbacks", () => {
       expect(target.log).toEqual(["halted"]);
     });
 
-    it("after callbacks still run when around does not yield", () => {
+    it("after callbacks are skipped when around does not yield", () => {
       const target = { log: [] as string[] };
       defineCallbacks(target, "save");
       setCallback(target, "save", "around", (t: any) => {
@@ -135,7 +135,7 @@ describe("Callbacks", () => {
         target.log.push("block");
       });
       expect(result).toBe(false);
-      expect(target.log).toEqual(["around", "after"]);
+      expect(target.log).toEqual(["around"]);
     });
   });
 

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -165,6 +165,19 @@ describe("Callbacks", () => {
       ).rejects.toThrow("boom");
     });
 
+    it("fire-and-forget next().catch() with no handler does not swallow rejection", async () => {
+      const target = { log: [] as string[] };
+      defineCallbacks(target, "save");
+      setCallback(target, "save", "around", (_t: any, next: any) => {
+        next().catch();
+      });
+      await expect(
+        runCallbacks(target, "save", async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+    });
+
     it("awaited around can rescue inner rejection", async () => {
       const target = { log: [] as string[] };
       defineCallbacks(target, "save");

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -137,6 +137,37 @@ describe("Callbacks", () => {
       expect(result).toBe(false);
       expect(target.log).toEqual(["around"]);
     });
+
+    it("fire-and-forget around does not swallow inner rejection", async () => {
+      const target = { log: [] as string[] };
+      defineCallbacks(target, "save");
+      setCallback(target, "save", "around", (_t: any, next: any) => {
+        // intentionally not awaiting / returning next()
+        next();
+      });
+      await expect(
+        runCallbacks(target, "save", async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+    });
+
+    it("awaited around can rescue inner rejection", async () => {
+      const target = { log: [] as string[] };
+      defineCallbacks(target, "save");
+      let caught: Error | null = null;
+      setCallback(target, "save", "around", async (_t: any, next: any) => {
+        try {
+          await next();
+        } catch (e) {
+          caught = e as Error;
+        }
+      });
+      await runCallbacks(target, "save", async () => {
+        throw new Error("boom");
+      });
+      expect(caught!.message).toBe("boom");
+    });
   });
 
   describe("conditional callbacks", () => {

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -152,6 +152,19 @@ describe("Callbacks", () => {
       ).rejects.toThrow("boom");
     });
 
+    it("fire-and-forget next().finally(...) does not swallow inner rejection", async () => {
+      const target = { log: [] as string[] };
+      defineCallbacks(target, "save");
+      setCallback(target, "save", "around", (_t: any, next: any) => {
+        next().finally(() => {});
+      });
+      await expect(
+        runCallbacks(target, "save", async () => {
+          throw new Error("boom");
+        }),
+      ).rejects.toThrow("boom");
+    });
+
     it("awaited around can rescue inner rejection", async () => {
       const target = { log: [] as string[] };
       defineCallbacks(target, "save");

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -919,11 +919,14 @@ export class CallbackChain {
           return (async () => {
             try {
               await cbResult;
-              if (pendingProceed) await pendingProceed;
             } catch (err) {
               if (pendingProceed) await pendingProceed.catch(() => {});
               throw err;
             }
+            // If the around resolved without throwing, it handled any block
+            // rejection — silently consume pendingProceed so we don't
+            // re-throw the error the around just caught.
+            if (pendingProceed) await pendingProceed.catch(() => {});
           })();
         }
       };
@@ -932,9 +935,9 @@ export class CallbackChain {
     const chainResult = chain();
 
     const finish = (): boolean | Promise<boolean> => {
-      // After callbacks run even when around halts (didn't yield) — mirrors the
-      // original _invoke which ran afters after core() regardless of whether
-      // the block executed. Return blockExecuted so callers can detect around-halt.
+      // Rails AS::Callbacks compiles arounds wrapping (befores + block + afters)
+      // as a single continuation: a non-yielding around skips the afters too.
+      if (!blockExecuted) return false;
       const afterResult = this._runAfters(afters, false, skipAfterIfTerminated, target, opts);
       if (isThenable(afterResult)) return Promise.resolve(afterResult).then(() => blockExecuted);
       return blockExecuted;

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -900,10 +900,21 @@ export class CallbackChain {
           // calling it fire-and-forget. `await` and `.then(...)` both invoke
           // .then on the wrapper; bare `next();` does not.
           const observed = pendingProceed;
+          const markObserved = () => {
+            proceedObserved = true;
+          };
           return {
             then(onFulfilled?: any, onRejected?: any) {
-              proceedObserved = true;
+              markObserved();
               return observed.then(onFulfilled, onRejected);
+            },
+            catch(onRejected?: any) {
+              markObserved();
+              return observed.catch(onRejected);
+            },
+            finally(onFinally?: any) {
+              markObserved();
+              return observed.finally(onFinally);
             },
           } as unknown as Promise<void>;
         };

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -915,6 +915,7 @@ export class CallbackChain {
               `Async callback on sync chain "${this.name}" — around callback or block returned a Promise`,
             );
           }
+          const cbWasThenable = isThenable(cbResult);
           return (async () => {
             try {
               await cbResult;
@@ -922,10 +923,14 @@ export class CallbackChain {
               if (pendingProceed) await pendingProceed.catch(() => {});
               throw err;
             }
-            // If the around resolved without throwing, it handled any block
-            // rejection — silently consume pendingProceed so we don't
-            // re-throw the error the around just caught.
-            if (pendingProceed) await pendingProceed.catch(() => {});
+            if (pendingProceed) {
+              // If the around returned a Promise it had an opportunity to await
+              // and rescue the inner rejection — consume silently to avoid
+              // re-throwing an error it just handled. A synchronous around
+              // could not have observed the rejection, so propagate.
+              if (cbWasThenable) await pendingProceed.catch(() => {});
+              else await pendingProceed;
+            }
           })();
         }
       };

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -906,16 +906,26 @@ export class CallbackChain {
               // internally passes an onRejected, `.then(_, r)` does too.
               // `.then(onFulfilled)` alone doesn't rescue, so the rejection
               // must still propagate via pendingProceed.
-              if (onRejected) proceedObserved = true;
-              return observed.then(onFulfilled, onRejected);
+              if (onRejected) {
+                proceedObserved = true;
+                return observed.then(onFulfilled, onRejected);
+              }
+              const p = observed.then(onFulfilled);
+              // Suppress unhandled-rejection on the unobserved chain; the
+              // canonical propagation path is pendingProceed.
+              p.catch(() => {});
+              return p;
             },
             catch(onRejected?: any) {
               proceedObserved = true;
               return observed.catch(onRejected);
             },
             finally(onFinally?: any) {
-              proceedObserved = true;
-              return observed.finally(onFinally);
+              // .finally does not rescue rejections — the rejection still
+              // propagates through the returned promise. Don't mark observed.
+              const p = observed.finally(onFinally);
+              p.catch(() => {});
+              return p;
             },
           } as unknown as Promise<void>;
         };

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -890,9 +890,20 @@ export class CallbackChain {
       const prev = chain;
       chain = () => {
         let pendingProceed: Promise<void> | undefined;
+        let proceedSettled = false;
         const next = (): void | Promise<void> => {
           const r = prev();
-          if (isThenable(r)) pendingProceed = Promise.resolve(r) as Promise<void>;
+          if (isThenable(r)) {
+            pendingProceed = Promise.resolve(r) as Promise<void>;
+            pendingProceed.then(
+              () => {
+                proceedSettled = true;
+              },
+              () => {
+                proceedSettled = true;
+              },
+            );
+          }
           return r;
         };
         let cbResult: void | Promise<void>;
@@ -915,7 +926,6 @@ export class CallbackChain {
               `Async callback on sync chain "${this.name}" — around callback or block returned a Promise`,
             );
           }
-          const cbWasThenable = isThenable(cbResult);
           return (async () => {
             try {
               await cbResult;
@@ -924,11 +934,11 @@ export class CallbackChain {
               throw err;
             }
             if (pendingProceed) {
-              // If the around returned a Promise it had an opportunity to await
-              // and rescue the inner rejection — consume silently to avoid
-              // re-throwing an error it just handled. A synchronous around
-              // could not have observed the rejection, so propagate.
-              if (cbWasThenable) await pendingProceed.catch(() => {});
+              // Swallow only when the around had observed next()'s outcome
+              // before resolving (proceedSettled set during its execution) —
+              // i.e., it awaited and may have rescued. Otherwise the around
+              // fired-and-forgot, so propagate the rejection.
+              if (proceedSettled) await pendingProceed.catch(() => {});
               else await pendingProceed;
             }
           })();

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -890,21 +890,22 @@ export class CallbackChain {
       const prev = chain;
       chain = () => {
         let pendingProceed: Promise<void> | undefined;
-        let proceedSettled = false;
+        let proceedObserved = false;
         const next = (): void | Promise<void> => {
           const r = prev();
-          if (isThenable(r)) {
-            pendingProceed = Promise.resolve(r) as Promise<void>;
-            pendingProceed.then(
-              () => {
-                proceedSettled = true;
-              },
-              () => {
-                proceedSettled = true;
-              },
-            );
-          }
-          return r;
+          if (!isThenable(r)) return r;
+          pendingProceed = Promise.resolve(r) as Promise<void>;
+          // Return a thenable wrapper so we can detect whether the around
+          // actually awaited/chained on next() (real observation) versus
+          // calling it fire-and-forget. `await` and `.then(...)` both invoke
+          // .then on the wrapper; bare `next();` does not.
+          const observed = pendingProceed;
+          return {
+            then(onFulfilled?: any, onRejected?: any) {
+              proceedObserved = true;
+              return observed.then(onFulfilled, onRejected);
+            },
+          } as unknown as Promise<void>;
         };
         let cbResult: void | Promise<void>;
         try {
@@ -934,11 +935,10 @@ export class CallbackChain {
               throw err;
             }
             if (pendingProceed) {
-              // Swallow only when the around had observed next()'s outcome
-              // before resolving (proceedSettled set during its execution) —
-              // i.e., it awaited and may have rescued. Otherwise the around
-              // fired-and-forgot, so propagate the rejection.
-              if (proceedSettled) await pendingProceed.catch(() => {});
+              // Swallow only when the around actually observed next() (awaited
+              // or chained). Fire-and-forget arounds couldn't have rescued, so
+              // propagate the inner rejection.
+              if (proceedObserved) await pendingProceed.catch(() => {});
               else await pendingProceed;
             }
           })();

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -875,13 +875,12 @@ export class CallbackChain {
   ): boolean | Promise<boolean> {
     let blockExecuted = false;
     const trackedBlock = (): void | Promise<void> => {
-      const r = block?.();
-      if (isThenable(r)) {
-        return Promise.resolve(r).then(() => {
-          blockExecuted = true;
-        });
-      }
+      // Track invocation, not successful completion: in Rails an around that
+      // rescues an exception raised by yield still runs the outer invoke_after
+      // (callbacks.rb#run_callbacks). Setting the flag here means a block
+      // rejection caught by an around no longer looks like "around did not yield".
       blockExecuted = true;
+      return block?.() as void | Promise<void>;
     };
 
     let chain: () => void | Promise<void> = trackedBlock;

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -906,7 +906,7 @@ export class CallbackChain {
               // internally passes an onRejected, `.then(_, r)` does too.
               // `.then(onFulfilled)` alone doesn't rescue, so the rejection
               // must still propagate via pendingProceed.
-              if (onRejected) {
+              if (typeof onRejected === "function") {
                 proceedObserved = true;
                 return observed.then(onFulfilled, onRejected);
               }
@@ -917,8 +917,13 @@ export class CallbackChain {
               return p;
             },
             catch(onRejected?: any) {
-              proceedObserved = true;
-              return observed.catch(onRejected);
+              if (typeof onRejected === "function") {
+                proceedObserved = true;
+                return observed.catch(onRejected);
+              }
+              const p = observed.catch(onRejected);
+              p.catch(() => {});
+              return p;
             },
             finally(onFinally?: any) {
               // .finally does not rescue rejections — the rejection still

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -900,20 +900,21 @@ export class CallbackChain {
           // calling it fire-and-forget. `await` and `.then(...)` both invoke
           // .then on the wrapper; bare `next();` does not.
           const observed = pendingProceed;
-          const markObserved = () => {
-            proceedObserved = true;
-          };
           return {
             then(onFulfilled?: any, onRejected?: any) {
-              markObserved();
+              // Only mark observed when a rejection path is wired — `await`
+              // internally passes an onRejected, `.then(_, r)` does too.
+              // `.then(onFulfilled)` alone doesn't rescue, so the rejection
+              // must still propagate via pendingProceed.
+              if (onRejected) proceedObserved = true;
               return observed.then(onFulfilled, onRejected);
             },
             catch(onRejected?: any) {
-              markObserved();
+              proceedObserved = true;
               return observed.catch(onRejected);
             },
             finally(onFinally?: any) {
-              markObserved();
+              proceedObserved = true;
               return observed.finally(onFinally);
             },
           } as unknown as Promise<void>;


### PR DESCRIPTION
## Summary

Fixes two pre-existing bugs in `@blazetrails/activesupport`'s `CallbackChain._runAroundAndAfter` that blocked actionpack from wiring `AbstractController::Callbacks` onto `AS::Callbacks`.

1. **Afters ran outside the around composition.** Rails compiles arounds wrapping (befores + block + afters); a non-yielding around skips afters too. The old code ran afters unconditionally after the around chain. (`blockExecuted` now also tracks invocation, not successful completion, so rescued block errors still trigger afters — matches Rails `run_callbacks` where `target.send` returns normally after a rescue and `invoke_after(env)` still runs.)
2. **`pendingProceed` re-threw errors an around caught.** When the inner block rejected and the around `try { await next() } catch {}`-rescued it, the wrapper re-awaited `pendingProceed` and re-threw — erasing the around's catch. Now `pendingProceed` is only silently consumed when the around actually observed `next()` (detected via a thenable wrapper that flips a flag on `.then`). Fire-and-forget patterns still propagate rejections.

The AS test at `callbacks.test.ts:125` that encoded bug #1 is replaced with the Rails-correct assertion (afters skipped when around does not yield). Two new regression tests cover the fire-and-forget propagation and the awaited-rescue path.

## Rails source verification

Verified against the upstream Rails source — locally at `vendor/rails/activesupport/lib/active_support/callbacks.rb` and `vendor/rails/activesupport/test/callbacks_test.rb` after running the vendor fetcher (`vendor/rails/` is gitignored, see `vendor/.gitignore`). Upstream: https://github.com/rails/rails/blob/main/activesupport/lib/active_support/callbacks.rb#L96-L143 (`run_callbacks` invoke_sequence loop).

## Test plan
- [x] `pnpm vitest run packages/activesupport/src/callbacks.test.ts` (119 pass)
- [x] `pnpm vitest run packages/actionpack/src/action-controller/controller/filters.test.ts` (17 pass, including "after_action not called when around does not yield" and "around_action can catch errors")
- [x] `pnpm api:compare --package activesupport`: 504/2144 (unchanged vs main)
- [x] `pnpm test:compare --package activesupport`: 2244/2859 (unchanged vs main)

## Known remaining gaps (Copilot review #9, deferred)

Stopped iterating after 9 Copilot cycles; one heuristic gap remains in the `next()` thenable wrapper's observation detection:

- **Awaited-chaining rescue patterns are not detected as observed.** `await next().then(onFulfilled)`, `await next().finally(...)`, and `await next().catch()` inside a try/catch can rescue a rejection, but `proceedObserved` only flips when the wrapper's own `.then`/`.catch` receives a function-typed `onRejected`. In these patterns the wrapper's `.then`/`.finally`/`.catch` is called with no rejection handler, so `proceedObserved` stays false and `_runAroundAndAfter` re-throws via `pendingProceed`, defeating the user's outer try/catch.

  Fully fixing this requires the wrapper to return chainable thenables that propagate the observation marker through subsequent `.then`/`.catch`/`.finally` calls (or the eventual `await`). This is a larger refactor than the bug-fix scope of this PR. The actionpack consumer (PR #2042) only uses `await next()`, which is correctly detected.
