### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in relation/ remainder

### DIFF
--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -2,15 +2,16 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: { title: "string", author: "string" },
@@ -18,6 +19,7 @@ beforeEach(async () => {
     users: { name: "string", age: "integer", active: "boolean" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -654,8 +654,8 @@ describe("Pluck (Rails-guided)", () => {
         this.adapter = adapter;
       }
     }
-    await User.create({ name: "Alice" });
-    await User.create({ name: "Bob" });
-    expect(await User.all().ids()).toEqual([1, 2]);
+    const alice = await User.create({ name: "Alice" });
+    const bob = await User.create({ name: "Bob" });
+    expect(await User.all().ids()).toEqual([alice.id, bob.id]);
   });
 });

--- a/packages/activerecord/src/relation/or.test.ts
+++ b/packages/activerecord/src/relation/or.test.ts
@@ -2,15 +2,16 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: {
@@ -23,6 +24,7 @@ beforeEach(async () => {
     users: { name: "string", age: "integer", role: "string", score: "integer" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -1,29 +1,24 @@
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import { Table, Visitors, Nodes } from "@blazetrails/arel";
 import { PredicateBuilder } from "./predicate-builder.js";
 import { Substitute } from "../statement-cache.js";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
 import { TableMetadata } from "../table-metadata.js";
 import { Base, registerModel, modelRegistry } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { dropAllTables } from "../test-helpers/drop-all-tables.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 describe("PredicateBuilderTest", () => {
   // Rails setup: Topic.predicate_builder.register_handler(Regexp, proc { |col, val| col ~ val.source })
   // Teardown: Topic.class_eval { @predicate_builder = nil }
   // We use a local custom class instead of Regexp to keep the test self-contained.
 
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       topics: { title: "string" },
       replies: { parent_id: "integer" },
@@ -32,6 +27,7 @@ describe("PredicateBuilderTest", () => {
       posts: { author_id: "integer", title: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);

--- a/packages/activerecord/src/relation/thenable.test.ts
+++ b/packages/activerecord/src/relation/thenable.test.ts
@@ -1,21 +1,25 @@
-import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi, afterEach } from "vitest";
 import { Base, Relation, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("Thenable", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   let ThenableUser: typeof Base;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       thenable_users: { name: "string", active: "integer" },
       thenable_posts: { title: "string" },
       thenable_comments: { body: "string", thenable_post_id: "integer" },
     });
+  });
+  withTransactionalFixtures(() => adapter);
+
+  beforeEach(() => {
     ThenableUser = class ThenableUser extends Base {
       static {
         this.attribute("id", "integer");

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -2,16 +2,17 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter = createTestAdapter();
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter = createTestAdapter();
+beforeAll(async () => {
   _adapter = createTestAdapter();
   const authorCols = { name: "string" as const };
   const postCols = {
@@ -36,8 +37,11 @@ beforeEach(async () => {
     ma_authors: authorCols,
     ma_categories: { name: "string" },
     rr_posts: postCols,
+    cpk_shops: { name: "string" },
+    cpk_orders: { shop_id: "integer", order_id: "integer", cpk_shop_id: "integer" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }
@@ -261,10 +265,6 @@ describe("WhereChainTest", () => {
 
   it("associated with composite primary key", async () => {
     const a = freshAdapter();
-    await defineSchema(a, {
-      cpk_shops: { name: "string" },
-      cpk_orders: { shop_id: "integer", order_id: "integer", cpk_shop_id: "integer" },
-    });
     class CpkShop extends Base {
       static {
         this.attribute("name", "string");

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -2,12 +2,13 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, defineEnum, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 // -- Helpers --
@@ -115,10 +116,15 @@ const SCHEMA: Schema = {
   },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
-  await defineSchema(adapter, SCHEMA);
-  return adapter;
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
+  _adapter = createTestAdapter();
+  await defineSchema(_adapter, SCHEMA);
+});
+withTransactionalFixtures(() => _adapter);
+
+function freshAdapter(): DatabaseAdapter {
+  return _adapter;
 }
 
 // ==========================================================================
@@ -128,7 +134,7 @@ describe("WhereTest", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
   });
 
   it("where with string generates sql", () => {
@@ -225,7 +231,7 @@ describe("WhereTest", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
   });
 
   it("where copies bind params", () => {
@@ -1363,7 +1369,7 @@ describe("where with Range", () => {
   });
 
   it("filters records with BETWEEN", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
 
     class User extends Base {
       static {
@@ -1383,7 +1389,7 @@ describe("where with Range", () => {
   });
 
   it("BETWEEN is inclusive on both ends", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
 
     class User extends Base {
       static {
@@ -1403,7 +1409,7 @@ describe("where with Range", () => {
 
 describe("Range edge cases", () => {
   it("count with Range condition", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
 
     class User extends Base {
       static {
@@ -1420,7 +1426,7 @@ describe("Range edge cases", () => {
   });
 
   it("Range combined with IN array in same where", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
 
     class User extends Base {
       static {
@@ -1444,7 +1450,7 @@ describe("Range edge cases", () => {
 describe("where with raw SQL", () => {
   let adapter: DatabaseAdapter;
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
   });
 
   it("supports raw SQL string with bind params", async () => {
@@ -1487,7 +1493,7 @@ describe("where with raw SQL", () => {
 describe("where with subquery", () => {
   let adapter: DatabaseAdapter;
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
   });
 
   it("supports Relation as value for IN subquery", async () => {
@@ -1521,7 +1527,7 @@ describe("where with subquery", () => {
 
 describe("rewhere clears NOT clauses", () => {
   it("replaces whereNot clauses for the same key", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -1543,7 +1549,7 @@ describe("rewhere clears NOT clauses", () => {
 
 describe("where with named binds", () => {
   it("replaces :name placeholders with values", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -1564,7 +1570,7 @@ describe("where with named binds", () => {
   });
 
   it("handles string named binds with quoting", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
     class User extends Base {
       static _tableName = "users";
     }
@@ -1583,7 +1589,7 @@ describe("where with named binds", () => {
 
 describe("whereAny", () => {
   it("matches records where ANY condition is true (OR)", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
     class User extends Base {
       static {
         this.attribute("id", "integer");
@@ -1602,7 +1608,7 @@ describe("whereAny", () => {
   });
 
   it("filters correctly with strict conditions", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
     class User extends Base {
       static {
         this.attribute("id", "integer");
@@ -1625,7 +1631,7 @@ describe("whereAny", () => {
 
 describe("whereAll", () => {
   it("matches records where ALL conditions are true (AND)", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
     class User extends Base {
       static {
         this.attribute("id", "integer");
@@ -1659,7 +1665,7 @@ describe("Relation Where (Rails-guided)", () => {
   }
 
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
     User.adapter = adapter;
     await User.create({ name: "Alice", email: "alice@test.com", age: 25, active: true });
     await User.create({ name: "Bob", email: "bob@test.com", age: 30, active: false });
@@ -1757,7 +1763,7 @@ describe("where with Range (Rails-guided)", () => {
   }
 
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
     Person.adapter = adapter;
     await Person.create({ name: "Child", age: 10 });
     await Person.create({ name: "Teen", age: 16 });
@@ -1805,7 +1811,7 @@ describe("Range / BETWEEN (Rails-guided)", () => {
   }
 
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
     Product.adapter = adapter;
   });
 
@@ -1846,7 +1852,7 @@ describe("Raw SQL Where (Rails-guided)", () => {
   let adapter: DatabaseAdapter;
 
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
   });
 
   // Rails: test "where with SQL string and bind values"
@@ -1936,7 +1942,7 @@ describe("Raw SQL Where (Rails-guided)", () => {
 describe("WhereTest", () => {
   let adapter: DatabaseAdapter;
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
   });
 
   function makeAuthor() {
@@ -2095,7 +2101,7 @@ describe("WhereTest", () => {
 describe("WhereTest Arel nodes", () => {
   let adapter: DatabaseAdapter;
   beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = freshAdapter();
   });
 
   it("where accepts an Arel node", async () => {
@@ -2153,7 +2159,7 @@ describe("WhereTest Arel nodes", () => {
 // ==========================================================================
 describe("WhereTest", () => {
   it("aliased attribute", async () => {
-    const adapter = await freshAdapter();
+    const adapter = freshAdapter();
     class Topic extends Base {
       static {
         this.attribute("title", "string");


### PR DESCRIPTION
## Summary

Follow-up to #2041. Migrates the remaining six `packages/activerecord/src/relation/` test files from per-test `beforeEach(defineSchema)` to once-per-file `beforeAll(defineSchema)` + `withTransactionalFixtures()`, per `docs/tm-unification-plan.md` Phase 6.

Files: `thenable`, `predicate-builder`, `merging`, `or`, `where-chain`, `where`.

`where-chain` had a mid-test `defineSchema(a, { cpk_shops, cpk_orders })` inside the `"associated with composite primary key"` test; those tables are now declared in the module-level schema and the inline call is removed.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/relation/{thenable,predicate-builder,merging,or,where-chain,where}.test.ts` — 300 pass, 44 pre-existing skips.