### PR TITLE
refactor(activerecord): wire encryption KeyGenerator through ActiveSupport::KeyGenerator

### DIFF
--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -12,6 +12,7 @@
       "@blazetrails/activesupport/message-verifier": [
         "../../activesupport/src/message-verifier.ts"
       ],
+      "@blazetrails/activesupport/key-generator": ["../../activesupport/src/key-generator.ts"],
       "@blazetrails/activesupport/temporal": ["../../activesupport/src/temporal.ts"],
       "@blazetrails/activesupport/gzip": ["../../activesupport/src/gzip.ts"],
       "@blazetrails/activesupport/sqlite-adapter": ["../../activesupport/src/sqlite-adapter.ts"],

--- a/packages/activerecord/src/encryption/key-generator.ts
+++ b/packages/activerecord/src/encryption/key-generator.ts
@@ -5,6 +5,7 @@
  */
 
 import { getCrypto } from "@blazetrails/activesupport";
+import { KeyGenerator as AsKeyGenerator } from "@blazetrails/activesupport/key-generator";
 import { Configurable } from "./configurable.js";
 
 export class KeyGenerator {
@@ -20,7 +21,8 @@ export class KeyGenerator {
 
   deriveKeyFrom(password: string, length?: number): string {
     const salt = this.keyDerivationSalt();
-    return this.deriveKey(password, length ?? this.keyLength(), salt);
+    const generator = new AsKeyGenerator(password, { hashDigestClass: this._hashDigestClass });
+    return generator.generateKey(salt, length ?? this.keyLength()).toString("base64");
   }
 
   generateRandomKey(length?: number): string {

--- a/packages/activesupport/src/key-generator.ts
+++ b/packages/activesupport/src/key-generator.ts
@@ -8,10 +8,12 @@ import { getCrypto } from "./crypto-adapter.js";
 export class KeyGenerator {
   private readonly secret: string;
   private readonly iterations: number;
+  private readonly hashDigestClass: string;
 
-  constructor(secret: string, options: { iterations?: number } = {}) {
+  constructor(secret: string, options: { iterations?: number; hashDigestClass?: string } = {}) {
     this.secret = secret;
     this.iterations = options.iterations ?? 65536;
+    this.hashDigestClass = options.hashDigestClass ?? "sha1";
   }
 
   /**
@@ -19,7 +21,18 @@ export class KeyGenerator {
    * Returns the key as a Buffer.
    */
   generateKey(salt: string, keySize: number = 64): Buffer {
-    return getCrypto().pbkdf2Sync(this.secret, salt, this.iterations, keySize, "sha1");
+    return getCrypto().pbkdf2Sync(
+      this.secret,
+      salt,
+      this.iterations,
+      keySize,
+      this.normalizedDigest(),
+    );
+  }
+
+  /** @internal */
+  private normalizedDigest(): string {
+    return this.hashDigestClass.toLowerCase().replace(/-/g, "");
   }
 
   inspect(): string {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -75,6 +75,10 @@ const alias = {
     __dirname,
     "packages/activesupport/src/sqlite-drivers/node-sqlite.ts",
   ),
+  "@blazetrails/activesupport/key-generator": path.resolve(
+    __dirname,
+    "packages/activesupport/src/key-generator.ts",
+  ),
   "@blazetrails/activesupport/glob": path.resolve(__dirname, "packages/activesupport/src/glob.ts"),
   "@blazetrails/activesupport/yaml": path.resolve(__dirname, "packages/activesupport/src/yaml.ts"),
   "@blazetrails/activesupport/gzip": path.resolve(__dirname, "packages/activesupport/src/gzip.ts"),


### PR DESCRIPTION
## Summary
- AS `KeyGenerator` accepts a `hashDigestClass` option (mirrors Rails AS).
- AR `Encryption::KeyGenerator#deriveKeyFrom` now delegates to
  `ActiveSupport::KeyGenerator#generateKey` instead of calling pbkdf2
  directly — matches Rails' implementation exactly.
- `lint:deps` activerecord → activesupport: 33/59 → 36/59 (55.9% → 61%).

## Test plan
- [x] `pnpm vitest run packages/activerecord/src/encryption/key-generator.test.ts packages/activesupport/src/key-generator.test.ts` — 36 passed
- [x] `pnpm lint:deps --package activerecord --dep activesupport` — confirms deriveKeyFrom flipped