### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in adapters/postgresql/ (4 files)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/bytea.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bytea.test.ts
@@ -1,11 +1,12 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/bytea_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { Bytea } from "../../connection-adapters/postgresql/oid/bytea.js";
 import { SchemaDumper } from "../../connection-adapters/abstract/schema-dumper.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -15,24 +16,20 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
-async function freshAdapter(): Promise<PostgreSQLAdapter> {
-  const adapter = new PostgreSQLAdapter(PG_TEST_URL);
-  await adapter.exec(`DROP TABLE IF EXISTS bytea_data_type`);
-  await defineSchema(adapter, {
-    bytea_data_type: { payload: "binary", serialized: "binary" },
-  });
-  return adapter;
-}
-
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await adapter.exec(`DROP TABLE IF EXISTS bytea_data_type`);
+    await defineSchema(adapter, {
+      bytea_data_type: { payload: "binary", serialized: "binary" },
+    });
   });
-  afterEach(async () => {
+  afterAll(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS bytea_data_type`);
     await adapter.close();
   });
+  withTransactionalFixtures(() => adapter);
 
   describe("PostgresqlByteaTest", () => {
     it("column", async () => {

--- a/packages/activerecord/src/adapters/postgresql/citext.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/citext.test.ts
@@ -1,11 +1,12 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/citext_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { Table as ArelTable } from "@blazetrails/arel";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -18,28 +19,24 @@ afterAll(() => {
 // The `citexts` table uses the PG-specific `citext` type, which isn't
 // expressible via defineSchema. The table is created via raw DDL below;
 // defineSchema(adapter, {}) marks the file as TM-Phase-5 compliant.
-async function freshAdapter(): Promise<PostgreSQLAdapter> {
-  const adapter = new PostgreSQLAdapter(PG_TEST_URL);
-  await defineSchema(adapter, {});
-  return adapter;
-}
-
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await defineSchema(adapter, {});
     await adapter.exec(`CREATE EXTENSION IF NOT EXISTS citext`);
     await adapter.exec(`DROP TABLE IF EXISTS citexts`);
     await adapter.exec(`CREATE TABLE citexts (id serial primary key, cival citext)`);
     await adapter.loadAdditionalTypes();
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS citexts`);
     await adapter.exec(`DROP EXTENSION IF EXISTS citext CASCADE`);
     await adapter.close();
   });
+  withTransactionalFixtures(() => adapter);
 
   describe("PostgresqlCitextTest", () => {
     it("citext enabled", async () => {

--- a/packages/activerecord/src/adapters/postgresql/infinity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/infinity.test.ts
@@ -1,10 +1,11 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/infinity_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { Range } from "../../index.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -14,20 +15,12 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
-// The `postgresql_infinities` table exists only to exercise PG ±Infinity
-// timestamp/date sentinel semantics — created via raw DDL below;
-// defineSchema(adapter, {}) marks the file as TM-Phase-5 compliant.
-async function freshAdapter(): Promise<PostgreSQLAdapter> {
-  const adapter = new PostgreSQLAdapter(PG_TEST_URL);
-  await defineSchema(adapter, {});
-  return adapter;
-}
-
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
     await adapter.exec(`DROP TABLE IF EXISTS postgresql_infinities`);
+    await defineSchema(adapter, {});
     await adapter.exec(`
       CREATE TABLE postgresql_infinities (
         id serial primary key,
@@ -37,10 +30,11 @@ describeIfPg("PostgreSQLAdapter", () => {
       )
     `);
   });
-  afterEach(async () => {
+  afterAll(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS postgresql_infinities`);
     await adapter.close();
   });
+  withTransactionalFixtures(() => adapter);
 
   async function modelClass() {
     const { Base } = await import("../../index.js");

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -1,11 +1,12 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/interval_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Duration } from "@blazetrails/activesupport";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -19,18 +20,13 @@ afterAll(() => {
 // (including `interval(3)` precision and `interval[]`), which isn't
 // expressible via defineSchema. The table is created via raw DDL below;
 // defineSchema(adapter, {}) marks the file as TM-Phase-5 compliant.
-async function freshAdapter(): Promise<PostgreSQLAdapter> {
-  const adapter = new PostgreSQLAdapter(PG_TEST_URL);
-  await defineSchema(adapter, {});
-  return adapter;
-}
-
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   let IntervalDataType: any;
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await defineSchema(adapter, {});
     await adapter.exec(`DROP TABLE IF EXISTS interval_data_types`);
     await adapter.exec(`
       CREATE TABLE interval_data_types (
@@ -55,10 +51,11 @@ describeIfPg("PostgreSQLAdapter", () => {
     IntervalDataType = IntervalDataTypeCls;
   });
 
-  afterEach(async () => {
+  afterAll(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS interval_data_types`);
     await adapter.close();
   });
+  withTransactionalFixtures(() => adapter);
 
   describe("PostgresqlIntervalTest", () => {
     it("column", async () => {


### PR DESCRIPTION
## Summary

Second Phase 6 PR (per \`docs/tm-unification-plan.md\`). Migrates four
\`packages/activerecord/src/adapters/postgresql/\` test files from per-test
\`beforeEach(defineSchema)\` (and per-test adapter setup) to once-per-file
\`beforeAll\` + \`withTransactionalFixtures()\`. Each test now wraps in a
BEGIN/ROLLBACK pair instead of dropping and recreating tables between tests.

Files: bytea, citext, infinity, interval.

## Audit notes

The other ~50 \`adapters/postgresql/\` test files were audited and skipped — most
either perform DDL inside test bodies (addColumn / CREATE / DROP TABLE: array,
bind-parameter, uuid, schema, explain, datatype, json, range, virtual-column,
hstore (per-test extension setup), foreign-table, etc.) or call
\`defineSchema\` inside \`it()\` bodies (define-schema-pg-types). Hoisting
those would require adapter schema-cache invalidation between tests, which
is outside this PR's scope and a candidate follow-up.

## Test plan

- [x] \`TEST_ADAPTER=postgresql pnpm vitest run --poolOptions.forks.singleFork=true packages/activerecord/src/adapters/postgresql/{bytea,citext,infinity,interval}.test.ts\` — 41 pass, 9 pre-existing skips
- [ ] CI parallel run (relies on \`AR_DB_FORKS=4\` per-worker DB isolation)