### PR TITLE
fix(action-dispatch): hoist leading-optional fix into Journey Pattern

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
@@ -325,4 +325,20 @@ describe("ActionDispatch::Journey::Path::Pattern — leading-optional normalizat
     const p = buildPath("/posts/:id");
     expect(p.toRegexp().source).toBe("^\\/posts\\/([^/.?]+)$");
   });
+
+  it("handles the single-group all-optional shape `/(/:locale)`", () => {
+    // Smallest all-optional path: one SLASH + one Group whose body
+    // starts with SLASH. Both `/` and `/en` should match.
+    const p = buildPath("/(/:locale)");
+    expect(p.match("/")).toBeDefined();
+    expect(p.match("/en")).toBeDefined();
+  });
+
+  it("doesn't rewrite when the second top-level Group's body is just a SLASH", () => {
+    // Degenerate body `(/)`: there's no symbol after the slash so the
+    // normalization can't safely drop it. Leave the spec alone.
+    const p = buildPath("/(/)/foo");
+    // No crash, no exception — that's the contract.
+    expect(p.toRegexp()).toBeInstanceOf(RegExp);
+  });
 });

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.test.ts
@@ -284,3 +284,45 @@ describe("ActionDispatch::Journey::Path::Pattern — requirements", () => {
     expect(symbol!.regexp.source).toBe("(.+)");
   });
 });
+
+describe("ActionDispatch::Journey::Path::Pattern — leading-optional normalization", () => {
+  // The Pattern constructor rewrites a leading-optional spec so callers
+  // don't have to do Mapper-style path-string surgery before building one.
+  // Two shapes are handled, both mirroring Rails Mapper.normalize_path.
+
+  it("drops a duplicate top-level SLASH when followed by an optional group starting with SLASH", () => {
+    // `(/:locale)/posts` after journey-normalize is `/(/:locale)/posts`.
+    // Without the fix the regex would be `^/(?:/(...))?/posts$` (matches
+    // neither `/posts` nor `/en/posts`). The fix drops the leading `/`.
+    const p = buildPath("/(/:locale)/posts");
+    expect(p.match("/posts")).toBeDefined();
+    expect(p.match("/en/posts")).toBeDefined();
+  });
+
+  it("keeps the top-level SLASH but drops the inner SLASH of the first group for all-optional paths", () => {
+    // `(/:locale)(/:platform)` normalized → `/(/:locale)(/:platform)`. We
+    // want `/`, `/en`, and `/en/us` to all match. The fix moves the slash
+    // out of the first group so the leading `/` separates the first
+    // capture: regex becomes `^/(?:(...))?(?:/(...))?$`.
+    const p = buildPath("/(/:locale)(/:platform)");
+    expect(p.match("/")).toBeDefined();
+    expect(p.match("/en")).toBeDefined();
+    expect(p.match("/en/us")).toBeDefined();
+  });
+
+  it("handles all-optional paths with non-`/:` second group (e.g. `(.:format)`)", () => {
+    // `(/:locale)(.:format)` is all-optional but the second group starts
+    // with `.`; the fix should still classify the path as all-optional.
+    const p = buildPath("/(/:locale)(.:format)");
+    expect(p.match("/")).toBeDefined();
+    expect(p.match("/en")).toBeDefined();
+    expect(p.match("/en.json")).toBeDefined();
+  });
+
+  it("leaves paths whose second top-level node isn't a SLASH-led Group alone", () => {
+    // `/posts/:id` has no leading-optional group — no rewrite, regex
+    // stays `^/posts/([^/.?]+)$`.
+    const p = buildPath("/posts/:id");
+    expect(p.toRegexp().source).toBe("^\\/posts\\/([^/.?]+)$");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -1,6 +1,6 @@
 import { Ast } from "../ast.js";
-import { Cat, Group as GroupCtor } from "../nodes/node.js";
-import type { Dot, Group, Literal, Node, Or, Slash, Star } from "../nodes/node.js";
+import { Cat, Group } from "../nodes/node.js";
+import type { Dot, Literal, Node, Or, Slash, Star } from "../nodes/node.js";
 import { FormatBuilder, Format, Visitor } from "../visitors.js";
 
 type Matchers = Record<string, RegExp | RegExp[]>;
@@ -398,53 +398,37 @@ export class Pattern {
  * @internal
  */
 function normalizeLeadingOptionalSpec(spec: Node): Node {
-  const parts: Node[] = [];
-  const flatten = (n: Node): void => {
-    if (n.isCat()) {
-      flatten((n as Cat).left as Node);
-      flatten((n as Cat).right);
-    } else {
-      parts.push(n);
-    }
-  };
-  flatten(spec);
-  if (parts.length < 2) return spec;
-  if (parts[0]!.type !== "SLASH") return spec;
+  const parts = flattenCat(spec);
+  if (parts.length < 2 || parts[0]!.type !== "SLASH") return spec;
   const second = parts[1]!;
   if (!second.isGroup()) return spec;
   // The second top-level node must be a Group whose body starts with a
   // SLASH terminal — otherwise there's no slash-doubling to undo.
-  let leftmost: Node = (second as Group).left as Node;
-  while (leftmost.isCat()) leftmost = (leftmost as Cat).left as Node;
-  if (leftmost.type !== "SLASH") return spec;
+  const innerParts = flattenCat((second as Group).left as Node);
+  if (innerParts.length < 2 || innerParts[0]!.type !== "SLASH") return spec;
   const allOptional = parts.slice(1).every((p) => p.isGroup());
-  let newParts: Node[];
-  if (allOptional) {
-    const newBody = dropLeftmostSlash((second as Group).left as Node);
-    newParts = [parts[0]!, new GroupCtor(newBody), ...parts.slice(2)];
-  } else {
-    newParts = parts.slice(1);
-  }
-  if (newParts.length === 1) return newParts[0]!;
-  return newParts.slice(1).reduce((acc, n) => new Cat(acc, n), newParts[0]!);
+  const newParts = allOptional
+    ? [parts[0]!, new Group(buildCat(innerParts.slice(1))), ...parts.slice(2)]
+    : parts.slice(1);
+  return buildCat(newParts);
 }
 
-/**
- * Return a copy of `node` with its leftmost terminal (which must be a
- * SLASH) removed. The body is a Cat chain like `Cat(Slash, Cat(...))`;
- * the surgery keeps the right-hand chain intact.
- *
- * @internal
- */
-function dropLeftmostSlash(node: Node): Node {
-  if (!node.isCat()) {
-    // Body was a bare SLASH — unusual but produce an empty-ish CAT so the
-    // caller sees no slash. Callers only invoke this after verifying the
-    // leftmost terminal is a SLASH, so this is the SLASH itself.
-    return node;
-  }
-  const cat = node as Cat;
-  const left = cat.left as Node;
-  if (left.type === "SLASH") return cat.right;
-  return new Cat(dropLeftmostSlash(left), cat.right);
+/** @internal Flatten a right-leaning Cat chain into an array of nodes. */
+function flattenCat(node: Node): Node[] {
+  const out: Node[] = [];
+  const walk = (n: Node): void => {
+    if (n.isCat()) {
+      walk((n as Cat).left as Node);
+      walk((n as Cat).right);
+    } else {
+      out.push(n);
+    }
+  };
+  walk(node);
+  return out;
+}
+
+/** @internal Rebuild a right-leaning Cat chain from a non-empty node list. */
+function buildCat(parts: readonly Node[]): Node {
+  return parts.slice(1).reduce((acc, n) => new Cat(acc, n), parts[0]!);
 }

--- a/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
+++ b/packages/actionpack/src/action-dispatch/journey/path/pattern.ts
@@ -1,5 +1,6 @@
 import { Ast } from "../ast.js";
-import type { Cat, Dot, Group, Literal, Node, Or, Slash, Star } from "../nodes/node.js";
+import { Cat, Group as GroupCtor } from "../nodes/node.js";
+import type { Dot, Group, Literal, Node, Or, Slash, Star } from "../nodes/node.js";
 import { FormatBuilder, Format, Visitor } from "../visitors.js";
 
 type Matchers = Record<string, RegExp | RegExp[]>;
@@ -237,6 +238,13 @@ export class Pattern {
   private _requirementsAnchoredCache?: Record<string, RegExp>;
 
   constructor(ast: Ast, requirements: Matchers, separators: string, anchored: boolean) {
+    // Apply the leading-optional normalization at the Ast level so that
+    // downstream consumers reading `path.ast.tree` (e.g. the GTG builder
+    // in `journey/routes.ts`) see the same tree as the regex/formatter.
+    const normalizedTree = normalizeLeadingOptionalSpec(ast.root);
+    if (normalizedTree !== ast.root) {
+      ast = new Ast(normalizedTree, true);
+    }
     this.ast = ast;
     this.spec = ast.root;
     this.requirements = requirements;
@@ -350,11 +358,6 @@ export class Pattern {
       if (!n.isSymbol()) continue;
       const name = n.toSym();
       if (Object.hasOwn(this.requirements, name)) {
-        // Count capture groups in the requirement regex by matching empty
-        // against `re|` (so the alternation succeeds with an empty match)
-        // and reading the resulting capture count. Mirrors Rails:
-        //   re = /#{Regexp.union(reqs)}|/
-        //   offsets.push((re.match("").length - 1) + last)
         const reqs = this.requirements[name]!;
         const src = regexUnion(reqs);
         const re = new RegExp(`(?:${src})|`, combinedFlagsFor([reqs], { outer: false }));
@@ -368,4 +371,80 @@ export class Pattern {
     this._offsets = offsets;
     return offsets;
   }
+}
+
+/**
+ * Normalize a spec whose first top-level node is a SLASH followed by a
+ * GROUP whose first descendant is also a SLASH. Mirrors Rails'
+ * `Mapper.normalize_path` — when a route is written as `(/:locale)/foo`
+ * and a caller has already prefixed `/`, the naive concatenation produces
+ * `^/(?:/(...))?/foo$` which matches neither `/foo` nor `/en/foo`. Two
+ * shapes need handling, both replicating the Mapper `gsub!`/restore pair:
+ *
+ *   1. Mixed (some non-optional top-level node, e.g. `/(/:locale)/foo`):
+ *      drop the duplicate top-level SLASH entirely so the optional group's
+ *      own SLASH provides the separator when the group fires.
+ *
+ *   2. All-optional (every top-level non-Slash is a Group, e.g.
+ *      `/(/:a)(/:b)`): keep the top-level SLASH (so `/` matches the
+ *      root-style empty case) and drop the leading SLASH inside the FIRST
+ *      group only (so `/en` matches with the leading `/` serving as the
+ *      separator for the first capture).
+ *
+ * Centralizing this in Pattern means any caller building a Pattern from a
+ * journey-normalized path string gets the right regex, without having to
+ * re-implement the Mapper-level workaround.
+ *
+ * @internal
+ */
+function normalizeLeadingOptionalSpec(spec: Node): Node {
+  const parts: Node[] = [];
+  const flatten = (n: Node): void => {
+    if (n.isCat()) {
+      flatten((n as Cat).left as Node);
+      flatten((n as Cat).right);
+    } else {
+      parts.push(n);
+    }
+  };
+  flatten(spec);
+  if (parts.length < 2) return spec;
+  if (parts[0]!.type !== "SLASH") return spec;
+  const second = parts[1]!;
+  if (!second.isGroup()) return spec;
+  // The second top-level node must be a Group whose body starts with a
+  // SLASH terminal — otherwise there's no slash-doubling to undo.
+  let leftmost: Node = (second as Group).left as Node;
+  while (leftmost.isCat()) leftmost = (leftmost as Cat).left as Node;
+  if (leftmost.type !== "SLASH") return spec;
+  const allOptional = parts.slice(1).every((p) => p.isGroup());
+  let newParts: Node[];
+  if (allOptional) {
+    const newBody = dropLeftmostSlash((second as Group).left as Node);
+    newParts = [parts[0]!, new GroupCtor(newBody), ...parts.slice(2)];
+  } else {
+    newParts = parts.slice(1);
+  }
+  if (newParts.length === 1) return newParts[0]!;
+  return newParts.slice(1).reduce((acc, n) => new Cat(acc, n), newParts[0]!);
+}
+
+/**
+ * Return a copy of `node` with its leftmost terminal (which must be a
+ * SLASH) removed. The body is a Cat chain like `Cat(Slash, Cat(...))`;
+ * the surgery keeps the right-hand chain intact.
+ *
+ * @internal
+ */
+function dropLeftmostSlash(node: Node): Node {
+  if (!node.isCat()) {
+    // Body was a bare SLASH — unusual but produce an empty-ish CAT so the
+    // caller sees no slash. Callers only invoke this after verifying the
+    // leftmost terminal is a SLASH, so this is the SLASH itself.
+    return node;
+  }
+  const cat = node as Cat;
+  const left = cat.left as Node;
+  if (left.type === "SLASH") return cat.right;
+  return new Cat(dropLeftmostSlash(left), cat.right);
 }

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -511,43 +511,13 @@ function collectParamNamesFromJourneyAst(path: string): string[] {
 }
 
 function normalizePath(p: string): string {
-  // Mirrors Rails `ActionDispatch::Routing::Mapper.normalize_path`:
-  // first apply Journey's `Utils.normalize_path` (leading-`/`, collapse
-  // duplicate slashes, strip trailing, uppercase `%xx`), then swap `/(`
-  // → `(/` so leading optional groups keep the `/` *inside* the optional.
-  // The leading `/(` form is restored only when the entire path is
-  // composed of adjacent optional segments (root-style routes).
-  let path = journeyNormalizePath(p);
-  path = path.replace(/\/(\(+)\/?/g, "$1/");
-  if (isAllOptional(path)) {
-    path = path.replace(/^(\(+)\//, "/$1");
-  }
-  return path;
-}
-
-/**
- * True when `path` consists only of adjacent balanced-paren optional
- * groups (no top-level literal characters between them). Mirrors what
- * Rails' Mapper.normalize_path treats as the "all-optional" shape —
- * paths like `(/:locale)(.:format)` or `(/:a)(/:b)(/:c)`.
- */
-function isAllOptional(path: string): boolean {
-  if (!path.startsWith("(")) return false;
-  let depth = 0;
-  for (let i = 0; i < path.length; i++) {
-    const ch = path[i];
-    if (ch === "(") {
-      depth++;
-    } else if (ch === ")") {
-      depth--;
-      if (depth < 0) return false;
-      // After closing a top-level group, only another `(` may follow
-      // (adjacent optional groups). Any literal between groups
-      // disqualifies the all-optional shape.
-      if (depth === 0 && i + 1 < path.length && path[i + 1] !== "(") return false;
-    }
-  }
-  return depth === 0;
+  // The leading-optional `(/...` fix that used to live here (swapping `/(`
+  // → `(/` so `(/:locale)/foo` compiled correctly) has moved into Journey's
+  // `Pattern` regex builder — see `normalizeLeadingOptionalSpec` in
+  // `journey/path/pattern.ts`. Anyone constructing a Pattern from a
+  // journey-normalized path now gets the right regex without callers
+  // re-implementing the workaround.
+  return journeyNormalizePath(p);
 }
 
 function interpolateRedirect(template: string, params: Record<string, string>): string {


### PR DESCRIPTION
## Summary

\`(/:locale)/foo\` patterns should compile correctly regardless of whether the caller has already prefixed \`/\` — previously \`route.ts:normalizePath\` papered over the slash-doubling with a Mapper-style string \`gsub!\` plus an \`isAllOptional\` restore step. Move the fix into Journey's \`Pattern\` constructor at the AST level so **any caller** building a Pattern from a journey-normalized path gets the right regex, then drop the route-side workaround.

The AST normalization handles two shapes, both mirroring Rails Mapper.normalize_path:

- **Mixed** (e.g. \`/(/:locale)/foo\`): drop the duplicate top-level SLASH so the optional group's own SLASH provides the separator when the group fires, and the trailing CAT provides it when the group is empty.
- **All-optional** (e.g. \`/(/:a)(/:b)\`): keep the top-level SLASH for the root \`/\` case, and drop the leading SLASH inside the first group so \`/en\` matches with the leading slash serving as the separator for the first capture.

The rebuilt Ast replaces the original so the GTG builder (which reads \`r.path.ast.tree\`) and the regex/formatter (which reads \`Pattern#spec\`) stay in lockstep.

## Follow-up

The second half of the originally-bundled task — replacing Mapper's sentinel encoding (\`__redirect__:…\` / \`__redirect_fn__:…\` strings round-tripped through \`JSON.stringify\`/\`JSON.parse\` in \`addRoute\`) with direct \`Redirect\` endpoint storage — was prototyped and shelved when the combined diff exceeded the 300-LOC ceiling. The mechanical changes (Mapper#redirect returning a \`Redirect\` instance, eager \`redirectEndpoint\` field on Route, dropping the \`redirectFns\` map + counter + JSON round-trip) plus migrating ~15 redirect tests in \`dispatch/routing.test.ts\` onto \`route.redirectEndpoint.buildResponse(new Request(env))\` and deleting \`Route#resolveRedirect\` + \`interpolateRedirect\` will land in a sibling PR (\`<base>b\`).

## Test plan

- [x] \`pnpm vitest run packages/actionpack/src/action-dispatch/journey/ packages/actionpack/src/action-dispatch/routing/\` — 456/456 pass, including 4 new \`Pattern — leading-optional normalization\` tests exercising the rewrite directly at the Pattern level.
- [x] \`pnpm vitest run packages/actionpack/src/action-dispatch/\` — 1627 pass, 4 pre-existing skips.
- [x] \`pnpm -w build\` clean.