### PR TITLE
feat(actionpack): AbstractController helpers + caching cluster fidelity

### DIFF
--- a/packages/actionpack/src/abstract-controller/caching.test.ts
+++ b/packages/actionpack/src/abstract-controller/caching.test.ts
@@ -8,9 +8,11 @@ import {
   cacheStore,
   CACHING_DEFAULTS,
   CACHING_SLOTS,
+  readFragment,
   setCacheStore,
   viewCacheDependencies,
   viewCacheDependency,
+  writeFragment,
   type CachingHost,
 } from "./caching.js";
 
@@ -131,6 +133,15 @@ describe("AbstractController::Caching", () => {
       const host = makeHost(store);
       cache.call(host, ["posts", 5, "edit"], () => "x");
       expect(store.read("controller/posts/5/edit")).toBe("x");
+    });
+  });
+
+  describe("fragment wrappers (Caching::Fragments republish)", () => {
+    it("writeFragment/readFragment round-trip via ./caching", () => {
+      const store = new MemoryStore();
+      const host = makeHost(store);
+      writeFragment.call(host, "post/1", "rendered body");
+      expect(readFragment.call(host, "post/1")).toBe("rendered body");
     });
   });
 });

--- a/packages/actionpack/src/abstract-controller/caching.ts
+++ b/packages/actionpack/src/abstract-controller/caching.ts
@@ -11,6 +11,16 @@
 
 import type { CacheOptions, CacheStore } from "@blazetrails/activesupport";
 
+import {
+  combinedFragmentCacheKey as _combinedFragmentCacheKey,
+  expireFragment as _expireFragment,
+  fragmentExist as _fragmentExist,
+  instrumentFragmentCache as _instrumentFragmentCache,
+  readFragment as _readFragment,
+  writeFragment as _writeFragment,
+  type FragmentsHost,
+} from "./fragments.js";
+
 const SLOTS = ["defaultStaticExtension", "performCaching", "enableFragmentCacheLogging"] as const;
 
 export type CachingSlot = (typeof SLOTS)[number];
@@ -145,6 +155,50 @@ export function cache<T>(
 function expandControllerCacheKey(key: unknown): string {
   const flat = Array.isArray(key) ? key.map(stringify).join("/") : stringify(key);
   return `controller/${flat}`;
+}
+
+// Rails `include AbstractController::Caching::Fragments` exposes the fragment
+// API on the `Caching` module itself. The implementations live in `fragments.ts`;
+// these thin wrappers republish them on `caching.ts` so `api:compare` sees the
+// surface where Rails exposes it. Re-export statements wouldn't suffice — the
+// extractor counts only direct `export function` declarations.
+
+export function combinedFragmentCacheKey(this: FragmentsHost, key: unknown): unknown[] {
+  return _combinedFragmentCacheKey.call(this, key);
+}
+
+export function writeFragment(
+  this: FragmentsHost,
+  key: unknown,
+  content: string,
+  options?: CacheOptions,
+): string {
+  return _writeFragment.call(this, key, content, options);
+}
+
+export function readFragment(this: FragmentsHost, key: unknown, options?: CacheOptions): unknown {
+  return _readFragment.call(this, key, options);
+}
+
+export function fragmentExist(
+  this: FragmentsHost,
+  key: unknown,
+  options?: CacheOptions,
+): boolean | undefined {
+  return _fragmentExist.call(this, key, options);
+}
+
+export function expireFragment(this: FragmentsHost, key: unknown, options?: CacheOptions): unknown {
+  return _expireFragment.call(this, key, options);
+}
+
+export function instrumentFragmentCache<T>(
+  host: FragmentsHost,
+  name: string,
+  key: unknown,
+  block: () => T,
+): T {
+  return _instrumentFragmentCache(host, name, key, block);
 }
 
 function stringify(part: unknown): string {

--- a/packages/actionpack/src/abstract-controller/fragments.ts
+++ b/packages/actionpack/src/abstract-controller/fragments.ts
@@ -18,8 +18,8 @@ import type { CacheOptions, CacheStore } from "@blazetrails/activesupport";
 // `cacheConfigured` is duplicated here (it also lives in `caching.ts`) so
 // the module graph stays acyclic: `caching.ts` now imports fragment wrappers
 // from this file to republish them on the `Caching` surface (per Rails'
-// `include AbstractController::Caching::Fragments`), and an import the other
-// direction would create a cycle. The predicate is a trivial two-property
+// `include AbstractController::Caching::Fragments`), and an import in the
+// other direction would create a cycle. The predicate is a trivial two-property
 // check — the duplication is cheaper than threading it through a third file.
 function cacheConfigured(host: FragmentsHost): boolean {
   const cls = host.constructor;

--- a/packages/actionpack/src/abstract-controller/fragments.ts
+++ b/packages/actionpack/src/abstract-controller/fragments.ts
@@ -15,7 +15,16 @@
 import { Notifications } from "@blazetrails/activesupport";
 import type { CacheOptions, CacheStore } from "@blazetrails/activesupport";
 
-import { cacheConfigured } from "./caching.js";
+// `cacheConfigured` is duplicated here (it also lives in `caching.ts`) so
+// the module graph stays acyclic: `caching.ts` now imports fragment wrappers
+// from this file to republish them on the `Caching` surface (per Rails'
+// `include AbstractController::Caching::Fragments`), and an import the other
+// direction would create a cycle. The predicate is a trivial two-property
+// check — the duplication is cheaper than threading it through a third file.
+function cacheConfigured(host: FragmentsHost): boolean {
+  const cls = host.constructor;
+  return Boolean(cls.performCaching && cls.cacheStore);
+}
 
 export type FragmentCacheKeyBlock = (this: FragmentsHost) => unknown;
 

--- a/packages/actionpack/src/abstract-controller/helpers.test.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  _helpers,
   _helpersForModification,
   _helpersInstance,
   applyHelpers,
   clearHelpers,
+  defineHelpersModule,
   helper,
   helperMethod,
   type HelperMethodsModule,
@@ -257,5 +259,72 @@ describe("_helpersForModification", () => {
     const cls = makeBase();
     helperMethod(cls, ["a", ["b", ["c"]]]);
     expect(cls._helperMethods).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("_helpers (class-level reader/writer)", () => {
+  it("reads from the class, falling through to the parent via prototype", () => {
+    const parent = makeBase();
+    helperMethod(parent, "fromParent");
+    const child: HelpersClassMethods = Object.create(parent) as HelpersClassMethods;
+
+    // No own slot — JS prototype lookup walks to parent (Rails' superclass fallback).
+    expect(_helpers(child)).toBe(parent._helpers);
+  });
+
+  it("writer assigns the slot; subsequent reads return that value", () => {
+    const cls = makeBase();
+    const mod = { hello: () => "world" } as unknown as HelperMethodsModule;
+    _helpers(cls, mod);
+    expect(cls._helpers).toBe(mod);
+    expect(_helpers(cls)).toBe(mod);
+  });
+
+  it("writer with null deletes the own slot to restore parent fallback", () => {
+    const parent = makeBase();
+    helperMethod(parent, "fromParent");
+    const child: HelpersClassMethods = Object.create(parent) as HelpersClassMethods;
+    const ownMod = {} as HelperMethodsModule;
+    _helpers(child, ownMod);
+    expect(child._helpers).toBe(ownMod);
+
+    _helpers(child, null);
+    expect(Object.prototype.hasOwnProperty.call(child, "_helpers")).toBe(false);
+    // After clearing, the inherited slot is visible again via prototype.
+    expect(child._helpers).toBe(parent._helpers);
+  });
+
+  it("instance form delegates to _helpersInstance (class._helpers)", () => {
+    const cls = makeBase();
+    helperMethod(cls, "shown");
+    const host = { constructor: cls } as HelpersHost;
+    const instanceReader = _helpers as (this: HelpersHost) => HelperMethodsModule;
+    expect(instanceReader.call(host)).toBe(cls._helpers);
+  });
+});
+
+describe("defineHelpersModule", () => {
+  it("is idempotent per class — same class returns the same module", () => {
+    const cls = makeBase();
+    const first = defineHelpersModule(cls);
+    const second = defineHelpersModule(cls);
+    expect(second).toBe(first);
+  });
+
+  it("does NOT write cls._helpers (caller is responsible, per Rails)", () => {
+    const cls = makeBase();
+    defineHelpersModule(cls);
+    expect(Object.prototype.hasOwnProperty.call(cls, "_helpers")).toBe(false);
+  });
+
+  it("splices the parent helpers module into the prototype chain", () => {
+    const parent = makeBase();
+    helperMethod(parent, "fromParent");
+    const child = makeBase();
+    const mod = defineHelpersModule(child, parent._helpers);
+    expect(Object.getPrototypeOf(mod)).toBe(parent._helpers);
+    // Live: methods added to parent after definition remain visible.
+    helperMethod(parent, "addedLater");
+    expect(typeof (mod as HelperMethodsModule).addedLater).toBe("function");
   });
 });

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -79,6 +79,61 @@ export function _helpersInstance(this: HelpersHost): HelperMethodsModule {
 }
 
 /**
+ * Rails exposes `_helpers` as both an instance reader (`def _helpers`) and a
+ * class-level reader/writer (`redefine_singleton_method(:_helpers)` plus
+ * `attr_writer :_helpers`). This overload mirrors both:
+ *   - bound to an instance, returns `this.class._helpers`
+ *   - called with a class + value, writes the slot (Rails `_helpers=`)
+ *   - called with a class only, reads from the class with superclass fallback
+ *     via JS prototype lookup
+ */
+export function _helpers(this: HelpersHost): HelperMethodsModule;
+export function _helpers(cls: HelpersClassMethods): HelperMethodsModule;
+export function _helpers(cls: HelpersClassMethods, value: HelperMethodsModule | null): void;
+export function _helpers(
+  this: HelpersHost | void,
+  clsOrValue?: HelpersClassMethods,
+  value?: HelperMethodsModule | null,
+): HelperMethodsModule | void {
+  if (clsOrValue && arguments.length >= 2) {
+    // `_helpers=` writer
+    clsOrValue._helpers = value ?? undefined;
+    return;
+  }
+  if (clsOrValue) {
+    return clsOrValue._helpers ?? (Object.create(null) as HelperMethodsModule);
+  }
+  return _helpersInstance.call(this as HelpersHost);
+}
+
+/**
+ * `ClassMethods#define_helpers_module(klass, helpers = nil)` — Rails' private
+ * helper that builds (and caches on the class) the `HelperMethods` module
+ * that backs `_helpers`. Idempotent under explicit `inherited` calls in
+ * tests: Rails reuses the existing `:HelperMethods` constant if one is
+ * already attached to the class. Trails has no constant namespace per class,
+ * so we cache by class identity in a WeakMap. Optionally splices a parent
+ * helpers module into the prototype chain so methods added to the parent
+ * after this call remain visible from the child.
+ *
+ * Does NOT assign to `cls._helpers` — that's the caller's responsibility
+ * (Rails likewise does the assignment in the `included` block and in
+ * `_helpers_for_modification`, not here).
+ */
+const helperMethodsByClass = new WeakMap<HelpersClassMethods, HelperMethodsModule>();
+
+export function defineHelpersModule(
+  cls: HelpersClassMethods,
+  helpers?: HelperMethodsModule | null,
+): HelperMethodsModule {
+  const existing = helperMethodsByClass.get(cls);
+  if (existing) return existing;
+  const mod = Object.create(helpers ?? null) as HelperMethodsModule;
+  helperMethodsByClass.set(cls, mod);
+  return mod;
+}
+
+/**
  * `ClassMethods#helper_method(*methods)` — register controller method
  * names as view helpers. Each name gets a proxy on the helpers module
  * that does `this.controller[name](...args)`. Nested-array inputs are
@@ -351,6 +406,19 @@ export function defaultHelperModule(cls: HelpersClassMethods, options: Resolutio
     if (err instanceof Error && err.message === `uninitialized constant ${expectedName}`) return;
     throw err;
   }
+}
+
+/**
+ * Bang-suffix alias for {@link defaultHelperModule} so the Rails name
+ * (`default_helper_module!`) is reachable by api:compare. Same behavior —
+ * Rails' bang here signals "swallows NameError for the specific helper name",
+ * not a destructive mutation, so a thin alias is the right shape.
+ */
+export function defaultHelperModuleBang(
+  cls: HelpersClassMethods,
+  options: ResolutionOptions,
+): void {
+  defaultHelperModule(cls, options);
 }
 
 function camelizeHelperPrefix(raw: string): string {

--- a/packages/actionpack/src/abstract-controller/helpers.ts
+++ b/packages/actionpack/src/abstract-controller/helpers.ts
@@ -96,8 +96,17 @@ export function _helpers(
   value?: HelperMethodsModule | null,
 ): HelperMethodsModule | void {
   if (clsOrValue && arguments.length >= 2) {
-    // `_helpers=` writer
-    clsOrValue._helpers = value ?? undefined;
+    // `_helpers=` writer. Rails' redefined reader treats a nil slot as
+    // "fall through to superclass" (`@_helpers ||= nil; superclass._helpers`),
+    // and `Helpers.inherited` calls `klass._helpers = nil` to re-enable
+    // that fallback on subclasses. Assigning `undefined` would create an
+    // own property that shadows the prototype chain; instead delete the
+    // own slot so JS prototype lookup walks to the parent class.
+    if (value == null) {
+      delete (clsOrValue as { _helpers?: HelperMethodsModule })._helpers;
+    } else {
+      clsOrValue._helpers = value;
+    }
     return;
   }
   if (clsOrValue) {


### PR DESCRIPTION
## Summary

Bundled fidelity sweep across two abstract-controller files. Follow-up to PRs #1793, #1797, #1780, #1784 (tracked in `docs/actionpack-100-percent.md` "Recent-merge followups").

- **`helpers.rb`**: 7/11 → 11/11. Adds the `_helpers` reader/writer overload (Rails' redefined `:_helpers` singleton + `attr_writer :_helpers`), the private `defineHelpersModule` helper, and a `defaultHelperModuleBang` alias for the existing `defaultHelperModule` (Ruby `default_helper_module!`).
- **`caching.rb`**: 6/12 → 12/12. Rails `include AbstractController::Caching::Fragments` exposes the fragment API on the `Caching` module itself. The implementations live in `fragments.ts`; thin delegating wrappers in `caching.ts` republish the 6 fragment methods (`combinedFragmentCacheKey`, `writeFragment`, `readFragment`, `fragmentExist`, `expireFragment`, `instrumentFragmentCache`) so api:compare credits them to the file Rails exposes them on. (Per the Wave-7 PR-27 finding, `export { ... } from` re-exports don't count — the extractor only sees `export function` declarations.)

## Notes

- `metal/helpers.ts` (the parallel instance registry under `action-controller`) was **not** reconciled — its 6-method gap is a separate concern and deferred.
- Light overlap with caching/fragments.rb's compare row: prior to this PR a path-inference rule was attributing the `fragments.ts` exports to `caching/fragments.rb`. After this PR the inference shifts; net actionpack methods matched goes up.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/abstract-controller/{helpers,caching,fragments}.test.ts` — 46/46 pass
- [x] `pnpm tsx scripts/api-compare/compare.ts actionpack --missing` confirms 11/11 + 12/12
- [x] LOC under ceiling (123 LOC, well under 300)