### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in autosave-association + calculations

### DIFF
--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { I18n, Error as ModelError } from "@blazetrails/activemodel";
 import {
   Base,
@@ -18,6 +18,7 @@ import { Associations, setBelongsTo, association, loadHasManyThrough } from "./a
 import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema, type Schema } from "./test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
+import type { DatabaseAdapter } from "./adapter.js";
 import {
   markForDestruction,
   isMarkedForDestruction,
@@ -1474,15 +1475,14 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
 });
 
 describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
-  let adapter: TestDatabaseAdapter;
+  let adapter: DatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeAll(async () => {
+  beforeEach(async () => {
     adapter = await setupAutosaveAdapter();
   });
-  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Pirate extends Base {

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { I18n, Error as ModelError } from "@blazetrails/activemodel";
 import {
   Base,
@@ -15,9 +15,9 @@ import {
 } from "./index.js";
 import { Associations, setBelongsTo, association, loadHasManyThrough } from "./associations.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema, type Schema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 import {
   markForDestruction,
   isMarkedForDestruction,
@@ -165,7 +165,7 @@ const UNIVERSAL_AUTOSAVE_SCHEMA: Schema = {
   nauto_tags: { name: "string", nauto_article_id: "integer" },
 };
 
-async function setupAutosaveAdapter(): Promise<DatabaseAdapter> {
+async function setupAutosaveAdapter(): Promise<TestDatabaseAdapter> {
   const a = createTestAdapter();
   await defineSchema(a, UNIVERSAL_AUTOSAVE_SCHEMA);
   return a;
@@ -177,12 +177,12 @@ function cacheAssoc(record: Base, name: string, value: unknown) {
 }
 
 describe("TestDestroyAsPartOfAutosaveAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
     await defineSchema(adapter, {
       pirates: { catchphrase: "string" },
@@ -193,6 +193,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
       parrots_pirates: { pirate_id: "integer", parrot_id: "integer" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   function makePirateShip() {
     class Pirate extends Base {
@@ -642,12 +643,12 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
 });
 
 describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
     await defineSchema(adapter, {
       companies: { name: "string" },
@@ -663,6 +664,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
       aid_developers: { name: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Company extends Base {
@@ -999,14 +1001,15 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
 });
 
 describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Firm extends Base {
@@ -1471,14 +1474,15 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
 });
 
 describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Pirate extends Base {
@@ -1795,14 +1799,15 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
 });
 
 describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Author extends Base {
@@ -2019,14 +2024,15 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
 });
 
 describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Pirate extends Base {
@@ -2187,14 +2193,15 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
 });
 
 describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttributes", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Pirate extends Base {
@@ -3083,14 +3090,15 @@ describe("TestAutosaveAssociationsInGeneral", () => {
 });
 
 describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Pirate extends Base {
@@ -3187,10 +3195,11 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
 });
 
 describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("should generate validation methods for has_many associations", async () => {
     class VmParent extends Base {
@@ -3373,14 +3382,15 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
 });
 
 describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   function cacheAssoc(record: Base, name: string, value: unknown) {
     if (!(record as any)._cachedAssociations) (record as any)._cachedAssociations = new Map();
     (record as any)._cachedAssociations.set(name, value);
   }
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Pirate extends Base {
@@ -3937,10 +3947,11 @@ describe("TestAutosaveAssociationOnAHasManyAssociationDefinedInSubclassWithAccep
 });
 
 describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttributes", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Pirate extends Base {
@@ -4468,10 +4479,11 @@ describe("should update children when autosave is true and parent is new but chi
 });
 
 describe("ChangedForAutosaveTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await setupAutosaveAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("parent is changed_for_autosave when nested autosave child is changed", () => {
     class Child extends Base {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -5,7 +5,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
  */
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
 import "./encryption.js";
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import {
   Base,
   association,
@@ -23,7 +23,9 @@ import type { JoinDependency } from "./associations/join-dependency.js";
 import { lookupCastTypeFromJoinDependencies } from "./relation/calculations.js";
 import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
+import type { DatabaseAdapter } from "./adapter.js";
 import { runBeforeCallbacksOnProto, runAfterCallbacksOnProto } from "@blazetrails/activemodel";
 import { setApp, _resetApp } from "@blazetrails/globalid";
 
@@ -2825,9 +2827,9 @@ describe("CalculationsTest", () => {
 });
 
 describe("CalculationsTest", () => {
-  let adapter: TestDatabaseAdapter;
+  let adapter: DatabaseAdapter;
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       accounts: { balance: "integer" },
@@ -2891,7 +2893,10 @@ describe("CalculationsTest", () => {
       vehicles: { name: "string", type: "string" },
     });
   });
-  withTransactionalFixtures(() => adapter);
+
+  afterAll(async () => {
+    await dropAllTables(adapter);
+  });
 
   // Rails: test "group count"
   it("group().count() returns counts keyed by group value", async () => {

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -5,7 +5,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
  */
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
 import "./encryption.js";
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import {
   Base,
   association,
@@ -21,15 +21,14 @@ import { ReadonlyAttributeError } from "./readonly-attributes.js";
 
 import type { JoinDependency } from "./associations/join-dependency.js";
 import { lookupCastTypeFromJoinDependencies } from "./relation/calculations.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 import { runBeforeCallbacksOnProto, runAfterCallbacksOnProto } from "@blazetrails/activemodel";
 import { setApp, _resetApp } from "@blazetrails/globalid";
 
 // -- Helpers --
-function freshAdapter(): DatabaseAdapter {
+function freshAdapter(): TestDatabaseAdapter {
   return createTestAdapter();
 }
 
@@ -37,9 +36,9 @@ function freshAdapter(): DatabaseAdapter {
 // CalculationsTest — targets calculations_test.rb
 // ==========================================================================
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       accounts: {
@@ -56,10 +55,7 @@ describe("CalculationsTest", () => {
       },
     });
   });
-
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("should return nil as average", async () => {
     class Account extends Base {
@@ -1772,8 +1768,8 @@ describe("CalculationsTest", () => {
 // CalculationsTestExtra — additional targets for calculations_test.rb
 // ==========================================================================
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       accounts: {
@@ -1785,10 +1781,7 @@ describe("CalculationsTest", () => {
       posts: { title: "string" },
     });
   });
-
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("should resolve aliased attributes", async () => {
     class Account extends Base {
@@ -2439,16 +2432,14 @@ describe("CalculationsTest", () => {
 });
 
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       orders: { status: "string", total: "integer" },
     });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("group().count() returns hash of counts", async () => {
     class Order extends Base {
@@ -2488,16 +2479,14 @@ describe("CalculationsTest", () => {
 });
 
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       items: { price: "integer" },
     });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("delegates to the appropriate aggregate method", async () => {
     class Item extends Base {
@@ -2520,16 +2509,14 @@ describe("CalculationsTest", () => {
 });
 
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       posts: { comments_count: "integer" },
     });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("increments a counter column by primary key", async () => {
     class Post extends Base {
@@ -2563,16 +2550,14 @@ describe("CalculationsTest", () => {
 });
 
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       posts: { likes_count: "integer", comments_count: "integer" },
     });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("updates multiple counters for a record", async () => {
     class Post extends Base {
@@ -2593,7 +2578,7 @@ describe("CalculationsTest", () => {
 });
 
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class Order extends Base {
     static {
@@ -2610,7 +2595,7 @@ describe("CalculationsTest", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       orders: { amount: "integer", status: "string", customer_id: "integer" },
@@ -2629,6 +2614,7 @@ describe("CalculationsTest", () => {
     await Account.create({ firm_id: 1, credit_limit: 60 });
     await Account.create({ firm_id: 2, credit_limit: 100 });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("should sum field", async () => {
     expect(await Order.all().sum("amount")).toBe(65);
@@ -2748,14 +2734,10 @@ describe("CalculationsTest", () => {
     }
     expect(await Empty.all().average("amount")).toBeNull();
   });
-
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
 });
 
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class Product extends Base {
     static {
@@ -2765,16 +2747,14 @@ describe("CalculationsTest", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       products: { name: "string", price: "integer", category: "string" },
     });
     Product.adapter = adapter;
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   // Rails: test_sum_on_empty_table
   it("sum on empty table returns 0", async () => {
@@ -2845,9 +2825,9 @@ describe("CalculationsTest", () => {
 });
 
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       accounts: { balance: "integer" },
@@ -2911,6 +2891,7 @@ describe("CalculationsTest", () => {
       vehicles: { name: "string", type: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   // Rails: test "group count"
   it("group().count() returns counts keyed by group value", async () => {
@@ -7080,16 +7061,14 @@ describe("CalculationsTest", () => {
 });
 
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       users: { name: "string", age: "integer" },
     });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("pick returns single column value from first record", async () => {
     class User extends Base {
@@ -7115,7 +7094,7 @@ describe("CalculationsTest", () => {
   });
 });
 describe("CalculationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class Product extends Base {
     static {
@@ -7126,7 +7105,7 @@ describe("CalculationsTest", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       products: {
@@ -7145,9 +7124,7 @@ describe("CalculationsTest", () => {
     await Product.create({ name: "Carrot", price: 3, quantity: 30, category: "vegetable" });
     await Product.create({ name: "Donut", price: 5, quantity: 5, category: "pastry" });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   describe("count", () => {
     it("counts all records", async () => {
@@ -7451,17 +7428,15 @@ describe("CalculationsTest", () => {
 //   count  → always integer (not through type)
 // ==========================================================================
 describe("bigint aggregates (big_integer columns)", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = freshAdapter();
     await defineSchema(adapter, {
       scores: { value: "big_integer", category: "string" },
       items: { qty: "integer" },
     });
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   function makeBigModel() {
     class Score extends Base {


### PR DESCRIPTION
## Summary

- Migrates `autosave-association.test.ts` and `calculations.test.ts` from per-test `beforeEach(defineSchema)` to once-per-describe `beforeAll(defineSchema)` + `withTransactionalFixtures()`, per `docs/tm-unification-plan.md` Phase 6 (follow-up to #2041 / #2046 / #2048).
- Per-describe pattern: each `describe`'s `beforeEach(adapter + defineSchema)` becomes `beforeAll`, followed by `withTransactionalFixtures(() => adapter)`. Each test wraps in a BEGIN/ROLLBACK instead of dropping and recreating tables.
- `afterAll(dropAllTables)` calls in the migrated `calculations.test.ts` describes are removed (no longer needed; transactional rollback covers cleanup).

## Exceptions (per Copilot review #1 / PG CI)

Two describes are intentionally left on the per-test `beforeEach(defineSchema)` path because they perform DDL inside individual test bodies, which would leak across tests under transactional fixtures (PG CI actually broke on the first one before the revert):

- `calculations.test.ts` "CalculationsTest" at L2827 — contains a `CREATE UNIQUE INDEX users_name_idx` and a `User.createTable()` call inside individual `it(...)` bodies. The `afterAll(dropAllTables)` cleanup is retained for this describe only.
- `autosave-association.test.ts` "TestAutosaveAssociationOnAHasOneAssociation" — two tests (`innerAdapter = await setupAutosaveAdapter()`) call `defineSchema` inside the test body.

The other 11 describes in each file are migrated.

## Deferred follow-ups

The other three giants from this PR's slot are left for separate PRs to stay under the 300-LOC ceiling:

- `associations.test.ts` — ~27 describes; mechanical but pushes diff size.
- `persistence.test.ts` — ~29 describes; same.
- `relations.test.ts` — ~13 describes + ~70 inline `defineSchema()` calls inside test bodies; needs careful audit before migrating.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/autosave-association.test.ts` — 193 pass, 15 pre-existing skips
- [x] `pnpm vitest run packages/activerecord/src/calculations.test.ts` — 543 pass, 3 pre-existing skips