### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in associations/ (8 files)

### DIFF
--- a/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
@@ -1,10 +1,10 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/has_many_through_disable_joins_associations_test.rb
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { Associations, association, loadHasMany } from "../associations.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
@@ -52,14 +52,14 @@ function djasScope(owner: Base, assocName: string): any {
   });
 }
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("HasManyThroughDisableJoinsAssociationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class DjAuthor extends Base {
     static {
@@ -110,7 +110,7 @@ describe("HasManyThroughDisableJoinsAssociationsTest", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
     DjAuthor.adapter = adapter;
     DjPost.adapter = adapter;
@@ -286,6 +286,7 @@ describe("HasManyThroughDisableJoinsAssociationsTest", () => {
       foreignKey: "dj_member_type_id",
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   async function setupData() {
     const author = await DjAuthor.create({ name: "Mary" });

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -1,10 +1,10 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/has_one_through_associations_test.rb
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import {
   Associations,
   loadHasOne,
@@ -71,14 +71,14 @@ const TEST_SCHEMA: Schema = {
   },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("HasOneThroughAssociationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class Club extends Base {
     static {
@@ -100,7 +100,7 @@ describe("HasOneThroughAssociationsTest", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
     Club.adapter = adapter;
     Membership.adapter = adapter;
@@ -129,6 +129,7 @@ describe("HasOneThroughAssociationsTest", () => {
 
     Associations.belongsTo.call(Membership, "club", { className: "Club", foreignKey: "club_id" });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("has one through with has one", async () => {
     // member -> membership -> club

--- a/packages/activerecord/src/associations/inner-join-association.test.ts
+++ b/packages/activerecord/src/associations/inner-join-association.test.ts
@@ -226,7 +226,7 @@ describe("InnerJoinAssociationTest", () => {
   });
 
   it("find with sti join", async () => {
-    const a = await freshAdapter();
+    const a = adapter;
     class Comment extends Base {
       static {
         this.attribute("body", "string");

--- a/packages/activerecord/src/associations/inner-join-association.test.ts
+++ b/packages/activerecord/src/associations/inner-join-association.test.ts
@@ -2,13 +2,13 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   authors: { name: "string" },
@@ -23,17 +23,18 @@ const TEST_SCHEMA: Schema = {
   habtm_posts_habtm_tags: { habtm_post_id: "integer", habtm_tag_id: "integer" },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("InnerJoinAssociationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Author extends Base {

--- a/packages/activerecord/src/associations/left-outer-join-association.test.ts
+++ b/packages/activerecord/src/associations/left-outer-join-association.test.ts
@@ -2,13 +2,13 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   authors: { name: "string" },
@@ -18,17 +18,18 @@ const TEST_SCHEMA: Schema = {
   l_comments: { body: "string", type: "string", post_id: "integer" },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("LeftOuterJoinAssociationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModels() {
     class Author extends Base {

--- a/packages/activerecord/src/associations/left-outer-join-association.test.ts
+++ b/packages/activerecord/src/associations/left-outer-join-association.test.ts
@@ -175,7 +175,7 @@ describe("LeftOuterJoinAssociationTest", () => {
   });
 
   it("find with sti join", async () => {
-    const a = await freshAdapter();
+    const a = adapter;
     class LComment extends Base {
       static {
         this.attribute("body", "string");

--- a/packages/activerecord/src/associations/nested-through-advanced.test.ts
+++ b/packages/activerecord/src/associations/nested-through-advanced.test.ts
@@ -6,12 +6,12 @@
  * autosave-skip guarantee. Mirrors selected scenarios from
  * vendor/rails/activerecord/test/cases/associations/nested_through_associations_test.rb.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasManyThrough } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   nta_authors: { name: "string" },
@@ -32,14 +32,14 @@ const TEST_SCHEMA: Schema = {
   nse_drink_designers: { name: "string" },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("HMT Slot E — nested-through advanced", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class NtaAuthor extends Base {
     static {
@@ -69,7 +69,7 @@ describe("HMT Slot E — nested-through advanced", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
     NtaAuthor.adapter = adapter;
     NtaPost.adapter = adapter;
@@ -118,6 +118,7 @@ describe("HMT Slot E — nested-through advanced", () => {
       scope: (rel: any) => rel.distinct(),
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   async function seedSharedTag() {
     const author = await NtaAuthor.create({ name: "David" });

--- a/packages/activerecord/src/associations/nested-through-preloader.test.ts
+++ b/packages/activerecord/src/associations/nested-through-preloader.test.ts
@@ -26,15 +26,15 @@
  * Mirrors selected scenarios from
  * vendor/rails/activerecord/test/cases/associations/nested_through_associations_test.rb.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel, registerSubclass, enableSti } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("HMT Slot D — nested-through preloader / STI / joins+includes", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class NtdAuthor extends Base {
     static {
@@ -70,7 +70,7 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
   enableSti(NtdRating);
   registerSubclass(NtdHighRating);
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       ntd_authors: { name: "string" },
@@ -120,6 +120,7 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
       source: "ntdRatings",
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   async function seed() {
     const a = await NtdAuthor.create({ name: "a" });

--- a/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
+++ b/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
@@ -32,12 +32,12 @@
  *   - test_has_many_through_with_sti_on_through_reflection (STI variant)
  *   - test_has_many_through_reset_source_reflection_after_loading_is_complete
  */
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel, registerSubclass, enableSti } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createTestAdapter } from "../test-adapter.js";
+import type { DatabaseAdapter } from "../adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
-import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   ps_hotels: { name: "string" },
@@ -51,14 +51,14 @@ const TEST_SCHEMA: Schema = {
   ps_drink_designers: { name: "string" },
 };
 
-async function freshAdapter(): Promise<TestDatabaseAdapter> {
+async function freshAdapter(): Promise<DatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("HABTM Slot E — polymorphic + STI through", () => {
-  let adapter: TestDatabaseAdapter;
+  let adapter: DatabaseAdapter;
 
   class PsHotel extends Base {
     static {
@@ -101,7 +101,7 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
   enableSti(PsCakeDesigner);
   registerSubclass(PsSpecialCakeDesigner);
 
-  beforeAll(async () => {
+  beforeEach(async () => {
     adapter = await freshAdapter();
     PsHotel.adapter = adapter;
     PsDepartment.adapter = adapter;
@@ -151,7 +151,6 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
       sourceType: "PsDrinkDesigner",
     });
   });
-  withTransactionalFixtures(() => adapter);
 
   async function seed() {
     const hotel = await PsHotel.create({ name: "h" });

--- a/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
+++ b/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
@@ -32,12 +32,12 @@
  *   - test_has_many_through_with_sti_on_through_reflection (STI variant)
  *   - test_has_many_through_reset_source_reflection_after_loading_is_complete
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel, registerSubclass, enableSti } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   ps_hotels: { name: "string" },
@@ -51,14 +51,14 @@ const TEST_SCHEMA: Schema = {
   ps_drink_designers: { name: "string" },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("HABTM Slot E — polymorphic + STI through", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class PsHotel extends Base {
     static {
@@ -101,7 +101,7 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
   enableSti(PsCakeDesigner);
   registerSubclass(PsSpecialCakeDesigner);
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
     PsHotel.adapter = adapter;
     PsDepartment.adapter = adapter;
@@ -151,6 +151,7 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
       sourceType: "PsDrinkDesigner",
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   async function seed() {
     const hotel = await PsHotel.create({ name: "h" });

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -2,16 +2,17 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter = createTestAdapter();
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter = createTestAdapter();
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     authors: { name: "string" },
@@ -33,6 +34,7 @@ beforeEach(async () => {
     rm_profiles: { bio: "string", r_m_user_id: "integer" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }


### PR DESCRIPTION
## Summary

Migrates 7 `packages/activerecord/src/associations/` test files from per-test `beforeEach(defineSchema)` to once-per-file `beforeAll(defineSchema)` + `withTransactionalFixtures()`. Each test now wraps in a BEGIN/ROLLBACK pair instead of dropping and recreating tables between tests.

Files:
- `required.test.ts` (module-level pattern)
- `inner-join-association.test.ts`
- `left-outer-join-association.test.ts`
- `has-one-through-associations.test.ts`
- `nested-through-advanced.test.ts`
- `nested-through-preloader.test.ts`
- `has-many-through-disable-joins-associations.test.ts`

Follows the patterns established in #2041 / #2046 / #2048.

## Follow-ups (deferred)

- `polymorphic-sti-through.test.ts` — originally batched in this PR; reverted after PG CI showed its `seed()` depends on PG sequence values colliding across tables (`expect(drink.id).toBe(strayCake.id)`). PG sequences don't roll back inside the per-test BEGIN/ROLLBACK that `withTransactionalFixtures()` wraps tests in, so the collision invariant breaks once the adapter is shared. Needs the seed rewritten to compute the collision dynamically (or stay on the per-test adapter pattern).
- `source-type-validation.test.ts` — each `it()` body registers its own associations; can't share a beforeAll-built model fixture.
- `has-one-associations.test.ts`, `eager.test.ts`, `cascaded-eager-loading.test.ts`, `has-one-through-disable-joins-associations.test.ts`, `nested-through-associations.test.ts`, `join-model.test.ts`, `has-and-belongs-to-many-associations.test.ts`, `belongs-to-associations.test.ts`, `has-many-associations.test.ts`, `callbacks.test.ts` — most call `await freshAdapter()` inside individual test bodies (each test owns its own adapter); migration requires per-test analysis.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/associations/` — 1412 pass, 281 pre-existing skips, 0 new failures.
- [x] PG CI green after reverting `polymorphic-sti-through.test.ts`.