### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in scoping/ (3 files)

### DIFF
--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -2,15 +2,16 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { Base, Relation } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: {
@@ -42,6 +43,7 @@ beforeEach(async () => {
     dev2s: { name: "string", salary: "integer", mentor_id: "integer" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -2,15 +2,16 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Relation } from "../index.js";
 
-import { createTestAdapter, adapterType } from "../test-adapter.js";
+import { createTestAdapter, adapterType, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   await defineSchema(_adapter, {
     posts: {
@@ -29,6 +30,7 @@ beforeEach(async () => {
     users: { name: "string", age: "integer", active: "boolean", role: "string" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -2,15 +2,16 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: DatabaseAdapter;
-beforeEach(async () => {
+let _adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   _adapter = createTestAdapter();
   const postCols = {
     title: "string" as const,
@@ -40,6 +41,7 @@ beforeEach(async () => {
     categories: { name: "string" },
   });
 });
+withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {
   return _adapter;
 }


### PR DESCRIPTION
## Summary

Migrates the remaining `packages/activerecord/src/scoping/` test files from
per-test `beforeEach(defineSchema)` to once-per-file `beforeAll(defineSchema)`
+ `withTransactionalFixtures()`. Each test now wraps in BEGIN/ROLLBACK
instead of dropping and recreating tables between tests.

Files:
- `default-scoping.test.ts`
- `named-scoping.test.ts`
- `relation-scoping.test.ts`

Follows the patterns from #2041 / #2046 / #2048 / #2053.

No DDL hazards in any file (no `createTable`/`addColumn`/etc. inside `it()`
bodies). All three files use a shared `freshAdapter()` helper that returns
the module-level `_adapter`, so the existing per-describe
`beforeEach(() => adapter = freshAdapter())` remains intact.

This also closes the `associations/` cluster: every file under
`packages/activerecord/src/associations/` either already uses
`withTransactionalFixtures` (8 in #2053 plus prior phases) or was documented
as a deferred follow-up in #2053's PR body (per-test adapter construction
or `it()`-local model registration).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/scoping/` — 313 pass, 27
  pre-existing skips, 0 new failures.