### PR TITLE
feat(actionpack): include TestProcess mixin on IntegrationTest

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -44,8 +44,6 @@ import {
 import type { ParameterFilter } from "@blazetrails/activesupport";
 import { RequestUtils, type ParamValue } from "../request/utils.js";
 import { COOKIES_APP_OPTIONS_KEY, type CookieJarOptions } from "../middleware/cookies.js";
-
-const FLASH_HASH_KEY = "action_dispatch.request.flash_hash";
 import {
   parameters as _parameters,
   parameterParsers as _parameterParsers,
@@ -59,6 +57,7 @@ import {
   type ParametersHost,
 } from "./parameters.js";
 
+const FLASH_HASH_KEY = "action_dispatch.request.flash_hash";
 const HTTP_HEADER_NAME = /^[A-Za-z0-9-]+$/;
 const CGI_VARIABLES: ReadonlySet<string> = new Set([
   "AUTH_TYPE",

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -43,6 +43,9 @@ import {
 } from "./filter-parameters.js";
 import type { ParameterFilter } from "@blazetrails/activesupport";
 import { RequestUtils, type ParamValue } from "../request/utils.js";
+import { COOKIES_APP_OPTIONS_KEY, type CookieJarOptions } from "../middleware/cookies.js";
+
+const FLASH_HASH_KEY = "action_dispatch.request.flash_hash";
 import {
   parameters as _parameters,
   parameterParsers as _parameterParsers,
@@ -588,6 +591,60 @@ export class Request {
 
   get session(): Record<string, unknown> {
     return (this.env["rack.session"] as Record<string, unknown>) || {};
+  }
+
+  // --- Flash ---
+  //
+  // Backed by an env header so the value survives the request lifecycle the
+  // same way Rails' flash middleware stores it (`action_dispatch.request.flash_hash`).
+
+  get flash(): unknown {
+    return this.env[FLASH_HASH_KEY];
+  }
+
+  set flash(value: unknown) {
+    this.env[FLASH_HASH_KEY] = value;
+  }
+
+  // --- Cookies ---
+  //
+  // Parses the `HTTP_COOKIE` header into a `name → value` map. Trails layers
+  // a richer `CookieJar` on top via `ActionDispatch::Cookies`; this getter
+  // returns the raw seed used to build it.
+
+  get cookies(): Record<string, string> {
+    const header = (this.env.HTTP_COOKIE as string | undefined) ?? "";
+    const out: Record<string, string> = {};
+    if (!header) return out;
+    for (const pair of header.split(";")) {
+      const eq = pair.indexOf("=");
+      if (eq < 0) continue;
+      const k = pair.slice(0, eq).trim();
+      const v = pair.slice(eq + 1).trim();
+      if (k) out[k] = v;
+    }
+    return out;
+  }
+
+  // --- Cookies (app-wide options) ---
+  //
+  // `cookiesAppOptions` is the bridge the `ActionDispatch::Cookies` middleware
+  // uses to pass the app-wide secret/serializer/etc. configuration into the
+  // signed/encrypted cookie jars. Rails stores each option in its own env
+  // header (`action_dispatch.signed_cookie_salt` and friends); trails
+  // collapses them into a single `CookieJarOptions` object stored under
+  // `COOKIES_APP_OPTIONS_KEY` until the full middleware lands.
+
+  get cookiesAppOptions(): CookieJarOptions | undefined {
+    return this.env[COOKIES_APP_OPTIONS_KEY] as CookieJarOptions | undefined;
+  }
+
+  set cookiesAppOptions(options: CookieJarOptions | undefined) {
+    if (options === undefined) {
+      delete this.env[COOKIES_APP_OPTIONS_KEY];
+    } else {
+      this.env[COOKIES_APP_OPTIONS_KEY] = options;
+    }
   }
 
   // --- Static factory ---

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -22,6 +22,15 @@ function toUTCString(expires: CookieExpires): string {
     : expires.toUTCString();
 }
 
+/**
+ * Rack env key under which {@link CookieJar.build} reads the app-wide
+ * {@link CookieJarOptions}. The `ActionDispatch::Cookies` middleware sets
+ * this so signed/encrypted cookie accessors can find their secrets.
+ *
+ * @internal
+ */
+export const COOKIES_APP_OPTIONS_KEY = "action_dispatch.cookies_app_options";
+
 export interface CookieJarOptions {
   secret?: string;
   signedSecret?: string;

--- a/packages/actionpack/src/action-dispatch/testing/integration.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.test.ts
@@ -302,7 +302,7 @@ describe("ActionDispatch::IntegrationTest", () => {
   describe("cookie persistence", () => {
     it("cookies persist across requests", async () => {
       await app.get("/posts/set-cookie");
-      expect(app.cookieJar.token).toBe("abc123");
+      expect(app.cookies.get("token")).toBe("abc123");
 
       await app.get("/posts/read-cookie");
       expect(app.responseBody).toContain("token=abc123");

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -34,9 +34,16 @@
 import { Request } from "../http/request.js";
 import { Response } from "../http/response.js";
 import { Parameters } from "../../action-controller/metal/strong-parameters.js";
+import { CookieJar } from "../middleware/cookies.js";
 import { FlashHash } from "../middleware/flash.js";
 import { RouteSet } from "../routing/route-set.js";
 import type { Metal } from "../../action-controller/metal.js";
+import {
+  cookies as testProcessCookies,
+  flash as testProcessFlash,
+  redirectToUrl as testProcessRedirectToUrl,
+  type TestProcessHost,
+} from "./test-process.js";
 
 type ControllerClass = new () => Metal;
 
@@ -67,8 +74,17 @@ export class IntegrationTest {
   /** Session data persisted across requests. */
   session: Record<string, unknown> = {};
 
-  /** Accumulated cookies across requests (simple key/value). */
-  cookieJar: Record<string, string> = {};
+  /** Accumulated cookies across requests (simple key/value), seeds the jar. */
+  private _persistentCookies: Record<string, string> = {};
+
+  /**
+   * Memoized CookieJar slot consumed by `ActionDispatch::TestProcess#cookies`.
+   * Cleared at the start of each request so the jar reflects the current
+   * request's `HTTP_COOKIE` header.
+   *
+   * @internal
+   */
+  _cookieJar?: CookieJar;
 
   /** The controller instance from the last request. */
   controller!: Metal;
@@ -99,10 +115,40 @@ export class IntegrationTest {
     return this.response?.getHeader("location") ?? this.controller?.getHeader("location");
   }
 
-  /** Flash from the last request. */
+  /**
+   * Flash from the last request. Delegates to
+   * `ActionDispatch::TestProcess#flash`, which reads off
+   * `this.request.flash` — wired up by `_processPath` after each dispatch so
+   * the value survives between requests like the real flash middleware.
+   */
   get flash(): FlashHash {
-    return (this.controller as any)?.flash ?? new FlashHash();
+    if (!this.request) return new FlashHash();
+    return testProcessFlash.call(this as unknown as TestProcessHost) as FlashHash;
   }
+
+  /**
+   * Cookies from the last request as a Rails-shaped `CookieJar`. Delegates
+   * to `ActionDispatch::TestProcess#cookies`, which builds the jar from
+   * `this.request.cookies` (parsed from `HTTP_COOKIE`) and memoizes it on
+   * `_cookieJar`. The slot is cleared on every new request and on `reset()`.
+   */
+  get cookies(): CookieJar {
+    if (!this.request) {
+      this._cookieJar ??= CookieJar.build(undefined, this._persistentCookies);
+      return this._cookieJar;
+    }
+    return testProcessCookies.call(this as unknown as TestProcessHost);
+  }
+
+  /** Mirror of `ActionDispatch::TestProcess#redirectToUrl`. */
+  get redirectToUrl(): string | undefined {
+    return testProcessRedirectToUrl.call(this as unknown as TestProcessHost);
+  }
+
+  /** Mirror of `ActionDispatch::TestProcess#session` (no-op delegation). */
+  // `session` is kept as an instance field above so multi-request tests can
+  // observe accumulated state directly. TestProcess#session reads the same
+  // value off the Request via `rack.session`, which `_processPath` syncs.
 
   /**
    * Register a controller class for a given name.
@@ -260,7 +306,8 @@ export class IntegrationTest {
    */
   reset(): void {
     this.session = {};
-    this.cookieJar = {};
+    this._persistentCookies = {};
+    this._cookieJar = undefined;
     this.controller = undefined!;
     this.request = undefined!;
     this.response = undefined!;
@@ -314,12 +361,16 @@ export class IntegrationTest {
       ...(options.env ?? {}),
     };
 
-    // Cookies from jar
-    if (Object.keys(this.cookieJar).length > 0) {
-      env.HTTP_COOKIE = Object.entries(this.cookieJar)
+    // Cookies from persistent jar
+    if (Object.keys(this._persistentCookies).length > 0) {
+      env.HTTP_COOKIE = Object.entries(this._persistentCookies)
         .map(([k, v]) => `${k}=${v}`)
         .join("; ");
     }
+
+    // Reset the TestProcess#cookies memoization slot — the jar must reflect
+    // the cookies parsed off this request, not the previous one.
+    this._cookieJar = undefined;
 
     // Format / content type
     if (options.format || options.as) {
@@ -379,6 +430,10 @@ export class IntegrationTest {
       Object.assign(this.session, (this.controller as any).session);
     }
 
+    // Surface the controller's flash on the request so `TestProcess#flash`
+    // (and the `flash` getter above) can find it.
+    this.request.flash = (this.controller as any).flash ?? new FlashHash();
+
     // Collect cookies from response
     const setCookies = this.response.getHeader("set-cookie");
     if (setCookies) {
@@ -388,10 +443,21 @@ export class IntegrationTest {
         if (eqIdx > 0) {
           const name = parts.slice(0, eqIdx).trim();
           const value = parts.slice(eqIdx + 1).trim();
-          this.cookieJar[name] = value;
+          this._persistentCookies[name] = value;
         }
       }
     }
+
+    // Reflect the up-to-date persistent jar on the request so subsequent
+    // reads of `app.cookies` (which delegates to `TestProcess#cookies`)
+    // see Set-Cookies from the just-finished response, not just the
+    // cookies that were sent in.
+    if (Object.keys(this._persistentCookies).length > 0) {
+      this.request.env.HTTP_COOKIE = Object.entries(this._persistentCookies)
+        .map(([k, v]) => `${k}=${v}`)
+        .join("; ");
+    }
+    this._cookieJar = undefined;
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/testing/test-process.ts
+++ b/packages/actionpack/src/action-dispatch/testing/test-process.ts
@@ -101,12 +101,24 @@ export function fileFixtureUpload(
 export const fixtureFileUpload = fileFixtureUpload;
 
 /**
+ * Mirror of Ruby's `NoMethodError`. Rails tests pattern-match on the error
+ * class (e.g. `assert_raises(NoMethodError)`), so use this rather than a
+ * bare `Error` when porting methods that raise it.
+ */
+export class NoMethodError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "NoMethodError";
+  }
+}
+
+/**
  * `assigns` has been extracted to a gem in Rails. Mirror the error so tests
  * relying on the legacy helper get the same message.
  */
 export function assigns(this: TestProcessHost, _key?: string | symbol): never {
-  throw new Error(
-    'NoMethodError: assigns has been extracted to a gem. To continue using it, add `gem "rails-controller-testing"` to your Gemfile.',
+  throw new NoMethodError(
+    'assigns has been extracted to a gem. To continue using it, add `gem "rails-controller-testing"` to your Gemfile.',
   );
 }
 


### PR DESCRIPTION
## Summary

Followup from PR #1864 ([docs/actionpack-100-percent.md](docs/actionpack-100-percent.md) "Recent-merge followups"). Three pieces of the `TestProcess` ↔ `IntegrationTest` reconciliation:

- **Item 1** — drop the ad-hoc `IntegrationTest.cookieJar: Record<string, string>` field and delegate `flash`/`cookies` (plus `redirectToUrl`) to the existing `ActionDispatch::TestProcess` mixin. `app.cookies` now returns a real `CookieJar`. The persistent `_persistentCookies` record seeds each request's `HTTP_COOKIE`; after every dispatch we re-stamp the request's `HTTP_COOKIE` so the jar reflects `Set-Cookie` responses too. The `_cookieJar` slot the mixin memoizes on is cleared at the start of every request and on `reset()`. The controller's `flash` is copied to `request.flash` after dispatch so the mixin's `flash` reader sees it.
- **Item 2** — wire `cookiesAppOptions` / `cookies` / `flash` onto `ActionDispatch::Request`, all env-backed (`action_dispatch.cookies_app_options`, `action_dispatch.request.flash_hash`, `HTTP_COOKIE`). `CookieJar.build(request, cookies)` was already reading `request.cookiesAppOptions`; this hooks up the getter/setter the Cookies middleware will write through.
- **Item 3** — add a Ruby-shaped `NoMethodError` class and throw it from `TestProcess#assigns` instead of a bare `Error` so Rails tests can `assert_raises(NoMethodError)`.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/testing/` — 68/68 pass
- [x] `pnpm exec tsc --build packages/actionpack` clean
- [ ] CI: full suite