### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in 12 small root tests

### DIFF
--- a/packages/activerecord/src/attribute-assignment.test.ts
+++ b/packages/activerecord/src/attribute-assignment.test.ts
@@ -2,13 +2,13 @@
  * Tests for ActiveRecord::AttributeAssignment
  * Mirrors: activerecord/test/cases/attribute_assignment_test.rb
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "./index.js";
 import { typeCastAttributeValue, findParameterPosition } from "./attribute-assignment.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA = {
   topics: { title: "string", author: "string" },
@@ -16,21 +16,17 @@ const TEST_SCHEMA = {
   events: { title: "string", starts_at: "datetime", starts_on: "date" },
 } as const;
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
-  await defineSchema(adapter, TEST_SCHEMA);
-  return adapter;
-}
-
 // ==========================================================================
 // AttributeAssignmentTest — targets attribute_assignment_test.rb
 // ==========================================================================
 describe("AttributeAssignmentTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("bulk assign attributes", () => {
     class Topic extends Base {

--- a/packages/activerecord/src/clone.test.ts
+++ b/packages/activerecord/src/clone.test.ts
@@ -2,15 +2,15 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
-beforeEach(async () => {
+let adapter: TestDatabaseAdapter;
+beforeAll(async () => {
   adapter = createTestAdapter();
   await defineSchema(adapter, {
     topics: { title: "string", author_name: "string" },
@@ -18,6 +18,7 @@ beforeEach(async () => {
     users: { name: "string" },
   });
 });
+withTransactionalFixtures(() => adapter);
 
 describe("CloneTest", () => {
   it("persisted", async () => {

--- a/packages/activerecord/src/delegate.test.ts
+++ b/packages/activerecord/src/delegate.test.ts
@@ -1,25 +1,20 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel, delegate } from "./index.js";
 import { Associations } from "./associations.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
   await defineSchema(adapter, {
     authors: { name: "string", city: "string" },
     posts: { title: "string", author_id: "integer" },
   });
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
-});
+withTransactionalFixtures(() => adapter);
 
 describe("Delegate (Rails-guided)", () => {
   // Rails: test "delegate to association"

--- a/packages/activerecord/src/dup.test.ts
+++ b/packages/activerecord/src/dup.test.ts
@@ -2,24 +2,20 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 describe("DupTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { topics: { title: "string", body: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModel() {
     class Topic extends Base {
@@ -168,11 +164,12 @@ describe("DupTest", () => {
 });
 
 describe("DupTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { items: { name: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("creates an unsaved copy without primary key", async () => {
     class Item extends Base {
@@ -191,11 +188,12 @@ describe("DupTest", () => {
 });
 
 describe("DupTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { animals: { name: "string" }, users: { name: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("transforms a record to another class", async () => {
     class Animal extends Base {

--- a/packages/activerecord/src/i18n.test.ts
+++ b/packages/activerecord/src/i18n.test.ts
@@ -1,23 +1,20 @@
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "./index.js";
 import { I18n } from "@blazetrails/activemodel";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
-  I18n.reset();
   await defineSchema(adapter, { topics: { title: "string" } });
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
+beforeEach(() => {
+  I18n.reset();
 });
+withTransactionalFixtures(() => adapter);
 
 describe("ActiveRecordI18nTests", () => {
   it("translated model attributes", () => {

--- a/packages/activerecord/src/mixin.test.ts
+++ b/packages/activerecord/src/mixin.test.ts
@@ -1,22 +1,19 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { Base } from "./index.js";
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 describe("TouchTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       mixins: { lft: "integer", updated_at: "datetime", created_at: "datetime" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterEach(() => {
     vi.useRealTimers();

--- a/packages/activerecord/src/modules.test.ts
+++ b/packages/activerecord/src/modules.test.ts
@@ -2,16 +2,16 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 describe("ModulesTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       accounts: { name: "string" },
@@ -23,6 +23,7 @@ describe("ModulesTest", () => {
       posts: { title: "string", author_id: "integer" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   it.skip("module spanning associations", () => {
     // PERMANENT-SKIP: Ruby-only (see scripts/api-compare/unported-files.ts) — ruby-module-semantics

--- a/packages/activerecord/src/null-relation.test.ts
+++ b/packages/activerecord/src/null-relation.test.ts
@@ -2,18 +2,12 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -27,16 +21,13 @@ afterAll(() => {
 // NullRelationTest — targets null_relation_test.rb
 // ==========================================================================
 describe("NullRelationTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { posts: { title: "string" } });
   });
-
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("none chainable", async () => {
     class Post extends Base {
@@ -76,15 +67,12 @@ describe("NullRelationTest", () => {
 });
 
 describe("NullRelationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { posts: { title: "string" } });
   });
-
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   function makeModel() {
     class Post extends Base {
@@ -139,15 +127,12 @@ describe("NullRelationTest", () => {
 });
 
 describe("NullRelationTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { items: { name: "string" }, devs: { name: "string" } });
   });
-
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("none returns empty for all terminal methods", async () => {
     class Item extends Base {

--- a/packages/activerecord/src/querying-methods-delegation.test.ts
+++ b/packages/activerecord/src/querying-methods-delegation.test.ts
@@ -2,18 +2,12 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -24,15 +18,12 @@ afterAll(() => {
 });
 
 describe("Base static query delegations", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { users: { name: "string" } });
   });
-
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
+  withTransactionalFixtures(() => adapter);
 
   it("Base.first() returns the first record", async () => {
     class User extends Base {

--- a/packages/activerecord/src/querying.test.ts
+++ b/packages/activerecord/src/querying.test.ts
@@ -1,16 +1,20 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
 import { Base, Relation } from "./index.js";
 import { registerModel } from "./associations.js";
 import { _queryBySql, _loadFromSql } from "./querying.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
+  await defineSchema(adapter, {
+    post_classes: { title: "string", status: "string" },
+  });
 });
+withTransactionalFixtures(() => adapter);
 
 describe("QueryingTest — static forwarders on Base", () => {
   let Post: typeof Base;
@@ -24,12 +28,6 @@ describe("QueryingTest — static forwarders on Base", () => {
       }
     }
     Post = PostClass;
-  });
-
-  beforeEach(async () => {
-    await defineSchema(adapter, {
-      post_classes: { title: "string", status: "string" },
-    });
   });
 
   it("includes() returns a Relation without throwing", () => {

--- a/packages/activerecord/src/strict-loading-sync-reader.test.ts
+++ b/packages/activerecord/src/strict-loading-sync-reader.test.ts
@@ -6,12 +6,11 @@
 //
 // Preserves Rails default (off) — strict loading is opt-in.
 
-import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Base, registerModel, StrictLoadingViolationError } from "./index.js";
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -22,7 +21,7 @@ afterAll(() => {
 });
 
 describe("strict loading — sync singular reader (Phase R.3)", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class SrAuthor extends Base {
     declare name: string;
@@ -52,7 +51,7 @@ describe("strict loading — sync singular reader (Phase R.3)", () => {
   SrAuthor.hasOne("srProfile", { className: "SrProfile" });
   SrPost.belongsTo("srAuthor", { className: "SrAuthor" });
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, {
       sr_authors: { name: "string" },
@@ -67,6 +66,7 @@ describe("strict loading — sync singular reader (Phase R.3)", () => {
     registerModel(SrPost);
     registerModel(SrProfile);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("sync belongsTo access throws when strict loading is enabled and not loaded", async () => {
     const author = new SrAuthor({ name: "dean" });
@@ -208,9 +208,5 @@ describe("strict loading — sync singular reader (Phase R.3)", () => {
     expect(((post as any).srAuthor as SrAuthor).name).toBe("dean");
     // Reader should have marked it loaded as a side effect.
     expect(assoc.loaded).toBe(true);
-  });
-
-  afterAll(async () => {
-    await dropAllTables(adapter);
   });
 });

--- a/packages/activerecord/src/touch-later.test.ts
+++ b/packages/activerecord/src/touch-later.test.ts
@@ -2,28 +2,23 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeAll(() => {
+beforeAll(async () => {
   adapter = createTestAdapter();
-});
-beforeEach(async () => {
   await defineSchema(adapter, {
     invoices: { amount: "integer", updated_at: "datetime", created_at: "datetime" },
   });
 });
-afterAll(async () => {
-  await dropAllTables(adapter);
-});
+withTransactionalFixtures(() => adapter);
 
 describe("TouchLaterTest", () => {
   function makeTouchModel() {


### PR DESCRIPTION
## Summary

TM Phase 6 — migrate 12 root-level test files from per-test
`beforeEach(defineSchema)` to once-per-file `beforeAll(defineSchema)` +
`withTransactionalFixtures()`.

All files were pre-screened for the inline-DDL hazard (no `createTable` /
`addColumn` / `defineSchema` calls inside `it()` bodies). Files with
mid-test DDL or non-transactional setup patterns were left for follow-up.

## Files migrated

- `mixin.test.ts`
- `modules.test.ts`
- `delegate.test.ts`
- `i18n.test.ts`
- `clone.test.ts`
- `attribute-assignment.test.ts`
- `querying-methods-delegation.test.ts`
- `touch-later.test.ts`
- `strict-loading-sync-reader.test.ts`
- `null-relation.test.ts` (3 describes, each migrated)
- `dup.test.ts` (3 describes, each migrated)
- `querying.test.ts`

12 files, +99 / -149.

## Test plan

- [x] `pnpm vitest run` on each migrated file — all pass locally on SQLite
- [ ] CI green (MariaDB included)