### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in hstore (1 file)

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -1,7 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/hstore_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import {
   Hstore,
@@ -10,6 +10,7 @@ import {
 } from "../../connection-adapters/postgresql/oid/hstore.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -22,24 +23,14 @@ afterAll(() => {
 // The `hstores` table uses the PG-specific `hstore` type, which isn't
 // expressible via defineSchema. The table is created via raw DDL below;
 // defineSchema(adapter, {}) marks the file as TM-Phase-5 compliant.
-async function freshAdapter(): Promise<PostgreSQLAdapter> {
-  const adapter = new PostgreSQLAdapter(PG_TEST_URL);
-  await defineSchema(adapter, {});
-  return adapter;
-}
-
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   let HstoreModel: any;
 
   beforeAll(async () => {
-    const setup = new PostgreSQLAdapter(PG_TEST_URL);
-    await setup.exec(`CREATE EXTENSION IF NOT EXISTS hstore`);
-    await setup.close();
-  });
-
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await defineSchema(adapter, {});
+    await adapter.exec(`CREATE EXTENSION IF NOT EXISTS hstore`);
     await adapter.exec(`DROP TABLE IF EXISTS hstores`);
     await adapter.exec(`
       CREATE TABLE hstores (
@@ -60,10 +51,13 @@ describeIfPg("PostgreSQLAdapter", () => {
     await HstoreModelCls.loadSchema();
     HstoreModel = HstoreModelCls;
   });
-  afterEach(async () => {
+
+  afterAll(async () => {
     await adapter.exec(`DROP TABLE IF EXISTS hstores`);
     await adapter.close();
   });
+
+  withTransactionalFixtures(() => adapter);
 
   async function freshStoreAccessorModel(a: PostgreSQLAdapter): Promise<any> {
     const { Base } = await import("../../index.js");


### PR DESCRIPTION
## Summary

Continues the Phase 6 adapter cluster (per `docs/tm-unification-plan.md`).
Migrates `packages/activerecord/src/adapters/postgresql/hstore.test.ts`
from per-test `beforeEach(adapter + DDL)` to once-per-file `beforeAll` +
`withTransactionalFixtures()`. Each test now runs in a BEGIN/ROLLBACK pair
instead of dropping and recreating `hstores` between tests.

## Why this file (and not the others)

PR #2048 audited every remaining `adapters/postgresql/` file and skipped
`hstore` citing "per-test extension setup". On re-read, the hstore
extension was already created once in a separate `beforeAll` block; only
the table DDL was running per-test. There is no DDL inside `it()` bodies,
so this file is safe to hoist.

The other unmigrated files in `adapters/postgresql/` stay deferred (per
the #2048 audit, re-verified here):

- DDL inside `it()` bodies: `array`, `datatype`, `explain`,
  `foreign-table`, `json`, `range`, `schema`, `uuid`, `virtual-column`
- `defineSchema(...)` inside `it()` bodies: `define-schema-pg-types`

Hoisting any of these would require either rewriting the tests away from
their per-test schema mutations or wiring per-test adapter schema-cache
invalidation — out of scope for this PR.

## Test plan

- [x] Local `TEST_ADAPTER=postgresql pnpm vitest run --poolOptions.forks.singleFork=true packages/activerecord/src/adapters/postgresql/hstore.test.ts` — 64 pass, 9 skipped, 6 pre-existing failures (identical to HEAD on the same machine)
- [ ] CI parallel run