### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in 9 medium root tests

### DIFF
--- a/packages/activerecord/src/autosave.test.ts
+++ b/packages/activerecord/src/autosave.test.ts
@@ -2,11 +2,11 @@
  * Autosave association tests.
  * Mirrors: activerecord/test/cases/autosave_association_test.rb
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "./index.js";
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 import {
   markForDestruction,
   isMarkedForDestruction,
@@ -28,7 +28,7 @@ const TEST_SCHEMA = {
   pirate_ships: { name: "string", pirate_id: "integer" },
 } as const;
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
@@ -39,11 +39,12 @@ async function freshAdapter(): Promise<DatabaseAdapter> {
 // ==========================================================================
 
 describe("TestAutosaveAssociationsInGeneral", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("markForDestruction and isMarkedForDestruction", () => {
     class Post extends Base {
@@ -154,7 +155,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
 // ==========================================================================
 
 describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class Company extends Base {
     static {
@@ -169,7 +170,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
     Company.adapter = adapter;
     Account.adapter = adapter;
@@ -178,6 +179,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
 
     Associations.hasOne.call(Company, "account", { autosave: true });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("test_should_save_parent_but_not_invalid_child", async () => {
     const company = new Company({ name: "Acme" });
@@ -247,7 +249,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
 // ==========================================================================
 
 describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class Post extends Base {
     static {
@@ -262,7 +264,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
     Post.adapter = adapter;
     Author.adapter = adapter;
@@ -271,6 +273,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
 
     Associations.belongsTo.call(Post, "author", { autosave: true });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("test_should_save_parent_but_not_invalid_child", async () => {
     const author = new Author({ name: "Dean" });
@@ -319,7 +322,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
 // ==========================================================================
 
 describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class Company extends Base {
     static {
@@ -335,7 +338,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
     Company.adapter = adapter;
     Employee.adapter = adapter;
@@ -344,6 +347,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
 
     Associations.hasMany.call(Company, "employees", { autosave: true });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("test_invalid_adding — parent fails to save when child is invalid", async () => {
     const company = new Company({ name: "Acme" });
@@ -403,7 +407,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
 // ==========================================================================
 
 describe("TestDestroyAsPartOfAutosaveAssociation", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class Ship extends Base {
     static {
@@ -418,7 +422,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
     }
   }
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
     Ship.adapter = adapter;
     Part.adapter = adapter;
@@ -427,6 +431,7 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
 
     Associations.hasMany.call(Ship, "parts", { autosave: true });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("should destroy the associated models when marked for destruction", async () => {
     const ship = await Ship.create({ name: "HMS Victory" });

--- a/packages/activerecord/src/cache-key.test.ts
+++ b/packages/activerecord/src/cache-key.test.ts
@@ -2,14 +2,15 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA = {
   posts: {
@@ -33,11 +34,13 @@ async function freshAdapter(): Promise<DatabaseAdapter> {
 // CacheKeyTest — targets cache_key_test.rb
 // ==========================================================================
 describe("CacheKeyTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("cache_key format is not too precise", async () => {
     class Post extends Base {

--- a/packages/activerecord/src/core.test.ts
+++ b/packages/activerecord/src/core.test.ts
@@ -2,12 +2,12 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA = {
   topics: { title: "string", author: "string" },
@@ -15,17 +15,18 @@ const TEST_SCHEMA = {
 } as const;
 
 // -- Helpers --
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("CoreTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModel() {
     class Topic extends Base {
@@ -447,10 +448,11 @@ describe("toKey()", () => {
 });
 
 describe("Base features (Rails-guided) - core", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("toParam returns id as string", async () => {
     class User extends Base {

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -2,19 +2,14 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Base, delegatedType, registerModel } from "./index.js";
 import { StringInquirer } from "@blazetrails/activesupport";
 
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -25,14 +20,15 @@ afterAll(() => {
 });
 
 describe("DelegatedTypeTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       entries: { entryable_id: "integer", entryable_type: "string", title: "string" },
       entry2s: { title: "string", custom_type: "string", custom_id: "integer" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -2,13 +2,14 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import { Base, registerModel } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -17,21 +18,17 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
-
 describe("ExplainTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       posts: { title: "string", score: "integer" },
       blogs: { name: "string" },
       articles: { title: "string", blog_id: "integer" },
     });
   });
+  withTransactionalFixtures(() => adapter);
   afterAll(async () => {
     await dropAllTables(adapter);
   });

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -2,12 +2,12 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema, type Schema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   topics: { title: "string" },
@@ -52,17 +52,18 @@ const TEST_SCHEMA: Schema = {
 };
 
 // -- Helpers --
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("PrimaryKeysTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeTopic() {
     class Topic extends Base {
@@ -506,10 +507,11 @@ describe("Base features (Rails-guided) - primary keys", () => {
 });
 
 describe("CompositePrimaryKeyTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("composite primary key", () => {
     class Order extends Base {

--- a/packages/activerecord/src/signed-id.test.ts
+++ b/packages/activerecord/src/signed-id.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base, RecordNotFound, registerSubclass } from "./index.js";
 import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
@@ -10,9 +10,9 @@ import { setSignedIdVerifierSecret, setSignedIdVerifier, signedIdVerifier } from
 import { UnknownPrimaryKey } from "./errors.js";
 import { SignedGlobalID, setApp, _resetApp } from "@blazetrails/globalid";
 
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema, type Schema } from "./test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 // Tables referenced by ad-hoc model classes declared per-test in this
 // file. Each `class X extends Base` derives its table via Rails-style
@@ -30,16 +30,19 @@ const TEST_SCHEMA: Schema = {
   mateys: { columns: { name: "string" }, primaryKey: false },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("SignedIdTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
+  });
+  withTransactionalFixtures(() => adapter);
+  beforeEach(() => {
     setSignedIdVerifierSecret("blazetrails-test-secret");
   });
 

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -7,10 +7,10 @@ import { Base } from "./index.js";
 import { generatesTokenFor, setTokenForSecret } from "./generates-token-for.js";
 import { setSignedIdVerifierSecret } from "./signed-id.js";
 
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -19,15 +19,10 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
-
 describe("TokenForTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       users: { name: "string", password_digest: "string" },
       user_short_expiries: { name: "string", password_digest: "string" },
@@ -39,6 +34,9 @@ describe("TokenForTest", () => {
       cpk_items: { shop_id: "integer", name: "string" },
       no_pk_items: { name: "string" },
     });
+  });
+  withTransactionalFixtures(() => adapter);
+  beforeEach(() => {
     setSignedIdVerifierSecret("blazetrails-test-secret");
     setTokenForSecret("blazetrails-test-token-secret");
   });
@@ -259,12 +257,15 @@ describe("TokenForTest", () => {
 });
 
 describe("TokenForTest", () => {
-  let adapter2: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter2 = freshAdapter();
+  let adapter2: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter2 = createTestAdapter();
     await defineSchema(adapter2, {
       users: { name: "string", password_digest: "string" },
     });
+  });
+  withTransactionalFixtures(() => adapter2);
+  beforeEach(() => {
     setTokenForSecret("blazetrails-test-token-secret");
   });
 

--- a/packages/activerecord/src/validations.test.ts
+++ b/packages/activerecord/src/validations.test.ts
@@ -2,12 +2,12 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA = {
   topics: { title: "string", score: "integer" },
@@ -18,17 +18,18 @@ const TEST_SCHEMA = {
 } as const;
 
 // -- Helpers --
-async function freshAdapter(): Promise<DatabaseAdapter> {
+async function freshAdapter(): Promise<TestDatabaseAdapter> {
   const adapter = createTestAdapter();
   await defineSchema(adapter, TEST_SCHEMA);
   return adapter;
 }
 
 describe("ValidationsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeModel() {
     class Topic extends Base {
@@ -264,10 +265,11 @@ describe("ValidationsTest", () => {
 });
 
 describe("ValidationsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("validates before save", async () => {
     class User extends Base {
@@ -361,10 +363,11 @@ describe("ValidationsTest", () => {
 });
 
 describe("ValidationsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("validate uniqueness", async () => {
     class Email extends Base {


### PR DESCRIPTION
## Summary

Migrates root-level test files from per-test `beforeEach(defineSchema)` to once-per-file (or per-describe) `beforeAll(defineSchema)` + `withTransactionalFixtures()`.

## Files migrated

All clean — no inline DDL inside `it()` bodies:

- `delegated-type.test.ts`
- `explain.test.ts`
- `token-for.test.ts` (2 describes)
- `cache-key.test.ts` (1st describe)
- `autosave.test.ts` (5 describes)
- `primary-keys.test.ts` (2 describes)
- `signed-id.test.ts` (1st describe only; other describes use `freshAdapter()` per-test, left alone)
- `validations.test.ts` (3 of 4 describes; 2nd uses `freshAdapter()` per-test, left alone)
- `core.test.ts` (2 describes)

## Files considered but skipped

- **Inline-DDL hazard** (`defineSchema` / DDL inside `it()` bodies): `timestamp.test.ts`, `aggregations.test.ts`, `locking.test.ts`, `defaults.test.ts`, `schema-dumper.test.ts`
- **Per-test isolated adapter by design**: `transaction-instrumentation.test.ts` (file comment explicitly explains why each test needs a fresh adapter)
- **Model mutation across tests in a shared `Contact` class**: `json-serialization.test.ts`

## Test plan

- [x] `pnpm vitest run` on each migrated file passes locally