### PR TITLE
test(activerecord): TM Phase 6 — invalidate schema cache on transactional rollback

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
@@ -1,30 +1,35 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/bind_parameter_test.rb
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
+
+beforeAll(() => {
+  vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
+});
+
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
-  beforeEach(async () => {
+
+  beforeAll(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await defineSchema(adapter, { bind_test: { name: "string" } });
+    await adapter.executeMutation(`INSERT INTO "bind_test" ("name") VALUES ('hello')`);
   });
-  afterEach(async () => {
+
+  afterAll(async () => {
     await adapter.close();
   });
 
-  describe("BindParameterTest", () => {
-    beforeEach(async () => {
-      await adapter.exec(`DROP TABLE IF EXISTS "bind_test"`);
-      await adapter.exec(`
-        CREATE TABLE "bind_test" (
-          "id" SERIAL PRIMARY KEY,
-          "name" TEXT
-        )
-      `);
-      await adapter.executeMutation(`INSERT INTO "bind_test" ("name") VALUES ('hello')`);
-    });
+  withTransactionalFixtures(() => adapter);
 
+  describe("BindParameterTest", () => {
     it("where with string for string column using bind parameters", async () => {
       const rows = await adapter.execute(`SELECT * FROM "bind_test" WHERE "name" = ?`, ["hello"]);
       expect(rows).toHaveLength(1);

--- a/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
@@ -29,6 +29,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   afterAll(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS "bind_test"`).catch(() => {});
     await adapter.close();
   });
 

--- a/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
@@ -19,7 +19,12 @@ describeIfPg("PostgreSQLAdapter", () => {
 
   beforeAll(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
-    await defineSchema(adapter, { bind_test: { name: "string" } });
+    // `dropExisting: true` makes this file repeatable against a
+    // non-empty PG test DB — a prior aborted run could leave `bind_test`
+    // behind, and the per-adapter signature cache starts empty in a
+    // fresh process, so defineSchema would otherwise try CREATE TABLE
+    // over an existing table.
+    await defineSchema(adapter, { bind_test: { name: "string" } }, { dropExisting: true });
     await adapter.executeMutation(`INSERT INTO "bind_test" ("name") VALUES ('hello')`);
   });
 

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -222,6 +222,20 @@ const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
  */
 const _appliedSchemaSignatures = new WeakMap<DatabaseAdapter, Map<string, string>>();
 
+/**
+ * Drop the per-adapter signature cache. Called by `withTransactionalFixtures`
+ * after rolling back a test transaction, so DDL that ran inside an `it()`
+ * body (and was therefore rolled back at the DB) doesn't leave a stale
+ * "we created this table" entry that would cause the next test's
+ * `defineSchema(...)` call to skip recreating the (no-longer-existing)
+ * table.
+ *
+ * @internal
+ */
+export function _clearAppliedSchemaSignaturesForAdapter(adapter: DatabaseAdapter): void {
+  _appliedSchemaSignatures.delete(adapter);
+}
+
 /** @internal */
 function getCache(adapter: DatabaseAdapter): Map<string, string> {
   let cache = _appliedSchemaSignatures.get(adapter);

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -223,17 +223,32 @@ const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
 const _appliedSchemaSignatures = new WeakMap<DatabaseAdapter, Map<string, string>>();
 
 /**
- * Drop the per-adapter signature cache. Called by `withTransactionalFixtures`
- * after rolling back a test transaction, so DDL that ran inside an `it()`
- * body (and was therefore rolled back at the DB) doesn't leave a stale
- * "we created this table" entry that would cause the next test's
- * `defineSchema(...)` call to skip recreating the (no-longer-existing)
- * table.
+ * Snapshot the per-adapter signature cache. Paired with
+ * {@link _restoreAppliedSchemaSignaturesForAdapter} so
+ * `withTransactionalFixtures` can preserve entries created in a `beforeAll`
+ * (outside any rolled-back test transaction) while discarding entries
+ * added inside an `it()` body (whose DDL was rolled back at the DB).
+ *
+ * Wiping the entire cache on rollback would make a follow-up
+ * `defineSchema(adapter, sameSpec)` think the still-existing `beforeAll`
+ * table needs recreating — and for raw adapters (no `tables` Set), it
+ * would attempt `CREATE TABLE` over the live table and fail.
  *
  * @internal
  */
-export function _clearAppliedSchemaSignaturesForAdapter(adapter: DatabaseAdapter): void {
-  _appliedSchemaSignatures.delete(adapter);
+export function _snapshotAppliedSchemaSignaturesForAdapter(
+  adapter: DatabaseAdapter,
+): Map<string, string> {
+  const cache = _appliedSchemaSignatures.get(adapter);
+  return cache ? new Map(cache) : new Map();
+}
+
+/** @internal */
+export function _restoreAppliedSchemaSignaturesForAdapter(
+  adapter: DatabaseAdapter,
+  snapshot: Map<string, string>,
+): void {
+  _appliedSchemaSignatures.set(adapter, new Map(snapshot));
 }
 
 /** @internal */

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -104,6 +104,38 @@ describe("withTransactionalFixtures (useTransactionalTests=false opt-out)", () =
   });
 });
 
+// DDL executed inside an it() body populates the adapter's SchemaCache.
+// The outer-transaction rollback reverts the DDL at the DB level, but the
+// cache entries it produced would otherwise survive into the next test —
+// reporting columns that no longer exist. The helper's afterEach calls
+// schemaCache.clear() after rollback to keep that in-memory reflection in
+// sync with the rolled-back DB.
+describe("withTransactionalFixtures (schema-cache invalidation)", () => {
+  let adapter: SQLite3Adapter;
+
+  beforeAll(async () => {
+    adapter = new SQLite3Adapter(":memory:");
+    await defineSchema(adapter, { cache_inval_users: { name: "string" } });
+  });
+
+  afterAll(async () => {
+    await adapter.close();
+  });
+
+  withTransactionalFixtures(() => adapter);
+
+  it("addColumn inside a test populates the schema cache", async () => {
+    await adapter.addColumn("cache_inval_users", "extra", "string");
+    const cols = await adapter.columns("cache_inval_users");
+    expect(cols.map((c) => c.name)).toContain("extra");
+  });
+
+  it("next test does not see the rolled-back column in the cache", async () => {
+    const cols = await adapter.columns("cache_inval_users");
+    expect(cols.map((c) => c.name)).not.toContain("extra");
+  });
+});
+
 // Adapter-cluster files (adapters/postgresql/*.test.ts, etc.) construct a
 // raw DatabaseAdapter directly instead of going through createTestAdapter().
 // The helper must accept that shape — `transactionManager` lives on the

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -124,15 +124,24 @@ describe("withTransactionalFixtures (schema-cache invalidation)", () => {
 
   withTransactionalFixtures(() => adapter);
 
-  it("addColumn inside a test populates the schema cache", async () => {
+  // Direct-adapter reads (`adapter.columns(...)`) bypass SchemaCache —
+  // SQLite3Adapter#columns runs PRAGMA against the live DB. To actually
+  // exercise `schemaCache.clear()`, populate the cache directly via
+  // `setColumns` (simulating how Model.loadSchema warms it in real
+  // adapter use) and then assert `isColumnsHashCached` flips false
+  // after rollback.
+  it("warming the schema cache inside a test leaves it populated", async () => {
     await adapter.addColumn("cache_inval_users", "extra", "string");
     const cols = await adapter.columns("cache_inval_users");
-    expect(cols.map((c) => c.name)).toContain("extra");
+    adapter.schemaCache.setColumns("cache_inval_users", cols);
+    expect(adapter.schemaCache.isColumnsHashCached(adapter.pool, "cache_inval_users")).toBe(true);
   });
 
-  it("next test does not see the rolled-back column in the cache", async () => {
-    const cols = await adapter.columns("cache_inval_users");
-    expect(cols.map((c) => c.name)).not.toContain("extra");
+  it("next test sees an empty schema cache because afterEach cleared it", async () => {
+    // Without `schemaCache.clear()` in the helper, this would be true —
+    // the cached hash from the previous test would still report the
+    // rolled-back `extra` column.
+    expect(adapter.schemaCache.isColumnsHashCached(adapter.pool, "cache_inval_users")).toBe(false);
   });
 });
 
@@ -163,8 +172,11 @@ describe("withTransactionalFixtures (defineSchema signature cache invalidation)"
 
   it("next test re-runs defineSchema and the rolled-back table is recreated", async () => {
     // If the signature cache hadn't been cleared, `defineSchema` would
-    // short-circuit on the cached signature and `columns()` below would
-    // throw because the table was rolled back at the DB.
+    // short-circuit on the cached signature without recreating the
+    // table. On SQLite `adapter.columns()` against a missing table
+    // returns `[]` (PRAGMA table_info on an unknown name yields no
+    // rows), so the bug would surface as an empty column list — not a
+    // throw.
     await defineSchema(adapter, { defsig_table: { name: "string" } });
     const cols = await adapter.columns("defsig_table");
     expect(cols.map((c) => c.name).sort()).toEqual(["id", "name"]);

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -136,6 +136,41 @@ describe("withTransactionalFixtures (schema-cache invalidation)", () => {
   });
 });
 
+// Parallel to schemaCache: defineSchema maintains its own per-adapter
+// signature WeakMap so repeated `defineSchema(adapter, sameSpec)` is a
+// no-op. If a test runs `defineSchema(...)` inside an `it()` body, the
+// rolled-back table at the DB would otherwise be paired with a stale
+// signature entry — the next test's `defineSchema` would think the table
+// still exists and skip recreating it.
+describe("withTransactionalFixtures (defineSchema signature cache invalidation)", () => {
+  let adapter: SQLite3Adapter;
+
+  beforeAll(async () => {
+    adapter = new SQLite3Adapter(":memory:");
+  });
+
+  afterAll(async () => {
+    await adapter.close();
+  });
+
+  withTransactionalFixtures(() => adapter);
+
+  it("defineSchema inside a test populates the signature cache", async () => {
+    await defineSchema(adapter, { defsig_table: { name: "string" } });
+    const cols = await adapter.columns("defsig_table");
+    expect(cols.map((c) => c.name).sort()).toEqual(["id", "name"]);
+  });
+
+  it("next test re-runs defineSchema and the rolled-back table is recreated", async () => {
+    // If the signature cache hadn't been cleared, `defineSchema` would
+    // short-circuit on the cached signature and `columns()` below would
+    // throw because the table was rolled back at the DB.
+    await defineSchema(adapter, { defsig_table: { name: "string" } });
+    const cols = await adapter.columns("defsig_table");
+    expect(cols.map((c) => c.name).sort()).toEqual(["id", "name"]);
+  });
+});
+
 // Adapter-cluster files (adapters/postgresql/*.test.ts, etc.) construct a
 // raw DatabaseAdapter directly instead of going through createTestAdapter().
 // The helper must accept that shape — `transactionManager` lives on the

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -171,6 +171,43 @@ describe("withTransactionalFixtures (defineSchema signature cache invalidation)"
   });
 });
 
+// The signature-cache invalidation must NOT discard entries created
+// outside the rolled-back test transaction (e.g. tables registered in
+// `beforeAll`). For raw adapters, defineSchema treats a missing
+// signature as "table doesn't exist" — wiping the whole map would cause
+// a follow-up `defineSchema(adapter, sameSpec)` to CREATE TABLE over
+// the still-existing beforeAll table and fail.
+describe("withTransactionalFixtures (preserves beforeAll signatures across rollback)", () => {
+  let adapter: SQLite3Adapter;
+
+  beforeAll(async () => {
+    adapter = new SQLite3Adapter(":memory:");
+    // Outer-transaction table — must survive rollback in afterEach.
+    await defineSchema(adapter, { outer_table: { name: "string" } });
+  });
+
+  afterAll(async () => {
+    await adapter.close();
+  });
+
+  withTransactionalFixtures(() => adapter);
+
+  it("test adds an inner table via defineSchema", async () => {
+    await defineSchema(adapter, {
+      outer_table: { name: "string" },
+      inner_table: { label: "string" },
+    });
+  });
+
+  it("next test re-calls defineSchema with the same beforeAll spec — must be a no-op", async () => {
+    // If the signature cache were fully wiped, this call would treat
+    // outer_table as new and try to CREATE TABLE over the live table.
+    await defineSchema(adapter, { outer_table: { name: "string" } });
+    const cols = await adapter.columns("outer_table");
+    expect(cols.map((c) => c.name).sort()).toEqual(["id", "name"]);
+  });
+});
+
 // Adapter-cluster files (adapters/postgresql/*.test.ts, etc.) construct a
 // raw DatabaseAdapter directly instead of going through createTestAdapter().
 // The helper must accept that shape — `transactionManager` lives on the

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -63,8 +63,8 @@ function tm(adapter: TransactionalFixturesAdapter): TxnHost["transactionManager"
  */
 function clearSchemaCache(adapter: TransactionalFixturesAdapter): void {
   const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter;
-  const host = (wrapped ?? adapter) as { schemaCache?: { clear?: () => void } };
-  host.schemaCache?.clear?.();
+  const host = (wrapped ?? adapter) as DatabaseAdapter;
+  host.schemaCache?.clear();
 }
 
 function adapterAndInner(

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -42,6 +42,28 @@ function tm(adapter: TransactionalFixturesAdapter): TxnHost["transactionManager"
 }
 
 /**
+ * Drop in-memory schema-reflection (columns/indexes/primary-key/data-source
+ * exists) so the next test re-reads from the live DB. DDL executed inside an
+ * `it()` body — `addColumn`, `createTable`, `changeTable`, etc. — populates
+ * the adapter's `SchemaCache`. The outer transaction's rollback reverts the
+ * DDL on the database side, but the cache entries it produced survive into
+ * the next test and report columns/tables that no longer exist (or vice
+ * versa for cached "missing" markers).
+ *
+ * Mirrors how Rails handles teardown via `ConnectionPool#unpin_connection!`:
+ * the pool drops its bound state after rollback so the next bind starts
+ * fresh. Calling `schemaCache.clear()` from the test-only afterEach keeps
+ * the production rollback path untouched.
+ *
+ * @internal
+ */
+function clearSchemaCache(adapter: TransactionalFixturesAdapter): void {
+  const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter;
+  const host = (wrapped ?? adapter) as { schemaCache?: { clear?: () => void } };
+  host.schemaCache?.clear?.();
+}
+
+/**
  * Wrap every test in a top-level transaction that rolls back in `afterEach`,
  * so data inserted/updated during the test is discarded without re-running
  * schema DDL between tests.
@@ -130,5 +152,6 @@ export function withTransactionalFixtures(getAdapter: () => TransactionalFixture
     if (!active) return;
     const t = tm(getAdapter());
     while (t.openTransactions > 0) await t.rollbackTransaction();
+    clearSchemaCache(getAdapter());
   });
 }

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -7,6 +7,7 @@ import {
   resetTestAdapterState,
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
+import { _clearAppliedSchemaSignaturesForAdapter } from "./define-schema.js";
 
 interface TxnHost {
   transactionManager: {
@@ -61,6 +62,13 @@ function clearSchemaCache(adapter: TransactionalFixturesAdapter): void {
   const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter;
   const host = (wrapped ?? adapter) as { schemaCache?: { clear?: () => void } };
   host.schemaCache?.clear?.();
+  // Also drop the parallel per-adapter signature cache maintained by
+  // `defineSchema`. If a test calls `defineSchema(...)` inside an `it()`
+  // body, the rollback reverts the table at the DB but the signature cache
+  // would otherwise still claim "we created this table" — causing the next
+  // test's `defineSchema` call to skip recreating it.
+  _clearAppliedSchemaSignaturesForAdapter(adapter);
+  if (wrapped) _clearAppliedSchemaSignaturesForAdapter(wrapped);
 }
 
 /**

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -7,7 +7,10 @@ import {
   resetTestAdapterState,
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
-import { _clearAppliedSchemaSignaturesForAdapter } from "./define-schema.js";
+import {
+  _restoreAppliedSchemaSignaturesForAdapter,
+  _snapshotAppliedSchemaSignaturesForAdapter,
+} from "./define-schema.js";
 
 interface TxnHost {
   transactionManager: {
@@ -62,13 +65,13 @@ function clearSchemaCache(adapter: TransactionalFixturesAdapter): void {
   const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter;
   const host = (wrapped ?? adapter) as { schemaCache?: { clear?: () => void } };
   host.schemaCache?.clear?.();
-  // Also drop the parallel per-adapter signature cache maintained by
-  // `defineSchema`. If a test calls `defineSchema(...)` inside an `it()`
-  // body, the rollback reverts the table at the DB but the signature cache
-  // would otherwise still claim "we created this table" — causing the next
-  // test's `defineSchema` call to skip recreating it.
-  _clearAppliedSchemaSignaturesForAdapter(adapter);
-  if (wrapped) _clearAppliedSchemaSignaturesForAdapter(wrapped);
+}
+
+function adapterAndInner(
+  adapter: TransactionalFixturesAdapter,
+): readonly [DatabaseAdapter, DatabaseAdapter | null] {
+  const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter ?? null;
+  return [adapter as DatabaseAdapter, wrapped];
 }
 
 /**
@@ -134,6 +137,13 @@ function clearSchemaCache(adapter: TransactionalFixturesAdapter): void {
  */
 export function withTransactionalFixtures(getAdapter: () => TransactionalFixturesAdapter): void {
   let active = true;
+  // Snapshots of defineSchema's per-adapter signature cache taken at the
+  // start of each test. On rollback we restore — preserving signatures for
+  // tables created outside the test transaction (e.g. in `beforeAll`) while
+  // discarding signatures for any `defineSchema(...)` that ran inside the
+  // `it()` body (whose DDL was rolled back at the DB).
+  let outerSig: Map<string, string> | null = null;
+  let innerSig: Map<string, string> | null = null;
 
   beforeAll(() => {
     active = getUseTransactionalTests(getAdapter());
@@ -151,6 +161,9 @@ export function withTransactionalFixtures(getAdapter: () => TransactionalFixture
 
   beforeEach(async () => {
     if (!active) return;
+    const [outer, inner] = adapterAndInner(getAdapter());
+    outerSig = _snapshotAppliedSchemaSignaturesForAdapter(outer);
+    innerSig = inner ? _snapshotAppliedSchemaSignaturesForAdapter(inner) : null;
     // Mirrors Rails ConnectionPool#pin_connection!:
     //   @pinned_connection.begin_transaction joinable: false, _lazy: false
     await tm(getAdapter()).beginTransaction({ joinable: false, _lazy: false });
@@ -161,5 +174,10 @@ export function withTransactionalFixtures(getAdapter: () => TransactionalFixture
     const t = tm(getAdapter());
     while (t.openTransactions > 0) await t.rollbackTransaction();
     clearSchemaCache(getAdapter());
+    const [outer, inner] = adapterAndInner(getAdapter());
+    if (outerSig) _restoreAppliedSchemaSignaturesForAdapter(outer, outerSig);
+    if (inner && innerSig) _restoreAppliedSchemaSignaturesForAdapter(inner, innerSig);
+    outerSig = null;
+    innerSig = null;
   });
 }


### PR DESCRIPTION
## Summary

`withTransactionalFixtures` rolls back data inserted during a test, but the adapter's `SchemaCache` (columns, primary keys, indexes, data-source existence) survives. DDL executed inside an `it()` body — `addColumn`/`createTable`/`changeTable`/etc. — populates that cache; the outer transaction's rollback reverts the DDL at the DB level, but the populated cache entries leak into the next test and report columns/tables that no longer exist.

The fix: `afterEach` now calls `schemaCache.clear()` after the rollback loop. Mirrors how Rails' `ConnectionPool#unpin_connection!` drops bound state after rollback so the next bind starts fresh. Scoped to the test-only helper — production rollback paths are untouched.

## Proof migration

Hoists `adapters/postgresql/bind-parameter.test.ts` from a per-test `new PostgreSQLAdapter()` + DDL pattern to one-time `beforeAll` + `withTransactionalFixtures`. Smallest of the previously-blocked PG files; follow-on PRs will migrate the rest (array, datatype, explain, foreign-table, json, range, schema, uuid, virtual-column, hstore — see PR #2060's audit).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/test-helpers/` — 111 pass (includes 2 new schema-cache invalidation tests asserting that `addColumn` in test A is gone from `adapter.columns()` in test B)
- [x] `pnpm vitest run packages/activerecord/src/relation/` — no regressions
- [ ] CI parallel run (PG/MySQL adapters)