### PR TITLE
refactor(actionpack): CSP bare-directive sentinel + DSL clear-on-empty parity

### DIFF
--- a/packages/actionpack/src/action-dispatch/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/content-security-policy.ts
@@ -2,5 +2,7 @@ export {
   ContentSecurityPolicy,
   MAPPINGS,
   type CSPSource,
+  type CSPSourceOrClear,
   type CspSymbol,
+  type DirectiveValue,
 } from "./http/content-security-policy.js";

--- a/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
@@ -313,7 +313,7 @@ describe("ContentSecurityPolicyTest", () => {
   it("DSL with falsy first arg clears the directive", () => {
     const policy = new ContentSecurityPolicy();
     policy.scriptSrc("'self'");
-    policy.scriptSrc(null as unknown as string);
+    policy.scriptSrc(null);
     expect(policy.hasDirective("script-src")).toBe(false);
   });
 

--- a/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
@@ -317,6 +317,14 @@ describe("ContentSecurityPolicyTest", () => {
     expect(policy.hasDirective("script-src")).toBe(false);
   });
 
+  // Ruby truthiness: empty string stays truthy, so DSL with "" preserves the
+  // directive (content_security_policy.rb:189-197).
+  it("DSL with empty-string first arg keeps the directive (Ruby truthiness)", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.scriptSrc("");
+    expect(policy.hasDirective("script-src")).toBe(true);
+  });
+
   // Bare directives store the `true` sentinel (Rails parity).
   it("block_all_mixed_content stores true sentinel", () => {
     const policy = new ContentSecurityPolicy();

--- a/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
@@ -270,27 +270,6 @@ describe("ContentSecurityPolicyTest", () => {
     policy.trustedTypes("default");
     expect(policy.build()).toBe("trusted-types default");
   });
-});
-
-describe("ContentSecurityPolicyIntegrationTest", () => {
-  it("adds nonce to script src content security policy", () => {
-    const policy = new ContentSecurityPolicy();
-    policy.scriptSrc("'self'");
-    const header = policy.build(undefined, "abc123");
-    expect(header).toContain("'nonce-abc123'");
-  });
-
-  it("adds nonce to style src content security policy", () => {
-    const policy = new ContentSecurityPolicy();
-    policy.styleSrc("'self'");
-    const header = policy.build(undefined, "xyz789");
-    expect(header).toContain("'nonce-xyz789'");
-  });
-
-  it("generates no content security policy", () => {
-    const policy = new ContentSecurityPolicy();
-    expect(policy.build()).toBe("");
-  });
 
   // Rails: test_mappings — every MAPPINGS key resolves through a fetch
   // directive (content_security_policy_test.rb).
@@ -317,7 +296,7 @@ describe("ContentSecurityPolicyIntegrationTest", () => {
 
   // Rails: test_raises_runtime_error_when_unexpected_source — Proc returns
   // an unexpected (non-string) value.
-  it("unexpected dynamic source raises", () => {
+  it("raises runtime error when unexpected source", () => {
     const policy = new ContentSecurityPolicy();
     policy.defaultSrc(() => 42 as unknown as string);
     expect(() => policy.build({})).toThrow(/Unexpected|Invalid/);
@@ -359,7 +338,7 @@ describe("ContentSecurityPolicyIntegrationTest", () => {
   });
 
   // Rails: test_whitespace_validation — embedded whitespace raises.
-  it("whitespace in source raises InvalidDirectiveError", () => {
+  it("whitespace validation", () => {
     const policy = new ContentSecurityPolicy();
     policy.defaultSrc("foo bar");
     expect(() => policy.build()).toThrow(/whitespace or semicolons/);
@@ -371,6 +350,27 @@ describe("ContentSecurityPolicyIntegrationTest", () => {
     const copy = policy.dup();
     expect(copy.getDirectives().get("upgrade-insecure-requests")).toBe(true);
     expect(copy.build()).toBe("upgrade-insecure-requests");
+  });
+});
+
+describe("ContentSecurityPolicyIntegrationTest", () => {
+  it("adds nonce to script src content security policy", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.scriptSrc("'self'");
+    const header = policy.build(undefined, "abc123");
+    expect(header).toContain("'nonce-abc123'");
+  });
+
+  it("adds nonce to style src content security policy", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.styleSrc("'self'");
+    const header = policy.build(undefined, "xyz789");
+    expect(header).toContain("'nonce-xyz789'");
+  });
+
+  it("generates no content security policy", () => {
+    const policy = new ContentSecurityPolicy();
+    expect(policy.build()).toBe("");
   });
 });
 

--- a/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/content-security-policy.test.ts
@@ -291,6 +291,87 @@ describe("ContentSecurityPolicyIntegrationTest", () => {
     const policy = new ContentSecurityPolicy();
     expect(policy.build()).toBe("");
   });
+
+  // Rails: test_mappings — every MAPPINGS key resolves through a fetch
+  // directive (content_security_policy_test.rb).
+  it("mappings table is exhaustive", () => {
+    for (const [key, expected] of Object.entries(MAPPINGS)) {
+      const policy = new ContentSecurityPolicy();
+      policy.defaultSrc(`:${key}`);
+      expect(policy.build()).toBe(`default-src ${expected}`);
+    }
+  });
+
+  // Rails: test_dynamic_directives — Proc returning Array<String> flattens.
+  it("dynamic directive returning array of sources", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.defaultSrc(() => ["https://a.example", "https://b.example"]);
+    expect(policy.build({})).toBe("default-src https://a.example https://b.example");
+  });
+
+  // Rails: test_invalid_directive_source — non-string/non-proc raises.
+  it("invalid directive source raises", () => {
+    const policy = new ContentSecurityPolicy();
+    expect(() => policy.defaultSrc(123 as unknown as string)).toThrow(/Invalid/);
+  });
+
+  // Rails: test_raises_runtime_error_when_unexpected_source — Proc returns
+  // an unexpected (non-string) value.
+  it("unexpected dynamic source raises", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.defaultSrc(() => 42 as unknown as string);
+    expect(() => policy.build({})).toThrow(/Unexpected|Invalid/);
+  });
+
+  // Rails: DSL with no args deletes the directive (content_security_policy.rb:189).
+  it("DSL with no args clears the directive", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.scriptSrc("'self'");
+    policy.scriptSrc();
+    expect(policy.hasDirective("script-src")).toBe(false);
+  });
+
+  it("DSL with falsy first arg clears the directive", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.scriptSrc("'self'");
+    policy.scriptSrc(null as unknown as string);
+    expect(policy.hasDirective("script-src")).toBe(false);
+  });
+
+  // Bare directives store the `true` sentinel (Rails parity).
+  it("block_all_mixed_content stores true sentinel", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.blockAllMixedContent();
+    expect(policy.getDirectives().get("block-all-mixed-content")).toBe(true);
+  });
+
+  it("upgrade_insecure_requests stores true sentinel", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.upgradeInsecureRequests();
+    expect(policy.getDirectives().get("upgrade-insecure-requests")).toBe(true);
+  });
+
+  it("sandbox with no args stores true sentinel", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.sandbox();
+    expect(policy.getDirectives().get("sandbox")).toBe(true);
+    expect(policy.build()).toBe("sandbox");
+  });
+
+  // Rails: test_whitespace_validation — embedded whitespace raises.
+  it("whitespace in source raises InvalidDirectiveError", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.defaultSrc("foo bar");
+    expect(() => policy.build()).toThrow(/whitespace or semicolons/);
+  });
+
+  it("dup preserves bare-directive sentinel", () => {
+    const policy = new ContentSecurityPolicy();
+    policy.upgradeInsecureRequests();
+    const copy = policy.dup();
+    expect(copy.getDirectives().get("upgrade-insecure-requests")).toBe(true);
+    expect(copy.build()).toBe("upgrade-insecure-requests");
+  });
 });
 
 describe("DefaultContentSecurityPolicyIntegrationTest", () => {

--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -40,6 +40,14 @@ export type CspSymbol = `:${keyof typeof MAPPINGS}`;
 export type CSPSource = CspSymbol | (string & {}) | ((request?: unknown) => string | string[]);
 
 /**
+ * What a directive setter accepts in its rest list. Rails treats only
+ * `nil`/`false` as falsy (content_security_policy.rb:189-197), so callers
+ * may pass `null`/`false` as the first arg to clear a directive without
+ * an unsafe cast.
+ */
+export type CSPSourceOrClear = CSPSource | null | false;
+
+/**
  * Rails' default nonce-eligible directives. Mirrors
  * `DEFAULT_NONCE_DIRECTIVES = %w[script-src style-src]`
  * (actionpack/lib/action_dispatch/http/content_security_policy.rb:174).
@@ -70,67 +78,67 @@ export class ContentSecurityPolicy {
 
   // --- Directive setters ---
 
-  defaultSrc(...sources: CSPSource[]): this {
+  defaultSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("default-src", sources);
   }
-  scriptSrc(...sources: CSPSource[]): this {
+  scriptSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("script-src", sources);
   }
-  scriptSrcAttr(...sources: CSPSource[]): this {
+  scriptSrcAttr(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("script-src-attr", sources);
   }
-  scriptSrcElem(...sources: CSPSource[]): this {
+  scriptSrcElem(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("script-src-elem", sources);
   }
-  styleSrc(...sources: CSPSource[]): this {
+  styleSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("style-src", sources);
   }
-  styleSrcAttr(...sources: CSPSource[]): this {
+  styleSrcAttr(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("style-src-attr", sources);
   }
-  styleSrcElem(...sources: CSPSource[]): this {
+  styleSrcElem(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("style-src-elem", sources);
   }
-  imgSrc(...sources: CSPSource[]): this {
+  imgSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("img-src", sources);
   }
-  fontSrc(...sources: CSPSource[]): this {
+  fontSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("font-src", sources);
   }
-  connectSrc(...sources: CSPSource[]): this {
+  connectSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("connect-src", sources);
   }
-  mediaSrc(...sources: CSPSource[]): this {
+  mediaSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("media-src", sources);
   }
-  objectSrc(...sources: CSPSource[]): this {
+  objectSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("object-src", sources);
   }
-  frameSrc(...sources: CSPSource[]): this {
+  frameSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("frame-src", sources);
   }
-  childSrc(...sources: CSPSource[]): this {
+  childSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("child-src", sources);
   }
-  workerSrc(...sources: CSPSource[]): this {
+  workerSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("worker-src", sources);
   }
-  frameAncestors(...sources: CSPSource[]): this {
+  frameAncestors(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("frame-ancestors", sources);
   }
-  formAction(...sources: CSPSource[]): this {
+  formAction(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("form-action", sources);
   }
-  baseUri(...sources: CSPSource[]): this {
+  baseUri(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("base-uri", sources);
   }
-  manifestSrc(...sources: CSPSource[]): this {
+  manifestSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("manifest-src", sources);
   }
-  prefetchSrc(...sources: CSPSource[]): this {
+  prefetchSrc(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("prefetch-src", sources);
   }
-  navigateTo(...sources: CSPSource[]): this {
+  navigateTo(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("navigate-to", sources);
   }
   sandbox(...sources: [false] | CSPSource[]): this {
@@ -158,10 +166,10 @@ export class ContentSecurityPolicy {
     }
     return this.setDirective("plugin-types", sources as CSPSource[]);
   }
-  reportUri(...sources: CSPSource[]): this {
+  reportUri(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("report-uri", sources);
   }
-  reportTo(...sources: CSPSource[]): this {
+  reportTo(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("report-to", sources);
   }
   blockAllMixedContent(enabled: boolean | null = true): this {
@@ -182,13 +190,13 @@ export class ContentSecurityPolicy {
     this.directives.set("upgrade-insecure-requests", true);
     return this;
   }
-  requireSriFor(...sources: CSPSource[]): this {
+  requireSriFor(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("require-sri-for", sources);
   }
-  requireTrustedTypesFor(...sources: CSPSource[]): this {
+  requireTrustedTypesFor(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("require-trusted-types-for", sources);
   }
-  trustedTypes(...sources: CSPSource[]): this {
+  trustedTypes(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("trusted-types", sources);
   }
 
@@ -199,16 +207,16 @@ export class ContentSecurityPolicy {
    * or `policy.scriptSrc(null)` removes the directive instead of setting an
    * empty list.
    */
-  private setDirective(name: string, sources: CSPSource[]): this {
+  private setDirective(name: string, sources: CSPSourceOrClear[]): this {
     // Rails `if sources.first` uses Ruby truthiness: only nil/false are falsy.
     // Empty strings stay truthy, so `policy.scriptSrc("")` must set the
     // directive (matching content_security_policy.rb:189-197).
-    const first = sources[0] as CSPSource | false | null | undefined;
+    const first = sources[0];
     if (sources.length === 0 || first == null || first === false) {
       this.directives.delete(name);
       return this;
     }
-    this.directives.set(name, this.applyMappings(sources));
+    this.directives.set(name, this.applyMappings(sources as CSPSource[]));
     return this;
   }
 

--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -200,7 +200,11 @@ export class ContentSecurityPolicy {
    * empty list.
    */
   private setDirective(name: string, sources: CSPSource[]): this {
-    if (sources.length === 0 || !sources[0]) {
+    // Rails `if sources.first` uses Ruby truthiness: only nil/false are falsy.
+    // Empty strings stay truthy, so `policy.scriptSrc("")` must set the
+    // directive (matching content_security_policy.rb:189-197).
+    const first = sources[0] as CSPSource | false | null | undefined;
+    if (sources.length === 0 || first == null || first === false) {
       this.directives.delete(name);
       return this;
     }

--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -141,7 +141,7 @@ export class ContentSecurityPolicy {
   navigateTo(...sources: CSPSourceOrClear[]): this {
     return this.setDirective("navigate-to", sources);
   }
-  sandbox(...sources: [false] | CSPSource[]): this {
+  sandbox(...sources: CSPSourceOrClear[]): this {
     // Rails: empty `*values` → bare directive (stored as `true`); `values.first`
     // nil/false → delete. Ruby truthiness only treats nil/false as falsy —
     // empty strings stay truthy.
@@ -156,7 +156,7 @@ export class ContentSecurityPolicy {
     }
     return this.setDirective("sandbox", sources as CSPSource[]);
   }
-  pluginTypes(...sources: [false] | CSPSource[]): this {
+  pluginTypes(...sources: CSPSourceOrClear[]): this {
     // Rails: `if types.first` — only nil/false delete (Ruby truthiness, so
     // empty string stays truthy and is passed through to the directive).
     const first = sources[0];

--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -54,8 +54,15 @@ type DirectiveName = string;
  */
 export class InvalidDirectiveError extends Error {}
 
+/**
+ * Shape of a stored directive. Rails uses `true` as a sentinel for bare
+ * directives that emit just the directive name (e.g. `upgrade-insecure-requests`)
+ * with no source list. Arrays are emitted as `name source1 source2 ...`.
+ */
+export type DirectiveValue = CSPSource[] | true;
+
 export class ContentSecurityPolicy {
-  private directives: Map<DirectiveName, CSPSource[]> = new Map();
+  private directives: Map<DirectiveName, DirectiveValue> = new Map();
 
   constructor(init?: (policy: ContentSecurityPolicy) => void) {
     if (init) init(this);
@@ -127,10 +134,11 @@ export class ContentSecurityPolicy {
     return this.setDirective("navigate-to", sources);
   }
   sandbox(...sources: [false] | CSPSource[]): this {
-    // Rails: empty `*values` → bare directive; `values.first` nil/false → delete.
-    // Ruby truthiness only treats nil/false as falsy — empty strings stay truthy.
+    // Rails: empty `*values` → bare directive (stored as `true`); `values.first`
+    // nil/false → delete. Ruby truthiness only treats nil/false as falsy —
+    // empty strings stay truthy.
     if (sources.length === 0) {
-      this.directives.set("sandbox", []);
+      this.directives.set("sandbox", true);
       return this;
     }
     const first = sources[0];
@@ -157,19 +165,22 @@ export class ContentSecurityPolicy {
     return this.setDirective("report-to", sources);
   }
   blockAllMixedContent(enabled: boolean | null = true): this {
-    // Rails `if enabled`: only nil/false delete; numeric/empty-string stay truthy.
+    // Rails `if enabled`: only nil/false delete; numeric/empty-string stay
+    // truthy. Bare directives store `true` (Rails parity, content_security_policy.rb:212-218).
     if (enabled === false || enabled == null) {
       this.directives.delete("block-all-mixed-content");
       return this;
     }
-    return this.setDirective("block-all-mixed-content", []);
+    this.directives.set("block-all-mixed-content", true);
+    return this;
   }
   upgradeInsecureRequests(enabled: boolean | null = true): this {
     if (enabled === false || enabled == null) {
       this.directives.delete("upgrade-insecure-requests");
       return this;
     }
-    return this.setDirective("upgrade-insecure-requests", []);
+    this.directives.set("upgrade-insecure-requests", true);
+    return this;
   }
   requireSriFor(...sources: CSPSource[]): this {
     return this.setDirective("require-sri-for", sources);
@@ -181,8 +192,18 @@ export class ContentSecurityPolicy {
     return this.setDirective("trusted-types", sources);
   }
 
-  /** @internal */
+  /**
+   * @internal
+   * Mirrors Rails' `DIRECTIVES.each { ... if sources.first ... else delete }`
+   * (content_security_policy.rb:189-197). A bare call like `policy.scriptSrc()`
+   * or `policy.scriptSrc(null)` removes the directive instead of setting an
+   * empty list.
+   */
   private setDirective(name: string, sources: CSPSource[]): this {
+    if (sources.length === 0 || !sources[0]) {
+      this.directives.delete(name);
+      return this;
+    }
     this.directives.set(name, this.applyMappings(sources));
     return this;
   }
@@ -241,14 +262,14 @@ export class ContentSecurityPolicy {
   ): (string | null)[] {
     const out: (string | null)[] = [];
     for (const [directive, sources] of this.directives) {
-      if (Array.isArray(sources) && sources.length > 0) {
+      if (Array.isArray(sources)) {
         const built = this.buildDirective(directive, sources, context).join(" ");
         if (nonce && this.isNonceDirective(directive, nonceDirectives)) {
           out.push(`${directive} ${built} 'nonce-${nonce}'`);
         } else {
           out.push(`${directive} ${built}`);
         }
-      } else if (sources) {
+      } else if (sources === true) {
         // Bare directive (no sources) — e.g. `block-all-mixed-content`.
         out.push(directive);
       } else {
@@ -329,14 +350,14 @@ export class ContentSecurityPolicy {
   dup(): ContentSecurityPolicy {
     const copy = new ContentSecurityPolicy();
     for (const [k, v] of this.directives) {
-      copy.directives.set(k, [...v]);
+      copy.directives.set(k, v === true ? true : [...v]);
     }
     return copy;
   }
 
   // --- Inspection ---
 
-  getDirectives(): Map<DirectiveName, CSPSource[]> {
+  getDirectives(): Map<DirectiveName, DirectiveValue> {
     return new Map(this.directives);
   }
 

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -57,7 +57,9 @@ export {
   ContentSecurityPolicy,
   MAPPINGS,
   type CSPSource,
+  type CSPSourceOrClear,
   type CspSymbol,
+  type DirectiveValue,
 } from "./http/content-security-policy.js";
 export { ContentSecurityPolicyMiddleware } from "./middleware/content-security-policy.js";
 export { redirectTo, redirectBack, type RedirectResult } from "./redirect.js";


### PR DESCRIPTION
## Summary

Rails-parity polish on `ActionDispatch::ContentSecurityPolicy` (followup to #1948 / #1998):

- **Bare directives store the `true` sentinel** (Rails `content_security_policy.rb:212-218`). `blockAllMixedContent`, `upgradeInsecureRequests`, and zero-arg `sandbox()` set `directives[name] = true` instead of `[]`. `buildDirectives` now emits the directive name when it sees `true` (replacing the previous `Array.isArray && length===0` branch).
- **DSL clear-on-empty.** `setDirective(name, [])` (or with a falsy first arg) now deletes the directive, matching Rails `DIRECTIVES.each { |...| if sources.first ... else @directives.delete(directive) end }`.
- **11 missing tests** ported from Rails `dispatch/content_security_policy_test.rb`: MAPPINGS exhaustiveness, dynamic-source-returning-array, invalid/unexpected source raises, whitespace validation, DSL clear-on-empty (both no-args and falsy-first), sentinel storage for bare directives, and `dup()` preserving the sentinel.

`getDirectives()` return type widened to `Map<string, CSPSource[] | true>` (new exported `DirectiveValue` type).

## Followups not included

- Item 1 from the bundled prompt (middleware nonce port, helperMethod wiring) — already landed in #1948 / base.ts:843 / #2058, no work remained.
- Item 3 `_routes` widening on `UrlForHost` — left for a separate PR; the narrow shape didn't clearly block any callsite, want a concrete consumer before changing the contract.
- 2 further CSP DefaultContentSecurityPolicyIntegrationTest cases (controller-mounted) depend on RouteSet `#call` + ActionController integration; tracked in `docs/actioncontroller-100-percent.md`.

## Test plan

- [x] `pnpm vitest run` on the three CSP test files (74/74 pass)
- [x] `pnpm --filter actionpack build` clean
- [x] `pnpm typecheck` clean