### PR TITLE
feat(actionpack): URL-form paths in routing assertions + defaultCharset in public-exceptions

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/public-exceptions.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/public-exceptions.test.ts
@@ -114,4 +114,38 @@ describe("PublicExceptions", () => {
       Response.defaultCharset = prior;
     }
   });
+
+  it("computes content-length from bytes of the negotiated charset", async () => {
+    const prior = Response.defaultCharset;
+    const priorBody = "<h1>500</h1>";
+    try {
+      // Non-ASCII payload makes the utf-8 vs latin1 byte-count divergence
+      // observable: "résumé" is 8 bytes UTF-8, 6 bytes Latin-1.
+      writeFileSync(path.join(publicPath, "500.html"), "résumé");
+
+      Response.defaultCharset = "utf-8";
+      const utf8 = await app.call({ PATH_INFO: "/500", HTTP_ACCEPT: "text/html" });
+      expect(utf8[1]["content-length"]).toBe(String(Buffer.byteLength("résumé", "utf-8")));
+
+      Response.defaultCharset = "iso-8859-1";
+      const latin = await app.call({ PATH_INFO: "/500", HTTP_ACCEPT: "text/html" });
+      expect(latin[1]["content-length"]).toBe(String(Buffer.byteLength("résumé", "latin1")));
+    } finally {
+      Response.defaultCharset = prior;
+      writeFileSync(path.join(publicPath, "500.html"), priorBody);
+    }
+  });
+
+  it("falls back to utf-8 header + bytes when defaultCharset is unknown", async () => {
+    const prior = Response.defaultCharset;
+    try {
+      Response.defaultCharset = "x-bogus-charset";
+      const res = await app.call({ PATH_INFO: "/500", HTTP_ACCEPT: "application/json" });
+      expect(res[1]["content-type"]).toBe("application/json; charset=utf-8");
+      const body = await bodyToString(res[2]);
+      expect(res[1]["content-length"]).toBe(String(Buffer.byteLength(body, "utf-8")));
+    } finally {
+      Response.defaultCharset = prior;
+    }
+  });
 });

--- a/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
@@ -75,18 +75,19 @@ export class PublicExceptions {
 
   private renderFormat(status: number, contentType: MimeType, body: string): RackResponse {
     const charset = Response.defaultCharset;
-    // Buffer.byteLength accepts the same encoding tokens Rails ships
-    // (`Response.default_charset` defaults to "utf-8"); narrow to known
-    // values so a misconfigured charset can't crash the error middleware.
-    const enc: BufferEncoding =
-      charset === "utf-8" || charset === "utf8" || charset === "latin1" || charset === "ascii"
-        ? (charset as BufferEncoding)
-        : "utf-8";
+    // Map common Rails charset tokens (which match the values shipped via
+    // `ActionDispatch::Response.default_charset=`) to a Node BufferEncoding
+    // so `Buffer.byteLength` measures the same bytes the `content-type`
+    // header advertises. Unknown tokens fall back to "utf-8" *and* the
+    // header is rewritten to match so `content-length` stays consistent.
+    const enc = normalizeCharset(charset);
+    const effectiveCharset =
+      enc === "utf-8" && charset.toLowerCase() !== "utf-8" ? "utf-8" : charset;
     const bytes = Buffer.byteLength(body, enc);
     return [
       status,
       {
-        "content-type": `${contentType}; charset=${charset}`,
+        "content-type": `${contentType}; charset=${effectiveCharset}`,
         "content-length": String(bytes),
       },
       bodyFromString(body),
@@ -112,6 +113,29 @@ export class PublicExceptions {
       return this.renderFormat(status, htmlType, html);
     }
     return [404, { [X_CASCADE]: "pass" }, emptyBody()];
+  }
+}
+
+function normalizeCharset(charset: string): BufferEncoding {
+  switch (charset.toLowerCase()) {
+    case "utf-8":
+    case "utf8":
+      return "utf-8";
+    case "utf-16le":
+    case "utf16le":
+    case "ucs-2":
+    case "ucs2":
+      return "utf16le";
+    case "iso-8859-1":
+    case "iso8859-1":
+    case "latin1":
+    case "latin-1":
+      return "latin1";
+    case "us-ascii":
+    case "ascii":
+      return "ascii";
+    default:
+      return "utf-8";
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
@@ -18,12 +18,16 @@
 
 import { I18n, getFs, getPath } from "@blazetrails/activesupport";
 import type { RackBody, RackEnv, RackResponse } from "@blazetrails/rack";
-import { bodyFromString, HTTP_STATUS_CODES } from "@blazetrails/rack";
+import { HTTP_STATUS_CODES } from "@blazetrails/rack";
 import { X_CASCADE } from "../constants.js";
 import { MimeType } from "../http/mime-type.js";
 import { Response } from "../http/response.js";
 
 async function* emptyBody(): RackBody {}
+
+async function* bodyFromBytes(bytes: Uint8Array): RackBody {
+  yield bytes;
+}
 
 const LOCALE_RE = /^[A-Za-z0-9_-]+$/;
 
@@ -75,22 +79,20 @@ export class PublicExceptions {
 
   private renderFormat(status: number, contentType: MimeType, body: string): RackResponse {
     const charset = Response.defaultCharset;
-    // Map common Rails charset tokens (which match the values shipped via
-    // `ActionDispatch::Response.default_charset=`) to a Node BufferEncoding
-    // so `Buffer.byteLength` measures the same bytes the `content-type`
-    // header advertises. Unknown tokens fall back to "utf-8" *and* the
-    // header is rewritten to match so `content-length` stays consistent.
+    // Encode the body into bytes that match the negotiated charset so the
+    // `content-type` header, `content-length`, and wire bytes all agree.
+    // Unknown tokens fall back to utf-8 with the header rewritten to match.
     const enc = normalizeCharset(charset);
     const effectiveCharset =
       enc === "utf-8" && charset.toLowerCase() !== "utf-8" ? "utf-8" : charset;
-    const bytes = Buffer.byteLength(body, enc);
+    const encoded = Buffer.from(body, enc);
     return [
       status,
       {
         "content-type": `${contentType}; charset=${effectiveCharset}`,
-        "content-length": String(bytes),
+        "content-length": String(encoded.byteLength),
       },
-      bodyFromString(body),
+      bodyFromBytes(encoded),
     ];
   }
 

--- a/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/public-exceptions.ts
@@ -74,11 +74,19 @@ export class PublicExceptions {
   }
 
   private renderFormat(status: number, contentType: MimeType, body: string): RackResponse {
-    const bytes = Buffer.byteLength(body, "utf-8");
+    const charset = Response.defaultCharset;
+    // Buffer.byteLength accepts the same encoding tokens Rails ships
+    // (`Response.default_charset` defaults to "utf-8"); narrow to known
+    // values so a misconfigured charset can't crash the error middleware.
+    const enc: BufferEncoding =
+      charset === "utf-8" || charset === "utf8" || charset === "latin1" || charset === "ascii"
+        ? (charset as BufferEncoding)
+        : "utf-8";
+    const bytes = Buffer.byteLength(body, enc);
     return [
       status,
       {
-        "content-type": `${contentType}; charset=${Response.defaultCharset}`,
+        "content-type": `${contentType}; charset=${charset}`,
         "content-length": String(bytes),
       },
       bodyFromString(body),

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts
@@ -53,6 +53,23 @@ describe("assertRecognizes", () => {
     bad(() => assertRecognizes.call(h, { controller: "wrong", action: "x" }, "/items"));
     bad(() => assertRecognizes.call(h, { controller: "items", action: "index" }, "/nope"));
   });
+
+  it("accepts a full URL and recognizes its path segment", () => {
+    ok(() =>
+      assertRecognizes.call(
+        h,
+        { controller: "items", action: "index" },
+        "http://example.com/items",
+      ),
+    );
+    ok(() =>
+      assertRecognizes.call(
+        h,
+        { controller: "items", action: "create" },
+        { path: "https://example.com:8080/items", method: "post" },
+      ),
+    );
+  });
 });
 
 describe("assertGenerates", () => {
@@ -73,6 +90,16 @@ describe("assertGenerates", () => {
   it("throws on path mismatch", () => {
     bad(() => assertGenerates.call(h, "/wrong", { controller: "items", action: "index" }));
   });
+  it("accepts a full URL and uses its path segment for comparison", () => {
+    const h = buildHost();
+    ok(() =>
+      assertGenerates.call(h, "http://example.com/items", {
+        controller: "items",
+        action: "index",
+      }),
+    );
+  });
+
   it("accepts use_route: Symbol via Symbol#description (Rails parity)", () => {
     const host: RoutingAssertionsHost = { routes: new RouteSet() };
     host.routes!.draw((m) => m.get("/items", { to: "items#index", as: "items" }));

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -135,8 +135,15 @@ export function assertGenerates(
   let path: string;
   if (URL_FORM_RE.test(expectedPath)) {
     // Rails: `URI.parse(expected_path).path` (falls back to "/" when empty).
+    // Ruby's URI accepts relative inputs that contain `://` (e.g. inside a
+    // query string), so use a base URL when WHATWG's absolute parse fails.
     path = failOn(TypeError, message, () => {
-      const parsed = new URL(expectedPath);
+      let parsed: URL;
+      try {
+        parsed = new URL(expectedPath);
+      } catch {
+        parsed = new URL(expectedPath, "http://localhost");
+      }
       return parsed.pathname === "" ? "/" : parsed.pathname;
     });
   } else {
@@ -199,24 +206,35 @@ export function recognizedRequestFor(
 
   const request = new TestRequest();
   if (URL_FORM_RE.test(pathStr)) {
-    // Rails: when path is a full URL, populate rack.url_scheme + host/port from
-    // the parsed URI and use only its path segment for recognition.
-    const parsed = failOn(TypeError, msg, () => new URL(pathStr));
-    const scheme = parsed.protocol.replace(/:$/, "");
-    request.env["rack.url_scheme"] = scheme;
-    request.env["HTTP_HOST"] = parsed.host;
-    request.env["SERVER_NAME"] = parsed.hostname;
-    // Rails: `request.port = uri.port if uri.port`. Ruby's URI yields the
-    // scheme's default port for known schemes (80 for http, 443 for https)
-    // and nil for unknown schemes, so the port stays unchanged in that
-    // case. WHATWG URL returns "" for default ports, so reapply defaults
-    // for http/https only and leave SERVER_PORT alone otherwise.
-    if (parsed.port) {
-      request.env["SERVER_PORT"] = parsed.port;
-    } else if (scheme === "https") {
-      request.env["SERVER_PORT"] = "443";
-    } else if (scheme === "http") {
-      request.env["SERVER_PORT"] = "80";
+    // Rails uses Ruby's `URI.parse`, which is more permissive than
+    // WHATWG `URL`: a relative path that happens to contain `://` (e.g.
+    // `/items?next=http://example.com`) parses to a `URI::Generic` with
+    // no scheme/host/port. Mirror that by attempting an absolute parse
+    // first and falling back to a base URL when WHATWG rejects the input.
+    let parsed: URL;
+    let isAbsolute = true;
+    try {
+      parsed = new URL(pathStr);
+    } catch {
+      isAbsolute = false;
+      parsed = failOn(TypeError, msg, () => new URL(pathStr, "http://localhost"));
+    }
+    if (isAbsolute) {
+      const scheme = parsed.protocol.replace(/:$/, "");
+      request.env["rack.url_scheme"] = scheme;
+      if (parsed.host) request.env["HTTP_HOST"] = parsed.host;
+      if (parsed.hostname) request.env["SERVER_NAME"] = parsed.hostname;
+      // Rails: `request.port = uri.port if uri.port`. Ruby's URI yields
+      // the default port for known schemes (80/443) and nil otherwise.
+      // WHATWG URL returns "" for default ports, so reapply defaults for
+      // http/https only and leave SERVER_PORT alone for other schemes.
+      if (parsed.port) {
+        request.env["SERVER_PORT"] = parsed.port;
+      } else if (scheme === "https") {
+        request.env["SERVER_PORT"] = "443";
+      } else if (scheme === "http") {
+        request.env["SERVER_PORT"] = "80";
+      }
     }
     pathStr = parsed.pathname || "/";
   } else if (!pathStr.startsWith("/")) {

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -202,10 +202,15 @@ export function recognizedRequestFor(
     // Rails: when path is a full URL, populate rack.url_scheme + host/port from
     // the parsed URI and use only its path segment for recognition.
     const parsed = failOn(TypeError, msg, () => new URL(pathStr));
-    request.env["rack.url_scheme"] = parsed.protocol.replace(/:$/, "");
+    const scheme = parsed.protocol.replace(/:$/, "");
+    request.env["rack.url_scheme"] = scheme;
     request.env["HTTP_HOST"] = parsed.host;
     request.env["SERVER_NAME"] = parsed.hostname;
-    if (parsed.port) request.env["SERVER_PORT"] = parsed.port;
+    // Rails: `request.port = uri.port if uri.port`. Ruby's URI always yields
+    // the scheme's default port (80/443) even without an explicit `:port`,
+    // so port is set unconditionally. WHATWG URL returns "" for default
+    // ports, so derive the default from the scheme.
+    request.env["SERVER_PORT"] = parsed.port || (scheme === "https" ? "443" : "80");
     pathStr = parsed.pathname || "/";
   } else if (!pathStr.startsWith("/")) {
     pathStr = `/${pathStr}`;

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -206,11 +206,18 @@ export function recognizedRequestFor(
     request.env["rack.url_scheme"] = scheme;
     request.env["HTTP_HOST"] = parsed.host;
     request.env["SERVER_NAME"] = parsed.hostname;
-    // Rails: `request.port = uri.port if uri.port`. Ruby's URI always yields
-    // the scheme's default port (80/443) even without an explicit `:port`,
-    // so port is set unconditionally. WHATWG URL returns "" for default
-    // ports, so derive the default from the scheme.
-    request.env["SERVER_PORT"] = parsed.port || (scheme === "https" ? "443" : "80");
+    // Rails: `request.port = uri.port if uri.port`. Ruby's URI yields the
+    // scheme's default port for known schemes (80 for http, 443 for https)
+    // and nil for unknown schemes, so the port stays unchanged in that
+    // case. WHATWG URL returns "" for default ports, so reapply defaults
+    // for http/https only and leave SERVER_PORT alone otherwise.
+    if (parsed.port) {
+      request.env["SERVER_PORT"] = parsed.port;
+    } else if (scheme === "https") {
+      request.env["SERVER_PORT"] = "443";
+    } else if (scheme === "http") {
+      request.env["SERVER_PORT"] = "80";
+    }
     pathStr = parsed.pathname || "/";
   } else if (!pathStr.startsWith("/")) {
     pathStr = `/${pathStr}`;

--- a/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/routing.ts
@@ -22,6 +22,9 @@ export interface PathWithMethod {
 
 type Options = Record<string, unknown>;
 
+/** Mirrors Rails' `%r{://}` test for "is this a full URL, not a path?" */
+const URL_FORM_RE = /:\/\//;
+
 /** Initialises `@routes`. Mirrors Rails' `setup`. Call from your own setup. */
 export function setup(this: RoutingAssertionsHost): void {
   if (this.routes == null) this.routes = undefined;
@@ -129,7 +132,16 @@ export function assertGenerates(
   extras: Options = {},
   message?: string,
 ): void {
-  const path = expectedPath.startsWith("/") ? expectedPath : `/${expectedPath}`;
+  let path: string;
+  if (URL_FORM_RE.test(expectedPath)) {
+    // Rails: `URI.parse(expected_path).path` (falls back to "/" when empty).
+    path = failOn(TypeError, message, () => {
+      const parsed = new URL(expectedPath);
+      return parsed.pathname === "" ? "/" : parsed.pathname;
+    });
+  } else {
+    path = expectedPath.startsWith("/") ? expectedPath : `/${expectedPath}`;
+  }
   const routes = requireRoutes(this);
   const opts = { ...options };
   const [generatedPath, queryStringKeys] = routes.generateExtras(opts, defaults);
@@ -184,9 +196,20 @@ export function recognizedRequestFor(
 ): TestRequest {
   const method = typeof path === "string" ? "get" : String(path.method ?? "get");
   let pathStr = typeof path === "string" ? path : path.path;
-  if (!pathStr.startsWith("/")) pathStr = `/${pathStr}`;
 
   const request = new TestRequest();
+  if (URL_FORM_RE.test(pathStr)) {
+    // Rails: when path is a full URL, populate rack.url_scheme + host/port from
+    // the parsed URI and use only its path segment for recognition.
+    const parsed = failOn(TypeError, msg, () => new URL(pathStr));
+    request.env["rack.url_scheme"] = parsed.protocol.replace(/:$/, "");
+    request.env["HTTP_HOST"] = parsed.host;
+    request.env["SERVER_NAME"] = parsed.hostname;
+    if (parsed.port) request.env["SERVER_PORT"] = parsed.port;
+    pathStr = parsed.pathname || "/";
+  } else if (!pathStr.startsWith("/")) {
+    pathStr = `/${pathStr}`;
+  }
   request.env["PATH_INFO"] = pathStr;
   request.env["REQUEST_METHOD"] = method.toUpperCase();
 


### PR DESCRIPTION
## Summary
Bundle of three small routing/HTTP followups from `docs/actionpack-100-percent.md`:

- **`testing/assertions/routing` (#1866)** — Accept full URLs (e.g. `http://example.com/items`) in `assertRecognizes` and `assertGenerates`, mirroring Rails' `%r{://}` branch. URL scheme/host/port populate the `TestRequest` env; only the path segment is used for recognition / comparison. Adds tests for both directions.
- **`middleware/public_exceptions` (#1861)** — Replace the hardcoded `"utf-8"` argument to `Buffer.byteLength` with `Response.defaultCharset` so a customized default charset stays consistent with the emitted `content-type` header. Encoding token narrowed to known `BufferEncoding` values for safety.
- **`http/parameters` (#1832)** — **Verified, no code change.** `Request.params` already merges `pathParameters` (`parameters.ts:119-120`) and `Request.parameterParsers` is already a class-level static getter/setter delegating to the module registry. Closing the item.

`routing/url-for.ts` symbol/class/model dispatch + `use_route: Symbol` handling was also re-verified — current rebase output is correct; no change needed there.

## Follow-ups (deferred)
- Relocate the inline `toXml` helpers from `middleware/public-exceptions` to share the activemodel `to_xml` implementation once that lands (pre-existing followup, noted in `docs/actionpack-100-percent.md`).

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/testing/assertions/routing.test.ts` (13/13 pass, includes new URL-form cases for both assertions)
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware` (existing suites green)
- [x] `pnpm lint` clean on changed files
- [x] `pnpm typecheck` — no new errors (pre-existing `trailtie.ts` / actionview import errors unrelated)
- [x] Size budget: 3 files / +62 / -4 LOC