### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in 5 PG adapter files

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -1,10 +1,11 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/array_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -17,17 +18,13 @@ afterAll(() => {
 // The pg_arrays table uses PG array columns (e.g. integer[],
 // numeric(10,2)[]) which are not expressible via defineSchema. The table
 // is created via raw DDL below; defineSchema(adapter, {}) marks the file
-// as TM-Phase-5 compliant.
-async function freshAdapter(): Promise<PostgreSQLAdapter> {
-  const adapter = new PostgreSQLAdapter(PG_TEST_URL);
-  await defineSchema(adapter, {});
-  return adapter;
-}
-
+// as TM-Phase-5 compliant. The outer per-test transaction rolls back
+// inserts and any addColumn DDL done inside it() bodies.
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await defineSchema(adapter, {});
     await adapter.exec(`DROP TABLE IF EXISTS pg_arrays`);
     await adapter.exec(`
       CREATE TABLE pg_arrays (
@@ -40,10 +37,11 @@ describeIfPg("PostgreSQLAdapter", () => {
     `);
     await adapter.loadAdditionalTypes();
   });
-  afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS pg_arrays`);
+  afterAll(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS pg_arrays`).catch(() => {});
     await adapter.close();
   });
+  withTransactionalFixtures(() => adapter);
 
   describe("PostgresqlArrayTest", () => {
     it("column", async () => {

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -1,9 +1,10 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/datatype_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -17,24 +18,17 @@ afterAll(() => {
 // types (interval, oid, name, char) that aren't expressible via defineSchema.
 // They're created via raw DDL inside each test; defineSchema(adapter, {}) marks
 // the file as TM-Phase-5 compliant (auto-schema path disabled, no model relies
-// on it).
-async function freshAdapter(): Promise<PostgreSQLAdapter> {
-  const adapter = new PostgreSQLAdapter(PG_TEST_URL);
-  await defineSchema(adapter, {});
-  return adapter;
-}
-
+// on it). The outer per-test transaction rolls back DDL between tests.
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await defineSchema(adapter, {});
   });
-  afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS ex CASCADE`);
-    await adapter.exec(`DROP TABLE IF EXISTS postgresql_times CASCADE`);
-    await adapter.exec(`DROP TABLE IF EXISTS postgresql_oids CASCADE`);
+  afterAll(async () => {
     await adapter.close();
   });
+  withTransactionalFixtures(() => adapter);
 
   async function setupTimesTable() {
     await adapter.exec(`DROP TABLE IF EXISTS postgresql_times`);

--- a/packages/activerecord/src/adapters/postgresql/explain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/explain.test.ts
@@ -1,9 +1,10 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/explain_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -15,26 +16,18 @@ afterAll(() => {
 
 // EXPLAIN tests build their own ad-hoc `ex_*` tables; nothing is
 // expressible as a static defineSchema spec. defineSchema(adapter, {})
-// marks the file as TM-Phase-5 compliant.
+// marks the file as TM-Phase-5 compliant. The outer transaction wrapping
+// each test rolls back those tables (PG DDL is transactional).
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     await defineSchema(adapter, {});
   });
-  afterEach(async () => {
-    try {
-      const tables = await adapter.execute(
-        `SELECT tablename FROM pg_tables WHERE schemaname = 'public' AND tablename LIKE 'ex_%'`,
-      );
-      for (const t of tables) {
-        await adapter.exec(`DROP TABLE IF EXISTS "${t.tablename}" CASCADE`);
-      }
-    } catch {
-      // ignore cleanup errors
-    }
+  afterAll(async () => {
     await adapter.close();
   });
+  withTransactionalFixtures(() => adapter);
 
   describe("PostgresqlExplainTest", () => {
     it("explain for one query", async () => {

--- a/packages/activerecord/src/adapters/postgresql/json.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/json.test.ts
@@ -1,10 +1,11 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/json_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { Base } from "../../index.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -17,25 +18,21 @@ afterAll(() => {
 // The `json_test` table uses the PG-specific `JSON` and `JSONB` types,
 // which aren't expressible via defineSchema. The table is created via raw
 // DDL below; defineSchema(adapter, {}) marks the file as TM-Phase-5 compliant.
-async function freshAdapter(): Promise<PostgreSQLAdapter> {
-  const adapter = new PostgreSQLAdapter(PG_TEST_URL);
-  await defineSchema(adapter, {});
-  return adapter;
-}
-
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+    await defineSchema(adapter, {});
     await adapter.exec(`DROP TABLE IF EXISTS "json_test"`);
     await adapter.exec(
       `CREATE TABLE "json_test" ("id" SERIAL PRIMARY KEY, "settings" JSON, "prefs" JSONB, "name" VARCHAR(255))`,
     );
   });
-  afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS "json_test"`);
+  afterAll(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS "json_test"`).catch(() => {});
     await adapter.close();
   });
+  withTransactionalFixtures(() => adapter);
 
   describe("PostgresqlJsonTest", () => {
     it("json column", async () => {

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -1,10 +1,11 @@
 /**
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/virtual_column_test.rb
  */
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { FixtureSet } from "../../test-helpers/fixture-set.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../../test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -21,7 +22,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
   let VirtualColumn: any;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = new PostgreSQLAdapter(PG_TEST_URL);
     await defineSchema(adapter, {});
     await adapter.exec(`DROP TABLE IF EXISTS virtual_columns`);
@@ -45,10 +46,11 @@ describeIfPg("PostgreSQLAdapter", () => {
     await VirtualColumn.create({ name: "Rails" });
   });
 
-  afterEach(async () => {
-    await adapter.exec(`DROP TABLE IF EXISTS virtual_columns`);
+  afterAll(async () => {
+    await adapter.exec(`DROP TABLE IF EXISTS virtual_columns`).catch(() => {});
     await adapter.close();
   });
+  withTransactionalFixtures(() => adapter);
 
   describe("PostgresqlVirtualColumnTest", () => {
     it("virtual column with full inserts", async () => {


### PR DESCRIPTION
## Summary

Migrates 5 of the 9 PG adapter-cluster test files unblocked by #2064 (transactional schema-cache invalidation) from per-test `new PostgreSQLAdapter()` + `defineSchema(adapter, {})` to once-per-file `beforeAll` + `withTransactionalFixtures`.

Files in scope (all under `packages/activerecord/src/adapters/postgresql/`):
- `array.test.ts`
- `datatype.test.ts`
- `explain.test.ts`
- `json.test.ts`
- `virtual-column.test.ts`

These files execute `addColumn`/`createTable`/raw `CREATE TABLE` inside `it()` bodies. Before #2064 their cached column reflection survived the outer transaction rollback. With the cache-clear hook in place, hoisting setup is safe — PG DDL is transactional, so the database-level rollback also cleans up table/column changes done mid-test.

Per-test temp tables (`json_default_test`, `ex_*`, etc.) are now cleaned up by the outer transaction rollback rather than explicit DROP TABLE in afterEach.

## Skipped (follow-up)

- `foreign-table.test.ts` — `ctx.skip()` inside `beforeEach` for the `postgres_fdw` extension probe is hard to preserve under `beforeAll`; needs a different gating approach.
- `range.test.ts` (1096 LOC), `schema.test.ts` (1041 LOC), `uuid.test.ts` (952 LOC) — each warrants its own PR.
- `hstore.test.ts` already migrated in #2060.

## Diff stat

5 files changed, 39 insertions(+), 55 deletions(-) — well under the 300 LOC ceiling.

## Test plan

- [ ] CI PG suite passes for the 5 migrated files
- [ ] No MariaDB regressions (these are PG-gated via `describeIfPg`)