### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in giant roots (safe subset)

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
 import {
   Base,
   RecordNotFound,
@@ -24,6 +24,7 @@ import { Notifications, Logger, TimeWithZone } from "@blazetrails/activesupport"
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 import { withTimezoneConfig } from "./test-helper.js";
 import { IntegerType } from "@blazetrails/activemodel";
 
@@ -38,10 +39,10 @@ function freshAdapter(): DatabaseAdapter {
 // BasicsTest — targets base_test.rb
 // ==========================================================================
 describe("BasicsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       users: {
         name: "string",
@@ -79,8 +80,11 @@ describe("BasicsTest", () => {
       orders: { shop_id: "integer", name: "string" },
       custom_users: { name: "string" },
       replies: { title: "string" },
+      pres_tz_topics: { written_on: "datetime", bonus_time: "time" },
+      tz_pets: { name: "string", created_at: "datetime", updated_at: "datetime" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -1829,9 +1833,6 @@ describe("BasicsTest", () => {
         this.adapter = adapter;
       }
     }
-    await defineSchema(adapter, {
-      pres_tz_topics: { written_on: "datetime", bonus_time: "time" },
-    });
     const inst1 = Temporal.Instant.from("2003-07-16T14:28:11.223300Z");
     const inst2 = Temporal.Instant.from("2003-07-16T14:28:11.009900Z");
     const inst3 = Temporal.Instant.from("2003-07-16T14:28:11.129346Z");
@@ -1871,7 +1872,6 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
-      await defineSchema(adapter, { pres_tz_topics: { written_on: "datetime" } });
       // Rails: Time.local(2000) in EST = 2000-01-01 00:00:00-05:00 = 05:00 UTC.
       // Pass an offset-bearing string to exercise the cast/serialize conversion path.
       const expectedUtc = Temporal.Instant.from("2000-01-01T05:00:00Z");
@@ -1891,7 +1891,6 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
-      await defineSchema(adapter, { pres_tz_topics: { written_on: "datetime" } });
       // Rails: Time.zone.local(2000) in CST = 2000-01-01 00:00:00-06:00 = 06:00 UTC.
       // Pass an offset-bearing string to exercise the cast/serialize conversion path.
       const expectedUtc = Temporal.Instant.from("2000-01-01T06:00:00Z");
@@ -1915,7 +1914,6 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
-      await defineSchema(adapter, { pres_tz_topics: { written_on: "datetime" } });
       const utcMidnight = Temporal.Instant.from("2000-01-01T00:00:00Z");
       const topic = await Topic.create({ written_on: utcMidnight });
       const saved = await Topic.find(topic.id);
@@ -1942,7 +1940,6 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
-      await defineSchema(adapter, { pres_tz_topics: { written_on: "datetime" } });
       // Rails: Time.zone.local(2000) in CST = 2000-01-01 00:00:00 CST (UTC-6) = 06:00 UTC = 01:00 EST
       const cstMidnight = Temporal.Instant.from("2000-01-01T06:00:00Z");
       const topic = await Topic.create({ written_on: cstMidnight });
@@ -1968,9 +1965,6 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
-      await defineSchema(adapter, {
-        tz_pets: { name: "string", created_at: "datetime", updated_at: "datetime" },
-      });
       const pet = await Pet.create({ name: "Bidu" });
       expect(pet.isPersisted()).toBe(true);
       const savedPet = await Pet.find(pet.id);
@@ -3085,8 +3079,8 @@ describe("BasicsTest", () => {
 // ==========================================================================
 describe("BasicsTest", () => {
   let Post: typeof Base;
-  let _adp2: DatabaseAdapter;
-  beforeEach(async () => {
+  let _adp2: TestDatabaseAdapter;
+  beforeAll(async () => {
     _adp2 = createTestAdapter();
     await defineSchema(_adp2, {
       posts: { title: "string", body: "string" },
@@ -3102,6 +3096,7 @@ describe("BasicsTest", () => {
     }
     Post = PostClass;
   });
+  withTransactionalFixtures(() => _adp2);
 
   afterAll(async () => {
     await dropAllTables(_adp2);

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, beforeEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
 import {
   Base,
   RecordNotFound,
@@ -24,7 +24,6 @@ import { Notifications, Logger, TimeWithZone } from "@blazetrails/activesupport"
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 import { withTimezoneConfig } from "./test-helper.js";
 import { IntegerType } from "@blazetrails/activemodel";
 
@@ -39,10 +38,10 @@ function freshAdapter(): DatabaseAdapter {
 // BasicsTest — targets base_test.rb
 // ==========================================================================
 describe("BasicsTest", () => {
-  let adapter: TestDatabaseAdapter;
+  let adapter: DatabaseAdapter;
 
-  beforeAll(async () => {
-    adapter = createTestAdapter();
+  beforeEach(async () => {
+    adapter = freshAdapter();
     await defineSchema(adapter, {
       users: {
         name: "string",
@@ -80,11 +79,8 @@ describe("BasicsTest", () => {
       orders: { shop_id: "integer", name: "string" },
       custom_users: { name: "string" },
       replies: { title: "string" },
-      pres_tz_topics: { written_on: "datetime", bonus_time: "time" },
-      tz_pets: { name: "string", created_at: "datetime", updated_at: "datetime" },
     });
   });
-  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -1833,6 +1829,9 @@ describe("BasicsTest", () => {
         this.adapter = adapter;
       }
     }
+    await defineSchema(adapter, {
+      pres_tz_topics: { written_on: "datetime", bonus_time: "time" },
+    });
     const inst1 = Temporal.Instant.from("2003-07-16T14:28:11.223300Z");
     const inst2 = Temporal.Instant.from("2003-07-16T14:28:11.009900Z");
     const inst3 = Temporal.Instant.from("2003-07-16T14:28:11.129346Z");
@@ -1872,6 +1871,7 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
+      await defineSchema(adapter, { pres_tz_topics: { written_on: "datetime" } });
       // Rails: Time.local(2000) in EST = 2000-01-01 00:00:00-05:00 = 05:00 UTC.
       // Pass an offset-bearing string to exercise the cast/serialize conversion path.
       const expectedUtc = Temporal.Instant.from("2000-01-01T05:00:00Z");
@@ -1891,6 +1891,7 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
+      await defineSchema(adapter, { pres_tz_topics: { written_on: "datetime" } });
       // Rails: Time.zone.local(2000) in CST = 2000-01-01 00:00:00-06:00 = 06:00 UTC.
       // Pass an offset-bearing string to exercise the cast/serialize conversion path.
       const expectedUtc = Temporal.Instant.from("2000-01-01T06:00:00Z");
@@ -1914,6 +1915,7 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
+      await defineSchema(adapter, { pres_tz_topics: { written_on: "datetime" } });
       const utcMidnight = Temporal.Instant.from("2000-01-01T00:00:00Z");
       const topic = await Topic.create({ written_on: utcMidnight });
       const saved = await Topic.find(topic.id);
@@ -1940,6 +1942,7 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
+      await defineSchema(adapter, { pres_tz_topics: { written_on: "datetime" } });
       // Rails: Time.zone.local(2000) in CST = 2000-01-01 00:00:00 CST (UTC-6) = 06:00 UTC = 01:00 EST
       const cstMidnight = Temporal.Instant.from("2000-01-01T06:00:00Z");
       const topic = await Topic.create({ written_on: cstMidnight });
@@ -1965,6 +1968,9 @@ describe("BasicsTest", () => {
           this.adapter = adapter;
         }
       }
+      await defineSchema(adapter, {
+        tz_pets: { name: "string", created_at: "datetime", updated_at: "datetime" },
+      });
       const pet = await Pet.create({ name: "Bidu" });
       expect(pet.isPersisted()).toBe(true);
       const savedPet = await Pet.find(pet.id);
@@ -3079,8 +3085,8 @@ describe("BasicsTest", () => {
 // ==========================================================================
 describe("BasicsTest", () => {
   let Post: typeof Base;
-  let _adp2: TestDatabaseAdapter;
-  beforeAll(async () => {
+  let _adp2: DatabaseAdapter;
+  beforeEach(async () => {
     _adp2 = createTestAdapter();
     await defineSchema(_adp2, {
       posts: { title: "string", body: "string" },
@@ -3096,7 +3102,6 @@ describe("BasicsTest", () => {
     }
     Post = PostClass;
   });
-  withTransactionalFixtures(() => _adp2);
 
   afterAll(async () => {
     await dropAllTables(_adp2);

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -2,11 +2,12 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, RecordNotFound, SoleRecordExceeded } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 const TEST_SCHEMA = {
@@ -2736,10 +2737,12 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("sole() returns the only matching record", async () => {
     class Item extends Base {
@@ -2819,10 +2822,12 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("returns the sole matching record", async () => {
     class Item extends Base {
@@ -2852,10 +2857,12 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("accepts conditions hash", async () => {
     class Item extends Base {
@@ -2885,10 +2892,12 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("second() returns the second record", async () => {
     class Item extends Base {
@@ -3370,7 +3379,7 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class Bird extends Base {
     static {
@@ -3379,10 +3388,12 @@ describe("FinderTest", () => {
     }
   }
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
     Bird.adapter = adapter;
   });
+  withTransactionalFixtures(() => adapter);
 
   it("find_or_create_by finds existing", async () => {
     await Bird.create({ name: "Parrot", color: "green" });
@@ -3421,7 +3432,7 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class User extends Base {
     static {
@@ -3431,10 +3442,12 @@ describe("FinderTest", () => {
     }
   }
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
     User.adapter = adapter;
   });
+  withTransactionalFixtures(() => adapter);
 
   // Rails: test_find_with_array_of_ids
   it("find with single id returns instance", async () => {
@@ -3489,10 +3502,12 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("finds a record by a single attribute", async () => {
     class User extends Base {
@@ -3523,10 +3538,12 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("returns true for valid dynamic finders", () => {
     class User extends Base {
@@ -3555,10 +3572,12 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("first(n) returns array of n records", async () => {
     class User extends Base {

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -2,12 +2,13 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterEach } from "vitest";
 import { Base, registerModel, enableSti, registerSubclass, SubclassNotFound } from "./index.js";
 import { getStiBase, isStiSubclass, setBaseClass } from "./inheritance.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema, type Schema } from "./test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 const TEST_SCHEMA: Schema = {
@@ -1534,10 +1535,12 @@ describe("InheritanceTest", () => {
 });
 
 describe("InheritanceComputeTypeTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   function makeHierarchy() {
     class Vehicle extends Base {
@@ -1617,11 +1620,13 @@ describe("InheritanceAttributeTest", () => {
 });
 
 describe("STI", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   it("subclasses share the parent table", () => {
     class Vehicle extends Base {
@@ -1715,11 +1720,13 @@ describe("STI", () => {
 });
 
 describe("STI (Rails-guided)", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
   });
+  withTransactionalFixtures(() => adapter);
 
   // Rails: test "subclass uses parent table"
   it("subclass inherits the base table name", () => {


### PR DESCRIPTION
## Summary

Retries the giant root files that were reverted from #2055. Per-test `beforeEach(defineSchema)` describes are migrated to `beforeAll` + `withTransactionalFixtures` where the pre-grep audit shows no in-`it()` DDL on the shared adapter and no literal-id assertions (which would break under PG sequence drift).

### base.test.ts
- **BasicsTest #1** (the largest describe): hoisted; pre-declared `pres_tz_topics` and `tz_pets` in the file-level schema and removed the 6 inline `defineSchema(adapter, ...)` calls inside the `preserving time objects` / `tz_pets` tests — the exact hazard flagged in #2055's post-merge findings.
- **BasicsTest #2** (Post-on-`_adp2`): hoisted with `withTransactionalFixtures(() => _adp2)`.
- **BasicsTest #3 sub-describes** (`persistence`, `finders`): left on per-test setup — `expect(p.id).toBe(1)` and `User.find(1)` assertions would break under PG sequence drift.

### inheritance.test.ts
- `InheritanceComputeTypeTest`, `STI`, `STI (Rails-guided)`: hoisted.
- Top-level `InheritanceTest` describe left untouched: 10+ in-`it()` `freshAdapter()` calls — too many for a coherent carve-out.

### finder.test.ts
- 9 of the smaller `describe("FinderTest", ...)` blocks hoisted (the ones whose tests use unique names rather than literal ids).
- Top-level `FinderTest` (line 51) and the seeded `find(1)` / `find([1, 3])` describes left on per-test setup — they would break under PG sequence drift or have too many in-`it()` adapter creations to migrate coherently.

## Follow-ups (not in scope here)
- `finder.test.ts` top describe + seeded-data describes: ~30 in-`it()` `freshAdapter()` calls each. The cleanest fix is to capture `.id` from creates and then migrate, but it doesn't fit one PR.
- `inheritance.test.ts` top describe: same shape (10 in-`it()` freshAdapter calls).
- `base.test.ts` BasicsTest #3 sub-describes: same shape — `expect(p.id).toBe(1)` assertions need to capture id first.

## Test plan
- [x] `pnpm vitest run` on all three files passes locally (SQLite).
- [ ] CI on PG + MariaDB — that's the gate that #2055 failed on; will watch.