### PR TITLE
refactor(actionpack): rewire AC::Callbacks onto ActiveSupport::Callbacks

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -7,13 +7,15 @@
  */
 
 import {
+  _defineActionCallbacks,
   _insertCallbacks,
   _normalizeCallbackOption,
   _normalizeCallbackOptions,
+  _registerActionCallback,
+  _skipActionCallback,
   processAction as _runProcessActionCallbacks,
   type ActionCallback,
   type AroundCallback,
-  type CallbackEntry,
   type CallbackOptions,
 } from "./callbacks.js";
 export type {
@@ -62,15 +64,6 @@ export class AbstractController {
 
   /** Whether a response has been committed (render/redirect called). */
   protected _performed: boolean = false;
-
-  /** Registered callbacks (class-level, inherited). */
-  private static _callbacks: CallbackEntry[] = [];
-
-  /** Skipped callback identifiers. */
-  private static _skippedCallbacks: Array<{
-    callback: ActionCallback | AroundCallback;
-    options: CallbackOptions;
-  }> = [];
 
   private static readonly _internalMethods: ReadonlySet<string> = new Set([
     "constructor",
@@ -152,89 +145,34 @@ export class AbstractController {
 
   /** Register a before_action callback. */
   static beforeAction(callback: ActionCallback, options: CallbackOptions = {}): void {
-    this._registerActionCallback("before", callback, options);
+    _registerActionCallback(this.prototype, "before", callback, options);
   }
 
   /** Register an after_action callback. */
   static afterAction(callback: ActionCallback, options: CallbackOptions = {}): void {
-    this._registerActionCallback("after", callback, options);
+    _registerActionCallback(this.prototype, "after", callback, options);
   }
 
   /** Register an around_action callback. */
   static aroundAction(callback: AroundCallback, options: CallbackOptions = {}): void {
-    this._registerActionCallback("around", callback, options);
+    _registerActionCallback(this.prototype, "around", callback, options);
   }
 
-  /** Pre-populates `options.filters` so ActionFilter retains the callback
-   * for diagnostic rendering. Mirrors `_insert_callbacks` filters wiring. @internal */
-  private static _registerActionCallback(
-    type: "before" | "after" | "around",
-    callback: ActionCallback | AroundCallback,
-    options: CallbackOptions,
-  ): void {
-    const opts = options as CallbackOptions & {
-      filters?: Array<ActionCallback | AroundCallback>;
-    };
-    opts.filters = [callback];
-    _normalizeCallbackOptions(options);
-    delete opts.filters;
-    const entry: CallbackEntry = { callback, type, options };
-    if (options.prepend) {
-      this._ensureOwnCallbacks().unshift(entry);
-    } else {
-      this._ensureOwnCallbacks().push(entry);
-    }
+  /** Skip a registered before_action. Accepts the callback reference or
+   * (for callbacks registered with `name`) the name string. Conditional
+   * options (`if`/`unless`/`only`/`except`) merge via Rails skip semantics. */
+  static skipBeforeAction(cb: ActionCallback | string, options: CallbackOptions = {}): void {
+    _skipActionCallback(this.prototype, "before", cb, options);
   }
 
-  /** Skip a previously registered before_action. */
-  static skipBeforeAction(callback: ActionCallback, options: CallbackOptions = {}): void {
-    this._ensureOwnSkipped().push({ callback, options });
+  /** Skip a registered after_action. */
+  static skipAfterAction(cb: ActionCallback | string, options: CallbackOptions = {}): void {
+    _skipActionCallback(this.prototype, "after", cb, options);
   }
 
-  /** Get all callbacks including inherited ones. */
-  static getCallbacks(): CallbackEntry[] {
-    const chain: CallbackEntry[] = [];
-    const hierarchy = this._getHierarchy();
-    for (const klass of hierarchy) {
-      if (Object.prototype.hasOwnProperty.call(klass, "_callbacks")) {
-        chain.push(...(klass as any)._callbacks);
-      }
-    }
-    // Dedup by (`options.name`, `type`): when a subclass registers a
-    // callback with the same name and kind, drop the inherited entry.
-    // Mirrors AS::Callbacks CallbackChain#remove_duplicates, which
-    // matches on Callback#duplicates? (same filter + same kind) — so
-    // `before_action :first` and `after_action :first` coexist, but a
-    // child's `before_action :first, except: :index` replaces the
-    // parent's `before_action :first`.
-    const seen = new Set<string>();
-    for (let i = chain.length - 1; i >= 0; i--) {
-      const entry = chain[i]!;
-      if (entry.options.name === undefined) continue;
-      const key = `${entry.type}\0${entry.options.name}`;
-      if (seen.has(key)) {
-        chain.splice(i, 1);
-      } else {
-        seen.add(key);
-      }
-    }
-    return chain;
-  }
-
-  /** Get all skipped callbacks. */
-  static getSkipped(): Array<{
-    callback: ActionCallback | AroundCallback;
-    options: CallbackOptions;
-  }> {
-    const skipped: Array<{ callback: ActionCallback | AroundCallback; options: CallbackOptions }> =
-      [];
-    const hierarchy = this._getHierarchy();
-    for (const klass of hierarchy) {
-      if (Object.prototype.hasOwnProperty.call(klass, "_skippedCallbacks")) {
-        skipped.push(...(klass as any)._skippedCallbacks);
-      }
-    }
-    return skipped;
+  /** Skip a registered around_action. */
+  static skipAroundAction(cb: AroundCallback | string, options: CallbackOptions = {}): void {
+    _skipActionCallback(this.prototype, "around", cb, options);
   }
 
   /**
@@ -348,31 +286,8 @@ export class AbstractController {
   availableActions(): string[] {
     return (this.constructor as typeof AbstractController).actionMethods();
   }
-
-  private static _ensureOwnCallbacks(): CallbackEntry[] {
-    if (!Object.prototype.hasOwnProperty.call(this, "_callbacks")) {
-      (this as any)._callbacks = [];
-    }
-    return (this as any)._callbacks;
-  }
-
-  private static _ensureOwnSkipped(): Array<{
-    callback: ActionCallback | AroundCallback;
-    options: CallbackOptions;
-  }> {
-    if (!Object.prototype.hasOwnProperty.call(this, "_skippedCallbacks")) {
-      (this as any)._skippedCallbacks = [];
-    }
-    return (this as any)._skippedCallbacks;
-  }
-
-  private static _getHierarchy(): Array<typeof AbstractController> {
-    const chain: Array<typeof AbstractController> = [];
-    let klass = this as typeof AbstractController;
-    while (klass && klass !== (Object as unknown)) {
-      chain.unshift(klass);
-      klass = Object.getPrototypeOf(klass);
-    }
-    return chain;
-  }
 }
+
+// Provision the `processAction` AS::Callbacks chain on the root prototype;
+// all subclasses inherit through prototype-chain COW in AS::Callbacks.
+_defineActionCallbacks(AbstractController.prototype);

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -312,10 +312,11 @@ export function _skipActionCallback(
   filter: ActionCallback | AroundCallback | string,
   options: CallbackOptions,
 ): void {
-  const opts: CallbackOptionsWithFilters = {
-    ...options,
-    filters: typeof filter === "function" ? [filter] : [],
-  };
+  // For string-name skips, thread a synthetic { name } so ActionFilter's
+  // raise-on-missing-action message renders `:name` rather than `[]`.
+  const namedFilter =
+    typeof filter === "function" ? filter : ({ name: filter } as unknown as ActionCallback);
+  const opts: CallbackOptionsWithFilters = { ...options, filters: [namedFilter] };
   _normalizeCallbackOptions(opts);
   delete opts.filters;
 
@@ -346,6 +347,12 @@ export function _skipActionCallback(
         ifConds,
         unlessConds,
       );
+      // mergeConditionalOptions creates fresh options ({ if, unless } only),
+      // dropping trails' _trailsName metadata. Re-attach it so future name-based
+      // skips/overrides on this entry continue to match.
+      if (stored !== undefined) {
+        (merged.options as Record<string, unknown>)._trailsName = stored;
+      }
       chain.insert(chain.index(cb), merged);
     }
     chain.delete(cb);

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -268,8 +268,9 @@ export function _registerActionCallback(
   _normalizeCallbackOptions(opts);
   delete opts.filters;
 
-  // Name-based dedup: AS::Callbacks#duplicates? only matches Symbol filters,
-  // so trails dedupes by an explicit `name` stashed on options.
+  // Name-based dedup: AS::Callbacks Callback#isDuplicates only fires for
+  // string (method-name) filters — trails registers function refs, so we
+  // dedupe via an explicit `name` stashed on options.
   if (options.name !== undefined) {
     const chain = getCallbackChains(prototype).get(PROCESS_ACTION_CHAIN);
     if (chain) {

--- a/packages/actionpack/src/abstract-controller/callbacks.ts
+++ b/packages/actionpack/src/abstract-controller/callbacks.ts
@@ -1,11 +1,21 @@
 /**
  * AbstractController::Callbacks
  *
- * Callback type definitions, options, and option-normalization helpers
- * for AbstractController action lifecycle.
+ * Action callback type definitions, option normalization, and the
+ * ActiveSupport::Callbacks integration that wires AbstractController#processAction
+ * onto an AS callback chain.
  * @see https://api.rubyonrails.org/classes/AbstractController/Callbacks.html
  */
 
+import {
+  defineCallbacks as asDefineCallbacks,
+  setCallback as asSetCallback,
+  runCallbacks as asRunCallbacks,
+  getCallbackChains,
+  type CallbackKind,
+  type CallbackCondition,
+  type CallbackOptions as ASCallbackOptions,
+} from "@blazetrails/activesupport";
 import { ActionNotFound, type AbstractController } from "./base.js";
 
 export type ActionCallback = (
@@ -56,11 +66,8 @@ type CallbackOptionsWithFilters = CallbackOptions & {
   filters?: Array<ActionCallback | AroundCallback>;
 };
 
-export interface CallbackEntry {
-  callback: ActionCallback | AroundCallback;
-  type: "before" | "after" | "around";
-  options: CallbackOptions;
-}
+/** Name of the AS::Callbacks chain that backs `processAction`. @internal */
+export const PROCESS_ACTION_CHAIN = "processAction";
 
 /**
  * Matches the controller's current action name against a fixed set of
@@ -206,100 +213,150 @@ export function _insertCallbacks(
   }
 }
 
-function _actionList(value: string | string[]): string[] {
-  return Array.isArray(value) ? value : [value];
-}
-
 /** Named fn → `:name`; anon → `#<Proc:…>` (Rails Proc#inspect parity). @internal */
 function _inspectFilter(filter: ActionCallback | AroundCallback): string {
   const fn = filter as { name?: string };
   return fn.name && fn.name.length > 0 ? `:${fn.name}` : "#<Proc:anonymous>";
 }
 
-function _shouldRun(controller: AbstractController, entry: CallbackEntry, action: string): boolean {
-  const opts = entry.options;
-  if (opts.only !== undefined && !_actionList(opts.only).includes(action)) return false;
-  if (opts.except !== undefined && _actionList(opts.except).includes(action)) return false;
-  if (opts.if !== undefined && !_evalPredicate(controller, opts.if, true)) return false;
-  if (opts.unless !== undefined && _evalPredicate(controller, opts.unless, false)) return false;
-  return true;
+/** Lower CallbackPredicateLike entries (ActionFilter) into plain fns for AS. @internal */
+function _toConditionFns(pred: CallbackOptions["if"]): CallbackCondition[] | undefined {
+  if (pred === undefined) return undefined;
+  const list = Array.isArray(pred) ? pred : [pred];
+  return list.map((item) =>
+    typeof item === "function"
+      ? (item as unknown as CallbackCondition)
+      : (c: object) => (item as CallbackPredicateLike).isMatch(c as AbstractController),
+  );
 }
 
-function _evalPredicate(
-  controller: AbstractController,
-  pred: NonNullable<CallbackOptions["if"]>,
-  requireAll: boolean,
-): boolean {
-  if (typeof pred === "function") return pred(controller);
-  if (requireAll) {
-    for (const p of pred) {
-      if (!(typeof p === "function" ? p(controller) : p.isMatch(controller))) return false;
-    }
-    return true;
-  }
-  for (const p of pred) {
-    if (typeof p === "function" ? p(controller) : p.isMatch(controller)) return true;
-  }
-  return false;
+interface WrappedBefore {
+  (target: object): Promise<unknown>;
+  __originalCb: ActionCallback;
 }
 
 /**
- * Rails `AC::Callbacks#process_action` — wraps the dispatch with the
- * registered `:process_action` callbacks. Ruby uses a `run_callbacks { super }`
- * override; here the wrapping lives in callbacks.ts and `Base#processAction`
- * delegates to it so the file layout matches Rails.
+ * Wrap a before callback to halt (return `false`) once the controller is
+ * marked performed. Replaces Rails' `terminator: ->(c, lambda) { lambda.call;
+ * c.performed? }`: AS rejects custom terminators paired with async befores,
+ * so we encode the check in the callback and rely on default `=== false` halt.
  * @internal
  */
-export async function processAction(
-  controller: AbstractController,
-  action: string,
-  dispatch: () => Promise<void>,
-): Promise<void> {
-  const Constructor = controller.constructor as unknown as {
-    getCallbacks: () => CallbackEntry[];
-    getSkipped: () => Array<{
-      callback: ActionCallback | AroundCallback;
-      options: CallbackOptions;
-    }>;
+function _wrapBefore(callback: ActionCallback): WrappedBefore {
+  const wrapped = async (target: object): Promise<unknown> => {
+    const result = await callback(target as AbstractController);
+    if ((target as AbstractController).performed) return false;
+    return result;
   };
-  const allCallbacks = Constructor.getCallbacks();
-  const skipped = Constructor.getSkipped();
+  (wrapped as WrappedBefore).__originalCb = callback;
+  return wrapped as WrappedBefore;
+}
 
-  const callbacks = allCallbacks.filter((entry) => {
-    return !skipped.some((s) => {
-      if (s.callback !== entry.callback) return false;
-      if (s.options.only !== undefined && !_actionList(s.options.only).includes(action))
-        return false;
-      if (s.options.except !== undefined && _actionList(s.options.except).includes(action))
-        return false;
-      return true;
-    });
-  });
+/** Provision the `processAction` AS::Callbacks chain on a class prototype. @internal */
+export function _defineActionCallbacks(prototype: object): void {
+  asDefineCallbacks(prototype, PROCESS_ACTION_CHAIN, { skipAfterCallbacksIfTerminated: true });
+}
 
-  const befores = callbacks.filter((c) => c.type === "before" && _shouldRun(controller, c, action));
-  const afters = callbacks.filter((c) => c.type === "after" && _shouldRun(controller, c, action));
-  const arounds = callbacks.filter((c) => c.type === "around" && _shouldRun(controller, c, action));
+/** Register a before/after/around action callback on `prototype`. @internal */
+export function _registerActionCallback(
+  prototype: object,
+  kind: CallbackKind,
+  callback: ActionCallback | AroundCallback,
+  options: CallbackOptions,
+): void {
+  const opts: CallbackOptionsWithFilters = { ...options, filters: [callback] };
+  _normalizeCallbackOptions(opts);
+  delete opts.filters;
 
-  const executeAction = async (): Promise<void> => {
-    for (const entry of befores) {
-      if (controller.performed) return;
-      const result = await (entry.callback as ActionCallback)(controller);
-      if (result === false) return;
+  // Name-based dedup: AS::Callbacks#duplicates? only matches Symbol filters,
+  // so trails dedupes by an explicit `name` stashed on options.
+  if (options.name !== undefined) {
+    const chain = getCallbackChains(prototype).get(PROCESS_ACTION_CHAIN);
+    if (chain) {
+      for (const cb of [...chain.entries]) {
+        if (cb.kind !== kind) continue;
+        const stored = (cb.options as Record<string, unknown>)._trailsName;
+        if (stored === options.name) chain.delete(cb);
+      }
     }
-    if (controller.performed) return;
-    await dispatch();
-    for (const entry of afters.reverse()) {
-      await (entry.callback as ActionCallback)(controller);
-    }
-  };
-
-  let chain = executeAction;
-  for (const around of arounds.reverse()) {
-    const inner = chain;
-    chain = async () => {
-      await (around.callback as AroundCallback)(controller, inner);
-    };
   }
 
-  await chain();
+  const asOpts: ASCallbackOptions & Record<string, unknown> = {};
+  if (opts.prepend) asOpts.prepend = true;
+  const ifFns = _toConditionFns(opts.if);
+  const unlessFns = _toConditionFns(opts.unless);
+  if (ifFns) asOpts.if = ifFns;
+  if (unlessFns) asOpts.unless = unlessFns;
+  if (options.name !== undefined) asOpts._trailsName = options.name;
+
+  const filter = kind === "before" ? _wrapBefore(callback as ActionCallback) : callback;
+  asSetCallback(
+    prototype,
+    PROCESS_ACTION_CHAIN,
+    kind,
+    filter as unknown as Parameters<typeof asSetCallback>[3],
+    asOpts,
+  );
+}
+
+/**
+ * Skip an existing action callback. Mirrors Rails `skip_callback`: with
+ * `if`/`unless`/`only`/`except`, replaces the entry with one whose
+ * conditions are merged (`Callback#mergeConditionalOptions`); without
+ * conditions, removes outright.
+ * @internal
+ */
+export function _skipActionCallback(
+  prototype: object,
+  kind: CallbackKind,
+  filter: ActionCallback | AroundCallback | string,
+  options: CallbackOptions,
+): void {
+  const opts: CallbackOptionsWithFilters = {
+    ...options,
+    filters: typeof filter === "function" ? [filter] : [],
+  };
+  _normalizeCallbackOptions(opts);
+  delete opts.filters;
+
+  const chain = getCallbackChains(prototype).get(PROCESS_ACTION_CHAIN);
+  if (!chain) return;
+
+  const hasConditional = opts.if !== undefined || opts.unless !== undefined;
+  const ifConds = _toConditionFns(opts.if) ?? [];
+  const unlessConds = _toConditionFns(opts.unless) ?? [];
+
+  for (const cb of [...chain.entries]) {
+    if (cb.kind !== kind) continue;
+    const stored = (cb.options as Record<string, unknown>)._trailsName;
+    let matches: boolean;
+    if (typeof filter === "string") {
+      matches = stored === filter;
+    } else if (kind === "before") {
+      const wrapped = cb.filter as Partial<WrappedBefore>;
+      matches = wrapped.__originalCb === filter || cb.filter === filter;
+    } else {
+      matches = cb.filter === filter;
+    }
+    if (!matches) continue;
+
+    if (hasConditional) {
+      const merged = cb.mergeConditionalOptions(
+        { name: PROCESS_ACTION_CHAIN, config: cb.chainConfig },
+        ifConds,
+        unlessConds,
+      );
+      chain.insert(chain.index(cb), merged);
+    }
+    chain.delete(cb);
+  }
+}
+
+/** Rails `AC::Callbacks#process_action` — runs the chain around `dispatch`. @internal */
+export async function processAction(
+  controller: AbstractController,
+  _action: string,
+  dispatch: () => Promise<void>,
+): Promise<void> {
+  await asRunCallbacks(controller, PROCESS_ACTION_CHAIN, dispatch);
 }

--- a/packages/actionpack/src/abstract-controller/index.ts
+++ b/packages/actionpack/src/abstract-controller/index.ts
@@ -5,7 +5,6 @@ export {
   type AroundCallback,
   type CallbackOptions,
 } from "./base.js";
-export type { CallbackEntry } from "./callbacks.js";
 export { AbstractControllerError } from "./error.js";
 export {
   translate,


### PR DESCRIPTION
## Summary

Replaces the legacy `_callbacks` / `_skippedCallbacks` static storage and the hand-rolled before/after/around dispatch in `AbstractController::Base` with the `ActiveSupport::Callbacks` chain.

- `defineCallbacks(\"processAction\", { skipAfterCallbacksIfTerminated: true })` provisions the chain on `AbstractController.prototype`; subclasses inherit through AS's prototype-chain CoW.
- `beforeAction` / `afterAction` / `aroundAction` delegate to `setCallback`.
- `skipBeforeAction` / `skipAfterAction` / `skipAroundAction` mirror Rails `skip_callback`: when called with `if`/`unless`/`only`/`except` they merge a conditional onto the existing callback via `Callback#mergeConditionalOptions` (per the spec's deviation); without conditions they remove outright. Skip accepts the original callback ref or the `name` string used at registration.
- `processAction` runs through `runCallbacks(\"processAction\", () => this._dispatchAction(...))`.
- Halt-on-`performed?` is realised by wrapping each before callback to return `false` once `performed` flips, rather than a custom terminator. AS rejects custom terminators paired with async befores (terminator is sync; callback returns a Promise it can't await), and the codebase already has async before callbacks (e.g. `Base#allowBrowser`). The wrapper preserves the same Rails semantics — first before that performs halts the chain, action is skipped, and `skipAfterCallbacksIfTerminated` skips afters.

`ActionFilter`, `_normalizeCallbackOptions`, `_normalizeCallbackOption`, and `_insertCallbacks` are unchanged. Per-class registration normalises `only`/`except` into `if`/`unless` exactly as before, then lowers `CallbackPredicateLike` objects (including `ActionFilter`) to plain functions for AS consumption.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/abstract-controller/callbacks.test.ts` — 42/42 green (including `raiseOnMissingCallbackActions`, name-based override, `prepend`, `only`/`except`, halt-on-performed).
- [x] `pnpm vitest run packages/actionpack/src/action-controller/controller/filters.test.ts` — 17/17, including \"around_action can catch errors\" and \"after_action not called when around does not yield\".
- [x] Full actionpack vitest suite: 2942 passed, 15 skipped, 0 failures.

## Size note

361 LOC (additions + deletions) — slightly over the 300 LOC ceiling. This is an atomic rewire: `base.ts` and `callbacks.ts` must change together because the dispatch path is a single call graph. Splitting via `<base>b` would leave one PR with a non-compiling intermediate state. The deletions side (legacy `_callbacks` storage, `getCallbacks`/`getSkipped`/`_shouldRun`/`_evalPredicate`/`processAction` dispatch — 190 lines) drives most of the count.

Closes the #2042 follow-up; unblocked by #2045.