### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in 5 small root/subdir files

### DIFF
--- a/packages/activerecord/src/coders/json.test.ts
+++ b/packages/activerecord/src/coders/json.test.ts
@@ -1,15 +1,16 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, serialize } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let adapter: DatabaseAdapter;
+let adapter: TestDatabaseAdapter;
 
-beforeEach(async () => {
+beforeAll(async () => {
   adapter = createTestAdapter();
   await defineSchema(adapter, { topics: { content: "string" } });
 });
+withTransactionalFixtures(() => adapter);
 
 describe("JSONTest", () => {
   it("returns nil if empty string given", async () => {

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -9,7 +9,6 @@ import { loadSchemaFromAdapter } from "./model-schema.js";
 import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
@@ -79,9 +78,6 @@ describe("DefaultNumbersTest", () => {
     await defineSchema(adapter, { counters: { value: "integer" } });
   });
   withTransactionalFixtures(() => adapter);
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
 
   function makeModel() {
     class Counter extends Base {
@@ -119,9 +115,6 @@ describe("DefaultBinaryTest", () => {
     await defineSchema(adp, { bin_records: { data: "string" } });
   });
   withTransactionalFixtures(() => adp);
-  afterAll(async () => {
-    await dropAllTables(adp);
-  });
   it("default varbinary string", async () => {
     class BinRecord extends Base {
       static {
@@ -198,9 +191,6 @@ describe("DefaultTextTest", () => {
     await defineSchema(adapter, { posts: { body: "string", title: "string" } });
   });
   withTransactionalFixtures(() => adapter);
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
   it("default texts", async () => {
     class Post extends Base {
       static {
@@ -230,9 +220,6 @@ describe("DefaultStringsTest", () => {
     await defineSchema(adapter, { posts: { title: "string", body: "string" } });
   });
   withTransactionalFixtures(() => adapter);
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
   it("default strings", async () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -2,14 +2,15 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, vi, beforeAll, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -72,11 +73,12 @@ describe("MysqlDefaultExpressionTest", () => {
 });
 
 describe("DefaultNumbersTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { counters: { value: "integer" } });
   });
+  withTransactionalFixtures(() => adapter);
   afterAll(async () => {
     await dropAllTables(adapter);
   });
@@ -111,11 +113,12 @@ describe("DefaultNumbersTest", () => {
 });
 
 describe("DefaultBinaryTest", () => {
-  let adp: DatabaseAdapter;
-  beforeEach(async () => {
-    adp = freshAdapter();
+  let adp: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adp = createTestAdapter();
     await defineSchema(adp, { bin_records: { data: "string" } });
   });
+  withTransactionalFixtures(() => adp);
   afterAll(async () => {
     await dropAllTables(adp);
   });
@@ -189,11 +192,12 @@ describe("DefaultsTestWithoutTransactionalFixtures", () => {
 });
 
 describe("DefaultTextTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { posts: { body: "string", title: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
   afterAll(async () => {
     await dropAllTables(adapter);
   });
@@ -220,11 +224,12 @@ describe("DefaultTextTest", () => {
 });
 
 describe("DefaultStringsTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { posts: { title: "string", body: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
   afterAll(async () => {
     await dropAllTables(adapter);
   });

--- a/packages/activerecord/src/json-serialization.test.ts
+++ b/packages/activerecord/src/json-serialization.test.ts
@@ -7,7 +7,6 @@ import { Base } from "./index.js";
 
 import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
@@ -135,9 +134,6 @@ describe("JsonSerializationTest", () => {
     contact.serializableHash(options);
     expect(options.only).toEqual(optionsBefore.only);
   });
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
 });
 
 describe("DatabaseConnectedJsonEncodingTest", () => {
@@ -168,9 +164,6 @@ describe("DatabaseConnectedJsonEncodingTest", () => {
     });
   });
   withTransactionalFixtures(() => adapter);
-  afterAll(async () => {
-    await dropAllTables(adapter);
-  });
 
   it("includes uses association name", async () => {
     class CommentJ1 extends Base {

--- a/packages/activerecord/src/json-serialization.test.ts
+++ b/packages/activerecord/src/json-serialization.test.ts
@@ -5,10 +5,10 @@
 import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -17,20 +17,19 @@ afterAll(() => {
   vi.unstubAllEnvs();
 });
 
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
-
 describe("JsonSerializationTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
   let Contact: typeof Base;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       contacts: { name: "string", age: "integer", created_at: "string", type: "string" },
     });
+  });
+  withTransactionalFixtures(() => adapter);
+
+  beforeEach(() => {
     Contact = class extends Base {};
     Contact._tableName = "contacts";
     Contact.attribute("id", "integer");
@@ -142,9 +141,9 @@ describe("JsonSerializationTest", () => {
 });
 
 describe("DatabaseConnectedJsonEncodingTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       post_j1s: { title: "string" },
       comment_j1s: { body: "string", post_id: "integer" },
@@ -168,6 +167,7 @@ describe("DatabaseConnectedJsonEncodingTest", () => {
       post_j11s: { title: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
   afterAll(async () => {
     await dropAllTables(adapter);
   });

--- a/packages/activerecord/src/type/date-time.test.ts
+++ b/packages/activerecord/src/type/date-time.test.ts
@@ -3,7 +3,6 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { DateTime } from "./date-time.js";
 import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import { dropAllTables } from "../test-helpers/drop-all-tables.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { Base } from "../index.js";
 
@@ -18,8 +17,7 @@ describe("DateTimeTest", () => {
   });
   withTransactionalFixtures(() => adapter);
 
-  afterAll(async () => {
-    await dropAllTables(adapter);
+  afterAll(() => {
     vi.unstubAllEnvs();
   });
 

--- a/packages/activerecord/src/type/date-time.test.ts
+++ b/packages/activerecord/src/type/date-time.test.ts
@@ -1,21 +1,22 @@
-import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { DateTime } from "./date-time.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { dropAllTables } from "../test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { Base } from "../index.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 describe("DateTimeTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, { tasks: { starting: "datetime" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);

--- a/packages/activerecord/src/type/string.test.ts
+++ b/packages/activerecord/src/type/string.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "../index.js";
 import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
-import { dropAllTables } from "../test-helpers/drop-all-tables.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -16,8 +15,7 @@ describe("StringTypeTest", () => {
   });
   withTransactionalFixtures(() => adapter);
 
-  afterAll(async () => {
-    await dropAllTables(adapter);
+  afterAll(() => {
     vi.unstubAllEnvs();
   });
 

--- a/packages/activerecord/src/type/string.test.ts
+++ b/packages/activerecord/src/type/string.test.ts
@@ -1,19 +1,20 @@
-import { describe, it, expect, beforeEach, afterAll, vi } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { Base } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { dropAllTables } from "../test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 describe("StringTypeTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = createTestAdapter();
     await defineSchema(adapter, { authors: { name: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);


### PR DESCRIPTION
## Summary

Migrates per-test `beforeEach(defineSchema)` describes to once-per-file `beforeAll` + `withTransactionalFixtures` in 5 files where the pre-grep audit shows no in-`it()` DDL on the shared adapter and no literal-id assertions.

Files:
- `packages/activerecord/src/coders/json.test.ts`
- `packages/activerecord/src/type/date-time.test.ts`
- `packages/activerecord/src/type/string.test.ts`
- `packages/activerecord/src/json-serialization.test.ts` (both describes)
- `packages/activerecord/src/defaults.test.ts` (4 describes: `DefaultNumbersTest`, `DefaultBinaryTest`, `DefaultTextTest`, `DefaultStringsTest`)

The remaining `DefaultTest` describes in `defaults.test.ts` use inline `freshAdapter()` per-test (some with their own `defineSchema` call in the body) — left as-is to keep this PR safe.

Skipped candidates from the task list (with reasons):
- `transaction-instrumentation.test.ts` — intentionally uses an isolated SQLite adapter per test (see the long comment in the file); shared adapter would break TM spy assertions.
- `date-time-precision.test.ts` — saturated with inline `ctx.createTable(...)` DDL in `it()` bodies.
- `transaction-isolation.test.ts` — multiple in-`it()` `defineSchema(..., { dropExisting: true })` and isolation semantics make it unsafe for the shared TM model.
- `time-precision.test.ts`, `serialization.test.ts`, `normalized-attribute.test.ts` — known-hazard files per the task brief.
- `tasks/*.test.ts` — don't use the `defineSchema`/adapter setup pattern.
- `adapters/sqlite3/**`, `adapters/abstract-mysql-adapter/**` — adapter-specific setup that bypasses `createTestAdapter()`.
- `test-helpers/*.test.ts` — test the helpers themselves; per-test setup is the point.

## Test plan
- [x] `pnpm vitest run` on all 5 migrated files passes locally (SQLite).
- [ ] CI on PG + MariaDB — that is the gate this kind of migration historically fails on; will watch.