### PR TITLE
feat(actionpack): close actiondispatch middleware leaves toward 100%

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/show-exceptions.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/show-exceptions.test.ts
@@ -158,6 +158,28 @@ describe("ShowExceptionsTest", () => {
     expect(headers["content-type"]).toContain("charset=utf-8");
   });
 
+  it("rewrites request method to GET and preserves original on env", async () => {
+    let seenMethod: string | undefined;
+    let seenOriginalMethod: string | undefined;
+    const captureApp = async (env: RackEnv): Promise<RackResponse> => {
+      seenMethod = env["REQUEST_METHOD"] as string;
+      seenOriginalMethod = env["action_dispatch.original_request_method"] as string;
+      return publicExceptionsApp(env);
+    };
+
+    const env: RackEnv = {
+      REQUEST_METHOD: "POST",
+      PATH_INFO: "/",
+      "action_dispatch.show_exceptions": "all",
+    };
+    const app = buildApp(captureApp);
+    await app.call(env);
+
+    expect(seenMethod).toBe("GET");
+    expect(seenOriginalMethod).toBe("POST");
+    expect(env["REQUEST_METHOD"]).toBe("POST");
+  });
+
   it("failsafe prevents raising if exceptions_app raises", async () => {
     const failApp = async (): Promise<RackResponse> => {
       throw new Error("exceptions app also failed");

--- a/packages/actionpack/src/action-dispatch/dispatch/ssl.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/ssl.test.ts
@@ -51,6 +51,28 @@ describe("RedirectSSLTest", () => {
     expect(headers.location).toBe("https://example.com/search?q=hello");
   });
 
+  it("non-GET/HEAD requests redirect with 307 to preserve method", async () => {
+    const ssl = new SSL(okApp);
+    const [status] = await ssl.call({
+      "rack.url_scheme": "http",
+      HTTP_HOST: "example.com",
+      PATH_INFO: "/posts",
+      REQUEST_METHOD: "POST",
+    });
+    expect(status).toBe(307);
+  });
+
+  it("sslDefaultRedirectStatus overrides 307 for non-GET/HEAD", async () => {
+    const ssl = new SSL(okApp, { sslDefaultRedirectStatus: 308 });
+    const [status] = await ssl.call({
+      "rack.url_scheme": "http",
+      HTTP_HOST: "example.com",
+      PATH_INFO: "/posts",
+      REQUEST_METHOD: "POST",
+    });
+    expect(status).toBe(308);
+  });
+
   it("redirect with custom status", async () => {
     const ssl = new SSL(okApp, { redirect: { status: 307 } });
     const [status] = await ssl.call({

--- a/packages/actionpack/src/action-dispatch/dispatch/ssl.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/ssl.test.ts
@@ -92,7 +92,7 @@ describe("RedirectSSLTest", () => {
       PATH_INFO: "/",
       REQUEST_METHOD: "GET",
     });
-    expect(headers["strict-transport-security"]).toBe("max-age=31536000");
+    expect(headers["strict-transport-security"]).toBe("max-age=63072000; includeSubDomains");
   });
 
   it("HSTS with subdomains", async () => {
@@ -125,7 +125,7 @@ describe("RedirectSSLTest", () => {
       PATH_INFO: "/",
       REQUEST_METHOD: "GET",
     });
-    expect(headers["strict-transport-security"]).toBe("max-age=3600");
+    expect(headers["strict-transport-security"]).toBe("max-age=3600; includeSubDomains");
   });
 
   it("HSTS disabled", async () => {
@@ -136,7 +136,7 @@ describe("RedirectSSLTest", () => {
       PATH_INFO: "/",
       REQUEST_METHOD: "GET",
     });
-    expect(headers["strict-transport-security"]).toBeUndefined();
+    expect(headers["strict-transport-security"]).toBe("max-age=0; includeSubDomains");
   });
 
   it("no HSTS on HTTP", async () => {

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -55,9 +55,13 @@ export class HostAuthorization {
   private blockedHosts(env: RackEnv, host: string): string[] {
     const out: string[] = [];
     if (!this.isAuthorized(host)) out.push(host);
-    const forwarded = (env["HTTP_X_FORWARDED_HOST"] as string | undefined)?.split(/,\s?/).pop();
-    if (forwarded && !this.isAuthorized(forwarded.toLowerCase())) {
-      out.push(forwarded);
+    const forwarded = (env["HTTP_X_FORWARDED_HOST"] as string | undefined)
+      ?.split(/,\s?/)
+      .pop()
+      ?.trim();
+    if (forwarded) {
+      const normalized = forwarded.replace(/:\d+$/, "").toLowerCase();
+      if (!this.isAuthorized(normalized)) out.push(normalized);
     }
     return out;
   }

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -30,20 +30,18 @@ export class HostAuthorization {
   }
 
   async call(env: RackEnv): Promise<RackResponse> {
-    if (this.exclude?.(env)) {
-      return this.app(env);
-    }
+    if (this.hosts.length === 0) return this.app(env);
 
     const host = this.extractHost(env);
+    const blocked = this.blockedHosts(env, host);
 
-    if (this.isAuthorized(host)) {
+    if (blocked.length === 0 || this.isExcluded(env)) {
+      this.markAsAuthorized(env, host);
       return this.app(env);
     }
 
-    if (this.responseApp) {
-      return this.responseApp(env);
-    }
-
+    env["action_dispatch.blocked_hosts"] = blocked;
+    if (this.responseApp) return this.responseApp(env);
     return this.blockedResponse(host);
   }
 
@@ -51,6 +49,27 @@ export class HostAuthorization {
     const httpHost = env["HTTP_HOST"] as string | undefined;
     if (httpHost) return httpHost.replace(/:\d+$/, "").toLowerCase();
     return ((env["SERVER_NAME"] as string) || "localhost").toLowerCase();
+  }
+
+  /** @internal */
+  private blockedHosts(env: RackEnv, host: string): string[] {
+    const out: string[] = [];
+    if (!this.isAuthorized(host)) out.push(host);
+    const forwarded = (env["HTTP_X_FORWARDED_HOST"] as string | undefined)?.split(/,\s?/).pop();
+    if (forwarded && !this.isAuthorized(forwarded.toLowerCase())) {
+      out.push(forwarded);
+    }
+    return out;
+  }
+
+  /** @internal */
+  private isExcluded(env: RackEnv): boolean {
+    return Boolean(this.exclude?.(env));
+  }
+
+  /** @internal */
+  private markAsAuthorized(env: RackEnv, host: string): void {
+    env["action_dispatch.authorized_host"] = host;
   }
 
   private isAuthorized(host: string): boolean {

--- a/packages/actionpack/src/action-dispatch/middleware/request-id.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/request-id.ts
@@ -36,10 +36,14 @@ export class RequestId {
     const headerKey = `HTTP_${this.header.toUpperCase().replace(/-/g, "_")}`;
     const existing = env[headerKey] as string | undefined;
     if (existing) {
-      // Sanitize: only allow alphanumeric, dashes, and underscores
-      const sanitized = existing.replace(/[^\w-]/g, "").slice(0, 255);
+      const sanitized = existing.replace(/[^\w-@]/g, "").slice(0, 255);
       if (sanitized.length > 0) return sanitized;
     }
+    return this.internalRequestId();
+  }
+
+  /** @internal */
+  private internalRequestId(): string {
     return getCrypto().randomUUID();
   }
 }

--- a/packages/actionpack/src/action-dispatch/middleware/request-id.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/request-id.ts
@@ -35,9 +35,8 @@ export class RequestId {
   private makeRequestId(env: RackEnv): string {
     const headerKey = `HTTP_${this.header.toUpperCase().replace(/-/g, "_")}`;
     const existing = env[headerKey] as string | undefined;
-    if (existing) {
-      const sanitized = existing.replace(/[^\w-@]/g, "").slice(0, 255);
-      if (sanitized.length > 0) return sanitized;
+    if (existing != null && existing !== "") {
+      return existing.replace(/[^\w\-@]/g, "").slice(0, 255);
     }
     return this.internalRequestId();
   }

--- a/packages/actionpack/src/action-dispatch/middleware/show-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/show-exceptions.ts
@@ -51,8 +51,9 @@ export class ShowExceptions {
   private async renderException(env: RackEnv, wrapper: ExceptionWrapper): Promise<RackResponse> {
     const status = wrapper.statusCode;
     const originalPath = env["PATH_INFO"];
+    const originalMethod = env["REQUEST_METHOD"];
     env["action_dispatch.original_path"] = originalPath;
-    env["action_dispatch.original_request_method"] = env["REQUEST_METHOD"];
+    env["action_dispatch.original_request_method"] = originalMethod;
     this.fallbackToHtmlFormatIfInvalidMimeType(env);
     env["PATH_INFO"] = `/${status}`;
     env["REQUEST_METHOD"] = "GET";
@@ -66,6 +67,7 @@ export class ShowExceptions {
       }
     } finally {
       env["PATH_INFO"] = originalPath;
+      env["REQUEST_METHOD"] = originalMethod;
     }
   }
 

--- a/packages/actionpack/src/action-dispatch/middleware/show-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/show-exceptions.ts
@@ -102,5 +102,6 @@ export class ShowExceptions {
 }
 
 function isValidMimeLike(value: string): boolean {
-  return /^[\w!#$&^_.+-]+\/[\w!#$&^_.+-]+/.test(value.split(",")[0]?.trim() ?? "");
+  const first = value.split(",")[0]?.trim().split(";")[0]?.trim() ?? "";
+  return /^[\w!#$&^_.+*-]+\/[\w!#$&^_.+*-]+$/.test(first);
 }

--- a/packages/actionpack/src/action-dispatch/middleware/show-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/show-exceptions.ts
@@ -43,25 +43,51 @@ export class ShowExceptions {
       }
 
       env["action_dispatch.exception"] = err;
-      const originalPath = env["PATH_INFO"];
-      env["action_dispatch.original_path"] = originalPath;
-      env["PATH_INFO"] = `/${wrapper.statusCode}`;
-
-      try {
-        try {
-          const response = await this.exceptionsApp(env);
-          const cascade = response[1]["x-cascade"] ?? response[1]["X-Cascade"];
-          if (cascade === "pass") {
-            return [wrapper.statusCode, { "content-type": "text/plain" }, bodyFromString("")];
-          }
-          return response;
-        } catch {
-          return this.failsafeResponse(wrapper);
-        }
-      } finally {
-        env["PATH_INFO"] = originalPath;
-      }
+      return this.renderException(env, wrapper);
     }
+  }
+
+  /** @internal */
+  private async renderException(env: RackEnv, wrapper: ExceptionWrapper): Promise<RackResponse> {
+    const status = wrapper.statusCode;
+    const originalPath = env["PATH_INFO"];
+    env["action_dispatch.original_path"] = originalPath;
+    env["action_dispatch.original_request_method"] = env["REQUEST_METHOD"];
+    this.fallbackToHtmlFormatIfInvalidMimeType(env);
+    env["PATH_INFO"] = `/${status}`;
+    env["REQUEST_METHOD"] = "GET";
+    try {
+      try {
+        const response = await this.exceptionsApp(env);
+        const cascade = response[1]["x-cascade"] ?? response[1]["X-Cascade"];
+        return cascade === "pass" ? this.passResponse(status) : response;
+      } catch {
+        return this.failsafeResponse(wrapper);
+      }
+    } finally {
+      env["PATH_INFO"] = originalPath;
+    }
+  }
+
+  /** @internal */
+  private fallbackToHtmlFormatIfInvalidMimeType(env: RackEnv): void {
+    const ct = env["CONTENT_TYPE"];
+    if (typeof ct === "string" && !isValidMimeLike(ct)) {
+      env["CONTENT_TYPE"] = "text/html";
+    }
+    const accept = env["HTTP_ACCEPT"];
+    if (typeof accept === "string" && !isValidMimeLike(accept)) {
+      env["HTTP_ACCEPT"] = "text/html";
+    }
+  }
+
+  /** @internal */
+  private passResponse(status: number): RackResponse {
+    return [
+      status,
+      { "content-type": "text/html; charset=utf-8", "content-length": "0" },
+      bodyFromString(""),
+    ];
   }
 
   private failsafeResponse(_wrapper: ExceptionWrapper): RackResponse {
@@ -71,4 +97,8 @@ export class ShowExceptions {
       bodyFromString("500 Internal Server Error\n"),
     ];
   }
+}
+
+function isValidMimeLike(value: string): boolean {
+  return /^[\w!#$&^_.+-]+\/[\w!#$&^_.+-]+/.test(value.split(",")[0]?.trim() ?? "");
 }

--- a/packages/actionpack/src/action-dispatch/middleware/ssl.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/ssl.ts
@@ -11,7 +11,7 @@ import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { bodyFromString } from "@blazetrails/rack";
 
 export interface SSLOptions {
-  redirect?: boolean | { status?: number; body?: string; port?: number };
+  redirect?: boolean | { status?: number; port?: number };
   hsts?: boolean | HSTSOptions;
   secureCookies?: boolean;
   exclude?: (env: RackEnv) => boolean;

--- a/packages/actionpack/src/action-dispatch/middleware/ssl.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/ssl.ts
@@ -32,7 +32,7 @@ export class SSL {
   private app: RackApp;
   private redirect: boolean;
   private redirectPort: number | undefined;
-  private hsts: HSTSOptions | false;
+  private hsts: Required<HSTSOptions>;
   private secureCookies: boolean;
   private sslDefaultRedirectStatus: number | undefined;
   private redirectStatusOverride: number | undefined;
@@ -62,7 +62,7 @@ export class SSL {
   }
 
   /** @internal */
-  private normalizeHstsOptions(options: SSLOptions["hsts"]): Required<HSTSOptions> | false {
+  private normalizeHstsOptions(options: SSLOptions["hsts"]): Required<HSTSOptions> {
     if (options === false) {
       return { ...SSL.defaultHstsOptions(), expires: 0 };
     }
@@ -88,7 +88,7 @@ export class SSL {
 
     const [status, headers, body] = await this.app(env);
 
-    if (isSSL && this.hsts) {
+    if (isSSL) {
       this.setHstsHeaderBang(headers);
     }
 
@@ -139,7 +139,7 @@ export class SSL {
   }
 
   private buildHstsHeader(): string {
-    const opts = this.hsts as Required<HSTSOptions>;
+    const opts = this.hsts;
     let header = `max-age=${opts.expires}`;
     if (opts.subdomains) header += "; includeSubDomains";
     if (opts.preload) header += "; preload";

--- a/packages/actionpack/src/action-dispatch/middleware/ssl.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/ssl.ts
@@ -31,7 +31,6 @@ const PERMANENT_REDIRECT_REQUEST_METHODS = ["GET", "HEAD"];
 export class SSL {
   private app: RackApp;
   private redirect: boolean;
-  private redirectStatus: number;
   private redirectPort: number | undefined;
   private hsts: HSTSOptions | false;
   private secureCookies: boolean;
@@ -49,18 +48,14 @@ export class SSL {
     this.secureCookies = options.secureCookies !== false;
     this.sslDefaultRedirectStatus = undefined;
 
-    // Redirect config
     if (options.redirect === false) {
       this.redirect = false;
-      this.redirectStatus = 301;
     } else if (typeof options.redirect === "object") {
       this.redirect = true;
-      this.redirectStatus = options.redirect.status ?? 301;
       this.redirectStatusOverride = options.redirect.status;
       this.redirectPort = options.redirect.port;
     } else {
       this.redirect = true;
-      this.redirectStatus = 301;
     }
 
     this.hsts = this.normalizeHstsOptions(options.hsts);
@@ -105,11 +100,12 @@ export class SSL {
   }
 
   private redirectToHttps(env: RackEnv): RackResponse {
+    const location = this.httpsLocationFor(env);
     return [
       this.redirectStatusOverride ?? this.redirectionStatus(env),
-      { "content-type": "text/html; charset=utf-8", location: this.httpsLocationFor(env) },
+      { "content-type": "text/html; charset=utf-8", location },
       bodyFromString(
-        `<html><body>You are being <a href="${this.httpsLocationFor(env)}">redirected</a>.</body></html>`,
+        `<html><body>You are being <a href="${location}">redirected</a>.</body></html>`,
       ),
     ];
   }

--- a/packages/actionpack/src/action-dispatch/middleware/ssl.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/ssl.ts
@@ -15,6 +15,8 @@ export interface SSLOptions {
   hsts?: boolean | HSTSOptions;
   secureCookies?: boolean;
   exclude?: (env: RackEnv) => boolean;
+  /** Mirrors Rails `ssl_default_redirect_status:` constructor kwarg. */
+  sslDefaultRedirectStatus?: number;
 }
 
 export interface HSTSOptions {
@@ -46,7 +48,7 @@ export class SSL {
     this.app = app;
     this.exclude = options.exclude;
     this.secureCookies = options.secureCookies !== false;
-    this.sslDefaultRedirectStatus = undefined;
+    this.sslDefaultRedirectStatus = options.sslDefaultRedirectStatus;
 
     if (options.redirect === false) {
       this.redirect = false;

--- a/packages/actionpack/src/action-dispatch/middleware/ssl.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/ssl.ts
@@ -25,7 +25,8 @@ export interface HSTSOptions {
 
 type RackApp = (env: RackEnv) => Promise<RackResponse>;
 
-const ONE_YEAR = 31536000;
+const HSTS_EXPIRES_IN = 63072000;
+const PERMANENT_REDIRECT_REQUEST_METHODS = ["GET", "HEAD"];
 
 export class SSL {
   private app: RackApp;
@@ -34,12 +35,19 @@ export class SSL {
   private redirectPort: number | undefined;
   private hsts: HSTSOptions | false;
   private secureCookies: boolean;
+  private sslDefaultRedirectStatus: number | undefined;
+  private redirectStatusOverride: number | undefined;
   private exclude?: (env: RackEnv) => boolean;
+
+  static defaultHstsOptions(): Required<HSTSOptions> {
+    return { expires: HSTS_EXPIRES_IN, subdomains: true, preload: false };
+  }
 
   constructor(app: RackApp, options: SSLOptions = {}) {
     this.app = app;
     this.exclude = options.exclude;
     this.secureCookies = options.secureCookies !== false;
+    this.sslDefaultRedirectStatus = undefined;
 
     // Redirect config
     if (options.redirect === false) {
@@ -48,24 +56,25 @@ export class SSL {
     } else if (typeof options.redirect === "object") {
       this.redirect = true;
       this.redirectStatus = options.redirect.status ?? 301;
+      this.redirectStatusOverride = options.redirect.status;
       this.redirectPort = options.redirect.port;
     } else {
       this.redirect = true;
       this.redirectStatus = 301;
     }
 
-    // HSTS config
-    if (options.hsts === false) {
-      this.hsts = false;
-    } else if (typeof options.hsts === "object") {
-      this.hsts = {
-        expires: options.hsts.expires ?? ONE_YEAR,
-        subdomains: options.hsts.subdomains ?? false,
-        preload: options.hsts.preload ?? false,
-      };
-    } else {
-      this.hsts = { expires: ONE_YEAR, subdomains: false, preload: false };
+    this.hsts = this.normalizeHstsOptions(options.hsts);
+  }
+
+  /** @internal */
+  private normalizeHstsOptions(options: SSLOptions["hsts"]): Required<HSTSOptions> | false {
+    if (options === false) {
+      return { ...SSL.defaultHstsOptions(), expires: 0 };
     }
+    if (options == null || options === true) {
+      return SSL.defaultHstsOptions();
+    }
+    return { ...SSL.defaultHstsOptions(), ...options };
   }
 
   async call(env: RackEnv): Promise<RackResponse> {
@@ -84,51 +93,70 @@ export class SSL {
 
     const [status, headers, body] = await this.app(env);
 
-    // Add HSTS header for HTTPS requests
     if (isSSL && this.hsts) {
-      headers["strict-transport-security"] = this.buildHstsHeader();
+      this.setHstsHeaderBang(headers);
     }
 
-    // Mark cookies as secure
     if (isSSL && this.secureCookies && headers["set-cookie"]) {
-      headers["set-cookie"] = this.flagCookiesAsSecure(headers["set-cookie"]);
+      this.flagCookiesAsSecureBang(headers);
     }
 
     return [status, headers, body];
   }
 
   private redirectToHttps(env: RackEnv): RackResponse {
-    const host = (env["HTTP_HOST"] as string) || (env["SERVER_NAME"] as string) || "localhost";
-    const path = (env["PATH_INFO"] as string) || "/";
-    const qs = (env["QUERY_STRING"] as string) || "";
-    const portSuffix = this.redirectPort ? `:${this.redirectPort}` : "";
-    const url = `https://${host.replace(/:\d+$/, "")}${portSuffix}${path}${qs ? "?" + qs : ""}`;
-
     return [
-      this.redirectStatus,
-      {
-        "content-type": "text/html; charset=utf-8",
-        location: url,
-      },
-      bodyFromString(`<html><body>You are being <a href="${url}">redirected</a>.</body></html>`),
+      this.redirectStatusOverride ?? this.redirectionStatus(env),
+      { "content-type": "text/html; charset=utf-8", location: this.httpsLocationFor(env) },
+      bodyFromString(
+        `<html><body>You are being <a href="${this.httpsLocationFor(env)}">redirected</a>.</body></html>`,
+      ),
     ];
   }
 
+  /** @internal */
+  private redirectionStatus(env: RackEnv): number {
+    const method = (env["REQUEST_METHOD"] as string | undefined) ?? "";
+    if (PERMANENT_REDIRECT_REQUEST_METHODS.includes(method)) return 301;
+    if (this.sslDefaultRedirectStatus != null) return this.sslDefaultRedirectStatus;
+    return 307;
+  }
+
+  /** @internal */
+  private httpsLocationFor(env: RackEnv): string {
+    const httpHost = (env["HTTP_HOST"] as string) || (env["SERVER_NAME"] as string) || "localhost";
+    const hostNoPort = httpHost.replace(/:\d+$/, "");
+    const port = this.redirectPort;
+    const path = (env["PATH_INFO"] as string) || "/";
+    const qs = (env["QUERY_STRING"] as string) || "";
+    let location = `https://${hostNoPort}`;
+    if (port && port !== 80 && port !== 443) location += `:${port}`;
+    location += path;
+    if (qs) location += `?${qs}`;
+    return location;
+  }
+
+  /** @internal */
+  private setHstsHeaderBang(headers: Record<string, string>): void {
+    if (headers["strict-transport-security"]) return;
+    headers["strict-transport-security"] = this.buildHstsHeader();
+  }
+
   private buildHstsHeader(): string {
-    const opts = this.hsts as HSTSOptions;
+    const opts = this.hsts as Required<HSTSOptions>;
     let header = `max-age=${opts.expires}`;
     if (opts.subdomains) header += "; includeSubDomains";
     if (opts.preload) header += "; preload";
     return header;
   }
 
-  private flagCookiesAsSecure(setCookie: string): string {
-    return setCookie
+  /** @internal */
+  private flagCookiesAsSecureBang(headers: Record<string, string>): void {
+    const cookies = headers["set-cookie"];
+    if (!cookies) return;
+    headers["set-cookie"] = cookies
       .split("\n")
-      .map((cookie) => {
-        if (cookie.toLowerCase().includes("; secure")) return cookie;
-        return cookie + "; secure";
-      })
+      .map((cookie) => (/;\s*secure\s*(;|$)/i.test(cookie) ? cookie : `${cookie}; secure`))
       .join("\n");
   }
 }

--- a/packages/actionpack/src/action-dispatch/request/utils.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.ts
@@ -66,8 +66,10 @@ export class RequestUtils {
    *
    * Walks the parsed param tree and raises on any string with an invalid
    * encoding. JS strings are UTF-16 and always well-formed, so this is a
-   * no-op in trails — included for surface parity (Rails-private callsites
-   * in `request.ts` invoke it before munging).
+   * no-op in trails — included for surface parity. The matching
+   * callsites in request.ts (Rails invokes this before params munging)
+   * are not yet ported; when they are, they should still route through
+   * here so a future encoding-aware backend slots in cleanly.
    *
    * @internal
    */

--- a/packages/actionpack/src/action-dispatch/request/utils.ts
+++ b/packages/actionpack/src/action-dispatch/request/utils.ts
@@ -62,6 +62,37 @@ export class RequestUtils {
   }
 
   /**
+   * Mirrors Rails `Request::Utils.check_param_encoding`.
+   *
+   * Walks the parsed param tree and raises on any string with an invalid
+   * encoding. JS strings are UTF-16 and always well-formed, so this is a
+   * no-op in trails — included for surface parity (Rails-private callsites
+   * in `request.ts` invoke it before munging).
+   *
+   * @internal
+   */
+  static checkParamEncoding(_params: ParamValue): void {
+    // no-op: JS strings cannot carry invalid encoding the way Ruby strings can.
+  }
+
+  /**
+   * Mirrors Rails `Request::Utils.set_binary_encoding`. In Rails this hands
+   * params off to `CustomParamEncoder` so per-action template encodings
+   * (`Encoding::ASCII_8BIT` etc.) can be applied. Trails has no equivalent
+   * encoding mechanism, so this returns params unchanged.
+   *
+   * @internal
+   */
+  static setBinaryEncoding<P extends ParamValue>(
+    _request: unknown,
+    params: P,
+    _controller: string | undefined,
+    _action: string | undefined,
+  ): P {
+    return params;
+  }
+
+  /**
    * Standalone deep-munge: strip `null` from arrays at every depth.
    * Equivalent to Rails' `NoNilParamEncoder.handle_array` applied
    * recursively. Always normalizes (compaction is unconditional here).


### PR DESCRIPTION
Fills missing Rails-private methods on five small middleware leaves under `actionpack/action-dispatch`, bringing them all to 100% parity.

## Surface added

- `middleware/request-id.ts`: `internalRequestId`
- `middleware/host-authorization.ts`: `blockedHosts`, `isExcluded`, `markAsAuthorized` (and now writes \`action_dispatch.blocked_hosts\` + \`authorized_host\` env keys per Rails)
- `middleware/show-exceptions.ts`: `renderException`, `passResponse`, `fallbackToHtmlFormatIfInvalidMimeType`
- `middleware/ssl.ts`: `defaultHstsOptions`, `normalizeHstsOptions`, `setHstsHeaderBang`, `flagCookiesAsSecureBang`, `redirectionStatus`, `httpsLocationFor`
- `request/utils.ts`: `checkParamEncoding`, `setBinaryEncoding`

## Behavior changes

- SSL HSTS defaults now match Rails: \`expires: 63072000\` (2y) and \`subdomains: true\`. Local trails defaults previously used 1y and \`subdomains: false\`.
- \`hsts: false\` now emits \`max-age=0; includeSubDomains\` (Rails behavior: explicitly clear browsers' remembered HSTS) instead of omitting the header.
- Two local ssl.test.ts assertions updated to match the Rails-correct behavior; test *names* unchanged.
- \`request/utils.ts\` adds \`checkParamEncoding\` / \`setBinaryEncoding\` as no-ops with \`@internal\` JSDoc — JS strings are always UTF-16 and trails has no per-action encoding template, but the surface lets callsites in \`request.ts\` invoke them without conditional guards.

## Numbers

actiondispatch: 705/1351 → 720/1351 (52.2% → 53.3%); files 74/83 → 79/83.

## Deferred follow-ups

- `middleware/debug-view.ts` `render` — blocked on \`ActionView::Base\` (Rails wraps \`super\` in \`logger.silence\`). Already noted in the file header.
- `middleware/flash.ts` (1/6) — needs a \`FlashHash\` port; separate PR.

## Test plan

- [x] \`pnpm vitest run\` on the five touched dispatch + request test files (65 passed)
- [x] \`pnpm build\` clean
- [x] \`pnpm api:compare\` shows the five files at 100%