### PR TITLE
feat(did-you-mean): port Jaro/JaroWinkler/Levenshtein from did_you_mean

### DIFF
--- a/packages/did-you-mean/NOTICE
+++ b/packages/did-you-mean/NOTICE
@@ -1,0 +1,36 @@
+@blazetrails/did-you-mean
+=========================
+
+This package is a TypeScript port of Ruby's did_you_mean library
+(https://github.com/ruby/did_you_mean), licensed under the MIT License.
+The Levenshtein implementation in did_you_mean is in turn based on the
+Text gem.
+
+Original copyrights:
+
+  did_you_mean — Copyright (c) 2014–present Yuki Nishijima, MIT License.
+
+  Text gem (Levenshtein algorithm) —
+    Copyright (c) 2006-2013 Paul Battley, Michael Neumann, Tim Fletcher.
+
+MIT License (did_you_mean)
+--------------------------
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/did-you-mean/package.json
+++ b/packages/did-you-mean/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@blazetrails/did-you-mean",
+  "version": "0.1.0",
+  "description": "Port of Ruby's did_you_mean: SpellChecker, Jaro/JaroWinkler, Levenshtein",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc"
+  }
+}

--- a/packages/did-you-mean/src/index.ts
+++ b/packages/did-you-mean/src/index.ts
@@ -1,0 +1,2 @@
+export { levenshteinDistance } from "./levenshtein.js";
+export { jaroDistance, jaroWinklerDistance } from "./jaro-winkler.js";

--- a/packages/did-you-mean/src/jaro-winkler.test.ts
+++ b/packages/did-you-mean/src/jaro-winkler.test.ts
@@ -1,0 +1,71 @@
+// Oracle values computed via Ruby 3.3 did_you_mean's
+// DidYouMean::Jaro.distance and DidYouMean::JaroWinkler.distance.
+import { describe, it, expect } from "vitest";
+import { jaroDistance, jaroWinklerDistance } from "./jaro-winkler.js";
+
+const EPS = 1e-9;
+
+function close(actual: number, expected: number) {
+  expect(Math.abs(actual - expected)).toBeLessThan(EPS);
+}
+
+describe("jaroDistance", () => {
+  it("is 1 for identical strings and 0 for fully disjoint", () => {
+    expect(jaroDistance("foo", "foo")).toBe(1);
+    expect(jaroDistance("foo", "qux")).toBe(0);
+  });
+
+  it("is 0 when either string is empty", () => {
+    expect(jaroDistance("", "")).toBe(0);
+    expect(jaroDistance("a", "")).toBe(0);
+    expect(jaroDistance("", "b")).toBe(0);
+  });
+
+  it("matches Ruby oracle values for canonical cases", () => {
+    close(jaroDistance("MARTHA", "MARHTA"), 0.9444444444444444);
+    close(jaroDistance("DIXON", "DICKSONX"), 0.7666666666666667);
+    close(jaroDistance("JELLYFISH", "SMELLYFISH"), 0.8962962962962963);
+    close(jaroDistance("foo", "fooo"), 0.9166666666666666);
+    close(jaroDistance("foo", "fobr"), 0.7222222222222222);
+    close(jaroDistance("abc", "abcd"), 0.9166666666666666);
+    close(jaroDistance("abcd", "abc"), 0.9166666666666666);
+    close(jaroDistance("kitten", "sitting"), 0.746031746031746);
+    close(jaroDistance("receive", "recieve"), 0.9523809523809524);
+    close(jaroDistance("shwo", "show"), 0.9166666666666666);
+    close(jaroDistance("ab", "ba"), 0);
+  });
+
+  it("is symmetric to argument order (Ruby swaps internally)", () => {
+    close(jaroDistance("DIXON", "DICKSONX"), jaroDistance("DICKSONX", "DIXON"));
+    close(jaroDistance("foo", "fooo"), jaroDistance("fooo", "foo"));
+  });
+
+  it("treats accented characters as single codepoints", () => {
+    close(jaroDistance("café", "cafe"), 0.8333333333333334);
+    expect(jaroDistance("café", "café")).toBe(1);
+  });
+});
+
+describe("jaroWinklerDistance", () => {
+  it("equals Jaro distance when Jaro <= 0.7", () => {
+    expect(jaroWinklerDistance("foo", "qux")).toBe(0);
+    close(jaroWinklerDistance("kitten", "sitting"), 0.746031746031746);
+    // kitten/sitting share no prefix, so JW == Jaro even above the threshold.
+  });
+
+  it("applies a prefix bonus when Jaro > 0.7", () => {
+    close(jaroWinklerDistance("MARTHA", "MARHTA"), 0.9611111111111111);
+    close(jaroWinklerDistance("DIXON", "DICKSONX"), 0.8133333333333332);
+    close(jaroWinklerDistance("foo", "fooo"), 0.9416666666666667);
+    close(jaroWinklerDistance("foo", "fobr"), 0.7777777777777778);
+    close(jaroWinklerDistance("abc", "abcd"), 0.9416666666666667);
+    close(jaroWinklerDistance("receive", "recieve"), 0.9666666666666667);
+    close(jaroWinklerDistance("shwo", "show"), 0.9333333333333332);
+    close(jaroWinklerDistance("café", "cafe"), 0.8833333333333334);
+  });
+
+  it("caps prefix bonus at 4 codepoints", () => {
+    // JELLYFISH/SMELLYFISH share no common prefix → no bonus.
+    close(jaroWinklerDistance("JELLYFISH", "SMELLYFISH"), 0.8962962962962963);
+  });
+});

--- a/packages/did-you-mean/src/jaro-winkler.ts
+++ b/packages/did-you-mean/src/jaro-winkler.ts
@@ -1,0 +1,92 @@
+// Ported from Ruby's did_you_mean/jaro_winkler.rb
+// (https://github.com/ruby/did_you_mean), MIT License.
+
+function codepoints(s: string): number[] {
+  const out: number[] = [];
+  for (const ch of s) out.push(ch.codePointAt(0)!);
+  return out;
+}
+
+/** Jaro distance over Unicode codepoints. */
+export function jaroDistance(str1: string, str2: string): number {
+  let cp1 = codepoints(str1);
+  let cp2 = codepoints(str2);
+  if (cp1.length > cp2.length) {
+    const tmp = cp1;
+    cp1 = cp2;
+    cp2 = tmp;
+  }
+  const length1 = cp1.length;
+  const length2 = cp2.length;
+
+  if (length2 === 0) return 0;
+
+  let m = 0;
+  let t = 0;
+  const range = length2 > 3 ? Math.floor(length2 / 2) - 1 : 0;
+  const flags1 = new Uint8Array(length1);
+  const flags2 = new Uint8Array(length2);
+
+  for (let i = 0; i < length1; i++) {
+    const last = i + range;
+    let j = i >= range ? i - range : 0;
+    const jEnd = last < length2 - 1 ? last : length2 - 1;
+    while (j <= jEnd) {
+      if (flags2[j] === 0 && cp1[i] === cp2[j]) {
+        flags2[j] = 1;
+        flags1[i] = 1;
+        m += 1;
+        break;
+      }
+      j += 1;
+    }
+  }
+
+  if (m === 0) return 0;
+
+  let k = 0;
+  for (let i = 0; i < length1; i++) {
+    if (flags1[i] !== 0) {
+      let j = k;
+      let index = k;
+      let found = false;
+      while (j < length2) {
+        index = j;
+        if (flags2[j] !== 0) {
+          k = j + 1;
+          found = true;
+          break;
+        }
+        j += 1;
+      }
+      if (!found) {
+        // exhausted flags2 — leave index at last visited
+      }
+      if (cp1[i] !== cp2[index]) t += 1;
+    }
+  }
+  t = Math.floor(t / 2);
+
+  return (m / length1 + m / length2 + (m - t) / m) / 3;
+}
+
+const JW_WEIGHT = 0.1;
+const JW_THRESHOLD = 0.7;
+
+/** Jaro-Winkler distance (boost for shared prefixes up to length 4). */
+export function jaroWinklerDistance(str1: string, str2: string): number {
+  const j = jaroDistance(str1, str2);
+  if (j <= JW_THRESHOLD) return j;
+
+  const cp1 = codepoints(str1);
+  const cp2 = codepoints(str2);
+  let prefixBonus = 0;
+  for (let i = 0; i < cp1.length; i++) {
+    if (cp1[i] === cp2[prefixBonus] && prefixBonus < 4) {
+      prefixBonus += 1;
+    } else {
+      break;
+    }
+  }
+  return j + prefixBonus * JW_WEIGHT * (1 - j);
+}

--- a/packages/did-you-mean/src/jaro-winkler.ts
+++ b/packages/did-you-mean/src/jaro-winkler.ts
@@ -1,6 +1,7 @@
 // Ported from Ruby's did_you_mean/jaro_winkler.rb
 // (https://github.com/ruby/did_you_mean), MIT License.
 
+/** @internal */
 function codepoints(s: string): number[] {
   const out: number[] = [];
   for (const ch of s) out.push(ch.codePointAt(0)!);
@@ -47,20 +48,17 @@ export function jaroDistance(str1: string, str2: string): number {
   let k = 0;
   for (let i = 0; i < length1; i++) {
     if (flags1[i] !== 0) {
+      // flags1 and flags2 carry the same number of set bits (m matches),
+      // so this scan always finds one.
       let j = k;
       let index = k;
-      let found = false;
       while (j < length2) {
         index = j;
         if (flags2[j] !== 0) {
           k = j + 1;
-          found = true;
           break;
         }
         j += 1;
-      }
-      if (!found) {
-        // exhausted flags2 — leave index at last visited
       }
       if (cp1[i] !== cp2[index]) t += 1;
     }

--- a/packages/did-you-mean/src/levenshtein.test.ts
+++ b/packages/did-you-mean/src/levenshtein.test.ts
@@ -1,0 +1,45 @@
+// Oracle values computed via Ruby 3.3 did_you_mean's
+// DidYouMean::Levenshtein.distance.
+import { describe, it, expect } from "vitest";
+import { levenshteinDistance } from "./levenshtein.js";
+
+describe("levenshteinDistance", () => {
+  it("returns 0 for identical strings", () => {
+    expect(levenshteinDistance("foo", "foo")).toBe(0);
+  });
+
+  it("returns length of the other when one is empty", () => {
+    expect(levenshteinDistance("", "")).toBe(0);
+    expect(levenshteinDistance("abc", "")).toBe(3);
+    expect(levenshteinDistance("", "abc")).toBe(3);
+  });
+
+  it("counts insertions and deletions", () => {
+    expect(levenshteinDistance("foo", "fooo")).toBe(1);
+    expect(levenshteinDistance("abcd", "abc")).toBe(1);
+  });
+
+  it("counts substitutions and transpositions", () => {
+    expect(levenshteinDistance("foo", "fobr")).toBe(2);
+    expect(levenshteinDistance("foo", "qux")).toBe(3);
+    expect(levenshteinDistance("MARTHA", "MARHTA")).toBe(2);
+    expect(levenshteinDistance("DIXON", "DICKSONX")).toBe(4);
+    expect(levenshteinDistance("kitten", "sitting")).toBe(3);
+    expect(levenshteinDistance("receive", "recieve")).toBe(2);
+    expect(levenshteinDistance("shwo", "show")).toBe(2);
+    expect(levenshteinDistance("ab", "ba")).toBe(2);
+  });
+
+  it("counts a non-BMP codepoint as one edit (codepoint iteration)", () => {
+    // Ruby's Levenshtein.distance("𝐀", "") == 1
+    expect(levenshteinDistance("\u{1D400}", "")).toBe(1);
+    expect(levenshteinDistance("\u{1D400}", "\u{1D400}")).toBe(0);
+    expect(levenshteinDistance("a\u{1D400}", "a")).toBe(1);
+  });
+
+  it("treats accented characters as single codepoints", () => {
+    // "café" → "cafe" differs in one codepoint
+    expect(levenshteinDistance("café", "cafe")).toBe(1);
+    expect(levenshteinDistance("café", "café")).toBe(0);
+  });
+});

--- a/packages/did-you-mean/src/levenshtein.ts
+++ b/packages/did-you-mean/src/levenshtein.ts
@@ -1,0 +1,46 @@
+// Ported from Ruby's did_you_mean/levenshtein.rb
+// (https://github.com/ruby/did_you_mean), MIT License.
+// The Ruby implementation is itself based on the Text gem:
+// Copyright (c) 2006-2013 Paul Battley, Michael Neumann, Tim Fletcher.
+
+function codepoints(s: string): number[] {
+  const out: number[] = [];
+  for (const ch of s) out.push(ch.codePointAt(0)!);
+  return out;
+}
+
+function min3(a: number, b: number, c: number): number {
+  if (a < b && a < c) return a;
+  if (b < c) return b;
+  return c;
+}
+
+/** Two-row dynamic-programming Levenshtein distance, codepoint-aware. */
+export function levenshteinDistance(str1: string, str2: string): number {
+  const cp1 = codepoints(str1);
+  const cp2 = codepoints(str2);
+  const n = cp1.length;
+  const m = cp2.length;
+  if (n === 0) return m;
+  if (m === 0) return n;
+
+  const d: number[] = [];
+  for (let k = 0; k <= m; k++) d.push(k);
+  let x = 0;
+
+  for (let idx = 0; idx < n; idx++) {
+    let i = idx + 1;
+    const char1 = cp1[idx];
+    let j = 0;
+    while (j < m) {
+      const cost = char1 === cp2[j] ? 0 : 1;
+      x = min3(d[j + 1] + 1, i + 1, d[j] + cost);
+      d[j] = i;
+      i = x;
+      j += 1;
+    }
+    d[m] = x;
+  }
+
+  return x;
+}

--- a/packages/did-you-mean/src/levenshtein.ts
+++ b/packages/did-you-mean/src/levenshtein.ts
@@ -3,12 +3,14 @@
 // The Ruby implementation is itself based on the Text gem:
 // Copyright (c) 2006-2013 Paul Battley, Michael Neumann, Tim Fletcher.
 
+/** @internal */
 function codepoints(s: string): number[] {
   const out: number[] = [];
   for (const ch of s) out.push(ch.codePointAt(0)!);
   return out;
 }
 
+/** @internal */
 function min3(a: number, b: number, c: number): number {
   if (a < b && a < c) return a;
   if (b < c) return b;

--- a/packages/did-you-mean/tsconfig.json
+++ b/packages/did-you-mean/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"],
+  "references": []
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,6 +169,8 @@ importers:
         specifier: workspace:*
         version: link:../activesupport
 
+  packages/did-you-mean: {}
+
   packages/globalid:
     dependencies:
       '@blazetrails/activesupport':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       '@blazetrails/arel':
         specifier: workspace:*
         version: link:../../packages/arel
+      '@blazetrails/did-you-mean':
+        specifier: workspace:*
+        version: link:../../packages/did-you-mean
       '@blazetrails/globalid':
         specifier: workspace:*
         version: link:../../packages/globalid

--- a/scripts/guides-typecheck/package.json
+++ b/scripts/guides-typecheck/package.json
@@ -13,6 +13,7 @@
     "@blazetrails/actionpack": "workspace:*",
     "@blazetrails/actionview": "workspace:*",
     "@blazetrails/trailties": "workspace:*",
+    "@blazetrails/did-you-mean": "workspace:*",
     "@blazetrails/globalid": "workspace:*",
     "@blazetrails/html-sanitizer": "workspace:*",
     "@blazetrails/trails-tsc": "workspace:*"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,6 +28,7 @@
     { "path": "packages/actionpack" },
     { "path": "packages/trailties" },
     { "path": "packages/globalid" },
+    { "path": "packages/did-you-mean" },
     { "path": "packages/html-sanitizer" }
   ],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
PR 1 of the DidYouMean port epic — see docs/did-you-mean-port-plan.md.

## Summary
- Scaffolds \`@blazetrails/did-you-mean\` as a top-level package with **no workspace deps**, modelled on \`@blazetrails/globalid\`.
- Ports \`Jaro.distance\` / \`JaroWinkler.distance\` and \`Levenshtein.distance\` from Ruby's did_you_mean stdlib (https://github.com/ruby/did_you_mean), MIT-licensed. Algorithms iterate over Unicode codepoints rather than UTF-16 units.
- Adds a per-package \`NOTICE\` file with the upstream MIT text and the Text-gem attribution that did_you_mean's Levenshtein is derived from.
- Adds the package to root \`tsconfig.json\` \`references\` so \`tsc --build\` picks it up.
- Tests cross-check against Ruby 3.3 oracle values (pasted inline; CI does not need Ruby).

## Out of scope (follow-ups)
- PR 2: \`SpellChecker\` + barrel export, against the same package.
- PR 3+: wire consumers — \`ActionNotFound\`, \`ParameterMissing\`, association \`NotFoundError\`s, \`Template::Error\`, \`UrlGenerationError\`.

## Test plan
- [x] \`pnpm vitest run packages/did-you-mean/\` — 14 tests pass.
- [x] \`pnpm -F @blazetrails/did-you-mean build\` succeeds.