### PR TITLE
feat(actionpack): close request/session + middleware/stack + testing/test-request to 100%

### DIFF
--- a/packages/actionpack/src/action-dispatch/middleware/stack.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/stack.ts
@@ -186,7 +186,7 @@ export class MiddlewareStack implements Iterable<MiddlewareEntry> {
   /** @internal */
   assertIndex(index: number | MiddlewareFactory, where: "before" | "after"): number {
     const i = typeof index === "number" ? index : this.indexOf(index);
-    if (i === -1 || i == null) {
+    if (i === -1) {
       throw new Error(`No such middleware to insert ${where}: ${String(index)}`);
     }
     return i;

--- a/packages/actionpack/src/action-dispatch/middleware/stack.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/stack.ts
@@ -52,9 +52,8 @@ export class MiddlewareStack implements Iterable<MiddlewareEntry> {
   deleteBang(target: MiddlewareFactory): void {
     const idx = this.findIndex(target);
     if (idx === -1) {
-      throw new Error(
-        `No such middleware to remove: ${String((target as { name?: string }).name)}`,
-      );
+      const name = (target as { name?: string }).name;
+      throw new Error(`No such middleware to remove: ${name || String(target)}`);
     }
     this.entries.splice(idx, 1);
   }

--- a/packages/actionpack/src/action-dispatch/middleware/stack.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/stack.ts
@@ -21,12 +21,42 @@ export interface MiddlewareEntry {
 export class MiddlewareStack implements Iterable<MiddlewareEntry> {
   private entries: MiddlewareEntry[] = [];
 
+  constructor() {
+    // matches Rails `initialize(*args)` — block form is not ported.
+  }
+
+  get middlewares(): MiddlewareEntry[] {
+    return this.entries;
+  }
+
+  set middlewares(value: MiddlewareEntry[]) {
+    this.entries = value;
+  }
+
   get length(): number {
     return this.entries.length;
   }
 
   get size(): number {
     return this.entries.length;
+  }
+
+  each(callback: (entry: MiddlewareEntry) => void): void {
+    for (const entry of this.entries) callback(entry);
+  }
+
+  last(): MiddlewareEntry | undefined {
+    return this.entries[this.entries.length - 1];
+  }
+
+  deleteBang(target: MiddlewareFactory): void {
+    const idx = this.findIndex(target);
+    if (idx === -1) {
+      throw new Error(
+        `No such middleware to remove: ${String((target as { name?: string }).name)}`,
+      );
+    }
+    this.entries.splice(idx, 1);
   }
 
   use(klass: MiddlewareFactory, ...args: unknown[]): void {
@@ -152,5 +182,28 @@ export class MiddlewareStack implements Iterable<MiddlewareEntry> {
 
   private findIndex(klass: MiddlewareFactory): number {
     return this.entries.findIndex((e) => e.klass === klass);
+  }
+
+  /** @internal */
+  assertIndex(index: number | MiddlewareFactory, where: "before" | "after"): number {
+    const i = typeof index === "number" ? index : this.indexOf(index);
+    if (i === -1 || i == null) {
+      throw new Error(`No such middleware to insert ${where}: ${String(index)}`);
+    }
+    return i;
+  }
+
+  /** @internal */
+  buildMiddleware(
+    klass: MiddlewareFactory,
+    args: unknown[],
+    block?: (app: RackApp) => RackApp,
+  ): MiddlewareEntry {
+    return { klass, args, block };
+  }
+
+  /** @internal */
+  indexOf(klass: MiddlewareFactory): number {
+    return this.findIndex(klass);
   }
 }

--- a/packages/actionpack/src/action-dispatch/request/session.ts
+++ b/packages/actionpack/src/action-dispatch/request/session.ts
@@ -84,7 +84,6 @@ export class Session {
 
   static disabled(req: { env: Record<string, unknown> }): Session {
     const session = new Session(null, req.env, { id: null }, false);
-    req.env[ENV_SESSION_KEY] = session;
     req.env[ENV_SESSION_OPTIONS_KEY] = { id: null };
     return session;
   }

--- a/packages/actionpack/src/action-dispatch/request/session.ts
+++ b/packages/actionpack/src/action-dispatch/request/session.ts
@@ -151,6 +151,8 @@ export class Session {
       const [sessionId, data] = this.store.loadSession(this.env);
       this.id = sessionId;
       this.data = { ...data };
+    } else if (this.data == null) {
+      this.data = {};
     }
     this.loaded = true;
   }

--- a/packages/actionpack/src/action-dispatch/request/session.ts
+++ b/packages/actionpack/src/action-dispatch/request/session.ts
@@ -18,8 +18,17 @@ export interface SessionStore {
 const ENV_SESSION_KEY = "rack.session";
 const ENV_SESSION_OPTIONS_KEY = "rack.session.options";
 
+export class DisabledSessionError extends Error {
+  constructor(
+    message = "Your application has sessions disabled. To write to the session you must first configure a session store",
+  ) {
+    super(message);
+    this.name = "DisabledSessionError";
+  }
+}
+
 export class Session {
-  private store: SessionStore;
+  private store: SessionStore | null;
   private env: Record<string, unknown>;
   private options: Record<string, unknown>;
   private data: Record<string, unknown> | null = null;
@@ -28,17 +37,20 @@ export class Session {
   private _idWas: unknown = null;
   private existed: boolean;
   private destroyed = false;
+  private _enabled: boolean;
 
   private constructor(
-    store: SessionStore,
+    store: SessionStore | null,
     env: Record<string, unknown>,
     options: Record<string, unknown>,
+    enabled = true,
   ) {
     this.store = store;
     this.env = env;
     this.options = options;
-    this.existed = store.sessionExists(env);
-    if (this.existed) {
+    this._enabled = enabled;
+    this.existed = enabled && store ? store.sessionExists(env) : false;
+    if (this.existed && store) {
       const [sessionId, data] = store.loadSession(env);
       this._idWas = sessionId;
       this.id = sessionId;
@@ -70,6 +82,13 @@ export class Session {
     return session;
   }
 
+  static disabled(req: { env: Record<string, unknown> }): Session {
+    const session = new Session(null, req.env, { id: null }, false);
+    req.env[ENV_SESSION_KEY] = session;
+    req.env[ENV_SESSION_OPTIONS_KEY] = { id: null };
+    return session;
+  }
+
   static find(req: { env: Record<string, unknown> }): Session | null {
     const session = req.env[ENV_SESSION_KEY];
     if (session instanceof Session) return session;
@@ -77,12 +96,64 @@ export class Session {
   }
 
   private loadData(): void {
-    if (!this.loaded && !this.destroyed) {
+    if (!this.loaded && !this.destroyed && this.store) {
       const [sessionId, data] = this.store.loadSession(this.env);
       this.id = sessionId;
       this.data = { ...data };
       this.loaded = true;
+    } else if (!this.loaded && !this.destroyed) {
+      this.data = {};
+      this.loaded = true;
     }
+  }
+
+  isEnabled(): boolean {
+    return this._enabled;
+  }
+
+  isExists(): boolean {
+    if (!this._enabled) return false;
+    return this.existed;
+  }
+
+  hasKey(key: string): boolean {
+    return key in this.getData();
+  }
+
+  each(callback: (key: string, value: unknown) => void): void {
+    const data = this.toHash();
+    for (const [key, value] of Object.entries(data)) {
+      callback(key, value);
+    }
+  }
+
+  /** @internal */
+  loadForReadBang(): void {
+    if (!this.loaded && this.isExists()) this.loadBang();
+  }
+
+  /** @internal */
+  loadForWriteBang(): void {
+    if (this._enabled) {
+      if (!this.loaded) this.loadBang();
+    } else {
+      throw new DisabledSessionError();
+    }
+  }
+
+  /** @internal */
+  loadForDeleteBang(): void {
+    if (this._enabled && !this.loaded) this.loadBang();
+  }
+
+  /** @internal */
+  loadBang(): void {
+    if (this._enabled && this.store) {
+      const [sessionId, data] = this.store.loadSession(this.env);
+      this.id = sessionId;
+      this.data = { ...data };
+    }
+    this.loaded = true;
   }
 
   private getData(): Record<string, unknown> {
@@ -164,7 +235,7 @@ export class Session {
     if (!this.loaded) {
       this.loadData();
     }
-    if (this.id != null) {
+    if (this.id != null && this.store) {
       this.store.deleteSession(this.env, this.id, this.options);
     }
     this.data = {};

--- a/packages/actionpack/src/action-dispatch/request/session.ts
+++ b/packages/actionpack/src/action-dispatch/request/session.ts
@@ -116,7 +116,7 @@ export class Session {
   }
 
   hasKey(key: string): boolean {
-    return key in this.getData();
+    return Object.hasOwn(this.getData(), key);
   }
 
   each(callback: (key: string, value: unknown) => void): void {
@@ -201,7 +201,7 @@ export class Session {
 
   fetch(key: string, ...args: unknown[]): unknown {
     const data = this.getData();
-    if (key in data) return data[key];
+    if (Object.hasOwn(data, key)) return data[key];
     if (args.length > 0) {
       if (typeof args[0] === "function") {
         return (args[0] as (key: string) => unknown)(key);

--- a/packages/actionpack/src/action-dispatch/testing/test-request.ts
+++ b/packages/actionpack/src/action-dispatch/testing/test-request.ts
@@ -1,6 +1,13 @@
 import type { RackEnv } from "@blazetrails/rack";
 import { Request } from "../http/request.js";
 
+/** @internal */
+const DEFAULT_ENV: RackEnv = {
+  HTTP_HOST: "test.host",
+  REMOTE_ADDR: "0.0.0.0",
+  HTTP_USER_AGENT: "Rails Testing",
+};
+
 export class TestRequest extends Request {
   constructor(env: RackEnv = {}) {
     super({
@@ -11,5 +18,22 @@ export class TestRequest extends Request {
       SERVER_PORT: "80",
       ...env,
     });
+  }
+
+  /** @internal */
+  static defaultEnv(): RackEnv {
+    return { ...DEFAULT_ENV };
+  }
+
+  set requestUri(uri: string) {
+    this.setHeader("REQUEST_URI", uri);
+  }
+
+  set action(actionName: string) {
+    this.pathParameters = { ...this.pathParameters, action: String(actionName) };
+  }
+
+  set remoteAddr(addr: string) {
+    this.setHeader("REMOTE_ADDR", addr);
   }
 }


### PR DESCRIPTION
Closes three small actionpack leaves to 100% via additive method-only changes.

## api:compare

| File | Before | After |
| --- | --- | --- |
| `request/session.rb` | 17/26 (65%) | 26/26 (100%) |
| `middleware/stack.rb` | 12/21 (57%) | 21/21 (100%) |
| `testing/test_request.rb` | 9/13 (69%) | 13/13 (100%) |

## Changes

**request/session.ts** — adds `isEnabled` / `isExists` / `hasKey` / `each` / `loadForReadBang` / `loadForWriteBang` / `loadForDeleteBang` / `loadBang` instance methods, static `disabled(req)`, and a `DisabledSessionError` class. Threads an `_enabled` flag through the (now nullable-store) constructor; `destroy`/`loadData` guard against `store == null`. Existing test surface (`get`/`set`/`store_value`/`empty`/`toHash`/`destroy`/etc.) is unchanged — all 21 session tests pass.

**middleware/stack.ts** — adds `middlewares` accessor (get/set over the existing `entries` array), `each`, `last`, `deleteBang`, and Rails-private `assertIndex` / `buildMiddleware` / `indexOf` (all `@internal`). No restructuring; existing methods untouched.

**testing/test-request.ts** — adds static `defaultEnv()` (`@internal`, matches `private_class_method`) and `requestUri` / `action` / `remoteAddr` setters that delegate to `setHeader` / `pathParameters` on the base `Request`.

## Notes

- Rails-private helpers carry `@internal`.
- camelCase throughout.
- No test renames.