### PR TITLE
feat(did-you-mean): add SpellChecker

### DIFF
--- a/packages/did-you-mean/src/index.ts
+++ b/packages/did-you-mean/src/index.ts
@@ -1,2 +1,4 @@
 export { levenshteinDistance } from "./levenshtein.js";
 export { jaroDistance, jaroWinklerDistance } from "./jaro-winkler.js";
+export { SpellChecker } from "./spell-checker.js";
+export type { SpellCheckerOptions } from "./spell-checker.js";

--- a/packages/did-you-mean/src/spell-checker.test.ts
+++ b/packages/did-you-mean/src/spell-checker.test.ts
@@ -49,14 +49,18 @@ describe("SpellChecker", () => {
   });
 
   it("falls through to the misspell fallback when Levenshtein filters all mistype candidates", () => {
-    // "caf" length 3 → mistypeThreshold = ceil(3 * 0.25) = 1. Levenshtein
-    // to "café"/"cafe" is 1/1, so both pass the mistype filter — but the
-    // ordering still matches Ruby (jw to original-cased "cafe" wins).
-    expect(correct("caf", ["café", "cafe"])).toEqual(["cafe", "café"]);
+    // "abcd" → mistypeThreshold = ceil(4 * 0.25) = 1. Lev("abcd","abdc") = 2
+    // (transposition costs two ops), so the mistype filter rejects it. JW is
+    // ~0.93 (above 0.834), so the candidate reaches the fallback, where
+    // Lev=2 < min(len)=4 keeps it.
+    expect(correct("abcd", ["abdc"])).toEqual(["abdc"]);
   });
 
-  it("treats non-BMP codepoints as one codepoint when ranking", () => {
-    expect(correct("café", ["cafe", "Cafe", "caf"])).toEqual(["caf", "cafe", "Cafe"]);
+  it("uses codepoint length (not UTF-16) when picking the JW threshold", () => {
+    // "🎉ab" is 3 codepoints (UTF-16 length 4). JW vs "🎉ac" is ~0.82, which
+    // sits between the short (0.77) and long (0.834) thresholds — so this
+    // test only passes if length is measured in codepoints.
+    expect(correct("🎉ab", ["🎉ac"])).toEqual(["🎉ac"]);
   });
 
   it("handles Rails-style action-name dictionaries", () => {

--- a/packages/did-you-mean/src/spell-checker.test.ts
+++ b/packages/did-you-mean/src/spell-checker.test.ts
@@ -1,0 +1,73 @@
+// Oracle outputs computed via Ruby 3.3 did_you_mean's
+// DidYouMean::SpellChecker.new(dictionary:).correct.
+import { describe, it, expect } from "vitest";
+import { SpellChecker } from "./spell-checker.js";
+
+function correct(input: string, dictionary: ReadonlyArray<string>): string[] {
+  return new SpellChecker({ dictionary }).correct(input);
+}
+
+describe("SpellChecker", () => {
+  it("returns nearest dictionary entries by Jaro-Winkler / Levenshtein", () => {
+    expect(correct("foo", ["fooo", "fobr", "qux"])).toEqual(["fooo"]);
+  });
+
+  it("uses the looser 0.77 threshold for short (≤3 codepoint) inputs", () => {
+    expect(correct("fo", ["foo"])).toEqual(["foo"]);
+  });
+
+  it("uses the stricter 0.834 threshold for longer inputs", () => {
+    // 'xyz' is below threshold against all candidates; no JW candidates
+    // means we never reach the misspell fallback.
+    expect(correct("xyz", ["foo", "bar", "baz"])).toEqual([]);
+  });
+
+  it("is case-insensitive via normalize() but preserves dictionary casing", () => {
+    expect(correct("FOO", ["foo"])).toEqual(["foo"]);
+    expect(correct("FOO", ["Foo", "foo", "FOOO"])).toEqual(["foo", "Foo", "FOOO"]);
+  });
+
+  it("strips '@' from input during normalization", () => {
+    expect(correct("@foo", ["foo"])).toEqual(["foo"]);
+  });
+
+  it("rejects exact-equality dictionary matches (step 5)", () => {
+    expect(correct("foo", ["foo"])).toEqual([]);
+  });
+
+  it("returns [] for empty input or empty dictionary", () => {
+    expect(correct("", ["foo"])).toEqual([]);
+    expect(correct("foo", [])).toEqual([]);
+  });
+
+  it("orders results by Jaro-Winkler score, descending, stable on ties", () => {
+    expect(correct("recieve", ["receive", "retrieve", "relieve"])).toEqual([
+      "receive",
+      "relieve",
+      "retrieve",
+    ]);
+  });
+
+  it("falls through to the misspell fallback when Levenshtein filters all mistype candidates", () => {
+    // "caf" length 3 → mistypeThreshold = ceil(3 * 0.25) = 1. Levenshtein
+    // to "café"/"cafe" is 1/1, so both pass the mistype filter — but the
+    // ordering still matches Ruby (jw to original-cased "cafe" wins).
+    expect(correct("caf", ["café", "cafe"])).toEqual(["cafe", "café"]);
+  });
+
+  it("treats non-BMP codepoints as one codepoint when ranking", () => {
+    expect(correct("café", ["cafe", "Cafe", "caf"])).toEqual(["caf", "cafe", "Cafe"]);
+  });
+
+  it("handles Rails-style action-name dictionaries", () => {
+    expect(correct("shwo", ["show", "index", "edit", "update", "destroy"])).toEqual(["show"]);
+  });
+
+  it("handles Rails-style strong-params key dictionaries", () => {
+    expect(correct("created_t", ["created_at", "updated_at", "id"])).toEqual(["created_at"]);
+  });
+
+  it("handles underscored Ruby-method-style entries", () => {
+    expect(correct("__send", ["__send__", "send"])).toEqual(["__send__", "send"]);
+  });
+});

--- a/packages/did-you-mean/src/spell-checker.ts
+++ b/packages/did-you-mean/src/spell-checker.ts
@@ -1,0 +1,72 @@
+// Ported from Ruby's did_you_mean/spell_checker.rb
+// (https://github.com/ruby/did_you_mean), MIT License.
+
+import { jaroWinklerDistance } from "./jaro-winkler.js";
+import { levenshteinDistance } from "./levenshtein.js";
+
+export interface SpellCheckerOptions {
+  dictionary: ReadonlyArray<string>;
+}
+
+/** @internal */
+function normalize(input: string): string {
+  return input.toLowerCase().replaceAll("@", "");
+}
+
+/**
+ * Port of Ruby's DidYouMean::SpellChecker. Suggests dictionary entries close
+ * to a misspelled input using Jaro-Winkler for ranking and Levenshtein for
+ * filtering, matching upstream thresholds and tie-breaking.
+ */
+export class SpellChecker {
+  readonly #dictionary: ReadonlyArray<string>;
+
+  constructor(options: SpellCheckerOptions) {
+    this.#dictionary = options.dictionary;
+  }
+
+  correct(input: string): string[] {
+    const rawInput = String(input);
+    const normalizedInput = normalize(rawInput);
+    const jwThreshold = normalizedInput.length > 3 ? 0.834 : 0.77;
+
+    const candidates: Array<{ word: string; index: number; score: number }> = [];
+    for (let i = 0; i < this.#dictionary.length; i++) {
+      const word = this.#dictionary[i];
+      if (rawInput === String(word)) continue;
+      const jw = jaroWinklerDistance(normalize(word), normalizedInput);
+      if (jw < jwThreshold) continue;
+      candidates.push({
+        word,
+        index: i,
+        score: jaroWinklerDistance(String(word), normalizedInput),
+      });
+    }
+
+    candidates.sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      // Ruby does `sort_by` then `reverse!`. MRI's sort is not stable, but
+      // the observable effect on ties in practice is that elements come out
+      // in reverse insertion order — match that.
+      return b.index - a.index;
+    });
+
+    const mistypeThreshold = Math.ceil(normalizedInput.length * 0.25);
+    let corrections = candidates
+      .filter((c) => levenshteinDistance(normalize(c.word), normalizedInput) <= mistypeThreshold)
+      .map((c) => c.word);
+
+    if (corrections.length === 0) {
+      corrections = candidates
+        .filter((c) => {
+          const w = normalize(c.word);
+          const len = Math.min(normalizedInput.length, w.length);
+          return levenshteinDistance(w, normalizedInput) < len;
+        })
+        .slice(0, 1)
+        .map((c) => c.word);
+    }
+
+    return corrections;
+  }
+}

--- a/packages/did-you-mean/src/spell-checker.ts
+++ b/packages/did-you-mean/src/spell-checker.ts
@@ -13,6 +13,13 @@ function normalize(input: string): string {
   return input.toLowerCase().replaceAll("@", "");
 }
 
+/** @internal */
+function codepointLength(s: string): number {
+  let n = 0;
+  for (const _ of s) n++;
+  return n;
+}
+
 /**
  * Port of Ruby's DidYouMean::SpellChecker. Suggests dictionary entries close
  * to a misspelled input using Jaro-Winkler for ranking and Levenshtein for
@@ -28,7 +35,8 @@ export class SpellChecker {
   correct(input: string): string[] {
     const rawInput = String(input);
     const normalizedInput = normalize(rawInput);
-    const jwThreshold = normalizedInput.length > 3 ? 0.834 : 0.77;
+    const inputLen = codepointLength(normalizedInput);
+    const jwThreshold = inputLen > 3 ? 0.834 : 0.77;
 
     const candidates: Array<{ word: string; index: number; score: number }> = [];
     for (let i = 0; i < this.#dictionary.length; i++) {
@@ -51,7 +59,7 @@ export class SpellChecker {
       return b.index - a.index;
     });
 
-    const mistypeThreshold = Math.ceil(normalizedInput.length * 0.25);
+    const mistypeThreshold = Math.ceil(inputLen * 0.25);
     let corrections = candidates
       .filter((c) => levenshteinDistance(normalize(c.word), normalizedInput) <= mistypeThreshold)
       .map((c) => c.word);
@@ -60,7 +68,7 @@ export class SpellChecker {
       corrections = candidates
         .filter((c) => {
           const w = normalize(c.word);
-          const len = Math.min(normalizedInput.length, w.length);
+          const len = Math.min(inputLen, codepointLength(w));
           return levenshteinDistance(w, normalizedInput) < len;
         })
         .slice(0, 1)


### PR DESCRIPTION
PR 2 of the DidYouMean port epic — see docs/did-you-mean-port-plan.md. Stacked on #2076.

## Summary
- Adds \`SpellChecker\` to \`@blazetrails/did-you-mean\`, completing the package's public surface.
- Faithfully ports Ruby's two-stage filter: Jaro-Winkler threshold (0.834 for inputs >3 codepoints, 0.77 otherwise) → Levenshtein mistype filter at \`ceil(len * 0.25)\` → misspell fallback (first candidate within length-Levenshtein bound) if the mistype filter returns nothing.
- Matches Ruby's exact tie-breaking: for candidates with equal Jaro-Winkler scores against the original-cased word, results come back in reverse insertion order. This matches MRI's \`sort_by; reverse!\` behaviour observed against did_you_mean 3.3.
- Normalisation (lowercase + strip \`@\`) is applied during filtering only; returned suggestions preserve dictionary casing.

## Out of scope (follow-ups)
- PR 3+: wire consumers — \`ActionNotFound\`, \`ParameterMissing\`, association \`NotFoundError\`s, \`Template::Error\`, \`UrlGenerationError\`.

## Test plan
- [x] \`pnpm vitest run packages/did-you-mean/\` — 27 tests pass.
- [x] All SpellChecker assertions oracle-verified against Ruby 3.3 \`DidYouMean::SpellChecker.new(dictionary:).correct\`.