### PR TITLE
feat(actionpack): testing/assertions.ts to 95% via include-mirror re-exports

### DIFF
--- a/packages/actionpack/src/action-dispatch/testing/assertions.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions.ts
@@ -1,27 +1,53 @@
 /**
- * ActionDispatch::Assertions — aggregates the test assertions provided by
- * ActionDispatch. Mirrors `action_dispatch/testing/assertions.rb`.
- * `htmlDocument` follows once rails-dom-testing is ported.
+ * ActionDispatch::Assertions — aggregator mirroring
+ * `action_dispatch/testing/assertions.rb`. Rails includes
+ * ResponseAssertions + RoutingAssertions + Rails::Dom::Testing::Assertions
+ * into the host test class; trails re-exports their helpers here as
+ * `this`-typed functions so api:compare sees the full mixed-in surface
+ * on this file.
+ *
+ * `htmlDocument` is intentionally not exported: it requires
+ * rails-dom-testing (Nokogiri / DOM parser), which is not yet ported. A
+ * stub would mislead callers, so the gap is tracked rather than papered
+ * over. Restore the export once rails-dom-testing lands.
  */
 
-export {
-  assertResponse,
-  assertRedirectedTo,
-  parameterize,
-  normalizeArgumentToRedirection,
-  type AssertionResponseHost,
-  type AssertionResponseLike,
-} from "./assertions/response.js";
+import * as response from "./assertions/response.js";
+import * as routing from "./assertions/routing.js";
 
-export {
-  assertRecognizes,
-  assertGenerates,
-  assertRouting,
-  withRouting,
-  setup,
-  type RoutingAssertionsHost,
-  type PathWithMethod,
-} from "./assertions/routing.js";
-// recognizedRequestFor / createRoutes / resetRoutes / failOn are @internal
-// — they're still exported from ./assertions/routing.js so api:compare
-// sees the full surface, but they aren't part of the public barrel.
+export type { AssertionResponseHost, AssertionResponseLike } from "./assertions/response.js";
+
+export type { RoutingAssertionsHost, PathWithMethod } from "./assertions/routing.js";
+
+// Response assertions
+export const assertResponse = response.assertResponse;
+export const assertRedirectedTo = response.assertRedirectedTo;
+/** @internal */
+export const parameterize = response.parameterize;
+/** @internal */
+export const normalizeArgumentToRedirection = response.normalizeArgumentToRedirection;
+/** @internal */
+export const generateResponseMessage = response.generateResponseMessage;
+/** @internal */
+export const responseBodyIfShort = response.responseBodyIfShort;
+/** @internal */
+export const exceptionIfPresent = response.exceptionIfPresent;
+/** @internal */
+export const locationIfRedirected = response.locationIfRedirected;
+/** @internal */
+export const codeWithName = response.codeWithName;
+
+// Routing assertions
+export const setup = routing.setup;
+export const withRouting = routing.withRouting;
+export const assertRecognizes = routing.assertRecognizes;
+export const assertGenerates = routing.assertGenerates;
+export const assertRouting = routing.assertRouting;
+/** @internal */
+export const recognizedRequestFor = routing.recognizedRequestFor;
+/** @internal */
+export const createRoutes = routing.createRoutes;
+/** @internal */
+export const resetRoutes = routing.resetRoutes;
+/** @internal */
+export const failOn = routing.failOn;

--- a/packages/actionpack/src/action-dispatch/testing/assertions/response.ts
+++ b/packages/actionpack/src/action-dispatch/testing/assertions/response.ts
@@ -118,7 +118,8 @@ export function normalizeArgumentToRedirection(
   return fragment;
 }
 
-function generateResponseMessage(
+/** @internal */
+export function generateResponseMessage(
   host: AssertionResponseHost,
   expected: number | string,
   actual: number,
@@ -132,11 +133,13 @@ function generateResponseMessage(
   return parts.join("");
 }
 
-function codeWithName(codeOrName: number | string): string {
+/** @internal */
+export function codeWithName(codeOrName: number | string): string {
   return new AssertionResponse(codeOrName).codeAndName();
 }
 
-function locationIfRedirected(host: AssertionResponseHost): string {
+/** @internal */
+export function locationIfRedirected(host: AssertionResponseHost): string {
   const status = host.response.status;
   if (status < 300 || status > 399) return "";
   const location = host.response.getHeader?.("location");
@@ -145,7 +148,8 @@ function locationIfRedirected(host: AssertionResponseHost): string {
   return ` redirect to <${String(normalized)}>`;
 }
 
-function exceptionIfPresent(host: AssertionResponseHost): string {
+/** @internal */
+export function exceptionIfPresent(host: AssertionResponseHost): string {
   const ex = host.request?.env?.["action_dispatch.exception"];
   if (!ex) return "";
   const name = ex instanceof Error ? ex.name || "Error" : "Error";
@@ -153,7 +157,8 @@ function exceptionIfPresent(host: AssertionResponseHost): string {
   return `\n\nException while processing request: ${name}: ${message}\n`;
 }
 
-function responseBodyIfShort(host: AssertionResponseHost): string {
+/** @internal */
+export function responseBodyIfShort(host: AssertionResponseHost): string {
   const body = host.response.body ?? "";
   if (body.length > 500) return "";
   return `\nResponse body: ${body}`;


### PR DESCRIPTION
ActionDispatch::Assertions in Rails `include`s `ResponseAssertions` and
`RoutingAssertions`, so api:compare expects all 19 mixed-in methods to
appear on this aggregator file. Re-export them as `@internal` where
Rails-private. The five file-local helpers in `assertions/response.ts`
(`generateResponseMessage`, `responseBodyIfShort`, `exceptionIfPresent`,
`locationIfRedirected`, `codeWithName`) are promoted to `@internal`
exports so the parent module can alias them.

testing/assertions.ts: 2/19 → 18/19 (95%).

## Deferred

`htmlDocument` is intentionally not exported. Rails delegates to
Nokogiri / `Rails::Dom::Testing.html_document`, neither of which is
ported. A stub would return `undefined` (or throw) for callers
expecting a DOM, which CLAUDE.md flags as worse than absence. The gap
is documented in the file header so the next pass after
rails-dom-testing lands can wire it.

Companion to #2083 (static).