### PR TITLE
feat(actionpack): http/request.ts fidelity 48%→80% (env-header passthroughs)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6400b0a0-2826-42be-a2cc-3b52898fdef3","pid":240377,"procStart":"118523745","acquiredAt":1779276147390}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6400b0a0-2826-42be-a2cc-3b52898fdef3","pid":240377,"procStart":"118523745","acquiredAt":1779276147390}

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ scripts/api-compare/.rails-source
 eslint/rails-private-methods.json
 eslint/rails-file-structure-method-order.json
 .claude/skills
+
+.claude/scheduled_tasks.lock

--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -129,11 +129,8 @@ export class Metal extends AbstractController {
   async dispatch(action: string, request: Request, response: Response): Promise<Response> {
     this.setRequestBang(request);
     this.setResponseBang(response);
-    const reqParams = (request as any).parameters;
-    this.params =
-      reqParams instanceof Parameters
-        ? reqParams
-        : new Parameters({ ...request.params, ...request.pathParameters });
+    const reqParams = request.parameters;
+    this.params = reqParams instanceof Parameters ? reqParams : new Parameters(reqParams);
 
     await this.processAction(action);
 

--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -129,9 +129,11 @@ export class Metal extends AbstractController {
   async dispatch(action: string, request: Request, response: Response): Promise<Response> {
     this.setRequestBang(request);
     this.setResponseBang(response);
+    const reqParams = (request as any).parameters;
     this.params =
-      (request as any).parameters ??
-      new Parameters({ ...request.params, ...request.pathParameters });
+      reqParams instanceof Parameters
+        ? reqParams
+        : new Parameters({ ...request.params, ...request.pathParameters });
 
     await this.processAction(action);
 

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -22,14 +22,18 @@ import {
   contentMimeType as _contentMimeType,
   format as _format,
   formats as _formats,
+  formatFromPathExtension as _formatFromPathExtension,
   hasContentType as _hasContentType,
   ignoreAcceptHeader as _ignoreAcceptHeader,
   negotiateMime as _negotiateMime,
+  paramsReadable as _paramsReadable,
   setFormat as _setFormat,
   setFormats as _setFormats,
   setIgnoreAcceptHeader as _setIgnoreAcceptHeader,
   setVariant as _setVariant,
   shouldApplyVaryHeader as _shouldApplyVaryHeader,
+  useAcceptHeader as _useAcceptHeader,
+  validAcceptHeader as _validAcceptHeader,
   variant as _variant,
   type MimeNegotiationHost,
   type NullType,
@@ -58,12 +62,6 @@ import {
   type ParameterParsers,
   type ParametersHost,
 } from "./parameters.js";
-import {
-  formatFromPathExtension as _formatFromPathExtension,
-  paramsReadable as _paramsReadable,
-  useAcceptHeader as _useAcceptHeader,
-  validAcceptHeader as _validAcceptHeader,
-} from "./mime-negotiation.js";
 import { Headers as HttpHeaders } from "./headers.js";
 
 const FLASH_HASH_KEY = "action_dispatch.request.flash_hash";

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -869,7 +869,12 @@ export class Request {
 
   /** Rails: `parameters` alias of `params`. */
   get parameters(): Record<string, unknown> {
+    const override = this.env["action_dispatch.request.parameters_override"];
+    if (override) return override as Record<string, unknown>;
     return this.params;
+  }
+  set parameters(value: Record<string, unknown>) {
+    this.env["action_dispatch.request.parameters_override"] = value;
   }
 
   // --- Early hints ---

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -57,8 +57,56 @@ import {
   type ParameterParsers,
   type ParametersHost,
 } from "./parameters.js";
+import {
+  formatFromPathExtension as _formatFromPathExtension,
+  paramsReadable as _paramsReadable,
+  useAcceptHeader as _useAcceptHeader,
+  validAcceptHeader as _validAcceptHeader,
+} from "./mime-negotiation.js";
+import { Headers as HttpHeaders } from "./headers.js";
 
 const FLASH_HASH_KEY = "action_dispatch.request.flash_hash";
+const ACTION_DISPATCH_REQUEST_ID = "action_dispatch.request_id";
+const FORM_DATA_MEDIA_TYPES = ["application/x-www-form-urlencoded", "multipart/form-data"] as const;
+const LOCALHOST_RE = /^(?:127(?:\.\d{1,3}){3}|::1|0:0:0:0:0:0:0:1(?:%.*)?)$/;
+
+const RFC_METHODS = [
+  "OPTIONS",
+  "GET",
+  "HEAD",
+  "POST",
+  "PUT",
+  "DELETE",
+  "TRACE",
+  "CONNECT",
+  "PROPFIND",
+  "PROPPATCH",
+  "MKCOL",
+  "COPY",
+  "MOVE",
+  "LOCK",
+  "UNLOCK",
+  "VERSION-CONTROL",
+  "REPORT",
+  "CHECKOUT",
+  "CHECKIN",
+  "UNCHECKOUT",
+  "MKWORKSPACE",
+  "UPDATE",
+  "LABEL",
+  "MERGE",
+  "BASELINE-CONTROL",
+  "MKACTIVITY",
+  "ORDERPATCH",
+  "ACL",
+  "SEARCH",
+  "MKCALENDAR",
+  "PATCH",
+] as const;
+const HTTP_METHOD_LOOKUP: Record<string, string> = Object.fromEntries(
+  RFC_METHODS.map((m) => [m, m.toLowerCase().replace(/-/g, "_")]),
+);
+
 const HTTP_HEADER_NAME = /^[A-Za-z0-9-]+$/;
 const CGI_VARIABLES: ReadonlySet<string> = new Set([
   "AUTH_TYPE",
@@ -629,10 +677,229 @@ export class Request {
     }
   }
 
+  // --- Headers wrapper ---
+
+  get headers(): HttpHeaders {
+    return new HttpHeaders(this.env as Record<string, unknown>);
+  }
+
+  // --- Method symbol ---
+
+  /** Returns the lowercase symbol form of {@link method} (RFC method name). */
+  get methodSymbol(): string | undefined {
+    return HTTP_METHOD_LOOKUP[this.method];
+  }
+
+  /** Returns the lowercase symbol form of {@link requestMethod}. */
+  get requestMethodSymbol(): string | undefined {
+    return HTTP_METHOD_LOOKUP[this.requestMethod];
+  }
+
+  /** @internal Validates `name` against the RFC methods list. */
+  protected checkMethod(name: string | undefined): string | undefined {
+    if (!name) return name;
+    if (HTTP_METHOD_LOOKUP[name] === undefined) {
+      throw new Error(`${name}, accepted HTTP methods are ${RFC_METHODS.join(", ")}`);
+    }
+    return name;
+  }
+
+  // --- Env-header passthroughs ---
+
+  /** Rails: `request.route_uri_pattern` (env: `action_dispatch.route_uri_pattern`). */
+  get routeUriPattern(): string | undefined {
+    return this.env["action_dispatch.route_uri_pattern"] as string | undefined;
+  }
+  set routeUriPattern(pattern: string | undefined) {
+    this.env["action_dispatch.route_uri_pattern"] = pattern;
+  }
+
+  /** @internal Rails: `request.routes` (env: `action_dispatch.routes`). */
+  get routes(): unknown {
+    return this.env["action_dispatch.routes"];
+  }
+  /** @internal */
+  set routes(routes: unknown) {
+    this.env["action_dispatch.routes"] = routes;
+  }
+
+  /** @internal Rails: `engine_script_name(_routes)` — env key from `_routes.env_key`. */
+  engineScriptName(routes: { envKey: string }): unknown {
+    return this.env[routes.envKey];
+  }
+
+  /** Rails: `http_auth_salt` env getter. */
+  get httpAuthSalt(): unknown {
+    return this.env["action_dispatch.http_auth_salt"];
+  }
+
+  /** Rails: `request_id` — set by `ActionDispatch::RequestId` middleware. */
+  get requestId(): string | undefined {
+    return this.env[ACTION_DISPATCH_REQUEST_ID] as string | undefined;
+  }
+  set requestId(id: string | undefined) {
+    this.env[ACTION_DISPATCH_REQUEST_ID] = id;
+  }
+
+  /** Alias of {@link requestId}. */
+  get uuid(): string | undefined {
+    return this.requestId;
+  }
+
+  /** Rails: `logger` — `action_dispatch.logger` env entry. */
+  get logger(): unknown {
+    return this.env["action_dispatch.logger"];
+  }
+
+  // --- Predicates / utility ---
+
+  /** Rails: `request.key?(name)` — alias of {@link hasHeader}. */
+  isKey(key: string): boolean {
+    return this.hasHeader(key);
+  }
+
+  /** Rails: `form_data?` — content-type is form-data. */
+  get isFormData(): boolean {
+    const mt = this.mediaType;
+    return mt != null && (FORM_DATA_MEDIA_TYPES as readonly string[]).includes(mt);
+  }
+
+  /** Rails: `local?` — REMOTE_ADDR and remoteIp both match localhost. */
+  get isLocal(): boolean {
+    const addr = (this.env["REMOTE_ADDR"] as string | undefined) ?? "";
+    const ip = this.remoteIp ?? "";
+    return LOCALHOST_RE.test(addr) && LOCALHOST_RE.test(ip);
+  }
+
+  /** Rails: `authorization` — checks 4 env keys in order. */
+  get authorization(): string | undefined {
+    return (this.env["HTTP_AUTHORIZATION"] ??
+      this.env["X-HTTP_AUTHORIZATION"] ??
+      this.env["X_HTTP_AUTHORIZATION"] ??
+      this.env["REDIRECT_X_HTTP_AUTHORIZATION"]) as string | undefined;
+  }
+
+  // --- Body ---
+
+  /** Rails: `body_stream` — raw `rack.input`. */
+  get bodyStream(): unknown {
+    return this.env["rack.input"];
+  }
+
+  /** @internal Rails: `read_body_stream` — drain `rack.input` with rewind guard. */
+  protected readBodyStream(): string {
+    const stream = this.bodyStream as
+      | { read?: (n?: number) => string; rewind?: () => void }
+      | undefined;
+    if (!stream || typeof stream.read !== "function") return "";
+    return this.resetStream(stream, () =>
+      this.hasHeader("HTTP_TRANSFER_ENCODING") ? stream.read!() : stream.read!(this.contentLength),
+    );
+  }
+
+  /** @internal Rails: `reset_stream` — rewind before+after yielding. */
+  protected resetStream<T>(stream: { rewind?: () => void }, fn: () => T): T {
+    if (typeof stream.rewind === "function") {
+      stream.rewind();
+      const result = fn();
+      stream.rewind();
+      return result;
+    }
+    return fn();
+  }
+
+  /** @internal Rails: `fallback_request_parameters` — parses raw post as form-urlencoded. */
+  protected fallbackRequestParameters(): Record<string, unknown> {
+    return this._fallbackRequestParameters();
+  }
+
+  // --- Session ---
+
+  /** Rails: `reset_session` — destroys session and resets CSRF token. */
+  resetSession(): void {
+    const session = this.env["rack.session"] as { destroy?: () => void } | undefined;
+    if (session && typeof session.destroy === "function") session.destroy();
+    else this.env["rack.session"] = {};
+    this.resetCsrfToken();
+  }
+
+  set sessionOptions(options: Record<string, unknown>) {
+    this.env["rack.session.options"] = options;
+  }
+
+  /** @internal Rails: `default_session` — returns a disabled-session sentinel. */
+  protected defaultSession(): Record<string, unknown> {
+    return {};
+  }
+
+  // --- CSRF ---
+
+  /** Rails: `reset_csrf_token` — forwards to `controller_instance` when supported. */
+  resetCsrfToken(): void {
+    const c = this.controllerInstance as { resetCsrfToken?: (req: unknown) => void } | undefined;
+    if (c && typeof c.resetCsrfToken === "function") c.resetCsrfToken(this);
+  }
+
+  /** Rails: `commit_csrf_token` — forwards to `controller_instance` when supported. */
+  commitCsrfToken(): void {
+    const c = this.controllerInstance as { commitCsrfToken?: (req: unknown) => void } | undefined;
+    if (c && typeof c.commitCsrfToken === "function") c.commitCsrfToken(this);
+  }
+
+  // --- Flash / cookie-jar lifecycle hooks (no-ops; Rails uses these as mixin overrides) ---
+
+  /** Rails: `commit_flash` — no-op on the bare Request; the Flash middleware overrides. */
+  commitFlash(): void {}
+
+  /** @internal Rails: `commit_cookie_jar!` — no-op on the bare Request. */
+  commitCookieJarBang(): void {}
+
+  // --- Aliases ---
+
+  /** Rails: `GET` alias of `query_parameters`. */
+  GET(): Record<string, unknown> {
+    return this.queryParameters;
+  }
+
+  /** Rails: `POST` alias of `request_parameters`. */
+  POST(): Record<string, unknown> {
+    return this.requestParameters;
+  }
+
+  /** Rails: `parameters` alias of `params`. */
+  get parameters(): Record<string, unknown> {
+    return this.params;
+  }
+
+  // --- Early hints ---
+
+  /** Rails: `send_early_hints(links)` — invokes the `rack.early_hints` callable. */
+  sendEarlyHints(links: Record<string, string>): void {
+    const cb = this.env["rack.early_hints"] as ((l: Record<string, string>) => void) | undefined;
+    if (typeof cb === "function") cb(links);
+  }
+
+  // --- Rack request wrapper (env-backed minimal shim) ---
+
+  get rackRequest(): { env: RackEnv } {
+    return { env: this.env };
+  }
+
+  // --- Mime-negotiation privates (declared; bound below via prototype) ---
+
+  declare validAcceptHeader: () => boolean;
+  declare useAcceptHeader: () => boolean;
+  declare formatFromPathExtension: () => MimeType | undefined;
+  declare isParamsReadable: () => boolean;
+
   // --- Static factory ---
 
   static create(env: RackEnv = {}): Request {
     return new Request(env);
+  }
+
+  static empty(): Request {
+    return new Request({});
   }
 }
 
@@ -738,3 +1005,17 @@ Request.prototype.filteredParameters = _filteredParameters;
 Request.prototype.filteredEnv = _filteredEnv;
 Request.prototype.filteredPath = _filteredPath;
 Request.prototype.parameterFilter = _parameterFilter;
+// Mime-negotiation privates wired via prototype; declared on the class for
+// typing. These mirror Rails' private predicates / lookup helpers.
+Request.prototype.validAcceptHeader = function (this: Request) {
+  return _validAcceptHeader.call(mimeHost(this));
+};
+Request.prototype.useAcceptHeader = function (this: Request) {
+  return _useAcceptHeader.call(mimeHost(this));
+};
+Request.prototype.formatFromPathExtension = function (this: Request) {
+  return _formatFromPathExtension.call(mimeHost(this));
+};
+Request.prototype.isParamsReadable = function (this: Request) {
+  return _paramsReadable.call(mimeHost(this));
+};

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -6,7 +6,8 @@
  */
 
 import type { RackEnv } from "@blazetrails/rack";
-import { parseNestedQuery } from "@blazetrails/rack";
+import { parseNestedQuery, Request as RackRequest } from "@blazetrails/rack";
+import { Session } from "../request/session.js";
 import {
   etagMatches as _etagMatches,
   fresh as _fresh,
@@ -828,8 +829,8 @@ export class Request {
   }
 
   /** @internal Rails: `default_session` — returns a disabled-session sentinel. */
-  protected defaultSession(): Record<string, unknown> {
-    return {};
+  protected defaultSession(): Session {
+    return Session.disabled(this);
   }
 
   // --- CSRF ---
@@ -881,8 +882,12 @@ export class Request {
 
   // --- Rack request wrapper (env-backed minimal shim) ---
 
-  get rackRequest(): { env: RackEnv } {
-    return { env: this.env };
+  get rackRequest(): RackRequest {
+    const cached = this.env["action_dispatch.rack_request"] as RackRequest | undefined;
+    if (cached) return cached;
+    const r = new RackRequest(this.env);
+    this.env["action_dispatch.rack_request"] = r;
+    return r;
   }
 
   // --- Mime-negotiation privates (declared; bound below via prototype) ---

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -102,8 +102,11 @@ const RFC_METHODS = [
   "MKCALENDAR",
   "PATCH",
 ] as const;
-const HTTP_METHOD_LOOKUP: Record<string, string> = Object.fromEntries(
-  RFC_METHODS.map((m) => [m, m.toLowerCase().replace(/-/g, "_")]),
+// Null-prototype lookup so `__proto__` / `constructor` can't shadow
+// prototype-chain lookups into apparent membership in `checkMethod`.
+const HTTP_METHOD_LOOKUP: Record<string, string> = Object.assign(
+  Object.create(null) as Record<string, string>,
+  Object.fromEntries(RFC_METHODS.map((m) => [m, m.toLowerCase().replace(/-/g, "_")])),
 );
 
 const HTTP_HEADER_NAME = /^[A-Za-z0-9-]+$/;
@@ -697,7 +700,7 @@ export class Request {
   /** @internal Validates `name` against the RFC methods list. */
   protected checkMethod(name: string | undefined): string | undefined {
     if (!name) return name;
-    if (HTTP_METHOD_LOOKUP[name] === undefined) {
+    if (!Object.hasOwn(HTTP_METHOD_LOOKUP, name)) {
       throw new Error(`${name}, accepted HTTP methods are ${RFC_METHODS.join(", ")}`);
     }
     return name;

--- a/packages/rack/src/index.ts
+++ b/packages/rack/src/index.ts
@@ -53,4 +53,5 @@ export {
   ParamsTooDeepError,
 } from "./utils.js";
 export { BodyProxy } from "./body-proxy.js";
+export { Request } from "./request.js";
 export { CONTENT_TYPE, CONTENT_LENGTH } from "./constants.js";


### PR DESCRIPTION
Wires the bulk of `ActionDispatch::Request` env-backed accessors, predicates, and method-lookup helpers onto the `Request` class. Mirrors Rails' module layout for:

- HTTP headers wrapper (\`request.headers\`)
- Method symbols (\`methodSymbol\`, \`requestMethodSymbol\`, \`checkMethod\` private + HTTP_METHOD_LOOKUP / RFC method table)
- Env-header passthroughs: \`requestId\` / \`uuid\`, \`routeUriPattern\`, \`routes\`, \`engineScriptName\`, \`httpAuthSalt\`, \`logger\`
- Predicates / utility: \`isKey\`, \`isFormData\`, \`isLocal\`, \`authorization\`
- Body: \`bodyStream\`, \`readBodyStream\`, \`resetStream\`, \`fallbackRequestParameters\` (privates)
- Session: \`resetSession\`, \`sessionOptions=\`, \`defaultSession\` (private)
- CSRF hooks: \`resetCsrfToken\`, \`commitCsrfToken\`
- Lifecycle no-ops: \`commitFlash\`, \`commitCookieJarBang\`
- Aliases: \`GET\` (→ \`queryParameters\`), \`POST\` (→ \`requestParameters\`), \`parameters\` (→ \`params\`)
- Early hints: \`sendEarlyHints\`
- Rack request shim: \`rackRequest\`
- Mime-negotiation privates wired via prototype: \`validAcceptHeader\`, \`useAcceptHeader\`, \`formatFromPathExtension\`, \`isParamsReadable\`
- Static \`empty()\` factory

api:compare for \`http/request.rb\` goes from 58/122 (48%) to 98/122 (80%).

Follow-ups (deferred to keep PR ≤ 300 LOC):
- CSP + PermissionsPolicy env-backed accessors (\`contentSecurityPolicy*\`, \`permissionsPolicy\`, \`generateContentSecurityPolicyNonce\`)
- Filter helpers wiring: \`envFilter\`, \`filteredQueryString\`, static \`parameterFilterFor\`
- \`PassNotFound\` sentinel + \`controllerClass\` / \`controllerClassFor\` / \`action\`
- Params parser privates: \`paramsParsers\`, \`parseFormattedParameters\`, \`logParseErrorOnce\`, \`requestParametersList\`
- \`http/response.ts\` (separate PR, currently 51%)

## Test plan
- [x] \`pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/request.test.ts\` (93 tests, green)
- [x] api:compare for \`actiondispatch\`