### PR TITLE
feat(actionpack): middleware/cookies.ts to 100% api:compare

### DIFF
--- a/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
@@ -1,11 +1,20 @@
 import { describe, expect, it } from "vitest";
 import { bodyFromString, type RackEnv, type RackResponse } from "@blazetrails/rack";
 import {
+  type ChainedCookieJarsHost,
+  type CookieSerializer,
+  type SerializedCookieJarsHost,
   CookieJar,
   Cookies,
   COOKIES_KEY,
   CookieOverflow,
   checkForOverflowBang,
+  commit,
+  isPrepareUpgradeLegacyHmacAesCbcCookies,
+  isReserialize,
+  isUpgradeLegacyHmacAesCbcCookies,
+  serializer,
+  signedOrEncrypted,
 } from "./cookies.js";
 
 function emptyResponse(): RackResponse {
@@ -118,6 +127,118 @@ describe("Cookies middleware", () => {
     jar.delete("a");
     expect(jar.get("a")).toBe("1");
     expect(jar.get("b")).toBeUndefined();
+  });
+});
+
+function chainedHost(env: Record<string, unknown>): ChainedCookieJarsHost {
+  const jar = new CookieJar({ secret: "secret-key-base-for-tests" });
+  return { request: { env, cookies: {} }, signed: jar.signed, encrypted: jar.encrypted };
+}
+
+describe("ChainedCookieJars predicates", () => {
+  it("signedOrEncrypted prefers encrypted when secret_key_base is present", () => {
+    const host = chainedHost({ "action_dispatch.secret_key_base": "abc" });
+    expect(signedOrEncrypted.call(host)).toBe(host.encrypted);
+  });
+
+  it("signedOrEncrypted falls back to signed when secret_key_base is absent", () => {
+    const host = chainedHost({});
+    expect(signedOrEncrypted.call(host)).toBe(host.signed);
+  });
+
+  it("signedOrEncrypted treats blank secret_key_base as absent", () => {
+    const host = chainedHost({ "action_dispatch.secret_key_base": "" });
+    expect(signedOrEncrypted.call(host)).toBe(host.signed);
+  });
+
+  it("isUpgradeLegacyHmacAesCbcCookies requires every legacy slot to be set", () => {
+    const full = chainedHost({
+      "action_dispatch.secret_key_base": "abc",
+      "action_dispatch.encrypted_signed_cookie_salt": "s1",
+      "action_dispatch.encrypted_cookie_salt": "s2",
+      "action_dispatch.use_authenticated_cookie_encryption": true,
+    });
+    expect(isUpgradeLegacyHmacAesCbcCookies.call(full)).toBe(true);
+
+    const missingFlag = chainedHost({
+      "action_dispatch.secret_key_base": "abc",
+      "action_dispatch.encrypted_signed_cookie_salt": "s1",
+      "action_dispatch.encrypted_cookie_salt": "s2",
+      "action_dispatch.use_authenticated_cookie_encryption": false,
+    });
+    expect(isUpgradeLegacyHmacAesCbcCookies.call(missingFlag)).toBe(false);
+
+    const missingSalt = chainedHost({
+      "action_dispatch.secret_key_base": "abc",
+      "action_dispatch.encrypted_cookie_salt": "s2",
+      "action_dispatch.use_authenticated_cookie_encryption": true,
+    });
+    expect(isUpgradeLegacyHmacAesCbcCookies.call(missingSalt)).toBe(false);
+  });
+
+  it("isPrepareUpgradeLegacyHmacAesCbcCookies requires the encryption flag to be OFF", () => {
+    const ready = chainedHost({
+      "action_dispatch.secret_key_base": "abc",
+      "action_dispatch.authenticated_encrypted_cookie_salt": "aec",
+      "action_dispatch.use_authenticated_cookie_encryption": false,
+    });
+    expect(isPrepareUpgradeLegacyHmacAesCbcCookies.call(ready)).toBe(true);
+
+    const flagOn = chainedHost({
+      "action_dispatch.secret_key_base": "abc",
+      "action_dispatch.authenticated_encrypted_cookie_salt": "aec",
+      "action_dispatch.use_authenticated_cookie_encryption": true,
+    });
+    expect(isPrepareUpgradeLegacyHmacAesCbcCookies.call(flagOn)).toBe(false);
+
+    const missingSalt = chainedHost({
+      "action_dispatch.secret_key_base": "abc",
+      "action_dispatch.use_authenticated_cookie_encryption": false,
+    });
+    expect(isPrepareUpgradeLegacyHmacAesCbcCookies.call(missingSalt)).toBe(false);
+  });
+});
+
+function serializedHost(env: Record<string, unknown> = {}): SerializedCookieJarsHost {
+  return { request: { env, cookies: {} } };
+}
+
+describe("SerializedCookieJars", () => {
+  it("commit dumps via the configured serializer (JSON by default)", () => {
+    const host = serializedHost();
+    const options = { value: { hello: "world" } } as { value: unknown };
+    commit.call(host, "session", options);
+    expect(options.value).toBe('{"hello":"world"}');
+  });
+
+  it("isReserialize is true when the payload was not produced by JSON", () => {
+    const host = serializedHost();
+    expect(isReserialize.call(host, "not-json")).toBe(true);
+    expect(isReserialize.call(host, '{"ok":true}')).toBe(false);
+  });
+
+  it("commit raises TypeError for unserializable values instead of silently dropping", () => {
+    const host = serializedHost();
+    const options = { value: undefined as unknown };
+    expect(() => commit.call(host, "session", options as { value: unknown })).toThrow(TypeError);
+  });
+
+  it("serializer honors a caller-supplied custom serializer object", () => {
+    const custom: CookieSerializer = {
+      dump: (v) => `!${String(v)}!`,
+      load: (s) => s.slice(1, -1),
+      dumped: (s) => s.startsWith("!") && s.endsWith("!"),
+    };
+    const host = serializedHost({ "action_dispatch.cookies_serializer": custom });
+    expect(serializer.call(host)).toBe(custom);
+    const options = { value: "abc" } as { value: unknown };
+    commit.call(host, "k", options);
+    expect(options.value).toBe("!abc!");
+  });
+
+  it("serializer falls back to JSON for symbol-style config values", () => {
+    const host = serializedHost({ "action_dispatch.cookies_serializer": "json" });
+    expect(serializer.call(host).dump("x")).toBe('"x"');
   });
 });
 

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
@@ -52,6 +52,43 @@ describe("Cookies middleware", () => {
     expect(headers["set-cookie"]).toBeUndefined();
   });
 
+  it("merges with an existing string set-cookie from the downstream app", async () => {
+    const cookies = new Cookies(async (env) => {
+      const jar = new CookieJar();
+      jar.set("b", "2");
+      env[COOKIES_KEY] = jar;
+      return [200, { "set-cookie": "a=1; path=/" }, bodyFromString("")];
+    });
+    const [, headers] = await cookies.call({});
+    const lines = headers["set-cookie"]!.split("\n");
+    expect(lines[0]).toBe("a=1; path=/");
+    expect(lines[1]).toContain("b=2");
+  });
+
+  it("merges with an existing array set-cookie without comma-stringifying", async () => {
+    const cookies = new Cookies(async (env) => {
+      const jar = new CookieJar();
+      jar.set("c", "3");
+      env[COOKIES_KEY] = jar;
+      // Rack::Response carries set-cookie as string[] when stacking
+      // multiple cookies. The RackResponse tuple narrows to string at
+      // the type level, but real downstream apps still emit arrays.
+      return [
+        200,
+        { "set-cookie": ["a=1; path=/", "b=2; path=/"] as unknown as string },
+        bodyFromString(""),
+      ];
+    });
+    const [, headers] = await cookies.call({});
+    const setCookie = headers["set-cookie"]!;
+    expect(setCookie).not.toContain(",");
+    expect(setCookie.split("\n")).toEqual([
+      "a=1; path=/",
+      "b=2; path=/",
+      expect.stringContaining("c=3"),
+    ]);
+  });
+
   it("commits the jar so further writes are dropped after the middleware runs", async () => {
     const jar = new CookieJar();
     const cookies = new Cookies(async (env) => {

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { bodyFromString, type RackEnv, type RackResponse } from "@blazetrails/rack";
+import {
+  CookieJar,
+  Cookies,
+  COOKIES_KEY,
+  CookieOverflow,
+  checkForOverflowBang,
+} from "./cookies.js";
+
+function emptyResponse(): RackResponse {
+  return [200, {}, bodyFromString("")];
+}
+
+describe("Cookies middleware", () => {
+  it("leaves headers untouched when downstream never builds a jar", async () => {
+    const cookies = new Cookies(async () => [200, { "x-foo": "bar" }, bodyFromString("ok")]);
+    const env: RackEnv = {};
+    const [status, headers] = await cookies.call(env);
+    expect(status).toBe(200);
+    expect(headers["set-cookie"]).toBeUndefined();
+    expect(headers["x-foo"]).toBe("bar");
+  });
+
+  it("flushes set/delete operations into a newline-joined set-cookie header", async () => {
+    const cookies = new Cookies(async (env) => {
+      const jar = new CookieJar();
+      jar.set("session", "abc");
+      jar.delete("stale");
+      env[COOKIES_KEY] = jar;
+      return emptyResponse();
+    });
+    const env: RackEnv = {};
+    const [, headers] = await cookies.call(env);
+    const setCookie = headers["set-cookie"];
+    expect(typeof setCookie).toBe("string");
+    expect(setCookie).toContain("session=abc");
+    expect(setCookie).toContain("stale=");
+    expect(setCookie!.split("\n")).toHaveLength(2);
+  });
+
+  it("does not double-flush a jar that was already committed", async () => {
+    const cookies = new Cookies(async (env) => {
+      const jar = new CookieJar();
+      jar.set("a", "1");
+      jar.commitBang();
+      env[COOKIES_KEY] = jar;
+      return emptyResponse();
+    });
+    const env: RackEnv = {};
+    const [, headers] = await cookies.call(env);
+    expect(headers["set-cookie"]).toBeUndefined();
+  });
+
+  it("commits the jar so further writes are dropped after the middleware runs", async () => {
+    const jar = new CookieJar();
+    const cookies = new Cookies(async (env) => {
+      jar.set("a", "1");
+      env[COOKIES_KEY] = jar;
+      return emptyResponse();
+    });
+    await cookies.call({});
+    expect(jar.isCommitted()).toBe(true);
+    jar.set("b", "2");
+    jar.delete("a");
+    expect(jar.get("a")).toBe("1");
+    expect(jar.get("b")).toBeUndefined();
+  });
+});
+
+describe("checkForOverflowBang", () => {
+  it("raises CookieOverflow once a value exceeds 4096 bytes", () => {
+    const big = "x".repeat(4097);
+    expect(() => checkForOverflowBang("session", { value: big })).toThrow(CookieOverflow);
+  });
+
+  it("passes values at the boundary", () => {
+    expect(() => checkForOverflowBang("session", { value: "x".repeat(4096) })).not.toThrow();
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
@@ -89,6 +89,22 @@ describe("Cookies middleware", () => {
     ]);
   });
 
+  it("merges with an existing Set-Cookie that uses non-lowercase casing", async () => {
+    const cookies = new Cookies(async (env) => {
+      const jar = new CookieJar();
+      jar.set("b", "2");
+      env[COOKIES_KEY] = jar;
+      return [200, { "Set-Cookie": "a=1; path=/" }, bodyFromString("")];
+    });
+    const [, headers] = await cookies.call({});
+    // The non-lowercase key is dropped; the merged canonical lowercase
+    // header carries both cookies.
+    expect(headers["Set-Cookie"]).toBeUndefined();
+    const lines = headers["set-cookie"]!.split("\n");
+    expect(lines[0]).toBe("a=1; path=/");
+    expect(lines[1]).toContain("b=2");
+  });
+
   it("commits the jar so further writes are dropped after the middleware runs", async () => {
     const jar = new CookieJar();
     const cookies = new Cookies(async (env) => {

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -12,9 +12,7 @@
 
 import { getCrypto } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import type { RackEnv, RackResponse } from "@blazetrails/rack";
-
-type RackApp = (env: RackEnv) => Promise<RackResponse>;
+import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
 
 /** Cookie expiry — accept either a Date or a Temporal.Instant from AR/AM. */
 export type CookieExpires = Date | Temporal.Instant;
@@ -86,8 +84,6 @@ export class CookieJar implements Iterable<[string, string]> {
    */
   commitBang(): void {
     this._committed = true;
-    Object.freeze(this._setCookies);
-    Object.freeze(this._deletedCookies);
   }
 
   /**
@@ -156,6 +152,7 @@ export class CookieJar implements Iterable<[string, string]> {
   // --- Write ---
 
   set(key: string, valueOrOptions: string | SetCookieOptions): void {
+    if (this._committed) return;
     if (typeof valueOrOptions === "string") {
       this._cookies.set(key, valueOrOptions);
       this._setCookies.set(key, { value: valueOrOptions });
@@ -168,6 +165,7 @@ export class CookieJar implements Iterable<[string, string]> {
   }
 
   delete(key: string, options?: { path?: string; domain?: string }): string | undefined {
+    if (this._committed) return undefined;
     const val = this._cookies.get(key);
     this._cookies.delete(key);
     this._setCookies.delete(key);
@@ -440,6 +438,7 @@ export class Cookies {
         ? [existing, ...setHeaders].join("\n")
         : setHeaders.join("\n");
     }
+    jar.commitBang();
     return [status, outHeaders, body];
   }
 }

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -62,9 +62,32 @@ export class CookieJar implements Iterable<[string, string]> {
   private _setCookies: Map<string, SetCookieOptions> = new Map();
   private _deletedCookies: Map<string, { path?: string; domain?: string }> = new Map();
   private _options: CookieJarOptions;
+  private _committed = false;
 
   constructor(options: CookieJarOptions = {}) {
     this._options = options;
+  }
+
+  /**
+   * Mirror of Rails `CookieJar#committed?` — true once the jar has been
+   * written to a response and further mutations have no effect.
+   *
+   * @internal
+   */
+  isCommitted(): boolean {
+    return this._committed;
+  }
+
+  /**
+   * Mirror of Rails `CookieJar#commit!` — freezes the set/delete sets so
+   * subsequent writes from downstream middleware are ignored.
+   *
+   * @internal
+   */
+  commitBang(): void {
+    this._committed = true;
+    Object.freeze(this._setCookies);
+    Object.freeze(this._deletedCookies);
   }
 
   /**
@@ -390,8 +413,10 @@ function capitalize(s: string): string {
 export const COOKIES_KEY = "action_dispatch.cookies";
 
 /**
- * `ActionDispatch::Cookies` middleware. Builds a {@link CookieJar} on the
- * way in, flushes accumulated `Set-Cookie` headers on the way out.
+ * `ActionDispatch::Cookies` middleware. Mirrors Rails' shape: the jar is
+ * built lazily by downstream code via `request.cookie_jar`; this middleware
+ * only flushes accumulated cookies on the way out if the jar was touched
+ * and not yet committed.
  */
 export class Cookies {
   private app: RackApp;
@@ -401,34 +426,22 @@ export class Cookies {
   }
 
   async call(env: RackEnv): Promise<RackResponse> {
-    const cookiesAppOptions = (env[COOKIES_APP_OPTIONS_KEY] as CookieJarOptions | undefined) ?? {};
-    const seed = parseCookieHeader((env.HTTP_COOKIE as string | undefined) ?? "");
-    const jar = CookieJar.build({ cookiesAppOptions }, seed);
-    env[COOKIES_KEY] = jar;
-    const [status, headers, body] = await this.app(env);
+    const response = await this.app(env);
+    const jar = env[COOKIES_KEY] as CookieJar | undefined;
+    if (!jar || jar.isCommitted()) return response;
+
+    const [status, headers, body] = response;
     const outHeaders: Record<string, string> = { ...headers };
     const setHeaders = jar.getSetCookieHeaders();
     if (setHeaders.length > 0) {
       const existing = outHeaders["set-cookie"];
+      // Rack convention is newline-joined values within a single header.
       outHeaders["set-cookie"] = existing
         ? [existing, ...setHeaders].join("\n")
         : setHeaders.join("\n");
     }
     return [status, outHeaders, body];
   }
-}
-
-function parseCookieHeader(header: string): Record<string, string> {
-  const out: Record<string, string> = {};
-  if (!header) return out;
-  for (const pair of header.split(";")) {
-    const eq = pair.indexOf("=");
-    if (eq < 0) continue;
-    const k = pair.slice(0, eq).trim();
-    const v = pair.slice(eq + 1).trim();
-    if (k) out[k] = decodeURIComponent(v);
-  }
-  return out;
 }
 
 // ===========================================================================
@@ -523,40 +536,61 @@ export const useCookiesWithMetadata = requestEnvAccessor<boolean>(
 // ===========================================================================
 
 /**
- * Combined signed-or-encrypted accessor on a jar. Rails picks `encrypted`
- * when `secret_key_base` is configured, otherwise falls back to `signed`.
+ * Host shape for {@link signedOrEncrypted} and the upgrade-path predicates.
+ * Matches the `request: RequestCookieMethods` view Rails' ChainedCookieJars
+ * relies on.
  *
  * @internal
  */
-export function signedOrEncrypted(jar: CookieJar): SignedCookieJar | EncryptedCookieJar {
-  try {
-    return jar.encrypted;
-  } catch {
-    return jar.signed;
-  }
+export interface ChainedCookieJarsHost {
+  request: RequestCookieMethodsHost;
+  signed: SignedCookieJar;
+  encrypted: EncryptedCookieJar;
 }
 
 /**
- * Rails: predicate that returns true while the deprecated HMAC-AES-CBC
- * cookie format is still being read alongside the newer AEAD format.
- * trails does not implement the legacy CBC path, so the predicate is
- * permanently false.
- *
- * @internal
+ * Returns the `encrypted` jar when `secret_key_base` is configured on the
+ * request, otherwise falls back to `signed`. Mirrors Rails'
+ * `signed_or_encrypted`, used by `ActionDispatch::Session::CookieStore`.
  */
-export function isUpgradeLegacyHmacAesCbcCookies(): boolean {
-  return false;
+export function signedOrEncrypted(
+  this: ChainedCookieJarsHost,
+): SignedCookieJar | EncryptedCookieJar {
+  return secretKeyBase.call(this.request) ? this.encrypted : this.signed;
 }
 
 /**
- * Rails: rewriter predicate complementing
- * {@link isUpgradeLegacyHmacAesCbcCookies}. Same rationale — false in
- * trails.
+ * Rails: true while the deprecated HMAC-AES-CBC cookie format is still
+ * being decoded alongside the newer AEAD format. Faithful predicate:
+ * secret_key_base present, both legacy salts present, and the
+ * authenticated-encryption flag set.
  *
  * @internal
  */
-export function isPrepareUpgradeLegacyHmacAesCbcCookies(): boolean {
-  return false;
+export function isUpgradeLegacyHmacAesCbcCookies(this: ChainedCookieJarsHost): boolean {
+  const req = this.request;
+  return Boolean(
+    secretKeyBase.call(req) &&
+    encryptedSignedCookieSalt.call(req) &&
+    encryptedCookieSalt.call(req) &&
+    useAuthenticatedCookieEncryption.call(req),
+  );
+}
+
+/**
+ * Rails: rewriter predicate — true when the legacy CBC salt is configured
+ * but authenticated encryption is *off*, signalling we should rewrite
+ * authenticated-encrypted cookies back into the legacy format.
+ *
+ * @internal
+ */
+export function isPrepareUpgradeLegacyHmacAesCbcCookies(this: ChainedCookieJarsHost): boolean {
+  const req = this.request;
+  return Boolean(
+    secretKeyBase.call(req) &&
+    authenticatedEncryptedCookieSalt.call(req) &&
+    !useAuthenticatedCookieEncryption.call(req),
+  );
 }
 
 // ===========================================================================
@@ -566,58 +600,91 @@ export function isPrepareUpgradeLegacyHmacAesCbcCookies(): boolean {
 const MAX_COOKIE_SIZE = 4096;
 
 /**
- * Selects the cookie value serializer. Mirrors Rails' `:json` / `:hybrid` /
- * `:marshal` choices; trails ships JSON-only.
- *
- * @internal
+ * Serializer protocol mirroring `ActiveSupport::Messages::SerializerWithFallback`.
+ * `dumped` lets the jar detect cookies written by a different serializer
+ * so {@link isReserialize} can flag them for rewrite.
  */
-export function serializer(): { dump(v: unknown): string; load(s: string): unknown } {
-  return {
-    dump: (v) => JSON.stringify(v),
-    load: (s) => {
-      try {
-        return JSON.parse(s);
-      } catch {
-        return null;
-      }
-    },
-  };
+export interface CookieSerializer {
+  dump(value: unknown): string;
+  load(dumped: string): unknown;
+  dumped(payload: string): boolean;
 }
 
 /**
- * Rails: returns true when a stored cookie was written with the legacy
- * serializer and must be re-serialized with the configured one. trails
- * has only ever shipped JSON, so reserialize is never required.
+ * Host shape for the SerializedCookieJars module. Carries the request
+ * (for `cookies_serializer` lookup) and a memoization slot.
  *
  * @internal
  */
-export function isReserialize(): boolean {
-  return false;
+export interface SerializedCookieJarsHost {
+  request: RequestCookieMethodsHost;
+  _serializer?: CookieSerializer;
+}
+
+const JSON_SERIALIZER: CookieSerializer = {
+  dump: (v) => JSON.stringify(v),
+  load: (s) => JSON.parse(s),
+  dumped: (s) => {
+    try {
+      JSON.parse(s);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+};
+
+/**
+ * Selects and memoizes the cookie value serializer. Rails dispatches on
+ * `request.cookies_serializer` (`:json`, `:hybrid`, `:marshal`, …); trails
+ * ports `:json` faithfully and treats every other choice as JSON since
+ * Marshal isn't a portable on-disk format.
+ *
+ * @internal
+ */
+export function serializer(this: SerializedCookieJarsHost): CookieSerializer {
+  if (this._serializer) return this._serializer;
+  this._serializer = JSON_SERIALIZER;
+  return this._serializer;
 }
 
 /**
- * Rails: hook called once the value has been mutated, before the jar is
- * written back to the response. Trails performs no buffering, so commit
- * is a no-op pass-through that returns the value unchanged.
+ * Returns true when `dumped` was produced by a serializer that differs
+ * from the currently-configured one, so the jar should rewrite it next
+ * commit. Mirrors Rails' `reserialize?`.
  *
  * @internal
  */
-export function commit<T>(value: T): T {
-  return value;
+export function isReserialize(this: SerializedCookieJarsHost, dumped: string): boolean {
+  return !serializer.call(this).dumped(dumped);
+}
+
+/**
+ * Rails: `commit(name, options)` — final transformation applied to a
+ * cookie's `:value` before it is written. The serialized cookie jars use
+ * this to call `serializer.dump`. Mutates `options.value` in place.
+ *
+ * @internal
+ */
+export function commit(
+  this: SerializedCookieJarsHost,
+  _name: string,
+  options: { value: unknown },
+): void {
+  options.value = serializer.call(this).dump(options.value);
 }
 
 /**
  * Rails raises `CookieOverflow` when a serialized value exceeds 4096
- * bytes (the browser-imposed cookie ceiling). Mirror the check.
+ * bytes (the browser-imposed cookie ceiling). Faithful port: checks
+ * `options.value.bytesize` post-serialization.
  *
  * @internal
  */
-export function checkForOverflowBang(serialized: string): void {
-  if (Buffer.byteLength(serialized, "utf8") > MAX_COOKIE_SIZE) {
-    throw new CookieOverflow(
-      `Cookie overflow: serialized value is ${Buffer.byteLength(serialized, "utf8")} bytes; ` +
-        `maximum is ${MAX_COOKIE_SIZE}.`,
-    );
+export function checkForOverflowBang(name: string, options: { value: string }): void {
+  const size = Buffer.byteLength(options.value, "utf8");
+  if (size > MAX_COOKIE_SIZE) {
+    throw new CookieOverflow(`${name} cookie overflowed with size ${size} bytes`);
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -432,11 +432,16 @@ export class Cookies {
     const outHeaders: Record<string, string> = { ...headers };
     const setHeaders = jar.getSetCookieHeaders();
     if (setHeaders.length > 0) {
-      const existing = outHeaders["set-cookie"];
-      // Rack convention is newline-joined values within a single header.
-      outHeaders["set-cookie"] = existing
-        ? [existing, ...setHeaders].join("\n")
-        : setHeaders.join("\n");
+      // Although the RackResponse tuple types headers as
+      // Record<string, string>, downstream apps backed by
+      // `Rack::Response` (Record<string, string | string[]>) can hand
+      // back set-cookie as an array — splatting it into a string
+      // template would stringify with commas and corrupt the header.
+      // Normalize both shapes to a flat string[] before joining with
+      // newlines (Rack's wire convention for multi-value set-cookie).
+      const existing = outHeaders["set-cookie"] as unknown as string | string[] | undefined;
+      const existingList = existing ? (Array.isArray(existing) ? existing : [existing]) : [];
+      outHeaders["set-cookie"] = [...existingList, ...setHeaders].join("\n");
     }
     jar.commitBang();
     return [status, outHeaders, body];

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -434,23 +434,26 @@ export class Cookies {
     if (setHeaders.length > 0) {
       // Rack 3 standardizes on lowercase header keys, but Rails-shaped
       // middleware can still emit `Set-Cookie` (or stranger casings).
-      // Find any existing variant case-insensitively, drop it, and
+      // Accumulate values from *every* set-cookie variant the response
+      // carries so nothing is dropped when more than one casing is
+      // present (e.g. both "Set-Cookie" and "set-cookie"), then
       // canonicalize on lowercase `set-cookie`.
-      let existing: string | string[] | undefined;
+      const existingList: string[] = [];
       for (const key of Object.keys(outHeaders)) {
-        if (key.toLowerCase() === "set-cookie") {
-          existing = outHeaders[key] as unknown as string | string[];
-          if (key !== "set-cookie") delete outHeaders[key];
-        }
+        if (key.toLowerCase() !== "set-cookie") continue;
+        // Although the RackResponse tuple types headers as
+        // Record<string, string>, downstream apps backed by
+        // `Rack::Response` (Record<string, string | string[]>) can
+        // hand back set-cookie as an array — splatting it into a
+        // string template would stringify with commas and corrupt the
+        // header. Normalize both shapes to a flat string[].
+        const v = outHeaders[key] as unknown as string | string[];
+        if (Array.isArray(v)) existingList.push(...v);
+        else existingList.push(v);
+        if (key !== "set-cookie") delete outHeaders[key];
       }
-      // Although the RackResponse tuple types headers as
-      // Record<string, string>, downstream apps backed by
-      // `Rack::Response` (Record<string, string | string[]>) can hand
-      // back set-cookie as an array — splatting it into a string
-      // template would stringify with commas and corrupt the header.
-      // Normalize both shapes to a flat string[] before joining with
-      // newlines (Rack's wire convention for multi-value set-cookie).
-      const existingList = existing ? (Array.isArray(existing) ? existing : [existing]) : [];
+      // Rack's wire convention is newline-joined values within a
+      // single set-cookie header.
       outHeaders["set-cookie"] = [...existingList, ...setHeaders].join("\n");
     }
     jar.commitBang();
@@ -661,15 +664,31 @@ const JSON_SERIALIZER: CookieSerializer = {
 
 /**
  * Selects and memoizes the cookie value serializer. Rails dispatches on
- * `request.cookies_serializer` (`:json`, `:hybrid`, `:marshal`, …); trails
- * ports `:json` faithfully and treats every other choice as JSON since
- * Marshal isn't a portable on-disk format.
+ * `request.cookies_serializer` (`:json`, `:hybrid`, `:marshal`, a custom
+ * serializer object, or `nil`); trails ports `:json` / `:hybrid` to the
+ * JSON serializer (Marshal isn't a portable on-disk format in JS) and
+ * honors a caller-supplied custom serializer object verbatim. Anything
+ * else falls back to JSON.
  *
  * @internal
  */
 export function serializer(this: SerializedCookieJarsHost): CookieSerializer {
   if (this._serializer) return this._serializer;
-  this._serializer = JSON_SERIALIZER;
+  // Read the env slot directly so a caller-supplied object serializer
+  // is visible (the public `cookiesSerializer` accessor narrows to
+  // string for the common Symbol-name case).
+  const configured = this.request.env["action_dispatch.cookies_serializer"];
+  if (
+    configured &&
+    typeof configured === "object" &&
+    typeof (configured as CookieSerializer).dump === "function" &&
+    typeof (configured as CookieSerializer).load === "function"
+  ) {
+    this._serializer = configured as CookieSerializer;
+  } else {
+    // `:json`, `:hybrid`, `nil`, unknown symbol → JSON.
+    this._serializer = JSON_SERIALIZER;
+  }
   return this._serializer;
 }
 

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -432,6 +432,17 @@ export class Cookies {
     const outHeaders: Record<string, string> = { ...headers };
     const setHeaders = jar.getSetCookieHeaders();
     if (setHeaders.length > 0) {
+      // Rack 3 standardizes on lowercase header keys, but Rails-shaped
+      // middleware can still emit `Set-Cookie` (or stranger casings).
+      // Find any existing variant case-insensitively, drop it, and
+      // canonicalize on lowercase `set-cookie`.
+      let existing: string | string[] | undefined;
+      for (const key of Object.keys(outHeaders)) {
+        if (key.toLowerCase() === "set-cookie") {
+          existing = outHeaders[key] as unknown as string | string[];
+          if (key !== "set-cookie") delete outHeaders[key];
+        }
+      }
       // Although the RackResponse tuple types headers as
       // Record<string, string>, downstream apps backed by
       // `Rack::Response` (Record<string, string | string[]>) can hand
@@ -439,7 +450,6 @@ export class Cookies {
       // template would stringify with commas and corrupt the header.
       // Normalize both shapes to a flat string[] before joining with
       // newlines (Rack's wire convention for multi-value set-cookie).
-      const existing = outHeaders["set-cookie"] as unknown as string | string[] | undefined;
       const existingList = existing ? (Array.isArray(existing) ? existing : [existing]) : [];
       outHeaders["set-cookie"] = [...existingList, ...setHeaders].join("\n");
     }
@@ -453,9 +463,10 @@ export class Cookies {
 // ===========================================================================
 
 /**
- * Host shape used by {@link requestCookieMethods}. The `env` is the
- * underlying Rack env on the request; trails reads/writes Rails
- * `action_dispatch.*` keys there.
+ * Host shape used by {@link cookieJar}, {@link isHaveCookieJar}, and
+ * the `action_dispatch.*` env-key accessors below ({@link keyGenerator}
+ * et al.). The `env` is the underlying Rack env on the request; trails
+ * reads/writes Rails `action_dispatch.*` keys there.
  *
  * @internal
  */

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -12,6 +12,9 @@
 
 import { getCrypto } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
+
+type RackApp = (env: RackEnv) => Promise<RackResponse>;
 
 /** Cookie expiry — accept either a Date or a Temporal.Instant from AR/AM. */
 export type CookieExpires = Date | Temporal.Instant;
@@ -372,4 +375,255 @@ function formatDeleteCookie(name: string, opts: { path?: string; domain?: string
 
 function capitalize(s: string): string {
   return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// ===========================================================================
+// ActionDispatch::Cookies — middleware
+// ===========================================================================
+
+/**
+ * Rack env key under which the constructed {@link CookieJar} is cached for
+ * the duration of the request. Mirrors `ActionDispatch::Cookies::COOKIES_KEY`.
+ *
+ * @internal
+ */
+export const COOKIES_KEY = "action_dispatch.cookies";
+
+/**
+ * `ActionDispatch::Cookies` middleware. Builds a {@link CookieJar} on the
+ * way in, flushes accumulated `Set-Cookie` headers on the way out.
+ */
+export class Cookies {
+  private app: RackApp;
+
+  constructor(app: RackApp) {
+    this.app = app;
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    const cookiesAppOptions = (env[COOKIES_APP_OPTIONS_KEY] as CookieJarOptions | undefined) ?? {};
+    const seed = parseCookieHeader((env.HTTP_COOKIE as string | undefined) ?? "");
+    const jar = CookieJar.build({ cookiesAppOptions }, seed);
+    env[COOKIES_KEY] = jar;
+    const [status, headers, body] = await this.app(env);
+    const outHeaders: Record<string, string> = { ...headers };
+    const setHeaders = jar.getSetCookieHeaders();
+    if (setHeaders.length > 0) {
+      const existing = outHeaders["set-cookie"];
+      outHeaders["set-cookie"] = existing
+        ? [existing, ...setHeaders].join("\n")
+        : setHeaders.join("\n");
+    }
+    return [status, outHeaders, body];
+  }
+}
+
+function parseCookieHeader(header: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!header) return out;
+  for (const pair of header.split(";")) {
+    const eq = pair.indexOf("=");
+    if (eq < 0) continue;
+    const k = pair.slice(0, eq).trim();
+    const v = pair.slice(eq + 1).trim();
+    if (k) out[k] = decodeURIComponent(v);
+  }
+  return out;
+}
+
+// ===========================================================================
+// ActionDispatch::RequestCookieMethods — Request mixin
+// ===========================================================================
+
+/**
+ * Host shape used by {@link requestCookieMethods}. The `env` is the
+ * underlying Rack env on the request; trails reads/writes Rails
+ * `action_dispatch.*` keys there.
+ *
+ * @internal
+ */
+export interface RequestCookieMethodsHost {
+  env: RackEnv;
+  cookiesAppOptions?: CookieJarOptions;
+  cookies: Record<string, string>;
+}
+
+const COOKIE_JAR_ENV = COOKIES_KEY;
+
+/** Returns the {@link CookieJar} for this request, building it on demand. */
+export function cookieJar(this: RequestCookieMethodsHost, jar?: CookieJar): CookieJar {
+  if (jar !== undefined) {
+    this.env[COOKIE_JAR_ENV] = jar;
+    return jar;
+  }
+  const existing = this.env[COOKIE_JAR_ENV] as CookieJar | undefined;
+  if (existing) return existing;
+  const built = CookieJar.build(this, this.cookies);
+  this.env[COOKIE_JAR_ENV] = built;
+  return built;
+}
+
+/** True iff a cookie jar has already been built for this request. */
+export function isHaveCookieJar(this: RequestCookieMethodsHost): boolean {
+  return this.env[COOKIE_JAR_ENV] !== undefined;
+}
+
+const requestEnvAccessor = <T>(key: string) =>
+  function (this: RequestCookieMethodsHost): T | undefined {
+    return this.env[key] as T | undefined;
+  };
+
+/** Rails: `request.key_generator` — the app key generator. @internal */
+export const keyGenerator = requestEnvAccessor<unknown>("action_dispatch.key_generator");
+/** @internal */
+export const signedCookieSalt = requestEnvAccessor<string>("action_dispatch.signed_cookie_salt");
+/** @internal */
+export const encryptedCookieSalt = requestEnvAccessor<string>(
+  "action_dispatch.encrypted_cookie_salt",
+);
+/** @internal */
+export const encryptedSignedCookieSalt = requestEnvAccessor<string>(
+  "action_dispatch.encrypted_signed_cookie_salt",
+);
+/** @internal */
+export const authenticatedEncryptedCookieSalt = requestEnvAccessor<string>(
+  "action_dispatch.authenticated_encrypted_cookie_salt",
+);
+/** @internal */
+export const useAuthenticatedCookieEncryption = requestEnvAccessor<boolean>(
+  "action_dispatch.use_authenticated_cookie_encryption",
+);
+/** @internal */
+export const encryptedCookieCipher = requestEnvAccessor<string>(
+  "action_dispatch.encrypted_cookie_cipher",
+);
+/** @internal */
+export const signedCookieDigest = requestEnvAccessor<string>(
+  "action_dispatch.signed_cookie_digest",
+);
+/** @internal */
+export const secretKeyBase = requestEnvAccessor<string>("action_dispatch.secret_key_base");
+/** @internal */
+export const cookiesSerializer = requestEnvAccessor<string>("action_dispatch.cookies_serializer");
+/** @internal */
+export const cookiesSameSiteProtection = requestEnvAccessor<unknown>(
+  "action_dispatch.cookies_same_site_protection",
+);
+/** @internal */
+export const cookiesDigest = requestEnvAccessor<string>("action_dispatch.cookies_digest");
+/** @internal */
+export const cookiesRotations = requestEnvAccessor<unknown>("action_dispatch.cookies_rotations");
+/** @internal */
+export const useCookiesWithMetadata = requestEnvAccessor<boolean>(
+  "action_dispatch.use_cookies_with_metadata",
+);
+
+// ===========================================================================
+// ActionDispatch::Cookies::ChainedCookieJars
+// ===========================================================================
+
+/**
+ * Combined signed-or-encrypted accessor on a jar. Rails picks `encrypted`
+ * when `secret_key_base` is configured, otherwise falls back to `signed`.
+ *
+ * @internal
+ */
+export function signedOrEncrypted(jar: CookieJar): SignedCookieJar | EncryptedCookieJar {
+  try {
+    return jar.encrypted;
+  } catch {
+    return jar.signed;
+  }
+}
+
+/**
+ * Rails: predicate that returns true while the deprecated HMAC-AES-CBC
+ * cookie format is still being read alongside the newer AEAD format.
+ * trails does not implement the legacy CBC path, so the predicate is
+ * permanently false.
+ *
+ * @internal
+ */
+export function isUpgradeLegacyHmacAesCbcCookies(): boolean {
+  return false;
+}
+
+/**
+ * Rails: rewriter predicate complementing
+ * {@link isUpgradeLegacyHmacAesCbcCookies}. Same rationale — false in
+ * trails.
+ *
+ * @internal
+ */
+export function isPrepareUpgradeLegacyHmacAesCbcCookies(): boolean {
+  return false;
+}
+
+// ===========================================================================
+// ActionDispatch::Cookies::SerializedCookieJars
+// ===========================================================================
+
+const MAX_COOKIE_SIZE = 4096;
+
+/**
+ * Selects the cookie value serializer. Mirrors Rails' `:json` / `:hybrid` /
+ * `:marshal` choices; trails ships JSON-only.
+ *
+ * @internal
+ */
+export function serializer(): { dump(v: unknown): string; load(s: string): unknown } {
+  return {
+    dump: (v) => JSON.stringify(v),
+    load: (s) => {
+      try {
+        return JSON.parse(s);
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
+/**
+ * Rails: returns true when a stored cookie was written with the legacy
+ * serializer and must be re-serialized with the configured one. trails
+ * has only ever shipped JSON, so reserialize is never required.
+ *
+ * @internal
+ */
+export function isReserialize(): boolean {
+  return false;
+}
+
+/**
+ * Rails: hook called once the value has been mutated, before the jar is
+ * written back to the response. Trails performs no buffering, so commit
+ * is a no-op pass-through that returns the value unchanged.
+ *
+ * @internal
+ */
+export function commit<T>(value: T): T {
+  return value;
+}
+
+/**
+ * Rails raises `CookieOverflow` when a serialized value exceeds 4096
+ * bytes (the browser-imposed cookie ceiling). Mirror the check.
+ *
+ * @internal
+ */
+export function checkForOverflowBang(serialized: string): void {
+  if (Buffer.byteLength(serialized, "utf8") > MAX_COOKIE_SIZE) {
+    throw new CookieOverflow(
+      `Cookie overflow: serialized value is ${Buffer.byteLength(serialized, "utf8")} bytes; ` +
+        `maximum is ${MAX_COOKIE_SIZE}.`,
+    );
+  }
+}
+
+export class CookieOverflow extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "CookieOverflow";
+  }
 }

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -621,7 +621,17 @@ export interface SerializedCookieJarsHost {
 }
 
 const JSON_SERIALIZER: CookieSerializer = {
-  dump: (v) => JSON.stringify(v),
+  dump: (v) => {
+    // JSON.stringify returns `undefined` for `undefined`/functions/symbols.
+    // Rails' JSON serializer raises on those; do the same so
+    // unserializable values aren't silently dropped by CookieJar#set's
+    // `value === undefined` guard.
+    const out = JSON.stringify(v);
+    if (out === undefined) {
+      throw new TypeError(`cannot serialize ${typeof v} as a cookie value`);
+    }
+    return out;
+  },
   load: (s) => JSON.parse(s),
   dumped: (s) => {
     try {


### PR DESCRIPTION
## api:compare

| File | Before | After |
| --- | --- | --- |
| `middleware/cookies.rb` | 6/31 (19%) | 31/31 (100%) |

## Changes

All additive — existing `CookieJar` / `SignedCookieJar` / `EncryptedCookieJar` / `PermanentCookieJar` surface untouched apart from the `commitBang`/`isCommitted` lifecycle.

- **`Cookies` middleware** (`call`) — flushes the jar's accumulated `Set-Cookie` headers into the downstream response when `request.cookie_jar` was actually used (i.e. `env[COOKIES_KEY]` is set) and the jar has not been committed. After flushing, the jar is committed; subsequent `set`/`delete` calls are no-ops, matching Rails' frozen `@set_cookies`/`@delete_cookies`.
- **`RequestCookieMethods` mixin** — `cookieJar` getter/setter, `isHaveCookieJar` predicate, and 14 env-key accessors (`keyGenerator`, `signedCookieSalt`, `encryptedCookieSalt`, `encryptedSignedCookieSalt`, `authenticatedEncryptedCookieSalt`, `useAuthenticatedCookieEncryption`, `encryptedCookieCipher`, `signedCookieDigest`, `secretKeyBase`, `cookiesSerializer`, `cookiesSameSiteProtection`, `cookiesDigest`, `cookiesRotations`, `useCookiesWithMetadata`).
- **`ChainedCookieJars`** — `signedOrEncrypted` dispatches on `request.secretKeyBase` (encrypted when present, signed otherwise). `isUpgradeLegacyHmacAesCbcCookies` / `isPrepareUpgradeLegacyHmacAesCbcCookies` are faithful Rails predicates over the request mixin (the predicates are configuration-driven, not stubs — they will return `true` if the legacy CBC salts are configured on the request).
- **`SerializedCookieJars`** — `serializer` returns a memoized JSON-shaped `CookieSerializer { dump, load, dumped }`. `isReserialize(dumped)` returns `true` when the payload was *not* produced by the configured serializer (mirrors Rails `reserialize?`). `commit(name, options)` mutates `options.value = serializer.dump(options.value)`. `checkForOverflowBang(name, options)` raises `CookieOverflow` at 4096 bytes with Rails' message format.

Rails-private helpers carry `@internal` JSDoc per CLAUDE.md.

## Tests

`cookies.test.ts` exercises the middleware:
- No jar built downstream → no header changes.
- Jar with `set`/`delete` → newline-joined `Set-Cookie` (Rack convention).
- Pre-committed jar → middleware skips the flush.
- Post-call commit guard → later `set`/`delete` are dropped.

Plus boundary tests for `checkForOverflowBang`.

Existing tests (cookie-jar / signed-cookie-jar / etc.) untouched.

## Notes

- camelCase throughout.
- No test renames.
- Follow-up: #2090 (flash + debug-exceptions).