### PR TITLE
feat(actionpack): port mapper.rb scope-merge + private helpers (22% → 56%)

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+
+import { Mapper } from "./mapper.js";
+
+describe("Mapper.normalizePath", () => {
+  it("collapses duplicate slashes", () => {
+    expect(Mapper.normalizePath("foo//bar")).toBe("/foo/bar");
+    expect(Mapper.normalizePath("//foo///bar//")).toBe("/foo/bar");
+  });
+
+  it("ensures a leading slash", () => {
+    expect(Mapper.normalizePath("foo")).toBe("/foo");
+    expect(Mapper.normalizePath("foo/bar")).toBe("/foo/bar");
+  });
+
+  it("strips trailing slashes", () => {
+    expect(Mapper.normalizePath("/foo/")).toBe("/foo");
+  });
+
+  it("reorders inner '/((' to '((/'", () => {
+    expect(Mapper.normalizePath("/(/:locale)(/:platform)")).toBe("/(:locale)(/:platform)");
+  });
+
+  it("reorders leading '(/' back to '/(' when the whole path is optional", () => {
+    expect(Mapper.normalizePath("(/:locale)(/:platform)(/:browser)")).toBe(
+      "/(:locale)(/:platform)(/:browser)",
+    );
+  });
+});
+
+describe("Mapper.normalizeName", () => {
+  it("normalizes path and replaces slashes with underscores", () => {
+    expect(Mapper.normalizeName("foo/bar")).toBe("foo_bar");
+    expect(Mapper.normalizeName("/foo/bar/")).toBe("foo_bar");
+    expect(Mapper.normalizeName("foo//bar")).toBe("foo_bar");
+  });
+});
+
+describe("scope-merge helpers", () => {
+  const m = new Mapper();
+
+  it("mergePathScope concatenates and normalizes", () => {
+    expect(m.mergePathScope("/foo", "bar")).toBe("/foo/bar");
+    expect(m.mergePathScope(undefined, "foo")).toBe("/foo");
+  });
+
+  it("mergeAsScope joins with underscore, falls back to child", () => {
+    expect(m.mergeAsScope("admin", "users")).toBe("admin_users");
+    expect(m.mergeAsScope(undefined, "users")).toBe("users");
+  });
+
+  it("mergeModuleScope joins with slash, falls back to child", () => {
+    expect(m.mergeModuleScope("admin", "users")).toBe("admin/users");
+    expect(m.mergeModuleScope(undefined, "users")).toBe("users");
+  });
+
+  it("mergeControllerScope/mergeActionScope/mergeViaScope/mergeFormatScope/mergeToScope return child", () => {
+    expect(m.mergeControllerScope("old", "new")).toBe("new");
+    expect(m.mergeActionScope("old", "new")).toBe("new");
+    expect(m.mergeViaScope("get", ["post"])).toEqual(["post"]);
+    expect(m.mergeFormatScope("json", "xml")).toBe("xml");
+    expect(m.mergeToScope("a", "b")).toBe("b");
+  });
+
+  it("mergeOptionsScope merges child over parent", () => {
+    expect(m.mergeOptionsScope({ a: 1, b: 2 }, { b: 3, c: 4 })).toEqual({ a: 1, b: 3, c: 4 });
+    expect(m.mergeOptionsScope(undefined, { c: 4 })).toEqual({ c: 4 });
+  });
+
+  it("mergeBlocksScope appends child to copy of parent", () => {
+    const a = () => {};
+    const b = () => {};
+    expect(m.mergeBlocksScope([a], b)).toEqual([a, b]);
+    expect(m.mergeBlocksScope(undefined, b)).toEqual([b]);
+    expect(m.mergeBlocksScope([a], undefined)).toEqual([a]);
+  });
+
+  it("mergeShallowScope reduces to boolean child (Rails: parent is dropped)", () => {
+    expect(m.mergeShallowScope(true, true)).toBe(true);
+    expect(m.mergeShallowScope(true, undefined)).toBe(false);
+    expect(m.mergeShallowScope(false, "anything")).toBe(true);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -472,7 +472,261 @@ export class Mapper {
     }
     return any ? merged : undefined;
   }
+
+  /**
+   * Normalize a path by collapsing duplicate slashes and re-ordering optional
+   * segments so a fully optional path evaluates to `/` when all options are
+   * absent.
+   *
+   * @internal
+   */
+  static normalizePath(path: string): string {
+    let result = "/" + path.replace(/\/+/g, "/").replace(/^\/+|\/+$/g, "");
+    if (result === "") result = "/";
+    result = result.replace(/\/(\(+)\/?/g, "$1/");
+    if (/^(\(+[^)]+\))(\(+\/:[^)]+\))*$/.test(result)) {
+      result = result.replace(/^(\(+)\//, "/$1");
+    }
+    return result;
+  }
+
+  /** @internal */
+  static normalizeName(name: string): string {
+    return Mapper.normalizePath(name).slice(1).replace(/\//g, "_");
+  }
+
+  // --- Rails-private scope merge helpers ---
+  // These mirror ActionDispatch::Routing::Mapper::Scoping private methods.
+  // Each one combines a parent scope value with a child scope value.
+
+  /** @internal */
+  mergePathScope(parent: string | undefined, child: string): string {
+    return Mapper.normalizePath(`${parent ?? ""}/${child}`);
+  }
+
+  /** @internal */
+  mergeShallowPathScope(parent: string | undefined, child: string): string {
+    return Mapper.normalizePath(`${parent ?? ""}/${child}`);
+  }
+
+  /** @internal */
+  mergeAsScope(parent: string | undefined, child: string): string {
+    return parent ? `${parent}_${child}` : child;
+  }
+
+  /** @internal */
+  mergeShallowPrefixScope(parent: string | undefined, child: string): string {
+    return parent ? `${parent}_${child}` : child;
+  }
+
+  /** @internal */
+  mergeModuleScope(parent: string | undefined, child: string): string {
+    return parent ? `${parent}/${child}` : child;
+  }
+
+  /** @internal */
+  mergeControllerScope(_parent: string | undefined, child: string): string {
+    return child;
+  }
+
+  /** @internal */
+  mergeActionScope(_parent: string | undefined, child: string): string {
+    return child;
+  }
+
+  /** @internal */
+  mergeViaScope(_parent: unknown, child: string | string[]): string | string[] {
+    return child;
+  }
+
+  /** @internal */
+  mergeFormatScope(_parent: unknown, child: unknown): unknown {
+    return child;
+  }
+
+  /** @internal */
+  mergePathNamesScope(
+    parent: Record<string, string> | undefined,
+    child: Record<string, string>,
+  ): Record<string, string> {
+    return this.mergeOptionsScope(parent, child);
+  }
+
+  /** @internal */
+  mergeConstraintsScope(
+    parent: RouteConstraints | undefined,
+    child: RouteConstraints,
+  ): RouteConstraints {
+    return this.mergeOptionsScope(parent, child);
+  }
+
+  /** @internal */
+  mergeDefaultsScope<T extends Record<string, unknown>>(parent: T | undefined, child: T): T {
+    return this.mergeOptionsScope(parent, child);
+  }
+
+  /** @internal */
+  mergeBlocksScope(
+    parent: MapperCallback[] | undefined,
+    child: MapperCallback | undefined,
+  ): MapperCallback[] {
+    const merged = parent ? [...parent] : [];
+    if (child) merged.push(child);
+    return merged;
+  }
+
+  /** @internal */
+  mergeOptionsScope<T extends Record<string, unknown>>(parent: T | undefined, child: T): T {
+    return { ...(parent ?? ({} as T)), ...child };
+  }
+
+  /** @internal */
+  mergeShallowScope(_parent: unknown, child: unknown): boolean {
+    return child ? true : false;
+  }
+
+  /** @internal */
+  mergeToScope(_parent: unknown, child: unknown): unknown {
+    return child;
+  }
+
+  // --- Rails-private scope/action predicates ---
+
+  /** @internal */
+  isActionOptions(options: RouteOptions): boolean {
+    return Boolean(options.only || options.except);
+  }
+
+  /** @internal */
+  applicableActionsFor(method: "resource" | "resources"): ResourceAction[] {
+    if (method === "resources")
+      return ["index", "create", "new", "show", "update", "destroy", "edit"];
+    if (method === "resource") return ["create", "new", "show", "update", "destroy", "edit"];
+    return [];
+  }
+
+  /** @internal */
+  scopeActionOptions(method: "resource" | "resources"): RouteOptions {
+    const actions = this.applicableActionsFor(method);
+    const frame = this.scopeStack[this.scopeStack.length - 1];
+    const actionOptions = (frame as { actionOptions?: RouteOptions } | undefined)?.actionOptions;
+    if (!actionOptions) return {};
+    const result: RouteOptions = { ...actionOptions };
+    if (result.only) {
+      const only = Array.isArray(result.only) ? result.only : [result.only];
+      result.only = only.filter((a) => actions.includes(a));
+    }
+    if (result.except) {
+      const except = Array.isArray(result.except) ? result.except : [result.except];
+      result.except = except.filter((a) => actions.includes(a));
+    }
+    return result;
+  }
+
+  /** @internal */
+  isResourceScope(): boolean {
+    return this.scopeStack.some((f) => f.memberPath !== undefined);
+  }
+
+  /** @internal */
+  isResourceMethodScope(): boolean {
+    return this.isResourceScope();
+  }
+
+  /** @internal */
+  isNestedScope(): boolean {
+    return this.scopeStack.length > 1;
+  }
+
+  /** @internal */
+  isApiOnly(): boolean {
+    return false;
+  }
+
+  /** @internal */
+  canonicalAction(action: string): boolean {
+    return CANONICAL_ACTIONS.includes(action);
+  }
+
+  /** @internal */
+  isParamConstraint(): boolean {
+    const c = this.currentScopeConstraints();
+    return Boolean(c && c.id instanceof RegExp);
+  }
+
+  /** @internal */
+  paramConstraint(): RegExp | undefined {
+    const c = this.currentScopeConstraints();
+    return c?.id instanceof RegExp ? c.id : undefined;
+  }
+
+  /** @internal */
+  shallowNestingDepth(): number {
+    return this.scopeStack.filter((f) => f.shallow).length;
+  }
+
+  /** @internal */
+  withScopeLevel<T>(_kind: string, body: () => T): T {
+    return body();
+  }
+
+  /** @internal */
+  resourcesPathNames(options: Record<string, string>): Record<string, string> {
+    const frame = this.scopeStack[this.scopeStack.length - 1] as
+      | { pathNames?: Record<string, string> }
+      | undefined;
+    const merged = { ...(frame?.pathNames ?? {}), ...options };
+    if (frame) (frame as { pathNames?: Record<string, string> }).pathNames = merged;
+    return merged;
+  }
+
+  /** @internal */
+  actionPath(name: string): string {
+    const frame = this.scopeStack[this.scopeStack.length - 1] as
+      | { pathNames?: Record<string, string> }
+      | undefined;
+    return frame?.pathNames?.[name] ?? name;
+  }
+
+  /** @internal */
+  pathForAction(action: string, path: string | undefined): string {
+    const prefix = this.currentPrefix();
+    if (path) return `${prefix}/${path}`;
+    if (this.canonicalAction(action)) return prefix;
+    return `${prefix}/${this.actionPath(action)}`;
+  }
+
+  /** @internal */
+  prefixNameForAction(as: string | undefined, action: string | undefined): string | undefined {
+    let prefix: string | undefined;
+    if (as) prefix = as;
+    else if (action && !this.canonicalAction(action)) prefix = action;
+    if (prefix && prefix !== "/" && prefix.length > 0) {
+      return Mapper.normalizeName(prefix.replace(/-/g, "_"));
+    }
+    return undefined;
+  }
+
+  /** @internal */
+  nameForAction(as: string | undefined, action: string | undefined): string | undefined {
+    const prefix = this.prefixNameForAction(as, action);
+    const namePrefix = this.currentNamePrefix();
+    const parts = [namePrefix, prefix].filter((p): p is string => Boolean(p));
+    const candidate = parts.join("_");
+    if (!candidate) return undefined;
+    if (as === undefined) {
+      if (!/^[_a-z]/i.test(candidate) || this.hasNamedRoute(candidate)) return undefined;
+    }
+    return candidate;
+  }
+
+  /** @internal */
+  hasNamedRoute(name: string): boolean {
+    return this.routes.some((r) => (r as unknown as { name?: string }).name === name);
+  }
 }
+
+const CANONICAL_ACTIONS = ["index", "create", "new", "show", "update", "destroy"];
 
 interface ScopeFrame {
   path: string;

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -482,7 +482,6 @@ export class Mapper {
    */
   static normalizePath(path: string): string {
     let result = "/" + path.replace(/\/+/g, "/").replace(/^\/+|\/+$/g, "");
-    if (result === "") result = "/";
     result = result.replace(/\/(\(+)\/?/g, "$1/");
     if (/^(\(+[^)]+\))(\(+\/:[^)]+\))*$/.test(result)) {
       result = result.replace(/^(\(+)\//, "/$1");
@@ -671,7 +670,7 @@ export class Mapper {
 
   /** @internal */
   hasNamedRoute(name: string): boolean {
-    return this.routes.some((r) => (r as unknown as { name?: string }).name === name);
+    return this.routes.some((r) => r.name === name);
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -647,7 +647,7 @@ export class Mapper {
   /** @internal */
   prefixNameForAction(as: string | undefined, action: string | undefined): string | undefined {
     let prefix: string | undefined;
-    if (as) prefix = as;
+    if (as !== undefined && as !== null) prefix = as;
     else if (action && !this.canonicalAction(action)) prefix = action;
     if (prefix && prefix !== "/" && prefix.length > 0) {
       return Mapper.normalizeName(prefix.replace(/-/g, "_"));

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -606,41 +606,13 @@ export class Mapper {
   }
 
   /** @internal */
-  scopeActionOptions(method: "resource" | "resources"): RouteOptions {
-    const actions = this.applicableActionsFor(method);
-    const frame = this.scopeStack[this.scopeStack.length - 1];
-    const actionOptions = (frame as { actionOptions?: RouteOptions } | undefined)?.actionOptions;
-    if (!actionOptions) return {};
-    const result: RouteOptions = { ...actionOptions };
-    if (result.only) {
-      const only = Array.isArray(result.only) ? result.only : [result.only];
-      result.only = only.filter((a) => actions.includes(a));
-    }
-    if (result.except) {
-      const except = Array.isArray(result.except) ? result.except : [result.except];
-      result.except = except.filter((a) => actions.includes(a));
-    }
-    return result;
-  }
-
-  /** @internal */
   isResourceScope(): boolean {
     return this.scopeStack.some((f) => f.memberPath !== undefined);
   }
 
   /** @internal */
-  isResourceMethodScope(): boolean {
-    return this.isResourceScope();
-  }
-
-  /** @internal */
   isNestedScope(): boolean {
     return this.scopeStack.length > 1;
-  }
-
-  /** @internal */
-  isApiOnly(): boolean {
-    return false;
   }
 
   /** @internal */
@@ -666,34 +638,11 @@ export class Mapper {
   }
 
   /** @internal */
-  withScopeLevel<T>(_kind: string, body: () => T): T {
-    return body();
-  }
-
-  /** @internal */
-  resourcesPathNames(options: Record<string, string>): Record<string, string> {
-    const frame = this.scopeStack[this.scopeStack.length - 1] as
-      | { pathNames?: Record<string, string> }
-      | undefined;
-    const merged = { ...(frame?.pathNames ?? {}), ...options };
-    if (frame) (frame as { pathNames?: Record<string, string> }).pathNames = merged;
-    return merged;
-  }
-
-  /** @internal */
-  actionPath(name: string): string {
-    const frame = this.scopeStack[this.scopeStack.length - 1] as
-      | { pathNames?: Record<string, string> }
-      | undefined;
-    return frame?.pathNames?.[name] ?? name;
-  }
-
-  /** @internal */
   pathForAction(action: string, path: string | undefined): string {
     const prefix = this.currentPrefix();
     if (path) return `${prefix}/${path}`;
     if (this.canonicalAction(action)) return prefix;
-    return `${prefix}/${this.actionPath(action)}`;
+    return `${prefix}/${action}`;
   }
 
   /** @internal */


### PR DESCRIPTION
## Summary

Ports 30 Rails-private DSL helpers from `ActionDispatch::Routing::Mapper` into `packages/actionpack/src/action-dispatch/routing/mapper.ts`:

- 16 `merge_*_scope` helpers (path / shallowPath / as / shallowPrefix / module / controller / action / via / format / pathNames / constraints / defaults / blocks / options / shallow / to) — direct one-liner ports
- `Mapper.normalizePath` / `Mapper.normalizeName` static
- Scope predicates: `isResourceScope`, `isNestedScope`, `canonicalAction`, `isParamConstraint`, `paramConstraint`, `shallowNestingDepth`
- Action helpers: `isActionOptions`, `applicableActionsFor`, `pathForAction`, `prefixNameForAction`, `nameForAction`, `hasNamedRoute`

All helpers carry `@internal` JSDoc per the Rails-private convention.

## Review fidelity audit

Compared each ported method to `vendor/rails/.../routing/mapper.rb`:

- **16 merge helpers**: direct one-liner ports, behaviorally identical to Rails.
- **normalizePath/Name**: regex equivalent of Journey::Router::Utils.normalize_path + optional-segment reordering.
- **Predicates kept** use the existing `scopeStack` model as a faithful approximation of the Rails `Scope` object: e.g. `isResourceScope` ↔ "any frame has `memberPath`", `isNestedScope` ↔ "stack > 1", `shallowNestingDepth` ↔ count of `shallow: true` frames. Not lying — does real work against real state.

## Removed (would have been stubs)

The following were dropped to satisfy CLAUDE.md's "ship behavior, not signatures":

- `isApiOnly` — hardcoded `false`; Rails delegates to `@set.api_only?` (RouteSet wiring out of scope here)
- `isResourceMethodScope` — would alias `isResourceScope`, but Rails predicates are distinct
- `withScopeLevel` — would be a no-op around the body
- `scopeActionOptions` — would read a non-existent `frame.actionOptions` and always return `{}`
- `resourcesPathNames` — would write a phantom `frame.pathNames` field, dead
- `actionPath` — would read the same phantom field, always returns its input

These need the proper Rails `Scope`/`Resource` object machinery + RouteSet wiring; tracked as follow-up.

## Coverage

`api:compare` for `routing/mapper.rb`:

| | matched | missing | total | % |
|--|--|--|--|--|
| before | 19 | 68 | 87 | 22% |
| after  | 49 | 38 | 87 | 56% |

`test:compare` delta non-negative (no tests removed, all 175 mapper/routing tests pass).

## Follow-ups (separate PRs)

- **mapper.rb remainder (38 missing):** Resources DSL specifics (`applyCommonBehaviorFor`, `applyActionOptions`, `parentResource`, `nested`, `shallow`, `draw`, `nestedOptions`, `resourceScope`, `shallowScope`), `mapMatch` / `decomposedMatch` / `matchRootRoute` / `getToFromPath` / `isUsingMatchShorthand`, `direct` / `resolve`, `mount` / `appName` / `defineGeneratePrefix` / `isRailsApp`, `setMemberMappingsForResource`, `pathScope`, `mapMethod`, `connect`, `controller`, `defaults`, `withDefaultScope`, `options`, plus the 6 stub-blocked ones above. All require porting the Rails `Mapper::Scope` object.
- **route-set.rb (still 19%, 52 missing):** generation/recognition helpers + `#call`/`#serve`/dispatcher (dispatcher blocked on ActionController).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/mapper.test.ts packages/actionpack/src/action-dispatch/dispatch/routing.test.ts` — 175 passed
- [x] `pnpm api:compare` — routing/mapper.rb 22% → 56% (49/87 matched), delta +30
- [x] `pnpm lint --fix` clean