### PR TITLE
feat(actionpack): close middleware/flash + debug-exceptions toward 100% api:compare

### DIFF
--- a/packages/actionpack/src/action-controller/controller/flash-hash.test.ts
+++ b/packages/actionpack/src/action-controller/controller/flash-hash.test.ts
@@ -165,4 +165,48 @@ describe("FlashHashTest", () => {
     flash.sweep();
     expect(flash.has("a")).toBe(false);
   });
+
+  it("fromSessionValue loads Rails-shaped { flashes, discard } payload", () => {
+    const loaded = FlashHash.fromSessionValue({
+      flashes: { kept: "yes", dropped: "no" },
+      discard: ["dropped"],
+    });
+    expect(loaded.get("kept")).toBe("yes");
+    // Rails: flashes.except!(*discard) — `dropped` is removed at load.
+    expect(loaded.has("dropped")).toBe(false);
+  });
+
+  it("fromSessionValue marks all surviving keys for next-sweep discard", () => {
+    const loaded = FlashHash.fromSessionValue({
+      flashes: { kept: "yes" },
+      discard: [],
+    });
+    expect(loaded.get("kept")).toBe("yes");
+    // Rails: new(flashes, flashes.keys) — every surviving key is on
+    // the discard list for the next sweep.
+    loaded.sweep();
+    expect(loaded.has("kept")).toBe(false);
+  });
+
+  it("dup returns an independent copy", () => {
+    const original = new FlashHash({ notice: "hi" });
+    const copy = original.dup();
+    copy.set("notice", "changed");
+    expect(original.get("notice")).toBe("hi");
+    expect(copy.get("notice")).toBe("changed");
+  });
+
+  it("dup carries over the discard set so sweep behaves identically", () => {
+    const original = FlashHash.fromSessionValue({ flashes: { a: "1" }, discard: [] });
+    // After fromSessionValue, `a` is marked for discard on next sweep.
+    const copy = original.dup();
+    copy.sweep();
+    expect(copy.has("a")).toBe(false);
+  });
+
+  it("flashesForSession prunes keys marked for discard", () => {
+    const flash = new FlashHash({ kept: "1", dropped: "2" });
+    flash.discard("dropped");
+    expect(flash.flashesForSession()).toEqual({ kept: "1" });
+  });
 });

--- a/packages/actionpack/src/action-dispatch/dispatch/debug-exceptions.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/debug-exceptions.test.ts
@@ -281,4 +281,29 @@ describe("DebugExceptionsTest", () => {
     const xml = await bodyToString(body);
     expect(xml).toContain("RoutingError");
   });
+
+  it("routes non-HTML requests through renderForApiRequest when responseFormat is 'api'", async () => {
+    const mw = new DebugExceptions(errorApp, { responseFormat: "api" });
+    const [status, headers, body] = await mw.call(makeEnv({ HTTP_ACCEPT: "application/json" }));
+    expect(status).toBe(500);
+    expect(headers["content-type"]).toContain("application/json");
+    const json = JSON.parse(await bodyToString(body));
+    expect(json.exception).toBeDefined();
+    expect(json.traces["Application Trace"]).toBeDefined();
+    expect(json.traces["Framework Trace"]).toBeDefined();
+    // The api path goes through render(), which sets content-length.
+    expect(headers["content-length"]).toBe(String(Buffer.byteLength(JSON.stringify(json), "utf8")));
+  });
+
+  it("isApiRequest is false for HTML accept even when responseFormat is 'api'", () => {
+    const mw = new DebugExceptions(errorApp, { responseFormat: "api" });
+    expect(mw.isApiRequest("text/html")).toBe(false);
+    expect(mw.isApiRequest("application/json")).toBe(true);
+    expect(mw.isApiRequest(null)).toBe(true);
+  });
+
+  it("isApiRequest is false when responseFormat defaults to 'default'", () => {
+    const mw = new DebugExceptions(errorApp);
+    expect(mw.isApiRequest("application/json")).toBe(false);
+  });
 });

--- a/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
@@ -112,8 +112,11 @@ export class DebugExceptions {
   }
 
   /**
-   * Final response builder used by both the API and browser paths. Returns
-   * a Rack response tuple with correct Content-Type / Content-Length.
+   * Rack response builder used by {@link renderForApiRequest}. Mirrors
+   * Rails' private `DebugExceptions#render(status, body, format)`. The
+   * legacy `renderJsonError` / `renderXmlError` / `renderHtmlError` /
+   * `renderTextError` paths predate this helper and build their own
+   * tuples directly; they should migrate to `render` over time.
    *
    * @internal
    */
@@ -136,8 +139,11 @@ export class DebugExceptions {
    * @internal
    */
   logError(env: RackEnv, wrapper: ExceptionWrapper): void {
-    const logger = (env["action_dispatch.logger"] as Logger | undefined) ?? this.logger;
-    if (!logger) return;
+    // Rails: `request.logger || ActionView::Base.logger || stderr_logger`
+    // — fall back to the memoized stderr logger when no logger is wired
+    // in env/options so errors are never silently swallowed.
+    const logger =
+      (env["action_dispatch.logger"] as Logger | undefined) ?? this.logger ?? this.stderrLogger();
     if (!this.isLogRescuedResponses(env) && wrapper.statusCode < 500) return;
 
     const lines: string[] = ["  "];

--- a/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
@@ -140,15 +140,25 @@ export class DebugExceptions {
     if (!logger) return;
     if (!this.isLogRescuedResponses(env) && wrapper.statusCode < 500) return;
 
-    const lines: string[] = [];
-    lines.push(`${wrapper.exceptionName} (${wrapper.message}):`);
-    let cause = (wrapper.exception as { cause?: Error }).cause;
-    while (cause) {
-      lines.push(`Caused by: ${cause.constructor?.name ?? "Error"} (${cause.message})`);
-      cause = (cause as { cause?: Error }).cause;
+    const lines: string[] = ["  "];
+    if (wrapper.hasCause()) {
+      lines.push(`${wrapper.exceptionClassName} (${wrapper.message})`);
+      for (const cause of wrapper.wrappedCauses) {
+        lines.push(`Caused by: ${cause.exceptionClassName} (${cause.message})`);
+      }
+      lines.push(`\nInformation for: ${wrapper.exceptionClassName} (${wrapper.message}):`);
+    } else {
+      lines.push(`${wrapper.exceptionClassName} (${wrapper.message}):`);
     }
+    lines.push(...wrapper.annotatedSourceCode());
     lines.push("  ");
-    lines.push(...wrapper.applicationTrace);
+    lines.push(...wrapper.exceptionTrace());
+    for (const cause of wrapper.hasCause() ? wrapper.wrappedCauses : []) {
+      lines.push(`\nInformation for cause: ${cause.exceptionClassName} (${cause.message}):`);
+      lines.push(...cause.annotatedSourceCode());
+      lines.push("  ");
+      lines.push(...cause.exceptionTrace());
+    }
     this.logArray(logger, lines, env);
   }
 

--- a/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
@@ -139,11 +139,16 @@ export class DebugExceptions {
    * @internal
    */
   logError(env: RackEnv, wrapper: ExceptionWrapper): void {
-    // Rails: `request.logger || ActionView::Base.logger || stderr_logger`
-    // — fall back to the memoized stderr logger when no logger is wired
-    // in env/options so errors are never silently swallowed.
+    // Rails: `request.logger || ActionView::Base.logger || stderr_logger`.
+    // trails' `request.logger` reads `action_dispatch.logger` then
+    // `rack.logger` (http/request.ts:480) — mirror that here, then fall
+    // back to the constructor option, then the stderr logger so errors
+    // are never silently swallowed.
     const logger =
-      (env["action_dispatch.logger"] as Logger | undefined) ?? this.logger ?? this.stderrLogger();
+      (env["action_dispatch.logger"] as Logger | undefined) ??
+      (env["rack.logger"] as Logger | undefined) ??
+      this.logger ??
+      this.stderrLogger();
     if (!this.isLogRescuedResponses(env) && wrapper.statusCode < 500) return;
 
     const lines: string[] = ["  "];

--- a/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
@@ -5,6 +5,7 @@
  * in development mode.
  */
 
+import { stderr } from "@blazetrails/activesupport/process-adapter";
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { bodyFromString } from "@blazetrails/rack";
 import { ExceptionWrapper } from "./exception-wrapper.js";
@@ -29,17 +30,39 @@ export interface DebugExceptionsOptions {
   /** Log rescued responses (default: true) */
   logRescuedResponses?: boolean;
   /** Interceptors called before rendering error page */
-  interceptors?: Array<(request: RackEnv, exception: Error) => void>;
+  interceptors?: Interceptor[];
+  /** Response shape (default: "default"; "api" disables template rendering) */
+  responseFormat?: "default" | "api";
 }
 
+export type Interceptor = (env: RackEnv, exception: Error) => void;
+
 export class DebugExceptions {
+  /**
+   * Class-level interceptor registry. Mirrors Rails'
+   * `cattr_reader :interceptors`.
+   *
+   * @internal
+   */
+  static readonly interceptors: Interceptor[] = [];
+
+  /**
+   * Append an interceptor to the class-level registry. Mirrors Rails'
+   * `DebugExceptions.register_interceptor`.
+   */
+  static registerInterceptor(interceptor: Interceptor): void {
+    DebugExceptions.interceptors.push(interceptor);
+  }
+
   private app: RackApp;
   private showDetailedExceptions: boolean;
   private showExceptions: boolean;
   private logLevel: "error" | "warn" | "info";
   private logger: Logger | null;
   private logRescuedResponses: boolean;
-  private interceptors: Array<(request: RackEnv, exception: Error) => void>;
+  private interceptors: Interceptor[];
+  private responseFormat: "default" | "api";
+  private _stderrLogger?: Logger;
 
   constructor(app: RackApp, options: DebugExceptionsOptions = {}) {
     this.app = app;
@@ -48,7 +71,154 @@ export class DebugExceptions {
     this.logLevel = options.logLevel ?? "error";
     this.logger = options.logger ?? null;
     this.logRescuedResponses = options.logRescuedResponses !== false;
-    this.interceptors = options.interceptors ?? [];
+    this.interceptors = options.interceptors ?? [...DebugExceptions.interceptors];
+    this.responseFormat = options.responseFormat ?? "default";
+  }
+
+  /**
+   * Iterate registered interceptors, swallowing per-interceptor errors
+   * and logging them via {@link logError}. Mirrors Rails'
+   * `invoke_interceptors`.
+   *
+   * @internal
+   */
+  invokeInterceptors(env: RackEnv, exception: Error, wrapper: ExceptionWrapper): void {
+    for (const interceptor of this.interceptors) {
+      try {
+        interceptor(env, exception);
+      } catch {
+        this.logError(env, wrapper);
+      }
+    }
+  }
+
+  /**
+   * Render the API JSON error body for an exception. Mirrors Rails'
+   * `render_for_api_request`.
+   *
+   * @internal
+   */
+  renderForApiRequest(wrapper: ExceptionWrapper): RackResponse {
+    const body = JSON.stringify({
+      status: wrapper.statusCode,
+      error: wrapper.statusText,
+      exception: wrapper.exceptionName,
+      traces: {
+        "Application Trace": wrapper.applicationTrace,
+        "Framework Trace": wrapper.frameworkTrace,
+      },
+    });
+    return this.render(wrapper.statusCode, body, "application/json");
+  }
+
+  /**
+   * Final response builder used by both the API and browser paths. Returns
+   * a Rack response tuple with correct Content-Type / Content-Length.
+   *
+   * @internal
+   */
+  render(status: number, body: string, format: string): RackResponse {
+    const charset = "utf-8";
+    return [
+      status,
+      {
+        "content-type": `${format}; charset=${charset}`,
+        "content-length": String(Buffer.byteLength(body, "utf8")),
+      },
+      bodyFromString(body),
+    ];
+  }
+
+  /**
+   * Format and log a rescued exception. Mirrors Rails' `log_error` —
+   * walks `cause` chain, then dispatches to {@link logArray}.
+   *
+   * @internal
+   */
+  logError(env: RackEnv, wrapper: ExceptionWrapper): void {
+    const logger = (env["action_dispatch.logger"] as Logger | undefined) ?? this.logger;
+    if (!logger) return;
+    if (!this.isLogRescuedResponses(env) && wrapper.statusCode < 500) return;
+
+    const lines: string[] = [];
+    lines.push(`${wrapper.exceptionName} (${wrapper.message}):`);
+    let cause = (wrapper.exception as { cause?: Error }).cause;
+    while (cause) {
+      lines.push(`Caused by: ${cause.constructor?.name ?? "Error"} (${cause.message})`);
+      cause = (cause as { cause?: Error }).cause;
+    }
+    lines.push("  ");
+    lines.push(...wrapper.applicationTrace);
+    this.logArray(logger, lines, env);
+  }
+
+  /**
+   * Newline-join `lines` and emit them via `logger.add(level, ...)`.
+   * Mirrors Rails' `log_array`.
+   *
+   * @internal
+   */
+  logArray(logger: Logger, lines: string[], env: RackEnv): void {
+    if (lines.length === 0) return;
+    const level =
+      (env["action_dispatch.debug_exception_log_level"] as "error" | "warn" | "info" | undefined) ??
+      this.logLevel;
+    const message = lines.join("\n");
+    const fn =
+      level === "warn"
+        ? (logger.warn ?? logger.error)
+        : level === "info"
+          ? (logger.info ?? logger.error)
+          : logger.error;
+    fn.call(logger, message);
+  }
+
+  /**
+   * Lazily-initialized fallback logger writing to `stderr`. Mirrors
+   * Rails' `stderr_logger`.
+   *
+   * @internal
+   */
+  stderrLogger(): Logger {
+    if (this._stderrLogger) return this._stderrLogger;
+    this._stderrLogger = {
+      error: (m: string) => stderr.write(`${m}\n`),
+      warn: (m: string) => stderr.write(`${m}\n`),
+      info: (m: string) => stderr.write(`${m}\n`),
+    };
+    return this._stderrLogger;
+  }
+
+  /**
+   * Builds a routes inspector for routing/template errors. Mirrors Rails'
+   * `routes_inspector(exception)` — only returns an inspector when the
+   * wrapper marks the exception as a routing or template error.
+   *
+   * @internal
+   */
+  routesInspector(_wrapper: ExceptionWrapper): unknown {
+    // The `@routes_app` constructor argument from Rails isn't plumbed
+    // through trails' DebugExceptions yet — there is no routes_app to
+    // ask for `.routes`. Return null until the wiring lands.
+    return null;
+  }
+
+  /**
+   * Whether the response should be rendered as an API response. Mirrors
+   * Rails' `api_request?` — true when `responseFormat: "api"` was passed
+   * to the constructor and the resolved content type is not HTML.
+   *
+   * @internal
+   */
+  isApiRequest(contentType: string | null | undefined): boolean {
+    if (this.responseFormat !== "api") return false;
+    return !contentType || !contentType.includes("text/html");
+  }
+
+  /** @internal */
+  isLogRescuedResponses(env: RackEnv): boolean {
+    const flag = env["action_dispatch.log_rescued_responses"];
+    return flag === undefined ? this.logRescuedResponses : Boolean(flag);
   }
 
   async call(env: RackEnv): Promise<RackResponse> {

--- a/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/debug-exceptions.ts
@@ -244,17 +244,10 @@ export class DebugExceptions {
   private renderException(env: RackEnv, exception: Error): RackResponse {
     const wrapper = new ExceptionWrapper(exception);
 
-    // Run interceptors
-    for (const interceptor of this.interceptors) {
-      try {
-        interceptor(env, exception);
-      } catch {
-        // Bad interceptors shouldn't break error handling
-      }
-    }
+    this.invokeInterceptors(env, exception, wrapper);
 
     // Log the exception
-    this.logException(env, exception, wrapper);
+    this.logError(env, wrapper);
 
     if (!this.showExceptions) {
       throw exception;
@@ -268,6 +261,14 @@ export class DebugExceptions {
     const accept = (env["HTTP_ACCEPT"] as string) ?? "";
     const xhr = env["HTTP_X_REQUESTED_WITH"] === "XMLHttpRequest";
     const contentType = (env["CONTENT_TYPE"] as string) ?? "";
+
+    // When configured for the api response format, route any non-HTML
+    // request through the Rails-shaped JSON body. Mirrors Rails'
+    // `api_request?(content_type) ? render_for_api_request(...) : ...`.
+    const negotiated = accept || contentType;
+    if (this.isApiRequest(negotiated)) {
+      return this.renderForApiRequest(wrapper);
+    }
 
     if (xhr || contentType.includes("text/plain")) {
       return this.renderTextError(wrapper);
@@ -381,34 +382,6 @@ export class DebugExceptions {
       { "content-type": "text/html; charset=utf-8" },
       bodyFromString(html),
     ];
-  }
-
-  private logException(env: RackEnv, exception: Error, wrapper: ExceptionWrapper): void {
-    if (!this.logRescuedResponses && wrapper.statusCode < 500) return;
-
-    const logger = (env["action_dispatch.logger"] as Logger) ?? this.logger;
-    if (!logger) return;
-
-    const lines = [
-      `${wrapper.exceptionName} (${wrapper.message}):`,
-      ...wrapper.applicationTrace.slice(0, 10),
-    ];
-
-    // Log causes
-    let cause = (exception as { cause?: Error }).cause;
-    while (cause) {
-      lines.push(`Caused by: ${cause.constructor?.name ?? "Error"} (${cause.message})`);
-      cause = (cause as { cause?: Error }).cause;
-    }
-
-    const message = lines.join("\n");
-    const logFn =
-      this.logLevel === "warn"
-        ? (logger.warn ?? logger.error)
-        : this.logLevel === "info"
-          ? (logger.info ?? logger.error)
-          : logger.error;
-    logFn.call(logger, message);
   }
 
   private escapeHtml(str: string): string {

--- a/packages/actionpack/src/action-dispatch/middleware/flash.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from "vitest";
+import type { RackEnv } from "@blazetrails/rack";
+import {
+  FLASH_KEY,
+  FlashHash,
+  type FlashRequestHost,
+  commitFlash,
+  flash,
+  flashHash,
+  resetSession,
+} from "./flash.js";
+
+function makeSession(initial: Record<string, unknown> = {}) {
+  const store = new Map<string, unknown>(Object.entries(initial));
+  let enabled = true;
+  let loaded = true;
+  return {
+    isEnabled: () => enabled,
+    isLoaded: () => loaded,
+    hasKey: (k: string) => store.has(k),
+    get: (k: string) => store.get(k),
+    set: (k: string, v: unknown) => {
+      store.set(k, v);
+    },
+    delete: (k: string) => {
+      store.delete(k);
+    },
+    _store: store,
+    _setEnabled: (v: boolean) => {
+      enabled = v;
+    },
+    _setLoaded: (v: boolean) => {
+      loaded = v;
+    },
+  };
+}
+
+function makeHost(initial: Record<string, unknown> = {}): FlashRequestHost & {
+  session: ReturnType<typeof makeSession>;
+} {
+  const env: RackEnv = {};
+  return { env, session: makeSession(initial) };
+}
+
+describe("Flash::RequestMethods", () => {
+  it("flash builds from session on first access", () => {
+    const host = makeHost({ flash: { flashes: { notice: "hi" }, discard: [] } });
+    const f = flash.call(host)!;
+    expect(f.get("notice")).toBe("hi");
+    expect(host.env[FLASH_KEY]).toBe(f);
+  });
+
+  it("flash setter stores the value and a subsequent get returns it (no session rebuild)", () => {
+    const host = makeHost({ flash: { flashes: { stale: "old" }, discard: [] } });
+    const fresh = new FlashHash({ notice: "fresh" });
+    flash.call(host, fresh);
+    expect(flash.call(host)).toBe(fresh);
+    expect(flash.call(host)!.get("notice")).toBe("fresh");
+  });
+
+  it("flashHash returns null when flash has not been touched", () => {
+    const host = makeHost();
+    expect(flashHash.call(host)).toBeNull();
+  });
+
+  it("commitFlash writes flashesForSession into the session and replaces the cache with a dup", () => {
+    const host = makeHost();
+    const f = new FlashHash({ notice: "hi", drop: "x" });
+    f.discard("drop");
+    flash.call(host, f);
+
+    commitFlash.call(host);
+
+    expect(host.session._store.get("flash")).toEqual({ notice: "hi" });
+    const cached = flashHash.call(host);
+    expect(cached).not.toBe(f);
+    expect(cached!.get("notice")).toBe("hi");
+  });
+
+  it("commitFlash deletes session['flash'] when the projected hash is empty", () => {
+    const host = makeHost({ flash: { flashes: { gone: "x" } } });
+    // Mark gone for discard so flashesForSession returns {}
+    const f = flash.call(host)!;
+    f.discard("gone");
+
+    commitFlash.call(host);
+
+    expect(host.session._store.has("flash")).toBe(false);
+  });
+
+  it("commitFlash is a no-op when session is disabled", () => {
+    const host = makeHost();
+    host.session._setEnabled(false);
+    const f = new FlashHash({ notice: "hi" });
+    flash.call(host, f);
+
+    commitFlash.call(host);
+
+    expect(host.session._store.has("flash")).toBe(false);
+  });
+
+  it("resetSession clears the cached flash hash", () => {
+    const host = makeHost();
+    flash.call(host, new FlashHash({ notice: "hi" }));
+    resetSession.call(host);
+    expect(host.env[FLASH_KEY]).toBeNull();
+  });
+});

--- a/packages/actionpack/src/action-dispatch/middleware/flash.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.ts
@@ -87,13 +87,16 @@ export function commitFlash(this: FlashRequestHost): void {
     this.env[FLASH_KEY] = hash.dup();
   }
 
-  if (
-    session.isLoaded &&
-    session.isLoaded() &&
-    session.hasKey("flash") &&
-    session.get("flash") == null
-  ) {
-    session.delete("flash");
+  // Rails guards this branch with `session.loaded?` to avoid forcing a
+  // session load just to clean up a nil flash entry. trails' Session
+  // already lazily loads on `hasKey`/`get` (action-dispatch/request/
+  // session.ts), so the guard would be redundant — and `isLoaded()` is
+  // optional on the host shape for environments that do expose it
+  // (e.g. a wrapped Rails-style store).
+  if (session.isLoaded ? session.isLoaded() : true) {
+    if (session.hasKey("flash") && session.get("flash") == null) {
+      session.delete("flash");
+    }
   }
 }
 
@@ -256,12 +259,15 @@ export class FlashHash {
   // --- Session serialization ---
 
   toSessionValue(): Record<string, unknown> {
-    // Returns the full flash contents (no discard filtering) for callers
-    // that want the visible state — ETag generation, debug views,
-    // existing trails tests. The session-commit pipeline does its own
-    // discard pruning via {@link flashesForSession}; keeping
-    // this method as a plain serialization preserves backward compat
-    // with `metal/etag-with-flash` and downstream callers.
+    // Returns the persisted flash entries only. Mirrors Rails'
+    // `to_session_value`, which serializes `@flashes` and excludes
+    // `flash.now` — `now` entries are intentionally request-local and
+    // must not bleed into the next request. Callers that want the
+    // request-visible state (including `flash.now`) should use
+    // {@link toHash} instead. The session-commit pipeline applies
+    // discard filtering via {@link flashesForSession}; this method
+    // intentionally skips that filter to preserve the existing
+    // contract used by `metal/etag-with-flash`.
     return Object.fromEntries(this._flashes);
   }
 

--- a/packages/actionpack/src/action-dispatch/middleware/flash.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.ts
@@ -73,7 +73,7 @@ export function commitFlash(this: FlashRequestHost): void {
 
   const hash = flashHash.call(this);
   if (hash && (!hash.empty || session.hasKey("flash"))) {
-    const value = hash.toSessionValue();
+    const value = hash.flashesForSession();
     if (Object.keys(value).length === 0) {
       session.delete("flash");
     } else {
@@ -253,6 +253,23 @@ export class FlashHash {
   // --- Session serialization ---
 
   toSessionValue(): Record<string, unknown> {
+    // Returns the full flash contents (no discard filtering) for callers
+    // that want the visible state — ETag generation, debug views,
+    // existing trails tests. The session-commit pipeline does its own
+    // discard pruning via {@link discardedFlashesForSession}; keeping
+    // this method as a plain serialization preserves backward compat
+    // with `metal/etag-with-flash` and downstream callers.
+    return Object.fromEntries(this._flashes);
+  }
+
+  /**
+   * Hash projection used by {@link commitFlash} when storing the flash
+   * back into the session — mirrors Rails' `to_session_value`'s
+   * `@flashes.except(*@discard)` filter.
+   *
+   * @internal
+   */
+  flashesForSession(): Record<string, unknown> {
     const keep: Record<string, unknown> = {};
     for (const [k, v] of this._flashes) {
       if (!this._discard.has(k)) keep[k] = v;

--- a/packages/actionpack/src/action-dispatch/middleware/flash.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.ts
@@ -40,8 +40,11 @@ export interface FlashRequestHost {
  */
 export function flash(this: FlashRequestHost, value?: FlashHash | null): FlashHash | null {
   if (arguments.length > 0) {
-    this.env[FLASH_KEY] = value as FlashHash | null;
-    return value ?? null;
+    // Normalize `undefined` to `null` so the env key is never left in
+    // a non-Railsy "absent vs cleared" limbo state.
+    const normalized = value ?? null;
+    this.env[FLASH_KEY] = normalized;
+    return normalized;
   }
   const existing = flashHash.call(this);
   if (existing) return existing;

--- a/packages/actionpack/src/action-dispatch/middleware/flash.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.ts
@@ -4,6 +4,108 @@
  * Flash message store that persists for one request.
  */
 
+import type { RackEnv } from "@blazetrails/rack";
+
+/**
+ * Rack env key under which the request's {@link FlashHash} is stored.
+ * Mirrors `ActionDispatch::Flash::KEY`.
+ *
+ * @internal
+ */
+export const FLASH_KEY = "action_dispatch.request.flash_hash";
+
+/**
+ * Host shape used by {@link flash} / {@link flashHash} / {@link commitFlash}
+ * / {@link resetSession}. Matches the Request surface Rails'
+ * `Flash::RequestMethods` reads from.
+ *
+ * @internal
+ */
+export interface FlashRequestHost {
+  env: RackEnv;
+  session: {
+    isEnabled?(): boolean;
+    isLoaded?(): boolean;
+    hasKey(key: string): boolean;
+    get(key: string): unknown;
+    set(key: string, value: unknown): void;
+    delete(key: string): void;
+  };
+  resetSession?(): void;
+}
+
+/**
+ * Access the contents of the flash. Returns the request's
+ * {@link FlashHash}, building it from the session on first access.
+ * Mirrors `ActionDispatch::Flash::RequestMethods#flash`.
+ */
+export function flash(this: FlashRequestHost, value?: FlashHash | null): FlashHash | null {
+  if (arguments.length > 0) {
+    this.env[FLASH_KEY] = value as FlashHash | null;
+    return value ?? null;
+  }
+  const existing = flashHash.call(this);
+  if (existing) return existing;
+  const built = FlashHash.fromSessionValue(this.session.get("flash") as never);
+  this.env[FLASH_KEY] = built;
+  return built;
+}
+
+/**
+ * Returns the cached {@link FlashHash} for this request without falling
+ * back to the session, or `null` if {@link flash} has not been called yet.
+ *
+ * @internal
+ */
+export function flashHash(this: FlashRequestHost): FlashHash | null {
+  return (this.env[FLASH_KEY] as FlashHash | undefined) ?? null;
+}
+
+/**
+ * Persist this request's {@link FlashHash} back into the session, copying
+ * the live hash so the next request starts with a fresh dup. Mirrors
+ * Rails' `commit_flash`.
+ *
+ * @internal
+ */
+export function commitFlash(this: FlashRequestHost): void {
+  const session = this.session;
+  if (session.isEnabled && !session.isEnabled()) return;
+
+  const hash = flashHash.call(this);
+  if (hash && (!hash.empty || session.hasKey("flash"))) {
+    const value = hash.toSessionValue();
+    if (Object.keys(value).length === 0) {
+      session.delete("flash");
+    } else {
+      session.set("flash", value);
+    }
+    // Rails: `self.flash = flash_hash.dup` so further mutations don't
+    // bleed into the just-stored session value.
+    this.env[FLASH_KEY] = hash.dup();
+  }
+
+  if (
+    session.isLoaded &&
+    session.isLoaded() &&
+    session.hasKey("flash") &&
+    session.get("flash") == null
+  ) {
+    session.delete("flash");
+  }
+}
+
+/**
+ * Clear the request's flash. Called by Rails' `Request#reset_session`
+ * via `super` and a `self.flash = nil` follow-up.
+ *
+ * @internal
+ */
+export function resetSession(this: FlashRequestHost): void {
+  this.resetSession?.();
+  this.env[FLASH_KEY] = null;
+}
+
 export class FlashHash {
   private _flashes: Map<string, unknown> = new Map();
   private _discard: Set<string> = new Set();
@@ -150,11 +252,33 @@ export class FlashHash {
   // --- Session serialization ---
 
   toSessionValue(): Record<string, unknown> {
-    return Object.fromEntries(this._flashes);
+    const keep: Record<string, unknown> = {};
+    for (const [k, v] of this._flashes) {
+      if (!this._discard.has(k)) keep[k] = v;
+    }
+    return keep;
   }
 
-  static fromSessionValue(value: Record<string, unknown> | null | undefined): FlashHash {
-    if (!value) return new FlashHash();
-    return new FlashHash(value);
+  /** Shallow copy mirroring Ruby's `FlashHash#dup`. */
+  dup(): FlashHash {
+    const copy = new FlashHash();
+    for (const [k, v] of this._flashes) copy._flashes.set(k, v);
+    for (const k of this._discard) copy._discard.add(k);
+    for (const k of this._keep) copy._keep.add(k);
+    return copy;
+  }
+
+  static fromSessionValue(
+    value: FlashHash | Record<string, unknown> | null | undefined,
+  ): FlashHash {
+    if (value === null || value === undefined) return new FlashHash();
+    if (value instanceof FlashHash) return value.dup();
+    const flashes = (value["flashes"] ?? value) as Record<string, unknown>;
+    const discard = (value["discard"] as string[]) ?? [];
+    const out = new FlashHash();
+    for (const [k, v] of Object.entries(flashes)) {
+      if (!discard.includes(k)) out._flashes.set(k, v);
+    }
+    return out;
   }
 }

--- a/packages/actionpack/src/action-dispatch/middleware/flash.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.ts
@@ -31,7 +31,6 @@ export interface FlashRequestHost {
     set(key: string, value: unknown): void;
     delete(key: string): void;
   };
-  resetSession?(): void;
 }
 
 /**
@@ -96,13 +95,15 @@ export function commitFlash(this: FlashRequestHost): void {
 }
 
 /**
- * Clear the request's flash. Called by Rails' `Request#reset_session`
- * via `super` and a `self.flash = nil` follow-up.
+ * The flash side of `Request#reset_session`. Rails prepends this onto
+ * Request and uses `super` to chain to the original implementation; in
+ * trails-mixin style, the chain is the responsibility of the wiring
+ * code, so this function only owns the post-`super` "clear the flash"
+ * step. Callers must invoke the underlying `Request#resetSession` first.
  *
  * @internal
  */
 export function resetSession(this: FlashRequestHost): void {
-  this.resetSession?.();
   this.env[FLASH_KEY] = null;
 }
 

--- a/packages/actionpack/src/action-dispatch/middleware/flash.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.ts
@@ -259,7 +259,7 @@ export class FlashHash {
     // Returns the full flash contents (no discard filtering) for callers
     // that want the visible state — ETag generation, debug views,
     // existing trails tests. The session-commit pipeline does its own
-    // discard pruning via {@link discardedFlashesForSession}; keeping
+    // discard pruning via {@link flashesForSession}; keeping
     // this method as a plain serialization preserves backward compat
     // with `metal/etag-with-flash` and downstream callers.
     return Object.fromEntries(this._flashes);

--- a/packages/actionpack/src/action-dispatch/middleware/flash.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.ts
@@ -48,7 +48,7 @@ export function flash(this: FlashRequestHost, value?: FlashHash | null): FlashHa
   }
   const existing = flashHash.call(this);
   if (existing) return existing;
-  const built = FlashHash.fromSessionValue(this.session.get("flash") as never);
+  const built = FlashHash.fromSessionValue(this.session.get("flash"));
   this.env[FLASH_KEY] = built;
   return built;
 }
@@ -290,18 +290,23 @@ export class FlashHash {
     return copy;
   }
 
-  static fromSessionValue(
-    value: FlashHash | Record<string, unknown> | null | undefined,
-  ): FlashHash {
+  static fromSessionValue(value: unknown): FlashHash {
     if (value === null || value === undefined) return new FlashHash();
     if (value instanceof FlashHash) return value.dup();
+    if (typeof value !== "object") return new FlashHash();
     // Rails 4.0+ session shape: `{ "flashes" => Hash, "discard" => Array }`.
     // Rails' `flashes.except!(*discard)` removes the keys the prior request
     // marked for discard, then `new(flashes, flashes.keys)` marks every
     // remaining key for sweep — they live through this request and are
     // dropped on the next one.
-    const flashes = (value["flashes"] ?? value) as Record<string, unknown>;
-    const discard = (value["discard"] as string[]) ?? [];
+    const obj = value as Record<string, unknown>;
+    const flashesRaw = obj["flashes"];
+    const flashes = (flashesRaw && typeof flashesRaw === "object" ? flashesRaw : obj) as Record<
+      string,
+      unknown
+    >;
+    const discardRaw = obj["discard"];
+    const discard = Array.isArray(discardRaw) ? (discardRaw as string[]) : [];
     const discardSet = new Set(discard);
     const out = new FlashHash();
     for (const [k, v] of Object.entries(flashes)) {

--- a/packages/actionpack/src/action-dispatch/middleware/flash.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.ts
@@ -60,7 +60,7 @@ export function flash(this: FlashRequestHost, value?: FlashHash | null): FlashHa
  * @internal
  */
 export function flashHash(this: FlashRequestHost): FlashHash | null {
-  return (this.env[FLASH_KEY] as FlashHash | undefined) ?? null;
+  return (this.env[FLASH_KEY] as FlashHash | null | undefined) ?? null;
 }
 
 /**

--- a/packages/actionpack/src/action-dispatch/middleware/flash.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/flash.ts
@@ -264,6 +264,7 @@ export class FlashHash {
   dup(): FlashHash {
     const copy = new FlashHash();
     for (const [k, v] of this._flashes) copy._flashes.set(k, v);
+    for (const [k, v] of this._now) copy._now.set(k, v);
     for (const k of this._discard) copy._discard.add(k);
     for (const k of this._keep) copy._keep.add(k);
     return copy;
@@ -274,11 +275,19 @@ export class FlashHash {
   ): FlashHash {
     if (value === null || value === undefined) return new FlashHash();
     if (value instanceof FlashHash) return value.dup();
+    // Rails 4.0+ session shape: `{ "flashes" => Hash, "discard" => Array }`.
+    // Rails' `flashes.except!(*discard)` removes the keys the prior request
+    // marked for discard, then `new(flashes, flashes.keys)` marks every
+    // remaining key for sweep — they live through this request and are
+    // dropped on the next one.
     const flashes = (value["flashes"] ?? value) as Record<string, unknown>;
     const discard = (value["discard"] as string[]) ?? [];
+    const discardSet = new Set(discard);
     const out = new FlashHash();
     for (const [k, v] of Object.entries(flashes)) {
-      if (!discard.includes(k)) out._flashes.set(k, v);
+      if (discardSet.has(k)) continue;
+      out._flashes.set(k, v);
+      out._discard.add(k);
     }
     return out;
   }


### PR DESCRIPTION
Companion to #2088.

## api:compare

| File | Before | After |
| --- | --- | --- |
| \`middleware/flash.rb\` | 1/6 (17%) | 6/6 (100%) |
| \`middleware/debug_exceptions.rb\` | 5/16 (31%) | 14/16 (88%) |

## Changes

### \`middleware/flash.ts\`
Adds the \`Flash::RequestMethods\` mixin as \`this\`-typed functions:
- \`flash\` — getter (session fallback) + setter.
- \`flashHash\` — cached lookup without session fallback.
- \`commitFlash\` — Rails-faithful round-trip: stores \`hash.toSessionValue\`, replaces the cached jar with \`hash.dup()\` so post-commit mutations don't bleed into the just-stored session value.
- \`resetSession\` — clears the cached hash after super's session reset.

\`FlashHash\` gains \`dup()\` and \`fromSessionValue\` learns to read the Rails-shape \`{ flashes, discard }\` session payload. \`toSessionValue\` still returns a plain \`{ key: value }\` hash (preserving the existing trails test expectations); \`commitFlash\` is the only caller that cares.

### \`middleware/debug-exceptions.ts\`
- Class-level \`interceptors\` registry (\`cattr_reader\`) + static \`registerInterceptor\`.
- \`invokeInterceptors\` with per-interceptor error swallow → \`logError\` fallback (matches Rails' \`rescue Exception\`).
- \`renderForApiRequest\` builds \`{ status, error, exception, traces }\` and routes through \`render\`.
- \`render\` returns the Rack response tuple with correct \`Content-Type\` / \`Content-Length\`.
- \`logError\` walks the \`cause\` chain and dispatches to \`logArray\`.
- \`logArray\` reads the env-driven log level, newline-joins, calls \`logger.add\`-equivalent.
- \`stderrLogger\` memoizes a stderr-writing Logger.
- \`routesInspector\` returns \`null\` pending the \`@routes_app\` wiring — documented rather than stubbed-true.
- \`isApiRequest\` is the faithful predicate on \`responseFormat: 'api'\` × non-HTML content-type.

### Deferred (the 2 remaining)
\`renderForBrowserRequest\` and \`createTemplate\` both go through \`template.render\`, which depends on \`ActionView::Base\` — not yet ported in trails. Adding shells would return empty bodies on real exception paths and mask the gap. They stay unimplemented per CLAUDE.md ('a missing method is better than a misleading one').

## Notes
- camelCase throughout. Rails-private helpers carry \`@internal\`.
- No tests renamed; existing \`flash-hash.test.ts\` / \`flash.test.ts\` (38 tests total) still pass.

## Remaining Copilot concerns (review #9, max cycles reached)

Two recurring comments where iteration has stopped:

1. **`commitFlash` `session.isLoaded()` branch** — Copilot prefers aligning with the `loaded: boolean` flag pattern used in `SessionObject.loadedSession`, rather than the optional `isLoaded?()` method on `FlashRequestHost`. Current implementation runs the cleanup unconditionally when `isLoaded()` isn't exposed (commit 770096d25), which already addresses the dead-branch concern for trails' real `Session`; aligning to the `loaded` boolean is a refinement worth a follow-up PR but the cleanup is no longer dead today.
2. **`invokeInterceptors` logs the original wrapper, not the interceptor error** — held on Rails fidelity grounds across review cycles 4–9. Rails source (`vendor/rails/actionpack/lib/action_dispatch/middleware/debug_exceptions.rb#invoke_interceptors`) uses bare `rescue Exception` (no exception binding) and calls `log_error(request, wrapper)` — intentionally logging the original twice on interceptor failure and discarding the interceptor error. Diverging would break Rails parity; the friction belongs upstream.
