### PR TITLE
feat(actionpack): http/response.ts fidelity 51%→94% (Buffer + lifecycle)

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6400b0a0-2826-42be-a2cc-3b52898fdef3","pid":240377,"procStart":"118523745","acquiredAt":1779276147390}

--- a/packages/actionpack/src/action-controller/metal/live.ts
+++ b/packages/actionpack/src/action-controller/metal/live.ts
@@ -134,6 +134,15 @@ export class Buffer {
   }
 
   /**
+   * Public iterator invoked by `DispatchResponse#each` / `bodyParts` /
+   * `rackResponse`. Mirrors Rails' `ActionDispatch::Response::Buffer#each`
+   * (Live::Buffer extends Response::Buffer in Rails, inheriting `each`).
+   */
+  *each(): IterableIterator<string> {
+    yield* this.eachChunk();
+  }
+
+  /**
    * Drain the queue, yielding each non-null chunk in order. Stops at the
    * sentinel `null` pushed by {@link close}.
    *

--- a/packages/actionpack/src/action-controller/metal/live.ts
+++ b/packages/actionpack/src/action-controller/metal/live.ts
@@ -224,7 +224,7 @@ export class SSE {
  * {@link Buffer}. Mirrors `ActionController::Live::Response`.
  */
 export class Response extends DispatchResponse {
-  stream: Buffer;
+  declare stream: Buffer;
 
   constructor(status = 200, headers: Record<string, string> = {}, body: string[] = []) {
     super(status, headers, body);
@@ -262,9 +262,9 @@ export class Response extends DispatchResponse {
    *
    * @internal
    */
-  protected buildBuffer(response: LiveResponseLike, body: Iterable<string>): Buffer {
+  buildBuffer(response: LiveResponseLike, body: unknown[]): Buffer {
     const buf = new Buffer(response);
-    for (const part of body) buf.write(part);
+    for (const part of body) buf.write(String(part));
     return buf;
   }
 }

--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -1,6 +1,20 @@
 import { describe, it, expect } from "vitest";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Request } from "../request.js";
 import { Response } from "../response.js";
+
+function withTempFile<T>(contents: string, fn: (path: string) => T): T {
+  const dir = mkdtempSync(join(tmpdir(), "trails-response-"));
+  const path = join(dir, "fixture");
+  writeFileSync(path, contents);
+  try {
+    return fn(path);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
 
 describe("ResponseTest", () => {
   it("simple output", () => {
@@ -559,20 +573,28 @@ describe("Response Cache::Response wiring", () => {
 
   describe("sendFile", () => {
     it("commits the response and exposes a Rack-compatible file body", () => {
-      const res = new Response();
-      res.sendFile("/etc/hostname");
-      expect(res.committed).toBe(true);
-      const stream = res.stream as { toPath(): string; each(): IterableIterator<string> };
-      expect(typeof stream.toPath).toBe("function");
-      expect(stream.toPath()).toBe("/etc/hostname");
+      withTempFile("hello", (path) => {
+        const res = new Response();
+        res.sendFile(path);
+        expect(res.committed).toBe(true);
+        const stream = res.stream as { toPath(): string; each(): IterableIterator<string> };
+        expect(typeof stream.toPath).toBe("function");
+        expect(stream.toPath()).toBe(path);
+      });
     });
 
-    it("toRack surfaces the file body when sendFile was called", () => {
-      const res = new Response();
-      res.sendFile("/etc/hostname");
-      const [status, , body] = res.toRack();
-      expect(status).toBe(200);
-      expect(body.length).toBeGreaterThan(0);
+    it("toRack surfaces the stream itself (preserving toPath) when sendFile was called", () => {
+      withTempFile("hello", (path) => {
+        const res = new Response();
+        res.sendFile(path);
+        const [status, , body] = res.toRack();
+        expect(status).toBe(200);
+        const stream = body as { toPath(): string; each(): IterableIterator<string> };
+        expect(stream.toPath()).toBe(path);
+        const chunks: string[] = [];
+        for (const c of stream.each()) chunks.push(c);
+        expect(chunks.join("")).toBe("hello");
+      });
     });
   });
 

--- a/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/response.test.ts
@@ -535,4 +535,51 @@ describe("Response Cache::Response wiring", () => {
     res.handleConditionalGetBang();
     expect(res.getHeader("Cache-Control")).toBeUndefined();
   });
+
+  describe("lifecycle (commit / sending / sent)", () => {
+    it("commitBang is idempotent and runs beforeCommitted once", () => {
+      const res = new Response();
+      res.commitBang();
+      expect(res.committed).toBe(true);
+      // Default content-type set by assignDefaultContentTypeAndCharsetBang
+      expect(res.getHeader("content-type")).toMatch(/text\/html/);
+      res.commitBang(); // second call is a no-op
+      expect(res.committed).toBe(true);
+    });
+
+    it("each wraps iteration in sending! / sent!", () => {
+      const res = new Response(200, {}, ["hello", " world"]);
+      const chunks: unknown[] = [];
+      for (const chunk of res.each()) chunks.push(chunk);
+      expect(chunks).toEqual(["hello", " world"]);
+      expect(res.isSending).toBe(true);
+      expect(res.isSent).toBe(true);
+    });
+  });
+
+  describe("sendFile", () => {
+    it("commits the response and exposes a Rack-compatible file body", () => {
+      const res = new Response();
+      res.sendFile("/etc/hostname");
+      expect(res.committed).toBe(true);
+      const stream = res.stream as { toPath(): string; each(): IterableIterator<string> };
+      expect(typeof stream.toPath).toBe("function");
+      expect(stream.toPath()).toBe("/etc/hostname");
+    });
+
+    it("toRack surfaces the file body when sendFile was called", () => {
+      const res = new Response();
+      res.sendFile("/etc/hostname");
+      const [status, , body] = res.toRack();
+      expect(status).toBe(200);
+      expect(body.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("bodyParts", () => {
+    it("drains the buffered body when no explicit stream is set", () => {
+      const res = new Response(200, {}, ["a", "b"]);
+      expect(res.bodyParts()).toEqual(["a", "b"]);
+    });
+  });
 });

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -76,7 +76,9 @@ export class ResponseBuffer {
     for (const chunk of this.buf) yield chunk;
   }
 
-  abort(): void {}
+  abort(): void {
+    this.close();
+  }
 
   close(): void {
     this.response.commitBang();
@@ -372,11 +374,11 @@ export class Response {
 
   // --- Rack response ---
 
-  toRack(): [number, Record<string, string>, unknown[]] {
-    // If a sendFile-style or buffered stream is installed, surface it through
-    // the Rack body so Rack::Sendfile / BodyProxy can intercept via toPath()
-    // or iterate via each().
-    if (this.stream) return [this._status, { ...this._headers }, this.bodyParts()];
+  toRack(): [number, Record<string, string>, unknown] {
+    // If a stream is installed, surface it directly so Rack::Sendfile /
+    // BodyProxy can intercept via toPath()/close() rather than draining
+    // the file into memory.
+    if (this.stream) return [this._status, { ...this._headers }, this.stream];
     return [this._status, { ...this._headers }, [...this._body]];
   }
 

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -29,7 +29,9 @@ import {
 } from "./cache.js";
 import { filteredLocation as _filteredLocation } from "./filter-redirect.js";
 
-const CONTENT_TYPE = "Content-Type";
+// Lowercase to match the rest of this file's header conventions; setHeader
+// is case-insensitive but call sites read `headers["content-type"]` directly.
+const CONTENT_TYPE = "content-type";
 const NO_CONTENT_CODES = [100, 101, 102, 103, 204, 205, 304] as const;
 const CONTENT_TYPE_PARSER =
   /^(?<mime_type>[^;\s]+\s*(?:;\s*(?!charset)[^;\s]+)*)?(?:;\s*charset="?(?<charset>[^;\s"]+)"?)?/;
@@ -370,7 +372,11 @@ export class Response {
 
   // --- Rack response ---
 
-  toRack(): [number, Record<string, string>, string[]] {
+  toRack(): [number, Record<string, string>, unknown[]] {
+    // If a sendFile-style or buffered stream is installed, surface it through
+    // the Rack body so Rack::Sendfile / BodyProxy can intercept via toPath()
+    // or iterate via each().
+    if (this.stream) return [this._status, { ...this._headers }, this.bodyParts()];
     return [this._status, { ...this._headers }, [...this._body]];
   }
 
@@ -394,8 +400,12 @@ export class Response {
     this.commitBang();
     let cached: string | null = null;
     const read = () => (cached ??= getFs().readFileSync(path, "latin1"));
+    // Rack::Sendfile detects file bodies via `body.toPath()` (callable);
+    // Rails' FileBody uses `attr_reader :to_path` which is also a method.
     this.stream = {
-      toPath: path,
+      toPath(): string {
+        return path;
+      },
       get body(): string {
         return read();
       },

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -30,7 +30,6 @@ import {
 import { filteredLocation as _filteredLocation } from "./filter-redirect.js";
 
 const CONTENT_TYPE = "Content-Type";
-const SET_COOKIE = "Set-Cookie";
 const NO_CONTENT_CODES = [100, 101, 102, 103, 204, 205, 304] as const;
 const CONTENT_TYPE_PARSER =
   /^(?<mime_type>[^;\s]+\s*(?:;\s*(?!charset)[^;\s]+)*)?(?:;\s*charset="?(?<charset>[^;\s"]+)"?)?/;
@@ -55,10 +54,9 @@ export class ResponseBuffer {
 
   get body(): string {
     if (this.strBody !== null) return this.strBody;
-    let acc = "";
-    for (const chunk of this.buf) acc += String(chunk);
-    this.strBody = acc;
-    return acc;
+    // Rails: `@buf.each { |chunk| buf << chunk }`. Join avoids O(n²) concat.
+    this.strBody = this.buf.map((c) => String(c)).join("");
+    return this.strBody;
   }
 
   write(value: string): void {
@@ -385,22 +383,24 @@ export class Response {
 
   /** Drains the stream into a parts array (Rails `body_parts`). */
   bodyParts(): unknown[] {
+    const stream = this._ensureStream() as { each(): IterableIterator<unknown> };
     const parts: unknown[] = [];
-    for (const chunk of (this.stream as { each(): IterableIterator<unknown> }).each())
-      parts.push(chunk);
+    for (const chunk of stream.each()) parts.push(chunk);
     return parts;
   }
 
   /** Mirrors `Response#send_file(path)` — commits + sets the stream to a `Response::FileBody`-style object. */
   sendFile(path: string): void {
     this.commitBang();
+    let cached: string | null = null;
+    const read = () => (cached ??= getFs().readFileSync(path, "latin1"));
     this.stream = {
       toPath: path,
       get body(): string {
-        return getFs().readFileSync(path, "latin1");
+        return read();
       },
       *each(): IterableIterator<string> {
-        yield getFs().readFileSync(path, "latin1");
+        yield read();
       },
     };
   }
@@ -413,8 +413,9 @@ export class Response {
 
   /** Wraps stream iteration in `sending!`/`sent!` (Rails `each(&block)`). */
   *each(): IterableIterator<unknown> {
+    const stream = this._ensureStream() as { each(): IterableIterator<unknown> };
     this.sendingBang();
-    for (const chunk of (this.stream as { each(): IterableIterator<unknown> }).each()) yield chunk;
+    for (const chunk of stream.each()) yield chunk;
     this.sentBang();
   }
 

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -4,6 +4,7 @@
  * Represents an HTTP response with status, headers, and body.
  */
 
+import { getFs } from "@blazetrails/activesupport";
 import type { CookieExpires } from "../middleware/cookies.js";
 import type { Request } from "./request.js";
 import {
@@ -40,11 +41,7 @@ interface ContentTypeHeader {
 }
 const NULL_CONTENT_TYPE_HEADER: ContentTypeHeader = { mimeType: undefined, charset: undefined };
 
-/**
- * Mirrors Rails' `ActionDispatch::Response::Buffer` (response.rb:100-157):
- * wraps the body iterable so writes go through `Response#commit!` and reads
- * cache a concatenated copy. Streamed chunks pass through `each`.
- */
+/** Mirrors Rails' `ActionDispatch::Response::Buffer` (response.rb:100-157). */
 export class ResponseBuffer {
   private response: Response;
   private buf: Array<unknown>;
@@ -103,7 +100,6 @@ export class Response {
   private _cookies: Map<string, CookieValue> = new Map();
   private _sending = false;
   private _sent = false;
-  /** Mirrors Rails `Response#stream` (`attr_reader :stream`). */
   stream: unknown = null;
   /** Rails: `response.sending_file = true` flag set by `send_file_headers!`. */
   sendingFile = false;
@@ -382,13 +378,12 @@ export class Response {
 
   // --- Stream / body parts ---
 
-  /** Lazy stream-init helper (Rails: `initialize` calls `self.body = body`). */
   private _ensureStream(): unknown {
     if (!this.stream) this.stream = this.buildBuffer(this, this.mungeBodyObject(this._body));
     return this.stream;
   }
 
-  /** Mirrors `Response#body_parts` — drains the stream into a parts array. */
+  /** Drains the stream into a parts array (Rails `body_parts`). */
   bodyParts(): unknown[] {
     const parts: unknown[] = [];
     for (const chunk of (this.stream as { each(): IterableIterator<unknown> }).each())
@@ -396,19 +391,27 @@ export class Response {
     return parts;
   }
 
-  /** Mirrors `Response#send_file(path)` — commits + replaces stream with a path-backed body. */
+  /** Mirrors `Response#send_file(path)` — commits + sets the stream to a `Response::FileBody`-style object. */
   sendFile(path: string): void {
     this.commitBang();
-    this.stream = { toPath: path, body: "", each: function* () {} };
+    this.stream = {
+      toPath: path,
+      get body(): string {
+        return getFs().readFileSync(path, "latin1");
+      },
+      *each(): IterableIterator<string> {
+        yield getFs().readFileSync(path, "latin1");
+      },
+    };
   }
 
-  /** Mirrors `Response#reset_body!` — discards stream contents. */
+  /** Discards stream contents (Rails `reset_body!`). */
   resetBodyBang(): void {
     this.stream = this.buildBuffer(this, []);
     this._body = [];
   }
 
-  /** Mirrors `Response#each(&block)` — wraps stream iteration in `sending!`/`sent!`. */
+  /** Wraps stream iteration in `sending!`/`sent!` (Rails `each(&block)`). */
   *each(): IterableIterator<unknown> {
     this.sendingBang();
     for (const chunk of (this.stream as { each(): IterableIterator<unknown> }).each()) yield chunk;
@@ -457,39 +460,29 @@ export class Response {
     return this._sent;
   }
 
-  /** Rails uses Ruby's MonitorMixin to block until committed; JS is single-threaded so this is a no-op once committed. */
+  /** Rails uses MonitorMixin to block; single-threaded JS makes this a no-op. */
   async awaitCommit(): Promise<void> {}
-
-  /** Mirrors `Response#await_sent` — no-op in single-threaded JS. */
   async awaitSent(): Promise<void> {}
 
   // --- Header / mime helpers ---
 
-  /** Alias of `headers` — mirrors Rails' `alias_method :header, :headers`. */
+  /** Rails: `alias_method :header, :headers`. */
   get header(): Record<string, string> {
     return this._headers;
   }
-
   hasHeader(key: string): boolean {
     return this.getHeader(key) !== undefined;
   }
-
-  /** Mirrors `Response#response_code` — the integer status. */
   get responseCode(): number {
     return this._status;
   }
-
-  /** Alias of `message`. */
   get statusMessage(): string {
     return this.message;
   }
-
-  /** Alias of `location` — Rails: `alias_method :redirect_url, :location`. */
+  /** Rails: `alias_method :redirect_url, :location`. */
   get redirectUrl(): string {
     return this.location;
   }
-
-  /** Mirrors `Response#media_type` — parsed mime type, no charset. */
   get mediaType(): string | undefined {
     return this.parsedContentTypeHeader().mimeType;
   }
@@ -525,7 +518,8 @@ export class Response {
   protected beforeCommitted(): void {
     if (this._committed) return;
     this.assignDefaultContentTypeAndCharsetBang();
-    // cacheControl wiring lives in cache.ts; no-op here when no parsed hash present.
+    this.mergeAndNormalizeCacheControlBang(this.cacheControl);
+    this.handleConditionalGetBang();
     this.handleNoContentBang();
   }
 

--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -9,6 +9,8 @@ import type { Request } from "./request.js";
 import {
   type CacheControlHash,
   cacheControl as _cacheControl,
+  generateStrongEtag as _generateStrongEtag,
+  generateWeakEtag as _generateWeakEtag,
   getDate as _getDate,
   getLastModified as _getLastModified,
   handleConditionalGetBang as _handleConditionalGetBang,
@@ -18,12 +20,76 @@ import {
   isStrongEtag as _isStrongEtag,
   mergeAndNormalizeCacheControlBang as _mergeAndNormalizeCacheControlBang,
   isWeakEtag as _isWeakEtag,
+  prepareCacheControlBang as _prepareCacheControlBang,
   setDate as _setDate,
   setLastModified as _setLastModified,
   strongEtag as _strongEtag,
   weakEtag as _weakEtag,
 } from "./cache.js";
 import { filteredLocation as _filteredLocation } from "./filter-redirect.js";
+
+const CONTENT_TYPE = "Content-Type";
+const SET_COOKIE = "Set-Cookie";
+const NO_CONTENT_CODES = [100, 101, 102, 103, 204, 205, 304] as const;
+const CONTENT_TYPE_PARSER =
+  /^(?<mime_type>[^;\s]+\s*(?:;\s*(?!charset)[^;\s]+)*)?(?:;\s*charset="?(?<charset>[^;\s"]+)"?)?/;
+
+interface ContentTypeHeader {
+  readonly mimeType: string | undefined;
+  readonly charset: string | undefined;
+}
+const NULL_CONTENT_TYPE_HEADER: ContentTypeHeader = { mimeType: undefined, charset: undefined };
+
+/**
+ * Mirrors Rails' `ActionDispatch::Response::Buffer` (response.rb:100-157):
+ * wraps the body iterable so writes go through `Response#commit!` and reads
+ * cache a concatenated copy. Streamed chunks pass through `each`.
+ */
+export class ResponseBuffer {
+  private response: Response;
+  private buf: Array<unknown>;
+  private closed = false;
+  private strBody: string | null = null;
+
+  constructor(response: Response, buf: Array<unknown>) {
+    this.response = response;
+    this.buf = buf;
+  }
+
+  get body(): string {
+    if (this.strBody !== null) return this.strBody;
+    let acc = "";
+    for (const chunk of this.buf) acc += String(chunk);
+    this.strBody = acc;
+    return acc;
+  }
+
+  write(value: string): void {
+    if (this.closed) throw new Error("closed stream");
+    this.strBody = null;
+    this.response.commitBang();
+    this.buf.push(value);
+  }
+
+  *each(): IterableIterator<unknown> {
+    if (this.strBody !== null) {
+      yield this.strBody;
+      return;
+    }
+    for (const chunk of this.buf) yield chunk;
+  }
+
+  abort(): void {}
+
+  close(): void {
+    this.response.commitBang();
+    this.closed = true;
+  }
+
+  get isClosed(): boolean {
+    return this.closed;
+  }
+}
 
 export class Response {
   /** Rails: `cattr_accessor :default_charset, default: "utf-8"`. */
@@ -36,9 +102,14 @@ export class Response {
   private _charset: string | undefined;
   private _cookies: Map<string, CookieValue> = new Map();
   private _sending = false;
+  private _sent = false;
+  /** Mirrors Rails `Response#stream` (`attr_reader :stream`). */
+  stream: unknown = null;
   /** Rails: `response.sending_file = true` flag set by `send_file_headers!`. */
   sendingFile = false;
   request: Request | null = null;
+  /** Rails: `cattr_accessor :default_headers`. */
+  static defaultHeaders: Record<string, string> | undefined;
 
   constructor(status = 200, headers: Record<string, string> = {}, body: string[] = []) {
     this._status = status;
@@ -307,6 +378,233 @@ export class Response {
 
   toRack(): [number, Record<string, string>, string[]] {
     return [this._status, { ...this._headers }, [...this._body]];
+  }
+
+  // --- Stream / body parts ---
+
+  /** Lazy stream-init helper (Rails: `initialize` calls `self.body = body`). */
+  private _ensureStream(): unknown {
+    if (!this.stream) this.stream = this.buildBuffer(this, this.mungeBodyObject(this._body));
+    return this.stream;
+  }
+
+  /** Mirrors `Response#body_parts` — drains the stream into a parts array. */
+  bodyParts(): unknown[] {
+    const parts: unknown[] = [];
+    for (const chunk of (this.stream as { each(): IterableIterator<unknown> }).each())
+      parts.push(chunk);
+    return parts;
+  }
+
+  /** Mirrors `Response#send_file(path)` — commits + replaces stream with a path-backed body. */
+  sendFile(path: string): void {
+    this.commitBang();
+    this.stream = { toPath: path, body: "", each: function* () {} };
+  }
+
+  /** Mirrors `Response#reset_body!` — discards stream contents. */
+  resetBodyBang(): void {
+    this.stream = this.buildBuffer(this, []);
+    this._body = [];
+  }
+
+  /** Mirrors `Response#each(&block)` — wraps stream iteration in `sending!`/`sent!`. */
+  *each(): IterableIterator<unknown> {
+    this.sendingBang();
+    for (const chunk of (this.stream as { each(): IterableIterator<unknown> }).each()) yield chunk;
+    this.sentBang();
+  }
+
+  /** Mirrors `Response#abort` — forwards to stream.abort, falling back to close. */
+  abort(): void {
+    const s = this.stream;
+    if (!s) return;
+    if (typeof (s as { abort?: () => void }).abort === "function") {
+      (s as { abort: () => void }).abort();
+    } else if (typeof (s as { close?: () => void }).close === "function") {
+      (s as { close: () => void }).close();
+    }
+  }
+
+  // --- Lifecycle (commit / sending / sent) ---
+
+  /** Mirrors `Response#commit!`. Idempotent; runs beforeCommitted on transition. */
+  commitBang(): void {
+    if (this._committed) return;
+    this.beforeCommitted();
+    this._committed = true;
+  }
+
+  /** Mirrors `Response#sending!`. */
+  sendingBang(): void {
+    if (this._sending) return;
+    this.beforeSending();
+    this._sending = true;
+  }
+
+  /** Mirrors `Response#sent!`. */
+  sentBang(): void {
+    this._sent = true;
+  }
+
+  /** Mirrors `Response#sending?`. */
+  get isSending(): boolean {
+    return this._sending;
+  }
+
+  /** Mirrors `Response#sent?`. */
+  get isSent(): boolean {
+    return this._sent;
+  }
+
+  /** Rails uses Ruby's MonitorMixin to block until committed; JS is single-threaded so this is a no-op once committed. */
+  async awaitCommit(): Promise<void> {}
+
+  /** Mirrors `Response#await_sent` — no-op in single-threaded JS. */
+  async awaitSent(): Promise<void> {}
+
+  // --- Header / mime helpers ---
+
+  /** Alias of `headers` — mirrors Rails' `alias_method :header, :headers`. */
+  get header(): Record<string, string> {
+    return this._headers;
+  }
+
+  hasHeader(key: string): boolean {
+    return this.getHeader(key) !== undefined;
+  }
+
+  /** Mirrors `Response#response_code` — the integer status. */
+  get responseCode(): number {
+    return this._status;
+  }
+
+  /** Alias of `message`. */
+  get statusMessage(): string {
+    return this.message;
+  }
+
+  /** Alias of `location` — Rails: `alias_method :redirect_url, :location`. */
+  get redirectUrl(): string {
+    return this.location;
+  }
+
+  /** Mirrors `Response#media_type` — parsed mime type, no charset. */
+  get mediaType(): string | undefined {
+    return this.parsedContentTypeHeader().mimeType;
+  }
+
+  // --- Content-type parsing (private in Rails) ---
+
+  /** @internal Rails: `parse_content_type(str)`. */
+  parseContentType(value: string | undefined): ContentTypeHeader {
+    if (!value) return NULL_CONTENT_TYPE_HEADER;
+    const match = CONTENT_TYPE_PARSER.exec(value);
+    if (!match) return NULL_CONTENT_TYPE_HEADER;
+    return {
+      mimeType: match.groups?.["mime_type"]?.trim() || undefined,
+      charset: match.groups?.["charset"] || undefined,
+    };
+  }
+
+  /** @internal Rails: `parsed_content_type_header` private. */
+  parsedContentTypeHeader(): ContentTypeHeader {
+    return this.parseContentType(this.getHeader(CONTENT_TYPE));
+  }
+
+  /** @internal Rails: `set_content_type(content_type, charset)` private. */
+  setContentType(contentType: string | undefined, charset: string | undefined): void {
+    const type = contentType ?? "";
+    const value = charset ? `${type}; charset=${String(charset).toLowerCase()}` : type;
+    this.setHeader(CONTENT_TYPE, value);
+  }
+
+  // --- Lifecycle hooks (private) ---
+
+  /** @internal Rails: `before_committed` private. */
+  protected beforeCommitted(): void {
+    if (this._committed) return;
+    this.assignDefaultContentTypeAndCharsetBang();
+    // cacheControl wiring lives in cache.ts; no-op here when no parsed hash present.
+    this.handleNoContentBang();
+  }
+
+  /** @internal Rails: `before_sending` — flushes cookie jar via request before headers freeze. */
+  beforeSending(): void {
+    if (!this._committed) this.commitBang();
+    const req = this.request as (Request & { commitCookieJarBang?: () => void }) | null;
+    if (req && typeof req.commitCookieJarBang === "function") req.commitCookieJarBang();
+  }
+
+  /** @internal Rails: `build_buffer(response, body)` private. */
+  buildBuffer(response: unknown, body: unknown[]): unknown {
+    return new ResponseBuffer(response as Response, body);
+  }
+
+  /** @internal Rails: `munge_body_object(body)` — wraps non-iterables into a 1-element array. */
+  mungeBodyObject(body: unknown): unknown[] {
+    if (Array.isArray(body)) return body;
+    if (
+      body != null &&
+      typeof (body as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function" &&
+      typeof body !== "string"
+    ) {
+      return Array.from(body as Iterable<unknown>);
+    }
+    return [body];
+  }
+
+  /** @internal Rails: `assign_default_content_type_and_charset!`. */
+  assignDefaultContentTypeAndCharsetBang(): void {
+    if (this.mediaType) return;
+    const ct = this.parsedContentTypeHeader();
+    const charset = ct.charset ?? (this.constructor as typeof Response).defaultCharset;
+    this.setContentType(ct.mimeType ?? "text/html", charset);
+  }
+
+  /** @internal Rails: `handle_no_content!` — strips body headers on 1xx/204/205/304. */
+  handleNoContentBang(): void {
+    if ((NO_CONTENT_CODES as readonly number[]).includes(this._status)) {
+      this.deleteHeader(CONTENT_TYPE);
+      this.deleteHeader("Content-Length");
+    }
+  }
+
+  /** @internal Rails: `rack_response(status, headers)` — empty body for no-content statuses. */
+  rackResponse(
+    status: number,
+    headers: Record<string, string>,
+  ): [number, Record<string, string>, unknown[]] {
+    if ((NO_CONTENT_CODES as readonly number[]).includes(status)) return [status, headers, []];
+    return [status, headers, this.bodyParts()];
+  }
+
+  // --- ETag generators (delegated to cache module) ---
+
+  /** Rails: `generate_weak_etag(validators)`. */
+  generateWeakEtag(validators: unknown): string {
+    return _generateWeakEtag(validators);
+  }
+
+  /** Rails: `generate_strong_etag(validators)`. */
+  generateStrongEtag(validators: unknown): string {
+    return _generateStrongEtag(validators);
+  }
+
+  /** Rails: `prepare_cache_control!` private. */
+  prepareCacheControlBang(): CacheControlHash {
+    return _prepareCacheControlBang.call(this);
+  }
+
+  // --- Default-headers merge (static) ---
+
+  /** Rails: `Response.merge_default_headers(original, default)`. */
+  static mergeDefaultHeaders(
+    original: Record<string, string>,
+    defaults: Record<string, string> | undefined,
+  ): Record<string, string> {
+    if (!defaults) return original;
+    return { ...defaults, ...original };
   }
 
   // --- Inspect ---

--- a/packages/actionpack/src/action-dispatch/routing/redirection.ts
+++ b/packages/actionpack/src/action-dispatch/routing/redirection.ts
@@ -113,7 +113,7 @@ export class Redirect extends Endpoint {
     return true;
   }
 
-  call(env: RackEnv): [number, Record<string, string>, unknown[]] {
+  call(env: RackEnv): [number, Record<string, string>, unknown] {
     const request = new Request(env);
     const response = this.buildResponse(request);
     return response.toRack();

--- a/packages/actionpack/src/action-dispatch/routing/redirection.ts
+++ b/packages/actionpack/src/action-dispatch/routing/redirection.ts
@@ -113,7 +113,7 @@ export class Redirect extends Endpoint {
     return true;
   }
 
-  call(env: RackEnv): [number, Record<string, string>, string[]] {
+  call(env: RackEnv): [number, Record<string, string>, unknown[]] {
     const request = new Request(env);
     const response = this.buildResponse(request);
     return response.toRack();

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -373,7 +373,7 @@ export class RouteSet {
       const [status, headers, bodyArr] = redirectEndpoint.call(env);
       const lowerHeaders: Record<string, string> = {};
       for (const [k, v] of Object.entries(headers)) lowerHeaders[k.toLowerCase()] = v;
-      return [status, lowerHeaders, bodyFromString(bodyArr.join(""))];
+      return [status, lowerHeaders, bodyFromString((bodyArr as string[]).join(""))];
     }
 
     // Merge route params into the env (like Rails does with request.params)


### PR DESCRIPTION
Adds the core \`ActionDispatch::Response\` infrastructure:

- \`ResponseBuffer\` class (mirrors \`Response::Buffer\`, response.rb:100-157) for stream-backed bodies with cached body string + commit-on-write semantics
- Lifecycle state machine: \`commitBang\`, \`sendingBang\`, \`sentBang\`, \`isSending\`, \`isSent\` (+ \`awaitCommit\` / \`awaitSent\` as single-threaded JS no-ops)
- Stream accessors: \`stream\`, \`each\`, \`bodyParts\`, \`sendFile\`, \`resetBodyBang\`, \`abort\`
- Aliases / accessors: \`header\`, \`hasHeader\`, \`mediaType\`, \`responseCode\`, \`statusMessage\`, \`redirectUrl\`
- Content-type parsing privates: \`parseContentType\`, \`parsedContentTypeHeader\`, \`setContentType\`
- Lifecycle hooks: \`beforeCommitted\`, \`beforeSending\`, \`buildBuffer\`, \`mungeBodyObject\`, \`assignDefaultContentTypeAndCharsetBang\`, \`handleNoContentBang\`, \`rackResponse\`
- ETag generators: \`generateWeakEtag\`, \`generateStrongEtag\`, \`prepareCacheControlBang\`
- Static \`mergeDefaultHeaders\` + \`defaultHeaders\` cattr

api:compare for \`http/response.rb\` goes from 39/77 (51%) to 72/77 (94%).

Aligns \`ActionController::Live::Response\` with the widened base: \`buildBuffer\` signature widened to \`(unknown, unknown[])\`, \`stream\` switched from instance field to \`declare\`, \`beforeCommitted\` visibility matched.

Follow-ups (5 methods, deferred to keep PR ≤ 300 LOC):
- \`locationFilters\`, \`isLocationFilterMatch\`, \`parameterFilteredLocation\` (filter-redirect wiring already exported)
- \`cacheControlSegments\`, \`cacheControlHeaders\` (cache.ts already exports these)

## Test plan
- [x] \`pnpm vitest run packages/actionpack/src/action-controller/metal/live.test.ts\`
- [x] \`pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/\` (862 tests)
- [x] api:compare for \`actiondispatch\`