### PR TITLE
feat(actionpack): Integration::Session core methods (15→33/81)

### DIFF
--- a/packages/actionpack/src/action-dispatch/testing/integration.test.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.test.ts
@@ -384,6 +384,74 @@ describe("ActionDispatch::IntegrationTest", () => {
       app.assertResponse("success");
     });
 
+    it("requestCount increments per request and resets on resetBang", async () => {
+      expect(app.requestCount).toBe(0);
+      await app.get("/posts");
+      await app.get("/posts");
+      expect(app.requestCount).toBe(2);
+      app.resetBang();
+      expect(app.requestCount).toBe(0);
+    });
+
+    it("httpsBang / isHttps flip the scheme on the rack env", async () => {
+      expect(app.isHttps()).toBe(false);
+      app.httpsBang();
+      expect(app.isHttps()).toBe(true);
+      await app.get("/posts");
+      expect(app.request.env["rack.url_scheme"]).toBe("https");
+      expect(app.request.env.HTTPS).toBe("on");
+      app.httpsBang(false);
+      expect(app.isHttps()).toBe(false);
+    });
+
+    it("host/remoteAddr/accept land in the rack env", async () => {
+      app.host = "api.example.com:8080";
+      app.remoteAddr = "10.0.0.5";
+      app.accept = "application/vnd.api+json";
+      await app.get("/posts");
+      expect(app.request.env.HTTP_HOST).toBe("api.example.com:8080");
+      expect(app.request.env.SERVER_NAME).toBe("api.example.com");
+      expect(app.request.env.SERVER_PORT).toBe("8080");
+      expect(app.request.env.REMOTE_ADDR).toBe("10.0.0.5");
+      expect(app.request.env.HTTP_ACCEPT).toBe("application/vnd.api+json");
+    });
+
+    it("urlOptions memoizes per request and clears across requests", async () => {
+      const before = app.urlOptions();
+      expect(before).toEqual({ host: "www.example.com", protocol: "http" });
+      expect(app.urlOptions()).toBe(before);
+      await app.get("/posts");
+      const after = app.urlOptions();
+      expect(after).not.toBe(before);
+    });
+
+    it("process() with an absolute URL updates host and https", async () => {
+      await app.process("get", "https://other.example.com/posts");
+      expect(app.host).toBe("other.example.com");
+      expect(app.isHttps()).toBe(true);
+      app.assertResponse("success");
+    });
+
+    it("_processPath splits query string off PATH_INFO", async () => {
+      await app.get("/posts?page=2&per=10");
+      expect(app.request.env.PATH_INFO).toBe("/posts");
+      expect(app.request.env.QUERY_STRING).toBe("page=2&per=10");
+      app.assertResponse("success");
+    });
+
+    it("followRedirectBang sets HTTP_REFERER to the prior request URL", async () => {
+      await app.get("/posts/redirect");
+      app.assertResponse("redirect");
+      const refererBefore = `http://www.example.com/posts/redirect`;
+      await app.followRedirectBang();
+      expect(app.request.env.HTTP_REFERER).toBe(refererBefore);
+    });
+
+    it("followRedirectBang throws when last response was not a redirect", async () => {
+      await app.get("/posts");
+      await expect(app.followRedirectBang()).rejects.toThrow(/not a redirect/);
+    });
+
     it("CRUD lifecycle", async () => {
       // Create
       await app.post("/posts", { params: { title: "CRUD" } });

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -498,6 +498,11 @@ export class IntegrationTest {
     options: IntegrationRequestOptions,
   ): Promise<void> {
     this.requestCount += 1;
+    // Clear per-request memos up front so they don't leak across requests,
+    // including down the no-route 404 path.
+    this._cookieJar = undefined;
+    this._urlOptions = undefined;
+
     // Split path into PATH_INFO + QUERY_STRING; Rack stores them separately.
     const qIdx = path.indexOf("?");
     const pathInfo = qIdx >= 0 ? path.slice(0, qIdx) : path;
@@ -505,8 +510,10 @@ export class IntegrationTest {
     // Match route on pathname only.
     const matched = this.routes.recognize(method, pathInfo);
     if (!matched) {
-      // No route matched — create a 404-like response
-      this.request = new Request({
+      // No route matched — create a 404-like response. Mirror the same
+      // host/scheme/cookie env keys as the matched branch so request.url and
+      // request.cookies are accurate for 404s too.
+      const noRouteEnv: Record<string, unknown> = {
         REQUEST_METHOD: method,
         PATH_INFO: pathInfo,
         QUERY_STRING: queryString,
@@ -517,7 +524,18 @@ export class IntegrationTest {
         "rack.url_scheme": this._https ? "https" : "http",
         REMOTE_ADDR: this.remoteAddr,
         HTTP_ACCEPT: this.accept,
-      });
+      };
+      if (Object.keys(this._persistentCookies).length > 0) {
+        noRouteEnv.HTTP_COOKIE = Object.entries(this._persistentCookies)
+          .map(([k, v]) => `${k}=${v}`)
+          .join("; ");
+      }
+      noRouteEnv.REQUEST_URI = this._buildFullUri(
+        (noRouteEnv.PATH_INFO as string) +
+          (noRouteEnv.QUERY_STRING ? `?${noRouteEnv.QUERY_STRING as string}` : ""),
+        noRouteEnv,
+      );
+      this.request = new Request(noRouteEnv);
       this.response = new Response();
       this.response.status = 404;
       this.response.body = `No route matches [${method}] "${pathInfo}"`;
@@ -570,12 +588,6 @@ export class IntegrationTest {
         .map(([k, v]) => `${k}=${v}`)
         .join("; ");
     }
-
-    // Reset the TestProcess#cookies memoization slot — the jar must reflect
-    // the cookies parsed off this request, not the previous one.
-    this._cookieJar = undefined;
-    // Clear url-options memo so the next call sees the up-to-date host/scheme.
-    this._urlOptions = undefined;
 
     // Format / content type
     if (options.format || options.as) {

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -173,8 +173,9 @@ export class IntegrationTest {
   }
 
   /**
-   * Build the absolute URI used by `process` when a relative path is given.
-   * Matches Rails `Integration::Session#build_full_uri(path, env)`.
+   * Build the absolute URI for the current request. Matches Rails
+   * `Integration::Session#build_full_uri(path, env)`. Called by `_processPath`
+   * to populate `env.REQUEST_URI`.
    *
    * @internal
    */
@@ -490,14 +491,18 @@ export class IntegrationTest {
     options: IntegrationRequestOptions,
   ): Promise<void> {
     this.requestCount += 1;
-    // Match route
-    const matched = this.routes.recognize(method, path);
+    // Split path into PATH_INFO + QUERY_STRING; Rack stores them separately.
+    const qIdx = path.indexOf("?");
+    const pathInfo = qIdx >= 0 ? path.slice(0, qIdx) : path;
+    const queryString = qIdx >= 0 ? path.slice(qIdx + 1) : "";
+    // Match route on pathname only.
+    const matched = this.routes.recognize(method, pathInfo);
     if (!matched) {
       // No route matched — create a 404-like response
-      this.request = new Request({ REQUEST_METHOD: method, PATH_INFO: path });
+      this.request = new Request({ REQUEST_METHOD: method, PATH_INFO: pathInfo });
       this.response = new Response();
       this.response.status = 404;
-      this.response.body = `No route matches [${method}] "${path}"`;
+      this.response.body = `No route matches [${method}] "${pathInfo}"`;
       this.controller = undefined!;
       return;
     }
@@ -518,7 +523,8 @@ export class IntegrationTest {
     // Build env
     const env: Record<string, unknown> = {
       REQUEST_METHOD: method,
-      PATH_INFO: path,
+      PATH_INFO: pathInfo,
+      QUERY_STRING: queryString,
       HTTP_HOST: this.host,
       SERVER_NAME: this.host.split(":")[0],
       SERVER_PORT: this.host.split(":")[1] ?? (this._https ? "443" : "80"),
@@ -534,6 +540,7 @@ export class IntegrationTest {
       },
       ...(options.env ?? {}),
     };
+    env.REQUEST_URI = this._buildFullUri(path, env);
 
     // Cookies from persistent jar
     if (Object.keys(this._persistentCookies).length > 0) {

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -239,9 +239,10 @@ export class IntegrationTest {
     );
     if (!hasReferer && this.request) {
       const env = this.request.env as Record<string, string | undefined>;
+      const qs = env.QUERY_STRING ? `?${env.QUERY_STRING}` : "";
       const prev =
         `${env["rack.url_scheme"] ?? "http"}://${env.HTTP_HOST ?? this.host}` +
-        `${env.PATH_INFO ?? ""}`;
+        `${env.PATH_INFO ?? ""}${qs}`;
       headers["HTTP_REFERER"] = prev;
     }
 
@@ -499,7 +500,18 @@ export class IntegrationTest {
     const matched = this.routes.recognize(method, pathInfo);
     if (!matched) {
       // No route matched — create a 404-like response
-      this.request = new Request({ REQUEST_METHOD: method, PATH_INFO: pathInfo });
+      this.request = new Request({
+        REQUEST_METHOD: method,
+        PATH_INFO: pathInfo,
+        QUERY_STRING: queryString,
+        HTTP_HOST: this.host,
+        SERVER_NAME: this.host.split(":")[0],
+        SERVER_PORT: this.host.split(":")[1] ?? (this._https ? "443" : "80"),
+        HTTPS: this._https ? "on" : "off",
+        "rack.url_scheme": this._https ? "https" : "http",
+        REMOTE_ADDR: this.remoteAddr,
+        HTTP_ACCEPT: this.accept,
+      });
       this.response = new Response();
       this.response.status = 404;
       this.response.body = `No route matches [${method}] "${pathInfo}"`;

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -64,6 +64,12 @@ const STATUS_RANGES: Record<string, [number, number]> = {
   error: [500, 599],
 };
 
+// Match only paths that *begin* with a scheme (e.g. `http://…`). Rails uses
+// `path.include?("://")` which is fine in Ruby because `URI.parse` is lenient
+// with relative inputs, but JS `new URL` throws on relative paths — so we
+// have to be stricter to avoid breaking `/callback?return=http://example.com`.
+const ABSOLUTE_URL_RE = /^[a-z][a-z0-9+.-]*:\/\//i;
+
 const DEFAULT_HOST = "www.example.com";
 const DEFAULT_REMOTE_ADDR = "127.0.0.1";
 const DEFAULT_ACCEPT =
@@ -191,7 +197,7 @@ export class IntegrationTest {
    * @internal
    */
   _buildExpandedPath(path: string, onLocation?: (url: URL) => void): string {
-    if (!path.includes("://")) return path;
+    if (!ABSOLUTE_URL_RE.test(path)) return path;
     const location = new URL(path);
     onLocation?.(location);
     return location.search ? `${location.pathname}${location.search}` : location.pathname;
@@ -206,7 +212,7 @@ export class IntegrationTest {
     options: IntegrationRequestOptions = {},
   ): Promise<number> {
     let expanded = path;
-    if (path.includes("://")) {
+    if (ABSOLUTE_URL_RE.test(path)) {
       expanded = this._buildExpandedPath(path, (loc) => {
         this.httpsBang(loc.protocol === "https:");
         if (loc.host) this.host = loc.host;
@@ -605,8 +611,16 @@ export class IntegrationTest {
     this.request = new Request(env);
     this.response = new Response();
 
-    // Build params: route params + request params
+    // Build params: route params + parsed query string + caller-supplied params.
+    // Rails merges request.GET/request.POST into request.parameters via the
+    // ParamsParser; we mirror that here so query-string params survive the
+    // PATH_INFO/QUERY_STRING split done above.
     const allParams: Record<string, unknown> = { ...params };
+    if (queryString) {
+      for (const [k, v] of new URLSearchParams(queryString)) {
+        allParams[k] = v;
+      }
+    }
     if (options.params) {
       Object.assign(allParams, options.params);
     }

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -629,9 +629,7 @@ export class IntegrationTest {
     // PATH_INFO/QUERY_STRING split done above.
     const allParams: Record<string, unknown> = { ...params };
     if (queryString) {
-      for (const [k, v] of new URLSearchParams(queryString)) {
-        allParams[k] = v;
-      }
+      Object.assign(allParams, this.request.queryParameters);
     }
     if (options.params) {
       Object.assign(allParams, options.params);

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -212,7 +212,6 @@ export class IntegrationTest {
       });
     }
     await this._processPath(method.toUpperCase(), expanded, options);
-    this.requestCount += 1;
     return this.status;
   }
 
@@ -490,6 +489,7 @@ export class IntegrationTest {
     path: string,
     options: IntegrationRequestOptions,
   ): Promise<void> {
+    this.requestCount += 1;
     // Match route
     const matched = this.routes.recognize(method, path);
     if (!matched) {

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -96,16 +96,18 @@ export class IntegrationTest {
   /** @internal */
   _https: boolean = false;
 
+  /** @internal */
+  _urlOptions?: Record<string, unknown>;
+
   /**
-   * Memoized mock-session slot. Rails uses `Rack::MockSession`; we have no
-   * equivalent, so it just holds the persistent cookie/session bag.
+   * Caller-supplied defaults merged into {@link urlOptions}. Rails sources
+   * this from the `UrlFor` mixin; until UrlFor is ported, sessions can still
+   * populate it directly (it's also what `Runner#default_url_options=` writes
+   * through to).
    *
    * @internal
    */
-  _mockSessionMemo?: { cookies: Record<string, string>; session: Record<string, unknown> };
-
-  /** @internal */
-  _urlOptions?: Record<string, unknown>;
+  _defaultUrlOptions: Record<string, unknown> = {};
 
   constructor() {
     this.resetBang();
@@ -123,7 +125,6 @@ export class IntegrationTest {
     this.request = undefined!;
     this.response = undefined!;
     this._https = false;
-    this._mockSessionMemo = undefined;
     this._urlOptions = undefined;
     this.requestCount = 0;
     this.host = DEFAULT_HOST;
@@ -147,42 +148,38 @@ export class IntegrationTest {
    * Rails (cleared inside `_processPath`).
    */
   urlOptions(): Record<string, unknown> {
-    this._urlOptions ??= {
-      host: this.host,
-      protocol: this._https ? "https" : "http",
-    };
+    if (!this._urlOptions) {
+      this._urlOptions = {
+        ...this._defaultUrlOptions,
+        host: this.host,
+        protocol: this._https ? "https" : "http",
+      };
+    }
     return this._urlOptions;
   }
 
   /**
-   * Default URL options getter that Runner clients (e.g. `urlFor`) call.
-   * Returns the same object as `urlOptions()`.
+   * Caller-supplied defaults merged into {@link urlOptions} (Rails
+   * `Runner#default_url_options`). Stored as a separate hash so writes don't
+   * clobber the per-request memo computed by {@link urlOptions}.
    */
   defaultUrlOptions(): Record<string, unknown> {
-    return this.urlOptions();
+    return this._defaultUrlOptions;
   }
 
-  /**
-   * Lazily-built mock-session bag. No `Rack::MockSession` to wrap, so we
-   * surface the persistent state used by the request loop.
-   *
-   * @internal
-   */
-  _mockSession(): { cookies: Record<string, string>; session: Record<string, unknown> } {
-    this._mockSessionMemo ??= { cookies: this._persistentCookies, session: this.session };
-    return this._mockSessionMemo;
+  setDefaultUrlOptions(options: Record<string, unknown>): void {
+    this._defaultUrlOptions = options;
+    this._urlOptions = undefined;
   }
 
   /**
    * Build the absolute URI used by `process` when a relative path is given.
+   * Matches Rails `Integration::Session#build_full_uri(path, env)`.
    *
    * @internal
    */
-  _buildFullUri(path: string): string {
-    const scheme = this._https ? "https" : "http";
-    const port = this._https ? "443" : "80";
-    const hostPart = this.host.includes(":") ? this.host : `${this.host}:${port}`;
-    return `${scheme}://${hostPart}${path}`;
+  _buildFullUri(path: string, env: Record<string, unknown>): string {
+    return `${env["rack.url_scheme"]}://${env["SERVER_NAME"]}:${env["SERVER_PORT"]}${path}`;
   }
 
   /**
@@ -219,11 +216,36 @@ export class IntegrationTest {
     return this.status;
   }
 
-  /** Rails-shaped `RequestHelpers#follow_redirect!`. */
+  /**
+   * Rails-shaped `RequestHelpers#follow_redirect!`. Preserves the verb on
+   * 307/308 (per RFC 7231/7538) and sets `HTTP_REFERER` to the previous URL,
+   * mirroring the Rails implementation.
+   */
   async followRedirectBang(options: IntegrationRequestOptions = {}): Promise<number> {
+    if (!this.response || this.status < 300 || this.status >= 400) {
+      throw new Error(`not a redirect! ${this.status}`);
+    }
     const location = this.redirectUrl;
-    if (!location) throw new Error("not a redirect!");
-    await this.get(location, options);
+    if (!location) throw new Error("not a redirect! (no Location header)");
+
+    const preserveVerb = this.status === 307 || this.status === 308;
+    const method = preserveVerb
+      ? ((this.request?.env?.REQUEST_METHOD as string | undefined)?.toLowerCase() ?? "get")
+      : "get";
+
+    const headers = { ...(options.headers ?? {}) };
+    const hasReferer = Object.keys(headers).some(
+      (k) => k === "HTTP_REFERER" || k.toLowerCase() === "referer",
+    );
+    if (!hasReferer && this.request) {
+      const env = this.request.env as Record<string, string | undefined>;
+      const prev =
+        `${env["rack.url_scheme"] ?? "http"}://${env.HTTP_HOST ?? this.host}` +
+        `${env.PATH_INFO ?? ""}`;
+      headers["HTTP_REFERER"] = prev;
+    }
+
+    await this.process(method, location, { ...options, headers });
     return this.status;
   }
 

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -628,7 +628,7 @@ export class IntegrationTest {
     // ParamsParser; we mirror that here so query-string params survive the
     // PATH_INFO/QUERY_STRING split done above.
     const allParams: Record<string, unknown> = { ...params };
-    if (queryString) {
+    if (env.QUERY_STRING) {
       Object.assign(allParams, this.request.queryParameters);
     }
     if (options.params) {

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -338,27 +338,27 @@ export class IntegrationTest {
   // --- HTTP verb methods ---
 
   async get(path: string, options: IntegrationRequestOptions = {}): Promise<void> {
-    await this._processPath("GET", path, options);
+    await this.process("GET", path, options);
   }
 
   async post(path: string, options: IntegrationRequestOptions = {}): Promise<void> {
-    await this._processPath("POST", path, options);
+    await this.process("POST", path, options);
   }
 
   async put(path: string, options: IntegrationRequestOptions = {}): Promise<void> {
-    await this._processPath("PUT", path, options);
+    await this.process("PUT", path, options);
   }
 
   async patch(path: string, options: IntegrationRequestOptions = {}): Promise<void> {
-    await this._processPath("PATCH", path, options);
+    await this.process("PATCH", path, options);
   }
 
   async delete(path: string, options: IntegrationRequestOptions = {}): Promise<void> {
-    await this._processPath("DELETE", path, options);
+    await this.process("DELETE", path, options);
   }
 
   async head(path: string, options: IntegrationRequestOptions = {}): Promise<void> {
-    await this._processPath("HEAD", path, options);
+    await this.process("HEAD", path, options);
   }
 
   /**
@@ -552,7 +552,11 @@ export class IntegrationTest {
       },
       ...(options.env ?? {}),
     };
-    env.REQUEST_URI = this._buildFullUri(path, env);
+    // Build REQUEST_URI from the *finalized* env so options.env overrides of
+    // PATH_INFO/QUERY_STRING are honored.
+    const finalPath =
+      (env.PATH_INFO as string) + (env.QUERY_STRING ? `?${env.QUERY_STRING as string}` : "");
+    env.REQUEST_URI = this._buildFullUri(finalPath, env);
 
     // Cookies from persistent jar
     if (Object.keys(this._persistentCookies).length > 0) {

--- a/packages/actionpack/src/action-dispatch/testing/integration.ts
+++ b/packages/actionpack/src/action-dispatch/testing/integration.ts
@@ -64,6 +64,13 @@ const STATUS_RANGES: Record<string, [number, number]> = {
   error: [500, 599],
 };
 
+const DEFAULT_HOST = "www.example.com";
+const DEFAULT_REMOTE_ADDR = "127.0.0.1";
+const DEFAULT_ACCEPT =
+  "text/xml,application/xml,application/xhtml+xml," +
+  "text/html;q=0.9,text/plain;q=0.8,image/png," +
+  "*/*;q=0.5";
+
 export class IntegrationTest {
   /** The route set for this test. */
   routes: RouteSet = new RouteSet();
@@ -73,6 +80,152 @@ export class IntegrationTest {
 
   /** Session data persisted across requests. */
   session: Record<string, unknown> = {};
+
+  /** The hostname used in the last request. */
+  host: string = DEFAULT_HOST;
+
+  /** The remote address used in the last request. */
+  remoteAddr: string = DEFAULT_REMOTE_ADDR;
+
+  /** The Accept header to send. */
+  accept: string = DEFAULT_ACCEPT;
+
+  /** A running counter of the number of requests processed. */
+  requestCount: number = 0;
+
+  /** @internal */
+  _https: boolean = false;
+
+  /**
+   * Memoized mock-session slot. Rails uses `Rack::MockSession`; we have no
+   * equivalent, so it just holds the persistent cookie/session bag.
+   *
+   * @internal
+   */
+  _mockSessionMemo?: { cookies: Record<string, string>; session: Record<string, unknown> };
+
+  /** @internal */
+  _urlOptions?: Record<string, unknown>;
+
+  constructor() {
+    this.resetBang();
+  }
+
+  /**
+   * Reset the instance. Mirrors `Integration::Session#reset!`. Existing
+   * `reset()` is kept as a friendly alias.
+   */
+  resetBang(): void {
+    this.session = {};
+    this._persistentCookies = {};
+    this._cookieJar = undefined;
+    this.controller = undefined!;
+    this.request = undefined!;
+    this.response = undefined!;
+    this._https = false;
+    this._mockSessionMemo = undefined;
+    this._urlOptions = undefined;
+    this.requestCount = 0;
+    this.host = DEFAULT_HOST;
+    this.remoteAddr = DEFAULT_REMOTE_ADDR;
+    this.accept = DEFAULT_ACCEPT;
+  }
+
+  /** Mirror of Rails `Integration::Session#https!`. */
+  httpsBang(flag: boolean = true): void {
+    this._https = flag;
+  }
+
+  /** Returns true if the session is mimicking a secure HTTPS request. */
+  isHttps(): boolean {
+    return this._https;
+  }
+
+  /**
+   * Default URL options for this session, derived from host/scheme.
+   * Mirrors `Integration::Session#url_options`, memoized per-request like
+   * Rails (cleared inside `_processPath`).
+   */
+  urlOptions(): Record<string, unknown> {
+    this._urlOptions ??= {
+      host: this.host,
+      protocol: this._https ? "https" : "http",
+    };
+    return this._urlOptions;
+  }
+
+  /**
+   * Default URL options getter that Runner clients (e.g. `urlFor`) call.
+   * Returns the same object as `urlOptions()`.
+   */
+  defaultUrlOptions(): Record<string, unknown> {
+    return this.urlOptions();
+  }
+
+  /**
+   * Lazily-built mock-session bag. No `Rack::MockSession` to wrap, so we
+   * surface the persistent state used by the request loop.
+   *
+   * @internal
+   */
+  _mockSession(): { cookies: Record<string, string>; session: Record<string, unknown> } {
+    this._mockSessionMemo ??= { cookies: this._persistentCookies, session: this.session };
+    return this._mockSessionMemo;
+  }
+
+  /**
+   * Build the absolute URI used by `process` when a relative path is given.
+   *
+   * @internal
+   */
+  _buildFullUri(path: string): string {
+    const scheme = this._https ? "https" : "http";
+    const port = this._https ? "443" : "80";
+    const hostPart = this.host.includes(":") ? this.host : `${this.host}:${port}`;
+    return `${scheme}://${hostPart}${path}`;
+  }
+
+  /**
+   * Expand a path that may itself contain a scheme/host, optionally letting
+   * the caller observe the parsed location to update `host`/`https`. Mirrors
+   * `Integration::Session#build_expanded_path`.
+   *
+   * @internal
+   */
+  _buildExpandedPath(path: string, onLocation?: (url: URL) => void): string {
+    if (!path.includes("://")) return path;
+    const location = new URL(path);
+    onLocation?.(location);
+    return location.search ? `${location.pathname}${location.search}` : location.pathname;
+  }
+
+  /**
+   * Rails-shaped `Integration::Session#process`. Verb helpers delegate here.
+   */
+  async process(
+    method: string,
+    path: string,
+    options: IntegrationRequestOptions = {},
+  ): Promise<number> {
+    let expanded = path;
+    if (path.includes("://")) {
+      expanded = this._buildExpandedPath(path, (loc) => {
+        this.httpsBang(loc.protocol === "https:");
+        if (loc.host) this.host = loc.host;
+      });
+    }
+    await this._processPath(method.toUpperCase(), expanded, options);
+    this.requestCount += 1;
+    return this.status;
+  }
+
+  /** Rails-shaped `RequestHelpers#follow_redirect!`. */
+  async followRedirectBang(options: IntegrationRequestOptions = {}): Promise<number> {
+    const location = this.redirectUrl;
+    if (!location) throw new Error("not a redirect!");
+    await this.get(location, options);
+    return this.status;
+  }
 
   /** Accumulated cookies across requests (simple key/value), seeds the jar. */
   private _persistentCookies: Record<string, string> = {};
@@ -302,15 +455,10 @@ export class IntegrationTest {
   }
 
   /**
-   * Reset all session state (cookies, session, flash).
+   * Reset all session state (cookies, session, flash). Alias of {@link resetBang}.
    */
   reset(): void {
-    this.session = {};
-    this._persistentCookies = {};
-    this._cookieJar = undefined;
-    this.controller = undefined!;
-    this.request = undefined!;
-    this.response = undefined!;
+    this.resetBang();
   }
 
   // --- Internal ---
@@ -349,9 +497,13 @@ export class IntegrationTest {
     const env: Record<string, unknown> = {
       REQUEST_METHOD: method,
       PATH_INFO: path,
-      HTTP_HOST: "www.example.com",
-      SERVER_NAME: "www.example.com",
-      SERVER_PORT: "80",
+      HTTP_HOST: this.host,
+      SERVER_NAME: this.host.split(":")[0],
+      SERVER_PORT: this.host.split(":")[1] ?? (this._https ? "443" : "80"),
+      HTTPS: this._https ? "on" : "off",
+      "rack.url_scheme": this._https ? "https" : "http",
+      REMOTE_ADDR: this.remoteAddr,
+      HTTP_ACCEPT: this.accept,
       "rack.session": { ...this.session },
       "action_dispatch.request.path_parameters": {
         controller: controllerName,
@@ -371,6 +523,8 @@ export class IntegrationTest {
     // Reset the TestProcess#cookies memoization slot — the jar must reflect
     // the cookies parsed off this request, not the previous one.
     this._cookieJar = undefined;
+    // Clear url-options memo so the next call sees the up-to-date host/scheme.
+    this._urlOptions = undefined;
 
     // Format / content type
     if (options.format || options.as) {


### PR DESCRIPTION
## Summary

Add the Session-class surface to `packages/actionpack/src/action-dispatch/testing/integration.ts`:

- `host`, `remoteAddr`, `accept`, `requestCount` accessors (wired into the request env)
- `httpsBang` / `isHttps`
- `urlOptions` (memoized + cleared per request) + `defaultUrlOptions` / `setDefaultUrlOptions` backing field
- `resetBang` (`reset()` aliases)
- `process` — Rails-shaped wrapper around `_processPath` that handles absolute paths via `_buildExpandedPath`
- `followRedirectBang` — preserves verb on 307/308, sets `HTTP_REFERER`
- explicit `constructor`
- internals: `_buildFullUri(path, env)`, `_buildExpandedPath(path, onLocation)`

`_processPath` now reads the new `host`/`remoteAddr`/`accept`/`_https` fields when building the rack env, increments `requestCount`, and clears the per-request `urlOptions` memo.

## api:compare

`testing/integration.rb` 15/81 (19%) → 32/81 (40%).

## Copilot review responses

- **requestCount only updated in `process()`** — fixed. Moved increment into `_processPath` so verb helpers (which bypass `process`) also advance the counter.
- **`host.split(\":\")` mishandles IPv6** — intentional Rails parity. `vendor/rails/actionpack/lib/action_dispatch/testing/integration.rb:246` does exactly `hostname, port = host.split(\":\")`. Not fixing here.
- **`_mockSession` mentioned but not present** — was added in the first commit then removed in the followup tightening pass (no `Rack::MockSession` equivalent to back it). Description updated accordingly.

## Follow-ups (separate PRs)

- Runner mixin: `integrationSession`, `createSession`, `openSession`, `copySessionVariablesBang`, `removeBang`
- `IntegrationTest::Behavior`: `app`, `app=`, `documentRootElement`, `registerEncoder`
- RoutingAssertions / UrlFor / PolymorphicRoutes families (depend on infra not yet ported)
- TestProcess::FixtureFile helpers
- `html_document`, `assigns`, misc
- `_mockSession` — needs a `Rack::MockSession`-equivalent or refactor so the slot actually backs cookies/last_response

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/testing/integration.test.ts` (39/39 pass)
- [x] api:compare delta: +17
- [x] test:compare delta: 0
- [x] tsc clean for the touched file

---

## Known follow-ups (post review-cycle cap)

Copilot's 9th review surfaced two issues we're deferring rather than iterate further:

1. **`_buildFullUri` always appends `SERVER_PORT`** — produces URLs like `http://www.example.com:80/...` even when the port is standard, so `env.REQUEST_URI` diverges from `Request#url` (which suppresses standard ports) and from the referer built in `followRedirectBang`. Fix: prefer `env.HTTP_HOST` when set and only append the port when non-standard for the scheme. Note: Rails' `build_full_uri` is `"#{env['rack.url_scheme']}://#{env['SERVER_NAME']}:#{env['SERVER_PORT']}#{path}"` — same naïve concatenation, so this is technically Rails-parity behavior. Cosmetic divergence with our `Request#url`, not a correctness bug.
2. **404 branch skips `options.env` / `options.headers` / `options.body`** — Callers can't set headers/env for negative-route assertions, and a `followRedirectBang` whose target doesn't match a route loses the injected `HTTP_REFERER`. Fix: run the same options merging/header normalization as the matched branch before constructing the 404 `Request`.