### PR TITLE
feat(actionpack): api/api_rendering to 100% + test-case helpers

### DIFF
--- a/packages/actionpack/src/action-controller/api/api-rendering.ts
+++ b/packages/actionpack/src/action-controller/api/api-rendering.ts
@@ -1,10 +1,38 @@
 /**
- * ActionController::ApiRendering
+ * ActionController::ApiRendering — aggregator mirroring
+ * `action_controller/api/api_rendering.rb`. Rails `includes Rendering`
+ * into the host class; trails re-exports the Rendering helpers here so
+ * api:compare sees the full mixed-in surface on this file.
  *
- * Rendering module included in API controllers. Overrides the default
- * render to use the API renderer (no template support).
  * @see https://api.rubyonrails.org/classes/ActionController/ApiRendering.html
  */
+
+import * as rendering from "../metal/rendering.js";
+
+/** @internal */
+export const renderToBody = rendering.renderToBody;
+/** @internal */
+export const render = rendering.render;
+/** @internal */
+export const renderToString = rendering.renderToString;
+/** @internal */
+export const processAction = rendering.processAction;
+/** @internal */
+export const _processVariant = rendering._processVariant;
+/** @internal */
+export const _renderInPriorities = rendering._renderInPriorities;
+/** @internal */
+export const _setHtmlContentType = rendering._setHtmlContentType;
+/** @internal */
+export const _setRenderedContentType = rendering._setRenderedContentType;
+/** @internal */
+export const _setVaryHeader = rendering._setVaryHeader;
+/** @internal */
+export const _normalizeOptions = rendering._normalizeOptions;
+/** @internal */
+export const _normalizeText = rendering._normalizeText;
+/** @internal */
+export const _processOptions = rendering._processOptions;
 
 function resolveContentType(options: Record<string, unknown>, fallback: string): string {
   return typeof options.contentType === "string" ? options.contentType : fallback;

--- a/packages/actionpack/src/action-controller/metal/rendering.test.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.test.ts
@@ -8,8 +8,12 @@ import {
   _setHtmlContentType,
   _setRenderedContentType,
   _setVaryHeader,
+  processAction,
+  render,
+  renderToString,
   RENDER_FORMATS_IN_PRIORITY,
 } from "./rendering.js";
+import { DoubleRenderError } from "../../abstract-controller/rendering.js";
 
 describe("_renderInPriorities", () => {
   test("returns first present priority key, ignoring prototype chain", () => {
@@ -207,6 +211,62 @@ describe("Metal wiring", () => {
     // when no key matches, so the " " fallback wins.
     expect(instance.renderToBody({ body: false })).toBe(" ");
     expect(instance.renderToBody({ body: null })).toBe(" ");
+  });
+
+  test("render throws DoubleRenderError when performed is already set", () => {
+    const host = {
+      performed: true,
+      responseBody: null,
+      renderToBody: () => "ignored",
+    };
+    expect(() => render.call(host)).toThrow(DoubleRenderError);
+  });
+
+  test("render delegates to abstract render when not yet performed", () => {
+    const host = {
+      performed: false,
+      responseBody: null as unknown,
+      renderToBody: (opts: Record<string, unknown>) => `body:${String(opts.plain ?? "")}`,
+      _setHtmlContentType: () => {},
+      _setRenderedContentType: () => {},
+      _setVaryHeader: () => {},
+      renderedFormat: () => null,
+    };
+    render.call(host, { plain: "hi" });
+    expect(host.responseBody).toBe("body:hi");
+  });
+
+  test("renderToString collapses iterable results into a string", () => {
+    const host = {
+      responseBody: null as unknown,
+      renderToBody: () => ["a", "b", "c"],
+    };
+    expect(renderToString.call(host, {})).toBe("abc");
+  });
+
+  test("renderToString passes non-iterable results through unchanged", () => {
+    const host = { responseBody: null as unknown, renderToBody: () => 42 };
+    expect(renderToString.call(host, {})).toBe(42);
+  });
+
+  test("processAction sets formats from request.formats via ref()", () => {
+    const host: { request: { formats: { ref: () => string }[] }; formats?: unknown } = {
+      request: {
+        formats: [{ ref: () => "html" }, { ref: () => "json" }],
+      },
+    };
+    processAction.call(host);
+    expect(host.formats).toEqual(["html", "json"]);
+  });
+
+  test("processAction filters out null refs (filter_map &:ref parity)", () => {
+    const host: { request: { formats: { ref: () => unknown }[] }; formats?: unknown } = {
+      request: {
+        formats: [{ ref: () => "html" }, { ref: () => null }, { ref: () => "json" }],
+      },
+    };
+    processAction.call(host);
+    expect(host.formats).toEqual(["html", "json"]);
   });
 
   test("renderToBody dispatches to a registered renderer before the priority resolver", async () => {

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -174,7 +174,11 @@ export function render<T extends { responseBody?: unknown } & AbstractRenderHost
   this: T,
   ...args: unknown[]
 ): void {
-  if (this.responseBody) throw new DoubleRenderError();
+  // Rails: `if response_body` — Ruby truthiness, so `""` and `0` already
+  // count as rendered. JS truthiness drops `""`/`0`, so explicit null-check.
+  if (this.responseBody != null && this.responseBody !== false) {
+    throw new DoubleRenderError();
+  }
   abstractRender.call(this, ...args);
 }
 
@@ -202,7 +206,10 @@ export function renderToString<T extends AbstractRenderHost>(this: T, ...args: u
 /**
  * Mirrors Rails `ActionController::Rendering#process_action(*)` — sets
  * `self.formats` from `request.formats.filter_map(&:ref)` before the
- * action runs. `this`-typed so include-style mixin works.
+ * action runs. Rails calls `super` to continue the include chain; in
+ * trails the host class is responsible for chaining (this helper just
+ * applies the formats side-effect). Synchronous to mirror the Ruby
+ * source — host-side dispatch handles async separately.
  * @internal
  */
 export function processAction<

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -194,8 +194,7 @@ export function renderToString<T extends AbstractRenderHost>(this: T, ...args: u
   if (
     result != null &&
     typeof result === "object" &&
-    typeof (result as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function" &&
-    typeof result !== "string"
+    typeof (result as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function"
   ) {
     const parts: string[] = [];
     for (const chunk of result as Iterable<unknown>) parts.push(String(chunk));

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -7,6 +7,12 @@
  */
 
 import { htmlEscape, isPresent } from "@blazetrails/activesupport";
+import {
+  DoubleRenderError,
+  render as abstractRender,
+  renderToString as abstractRenderToString,
+  type RenderingHost as AbstractRenderHost,
+} from "../../abstract-controller/rendering.js";
 import { Renderer } from "../renderer.js";
 import { resolveStatus } from "./status-codes.js";
 
@@ -155,6 +161,64 @@ export function _processOptions(
 export function renderToBody(options: Record<string, unknown> = {}): string {
   const body = _renderInPriorities(options);
   return body !== null ? String(body) : " ";
+}
+
+/**
+ * Mirrors Rails `ActionController::Rendering#render(*args)`. Raises
+ * `DoubleRenderError` if the response body has already been set, then
+ * delegates to the abstract `render`. `this`-typed so subclasses can
+ * mix it in via include-style assignment.
+ * @internal
+ */
+export function render<T extends { responseBody?: unknown } & AbstractRenderHost>(
+  this: T,
+  ...args: unknown[]
+): void {
+  if (this.responseBody) throw new DoubleRenderError();
+  abstractRender.call(this, ...args);
+}
+
+/**
+ * Mirrors Rails `ActionController::Rendering#render_to_string(*)`. The
+ * abstract layer may produce an iterable (Rack body); collapse those
+ * into a single string. Non-iterables pass through.
+ * @internal
+ */
+export function renderToString<T extends AbstractRenderHost>(this: T, ...args: unknown[]): unknown {
+  const result = abstractRenderToString.call(this, ...args);
+  if (
+    result != null &&
+    typeof result === "object" &&
+    typeof (result as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function" &&
+    typeof result !== "string"
+  ) {
+    let buf = "";
+    for (const chunk of result as Iterable<unknown>) buf += String(chunk);
+    return buf;
+  }
+  return result;
+}
+
+/**
+ * Mirrors Rails `ActionController::Rendering#process_action(*)` — sets
+ * `self.formats` from `request.formats.filter_map(&:ref)` before the
+ * action runs. `this`-typed so include-style mixin works.
+ * @internal
+ */
+export function processAction<
+  T extends {
+    request?: { formats?: Array<{ ref?: () => unknown } | { ref?: unknown }> | undefined };
+    formats?: unknown;
+  },
+>(this: T, ..._args: unknown[]): void {
+  const reqFormats = this.request?.formats ?? [];
+  const out: unknown[] = [];
+  for (const f of reqFormats) {
+    const ref = (f as { ref?: unknown }).ref;
+    const v = typeof ref === "function" ? (ref as () => unknown).call(f) : ref;
+    if (v != null) out.push(v);
+  }
+  this.formats = out;
 }
 
 type ControllerClass = abstract new (...args: unknown[]) => unknown;

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -170,15 +170,16 @@ export function renderToBody(options: Record<string, unknown> = {}): string {
  * mix it in via include-style assignment.
  * @internal
  */
-export function render<T extends { responseBody?: unknown } & AbstractRenderHost>(
+export function render<T extends { performed?: boolean } & AbstractRenderHost>(
   this: T,
   ...args: unknown[]
 ): void {
-  // Rails: `if response_body` — Ruby truthiness, so `""` and `0` already
-  // count as rendered. JS truthiness drops `""`/`0`, so explicit null-check.
-  if (this.responseBody != null && this.responseBody !== false) {
-    throw new DoubleRenderError();
-  }
+  // Rails: `if response_body` — Ruby-truthiness on the raw `@_response_body`
+  // ivar. Trails' Metal `responseBody` getter stringifies to `""` even when
+  // unrendered, so guarding on it would throw on the first render. Use
+  // `performed` (set by Metal `markPerformed()`), which is the trails
+  // equivalent of "has this action committed a response yet".
+  if (this.performed) throw new DoubleRenderError();
   abstractRender.call(this, ...args);
 }
 

--- a/packages/actionpack/src/action-controller/metal/rendering.ts
+++ b/packages/actionpack/src/action-controller/metal/rendering.ts
@@ -197,9 +197,9 @@ export function renderToString<T extends AbstractRenderHost>(this: T, ...args: u
     typeof (result as { [Symbol.iterator]?: unknown })[Symbol.iterator] === "function" &&
     typeof result !== "string"
   ) {
-    let buf = "";
-    for (const chunk of result as Iterable<unknown>) buf += String(chunk);
-    return buf;
+    const parts: string[] = [];
+    for (const chunk of result as Iterable<unknown>) parts.push(String(chunk));
+    return parts.join("");
   }
   return result;
 }

--- a/packages/actionpack/src/action-controller/test-case.test.ts
+++ b/packages/actionpack/src/action-controller/test-case.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import { TestCase, TestSession } from "./test-case.js";
+import { Base } from "./base.js";
+
+describe("TestSession Rails-mirroring API", () => {
+  it("isExists / isEnabled are always true (Rails: exists?/enabled?)", () => {
+    const s = new TestSession();
+    expect(s.isExists()).toBe(true);
+    expect(s.isEnabled()).toBe(true);
+  });
+
+  it("keys / values reflect stored data", () => {
+    const s = new TestSession({ a: 1, b: 2 });
+    expect(s.keys()).toEqual(["a", "b"]);
+    expect(s.values()).toEqual([1, 2]);
+  });
+
+  it("destroy clears stored data", () => {
+    const s = new TestSession({ a: 1 });
+    s.destroy();
+    expect(s.keys()).toEqual([]);
+  });
+
+  it("dig stringifies the first key (mirrors Rails)", () => {
+    const s = new TestSession({ user: { name: "Ada" } });
+    expect(s.dig("user", "name")).toBe("Ada");
+    expect(s.dig("missing")).toBeUndefined();
+  });
+
+  it("fetch returns the value, the fallback, or throws", () => {
+    const s = new TestSession({ a: 1 });
+    expect(s.fetch("a")).toBe(1);
+    expect(s.fetch("b", 99)).toBe(99);
+    expect(s.fetch("c", () => "lazy")).toBe("lazy");
+    expect(() => s.fetch("missing")).toThrow();
+  });
+
+  it("idWas / loadBang return the constructor-frozen id", () => {
+    const s = new TestSession({}, "abc123");
+    expect(s.idWas()).toBe("abc123");
+    expect(s.loadBang()).toBe("abc123");
+  });
+});
+
+describe("TestCase class helpers", () => {
+  class PostsController extends Base {}
+
+  it("tests(class) sets controllerClass", () => {
+    class Sub extends TestCase {}
+    Sub.tests(PostsController);
+    expect(Sub.controllerClass).toBe(PostsController);
+  });
+
+  it("tests(string) resolves <Name>Controller via globalThis", () => {
+    (globalThis as Record<string, unknown>).WidgetController = PostsController;
+    class Sub extends TestCase {}
+    Sub.tests("widget");
+    expect(Sub.controllerClass).toBe(PostsController);
+    delete (globalThis as Record<string, unknown>).WidgetController;
+  });
+
+  it("tests(string) raises when no matching constant exists", () => {
+    class Sub extends TestCase {}
+    expect(() => Sub.tests("nonexistent_blarg")).toThrow(/String or Class/);
+  });
+
+  it("controllerClassName returns the configured class name", () => {
+    class Sub extends TestCase {}
+    Sub.tests(PostsController);
+    const tc = new Sub(PostsController);
+    expect(tc.controllerClassName()).toBe("PostsController");
+  });
+
+  it("determineDefaultControllerClass strips trailing Test and looks up", () => {
+    (globalThis as Record<string, unknown>).BooksController = PostsController;
+    expect(TestCase.determineDefaultControllerClass("BooksControllerTest")).toBe(PostsController);
+    expect(TestCase.determineDefaultControllerClass("MissingTest")).toBeNull();
+    delete (globalThis as Record<string, unknown>).BooksController;
+  });
+});

--- a/packages/actionpack/src/action-controller/test-case.test.ts
+++ b/packages/actionpack/src/action-controller/test-case.test.ts
@@ -32,6 +32,7 @@ describe("TestSession Rails-mirroring API", () => {
     expect(s.fetch("a")).toBe(1);
     expect(s.fetch("b", 99)).toBe(99);
     expect(s.fetch("c", () => "lazy")).toBe("lazy");
+    expect(s.fetch("d", (k: string) => `missing:${k}`)).toBe("missing:d");
     expect(() => s.fetch("missing")).toThrow();
   });
 

--- a/packages/actionpack/src/action-controller/test-case.test.ts
+++ b/packages/actionpack/src/action-controller/test-case.test.ts
@@ -69,6 +69,16 @@ describe("TestCase class helpers", () => {
     );
   });
 
+  it("controllerClass is per-class — subclasses don't inherit the base's setting", () => {
+    class Base1 extends TestCase {}
+    class Sub1 extends Base1 {}
+    Base1.tests(PostsController);
+    expect(Base1.controllerClass).toBe(PostsController);
+    // Sub1 never set its own controllerClass; it should infer (returns
+    // null here since no matching constant), not pick up Base1's value.
+    expect(Sub1.controllerClass).toBeNull();
+  });
+
   it("controllerClassName returns the configured class name", () => {
     class Sub extends TestCase {}
     Sub.tests(PostsController);

--- a/packages/actionpack/src/action-controller/test-case.test.ts
+++ b/packages/actionpack/src/action-controller/test-case.test.ts
@@ -53,15 +53,20 @@ describe("TestCase class helpers", () => {
 
   it("tests(string) resolves <Name>Controller via globalThis", () => {
     (globalThis as Record<string, unknown>).WidgetController = PostsController;
-    class Sub extends TestCase {}
-    Sub.tests("widget");
-    expect(Sub.controllerClass).toBe(PostsController);
-    delete (globalThis as Record<string, unknown>).WidgetController;
+    try {
+      class Sub extends TestCase {}
+      Sub.tests("widget");
+      expect(Sub.controllerClass).toBe(PostsController);
+    } finally {
+      delete (globalThis as Record<string, unknown>).WidgetController;
+    }
   });
 
-  it("tests(string) raises when no matching constant exists", () => {
+  it("tests(string) raises NameError-style when no matching constant exists", () => {
     class Sub extends TestCase {}
-    expect(() => Sub.tests("nonexistent_blarg")).toThrow(/String or Class/);
+    expect(() => Sub.tests("nonexistent_blarg")).toThrow(
+      /uninitialized constant NonexistentBlargController/,
+    );
   });
 
   it("controllerClassName returns the configured class name", () => {
@@ -73,8 +78,11 @@ describe("TestCase class helpers", () => {
 
   it("determineDefaultControllerClass strips trailing Test and looks up", () => {
     (globalThis as Record<string, unknown>).BooksController = PostsController;
-    expect(TestCase.determineDefaultControllerClass("BooksControllerTest")).toBe(PostsController);
-    expect(TestCase.determineDefaultControllerClass("MissingTest")).toBeNull();
-    delete (globalThis as Record<string, unknown>).BooksController;
+    try {
+      expect(TestCase.determineDefaultControllerClass("BooksControllerTest")).toBe(PostsController);
+      expect(TestCase.determineDefaultControllerClass("MissingTest")).toBeNull();
+    } finally {
+      delete (globalThis as Record<string, unknown>).BooksController;
+    }
   });
 });

--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -90,12 +90,17 @@ export class TestCase {
   /**
    * Mirrors Rails `TestCase.controller_class` / `controller_class=`.
    * Reading lazily falls back to `determineDefaultControllerClass(name)`.
+   * Per-class (not inherited): Rails class ivars don't walk the
+   * superclass chain, so we gate on `Object.hasOwn` to keep subclasses
+   * from picking up the base class's controller.
    */
   static get controllerClass(): ControllerClass | null {
-    if (this._controllerClass) return this._controllerClass;
+    if (Object.hasOwn(this, "_controllerClass") && this._controllerClass) {
+      return this._controllerClass;
+    }
     const inferred = this.determineDefaultControllerClass(this.name);
     if (inferred) this._controllerClass = inferred;
-    return this._controllerClass;
+    return Object.hasOwn(this, "_controllerClass") ? this._controllerClass : null;
   }
   static set controllerClass(v: ControllerClass | null) {
     this._controllerClass = v;

--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -508,7 +508,9 @@ export class TestSession {
     const k = String(key);
     if (this._data.has(k)) return this._data.get(k);
     if (arguments.length >= 2) {
-      return typeof fallback === "function" ? (fallback as () => unknown)() : fallback;
+      // Ruby `Hash#fetch(key) { |k| ... }` yields the missing key to the
+      // block; mirror by passing the stringified key when fallback is callable.
+      return typeof fallback === "function" ? (fallback as (key: string) => unknown)(k) : fallback;
     }
     const err = new Error(`key not found: "${k}"`);
     err.name = "KeyError";

--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -475,9 +475,9 @@ export class TestSession {
     return [...this._data.values()];
   }
 
-  /** Mirrors Rails `TestSession#destroy` — clears the stored data. */
+  /** Mirrors Rails `TestSession#destroy` — `def destroy; clear; end`. */
   destroy(): void {
-    this._data.clear();
+    this.clear();
   }
 
   /** Mirrors Rails `TestSession#dig(*keys)` — first key is coerced to string. */

--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -60,6 +60,63 @@ const STATUS_RANGES: Record<string, [number, number]> = {
 };
 
 export class TestCase {
+  /** @internal Backing slot for the `controllerClass` static accessor. */
+  private static _controllerClass: ControllerClass | null = null;
+
+  /**
+   * Mirrors Rails `TestCase.tests(controller_class)`. Accepts a
+   * controller class or a name that resolves to one. Strings/symbols
+   * receive `"#{name}Controller"` lookup via `globalThis`.
+   */
+  static tests(controllerClass: ControllerClass | string): void {
+    if (typeof controllerClass === "string") {
+      const camel =
+        controllerClass.charAt(0).toUpperCase() +
+        controllerClass.slice(1).replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+      const klass = (globalThis as Record<string, unknown>)[`${camel}Controller`];
+      if (typeof klass !== "function") {
+        throw new Error(`controller class must be a String, Symbol, or Class`);
+      }
+      this._controllerClass = klass as ControllerClass;
+      return;
+    }
+    if (typeof controllerClass !== "function") {
+      throw new Error("controller class must be a String, Symbol, or Class");
+    }
+    this._controllerClass = controllerClass;
+  }
+
+  /**
+   * Mirrors Rails `TestCase.controller_class` / `controller_class=`.
+   * Reading lazily falls back to `determineDefaultControllerClass(name)`.
+   */
+  static get controllerClass(): ControllerClass | null {
+    if (this._controllerClass) return this._controllerClass;
+    const inferred = this.determineDefaultControllerClass(this.name);
+    if (inferred) this._controllerClass = inferred;
+    return this._controllerClass;
+  }
+  static set controllerClass(v: ControllerClass | null) {
+    this._controllerClass = v;
+  }
+
+  /**
+   * Mirrors Rails `determine_default_controller_class(name)` — strips
+   * a trailing `Test` from the class name and looks the result up on
+   * `globalThis`. Returns `null` when no controller class can be found.
+   */
+  static determineDefaultControllerClass(name: string): ControllerClass | null {
+    if (!name) return null;
+    const stripped = name.replace(/Test$/, "");
+    const candidate = (globalThis as Record<string, unknown>)[stripped];
+    return typeof candidate === "function" ? (candidate as ControllerClass) : null;
+  }
+
+  /** Mirrors Rails `controller_class_name` — the class's `controllerClass.name`. */
+  controllerClassName(): string {
+    return (this.constructor as typeof TestCase).controllerClass?.name ?? "";
+  }
+
   private _controllerClass: ControllerClass;
 
   /** The controller instance from the last request. */
@@ -362,6 +419,13 @@ export class LiveTestResponse extends Response {}
 
 export class TestSession {
   private _data = new Map<string, unknown>();
+  /** @internal Mirrors Rails `@id`. */
+  private _id: string;
+
+  constructor(initial: Record<string, unknown> = {}, id?: string) {
+    this._id = id ?? randomHex(16);
+    for (const [k, v] of Object.entries(initial)) this._data.set(String(k), v);
+  }
 
   get(key: string): unknown {
     return this._data.get(key);
@@ -394,6 +458,79 @@ export class TestSession {
   toObject(): Record<string, unknown> {
     return this.toHash();
   }
+
+  /** Mirrors Rails `TestSession#exists?` — always `true`. */
+  isExists(): boolean {
+    return true;
+  }
+
+  /** Mirrors Rails `TestSession#keys` — stored data keys. */
+  keys(): string[] {
+    return [...this._data.keys()];
+  }
+
+  /** Mirrors Rails `TestSession#values` — stored data values. */
+  values(): unknown[] {
+    return [...this._data.values()];
+  }
+
+  /** Mirrors Rails `TestSession#destroy` — clears the stored data. */
+  destroy(): void {
+    this._data.clear();
+  }
+
+  /** Mirrors Rails `TestSession#dig(*keys)` — first key is coerced to string. */
+  dig(...keys: unknown[]): unknown {
+    if (keys.length === 0) return undefined;
+    let cur: unknown = this._data.get(String(keys[0]));
+    for (let i = 1; i < keys.length; i++) {
+      if (cur == null) return undefined;
+      const k = keys[i] as string;
+      if (cur instanceof Map) cur = cur.get(k);
+      else if (typeof cur === "object") cur = (cur as Record<string, unknown>)[k];
+      else return undefined;
+    }
+    return cur;
+  }
+
+  /**
+   * Mirrors Rails `TestSession#fetch(key, *args, &block)`. Returns the
+   * value at `key`; if missing, returns `fallback` (or the result of
+   * `fallback()` when callable), else throws.
+   */
+  fetch(key: string, fallback?: unknown): unknown {
+    const k = String(key);
+    if (this._data.has(k)) return this._data.get(k);
+    if (arguments.length >= 2) {
+      return typeof fallback === "function" ? (fallback as () => unknown)() : fallback;
+    }
+    throw new Error(`key not found: ${k}`);
+  }
+
+  /** Mirrors Rails `TestSession#enabled?` — always `true`. */
+  isEnabled(): boolean {
+    return true;
+  }
+
+  /** Mirrors Rails `TestSession#id_was` — the session id frozen at init. */
+  idWas(): string {
+    return this._id;
+  }
+
+  /** @internal Mirrors Rails private `TestSession#load!` — returns `@id`. */
+  loadBang(): string {
+    return this._id;
+  }
+}
+
+function randomHex(bytes: number): string {
+  let out = "";
+  for (let i = 0; i < bytes; i++) {
+    out += Math.floor(Math.random() * 256)
+      .toString(16)
+      .padStart(2, "0");
+  }
+  return out;
 }
 
 function formatToMime(format: string): string {

--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -525,7 +525,7 @@ export class TestSession {
 }
 
 function randomHex(bytes: number): string {
-  return Buffer.from(getCrypto().randomBytes(bytes)).toString("hex");
+  return getCrypto().randomBytes(bytes).toString("hex");
 }
 
 function formatToMime(format: string): string {

--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -33,6 +33,7 @@
  *   });
  */
 
+import { camelize } from "@blazetrails/activesupport";
 import { Request } from "../action-dispatch/http/request.js";
 import { Response } from "../action-dispatch/http/response.js";
 import { Parameters } from "./metal/strong-parameters.js";
@@ -65,23 +66,24 @@ export class TestCase {
 
   /**
    * Mirrors Rails `TestCase.tests(controller_class)`. Accepts a
-   * controller class or a name that resolves to one. Strings/symbols
-   * receive `"#{name}Controller"` lookup via `globalThis`.
+   * controller class or a string name; the string is camelized + suffixed
+   * with `Controller` and looked up on `globalThis` (the closest JS
+   * analogue to Ruby's `constantize`). Rails also accepts symbols; JS
+   * has no symbol/constant lookup, so the string form covers that case.
    */
   static tests(controllerClass: ControllerClass | string): void {
     if (typeof controllerClass === "string") {
-      const camel =
-        controllerClass.charAt(0).toUpperCase() +
-        controllerClass.slice(1).replace(/_([a-z])/g, (_, c) => c.toUpperCase());
-      const klass = (globalThis as Record<string, unknown>)[`${camel}Controller`];
+      const klass = (globalThis as Record<string, unknown>)[
+        `${camelize(controllerClass)}Controller`
+      ];
       if (typeof klass !== "function") {
-        throw new Error(`controller class must be a String, Symbol, or Class`);
+        throw new Error("controller class must be a String or Class");
       }
       this._controllerClass = klass as ControllerClass;
       return;
     }
     if (typeof controllerClass !== "function") {
-      throw new Error("controller class must be a String, Symbol, or Class");
+      throw new Error("controller class must be a String or Class");
     }
     this._controllerClass = controllerClass;
   }

--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -33,7 +33,7 @@
  *   });
  */
 
-import { camelize } from "@blazetrails/activesupport";
+import { camelize, getCrypto } from "@blazetrails/activesupport";
 import { Request } from "../action-dispatch/http/request.js";
 import { Response } from "../action-dispatch/http/response.js";
 import { Parameters } from "./metal/strong-parameters.js";
@@ -73,11 +73,10 @@ export class TestCase {
    */
   static tests(controllerClass: ControllerClass | string): void {
     if (typeof controllerClass === "string") {
-      const klass = (globalThis as Record<string, unknown>)[
-        `${camelize(controllerClass)}Controller`
-      ];
+      const constantName = `${camelize(controllerClass)}Controller`;
+      const klass = (globalThis as Record<string, unknown>)[constantName];
       if (typeof klass !== "function") {
-        throw new Error("controller class must be a String or Class");
+        throw new Error(`uninitialized constant ${constantName}`);
       }
       this._controllerClass = klass as ControllerClass;
       return;
@@ -526,13 +525,7 @@ export class TestSession {
 }
 
 function randomHex(bytes: number): string {
-  let out = "";
-  for (let i = 0; i < bytes; i++) {
-    out += Math.floor(Math.random() * 256)
-      .toString(16)
-      .padStart(2, "0");
-  }
-  return out;
+  return Buffer.from(getCrypto().randomBytes(bytes)).toString("hex");
 }
 
 function formatToMime(format: string): string {

--- a/packages/actionpack/src/action-controller/test-case.ts
+++ b/packages/actionpack/src/action-controller/test-case.ts
@@ -505,7 +505,9 @@ export class TestSession {
     if (arguments.length >= 2) {
       return typeof fallback === "function" ? (fallback as () => unknown)() : fallback;
     }
-    throw new Error(`key not found: ${k}`);
+    const err = new Error(`key not found: "${k}"`);
+    err.name = "KeyError";
+    throw err;
   }
 
   /** Mirrors Rails `TestSession#enabled?` — always `true`. */


### PR DESCRIPTION
## Summary
- `api/api_rendering.rb` → `api/api-rendering.ts`: 0/12 → **12/12 (100%)** via include-mirror re-exports. ApiRendering `includes Rendering`, so api:compare expects the full Rendering surface on this file. Adds the three missing Rendering names (`render`, `renderToString`, `processAction`) to `metal/rendering.ts` as `@internal` `this`-typed functions mirroring Rails semantics, then re-exports the full surface from `api/api-rendering.ts`.
- `test_case.rb` → `test-case.ts`: 9/49 → **23/49 (47%)**. Wires `TestSession` (`isExists`, `keys`, `values`, `destroy`, `dig`, `fetch`, `isEnabled`, `idWas`, `loadBang`) and `TestCase` class helpers (`tests`, `controllerClass` getter/setter, `determineDefaultControllerClass`, `controllerClassName`).

## Deferred (follow-up PRs)
The remaining 26 test_case methods need TestRequest/TestResponse infrastructure plus ActionView template-assertion wiring. Split per the `<base>` / `<base>b` / `<base>c` pattern:

- `<base>b`: TestRequest helpers (`queryString`, `contentType`, `assignParameters`, `shouldMultipart`, `paramsParsers`, `newSession`, `create`, `defaultEnv`) + TestResponse status predicates (`isSuccess`, `isMissing`, `isError`).
- `<base>c`: `process` / `setupRequest` / `buildResponse` / `wrapExecution` / `processControllerResponse` / `setupControllerRequestAndResponse` / `scrubEnvBang` / `documentRootElement` / `checkRequiredIvars` / `assertTemplate` / `executorAroundEachRequest` / `generatedPath` / `queryParameterNames`.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-controller/api/api-rendering.test.ts`
- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/rendering.test.ts`
- [x] `pnpm tsc --build`
- [x] `pnpm api:compare --package actioncontroller` shows api/api_rendering at 100% and test_case at 47%