### PR TITLE
feat(scripts): wire did-you-mean suggestions into api/test compare + vendor fetch

### DIFF
--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -36,9 +36,11 @@ import {
   DIR_TO_PACKAGES,
   OUTPUT_DIR,
   PACKAGE_DIR_OVERRIDES,
+  PACKAGES,
   ROOT_DIR,
   packageSrcDir,
 } from "./config.js";
+import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
 import { rubyFileToTs, rubyMethodToTs } from "./conventions.js";
 import { isSourceUnported } from "./unported-files.js";
 
@@ -564,6 +566,13 @@ function main() {
     const value = args[pkgIndex + 1];
     if (!value || value.startsWith("--")) {
       console.error("--package requires a package name (e.g. --package activerecord)");
+      process.exit(1);
+    }
+    if (!PACKAGES.includes(value)) {
+      const suggestions = new SpellChecker({ dictionary: PACKAGES }).correct(value);
+      const hint = suggestions.length ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+      console.error(`--package: unknown package "${value}".${hint}`);
+      console.error(`Available: ${PACKAGES.join(", ")}`);
       process.exit(1);
     }
     filterPkg = value;

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -165,7 +165,16 @@ interface TsTestInfo {
 
 function main() {
   const args = process.argv.slice(2);
-  const filterPkg = args.includes("--package") ? args[args.indexOf("--package") + 1] : null;
+  const pkgIndex = args.indexOf("--package");
+  let filterPkg: string | null = null;
+  if (pkgIndex !== -1) {
+    const value = args[pkgIndex + 1];
+    if (!value || value.startsWith("--")) {
+      console.error("--package requires a package name (e.g. --package activerecord)");
+      process.exit(1);
+    }
+    filterPkg = value;
+  }
   const showMissing = args.includes("--missing");
   const jsonOutput = args.includes("--json");
   const showIncomplete = args.includes("--incomplete");

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -34,6 +34,7 @@ import * as fs from "fs";
 import * as path from "path";
 import type { TestManifest } from "./types.js";
 import { isTestCaseUnported, isTestFileUnported } from "../api-compare/unported-files.js";
+import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
 
 const SCRIPT_DIR = __dirname;
 const OUTPUT_DIR = path.join(SCRIPT_DIR, "output");
@@ -179,6 +180,19 @@ function main() {
 
   const ruby: TestManifest = JSON.parse(fs.readFileSync(rubyPath, "utf-8"));
   const ts: TestManifest = JSON.parse(fs.readFileSync(tsPath, "utf-8"));
+
+  if (filterPkg) {
+    const knownPkgs = Array.from(
+      new Set([...Object.keys(ruby.packages), ...Object.keys(ts.packages)]),
+    ).sort();
+    if (!knownPkgs.includes(filterPkg)) {
+      const suggestions = new SpellChecker({ dictionary: knownPkgs }).correct(filterPkg);
+      const hint = suggestions.length ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+      console.error(`--package: unknown package "${filterPkg}".${hint}`);
+      console.error(`Available: ${knownPkgs.join(", ")}`);
+      process.exit(1);
+    }
+  }
 
   // Build TS lookups per package.
   // Per-file, we store an ordered list of test info plus pre-indexed queues

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -34,6 +34,7 @@ import * as fs from "fs";
 import * as path from "path";
 import type { TestManifest } from "./types.js";
 import { isTestCaseUnported, isTestFileUnported } from "../api-compare/unported-files.js";
+import { PACKAGES } from "../api-compare/config.js";
 import { SpellChecker } from "../../packages/did-you-mean/src/spell-checker.js";
 
 const SCRIPT_DIR = __dirname;
@@ -169,6 +170,14 @@ function main() {
   const jsonOutput = args.includes("--json");
   const showIncomplete = args.includes("--incomplete");
 
+  if (filterPkg && !PACKAGES.includes(filterPkg)) {
+    const suggestions = new SpellChecker({ dictionary: PACKAGES }).correct(filterPkg);
+    const hint = suggestions.length ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+    console.error(`--package: unknown package "${filterPkg}".${hint}`);
+    console.error(`Available: ${PACKAGES.join(", ")}`);
+    process.exit(1);
+  }
+
   const rubyPath = path.join(OUTPUT_DIR, "rails-tests.json");
   const tsPath = path.join(OUTPUT_DIR, "ts-tests.json");
 
@@ -180,19 +189,6 @@ function main() {
 
   const ruby: TestManifest = JSON.parse(fs.readFileSync(rubyPath, "utf-8"));
   const ts: TestManifest = JSON.parse(fs.readFileSync(tsPath, "utf-8"));
-
-  if (filterPkg) {
-    const knownPkgs = Array.from(
-      new Set([...Object.keys(ruby.packages), ...Object.keys(ts.packages)]),
-    ).sort();
-    if (!knownPkgs.includes(filterPkg)) {
-      const suggestions = new SpellChecker({ dictionary: knownPkgs }).correct(filterPkg);
-      const hint = suggestions.length ? ` Did you mean: ${suggestions.join(", ")}?` : "";
-      console.error(`--package: unknown package "${filterPkg}".${hint}`);
-      console.error(`Available: ${knownPkgs.join(", ")}`);
-      process.exit(1);
-    }
-  }
 
   // Build TS lookups per package.
   // Per-file, we store an ordered list of test info plus pre-indexed queues

--- a/vendor/fetch.ts
+++ b/vendor/fetch.ts
@@ -26,6 +26,7 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 
 import { libPathsManifest, SOURCES, testPathsManifest, type UpstreamSource } from "./sources.js";
+import { SpellChecker } from "../packages/did-you-mean/src/spell-checker.js";
 
 const VENDOR_DIR = dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = resolve(VENDOR_DIR, "..");
@@ -146,6 +147,12 @@ function verifyPackages(source: UpstreamSource): void {
 }
 
 function printPaths(filter: string | undefined): void {
+  if (filter && !SOURCES.some((s) => s.name === filter)) {
+    const names = SOURCES.map((s) => s.name);
+    const suggestions = new SpellChecker({ dictionary: names }).correct(filter);
+    const hint = suggestions.length ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+    throw new Error(`--print-paths: no entry named "${filter}" in vendor/sources.ts.${hint}`);
+  }
   for (const source of SOURCES) {
     if (filter && source.name !== filter) continue;
     process.stdout.write(destFor(source) + "\n");
@@ -210,7 +217,10 @@ async function main(argv: string[]): Promise<void> {
 
   const targets = args.sourceFilter ? SOURCES.filter((s) => s.name === args.sourceFilter) : SOURCES;
   if (args.sourceFilter && targets.length === 0) {
-    throw new Error(`--source: no entry named "${args.sourceFilter}" in vendor/sources.ts`);
+    const names = SOURCES.map((s) => s.name);
+    const suggestions = new SpellChecker({ dictionary: names }).correct(args.sourceFilter);
+    const hint = suggestions.length ? ` Did you mean: ${suggestions.join(", ")}?` : "";
+    throw new Error(`--source: no entry named "${args.sourceFilter}" in vendor/sources.ts.${hint}`);
   }
 
   // Fetch in parallel: cold runs are sum(clone times) sequentially → max(...)


### PR DESCRIPTION
## Summary
- `scripts/api-compare/compare.ts`: `--package` now validates against `PACKAGES` (previously silently filtered to an empty result) and suggests the nearest match on typo via `SpellChecker`.
- `scripts/test-compare/test-compare.ts`: `--package` validates against the canonical `PACKAGES` list (api-compare/config) **before** loading the rails/ts manifests, so a typo fails fast with a suggestion instead of parsing two large JSON files first. Also rejects `--package` without a value.
- `vendor/fetch.ts`: both `--source <name>` and `--print-paths <name>` suggest the nearest `SOURCES` entry on typo.

Imports are relative into `packages/did-you-mean/src/` (matches how scripts already reach into the workspace) so no root devDep / build step is needed.

## Test plan
- [x] `pnpm tsx vendor/fetch.ts --source ralis` → suggests \`rails\`
- [x] `pnpm tsx vendor/fetch.ts --print-paths rials` → suggests \`rails\`
- [x] `pnpm tsx scripts/api-compare/compare.ts --package activerecrd` → suggests \`activerecord\`
- [x] `pnpm tsx scripts/test-compare/test-compare.ts --package actiopack` → suggests nearest \`PACKAGES\` entry (fails before manifest I/O)
- [x] `pnpm tsx scripts/test-compare/test-compare.ts --package` (no value) → usage error