### PR TITLE
feat(actionpack): middleware/session/mem-cache-store mixin includes (5/10→100%)

### DIFF
--- a/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.test.ts
@@ -31,4 +31,29 @@ describe("ActionDispatch::Session::MemCacheStore", () => {
   it("requires a cache option", () => {
     expect(() => new MemCacheStore(() => undefined, {})).toThrow(/cache/);
   });
+
+  // Rails: `class MemCacheStore < Rack::Session::Dalli; include Compatibility;
+  // include StaleSessionCheck; include SessionObject`. The mixins must land on
+  // MemCacheStore's own prototype (not just inherited via CacheStore) so the
+  // class's effective surface matches Rails.
+  it("registers mixin methods as own properties on the prototype", () => {
+    const proto = MemCacheStore.prototype;
+    const ownNames = [
+      "initializeSid", // Compatibility
+      "makeRequest", // Compatibility
+      "staleSessionCheckBang", // StaleSessionCheck
+      "prepareSession", // SessionObject
+      "loadedSession", // SessionObject
+      "generateSid", // class-defined override; not the Compatibility hex form
+    ];
+    for (const name of ownNames) {
+      expect(Object.prototype.hasOwnProperty.call(proto, name)).toBe(true);
+    }
+  });
+
+  it("keeps generateSid returning SessionId after mixin inclusion", () => {
+    const cache = new MemoryStore();
+    const store = new MemCacheStore(() => undefined, { cache });
+    expect(store.generateSid()).toBeInstanceOf(SessionId);
+  });
 });

--- a/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.ts
@@ -47,7 +47,7 @@ export class MemCacheStore extends CacheStore {
    * copied onto this prototype by the `include` calls below.
    */
   override generateSid(): SessionId {
-    return CacheStore.prototype.generateSid.call(this) as SessionId;
+    return super.generateSid();
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/session/mem-cache-store.ts
@@ -15,6 +15,13 @@
  *   automatically expiring. Falls back to `expires` (Rails alias).
  */
 
+import { include } from "@blazetrails/activesupport";
+import {
+  Compatibility,
+  type SessionId,
+  SessionObject,
+  StaleSessionCheck,
+} from "./abstract-store.js";
 import { CacheStore, type CacheStoreSessionOptions } from "./cache-store.js";
 
 export interface MemCacheStoreSessionOptions extends CacheStoreSessionOptions {
@@ -32,4 +39,22 @@ export class MemCacheStore extends CacheStore {
     }
     super(app, options);
   }
+
+  /**
+   * Preserve the `SessionId`-returning shape inherited from
+   * `AbstractSecureStore` / `CacheStore`. Rails' `Compatibility` mixin
+   * redefines `generate_sid` as a hex string, which would otherwise be
+   * copied onto this prototype by the `include` calls below.
+   */
+  override generateSid(): SessionId {
+    return CacheStore.prototype.generateSid.call(this) as SessionId;
+  }
 }
+
+// Rails: `include Compatibility; include StaleSessionCheck; include SessionObject`.
+// The CacheStore parent also mixes these in, but Rails registers them on
+// MemCacheStore directly (since the parent there is Rack::Session::Dalli),
+// so api:compare expects the methods on MemCacheStore's own surface.
+include(MemCacheStore, Compatibility);
+include(MemCacheStore, StaleSessionCheck);
+include(MemCacheStore, SessionObject);


### PR DESCRIPTION
## Summary

Adds `include(Compatibility)` / `include(StaleSessionCheck)` /
`include(SessionObject)` on `MemCacheStore` so the mixin methods
(`initializeSid`, `makeRequest`, `staleSessionCheckBang`,
`prepareSession`, `loadedSession`) appear on the class's own surface,
matching Rails.

`generateSid` is overridden to keep the inherited `SessionId`-returning
shape (the `Compatibility` mixin would otherwise paper over it with the
hex-string form used by `Rack::Session::Dalli`).

- `middleware/session/mem_cache_store.rb`: 5/10 → 10/10 ✓

## Notes on other sweep targets

The other actiondispatch leaves named in the brief turned out to be
either blocked or substantial rewrites rather than fidelity polish, so
they're left for a future pass:

- `journey/router.ts` (`visualizer`) — depends on Rails-side ERB +
  the unported `to_svg` graphviz helper on `GTG::TransitionTable`.
  Already documented as out-of-scope at the call site.
- `testing/assertions.ts` (`htmlDocument`) — depends on
  `rails-dom-testing` (Nokogiri / DOM parser); intentionally not
  exported until that lands.
- `middleware/debug-view.ts` (`render`) — wraps `ActionView::Base#render`
  with logger silencing; needs `ActionView::Base` first.
- `middleware/debug-exceptions.ts` (`renderForBrowserRequest`,
  `createTemplate`) — Rails renders rescue templates via `DebugView` /
  ActionView. The trails port builds HTML inline, so the Rails-shaped
  template surface needs ActionView::Base.
- `middleware/session/cookie-store.ts` (9 missing) — current port is a
  bespoke `load`/`save`/`cookieOptions` design; Rails-shaped
  `deleteSession` / `loadSession` / `cookieJar` etc. would be a full
  rewrite on top of `AbstractSecureStore` + the cookies cookie-jar
  bridge, not a fidelity tweak.
- `http/mime-type.rb` (18 missing) — most live on the internal `Mimes`
  / `AcceptItem` / `AcceptList` helper classes the TS port doesn't
  model; needs a structural refactor.
- `http/permissions-policy.rb` (7 missing) — the TS port targets the
  modern Permissions-Policy header syntax; Rails' `apply_mappings` /
  `build_directives` / `resolve_source` belong to the legacy
  Feature-Policy design. Tests already pin the modern format, so
  closing the gap means picking which surface to keep.
- `deprecator.rb` (0/18) — extractor attributes the cookies-config
  attrs (`cookie_jar`, `key_generator`, …) that live on
  `middleware/cookies.rb` to `deprecator.rb`; nothing to port here.

## Test plan
- [x] `pnpm vitest run packages/actionpack/.../session/{mem-cache,cache,abstract}-store.test.ts`
- [x] `pnpm api:compare` confirms `mem_cache_store.rb` → 10/10