### PR TITLE
feat(actionpack): api-rendering + metal leaves to 100% (392→413)

### DIFF
--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -308,6 +308,50 @@ export class Metal extends AbstractController {
   static resolveStatus = resolveStatus;
 
   /**
+   * Rails `Metal.build_middleware` — wraps a middleware klass + args
+   * into the action-aware `:only`/`:except` predicate form consumed by
+   * the dispatch middleware stack.
+   *
+   * @internal
+   */
+  static buildMiddleware(
+    klass: MiddlewareEntry["klass"],
+    args: unknown[],
+    _block?: unknown,
+  ): Middleware & { valid(action: string): boolean } {
+    const next = [...args];
+    const last = next[next.length - 1];
+    // Clone the options object so we can safely delete `only`/`except`
+    // without mutating the caller's hash (Rails' `extract_options!` pops
+    // the trailing hash off `args` — the hash itself is still the caller's
+    // reference; trails defensively copies to avoid surprising the caller).
+    const options: Record<string, unknown> =
+      last && typeof last === "object" && !Array.isArray(last)
+        ? { ...(next.pop() as Record<string, unknown>) }
+        : {};
+    const only = ([] as string[]).concat((options.only as string | string[]) ?? []).map(String);
+    const except = ([] as string[]).concat((options.except as string | string[]) ?? []).map(String);
+    delete options.only;
+    delete options.except;
+    if (Object.keys(options).length > 0) next.push(options);
+
+    let strategy: (list: string[] | null, action: string) => boolean = () => true;
+    let list: string[] | null = null;
+    if (only.length > 0) {
+      strategy = (l, a) => (l ?? []).includes(a);
+      list = only;
+    } else if (except.length > 0) {
+      strategy = (l, a) => !(l ?? []).includes(a);
+      list = except;
+    }
+    const wrapped = new Middleware(klass, next) as Middleware & {
+      valid(action: string): boolean;
+    };
+    wrapped.valid = (action: string) => strategy(list, action);
+    return wrapped;
+  }
+
+  /**
    * Composes the Rails `render_to_body` chain. With `ActionController::Base`'s
    * include order, the effective chain is:
    *

--- a/packages/actionpack/src/action-controller/metal/conditional-get.ts
+++ b/packages/actionpack/src/action-controller/metal/conditional-get.ts
@@ -10,6 +10,18 @@
 
 import { getCrypto } from "@blazetrails/activesupport";
 
+import { includeContent as _includeContent } from "./head.js";
+
+/**
+ * Rails `Head#include_content?` — re-exposed because `ConditionalGet`
+ * includes `Head`, so the predicate is part of its mixed-in surface.
+ *
+ * @internal
+ */
+export function includeContent(status: number): boolean {
+  return _includeContent(status);
+}
+
 export function generateWeakEtag(seed: string): string {
   const hash = getCrypto().createHash("sha256").update(seed).digest("hex").slice(0, 32);
   return `W/"${hash}"`;

--- a/packages/actionpack/src/action-controller/metal/implicit-render.ts
+++ b/packages/actionpack/src/action-controller/metal/implicit-render.ts
@@ -8,6 +8,103 @@
 
 import { UnknownFormat, MissingExactTemplate } from "./exceptions.js";
 
+import { sendAction as _sendAction } from "./basic-implicit-render.js";
+
+/**
+ * Rails `BasicImplicitRender#send_action` — re-exposed because
+ * `ImplicitRender` includes `BasicImplicitRender`.
+ *
+ * @internal
+ */
+export function sendAction(
+  controller: { performed: boolean; head(status: number): void },
+  method: () => unknown,
+): unknown {
+  return _sendAction(controller, method);
+}
+
+interface ImplicitRenderHost {
+  performed: boolean;
+  actionName: string;
+  controllerName?: string;
+  request?: {
+    isGet?(): boolean;
+    get?: boolean;
+    format?: { ref?: string; symbol?: string | null };
+    isXhr?(): boolean;
+    xhr?: boolean;
+  };
+  templateExists?(action: string, prefixes?: unknown, opts?: unknown): boolean;
+  anyTemplates?(action: string, prefixes?: unknown): boolean;
+  head(status: number): void;
+  render(): void;
+  logger?: { info(msg: string): void };
+}
+
+/**
+ * Rails `ImplicitRender#default_render` — picks a template, raises with
+ * UnknownFormat / MissingExactTemplate, or falls back to `head :no_content`.
+ *
+ * @internal
+ */
+export function defaultRender(this: ImplicitRenderHost): void {
+  if (this.templateExists?.(this.actionName)) {
+    this.render();
+    return;
+  }
+  if (this.anyTemplates?.(this.actionName)) {
+    const name = this.controllerName ?? "";
+    throw new UnknownFormat(
+      `${name}#${this.actionName} is missing a template for this request format and variant.`,
+    );
+  }
+  if (isInteractiveBrowserRequest.call(this)) {
+    const name = this.controllerName ?? "";
+    throw new MissingExactTemplate(
+      `${name}#${this.actionName} is missing a template for request formats.`,
+      name,
+      this.actionName,
+    );
+  }
+  this.logger?.info(
+    `No template found for ${this.controllerName ?? ""}#${this.actionName}, rendering head :no_content`,
+  );
+  this.head(204);
+}
+
+/**
+ * Rails `ImplicitRender#method_for_action` — Rails returns the string
+ * `"default_render"`; trails uses camelCase identifiers per CLAUDE.md
+ * so we return `"defaultRender"`, matching the export name on this
+ * module.
+ *
+ * @internal
+ */
+export function methodForAction(
+  this: ImplicitRenderHost & { _superMethodForAction?(name: string): string | undefined },
+  actionName: string,
+): string | undefined {
+  const sup = this._superMethodForAction?.(actionName);
+  if (sup) return sup;
+  if (this.templateExists?.(actionName)) return "defaultRender";
+  return undefined;
+}
+
+/**
+ * Rails `ImplicitRender#interactive_browser_request?` — GET request for
+ * HTML content that isn't an XHR.
+ *
+ * @internal
+ */
+export function isInteractiveBrowserRequest(this: ImplicitRenderHost): boolean {
+  const req = this.request;
+  if (!req) return false;
+  const isGet = typeof req.isGet === "function" ? req.isGet() : req.get === true;
+  const isHtml = req.format?.ref === "html" || req.format?.symbol === "html";
+  const isXhr = typeof req.isXhr === "function" ? req.isXhr() : req.xhr === true;
+  return Boolean(isGet) && Boolean(isHtml) && !isXhr;
+}
+
 export function implicitRender(context: {
   performed: boolean;
   actionName: string;

--- a/packages/actionpack/src/action-controller/metal/instrumentation.ts
+++ b/packages/actionpack/src/action-controller/metal/instrumentation.ts
@@ -73,6 +73,43 @@ export function instrumentRender(
   return { result, viewRuntime };
 }
 
+/**
+ * Rails `Instrumentation#halted_callback_hook` — emitted by AS::Callbacks
+ * whenever a before-action halts the chain.
+ *
+ * @internal
+ */
+export function haltedCallbackHook(filter: unknown, _name?: unknown, notifier?: Notifier): void {
+  notifier?.instrument("halted_callback.action_controller", { filter });
+}
+
+/**
+ * Rails `Instrumentation#cleanup_view_runtime` — wrapper hook for
+ * subclasses (e.g. AR's ControllerRuntime) to subtract DB time from
+ * view runtime. The default just yields.
+ *
+ * @internal
+ */
+export function cleanupViewRuntime<T>(block: () => T): T {
+  return block();
+}
+
+/**
+ * Rails `Instrumentation#append_info_to_payload` — extension hook for
+ * subclasses to enrich the `process_action` payload. Default copies
+ * `viewRuntime` onto the payload.
+ *
+ * @internal
+ */
+export function appendInfoToPayload(
+  this: { viewRuntime?: number } | undefined,
+  payload: Record<string, unknown>,
+): void {
+  if (this && this.viewRuntime !== undefined) {
+    payload.viewRuntime = this.viewRuntime;
+  }
+}
+
 export function logProcessAction(payload: Record<string, unknown>): string[] {
   const messages: string[] = [];
   const viewRuntime = payload.view_runtime ?? payload.viewRuntime;


### PR DESCRIPTION
## Summary

actioncontroller: **392/581 (67.5%) → 413/581 (71.1%)**.

5 files closed to 100%:
- `api/api-rendering.ts` 0/12 → **12/12** — delegating wrappers for the 11 methods inherited from `Rendering` plus the existing `render_to_body`.
- `metal.ts` 18/19 → **19/19** — `Metal.buildMiddleware` mirroring Rails' `:only`/`:except` strategy wrapping.
- `metal/conditional-get.ts` 9/10 → **10/10** — re-exposes `Head#include_content?` (ConditionalGet includes Head).
- `metal/implicit-render.ts` 0/4 → **4/4** — `defaultRender`, `methodForAction`, `isInteractiveBrowserRequest`, plus delegated `sendAction`.
- `metal/instrumentation.ts` 7/10 → **10/10** — `haltedCallbackHook`, `cleanupViewRuntime`, `appendInfoToPayload`.

`metal/rendering.ts` gains `render`, `renderToString`, `processAction` so api-rendering can delegate.

## Test plan
- [x] `pnpm tsx scripts/api-compare/compare.ts --package actioncontroller` — all 5 targeted files at 100%
- [x] `vitest run` for conditional-get, api-rendering, http-authentication — passes
- [x] LOC under 300 ceiling (290)

## Follow-ups
- `metal/strong-parameters.ts` 65/89 — handled in next PR
- `abstract-controller/base.ts` 90.2% drop — handled in next PR