### PR TITLE
feat(did-you-mean): track in api:compare (3/3 ported files at 100%)

### DIFF
--- a/packages/did-you-mean/src/edit-distance/test-jaro-winkler.test.ts
+++ b/packages/did-you-mean/src/edit-distance/test-jaro-winkler.test.ts
@@ -1,0 +1,36 @@
+// Port of vendor/did_you_mean/test/edit_distance/test_jaro_winkler.rb.
+// Test names mirror the Ruby file so test:compare matches.
+import { describe, it, expect } from "vitest";
+
+import { JaroWinkler } from "../jaro-winkler.js";
+
+function assertDistance(score: number, str1: string, str2: string): void {
+  expect(round4(JaroWinkler.distance(str1, str2))).toBe(score);
+}
+
+function round4(n: number): number {
+  return Math.round(n * 10000) / 10000;
+}
+
+describe("JaroWinklerTest", () => {
+  it("jaro winkler distance", () => {
+    assertDistance(0.9667, "henka", "henkan");
+    assertDistance(1.0, "al", "al");
+    assertDistance(0.9611, "martha", "marhta");
+    assertDistance(0.8324, "jones", "johnson");
+    assertDistance(0.9167, "abcvwxyz", "zabcvwxy");
+    assertDistance(0.9583, "abcvwxyz", "cabvwxyz");
+    assertDistance(0.84, "dwayne", "duane");
+    assertDistance(0.8133, "dixon", "dicksonx");
+    assertDistance(0.0, "fvie", "ten");
+    assertDistance(0.9067, "does_exist", "doesnt_exist");
+    assertDistance(1.0, "x", "x");
+  });
+
+  it("jarowinkler distance with utf8 strings", () => {
+    assertDistance(0.9818, "變形金剛4:絕跡重生", "變形金剛4: 絕跡重生");
+    assertDistance(0.8222, "連勝文", "連勝丼");
+    assertDistance(0.8222, "馬英九", "馬英丸");
+    assertDistance(0.6667, "良い", "いい");
+  });
+});

--- a/packages/did-you-mean/src/index.ts
+++ b/packages/did-you-mean/src/index.ts
@@ -1,4 +1,4 @@
-export { levenshteinDistance } from "./levenshtein.js";
-export { jaroDistance, jaroWinklerDistance } from "./jaro-winkler.js";
+export { Levenshtein, levenshteinDistance } from "./levenshtein.js";
+export { Jaro, JaroWinkler, jaroDistance, jaroWinklerDistance } from "./jaro-winkler.js";
 export { SpellChecker } from "./spell-checker.js";
 export type { SpellCheckerOptions } from "./spell-checker.js";

--- a/packages/did-you-mean/src/index.ts
+++ b/packages/did-you-mean/src/index.ts
@@ -1,4 +1,4 @@
-export { Levenshtein, levenshteinDistance } from "./levenshtein.js";
-export { Jaro, JaroWinkler, jaroDistance, jaroWinklerDistance } from "./jaro-winkler.js";
+export { Levenshtein } from "./levenshtein.js";
+export { Jaro, JaroWinkler } from "./jaro-winkler.js";
 export { SpellChecker } from "./spell-checker.js";
 export type { SpellCheckerOptions } from "./spell-checker.js";

--- a/packages/did-you-mean/src/jaro-winkler.test.ts
+++ b/packages/did-you-mean/src/jaro-winkler.test.ts
@@ -1,7 +1,7 @@
 // Oracle values computed via Ruby 3.3 did_you_mean's
 // DidYouMean::Jaro.distance and DidYouMean::JaroWinkler.distance.
 import { describe, it, expect } from "vitest";
-import { jaroDistance, jaroWinklerDistance } from "./jaro-winkler.js";
+import { Jaro, JaroWinkler } from "./jaro-winkler.js";
 
 const EPS = 1e-9;
 
@@ -9,63 +9,63 @@ function close(actual: number, expected: number) {
   expect(Math.abs(actual - expected)).toBeLessThan(EPS);
 }
 
-describe("jaroDistance", () => {
+describe("Jaro.distance", () => {
   it("is 1 for identical strings and 0 for fully disjoint", () => {
-    expect(jaroDistance("foo", "foo")).toBe(1);
-    expect(jaroDistance("foo", "qux")).toBe(0);
+    expect(Jaro.distance("foo", "foo")).toBe(1);
+    expect(Jaro.distance("foo", "qux")).toBe(0);
   });
 
   it("is 0 when either string is empty", () => {
-    expect(jaroDistance("", "")).toBe(0);
-    expect(jaroDistance("a", "")).toBe(0);
-    expect(jaroDistance("", "b")).toBe(0);
+    expect(Jaro.distance("", "")).toBe(0);
+    expect(Jaro.distance("a", "")).toBe(0);
+    expect(Jaro.distance("", "b")).toBe(0);
   });
 
   it("matches Ruby oracle values for canonical cases", () => {
-    close(jaroDistance("MARTHA", "MARHTA"), 0.9444444444444444);
-    close(jaroDistance("DIXON", "DICKSONX"), 0.7666666666666667);
-    close(jaroDistance("JELLYFISH", "SMELLYFISH"), 0.8962962962962963);
-    close(jaroDistance("foo", "fooo"), 0.9166666666666666);
-    close(jaroDistance("foo", "fobr"), 0.7222222222222222);
-    close(jaroDistance("abc", "abcd"), 0.9166666666666666);
-    close(jaroDistance("abcd", "abc"), 0.9166666666666666);
-    close(jaroDistance("kitten", "sitting"), 0.746031746031746);
-    close(jaroDistance("receive", "recieve"), 0.9523809523809524);
-    close(jaroDistance("shwo", "show"), 0.9166666666666666);
-    close(jaroDistance("ab", "ba"), 0);
+    close(Jaro.distance("MARTHA", "MARHTA"), 0.9444444444444444);
+    close(Jaro.distance("DIXON", "DICKSONX"), 0.7666666666666667);
+    close(Jaro.distance("JELLYFISH", "SMELLYFISH"), 0.8962962962962963);
+    close(Jaro.distance("foo", "fooo"), 0.9166666666666666);
+    close(Jaro.distance("foo", "fobr"), 0.7222222222222222);
+    close(Jaro.distance("abc", "abcd"), 0.9166666666666666);
+    close(Jaro.distance("abcd", "abc"), 0.9166666666666666);
+    close(Jaro.distance("kitten", "sitting"), 0.746031746031746);
+    close(Jaro.distance("receive", "recieve"), 0.9523809523809524);
+    close(Jaro.distance("shwo", "show"), 0.9166666666666666);
+    close(Jaro.distance("ab", "ba"), 0);
   });
 
   it("is symmetric to argument order (Ruby swaps internally)", () => {
-    close(jaroDistance("DIXON", "DICKSONX"), jaroDistance("DICKSONX", "DIXON"));
-    close(jaroDistance("foo", "fooo"), jaroDistance("fooo", "foo"));
+    close(Jaro.distance("DIXON", "DICKSONX"), Jaro.distance("DICKSONX", "DIXON"));
+    close(Jaro.distance("foo", "fooo"), Jaro.distance("fooo", "foo"));
   });
 
   it("treats accented characters as single codepoints", () => {
-    close(jaroDistance("café", "cafe"), 0.8333333333333334);
-    expect(jaroDistance("café", "café")).toBe(1);
+    close(Jaro.distance("café", "cafe"), 0.8333333333333334);
+    expect(Jaro.distance("café", "café")).toBe(1);
   });
 });
 
-describe("jaroWinklerDistance", () => {
+describe("JaroWinkler.distance", () => {
   it("equals Jaro distance when Jaro <= 0.7", () => {
-    expect(jaroWinklerDistance("foo", "qux")).toBe(0);
-    close(jaroWinklerDistance("kitten", "sitting"), 0.746031746031746);
+    expect(JaroWinkler.distance("foo", "qux")).toBe(0);
+    close(JaroWinkler.distance("kitten", "sitting"), 0.746031746031746);
     // kitten/sitting share no prefix, so JW == Jaro even above the threshold.
   });
 
   it("applies a prefix bonus when Jaro > 0.7", () => {
-    close(jaroWinklerDistance("MARTHA", "MARHTA"), 0.9611111111111111);
-    close(jaroWinklerDistance("DIXON", "DICKSONX"), 0.8133333333333332);
-    close(jaroWinklerDistance("foo", "fooo"), 0.9416666666666667);
-    close(jaroWinklerDistance("foo", "fobr"), 0.7777777777777778);
-    close(jaroWinklerDistance("abc", "abcd"), 0.9416666666666667);
-    close(jaroWinklerDistance("receive", "recieve"), 0.9666666666666667);
-    close(jaroWinklerDistance("shwo", "show"), 0.9333333333333332);
-    close(jaroWinklerDistance("café", "cafe"), 0.8833333333333334);
+    close(JaroWinkler.distance("MARTHA", "MARHTA"), 0.9611111111111111);
+    close(JaroWinkler.distance("DIXON", "DICKSONX"), 0.8133333333333332);
+    close(JaroWinkler.distance("foo", "fooo"), 0.9416666666666667);
+    close(JaroWinkler.distance("foo", "fobr"), 0.7777777777777778);
+    close(JaroWinkler.distance("abc", "abcd"), 0.9416666666666667);
+    close(JaroWinkler.distance("receive", "recieve"), 0.9666666666666667);
+    close(JaroWinkler.distance("shwo", "show"), 0.9333333333333332);
+    close(JaroWinkler.distance("café", "cafe"), 0.8833333333333334);
   });
 
   it("caps prefix bonus at 4 codepoints", () => {
     // JELLYFISH/SMELLYFISH share no common prefix → no bonus.
-    close(jaroWinklerDistance("JELLYFISH", "SMELLYFISH"), 0.8962962962962963);
+    close(JaroWinkler.distance("JELLYFISH", "SMELLYFISH"), 0.8962962962962963);
   });
 });

--- a/packages/did-you-mean/src/jaro-winkler.ts
+++ b/packages/did-you-mean/src/jaro-winkler.ts
@@ -8,97 +8,89 @@ function codepoints(s: string): number[] {
   return out;
 }
 
-/** Jaro distance over Unicode codepoints. */
-export function jaroDistance(str1: string, str2: string): number {
-  let cp1 = codepoints(str1);
-  let cp2 = codepoints(str2);
-  if (cp1.length > cp2.length) {
-    const tmp = cp1;
-    cp1 = cp2;
-    cp2 = tmp;
-  }
-  const length1 = cp1.length;
-  const length2 = cp2.length;
-
-  if (length2 === 0) return 0;
-
-  let m = 0;
-  let t = 0;
-  const range = length2 > 3 ? Math.floor(length2 / 2) - 1 : 0;
-  const flags1 = new Uint8Array(length1);
-  const flags2 = new Uint8Array(length2);
-
-  for (let i = 0; i < length1; i++) {
-    const last = i + range;
-    let j = i >= range ? i - range : 0;
-    const jEnd = last < length2 - 1 ? last : length2 - 1;
-    while (j <= jEnd) {
-      if (flags2[j] === 0 && cp1[i] === cp2[j]) {
-        flags2[j] = 1;
-        flags1[i] = 1;
-        m += 1;
-        break;
-      }
-      j += 1;
+/** Mirrors Ruby `DidYouMean::Jaro.distance`. */
+export class Jaro {
+  /** Jaro distance over Unicode codepoints. */
+  static distance(str1: string, str2: string): number {
+    let cp1 = codepoints(str1);
+    let cp2 = codepoints(str2);
+    if (cp1.length > cp2.length) {
+      const tmp = cp1;
+      cp1 = cp2;
+      cp2 = tmp;
     }
-  }
+    const length1 = cp1.length;
+    const length2 = cp2.length;
 
-  if (m === 0) return 0;
+    if (length2 === 0) return 0;
 
-  let k = 0;
-  for (let i = 0; i < length1; i++) {
-    if (flags1[i] !== 0) {
-      // flags1 and flags2 carry the same number of set bits (m matches),
-      // so this scan always finds one.
-      let j = k;
-      let index = k;
-      while (j < length2) {
-        index = j;
-        if (flags2[j] !== 0) {
-          k = j + 1;
+    let m = 0;
+    let t = 0;
+    const range = length2 > 3 ? Math.floor(length2 / 2) - 1 : 0;
+    const flags1 = new Uint8Array(length1);
+    const flags2 = new Uint8Array(length2);
+
+    for (let i = 0; i < length1; i++) {
+      const last = i + range;
+      let j = i >= range ? i - range : 0;
+      const jEnd = last < length2 - 1 ? last : length2 - 1;
+      while (j <= jEnd) {
+        if (flags2[j] === 0 && cp1[i] === cp2[j]) {
+          flags2[j] = 1;
+          flags1[i] = 1;
+          m += 1;
           break;
         }
         j += 1;
       }
-      if (cp1[i] !== cp2[index]) t += 1;
     }
-  }
-  t = Math.floor(t / 2);
 
-  return (m / length1 + m / length2 + (m - t) / m) / 3;
-}
+    if (m === 0) return 0;
 
-/** Mirrors Ruby `DidYouMean::Jaro.distance`. */
-export class Jaro {
-  static distance(str1: string, str2: string): number {
-    return jaroDistance(str1, str2);
+    let k = 0;
+    for (let i = 0; i < length1; i++) {
+      if (flags1[i] !== 0) {
+        // flags1 and flags2 carry the same number of set bits (m matches),
+        // so this scan always finds one.
+        let j = k;
+        let index = k;
+        while (j < length2) {
+          index = j;
+          if (flags2[j] !== 0) {
+            k = j + 1;
+            break;
+          }
+          j += 1;
+        }
+        if (cp1[i] !== cp2[index]) t += 1;
+      }
+    }
+    t = Math.floor(t / 2);
+
+    return (m / length1 + m / length2 + (m - t) / m) / 3;
   }
 }
 
 const JW_WEIGHT = 0.1;
 const JW_THRESHOLD = 0.7;
 
-/** Jaro-Winkler distance (boost for shared prefixes up to length 4). */
-export function jaroWinklerDistance(str1: string, str2: string): number {
-  const j = jaroDistance(str1, str2);
-  if (j <= JW_THRESHOLD) return j;
-
-  const cp1 = codepoints(str1);
-  const cp2 = codepoints(str2);
-  let prefixBonus = 0;
-  for (let i = 0; i < cp1.length; i++) {
-    if (cp1[i] === cp2[prefixBonus] && prefixBonus < 4) {
-      prefixBonus += 1;
-    } else {
-      break;
-    }
-  }
-  return j + prefixBonus * JW_WEIGHT * (1 - j);
-}
-
 /** Mirrors Ruby `DidYouMean::JaroWinkler.distance`. */
 export class JaroWinkler {
+  /** Jaro-Winkler distance (boost for shared prefixes up to length 4). */
   static distance(str1: string, str2: string): number {
-    return jaroWinklerDistance(str1, str2);
+    const j = Jaro.distance(str1, str2);
+    if (j <= JW_THRESHOLD) return j;
+
+    const cp1 = codepoints(str1);
+    const cp2 = codepoints(str2);
+    let prefixBonus = 0;
+    for (let i = 0; i < cp1.length; i++) {
+      if (cp1[i] === cp2[prefixBonus] && prefixBonus < 4) {
+        prefixBonus += 1;
+      } else {
+        break;
+      }
+    }
+    return j + prefixBonus * JW_WEIGHT * (1 - j);
   }
 }

--- a/packages/did-you-mean/src/jaro-winkler.ts
+++ b/packages/did-you-mean/src/jaro-winkler.ts
@@ -68,6 +68,13 @@ export function jaroDistance(str1: string, str2: string): number {
   return (m / length1 + m / length2 + (m - t) / m) / 3;
 }
 
+/** Mirrors Ruby `DidYouMean::Jaro.distance`. */
+export class Jaro {
+  static distance(str1: string, str2: string): number {
+    return jaroDistance(str1, str2);
+  }
+}
+
 const JW_WEIGHT = 0.1;
 const JW_THRESHOLD = 0.7;
 
@@ -87,4 +94,11 @@ export function jaroWinklerDistance(str1: string, str2: string): number {
     }
   }
   return j + prefixBonus * JW_WEIGHT * (1 - j);
+}
+
+/** Mirrors Ruby `DidYouMean::JaroWinkler.distance`. */
+export class JaroWinkler {
+  static distance(str1: string, str2: string): number {
+    return jaroWinklerDistance(str1, str2);
+  }
 }

--- a/packages/did-you-mean/src/levenshtein.test.ts
+++ b/packages/did-you-mean/src/levenshtein.test.ts
@@ -1,45 +1,45 @@
 // Oracle values computed via Ruby 3.3 did_you_mean's
 // DidYouMean::Levenshtein.distance.
 import { describe, it, expect } from "vitest";
-import { levenshteinDistance } from "./levenshtein.js";
+import { Levenshtein } from "./levenshtein.js";
 
-describe("levenshteinDistance", () => {
+describe("Levenshtein.distance", () => {
   it("returns 0 for identical strings", () => {
-    expect(levenshteinDistance("foo", "foo")).toBe(0);
+    expect(Levenshtein.distance("foo", "foo")).toBe(0);
   });
 
   it("returns length of the other when one is empty", () => {
-    expect(levenshteinDistance("", "")).toBe(0);
-    expect(levenshteinDistance("abc", "")).toBe(3);
-    expect(levenshteinDistance("", "abc")).toBe(3);
+    expect(Levenshtein.distance("", "")).toBe(0);
+    expect(Levenshtein.distance("abc", "")).toBe(3);
+    expect(Levenshtein.distance("", "abc")).toBe(3);
   });
 
   it("counts insertions and deletions", () => {
-    expect(levenshteinDistance("foo", "fooo")).toBe(1);
-    expect(levenshteinDistance("abcd", "abc")).toBe(1);
+    expect(Levenshtein.distance("foo", "fooo")).toBe(1);
+    expect(Levenshtein.distance("abcd", "abc")).toBe(1);
   });
 
   it("counts substitutions and transpositions", () => {
-    expect(levenshteinDistance("foo", "fobr")).toBe(2);
-    expect(levenshteinDistance("foo", "qux")).toBe(3);
-    expect(levenshteinDistance("MARTHA", "MARHTA")).toBe(2);
-    expect(levenshteinDistance("DIXON", "DICKSONX")).toBe(4);
-    expect(levenshteinDistance("kitten", "sitting")).toBe(3);
-    expect(levenshteinDistance("receive", "recieve")).toBe(2);
-    expect(levenshteinDistance("shwo", "show")).toBe(2);
-    expect(levenshteinDistance("ab", "ba")).toBe(2);
+    expect(Levenshtein.distance("foo", "fobr")).toBe(2);
+    expect(Levenshtein.distance("foo", "qux")).toBe(3);
+    expect(Levenshtein.distance("MARTHA", "MARHTA")).toBe(2);
+    expect(Levenshtein.distance("DIXON", "DICKSONX")).toBe(4);
+    expect(Levenshtein.distance("kitten", "sitting")).toBe(3);
+    expect(Levenshtein.distance("receive", "recieve")).toBe(2);
+    expect(Levenshtein.distance("shwo", "show")).toBe(2);
+    expect(Levenshtein.distance("ab", "ba")).toBe(2);
   });
 
   it("counts a non-BMP codepoint as one edit (codepoint iteration)", () => {
     // Ruby's Levenshtein.distance("𝐀", "") == 1
-    expect(levenshteinDistance("\u{1D400}", "")).toBe(1);
-    expect(levenshteinDistance("\u{1D400}", "\u{1D400}")).toBe(0);
-    expect(levenshteinDistance("a\u{1D400}", "a")).toBe(1);
+    expect(Levenshtein.distance("\u{1D400}", "")).toBe(1);
+    expect(Levenshtein.distance("\u{1D400}", "\u{1D400}")).toBe(0);
+    expect(Levenshtein.distance("a\u{1D400}", "a")).toBe(1);
   });
 
   it("treats accented characters as single codepoints", () => {
     // "café" → "cafe" differs in one codepoint
-    expect(levenshteinDistance("café", "cafe")).toBe(1);
-    expect(levenshteinDistance("café", "café")).toBe(0);
+    expect(Levenshtein.distance("café", "cafe")).toBe(1);
+    expect(Levenshtein.distance("café", "café")).toBe(0);
   });
 });

--- a/packages/did-you-mean/src/levenshtein.ts
+++ b/packages/did-you-mean/src/levenshtein.ts
@@ -17,6 +17,13 @@ function min3(a: number, b: number, c: number): number {
   return c;
 }
 
+/** Mirrors Ruby `DidYouMean::Levenshtein.distance`. */
+export class Levenshtein {
+  static distance(str1: string, str2: string): number {
+    return levenshteinDistance(str1, str2);
+  }
+}
+
 /** Two-row dynamic-programming Levenshtein distance, codepoint-aware. */
 export function levenshteinDistance(str1: string, str2: string): number {
   const cp1 = codepoints(str1);

--- a/packages/did-you-mean/src/levenshtein.ts
+++ b/packages/did-you-mean/src/levenshtein.ts
@@ -19,37 +19,33 @@ function min3(a: number, b: number, c: number): number {
 
 /** Mirrors Ruby `DidYouMean::Levenshtein.distance`. */
 export class Levenshtein {
+  /** Two-row dynamic-programming Levenshtein distance, codepoint-aware. */
   static distance(str1: string, str2: string): number {
-    return levenshteinDistance(str1, str2);
-  }
-}
+    const cp1 = codepoints(str1);
+    const cp2 = codepoints(str2);
+    const n = cp1.length;
+    const m = cp2.length;
+    if (n === 0) return m;
+    if (m === 0) return n;
 
-/** Two-row dynamic-programming Levenshtein distance, codepoint-aware. */
-export function levenshteinDistance(str1: string, str2: string): number {
-  const cp1 = codepoints(str1);
-  const cp2 = codepoints(str2);
-  const n = cp1.length;
-  const m = cp2.length;
-  if (n === 0) return m;
-  if (m === 0) return n;
+    const d: number[] = [];
+    for (let k = 0; k <= m; k++) d.push(k);
+    let x = 0;
 
-  const d: number[] = [];
-  for (let k = 0; k <= m; k++) d.push(k);
-  let x = 0;
-
-  for (let idx = 0; idx < n; idx++) {
-    let i = idx + 1;
-    const char1 = cp1[idx];
-    let j = 0;
-    while (j < m) {
-      const cost = char1 === cp2[j] ? 0 : 1;
-      x = min3(d[j + 1] + 1, i + 1, d[j] + cost);
-      d[j] = i;
-      i = x;
-      j += 1;
+    for (let idx = 0; idx < n; idx++) {
+      let i = idx + 1;
+      const char1 = cp1[idx];
+      let j = 0;
+      while (j < m) {
+        const cost = char1 === cp2[j] ? 0 : 1;
+        x = min3(d[j + 1] + 1, i + 1, d[j] + cost);
+        d[j] = i;
+        i = x;
+        j += 1;
+      }
+      d[m] = x;
     }
-    d[m] = x;
-  }
 
-  return x;
+    return x;
+  }
 }

--- a/packages/did-you-mean/src/spell-checker.ts
+++ b/packages/did-you-mean/src/spell-checker.ts
@@ -1,8 +1,8 @@
 // Ported from Ruby's did_you_mean/spell_checker.rb
 // (https://github.com/ruby/did_you_mean), MIT License.
 
-import { jaroWinklerDistance } from "./jaro-winkler.js";
-import { levenshteinDistance } from "./levenshtein.js";
+import { JaroWinkler } from "./jaro-winkler.js";
+import { Levenshtein } from "./levenshtein.js";
 
 export interface SpellCheckerOptions {
   dictionary: ReadonlyArray<string>;
@@ -42,12 +42,12 @@ export class SpellChecker {
     for (let i = 0; i < this.#dictionary.length; i++) {
       const word = this.#dictionary[i];
       if (rawInput === String(word)) continue;
-      const jw = jaroWinklerDistance(normalize(word), normalizedInput);
+      const jw = JaroWinkler.distance(normalize(word), normalizedInput);
       if (jw < jwThreshold) continue;
       candidates.push({
         word,
         index: i,
-        score: jaroWinklerDistance(String(word), normalizedInput),
+        score: JaroWinkler.distance(String(word), normalizedInput),
       });
     }
 
@@ -61,7 +61,7 @@ export class SpellChecker {
 
     const mistypeThreshold = Math.ceil(inputLen * 0.25);
     let corrections = candidates
-      .filter((c) => levenshteinDistance(normalize(c.word), normalizedInput) <= mistypeThreshold)
+      .filter((c) => Levenshtein.distance(normalize(c.word), normalizedInput) <= mistypeThreshold)
       .map((c) => c.word);
 
     if (corrections.length === 0) {
@@ -69,7 +69,7 @@ export class SpellChecker {
         .filter((c) => {
           const w = normalize(c.word);
           const len = Math.min(inputLen, codepointLength(w));
-          return levenshteinDistance(w, normalizedInput) < len;
+          return Levenshtein.distance(w, normalizedInput) < len;
         })
         .slice(0, 1)
         .map((c) => c.word);

--- a/packages/did-you-mean/src/test-spell-checker.test.ts
+++ b/packages/did-you-mean/src/test-spell-checker.test.ts
@@ -1,0 +1,66 @@
+// Port of vendor/did_you_mean/test/test_spell_checker.rb.
+// Test names mirror the Ruby file so test:compare matches.
+import { describe, it, expect } from "vitest";
+
+import { SpellChecker } from "./spell-checker.js";
+
+function assertSpell(expected: string | string[], input: string, dictionary: string[]): void {
+  const corrections = new SpellChecker({ dictionary }).correct(input);
+  expect(corrections).toEqual(Array.isArray(expected) ? expected : [expected]);
+}
+
+describe("SpellCheckerTest", () => {
+  it("spell checker corrects mistypes", () => {
+    assertSpell("foo", "doo", ["foo", "fork"]);
+    assertSpell("email", "meail", ["email", "fail", "eval"]);
+    assertSpell("fail", "fial", ["email", "fail", "eval"]);
+    assertSpell("fail", "afil", ["email", "fail", "eval"]);
+    assertSpell("eval", "eavl", ["email", "fail", "eval"]);
+    assertSpell("eval", "veal", ["email", "fail", "eval"]);
+    assertSpell("sub!", "suv!", ["sub", "gsub", "sub!"]);
+    assertSpell("sub", "suv", ["sub", "gsub", "sub!"]);
+    assertSpell("Foo", "FOo", ["Foo", "FOo"]);
+
+    assertSpell(["gsub!", "gsub"], "gsuv!", ["sub", "gsub", "gsub!"]);
+    assertSpell(["sub!", "sub", "gsub!"], "ssub!", ["sub", "sub!", "gsub", "gsub!"]);
+
+    const groupMethods = ["groups", "group_url", "groups_url", "group_path"];
+    assertSpell("groups", "group", groupMethods);
+
+    const groupClasses = [
+      "GroupMembership",
+      "GroupMembershipPolicy",
+      "GroupMembershipDecorator",
+      "GroupMembershipSerializer",
+      "GroupHelper",
+      "Group",
+      "GroupMailer",
+      "NullGroupMembership",
+    ];
+    assertSpell("GroupMembership", "GroupMemberhip", groupClasses);
+    assertSpell("GroupMembershipDecorator", "GroupMemberhipDecorator", groupClasses);
+
+    const names = ["first_name_change", "first_name_changed?", "first_name_will_change!"];
+    assertSpell(names, "first_name_change!", names);
+
+    expect(new SpellChecker({ dictionary: ["proc"] }).correct("product_path")).toEqual([]);
+    expect(new SpellChecker({ dictionary: ["fork"] }).correct("fooo")).toEqual([]);
+  });
+
+  it("spell checker corrects misspells", () => {
+    assertSpell("descendants", "dependents", ["descendants"]);
+    assertSpell("drag_to", "drag", ["drag_to"]);
+    assertSpell("set_result_count", "set_result", ["set_result_count"]);
+  });
+
+  it("spell checker sorts results by simiarity", () => {
+    const actual = new SpellChecker({
+      dictionary: ["name12", "name123", "name1234", "name12345", "name123456"],
+    }).correct("name123456");
+    expect(actual).toEqual(["name12345", "name1234", "name123"]);
+  });
+
+  it("spell checker excludes input from dictionary", () => {
+    expect(new SpellChecker({ dictionary: ["input"] }).correct("input")).toEqual([]);
+  });
+});

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -870,7 +870,7 @@ function main() {
     const excludedFiles = new Set<string>();
     for (const item of allRuby) {
       const file = item.info.file || "unknown.rb";
-      if (isSourceUnported(file)) {
+      if (isSourceUnported(file, pkg)) {
         excludedFiles.add(file);
         continue;
       }
@@ -1116,7 +1116,7 @@ function main() {
       };
 
       for (const { fqn, info } of allRuby) {
-        if (!info.file || isSourceUnported(info.file)) continue;
+        if (!info.file || isSourceUnported(info.file, pkg)) continue;
         if (primaryClassPerFile.get(info.file) !== fqn) continue;
         // `allRuby` mixes classes and modules; modules don't carry superclass.
         if (!(fqn in rubyPkg.classes)) continue;

--- a/scripts/api-compare/unported-files.test.ts
+++ b/scripts/api-compare/unported-files.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+
+import { isSourceUnported, UNPORTED_FILES, type UnportedFile } from "./unported-files.js";
+
+describe("isSourceUnported package scoping", () => {
+  it("matches an unscoped pattern across every package", () => {
+    expect(isSourceUnported("promise.rb", "activerecord")).toBe(true);
+    expect(isSourceUnported("promise.rb", "activesupport")).toBe(true);
+    expect(isSourceUnported("promise.rb")).toBe(true);
+  });
+
+  it("matches a package-scoped pattern only inside that package", () => {
+    // did-you-mean and activesupport both ship `core_ext/name_error.rb`,
+    // but only did-you-mean's is unported.
+    expect(isSourceUnported("core_ext/name_error.rb", "did-you-mean")).toBe(true);
+    expect(isSourceUnported("core_ext/name_error.rb", "activesupport")).toBe(false);
+  });
+
+  it("treats an absent pkg argument as 'any package' to preserve legacy callers", () => {
+    expect(isSourceUnported("core_ext/name_error.rb")).toBe(true);
+  });
+
+  it("does not match unrelated source files", () => {
+    expect(isSourceUnported("some/unrelated/file.rb", "did-you-mean")).toBe(false);
+  });
+});
+
+describe("UNPORTED_FILES schema", () => {
+  it("only uses `package` on entries that also have a `pattern`", () => {
+    // testFile-only entries operate on test paths, where the test-extractor
+    // already namespaces by package — `package` would be redundant there.
+    for (const entry of UNPORTED_FILES as UnportedFile[]) {
+      if (entry.package !== undefined) {
+        expect(entry.pattern, `entry ${JSON.stringify(entry)} must have a pattern`).toBeTruthy();
+      }
+    }
+  });
+});

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -21,7 +21,11 @@
 // `testFile` because their TS source counterparts either don't exist or
 // are being actively ported.
 
-export type UnportedFile = { reason: string } & (
+// `package` (optional) scopes the entry to a single api-compare package.
+// Without it, the `pattern` substring is matched across every package — used
+// for shared file basenames (e.g. `core_ext/name_error.rb` exists in both
+// activesupport and did_you_mean) where the exclusion should only apply to one.
+export type UnportedFile = { reason: string; package?: string } & (
   | { pattern: string; testFile?: string; tests?: never }
   | { pattern?: string; testFile: string; tests?: never }
   // Per-test exclusion: test-only — never affects api:compare.
@@ -472,6 +476,93 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "`SignedGlobalID#equals` contract is symmetric only within its own " +
       "class. Same-class equality is covered by `value equality`.",
   },
+  // --- did-you-mean: Ruby-only checkers ---
+  // The DidYouMean port is scoped to the algorithms Rails consumes
+  // (SpellChecker + Jaro/JaroWinkler/Levenshtein). The remaining files
+  // patch Ruby's exception hierarchy (NameError#corrections via
+  // core_ext/name_error.rb + formatter.rb), or implement checkers that
+  // suggest names for Ruby-only failure modes — NoMethodError method
+  // names, NameError class/variable names, KeyError keys,
+  // NoMatchingPatternKeyError keys, $LOAD_PATH require targets. None of
+  // these map onto JS errors.
+  {
+    package: "did-you-mean",
+    pattern: "core_ext/name_error.rb",
+    reason:
+      "Patches Ruby's NameError with `corrections`, `original_message`, " +
+      "`detailed_message`, `spell_checker`. JS has no NameError; trails " +
+      "errors carry their own per-subclass `corrections` getter (see " +
+      "ActionNotFound, ParameterMissing, AssociationNotFoundError, etc.).",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "formatter.rb",
+    reason:
+      "Formats `Did you mean? …` suffix for Ruby's Exception#detailed_message " +
+      "integration. JS error stringification is per-error, not via a stdlib hook.",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "spell_checkers/key_error_checker.rb",
+    reason: "Suggests Hash/ENV keys on Ruby KeyError. JS Map/object access doesn't raise.",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "spell_checkers/method_name_checker.rb",
+    reason:
+      "Suggests method names on Ruby NoMethodError using receiver.methods. " +
+      "JS has no NoMethodError; undefined property access returns undefined.",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "spell_checkers/name_error_checkers.rb",
+    reason: "Dispatcher for class/variable name checkers; both checkers are Ruby-only (see below).",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "spell_checkers/name_error_checkers/class_name_checker.rb",
+    reason:
+      "Suggests constant/class names by walking Module#constants + ancestor scopes. " +
+      "Ruby-only — JS has no equivalent constant introspection.",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "spell_checkers/name_error_checkers/variable_name_checker.rb",
+    reason:
+      "Suggests local/instance/class variable names from Binding#local_variables, " +
+      "Object#instance_variables, etc. Ruby-only introspection surface.",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "spell_checkers/null_checker.rb",
+    reason:
+      "Null-object fallback in Ruby's checker registry. Not needed in our " +
+      "error-subclass approach.",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "spell_checkers/pattern_key_name_checker.rb",
+    reason:
+      "Suggests keys on Ruby NoMatchingPatternKeyError (one-liner pattern matching). " +
+      "No JS equivalent.",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "spell_checkers/require_path_checker.rb",
+    reason:
+      "Suggests $LOAD_PATH targets on Ruby LoadError. JS module resolution is " +
+      "engine-handled and doesn't surface this kind of typo suggestion.",
+  },
+  {
+    package: "did-you-mean",
+    pattern: "tree_spell_checker.rb",
+    reason:
+      "Path-segment spell checker used by Rails::TestUnit::InvalidTestError to " +
+      "suggest test file paths. Pre-1.0 scope: trails doesn't yet port " +
+      "`bin/rails test` runner wiring, and the algorithm has no other consumer " +
+      "in the call sites we target.",
+  },
+
   // --- globalid: Ruby-Marshal exact-token assertion ---
   {
     testFile: "verifier_test.rb",
@@ -489,8 +580,13 @@ export const UNPORTED_FILES: UnportedFile[] = [
   },
 ];
 
-export function isSourceUnported(file: string): boolean {
-  return UNPORTED_FILES.some((e) => e.pattern && file.includes(e.pattern));
+export function isSourceUnported(file: string, pkg?: string): boolean {
+  return UNPORTED_FILES.some(
+    (e) =>
+      e.pattern &&
+      file.includes(e.pattern) &&
+      (e.package === undefined || pkg === undefined || e.package === pkg),
+  );
 }
 
 export function isTestFileUnported(testFile: string): boolean {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -15,16 +15,18 @@
 //                (from extract-ruby-tests.rb, e.g. "message_pack_test.rb").
 //                Consumed by isTestFileUnported() → test:compare.
 //                Omit when there is no corresponding Rails test file.
+//   `package`  — (optional) scopes a `pattern` entry to one api-compare
+//                package. Required when the same source basename exists in
+//                more than one package — e.g. `core_ext/name_error.rb`
+//                lives in both activesupport and did_you_mean and the
+//                exclusion should only apply to one. Unscoped patterns
+//                match across all packages.
 //
 // Most entries set both (source and test excluded together).
 // Test-only entries (GVL, Rake, dbconsole, Ruby serialization) set only
 // `testFile` because their TS source counterparts either don't exist or
 // are being actively ported.
 
-// `package` (optional) scopes the entry to a single api-compare package.
-// Without it, the `pattern` substring is matched across every package — used
-// for shared file basenames (e.g. `core_ext/name_error.rb` exists in both
-// activesupport and did_you_mean) where the exclusion should only apply to one.
 export type UnportedFile = { reason: string; package?: string } & (
   | { pattern: string; testFile?: string; tests?: never }
   | { pattern?: string; testFile: string; tests?: never }

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -27,15 +27,19 @@
 // `testFile` because their TS source counterparts either don't exist or
 // are being actively ported.
 
-export type UnportedFile = { reason: string; package?: string } & (
-  | { pattern: string; testFile?: string; tests?: never }
-  | { pattern?: string; testFile: string; tests?: never }
-  // Per-test exclusion: test-only — never affects api:compare.
-  // Only the listed Ruby test descriptions are dropped from test:compare counts.
-  // `className` narrows the match to a specific Ruby *Test class within the file,
-  // enabling exclusion of GVL-only subclasses that share test names with portable ones.
-  | { pattern?: never; testFile: string; className?: string; tests: string[] }
-);
+export type UnportedFile = { reason: string } &
+  // `package` is only valid alongside `pattern`: it scopes the source-path
+  // substring match to one api-compare package. testFile-only and per-test
+  // entries operate on Ruby test paths which the test extractor already
+  // namespaces per-package, so `package` would have no effect there.
+  (| { pattern: string; testFile?: string; tests?: never; package?: string }
+    | { pattern?: string; testFile: string; tests?: never }
+    // Per-test exclusion: test-only — never affects api:compare.
+    // Only the listed Ruby test descriptions are dropped from test:compare counts.
+    // `className` narrows the match to a specific Ruby *Test class within the file,
+    // enabling exclusion of GVL-only subclasses that share test names with portable ones.
+    | { pattern?: never; testFile: string; className?: string; tests: string[] }
+  );
 
 export const UNPORTED_FILES: UnportedFile[] = [
   {
@@ -490,6 +494,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   {
     package: "did-you-mean",
     pattern: "core_ext/name_error.rb",
+    testFile: "core_ext/test_name_error_extension.rb",
     reason:
       "Patches Ruby's NameError with `corrections`, `original_message`, " +
       "`detailed_message`, `spell_checker`. JS has no NameError; trails " +
@@ -506,11 +511,13 @@ export const UNPORTED_FILES: UnportedFile[] = [
   {
     package: "did-you-mean",
     pattern: "spell_checkers/key_error_checker.rb",
+    testFile: "spell_checking/test_key_name_check.rb",
     reason: "Suggests Hash/ENV keys on Ruby KeyError. JS Map/object access doesn't raise.",
   },
   {
     package: "did-you-mean",
     pattern: "spell_checkers/method_name_checker.rb",
+    testFile: "spell_checking/test_method_name_check.rb",
     reason:
       "Suggests method names on Ruby NoMethodError using receiver.methods. " +
       "JS has no NoMethodError; undefined property access returns undefined.",
@@ -523,6 +530,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   {
     package: "did-you-mean",
     pattern: "spell_checkers/name_error_checkers/class_name_checker.rb",
+    testFile: "spell_checking/test_class_name_check.rb",
     reason:
       "Suggests constant/class names by walking Module#constants + ancestor scopes. " +
       "Ruby-only — JS has no equivalent constant introspection.",
@@ -530,6 +538,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   {
     package: "did-you-mean",
     pattern: "spell_checkers/name_error_checkers/variable_name_checker.rb",
+    testFile: "spell_checking/test_variable_name_check.rb",
     reason:
       "Suggests local/instance/class variable names from Binding#local_variables, " +
       "Object#instance_variables, etc. Ruby-only introspection surface.",
@@ -537,6 +546,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   {
     package: "did-you-mean",
     pattern: "spell_checkers/null_checker.rb",
+    testFile: "spell_checking/test_uncorrectable_name_check.rb",
     reason:
       "Null-object fallback in Ruby's checker registry. Not needed in our " +
       "error-subclass approach.",
@@ -544,6 +554,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   {
     package: "did-you-mean",
     pattern: "spell_checkers/pattern_key_name_checker.rb",
+    testFile: "spell_checking/test_pattern_key_name_check.rb",
     reason:
       "Suggests keys on Ruby NoMatchingPatternKeyError (one-liner pattern matching). " +
       "No JS equivalent.",
@@ -551,6 +562,7 @@ export const UNPORTED_FILES: UnportedFile[] = [
   {
     package: "did-you-mean",
     pattern: "spell_checkers/require_path_checker.rb",
+    testFile: "spell_checking/test_require_path_check.rb",
     reason:
       "Suggests $LOAD_PATH targets on Ruby LoadError. JS module resolution is " +
       "engine-handled and doesn't surface this kind of typo suggestion.",
@@ -558,11 +570,30 @@ export const UNPORTED_FILES: UnportedFile[] = [
   {
     package: "did-you-mean",
     pattern: "tree_spell_checker.rb",
+    testFile: "test_tree_spell_checker.rb",
     reason:
       "Path-segment spell checker used by Rails::TestUnit::InvalidTestError to " +
       "suggest test file paths. Pre-1.0 scope: trails doesn't yet port " +
       "`bin/rails test` runner wiring, and the algorithm has no other consumer " +
       "in the call sites we target.",
+  },
+  {
+    testFile: "tree_spell/test_change_word.rb",
+    reason: "tree_spell helper test — excluded transitively with tree_spell_checker.rb.",
+  },
+  {
+    testFile: "tree_spell/test_explore.rb",
+    reason: "tree_spell helper test — excluded transitively with tree_spell_checker.rb.",
+  },
+  {
+    testFile: "tree_spell/test_human_typo.rb",
+    reason: "tree_spell helper test — excluded transitively with tree_spell_checker.rb.",
+  },
+  {
+    testFile: "test_ractor_compatibility.rb",
+    reason:
+      "Exercises Ruby's Ractor (actor-model concurrency) isolation guarantees " +
+      "for DidYouMean checkers. JS has no Ractor equivalent.",
   },
 
   // --- globalid: Ruby-Marshal exact-token assertion ---
@@ -583,12 +614,12 @@ export const UNPORTED_FILES: UnportedFile[] = [
 ];
 
 export function isSourceUnported(file: string, pkg?: string): boolean {
-  return UNPORTED_FILES.some(
-    (e) =>
-      e.pattern &&
-      file.includes(e.pattern) &&
-      (e.package === undefined || pkg === undefined || e.package === pkg),
-  );
+  return UNPORTED_FILES.some((e) => {
+    if (!e.pattern || !file.includes(e.pattern)) return false;
+    // `package` only exists on the pattern-bearing variant of the union.
+    const scope = "package" in e ? e.package : undefined;
+    return scope === undefined || pkg === undefined || scope === pkg;
+  });
 }
 
 export function isTestFileUnported(testFile: string): boolean {

--- a/scripts/test-compare/extract-ts-tests.ts
+++ b/scripts/test-compare/extract-ts-tests.ts
@@ -20,6 +20,7 @@ function getPackageTestFiles(): Record<string, string[]> {
     "actionview",
     "trailties",
     "globalid",
+    "did-you-mean",
   ];
   const packageAliases: Record<string, string> = {};
   const result: Record<string, string[]> = {};

--- a/scripts/test-compare/test-compare.ts
+++ b/scripts/test-compare/test-compare.ts
@@ -679,6 +679,7 @@ function extractRelativeTsPath(fullPath: string, pkg: string): string {
     actionview: "packages/actionview/src/",
     trailties: "packages/trailties/src/",
     globalid: "packages/globalid/src/",
+    "did-you-mean": "packages/did-you-mean/src/",
   };
 
   const prefix = pkgDirs[pkg];

--- a/vendor/sources.lock.json
+++ b/vendor/sources.lock.json
@@ -1,5 +1,9 @@
 {
   "sources": {
+    "did_you_mean": {
+      "ref": "v1.6.3",
+      "sha": "f7703add765054b6e63ef581818a0c307fdd4abf"
+    },
     "globalid": {
       "ref": "v1.3.0",
       "sha": "a10102196ceaa9ffec3744eda857ebe421a57134"

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -134,6 +134,25 @@ export const SOURCES: readonly UpstreamSource[] = [
     packages: [{ name: "rack", libPath: "lib/rack", testPath: "test" }],
   },
   {
+    name: "did_you_mean",
+    origin: {
+      type: "git",
+      url: "https://github.com/ruby/did_you_mean.git",
+      ref: "v1.6.3",
+    },
+    packages: [
+      {
+        // TS-side workspace dir is `packages/did-you-mean/src`; api-compare
+        // derives that from the package name, so use the kebab form.
+        name: "did-you-mean",
+        libPath: "lib/did_you_mean",
+        // No testPath — did_you_mean's test/ uses a different layout from
+        // Rails (test/did_you_mean/spell_checking/*) and we aren't wiring
+        // test-compare for this package yet.
+      },
+    ],
+  },
+  {
     name: "globalid",
     origin: {
       type: "git",

--- a/vendor/sources.ts
+++ b/vendor/sources.ts
@@ -146,9 +146,7 @@ export const SOURCES: readonly UpstreamSource[] = [
         // derives that from the package name, so use the kebab form.
         name: "did-you-mean",
         libPath: "lib/did_you_mean",
-        // No testPath — did_you_mean's test/ uses a different layout from
-        // Rails (test/did_you_mean/spell_checking/*) and we aren't wiring
-        // test-compare for this package yet.
+        testPath: "test",
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Register `ruby/did_you_mean` v1.6.3 as a new upstream source in `vendor/sources.ts` so `did-you-mean` flows through into `api:compare`'s PACKAGES list automatically. Same entry adds `testPath: "test"` so `test:compare` picks it up too.
- Expose `Jaro`, `JaroWinkler`, and `Levenshtein` classes (impl bodies live on the static methods) mirroring Ruby's `module_function` shape. **Breaking pre-1.0 change**: the lower-case `jaroDistance` / `jaroWinklerDistance` / `levenshteinDistance` function exports are removed — the class form is the single canonical surface. Only internal callers (the package's own `SpellChecker`) used them.
- Add an optional `package` field to `UnportedFile` so a `pattern` substring can be scoped to one api-compare package. Constrained at the type level to the pattern-bearing variant of the union, since testFile-only / per-test entries already namespace by package via the test extractor. Needed because `core_ext/name_error.rb` exists in both `activesupport` and `did_you_mean` and we only want to exclude the latter.
- Mark 11 Ruby-only did_you_mean source files unported (NameError patches, `formatter.rb`, the six `spell_checkers/*` checkers, `tree_spell_checker.rb`) and the 13 Ruby-only test files (Ractor compat, NameError extension test, the seven `spell_checking/*` checker tests, `tree_spell_checker` + helpers). Each entry documents why it doesn't map to JS.
- Add Ruby-mirror test files so the portable Ruby suites match by convention path and test name: `edit-distance/test-jaro-winkler.test.ts`, `test-spell-checker.test.ts`. Bodies port the upstream assertions verbatim. Existing oracle test files stay for extra coverage.

Result:
- `pnpm api:compare --package did-you-mean` → **6/6 methods (100%), 3/3 files**
- `pnpm test:compare --package did-you-mean` → **6/6 tests (100%), 2/2 files**

## Test plan
- [x] `pnpm api:compare --package did-you-mean` → 100%
- [x] `pnpm test:compare --package did-you-mean` → 100%
- [x] `pnpm api:compare --package activesupport` still tracks its own `core_ext/name_error.rb` (3/3 missing, unchanged)
- [x] `pnpm vitest run packages/did-you-mean scripts/api-compare/unported-files.test.ts` → 38/38 pass
- [x] `pnpm --filter @blazetrails/did-you-mean build` clean
- [x] `pnpm lint` clean