### PR TITLE
feat(actionpack): wire SpellChecker into UrlGenerationError#corrections

### DIFF
--- a/packages/actionpack/src/action-controller/metal/exceptions.test.ts
+++ b/packages/actionpack/src/action-controller/metal/exceptions.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { UrlGenerationError } from "./exceptions.js";
+
+function makeRoutes(helperNames: string[]) {
+  return { namedRoutes: { helperNames } };
+}
+
+describe("UrlGenerationError#corrections", () => {
+  it("returns SpellChecker suggestions narrowed by substring grep", () => {
+    const err = new UrlGenerationError(
+      "missing",
+      makeRoutes(["user_path", "users_path", "post_path", "comment_path"]),
+      "user_pat",
+      null,
+    );
+    expect(err.corrections).toContain("user_path");
+  });
+
+  it("excludes the exact methodName from the grep dictionary", () => {
+    const err = new UrlGenerationError(
+      "missing",
+      makeRoutes(["user_path", "users_path"]),
+      "user_pat",
+      "user_path",
+    );
+    expect(err.corrections).not.toContain("user_path");
+  });
+
+  it("returns [] when routeName is null", () => {
+    const err = new UrlGenerationError("missing", makeRoutes(["user_path"]), null, null);
+    expect(err.corrections).toEqual([]);
+  });
+
+  it("returns [] when routes is null", () => {
+    const err = new UrlGenerationError("missing", null, "user_path", null);
+    expect(err.corrections).toEqual([]);
+  });
+
+  it("memoizes the result", () => {
+    const err = new UrlGenerationError(
+      "missing",
+      makeRoutes(["user_path", "users_path"]),
+      "user_path",
+      null,
+    );
+    expect(err.corrections).toBe(err.corrections);
+  });
+});

--- a/packages/actionpack/src/action-controller/metal/exceptions.ts
+++ b/packages/actionpack/src/action-controller/metal/exceptions.ts
@@ -5,6 +5,8 @@
  * @see https://api.rubyonrails.org/classes/ActionController.html
  */
 
+import { SpellChecker } from "@blazetrails/did-you-mean";
+
 import type { RouteSetLike } from "../../abstract-controller/url-for.js";
 
 export class ActionControllerError extends Error {
@@ -42,6 +44,7 @@ export class UrlGenerationError extends ActionControllerError {
   readonly routes: unknown;
   readonly routeName: string | null;
   readonly methodName: string | null;
+  #cachedCorrections: string[] | null = null;
 
   constructor(
     message: string,
@@ -56,17 +59,24 @@ export class UrlGenerationError extends ActionControllerError {
     this.methodName = methodName;
   }
 
+  /**
+   * Rails parity: grep `helper_names` for substrings of `route_name`,
+   * drop the exact `method_name`, then run `SpellChecker` against the
+   * filtered dictionary.
+   * @see vendor/rails/actionpack/lib/action_controller/metal/exceptions.rb
+   */
   get corrections(): string[] {
-    if (!this.routeName || !this.routes) return [];
-    // `this.routes` may be a full `RouteSetLike` OR a Journey
-    // `FormatterHost` (which has `namedRoutes.has/get`, not
-    // `namedRoutes.helperNames`). Treat both shapes as optional.
+    if (this.#cachedCorrections !== null) return this.#cachedCorrections;
+    if (!this.routeName || !this.routes) {
+      this.#cachedCorrections = [];
+      return this.#cachedCorrections;
+    }
     const routes = this.routes as Partial<RouteSetLike> | undefined;
     const helpers = routes?.namedRoutes?.helperNames ?? [];
-    const target = this.routeName.toLowerCase();
-    return helpers
-      .filter((name) => name !== this.methodName && name.toLowerCase().includes(target))
-      .slice(0, 5);
+    const pattern = new RegExp(this.routeName);
+    const maybeThese = helpers.filter((name) => pattern.test(name) && name !== this.methodName);
+    this.#cachedCorrections = new SpellChecker({ dictionary: maybeThese }).correct(this.routeName);
+    return this.#cachedCorrections;
   }
 }
 


### PR DESCRIPTION
## Summary

- Replace `UrlGenerationError#corrections` substring-match suggestion with the Rails-canonical `SpellChecker` pipeline: grep `helperNames` by `routeName`, drop the exact `methodName`, then run `@blazetrails/did-you-mean` against the filtered dictionary.
- Memoize the result, matching Rails' `@corrections ||=` idiom.
- Adds focused vitest coverage.

Mirrors `vendor/rails/actionpack/lib/action_controller/metal/exceptions.rb`.

Part of the did-you-mean port plan (`docs/did-you-mean-port-plan.md`); remaining call sites: Association*Error (activerecord) and `Template::Error` (actionview, needs `jaroDistance` export).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-controller/metal/exceptions.test.ts`
- [ ] CI green