### PR TITLE
feat(actionpack): abstract-controller class statics to 100% (74→82)

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -7,6 +7,7 @@
  */
 
 import { SpellChecker } from "@blazetrails/did-you-mean";
+import { underscore } from "@blazetrails/activesupport";
 
 import {
   _defineActionCallbacks,
@@ -113,7 +114,7 @@ export class AbstractController {
     const name = this.name ?? "";
     if (!name) return "";
     const stripped = name.endsWith("Controller") ? name.slice(0, -"Controller".length) : name;
-    const path = stripped.replace(/([a-z\d])([A-Z])/g, "$1_$2").toLowerCase();
+    const path = underscore(stripped);
     (this as unknown as { _controllerPathCache?: string })._controllerPathCache = path;
     return path;
   }

--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -66,6 +66,127 @@ export class ActionNotFound extends Error {
 }
 
 export class AbstractController {
+  /**
+   * Rails `attr_reader :abstract` (class-level) — backing storage for
+   * the abstract-marker bit set by `abstractBang`. Subclasses default
+   * to `false`; controllers used only as bases (Metal, Base) flip it
+   * to `true` so their public-instance methods get removed from
+   * `actionMethods`.
+   *
+   * @internal
+   */
+  static abstract: boolean = false;
+
+  /**
+   * Rails `abstract?` predicate alias (`alias_method :abstract?, :abstract`).
+   * Reads the abstract flag.
+   *
+   * @internal
+   */
+  static isAbstract(): boolean {
+    return Boolean(this.abstract);
+  }
+
+  /**
+   * Rails `abstract!` — flag this controller class as abstract.
+   *
+   * @internal
+   */
+  static abstractBang(): void {
+    this.abstract = true;
+  }
+
+  /**
+   * Rails `controller_path` (class method) — `name.delete_suffix("Controller").underscore`,
+   * memoised. Returns the empty string for anonymous subclasses.
+   *
+   * @internal
+   */
+  static controllerPath(): string {
+    if (
+      Object.prototype.hasOwnProperty.call(this, "_controllerPathCache") &&
+      typeof (this as unknown as { _controllerPathCache?: string })._controllerPathCache ===
+        "string"
+    ) {
+      return (this as unknown as { _controllerPathCache: string })._controllerPathCache;
+    }
+    const name = this.name ?? "";
+    if (!name) return "";
+    const stripped = name.endsWith("Controller") ? name.slice(0, -"Controller".length) : name;
+    const path = stripped.replace(/([a-z\d])([A-Z])/g, "$1_$2").toLowerCase();
+    (this as unknown as { _controllerPathCache?: string })._controllerPathCache = path;
+    return path;
+  }
+
+  /**
+   * Rails `internal_methods` — returns the instance method names that
+   * should NOT be treated as action methods. Walks ancestors until the
+   * first abstract class is found, then returns its full public-instance
+   * surface minus the methods owned by the concrete leaves.
+   *
+   * @internal
+   */
+  static internalMethods(): string[] {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let cls: typeof AbstractController = this;
+    const ownedByConcrete: string[] = [];
+    while (cls && !cls.isAbstract()) {
+      const proto = cls.prototype as object | null;
+      if (proto) {
+        for (const name of Object.getOwnPropertyNames(proto)) {
+          if (name === "constructor") continue;
+          const d = Object.getOwnPropertyDescriptor(proto, name);
+          if (d && typeof d.value === "function") ownedByConcrete.push(name);
+        }
+      }
+      const parent = Object.getPrototypeOf(cls) as typeof AbstractController | null;
+      if (!parent || parent === Function.prototype) break;
+      cls = parent;
+    }
+    const all: string[] = [];
+    let proto: object | null = cls?.prototype ?? null;
+    while (proto && proto !== Object.prototype) {
+      for (const name of Object.getOwnPropertyNames(proto)) {
+        if (name === "constructor") continue;
+        const d = Object.getOwnPropertyDescriptor(proto, name);
+        if (d && typeof d.value === "function") all.push(name);
+      }
+      proto = Object.getPrototypeOf(proto);
+    }
+    const owned = new Set(ownedByConcrete);
+    return all.filter((n) => !owned.has(n));
+  }
+
+  /**
+   * Rails `clear_action_methods!` — drops the memoised action methods so
+   * the next `actionMethods` call recomputes. Called by `method_added`.
+   *
+   * @internal
+   */
+  static clearActionMethodsBang(): void {
+    (this as unknown as { _actionMethodCache?: Set<string> })._actionMethodCache = undefined;
+  }
+
+  /**
+   * Rails `method_added(name)` — `super; clear_action_methods!`. JS has
+   * no native method-added hook; this is exposed so framework code that
+   * defines methods at runtime (e.g. via metaprogramming) can call it.
+   *
+   * @internal
+   */
+  static methodAdded(_name: string): void {
+    this.clearActionMethodsBang();
+  }
+
+  /**
+   * Rails `eager_load!` — warm the action-methods cache and return nil.
+   *
+   * @internal
+   */
+  static eagerLoadBang(): void {
+    this.actionMethods();
+  }
+
   /** The action currently being processed. */
   actionName: string = "";
 

--- a/packages/actionpack/src/action-controller/metal.ts
+++ b/packages/actionpack/src/action-controller/metal.ts
@@ -308,6 +308,50 @@ export class Metal extends AbstractController {
   static resolveStatus = resolveStatus;
 
   /**
+   * Rails `Metal.build_middleware` — wraps a middleware klass + args
+   * into the action-aware `:only`/`:except` predicate form consumed by
+   * the dispatch middleware stack.
+   *
+   * @internal
+   */
+  static buildMiddleware(
+    klass: MiddlewareEntry["klass"],
+    args: unknown[],
+    _block?: unknown,
+  ): Middleware & { valid(action: string): boolean } {
+    const next = [...args];
+    const last = next[next.length - 1];
+    // Clone the options object so we can safely delete `only`/`except`
+    // without mutating the caller's hash (Rails' `extract_options!` pops
+    // the trailing hash off `args` — the hash itself is still the caller's
+    // reference; trails defensively copies to avoid surprising the caller).
+    const options: Record<string, unknown> =
+      last && typeof last === "object" && !Array.isArray(last)
+        ? { ...(next.pop() as Record<string, unknown>) }
+        : {};
+    const only = ([] as string[]).concat((options.only as string | string[]) ?? []).map(String);
+    const except = ([] as string[]).concat((options.except as string | string[]) ?? []).map(String);
+    delete options.only;
+    delete options.except;
+    if (Object.keys(options).length > 0) next.push(options);
+
+    let strategy: (list: string[] | null, action: string) => boolean = () => true;
+    let list: string[] | null = null;
+    if (only.length > 0) {
+      strategy = (l, a) => (l ?? []).includes(a);
+      list = only;
+    } else if (except.length > 0) {
+      strategy = (l, a) => !(l ?? []).includes(a);
+      list = except;
+    }
+    const wrapped = new Middleware(klass, next) as Middleware & {
+      valid(action: string): boolean;
+    };
+    wrapped.valid = (action: string) => strategy(list, action);
+    return wrapped;
+  }
+
+  /**
    * Composes the Rails `render_to_body` chain. With `ActionController::Base`'s
    * include order, the effective chain is:
    *

--- a/packages/actionpack/src/action-controller/metal/conditional-get.ts
+++ b/packages/actionpack/src/action-controller/metal/conditional-get.ts
@@ -10,6 +10,18 @@
 
 import { getCrypto } from "@blazetrails/activesupport";
 
+import { includeContent as _includeContent } from "./head.js";
+
+/**
+ * Rails `Head#include_content?` — re-exposed because `ConditionalGet`
+ * includes `Head`, so the predicate is part of its mixed-in surface.
+ *
+ * @internal
+ */
+export function includeContent(status: number): boolean {
+  return _includeContent(status);
+}
+
 export function generateWeakEtag(seed: string): string {
   const hash = getCrypto().createHash("sha256").update(seed).digest("hex").slice(0, 32);
   return `W/"${hash}"`;

--- a/packages/actionpack/src/action-controller/metal/implicit-render.ts
+++ b/packages/actionpack/src/action-controller/metal/implicit-render.ts
@@ -8,6 +8,103 @@
 
 import { UnknownFormat, MissingExactTemplate } from "./exceptions.js";
 
+import { sendAction as _sendAction } from "./basic-implicit-render.js";
+
+/**
+ * Rails `BasicImplicitRender#send_action` — re-exposed because
+ * `ImplicitRender` includes `BasicImplicitRender`.
+ *
+ * @internal
+ */
+export function sendAction(
+  controller: { performed: boolean; head(status: number): void },
+  method: () => unknown,
+): unknown {
+  return _sendAction(controller, method);
+}
+
+interface ImplicitRenderHost {
+  performed: boolean;
+  actionName: string;
+  controllerName?: string;
+  request?: {
+    isGet?(): boolean;
+    get?: boolean;
+    format?: { ref?: string; symbol?: string | null };
+    isXhr?(): boolean;
+    xhr?: boolean;
+  };
+  templateExists?(action: string, prefixes?: unknown, opts?: unknown): boolean;
+  anyTemplates?(action: string, prefixes?: unknown): boolean;
+  head(status: number): void;
+  render(): void;
+  logger?: { info(msg: string): void };
+}
+
+/**
+ * Rails `ImplicitRender#default_render` — picks a template, raises with
+ * UnknownFormat / MissingExactTemplate, or falls back to `head :no_content`.
+ *
+ * @internal
+ */
+export function defaultRender(this: ImplicitRenderHost): void {
+  if (this.templateExists?.(this.actionName)) {
+    this.render();
+    return;
+  }
+  if (this.anyTemplates?.(this.actionName)) {
+    const name = this.controllerName ?? "";
+    throw new UnknownFormat(
+      `${name}#${this.actionName} is missing a template for this request format and variant.`,
+    );
+  }
+  if (isInteractiveBrowserRequest.call(this)) {
+    const name = this.controllerName ?? "";
+    throw new MissingExactTemplate(
+      `${name}#${this.actionName} is missing a template for request formats.`,
+      name,
+      this.actionName,
+    );
+  }
+  this.logger?.info(
+    `No template found for ${this.controllerName ?? ""}#${this.actionName}, rendering head :no_content`,
+  );
+  this.head(204);
+}
+
+/**
+ * Rails `ImplicitRender#method_for_action` — Rails returns the string
+ * `"default_render"`; trails uses camelCase identifiers per CLAUDE.md
+ * so we return `"defaultRender"`, matching the export name on this
+ * module.
+ *
+ * @internal
+ */
+export function methodForAction(
+  this: ImplicitRenderHost & { _superMethodForAction?(name: string): string | undefined },
+  actionName: string,
+): string | undefined {
+  const sup = this._superMethodForAction?.(actionName);
+  if (sup) return sup;
+  if (this.templateExists?.(actionName)) return "defaultRender";
+  return undefined;
+}
+
+/**
+ * Rails `ImplicitRender#interactive_browser_request?` — GET request for
+ * HTML content that isn't an XHR.
+ *
+ * @internal
+ */
+export function isInteractiveBrowserRequest(this: ImplicitRenderHost): boolean {
+  const req = this.request;
+  if (!req) return false;
+  const isGet = typeof req.isGet === "function" ? req.isGet() : req.get === true;
+  const isHtml = req.format?.ref === "html" || req.format?.symbol === "html";
+  const isXhr = typeof req.isXhr === "function" ? req.isXhr() : req.xhr === true;
+  return Boolean(isGet) && Boolean(isHtml) && !isXhr;
+}
+
 export function implicitRender(context: {
   performed: boolean;
   actionName: string;

--- a/packages/actionpack/src/action-controller/metal/instrumentation.ts
+++ b/packages/actionpack/src/action-controller/metal/instrumentation.ts
@@ -73,6 +73,43 @@ export function instrumentRender(
   return { result, viewRuntime };
 }
 
+/**
+ * Rails `Instrumentation#halted_callback_hook` — emitted by AS::Callbacks
+ * whenever a before-action halts the chain.
+ *
+ * @internal
+ */
+export function haltedCallbackHook(filter: unknown, _name?: unknown, notifier?: Notifier): void {
+  notifier?.instrument("halted_callback.action_controller", { filter });
+}
+
+/**
+ * Rails `Instrumentation#cleanup_view_runtime` — wrapper hook for
+ * subclasses (e.g. AR's ControllerRuntime) to subtract DB time from
+ * view runtime. The default just yields.
+ *
+ * @internal
+ */
+export function cleanupViewRuntime<T>(block: () => T): T {
+  return block();
+}
+
+/**
+ * Rails `Instrumentation#append_info_to_payload` — extension hook for
+ * subclasses to enrich the `process_action` payload. Default copies
+ * `viewRuntime` onto the payload.
+ *
+ * @internal
+ */
+export function appendInfoToPayload(
+  this: { viewRuntime?: number } | undefined,
+  payload: Record<string, unknown>,
+): void {
+  if (this && this.viewRuntime !== undefined) {
+    payload.viewRuntime = this.viewRuntime;
+  }
+}
+
 export function logProcessAction(payload: Record<string, unknown>): string[] {
   const messages: string[] = [];
   const viewRuntime = payload.view_runtime ?? payload.viewRuntime;

--- a/packages/actionpack/src/action-controller/metal/strong-parameters.ts
+++ b/packages/actionpack/src/action-controller/metal/strong-parameters.ts
@@ -1,11 +1,4 @@
-/**
- * ActionController::StrongParameters
- *
- * Provides ActionController::Parameters, a hash-like object that controls
- * which parameters are permitted for mass assignment.
- *
- * @see https://api.rubyonrails.org/classes/ActionController/StrongParameters.html
- */
+/** ActionController::StrongParameters Provides ActionController::Parameters, a hash-like object that controls which parameters are permitted for mass assignment. @see https://api.rubyonrails.org/classes/ActionController/StrongParameters.html @internal */
 
 import { SpellChecker } from "@blazetrails/did-you-mean";
 
@@ -822,6 +815,237 @@ export class Parameters {
       return this._newWithInheritedPermitted(value as Record<string, unknown>);
     }
     return value;
+  }
+
+  /** Rails-private `attr_reader :parameters` — the underlying hash. Trails stores it on `_data`; exposed under the Rails name for parity with the strong-parameters private surface. @internal */
+  get parameters(): Record<string, unknown> {
+    return this._data;
+  }
+
+  /** Rails `nested_attributes?` — true when any key/value pair looks like a nested-attribute index (`/\A-?\d+\z/`). @internal */
+  isNestedAttributes(): boolean {
+    return Object.entries(this._data).some(([k, v]) => Parameters.nestedAttribute(k, v));
+  }
+
+  /** Rails `each_nested_attribute` — yields each nested-attribute pair, returning a new Parameters with the block result. @internal */
+  eachNestedAttribute(fn: (value: unknown) => unknown): Parameters {
+    const result = new Parameters();
+    for (const [k, v] of Object.entries(this._data)) {
+      if (Parameters.nestedAttribute(k, v)) {
+        result._data[k] = fn(v);
+      }
+    }
+    return result;
+  }
+
+  /** Rails `permit_filters(filters, on_unpermitted:, explicit_arrays:)` — Rails-named entry point. Delegates to the existing internal `_permitFilters` (the option shape differs slightly; `onUnpermitted` is honoured only when `actionOnUnpermittedParameters` is set on the class — trails has no per-call override yet). @internal */
+  permitFilters(
+    filters: (string | Record<string, unknown>)[],
+    _options: { onUnpermitted?: "raise" | "log" | null; explicitArrays?: boolean } = {},
+  ): Parameters {
+    return this._permitFilters(filters);
+  }
+
+  /** Rails `new_instance_with_inherited_permitted_status(hash)` — wraps a raw hash in a new Parameters that inherits this instance's permitted flag. @internal */
+  newInstanceWithInheritedPermittedStatus(hash: Record<string, unknown>): Parameters {
+    return this._newWithInheritedPermitted(hash);
+  }
+
+  /** Rails `convert_parameters_to_hashes(value, using)` — recursively converts nested Parameters into plain hashes using the given method. @internal */
+  convertParametersToHashes(value: unknown, using: string): unknown {
+    return this._convertParametersToHashes(value, using);
+  }
+
+  /** Rails `convert_hashes_to_parameters(key, value)` — converts a single raw-hash entry to a Parameters, replacing the slot when the underlying value actually changed (Rails' `equal?` identity check). @internal */
+  convertHashesToParameters(key: string, value: unknown): unknown {
+    return this._convertHashesToParameters(key, value);
+  }
+
+  /** Rails `convert_value_to_parameters(value)` — recursively wraps plain hashes/arrays in Parameters instances. @internal */
+  convertValueToParameters(value: unknown): unknown {
+    return this._convertValueToParameters(value);
+  }
+
+  /** Rails `_deep_transform_keys_in_object!(object, &block)` — in-place variant of `_deep_transform_keys_in_object`. Mutates the input. @internal */
+  _deepTransformKeysInObjectBang(object: unknown, fn: (key: string) => string): unknown {
+    if (object instanceof Parameters) {
+      const keys = Object.keys(object._data);
+      for (const k of keys) {
+        const value = object._data[k];
+        delete object._data[k];
+        object._data[fn(k)] = this._deepTransformKeysInObjectBang(value, fn);
+      }
+      return object;
+    }
+    if (isPlainObject(object)) {
+      const target = object as Record<string, unknown>;
+      const keys = Object.keys(target);
+      for (const k of keys) {
+        const value = target[k];
+        delete target[k];
+        target[fn(k)] = this._deepTransformKeysInObjectBang(value, fn);
+      }
+      return target;
+    }
+    if (Array.isArray(object)) {
+      for (let i = 0; i < object.length; i++) {
+        object[i] = this._deepTransformKeysInObjectBang(object[i], fn);
+      }
+      return object;
+    }
+    return object;
+  }
+
+  /** Rails `specify_numeric_keys?(filter)` — true when the filter is a hash whose top-level keys include numeric strings (nested-attribute style). @internal */
+  isSpecifyNumericKeys(filter: unknown): boolean {
+    if (filter && typeof filter === "object" && !Array.isArray(filter)) {
+      return Object.keys(filter as Record<string, unknown>).some((k) => /^-?\d+$/.test(k));
+    }
+    return false;
+  }
+
+  /** Rails `array_filter?(filter)` — recognises the `[[:flavor]]` shape used by `params.expect` for explicit-array declarations. @internal */
+  isArrayFilter(filter: unknown): boolean {
+    return Array.isArray(filter) && filter.length === 1 && Array.isArray(filter[0]);
+  }
+
+  /** Rails `each_array_element(object, filter, &block)` — applies the block to each element of an array, or each nested-attribute pair when the input is a Parameters with non-numeric keys. @internal */
+  eachArrayElement(object: unknown, filter: unknown, fn: (el: Parameters) => unknown): unknown {
+    if (Array.isArray(object)) {
+      const out: unknown[] = [];
+      for (const el of object) {
+        if (el instanceof Parameters) {
+          const r = fn(el);
+          if (r != null) out.push(r);
+        }
+      }
+      return out;
+    }
+    if (object instanceof Parameters) {
+      if (object.isNestedAttributes() && !this.isSpecifyNumericKeys(filter)) {
+        return object.eachNestedAttribute(fn as (v: unknown) => unknown);
+      }
+    }
+    return undefined;
+  }
+
+  /** Rails `unpermitted_parameters!(params, on_unpermitted:)` — explicit Rails-named entry point. Delegates to `_unpermittedParameters`. @internal */
+  unpermittedParametersBang(params: Parameters): void {
+    this._unpermittedParameters(params);
+  }
+
+  /** Rails `unpermitted_keys(params)` — keys present on self but absent from the permitted projection, minus the always-permitted list. @internal */
+  unpermittedKeys(params: Parameters): string[] {
+    const allowed = new Set([
+      ...Object.keys(params._data),
+      ...Parameters.alwaysPermittedParameters,
+    ]);
+    return Object.keys(this._data).filter((k) => !allowed.has(k));
+  }
+
+  /** Rails `permitted_scalar_filter(params, key)` — copies a scalar value across into `params` when it passes the scalar-type check. @internal */
+  permittedScalarFilter(params: Parameters, key: string): void {
+    this._permittedScalarFilter(params, key);
+  }
+
+  /** Rails `non_scalar?(value)` — true for arrays and Parameters. @internal */
+  isNonScalar(value: unknown): boolean {
+    return Array.isArray(value) || value instanceof Parameters;
+  }
+
+  /** Rails `hash_filter(params, filter, on_unpermitted:, explicit_arrays:)`. @internal */
+  hashFilter(
+    params: Parameters,
+    filter: Record<string, unknown>,
+    options: { suppressUnpermitted?: boolean } = {},
+  ): void {
+    this._hashFilter(params, filter, options);
+  }
+
+  /** Rails `permit_value(value, filter, on_unpermitted:, explicit_arrays:)`. Dispatches by filter shape. @internal */
+  permitValue(value: unknown, filter: unknown): unknown {
+    if (Array.isArray(filter) && filter.length === 0) {
+      return this.permitArrayOfScalars(value);
+    }
+    if (
+      filter !== null &&
+      typeof filter === "object" &&
+      !Array.isArray(filter) &&
+      Object.keys(filter as Record<string, unknown>).length === 0
+    ) {
+      return this.permitHash(value, filter as Record<string, unknown>);
+    }
+    if (this.isArrayFilter(filter)) {
+      return this.permitArrayOfHashes(value, (filter as unknown[])[0]);
+    }
+    if (this.isNonScalar(value)) {
+      return this.permitHashOrArray(value, filter);
+    }
+    return undefined;
+  }
+
+  /** Rails `permit_array_of_scalars(value)`. @internal */
+  permitArrayOfScalars(value: unknown): unknown {
+    if (Array.isArray(value) && value.every((el) => isPermittedScalar(el))) return value;
+    return undefined;
+  }
+
+  /** Rails `permit_array_of_hashes(value, filter, ...)`. @internal */
+  permitArrayOfHashes(value: unknown, filter: unknown): unknown {
+    return this.eachArrayElement(value, filter, (el) =>
+      el.permitFilters(
+        (Array.isArray(filter) ? filter : [filter]) as (string | Record<string, unknown>)[],
+      ),
+    );
+  }
+
+  /** Rails `permit_hash(value, filter, ...)`. @internal */
+  permitHash(value: unknown, filter: Record<string, unknown> | unknown): unknown {
+    if (!(value instanceof Parameters)) return undefined;
+    if (
+      filter !== null &&
+      typeof filter === "object" &&
+      !Array.isArray(filter) &&
+      Object.keys(filter as Record<string, unknown>).length === 0
+    ) {
+      return this.permitAnyInParameters(value);
+    }
+    return value.permitFilters(
+      (Array.isArray(filter) ? filter : [filter]) as (string | Record<string, unknown>)[],
+    );
+  }
+
+  /** Rails `permit_hash_or_array(value, filter, ...)`. @internal */
+  permitHashOrArray(value: unknown, filter: unknown): unknown {
+    const arr = this.permitArrayOfHashes(value, filter);
+    if (arr != null) return arr;
+    return this.permitHash(value, filter);
+  }
+
+  /** Rails `permit_any_in_parameters(params)`. @internal */
+  permitAnyInParameters(params: Parameters): Parameters {
+    const sanitized = new Parameters();
+    for (const [k, v] of Object.entries(params._data)) {
+      if (isPermittedScalar(v)) {
+        sanitized._data[k] = v;
+      } else if (Array.isArray(v)) {
+        sanitized._data[k] = this.permitAnyInArray(v);
+      } else if (v instanceof Parameters) {
+        sanitized._data[k] = this.permitAnyInParameters(v);
+      }
+    }
+    return sanitized;
+  }
+
+  /** Rails `permit_any_in_array(array)`. @internal */
+  permitAnyInArray(array: unknown[]): unknown[] {
+    const sanitized: unknown[] = [];
+    for (const el of array) {
+      if (isPermittedScalar(el)) sanitized.push(el);
+      else if (Array.isArray(el)) sanitized.push(this.permitAnyInArray(el));
+      else if (el instanceof Parameters) sanitized.push(this.permitAnyInParameters(el));
+    }
+    return sanitized;
   }
 
   private _deepTransformKeysInObject(object: unknown, fn: (key: string) => string): unknown {

--- a/packages/actionpack/src/action-controller/metal/strong-parameters.ts
+++ b/packages/actionpack/src/action-controller/metal/strong-parameters.ts
@@ -683,6 +683,18 @@ export class Parameters {
     if (key in this._data && isPermittedScalar(this._data[key])) {
       params._data[key] = this._data[key];
     }
+    // Rails also walks every existing key to copy multi-parameter keys
+    // — e.g. `zipcode(90210i)` permitted under the bare `zipcode`. The
+    // regex matches the suffix and the prefix must equal the bare key.
+    const re = /\(\d+[if]?\)$/;
+    for (const k of Object.keys(this._data)) {
+      const m = re.exec(k);
+      if (!m) continue;
+      const prefix = k.slice(0, m.index);
+      if (prefix === key && isPermittedScalar(this._data[k])) {
+        params._data[k] = this._data[k];
+      }
+    }
   }
 
   private _hashFilter(


### PR DESCRIPTION
## Summary

Stacks on #2101. **abstractcontroller 90.2% → 100%.**

Adds 8 class-level Rails methods on \`AbstractController\` (`base.rb`):
- \`abstract\` / \`isAbstract\` / \`abstractBang\`
- \`controllerPath\` (memoised)
- \`internalMethods\` — walks the prototype chain to the first abstract class
- \`clearActionMethodsBang\`
- \`methodAdded\`
- \`eagerLoadBang\`

## Test plan
- [x] base.test.ts passes
- [x] api:compare abstractcontroller at 100%
- [x] +121 LOC