### PR TITLE
feat(activerecord): wire SpellChecker into Association*Error corrections

### DIFF
--- a/packages/activerecord/dx-tests/tsconfig.json
+++ b/packages/activerecord/dx-tests/tsconfig.json
@@ -23,6 +23,7 @@
       "@blazetrails/activesupport/testing/temporal-helpers": [
         "../../activesupport/src/testing/temporal-helpers.ts"
       ],
+      "@blazetrails/did-you-mean": ["../../did-you-mean/src/index.ts"],
       "@blazetrails/globalid": ["../../globalid/src/index.ts"],
       "@blazetrails/globalid/wire": ["../../globalid/src/wire.ts"],
       "@blazetrails/globalid/signed-global-id": ["../../globalid/src/signed-global-id.ts"]

--- a/packages/activerecord/package.json
+++ b/packages/activerecord/package.json
@@ -51,6 +51,7 @@
     "@blazetrails/activesupport": "workspace:*",
     "@blazetrails/arel": "workspace:*",
     "@blazetrails/activemodel": "workspace:*",
+    "@blazetrails/did-you-mean": "workspace:*",
     "@blazetrails/globalid": "workspace:*",
     "@blazetrails/trails-tsc": "workspace:*"
   },

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1,6 +1,7 @@
 import type { Base } from "./base.js";
 import type { Relation } from "./relation.js";
 import { Table as ArelTable } from "@blazetrails/arel";
+import { SpellChecker } from "@blazetrails/did-you-mean";
 import type { CollectionProxy, AssociationProxy } from "./associations/collection-proxy.js";
 import { _CollectionProxyCtor } from "./associations/collection-proxy-slot.js";
 // Re-export the slot's setter so the package entry and other internal
@@ -231,12 +232,8 @@ function validateInverseOf(targetModel: typeof Base, assocName: string, inverseO
   if (targetAssocs.length === 0) return;
   if (targetAssocs.some((a) => a.name === inverseOf)) return;
 
-  const corrections: string[] = [];
-  for (const a of targetAssocs) {
-    if (levenshtein(a.name, inverseOf) <= 3) {
-      corrections.push(a.name);
-    }
-  }
+  const dictionary = targetAssocs.map((a) => a.name);
+  const corrections = new SpellChecker({ dictionary }).correct(inverseOf);
   throw new InverseOfAssociationNotFoundError(assocName, inverseOf, corrections, targetModel.name);
 }
 
@@ -323,28 +320,9 @@ export function _hmtNotFound(
   through: string,
 ): HasManyThroughAssociationNotFoundError {
   const assocs: AssociationDefinition[] = ctor._associations ?? [];
-  const corrections = assocs
-    .map((a) => a.name)
-    .filter((n) => n !== assocName && levenshtein(n, through) <= 3);
+  const dictionary = assocs.map((a) => a.name).filter((n) => n !== assocName);
+  const corrections = new SpellChecker({ dictionary }).correct(through);
   return new HasManyThroughAssociationNotFoundError(ctor.name, through, assocName, corrections);
-}
-
-/** @internal */
-export function levenshtein(a: string, b: string): number {
-  const m = a.length;
-  const n = b.length;
-  const dp: number[][] = Array.from({ length: m + 1 }, () => Array(n + 1).fill(0));
-  for (let i = 0; i <= m; i++) dp[i][0] = i;
-  for (let j = 0; j <= n; j++) dp[0][j] = j;
-  for (let i = 1; i <= m; i++) {
-    for (let j = 1; j <= n; j++) {
-      dp[i][j] =
-        a[i - 1] === b[j - 1]
-          ? dp[i - 1][j - 1]
-          : 1 + Math.min(dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]);
-    }
-  }
-  return dp[m][n];
 }
 
 /**

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -233,7 +233,7 @@ function validateInverseOf(targetModel: typeof Base, assocName: string, inverseO
   if (targetAssocs.some((a) => a.name === inverseOf)) return;
 
   const dictionary = targetAssocs.map((a) => a.name);
-  const corrections = new SpellChecker({ dictionary }).correct(inverseOf);
+  const corrections = _correctNames(dictionary, inverseOf);
   throw new InverseOfAssociationNotFoundError(assocName, inverseOf, corrections, targetModel.name);
 }
 
@@ -321,8 +321,17 @@ export function _hmtNotFound(
 ): HasManyThroughAssociationNotFoundError {
   const assocs: AssociationDefinition[] = ctor._associations ?? [];
   const dictionary = assocs.map((a) => a.name).filter((n) => n !== assocName);
-  const corrections = new SpellChecker({ dictionary }).correct(through);
+  const corrections = _correctNames(dictionary, through);
   return new HasManyThroughAssociationNotFoundError(ctor.name, through, assocName, corrections);
+}
+
+/**
+ * @internal
+ * Shared helper for did_you_mean-style name corrections used by the
+ * association error call sites (and reflection.ts).
+ */
+export function _correctNames(dictionary: string[], input: string): string[] {
+  return new SpellChecker({ dictionary }).correct(input);
 }
 
 /**

--- a/packages/activerecord/src/bin/trails-models-dump.test.ts
+++ b/packages/activerecord/src/bin/trails-models-dump.test.ts
@@ -61,7 +61,7 @@ function applySchema(dbPath: string, sql: string): void {
 // is predictable and still fast when already built (tsc incremental).
 beforeAll(() => {
   const packagesRoot = resolve(REPO_ROOT, "packages");
-  const depsInOrder = ["activesupport", "activemodel", "arel", "globalid"];
+  const depsInOrder = ["activesupport", "activemodel", "arel", "did-you-mean", "globalid"];
   const anyMissing = depsInOrder.some(
     (p) => !existsSync(join(packagesRoot, p, "dist", "index.js")),
   );

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -10,7 +10,9 @@ import {
   foreignKey as deriveForeignKey,
 } from "@blazetrails/activesupport";
 import { Table } from "@blazetrails/arel";
-import { modelRegistry, levenshtein } from "./associations.js";
+import { SpellChecker } from "@blazetrails/did-you-mean";
+
+import { modelRegistry } from "./associations.js";
 import {
   hasQueryConstraints,
   queryConstraintsList,
@@ -1540,17 +1542,16 @@ export class ThroughReflection extends AbstractReflection {
 
   /**
    * @internal
-   * Mirrors ActiveRecord's DidYouMean-powered suggestions for
-   * HasManyThroughAssociationNotFoundError. Returns reflection names on
-   * the active_record that are within Levenshtein distance 3 of the
-   * misspelled `:through` name, excluding the failing reflection.
+   * Mirrors `HasManyThroughAssociationNotFoundError#corrections`: feeds the
+   * owner's reflection names (minus the failing one) into `SpellChecker`,
+   * which applies the Jaro-Winkler + Levenshtein thresholds from Ruby's
+   * `did_you_mean`.
    */
   private _throughCorrections(): string[] {
     const rawReflections: Record<string, unknown> =
       (this.activeRecord as { _reflections?: Record<string, unknown> })._reflections ?? {};
-    const candidates = Object.keys(rawReflections).filter((k) => k !== this.name);
-    const target = this.through;
-    return candidates.filter((k) => levenshtein(k, target) <= 3);
+    const dictionary = Object.keys(rawReflections).filter((k) => k !== this.name);
+    return new SpellChecker({ dictionary }).correct(this.through);
   }
 
   /**

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -10,7 +10,7 @@ import {
   foreignKey as deriveForeignKey,
 } from "@blazetrails/activesupport";
 import { Table } from "@blazetrails/arel";
-import { SpellChecker } from "@blazetrails/did-you-mean";
+import { _correctNames } from "./associations.js";
 
 import { modelRegistry } from "./associations.js";
 import {
@@ -1543,15 +1543,14 @@ export class ThroughReflection extends AbstractReflection {
   /**
    * @internal
    * Mirrors `HasManyThroughAssociationNotFoundError#corrections`: feeds the
-   * owner's reflection names (minus the failing one) into `SpellChecker`,
-   * which applies the Jaro-Winkler + Levenshtein thresholds from Ruby's
-   * `did_you_mean`.
+   * owner's reflection names (minus the failing one) into the shared
+   * did_you_mean-compatible SpellChecker.
    */
   private _throughCorrections(): string[] {
     const rawReflections: Record<string, unknown> =
       (this.activeRecord as { _reflections?: Record<string, unknown> })._reflections ?? {};
     const dictionary = Object.keys(rawReflections).filter((k) => k !== this.name);
-    return new SpellChecker({ dictionary }).correct(this.through);
+    return _correctNames(dictionary, this.through);
   }
 
   /**

--- a/packages/activerecord/tsconfig.json
+++ b/packages/activerecord/tsconfig.json
@@ -10,6 +10,7 @@
   "references": [
     { "path": "../arel" },
     { "path": "../activemodel" },
+    { "path": "../did-you-mean" },
     { "path": "../globalid" },
     { "path": "../trails-tsc" }
   ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@blazetrails/arel':
         specifier: workspace:*
         version: link:../arel
+      '@blazetrails/did-you-mean':
+        specifier: workspace:*
+        version: link:../did-you-mean
       '@blazetrails/globalid':
         specifier: workspace:*
         version: link:../globalid


### PR DESCRIPTION
## Summary

Replaces the ad-hoc `levenshtein()` <= 3 helper with the shared `@blazetrails/did-you-mean` `SpellChecker` at all three Association error call sites:

- `validateInverseOf` → `InverseOfAssociationNotFoundError`
- `_hmtNotFound` → `HasManyThroughAssociationNotFoundError`
- `ThroughReflection#_throughCorrections` (used by the same error)

Mirrors `vendor/rails/activerecord/lib/active_record/associations/errors.rb`. Deletes the now-unused `levenshtein()` export from `associations.ts`. Adds `@blazetrails/did-you-mean` as an activerecord dep + tsconfig project ref.

Part of the did-you-mean port plan (`docs/did-you-mean-port-plan.md`). Remaining call site after this: `Template::Error` (actionview, needs `jaroDistance` export).

## Test plan

- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [ ] CI: full activerecord suite covers the corrections paths