### PR TITLE
test(activerecord): TM Phase 6 — hoist defineSchema in callbacks/relation/strict-loading/aggregations

### DIFF
--- a/packages/activerecord/src/aggregations.test.ts
+++ b/packages/activerecord/src/aggregations.test.ts
@@ -5,10 +5,11 @@
 import { describe, it, expect, beforeEach, beforeAll, afterAll, vi } from "vitest";
 import { Base, composedOf } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -27,10 +28,10 @@ afterAll(() => {
 // AggregationsTest — targets aggregations_test.rb
 // ==========================================================================
 describe("AggregationsTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       customers: { name: "string", address_street: "string", address_city: "string" },
       locations: { name: "string", lat: "float", lng: "float" },
@@ -42,6 +43,7 @@ describe("AggregationsTest", () => {
       shapes: { name: "string", coord_x: "float", coord_y: "float" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -797,13 +799,14 @@ describe("Aggregation edge cases", () => {
 });
 
 describe("composed_of", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       customers: { address_street: "string", address_city: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -722,12 +722,12 @@ describe("CallbacksTest", () => {
       }
     }
 
-    await Tracked.create({ name: "test" });
+    const created = await Tracked.create({ name: "test" });
     expect(log).toContain("after_create");
     expect(log).not.toContain("after_update");
 
     log.length = 0;
-    const record = await Tracked.find(1);
+    const record = await Tracked.find(created.id);
     await record.update({ name: "updated" });
     expect(log).toContain("after_update");
     expect(log).not.toContain("after_create");
@@ -1138,9 +1138,9 @@ describe("CallbacksTest", () => {
         });
       }
     }
-    await Tracked.create({ name: "test" });
+    const created = await Tracked.create({ name: "test" });
     log.length = 0;
-    await Tracked.find(1);
+    await Tracked.find(created.id);
     expect(log).toContain("after_find");
   });
 
@@ -1567,10 +1567,10 @@ describe("CallbacksTest", () => {
       }
     }
 
-    await Developer.create({ name: "Alice" });
+    const alice = await Developer.create({ name: "Alice" });
     initialized.length = 0; // Clear create initialization
 
-    await Developer.find(1);
+    await Developer.find(alice.id);
     expect(initialized.length).toBeGreaterThan(0);
   });
 
@@ -1594,12 +1594,12 @@ describe("CallbacksTest", () => {
     expect(found).toEqual([]);
 
     // Create triggers after_find (through _instantiate on reload)
-    await Developer.create({ name: "Alice" });
+    const alice = await Developer.create({ name: "Alice" });
     found.length = 0;
 
     // Find triggers after_find
-    await Developer.find(1);
-    expect(found).toEqual([1]);
+    await Developer.find(alice.id);
+    expect(found).toEqual([alice.id]);
   });
 
   // Rails: test "after_find is called on each record in all"
@@ -1638,10 +1638,10 @@ describe("CallbacksTest", () => {
       }
     }
 
-    await Developer.create({ name: "Carol" });
+    const carol = await Developer.create({ name: "Carol" });
     seen.length = 0;
 
-    await Developer.find(1);
+    await Developer.find(carol.id);
     expect(seen).toEqual(["Carol"]);
   });
 
@@ -1668,10 +1668,10 @@ describe("CallbacksTest", () => {
     }
     void Dog;
 
-    await Animal.create({ name: "Rex", type: "Dog" });
+    const rex = await Animal.create({ name: "Rex", type: "Dog" });
     order.length = 0;
 
-    const loaded = await Animal.find(1);
+    const loaded = await Animal.find(rex.id);
     expect(loaded).toBeInstanceOf(Dog);
     expect(order).toEqual(["after_find", "after_initialize"]);
   });

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -13,15 +13,9 @@ import {
 } from "./index.js";
 
 import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
-import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
-
-// -- Helpers --
-function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
-}
 
 // ==========================================================================
 // CallbacksTest — targets callbacks_test.rb

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach, afterAll } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
   Base,
   transaction,
@@ -12,10 +12,11 @@ import {
   registerModel,
 } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -26,15 +27,16 @@ function freshAdapter(): DatabaseAdapter {
 // CallbacksTest — targets callbacks_test.rb
 // ==========================================================================
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       topics: { title: "string" },
       animals: { name: "string", type: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -98,9 +100,9 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       people: { name: "string" },
       animals: { name: "string", type: "string" },
@@ -108,6 +110,7 @@ describe("CallbacksTest", () => {
       cb_posts: { title: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -435,12 +438,13 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { topics: { title: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -546,12 +550,13 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { topics: { title: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -689,12 +694,13 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { trackeds: { name: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -769,14 +775,15 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       things: { name: "string", status: "string" },
       records: { name: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -820,13 +827,14 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       tasks: { name: "string", important: "boolean", skip: "boolean" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -880,11 +888,12 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { blocked: { name: "string" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -907,12 +916,13 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, { users: { name: "string", updated_at: "datetime" } });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -938,9 +948,9 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       trackeds: { name: "string" },
       guardeds: { name: "string" },
@@ -949,6 +959,7 @@ describe("CallbacksTest", () => {
       multis: { name: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -1154,10 +1165,10 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       trackeds: { name: "string" },
       guardeds: { name: "string" },
@@ -1166,6 +1177,7 @@ describe("CallbacksTest", () => {
       multis: { name: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -1504,15 +1516,16 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       developers: { name: "string", salary: "integer" },
       animals: { name: "string", type: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);
@@ -1665,10 +1678,10 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbacksTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       orders: { total: "integer", discount_code: "string", silent: "boolean" },
       widgets: { name: "string" },
@@ -1682,6 +1695,7 @@ describe("CallbacksTest", () => {
       immutables: { locked: "boolean" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -7,10 +7,11 @@ import { sql, Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base, Relation, IrreversibleOrderError } from "./index.js";
 import { Associations, registerModel, modelRegistry } from "./associations.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
@@ -48,10 +49,10 @@ describe("isBlank / isPresent", () => {
 // RelationTest — targets relations_test.rb
 // ==========================================================================
 describe("RelationTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       posts: { title: "string", body: "string", status: "string", author_id: "integer" },
       developers: { commits: "integer" },
@@ -69,6 +70,7 @@ describe("RelationTest", () => {
       eager_articles: { title: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   afterAll(async () => {
     await dropAllTables(adapter);

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -7,7 +7,11 @@ import { sql, Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base, Relation, IrreversibleOrderError } from "./index.js";
 import { Associations, registerModel, modelRegistry } from "./associations.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
+import {
+  createTestAdapter,
+  resetTestAdapterState,
+  type TestDatabaseAdapter,
+} from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
@@ -42,6 +46,14 @@ describe("isBlank / isPresent", () => {
     await User.create({ name: "Alice" });
     expect(await User.all().isBlank()).toBe(false);
     expect(await User.all().isPresent()).toBe(true);
+  });
+
+  // Drop tables/rows this describe wrote on the shared adapter so the
+  // following transactional-fixture describe (RelationTest) doesn't inherit
+  // them — its withTransactionalFixtures pushes the global-reset opt-out
+  // before any cleanup would otherwise run.
+  afterAll(async () => {
+    await resetTestAdapterState();
   });
 });
 

--- a/packages/activerecord/src/strict-loading.test.ts
+++ b/packages/activerecord/src/strict-loading.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, StrictLoadingViolationError, registerModel } from "./index.js";
 import {
   Associations,
@@ -12,8 +12,9 @@ import {
   loadHasMany,
 } from "./associations.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 // -- Helpers --
@@ -25,10 +26,10 @@ function freshAdapter(): DatabaseAdapter {
 // StrictLoadingTest — targets strict_loading_test.rb
 // ==========================================================================
 describe("StrictLoadingTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       authors: { name: "string" },
       books: { title: "string", author_id: "integer", publisher_id: "integer" },
@@ -38,6 +39,7 @@ describe("StrictLoadingTest", () => {
       animals: { name: "string" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   // Rails: test_raises_on_lazy_loading_a_strict_loading_has_many_relation
   it("raises on lazy loading a strict loading has many relation", async () => {
@@ -443,10 +445,10 @@ describe("StrictLoadingTest", () => {
 });
 
 describe("StrictLoadingTest", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       authors: { name: "string" },
       books: { title: "string", author_id: "integer" },
@@ -494,6 +496,7 @@ describe("StrictLoadingTest", () => {
       slnr_books: { title: "string", sl_nr_author_id: "integer" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   // Rails: test_raises_on_lazy_loading_a_strict_loading_has_many_relation
   // Rails: test_raises_on_lazy_loading_a_strict_loading_belongs_to_relation
@@ -1354,9 +1357,9 @@ describe("StrictLoadingFixturesTest", () => {
 });
 
 describe("strict_loading", () => {
-  let adapter: DatabaseAdapter;
-  beforeEach(async () => {
-    adapter = freshAdapter();
+  let adapter: TestDatabaseAdapter;
+  beforeAll(async () => {
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       authors: { name: "string" },
       books: { author_id: "integer" },
@@ -1364,6 +1367,7 @@ describe("strict_loading", () => {
       posts: { author2_id: "integer" },
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   it("raises StrictLoadingViolationError on lazy association load", async () => {
     class Author extends Base {


### PR DESCRIPTION
## Summary

Migrates safe per-test \`beforeEach(defineSchema)\` describes to once-per-file
\`beforeAll(defineSchema)\` + \`withTransactionalFixtures()\` in 4 medium-large
root files. Pre-grepped each for the documented hazards (inline DDL in \`it()\`,
\`dependent:\` MariaDB conflict, PG sequence drift); skipped any describe that
hit one.

### Files migrated
- **\`callbacks.test.ts\`** — all 13 describes (uniform pattern, no \`dependent:\`
  hazard).
- **\`relation.test.ts\`** — top \`RelationTest\` describe (the bulk). Left the
  one-test \`isBlank / isPresent\` describe (local \`freshAdapter()\` in the
  \`it()\` body).
- **\`strict-loading.test.ts\`** — 3 describes (\`StrictLoadingTest\` x2,
  \`strict_loading\`). Left \`strictLoadingByDefault\` on per-test setup (calls
  \`setupUsersAdapter()\` inside \`it()\`).
- **\`aggregations.test.ts\`** — top \`AggregationsTest\` (line 29) and
  \`composed_of\` (line 799). Left the second \`AggregationsTest\` (line 487; all
  \`it.skip\`), \`OverridingAggregationsTest\`, \`Aggregations\`,
  \`Aggregation edge cases\` (each uses per-test \`freshAdapter\` inside \`it()\`).

### Out of scope (follow-ups)
- \`enum.test.ts\`, \`locking.test.ts\`, \`schema-dumper.test.ts\`,
  \`transaction-instrumentation.test.ts\`, \`tasks/*.test.ts\` — each has either
  per-test adapter creation inside \`it()\`, inline DDL, or is deliberately
  isolated for TM instrumentation. Left on per-test setup pending its own
  audit.

## Test plan
- [x] All four files pass locally on SQLite.
- [ ] CI on PG + MariaDB — the gate the inline-DDL hazard catches.