### PR TITLE
test(activerecord): TM Phase 6 revert-fixes (batches + polymorphic-sti-through)

### DIFF
--- a/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
+++ b/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
@@ -32,12 +32,12 @@
  *   - test_has_many_through_with_sti_on_through_reflection (STI variant)
  *   - test_has_many_through_reset_source_reflection_after_loading_is_complete
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel, registerSubclass, enableSti } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
-import type { DatabaseAdapter } from "../adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 const TEST_SCHEMA: Schema = {
   ps_hotels: { name: "string" },
@@ -51,14 +51,8 @@ const TEST_SCHEMA: Schema = {
   ps_drink_designers: { name: "string" },
 };
 
-async function freshAdapter(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
-  await defineSchema(adapter, TEST_SCHEMA);
-  return adapter;
-}
-
 describe("HABTM Slot E — polymorphic + STI through", () => {
-  let adapter: DatabaseAdapter;
+  let adapter: TestDatabaseAdapter;
 
   class PsHotel extends Base {
     static {
@@ -101,8 +95,9 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
   enableSti(PsCakeDesigner);
   registerSubclass(PsSpecialCakeDesigner);
 
-  beforeEach(async () => {
-    adapter = await freshAdapter();
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+    await defineSchema(adapter, TEST_SCHEMA);
     PsHotel.adapter = adapter;
     PsDepartment.adapter = adapter;
     PsChef.adapter = adapter;
@@ -115,9 +110,6 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
     registerModel("PsCakeDesigner", PsCakeDesigner);
     registerModel("PsDrinkDesigner", PsDrinkDesigner);
     registerModel("PsSpecialCakeDesigner", PsSpecialCakeDesigner);
-    (PsHotel as any)._associations = [];
-    (PsDepartment as any)._associations = [];
-    (PsChef as any)._associations = [];
 
     Associations.hasMany.call(PsHotel, "psDepartments", {
       className: "PsDepartment",
@@ -151,6 +143,7 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
       sourceType: "PsDrinkDesigner",
     });
   });
+  withTransactionalFixtures(() => adapter);
 
   async function seed() {
     const hotel = await PsHotel.create({ name: "h" });
@@ -160,16 +153,23 @@ describe("HABTM Slot E — polymorphic + STI through", () => {
     })) as any;
     const cake1 = (await PsCakeDesigner.create({ name: "cake1" })) as any;
     const cake2 = (await PsCakeDesigner.create({ name: "cake2" })) as any;
-    // strayCake has no chef row pointing at it. Burn enough drink
-    // rows to bump the per-table sequence so the actual drink-type
-    // chef points at a drink whose id collides with strayCake (=3).
-    // If the source_type filter is missing, the unfiltered through
-    // walk hands strayCake.id to the cake-table load and strayCake
-    // leaks into the cakeDesigners result.
-    const strayCake = (await PsCakeDesigner.create({ name: "stray" })) as any;
-    await PsDrinkDesigner.create({ name: "filler1" });
-    await PsDrinkDesigner.create({ name: "filler2" });
-    const drink = (await PsDrinkDesigner.create({ name: "drink" })) as any;
+    // strayCake has no chef row pointing at it. Engineer a cross-table id
+    // collision dynamically by padding whichever sequence is behind until
+    // drink.id === strayCake.id (PG sequences don't roll back across the
+    // outer txn, so absolute sequence values drift between tests under
+    // withTransactionalFixtures — see feedback_tm_phase6_pg_sequence_drift).
+    // If the source_type filter is missing, the unfiltered through walk
+    // hands strayCake.id to the cake-table load and strayCake leaks into
+    // the cakeDesigners result.
+    let drink = (await PsDrinkDesigner.create({ name: "drink" })) as any;
+    let strayCake = (await PsCakeDesigner.create({ name: "stray" })) as any;
+    while (drink.id !== strayCake.id) {
+      if (drink.id < strayCake.id) {
+        drink = (await PsDrinkDesigner.create({ name: "drink-pad" })) as any;
+      } else {
+        strayCake = (await PsCakeDesigner.create({ name: "stray-pad" })) as any;
+      }
+    }
     expect(drink.id).toBe(strayCake.id);
 
     await PsChef.create({

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -2,7 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import { describe, it, expect, beforeAll } from "vitest";
 import { Base, Relation } from "./index.js";
 import { activeRecordConfig } from "./relation/batches.js";
 
@@ -128,13 +128,11 @@ describe("EachTest", () => {
 // More EachTest — targets batches_test.rb
 // ==========================================================================
 describe("EachTest", () => {
-  // NOTE: not migrated to beforeAll + withTransactionalFixtures — one test
-  // ("each should return a sized enumerator") calls freshAdapter() inline,
-  // which issues DDL on MariaDB and breaks the wrapping savepoint.
   let adapter: TestDatabaseAdapter;
-  beforeEach(async () => {
+  beforeAll(async () => {
     adapter = await freshAdapter();
   });
+  withTransactionalFixtures(() => adapter);
 
   it("in batches has attribute readers", async () => {
     class Post extends Base {
@@ -151,11 +149,10 @@ describe("EachTest", () => {
   });
 
   it("each should return a sized enumerator", async () => {
-    const freshAdp = await freshAdapter();
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = freshAdp;
+        this.adapter = adapter;
       }
     }
     for (let i = 0; i < 5; i++) await Post.create({ title: `post ${i}` });


### PR DESCRIPTION
## Summary

Two of the four planned TM Phase 6 revert-fixes. The other two (inheritance.test.ts, has-one-associations.test.ts) need a non-tx sub-describe carve-out to be safe, which would change describe nesting and break test:compare matching — deferring those (see follow-ups).

### batches.test.ts — "More EachTest" describe
- Drop the inline `freshAdapter()` in "each should return a sized enumerator" — it isn't exercising isolation, just `findEach({ batchSize: 2 })`. Have it share the outer-describe adapter.
- Hoist the describe to `beforeAll` + `withTransactionalFixtures`.

Closes the loose end from PR #2063.

### polymorphic-sti-through.test.ts
- Hoist describe to `beforeAll` + `withTransactionalFixtures`.
- Rewrite `seed()` so the cross-table id collision is engineered dynamically (pad whichever sequence is behind until `drink.id === strayCake.id`) instead of burning a fixed number of drink rows. PG sequences don't roll back across the outer txn, so absolute sequence values drift between tests.

Closes the seed-side loose end from PR #2062.

## Deferred (not in this PR)

- `inheritance.test.ts` retry — the inline-DDL tests (~20 cases starting at line 1063 in the main `InheritanceTest` describe) shadow `adapter` with their own `freshAdapter()`. Safe migration requires carving them into a separate non-tx describe, which would add a new top-level `describe(...)` block and disturb test:compare matching. Leaving as-is.
- `has-one-associations.test.ts` `dependent:` cluster carve-out — same constraint: the cluster needs its own describe to skip `withTransactionalFixtures` on MariaDB. Leaving as-is.

Both should be tackled either with a test:compare-tolerant carve mechanism, or by fixing `withTransactionalFixtures` to be MariaDB-savepoint-tolerant (see `feedback_tm_phase6_mariadb_savepoint`).

## Test plan
- [ ] `pnpm vitest run packages/activerecord/src/batches.test.ts` — green
- [ ] `pnpm vitest run packages/activerecord/src/associations/polymorphic-sti-through.test.ts` — green
- [ ] CI: PG + MariaDB matrices pass (the previously-reverted scenarios)