### PR TITLE
feat(actionpack): wire CSP/PermissionsPolicy/filter/parser privates on Request (80→100%)

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
-import { Request } from "../request.js";
+import { Request, PassNotFound } from "../request.js";
 import { MimeType } from "../http/mime-type.js";
+import { X_CASCADE } from "../constants.js";
 
 describe("RequestUrlFor", () => {
   it("url_for class method", () => {
@@ -718,6 +719,60 @@ describe("RequestContentSecurityPolicy", () => {
     req.contentSecurityPolicyNonceGenerator = null;
     expect(req.env["action_dispatch.content_security_policy_nonce_generator"]).toBeNull();
     expect(req.contentSecurityPolicyNonceGenerator).toBeNull();
+  });
+});
+
+describe("RequestControllerClass", () => {
+  it("controllerClassFor returns PassNotFound when name is absent", () => {
+    const req = new Request({});
+    expect(req.controllerClassFor(null)).toBe(PassNotFound);
+    expect(req.controllerClassFor(undefined)).toBe(PassNotFound);
+  });
+
+  it("controllerClassFor throws when a controller name is supplied", () => {
+    const req = new Request({});
+    expect(() => req.controllerClassFor("posts")).toThrow(/no global controller constant table/);
+  });
+
+  it("controllerClass defaults action to 'index' and returns PassNotFound without a controller", () => {
+    const req = new Request({});
+    expect(req.controllerClass()).toBe(PassNotFound);
+    expect(req.pathParameters["action"]).toBe("index");
+  });
+
+  it("PassNotFound.call returns 404 with x-cascade pass", async () => {
+    const [status, headers, body] = PassNotFound.call({});
+    expect(status).toBe(404);
+    expect(headers[X_CASCADE]).toBe("pass");
+    const chunks: unknown[] = [];
+    for await (const c of body) chunks.push(c);
+    expect(chunks).toEqual([]);
+  });
+
+  it("PassNotFound.action returns the sentinel itself", () => {
+    expect(PassNotFound.action("show")).toBe(PassNotFound);
+    expect(PassNotFound.actionEncodingTemplate("show")).toBe(false);
+  });
+});
+
+describe("RequestParametersList", () => {
+  it("returns rack.request.form_pairs verbatim when present", () => {
+    const pairs: Array<[string, unknown]> = [["a", "1"]];
+    const req = new Request({ "rack.request.form_pairs": pairs });
+    expect(req.requestParametersList()).toBe(pairs);
+  });
+
+  it("parses rack.request.form_vars via QueryParser.eachPair", () => {
+    const req = new Request({ "rack.request.form_vars": "a=1&b=2" });
+    expect(req.requestParametersList()).toEqual([
+      ["a", "1"],
+      ["b", "2"],
+    ]);
+  });
+
+  it("returns [] when no body has been parsed", () => {
+    const req = new Request({});
+    expect(req.requestParametersList()).toEqual([]);
   });
 });
 

--- a/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/request.test.ts
@@ -678,3 +678,57 @@ describe("RequestFilterParameters", () => {
     expect(req.parameterFilter().filter({ password: "x" })).toEqual({ password: "x" });
   });
 });
+
+describe("RequestContentSecurityPolicy", () => {
+  it("reads and writes the policy under the env header", () => {
+    const req = new Request({});
+    expect(req.contentSecurityPolicy).toBeUndefined();
+    const policy = { build: () => "default-src 'self'" };
+
+    req.contentSecurityPolicy = policy as any;
+    expect(req.env["action_dispatch.content_security_policy"]).toBe(policy);
+    expect(req.contentSecurityPolicy).toBe(policy);
+  });
+
+  it("reportOnly toggles the report-only env flag", () => {
+    const req = new Request({});
+    expect(req.contentSecurityPolicyReportOnly).toBeUndefined();
+    req.contentSecurityPolicyReportOnly = true;
+    expect(req.contentSecurityPolicyReportOnly).toBe(true);
+  });
+
+  it("nonce is undefined without a generator and memoizes on read", () => {
+    const req = new Request({});
+    expect(req.contentSecurityPolicyNonce).toBeUndefined();
+    let calls = 0;
+    req.contentSecurityPolicyNonceGenerator = () => `nonce-${++calls}`;
+    expect(req.contentSecurityPolicyNonce).toBe("nonce-1");
+    expect(req.contentSecurityPolicyNonce).toBe("nonce-1");
+  });
+
+  it("nonce directives default to undefined and round-trip arrays", () => {
+    const req = new Request({});
+    expect(req.contentSecurityPolicyNonceDirectives).toBeUndefined();
+    req.contentSecurityPolicyNonceDirectives = ["script-src"];
+    expect(req.contentSecurityPolicyNonceDirectives).toEqual(["script-src"]);
+  });
+
+  it("null assignments persist as null on the env (matches Rails setter)", () => {
+    const req = new Request({});
+    req.contentSecurityPolicyNonceGenerator = null;
+    expect(req.env["action_dispatch.content_security_policy_nonce_generator"]).toBeNull();
+    expect(req.contentSecurityPolicyNonceGenerator).toBeNull();
+  });
+});
+
+describe("RequestPermissionsPolicy", () => {
+  it("round-trips through the env header", () => {
+    const req = new Request({});
+    expect(req.permissionsPolicy).toBeUndefined();
+    const policy = { build: () => "geolocation=()" };
+
+    req.permissionsPolicy = policy as any;
+    expect(req.env["action_dispatch.permissions_policy"]).toBe(policy);
+    expect(req.permissionsPolicy).toBe(policy);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/http/content-security-policy.ts
@@ -425,8 +425,8 @@ export function setContentSecurityPolicyReportOnly(this: CspRequestHost, value: 
 
 export function contentSecurityPolicyNonceGenerator(
   this: CspRequestHost,
-): NonceGenerator | undefined {
-  return this.getHeader(NONCE_GENERATOR) as NonceGenerator | undefined;
+): NonceGenerator | null | undefined {
+  return this.getHeader(NONCE_GENERATOR) as NonceGenerator | null | undefined;
 }
 
 export function setContentSecurityPolicyNonceGenerator(
@@ -438,8 +438,8 @@ export function setContentSecurityPolicyNonceGenerator(
 
 export function contentSecurityPolicyNonceDirectives(
   this: CspRequestHost,
-): readonly string[] | undefined {
-  return this.getHeader(NONCE_DIRECTIVES) as readonly string[] | undefined;
+): readonly string[] | null | undefined {
+  return this.getHeader(NONCE_DIRECTIVES) as readonly string[] | null | undefined;
 }
 
 export function setContentSecurityPolicyNonceDirectives(

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -42,11 +42,30 @@ import type { ArrayInquirer } from "@blazetrails/activesupport";
 import type { MimeType } from "./mime-type.js";
 import { URL as HttpURL } from "./url.js";
 import {
+  envFilter as _envFilter,
   filteredEnv as _filteredEnv,
   filteredParameters as _filteredParameters,
   filteredPath as _filteredPath,
+  filteredQueryString as _filteredQueryString,
   parameterFilter as _parameterFilter,
+  parameterFilterFor as _parameterFilterFor,
 } from "./filter-parameters.js";
+import {
+  contentSecurityPolicy as _contentSecurityPolicy,
+  contentSecurityPolicyNonce as _contentSecurityPolicyNonce,
+  contentSecurityPolicyNonceDirectives as _contentSecurityPolicyNonceDirectives,
+  contentSecurityPolicyNonceGenerator as _contentSecurityPolicyNonceGenerator,
+  contentSecurityPolicyReportOnly as _contentSecurityPolicyReportOnly,
+  generateContentSecurityPolicyNonce as _generateContentSecurityPolicyNonce,
+  setContentSecurityPolicy as _setContentSecurityPolicy,
+  setContentSecurityPolicyNonceDirectives as _setContentSecurityPolicyNonceDirectives,
+  setContentSecurityPolicyNonceGenerator as _setContentSecurityPolicyNonceGenerator,
+  setContentSecurityPolicyReportOnly as _setContentSecurityPolicyReportOnly,
+  type ContentSecurityPolicy,
+  type NonceGenerator,
+} from "./content-security-policy.js";
+import { QueryParser, type QueryPair } from "./query-parser.js";
+import type { PermissionsPolicy } from "../permissions-policy.js";
 import type { ParameterFilter } from "@blazetrails/activesupport";
 import { RequestUtils, type ParamValue } from "../request/utils.js";
 import { COOKIES_APP_OPTIONS_KEY, type CookieJarOptions } from "../middleware/cookies.js";
@@ -58,6 +77,7 @@ import {
   pathParameters as _pathParameters,
   setParameterParsers as _setParameterParsers,
   setPathParameters as _setPathParameters,
+  logParseErrorOnce as _logParseErrorOnce,
   type ParameterParser,
   type ParameterParsers,
   type ParametersHost,
@@ -388,6 +408,60 @@ export class Request {
   declare filteredEnv: () => Record<string, unknown>;
   declare filteredPath: () => string;
   declare parameterFilter: () => ParameterFilter;
+  /** @internal */
+  declare envFilter: () => ParameterFilter;
+  /** @internal */
+  declare filteredQueryString: () => string;
+  /** @internal */
+  declare parameterFilterFor: (filters: Array<string | RegExp>) => ParameterFilter;
+
+  // --- Content Security Policy (ActionDispatch::ContentSecurityPolicy::Request) ---
+
+  get contentSecurityPolicy(): ContentSecurityPolicy | null | undefined {
+    return _contentSecurityPolicy.call(this);
+  }
+  set contentSecurityPolicy(policy: ContentSecurityPolicy | null) {
+    _setContentSecurityPolicy.call(this, policy);
+  }
+
+  get contentSecurityPolicyReportOnly(): boolean | undefined {
+    return _contentSecurityPolicyReportOnly.call(this);
+  }
+  set contentSecurityPolicyReportOnly(value: boolean) {
+    _setContentSecurityPolicyReportOnly.call(this, value);
+  }
+
+  get contentSecurityPolicyNonceGenerator(): NonceGenerator | undefined {
+    return _contentSecurityPolicyNonceGenerator.call(this);
+  }
+  set contentSecurityPolicyNonceGenerator(generator: NonceGenerator | null) {
+    _setContentSecurityPolicyNonceGenerator.call(this, generator);
+  }
+
+  get contentSecurityPolicyNonceDirectives(): readonly string[] | undefined {
+    return _contentSecurityPolicyNonceDirectives.call(this);
+  }
+  set contentSecurityPolicyNonceDirectives(directives: readonly string[] | null) {
+    _setContentSecurityPolicyNonceDirectives.call(this, directives);
+  }
+
+  get contentSecurityPolicyNonce(): string | undefined {
+    return _contentSecurityPolicyNonce.call(this);
+  }
+
+  /** @internal */
+  generateContentSecurityPolicyNonce(): string {
+    return _generateContentSecurityPolicyNonce.call(this);
+  }
+
+  // --- Permissions Policy (ActionDispatch::PermissionsPolicy::Request) ---
+
+  get permissionsPolicy(): PermissionsPolicy | null | undefined {
+    return this.env["action_dispatch.permissions_policy"] as PermissionsPolicy | null | undefined;
+  }
+  set permissionsPolicy(policy: PermissionsPolicy | null) {
+    this.env["action_dispatch.permissions_policy"] = policy;
+  }
 
   // --- Request type checks ---
 
@@ -504,7 +578,7 @@ export class Request {
   }
 
   /** @internal */
-  private get _paramsHost(): ParametersHost {
+  get _paramsHost(): ParametersHost {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const req = this;
     return {
@@ -903,6 +977,66 @@ export class Request {
   declare formatFromPathExtension: () => MimeType | undefined;
   declare isParamsReadable: () => boolean;
 
+  // --- Controller dispatch ---
+
+  /**
+   * Rails: `request.controller_class` (request.rb:88-92). Defaults the
+   * `action` path-parameter to `"index"` and resolves the controller class
+   * via {@link controllerClassFor}.
+   */
+  controllerClass(): typeof PassNotFound | unknown {
+    const params = this.pathParameters as Record<string, unknown>;
+    if (params["action"] == null) params["action"] = "index";
+    return this.controllerClassFor(params["controller"] as string | undefined);
+  }
+
+  /**
+   * Rails: `request.controller_class_for(name)` (request.rb:94-110).
+   * Sentinel-only path: returns {@link PassNotFound} when `name` is absent.
+   * Registry-backed name resolution is a follow-up.
+   */
+  controllerClassFor(name: string | undefined | null): typeof PassNotFound | unknown {
+    if (name) {
+      throw new Error(
+        `controllerClassFor(${name}): controller registry resolution not yet implemented`,
+      );
+    }
+    return PassNotFound;
+  }
+
+  // --- Request parameters (Rack form pairs / vars) ---
+
+  /**
+   * Rails: `request_parameters_list` (request.rb:437-456). Drives the
+   * `from_pairs` builder by surfacing whichever flat form list Rack has
+   * populated under `rack.request.form_pairs` / `rack.request.form_vars`.
+   * Returns `[]` when the body is empty and `null` when Rack parsed
+   * multipart but did not preserve a pair list.
+   */
+  requestParametersList(): QueryPair[] | null {
+    const rackPost = this.rackRequest.POST;
+    const formPairs = this.env["rack.request.form_pairs"];
+    if (formPairs != null) return formPairs as QueryPair[];
+    const formVars = this.env["rack.request.form_vars"];
+    if (formVars != null) return Array.from(QueryParser.eachPair(formVars as string));
+    if (rackPost && typeof rackPost === "object" && Object.keys(rackPost as object).length > 0) {
+      return null;
+    }
+    return [];
+  }
+
+  // --- Parameters mixin privates (declared; bound below via prototype) ---
+
+  /** @internal */
+  declare paramsParsers: () => ParameterParsers;
+  /** @internal */
+  declare parseFormattedParameters: (
+    parsers: ParameterParsers,
+    fallback: () => Record<string, unknown>,
+  ) => Record<string, unknown>;
+  /** @internal */
+  declare logParseErrorOnce: () => void;
+
   // --- Static factory ---
 
   static create(env: RackEnv = {}): Request {
@@ -1016,6 +1150,47 @@ Request.prototype.filteredParameters = _filteredParameters;
 Request.prototype.filteredEnv = _filteredEnv;
 Request.prototype.filteredPath = _filteredPath;
 Request.prototype.parameterFilter = _parameterFilter;
+Request.prototype.envFilter = _envFilter;
+Request.prototype.filteredQueryString = _filteredQueryString;
+Request.prototype.parameterFilterFor = _parameterFilterFor as (
+  this: Request,
+  filters: Array<string | RegExp>,
+) => ParameterFilter;
+
+// Parameters mixin privates. The host shape comes from `_paramsHost`; these
+// just delegate so `request.paramsParsers()` matches Rails' private API.
+Request.prototype.paramsParsers = function (this: Request) {
+  return _paramsParsers.call(this._paramsHost);
+};
+Request.prototype.parseFormattedParameters = function (
+  this: Request,
+  parsers: ParameterParsers,
+  fallback: () => Record<string, unknown>,
+) {
+  return _parseFormattedParameters.call(this._paramsHost, parsers, fallback);
+};
+Request.prototype.logParseErrorOnce = function (this: Request) {
+  _logParseErrorOnce.call(this._paramsHost);
+};
+
+/**
+ * Sentinel controller used when {@link Request.controllerClassFor} is called
+ * without a controller name. Mirrors Rails' `PASS_NOT_FOUND` anonymous class
+ * (request.rb:82-86): every dispatch path returns the sentinel itself, and
+ * `call` short-circuits to a `404` with the `X-Cascade: pass` header so the
+ * router falls through to the next matching route.
+ */
+export class PassNotFound {
+  static action(_name: unknown): typeof PassNotFound {
+    return PassNotFound;
+  }
+  static call(_env: RackEnv): [number, Record<string, string>, string[]] {
+    return [404, { "x-cascade": "pass" }, []];
+  }
+  static actionEncodingTemplate(_action: unknown): false {
+    return false;
+  }
+}
 // Mime-negotiation privates wired via prototype; declared on the class for
 // typing. These mirror Rails' private predicates / lookup helpers.
 Request.prototype.validAcceptHeader = function (this: Request) {

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -5,7 +5,7 @@
  * mirroring the Rails Request API.
  */
 
-import type { RackEnv } from "@blazetrails/rack";
+import type { RackBody, RackEnv, RackResponse } from "@blazetrails/rack";
 import { parseNestedQuery, Request as RackRequest } from "@blazetrails/rack";
 import { Session } from "../request/session.js";
 import {
@@ -432,15 +432,17 @@ export class Request {
     _setContentSecurityPolicyReportOnly.call(this, value);
   }
 
-  get contentSecurityPolicyNonceGenerator(): NonceGenerator | undefined {
-    return _contentSecurityPolicyNonceGenerator.call(this);
+  get contentSecurityPolicyNonceGenerator(): NonceGenerator | null | undefined {
+    // Env may hold `null` from `request.csp_nonce_generator = nil`; widen to
+    // include it so callers see the same shape the setter accepts.
+    return _contentSecurityPolicyNonceGenerator.call(this) as NonceGenerator | null | undefined;
   }
   set contentSecurityPolicyNonceGenerator(generator: NonceGenerator | null) {
     _setContentSecurityPolicyNonceGenerator.call(this, generator);
   }
 
-  get contentSecurityPolicyNonceDirectives(): readonly string[] | undefined {
-    return _contentSecurityPolicyNonceDirectives.call(this);
+  get contentSecurityPolicyNonceDirectives(): readonly string[] | null | undefined {
+    return _contentSecurityPolicyNonceDirectives.call(this) as readonly string[] | null | undefined;
   }
   set contentSecurityPolicyNonceDirectives(directives: readonly string[] | null) {
     _setContentSecurityPolicyNonceDirectives.call(this, directives);
@@ -1190,14 +1192,16 @@ Request.prototype.logParseErrorOnce = function (this: Request) {
  * `call` short-circuits to a `404` with the `X-Cascade: pass` header so the
  * router falls through to the next matching route.
  */
+async function* emptyRackBody(): RackBody {}
+
 export class PassNotFound {
   /** @internal */
   static action(_name: unknown): typeof PassNotFound {
     return PassNotFound;
   }
   /** @internal */
-  static call(_env: RackEnv): [number, Record<string, string>, string[]] {
-    return [404, { [X_CASCADE]: "pass" }, []];
+  static call(_env: RackEnv): RackResponse {
+    return [404, { [X_CASCADE]: "pass" }, emptyRackBody()];
   }
   /** @internal */
   static actionEncodingTemplate(_action: unknown): false {

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -581,7 +581,7 @@ export class Request {
   }
 
   /** @internal */
-  get _paramsHost(): ParametersHost {
+  private get _paramsHost(): ParametersHost {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
     const req = this;
     return {
@@ -1037,17 +1037,23 @@ export class Request {
     return [];
   }
 
-  // --- Parameters mixin privates (declared; bound below via prototype) ---
+  // --- Parameters mixin privates (Rails: private instance methods on Request) ---
 
   /** @internal */
-  declare paramsParsers: () => ParameterParsers;
+  paramsParsers(): ParameterParsers {
+    return _paramsParsers.call(this._paramsHost);
+  }
   /** @internal */
-  declare parseFormattedParameters: (
+  parseFormattedParameters(
     parsers: ParameterParsers,
     fallback: () => Record<string, unknown>,
-  ) => Record<string, unknown>;
+  ): Record<string, unknown> {
+    return _parseFormattedParameters.call(this._paramsHost, parsers, fallback);
+  }
   /** @internal */
-  declare logParseErrorOnce: () => void;
+  logParseErrorOnce(): void {
+    _logParseErrorOnce.call(this._paramsHost);
+  }
 
   // --- Static factory ---
 
@@ -1168,22 +1174,6 @@ Request.prototype.parameterFilterFor = _parameterFilterFor as (
   this: Request,
   filters: Array<string | RegExp>,
 ) => ParameterFilter;
-
-// Parameters mixin privates. The host shape comes from `_paramsHost`; these
-// just delegate so `request.paramsParsers()` matches Rails' private API.
-Request.prototype.paramsParsers = function (this: Request) {
-  return _paramsParsers.call(this._paramsHost);
-};
-Request.prototype.parseFormattedParameters = function (
-  this: Request,
-  parsers: ParameterParsers,
-  fallback: () => Record<string, unknown>,
-) {
-  return _parseFormattedParameters.call(this._paramsHost, parsers, fallback);
-};
-Request.prototype.logParseErrorOnce = function (this: Request) {
-  _logParseErrorOnce.call(this._paramsHost);
-};
 
 /**
  * Sentinel controller used when {@link Request.controllerClassFor} is called

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -433,16 +433,14 @@ export class Request {
   }
 
   get contentSecurityPolicyNonceGenerator(): NonceGenerator | null | undefined {
-    // Env may hold `null` from `request.csp_nonce_generator = nil`; widen to
-    // include it so callers see the same shape the setter accepts.
-    return _contentSecurityPolicyNonceGenerator.call(this) as NonceGenerator | null | undefined;
+    return _contentSecurityPolicyNonceGenerator.call(this);
   }
   set contentSecurityPolicyNonceGenerator(generator: NonceGenerator | null) {
     _setContentSecurityPolicyNonceGenerator.call(this, generator);
   }
 
   get contentSecurityPolicyNonceDirectives(): readonly string[] | null | undefined {
-    return _contentSecurityPolicyNonceDirectives.call(this) as readonly string[] | null | undefined;
+    return _contentSecurityPolicyNonceDirectives.call(this);
   }
   set contentSecurityPolicyNonceDirectives(directives: readonly string[] | null) {
     _setContentSecurityPolicyNonceDirectives.call(this, directives);

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -64,7 +64,7 @@ import {
   type ContentSecurityPolicy,
   type NonceGenerator,
 } from "./content-security-policy.js";
-import { QueryParser, type QueryPair } from "./query-parser.js";
+import { QueryParser } from "./query-parser.js";
 import { X_CASCADE } from "../constants.js";
 import type { PermissionsPolicy } from "../permissions-policy.js";
 import type { ParameterFilter } from "@blazetrails/activesupport";
@@ -1000,7 +1000,10 @@ export class Request {
    * controllers for a route) until that bridge lands.
    */
   controllerClassFor(name: string | undefined | null): typeof PassNotFound {
-    if (name) {
+    // Ruby `if name` is truthy for empty strings; only nil/false fall through
+    // to the PASS_NOT_FOUND branch. Mirror with explicit null-check so `""`
+    // takes the resolution path (and surfaces the not-implemented error).
+    if (name != null) {
       throw new Error(
         `controllerClassFor(${name}): Trails has no global controller constant table; ` +
           `resolve the controller class via the router instead.`,
@@ -1018,10 +1021,12 @@ export class Request {
    * Returns `[]` when the body is empty and `null` when Rack parsed
    * multipart but did not preserve a pair list.
    */
-  requestParametersList(): QueryPair[] | null {
+  requestParametersList(): Array<[string, unknown]> | null {
     const rackPost = this.rackRequest.POST;
     const formPairs = this.env["rack.request.form_pairs"];
-    if (formPairs != null) return formPairs as QueryPair[];
+    // Multipart form_pairs values may be UploadedFile-like objects, not just
+    // strings; surface as `unknown` rather than narrowing to QueryPair.
+    if (formPairs != null) return formPairs as Array<[string, unknown]>;
     const formVars = this.env["rack.request.form_vars"];
     if (formVars != null) return Array.from(QueryParser.eachPair(formVars as string));
     if (rackPost && typeof rackPost === "object" && Object.keys(rackPost as object).length > 0) {

--- a/packages/actionpack/src/action-dispatch/http/request.ts
+++ b/packages/actionpack/src/action-dispatch/http/request.ts
@@ -65,6 +65,7 @@ import {
   type NonceGenerator,
 } from "./content-security-policy.js";
 import { QueryParser, type QueryPair } from "./query-parser.js";
+import { X_CASCADE } from "../constants.js";
 import type { PermissionsPolicy } from "../permissions-policy.js";
 import type { ParameterFilter } from "@blazetrails/activesupport";
 import { RequestUtils, type ParamValue } from "../request/utils.js";
@@ -984,21 +985,25 @@ export class Request {
    * `action` path-parameter to `"index"` and resolves the controller class
    * via {@link controllerClassFor}.
    */
-  controllerClass(): typeof PassNotFound | unknown {
-    const params = this.pathParameters as Record<string, unknown>;
+  controllerClass(): typeof PassNotFound {
+    const params = this.pathParameters;
     if (params["action"] == null) params["action"] = "index";
     return this.controllerClassFor(params["controller"] as string | undefined);
   }
 
   /**
-   * Rails: `request.controller_class_for(name)` (request.rb:94-110).
-   * Sentinel-only path: returns {@link PassNotFound} when `name` is absent.
-   * Registry-backed name resolution is a follow-up.
+   * Rails: `request.controller_class_for(name)` (request.rb:94-110). When
+   * `name` is absent, returns the {@link PassNotFound} sentinel; otherwise
+   * throws — Trails has no global constant table to back Rails'
+   * `"#{name.camelize}Controller".constantize` lookup, so callers must
+   * resolve the class through the router (which knows the registered
+   * controllers for a route) until that bridge lands.
    */
-  controllerClassFor(name: string | undefined | null): typeof PassNotFound | unknown {
+  controllerClassFor(name: string | undefined | null): typeof PassNotFound {
     if (name) {
       throw new Error(
-        `controllerClassFor(${name}): controller registry resolution not yet implemented`,
+        `controllerClassFor(${name}): Trails has no global controller constant table; ` +
+          `resolve the controller class via the router instead.`,
       );
     }
     return PassNotFound;
@@ -1181,12 +1186,15 @@ Request.prototype.logParseErrorOnce = function (this: Request) {
  * router falls through to the next matching route.
  */
 export class PassNotFound {
+  /** @internal */
   static action(_name: unknown): typeof PassNotFound {
     return PassNotFound;
   }
+  /** @internal */
   static call(_env: RackEnv): [number, Record<string, string>, string[]] {
-    return [404, { "x-cascade": "pass" }, []];
+    return [404, { [X_CASCADE]: "pass" }, []];
   }
+  /** @internal */
   static actionEncodingTemplate(_action: unknown): false {
     return false;
   }

--- a/packages/actionpack/src/action-dispatch/middleware/content-security-policy.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/content-security-policy.ts
@@ -42,7 +42,7 @@ export class ContentSecurityPolicyMiddleware {
     // (content_security_policy.rb:51).
     const context = request.controllerInstance ?? request;
 
-    headers[this.headerName(request)] = policy.build(context, nonce, nonceDirectives);
+    headers[this.headerName(request)] = policy.build(context, nonce, nonceDirectives ?? undefined);
     return response;
   }
 

--- a/packages/actionpack/src/action-dispatch/request.ts
+++ b/packages/actionpack/src/action-dispatch/request.ts
@@ -1,1 +1,1 @@
-export { Request } from "./http/request.js";
+export { Request, PassNotFound } from "./http/request.js";


### PR DESCRIPTION
## Summary
Closes the remaining gap on `actionpack/lib/action_dispatch/http/request.rb`:
**80% → 100%** (24 missing → 0).

Existing helpers in `content-security-policy.ts`, `filter-parameters.ts`,
and `parameters.ts` already implemented the behavior — this PR wires them
onto `ActionDispatch::Request` and adds the few small surfaces that were
still missing:

- **CSP mixin (`ContentSecurityPolicy::Request`)** — `contentSecurityPolicy`,
  `…ReportOnly`, `…NonceGenerator`, `…NonceDirectives` (g/s) + `…Nonce` (g)
  + `generateContentSecurityPolicyNonce`.
- **PermissionsPolicy::Request** — `permissionsPolicy` g/s, env-backed
  under `action_dispatch.permissions_policy`.
- **FilterParameters privates** — `envFilter`, `filteredQueryString`,
  `parameterFilterFor` mixed onto `Request.prototype`.
- **Parameters privates** — `paramsParsers`, `parseFormattedParameters`,
  `logParseErrorOnce` mixed onto `Request.prototype`.
- **PassNotFound sentinel** — exported with `action` / `call` /
  `actionEncodingTemplate` mirroring Rails' anonymous-class shape
  (request.rb:82-86). `controllerClass` defaults `params[:action]` to
  `"index"` and delegates to `controllerClassFor`, which ships the
  sentinel-only path (named-resolution throws until the controller
  registry lands — flagged as a Rails follow-up).
- **`requestParametersList`** — surfaces `rack.request.form_pairs` /
  `form_vars` (parsed via `QueryParser.eachPair`), matching the Rails
  branch order for empty body vs. opaque-multipart.

## Follow-ups (not in this PR)
- `controllerClassFor(name)` registry-backed name → class resolution.

## Test plan
- [x] `pnpm api:compare --package actiondispatch --files http/request` → `122/122 (100%)`
- [x] `pnpm vitest run` on `filter-parameters.test.ts` + `parameters.test.ts` (38 pass)
- [x] `pnpm build` (actionpack) clean
- [x] `pnpm eslint packages/actionpack/src/action-dispatch/http/request.ts` clean