### PR TITLE
test(activerecord): TM Phase 6 helpers — DDL-tracker restore + invalidateSchemaCache opt-out

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -80,6 +80,41 @@ function _txLockStorage(): AsyncContext<true> {
 // `@pinned_connections_depth` (connection_pool.rb:327, 345).
 let _skipGlobalResetDepth = 0;
 
+/**
+ * Snapshot the global DDL trackers so a wrapping `withTransactionalFixtures`
+ * scope can restore them after the outer transaction rolls back. DDL parsed
+ * during an `it()` body adds entries to `_createdTables` / `_createdColumns`
+ * (via `recordDdlTracking`); the rollback reverts the DDL on the DB side, but
+ * the trackers would otherwise report the rolled-back table as still-created.
+ *
+ * Today this is harmless because `defineSchema` consults its signature cache
+ * first (which is snapshot/restored via `_snapshotAppliedSchemaSignaturesForAdapter`).
+ * But a future test pattern — `defineSchema` in `beforeAll` plus raw
+ * `createTable` inside an `it()` body — would leak. Snapshot/restore plugs
+ * that gap before it surfaces.
+ *
+ * @internal
+ */
+export function _snapshotDdlTrackers(): {
+  tables: Set<string>;
+  columns: Map<string, Set<string>>;
+} {
+  const columns = new Map<string, Set<string>>();
+  for (const [k, v] of _createdColumns) columns.set(k, new Set(v));
+  return { tables: new Set(_createdTables), columns };
+}
+
+/** @internal */
+export function _restoreDdlTrackers(snapshot: {
+  tables: Set<string>;
+  columns: Map<string, Set<string>>;
+}): void {
+  _createdTables.clear();
+  for (const t of snapshot.tables) _createdTables.add(t);
+  _createdColumns.clear();
+  for (const [k, v] of snapshot.columns) _createdColumns.set(k, new Set(v));
+}
+
 /** @internal */
 export function pushSkipGlobalReset(): void {
   _skipGlobalResetDepth += 1;

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -251,3 +251,57 @@ describe("withTransactionalFixtures (raw adapter)", () => {
     expect(rows).toHaveLength(0);
   });
 });
+
+// DDL inside an it() body updates the module-level `_createdTables` /
+// `_createdColumns` trackers (via `recordDdlTracking`). The outer
+// transaction rolls back the DDL on the DB side; the helper restores the
+// trackers to their pre-test snapshot so a follow-up `defineSchema` call
+// can correctly recreate the rolled-back table.
+describe("withTransactionalFixtures (DDL tracker invalidation)", () => {
+  let adapter: TestDatabaseAdapter;
+
+  beforeAll(async () => {
+    adapter = createTestAdapter();
+  });
+
+  withTransactionalFixtures(() => adapter);
+
+  it("createTable inside a test populates the tables tracker", async () => {
+    await (adapter as unknown as AdapterWithExec).exec(
+      `CREATE TABLE ddl_tracker_inner (id INTEGER PRIMARY KEY, name TEXT)`,
+    );
+    expect(adapter.tables.has("ddl_tracker_inner")).toBe(true);
+  });
+
+  it("next test sees the tracker reset because afterEach restored the snapshot", () => {
+    expect(adapter.tables.has("ddl_tracker_inner")).toBe(false);
+  });
+});
+
+// When `invalidateSchemaCache: false`, the helper skips `schemaCache.clear()`
+// in afterEach. Cached column reflection survives across tests — pay this
+// cost only when the file does pure DML.
+describe("withTransactionalFixtures (invalidateSchemaCache: false)", () => {
+  let adapter: SQLite3Adapter;
+
+  beforeAll(async () => {
+    adapter = new SQLite3Adapter(":memory:");
+    await defineSchema(adapter, { opt_out_cache_users: { name: "string" } });
+  });
+
+  afterAll(async () => {
+    await adapter.close();
+  });
+
+  withTransactionalFixtures(() => adapter, { invalidateSchemaCache: false });
+
+  it("warming the schema cache leaves it populated", async () => {
+    const cols = await adapter.columns("opt_out_cache_users");
+    adapter.schemaCache.setColumns("opt_out_cache_users", cols);
+    expect(adapter.schemaCache.isColumnsHashCached(adapter.pool, "opt_out_cache_users")).toBe(true);
+  });
+
+  it("next test still sees the cached columns because the opt-out skipped clear()", () => {
+    expect(adapter.schemaCache.isColumnsHashCached(adapter.pool, "opt_out_cache_users")).toBe(true);
+  });
+});

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -272,9 +272,14 @@ describe.skipIf(adapterType === "mysql")(
     let adapter: TestDatabaseAdapter;
     let outerTables: Set<string>;
 
-    beforeAll(() => {
+    beforeAll(async () => {
       adapter = createTestAdapter();
+      // Register an outer-scope table so the snapshot has at least one
+      // entry to preserve across rollback — without this, the
+      // preservation assertion below would be vacuous.
+      await defineSchema(adapter, { ddl_tracker_outer: { name: "string" } });
       outerTables = _snapshotDdlTrackers().tables;
+      expect(outerTables.has("ddl_tracker_outer")).toBe(true);
     });
 
     withTransactionalFixtures(() => adapter);
@@ -283,13 +288,15 @@ describe.skipIf(adapterType === "mysql")(
       await (adapter as unknown as AdapterWithExec).exec(
         `CREATE TABLE ddl_tracker_inner (id INTEGER PRIMARY KEY)`,
       );
-      expect(_snapshotDdlTrackers().tables.has("ddl_tracker_inner")).toBe(true);
+      const tables = _snapshotDdlTrackers().tables;
+      expect(tables.has("ddl_tracker_inner")).toBe(true);
+      expect(tables.has("ddl_tracker_outer")).toBe(true);
     });
 
-    it("next test sees the tracker reset because afterEach restored the snapshot", () => {
+    it("next test sees the inner tracker reset but outer entries preserved", () => {
       const tables = _snapshotDdlTrackers().tables;
       expect(tables.has("ddl_tracker_inner")).toBe(false);
-      // Sanity: outer-scope entries from beforeAll-time still present.
+      expect(tables.has("ddl_tracker_outer")).toBe(true);
       for (const t of outerTables) expect(tables.has(t)).toBe(true);
     });
   },

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
+  _snapshotDdlTrackers,
+  adapterType,
   createTestAdapter,
   shouldSkipGlobalReset,
   type TestDatabaseAdapter,
@@ -253,30 +255,45 @@ describe("withTransactionalFixtures (raw adapter)", () => {
 });
 
 // DDL inside an it() body updates the module-level `_createdTables` /
-// `_createdColumns` trackers (via `recordDdlTracking`). The outer
-// transaction rolls back the DDL on the DB side; the helper restores the
-// trackers to their pre-test snapshot so a follow-up `defineSchema` call
-// can correctly recreate the rolled-back table.
-describe("withTransactionalFixtures (DDL tracker invalidation)", () => {
-  let adapter: TestDatabaseAdapter;
+// `_createdColumns` trackers (via `recordDdlTracking` in the
+// `SchemaAdapter` wrapper). The outer transaction rolls back the DDL on
+// the DB side; the helper restores the trackers to their pre-test
+// snapshot so a follow-up `defineSchema` call can correctly recreate the
+// rolled-back table.
+//
+// Skipped on MySQL/MariaDB: the helper's docs flag DDL inside `it()` as
+// undefined behavior there (DDL implicitly commits and escapes the
+// wrap). Running this describe against MySQL would leak the table into
+// the live schema. SQLite + PG (which do transactional DDL) cover the
+// behavior under test.
+describe.skipIf(adapterType === "mysql")(
+  "withTransactionalFixtures (DDL tracker invalidation)",
+  () => {
+    let adapter: TestDatabaseAdapter;
+    let outerTables: Set<string>;
 
-  beforeAll(async () => {
-    adapter = createTestAdapter();
-  });
+    beforeAll(() => {
+      adapter = createTestAdapter();
+      outerTables = _snapshotDdlTrackers().tables;
+    });
 
-  withTransactionalFixtures(() => adapter);
+    withTransactionalFixtures(() => adapter);
 
-  it("createTable inside a test populates the tables tracker", async () => {
-    await (adapter as unknown as AdapterWithExec).exec(
-      `CREATE TABLE ddl_tracker_inner (id INTEGER PRIMARY KEY, name TEXT)`,
-    );
-    expect(adapter.tables.has("ddl_tracker_inner")).toBe(true);
-  });
+    it("createTable inside a test populates the tables tracker", async () => {
+      await (adapter as unknown as AdapterWithExec).exec(
+        `CREATE TABLE ddl_tracker_inner (id INTEGER PRIMARY KEY)`,
+      );
+      expect(_snapshotDdlTrackers().tables.has("ddl_tracker_inner")).toBe(true);
+    });
 
-  it("next test sees the tracker reset because afterEach restored the snapshot", () => {
-    expect(adapter.tables.has("ddl_tracker_inner")).toBe(false);
-  });
-});
+    it("next test sees the tracker reset because afterEach restored the snapshot", () => {
+      const tables = _snapshotDdlTrackers().tables;
+      expect(tables.has("ddl_tracker_inner")).toBe(false);
+      // Sanity: outer-scope entries from beforeAll-time still present.
+      for (const t of outerTables) expect(tables.has(t)).toBe(true);
+    });
+  },
+);
 
 // When `invalidateSchemaCache: false`, the helper skips `schemaCache.clear()`
 // in afterEach. Cached column reflection survives across tests — pay this

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -1,6 +1,8 @@
 import { beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import type { DatabaseAdapter } from "../adapter.js";
 import {
+  _restoreDdlTrackers,
+  _snapshotDdlTrackers,
   getUseTransactionalTests,
   popSkipGlobalReset,
   pushSkipGlobalReset,
@@ -135,7 +137,27 @@ function adapterAndInner(
  *   });
  *   withTransactionalFixtures(() => adapter);
  */
-export function withTransactionalFixtures(getAdapter: () => TransactionalFixturesAdapter): void {
+/**
+ * Options for {@link withTransactionalFixtures}.
+ */
+export interface WithTransactionalFixturesOptions {
+  /**
+   * Whether to call `schemaCache.clear()` on the adapter after the outer
+   * transaction rolls back. Defaults to `true`, matching the historical
+   * (and safe-by-default) behavior introduced in PR #2064.
+   *
+   * Files that do pure DML (no `addColumn` / `createTable` / `changeTable`
+   * inside `it()` bodies) can set this to `false` to skip the
+   * re-introspection cost on every teardown.
+   */
+  invalidateSchemaCache?: boolean;
+}
+
+export function withTransactionalFixtures(
+  getAdapter: () => TransactionalFixturesAdapter,
+  options: WithTransactionalFixturesOptions = {},
+): void {
+  const { invalidateSchemaCache = true } = options;
   let active = true;
   // Snapshots of defineSchema's per-adapter signature cache taken at the
   // start of each test. On rollback we restore — preserving signatures for
@@ -144,6 +166,7 @@ export function withTransactionalFixtures(getAdapter: () => TransactionalFixture
   // `it()` body (whose DDL was rolled back at the DB).
   let outerSig: Map<string, string> | null = null;
   let innerSig: Map<string, string> | null = null;
+  let ddlSnapshot: ReturnType<typeof _snapshotDdlTrackers> | null = null;
 
   beforeAll(() => {
     active = getUseTransactionalTests(getAdapter());
@@ -164,6 +187,7 @@ export function withTransactionalFixtures(getAdapter: () => TransactionalFixture
     const [outer, inner] = adapterAndInner(getAdapter());
     outerSig = _snapshotAppliedSchemaSignaturesForAdapter(outer);
     innerSig = inner ? _snapshotAppliedSchemaSignaturesForAdapter(inner) : null;
+    ddlSnapshot = _snapshotDdlTrackers();
     // Mirrors Rails ConnectionPool#pin_connection!:
     //   @pinned_connection.begin_transaction joinable: false, _lazy: false
     await tm(getAdapter()).beginTransaction({ joinable: false, _lazy: false });
@@ -173,11 +197,13 @@ export function withTransactionalFixtures(getAdapter: () => TransactionalFixture
     if (!active) return;
     const t = tm(getAdapter());
     while (t.openTransactions > 0) await t.rollbackTransaction();
-    clearSchemaCache(getAdapter());
+    if (invalidateSchemaCache) clearSchemaCache(getAdapter());
     const [outer, inner] = adapterAndInner(getAdapter());
     if (outerSig) _restoreAppliedSchemaSignaturesForAdapter(outer, outerSig);
     if (inner && innerSig) _restoreAppliedSchemaSignaturesForAdapter(inner, innerSig);
+    if (ddlSnapshot) _restoreDdlTrackers(ddlSnapshot);
     outerSig = null;
     innerSig = null;
+    ddlSnapshot = null;
   });
 }


### PR DESCRIPTION
## Summary

Two small `withTransactionalFixtures` extensions from the #2064 follow-up list. Both are tightly scoped infra; no tests migrated in this PR.

### 1. DDL tracker snapshot/restore

`_createdTables` / `_createdColumns` are module-level Sets in `test-adapter.ts` that `recordDdlTracking` updates on every parsed CREATE/DROP TABLE. PR #2064 snapshot/restored the `defineSchema` signature cache + cleared `schemaCache` on rollback, but left these trackers alone. Today harmless (because `defineSchema` consults the signature cache first, which IS restored), but a future test calling `defineSchema` in `beforeAll` + raw `createTable` inside an `it()` body would have a stale `_createdTables` entry surviving rollback and trigger a redundant `dropTable`.

Fix: export `_snapshotDdlTrackers` / `_restoreDdlTrackers` from `test-adapter.ts` and call them from the helper's `beforeEach` / `afterEach`, mirroring how the signature cache is already handled.

### 2. `invalidateSchemaCache` opt-out option

New options arg on `withTransactionalFixtures`:

```ts
withTransactionalFixtures(getAdapter, { invalidateSchemaCache: false })
```

Default `true` — current behavior. When `false`, the helper skips `schemaCache.clear()` in `afterEach`. DML-only files can opt out to avoid re-introspection cost on every teardown (Copilot review #5 / comment #3 on #2064). No tests migrated to use it here — that's a follow-up.

## Deferred from original bundle

The original brief also included MariaDB savepoint-tolerance + a `has-one-associations.test.ts` proof migration. Deferred: that file has 30+ inline `freshAdapter()` / `defineSchema()` calls inside `it()` bodies, which is the documented inline-DDL hazard. A clean savepoint-tolerance design needs more investigation than fits this PR's budget.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts` — 18 tests pass (4 new: tracker reset across rollback × 2, opt-out keeps cache populated × 2)
- [ ] CI parallel run (PG / MySQL / MariaDB adapters)