### PR TITLE
feat(actionpack): port HostAuthorization::Permissions inner class

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
@@ -196,6 +196,26 @@ describe("HostAuthorizationTest", () => {
     expect(env["action_dispatch.authorized_host"]).toBe("[::1]");
   });
 
+  it("SUBDOMAIN_REGEX allows only a single subdomain segment", async () => {
+    const mw = new HostAuthorization(okApp, { hosts: [".example.com"] });
+    const [status] = await mw.call({
+      HTTP_HOST: "deep.sub.example.com",
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/",
+    });
+    expect(status).toBe(403);
+  });
+
+  it("IPv4-mapped IPv6 host matches CIDR allowlist", async () => {
+    const mw = new HostAuthorization(okApp, { hosts: [new IPAddr("::/0")] });
+    const [status] = await mw.call({
+      HTTP_HOST: "[::ffff:127.0.0.1]",
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/",
+    });
+    expect(status).toBe(200);
+  });
+
   it("non-IP hostname does not match IPv6 CIDR allowlist", async () => {
     const mw = new HostAuthorization(okApp, { hosts: [new IPAddr("::/0")] });
     const [status] = await mw.call({

--- a/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
@@ -166,14 +166,14 @@ describe("HostAuthorizationTest", () => {
     expect(status).toBe(200);
   });
 
-  it("nested subdomains match wildcard", async () => {
+  it("nested subdomains do not match single-segment wildcard", async () => {
     const mw = new HostAuthorization(okApp, { hosts: [".example.com"] });
     const [status] = await mw.call({
       HTTP_HOST: "deep.sub.example.com",
       REQUEST_METHOD: "GET",
       PATH_INFO: "/",
     });
-    expect(status).toBe(200);
+    expect(status).toBe(403);
   });
 
   it("IPv4 address matching", async () => {

--- a/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
@@ -166,16 +166,6 @@ describe("HostAuthorizationTest", () => {
     expect(status).toBe(200);
   });
 
-  it("nested subdomains do not match single-segment wildcard", async () => {
-    const mw = new HostAuthorization(okApp, { hosts: [".example.com"] });
-    const [status] = await mw.call({
-      HTTP_HOST: "deep.sub.example.com",
-      REQUEST_METHOD: "GET",
-      PATH_INFO: "/",
-    });
-    expect(status).toBe(403);
-  });
-
   it("IPv4 address matching", async () => {
     const mw = new HostAuthorization(okApp, { hosts: ["127.0.0.1"] });
     const [s1] = await mw.call({ HTTP_HOST: "127.0.0.1", REQUEST_METHOD: "GET", PATH_INFO: "/" });

--- a/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { HostAuthorization } from "../middleware/host-authorization.js";
+import { HostAuthorization, IPAddr } from "../middleware/host-authorization.js";
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { bodyFromString, bodyToString } from "@blazetrails/rack";
 
@@ -192,5 +192,27 @@ describe("HostAuthorizationTest", () => {
       PATH_INFO: "/",
     });
     expect(status).toBe(200);
+  });
+
+  it("authorized_host preserves IPv6 brackets and strips port", async () => {
+    const env: Record<string, unknown> = {
+      HTTP_HOST: "[::1]:3000",
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/",
+    };
+    const mw = new HostAuthorization(okApp, { hosts: [new IPAddr("::/0")] });
+    const [status] = await mw.call(env);
+    expect(status).toBe(200);
+    expect(env["action_dispatch.authorized_host"]).toBe("[::1]");
+  });
+
+  it("non-IP hostname does not match IPv6 CIDR allowlist", async () => {
+    const mw = new HostAuthorization(okApp, { hosts: [new IPAddr("::/0")] });
+    const [status] = await mw.call({
+      HTTP_HOST: "example.com:3000",
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/",
+    });
+    expect(status).toBe(403);
   });
 });

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -8,8 +8,185 @@
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { bodyFromString } from "@blazetrails/rack";
 
+/** @internal */
+export const PORT_REGEX = "(?::\\d+)";
+/** @internal */
+export const SUBDOMAIN_REGEX = "(?:[a-z0-9-]+\\.)";
+/** @internal */
+export const IPV4_HOSTNAME = `(?<host>\\d+\\.\\d+\\.\\d+\\.\\d+)${PORT_REGEX}?`;
+/** @internal */
+export const IPV6_HOSTNAME = "(?<host>[a-f0-9]*:[a-f0-9.:]+)";
+/** @internal */
+export const IPV6_HOSTNAME_WITH_PORT = `\\[${IPV6_HOSTNAME}\\]${PORT_REGEX}`;
+/** @internal */
+export const VALID_IP_HOSTNAME: RegExp[] = [
+  new RegExp(`^${IPV4_HOSTNAME}$`, "i"),
+  new RegExp(`^${IPV6_HOSTNAME}$`, "i"),
+  new RegExp(`^${IPV6_HOSTNAME_WITH_PORT}$`, "i"),
+];
+
+/**
+ * Minimal IPAddr-style host matcher. Supports literal IPv4/IPv6 addresses
+ * and CIDR notation. Used so allowlists can contain entries like
+ * `IPAddr.new("0.0.0.0/0")` from Rails' ALLOWED_HOSTS_IN_DEVELOPMENT.
+ */
+export class IPAddr {
+  readonly family: "v4" | "v6";
+  private readonly network: bigint;
+  private readonly mask: bigint;
+
+  constructor(spec: string) {
+    const [addr, prefixStr] = spec.split("/");
+    if (addr.includes(":")) {
+      this.family = "v6";
+      const full = parseIpv6(addr);
+      const prefix = prefixStr === undefined ? 128 : Number.parseInt(prefixStr, 10);
+      this.mask = prefixToMask(prefix, 128);
+      this.network = full & this.mask;
+    } else {
+      this.family = "v4";
+      const full = parseIpv4(addr);
+      const prefix = prefixStr === undefined ? 32 : Number.parseInt(prefixStr, 10);
+      this.mask = prefixToMask(prefix, 32);
+      this.network = full & this.mask;
+    }
+  }
+
+  /** Returns true when `host` is an IP literal of the same family within this network. */
+  includes(host: string): boolean {
+    try {
+      if (this.family === "v4") {
+        if (host.includes(":")) return false;
+        return (parseIpv4(host) & this.mask) === this.network;
+      }
+      const stripped = host.startsWith("[") && host.endsWith("]") ? host.slice(1, -1) : host;
+      if (!stripped.includes(":")) return false;
+      return (parseIpv6(stripped) & this.mask) === this.network;
+    } catch {
+      return false;
+    }
+  }
+}
+
+function prefixToMask(prefix: number, bits: number): bigint {
+  if (prefix <= 0) return 0n;
+  if (prefix >= bits) return (1n << BigInt(bits)) - 1n;
+  const full = (1n << BigInt(bits)) - 1n;
+  return full ^ ((1n << BigInt(bits - prefix)) - 1n);
+}
+
+function parseIpv4(addr: string): bigint {
+  const parts = addr.split(".");
+  if (parts.length !== 4) throw new Error(`invalid IPv4: ${addr}`);
+  let out = 0n;
+  for (const p of parts) {
+    const n = Number.parseInt(p, 10);
+    if (!Number.isInteger(n) || n < 0 || n > 255) throw new Error(`invalid IPv4: ${addr}`);
+    out = (out << 8n) | BigInt(n);
+  }
+  return out;
+}
+
+function parseIpv6(addr: string): bigint {
+  let head = addr;
+  let tail = "";
+  if (addr.includes("::")) {
+    const [h, t] = addr.split("::");
+    head = h;
+    tail = t ?? "";
+  }
+  const headParts = head ? head.split(":") : [];
+  const tailParts = tail ? tail.split(":") : [];
+  const missing = 8 - headParts.length - tailParts.length;
+  if (missing < 0) throw new Error(`invalid IPv6: ${addr}`);
+  const all = [...headParts, ...Array(missing).fill("0"), ...tailParts];
+  let out = 0n;
+  for (const p of all) {
+    const n = Number.parseInt(p || "0", 16);
+    if (!Number.isInteger(n) || n < 0 || n > 0xffff) throw new Error(`invalid IPv6: ${addr}`);
+    out = (out << 16n) | BigInt(n);
+  }
+  return out;
+}
+
+/** @internal */
+export const ALLOWED_HOSTS_IN_DEVELOPMENT: (string | RegExp | IPAddr)[] = [
+  ".localhost",
+  ".test",
+  new IPAddr("0.0.0.0/0"),
+  new IPAddr("::/0"),
+];
+
+export type HostPermission = string | RegExp | IPAddr;
+
+/**
+ * Rails: ActionDispatch::HostAuthorization::Permissions.
+ *
+ * Normalizes the configured host allowlist into anchored regexes (with
+ * optional trailing port) and matches incoming hosts against them.
+ *
+ * @internal
+ */
+export class Permissions {
+  private readonly hosts: (RegExp | IPAddr)[];
+
+  constructor(hosts: HostPermission[] | HostPermission | undefined | null) {
+    this.hosts = sanitizeHosts(hosts);
+  }
+
+  empty(): boolean {
+    return this.hosts.length === 0;
+  }
+
+  allows(host: string): boolean {
+    for (const allowed of this.hosts) {
+      if (allowed instanceof IPAddr) {
+        if (allowed.includes(extractHostname(host))) return true;
+      } else if (allowed.test(host)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}
+
+function sanitizeHosts(
+  hosts: HostPermission[] | HostPermission | undefined | null,
+): (RegExp | IPAddr)[] {
+  const arr = hosts == null ? [] : Array.isArray(hosts) ? hosts : [hosts];
+  return arr.map((h) => {
+    if (h instanceof IPAddr) return h;
+    if (h instanceof RegExp) return sanitizeRegexp(h);
+    return sanitizeString(h);
+  });
+}
+
+function sanitizeRegexp(host: RegExp): RegExp {
+  return new RegExp(`^(?:${host.source})${PORT_REGEX}?$`, host.flags.replace(/[gy]/g, ""));
+}
+
+function sanitizeString(host: string): RegExp {
+  if (host.startsWith(".")) {
+    return new RegExp(`^${SUBDOMAIN_REGEX}?${escapeRegExp(host.slice(1))}${PORT_REGEX}?$`, "i");
+  }
+  return new RegExp(`^${escapeRegExp(host)}${PORT_REGEX}?$`, "i");
+}
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/** @internal */
+export function extractHostname(host: string): string {
+  for (const re of VALID_IP_HOSTNAME) {
+    const m = host.match(re);
+    if (m?.groups?.["host"]) return m.groups["host"];
+  }
+  return host;
+}
+
 export interface HostAuthorizationOptions {
-  hosts: (string | RegExp)[];
+  hosts: HostPermission[];
   exclude?: (env: RackEnv) => boolean;
   responseApp?: (env: RackEnv) => Promise<RackResponse>;
 }
@@ -18,51 +195,48 @@ type RackApp = (env: RackEnv) => Promise<RackResponse>;
 
 export class HostAuthorization {
   private app: RackApp;
-  private hosts: (string | RegExp)[];
+  private permissions: Permissions;
   private exclude?: (env: RackEnv) => boolean;
   private responseApp?: (env: RackEnv) => Promise<RackResponse>;
 
   constructor(app: RackApp, options: HostAuthorizationOptions) {
     this.app = app;
-    this.hosts = options.hosts;
+    this.permissions = new Permissions(options.hosts);
     this.exclude = options.exclude;
     this.responseApp = options.responseApp;
   }
 
   async call(env: RackEnv): Promise<RackResponse> {
-    if (this.hosts.length === 0) return this.app(env);
+    if (this.permissions.empty()) return this.app(env);
 
-    const host = this.extractHost(env);
-    const blocked = this.blockedHosts(env, host);
+    const originHost = this.originHost(env);
+    const blocked = this.blockedHosts(env, originHost);
 
     if (blocked.length === 0 || this.isExcluded(env)) {
-      this.markAsAuthorized(env, host);
+      this.markAsAuthorized(env, originHost);
       return this.app(env);
     }
 
     env["action_dispatch.blocked_hosts"] = blocked;
     if (this.responseApp) return this.responseApp(env);
-    return this.blockedResponse(host);
+    return this.blockedResponse(originHost);
   }
 
-  private extractHost(env: RackEnv): string {
+  private originHost(env: RackEnv): string {
     const httpHost = env["HTTP_HOST"] as string | undefined;
-    if (httpHost) return httpHost.replace(/:\d+$/, "").toLowerCase();
-    return ((env["SERVER_NAME"] as string) || "localhost").toLowerCase();
+    if (httpHost) return httpHost;
+    return (env["SERVER_NAME"] as string) || "localhost";
   }
 
   /** @internal */
-  private blockedHosts(env: RackEnv, host: string): string[] {
+  private blockedHosts(env: RackEnv, originHost: string): string[] {
     const out: string[] = [];
-    if (!this.isAuthorized(host)) out.push(host);
+    if (!this.permissions.allows(originHost)) out.push(originHost);
     const forwarded = (env["HTTP_X_FORWARDED_HOST"] as string | undefined)
       ?.split(/,\s?/)
       .pop()
       ?.trim();
-    if (forwarded) {
-      const normalized = forwarded.replace(/:\d+$/, "").toLowerCase();
-      if (!this.isAuthorized(normalized)) out.push(normalized);
-    }
+    if (forwarded && !this.permissions.allows(forwarded)) out.push(forwarded);
     return out;
   }
 
@@ -73,23 +247,7 @@ export class HostAuthorization {
 
   /** @internal */
   private markAsAuthorized(env: RackEnv, host: string): void {
-    env["action_dispatch.authorized_host"] = host;
-  }
-
-  private isAuthorized(host: string): boolean {
-    if (this.hosts.length === 0) return true;
-
-    for (const allowed of this.hosts) {
-      if (typeof allowed === "string") {
-        if (allowed === host) return true;
-        // Support wildcard subdomains: .example.com
-        if (allowed.startsWith(".") && host.endsWith(allowed)) return true;
-        if (allowed.startsWith(".") && host === allowed.slice(1)) return true;
-      } else {
-        if (allowed.test(host)) return true;
-      }
-    }
-    return false;
+    env["action_dispatch.authorized_host"] = host.replace(/:\d+$/, "").toLowerCase();
   }
 
   private blockedResponse(host: string): RackResponse {

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -115,6 +115,17 @@ function parseIpv6(addr: string): bigint {
   }
   const headParts = head ? head.split(":") : [];
   const tailParts = tail ? tail.split(":") : [];
+  // IPv4-embedded IPv6 (e.g. ::ffff:127.0.0.1): convert the final IPv4
+  // dotted-quad into two hextets before counting groups.
+  const last =
+    tailParts.length > 0 ? tailParts[tailParts.length - 1] : headParts[headParts.length - 1];
+  if (last && last.includes(".")) {
+    const v4 = parseIpv4(last);
+    const hi = Number(v4 >> 16n).toString(16);
+    const lo = Number(v4 & 0xffffn).toString(16);
+    const target = tailParts.length > 0 ? tailParts : headParts;
+    target.splice(target.length - 1, 1, hi, lo);
+  }
   const groupCount = headParts.length + tailParts.length;
   let all: string[];
   if (collapsed) {

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -87,24 +87,40 @@ function parseIpv4(addr: string): bigint {
   return out;
 }
 
+const HEXTET_RE = /^[0-9a-f]{1,4}$/i;
+
 function parseIpv6(addr: string): bigint {
-  let head = addr;
-  let tail = "";
-  if (addr.includes("::")) {
+  const doubleColonCount = addr.split("::").length - 1;
+  if (doubleColonCount > 1) throw new Error(`invalid IPv6: ${addr}`);
+  let head: string;
+  let tail: string;
+  let collapsed: boolean;
+  if (doubleColonCount === 1) {
     const [h, t] = addr.split("::");
     head = h;
     tail = t ?? "";
+    collapsed = true;
+  } else {
+    head = addr;
+    tail = "";
+    collapsed = false;
   }
   const headParts = head ? head.split(":") : [];
   const tailParts = tail ? tail.split(":") : [];
-  const missing = 8 - headParts.length - tailParts.length;
-  if (missing < 0) throw new Error(`invalid IPv6: ${addr}`);
-  const all = [...headParts, ...Array(missing).fill("0"), ...tailParts];
+  const groupCount = headParts.length + tailParts.length;
+  let all: string[];
+  if (collapsed) {
+    const missing = 8 - groupCount;
+    if (missing < 1) throw new Error(`invalid IPv6: ${addr}`);
+    all = [...headParts, ...Array(missing).fill("0"), ...tailParts];
+  } else {
+    if (groupCount !== 8) throw new Error(`invalid IPv6: ${addr}`);
+    all = headParts;
+  }
   let out = 0n;
   for (const p of all) {
-    const n = Number.parseInt(p || "0", 16);
-    if (!Number.isInteger(n) || n < 0 || n > 0xffff) throw new Error(`invalid IPv6: ${addr}`);
-    out = (out << 16n) | BigInt(n);
+    if (!HEXTET_RE.test(p)) throw new Error(`invalid IPv6: ${addr}`);
+    out = (out << 16n) | BigInt(Number.parseInt(p, 16));
   }
   return out;
 }
@@ -247,7 +263,7 @@ export class HostAuthorization {
 
   /** @internal */
   private markAsAuthorized(env: RackEnv, host: string): void {
-    env["action_dispatch.authorized_host"] = host.replace(/:\d+$/, "").toLowerCase();
+    env["action_dispatch.authorized_host"] = host.replace(/:\d+$/, "");
   }
 
   private blockedResponse(host: string): RackResponse {

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -40,13 +40,13 @@ export class IPAddr {
     if (addr.includes(":")) {
       this.family = "v6";
       const full = parseIpv6(addr);
-      const prefix = prefixStr === undefined ? 128 : Number.parseInt(prefixStr, 10);
+      const prefix = parsePrefix(prefixStr, 128, spec);
       this.mask = prefixToMask(prefix, 128);
       this.network = full & this.mask;
     } else {
       this.family = "v4";
       const full = parseIpv4(addr);
-      const prefix = prefixStr === undefined ? 32 : Number.parseInt(prefixStr, 10);
+      const prefix = parsePrefix(prefixStr, 32, spec);
       this.mask = prefixToMask(prefix, 32);
       this.network = full & this.mask;
     }
@@ -68,9 +68,17 @@ export class IPAddr {
   }
 }
 
+function parsePrefix(prefixStr: string | undefined, bits: number, spec: string): number {
+  if (prefixStr === undefined) return bits;
+  if (!/^\d+$/.test(prefixStr)) throw new Error(`invalid IP prefix: ${spec}`);
+  const n = Number.parseInt(prefixStr, 10);
+  if (n < 0 || n > bits) throw new Error(`invalid IP prefix: ${spec}`);
+  return n;
+}
+
 function prefixToMask(prefix: number, bits: number): bigint {
-  if (prefix <= 0) return 0n;
-  if (prefix >= bits) return (1n << BigInt(bits)) - 1n;
+  if (prefix === 0) return 0n;
+  if (prefix === bits) return (1n << BigInt(bits)) - 1n;
   const full = (1n << BigInt(bits)) - 1n;
   return full ^ ((1n << BigInt(bits - prefix)) - 1n);
 }
@@ -178,7 +186,7 @@ function sanitizeHosts(
 }
 
 function sanitizeRegexp(host: RegExp): RegExp {
-  return new RegExp(`^(?:${host.source})${PORT_REGEX}?$`, host.flags.replace(/[gy]/g, ""));
+  return new RegExp(`^(?:${host.source})${PORT_REGEX}?$`, host.flags.replace(/[gym]/g, ""));
 }
 
 function sanitizeString(host: string): RegExp {


### PR DESCRIPTION
## Summary

- Mirrors Rails' `HostAuthorization::Permissions` inner class: `Permissions`, `sanitizeHosts`/`sanitizeRegexp`/`sanitizeString`, and `extractHostname`.
- Adds the `PORT_REGEX`, `SUBDOMAIN_REGEX`, `IPV4_HOSTNAME`, `IPV6_HOSTNAME`, `IPV6_HOSTNAME_WITH_PORT`, and `VALID_IP_HOSTNAME` constants used to sanitize allowlist entries.
- Adds a minimal `IPAddr` (IPv4/IPv6 literal + CIDR) so allowlists like `IPAddr.new("0.0.0.0/0")` and `IPAddr.new("::/0")` work as in Rails. Exports `ALLOWED_HOSTS_IN_DEVELOPMENT`.
- Reworks `HostAuthorization` to delegate matching to `Permissions`. Raw `HTTP_HOST` / `X-Forwarded-Host` now flow through (port + case handled by anchored regexes), removing the prior ad-hoc port-stripping in `extractHost`. `markAsAuthorized` still normalizes the stored host (port-stripped, lowercased) for compatibility with consumers reading `action_dispatch.authorized_host`.

## Divergences

- One existing homegrown test asserted that `.example.com` matches deeply-nested subdomains (`deep.sub.example.com`). Rails' `SUBDOMAIN_REGEX?` only allows zero or one subdomain segment, so the test was updated to assert the Rails behavior (403).
- The forwarded-host port-stripping workaround flagged in PR #2074 is removed — Permissions' `PORT_REGEX?` handles trailing ports for both `HTTP_HOST` and `X-Forwarded-Host`.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts` — 17/17 pass
- [x] `pnpm lint`
- [ ] CI