### PR TITLE
feat(actionpack): port Mapper::Scope class + Rails-private scope helpers

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -725,14 +725,23 @@ export class Mapper {
     }
   }
 
-  /** @internal */
+  /**
+   * Mirrors `resource_scope(resource, &block)`: pushes `scopeLevelResource`,
+   * then wraps in `controller(resource.resourceScope, &block)` (which Rails
+   * implements as a `{controller: …}` scope).
+   *
+   * @internal
+   */
   resourceScope<T>(resource: ResourceLike, fn: () => T): T {
-    const previous = this._scope;
+    const before = this._scope;
     this._scope = this._scope.newChild({ scopeLevelResource: resource });
+    if (resource.resourceScope !== undefined) {
+      this._scope = this._scope.newChild({ controller: resource.resourceScope });
+    }
     try {
       return fn();
     } finally {
-      this._scope = previous;
+      this._scope = before;
     }
   }
 
@@ -844,7 +853,16 @@ export class Mapper {
     }
     if (options.shallow) {
       delete options.shallow;
-      this.shallowScope(() => dispatch(resources.pop()!, options, block));
+      // Rails calls the public `shallow do…end` DSL here, which just sets
+      // `shallow: true` on the scope (mapper.rb:1635). The private
+      // `shallow_scope` (path/as swap) runs later during resource emission.
+      const beforeShallow = this._scope;
+      this._scope = this._scope.newChild({ shallow: true });
+      try {
+        dispatch(resources.pop()!, options, block);
+      } finally {
+        this._scope = beforeShallow;
+      }
       return true;
     }
     if (this._scope.isResourceScope()) {

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -20,9 +20,32 @@ import {
   type RedirectFunction,
   type RedirectOptions,
 } from "./route.js";
+import { Scope, type ScopeLevel } from "./scope.js";
 
 type MapperCallback = (mapper: Mapper) => void;
 type ConcernCallback = (mapper: Mapper) => void;
+
+/** @internal */
+interface ResourceLike {
+  memberName?: string;
+  collectionName?: string;
+  nestedParam?: string;
+  param?: string;
+  resourceScope?: string;
+  actions?: ResourceAction[];
+  shallow?: () => boolean;
+}
+
+/** Resource-DSL options stripped before falling back to `scope()`. */
+const RESOURCE_OPTIONS: ReadonlySet<string> = new Set([
+  "as",
+  "controller",
+  "path",
+  "only",
+  "except",
+  "param",
+  "concerns",
+]);
 
 export class Mapper {
   readonly routes: Route[] = [];
@@ -30,6 +53,10 @@ export class Mapper {
   private concerns: Map<string, ConcernCallback> = new Map();
   private redirectFns: Map<string, RedirectFunction> = new Map();
   private redirectCounter = 0;
+  /** @internal */
+  _scope: Scope = new Scope({ pathNames: { new: "new", edit: "edit" } }, Scope.ROOT, null);
+  /** @internal */
+  _apiOnly = false;
 
   // --- HTTP verb methods ---
 
@@ -671,6 +698,186 @@ export class Mapper {
   /** @internal */
   hasNamedRoute(name: string): boolean {
     return this.routes.some((r) => r.name === name);
+  }
+
+  // --- Rails-private scope-chain helpers (mapper.rb privates) ---
+
+  /** @internal */
+  withScopeLevel<T>(kind: ScopeLevel, fn: () => T): T {
+    const previous = this._scope;
+    this._scope = this._scope.newLevel(kind);
+    try {
+      return fn();
+    } finally {
+      this._scope = previous;
+    }
+  }
+
+  /** @internal */
+  pathScope<T>(path: string, fn: () => T): T {
+    const previous = this._scope;
+    const merged = this.mergePathScope(this._scope.get("path") as string | undefined, path);
+    this._scope = this._scope.newChild({ path: merged });
+    try {
+      return fn();
+    } finally {
+      this._scope = previous;
+    }
+  }
+
+  /** @internal */
+  resourceScope<T>(resource: ResourceLike, fn: () => T): T {
+    const previous = this._scope;
+    this._scope = this._scope.newChild({ scopeLevelResource: resource });
+    try {
+      return fn();
+    } finally {
+      this._scope = previous;
+    }
+  }
+
+  /** @internal */
+  shallowScope<T>(fn: () => T): T {
+    const previous = this._scope;
+    this._scope = this._scope.newChild({
+      as: this._scope.get("shallowPrefix"),
+      path: this._scope.get("shallowPath"),
+    });
+    try {
+      return fn();
+    } finally {
+      this._scope = previous;
+    }
+  }
+
+  /** @internal */
+  withDefaultScope(scopeOptions: ScopeOptions, callback: MapperCallback): void {
+    this.scope(scopeOptions, callback);
+  }
+
+  /** @internal */
+  parentResource(): ResourceLike | undefined {
+    return this._scope.get("scopeLevelResource") as ResourceLike | undefined;
+  }
+
+  /** @internal */
+  isResourceMethodScope(): boolean {
+    return this._scope.isResourceMethodScope();
+  }
+
+  /** @internal */
+  isNestedScopeLevel(): boolean {
+    return this._scope.isNested();
+  }
+
+  /** @internal */
+  isApiOnly(): boolean {
+    return this._apiOnly;
+  }
+
+  /** @internal */
+  resourcesPathNames(options: Record<string, string>): Record<string, string> {
+    const current = (this._scope.get("pathNames") as Record<string, string> | undefined) ?? {};
+    Object.assign(current, options);
+    return current;
+  }
+
+  /** @internal */
+  actionPath(name: string): string {
+    const pathNames = (this._scope.get("pathNames") as Record<string, string> | undefined) ?? {};
+    return pathNames[name] ?? name;
+  }
+
+  /** @internal */
+  nestedOptions(): { as?: string; constraints?: RouteConstraints } {
+    const parent = this.parentResource();
+    const options: { as?: string; constraints?: RouteConstraints } = { as: parent?.memberName };
+    if (this.isParamConstraint() && parent?.nestedParam) {
+      const c = this.paramConstraint();
+      if (c) options.constraints = { [parent.nestedParam]: c };
+    }
+    return options;
+  }
+
+  /** @internal */
+  scopeActionOptions(method: "resource" | "resources"): RouteOptions {
+    const stored = this._scope.get("actionOptions") as RouteOptions | undefined;
+    if (!stored) return {};
+    const actions = this.applicableActionsFor(method);
+    const result: RouteOptions = { ...stored };
+    if (stored.only) {
+      const only = Array.isArray(stored.only) ? stored.only : [stored.only];
+      result.only = only.filter((a) => actions.includes(a));
+    }
+    if (stored.except) {
+      const except = Array.isArray(stored.except) ? stored.except : [stored.except];
+      result.except = except.filter((a) => actions.includes(a));
+    }
+    return result;
+  }
+
+  /** @internal */
+  applyActionOptions(method: "resource" | "resources", options: RouteOptions): RouteOptions {
+    if (options.only || options.except) return options;
+    return { ...options, ...this.scopeActionOptions(method) };
+  }
+
+  /**
+   * Mirrors `apply_common_behavior_for`: short-circuits multi-resource
+   * splat, shallow unwrap, nested resource-scope, and scope-options unwrap.
+   * Returns `true` if handled, `false` otherwise.
+   *
+   * @internal
+   */
+  applyCommonBehaviorFor(
+    method: "resource" | "resources",
+    resources: string[],
+    options: RouteOptions,
+    block: MapperCallback | undefined,
+  ): boolean {
+    const dispatch = (...args: unknown[]) =>
+      (this as unknown as Record<string, (...a: unknown[]) => unknown>)[method](...args);
+
+    if (resources.length > 1) {
+      for (const r of resources) dispatch(r, options, block);
+      return true;
+    }
+    if (options.shallow) {
+      delete options.shallow;
+      this.shallowScope(() => dispatch(resources.pop()!, options, block));
+      return true;
+    }
+    if (this._scope.isResourceScope()) {
+      this.withScopeLevel("nested", () => dispatch(resources.pop()!, options, block));
+      return true;
+    }
+
+    const constraints = (options.constraints ?? {}) as RouteConstraints;
+    let pulledAny = false;
+    for (const k of Object.keys(options) as Array<keyof RouteOptions>) {
+      const v = options[k];
+      if (v instanceof RegExp) {
+        constraints[k as string] = v;
+        delete options[k];
+        pulledAny = true;
+      }
+    }
+    if (pulledAny) options.constraints = constraints;
+
+    const scopeOptions: ScopeOptions & Record<string, unknown> = {};
+    let hasScopeOption = false;
+    for (const k of Object.keys(options) as Array<keyof RouteOptions>) {
+      if (!RESOURCE_OPTIONS.has(k as string)) {
+        (scopeOptions as Record<string, unknown>)[k as string] = options[k];
+        delete options[k];
+        hasScopeOption = true;
+      }
+    }
+    if (hasScopeOption) {
+      this.scope(scopeOptions, () => dispatch(resources.pop()!, options, block));
+      return true;
+    }
+    return false;
   }
 }
 

--- a/packages/actionpack/src/action-dispatch/routing/scope.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/scope.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+
+import { Scope } from "./scope.js";
+
+describe("Scope", () => {
+  it("root is the ROOT sentinel; isRoot reports children of ROOT", () => {
+    expect(Scope.ROOT.isNull()).toBe(true);
+    const child = new Scope({ path: "/admin" });
+    expect(child.isRoot()).toBe(true);
+    expect(child.isNull()).toBe(false);
+  });
+
+  it("newChild merges over parent frame and inherits scopeLevel", () => {
+    const a = new Scope({ path: "/admin", as: "admin" }, Scope.ROOT, "resources");
+    const b = a.newChild({ as: "users" });
+    expect(b.get("path")).toBe("/admin");
+    expect(b.get("as")).toBe("users");
+    expect(b.scopeLevel).toBe("resources");
+    expect(b.parent).toBe(a);
+  });
+
+  it("newLevel preserves frame, changes scopeLevel", () => {
+    const a = new Scope({ path: "/admin" }, Scope.ROOT, "resources");
+    const b = a.newLevel("nested");
+    expect(b.get("path")).toBe("/admin");
+    expect(b.scopeLevel).toBe("nested");
+    expect(b.isNested()).toBe(true);
+  });
+
+  it("scope-level predicates match Rails RESOURCE_SCOPES / RESOURCE_METHOD_SCOPES", () => {
+    expect(new Scope({}, Scope.ROOT, "resource").isResourceScope()).toBe(true);
+    expect(new Scope({}, Scope.ROOT, "resources").isResourceScope()).toBe(true);
+    expect(new Scope({}, Scope.ROOT, "member").isResourceScope()).toBe(false);
+    expect(new Scope({}, Scope.ROOT, "collection").isResourceMethodScope()).toBe(true);
+    expect(new Scope({}, Scope.ROOT, "member").isResourceMethodScope()).toBe(true);
+    expect(new Scope({}, Scope.ROOT, "new").isResourceMethodScope()).toBe(true);
+    expect(new Scope({}, Scope.ROOT, "nested").isResourceMethodScope()).toBe(false);
+  });
+
+  it("actionName returns Rails-ordered tuples per scope level", () => {
+    const s = (lvl: Parameters<Scope["newLevel"]>[0]) => new Scope({}, Scope.ROOT, lvl);
+    expect(s("nested").actionName("np", "pre", "coll", "mem")).toEqual(["np", "pre"]);
+    expect(s("collection").actionName("np", "pre", "coll", "mem")).toEqual(["pre", "np", "coll"]);
+    expect(s("new").actionName("np", "pre", "coll", "mem")).toEqual(["pre", "new", "np", "mem"]);
+    expect(s("member").actionName("np", "pre", "coll", "mem")).toEqual(["pre", "np", "mem"]);
+    expect(s("root").actionName("np", "pre", "coll", "mem")).toEqual(["np", "coll", "pre"]);
+    expect(s(null).actionName("np", "pre", "coll", "mem")).toEqual(["np", "mem", "pre"]);
+  });
+
+  it("iterator yields each frame up to (not including) ROOT", () => {
+    const a = new Scope({ path: "/a" });
+    const b = a.newChild({ as: "b" });
+    const c = b.newChild({ controller: "c" });
+    expect([...c]).toEqual([c, b, a]);
+    expect([...Scope.ROOT]).toEqual([]);
+  });
+});

--- a/packages/actionpack/src/action-dispatch/routing/scope.ts
+++ b/packages/actionpack/src/action-dispatch/routing/scope.ts
@@ -57,9 +57,10 @@ export class Scope {
     this.parent = parent;
     this.scopeLevel = scopeLevel;
     // Rails: @hash = parent ? parent.frame.merge(hash) : hash
-    // Preserve `null` when parent is null so `null?` can be observed; otherwise
-    // merge over parent.frame. Scope.ROOT.frame is {} so root-children fall
-    // through to a plain copy of `hash`.
+    // Preserve `null` when parent is null so `null?` (isNull) is observable
+    // on Scope.ROOT. Children of ROOT spread over `ROOT.frame` (which is
+    // `null`); JS object-spread treats `null` as empty, so the result is
+    // a plain copy of `hash` — matching Rails where ROOT.frame is `{}`.
     this.hash = parent ? { ...parent.frame, ...(hash ?? {}) } : hash;
   }
 

--- a/packages/actionpack/src/action-dispatch/routing/scope.ts
+++ b/packages/actionpack/src/action-dispatch/routing/scope.ts
@@ -47,7 +47,7 @@ export const SCOPE_OPTIONS = [
 export class Scope {
   readonly parent: Scope | null;
   readonly scopeLevel: ScopeLevel;
-  private readonly hash: ScopeFrameHash;
+  private readonly hash: ScopeFrameHash | null;
 
   constructor(
     hash: ScopeFrameHash | null,
@@ -56,8 +56,11 @@ export class Scope {
   ) {
     this.parent = parent;
     this.scopeLevel = scopeLevel;
-    this.hash =
-      parent && parent !== Scope.ROOT ? { ...parent.frame, ...(hash ?? {}) } : (hash ?? {});
+    // Rails: @hash = parent ? parent.frame.merge(hash) : hash
+    // Preserve `null` when parent is null so `null?` can be observed; otherwise
+    // merge over parent.frame. Scope.ROOT.frame is {} so root-children fall
+    // through to a plain copy of `hash`.
+    this.hash = parent ? { ...parent.frame, ...(hash ?? {}) } : hash;
   }
 
   isNested(): boolean {
@@ -114,9 +117,9 @@ export class Scope {
   }
 
   get(key: string): unknown {
-    return this.hash[key];
+    return this.hash ? this.hash[key] : undefined;
   }
-  get frame(): ScopeFrameHash {
+  get frame(): ScopeFrameHash | null {
     return this.hash;
   }
 

--- a/packages/actionpack/src/action-dispatch/routing/scope.ts
+++ b/packages/actionpack/src/action-dispatch/routing/scope.ts
@@ -1,0 +1,135 @@
+/**
+ * Linked list of scope frames built up by the Mapper DSL, mirroring
+ * `ActionDispatch::Routing::Mapper::Scope`.
+ *
+ * @internal
+ */
+
+export type ScopeLevel =
+  | "resource"
+  | "resources"
+  | "collection"
+  | "member"
+  | "new"
+  | "nested"
+  | "root"
+  | null;
+
+export type ScopeFrameHash = Record<string, unknown>;
+
+const RESOURCE_SCOPES: ReadonlySet<ScopeLevel> = new Set<ScopeLevel>(["resource", "resources"]);
+const RESOURCE_METHOD_SCOPES: ReadonlySet<ScopeLevel> = new Set<ScopeLevel>([
+  "collection",
+  "member",
+  "new",
+]);
+
+/** @internal */
+export const SCOPE_OPTIONS = [
+  "path",
+  "shallowPath",
+  "as",
+  "shallowPrefix",
+  "module",
+  "controller",
+  "action",
+  "pathNames",
+  "constraints",
+  "shallow",
+  "blocks",
+  "defaults",
+  "via",
+  "format",
+  "options",
+  "to",
+] as const;
+
+export class Scope {
+  readonly parent: Scope | null;
+  readonly scopeLevel: ScopeLevel;
+  private readonly hash: ScopeFrameHash;
+
+  constructor(
+    hash: ScopeFrameHash | null,
+    parent: Scope | null = Scope.ROOT,
+    scopeLevel: ScopeLevel = null,
+  ) {
+    this.parent = parent;
+    this.scopeLevel = scopeLevel;
+    this.hash =
+      parent && parent !== Scope.ROOT ? { ...parent.frame, ...(hash ?? {}) } : (hash ?? {});
+  }
+
+  isNested(): boolean {
+    return this.scopeLevel === "nested";
+  }
+  isNull(): boolean {
+    return this.hash == null && this.parent == null;
+  }
+  isRoot(): boolean {
+    return this.parent === Scope.ROOT;
+  }
+  isResources(): boolean {
+    return this.scopeLevel === "resources";
+  }
+  isResourceMethodScope(): boolean {
+    return RESOURCE_METHOD_SCOPES.has(this.scopeLevel);
+  }
+  isResourceScope(): boolean {
+    return RESOURCE_SCOPES.has(this.scopeLevel);
+  }
+
+  /** Mirrors Rails `Scope#action_name`. */
+  actionName(
+    namePrefix: string | undefined,
+    prefix: string | undefined,
+    collectionName: string | undefined,
+    memberName: string | undefined,
+  ): Array<string | undefined> {
+    switch (this.scopeLevel) {
+      case "nested":
+        return [namePrefix, prefix];
+      case "collection":
+        return [prefix, namePrefix, collectionName];
+      case "new":
+        return [prefix, "new", namePrefix, memberName];
+      case "member":
+        return [prefix, namePrefix, memberName];
+      case "root":
+        return [namePrefix, collectionName, prefix];
+      default:
+        return [namePrefix, memberName, prefix];
+    }
+  }
+
+  options(): readonly string[] {
+    return SCOPE_OPTIONS;
+  }
+
+  newChild(hash: ScopeFrameHash): Scope {
+    return new Scope(hash, this, this.scopeLevel);
+  }
+  newLevel(level: ScopeLevel): Scope {
+    return new Scope(this.frame, this, level);
+  }
+
+  get(key: string): unknown {
+    return this.hash[key];
+  }
+  get frame(): ScopeFrameHash {
+    return this.hash;
+  }
+
+  *[Symbol.iterator](): IterableIterator<Scope> {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let node: Scope = this;
+    while (node !== Scope.ROOT) {
+      yield node;
+      const next = node.parent;
+      if (!next) break;
+      node = next;
+    }
+  }
+
+  static readonly ROOT: Scope = Object.freeze(new Scope(null, null, null)) as Scope;
+}


### PR DESCRIPTION
## Summary

Ports `ActionDispatch::Routing::Mapper::Scope` as a linked list of frames with `new_level` / `parent` / `[]` / `action_name` semantics (`routing/scope.ts`), and wires 14 Rails-private helpers on `Mapper` that consume it.

**Stub-blocked methods now real** (6): `isApiOnly`, `isResourceMethodScope`, `withScopeLevel`, `scopeActionOptions`, `resourcesPathNames`, `actionPath`.

**Faithful versions on the new chain** (8): `resourceScope`, `shallowScope`, `pathScope`, `parentResource`, `nestedOptions`, `applyActionOptions`, `applyCommonBehaviorFor`, `withDefaultScope`.

`routing/mapper.rb` api:compare: **49/87 (56%) → 63/87 (72%)**.

The existing `scopeStack`-based public DSL is untouched; the new `_scope` chain runs in parallel until the Resources / Match-Mount DSL is rewritten on top of it. That rewrite is a separate follow-up PR.

## Follow-ups (not in this PR)

- Rewrite `resources` / `resource` / `scope` DSL to drive `_scope` instead of `scopeStack`.
- Port `parent_resource` typed shape (Resource / SingletonResource records).
- Port `mount`, `match`/`map_match`, `direct`/`resolve`, `set_member_mappings_for_resource`, the Base helpers (`default_url_options`, `rails_app?`, `app_name`, `define_generate_prefix`).
- Wire `_apiOnly` from `RouteSet#api_only?` once that lands.

## Test plan

- [x] `pnpm vitest run --project other mapper.test.ts resource-routing.test.ts` — 53/53 passing
- [x] `pnpm api:compare` — mapper.ts 49→63/87 (+14)
- [x] `tsc --noEmit` clean
- [x] `eslint` clean