### PR TITLE
docs: refresh README stats + add no-stacked-PRs rule to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,10 @@ When NOT to use this:
   Tests and fixtures count. The historical 20-method rule is a soft guide;
   300 LOC is the hard one — review-cycle data shows PRs ≥400 LOC need 4–6
   rounds minimum and ≥700 LOC need 13+. If a feature is larger, split via the
-  `<base>` / `<base>b` / `<base>c` pattern before opening. Splitting
-  heuristic, in order:
+  `<base>` / `<base>b` / `<base>c` pattern before opening — these are sibling
+  branches each off `main` with **non-overlapping files**, merged sequentially,
+  **not** stacked branches (see "Do NOT stack PRs" below). Splitting heuristic,
+  in order:
   (1) impl + smoke test in `<base>`, full Rails-mirrored tests in `<base>b`;
   (2) public surface first, privates follow; (3) one Rails source file per
   PR when multiple are touched; (4) happy path vs edges only as a last

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,6 +80,15 @@ When NOT to use this:
 - Do NOT use subagents unless explicitly requested.
 - Do use worktrees for any changes; leave the default worktree for the user.
   Always use `scripts/start-worktree.sh` to start a worktree.
+- **Do NOT stack PRs.** Each PR branches from `main` and stands alone.
+  We don't have spare CI runners or review bandwidth — stacked branches
+  (`<base>b` off `<base>`, `<base>c` off `<base>b`, etc.) re-run CI on
+  every parent rebase and force Copilot/the human to re-review the same
+  diff multiple times. They also produce file-overlap conflicts with
+  sibling agents working in parallel. If a feature needs splitting,
+  open each split PR from `main` with **non-overlapping files**; if
+  true ordering is required, ship the first PR, wait for merge, then
+  open the next from updated `main`.
 - Open new PRs in **draft** status.
 - After opening a PR, run the `/link` skill with the PR number so webhook
   notifications (Copilot reviews, CI failures) are delivered to this pane.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Ruby-to-TypeScript translation table.
 | `@blazetrails/arel`         | [Arel](https://api.rubyonrails.org/classes/Arel.html)                 | **100%**  | **99.4%** | SQL AST builder and query generation                     |
 | `@blazetrails/activemodel`  | [ActiveModel](https://api.rubyonrails.org/classes/ActiveModel.html)   | **99.8%** | **99.6%** | Attributes, validations, callbacks, dirty tracking, i18n |
 
-**Data Layer Parity** (ActiveRecord + Arel + ActiveModel): **99.8% API** (4412/4419) | **~88% Tests** (9515/9531 across the three packages, weighted)
+**Data Layer Parity** (ActiveRecord + Arel + ActiveModel): **99.8% API** (4412/4419) | **87.4% Tests** (8326/9531 non-skipped, weighted across the three packages)
 
 Per-package deviation guides catalog the places where Trails diverges
 from Rails on purpose (and why): [ActiveRecord](packages/website/docs/guides/activerecord-rails-deviations.md)

--- a/README.md
+++ b/README.md
@@ -181,11 +181,11 @@ Ruby-to-TypeScript translation table.
 
 | Package                     | Rails Equivalent                                                      | API       | Tests     | Description                                              |
 | --------------------------- | --------------------------------------------------------------------- | --------- | --------- | -------------------------------------------------------- |
-| `@blazetrails/activerecord` | [ActiveRecord](https://api.rubyonrails.org/classes/ActiveRecord.html) | **100%**  | **75.6%** | ORM — persistence, querying, associations, migrations    |
+| `@blazetrails/activerecord` | [ActiveRecord](https://api.rubyonrails.org/classes/ActiveRecord.html) | **99.8%** | **84.8%** | ORM — persistence, querying, associations, migrations    |
 | `@blazetrails/arel`         | [Arel](https://api.rubyonrails.org/classes/Arel.html)                 | **100%**  | **99.4%** | SQL AST builder and query generation                     |
-| `@blazetrails/activemodel`  | [ActiveModel](https://api.rubyonrails.org/classes/ActiveModel.html)   | **99.6%** | **99.6%** | Attributes, validations, callbacks, dirty tracking, i18n |
+| `@blazetrails/activemodel`  | [ActiveModel](https://api.rubyonrails.org/classes/ActiveModel.html)   | **99.8%** | **99.6%** | Attributes, validations, callbacks, dirty tracking, i18n |
 
-**Data Layer Parity** (ActiveRecord + Arel + ActiveModel): **99.9% API** (6473/6478) | **~78% Tests** _(test percentage pending a `sync-stats` refresh; AR + Arel public API at 100%, ActiveModel at 99.2%)_
+**Data Layer Parity** (ActiveRecord + Arel + ActiveModel): **99.8% API** (4412/4419) | **~88% Tests** (9515/9531 across the three packages, weighted)
 
 Per-package deviation guides catalog the places where Trails diverges
 from Rails on purpose (and why): [ActiveRecord](packages/website/docs/guides/activerecord-rails-deviations.md)
@@ -196,12 +196,12 @@ from Rails on purpose (and why): [ActiveRecord](packages/website/docs/guides/act
 
 | Package                      | Rails Equivalent                                                              | API       | Tests     | Description                                                |
 | ---------------------------- | ----------------------------------------------------------------------------- | --------- | --------- | ---------------------------------------------------------- |
-| `@blazetrails/activesupport` | [ActiveSupport](https://api.rubyonrails.org/classes/ActiveSupport.html)       | **28.5%** | **78.5%** | Core utilities, inflection, caching, notifications         |
+| `@blazetrails/activesupport` | [ActiveSupport](https://api.rubyonrails.org/classes/ActiveSupport.html)       | **28.6%** | **78.5%** | Core utilities, inflection, caching, notifications         |
 | `@blazetrails/rack`          | [Rack](https://rack.github.io/)                                               | —         | **100%**  | Modular web server interface, request/response, middleware |
-| `@blazetrails/actionpack`    | [ActionController](https://api.rubyonrails.org/classes/ActionController.html) | **57.0%** | **28.3%** | Controller layer, rendering, filters, parameters           |
-|                              | [ActionDispatch](https://api.rubyonrails.org/classes/ActionDispatch.html)     | **5.3%**  | **37.3%** | Routing, middleware stack, cookies, sessions, security     |
-| `@blazetrails/actionview`    | [ActionView](https://api.rubyonrails.org/classes/ActionView.html)             | **1.2%**  | **5.1%**  | Templates, rendering, view helpers                         |
-| `@blazetrails/trailties`     | [Railties](https://api.rubyonrails.org/classes/Rails.html)                    | —         | **3.9%**  | CLI, generators, application bootstrap                     |
+| `@blazetrails/actionpack`    | [ActionController](https://api.rubyonrails.org/classes/ActionController.html) | **73.2%** | **28.3%** | Controller layer, rendering, filters, parameters           |
+|                              | [ActionDispatch](https://api.rubyonrails.org/classes/ActionDispatch.html)     | **77.1%** | **35.8%** | Routing, middleware stack, cookies, sessions, security     |
+| `@blazetrails/actionview`    | [ActionView](https://api.rubyonrails.org/classes/ActionView.html)             | **8.5%**  | **8.3%**  | Templates, rendering, view helpers                         |
+| `@blazetrails/trailties`     | [Railties](https://api.rubyonrails.org/classes/Rails.html)                    | —         | **4.8%**  | CLI, generators, application bootstrap                     |
 
 **Tests** = `test:compare` — matches our test names against the Rails test suite. **API** = `pnpm api:compare -- --public-only` — matches individual public methods against Rails source (method-level, not class/module wrappers). The default `api:compare` mode also includes Rails-private/internal helpers; this README reports the public-surface filter so the headline percentages reflect contract coverage. Rack doesn't have API comparison yet (it's not a Rails gem). Trailties' API column is em-dashed because `api:compare` finds no public-method overlap between our `packages/trailties/src/` files and the bundled `railties/lib/rails` source yet, so the package summary is omitted from the report.
 


### PR DESCRIPTION
## Summary
- Refresh package tables in README with fresh \`pnpm api:compare --public-only\` and \`pnpm test:compare\` numbers.
- Carry along the CLAUDE.md update adding the \"Do NOT stack PRs\" rule.

Notable shifts:
- ActionDispatch API **5.3% → 77.1%**
- ActionController API **57.0% → 73.2%**
- ActionView API **1.2% → 8.5%**
- ActiveRecord tests **75.6% → 84.8%**
- ActiveModel API **99.6% → 99.8%**
- Trailties tests **3.9% → 4.8%**

Data layer parity line updated to **4412/4419 (99.8%)**.

## Test plan
- [ ] CI passes (docs-only change)