### PR TITLE
feat(actionpack): action_dispatch/deprecator.rb port + abstract_controller statics regression

### DIFF
--- a/packages/actionpack/src/abstract-controller/base.ts
+++ b/packages/actionpack/src/abstract-controller/base.ts
@@ -6,7 +6,29 @@
  * @see https://api.rubyonrails.org/classes/AbstractController/Base.html
  */
 
+import { underscore } from "@blazetrails/activesupport";
 import { SpellChecker } from "@blazetrails/did-you-mean";
+
+function ownPublicMethodNames(proto: object | null | undefined): string[] {
+  if (!proto) return [];
+  const out: string[] = [];
+  for (const name of Object.getOwnPropertyNames(proto)) {
+    if (name === "constructor" || name.startsWith("_")) continue;
+    const d = Object.getOwnPropertyDescriptor(proto, name);
+    if (d && typeof d.value === "function") out.push(name);
+  }
+  return out;
+}
+
+function allPublicMethodNames(proto: object | null | undefined): string[] {
+  const out = new Set<string>();
+  let cur: object | null = proto ?? null;
+  while (cur && cur !== Object.prototype) {
+    for (const name of ownPublicMethodNames(cur)) out.add(name);
+    cur = Object.getPrototypeOf(cur);
+  }
+  return [...out];
+}
 
 import {
   _defineActionCallbacks,
@@ -123,6 +145,94 @@ export class AbstractController {
   ]);
 
   private static _actionMethodCache?: Set<string>;
+
+  /** Rails `attr_reader :abstract` — class-level abstract flag. Defaults
+   * to `false`; flipped via `abstractBang()`. */
+  protected static _abstract: boolean = false;
+
+  /** Rails `class << self; attr_reader :abstract`. @internal */
+  static get abstract(): boolean {
+    return Object.prototype.hasOwnProperty.call(this, "_abstract")
+      ? (this as unknown as { _abstract: boolean })._abstract
+      : false;
+  }
+
+  /** Rails `abstract?` predicate; aliases `abstract`. @internal */
+  static isAbstract(): boolean {
+    return this.abstract;
+  }
+
+  /** Rails `abstract!` — marks this class as abstract. @internal */
+  static abstractBang(): void {
+    (this as unknown as { _abstract: boolean })._abstract = true;
+  }
+
+  /** Cached controller_path memo (per-class own property). @internal */
+  protected static _controllerPath?: string;
+
+  /**
+   * Rails `controller_path` — the controller's underscored name with
+   * the `Controller` suffix stripped (`MyApp::MyPostsController` →
+   * `"my_app/my_posts"`). Returns the empty string for anonymous classes.
+   */
+  static controllerPath(): string {
+    if (Object.prototype.hasOwnProperty.call(this, "_controllerPath")) {
+      return (this as unknown as { _controllerPath: string })._controllerPath;
+    }
+    const name = this.name;
+    if (!name) return ((this as unknown as { _controllerPath: string })._controllerPath = "");
+    const SUFFIX = "Controller";
+    const stripped = name.endsWith(SUFFIX) ? name.slice(0, -SUFFIX.length) : name;
+    return ((this as unknown as { _controllerPath: string })._controllerPath =
+      underscore(stripped));
+  }
+
+  /**
+   * Rails `internal_methods` — walks the superclass chain up to the
+   * first abstract ancestor, collecting non-abstract subclasses' own
+   * public instance methods, then returns the abstract ancestor's full
+   * public method set minus those collected. Combined with the
+   * curated `_internalMethods` constant so wired-up entry points
+   * (`processAction`, `render`, …) are always treated as internal even
+   * before the class chain marks them.
+   * @internal
+   */
+  static internalMethods(): string[] {
+    const collected = new Set<string>();
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    let cursor: typeof AbstractController = this;
+    while (cursor && !cursor.isAbstract()) {
+      for (const name of ownPublicMethodNames(cursor.prototype)) collected.add(name);
+      const next = Object.getPrototypeOf(cursor);
+      if (!next || next === Function.prototype) break;
+      cursor = next as typeof AbstractController;
+    }
+    const abstractProto = cursor?.prototype ?? AbstractController.prototype;
+    const all = new Set<string>(allPublicMethodNames(abstractProto));
+    for (const name of collected) all.delete(name);
+    for (const name of AbstractController._internalMethods) all.add(name);
+    return [...all];
+  }
+
+  /** Rails `clear_action_methods!` — invalidate the cached action set. @internal */
+  static clearActionMethodsBang(): void {
+    (this as unknown as { _actionMethodCache?: Set<string> })._actionMethodCache = undefined;
+  }
+
+  /**
+   * Rails `method_added(name)` hook — invalidates the action-method
+   * cache when a new method is defined on the controller. JS has no
+   * `method_added` hook; callers (e.g. helpers wiring that defines
+   * methods at runtime) must invoke this explicitly. @internal
+   */
+  static methodAdded(_name: string): void {
+    this.clearActionMethodsBang();
+  }
+
+  /** Rails `eager_load!` — warm the action-method cache. @internal */
+  static eagerLoadBang(): void {
+    this.actionMethods();
+  }
 
   /** Returns the set of public action methods defined on this controller. */
   static actionMethods(): string[] {

--- a/packages/actionpack/src/action-dispatch/deprecator.ts
+++ b/packages/actionpack/src/action-dispatch/deprecator.ts
@@ -29,7 +29,7 @@ let _deprecator: Deprecation | undefined;
  * namespace. Mirrors Rails `ActionDispatch.deprecator`.
  */
 export function deprecator(): Deprecation {
-  if (!_deprecator) _deprecator = new Deprecation({ gem: "actionpack" });
+  if (!_deprecator) _deprecator = new Deprecation();
   return _deprecator;
 }
 

--- a/packages/actionpack/src/action-dispatch/deprecator.ts
+++ b/packages/actionpack/src/action-dispatch/deprecator.ts
@@ -1,5 +1,53 @@
+/**
+ * ActionDispatch deprecator + RequestCookieMethods re-exports.
+ *
+ * Mirrors Rails `actionpack/lib/action_dispatch/deprecator.rb`:
+ *
+ *     module ActionDispatch
+ *       def self.deprecator
+ *         @deprecator ||= ActiveSupport::Deprecation.new
+ *       end
+ *     end
+ *
+ * `RequestCookieMethods` instance methods are included into the
+ * `ActionDispatch` module at load time (via the `on_load` block in
+ * `middleware/cookies.rb`), so the Ruby-API extractor attributes them
+ * to the file where `module ActionDispatch` is first opened
+ * (`deprecator.rb`). Re-exporting them here keeps api:compare matching
+ * the Rails surface without duplicating the implementations.
+ */
+
 import { Deprecation } from "@blazetrails/activesupport";
+import * as _cookies from "./middleware/cookies.js";
 
 export { Deprecation as Deprecator };
 
-export const deprecator = new Deprecation({ gem: "actionpack" });
+let _deprecator: Deprecation | undefined;
+
+/**
+ * Lazily-initialized Deprecation instance for the ActionDispatch
+ * namespace. Mirrors Rails `ActionDispatch.deprecator`.
+ */
+export function deprecator(): Deprecation {
+  if (!_deprecator) _deprecator = new Deprecation({ gem: "actionpack" });
+  return _deprecator;
+}
+
+/** @internal */ export const cookieJar = _cookies.cookieJar;
+/** @internal */ export const isHaveCookieJar = _cookies.isHaveCookieJar;
+/** @internal */ export const keyGenerator = _cookies.keyGenerator;
+/** @internal */ export const signedCookieSalt = _cookies.signedCookieSalt;
+/** @internal */ export const encryptedCookieSalt = _cookies.encryptedCookieSalt;
+/** @internal */ export const encryptedSignedCookieSalt = _cookies.encryptedSignedCookieSalt;
+/** @internal */ export const authenticatedEncryptedCookieSalt =
+  _cookies.authenticatedEncryptedCookieSalt;
+/** @internal */ export const useAuthenticatedCookieEncryption =
+  _cookies.useAuthenticatedCookieEncryption;
+/** @internal */ export const encryptedCookieCipher = _cookies.encryptedCookieCipher;
+/** @internal */ export const signedCookieDigest = _cookies.signedCookieDigest;
+/** @internal */ export const secretKeyBase = _cookies.secretKeyBase;
+/** @internal */ export const cookiesSerializer = _cookies.cookiesSerializer;
+/** @internal */ export const cookiesSameSiteProtection = _cookies.cookiesSameSiteProtection;
+/** @internal */ export const cookiesDigest = _cookies.cookiesDigest;
+/** @internal */ export const cookiesRotations = _cookies.cookiesRotations;
+/** @internal */ export const useCookiesWithMetadata = _cookies.useCookiesWithMetadata;

--- a/packages/actionpack/src/action-dispatch/http/param-builder.ts
+++ b/packages/actionpack/src/action-dispatch/http/param-builder.ts
@@ -210,7 +210,7 @@ function storeNestedParamImpl(
         const matched = m[0];
         after = name.slice(matched.length);
         if (ignoreLeading !== true && (k !== matched || (after !== "" && !after.startsWith("[")))) {
-          deprecator.warn(
+          deprecator().warn(
             `Skipping over leading brackets in parameter name ${JSON.stringify(name)} is deprecated and will parse differently in Rails 8.1 or Rack 3.0.`,
           );
         }

--- a/packages/actionpack/src/action-dispatch/trailtie.ts
+++ b/packages/actionpack/src/action-dispatch/trailtie.ts
@@ -140,7 +140,7 @@ export class Trailtie extends BaseRailtie {
     this.config["contentSecurityPolicy"] = defaultContentSecurityPolicyConfig();
 
     this.initializer("action_dispatch.deprecator", () => {
-      BaseRailtie.deprecators["actionDispatch"] = deprecator;
+      BaseRailtie.deprecators["actionDispatch"] = deprecator();
     });
 
     this.initializer("action_dispatch.configure", () => {


### PR DESCRIPTION
## Summary

- **action_dispatch/deprecator.ts (0/18 → 18/18)** — convert
  `deprecator` to a lazily-initialized function (matches Rails
  `def self.deprecator`) and re-export the 17 `RequestCookieMethods`
  accessors. The Ruby-API extractor attributes those instance methods
  to `deprecator.rb` because `module ActionDispatch` is first opened
  there and `RequestCookieMethods` is included into the module at
  load time. Re-exporting from cookies.ts keeps a single source of
  truth for the implementations.
- **abstract_controller/base.rb (74/82 → 82/82)** — restore the eight
  class statics (`abstract` / `isAbstract` / `abstractBang` /
  `controllerPath` / `internalMethods` / `clearActionMethodsBang` /
  `methodAdded` / `eagerLoadBang`) that PR #2072 added and PR #2079
  inadvertently dropped when wiring SpellChecker into
  `ActionNotFound#corrections`.
- Update two pre-existing `deprecator` callers
  (`http/param-builder.ts`, `action-dispatch/trailtie.ts`) for the new
  function shape.

## Test plan

- [x] `pnpm api:compare` — abstractcontroller 82/82 (100%), actiondispatch
      deprecator.rb 18/18 (100%); overall actiondispatch 1063/1351 → 1081/1351.
- [x] `pnpm vitest run packages/actionpack/src/abstract-controller/base.test.ts`
      — 3 passed.
- [x] `pnpm build` (via pre-commit) clean.