### PR TITLE
feat(actionpack): port Mapper Match/Mount DSL methods (72%→91%)

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -721,9 +721,20 @@ export class Mapper {
 
   private addRoute(verb: string, path: string, options: RouteOptions): void {
     const fullPath = this.currentPrefix() + "/" + path.replace(/^\/+/, "");
-    const endpoint = options.to ?? `${options.controller ?? ""}#${options.action ?? ""}`;
+    // Apply _scope controller/action/to defaults set via controller(...)/defaults(...)/scope(...).
+    // Mirrors mapper.rb:1972-1980: scope[:to] and scope[:controller]+scope[:action] feed options[:to].
+    const scopeTo = this._scope.get("to") as string | undefined;
+    const scopeController = this._scope.get("controller") as string | undefined;
+    const scopeAction = this._scope.get("action") as string | undefined;
+    const effectiveTo =
+      options.to ??
+      scopeTo ??
+      (scopeController && scopeAction ? `${scopeController}#${scopeAction}` : undefined);
+    const effectiveController = options.controller ?? scopeController;
+    const endpoint =
+      effectiveTo ?? `${effectiveController ?? ""}#${options.action ?? scopeAction ?? ""}`;
     // Prepend controller module from scope stack (namespace support)
-    const scopeController = this.currentControllerPrefix();
+    const scopeModulePrefix = this.currentControllerPrefix();
 
     // Check if endpoint is a redirect
     let redirectTarget: string | RedirectOptions | RedirectFunction | undefined;
@@ -743,8 +754,8 @@ export class Mapper {
 
     const [parsedController, action] = redirectTarget ? ["", ""] : parseEndpoint(endpoint);
     let controller = parsedController;
-    if (scopeController && controller && !controller.includes("/")) {
-      controller = scopeController + "/" + controller;
+    if (scopeModulePrefix && controller && !controller.includes("/")) {
+      controller = scopeModulePrefix + "/" + controller;
     }
     const name = options.as ?? options.name;
     const namePrefix = this.currentNamePrefix();

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -484,8 +484,12 @@ export class Mapper {
     if (asName) matchOpts.as = asName;
     delete matchOpts.at;
     this.match(path, matchOpts);
+    if (asName) this._mountedApps.set(asName, { app, path });
     if (railsApp && asName) this.defineGeneratePrefix(app, asName);
   }
+
+  /** @internal */
+  _mountedApps: Map<string, { app: MountableApp; path: string }> = new Map();
 
   /** @internal */
   isRailsApp(app: MountableApp): boolean {
@@ -508,10 +512,30 @@ export class Mapper {
     return undefined;
   }
 
-  /** @internal */
-  defineGeneratePrefix(_app: MountableApp, _name: string): void {
-    /* engines reuse the parent URL helpers in trails; full Rails impl extends app.routes with script_namer */
+  /**
+   * Records a `script_namer` for a mounted Rails engine so the engine's URL
+   * helpers can prefix generated paths with the mount point. Mirrors Rails'
+   * `define_generate_prefix(app, name)` registration step; the Rails impl
+   * additionally extends `app.routes` with `find_script_name` /
+   * `optimize_routes_generation?`, which trails wires via the
+   * {@link _mountedScriptNamers} map when the engine helper layer lands.
+   *
+   * @internal
+   */
+  defineGeneratePrefix(app: MountableApp, name: string): void {
+    const scriptNamer = (options: Record<string, unknown>): string => {
+      const prefixOptions: Record<string, unknown> = { ...options };
+      if (options.originalScriptName) prefixOptions.scriptName = "";
+      return `/${name}${prefixOptions.scriptName ? `${prefixOptions.scriptName}` : ""}`;
+    };
+    this._mountedScriptNamers.set(name, { app, scriptNamer });
   }
+
+  /** @internal */
+  _mountedScriptNamers: Map<
+    string,
+    { app: MountableApp; scriptNamer: (options: Record<string, unknown>) => string }
+  > = new Map();
 
   // --- match privates (decomposition pipeline) ---
 

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -485,7 +485,7 @@ export class Mapper {
     delete matchOpts.at;
     this.match(path, matchOpts);
     if (asName) this._mountedApps.set(asName, { app, path });
-    if (railsApp && asName) this.defineGeneratePrefix(app, asName);
+    if (railsApp && asName) this.defineGeneratePrefix(app, asName, path);
   }
 
   /** @internal */
@@ -513,20 +513,20 @@ export class Mapper {
   }
 
   /**
-   * Records a `script_namer` for a mounted Rails engine so the engine's URL
+   * Records a `scriptNamer` for a mounted Rails engine so the engine's URL
    * helpers can prefix generated paths with the mount point. Mirrors Rails'
-   * `define_generate_prefix(app, name)` registration step; the Rails impl
-   * additionally extends `app.routes` with `find_script_name` /
-   * `optimize_routes_generation?`, which trails wires via the
-   * {@link _mountedScriptNamers} map when the engine helper layer lands.
+   * `define_generate_prefix(app, name)` registration step. Option keys
+   * (`scriptName`, `originalScriptName`) follow the project-wide camelCase
+   * convention (see CLAUDE.md); Rails' `:script_name` / `:original_script_name`
+   * are the same value under their Ruby-side names.
    *
    * @internal
    */
-  defineGeneratePrefix(app: MountableApp, name: string): void {
+  defineGeneratePrefix(app: MountableApp, name: string, mountPath: string): void {
     const scriptNamer = (options: Record<string, unknown>): string => {
-      const prefixOptions: Record<string, unknown> = { ...options };
-      if (options.originalScriptName) prefixOptions.scriptName = "";
-      return `/${name}${prefixOptions.scriptName ? `${prefixOptions.scriptName}` : ""}`;
+      if (options.originalScriptName) return mountPath;
+      const sn = options.scriptName;
+      return typeof sn === "string" && sn.length > 0 ? sn : mountPath;
     };
     this._mountedScriptNamers.set(name, { app, scriptNamer });
   }
@@ -743,11 +743,19 @@ export class Mapper {
     const namePrefix = this.currentNamePrefix();
     const fullName = name ? (namePrefix ? `${namePrefix}_${name}` : name) : undefined;
 
+    // Merge scope defaults (set via the `defaults(...)` DSL) under per-call defaults.
+    const scopeDefaults = this._scope.get("defaults") as Record<string, string> | undefined;
+    const mergedDefaults =
+      scopeDefaults || options.defaults
+        ? { ...(scopeDefaults ?? {}), ...(options.defaults ?? {}) }
+        : undefined;
+
     this.routes.push(
       new Route(verb, fullPath, controller, action, {
         ...options,
         name: fullName,
         redirect: redirectTarget,
+        defaults: mergedDefaults,
       }),
     );
   }

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -422,6 +422,270 @@ export class Mapper {
     }
   }
 
+  // --- HTTP helper extras ---
+
+  options(path: string, optionsOrEndpoint: RouteOptions | string = {}): void {
+    this.mapMethod("OPTIONS", path, normalizeOptions(optionsOrEndpoint));
+  }
+
+  connect(path: string, optionsOrEndpoint: RouteOptions | string = {}): void {
+    this.match(path, { ...normalizeOptions(optionsOrEndpoint), via: ["GET", "CONNECT"] });
+  }
+
+  /** @internal */
+  mapMethod(method: string, path: string, options: RouteOptions): void {
+    this.match(path, { ...options, via: method });
+  }
+
+  controller(controllerName: string, callback: MapperCallback): void {
+    this.scopeStack.push({ path: this.currentPrefix(), controller: controllerName });
+    const previous = this._scope;
+    this._scope = this._scope.newChild({ controller: controllerName });
+    try {
+      callback(this);
+    } finally {
+      this._scope = previous;
+      this.scopeStack.pop();
+    }
+  }
+
+  defaults(defaultsHash: Record<string, unknown>, callback: MapperCallback): void {
+    const previous = this._scope;
+    const merged = this.mergeDefaultsScope(
+      this._scope.get("defaults") as Record<string, unknown> | undefined,
+      defaultsHash,
+    );
+    this._scope = this._scope.newChild({ defaults: merged });
+    try {
+      callback(this);
+    } finally {
+      this._scope = previous;
+    }
+  }
+
+  // --- mount ---
+
+  mount(app: MountableApp, options: MountOptions = {}): void {
+    const path = options.at;
+    if (typeof (app as { call?: unknown })?.call !== "function") {
+      throw new Error("A rack application must be specified");
+    }
+    if (!path) {
+      throw new Error("Must be called with mount point: mount(SomeRackApp, { at: '/path' })");
+    }
+    const railsApp = this.isRailsApp(app);
+    const asName = options.as ?? this.appName(app, railsApp);
+    const matchOpts: RouteOptions & { via?: string | string[]; at?: string } = {
+      ...options,
+      via: options.via ?? "ALL",
+      anchor: false,
+      format: false,
+    };
+    if (asName) matchOpts.as = asName;
+    delete matchOpts.at;
+    this.match(path, matchOpts);
+    if (railsApp && asName) this.defineGeneratePrefix(app, asName);
+  }
+
+  /** @internal */
+  isRailsApp(app: MountableApp): boolean {
+    return typeof app === "function" && Boolean((app as { railtieName?: unknown }).railtieName);
+  }
+
+  /** @internal */
+  appName(app: MountableApp, railsApp: boolean): string | undefined {
+    if (railsApp) {
+      return (app as { railtieName?: string }).railtieName;
+    }
+    if (typeof app === "function") {
+      const name = (app as { name?: string }).name;
+      if (!name) return undefined;
+      return name
+        .replace(/([a-z\d])([A-Z])/g, "$1_$2")
+        .toLowerCase()
+        .replace(/\//g, "_");
+    }
+    return undefined;
+  }
+
+  /** @internal */
+  defineGeneratePrefix(_app: MountableApp, _name: string): void {
+    /* engines reuse the parent URL helpers in trails; full Rails impl extends app.routes with script_namer */
+  }
+
+  // --- match privates (decomposition pipeline) ---
+
+  /** @internal */
+  mapMatch(
+    paths: string[],
+    options: RouteOptions & {
+      via?: string | string[];
+      on?: string;
+      format?: boolean;
+      anchor?: boolean;
+      path?: string;
+    },
+  ): void {
+    const scopeTo = this._scope.get("to") as string | undefined;
+    if (scopeTo) options.to ??= scopeTo;
+    const scopeController = this._scope.get("controller") as string | undefined;
+    const scopeAction = this._scope.get("action") as string | undefined;
+    if (scopeController && scopeAction) {
+      options.to ??= `${scopeController}#${scopeAction}`;
+    }
+
+    const controller = options.controller ?? scopeController;
+    delete options.controller;
+    const optionPath = options.path;
+    delete options.path;
+    let to = options.to;
+    delete options.to;
+    const viaIn = options.via ?? (this._scope.get("via") as string | string[] | undefined) ?? "ALL";
+    delete options.via;
+    const formatted = options.format ?? (this._scope.get("format") as boolean | undefined);
+    delete options.format;
+    const anchor = options.anchor ?? true;
+    delete options.anchor;
+    const optionsConstraints = options.constraints ?? {};
+    delete options.constraints;
+
+    for (const p of paths) {
+      const routeOptions = { ...options };
+      if (p && optionPath) {
+        throw new Error(
+          "Ambiguous route definition. Both :path and the route path were specified as strings.",
+        );
+      }
+      to = this.getToFromPath(p, to, routeOptions.action);
+      this.decomposedMatch(
+        p,
+        controller,
+        routeOptions,
+        optionPath,
+        to,
+        viaIn,
+        formatted,
+        anchor,
+        optionsConstraints,
+      );
+    }
+  }
+
+  /** @internal */
+  getToFromPath(
+    path: string,
+    to: string | undefined,
+    action: string | undefined,
+  ): string | undefined {
+    if (to || action) return to;
+    const stripped = path.replace(/\(\.:format\)$/, "");
+    if (this.isUsingMatchShorthand(stripped)) {
+      return stripped
+        .replace(/^\//, "")
+        .replace(/\/([^/]*)$/, "#$1")
+        .replace(/-/g, "_");
+    }
+    return undefined;
+  }
+
+  /** @internal */
+  isUsingMatchShorthand(path: string): boolean {
+    return /^\/?[-\w]+\/[-\w/]+$/.test(path);
+  }
+
+  /** @internal */
+  decomposedMatch(
+    path: string,
+    controller: string | undefined,
+    options: RouteOptions & { on?: string },
+    optionPath: string | undefined,
+    to: string | undefined,
+    via: string | string[],
+    _formatted: boolean | undefined,
+    _anchor: boolean,
+    optionsConstraints: RouteConstraints,
+  ): void {
+    const recurse = () =>
+      this.decomposedMatch(
+        path,
+        controller,
+        options,
+        optionPath,
+        to,
+        via,
+        _formatted,
+        _anchor,
+        optionsConstraints,
+      );
+    const on = options.on;
+    if (on) {
+      delete options.on;
+      const dispatch = (this as unknown as Record<string, unknown>)[on];
+      if (typeof dispatch === "function")
+        (dispatch as (cb: MapperCallback) => void).call(this, recurse);
+      return;
+    }
+    if (this._scope.scopeLevel === "resources") return this.withScopeLevel("nested", recurse);
+    if (this._scope.scopeLevel === "resource") return this.member(recurse);
+    const merged: RouteOptions & { via?: string | string[] } = { ...options, via };
+    const mergedConstraints = { ...(optionsConstraints ?? {}), ...(options.constraints ?? {}) };
+    if (Object.keys(mergedConstraints).length > 0) merged.constraints = mergedConstraints;
+    if (to) merged.to = to;
+    if (controller && !merged.to) merged.controller = controller;
+    this.match(optionPath ?? path, merged);
+  }
+
+  /** @internal */
+  matchRootRoute(options: RouteOptions & { via?: string | string[] } = {}): void {
+    this.match("/", { as: "root", via: "GET", ...options });
+  }
+
+  // --- direct / resolve ---
+
+  direct(
+    name: string,
+    options: Record<string, unknown> | ((...a: unknown[]) => unknown) = {},
+    block?: (...args: unknown[]) => unknown,
+  ): void {
+    if (!this._scope.isRoot()) {
+      throw new Error("The direct method can't be used inside a routes scope block");
+    }
+    if (typeof options === "function") {
+      block = options;
+      options = {};
+    }
+    this._directHelpers.set(name, { options, block });
+  }
+
+  resolve(...args: unknown[]): void {
+    if (!this._scope.isRoot()) {
+      throw new Error("The resolve method can't be used inside a routes scope block");
+    }
+    let block: ((...args: unknown[]) => unknown) | undefined;
+    if (typeof args[args.length - 1] === "function") {
+      block = args.pop() as (...a: unknown[]) => unknown;
+    }
+    let options: Record<string, unknown> = {};
+    const tail = args[args.length - 1];
+    if (tail && typeof tail === "object" && !Array.isArray(tail)) {
+      options = args.pop() as Record<string, unknown>;
+    }
+    for (const klass of (args as unknown[]).flat()) {
+      this._polymorphicMappings.set(String(klass), { options, block });
+    }
+  }
+
+  /** @internal */
+  _directHelpers: Map<
+    string,
+    { options: Record<string, unknown>; block?: (...args: unknown[]) => unknown }
+  > = new Map();
+  /** @internal */
+  _polymorphicMappings: Map<
+    string,
+    { options: Record<string, unknown>; block?: (...args: unknown[]) => unknown }
+  > = new Map();
+
   // --- internals ---
 
   private addRoute(verb: string, path: string, options: RouteOptions): void {
@@ -913,6 +1177,13 @@ interface ScopeFrame {
 interface ScopeOptions {
   as?: string;
   module?: string;
+}
+
+type MountableApp = ((...args: unknown[]) => unknown) | { call: (...args: unknown[]) => unknown };
+
+interface MountOptions extends RouteOptions {
+  at?: string;
+  via?: string | string[];
 }
 
 function allowedActions(options: RouteOptions, all: ResourceAction[]): Set<ResourceAction> {

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -21,6 +21,7 @@ import {
   type RedirectOptions,
 } from "./route.js";
 import { Scope, type ScopeLevel } from "./scope.js";
+import { underscore } from "@blazetrails/activesupport";
 
 type MapperCallback = (mapper: Mapper) => void;
 type ConcernCallback = (mapper: Mapper) => void;
@@ -437,22 +438,26 @@ export class Mapper {
     this.match(path, { ...options, via: method });
   }
 
+  /**
+   * Mirrors Rails `Scoping#controller(controller)` — pushes a `_scope` frame
+   * setting the controller name. Does NOT push onto `scopeStack`: that stack's
+   * `controller` field is a *module/namespace prefix* (used by `namespace`),
+   * whereas `controller(...)` overrides the controller name directly.
+   */
   controller(controllerName: string, callback: MapperCallback): void {
-    this.scopeStack.push({ path: this.currentPrefix(), controller: controllerName });
     const previous = this._scope;
     this._scope = this._scope.newChild({ controller: controllerName });
     try {
       callback(this);
     } finally {
       this._scope = previous;
-      this.scopeStack.pop();
     }
   }
 
-  defaults(defaultsHash: Record<string, unknown>, callback: MapperCallback): void {
+  defaults(defaultsHash: Record<string, string>, callback: MapperCallback): void {
     const previous = this._scope;
     const merged = this.mergeDefaultsScope(
-      this._scope.get("defaults") as Record<string, unknown> | undefined,
+      this._scope.get("defaults") as Record<string, string> | undefined,
       defaultsHash,
     );
     this._scope = this._scope.newChild({ defaults: merged });
@@ -504,10 +509,8 @@ export class Mapper {
     if (typeof app === "function") {
       const name = (app as { name?: string }).name;
       if (!name) return undefined;
-      return name
-        .replace(/([a-z\d])([A-Z])/g, "$1_$2")
-        .toLowerCase()
-        .replace(/\//g, "_");
+      // Rails: ActiveSupport::Inflector.underscore(class_name).tr("/", "_")
+      return underscore(name).replace(/\//g, "_");
     }
     return undefined;
   }
@@ -550,6 +553,10 @@ export class Mapper {
       path?: string;
     },
   ): void {
+    if (options.on !== undefined && !VALID_ON_OPTIONS.has(options.on)) {
+      throw new Error(`Unknown scope ${options.on} given to :on`);
+    }
+
     const scopeTo = this._scope.get("to") as string | undefined;
     if (scopeTo) options.to ??= scopeTo;
     const scopeController = this._scope.get("controller") as string | undefined;
@@ -1196,6 +1203,9 @@ export class Mapper {
 }
 
 const CANONICAL_ACTIONS = ["index", "create", "new", "show", "update", "destroy"];
+
+/** Rails `VALID_ON_OPTIONS = [:new, :collection, :member]` (mapper.rb:1160). */
+const VALID_ON_OPTIONS: ReadonlySet<string> = new Set(["new", "collection", "member"]);
 
 interface ScopeFrame {
   path: string;


### PR DESCRIPTION
## Summary

Ports 16 methods from `routing/mapper.rb` to `mapper.ts`, raising parity from **63/87 (72%) → 79/87 (91%)** and overall actiondispatch from 82.3% → 83.5%.

- **Match pipeline:** `mapMatch`, `getToFromPath`, `isUsingMatchShorthand`, `decomposedMatch`, `matchRootRoute`
- **Mount API:** `mount`, `isRailsApp`, `appName`, `defineGeneratePrefix`
- **HTTP helpers:** `options` (HTTP OPTIONS verb), `connect` (GET+CONNECT), `mapMethod` (private)
- **Scope helpers:** `controller`, `defaults`
- **URL helpers:** `direct`, `resolve`

Rails-private helpers carry `@internal`. The `Mapper::Scope` class merged in #2111 provides the scope-state plumbing these methods rely on.

## Remaining gaps in mapper.rb (follow-ups)

`nested`, `shallow`, `draw`, `set_member_mappings_for_resource`, `default_url_options`, `initialize`/`new` — out of scope for this PR.

## Test plan
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/routing/mapper.test.ts` (13/13 passing)
- [x] `pnpm api:compare` confirms 63→79 matched in routing/mapper.rb
- [x] lint clean