### PR TITLE
feat(actionview): close buffers/sanitize_helper/template handlers to 100%

### DIFF
--- a/packages/actionview/src/buffers.test.ts
+++ b/packages/actionview/src/buffers.test.ts
@@ -152,6 +152,14 @@ describe("StreamingBuffer", () => {
     expect(chunks).toEqual([""]);
   });
 
+  it("safeConcat passes nil through as empty string (Rails parity)", () => {
+    const chunks: string[] = [];
+    const buf = new StreamingBuffer((v) => chunks.push(v));
+    buf.safeConcat(null);
+    buf.safeConcat(undefined);
+    expect(chunks).toEqual(["", ""]);
+  });
+
   it("capture swaps the sink and restores it", () => {
     const chunks: string[] = [];
     const buf = new StreamingBuffer((v) => chunks.push(v));

--- a/packages/actionview/src/buffers.test.ts
+++ b/packages/actionview/src/buffers.test.ts
@@ -160,6 +160,15 @@ describe("StreamingBuffer", () => {
     expect(chunks).toEqual(["", ""]);
   });
 
+  it("concat/safeConcat accept an OutputBuffer without throwing", () => {
+    const chunks: string[] = [];
+    const buf = new StreamingBuffer((v) => chunks.push(v));
+    const ob = new OutputBuffer("<x>");
+    buf.concat(ob);
+    buf.safeConcat(ob);
+    expect(chunks).toEqual(["<x>", "<x>"]);
+  });
+
   it("capture swaps the sink and restores it", () => {
     const chunks: string[] = [];
     const buf = new StreamingBuffer((v) => chunks.push(v));

--- a/packages/actionview/src/buffers.test.ts
+++ b/packages/actionview/src/buffers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { htmlSafe, SafeBuffer } from "@blazetrails/activesupport";
-import { OutputBuffer, RawOutputBuffer } from "./buffers.js";
+import { OutputBuffer, RawOutputBuffer, RawStreamingBuffer, StreamingBuffer } from "./buffers.js";
 
 describe("OutputBuffer", () => {
   it("initializes from a string", () => {
@@ -127,6 +127,72 @@ describe("RawOutputBuffer", () => {
 
   it("raw() returns self", () => {
     const raw = new OutputBuffer().raw();
+    expect(raw.raw()).toBe(raw);
+  });
+});
+
+describe("StreamingBuffer", () => {
+  it("streams concat through the block, escaping unsafe values", () => {
+    const chunks: string[] = [];
+    const buf = new StreamingBuffer((v) => chunks.push(v));
+    buf.concat("<unsafe>");
+    buf.concat(htmlSafe("<safe>"));
+    expect(chunks).toEqual(["&lt;unsafe&gt;", "<safe>"]);
+  });
+
+  it("safeConcat bypasses escaping", () => {
+    const chunks: string[] = [];
+    new StreamingBuffer((v) => chunks.push(v)).safeConcat("<x>");
+    expect(chunks).toEqual(["<x>"]);
+  });
+
+  it("skips nil on concat", () => {
+    const chunks: string[] = [];
+    new StreamingBuffer((v) => chunks.push(v)).concat(null);
+    expect(chunks).toEqual([]);
+  });
+
+  it("capture swaps the sink and restores it", () => {
+    const chunks: string[] = [];
+    const buf = new StreamingBuffer((v) => chunks.push(v));
+    const captured = buf.capture(() => buf.safeConcat("inside"));
+    expect(captured).toBeInstanceOf(SafeBuffer);
+    expect(captured.toString()).toBe("inside");
+    expect(chunks).toEqual([]);
+    buf.safeConcat("after");
+    expect(chunks).toEqual(["after"]);
+  });
+
+  it("htmlSafe()/isHtmlSafe() report safe", () => {
+    const buf = new StreamingBuffer(() => {});
+    expect(buf.isHtmlSafe()).toBe(true);
+    expect(buf.htmlSafe()).toBe(buf);
+  });
+
+  it("exposes block via reader", () => {
+    const block = () => {};
+    expect(new StreamingBuffer(block).block).toBe(block);
+  });
+});
+
+describe("RawStreamingBuffer", () => {
+  it("writes through without escaping", () => {
+    const chunks: string[] = [];
+    const buf = new StreamingBuffer((v) => chunks.push(v));
+    const raw = buf.raw();
+    expect(raw).toBeInstanceOf(RawStreamingBuffer);
+    raw.concat("<unsafe>");
+    expect(chunks).toEqual(["<unsafe>"]);
+  });
+
+  it("skips nil values", () => {
+    const chunks: string[] = [];
+    new StreamingBuffer((v) => chunks.push(v)).raw().concat(null);
+    expect(chunks).toEqual([]);
+  });
+
+  it("raw() returns self", () => {
+    const raw = new StreamingBuffer(() => {}).raw();
     expect(raw.raw()).toBe(raw);
   });
 });

--- a/packages/actionview/src/buffers.test.ts
+++ b/packages/actionview/src/buffers.test.ts
@@ -146,10 +146,10 @@ describe("StreamingBuffer", () => {
     expect(chunks).toEqual(["<x>"]);
   });
 
-  it("skips nil on concat", () => {
+  it("concat passes nil through as empty string (Rails parity)", () => {
     const chunks: string[] = [];
     new StreamingBuffer((v) => chunks.push(v)).concat(null);
-    expect(chunks).toEqual([]);
+    expect(chunks).toEqual([""]);
   });
 
   it("capture swaps the sink and restores it", () => {

--- a/packages/actionview/src/buffers.ts
+++ b/packages/actionview/src/buffers.ts
@@ -152,8 +152,9 @@ export class StreamingBuffer {
    * produces `""`, which is still passed through to the block.
    */
   concat(value: unknown): this {
-    const str = value instanceof SafeBuffer ? value.toString() : value == null ? "" : String(value);
-    this._block(isHtmlSafe(value) ? str : htmlEscape(str).toString());
+    const str = toRawString(value);
+    const safe = isHtmlSafe(value) || value instanceof OutputBuffer;
+    this._block(safe ? str : htmlEscape(str).toString());
     return this;
   }
 
@@ -163,8 +164,7 @@ export class StreamingBuffer {
    * through as an empty chunk rather than the literal "null"/"undefined".
    */
   safeConcat(value: unknown): this {
-    const str = value instanceof SafeBuffer ? value.toString() : value == null ? "" : String(value);
-    this._block(str);
+    this._block(toRawString(value));
     return this;
   }
 
@@ -209,11 +209,24 @@ export class RawStreamingBuffer {
 
   concat(value: unknown): this {
     if (value === null || value === undefined) return this;
-    this.buffer.block(value instanceof SafeBuffer ? value.toString() : String(value));
+    this.buffer.block(toRawString(value));
     return this;
   }
 
   raw(): this {
     return this;
   }
+}
+
+/**
+ * Stringify a value the way Rails `to_s` would for streaming/output
+ * buffers: `nil → ""`, `SafeBuffer → underlying string`, `OutputBuffer →
+ * underlying raw string` (avoids `String(outputBuffer)` throwing because
+ * `OutputBuffer.toString()` returns a non-primitive `SafeBuffer`).
+ */
+function toRawString(value: unknown): string {
+  if (value == null) return "";
+  if (value instanceof SafeBuffer) return value.toString();
+  if (value instanceof OutputBuffer) return value.toStr();
+  return String(value);
 }

--- a/packages/actionview/src/buffers.ts
+++ b/packages/actionview/src/buffers.ts
@@ -157,9 +157,14 @@ export class StreamingBuffer {
     return this;
   }
 
-  /** Append without escaping. Mirrors Rails `safe_concat` / `safe_append=`. */
+  /**
+   * Append without escaping. Mirrors Rails `safe_concat` / `safe_append=`,
+   * which is `@block.call(value.to_s)` — `nil.to_s` is `""`, so nil flows
+   * through as an empty chunk rather than the literal "null"/"undefined".
+   */
   safeConcat(value: unknown): this {
-    this._block(value instanceof SafeBuffer ? value.toString() : String(value));
+    const str = value instanceof SafeBuffer ? value.toString() : value == null ? "" : String(value);
+    this._block(str);
     return this;
   }
 

--- a/packages/actionview/src/buffers.ts
+++ b/packages/actionview/src/buffers.ts
@@ -146,10 +146,13 @@ export class StreamingBuffer {
     return this._block;
   }
 
-  /** Append a value, escaping if not html-safe. */
+  /**
+   * Append a value, escaping if not html-safe. Mirrors Rails `<<` — unlike
+   * `OutputBuffer`/`RawStreamingBuffer`, nil is NOT skipped: `nil.to_s`
+   * produces `""`, which is still passed through to the block.
+   */
   concat(value: unknown): this {
-    if (value === null || value === undefined) return this;
-    const str = value instanceof SafeBuffer ? value.toString() : String(value);
+    const str = value instanceof SafeBuffer ? value.toString() : value == null ? "" : String(value);
     this._block(isHtmlSafe(value) ? str : htmlEscape(str).toString());
     return this;
   }

--- a/packages/actionview/src/buffers.ts
+++ b/packages/actionview/src/buffers.ts
@@ -127,3 +127,85 @@ export class RawOutputBuffer {
     return this;
   }
 }
+
+/**
+ * StreamingBuffer — buffer that streams writes through a callback instead
+ * of accumulating into a string. Mirrors ActionView::StreamingBuffer; used
+ * by `render stream: true` to push chunks to the response as they're
+ * produced.
+ */
+export class StreamingBuffer {
+  private _block: (value: string) => void;
+
+  constructor(block: (value: string) => void) {
+    this._block = block;
+  }
+
+  /** The current chunk sink. Mirrors Rails `attr_reader :block`. */
+  get block(): (value: string) => void {
+    return this._block;
+  }
+
+  /** Append a value, escaping if not html-safe. */
+  concat(value: unknown): this {
+    if (value === null || value === undefined) return this;
+    const str = value instanceof SafeBuffer ? value.toString() : String(value);
+    this._block(isHtmlSafe(value) ? str : htmlEscape(str).toString());
+    return this;
+  }
+
+  /** Append without escaping. Mirrors Rails `safe_concat` / `safe_append=`. */
+  safeConcat(value: unknown): this {
+    this._block(value instanceof SafeBuffer ? value.toString() : String(value));
+    return this;
+  }
+
+  /**
+   * Swap the chunk sink for the duration of `fn`, returning everything it
+   * appended as an HTML-safe string. Mirrors Rails `capture`.
+   */
+  capture(fn: () => void): SafeBuffer {
+    let buffer = "";
+    const previous = this._block;
+    this._block = (value: string) => {
+      buffer += value;
+    };
+    try {
+      fn();
+      return htmlSafe(buffer);
+    } finally {
+      this._block = previous;
+    }
+  }
+
+  isHtmlSafe(): boolean {
+    return true;
+  }
+
+  htmlSafe(): this {
+    return this;
+  }
+
+  raw(): RawStreamingBuffer {
+    return new RawStreamingBuffer(this);
+  }
+}
+
+/**
+ * RawStreamingBuffer — bypasses escaping when streaming through a
+ * StreamingBuffer. Used by the template compiler for `<%== %>` in
+ * streaming responses.
+ */
+export class RawStreamingBuffer {
+  constructor(private readonly buffer: StreamingBuffer) {}
+
+  concat(value: unknown): this {
+    if (value === null || value === undefined) return this;
+    this.buffer.block(value instanceof SafeBuffer ? value.toString() : String(value));
+    return this;
+  }
+
+  raw(): this {
+    return this;
+  }
+}

--- a/packages/actionview/src/helpers/index.ts
+++ b/packages/actionview/src/helpers/index.ts
@@ -49,6 +49,7 @@ export {
   setSafeListSanitizer,
   sanitizedAllowedTags,
   sanitizedAllowedAttributes,
+  SanitizeHelper,
 } from "./sanitize-helper.js";
 export type { Sanitizer, SanitizerClass, SanitizerVendor } from "./sanitize-helper.js";
 

--- a/packages/actionview/src/helpers/sanitize-helper.test.ts
+++ b/packages/actionview/src/helpers/sanitize-helper.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  SanitizeHelper,
+  getFullSanitizer,
+  getLinkSanitizer,
+  getSafeListSanitizer,
+  getSanitizerVendor,
+  setFullSanitizer,
+  setLinkSanitizer,
+  setSafeListSanitizer,
+  setSanitizerVendor,
+  type Sanitizer,
+} from "./sanitize-helper.js";
+
+const baseline = {
+  vendor: getSanitizerVendor(),
+  full: getFullSanitizer(),
+  link: getLinkSanitizer(),
+  safeList: getSafeListSanitizer(),
+};
+
+afterEach(() => {
+  setSanitizerVendor(baseline.vendor);
+  setFullSanitizer(baseline.full);
+  setLinkSanitizer(baseline.link);
+  setSafeListSanitizer(baseline.safeList);
+});
+
+describe("SanitizeHelper class accessors", () => {
+  const stub = (label: string): Sanitizer => ({
+    sanitize: (html) => `[${label}:${html ?? ""}]`,
+  });
+
+  it("readers return the memoized module-level instances", () => {
+    expect(SanitizeHelper.fullSanitizer).toBe(getFullSanitizer());
+    expect(SanitizeHelper.linkSanitizer).toBe(getLinkSanitizer());
+    expect(SanitizeHelper.safeListSanitizer).toBe(getSafeListSanitizer());
+    expect(SanitizeHelper.sanitizerVendor).toBe(getSanitizerVendor());
+  });
+
+  it("writers replace the underlying instance seen by get* functions", () => {
+    const full = stub("full");
+    const link = stub("link");
+    const safe = stub("safe");
+
+    SanitizeHelper.fullSanitizer = full;
+    SanitizeHelper.linkSanitizer = link;
+    SanitizeHelper.safeListSanitizer = safe;
+
+    expect(getFullSanitizer()).toBe(full);
+    expect(getLinkSanitizer()).toBe(link);
+    expect(getSafeListSanitizer()).toBe(safe);
+    expect(SanitizeHelper.fullSanitizer).toBe(full);
+  });
+});

--- a/packages/actionview/src/helpers/sanitize-helper.ts
+++ b/packages/actionview/src/helpers/sanitize-helper.ts
@@ -283,8 +283,10 @@ export function stripLinks(html: string | null | undefined): string {
  * Rails mirrors a `ClassMethods` sub-module included via Concern that
  * exposes `full_sanitizer`, `link_sanitizer`, `safe_list_sanitizer` (with
  * matching writers) plus `sanitizer_vendor`. Exposed here as static
- * getter/setter accessors so framework code can read or replace them
- * with the same names Rails uses.
+ * getter/setter accessors using the camelCase equivalents of those
+ * Rails snake_case names (`fullSanitizer`, `linkSanitizer`,
+ * `safeListSanitizer`, `sanitizerVendor`) per the trails camelCase
+ * convention.
  */
 export class SanitizeHelper {
   static get fullSanitizer(): Sanitizer {

--- a/packages/actionview/src/helpers/sanitize-helper.ts
+++ b/packages/actionview/src/helpers/sanitize-helper.ts
@@ -276,3 +276,39 @@ export function stripTags(html: string | null | undefined): SafeBuffer {
 export function stripLinks(html: string | null | undefined): string {
   return getLinkSanitizer().sanitize(html ?? "");
 }
+
+/**
+ * ActionView::Helpers::SanitizeHelper class-method surface.
+ *
+ * Rails mirrors a `ClassMethods` sub-module included via Concern that
+ * exposes `full_sanitizer`, `link_sanitizer`, `safe_list_sanitizer` (with
+ * matching writers) plus `sanitizer_vendor`. Exposed here as static
+ * getter/setter accessors so framework code can read or replace them
+ * with the same names Rails uses.
+ */
+export class SanitizeHelper {
+  static get fullSanitizer(): Sanitizer {
+    return getFullSanitizer();
+  }
+  static set fullSanitizer(value: Sanitizer) {
+    setFullSanitizer(value);
+  }
+
+  static get linkSanitizer(): Sanitizer {
+    return getLinkSanitizer();
+  }
+  static set linkSanitizer(value: Sanitizer) {
+    setLinkSanitizer(value);
+  }
+
+  static get safeListSanitizer(): Sanitizer {
+    return getSafeListSanitizer();
+  }
+  static set safeListSanitizer(value: Sanitizer) {
+    setSafeListSanitizer(value);
+  }
+
+  static get sanitizerVendor(): SanitizerVendor {
+    return getSanitizerVendor();
+  }
+}

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -43,7 +43,7 @@ export {
   type RenderOptions as RendererOptions,
 } from "./renderer.js";
 
-export { OutputBuffer, RawOutputBuffer } from "./buffers.js";
+export { OutputBuffer, RawOutputBuffer, StreamingBuffer, RawStreamingBuffer } from "./buffers.js";
 
 export { PathSet, type PathSetResolver } from "./path-set.js";
 export { TemplatePath } from "./template-path.js";

--- a/packages/actionview/src/template/handlers.test.ts
+++ b/packages/actionview/src/template/handlers.test.ts
@@ -74,12 +74,12 @@ describe("Template::Handlers", () => {
 
   it("extensions memoizes and invalidates on register/unregister", () => {
     TemplateHandlers.registerTemplateHandler("tse", makeHandler(["tse"]));
-    const first = TemplateHandlers.extensions;
-    expect(TemplateHandlers.extensions).toBe(first);
+    const first = TemplateHandlers.extensions();
+    expect(TemplateHandlers.extensions()).toBe(first);
 
     TemplateHandlers.registerTemplateHandler("raw", makeHandler(["raw"]));
-    expect(TemplateHandlers.extensions).not.toBe(first);
-    expect(TemplateHandlers.extensions).toEqual(["tse", "raw"]);
+    expect(TemplateHandlers.extensions()).not.toBe(first);
+    expect(TemplateHandlers.extensions()).toEqual(["tse", "raw"]);
   });
 });
 

--- a/packages/actionview/src/template/handlers.ts
+++ b/packages/actionview/src/template/handlers.ts
@@ -115,7 +115,7 @@ export const TemplateHandlers = {
    * All registered extensions, lazily memoized. Rails memoizes via
    * `@@template_extensions ||= @@template_handlers.keys`.
    */
-  get extensions(): string[] {
+  extensions(): string[] {
     return (cachedExtensions ??= [...handlers.keys()]);
   },
 
@@ -149,7 +149,7 @@ export const TemplateHandlerRegistry = {
     return TemplateHandlers.handlerForExtension(ext);
   },
   get extensions(): string[] {
-    return TemplateHandlers.extensions;
+    return TemplateHandlers.extensions();
   },
   has(ext: string): boolean {
     return TemplateHandlers.registeredTemplateHandler(ext) !== undefined;


### PR DESCRIPTION
## Summary

Three small, self-contained leaves brought to 100% in actionview. Net **198 → 207 methods** (+9), three files closed.

- **`buffers.rb` 10/11 → 11/11.** Port `StreamingBuffer` + `RawStreamingBuffer` (mirrors `ActionView::StreamingBuffer`; used by `render stream: true`). Closes the `block` reader gap.
- **`helpers/sanitize_helper.rb` 6/13 → 13/13.** Add a `SanitizeHelper` class with static `fullSanitizer` / `linkSanitizer` / `safeListSanitizer` getter+setter pairs and a `sanitizerVendor` reader, mirroring Rails' `ClassMethods` accessor surface. Pure wrapper around the existing module-level `get*` / `set*` functions — no behavioral change.
- **`template/handlers.rb` 6/7 → 7/7.** Convert `TemplateHandlers.extensions` from a getter to a regular method so it matches Rails' `self.extensions` and is detected by `extract-ts-api`.

## Audited but deferred

Per `docs/actionview-100-percent.md`, the remaining sub-100% files all depend on infrastructure that isn't ported yet:

- `helpers/tag_helper.rb` (24/29) — 5 missing are `capture_helper` methods (`capture`, `contentFor`, `provide`, `isContentFor`, `withOutputBuffer`) that need `@output_buffer` / `@view_flow` instance state on `Base` (Phase 4).
- `helpers/translation_helper.rb` (12/23) — same 5 capture_helper methods + I18n-on-host (Phase 4).
- `digestor.rb` (1/4) — `logger` / `tree` / `findTemplate` need the `DependencyTracker` walker (Phase 6).
- `path_registry.rb` (1/6) and `view_paths.rb` (7/11) — view-path registry/state (Phase 1c / Phase 4).
- `template.rb`, `template/error.rb`, `rendering.rb`, `helpers/text-helper.rb`, `helpers/date-helper.rb` — Base/ERB pipeline.

## Test plan

- [x] `pnpm vitest run packages/actionview/src/buffers.test.ts` (28 tests, +9 new for `StreamingBuffer` / `RawStreamingBuffer`)
- [x] `pnpm vitest run packages/actionview/src/template/handlers.test.ts` (11 tests, updated for method call)
- [x] `pnpm --filter @blazetrails/actionview... build`
- [x] `pnpm api:compare --package actionview` confirms 3 files moved to 100%