### PR TITLE
refactor(activerecord): TM Phase 9a-1 — relocate fixSqliteCompat into SQLite3Adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -107,6 +107,75 @@ export class SQLiteDateTimeType extends ARDateTimeType {
  * Mirrors: ActiveRecord::ConnectionAdapters::SQLite3Adapter
  */
 
+/**
+ * Strip the outer parens from a `(SELECT ...) UNION (SELECT ...)` shape.
+ * SQLite rejects parenthesized SELECT operands of compound queries; PG/MySQL
+ * accept either form. Mirrors the end behavior of Rails'
+ * `Arel::Visitors::SQLite#infix_value_with_paren`. Top-level only — nested
+ * parens inside the SELECTs are left alone.
+ *
+ * @internal
+ */
+function unwrapCompoundSelect(sql: string): string {
+  const ops = /^\s*(UNION\s+ALL|UNION|INTERSECT|EXCEPT)\s+/i;
+  const trimmed = sql.trim();
+  if (trimmed[0] !== "(") return sql;
+
+  let depth = 0;
+  let i = 0;
+  for (; i < trimmed.length; i++) {
+    if (trimmed[i] === "(") depth++;
+    else if (trimmed[i] === ")") {
+      depth--;
+      if (depth === 0) break;
+    }
+  }
+  if (depth !== 0) return sql;
+
+  const left = trimmed.slice(1, i).trim();
+  const rest = trimmed.slice(i + 1).trim();
+  const opMatch = rest.match(ops);
+  if (!opMatch) return sql;
+
+  const op = opMatch[1];
+  let right = rest.slice(opMatch[0].length).trim();
+  if (right.startsWith("(") && right.endsWith(")")) {
+    right = right.slice(1, -1).trim();
+  }
+  return `${left} ${op} ${right}`;
+}
+
+/**
+ * Rewrite SQL fragments that PG/MySQL accept but SQLite rejects:
+ *   1. Strip `FOR UPDATE` / `FOR SHARE` row-locking clauses (SQLite has no
+ *      row-level locks; mirrors Rails'
+ *      `Arel::Visitors::SQLite#visit_Arel_Nodes_Lock`, which emits nothing).
+ *   2. Insert `LIMIT -1` before a bare `OFFSET` (SQLite requires a LIMIT
+ *      when OFFSET is present; mirrors Rails' SQLite
+ *      `visit_Arel_Nodes_SelectStatement`).
+ *   3. Unwrap top-level parens around compound SELECTs.
+ *
+ * Applied inside {@link SQLite3Adapter#execute} and
+ * {@link SQLite3Adapter#executeMutation} so production callers — not just
+ * the test wrapper — get the same compat treatment. Phase 9a moved this
+ * out of `SchemaAdapter`. Phase 9a-2 will activate the trails
+ * `Arel::Visitors::SQLite` (currently dormant) and shrink this helper to
+ * raw-SQL callers only.
+ *
+ * @internal
+ */
+function fixSqliteCompat(sql: string): string {
+  sql = sql.replace(
+    /\s+FOR\s+(NO\s+KEY\s+)?(UPDATE|SHARE|KEY\s+SHARE)(\s+OF\s+\w+)?(\s+NOWAIT|\s+SKIP\s+LOCKED)?/gi,
+    "",
+  );
+  if (/OFFSET/i.test(sql) && !/LIMIT/i.test(sql)) {
+    sql = sql.replace(/(OFFSET)/i, "LIMIT -1 $1");
+  }
+  sql = unwrapCompoundSelect(sql);
+  return sql;
+}
+
 function _isSqliteMissingDbError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const e = error as { code?: unknown; message?: unknown };
@@ -251,6 +320,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
     name: string = "SQL",
   ): Promise<Record<string, unknown>[]> {
     await this.materializeTransactions();
+    sql = fixSqliteCompat(sql);
 
     const payload: Record<string, unknown> = {
       sql,
@@ -343,6 +413,7 @@ export class SQLite3Adapter extends AbstractAdapter implements DatabaseAdapter {
    */
   async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
     await this.materializeTransactions();
+    sql = fixSqliteCompat(sql);
     if (this._preventWrites) {
       throw new ReadOnlyError("Write query attempted while preventing writes");
     }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -40,9 +40,6 @@ export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL
     ? "mysql"
     : "sqlite";
 
-const isPg = (): boolean => !!PG_TEST_URL;
-const isMysql = (): boolean => !!MYSQL_TEST_URL;
-
 let _sharedAdapter: any = null;
 
 // Schema tracking — what tables/columns have been created. Maintained
@@ -382,9 +379,12 @@ export async function resetTestAdapterState(): Promise<void> {
  * Thin wrapper around a real database adapter that:
  *   1. Routes transactions through the inner adapter's TM (Phase 1)
  *   2. Provides async-chain-aware visibility for `currentTransaction()`
- *   3. Patches SQLite-specific SQL incompatibilities (Phase 9 will move
- *      these into SQLite3Adapter directly)
- *   4. Tracks CREATE/DROP TABLE for `defineSchema`'s cache invalidation
+ *   3. Tracks CREATE/DROP TABLE for `defineSchema`'s cache invalidation
+ *
+ * SQLite-specific SQL incompatibilities (FOR UPDATE strip, OFFSET-without-
+ * LIMIT, compound-SELECT parens) are patched inside `SQLite3Adapter` itself
+ * as of Phase 9a, so production callers — not just the test wrapper — get
+ * the same treatment.
  */
 type BooleanCapability =
   | "supportsIndexesInCreate"
@@ -491,61 +491,11 @@ class SchemaAdapter implements DatabaseAdapter {
     return _createdTables;
   }
 
-  private unwrapCompoundSelect(sql: string): string {
-    const ops = /^\s*(UNION\s+ALL|UNION|INTERSECT|EXCEPT)\s+/i;
-    const trimmed = sql.trim();
-    if (trimmed[0] !== "(") return sql;
-
-    // Find the matching close-paren for the opening paren
-    let depth = 0;
-    let i = 0;
-    for (; i < trimmed.length; i++) {
-      if (trimmed[i] === "(") depth++;
-      else if (trimmed[i] === ")") {
-        depth--;
-        if (depth === 0) break;
-      }
-    }
-    if (depth !== 0) return sql;
-
-    const left = trimmed.slice(1, i).trim();
-    const rest = trimmed.slice(i + 1).trim();
-    const opMatch = rest.match(ops);
-    if (!opMatch) return sql;
-
-    const op = opMatch[1];
-    let right = rest.slice(opMatch[0].length).trim();
-    // Unwrap right-side parens if present
-    if (right.startsWith("(") && right.endsWith(")")) {
-      right = right.slice(1, -1).trim();
-    }
-    return `${left} ${op} ${right}`;
-  }
-
-  private fixSqliteCompat(sql: string): string {
-    if (isPg() || isMysql()) return sql;
-    // SQLite doesn't support FOR UPDATE / FOR SHARE
-    sql = sql.replace(
-      /\s+FOR\s+(NO\s+KEY\s+)?(UPDATE|SHARE|KEY\s+SHARE)(\s+OF\s+\w+)?(\s+NOWAIT|\s+SKIP\s+LOCKED)?/gi,
-      "",
-    );
-    // SQLite doesn't support OFFSET without LIMIT
-    if (/OFFSET/i.test(sql) && !/LIMIT/i.test(sql)) {
-      sql = sql.replace(/(OFFSET)/i, "LIMIT -1 $1");
-    }
-    // SQLite doesn't support parenthesized compound SELECT: (SELECT ...) UNION (SELECT ...)
-    // Unwrap only top-level parens by tracking nesting depth
-    sql = this.unwrapCompoundSelect(sql);
-    return sql;
-  }
-
   async execute(sql: string, binds?: unknown[], name?: string): Promise<Record<string, unknown>[]> {
-    return this.inner.execute(this.fixSqliteCompat(sql), binds, name);
+    return this.inner.execute(sql, binds, name);
   }
 
   async executeMutation(sql: string, binds?: unknown[], name?: string): Promise<number> {
-    sql = this.fixSqliteCompat(sql);
-
     const createMatch = sql.match(
       /CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+(?:["`](\w+)["`]|(\w+))/i,
     );


### PR DESCRIPTION
## Summary

Move the SQLite SQL compat regex out of \`SchemaAdapter\` and into
\`SQLite3Adapter.execute\` / \`executeMutation\` so production callers — not
just the test wrapper — get the same treatment. \`SchemaAdapter.execute\` /
\`executeMutation\` become pure delegation (modulo DDL tracking), unblocking
Phase 9b which will delete the wrapper class.

## What changed (21 net LOC)

- **\`sqlite3-adapter.ts\`** — add module-private \`fixSqliteCompat\` +
  \`unwrapCompoundSelect\` helpers; call \`fixSqliteCompat\` at the top of
  \`execute\` / \`executeMutation\`. The helpers mirror the end behavior of
  Rails' \`Arel::Visitors::SQLite\` (Lock → nothing,
  OFFSET-without-LIMIT → \`LIMIT -1\` prepended, compound-SELECT parens
  stripped).
- **\`test-adapter.ts\`** — \`execute\` / \`executeMutation\` reduced to pure
  delegation; \`fixSqliteCompat\` / \`unwrapCompoundSelect\` /
  \`isPg\` / \`isMysql\` deleted. Class doc updated.

## Scope split (was originally Phase 9a in one shot)

The first attempt at this PR also delegated \`SchemaAdapter.arelVisitor\` to
the inner adapter, activating the dormant \`Arel::Visitors::SQLite\` for
all callers — the Rails-faithful approach. CI revealed broader fallout:

- 4 tests in \`association-scope.test.ts\` assert \`.toSql()\` contains
  \`"published" = TRUE\`. With the SQLite visitor active, this becomes
  \`= 1\` (matching Rails' \`visit_Arel_Nodes_True\` which emits \`"1"\`).
- 4 tests in \`encryption/encryptable-record*.test.ts\` fail with
  \`TypeError: can't quote [object Object]\` — the SQLite visitor uses the
  adapter's strict \`quote()\` which throws on unknown objects, whereas
  the dormant-default-visitor path used a lenient \`String(value)\`
  fallback. This exposes a real encryption attribute serialization gap
  that's outside this PR's scope.
- Plus the existing locking/lock-clause tests (\`relations.test.ts\`,
  \`base.test.ts\`, etc.) that need adapter gates.

Split into three phases:

- **9a-1 (this PR):** regex relocation only. Zero test churn.
- **9a-2 (future PR):** activate the SQLite Arel visitor via \`arelVisitor\`
  delegation; gate the ~30 affected tests by adapter (Rails-style:
  \`unless in_memory_db?\` / \`if current_adapter?(:PostgreSQLAdapter)\`);
  fix the encryption serialization gap; refactor \`Relation#_toSql\` set-op
  builder to use \`Nodes.Union\` instead of a raw string template.
- **9b (future PR):** delete \`SchemaAdapter\` entirely;
  \`createTestAdapter()\` returns the inner adapter directly; sweep 148
  consumers.

## Verification

- [x] \`pnpm vitest run\` across affected suites — all green.
- [x] \`pnpm api:compare --package activerecord\` — \`4956/4958 methods (100%)\`,
  identical to main.
- [x] No public API changes; no new stubs.
- [ ] CI green on SQLite / MariaDB / PG / api-compare / test-compare.