### PR TITLE
feat(api-compare): rename erb→tse token in method/module names

### DIFF
--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -35,6 +35,23 @@ describe("snakeToCamel", () => {
     expect(snakeToCamel("name")).toBe("name");
     expect(snakeToCamel("expr")).toBe("expr");
   });
+
+  it("renames `erb` token to `tse` (trails uses .tse in place of .erb)", () => {
+    expect(snakeToCamel("erb")).toBe("tse");
+    expect(snakeToCamel("erb_handler")).toBe("tseHandler");
+    expect(snakeToCamel("compile_erb")).toBe("compileTse");
+    expect(snakeToCamel("compile_erb_template")).toBe("compileTseTemplate");
+    expect(snakeToCamel("_erb_source")).toBe("_tseSource");
+  });
+
+  it("does NOT rename `erb` when it appears as a substring of another token", () => {
+    // Guard: only standalone snake-case segments should be substituted,
+    // not embedded substrings like `verb`, `verbatim`, `superb`, `reverb`.
+    expect(snakeToCamel("verb")).toBe("verb");
+    expect(snakeToCamel("verbatim_copy")).toBe("verbatimCopy");
+    expect(snakeToCamel("http_verb")).toBe("httpVerb");
+    expect(snakeToCamel("superb_thing")).toBe("superbThing");
+  });
 });
 
 describe("rubyMethodToTs", () => {

--- a/scripts/api-compare/conventions.test.ts
+++ b/scripts/api-compare/conventions.test.ts
@@ -44,6 +44,16 @@ describe("snakeToCamel", () => {
     expect(snakeToCamel("_erb_source")).toBe("_tseSource");
   });
 
+  it("renames `ERB` and `Erb` constant-token casings (dot-notation names)", () => {
+    // Mirrors the `visit_Arel_Nodes_X` dot-notation pattern: Ruby methods that
+    // walk constants embed module names verbatim as snake segments. ERB-token
+    // constants (both ALL-CAPS like `ERB` and PascalCase like `Erb`) must
+    // rename the same way for api:compare to match the TS counterpart.
+    expect(snakeToCamel("visit_ERB")).toBe("visitTSE");
+    expect(snakeToCamel("visit_ERB_Template")).toBe("visitTSETemplate");
+    expect(snakeToCamel("visit_Erb_Node")).toBe("visitTseNode");
+  });
+
   it("does NOT rename `erb` when it appears as a substring of another token", () => {
     // Guard: only standalone snake-case segments should be substituted,
     // not embedded substrings like `verb`, `verbatim`, `superb`, `reverb`.

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -5,11 +5,33 @@
 
 import * as path from "path";
 
+/**
+ * Token-level Ruby→TS renames applied before camelization.
+ *
+ * `erb` → `tse`: trails uses a `.tse` (Trails Server Embedded) template
+ * extension in place of Rails' `.erb`. Any Rails identifier referring to
+ * ERB (file, method, module, parameter) is expected to use `tse` in
+ * trails — see docs/actionview-100-percent.md. File paths get this same
+ * substitution in `rubyFileToTs` below.
+ */
+const TOKEN_RENAMES: Record<string, string> = {
+  erb: "tse",
+  ERB: "TSE",
+  Erb: "Tse",
+};
+
+function applyTokenRenames(snake: string): string {
+  return snake.replace(
+    /(^|_)(erb|ERB|Erb)(?=_|$)/g,
+    (_m, pre, tok: string) => pre + TOKEN_RENAMES[tok],
+  );
+}
+
 export function snakeToCamel(name: string): string {
   // Preserve leading underscores (e.g., _load_from → _loadFrom)
   const match = name.match(/^(_+)/);
   const prefix = match ? match[1] : "";
-  const rest = name.slice(prefix.length);
+  const rest = applyTokenRenames(name.slice(prefix.length));
   // Match runs of `_` followed by any letter or digit so Ruby names with
   // capitalized segments (e.g. `visit_Arel_Nodes_SelectStatement`) OR
   // doubled underscores (Ruby's private-alias-target convention, e.g.

--- a/scripts/api-compare/conventions.ts
+++ b/scripts/api-compare/conventions.ts
@@ -9,10 +9,13 @@ import * as path from "path";
  * Token-level Ruby→TS renames applied before camelization.
  *
  * `erb` → `tse`: trails uses a `.tse` (Trails Server Embedded) template
- * extension in place of Rails' `.erb`. Any Rails identifier referring to
- * ERB (file, method, module, parameter) is expected to use `tse` in
- * trails — see docs/actionview-100-percent.md. File paths get this same
- * substitution in `rubyFileToTs` below.
+ * extension in place of Rails' `.erb` — see docs/actionview-100-percent.md.
+ *
+ * Applied to every identifier that flows through `snakeToCamel` —
+ * currently Ruby method names (via `rubyMethodToTs`) and constant
+ * fragments embedded in dot-notation method names like
+ * `visit_Arel_Nodes_X`. File paths get the equivalent substitution
+ * separately in `rubyFileToTs` below.
  */
 const TOKEN_RENAMES: Record<string, string> = {
   erb: "tse",


### PR DESCRIPTION
## Summary

- trails uses a `.tse` (Trails Server Embedded) template extension in place of Rails' `.erb` (see `docs/actionview-100-percent.md`).
- File paths already mapped `erb` → `tse` in `rubyFileToTs` (lines 74/78). This extends the same rule to identifiers that flow through `snakeToCamel` — methods, parameters, modules — via a `TOKEN_RENAMES` table applied before camelization.
- `test-compare` already handles erb→tse on paths + test names, so this closes the matching gap on the `api:compare` side.

## Verification

- `pnpm vitest run scripts/api-compare/conventions.test.ts` — 19/19 pass.
- `pnpm run api:compare --package actionview` — `template/handlers/erb.rb` now maps to `template/handlers/tse.ts`; `template/handlers/erb/erubi.rb` → `template/handlers/tse/erubi.ts`. 2 misplaced files unrelated to erb/tse (`dependency_tracker/ruby_tracker.rb`, `helpers/translation_helper.rb`) — pre-existing.

## Test plan

- [ ] CI green