### PR TITLE
feat(scripts): fixtures:compare diff script (PR 0 of fixtures port)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -480,6 +480,8 @@ jobs:
         run: pnpm exec tsx scripts/build-rails-privates-manifest.ts && pnpm exec eslint packages/arel/src
       - name: Test comparison
         run: pnpm exec tsx scripts/test-compare/extract-ts-tests.ts && pnpm exec tsx scripts/test-compare/test-compare.ts
+      - name: Fixtures comparison (DIFF/MISSING soft per Decision 4 until PR 7; runtime errors hard-fail)
+        run: pnpm exec tsx scripts/fixtures-compare/compare.ts --package activerecord
 
   schema-parity-rails:
     name: Schema Parity (Rails side)

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "db:up": "docker compose up -d --wait",
     "db:down": "docker compose down",
     "api:compare": "bash scripts/api-compare/run.sh",
+    "fixtures:compare": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/fixtures-compare/compare.ts",
     "rails-privates:manifest": "pnpm tsx scripts/build-rails-privates-manifest.ts",
     "api:moves": "pnpm tsx scripts/api-compare/moves.ts",
     "lint:deps": "pnpm vendor:fetch && LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths) LOCKFILE_PATH=$PWD/vendor/sources.lock.json ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { stripErb, isRefLike, compareValue, compareFile } from "./compare.js";
+
+// prettier-ignore
+const idIndex = new Map<string, Map<number, string[]>>([["authors", new Map([[1, ["david"]], [2, ["mary"]], [3, ["dup_a", "dup_b"]]])]]);
+const ref = (table: string, name: string) => ({ tableName: table, fixtureName: name });
+const cmp = (ts: unknown, rails: unknown, notes: string[] = []) =>
+  [compareValue(ts, rails, "x", idIndex, notes), notes] as const;
+
+it("stripErb stubs adapter_name; flags other tags as unsupported", () => {
+  expect(stripErb("a <%= ActiveRecord::Base.connection.adapter_name %> b")).toEqual({ rendered: "a SQLite b", unsupported: false }); // prettier-ignore
+  expect(stripErb("<% 3.times do %>x<% end %>").unsupported).toBe(true);
+  expect(stripErb("id: 1").unsupported).toBe(false);
+});
+
+it("isRefLike only accepts shapes with both string fields", () => {
+  expect(isRefLike(ref("authors", "david"))).toBe(true);
+  expect(isRefLike({ tableName: "x" })).toBe(false);
+  expect(isRefLike(null)).toBe(false);
+});
+
+describe("compareValue", () => {
+  it("reverse-resolves numeric FK → ref via id index", () => {
+    expect(cmp(ref("authors", "david"), 1)[0]).toBe(true);
+  });
+  it("flags wrong row-name behind a numeric FK", () => {
+    const [ok, notes] = cmp(ref("authors", "mary"), 1);
+    expect(ok).toBe(false);
+    expect(notes[0]).toMatch(/id=1.*"david"/);
+  });
+  it("flags ambiguous-fk when the target id maps to multiple rows", () => {
+    expect(cmp(ref("authors", "dup_a"), 3)[1][0]).toMatch(/^ambiguous-fk:/);
+  });
+  it("matches string FK against fixtureName; otherwise flags value-differs", () => {
+    expect(cmp(ref("e", "modest"), "modest")[0]).toBe(true);
+    expect(cmp("a", "b")[1][0]).toMatch(/^value-differs:/);
+  });
+});
+
+describe("compareFile", () => {
+  const empty = new Map();
+  it("returns MISSING when the TS counterpart doesn't exist", async () => {
+    const rows = new Map([["pirates", { blackbeard: { id: 1 } }]]);
+    const r = await compareFile("pirates.yml", rows, empty, undefined);
+    expect(r.status).toBe("MISSING");
+    expect(r.tsBase).toBeNull();
+  });
+  it("propagates a prelim YAML-PARSE-ERR untouched", async () => {
+    expect((await compareFile("authors.yml", empty, empty, "YAML-PARSE-ERR")).status).toBe(
+      "YAML-PARSE-ERR",
+    );
+  });
+});

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -1,0 +1,237 @@
+// fixtures:compare — diff Rails activerecord/test/fixtures/*.yml against
+// packages/activerecord/src/test-helpers/fixtures/<kebab-name>.ts. Soft
+// failure only per docs/fixtures-port-plan.md (Decision 4); PR 7 flips
+// to hard-fail. ERB stubs adapter_name to "SQLite"; other ERB → skipped.
+import { readdirSync, readFileSync, existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { parse as parseYaml } from "yaml";
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(HERE, "..", "..");
+const YML_DIR = path.join(ROOT, "vendor/rails/activerecord/test/fixtures");
+const TS_DIR = path.join(ROOT, "packages/activerecord/src/test-helpers/fixtures");
+
+type Row = Record<string, unknown>;
+type FixtureMap = Record<string, Row>;
+// prettier-ignore
+type Status = "MATCH" | "MISSING" | "DIFF" | "ERB-UNSUPPORTED" | "YAML-PARSE-ERR" | "TS-IMPORT-ERR" | "TS-EXPORT-MISSING";
+
+interface FileResult { yamlBase: string; tsBase: string | null; status: Status; rowsMatched: number; rowsTotal: number; attrsMatched: number; attrsTotal: number; notes: string[]; } // prettier-ignore
+
+function parseArgs(argv: string[]): { pkg: string; filter: string | null } {
+  let pkg = "activerecord";
+  let filter: string | null = null;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--package") {
+      if (!argv[i + 1]) throw new Error("--package requires a value");
+      pkg = argv[++i];
+    } else if (a.startsWith("--package=")) {
+      pkg = a.slice(10);
+      if (!pkg) throw new Error("--package= requires a value");
+    } else if (!a.startsWith("--") && filter === null) filter = a;
+  }
+  return { pkg, filter };
+}
+
+const kebab = (s: string): string => s.replace(/_/g, "-");
+
+export function stripErb(text: string): { rendered: string; unsupported: boolean } {
+  const rendered = text.replace(/<%=\s*ActiveRecord::Base\.connection\.adapter_name\s*%>/g, "SQLite"); // prettier-ignore
+  return { rendered, unsupported: /<%[=#]?[^%]*%>/.test(rendered) };
+}
+
+// prettier-ignore
+function loadRailsYaml(file: string): { ok: true; data: FixtureMap } | { ok: false; reason: Status } {
+  const raw = readFileSync(file, "utf8");
+  const { rendered, unsupported } = stripErb(raw);
+  if (unsupported) return { ok: false, reason: "ERB-UNSUPPORTED" };
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(rendered);
+  } catch {
+    return { ok: false, reason: "YAML-PARSE-ERR" };
+  }
+  const out: FixtureMap = {};
+  if (!parsed || typeof parsed !== "object") return { ok: true, data: out };
+  // YAML !omap → array of single-key maps; otherwise a plain object.
+  const entries = Array.isArray(parsed)
+    ? parsed.flatMap((e) => (e && typeof e === "object" ? Object.entries(e) : []))
+    : Object.entries(parsed as Record<string, unknown>);
+  for (const [k, v] of entries)
+    if (v && typeof v === "object" && !Array.isArray(v)) out[k] = v as Row;
+  return { ok: true, data: out };
+}
+
+function buildIdIndex(yamls: Map<string, FixtureMap>): Map<string, Map<number, string[]>> {
+  const idx = new Map<string, Map<number, string[]>>();
+  for (const [table, rows] of yamls) {
+    const inner = new Map<number, string[]>();
+    for (const [name, row] of Object.entries(rows)) {
+      if (typeof row.id === "number") inner.set(row.id, [...(inner.get(row.id) ?? []), name]);
+    }
+    idx.set(table, inner);
+  }
+  return idx;
+}
+
+export function isRefLike(v: unknown): v is { tableName: string; fixtureName: string } {
+  const o = v as Record<string, unknown> | null;
+  return !!o && typeof o === "object" && typeof o.tableName === "string" && typeof o.fixtureName === "string"; // prettier-ignore
+}
+
+// prettier-ignore
+export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, idIndex: Map<string, Map<number, string[]>>, notes: string[]): boolean {
+  if (isRefLike(tsVal)) {
+    const { tableName, fixtureName } = tsVal;
+    if (typeof railsVal === "number") {
+      const cands = idIndex.get(tableName)?.get(railsVal) ?? [];
+      if (cands.length === 1 && cands[0] === fixtureName) return true;
+      const msg =
+        cands.length > 1
+          ? `ambiguous-fk: ${attr} id=${railsVal} matches ${cands.length}`
+          : cands.length === 0
+            ? `${attr}: no row in "${tableName}" with id=${railsVal}`
+            : `${attr}: ref("${tableName}","${fixtureName}") but id=${railsVal} → "${cands[0]}"`;
+      notes.push(msg);
+      return false;
+    }
+    if (typeof railsVal === "string") {
+      if (railsVal === fixtureName) return true;
+      notes.push(`${attr}: ref "${fixtureName}" vs Rails string "${railsVal}"`);
+      return false;
+    }
+    notes.push(`${attr}: ref vs unexpected Rails type ${typeof railsVal}`);
+    return false;
+  }
+  if (tsVal === railsVal) return true;
+  notes.push(`value-differs: ${attr}: ts=${JSON.stringify(tsVal)} rails=${JSON.stringify(railsVal)}`); // prettier-ignore
+  return false;
+}
+
+// prettier-ignore
+export async function compareFile(yamlBase: string, yamlByTable: Map<string, FixtureMap>, idIndex: Map<string, Map<number, string[]>>, prelimFailure: Status | undefined): Promise<FileResult> {
+  const snake = yamlBase.replace(/\.yml$/, "");
+  const tsFile = path.join(TS_DIR, `${kebab(snake)}.ts`);
+  const tsBase = existsSync(tsFile) ? `${kebab(snake)}.ts` : null;
+  const r: FileResult = { yamlBase, tsBase, status: "MATCH", rowsMatched: 0, rowsTotal: 0, attrsMatched: 0, attrsTotal: 0, notes: [] }; // prettier-ignore
+  if (prelimFailure) { r.status = prelimFailure; return r; } // prettier-ignore
+  const railsRows = yamlByTable.get(snake)!;
+  r.rowsTotal = Object.keys(railsRows).length;
+  if (!tsBase) { r.status = "MISSING"; return r; } // prettier-ignore
+  let mod: Record<string, unknown>;
+  try {
+    mod = (await import(pathToFileURL(tsFile).href)) as Record<string, unknown>;
+  } catch (e) {
+    r.status = "TS-IMPORT-ERR";
+    r.notes.push((e as Error).message);
+    return r;
+  }
+  // Fixture modules export singular names (authorFixtureData, not authorsFixtureData), and
+  // developers-projects.ts uses developersProjectsFixtureData — too irregular to derive from the
+  // file stem. Require exactly one *FixtureData export so an ambiguous file fails loudly.
+  const keys = Object.keys(mod).filter((n) => n.endsWith("FixtureData"));
+  const tsRows = keys.length === 1 ? (mod[keys[0]] as FixtureMap | undefined) : undefined;
+  if (!tsRows || typeof tsRows !== "object") {
+    r.status = "TS-EXPORT-MISSING";
+    r.notes.push(keys.length > 1 ? `${tsBase} exports ${keys.length} *FixtureData symbols (expected 1)` : `no *FixtureData export in ${tsBase}`); // prettier-ignore
+    return r;
+  }
+  let anyDiff = false;
+  for (const [rowName, railsRow] of Object.entries(railsRows)) {
+    const tsRow = tsRows[rowName];
+    if (!tsRow || typeof tsRow !== "object") {
+      r.notes.push(`row missing in TS: ${rowName}`);
+      anyDiff = true;
+      continue;
+    }
+    r.rowsMatched++;
+    if ("id" in railsRow && (!("id" in tsRow) || tsRow.id !== railsRow.id)) {
+      r.notes.push(`id-divergence: ${rowName} ts=${String(tsRow.id)} rails=${String(railsRow.id)}`);
+      anyDiff = true;
+    }
+    for (const attr of new Set([...Object.keys(railsRow), ...Object.keys(tsRow)])) {
+      r.attrsTotal++;
+      if (!(attr in tsRow) || !(attr in railsRow)) {
+        r.notes.push(`${attr in tsRow ? "extra" : "missing"}-in-ts: ${rowName}.${attr}`);
+        anyDiff = true;
+        continue;
+      }
+      if (attr === "id") { if (tsRow.id === railsRow.id) r.attrsMatched++; continue; } // prettier-ignore
+      if (compareValue(tsRow[attr], railsRow[attr], `${rowName}.${attr}`, idIndex, r.notes))
+        r.attrsMatched++; // prettier-ignore
+      else anyDiff = true;
+    }
+  }
+  for (const rowName of Object.keys(tsRows)) {
+    if (!(rowName in railsRows)) { r.notes.push(`extra-row-in-ts: ${rowName}`); anyDiff = true; } // prettier-ignore
+  }
+  r.status = anyDiff ? "DIFF" : "MATCH";
+  return r;
+}
+
+function formatLine(r: FileResult): string {
+  const pct = r.attrsTotal === 0 ? "—" : `${Math.round((r.attrsMatched / r.attrsTotal) * 100)}%`;
+  return (
+    r.yamlBase.padEnd(32) +
+    (r.tsBase ?? "(missing)").padEnd(28) +
+    `rows: ${r.rowsMatched}/${r.rowsTotal}`.padEnd(14) +
+    `attrs: ${r.attrsMatched}/${r.attrsTotal}`.padEnd(16) +
+    pct.padEnd(6) +
+    r.status
+  );
+}
+
+async function main(): Promise<void> {
+  const { pkg, filter } = parseArgs(process.argv.slice(2));
+  if (pkg !== "activerecord") {
+    console.error(`fixtures:compare: --package ${pkg} not supported yet`);
+    process.exit(2);
+  }
+
+  const allYamls = readdirSync(YML_DIR)
+    .filter((f) => f.endsWith(".yml"))
+    .sort();
+  const yamlFiles = filter ? allYamls.filter((f) => f.includes(filter)) : allYamls;
+
+  // Parse every YAML so the id index is complete even when --filter narrows the per-file pass.
+  const yamlByTable = new Map<string, FixtureMap>();
+  const prelim = new Map<string, Status>();
+  for (const f of allYamls) {
+    const snake = f.replace(/\.yml$/, "");
+    const loaded = loadRailsYaml(path.join(YML_DIR, f));
+    if (loaded.ok) yamlByTable.set(snake, loaded.data);
+    else prelim.set(snake, loaded.reason);
+  }
+  const idIndex = buildIdIndex(yamlByTable);
+
+  const results: FileResult[] = [];
+  for (const f of yamlFiles) {
+    const snake = f.replace(/\.yml$/, "");
+    results.push(await compareFile(f, yamlByTable, idIndex, prelim.get(snake)));
+  }
+
+  for (const r of results) {
+    console.log(formatLine(r));
+    if (process.env.FIXTURES_COMPARE_VERBOSE === "1") {
+      for (const n of r.notes) console.log(`    ${n}`);
+    }
+  }
+  const n = (s: Status): number => results.filter((r) => r.status === s).length;
+  const other = results.length - n("MATCH") - n("DIFF") - n("MISSING") - n("ERB-UNSUPPORTED");
+  console.log(`\n${results.length} files — match=${n("MATCH")} diff=${n("DIFF")} missing=${n("MISSING")} erb-unsupported=${n("ERB-UNSUPPORTED")} other=${other}`); // prettier-ignore
+  console.log("(MISSING/DIFF soft per Decision 4 until PR 7; runtime errors hard-fail)");
+  // Decision 4 names DIFF/MISSING as soft; YAML/TS load errors are script-runtime, hard-fail.
+  const hard: readonly Status[] = ["YAML-PARSE-ERR", "TS-IMPORT-ERR", "TS-EXPORT-MISSING"];
+  if (results.some((r) => hard.includes(r.status))) process.exit(1);
+}
+
+// Run as a script when invoked directly, but stay importable from tests.
+// Resolve to an absolute path before comparing — `process.argv[1]` can be relative under some launchers.
+if (process.argv[1] && fileURLToPath(import.meta.url) === path.resolve(process.argv[1])) {
+  main().catch((e) => {
+    console.error(e);
+    process.exit(1);
+  });
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -176,6 +176,7 @@ export default defineConfig({
             "packages/*/src/**/*.test.ts",
             "scripts/guides-typecheck/*.test.ts",
             "scripts/api-compare/*.test.ts",
+            "scripts/fixtures-compare/*.test.ts",
             "scripts/parity/**/*.test.ts",
             "vendor/*.test.ts",
           ],


### PR DESCRIPTION
## Summary

First PR of the fixtures port (docs/fixtures-port-plan.md, PR 0). Lands the
verification script so the per-cluster fixture/schema PRs that follow are
self-checking from day one.

- `scripts/fixtures-compare/compare.ts`: per-file diff of each
  `vendor/rails/activerecord/test/fixtures/*.yml` against its TS
  counterpart at
  `packages/activerecord/src/test-helpers/fixtures/<kebab-name>.ts`.
  Reports rows/attrs parity, `id-divergence`, `value-differs`,
  `ambiguous-fk`, `MISSING`, and `ERB-UNSUPPORTED`.
- Minimal ERB renderer stubs `ActiveRecord::Base.connection.adapter_name`
  to `"SQLite"` per Decision 3; files with any other ERB tag report
  `ERB-UNSUPPORTED` and are skipped (per-adapter rendering is a later
  enhancement; soft failure makes this safe).
- `ref()` comparison: reverse-resolves Rails numeric FKs via a
  cross-table id index built from all 122 YAMLs in pass 1; string FKs
  compare to `fixtureName`.
- `pnpm fixtures:compare` wired in root `package.json` with a
  `--package activerecord` flag for future generalization. Positional
  arg is a filename substring filter (e.g. `pnpm fixtures:compare authors.yml`).
- CI step added under the `rails-comparison` job with
  `continue-on-error: true` per Decision 4 (soft failure until PR 7).

Current output (12 ported fixtures → all DIFF; explicit id backfill is
PR 0.75, so id-divergence is expected):

```
122 files — match=0 diff=10 missing=92 erb-unsupported=20 other=0
```

## Out of scope (per plan)

- Fixture content (PRs 1a–6b).
- `test-schema.ts` schema port (PR 0.5).
- Id backfill on the 12 already-translated fixtures + `ref()` resolver
  read-declared-id change + `adapterName()` helper (PR 0.75).
- Removing exclusions from `scripts/api-compare/unported-files.ts` and
  flipping to hard-fail (PR 7).

## Test plan

- [x] `pnpm fixtures:compare` runs locally and exits 0 (soft failure).
- [x] Filter form `pnpm fixtures:compare authors.yml` narrows output.
- [x] `FIXTURES_COMPARE_VERBOSE=1 pnpm fixtures:compare authors.yml`
      surfaces per-row notes (id-divergence, ref drift).
- [ ] CI `rails-comparison` job shows the new step running and not
      blocking the build.

---

## Response to Copilot review (round 1)

- **ERB trim-mode (`-%>` / `<%-`)** — ignored. Grepped all 122 `vendor/rails/activerecord/test/fixtures/*.yml`; zero use trim-mode delimiters. Theoretical risk, not a real one; will revisit if a future Rails sync introduces such a fixture.
- **`parseArgs` swallows missing `--package` value** — fixed: throws `--package requires a value` when the next argv slot is empty.
- **`main()` always exits 0** — fixed: `YAML-PARSE-ERR` / `TS-IMPORT-ERR` / `TS-EXPORT-MISSING` now hard-fail (`process.exit(1)`). Plan Decision 4 explicitly names only `MISSING` / `value-differs` / `id-divergence` / `ambiguous-fk` as soft; runtime/load errors fall outside that list and should not be silenced.
- **`compareFile` untested** — addressed: exported and added two targeted tests (MISSING path with no TS counterpart; prelim YAML-PARSE-ERR propagation). Test count: 6 → 8.


---

## Response to Copilot review (round 2)

- **TS-only rows ignored** — fixed. Added a second pass over `Object.keys(tsRows)` that flags any row present in TS but absent in the Rails YAML as `extra-row-in-ts: <name>` and marks the file as DIFF.
- **`pathToFileURL` on a possibly-relative `argv[1]`** — fixed. Entrypoint guard now uses `fileURLToPath(import.meta.url) === path.resolve(process.argv[1])`, with a falsy-guard on `argv[1]`.
- **`continue-on-error` masks runtime errors** — fixed. The CI step no longer carries `continue-on-error`. Since the script already exits 0 for soft statuses (`DIFF` / `MISSING` / `ERB-UNSUPPORTED`) and nonzero only for runtime errors (`YAML-PARSE-ERR` / `TS-IMPORT-ERR` / `TS-EXPORT-MISSING`), dropping the mask keeps DIFF/MISSING soft while letting real script breakage surface.


---

## Response to Copilot review (round 3)

- **`--package=` empty string** — fixed. The `=` form now also throws `--package= requires a value`.
- **`exportName` derives plural, fixtures export singular** — fixed. Confirmed via `grep "^export const"` over the 12 ported fixture files: 11 are singular (`authorFixtureData`, `topicFixtureData`, …) and one is `developersProjectsFixtureData` (HABTM join). No clean derivation from the file stem covers both. Dropped `exportName` entirely; the script now looks up `*FixtureData` exports by suffix.
- **Ambiguous `*FixtureData` fallback** — fixed. The script now requires exactly one `*FixtureData` export; 0 or >1 produces `TS-EXPORT-MISSING` with a distinct note (`<file> exports N *FixtureData symbols (expected 1)`), and per Decision 4 this is a runtime error that hard-fails.
