### PR TITLE
fix(activerecord): handle BinaryData in adapter quote() — TM Phase 9a follow-up

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { BinaryData } from "@blazetrails/activemodel";
 import {
   quote,
   quoteIdentifier,
@@ -67,6 +68,10 @@ describe("MySQL quoting — typeCast", () => {
 
   it("quotes Uint8Array values as hex literals via quotedBinary", () => {
     expect(quote(new Uint8Array([0xca, 0xfe]))).toBe("x'cafe'");
+  });
+
+  it("quotes BinaryData by unwrapping to bytes via quotedBinary", () => {
+    expect(quote(new BinaryData(new Uint8Array([0xca, 0xfe])))).toBe("x'cafe'");
   });
 
   it("throws on Date — Date is no longer accepted", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -19,6 +19,7 @@ import {
   formatPlainTimeForSqlMysql as formatPlainTimeForSql,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { BinaryData } from "@blazetrails/activemodel";
 
 export interface Quoting {
   quotedTrue(): string;
@@ -187,6 +188,8 @@ export function quote(value: unknown): string {
       "quote: JS Date is not accepted — use a Temporal type (Instant, PlainDateTime, etc.)",
     );
   if (value instanceof Buffer || value instanceof Uint8Array) return quotedBinary(value);
+  // Mirrors Rails abstract/quoting.rb: `when Type::Binary::Data then quoted_binary(value)`.
+  if (value instanceof BinaryData) return quotedBinary(value.bytes);
   if (typeof value === "symbol") {
     const desc = value.description;
     if (desc === undefined) throw new TypeError("Cannot quote a Symbol without a description");

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -159,6 +159,10 @@ describe("PostgreSQL quoting", () => {
     expect(quote(new Uint8Array([0x1f, 0x8b]))).toBe("'\\x1f8b'");
   });
 
+  it("quote(BinaryData) unwraps to bytes via quotedBinary", () => {
+    expect(quote(new BinaryData(new Uint8Array([0x1f, 0x8b])))).toBe("'\\x1f8b'");
+  });
+
   it("checkIntInRange is the Rails name for checkIntegerRange", () => {
     expect(() => checkIntInRange(BigInt("9223372036854775808"))).toThrow(IntegerOutOf64BitRange);
     expect(() => checkIntInRange(BigInt("9223372036854775807"))).not.toThrow();

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -157,6 +157,8 @@ export function quote(value: unknown): string {
     return String(value);
   }
   if (value instanceof Uint8Array) return quotedBinary(value);
+  // Mirrors Rails abstract/quoting.rb: `when Type::Binary::Data then quoted_binary(value)`.
+  if (value instanceof BinaryData) return quotedBinary(value.bytes);
   if (typeof value === "string") return quoteString(value);
   return abstractQuote(value);
 }

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { BinaryData } from "@blazetrails/activemodel";
 import { SQLite3Adapter, SQLiteDateTimeType } from "../sqlite3-adapter.js";
 import { Date as DateType } from "../../type/date.js";
 import { Time as TimeType } from "../../type/time.js";
@@ -183,6 +184,10 @@ describe("SQLite3::Quoting", () => {
   describe("quotedBinary", () => {
     it("formats as hex literal", () => {
       expect(quotedBinary(new Uint8Array([0xde, 0xad, 0xbe, 0xef]))).toBe("x'deadbeef'");
+    });
+
+    it("quote(BinaryData) unwraps to bytes via quotedBinary", () => {
+      expect(quote(new BinaryData(new Uint8Array([0xde, 0xad, 0xbe, 0xef])))).toBe("x'deadbeef'");
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -15,6 +15,7 @@ import {
   formatPlainTimeForSql,
 } from "../abstract/quoting.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { BinaryData } from "@blazetrails/activemodel";
 
 export interface Quoting {
   quotedTrue(): string;
@@ -93,6 +94,9 @@ export function quote(value: unknown): string {
   if (value instanceof Uint8Array || value instanceof ArrayBuffer) {
     return quotedBinary(value);
   }
+  // Mirrors Rails abstract/quoting.rb: `when Type::Binary::Data then quoted_binary(value)`.
+  // BinaryData wraps raw bytes from serialize() (e.g. encryption ciphertext for binary columns).
+  if (value instanceof BinaryData) return quotedBinary(value.bytes);
   if (typeof value === "function" && value.name) {
     return quoteString(value.name);
   }

--- a/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
@@ -31,18 +31,14 @@ describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest",
     restoreEncryptionConfig(configSnapshot);
   });
 
-  // BLOCKED on TM Phase 9a follow-up (Category B): encryption binary writes
-  // bypass type.serialize so the EncryptedMessage object reaches
-  // adapter.quote() and throws.
-  it.skip("binary data can be serialized with message pack", async () => {
+  it("binary data can be serialized with message pack", async () => {
     const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
     const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
     const book = await Book.create({ logo: allBytes });
     await assertEncryptedAttribute(book, "logo", allBytes);
   });
 
-  // BLOCKED on TM Phase 9a follow-up (Category B): see preceding skip.
-  it.skip("binary data can be encrypted uncompressed and serialized with message pack", async () => {
+  it("binary data can be encrypted uncompressed and serialized with message pack", async () => {
     const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
     // Rails: both ranges are 128 bytes (< 140 threshold) so neither is compressed.
     // TS note: highBytes (128–255) encoded as Latin-1 measures as 256 UTF-8 bytes so

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -585,21 +585,14 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     const overridingInstance = found!.becomes(OverridingBook);
     expect(overridingInstance.name).toBe("Dune-overridden");
   });
-  // BLOCKED on TM Phase 9a follow-up (Category B): encryption binary writes
-  // bypass type.serialize so the EncryptedMessage object reaches
-  // adapter.quote() and throws. Pre-existed; the prior fixSqliteCompat regex
-  // wrap masked it because the dormant-visitor fallback used Arel's lenient
-  // defaultQuoter (String-coerced unknown objects → silent garbage insert).
-  // Fix at the encryption type/serialize layer, not the visitor.
-  it.skip("binary data can be encrypted", async () => {
+  it("binary data can be encrypted", async () => {
     const Book = makeEncryptedBookWithBinary(await freshAdapter());
     const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
     expect((await Book.create({ logo: allBytes })).logo).toEqual(allBytes);
     expect((await Book.create({ logo: null })).logo).toBeNull();
     expect((await Book.create({ logo: new Uint8Array(0) })).logo).toEqual(new Uint8Array(0));
   });
-  // BLOCKED on TM Phase 9a follow-up (Category B): see preceding skip.
-  it.skip("binary data can be encrypted uncompressed", async () => {
+  it("binary data can be encrypted uncompressed", async () => {
     const Book = makeEncryptedBookWithBinary(await freshAdapter());
     const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
     const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);


### PR DESCRIPTION
## Summary

PR #2127 activated the strict SQLite Arel visitor and surfaced a pre-existing gap: encryption writes to binary columns produce a `BinaryData` wrapper from `EncryptedAttributeType.textToDatabaseType` (and plain `BinaryType.serialize` does the same in Rails), but trails' adapter `quote()` functions only branched on `Uint8Array` — not `BinaryData` — so the value hit the `can't quote [object Object]` throw.

Rails handles this in `abstract/quoting.rb`:

```ruby
when Type::Binary::Data then quoted_binary(value)
```

This PR mirrors that branch in the SQLite, MySQL, and PG `quote()` functions (one line each, next to the existing `Uint8Array` branch). Re-enables the 4 encryption binary tests that #2127 skipped:

- `binary data can be encrypted`
- `binary data can be encrypted uncompressed`
- `binary data can be serialized with message pack`
- `binary data can be encrypted uncompressed and serialized with message pack`

## Why not "fix at the serialization layer"

The original follow-up note suggested the fix should be at `type.serialize`. Investigation showed `serialize` already runs and produces the correct value — a `BinaryData` wrapper, which is the Rails-parity return shape for `Binary::Data.serialize`. The actual gap is on the consumer side: `quote()` didn't recognize the wrapper. Patching `quote()` here is literal Rails parity, not an end-run around strict quoting.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/encryption/` (30 files, 289 pass, 1 skip [unrelated deterministic-ciphertext]) — local SQLite
- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts` (54 pass)
- [ ] PG + MySQL via CI