### PR TITLE
feat(scripts): fixtures:compare schema-diff pass

### DIFF
--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { stripErb, isRefLike, compareValue, compareFile } from "./compare.js";
+import { stripErb, isRefLike, compareValue, compareFile, schemaCheck } from "./compare.js";
+import type { Schema } from "../../packages/activerecord/src/test-helpers/define-schema.js";
 
 // prettier-ignore
 const idIndex = new Map<string, Map<number, string[]>>([["authors", new Map([[1, ["david"]], [2, ["mary"]], [3, ["dup_a", "dup_b"]]])]]);
@@ -34,6 +35,87 @@ describe("compareValue", () => {
   it("matches string FK against fixtureName; otherwise flags value-differs", () => {
     expect(cmp(ref("e", "modest"), "modest")[0]).toBe(true);
     expect(cmp("a", "b")[1][0]).toMatch(/^value-differs:/);
+  });
+});
+
+describe("schemaCheck", () => {
+  const schema: Schema = {
+    authors: { name: "string" },
+    wrapped: { columns: { name: "string" }, primaryKey: ["name"] },
+  };
+  it("reports not-ported when the table isn't in TEST_SCHEMA", () => {
+    const out = schemaCheck("pirates", { blackbeard: { id: 1 } }, schema, []);
+    expect(out).toEqual({ ported: false, extras: 0 });
+  });
+  it("allows implicit `id` and declared columns", () => {
+    const notes: string[] = [];
+    const out = schemaCheck("authors", { david: { id: 1, name: "David" } }, schema, notes);
+    expect(out).toEqual({ ported: true, extras: 0 });
+    expect(notes).toEqual([]);
+  });
+  it("flags columns not declared in TEST_SCHEMA", () => {
+    const notes: string[] = [];
+    const out = schemaCheck("authors", { david: { id: 1, name: "D", bogus: 1 } }, schema, notes);
+    expect(out).toEqual({ ported: true, extras: 1 });
+    expect(notes[0]).toMatch(/^schema-extra-col: david\.bogus/);
+  });
+  it("reads columns from the WrappedTableSchema shape (composite PK keeps implicit id off, but PK columns are declared)", () => {
+    expect(schemaCheck("wrapped", { row: { id: 1, name: "n" } }, schema, []).extras).toBe(0);
+    expect(schemaCheck("wrapped", { row: { name: "n", extra: 1 } }, schema, []).extras).toBe(1);
+  });
+  it("flags `id` as drift on a wrapped table with primaryKey: false (no implicit id column)", () => {
+    const pkFalse: Schema = { sessions: { columns: { token: "string" }, primaryKey: false } };
+    const notes: string[] = [];
+    const out = schemaCheck("sessions", { s1: { id: 1, token: "abc" } }, pkFalse, notes);
+    expect(out.extras).toBe(1);
+    expect(notes[0]).toMatch(/^schema-extra-col: s1\.id /);
+  });
+});
+
+describe("compareFile + schema integration", () => {
+  // authors is in TEST_SCHEMA (PR 0.5a A-tables group); use it to prove
+  // schemaPorted/schemaExtras flow through compareFile and that extras flip
+  // an otherwise-MATCH row into DIFF. Use the schema-arg override so the
+  // assertions stay decoupled from how TEST_SCHEMA evolves.
+  const railsAuthorsLike: Record<string, Record<string, unknown>> = {
+    david: { id: 1, name: "David" },
+  };
+  const rows = () => new Map([["authors", railsAuthorsLike]]);
+
+  it("populates schemaPorted=true when the table is in the supplied schema", async () => {
+    // Schema mirrors every non-id column authors.ts uses so extras stays 0
+    // and the assertion proves the ported path, not a row-shape coincidence.
+    const r = await compareFile("authors.yml", rows(), new Map(), undefined, {
+      authors: {
+        name: "string",
+        author_address_id: "integer",
+        author_address_extra_id: "integer",
+        owned_essay_id: "integer",
+        organization_id: "string",
+      },
+    });
+    expect(r.schemaPorted).toBe(true);
+    expect(r.schemaExtras).toBe(0);
+  });
+
+  it("propagates schemaPorted=false when the supplied schema omits the table", async () => {
+    // Empty schema → ported=false even though the TS file exists. Proves
+    // the path through schemaCheck, not just the FileResult initializer.
+    const r = await compareFile("authors.yml", rows(), new Map(), undefined, {});
+    expect(r.schemaPorted).toBe(false);
+    expect(r.schemaExtras).toBe(0);
+  });
+
+  it("flips status to DIFF and counts extras when the TS row uses an undeclared column", async () => {
+    // Force a schema that declares only `id` (no `name`). authors.ts has a
+    // `name` field, so every row should flag exactly one extra.
+    const r = await compareFile("authors.yml", rows(), new Map(), undefined, {
+      authors: {},
+    });
+    expect(r.schemaPorted).toBe(true);
+    expect(r.schemaExtras).toBeGreaterThan(0);
+    expect(r.status).toBe("DIFF");
+    expect(r.notes.some((n) => /^schema-extra-col: .*\.name/.test(n))).toBe(true);
   });
 });
 

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -59,8 +59,12 @@ describe("schemaCheck", () => {
     expect(out).toEqual({ ported: true, extras: 1 });
     expect(notes[0]).toMatch(/^schema-extra-col: david\.bogus/);
   });
-  it("reads columns from the WrappedTableSchema shape (composite PK keeps implicit id off, but PK columns are declared)", () => {
-    expect(schemaCheck("wrapped", { row: { id: 1, name: "n" } }, schema, []).extras).toBe(0);
+  it("reads columns from the WrappedTableSchema shape; composite PK suppresses implicit `id`", () => {
+    // define-schema.ts sets createOpts.id = false for both primaryKey:false
+    // and primaryKey:string[], so any wrapped table that lists `id` in a
+    // fixture row is drift.
+    expect(schemaCheck("wrapped", { row: { name: "n" } }, schema, []).extras).toBe(0);
+    expect(schemaCheck("wrapped", { row: { id: 1, name: "n" } }, schema, []).extras).toBe(1);
     expect(schemaCheck("wrapped", { row: { name: "n", extra: 1 } }, schema, []).extras).toBe(1);
   });
   it("flags `id` as drift on a wrapped table with primaryKey: false (no implicit id column)", () => {

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -116,21 +116,24 @@ export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, id
   return false;
 }
 
-// Mirror of the (non-exported) discriminator in define-schema.ts: the
-// `WrappedTableSchema` shape is identified by the presence of a wrapper-shaped
-// `primaryKey` (string[] | false) alongside a `columns` map. Returns the
-// column map plus whether `defineSchema` creates an implicit `id` column.
-// Only the legacy shape gets one — define-schema.ts sets `createOpts.id =
-// false` for BOTH `primaryKey: false` and `primaryKey: string[]` (composite
-// PK), so any wrapped form has no implicit `id`.
+// Mirror of the (non-exported) discriminator in define-schema.ts. Kept in
+// strict step with `isWrappedSchema` there (require well-typed primaryKey,
+// columns map, AND no other top-level keys; PK arrays must be all strings).
+// Returns the column map plus whether `defineSchema` creates an implicit
+// `id` column — only the legacy shape gets one; define-schema.ts sets
+// `createOpts.id = false` for BOTH `primaryKey: false` and `primaryKey:
+// string[]`, so any wrapped form has no implicit `id`.
+const WRAPPER_KEYS = new Set(["columns", "primaryKey"]);
 function tableShape(table: TableSchema): {
   columns: Record<string, unknown>;
   hasImplicitId: boolean;
 } {
-  if (table && typeof table === "object" && "primaryKey" in table && "columns" in table) {
+  if (table && typeof table === "object" && "primaryKey" in table) {
     const pk = (table as { primaryKey?: unknown }).primaryKey;
     const cols = (table as { columns?: unknown }).columns;
-    if ((pk === false || Array.isArray(pk)) && cols && typeof cols === "object") {
+    const pkOk = pk === false || (Array.isArray(pk) && pk.every((v) => typeof v === "string"));
+    const onlyWrapperKeys = Object.keys(table).every((k) => WRAPPER_KEYS.has(k));
+    if (pkOk && cols && typeof cols === "object" && onlyWrapperKeys) {
       return { columns: cols as Record<string, unknown>, hasImplicitId: false };
     }
   }
@@ -173,7 +176,7 @@ export function schemaCheck(
     if (!row || typeof row !== "object") continue;
     for (const attr of Object.keys(row)) {
       if (!declared.has(attr)) {
-        notes.push(`schema-extra-col: ${rowName}.${attr} not in TEST_SCHEMA["${snake}"]`);
+        notes.push(`schema-extra-col: ${rowName}.${attr} not in schema["${snake}"]`);
         extras++;
       }
     }

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -6,6 +6,11 @@ import { readdirSync, readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { parse as parseYaml } from "yaml";
+import { TEST_SCHEMA } from "../../packages/activerecord/src/test-helpers/test-schema.js";
+import type {
+  Schema,
+  TableSchema,
+} from "../../packages/activerecord/src/test-helpers/define-schema.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(HERE, "..", "..");
@@ -17,7 +22,8 @@ type FixtureMap = Record<string, Row>;
 // prettier-ignore
 type Status = "MATCH" | "MISSING" | "DIFF" | "ERB-UNSUPPORTED" | "YAML-PARSE-ERR" | "TS-IMPORT-ERR" | "TS-EXPORT-MISSING";
 
-interface FileResult { yamlBase: string; tsBase: string | null; status: Status; rowsMatched: number; rowsTotal: number; attrsMatched: number; attrsTotal: number; notes: string[]; } // prettier-ignore
+// prettier-ignore
+interface FileResult { yamlBase: string; tsBase: string | null; status: Status; rowsMatched: number; rowsTotal: number; attrsMatched: number; attrsTotal: number; schemaPorted: boolean; schemaExtras: number; notes: string[]; }
 
 function parseArgs(argv: string[]): { pkg: string; filter: string | null } {
   let pkg = "activerecord";
@@ -110,12 +116,71 @@ export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, id
   return false;
 }
 
+// Mirror of the (non-exported) discriminator in define-schema.ts: the
+// `WrappedTableSchema` shape is identified by the presence of a wrapper-shaped
+// `primaryKey` (string[] | false) alongside a `columns` map. Returns the
+// column map plus whether an implicit `id` column is created — only legacy
+// shape and wrappers with `primaryKey: string[]` get one; `primaryKey: false`
+// suppresses it (matching defineSchema semantics).
+function tableShape(table: TableSchema): {
+  columns: Record<string, unknown>;
+  hasImplicitId: boolean;
+} {
+  if (table && typeof table === "object" && "primaryKey" in table && "columns" in table) {
+    const pk = (table as { primaryKey?: unknown }).primaryKey;
+    const cols = (table as { columns?: unknown }).columns;
+    if ((pk === false || Array.isArray(pk)) && cols && typeof cols === "object") {
+      return { columns: cols as Record<string, unknown>, hasImplicitId: pk !== false };
+    }
+  }
+  return { columns: table as Record<string, unknown>, hasImplicitId: true };
+}
+
+/**
+ * Per-fixture schema-parity check. Complements the Rails-YAML diff: catches
+ * drift between a TS fixture and `TEST_SCHEMA` even when the Rails YAML and
+ * TS rows agree (typo'd column, column dropped from schema, etc.). Stays
+ * useful after Rails-diff hits 100% — fixtures and schema can drift
+ * independently afterward.
+ *
+ * `id` is allowed only when defineSchema would create one — legacy-shape
+ * tables and wrappers with composite `primaryKey: string[]` get an implicit
+ * `id`; wrappers with `primaryKey: false` do not, so a stray `id` on such a
+ * fixture flags as drift.
+ *
+ * Returns `ported=false` when the table hasn't landed in TEST_SCHEMA yet —
+ * expected during the 0.5a..0.5h schema port and treated as informational,
+ * not drift.
+ */
+export function schemaCheck(
+  snake: string,
+  tsRows: FixtureMap,
+  schema: Schema,
+  notes: string[],
+): { ported: boolean; extras: number } {
+  const table = schema[snake];
+  if (!table) return { ported: false, extras: 0 };
+  const shape = tableShape(table);
+  const declared = new Set(Object.keys(shape.columns));
+  if (shape.hasImplicitId) declared.add("id");
+  let extras = 0;
+  for (const [rowName, row] of Object.entries(tsRows)) {
+    for (const attr of Object.keys(row)) {
+      if (!declared.has(attr)) {
+        notes.push(`schema-extra-col: ${rowName}.${attr} not in TEST_SCHEMA["${snake}"]`);
+        extras++;
+      }
+    }
+  }
+  return { ported: true, extras };
+}
+
 // prettier-ignore
-export async function compareFile(yamlBase: string, yamlByTable: Map<string, FixtureMap>, idIndex: Map<string, Map<number, string[]>>, prelimFailure: Status | undefined): Promise<FileResult> {
+export async function compareFile(yamlBase: string, yamlByTable: Map<string, FixtureMap>, idIndex: Map<string, Map<number, string[]>>, prelimFailure: Status | undefined, schema: Schema = TEST_SCHEMA): Promise<FileResult> {
   const snake = yamlBase.replace(/\.yml$/, "");
   const tsFile = path.join(TS_DIR, `${kebab(snake)}.ts`);
   const tsBase = existsSync(tsFile) ? `${kebab(snake)}.ts` : null;
-  const r: FileResult = { yamlBase, tsBase, status: "MATCH", rowsMatched: 0, rowsTotal: 0, attrsMatched: 0, attrsTotal: 0, notes: [] }; // prettier-ignore
+  const r: FileResult = { yamlBase, tsBase, status: "MATCH", rowsMatched: 0, rowsTotal: 0, attrsMatched: 0, attrsTotal: 0, schemaPorted: false, schemaExtras: 0, notes: [] }; // prettier-ignore
   if (prelimFailure) { r.status = prelimFailure; return r; } // prettier-ignore
   const railsRows = yamlByTable.get(snake)!;
   r.rowsTotal = Object.keys(railsRows).length;
@@ -138,7 +203,10 @@ export async function compareFile(yamlBase: string, yamlByTable: Map<string, Fix
     r.notes.push(keys.length > 1 ? `${tsBase} exports ${keys.length} *FixtureData symbols (expected 1)` : `no *FixtureData export in ${tsBase}`); // prettier-ignore
     return r;
   }
-  let anyDiff = false;
+  const sc = schemaCheck(snake, tsRows, schema, r.notes);
+  r.schemaPorted = sc.ported;
+  r.schemaExtras = sc.extras;
+  let anyDiff = sc.extras > 0;
   for (const [rowName, railsRow] of Object.entries(railsRows)) {
     const tsRow = tsRows[rowName];
     if (!tsRow || typeof tsRow !== "object") {
@@ -173,12 +241,20 @@ export async function compareFile(yamlBase: string, yamlByTable: Map<string, Fix
 
 function formatLine(r: FileResult): string {
   const pct = r.attrsTotal === 0 ? "—" : `${Math.round((r.attrsMatched / r.attrsTotal) * 100)}%`;
+  const sch = !r.tsBase
+    ? ""
+    : !r.schemaPorted
+      ? "schema:not-ported"
+      : r.schemaExtras > 0
+        ? `schema:extras=${r.schemaExtras}`
+        : "schema:ok";
   return (
     r.yamlBase.padEnd(32) +
     (r.tsBase ?? "(missing)").padEnd(28) +
     `rows: ${r.rowsMatched}/${r.rowsTotal}`.padEnd(14) +
     `attrs: ${r.attrsMatched}/${r.attrsTotal}`.padEnd(16) +
     pct.padEnd(6) +
+    sch.padEnd(20) +
     r.status
   );
 }
@@ -220,7 +296,11 @@ async function main(): Promise<void> {
   }
   const n = (s: Status): number => results.filter((r) => r.status === s).length;
   const other = results.length - n("MATCH") - n("DIFF") - n("MISSING") - n("ERB-UNSUPPORTED");
+  const considered = results.filter((r) => r.tsBase);
+  const ported = considered.filter((r) => r.schemaPorted).length;
+  const withExtras = considered.filter((r) => r.schemaExtras > 0).length;
   console.log(`\n${results.length} files — match=${n("MATCH")} diff=${n("DIFF")} missing=${n("MISSING")} erb-unsupported=${n("ERB-UNSUPPORTED")} other=${other}`); // prettier-ignore
+  console.log(`schema — ported=${ported}/${considered.length} extras-flagged=${withExtras}`);
   console.log("(MISSING/DIFF soft per Decision 4 until PR 7; runtime errors hard-fail)");
   // Decision 4 names DIFF/MISSING as soft; YAML/TS load errors are script-runtime, hard-fail.
   const hard: readonly Status[] = ["YAML-PARSE-ERR", "TS-IMPORT-ERR", "TS-EXPORT-MISSING"];

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -248,9 +248,18 @@ export async function compareFile(yamlBase: string, yamlByTable: Map<string, Fix
   return r;
 }
 
+// `schemaCheck` only runs after a successful TS import, so a result has
+// real schema data exactly when its final status is MATCH or DIFF. Early-
+// return statuses (MISSING, ERB-UNSUPPORTED, YAML-PARSE-ERR, TS-IMPORT-ERR,
+// TS-EXPORT-MISSING) skip the check entirely — distinguish "not evaluated"
+// from "evaluated, no schema entry" both in per-file output and totals.
+function schemaEvaluated(r: FileResult): boolean {
+  return r.status === "MATCH" || r.status === "DIFF";
+}
+
 function formatLine(r: FileResult): string {
   const pct = r.attrsTotal === 0 ? "—" : `${Math.round((r.attrsMatched / r.attrsTotal) * 100)}%`;
-  const sch = !r.tsBase
+  const sch = !schemaEvaluated(r)
     ? ""
     : !r.schemaPorted
       ? "schema:not-ported"
@@ -305,11 +314,13 @@ async function main(): Promise<void> {
   }
   const n = (s: Status): number => results.filter((r) => r.status === s).length;
   const other = results.length - n("MATCH") - n("DIFF") - n("MISSING") - n("ERB-UNSUPPORTED");
-  const considered = results.filter((r) => r.tsBase);
-  const ported = considered.filter((r) => r.schemaPorted).length;
-  const withExtras = considered.filter((r) => r.schemaExtras > 0).length;
+  const evaluated = results.filter(schemaEvaluated);
+  const ported = evaluated.filter((r) => r.schemaPorted).length;
+  const withExtras = evaluated.filter((r) => r.schemaExtras > 0).length;
   console.log(`\n${results.length} files — match=${n("MATCH")} diff=${n("DIFF")} missing=${n("MISSING")} erb-unsupported=${n("ERB-UNSUPPORTED")} other=${other}`); // prettier-ignore
-  console.log(`schema — ported=${ported}/${considered.length} extras-flagged=${withExtras}`);
+  console.log(
+    `schema — ported=${ported}/${evaluated.length} extras-flagged=${withExtras} (skipped ${results.length - evaluated.length})`,
+  );
   console.log("(MISSING/DIFF soft per Decision 4 until PR 7; runtime errors hard-fail)");
   // Decision 4 names DIFF/MISSING as soft; YAML/TS load errors are script-runtime, hard-fail.
   const hard: readonly Status[] = ["YAML-PARSE-ERR", "TS-IMPORT-ERR", "TS-EXPORT-MISSING"];

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -119,9 +119,10 @@ export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, id
 // Mirror of the (non-exported) discriminator in define-schema.ts: the
 // `WrappedTableSchema` shape is identified by the presence of a wrapper-shaped
 // `primaryKey` (string[] | false) alongside a `columns` map. Returns the
-// column map plus whether an implicit `id` column is created — only legacy
-// shape and wrappers with `primaryKey: string[]` get one; `primaryKey: false`
-// suppresses it (matching defineSchema semantics).
+// column map plus whether `defineSchema` creates an implicit `id` column.
+// Only the legacy shape gets one — define-schema.ts sets `createOpts.id =
+// false` for BOTH `primaryKey: false` and `primaryKey: string[]` (composite
+// PK), so any wrapped form has no implicit `id`.
 function tableShape(table: TableSchema): {
   columns: Record<string, unknown>;
   hasImplicitId: boolean;
@@ -130,7 +131,7 @@ function tableShape(table: TableSchema): {
     const pk = (table as { primaryKey?: unknown }).primaryKey;
     const cols = (table as { columns?: unknown }).columns;
     if ((pk === false || Array.isArray(pk)) && cols && typeof cols === "object") {
-      return { columns: cols as Record<string, unknown>, hasImplicitId: pk !== false };
+      return { columns: cols as Record<string, unknown>, hasImplicitId: false };
     }
   }
   return { columns: table as Record<string, unknown>, hasImplicitId: true };
@@ -143,10 +144,11 @@ function tableShape(table: TableSchema): {
  * useful after Rails-diff hits 100% — fixtures and schema can drift
  * independently afterward.
  *
- * `id` is allowed only when defineSchema would create one — legacy-shape
- * tables and wrappers with composite `primaryKey: string[]` get an implicit
- * `id`; wrappers with `primaryKey: false` do not, so a stray `id` on such a
- * fixture flags as drift.
+ * `id` is allowed only when defineSchema would create one — that's the
+ * legacy `Record<colName, ColumnSpec>` shape only. Any wrapped table
+ * (`primaryKey: false` *or* `primaryKey: string[]`) has `id` suppressed
+ * (see define-schema.ts setting `createOpts.id = false` for both),
+ * so a stray `id` on those flags as drift.
  *
  * Returns `ported=false` when the table hasn't landed in TEST_SCHEMA yet —
  * expected during the 0.5a..0.5h schema port and treated as informational,
@@ -165,6 +167,10 @@ export function schemaCheck(
   if (shape.hasImplicitId) declared.add("id");
   let extras = 0;
   for (const [rowName, row] of Object.entries(tsRows)) {
+    // Skip non-object rows (null/undefined/scalar). compareFile's own row-
+    // shape pass reports those as "row missing in TS"; the schema check
+    // shouldn't promote a malformed-fixture soft DIFF to a runtime crash.
+    if (!row || typeof row !== "object") continue;
     for (const attr of Object.keys(row)) {
       if (!declared.has(attr)) {
         notes.push(`schema-extra-col: ${rowName}.${attr} not in TEST_SCHEMA["${snake}"]`);


### PR DESCRIPTION
## Summary

Adds a second pass to `fixtures:compare` that checks each TS fixture against `TEST_SCHEMA`. Catches drift the Rails-YAML diff can't see — typo'd columns, columns dropped from the schema port, or fixtures that ran ahead of the schema. Stays useful after Rails-diff hits 100% (PR 7), since fixtures and `test-schema.ts` can drift independently after that.

- Per-fixture output adds a `schema:` segment — `schema:ok`, `schema:extras=N`, or `schema:not-ported` (table not yet in `TEST_SCHEMA`). The segment is suppressed for statuses where `schemaCheck` never ran (MISSING / ERB-UNSUPPORTED / YAML-PARSE-ERR / TS-IMPORT-ERR / TS-EXPORT-MISSING).
- Footer reports `ported=N/M extras-flagged=X (skipped K)` where M is the count of files for which the schema check was actually evaluated (status ∈ {MATCH, DIFF}).
- Soft signal: extras flip the row to `DIFF` (already soft per Decision 4), no hard-fail behavior change.
- `id` is whitelisted only when `defineSchema` would create one — the legacy `Record<colName, ColumnSpec>` shape only. Any wrapped table (`primaryKey: false` **or** `primaryKey: string[]`) has the implicit `id` suppressed (see `define-schema.ts` setting `createOpts.id = false` for both), so a stray `id` on those flags as drift.
- The wrapper-vs-legacy discriminator (`tableShape`) mirrors the exact checks in `isWrappedSchema`: PK arrays must be all strings, and no top-level keys beyond `{columns, primaryKey}` are allowed.

First real catch on `main`:

```
comments.yml   comments.ts   rows: 12/12   attrs: 49/51   96%   schema:extras=1   DIFF
    schema-extra-col: recursive_association_comment.company_id not in schema["comments"]
```

## What this does NOT check (deliberately)

- **Type coherence** (string-vs-integer on a column) — needs a value-coercion table; defer.
- **Required columns / null violations** — fixtures legitimately omit timestamps/server defaults; too noisy without a defaults table.
- **Schema-orphan tables** (declared in `TEST_SCHEMA` but no fixture, or fixture exists but doesn't reference some columns). Asymmetric on purpose: `defineSchema` happily creates unused columns, so an orphan column isn't drift, it's just unused.

## Test plan

- [x] `pnpm vitest run scripts/fixtures-compare/compare.test.ts` — 16/16 passing (5 `schemaCheck` unit cases incl. `primaryKey: false` and composite-PK `id`-flag edges; 3 `compareFile` integration cases proving `schemaPorted`/`schemaExtras` propagation and that extras flip a row to `DIFF`)
- [x] `pnpm typecheck`
- [x] `pnpm fixtures:compare` end-to-end: `schema — ported=9/10 extras-flagged=1 (skipped 112)`