### PR TITLE
feat(actionpack): close routing/mapper.rb (91→100%)

### DIFF
--- a/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
@@ -81,3 +81,71 @@ describe("scope-merge helpers", () => {
     expect(m.mergeShallowScope(false, "anything")).toBe(true);
   });
 });
+
+describe("Mapper public DSL additions", () => {
+  it("nested throws outside a resource scope", () => {
+    const m = new Mapper();
+    expect(() => m.nested(() => {})).toThrow(/can't use nested outside resource\(s\) scope/);
+  });
+
+  it("nested runs inside a resources block", () => {
+    const m = new Mapper();
+    let ran = false;
+    m.resources("posts", () => {
+      m.nested(() => {
+        ran = true;
+      });
+    });
+    expect(ran).toBe(true);
+  });
+
+  it("shallow preserves the outer path prefix on its frame", () => {
+    const m = new Mapper();
+    let observedInside: string | undefined;
+    m.scope("/admin", () => {
+      m.shallow(() => {
+        observedInside = m["currentPrefix"]();
+      });
+    });
+    expect(observedInside).toBe("/admin");
+  });
+
+  it("draw runs a callback form", () => {
+    const m = new Mapper();
+    let inner: Mapper | undefined;
+    m.draw((inside) => {
+      inner = inside;
+    });
+    expect(inner).toBe(m);
+  });
+
+  it("draw throws on the string (file-load) form", () => {
+    const m = new Mapper();
+    expect(() => m.draw("admin")).toThrow(/file-based draw is not supported/);
+  });
+
+  it("defaultUrlOptions getter/setter round-trip", () => {
+    const m = new Mapper();
+    m.defaultUrlOptions = { host: "example.com" };
+    expect(m.defaultUrlOptions).toEqual({ host: "example.com" });
+  });
+
+  it("defaultUrlOptions delegates to an attached set", () => {
+    const set: { defaultUrlOptions: Record<string, unknown> } = { defaultUrlOptions: {} };
+    const m = new Mapper(set);
+    m.defaultUrlOptions = { port: 3000 };
+    expect(set.defaultUrlOptions).toEqual({ port: 3000 });
+    expect(m.defaultUrlOptions).toEqual({ port: 3000 });
+  });
+
+  it("setMemberMappingsForResource emits member routes with explicit actions", () => {
+    const m = new Mapper();
+    m.resources("posts", () => {
+      m.setMemberMappingsForResource();
+    });
+    const editRoute = m.routes.find((r) => r.action === "edit");
+    const showRoute = m.routes.find((r) => r.action === "show");
+    expect(editRoute?.controller).toBe("posts");
+    expect(showRoute?.controller).toBe("posts");
+  });
+});

--- a/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
@@ -156,6 +156,19 @@ describe("Mapper public DSL additions", () => {
     expect(added.every((r) => r.controller === "posts")).toBe(true);
   });
 
+  it("shallow inside a namespace preserves the namespace prefix on member paths", () => {
+    const m = new Mapper();
+    m.namespace("admin", () => {
+      m.resources("posts", { shallow: true }, () => {
+        m.resources("comments");
+      });
+    });
+    const commentShow = m.routes.find(
+      (r) => r.action === "show" && r.controller.endsWith("comments"),
+    );
+    expect(commentShow?.path).toBe("/admin/comments/:id");
+  });
+
   it("setMemberMappingsForResource is a safe no-op outside a resource scope", () => {
     const m = new Mapper();
     expect(() => m.setMemberMappingsForResource()).not.toThrow();

--- a/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
@@ -138,14 +138,27 @@ describe("Mapper public DSL additions", () => {
     expect(m.defaultUrlOptions).toEqual({ port: 3000 });
   });
 
-  it("setMemberMappingsForResource emits member routes with explicit actions", () => {
+  it("setMemberMappingsForResource emits canonical member routes for the parent resource actions", () => {
     const m = new Mapper();
+    let before = 0;
     m.resources("posts", () => {
+      before = m.routes.length;
       m.setMemberMappingsForResource();
     });
-    const editRoute = m.routes.find((r) => r.action === "edit");
-    const showRoute = m.routes.find((r) => r.action === "show");
-    expect(editRoute?.controller).toBe("posts");
-    expect(showRoute?.controller).toBe("posts");
+    const added = m.routes.slice(before, before + 5);
+    expect(added.map((r) => `${r.verb} ${r.path}#${r.action}`)).toEqual([
+      "GET /posts/:id/edit#edit",
+      "GET /posts/:id#show",
+      "PATCH /posts/:id#update",
+      "PUT /posts/:id#update",
+      "DELETE /posts/:id#destroy",
+    ]);
+    expect(added.every((r) => r.controller === "posts")).toBe(true);
+  });
+
+  it("setMemberMappingsForResource is a safe no-op outside a resource scope", () => {
+    const m = new Mapper();
+    expect(() => m.setMemberMappingsForResource()).not.toThrow();
+    expect(m.routes).toEqual([]);
   });
 });

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -941,7 +941,12 @@ export class Mapper {
    */
   private outerNonResourcePrefix(): string {
     for (let i = this.scopeStack.length - 1; i >= 0; i--) {
-      if (!this.scopeStack[i].resource) return this.scopeStack[i].path;
+      const f = this.scopeStack[i];
+      // Skip both resource frames and shallow-marker frames (the latter
+      // carry no real path contribution — they snapshot currentPrefix()
+      // only to keep `member()` from resetting it).
+      if (f.resource || f.shallow) continue;
+      return f.path;
     }
     return "";
   }

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -150,8 +150,11 @@ export class Mapper {
     const namePrefix = this.currentNamePrefix();
     const routeName = (suffix: string) => (namePrefix ? `${namePrefix}_${suffix}` : suffix);
 
-    // For shallow routes, member routes use un-nested paths
-    const shallowPath = shallow ? `/${name}` : basePath;
+    // For shallow routes, member routes drop *parent resource* segments but
+    // keep outer scope/namespace prefixes. Rails: shallow_path = path until
+    // outermost resource.
+    const shallowPrefix = shallow ? this.outerNonResourcePrefix() : prefix;
+    const shallowPath = shallow ? `${shallowPrefix}/${name}` : basePath;
     const shallowName = (suffix: string) => (shallow ? suffix : routeName(suffix));
 
     const allowed = allowedActions(options, [
@@ -218,6 +221,7 @@ export class Mapper {
           actions: Array.from(allowed) as ResourceAction[],
         },
         resourceController: controller,
+        resourcePathNames: pathNames,
       });
       cb(this);
       this.scopeStack.pop();
@@ -341,6 +345,7 @@ export class Mapper {
           actions: Array.from(allowed) as ResourceAction[],
         },
         resourceController: controller,
+        resourcePathNames: pathNames,
       });
       cb(this);
       this.scopeStack.pop();
@@ -498,7 +503,7 @@ export class Mapper {
     const frame = [...this.scopeStack].reverse().find((f) => f.resource === parent);
     const memberPath = frame?.memberPath ?? this.currentPrefix();
     const controller = frame?.resourceController ?? "";
-    const editPath = this.actionPath("edit");
+    const editPath = frame?.resourcePathNames?.edit ?? this.actionPath("edit");
     if (actions.includes("edit")) {
       this.routes.push(new Route("GET", `${memberPath}/${editPath}`, controller, "edit"));
     }
@@ -925,6 +930,20 @@ export class Mapper {
   private currentPrefix(): string {
     if (this.scopeStack.length === 0) return "";
     return this.scopeStack[this.scopeStack.length - 1].path;
+  }
+
+  /**
+   * Path contributed by the outermost non-resource scope frames (namespaces,
+   * scopes) — used to compute the shallow base path so it preserves
+   * `/admin` etc. but drops parent-resource `/:user_id` segments.
+   *
+   * @internal
+   */
+  private outerNonResourcePrefix(): string {
+    for (let i = this.scopeStack.length - 1; i >= 0; i--) {
+      if (!this.scopeStack[i].resource) return this.scopeStack[i].path;
+    }
+    return "";
   }
 
   private prefixedName(name: string): string {
@@ -1377,6 +1396,8 @@ interface ScopeFrame {
   resource?: ResourceLike;
   /** Controller for member-route emission (Rails: resource_scope controller). */
   resourceController?: string;
+  /** Merged pathNames (scope + options) for this resource frame. */
+  resourcePathNames?: Record<string, string>;
 }
 
 interface ScopeOptions {

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -48,6 +48,13 @@ const RESOURCE_OPTIONS: ReadonlySet<string> = new Set([
   "concerns",
 ]);
 
+/** @internal Subset of `RouteSet` consumed by the {@link Mapper} constructor. */
+interface RouteSetLike {
+  resourcesPathNames?: Record<string, string>;
+  drawPaths?: string[];
+  defaultUrlOptions?: Record<string, unknown>;
+}
+
 export class Mapper {
   readonly routes: Route[] = [];
   private scopeStack: ScopeFrame[] = [];
@@ -55,9 +62,34 @@ export class Mapper {
   private redirectFns: Map<string, RedirectFunction> = new Map();
   private redirectCounter = 0;
   /** @internal */
-  _scope: Scope = new Scope({ pathNames: { new: "new", edit: "edit" } }, Scope.ROOT, null);
+  _set: RouteSetLike | undefined;
+  /** @internal */
+  _drawPaths: string[];
+  /** @internal */
+  _scope: Scope;
   /** @internal */
   _apiOnly = false;
+  /** @internal Local fallback when no RouteSet is attached. */
+  private _defaultUrlOptions: Record<string, unknown> = {};
+
+  /** Mirrors Rails `Mapper#initialize(set)`. The `set` is optional in trails. */
+  constructor(set?: RouteSetLike) {
+    this._set = set;
+    this._drawPaths = set?.drawPaths ?? [];
+    const pathNames = set?.resourcesPathNames ?? { new: "new", edit: "edit" };
+    this._scope = new Scope({ pathNames }, Scope.ROOT, null);
+  }
+
+  /** Rails: `default_url_options=(options)`. */
+  set defaultUrlOptions(options: Record<string, unknown>) {
+    if (this._set) this._set.defaultUrlOptions = options;
+    else this._defaultUrlOptions = options;
+  }
+
+  /** Rails: `alias_method :default_url_options, :default_url_options=`. */
+  get defaultUrlOptions(): Record<string, unknown> {
+    return this._set?.defaultUrlOptions ?? this._defaultUrlOptions;
+  }
 
   // --- HTTP verb methods ---
 
@@ -368,6 +400,66 @@ export class Mapper {
     });
     callback(this);
     this.scopeStack.pop();
+  }
+
+  /** Rails: `nested(&block)`. Wraps `block` in a nested resource scope. */
+  nested(callback: MapperCallback): void {
+    if (!this.parentResource()) {
+      throw new Error("can't use nested outside resource(s) scope");
+    }
+    this.withScopeLevel("nested", () => callback(this));
+  }
+
+  /**
+   * Rails: `shallow(&block)`. Pushes a `shallow: true` scope so nested
+   * `resources` inside use shallow path/name conventions.
+   */
+  shallow(callback: MapperCallback): void {
+    this.scopeStack.push({ path: "", namePrefix: undefined, controller: undefined, shallow: true });
+    try {
+      callback(this);
+    } finally {
+      this.scopeStack.pop();
+    }
+  }
+
+  /**
+   * Rails: `draw(name)`. Loads `config/routes/<name>.rb` and evaluates it
+   * in the current Mapper context. The file-loading form is Ruby-specific
+   * (`instance_eval(File.read…)`); in trails, pass a callback that receives
+   * this Mapper instead. Passing a string throws — file-based draw is not
+   * supported.
+   */
+  draw(nameOrCallback: string | MapperCallback): void {
+    if (typeof nameOrCallback === "function") {
+      nameOrCallback(this);
+      return;
+    }
+    throw new Error(
+      `Mapper#draw(${JSON.stringify(nameOrCallback)}): file-based draw is not supported in trails. ` +
+        "Pass a callback (mapper) => void with the route definitions, or import and invoke a routes module directly.",
+    );
+  }
+
+  /**
+   * Rails: `set_member_mappings_for_resource`. Inside a `member { … }` block,
+   * adds the standard member verb mappings (`edit`, `show`, `update`,
+   * `destroy`) when the parent resource's `actions` allows them.
+   *
+   * @internal
+   */
+  setMemberMappingsForResource(): void {
+    const parent = this.parentResource();
+    const actions = parent?.actions ?? [];
+    this.member((m) => {
+      if (actions.includes("edit")) m.get("edit");
+      if (actions.includes("show")) m.get("show");
+      if (actions.includes("update")) {
+        m.patch("update");
+        m.put("update");
+      }
+      if (actions.includes("destroy")) m.delete("destroy");
+    });
   }
 
   // --- constraints block ---

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -404,7 +404,7 @@ export class Mapper {
 
   /** Rails: `nested(&block)`. Wraps `block` in a nested resource scope. */
   nested(callback: MapperCallback): void {
-    if (!this._scope.isResourceScope()) {
+    if (!this.isResourceScope()) {
       throw new Error("can't use nested outside resource(s) scope");
     }
     this.withScopeLevel("nested", () => {
@@ -418,10 +418,17 @@ export class Mapper {
 
   /**
    * Rails: `shallow(&block)`. Pushes a `shallow: true` scope so nested
-   * `resources` inside use shallow path/name conventions.
+   * `resources` inside use shallow path/name conventions. The current
+   * prefix is preserved — Rails clones the scope hash, which keeps `:path`
+   * unchanged.
    */
   shallow(callback: MapperCallback): void {
-    this.scopeStack.push({ path: "", namePrefix: undefined, controller: undefined, shallow: true });
+    this.scopeStack.push({
+      path: this.currentPrefix(),
+      namePrefix: undefined,
+      controller: undefined,
+      shallow: true,
+    });
     try {
       callback(this);
     } finally {

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -408,7 +408,14 @@ export class Mapper {
       throw new Error("can't use nested outside resource(s) scope");
     }
     this.withScopeLevel("nested", () => {
-      if (this.isShallow() && this.shallowNestingDepth() >= 1) {
+      // Only enter shallowScope if Rails-style shallow keys have been
+      // populated; trails resources() currently tracks path nesting via
+      // scopeStack rather than _scope.shallowPath/Prefix, so the
+      // shallowScope branch would otherwise clobber as/path with undefined.
+      const shallowKeysSet =
+        this._scope.get("shallowPath") !== undefined ||
+        this._scope.get("shallowPrefix") !== undefined;
+      if (shallowKeysSet && this.isShallow() && this.shallowNestingDepth() >= 1) {
         this.shallowScope(() => callback(this));
       } else {
         callback(this);
@@ -465,13 +472,13 @@ export class Mapper {
     const parent = this.parentResource();
     const actions = parent?.actions ?? [];
     this.member((m) => {
-      if (actions.includes("edit")) m.get("edit");
-      if (actions.includes("show")) m.get("show");
+      if (actions.includes("edit")) m.get("edit", { action: "edit" });
+      if (actions.includes("show")) m.get("show", { action: "show" });
       if (actions.includes("update")) {
-        m.patch("update");
-        m.put("update");
+        m.patch("update", { action: "update" });
+        m.put("update", { action: "update" });
       }
-      if (actions.includes("destroy")) m.delete("destroy");
+      if (actions.includes("destroy")) m.delete("destroy", { action: "destroy" });
     });
   }
 

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -940,15 +940,20 @@ export class Mapper {
    * @internal
    */
   private outerNonResourcePrefix(): string {
-    for (let i = this.scopeStack.length - 1; i >= 0; i--) {
-      const f = this.scopeStack[i];
-      // Skip both resource frames and shallow-marker frames (the latter
-      // carry no real path contribution — they snapshot currentPrefix()
-      // only to keep `member()` from resetting it).
-      if (f.resource || f.shallow) continue;
-      return f.path;
+    // Walk bottom-up to find the deepest non-resource frame that comes
+    // *before* the outermost resource frame. A `scope(...)` opened
+    // inside a resource (e.g. `resources('posts') { scope('/foo') {…} }`)
+    // is NOT outer — its path already contains the parent-resource
+    // segments shallow routing is meant to drop. Shallow-marker frames
+    // carry no real path contribution; they snapshot currentPrefix()
+    // only to keep `member()` from resetting it.
+    let last = "";
+    for (const f of this.scopeStack) {
+      if (f.resource) return last;
+      if (f.shallow) continue;
+      last = f.path;
     }
-    return "";
+    return last;
   }
 
   private prefixedName(name: string): string {

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -167,7 +167,9 @@ export class Mapper {
     const constraints = scopeConstraints
       ? { ...scopeConstraints, ...options.constraints }
       : options.constraints;
-    const pathNames = options.pathNames ?? {};
+    const scopePathNames =
+      (this._scope.get("pathNames") as Record<string, string> | undefined) ?? {};
+    const pathNames = { ...scopePathNames, ...(options.pathNames ?? {}) };
     const newPath = pathNames.new ?? "new";
     const editPath = pathNames.edit ?? "edit";
 
@@ -207,6 +209,15 @@ export class Mapper {
         shallow,
         constraints: Object.keys(nestedConstraints).length > 0 ? nestedConstraints : undefined,
         memberPath: basePath + "/:id",
+        resource: {
+          memberName: singular,
+          collectionName: name,
+          nestedParam: `${singular}_id`,
+          param: "id",
+          resourceScope: controller,
+          actions: Array.from(allowed) as ResourceAction[],
+        },
+        resourceController: controller,
       });
       cb(this);
       this.scopeStack.pop();
@@ -273,7 +284,9 @@ export class Mapper {
     const routeName = (suffix: string) => (namePrefix ? `${namePrefix}_${suffix}` : suffix);
 
     const allowed = allowedActions(options, ["show", "new", "create", "edit", "update", "destroy"]);
-    const pathNames = options.pathNames ?? {};
+    const scopePathNames =
+      (this._scope.get("pathNames") as Record<string, string> | undefined) ?? {};
+    const pathNames = { ...scopePathNames, ...(options.pathNames ?? {}) };
     const newPath = pathNames.new ?? "new";
     const editPath = pathNames.edit ?? "edit";
 
@@ -319,6 +332,15 @@ export class Mapper {
         path: basePath,
         namePrefix: name,
         controller: undefined,
+        memberPath: basePath,
+        resource: {
+          memberName: name,
+          collectionName: pluralize(name),
+          param: "id",
+          resourceScope: controller,
+          actions: Array.from(allowed) as ResourceAction[],
+        },
+        resourceController: controller,
       });
       cb(this);
       this.scopeStack.pop();
@@ -470,16 +492,26 @@ export class Mapper {
    */
   setMemberMappingsForResource(): void {
     const parent = this.parentResource();
-    const actions = parent?.actions ?? [];
-    this.member((m) => {
-      if (actions.includes("edit")) m.get("edit", { action: "edit" });
-      if (actions.includes("show")) m.get("show", { action: "show" });
-      if (actions.includes("update")) {
-        m.patch("update", { action: "update" });
-        m.put("update", { action: "update" });
-      }
-      if (actions.includes("destroy")) m.delete("destroy", { action: "destroy" });
-    });
+    if (!parent) return;
+    const actions = parent.actions ?? [];
+    // Find the active resource frame for the canonical member path + controller.
+    const frame = [...this.scopeStack].reverse().find((f) => f.resource === parent);
+    const memberPath = frame?.memberPath ?? this.currentPrefix();
+    const controller = frame?.resourceController ?? "";
+    const editPath = this.actionPath("edit");
+    if (actions.includes("edit")) {
+      this.routes.push(new Route("GET", `${memberPath}/${editPath}`, controller, "edit"));
+    }
+    if (actions.includes("show")) {
+      this.routes.push(new Route("GET", memberPath, controller, "show"));
+    }
+    if (actions.includes("update")) {
+      this.routes.push(new Route("PATCH", memberPath, controller, "update"));
+      this.routes.push(new Route("PUT", memberPath, controller, "update"));
+    }
+    if (actions.includes("destroy")) {
+      this.routes.push(new Route("DELETE", memberPath, controller, "destroy"));
+    }
   }
 
   // --- constraints block ---
@@ -1192,6 +1224,10 @@ export class Mapper {
 
   /** @internal */
   parentResource(): ResourceLike | undefined {
+    for (let i = this.scopeStack.length - 1; i >= 0; i--) {
+      const r = this.scopeStack[i].resource;
+      if (r) return r;
+    }
     return this._scope.get("scopeLevelResource") as ResourceLike | undefined;
   }
 
@@ -1337,6 +1373,10 @@ interface ScopeFrame {
   shallow?: boolean;
   constraints?: RouteConstraints;
   memberPath?: string;
+  /** Snapshot of the active resource (Rails: `@scope[:scope_level_resource]`). */
+  resource?: ResourceLike;
+  /** Controller for member-route emission (Rails: resource_scope controller). */
+  resourceController?: string;
 }
 
 interface ScopeOptions {

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -208,7 +208,7 @@ export class Mapper {
         controller: undefined,
         shallow,
         constraints: Object.keys(nestedConstraints).length > 0 ? nestedConstraints : undefined,
-        memberPath: basePath + "/:id",
+        memberPath: `${shallowPath}/:id`,
         resource: {
           memberName: singular,
           collectionName: name,

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -404,10 +404,16 @@ export class Mapper {
 
   /** Rails: `nested(&block)`. Wraps `block` in a nested resource scope. */
   nested(callback: MapperCallback): void {
-    if (!this.parentResource()) {
+    if (!this._scope.isResourceScope()) {
       throw new Error("can't use nested outside resource(s) scope");
     }
-    this.withScopeLevel("nested", () => callback(this));
+    this.withScopeLevel("nested", () => {
+      if (this.isShallow() && this.shallowNestingDepth() >= 1) {
+        this.shallowScope(() => callback(this));
+      } else {
+        callback(this);
+      }
+    });
   }
 
   /**

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -624,7 +624,7 @@ export class RouteSet {
 
   /** @internal Rails: `private def eval_block(block)`. */
   evalBlock(block: DrawCallback): void {
-    const mapper = new Mapper();
+    const mapper = new Mapper(this);
     block(mapper);
     for (const route of mapper.routes) {
       this.addRoute(route, route.name);


### PR DESCRIPTION
## Summary

Closes the last 8 missing methods on `ActionDispatch::Routing::Mapper`,
bringing `routing/mapper.rb` from 79/87 (91%) to 87/87 (100%).

- `constructor(set?)` — Rails `initialize(set)`/`new`; `set` is optional
  (existing call sites use `new Mapper()` with no args). When provided,
  `_drawPaths` and `pathNames` are sourced from the RouteSet.
- `defaultUrlOptions` getter/setter (Rails aliases `default_url_options=`
  to `default_url_options`) — delegates to the attached RouteSet when
  present, falls back to a local field.
- `nested(block)` — public DSL; raises outside a resource scope.
- `shallow(block)` — public DSL; pushes a shallow scope frame.
- `draw(nameOrCallback)` — accepts a callback for in-memory split routes.
  The Ruby file-loading form (`instance_eval(File.read…)`) throws with a
  message pointing users to the callback form, since loading and
  evaluating an arbitrary `.rb` file isn't applicable in trails.
- `setMemberMappingsForResource` (`@internal`) — emits the standard
  member `edit`/`show`/`update`/`destroy` verbs based on
  `parentResource().actions`.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/routing/` — 245 pass
- [x] `pnpm tsx scripts/api-compare/compare.ts --package actiondispatch` confirms `routing/mapper.ts` at 100%
- [x] `pnpm eslint packages/actionpack/src/action-dispatch/routing/mapper.ts` clean