### PR TITLE
test(activerecord): finish schema port + wire into setup-adapter-suite (PR 0.5g)

### DIFF
--- a/packages/activerecord/src/test-helpers/setup-adapter-suite.ts
+++ b/packages/activerecord/src/test-helpers/setup-adapter-suite.ts
@@ -1,6 +1,7 @@
 import { beforeAll, afterAll } from "vitest";
 import type { DatabaseAdapter } from "../adapter.js";
 import { defineSchema, type Schema } from "./define-schema.js";
+import { TEST_SCHEMA } from "./test-schema.js";
 
 /**
  * Subset of {@link DefineSchemaOpts} exposed through this helper.
@@ -25,9 +26,12 @@ export interface AdapterSuiteOptions<A extends TransactionalFixturesAdapter> {
   /** Builds the adapter once per file in `beforeAll`. */
   factory: () => A | Promise<A>;
   /**
-   * Schema to declare via {@link defineSchema}. Defaults to `{}` so the file
-   * is marked Phase-5 compliant even when no expressible tables exist
-   * (e.g. PG-only types created via raw DDL in {@link setup}).
+   * Schema to declare via {@link defineSchema}. Defaults to the canonical
+   * {@link TEST_SCHEMA} (mirror of `vendor/rails/activerecord/test/schema/schema.rb`)
+   * so fixture-driven tests resolve named rows without inlining their own
+   * mini-schemas. Pass an explicit object (or `{}`) to override — useful for
+   * adapter-specific suites (e.g. PG-only types created via raw DDL in
+   * {@link setup}).
    */
   schema?: Schema;
   schemaOptions?: AdapterSuiteSchemaOpts;
@@ -97,7 +101,7 @@ export function setupAdapterSuite<A extends TransactionalFixturesAdapter>(
     adapter = await opts.factory();
     await defineSchema(
       adapter as unknown as DatabaseAdapter,
-      opts.schema ?? {},
+      opts.schema ?? TEST_SCHEMA,
       opts.schemaOptions,
     );
     if (opts.setup) await opts.setup(adapter);

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -1470,22 +1470,23 @@ export const TEST_SCHEMA: Schema = {
     wheelable_type: "string",
   },
 
-  // Rails declares `id: false` with a string primary_key column — modeled
-  // here via `primaryKey: false` plus an explicit non-null string column.
+  // Rails declares `id: false` with `t.string :<x>_id, primary_key: true` —
+  // a real DB-level primary key on the string column rather than the
+  // implicit `id`. Modeled via `primaryKey: [name]` (NOT NULL implied).
   countries: {
     columns: {
-      country_id: { type: "string", null: false },
+      country_id: "string",
       name: "string",
     },
-    primaryKey: false,
+    primaryKey: ["country_id"],
   },
 
   treaties: {
     columns: {
-      treaty_id: { type: "string", null: false },
+      treaty_id: "string",
       name: "string",
     },
-    primaryKey: false,
+    primaryKey: ["treaty_id"],
   },
 
   countries_treaties: {

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -1427,4 +1427,196 @@ export const TEST_SCHEMA: Schema = {
   vertices: { label: "string" },
 
   "warehouse-things": { value: "integer" },
+
+  // Tail section: Rails' schema.rb declares these after the alphabetical
+  // block (lines 1273..1462 of schema.rb). Kept in Rails source order to
+  // keep the diff against the source minimal.
+
+  circles: {},
+  squares: {},
+  triangles: {},
+  non_poly_ones: {},
+  non_poly_twos: {},
+
+  humans: { name: "string" },
+
+  faces: {
+    description: "string",
+    human_id: "integer",
+    polymorphic_human_id: "integer",
+    polymorphic_human_type: "string",
+    poly_human_without_inverse_id: "integer",
+    poly_human_without_inverse_type: "string",
+    puzzled_polymorphic_human_id: "integer",
+    puzzled_polymorphic_human_type: "string",
+    super_human_id: "integer",
+    super_human_type: "string",
+  },
+
+  interests: {
+    topic: "string",
+    human_id: "integer",
+    polymorphic_human_id: "integer",
+    polymorphic_human_type: "string",
+    zine_id: "integer",
+  },
+
+  zines: { title: "string" },
+  strict_zines: { title: "string" },
+
+  wheels: {
+    size: "integer",
+    wheelable_id: "integer",
+    wheelable_type: "string",
+  },
+
+  // Rails declares `id: false` with a string primary_key column — modeled
+  // here via `primaryKey: false` plus an explicit non-null string column.
+  countries: {
+    columns: {
+      country_id: { type: "string", null: false },
+      name: "string",
+    },
+    primaryKey: false,
+  },
+
+  treaties: {
+    columns: {
+      treaty_id: { type: "string", null: false },
+      name: "string",
+    },
+    primaryKey: false,
+  },
+
+  countries_treaties: {
+    columns: {
+      country_id: { type: "string", null: false },
+      treaty_id: { type: "string", null: false },
+    },
+    primaryKey: ["country_id", "treaty_id"],
+  },
+
+  liquid: { name: "string" },
+  molecules: { liquid_id: "integer", name: "string" },
+  electrons: { molecule_id: "integer", name: "string" },
+
+  // Rails column names include special characters; keep them verbatim as
+  // string keys.
+  weirds: {
+    a$b: "string",
+    なまえ: "string",
+    from: "string",
+  },
+
+  nodes: {
+    tree_id: "integer",
+    parent_id: "integer",
+    name: "string",
+    updated_at: "datetime",
+  },
+  trees: {
+    name: "string",
+    updated_at: "datetime",
+  },
+
+  hotels: {},
+  departments: { hotel_id: "integer" },
+  cake_designers: {},
+  drink_designers: { name: "string" },
+  chefs: {
+    employable_id: "integer",
+    employable_type: "string",
+    department_id: "integer",
+    employable_list_type: "string",
+    employable_list_id: "integer",
+    created_at: "datetime",
+    updated_at: "datetime",
+  },
+  recipes: { chef_id: "integer", hotel_id: "integer" },
+
+  recipients: {
+    message_id: "integer",
+    email_address: "string",
+  },
+
+  records: {},
+
+  // Rails declares `primary_key: "pk_id"` — DB-level PK on a non-`id`
+  // column; no synthetic `id`. The foreign_key constraint Rails declares
+  // on fk_test_has_fk is dropped (defineSchema can't express FKs; see
+  // header note).
+  fk_test_has_pk: {
+    columns: {
+      pk_id: { type: "integer", null: false },
+    },
+    primaryKey: ["pk_id"],
+  },
+  fk_test_has_fk: {
+    fk_id: { type: "integer", null: false },
+  },
+
+  fk_object_to_point_tos: {},
+  fk_pointing_to_non_existent_objects: {
+    fk_object_to_point_to_id: { type: "integer", null: false },
+  },
+
+  overloaded_types: {
+    overloaded_float: { type: "float", default: 500 },
+    unoverloaded_float: "float",
+    overloaded_string_with_limit: { type: "string", limit: 255 },
+    string_with_default: { type: "string", default: "the original default" },
+    inferred_string: { type: "string", limit: 255 },
+    starts_at: "datetime",
+    ends_at: "datetime",
+  },
+
+  users: {
+    token: "string",
+    auth_token: "string",
+    password_digest: "string",
+    recovery_password_digest: "string",
+    created_at: { type: "datetime", null: true },
+    updated_at: { type: "datetime", null: true },
+  },
+
+  user_comments_counts: {
+    comments_count: { type: "integer", default: 0 },
+  },
+
+  test_with_keyword_column_name: {
+    desc: "string",
+  },
+
+  // Rails declares `id: false` with an explicit integer `id` column — no
+  // DB-level PK constraint.
+  non_primary_keys: {
+    columns: {
+      id: "integer",
+      created_at: "datetime",
+    },
+    primaryKey: false,
+  },
+
+  toooooooooooooooooooooooooooooooooo_long_table_names: {
+    toooooooo_long_a_id: { type: "big_integer", null: false },
+    toooooooo_long_b_id: { type: "big_integer", null: false },
+  },
+
+  // Rails declares these on alternate connections (Course/College/
+  // Professor.lease_connection). In our test suite the canonical schema
+  // loads them on the default adapter; per-connection placement is the
+  // responsibility of multi-DB tests.
+  courses: {
+    name: { type: "string", null: false },
+    college_id: "integer",
+  },
+  colleges: { name: { type: "string", null: false } },
+  professors: { name: { type: "string", null: false } },
+  courses_professors: {
+    columns: {
+      course_id: "integer",
+      professor_id: "integer",
+    },
+    primaryKey: false,
+  },
 };


### PR DESCRIPTION
## Summary

Final split-suffix PR of the test-schema port (per `docs/fixtures-port-plan.md` Decision 2):

- **Adds the 37 remaining tables** from the tail of `vendor/rails/activerecord/test/schema/schema.rb` (lines 1273..1462) — the section after the alphabetical block. Includes the schema-cases tables (`humans`, `faces`, `interests`, `zines`/`strict_zines`, `wheels`, `weirds`, `nodes`/`trees`, `hotels`/`departments`/`cake_designers`/`drink_designers`/`chefs`/`recipes`/`recipients`/`records`, `fk_test_has_pk`/`fk_test_has_fk`/`fk_object_to_point_tos`/`fk_pointing_to_non_existent_objects`, `overloaded_types`, `users`/`user_comments_counts`/`test_with_keyword_column_name`/`non_primary_keys`/`toooooo…_long_table_names`, the poly stubs `circles`/`squares`/`triangles`/`non_poly_ones`/`non_poly_twos`, and the alternate-connection tables `courses`/`colleges`/`professors`/`courses_professors`). Added in Rails source order in a clearly-marked tail block.
- **Wires `TEST_SCHEMA` as the default schema for `setupAdapterSuite`.** Callers passing an explicit `schema` still override; tests that pass nothing now get the canonical schema, per the plan's "no per-cluster mini-schemas" rule.

Closes the PR 0.5a..0.5g split chain.

## Test plan

- [x] `pnpm fixtures:compare` — exits clean (no `TS-IMPORT-ERR` / `TS-EXPORT-MISSING` hard failures). Remaining `DIFF`s are in the 12 pre-existing backfilled fixtures (authors/books/comments/developers-projects/topics), which are PR 0.75 territory per the plan.
- [x] `tsc --build` clean.
- [ ] CI green.

## Notes

- Foreign-key constraints Rails declares on `fk_test_has_fk` / `fk_pointing_to_non_existent_objects` are dropped, matching the existing file-header note ("defineSchema cannot yet express ... add_foreign_key").
- Rails' `primary_key: "pk_id"` on `fk_test_has_pk` is modeled as `primaryKey: ["pk_id"]` with the explicit column, mirroring the `goofy_string_id`/`dashboards` pattern already in this file.
- `weirds` keeps Rails' special-character column names verbatim (`a$b`, `なまえ`, `from`) as string keys.
- The four `Course/College/Professor.lease_connection.create_table` declarations at the bottom of `schema.rb` are loaded on the default adapter here; per-connection placement is left to the multi-DB tests that exercise them.