### PR TITLE
test(activerecord): port cluster 1 fixtures first half (PR 1a)

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/categories-ordered.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/categories-ordered.ts
@@ -1,0 +1,9 @@
+// activerecord/test/fixtures/categories_ordered.yml
+// Rails ERB-renders 100 rows; we generate the same shape in TS. Loaded into
+// the `categories` table via explicit class (see Rails fixtures_test.rb).
+export const categoriesOrderedFixtureData = Object.fromEntries(
+  Array.from({ length: 100 }, (_, i) => [
+    `fixture_no_${i}`,
+    { id: i, name: `Category ${i}`, type: "Category" },
+  ]),
+);

--- a/packages/activerecord/src/test-helpers/fixtures/categories-posts.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/categories-posts.ts
@@ -1,0 +1,38 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/categories_posts.yml
+// HABTM join — Rails sets `_fixture: model_class: Post::CategoryPost`; ports omit metadata rows.
+export const categoriesPostsFixtureData = {
+  general_welcome: {
+    category_id: ref("categories", "general"),
+    post_id: ref("posts", "welcome"),
+  },
+  technology_welcome: {
+    category_id: ref("categories", "technology"),
+    post_id: ref("posts", "welcome"),
+  },
+  general_thinking: {
+    category_id: ref("categories", "general"),
+    post_id: ref("posts", "thinking"),
+  },
+  general_sti_habtm: {
+    category_id: ref("categories", "general"),
+    post_id: ref("posts", "sti_habtm"),
+  },
+  sti_test_sti_habtm: {
+    category_id: ref("categories", "sti_test"),
+    post_id: ref("posts", "sti_habtm"),
+  },
+  general_hello: {
+    category_id: ref("categories", "general"),
+    post_id: ref("posts", "sti_comments"),
+  },
+  general_misc_by_bob: {
+    category_id: ref("categories", "general"),
+    post_id: ref("posts", "misc_by_bob"),
+  },
+  cooking_misc_by_bob: {
+    category_id: ref("categories", "cooking"),
+    post_id: ref("posts", "misc_by_bob"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/categories.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/categories.ts
@@ -1,0 +1,23 @@
+// activerecord/test/fixtures/categories.yml
+export const categoryFixtureData = {
+  general: {
+    id: 1,
+    name: "General",
+    type: "Category",
+  },
+  technology: {
+    id: 2,
+    name: "Technology",
+    type: "Category",
+  },
+  sti_test: {
+    id: 3,
+    name: "Special category",
+    type: "SpecialCategory",
+  },
+  cooking: {
+    id: 4,
+    name: "Cooking",
+    type: "Category",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/categorizations.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/categorizations.ts
@@ -1,0 +1,29 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/categorizations.yml
+export const categorizationFixtureData = {
+  david_welcome_general: {
+    id: 1,
+    author_id: ref("authors", "david"),
+    post_id: ref("posts", "welcome"),
+    category_id: ref("categories", "general"),
+  },
+  mary_thinking_sti: {
+    id: 2,
+    author_id: ref("authors", "mary"),
+    post_id: ref("posts", "thinking"),
+    category_id: ref("categories", "sti_test"),
+  },
+  mary_thinking_general: {
+    id: 3,
+    author_id: ref("authors", "mary"),
+    post_id: ref("posts", "thinking"),
+    category_id: ref("categories", "general"),
+  },
+  bob_misc_by_bob_technology: {
+    id: 4,
+    author_id: ref("authors", "bob"),
+    post_id: ref("posts", "misc_by_bob"),
+    category_id: ref("categories", "technology"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/essays.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/essays.ts
@@ -1,0 +1,22 @@
+// activerecord/test/fixtures/essays.yml
+// writer_id/category_id/author_id are string columns; values are literals,
+// not row-name refs (e.g. writer_id "David" is the Author#name, not a fixture label).
+export const essayFixtureData = {
+  david_modest_proposal: {
+    name: "A Modest Proposal",
+    writer_type: "Author",
+    writer_id: "David",
+    category_id: "General",
+    author_id: "David",
+  },
+  mary_stay_home: {
+    name: "Stay Home",
+    writer_type: "Author",
+    writer_id: "Mary",
+  },
+  steve_connecting_the_dots: {
+    name: "Connecting The Dots",
+    writer_type: "Human",
+    writer_id: "Steve",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/readers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/readers.ts
@@ -1,0 +1,24 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/readers.yml
+// person_id: 4 has no matching row in people.yml — kept as literal to mirror Rails.
+export const readerFixtureData = {
+  michael_welcome: {
+    id: 1,
+    post_id: ref("posts", "welcome"),
+    person_id: ref("people", "michael"),
+    first_post_id: ref("posts", "thinking"),
+  },
+  michael_authorless: {
+    id: 2,
+    post_id: ref("posts", "authorless"),
+    person_id: ref("people", "michael"),
+    first_post_id: ref("posts", "authorless"),
+  },
+  bob_welcome: {
+    id: 3,
+    post_id: ref("posts", "misc_by_bob"),
+    person_id: 4,
+    first_post_id: ref("posts", "other_by_bob"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/taggings.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/taggings.ts
@@ -1,0 +1,84 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/taggings.yml
+export const taggingFixtureData = {
+  welcome_general: {
+    id: 1,
+    tag_id: ref("tags", "general"),
+    super_tag_id: ref("tags", "misc"),
+    taggable_id: ref("posts", "welcome"),
+    taggable_type: "Post",
+  },
+  thinking_general: {
+    id: 2,
+    tag_id: ref("tags", "general"),
+    taggable_id: ref("posts", "thinking"),
+    taggable_type: "Post",
+  },
+  fake: {
+    id: 3,
+    tag_id: ref("tags", "general"),
+    taggable_id: 1,
+    taggable_type: "FakeModel",
+  },
+  godfather: {
+    id: 4,
+    tag_id: ref("tags", "general"),
+    taggable_id: 1,
+    taggable_type: "Item",
+  },
+  orphaned: {
+    id: 5,
+    tag_id: ref("tags", "general"),
+  },
+  misc_post_by_bob: {
+    id: 6,
+    tag_id: ref("tags", "misc"),
+    taggable_id: ref("posts", "misc_by_bob"),
+    taggable_type: "Post",
+  },
+  misc_post_by_mary: {
+    id: 7,
+    tag_id: ref("tags", "misc"),
+    taggable_id: ref("posts", "misc_by_mary"),
+    taggable_type: "Post",
+  },
+  misc_by_bob_blue_first: {
+    id: 8,
+    tag_id: ref("tags", "blue"),
+    taggable_id: ref("posts", "misc_by_bob"),
+    taggable_type: "Post",
+    comment: "first",
+  },
+  misc_by_bob_blue_second: {
+    id: 9,
+    tag_id: ref("tags", "blue"),
+    taggable_id: ref("posts", "misc_by_bob"),
+    taggable_type: "Post",
+    comment: "second",
+  },
+  other_by_bob_blue: {
+    id: 10,
+    tag_id: ref("tags", "blue"),
+    taggable_id: ref("posts", "other_by_bob"),
+    taggable_type: "Post",
+    comment: "first",
+  },
+  other_by_mary_blue: {
+    id: 11,
+    tag_id: ref("tags", "blue"),
+    taggable_id: ref("posts", "other_by_mary"),
+    taggable_type: "Post",
+    comment: "first",
+  },
+  special_comment_rating: {
+    id: 12,
+    taggable_id: 2,
+    taggable_type: "Rating",
+  },
+  normal_comment_rating: {
+    id: 13,
+    taggable_id: 1,
+    taggable_type: "Rating",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/tags.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/tags.ts
@@ -1,0 +1,15 @@
+// activerecord/test/fixtures/tags.yml
+export const tagFixtureData = {
+  general: {
+    id: 1,
+    name: "General",
+  },
+  misc: {
+    id: 2,
+    name: "Misc",
+  },
+  blue: {
+    id: 3,
+    name: "Blue",
+  },
+};


### PR DESCRIPTION
## Summary

Ports 8 Rails YAML fixtures to TS under `packages/activerecord/src/test-helpers/fixtures/` per `docs/fixtures-port-plan.md` PR 1a (cluster 1 first half):

- `categories.ts`, `categorizations.ts`, `categories-posts.ts`, `categories-ordered.ts`
- `taggings.ts`, `tags.ts`, `essays.ts`, `readers.ts`

All rows carry the Rails `id` verbatim (Decision 1); FKs use `ref(table, row)` against declared ids.

## Verification

`pnpm fixtures:compare` for the 8 files:

```
categories.yml          rows: 4/4   attrs: 12/12  100%  MATCH
categories_ordered.yml                              —   ERB-UNSUPPORTED
categories_posts.yml    rows: 8/9   attrs: 16/16  100%  DIFF
categorizations.yml     rows: 4/4   attrs: 16/16  100%  MATCH
essays.yml              rows: 3/3   attrs: 11/11  100%  MATCH
readers.yml             rows: 3/3   attrs: 12/12  100%  MATCH
taggings.yml            rows: 13/13 attrs: 53/53  100%  MATCH
tags.yml                rows: 3/3   attrs: 6/6    100%  MATCH
```

Notes:
- `categories_posts` DIFF is the Rails-only `_fixture: model_class` metadata row; not a real fixture row. Soft per Decision 4.
- `categories_ordered.yml` uses an ERB loop unsupported by `fixtures:compare`; the TS port reproduces all 100 rows via `Array.from`.
- `readers.bob_welcome.person_id` is a literal `4` (no matching row in `people.yml`), mirroring Rails.

## Test plan

- [x] `pnpm fixtures:compare` — 7/8 MATCH, 1 ERB-UNSUPPORTED (expected)
- [x] LOC: 244 (under 300 ceiling)