### PR TITLE
fix(arel): route Table#star through Attribute for dialect-correct quoting

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3359,7 +3359,7 @@ export class Relation<T extends Base> {
    * caller's responsibility to ensure the target table is in
    * scope, or to override with `.select("*")`. We match.
    */
-  private _defaultProjection(table: Table): Nodes.SqlLiteral {
+  private _defaultProjection(table: Table): Nodes.Attribute {
     return table.star;
   }
 

--- a/packages/arel/src/table.test.ts
+++ b/packages/arel/src/table.test.ts
@@ -172,22 +172,28 @@ describe("TableTest", () => {
     expect(aliased.tableAlias).toBe("u");
   });
 
-  it("star returns table.*", () => {
-    expect(users.star.value).toBe('"users".*');
+  it("star returns an Attribute that compiles to table.*", () => {
+    expect(users.star).toBeInstanceOf(Nodes.Attribute);
+    expect(users.star.toSql()).toBe('"users".*');
   });
 
   it("star splits schema-qualified name", () => {
-    expect(new Table("test_schema.things").star.value).toBe('"test_schema"."things".*');
+    expect(new Table("test_schema.things").star.toSql()).toBe('"test_schema"."things".*');
   });
 
   it("star preserves quoted table name with dot", () => {
-    expect(new Table('test_schema."things.table"').star.value).toBe(
+    expect(new Table('test_schema."things.table"').star.toSql()).toBe(
       '"test_schema"."things.table".*',
     );
   });
 
   it("star preserves quoted schema name with dot", () => {
-    expect(new Table('"my.schema".articles').star.value).toBe('"my.schema"."articles".*');
+    expect(new Table('"my.schema".articles').star.toSql()).toBe('"my.schema"."articles".*');
+  });
+
+  it("star routes table-name quoting through the adapter visitor (MySQL=backticks)", () => {
+    const sql = new Visitors.MySQL().compile(users.star);
+    expect(sql).toBe("`users`.*");
   });
 
   it("alias references use the alias in SQL", () => {

--- a/packages/arel/src/table.ts
+++ b/packages/arel/src/table.ts
@@ -1,12 +1,10 @@
 import { Attribute } from "./attributes/attribute.js";
 import { EmptyJoinError } from "./errors.js";
-import { SqlLiteral } from "./nodes/sql-literal.js";
 import { Node, NodeVisitor } from "./nodes/node.js";
 import { SelectManager } from "./select-manager.js";
 import { InnerJoin } from "./nodes/inner-join.js";
 import type { Join } from "./nodes/binary.js";
 import { TableAlias } from "./nodes/table-alias.js";
-import { quoteSchemaQualifiedName } from "./visitors/split-schema-qualified-name.js";
 
 /** Structural duck-type for Rails' `@klass.attribute_aliases`.
  *  Kept minimal so arel does not import activerecord. */
@@ -194,8 +192,18 @@ export class Table extends Node {
     return this.get(name);
   }
 
-  get star(): SqlLiteral {
-    return new SqlLiteral(`${quoteSchemaQualifiedName(this.name)}.*`);
+  /**
+   * The `*` projection for this table — `table.*` after visitor compilation.
+   *
+   * Mirrors Rails' `Arel::Table#[Arel.star]`: returns an `Attribute` rather
+   * than a pre-baked SQL literal, so the table identifier is quoted by the
+   * adapter visitor (ANSI for SQLite/PG, backticks for MySQL). The `"*"`
+   * sentinel is handled by `visit_Arel_Attributes_Attribute` and skips
+   * column-name quoting (matches Rails' `quote_column_name(Arel.star)`,
+   * which passes the `SqlLiteral` through unchanged).
+   */
+  get star(): Attribute {
+    return new Attribute(this, "*");
   }
 
   /**

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1139,7 +1139,11 @@ export class ToSql extends Visitor implements NodeVisitor<SQLString> {
 
   private visitArelAttributesAttribute(node: Nodes.Attribute): SQLString {
     const tbl = node.relation.tableAlias || node.relation.name;
-    this.collector.append(`${this.quoteTableName(tbl)}.${this.quoteColumnName(node.name)}`);
+    // Rails: `quote_column_name(Arel.star)` returns the `SqlLiteral("*")`
+    // unchanged. We model `Arel.star` as the string sentinel `"*"` on the
+    // Attribute, so short-circuit identifier quoting here.
+    const col = node.name === "*" ? "*" : this.quoteColumnName(node.name);
+    this.collector.append(`${this.quoteTableName(tbl)}.${col}`);
     return this.collector;
   }
 


### PR DESCRIPTION
## Summary

Prerequisite for **TM Phase 9b-2** (MySQL Arel visitor activation).

`Table#star` returned a pre-baked `SqlLiteral` formed via `quoteSchemaQualifiedName(name) + \".*\"` — always ANSI double-quoted, bypassing the adapter visitor. PR #2141 (Phase 9b-2 attempt) was closed when flipping the MySQL gate surfaced 56 MariaDB failures rooted in mixed-quote SQL like:

```
SELECT \"users\".* FROM \`users\`
       ^^^^^^^^^      ^^^^^^^
       ANSI (Table.star)   backticks (Visitors::MySQL)
```

This PR mirrors Rails' `Arel::Table#[Arel.star]` shape: `Table#star` now returns `new Attribute(this, \"*\")` and lets `visit_Arel_Attributes_Attribute` quote the table identifier via the adapter. The `*` sentinel short-circuits column-name quoting (matches Rails: `quote_column_name(Arel.star)` passes the `SqlLiteral` through unchanged).

## Behaviour

- SQLite / PostgreSQL (default ANSI quoter): `\"users\".*` — unchanged
- MySQL (`Visitors.MySQL`): `` `users`.* `` — now dialect-correct
- Schema-qualified names still parse correctly (`test_schema.things` → `\"test_schema\".\"things\".*`)

New test pins the MySQL backtick path so a future regression can't reintroduce the mixed-quote bug.

## Type signature change

`Table#star: SqlLiteral` → `Table#star: Attribute`. One internal call site in `relation.ts#_defaultProjection` updated to match. Public AR behaviour unchanged (the projection still compiles to the same SQL on SQLite/PG; consumers pass it to `project()` / `_compileArelNode`, both of which accept any `Node`).

## Out of scope (follow-ups for 9b-2b)

- Flipping the MySQL gate in `test-adapter.ts` and the mechanical sweep of test assertions that hardcode ANSI `\"name\"` quoting.
- PG visitor parity audit from PR #2139 carries over unchanged.

## Test plan

- [x] `pnpm vitest run packages/arel/` (1405 pass)
- [x] `pnpm vitest run packages/activerecord/src/relation/select-star-join-collision.test.ts packages/activerecord/src/relation/where.test.ts` (green)
- [x] `pnpm api:compare --package arel` (884/884, 100%)
- [x] `tsc --build` clean