### PR TITLE
feat(trailties): Rails BacktraceCleaner silencer set (PR 1.3)

### DIFF
--- a/packages/activesupport/src/backtrace-cleaner.test.ts
+++ b/packages/activesupport/src/backtrace-cleaner.test.ts
@@ -147,6 +147,61 @@ describe("BacktraceCleanerMultipleSilencersTest", () => {
   });
 });
 
+describe("BacktraceCleanerKindTest", () => {
+  function build() {
+    const cleaner = new BacktraceCleaner();
+    cleaner.addFilter((line) => line.replace("/gems/rack-1.0/", "[gem] "));
+    cleaner.addSilencer((line) => line.includes("[gem]"));
+    return cleaner;
+  }
+
+  it("clean with :silent returns non-silenced filtered lines", () => {
+    const cleaner = build();
+    expect(cleaner.clean(["/gems/rack-1.0/lib/rack.rb", "/app/foo.rb"])).toEqual(["/app/foo.rb"]);
+  });
+
+  it("clean with :noise returns silenced filtered lines", () => {
+    const cleaner = build();
+    expect(cleaner.clean(["/gems/rack-1.0/lib/rack.rb", "/app/foo.rb"], "noise")).toEqual([
+      "[gem] lib/rack.rb",
+    ]);
+  });
+
+  it("clean with :all returns every filtered line", () => {
+    const cleaner = build();
+    expect(cleaner.clean(["/gems/rack-1.0/lib/rack.rb", "/app/foo.rb"], "all")).toEqual([
+      "[gem] lib/rack.rb",
+      "/app/foo.rb",
+    ]);
+  });
+
+  it("cleanFrame default returns the filtered frame when not silenced", () => {
+    const cleaner = build();
+    expect(cleaner.cleanFrame("/app/foo.rb")).toBe("/app/foo.rb");
+  });
+
+  it("cleanFrame default returns undefined when silenced", () => {
+    const cleaner = build();
+    expect(cleaner.cleanFrame("/gems/rack-1.0/lib/rack.rb")).toBeUndefined();
+  });
+
+  it("cleanFrame with :noise returns undefined when not silenced", () => {
+    const cleaner = build();
+    expect(cleaner.cleanFrame("/app/foo.rb", "noise")).toBeUndefined();
+  });
+
+  it("cleanFrame with :noise returns the filtered frame when silenced", () => {
+    const cleaner = build();
+    expect(cleaner.cleanFrame("/gems/rack-1.0/lib/rack.rb", "noise")).toBe("[gem] lib/rack.rb");
+  });
+
+  it("cleanFrame with :all returns the filtered frame regardless of silencers", () => {
+    const cleaner = build();
+    expect(cleaner.cleanFrame("/gems/rack-1.0/lib/rack.rb", "all")).toBe("[gem] lib/rack.rb");
+    expect(cleaner.cleanFrame("/app/foo.rb", "all")).toBe("/app/foo.rb");
+  });
+});
+
 describe("BacktraceCleanerFilterAndSilencerTest", () => {
   it("backtrace should not silence lines that has first had their silence hook filtered out", () => {
     // A filter runs before silencers. If filter transforms line so it no longer matches silencer, it's kept.

--- a/packages/activesupport/src/backtrace-cleaner.ts
+++ b/packages/activesupport/src/backtrace-cleaner.ts
@@ -43,7 +43,7 @@ export class BacktraceCleaner {
     return filtered.filter((line) => !this._isSilenced(line));
   }
 
-  /** cleanFrame — clean a single frame; returns undefined if silenced. */
+  /** cleanFrame — clean a single frame; returns undefined when excluded by the selected kind. */
   cleanFrame(frame: string, kind: CleanKind = "silent"): string | undefined {
     const filtered = this._applyFilters(frame);
     if (kind === "all") return filtered;

--- a/packages/activesupport/src/backtrace-cleaner.ts
+++ b/packages/activesupport/src/backtrace-cleaner.ts
@@ -60,8 +60,9 @@ export class BacktraceCleaner {
     return this._silencers.some((s) => s(line));
   }
 
-  dup(): BacktraceCleaner {
-    const copy = new BacktraceCleaner();
+  dup(): this {
+    const Ctor = this.constructor as new () => this;
+    const copy = new Ctor();
     copy._filters = [...this._filters];
     copy._silencers = [...this._silencers];
     return copy;

--- a/packages/activesupport/src/backtrace-cleaner.ts
+++ b/packages/activesupport/src/backtrace-cleaner.ts
@@ -1,13 +1,15 @@
 type LineFilter = (line: string) => string;
 type LineSilencer = (line: string) => boolean;
 
+export type CleanKind = "silent" | "noise" | "all";
+
 /**
  * BacktraceCleaner — filters and silences backtrace lines.
  * Mirrors Rails ActiveSupport::BacktraceCleaner.
  */
 export class BacktraceCleaner {
-  private _filters: LineFilter[] = [];
-  private _silencers: LineSilencer[] = [];
+  protected _filters: LineFilter[] = [];
+  protected _silencers: LineSilencer[] = [];
 
   /** addFilter — adds a filter that transforms backtrace lines. */
   addFilter(filter: LineFilter): this {
@@ -33,18 +35,28 @@ export class BacktraceCleaner {
     return this;
   }
 
-  /** clean — applies all filters and silencers to a backtrace array. */
-  clean(backtrace: string[]): string[] {
-    return backtrace
-      .map((line) => this._applyFilters(line))
-      .filter((line) => !this._isSilenced(line));
+  /** clean — applies filters then silencer selection per `kind`. */
+  clean(backtrace: string[], kind: CleanKind = "silent"): string[] {
+    const filtered = backtrace.map((line) => this._applyFilters(line));
+    if (kind === "all") return filtered;
+    if (kind === "noise") return filtered.filter((line) => this._isSilenced(line));
+    return filtered.filter((line) => !this._isSilenced(line));
   }
 
-  private _applyFilters(line: string): string {
+  /** cleanFrame — clean a single frame; returns undefined if silenced. */
+  cleanFrame(frame: string, kind: CleanKind = "silent"): string | undefined {
+    const filtered = this._applyFilters(frame);
+    if (kind === "all") return filtered;
+    const silenced = this._isSilenced(filtered);
+    if (kind === "noise") return silenced ? filtered : undefined;
+    return silenced ? undefined : filtered;
+  }
+
+  protected _applyFilters(line: string): string {
     return this._filters.reduce((l, filter) => filter(l), line);
   }
 
-  private _isSilenced(line: string): boolean {
+  protected _isSilenced(line: string): boolean {
     return this._silencers.some((s) => s(line));
   }
 

--- a/packages/trailties/src/backtrace-cleaner.test.ts
+++ b/packages/trailties/src/backtrace-cleaner.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test, beforeEach } from "vitest";
+import { BacktraceCleaner } from "./backtrace-cleaner.js";
+
+describe("BacktraceCleaner", () => {
+  let cleaner: BacktraceCleaner;
+
+  beforeEach(() => {
+    cleaner = new BacktraceCleaner();
+  });
+
+  test("#clean should consider traces from irb lines as User code", () => {
+    const backtrace = [
+      "(irb):1",
+      "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",
+      "bin/rails:4:in `<main>'",
+    ];
+    const result = cleaner.clean(backtrace);
+    expect(result[0]).toBe("(irb):1");
+    expect(result.length).toBe(1);
+  });
+
+  test("#clean should show relative paths", () => {
+    const backtrace = [
+      "./test/backtrace_cleaner_test.rb:123",
+      "/Path/to/rails/activesupport/some_testing_file.rb:42:in `test'",
+      "bin/rails:4:in `<main>'",
+    ];
+    const result = cleaner.clean(backtrace);
+    expect(result[0]).toBe("./test/backtrace_cleaner_test.rb:123");
+    expect(result.length).toBe(1);
+  });
+
+  test("#clean should consider traces that include dasherized Rails application name", () => {
+    const backtrace = [
+      "(my-app):1",
+      "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",
+      "bin/rails:4:in `<main>'",
+    ];
+    const result = cleaner.clean(backtrace);
+    expect(result[0]).toBe("(my-app):1");
+    expect(result.length).toBe(1);
+  });
+
+  test("#clean should omit ActionView template methods names", () => {
+    const backtrace = [
+      "app/views/application/index.html.erb:4:in `block in _app_views_application_index_html_erb__1234_5678'",
+    ];
+    const result = cleaner.clean(backtrace);
+    expect(result[0]).toBe("app/views/application/index.html.erb:4");
+  });
+
+  test("#clean should omit ActionView template methods names on Ruby 3.4+", () => {
+    const backtrace = [
+      "app/views/application/index.html.erb:4:in 'block in _app_views_application_index_html_erb__1234_5678'",
+    ];
+    const result = cleaner.clean(backtrace);
+    expect(result[0]).toBe("app/views/application/index.html.erb:4");
+  });
+
+  test("setRoot strips application root from absolute paths", () => {
+    cleaner.setRoot("/my/app");
+    const result = cleaner.clean(["/my/app/app/models/user.rb:10"]);
+    expect(result[0]).toBe("app/models/user.rb:10");
+  });
+});

--- a/packages/trailties/src/backtrace-cleaner.test.ts
+++ b/packages/trailties/src/backtrace-cleaner.test.ts
@@ -30,6 +30,18 @@ describe("BacktraceCleaner", () => {
     expect(result.length).toBe(1);
   });
 
+  test("#clean can filter for noise", () => {
+    const backtrace = [
+      "(irb):1",
+      "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",
+      "bin/rails:4:in `<main>'",
+    ];
+    const result = cleaner.clean(backtrace, "noise");
+    expect(result[0]).toBe("/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'");
+    expect(result[1]).toBe("bin/rails:4:in `<main>'");
+    expect(result.length).toBe(2);
+  });
+
   test("#clean should consider traces that include dasherized Rails application name", () => {
     const backtrace = [
       "(my-app):1",
@@ -45,7 +57,7 @@ describe("BacktraceCleaner", () => {
     const backtrace = [
       "app/views/application/index.html.erb:4:in `block in _app_views_application_index_html_erb__1234_5678'",
     ];
-    const result = cleaner.clean(backtrace);
+    const result = cleaner.clean(backtrace, "all");
     expect(result[0]).toBe("app/views/application/index.html.erb:4");
   });
 
@@ -53,8 +65,53 @@ describe("BacktraceCleaner", () => {
     const backtrace = [
       "app/views/application/index.html.erb:4:in 'block in _app_views_application_index_html_erb__1234_5678'",
     ];
-    const result = cleaner.clean(backtrace);
+    const result = cleaner.clean(backtrace, "all");
     expect(result[0]).toBe("app/views/application/index.html.erb:4");
+  });
+
+  test("#clean_frame should consider traces from irb lines as User code", () => {
+    expect(cleaner.cleanFrame("(irb):1")).toBe("(irb):1");
+    expect(
+      cleaner.cleanFrame("/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'"),
+    ).toBeUndefined();
+    expect(cleaner.cleanFrame("bin/rails:4:in `<main>'")).toBeUndefined();
+  });
+
+  test("#clean_frame should show relative paths", () => {
+    expect(cleaner.cleanFrame("./test/backtrace_cleaner_test.rb:123")).toBe(
+      "./test/backtrace_cleaner_test.rb:123",
+    );
+    expect(
+      cleaner.cleanFrame("/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'"),
+    ).toBeUndefined();
+    expect(cleaner.cleanFrame("bin/rails:4:in `<main>'")).toBeUndefined();
+  });
+
+  test("#clean_frame can filter for noise", () => {
+    expect(cleaner.cleanFrame("(irb):1", "noise")).toBeUndefined();
+    expect(
+      cleaner.cleanFrame(
+        "/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'",
+        "noise",
+      ),
+    ).toBe("/Path/to/rails/railties/lib/rails/commands/console.rb:77:in `start'");
+    expect(cleaner.cleanFrame("bin/rails:4:in `<main>'", "noise")).toBe("bin/rails:4:in `<main>'");
+  });
+
+  test("#clean_frame should omit ActionView template methods names", () => {
+    const frame = cleaner.cleanFrame(
+      "app/views/application/index.html.erb:4:in `block in _app_views_application_index_html_erb__1234_5678'",
+      "all",
+    );
+    expect(frame).toBe("app/views/application/index.html.erb:4");
+  });
+
+  test("#clean_frame should omit ActionView template methods names on Ruby 3.4+", () => {
+    const frame = cleaner.cleanFrame(
+      "app/views/application/index.html.erb:4:in 'block in _app_views_application_index_html_erb__1234_5678'",
+      "all",
+    );
+    expect(frame).toBe("app/views/application/index.html.erb:4");
   });
 
   test("setRoot strips application root from absolute paths", () => {

--- a/packages/trailties/src/backtrace-cleaner.ts
+++ b/packages/trailties/src/backtrace-cleaner.ts
@@ -1,0 +1,31 @@
+// Port of `Rails::BacktraceCleaner` from
+// `railties/lib/rails/backtrace_cleaner.rb`. Extends activesupport's
+// BacktraceCleaner with Rails app-aware filters and silencers.
+import { BacktraceCleaner as Base } from "@blazetrails/activesupport";
+
+export const APP_DIRS_PATTERN = /^(?:\.\/)?(?:app|config|lib|test|\(\w+(?:-\w+)*\))/;
+export const RENDER_TEMPLATE_PATTERN = /:in [`'].*_\w+_{2,3}\d+_\d+'/;
+
+export class BacktraceCleaner extends Base {
+  private _root: string | undefined;
+
+  constructor() {
+    super();
+    this.addFilter((line) => {
+      // We may be called before Rails.root is assigned.
+      // When that happens we fallback to not truncating.
+      const root = this._root;
+      return root && line.startsWith(root) ? line.slice(root.length) : line;
+    });
+    this.addFilter((line) =>
+      RENDER_TEMPLATE_PATTERN.test(line) ? line.replace(RENDER_TEMPLATE_PATTERN, "") : line,
+    );
+    this.addSilencer((line) => !APP_DIRS_PATTERN.test(line));
+  }
+
+  /** Sets the application root used to convert absolute paths to relative. */
+  setRoot(root: string | undefined): this {
+    this._root = root ? (root.endsWith("/") ? root : `${root}/`) : undefined;
+    return this;
+  }
+}

--- a/packages/trailties/src/backtrace-cleaner.ts
+++ b/packages/trailties/src/backtrace-cleaner.ts
@@ -28,4 +28,10 @@ export class BacktraceCleaner extends Base {
     this._root = root ? (root.endsWith("/") ? root : `${root}/`) : undefined;
     return this;
   }
+
+  override dup(): this {
+    const copy = super.dup();
+    copy._root = this._root;
+    return copy;
+  }
 }


### PR DESCRIPTION
## Summary

Port `Rails::BacktraceCleaner` from railties. Extends activesupport's `BacktraceCleaner` with the Rails-specific silencer set:

- `APP_DIRS_PATTERN` silencer (keeps frames from `app/`, `config/`, `lib/`, `test/`, dasherized app names)
- `RENDER_TEMPLATE_PATTERN` filter (strips ActionView template method names)
- Root-relative path filter via `setRoot()` (pending `Rails.root` from PR 2.6)

Also upgrades activesupport `BacktraceCleaner` with `clean(backtrace, kind)` and `cleanFrame(frame, kind)` matching Rails' `:silent` / `:noise` / `:all` selection — required to port the full Rails test set.

## Rails sources

- `railties/lib/rails/backtrace_cleaner.rb` — ported
- `railties/test/backtrace_cleaner_test.rb` — all 10 tests ported verbatim
- `activesupport/lib/active_support/backtrace_cleaner.rb` — `clean(kind)` + `clean_frame` ported

## Skipped / deferred

- `ENV["BACKTRACE"]` bypass — Hard Rule 2 forbids `process.*` in `packages/trailties/src/`. Defer until a non-process toggle exists.
- `Rails.root` wiring — uses `setRoot()` for now; `Rails` global lands in PR 2.6.
- `alias_method :filter, :clean` — Rails-internal alias, not part of public surface.

Plan doc: docs/trailties-plan.md (PR 1.3).