### PR TITLE
chore(activerecord): drop trilogy references

### DIFF
--- a/docs/activerecord-100-plan.md
+++ b/docs/activerecord-100-plan.md
@@ -523,7 +523,7 @@ Followup from #1873. File passes audit but fails `AR_NO_AUTO_SCHEMA=1` — large
 
 ### Batch B1898 — MySQL precision helper extraction (~20 LOC, risk: low)
 
-Followup from #1898. Lift `extractMysqlTimePrecision` from `initializeTypeMap` local to a shared `mysql/schema-statements.ts` export for the `fetchTypeMetadata` (SHOW FULL FIELDS) path. Also audit `Trilogy` adapter for the same `register_class_with_precision` pattern (deferred until Trilogy is ported).
+Followup from #1898. Lift `extractMysqlTimePrecision` from `initializeTypeMap` local to a shared `mysql/schema-statements.ts` export for the `fetchTypeMetadata` (SHOW FULL FIELDS) path.
 
 ### Batch B1872 — actionpack CacheStore session options + Rails.cache (~25 LOC, risk: low, cross-package)
 

--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -63,12 +63,12 @@ describe("AdapterTest", () => {
   });
   it.skip("charset", () => {
     // BLOCKED: adapter-mysql
-    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts#charset: MySQL/Trilogy-only; needs MYSQL_TEST_URL test context
+    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts#charset: MySQL-only; needs MYSQL_TEST_URL test context
     // SCOPE: ~10 LOC port; affects ~3 tests
   });
   it.skip("show nonexistent variable returns nil", () => {
     // BLOCKED: adapter-mysql
-    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts#showVariable: MySQL/Trilogy-only; needs MYSQL_TEST_URL test context
+    // ROOT-CAUSE: connection-adapters/abstract-mysql-adapter.ts#showVariable: MySQL-only; needs MYSQL_TEST_URL test context
     // SCOPE: ~5 LOC port; affects ~1 test
   });
   it.skip("not specifying database name for cross database selects", () => {

--- a/packages/activerecord/src/adapter.ts
+++ b/packages/activerecord/src/adapter.ts
@@ -136,7 +136,7 @@ export function inspectExplainOption(o: unknown): string {
  * Normalized adapter family name used for dialect branching.
  *
  * Mirrors: the three families Rails branches on throughout
- * ActiveRecord (sqlite3, postgresql, mysql2/trilogy).
+ * ActiveRecord (sqlite3, postgresql, mysql2).
  */
 export type AdapterName = "sqlite" | "postgres" | "mysql";
 
@@ -157,7 +157,6 @@ export function adapterNameFromConfig(configAdapter: string | undefined): Adapte
       return "postgres";
     case "mysql":
     case "mysql2":
-    case "trilogy":
     case "mariadb":
       return "mysql";
     default:

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/bulk-alter.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/bulk-alter.test.ts
@@ -1,6 +1,6 @@
 /**
  * Mirrors Rails activerecord/test/cases/migration_test.rb
- * BulkAlterTableMigrationsTest — MySQL/Trilogy-only cases.
+ * BulkAlterTableMigrationsTest — MySQL-only cases.
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -3,7 +3,7 @@
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter
  *
- * Provides shared behavior for Mysql2Adapter and TrilogyAdapter.
+ * Provides shared behavior for Mysql2Adapter.
  * Includes MySQL-specific feature detection, DDL operations,
  * transaction handling, and advisory lock support.
  */
@@ -157,7 +157,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * `AbstractMysqlAdapter#columns` (via `SchemaStatements#columns`):
    * `column_definitions` rows mapped through `new_column_from_field`, which
    * centralizes function-default and on_update detection. Concrete adapters
-   * (Mysql2Adapter, TrilogyAdapter) may still override for performance.
+   * (Mysql2Adapter) may still override for performance.
    */
   async columns(tableName: string): Promise<Column[]> {
     const fields = await this.columnDefinitions(tableName);
@@ -215,8 +215,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   // Rails' `statement_limit` database.yml key — max prepared
   // statements cached per session before LRU eviction (default 1000).
   // Mirrors the same surface we expose on PostgreSQLAdapter; driver-
-  // specific subclasses (Mysql2Adapter, TrilogyAdapter) decide how to
-  // actually wire the per-connection pool.
+  // specific subclasses (Mysql2Adapter) decide how to actually wire
+  // the per-connection pool.
   protected _statementLimit = 1000;
 
   /**
@@ -255,12 +255,10 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   /**
    * Quote a value using MySQL-family escape rules (`\0 \n \r \Z \\ ''`
    * via MYSQL_ESCAPE_MAP, booleans as `1/0`, Dates as
-   * `'YYYY-MM-DD HH:MM:SS[.microseconds]'`). Defined here so every
-   * MySQL-family adapter (Mysql2, Trilogy) inherits MySQL semantics
-   * by default without needing to override themselves; without this,
-   * Trilogy would fall through to the abstract SQL-92 defaults
-   * (booleans → `TRUE/FALSE`, plain `''` string escaping) and
-   * diverge from Rails.
+   * `'YYYY-MM-DD HH:MM:SS[.microseconds]'`). Defined here so the
+   * MySQL-family adapter inherits MySQL semantics by default instead
+   * of falling through to the abstract SQL-92 defaults (booleans →
+   * `TRUE/FALSE`, plain `''` string escaping).
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#quote
    */
@@ -270,8 +268,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /**
    * Cast a value to the primitive form MySQL drivers expect for
-   * binds. Same motivation as `quote()` above — inherited by
-   * Trilogy so it gets MySQL semantics automatically.
+   * binds. Same motivation as `quote()` above.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::Quoting#type_cast
    */
@@ -599,7 +596,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
   /**
    * Execute a DDL/DML statement on the concrete adapter.
    * AbstractMysqlAdapter itself does not hold a connection; this delegates to
-   * the concrete subclass (Mysql2Adapter, TrilogyAdapter) which implements
+   * the concrete subclass (Mysql2Adapter) which implements
    * executeMutation on DatabaseAdapter.
    * @internal
    */
@@ -1151,8 +1148,8 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /**
    * Build the printed header prefix used by `Relation#explain` on MySQL
-   * (`"EXPLAIN ANALYZE FORMAT=JSON for:"`). Shared by Mysql2 and Trilogy
-   * adapters — the clause shape is driver-independent.
+   * (`"EXPLAIN ANALYZE FORMAT=JSON for:"`). The clause shape is
+   * driver-independent.
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#build_explain_clause
    */
@@ -1430,7 +1427,7 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
   /**
    * Fetch the raw version string from the MySQL server (e.g. "8.0.28-ubuntu").
-   * Concrete adapters (Mysql2Adapter, TrilogyAdapter) override this to query
+   * Concrete adapters (Mysql2Adapter) override this to query
    * the live connection. Base implementation throws — callers must call
    * `getDatabaseVersion()` only after a subclass has wired this.
    * @internal

--- a/packages/activerecord/src/connection-adapters/mysql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/quoting.ts
@@ -83,9 +83,9 @@ const MYSQL_ESCAPE_MAP: Record<string, string> = {
  * Quote a string value for use in SQL. Single/double quotes, backslash,
  * and control characters (NUL, newline, carriage return, Ctrl-Z) are
  * escaped with backslashes. Mirrors Rails MySQL `quote_string`, which
- * delegates to `mysql2`/`trilogy`'s connection-level escape — both of
- * which use backslash-escapes (not SQL-standard `''` doubling). The npm
- * `mysql2` driver's `escape()` matches this same shape.
+ * delegates to `mysql2`'s connection-level escape — uses backslash-escapes
+ * (not SQL-standard `''` doubling). The npm `mysql2` driver's `escape()`
+ * matches this same shape.
  */
 export function quoteString(value: string): string {
   return `'${value.replace(MYSQL_ESCAPE_RE, (ch) => MYSQL_ESCAPE_MAP[ch] ?? ch)}'`;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -892,8 +892,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   //
   // `buildExplainClause` / `_validateExplainOptions` / `_explainStatementClause`
   // and the EXPLAIN_FLAGS / EXPLAIN_FORMATS allowlists live on
-  // AbstractMysqlAdapter so TrilogyAdapter inherits the same MySQL
-  // clause shape.
+  // AbstractMysqlAdapter.
 
   /**
    * Execute raw SQL (for DDL and other non-query statements).

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -1233,7 +1233,6 @@ describe("adapterNameFromConfig", () => {
   it("maps mysql variants to mysql", () => {
     expect(adapterNameFromConfig("mysql2")).toBe("mysql");
     expect(adapterNameFromConfig("mysql")).toBe("mysql");
-    expect(adapterNameFromConfig("trilogy")).toBe("mysql");
     expect(adapterNameFromConfig("mariadb")).toBe("mysql");
   });
 

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2544,7 +2544,7 @@ describe("MigrationTest", () => {
     // functions on columns" live in adapters/postgresql/change-schema.test.ts
     // (describeIfPg) — they require PostgreSQL.
     // "updating auto increment" lives in adapters/abstract-mysql-adapter/bulk-alter.test.ts
-    // (describeIfMysql) — it requires MySQL/Trilogy.
+    // (describeIfMysql) — it requires MySQL.
 
     it("changing index", async () => {
       // Create table with a non-unique index, then swap to a unique index

--- a/packages/activerecord/src/tasks/database-tasks.test.ts
+++ b/packages/activerecord/src/tasks/database-tasks.test.ts
@@ -1330,8 +1330,7 @@ describe("DatabaseTasks _appendSchemaInformation adapter quoting", () => {
    */
   function stubAdapter(adapterName: string, versions: string[]) {
     const lower = adapterName.toLowerCase();
-    const isMySQL =
-      lower.includes("mysql") || lower.includes("trilogy") || lower.includes("mariadb");
+    const isMySQL = lower.includes("mysql") || lower.includes("mariadb");
     return {
       adapterName,
       quoteTableName: (name: string) =>

--- a/packages/activerecord/src/time-precision.test.ts
+++ b/packages/activerecord/src/time-precision.test.ts
@@ -71,7 +71,7 @@ describe("TimePrecisionTest", () => {
     expect(nsecTime((foo as any).finish)).toBe(123456000);
   });
 
-  // Rails skips this on Mysql2Adapter/TrilogyAdapter: a `TIME` column without
+  // Rails skips this on Mysql2Adapter: a `TIME` column without
   // explicit precision is `TIME(0)` on MySQL/MariaDB, so the assignment does
   // truncate. See vendor/rails/activerecord/test/cases/time_precision_test.rb.
   it.skipIf(adapterType === "mysql")("no time precision isnt truncated on assignment", async () => {

--- a/packages/trailties/src/commands/db.ts
+++ b/packages/trailties/src/commands/db.ts
@@ -235,7 +235,6 @@ function inferAdapterFromUrl(url: string): string | undefined {
         return "postgresql";
       case "mysql:":
       case "mysql2:":
-      case "trilogy:":
         return "mysql2";
       case "sqlite:":
       case "sqlite3:":

--- a/scripts/test-compare/normalize-skips.ts
+++ b/scripts/test-compare/normalize-skips.ts
@@ -164,7 +164,7 @@ function categorize(relPath: string, describeName: string, testName: string): An
     };
   }
 
-  // --- MySQL adapter (mysql2 / trilogy / abstract-mysql) ---
+  // --- MySQL adapter (mysql2 / abstract-mysql); `trilogy` is unported ---
   if (
     p.startsWith("adapters/mysql2/") ||
     p.startsWith("adapters/trilogy/") ||


### PR DESCRIPTION
## Summary

There is no Trilogy driver in Node — `scripts/api-compare/unported-files.ts` already excludes Rails' `adapters/trilogy` and `scripts/test-compare/normalize-skips.ts` already routes `adapters/trilogy/` skips. This sweep removes stale `Trilogy` mentions from comments, URL-scheme dispatch, and adapter-family branching so the codebase reflects what we actually ship.

Touched:
- `packages/activerecord/src/adapter.ts` — drop `trilogy` case from `adapterNameFromConfig`
- `packages/trailties/src/commands/db.ts` — drop `trilogy:` URL scheme from `inferAdapterFromUrl`
- `packages/activerecord/src/connection-pool.test.ts`, `tasks/database-tasks.test.ts` — drop assertions/branches on `trilogy`
- `connection-adapters/abstract-mysql-adapter.ts`, `mysql2-adapter.ts`, `mysql/quoting.ts` — comment scrub
- `adapter.test.ts`, `time-precision.test.ts`, `migration.test.ts`, `adapters/abstract-mysql-adapter/bulk-alter.test.ts` — comment scrub
- `scripts/test-compare/normalize-skips.ts` — clarifying comment
- `docs/activerecord-100-plan.md` — drop Trilogy follow-up note

Test name `test_registers_mysql_and_trilogy_patterns` is kept (Rails parity via test:compare).

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/connection-pool.test.ts -t "maps mysql variants"` passes
- [x] `pnpm vitest run packages/activerecord/src/tasks/database-tasks.test.ts packages/activerecord/src/tasks/mysql-database-tasks.test.ts` passes
- [x] `pnpm vitest run packages/trailties` passes
- [x] `tsc --build` passes (lefthook ran in commit)