### PR TITLE
feat(actionpack): Mapper#mount dispatch (Trailties PR 1.5a)

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/mapper.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { bodyFromString } from "@blazetrails/rack";
 import { Mapper } from "../routing/mapper.js";
 import { RouteSet } from "../routing/route-set.js";
 
@@ -14,7 +15,7 @@ describe("MapperTest", () => {
     expect(routes.getRoutes().length).toBeGreaterThan(0);
   });
 
-  const app = (_env: Record<string, unknown>) => [200, {}, [""]] as const;
+  const app = (_env: Record<string, unknown>) => [200, {}, bodyFromString("")] as const;
 
   it("can pass anchor to mount", () => {
     const m = new Mapper();
@@ -44,7 +45,7 @@ describe("Mapper#mount dispatch", () => {
     const seen: Array<Record<string, unknown>> = [];
     const engine = (env: Record<string, unknown>) => {
       seen.push({ SCRIPT_NAME: env["SCRIPT_NAME"], PATH_INFO: env["PATH_INFO"] });
-      return [200, { "content-type": "text/plain" }, ["engine-ok"]];
+      return [200, { "content-type": "text/plain" }, bodyFromString("engine-ok")];
     };
     const routes = new RouteSet();
     routes.draw((r) => r.mount(engine, { at: "/foo" }));
@@ -62,7 +63,7 @@ describe("Mapper#mount dispatch", () => {
         PATH_INFO: env["PATH_INFO"],
         path_parameters: env["action_dispatch.request.path_parameters"],
       });
-      return [200, {}, [""]];
+      return [200, {}, bodyFromString("")];
     };
     const routes = new RouteSet();
     routes.draw((r) => r.mount(engine, { at: "/:tenant" }));

--- a/packages/actionpack/src/action-dispatch/dispatch/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/mapper.test.ts
@@ -53,4 +53,17 @@ describe("Mapper#mount dispatch", () => {
     expect(res[0]).toBe(200);
     expect(seen).toEqual([{ SCRIPT_NAME: "/foo", PATH_INFO: "/bar" }]);
   });
+
+  it("dynamic mount points get SCRIPT_NAME from Journey's matched prefix", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const engine = (env: Record<string, unknown>) => {
+      seen.push({ SCRIPT_NAME: env["SCRIPT_NAME"], PATH_INFO: env["PATH_INFO"] });
+      return [200, {}, [""]];
+    };
+    const routes = new RouteSet();
+    routes.draw((r) => r.mount(engine, { at: "/:tenant" }));
+
+    await routes.call({ REQUEST_METHOD: "GET", PATH_INFO: "/acme/widgets" });
+    expect(seen).toEqual([{ SCRIPT_NAME: "/acme", PATH_INFO: "/widgets" }]);
+  });
 });

--- a/packages/actionpack/src/action-dispatch/dispatch/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/mapper.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { Mapper } from "../routing/mapper.js";
 import { RouteSet } from "../routing/route-set.js";
 
 // ==========================================================================
@@ -11,5 +12,45 @@ describe("MapperTest", () => {
       r.get("/foo", { to: "foo#index" });
     });
     expect(routes.getRoutes().length).toBeGreaterThan(0);
+  });
+
+  const app = (_env: Record<string, unknown>) => [200, {}, [""]] as const;
+
+  it("can pass anchor to mount", () => {
+    const m = new Mapper();
+    m.mount(app, { at: "/path", anchor: true });
+    expect(m.routes[0].path).toBe("/path");
+    expect(m.routes[0].anchor).toBe(true);
+  });
+
+  it("raising error when path is not passed", () => {
+    const m = new Mapper();
+    expect(() => m.mount(app)).toThrow(/mount point/);
+  });
+
+  it("raising error when rack app is not passed", () => {
+    const m = new Mapper();
+    expect(() =>
+      m.mount(10 as unknown as Parameters<Mapper["mount"]>[0], { as: "exciting" }),
+    ).toThrow(/rack application must be specified/);
+    expect(() =>
+      m.mount(undefined as unknown as Parameters<Mapper["mount"]>[0], { as: "exciting" }),
+    ).toThrow(/rack application must be specified/);
+  });
+});
+
+describe("Mapper#mount dispatch", () => {
+  it("forwards a matched request to the mounted app with SCRIPT_NAME/PATH_INFO rewritten", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const engine = (env: Record<string, unknown>) => {
+      seen.push({ SCRIPT_NAME: env["SCRIPT_NAME"], PATH_INFO: env["PATH_INFO"] });
+      return [200, { "content-type": "text/plain" }, ["engine-ok"]];
+    };
+    const routes = new RouteSet();
+    routes.draw((r) => r.mount(engine, { at: "/foo" }));
+
+    const res = await routes.call({ REQUEST_METHOD: "GET", PATH_INFO: "/foo/bar" });
+    expect(res[0]).toBe(200);
+    expect(seen).toEqual([{ SCRIPT_NAME: "/foo", PATH_INFO: "/bar" }]);
   });
 });

--- a/packages/actionpack/src/action-dispatch/dispatch/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/mapper.test.ts
@@ -57,13 +57,19 @@ describe("Mapper#mount dispatch", () => {
   it("dynamic mount points get SCRIPT_NAME from Journey's matched prefix", async () => {
     const seen: Array<Record<string, unknown>> = [];
     const engine = (env: Record<string, unknown>) => {
-      seen.push({ SCRIPT_NAME: env["SCRIPT_NAME"], PATH_INFO: env["PATH_INFO"] });
+      seen.push({
+        SCRIPT_NAME: env["SCRIPT_NAME"],
+        PATH_INFO: env["PATH_INFO"],
+        path_parameters: env["action_dispatch.request.path_parameters"],
+      });
       return [200, {}, [""]];
     };
     const routes = new RouteSet();
     routes.draw((r) => r.mount(engine, { at: "/:tenant" }));
 
     await routes.call({ REQUEST_METHOD: "GET", PATH_INFO: "/acme/widgets" });
-    expect(seen).toEqual([{ SCRIPT_NAME: "/acme", PATH_INFO: "/widgets" }]);
+    expect(seen).toEqual([
+      { SCRIPT_NAME: "/acme", PATH_INFO: "/widgets", path_parameters: { tenant: "acme" } },
+    ]);
   });
 });

--- a/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
+++ b/packages/actionpack/src/action-dispatch/routing/journey-bridge.ts
@@ -26,6 +26,19 @@ const JOURNEY_TO_LOCAL = new WeakMap<JourneyRoute, LocalRoute>();
 export interface JourneyMatch {
   route: LocalRoute;
   params: Record<string, string>;
+  /**
+   * For unanchored routes (e.g. `mount`), the matched prefix that should be
+   * appended to `SCRIPT_NAME` when forwarding to a mounted Rack app. Mirrors
+   * `match.to_s` in Rails' `action_dispatch/journey/router.rb`. Undefined for
+   * anchored routes.
+   */
+  matchedPrefix?: string;
+  /**
+   * For unanchored routes, the un-matched remainder of `PATH_INFO` (always
+   * starting with `/`). Mirrors `match.post_match` in Rails' Journey router.
+   * Undefined for anchored routes.
+   */
+  postMatch?: string;
 }
 
 export interface BuildJourneyRouterOptions {
@@ -123,6 +136,14 @@ export function journeyRecognize(
       }
     }
     result = { route: local, params };
+    // For unanchored routes (mounts), expose the matched prefix and
+    // post-match so callers can rewrite SCRIPT_NAME / PATH_INFO the same
+    // way Rails' Journey router does (action_dispatch/journey/router.rb).
+    if (match && !journeyRoute.path.anchored) {
+      const post = match.postMatch();
+      result.matchedPrefix = match.toString().replace(/\/$/, "");
+      result.postMatch = post.startsWith("/") ? post : "/" + post;
+    }
     return true; // stop iterating after the first hit
   });
   return result;

--- a/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 
 import { Mapper } from "./mapper.js";
-import { RouteSet } from "./route-set.js";
 
 describe("Mapper.normalizePath", () => {
   it("collapses duplicate slashes", () => {
@@ -174,58 +173,5 @@ describe("Mapper public DSL additions", () => {
     const m = new Mapper();
     expect(() => m.setMemberMappingsForResource()).not.toThrow();
     expect(m.routes).toEqual([]);
-  });
-});
-
-describe("Mapper#mount", () => {
-  const app = (_env: Record<string, unknown>) => [200, {}, [""]] as const;
-
-  it("test_can_pass_anchor_to_mount", () => {
-    const m = new Mapper();
-    m.mount(app, { at: "/path", anchor: true });
-    expect(m.routes[0].path).toBe("/path");
-    expect(m.routes[0].anchor).toBe(true);
-  });
-
-  it("test_raising_error_when_path_is_not_passed", () => {
-    const m = new Mapper();
-    expect(() => m.mount(app)).toThrow(/mount point/);
-  });
-
-  it("test_raising_error_when_rack_app_is_not_passed", () => {
-    const m = new Mapper();
-    expect(() =>
-      m.mount(10 as unknown as Parameters<Mapper["mount"]>[0], { as: "exciting" }),
-    ).toThrow(/rack application must be specified/);
-    expect(() =>
-      m.mount(undefined as unknown as Parameters<Mapper["mount"]>[0], { as: "exciting" }),
-    ).toThrow(/rack application must be specified/);
-  });
-
-  it("defaults anchor to false so prefix paths match nested URLs", () => {
-    const m = new Mapper();
-    m.mount(app, { at: "/foo" });
-    expect(m.routes[0].path).toBe("/foo");
-    expect(m.routes[0].anchor).toBe(false);
-  });
-
-  it("stores the mounted app on the route for dispatch", () => {
-    const m = new Mapper();
-    m.mount(app, { at: "/foo" });
-    expect(m.routes[0].app).toBe(app);
-  });
-
-  it("RouteSet#call forwards a matched request to the mounted app with SCRIPT_NAME/PATH_INFO rewritten", async () => {
-    const seen: Array<Record<string, unknown>> = [];
-    const engine = (env: Record<string, unknown>) => {
-      seen.push({ SCRIPT_NAME: env["SCRIPT_NAME"], PATH_INFO: env["PATH_INFO"] });
-      return [200, { "content-type": "text/plain" }, ["engine-ok"]];
-    };
-    const routes = new RouteSet();
-    routes.draw((r) => r.mount(engine, { at: "/foo" }));
-
-    const res = await routes.call({ REQUEST_METHOD: "GET", PATH_INFO: "/foo/bar" });
-    expect(res[0]).toBe(200);
-    expect(seen).toEqual([{ SCRIPT_NAME: "/foo", PATH_INFO: "/bar" }]);
   });
 });

--- a/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import { Mapper } from "./mapper.js";
+import { RouteSet } from "./route-set.js";
 
 describe("Mapper.normalizePath", () => {
   it("collapses duplicate slashes", () => {
@@ -173,5 +174,58 @@ describe("Mapper public DSL additions", () => {
     const m = new Mapper();
     expect(() => m.setMemberMappingsForResource()).not.toThrow();
     expect(m.routes).toEqual([]);
+  });
+});
+
+describe("Mapper#mount", () => {
+  const app = (_env: Record<string, unknown>) => [200, {}, [""]] as const;
+
+  it("test_can_pass_anchor_to_mount", () => {
+    const m = new Mapper();
+    m.mount(app, { at: "/path", anchor: true });
+    expect(m.routes[0].path).toBe("/path");
+    expect(m.routes[0].anchor).toBe(true);
+  });
+
+  it("test_raising_error_when_path_is_not_passed", () => {
+    const m = new Mapper();
+    expect(() => m.mount(app)).toThrow(/mount point/);
+  });
+
+  it("test_raising_error_when_rack_app_is_not_passed", () => {
+    const m = new Mapper();
+    expect(() =>
+      m.mount(10 as unknown as Parameters<Mapper["mount"]>[0], { as: "exciting" }),
+    ).toThrow(/rack application must be specified/);
+    expect(() =>
+      m.mount(undefined as unknown as Parameters<Mapper["mount"]>[0], { as: "exciting" }),
+    ).toThrow(/rack application must be specified/);
+  });
+
+  it("defaults anchor to false so prefix paths match nested URLs", () => {
+    const m = new Mapper();
+    m.mount(app, { at: "/foo" });
+    expect(m.routes[0].path).toBe("/foo");
+    expect(m.routes[0].anchor).toBe(false);
+  });
+
+  it("stores the mounted app on the route for dispatch", () => {
+    const m = new Mapper();
+    m.mount(app, { at: "/foo" });
+    expect(m.routes[0].app).toBe(app);
+  });
+
+  it("RouteSet#call forwards a matched request to the mounted app with SCRIPT_NAME/PATH_INFO rewritten", async () => {
+    const seen: Array<Record<string, unknown>> = [];
+    const engine = (env: Record<string, unknown>) => {
+      seen.push({ SCRIPT_NAME: env["SCRIPT_NAME"], PATH_INFO: env["PATH_INFO"] });
+      return [200, { "content-type": "text/plain" }, ["engine-ok"]];
+    };
+    const routes = new RouteSet();
+    routes.draw((r) => r.mount(engine, { at: "/foo" }));
+
+    const res = await routes.call({ REQUEST_METHOD: "GET", PATH_INFO: "/foo/bar" });
+    expect(res[0]).toBe(200);
+    expect(seen).toEqual([{ SCRIPT_NAME: "/foo", PATH_INFO: "/bar" }]);
   });
 });

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -19,6 +19,7 @@ import {
   type ResourceAction,
   type RedirectFunction,
   type RedirectOptions,
+  type MountableApp,
 } from "./route.js";
 import { Scope, type ScopeLevel } from "./scope.js";
 import { underscore } from "@blazetrails/activesupport";
@@ -621,19 +622,22 @@ export class Mapper {
 
   mount(app: MountableApp, options: MountOptions = {}): void {
     const path = options.at;
-    if (typeof (app as { call?: unknown })?.call !== "function") {
+    if (typeof app !== "function" && typeof (app as { call?: unknown })?.call !== "function") {
       throw new Error("A rack application must be specified");
     }
     if (!path) {
-      throw new Error("Must be called with mount point: mount(SomeRackApp, { at: '/path' })");
+      throw new Error('Must be called with mount point\n\n  mount SomeRackApp, at: "some_route"');
     }
     const railsApp = this.isRailsApp(app);
     const asName = options.as ?? this.appName(app, railsApp);
+    // Rails: `{ to: app, anchor: false, format: false }.merge(options)` — options
+    // override the anchor/format defaults but not the mounted app.
     const matchOpts: RouteOptions & { via?: string | string[]; at?: string } = {
-      ...options,
-      via: options.via ?? "ALL",
       anchor: false,
       format: false,
+      ...options,
+      via: options.via ?? "ALL",
+      app,
     };
     if (asName) matchOpts.as = asName;
     delete matchOpts.at;
@@ -1414,8 +1418,6 @@ interface ScopeOptions {
   as?: string;
   module?: string;
 }
-
-type MountableApp = ((...args: unknown[]) => unknown) | { call: (...args: unknown[]) => unknown };
 
 interface MountOptions extends RouteOptions {
   at?: string;

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -1093,10 +1093,21 @@ export class RouteSet {
       const forwarded: RackEnv = { ...env };
       if (matched.matchedPrefix !== undefined) {
         const scriptName = (env["SCRIPT_NAME"] as string) ?? "";
-        forwarded["SCRIPT_NAME"] = scriptName + matched.matchedPrefix;
+        // Rails: `(script_name.to_s + match.to_s).chomp("/")` — chomp the
+        // combined value so a trailing slash on either side doesn't leak.
+        forwarded["SCRIPT_NAME"] = (scriptName + matched.matchedPrefix).replace(/\/$/, "");
         forwarded["PATH_INFO"] = matched.postMatch ?? "/";
       }
-      forwarded["action_dispatch.request.path_parameters"] = { ...route.defaults, ...params };
+      // Rails (journey/router.rb:45-50): `tmp_params = set_params.merge route.defaults`
+      // then overlay matched parameters. Preserves outer-mount captures
+      // when engines are nested.
+      const setParams =
+        (env["action_dispatch.request.path_parameters"] as Record<string, unknown>) ?? {};
+      forwarded["action_dispatch.request.path_parameters"] = {
+        ...setParams,
+        ...route.defaults,
+        ...params,
+      };
       return typeof mountedApp === "function"
         ? await mountedApp(forwarded)
         : await mountedApp.call(forwarded);

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -1083,15 +1083,21 @@ export class RouteSet {
     if (mountedApp) {
       const scriptName = (env["SCRIPT_NAME"] as string) ?? "";
       const mountPath = route.path.replace(/\/$/, "");
-      const remaining = path.startsWith(mountPath) ? path.slice(mountPath.length) : path;
-      const forwarded: Record<string, unknown> = {
+      // Only strip the mount prefix when the next character is `/` or
+      // end-of-path. Otherwise `/foo-bar` against a `/foo` mount would forward
+      // `PATH_INFO: "-bar"`, violating the Rack origin-form invariant that
+      // PATH_INFO must be empty or start with `/` (packages/rack/src/lint.ts).
+      const after = path.length === mountPath.length ? "" : path.charAt(mountPath.length);
+      const stripped = path.startsWith(mountPath) && (after === "" || after === "/");
+      const remaining = stripped ? path.slice(mountPath.length) : path;
+      const forwarded: RackEnv = {
         ...env,
         SCRIPT_NAME: scriptName + mountPath,
         PATH_INFO: remaining.length === 0 ? "/" : remaining,
       };
-      const call =
-        typeof mountedApp === "function" ? mountedApp.bind(null) : mountedApp.call.bind(mountedApp);
-      return (await call(forwarded)) as RackResponse;
+      return typeof mountedApp === "function"
+        ? await mountedApp(forwarded)
+        : await mountedApp.call(forwarded);
     }
 
     // Merge route params into the env (like Rails does with request.params)

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -1081,19 +1081,22 @@ export class RouteSet {
     // anchor: false dispatch into the engine's app.
     const mountedApp = route.app;
     if (mountedApp) {
-      // Use Journey's actual unanchored match data (matchedPrefix /
-      // postMatch) — same as Rails' Journey router: `req.script_name +
-      // match.to_s` and `match.post_match`. This handles dynamic mount
-      // points (`/:tenant`) and segment-boundary cases that a literal
-      // `route.path.startsWith(...)` would get wrong.
-      const scriptName = (env["SCRIPT_NAME"] as string) ?? "";
-      const matchedPrefix = matched.matchedPrefix ?? route.path.replace(/\/$/, "");
-      const remaining = matched.postMatch ?? "/";
-      const forwarded: RackEnv = {
-        ...env,
-        SCRIPT_NAME: scriptName + matchedPrefix,
-        PATH_INFO: remaining,
-      };
+      // Mirrors Rails' `action_dispatch/journey/router.rb#serve`:
+      // - SCRIPT_NAME/PATH_INFO are rewritten ONLY for unanchored routes
+      //   (`unless route.path.anchored`). Anchored mounts forward env
+      //   unchanged. matchedPrefix / postMatch on `matched` are populated
+      //   by `journeyRecognize` from `match.to_s` / `match.post_match`,
+      //   so dynamic mount points (`/:tenant` → `/acme`) work without
+      //   relying on literal `route.path` slicing.
+      // - `path_parameters` is set on the forwarded request unconditionally
+      //   (Rails: `req.path_parameters = tmp_params` before `route.app.serve`).
+      const forwarded: RackEnv = { ...env };
+      if (matched.matchedPrefix !== undefined) {
+        const scriptName = (env["SCRIPT_NAME"] as string) ?? "";
+        forwarded["SCRIPT_NAME"] = scriptName + matched.matchedPrefix;
+        forwarded["PATH_INFO"] = matched.postMatch ?? "/";
+      }
+      forwarded["action_dispatch.request.path_parameters"] = { ...route.defaults, ...params };
       return typeof mountedApp === "function"
         ? await mountedApp(forwarded)
         : await mountedApp.call(forwarded);

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -1076,6 +1076,24 @@ export class RouteSet {
       return [status, lowerHeaders, bodyFromString((bodyArr as string[]).join(""))];
     }
 
+    // Mounted Rack app: forward the request after stripping the mount prefix
+    // from PATH_INFO and appending it to SCRIPT_NAME. Mirrors Rails' Journey
+    // anchor: false dispatch into the engine's app.
+    const mountedApp = route.app;
+    if (mountedApp) {
+      const scriptName = (env["SCRIPT_NAME"] as string) ?? "";
+      const mountPath = route.path.replace(/\/$/, "");
+      const remaining = path.startsWith(mountPath) ? path.slice(mountPath.length) : path;
+      const forwarded: Record<string, unknown> = {
+        ...env,
+        SCRIPT_NAME: scriptName + mountPath,
+        PATH_INFO: remaining.length === 0 ? "/" : remaining,
+      };
+      const call =
+        typeof mountedApp === "function" ? mountedApp.bind(null) : mountedApp.call.bind(mountedApp);
+      return (await call(forwarded)) as RackResponse;
+    }
+
     // Merge route params into the env (like Rails does with request.params)
     env["action_dispatch.request.path_parameters"] = {
       controller: route.controller,

--- a/packages/actionpack/src/action-dispatch/routing/route-set.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route-set.ts
@@ -1081,19 +1081,18 @@ export class RouteSet {
     // anchor: false dispatch into the engine's app.
     const mountedApp = route.app;
     if (mountedApp) {
+      // Use Journey's actual unanchored match data (matchedPrefix /
+      // postMatch) — same as Rails' Journey router: `req.script_name +
+      // match.to_s` and `match.post_match`. This handles dynamic mount
+      // points (`/:tenant`) and segment-boundary cases that a literal
+      // `route.path.startsWith(...)` would get wrong.
       const scriptName = (env["SCRIPT_NAME"] as string) ?? "";
-      const mountPath = route.path.replace(/\/$/, "");
-      // Only strip the mount prefix when the next character is `/` or
-      // end-of-path. Otherwise `/foo-bar` against a `/foo` mount would forward
-      // `PATH_INFO: "-bar"`, violating the Rack origin-form invariant that
-      // PATH_INFO must be empty or start with `/` (packages/rack/src/lint.ts).
-      const after = path.length === mountPath.length ? "" : path.charAt(mountPath.length);
-      const stripped = path.startsWith(mountPath) && (after === "" || after === "/");
-      const remaining = stripped ? path.slice(mountPath.length) : path;
+      const matchedPrefix = matched.matchedPrefix ?? route.path.replace(/\/$/, "");
+      const remaining = matched.postMatch ?? "/";
       const forwarded: RackEnv = {
         ...env,
-        SCRIPT_NAME: scriptName + mountPath,
-        PATH_INFO: remaining.length === 0 ? "/" : remaining,
+        SCRIPT_NAME: scriptName + matchedPrefix,
+        PATH_INFO: remaining,
       };
       return typeof mountedApp === "function"
         ? await mountedApp(forwarded)

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -18,6 +18,15 @@ export interface RouteConstraints {
   [key: string]: string | RegExp;
 }
 
+/**
+ * A Rack-style application: anything that responds to `call(env)`. Functions
+ * (Rails' lambda apps) and class-like objects with a `call` method are both
+ * accepted, matching `app.respond_to?(:call)` in Rails' `mount`.
+ */
+export type MountableApp =
+  | ((env: Record<string, unknown>) => unknown)
+  | { call: (env: Record<string, unknown>) => unknown };
+
 export interface RouteOptions {
   name?: string;
   constraints?: RouteConstraints;
@@ -35,6 +44,11 @@ export interface RouteOptions {
   anchor?: boolean;
   shallow?: boolean;
   internal?: boolean;
+  /**
+   * Mounted Rack-compatible app (set by `Mapper#mount`). When present the
+   * route forwards requests to this app rather than to a controller action.
+   */
+  app?: MountableApp;
 }
 
 export type ResourceAction = "index" | "show" | "new" | "create" | "edit" | "update" | "destroy";
@@ -70,6 +84,8 @@ export class Route {
   readonly anchor: boolean;
   /** Marks routes that should be hidden from `bin/rails routes` (info routes etc). */
   readonly internal: boolean;
+  /** Mounted Rack app, set by `Mapper#mount`. */
+  readonly app: MountableApp | undefined;
 
   private readonly paramNames: string[];
   /** @internal lazy single-route Journey router for match() */
@@ -103,6 +119,7 @@ export class Route {
     this.redirectTarget = options.redirect;
     this.anchor = options.anchor !== false;
     this.internal = options.internal === true;
+    this.app = options.app;
 
     // Derive capture names from the Journey parser/AST — the same source
     // the Journey bridge uses. Keeps the path-vs-request constraint split

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -11,6 +11,7 @@ import { buildJourneyRouter, journeyRecognize } from "./journey-bridge.js";
 import type { Router as JourneyRouter } from "../journey/router.js";
 import { OptionRedirect, PathRedirect, Redirect, type RedirectBlock } from "./redirection.js";
 import type { Request } from "../http/request.js";
+import type { RackEnv, RackResponse } from "@blazetrails/rack";
 
 const PATHFOR_SEPARATORS = "/.?";
 
@@ -24,8 +25,8 @@ export interface RouteConstraints {
  * accepted, matching `app.respond_to?(:call)` in Rails' `mount`.
  */
 export type MountableApp =
-  | ((env: Record<string, unknown>) => unknown)
-  | { call: (env: Record<string, unknown>) => unknown };
+  | ((env: RackEnv) => RackResponse | Promise<RackResponse>)
+  | { call: (env: RackEnv) => RackResponse | Promise<RackResponse> };
 
 export interface RouteOptions {
   name?: string;

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -70,6 +70,10 @@ export interface RedirectOptions {
 export interface MatchedRoute {
   route: Route;
   params: Record<string, string>;
+  /** For unanchored mount routes: matched prefix to append to SCRIPT_NAME. */
+  matchedPrefix?: string;
+  /** For unanchored mount routes: remaining PATH_INFO (always begins with `/`). */
+  postMatch?: string;
 }
 
 export class Route {


### PR DESCRIPTION
## Summary

Wires `Mapper#mount` through to `RouteSet` dispatch so mounted Rack apps
receive requests with `SCRIPT_NAME`/`PATH_INFO` rewritten relative to the
mount point. Trailties Phase 1.5 prerequisite that unblocks PR 2.2 (Engine).

- `Route` gains an `app` field plumbed from `RouteOptions.app`.
- `Mapper#mount` now passes the mounted app through `match()` options,
  matching Rails' `{ to: app, anchor: false, format: false }.merge(options)`
  so a caller-supplied `anchor: true` is honored (`test_can_pass_anchor_to_mount`).
- `RouteSet#call` recognizes mounted routes via `route.app` and forwards
  with `SCRIPT_NAME += mountPath`, `PATH_INFO = remainder`.
- Ports the 4 Rails mount tests verbatim by name from
  `actionpack/test/dispatch/mapper_test.rb` plus an end-to-end dispatch
  test for the acceptance criterion (`mount FooEngine, at: "/foo"` →
  request to `/foo/bar` arrives at the engine with `PATH_INFO = "/bar"`).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/routing/mapper.test.ts` (29 passed)
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/routing/` (261 passed — no regressions in routing)
- [x] `pnpm typecheck`