### PR TITLE
feat(trailties): Rack::Logger + SilenceRequest middleware (PR 1.11)

### DIFF
--- a/packages/trailties/src/rack/logger.test.ts
+++ b/packages/trailties/src/rack/logger.test.ts
@@ -29,9 +29,19 @@ describe("Rack::Logger", () => {
     const failingApp: RackApp = async () => {
       throw new Error("boom");
     };
+    const popped: number[] = [];
     let captured: unknown;
     const events = await Notifications.collectEventsAsync("request.action_dispatch", async () => {
-      const middleware = new Logger(failingApp);
+      const middleware = new Logger(failingApp, {
+        logger: {
+          pushTags: (...tags) => tags,
+          popTags: (n = 1) => {
+            popped.push(n);
+            return [];
+          },
+        },
+        taggers: ["t"],
+      });
       try {
         await middleware.call({ REQUEST_METHOD: "GET" });
       } catch (e) {
@@ -40,6 +50,7 @@ describe("Rack::Logger", () => {
     });
     expect((captured as Error).message).toBe("boom");
     expect(events).toHaveLength(1);
+    expect(popped).toEqual([1]);
   });
 
   it("logger does not mutate app return", async () => {

--- a/packages/trailties/src/rack/logger.test.ts
+++ b/packages/trailties/src/rack/logger.test.ts
@@ -1,82 +1,91 @@
-import { it, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 import { Logger } from "./logger.js";
 import { Notifications } from "@blazetrails/activesupport";
-import type { RackApp, RackResponse } from "@blazetrails/rack";
+import type { RackApp, RackBody, RackResponse } from "@blazetrails/rack";
 
-const emptyBody = (): AsyncIterable<string> => ({
+const emptyBody = (): RackBody => ({
   async *[Symbol.asyncIterator]() {
     /* empty */
   },
 });
 
-const okApp: RackApp = async () => [200, {}, emptyBody() as any];
+const okApp: RackApp = async () => [200, {}, emptyBody()];
 
-it("notification", async () => {
-  const events = await Notifications.collectEventsAsync("request.action_dispatch", async () => {
-    const middleware = new Logger(okApp);
+const closeBody = (body: RackBody): void => {
+  (body as unknown as { close: () => void }).close();
+};
+
+describe("Rack::Logger", () => {
+  it("notification", async () => {
+    const events = await Notifications.collectEventsAsync("request.action_dispatch", async () => {
+      const middleware = new Logger(okApp);
+      const [, , body] = await middleware.call({ REQUEST_METHOD: "GET" });
+      closeBody(body);
+    });
+    expect(events).toHaveLength(1);
+  });
+
+  it("notification on raise", async () => {
+    const failingApp: RackApp = async () => {
+      throw new Error("boom");
+    };
+    let captured: unknown;
+    const events = await Notifications.collectEventsAsync("request.action_dispatch", async () => {
+      const middleware = new Logger(failingApp);
+      try {
+        await middleware.call({ REQUEST_METHOD: "GET" });
+      } catch (e) {
+        captured = e;
+      }
+    });
+    expect((captured as Error).message).toBe("boom");
+    expect(events).toHaveLength(1);
+  });
+
+  it("logger does not mutate app return", async () => {
+    const response = Object.freeze([200, {}, emptyBody()]) as RackResponse;
+    const middleware = new Logger(async () => response);
+    const out = await middleware.call({ REQUEST_METHOD: "GET" });
+    expect(out).not.toBe(response);
+    expect(out[0]).toBe(200);
+  });
+
+  it("logger is flushed after request finished", async () => {
+    const calls: string[] = [];
+    const middleware = new Logger(okApp, {
+      logger: {
+        info(msg) {
+          calls.push(msg);
+        },
+      },
+    });
+    const [, , body] = await middleware.call({
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/x",
+    });
+    expect(calls[0]).toMatch(/^Started GET "\/x"/);
+    closeBody(body);
+  });
+
+  it("logger pushes tags", async () => {
+    const pushed: string[][] = [];
+    const popped: number[] = [];
+    const middleware = new Logger(okApp, {
+      logger: {
+        pushTags(...tags) {
+          pushed.push(tags);
+          return tags;
+        },
+        popTags(n = 1) {
+          popped.push(n);
+          return [];
+        },
+      },
+      taggers: ["tag1", (env) => String(env["REQUEST_METHOD"])],
+    });
     const [, , body] = await middleware.call({ REQUEST_METHOD: "GET" });
-    (body as unknown as { close: () => void }).close();
+    expect(pushed).toEqual([["tag1", "GET"]]);
+    closeBody(body);
+    expect(popped).toEqual([2]);
   });
-  expect(events).toHaveLength(1);
-});
-
-it("notification on raise", async () => {
-  const failingApp: RackApp = async () => {
-    throw new Error("boom");
-  };
-  let captured: unknown;
-  const events = await Notifications.collectEventsAsync("request.action_dispatch", async () => {
-    const middleware = new Logger(failingApp);
-    try {
-      await middleware.call({ REQUEST_METHOD: "GET" });
-    } catch (e) {
-      captured = e;
-    }
-  });
-  expect((captured as Error).message).toBe("boom");
-  expect(events).toHaveLength(1);
-});
-
-it("logger does not mutate app return", async () => {
-  const response: RackResponse = Object.freeze([200, {}, emptyBody() as any]) as RackResponse;
-  const middleware = new Logger(async () => response);
-  const out = await middleware.call({ REQUEST_METHOD: "GET" });
-  expect(out).not.toBe(response);
-  expect(out[0]).toBe(200);
-});
-
-it("logger is flushed after request finished", async () => {
-  const calls: string[] = [];
-  const middleware = new Logger(okApp, {
-    logger: {
-      info(msg) {
-        calls.push(msg);
-      },
-    },
-  });
-  const [, , body] = await middleware.call({ REQUEST_METHOD: "GET", PATH_INFO: "/x" });
-  expect(calls[0]).toMatch(/^Started GET "\/x"/);
-  (body as unknown as { close: () => void }).close();
-});
-
-it("logger pushes tags", async () => {
-  const pushed: string[][] = [];
-  const popped: number[] = [];
-  const middleware = new Logger(okApp, {
-    logger: {
-      pushTags(...tags) {
-        pushed.push(tags);
-        return tags;
-      },
-      popTags(n = 1) {
-        popped.push(n);
-        return [];
-      },
-    },
-    taggers: ["tag1", (env) => String(env["REQUEST_METHOD"])],
-  });
-  const [, , body] = await middleware.call({ REQUEST_METHOD: "GET" });
-  expect(pushed).toEqual([["tag1", "GET"]]);
-  (body as unknown as { close: () => void }).close();
-  expect(popped).toEqual([2]);
 });

--- a/packages/trailties/src/rack/logger.test.ts
+++ b/packages/trailties/src/rack/logger.test.ts
@@ -1,0 +1,82 @@
+import { it, expect } from "vitest";
+import { Logger } from "./logger.js";
+import { Notifications } from "@blazetrails/activesupport";
+import type { RackApp, RackResponse } from "@blazetrails/rack";
+
+const emptyBody = (): AsyncIterable<string> => ({
+  async *[Symbol.asyncIterator]() {
+    /* empty */
+  },
+});
+
+const okApp: RackApp = async () => [200, {}, emptyBody() as any];
+
+it("notification", async () => {
+  const events = await Notifications.collectEventsAsync("request.action_dispatch", async () => {
+    const middleware = new Logger(okApp);
+    const [, , body] = await middleware.call({ REQUEST_METHOD: "GET" });
+    (body as unknown as { close: () => void }).close();
+  });
+  expect(events).toHaveLength(1);
+});
+
+it("notification on raise", async () => {
+  const failingApp: RackApp = async () => {
+    throw new Error("boom");
+  };
+  let captured: unknown;
+  const events = await Notifications.collectEventsAsync("request.action_dispatch", async () => {
+    const middleware = new Logger(failingApp);
+    try {
+      await middleware.call({ REQUEST_METHOD: "GET" });
+    } catch (e) {
+      captured = e;
+    }
+  });
+  expect((captured as Error).message).toBe("boom");
+  expect(events).toHaveLength(1);
+});
+
+it("logger does not mutate app return", async () => {
+  const response: RackResponse = Object.freeze([200, {}, emptyBody() as any]) as RackResponse;
+  const middleware = new Logger(async () => response);
+  const out = await middleware.call({ REQUEST_METHOD: "GET" });
+  expect(out).not.toBe(response);
+  expect(out[0]).toBe(200);
+});
+
+it("logger is flushed after request finished", async () => {
+  const calls: string[] = [];
+  const middleware = new Logger(okApp, {
+    logger: {
+      info(msg) {
+        calls.push(msg);
+      },
+    },
+  });
+  const [, , body] = await middleware.call({ REQUEST_METHOD: "GET", PATH_INFO: "/x" });
+  expect(calls[0]).toMatch(/^Started GET "\/x"/);
+  (body as unknown as { close: () => void }).close();
+});
+
+it("logger pushes tags", async () => {
+  const pushed: string[][] = [];
+  const popped: number[] = [];
+  const middleware = new Logger(okApp, {
+    logger: {
+      pushTags(...tags) {
+        pushed.push(tags);
+        return tags;
+      },
+      popTags(n = 1) {
+        popped.push(n);
+        return [];
+      },
+    },
+    taggers: ["tag1", (env) => String(env["REQUEST_METHOD"])],
+  });
+  const [, , body] = await middleware.call({ REQUEST_METHOD: "GET" });
+  expect(pushed).toEqual([["tag1", "GET"]]);
+  (body as unknown as { close: () => void }).close();
+  expect(popped).toEqual([2]);
+});

--- a/packages/trailties/src/rack/logger.ts
+++ b/packages/trailties/src/rack/logger.ts
@@ -1,0 +1,84 @@
+/**
+ * Rails::Rack::Logger — Rack middleware that sets log tags, logs the
+ * request, calls the app, and finalizes instrumentation when the body
+ * closes.
+ *
+ * Port of `railties/lib/rails/rack/logger.rb`.
+ */
+
+import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
+import { BodyProxy } from "@blazetrails/rack";
+import { Notifications } from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
+export type Tagger = string | ((env: RackEnv) => string);
+
+export interface RackLoggerLike {
+  info?(msg: string): void;
+  pushTags?(...tags: string[]): string[];
+  popTags?(count?: number): string[];
+}
+
+export interface LoggerOptions {
+  logger?: RackLoggerLike;
+  taggers?: Tagger[];
+}
+
+const NOOP_LOGGER: RackLoggerLike = {};
+
+export class Logger {
+  private app: RackApp;
+  private logger: RackLoggerLike;
+  private taggers: Tagger[];
+
+  constructor(app: RackApp, options: LoggerOptions = {}) {
+    this.app = app;
+    this.logger = options.logger ?? NOOP_LOGGER;
+    this.taggers = options.taggers ?? [];
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    const tagCount = this.logger.pushTags
+      ? this.logger.pushTags(...this.computeTags(env)).length
+      : 0;
+    env["rails.rackLoggerTagCount"] = tagCount;
+
+    const startedAt = Date.now();
+    let finished = false;
+    const finish = (): void => {
+      if (finished) return;
+      finished = true;
+      Notifications.publish("request.action_dispatch", {
+        request: env,
+        elapsed: Date.now() - startedAt,
+      });
+      if (this.logger.popTags && tagCount > 0) this.logger.popTags(tagCount);
+    };
+
+    try {
+      this.logger.info?.(this.startedRequestMessage(env));
+      const response = await this.app(env);
+      const [status, headers, body] = response;
+      const wrapped = new BodyProxy(body as AsyncIterable<unknown>, finish);
+      if (Object.isFrozen(response)) {
+        return [status, headers, wrapped] as RackResponse;
+      }
+      (response as unknown as [number, Record<string, string>, unknown])[2] = wrapped;
+      return response;
+    } catch (err) {
+      finish();
+      throw err;
+    }
+  }
+
+  private startedRequestMessage(env: RackEnv): string {
+    const method = env["REQUEST_METHOD"] ?? "GET";
+    const path = env["PATH_INFO"] ?? "/";
+    const remote = env["REMOTE_ADDR"] ?? "-";
+    return `Started ${String(method)} "${String(path)}" for ${String(remote)} at ${Temporal.Now.instant().toString()}`;
+  }
+
+  private computeTags(env: RackEnv): string[] {
+    return this.taggers.map((t) => (typeof t === "function" ? t(env) : t));
+  }
+}

--- a/packages/trailties/src/rack/logger.ts
+++ b/packages/trailties/src/rack/logger.ts
@@ -43,14 +43,14 @@ export class Logger {
       : 0;
     env["rails.rackLoggerTagCount"] = tagCount;
 
-    const startedAt = Date.now();
+    const startedAt = performance.now();
     let finished = false;
     const finish = (): void => {
       if (finished) return;
       finished = true;
       Notifications.publish("request.action_dispatch", {
         request: env,
-        elapsed: Date.now() - startedAt,
+        elapsed: performance.now() - startedAt,
       });
       if (this.logger.popTags && tagCount > 0) this.logger.popTags(tagCount);
     };

--- a/packages/trailties/src/rack/silence-request.test.ts
+++ b/packages/trailties/src/rack/silence-request.test.ts
@@ -12,9 +12,9 @@ describe("Rack::SilenceRequest", () => {
   it("silence request only to specific path", async () => {
     const calls: string[] = [];
     const logger = {
-      silence(_level: number | string, fn: () => void) {
+      silence<T>(_level: number | string, fn: () => T): T {
         calls.push("silence");
-        fn();
+        return fn();
       },
     };
 
@@ -31,10 +31,11 @@ describe("Rack::SilenceRequest", () => {
   it("prefers silenceAsync when available", async () => {
     const calls: string[] = [];
     const logger = {
-      silence() {
+      silence<T>(_level: number | string, fn: () => T): T {
         calls.push("silence");
+        return fn();
       },
-      async silenceAsync(_level: number | string, fn: () => Promise<unknown>) {
+      async silenceAsync<T>(_level: number | string, fn: () => Promise<T>): Promise<T> {
         calls.push("silenceAsync:start");
         const out = await fn();
         calls.push("silenceAsync:end");

--- a/packages/trailties/src/rack/silence-request.test.ts
+++ b/packages/trailties/src/rack/silence-request.test.ts
@@ -1,26 +1,55 @@
-import { it, expect } from "vitest";
+import { describe, it, expect } from "vitest";
 import { SilenceRequest } from "./silence-request.js";
-import type { RackApp } from "@blazetrails/rack";
+import type { RackApp, RackBody } from "@blazetrails/rack";
 
-it("silence request only to specific path", async () => {
-  const calls: Array<number | string> = [];
-  const logger = {
-    silence(_level: number | string, fn: () => void) {
-      calls.push("silence");
-      fn();
-    },
-  };
+const emptyBody = (): RackBody => ({
+  async *[Symbol.asyncIterator]() {
+    /* empty */
+  },
+});
 
-  const app: RackApp = async (env: Record<string, unknown>) => [
-    200,
-    env as Record<string, string>,
-    [] as any,
-  ];
+describe("Rack::SilenceRequest", () => {
+  it("silence request only to specific path", async () => {
+    const calls: string[] = [];
+    const logger = {
+      silence(_level: number | string, fn: () => void) {
+        calls.push("silence");
+        fn();
+      },
+    };
 
-  const middleware = new SilenceRequest(app, { path: "/up", logger });
+    const app: RackApp = async () => [200, {}, emptyBody()];
 
-  await middleware.call({ PATH_INFO: "/up" });
-  await middleware.call({ PATH_INFO: "/down" });
+    const middleware = new SilenceRequest(app, { path: "/up", logger });
 
-  expect(calls).toEqual(["silence"]);
+    await middleware.call({ PATH_INFO: "/up" });
+    await middleware.call({ PATH_INFO: "/down" });
+
+    expect(calls).toEqual(["silence"]);
+  });
+
+  it("prefers silenceAsync when available", async () => {
+    const calls: string[] = [];
+    const logger = {
+      silence() {
+        calls.push("silence");
+      },
+      async silenceAsync(_level: number | string, fn: () => Promise<unknown>) {
+        calls.push("silenceAsync:start");
+        const out = await fn();
+        calls.push("silenceAsync:end");
+        return out;
+      },
+    };
+
+    const app: RackApp = async () => {
+      calls.push("app");
+      return [200, {}, emptyBody()];
+    };
+
+    const middleware = new SilenceRequest(app, { path: "/up", logger });
+    await middleware.call({ PATH_INFO: "/up" });
+
+    expect(calls).toEqual(["silenceAsync:start", "app", "silenceAsync:end"]);
+  });
 });

--- a/packages/trailties/src/rack/silence-request.test.ts
+++ b/packages/trailties/src/rack/silence-request.test.ts
@@ -12,9 +12,9 @@ describe("Rack::SilenceRequest", () => {
   it("silence request only to specific path", async () => {
     const calls: string[] = [];
     const logger = {
-      silence<T>(_level: number | string, fn: () => T): T {
+      silence(_level: number | string, fn: () => void) {
         calls.push("silence");
-        return fn();
+        fn();
       },
     };
 
@@ -31,9 +31,9 @@ describe("Rack::SilenceRequest", () => {
   it("prefers silenceAsync when available", async () => {
     const calls: string[] = [];
     const logger = {
-      silence<T>(_level: number | string, fn: () => T): T {
+      silence(_level: number | string, fn: () => void) {
         calls.push("silence");
-        return fn();
+        fn();
       },
       async silenceAsync<T>(_level: number | string, fn: () => Promise<T>): Promise<T> {
         calls.push("silenceAsync:start");

--- a/packages/trailties/src/rack/silence-request.test.ts
+++ b/packages/trailties/src/rack/silence-request.test.ts
@@ -1,0 +1,26 @@
+import { it, expect } from "vitest";
+import { SilenceRequest } from "./silence-request.js";
+import type { RackApp } from "@blazetrails/rack";
+
+it("silence request only to specific path", async () => {
+  const calls: Array<number | string> = [];
+  const logger = {
+    silence(_level: number | string, fn: () => void) {
+      calls.push("silence");
+      fn();
+    },
+  };
+
+  const app: RackApp = async (env: Record<string, unknown>) => [
+    200,
+    env as Record<string, string>,
+    [] as any,
+  ];
+
+  const middleware = new SilenceRequest(app, { path: "/up", logger });
+
+  await middleware.call({ PATH_INFO: "/up" });
+  await middleware.call({ PATH_INFO: "/down" });
+
+  expect(calls).toEqual(["silence"]);
+});

--- a/packages/trailties/src/rack/silence-request.ts
+++ b/packages/trailties/src/rack/silence-request.ts
@@ -9,6 +9,7 @@ import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
 
 export interface Silencer {
   silence(level: number | string, fn: () => void): void;
+  silenceAsync?(level: number | string, fn: () => Promise<unknown>): Promise<unknown>;
 }
 
 export interface SilenceRequestOptions {
@@ -29,8 +30,12 @@ export class SilenceRequest {
 
   async call(env: RackEnv): Promise<RackResponse> {
     if (env["PATH_INFO"] === this.path && this.logger) {
+      const logger = this.logger;
+      if (logger.silenceAsync) {
+        return (await logger.silenceAsync(2, () => this.app(env))) as RackResponse;
+      }
       let pending: Promise<RackResponse> | undefined;
-      this.logger.silence(2, () => {
+      logger.silence(2, () => {
         pending = this.app(env);
       });
       return pending!;

--- a/packages/trailties/src/rack/silence-request.ts
+++ b/packages/trailties/src/rack/silence-request.ts
@@ -8,9 +8,13 @@
 import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
 
 export interface Silencer {
-  silence(level: number | string, fn: () => void): void;
-  silenceAsync?(level: number | string, fn: () => Promise<unknown>): Promise<unknown>;
+  silence<T>(level: number | string, fn: () => T): T;
+  silenceAsync?<T>(level: number | string, fn: () => Promise<T>): Promise<T>;
 }
+
+// Rails' Rack::SilenceRequest calls `Rails.logger.silence { ... }` with no
+// argument, which defaults to ActiveSupport::Logger::ERROR (= 3).
+const ERROR_LEVEL = 3;
 
 export interface SilenceRequestOptions {
   path: string;
@@ -32,13 +36,9 @@ export class SilenceRequest {
     if (env["PATH_INFO"] === this.path && this.logger) {
       const logger = this.logger;
       if (logger.silenceAsync) {
-        return (await logger.silenceAsync(2, () => this.app(env))) as RackResponse;
+        return logger.silenceAsync(ERROR_LEVEL, () => this.app(env));
       }
-      let pending: Promise<RackResponse> | undefined;
-      logger.silence(2, () => {
-        pending = this.app(env);
-      });
-      return pending!;
+      return logger.silence(ERROR_LEVEL, () => this.app(env));
     }
     return this.app(env);
   }

--- a/packages/trailties/src/rack/silence-request.ts
+++ b/packages/trailties/src/rack/silence-request.ts
@@ -6,6 +6,7 @@
  */
 
 import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
+import { Logger as ASLogger } from "@blazetrails/activesupport";
 
 export interface Silencer {
   silence<T>(level: number | string, fn: () => T): T;
@@ -13,8 +14,8 @@ export interface Silencer {
 }
 
 // Rails' Rack::SilenceRequest calls `Rails.logger.silence { ... }` with no
-// argument, which defaults to ActiveSupport::Logger::ERROR (= 3).
-const ERROR_LEVEL = 3;
+// argument, which defaults to ActiveSupport::Logger::ERROR.
+const ERROR_LEVEL = ASLogger.ERROR;
 
 export interface SilenceRequestOptions {
   path: string;

--- a/packages/trailties/src/rack/silence-request.ts
+++ b/packages/trailties/src/rack/silence-request.ts
@@ -9,7 +9,7 @@ import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
 import { Logger as ASLogger } from "@blazetrails/activesupport";
 
 export interface Silencer {
-  silence<T>(level: number | string, fn: () => T): T;
+  silence(level: number | string, fn: () => void): void;
   silenceAsync?<T>(level: number | string, fn: () => Promise<T>): Promise<T>;
 }
 
@@ -39,7 +39,16 @@ export class SilenceRequest {
       if (logger.silenceAsync) {
         return logger.silenceAsync(ERROR_LEVEL, () => this.app(env));
       }
-      return logger.silence(ERROR_LEVEL, () => this.app(env));
+      let pending: Promise<RackResponse> | undefined;
+      logger.silence(ERROR_LEVEL, () => {
+        pending = this.app(env);
+      });
+      if (!pending) {
+        throw new Error(
+          "Silencer.silence did not invoke callback synchronously; provide silenceAsync for async-aware silencing.",
+        );
+      }
+      return pending;
     }
     return this.app(env);
   }

--- a/packages/trailties/src/rack/silence-request.ts
+++ b/packages/trailties/src/rack/silence-request.ts
@@ -1,0 +1,40 @@
+/**
+ * Rails::Rack::SilenceRequest — silences requests to a specific path
+ * (e.g. `/up` health checks) so they don't clog the log.
+ *
+ * Port of `railties/lib/rails/rack/silence_request.rb`.
+ */
+
+import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
+
+export interface Silencer {
+  silence(level: number | string, fn: () => void): void;
+}
+
+export interface SilenceRequestOptions {
+  path: string;
+  logger?: Silencer;
+}
+
+export class SilenceRequest {
+  private app: RackApp;
+  private path: string;
+  private logger?: Silencer;
+
+  constructor(app: RackApp, options: SilenceRequestOptions) {
+    this.app = app;
+    this.path = options.path;
+    this.logger = options.logger;
+  }
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    if (env["PATH_INFO"] === this.path && this.logger) {
+      let pending: Promise<RackResponse> | undefined;
+      this.logger.silence(2, () => {
+        pending = this.app(env);
+      });
+      return pending!;
+    }
+    return this.app(env);
+  }
+}


### PR DESCRIPTION
## Summary

Ports Rails-specific Rack middleware from `railties/lib/rails/rack/` into
`packages/trailties/src/rack/`:

- `Logger` — sets log tags via the configured logger, emits the
  `Started <METHOD> "<PATH>"` line, and publishes a
  `request.action_dispatch` ActiveSupport::Notifications event when the
  response body closes (via `BodyProxy`). Tags are popped on body close.
- `SilenceRequest` — wraps the downstream app in `logger.silence` when
  `PATH_INFO` matches the configured `path` (e.g. `/up` health checks).

## Rails sources

- `railties/lib/rails/rack/logger.rb` (kept)
- `railties/lib/rails/rack/silence_request.rb` (kept)
- `railties/test/rack_logger_test.rb` (kept — verbatim names)
- `railties/test/rack_silence_request_test.rb` (kept — verbatim name)

## Intentionally skipped / adapted

- `ActiveSupport::LogSubscriber.flush_all!` — no log-subscriber registry
  in our port yet; replaced by the `request.action_dispatch` publish in
  the body-close hook.
- `instrumenter.build_handle` start/finish split — our `Notifications`
  API exposes `publish` only, so the event fires once on body close
  rather than as separate start/finish pairs. The
  `test_notification`/`test_notification_on_raise` assertions are
  adapted to verify a single published event (subscribers in our world
  only see finished events).
- `ActionDispatch::Request` wrapping — not yet ported; the middleware
  reads env keys directly.
- `Rails.logger` global — no global singleton yet; the logger is passed
  via constructor options with a no-op default.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/rack/` (6/6 pass)
- [x] `pnpm lint packages/trailties/src/rack/`
- [x] `pnpm exec tsc -p packages/trailties/tsconfig.json --noEmit`