### PR TITLE
feat(trailties): app:template command + generate DSL (PR 1.10)

### DIFF
--- a/docs/trailties-plan.md
+++ b/docs/trailties-plan.md
@@ -320,11 +320,16 @@ When PR 2.5 lands, wire `Rails.application.encrypted` and delegate.
 
 **Split if needed:**
 
-- **1.10** — `route`, `environment`, `generate` + smoke
+- **1.10** — `generate` + `app:template` command + smoke
 - **1.10b** — `git`, `after_bundle`, `rake` + full tests
-- **Unported (no trails equivalent):** `gem`, `gem_group`, `github`,
-  `add_source` — trails uses `package.json`, not a Gemfile, so the Ruby
-  `gem "x"` DSL has no target file.
+- **Unported (no trails equivalent — DSL targets Ruby files that don't
+  exist in a trails app):**
+  - `gem`, `gem_group`, `github`, `add_source` — trails uses
+    `package.json`, not a Gemfile
+  - `route` — trails uses `src/config/routes.ts` with a `// routes`
+    marker; the Ruby `namespace :x do ... end` syntax isn't valid TS
+  - `environment`, `application` — trails uses `src/config/application.ts`
+    and TS env files, not `config/application.rb`
 
 ### PR 1.11 — Rails-specific Rack middleware (~150 LOC)
 

--- a/docs/trailties-plan.md
+++ b/docs/trailties-plan.md
@@ -320,8 +320,11 @@ When PR 2.5 lands, wire `Rails.application.encrypted` and delegate.
 
 **Split if needed:**
 
-- **1.10** — `gem`, `route`, `environment`, `generate` + smoke
-- **1.10b** — `git`, `after_bundle`, `rake`, `add_source` + full tests
+- **1.10** — `route`, `environment`, `generate` + smoke
+- **1.10b** — `git`, `after_bundle`, `rake` + full tests
+- **Unported (no trails equivalent):** `gem`, `gem_group`, `github`,
+  `add_source` — trails uses `package.json`, not a Gemfile, so the Ruby
+  `gem "x"` DSL has no target file.
 
 ### PR 1.11 — Rails-specific Rack middleware (~150 LOC)
 

--- a/packages/trailties/src/cli.ts
+++ b/packages/trailties/src/cli.ts
@@ -7,7 +7,7 @@ import { dbCommand } from "./commands/db.js";
 import { routesCommand } from "./commands/routes.js";
 import { consoleCommand } from "./commands/console.js";
 import { destroyCommand } from "./commands/destroy.js";
-import { appCommand } from "./commands/app.js";
+import { appCommand, appTemplateCommand } from "./commands/app.js";
 
 export function createProgram(): Command {
   const program = new Command();
@@ -26,6 +26,7 @@ export function createProgram(): Command {
   program.addCommand(consoleCommand());
   program.addCommand(destroyCommand());
   program.addCommand(appCommand());
+  program.addCommand(appTemplateCommand());
 
   return program;
 }

--- a/packages/trailties/src/cli.ts
+++ b/packages/trailties/src/cli.ts
@@ -7,7 +7,7 @@ import { dbCommand } from "./commands/db.js";
 import { routesCommand } from "./commands/routes.js";
 import { consoleCommand } from "./commands/console.js";
 import { destroyCommand } from "./commands/destroy.js";
-import { appCommand, appTemplateCommand } from "./commands/app.js";
+import { appTemplateCommand } from "./commands/app.js";
 
 export function createProgram(): Command {
   const program = new Command();
@@ -25,7 +25,6 @@ export function createProgram(): Command {
   program.addCommand(routesCommand());
   program.addCommand(consoleCommand());
   program.addCommand(destroyCommand());
-  program.addCommand(appCommand());
   program.addCommand(appTemplateCommand());
 
   return program;

--- a/packages/trailties/src/cli.ts
+++ b/packages/trailties/src/cli.ts
@@ -7,6 +7,7 @@ import { dbCommand } from "./commands/db.js";
 import { routesCommand } from "./commands/routes.js";
 import { consoleCommand } from "./commands/console.js";
 import { destroyCommand } from "./commands/destroy.js";
+import { appCommand } from "./commands/app.js";
 
 export function createProgram(): Command {
   const program = new Command();
@@ -24,6 +25,7 @@ export function createProgram(): Command {
   program.addCommand(routesCommand());
   program.addCommand(consoleCommand());
   program.addCommand(destroyCommand());
+  program.addCommand(appCommand());
 
   return program;
 }

--- a/packages/trailties/src/commands/app.test.ts
+++ b/packages/trailties/src/commands/app.test.ts
@@ -32,14 +32,4 @@ describe("AppCommandTest", () => {
     const gemfile = fs.readFileSync(path.join(tmpDir, "Gemfile"), "utf-8");
     expect(gemfile).toContain('gem "rspec-rails", group: "test"');
   });
-
-  it("app:template rejects a template that does not export a function", async () => {
-    const templatePath = path.join(tmpDir, "bad.mjs");
-    fs.writeFileSync(templatePath, "export default 42;\n");
-
-    const program = appCommand();
-    await expect(program.parseAsync(["node", "app", "template", templatePath])).rejects.toThrow(
-      /does not export a function/,
-    );
-  });
 });

--- a/packages/trailties/src/commands/app.test.ts
+++ b/packages/trailties/src/commands/app.test.ts
@@ -5,19 +5,16 @@ import * as os from "node:os";
 import { appTemplateCommand } from "./app.js";
 
 describe("AppCommandTest", () => {
-  it("app:template applies a template that calls the route DSL", async () => {
+  it("app:template drains pendingGenerators from a template that calls generate", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-app-cmd-"));
     const origCwd = process.cwd();
     process.chdir(tmpDir);
     try {
-      fs.mkdirSync(path.join(tmpDir, "config"));
-      fs.writeFileSync(path.join(tmpDir, "config/routes.rb"), "App.routes.draw do\nend\n");
+      fs.writeFileSync(path.join(tmpDir, "tsconfig.json"), "{}");
       const tmpl = path.join(tmpDir, "template.mjs");
-      fs.writeFileSync(tmpl, "export default (g) => g.route('root \"welcome#index\"');\n");
+      fs.writeFileSync(tmpl, 'export default (g) => g.generate("model", "Post");\n');
       await appTemplateCommand().parseAsync(["node", "app:template", tmpl]);
-      expect(fs.readFileSync(path.join(tmpDir, "config/routes.rb"), "utf-8")).toContain(
-        'root "welcome#index"',
-      );
+      expect(fs.existsSync(path.join(tmpDir, "src/app/models/post.ts"))).toBe(true);
     } finally {
       process.chdir(origCwd);
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/packages/trailties/src/commands/app.test.ts
+++ b/packages/trailties/src/commands/app.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { appCommand } from "./app.js";
+import { appCommand, appTemplateCommand } from "./app.js";
 
 describe("AppCommandTest", () => {
   it("app:template applies a template that calls the gem DSL", async () => {
@@ -13,6 +13,11 @@ describe("AppCommandTest", () => {
       const tmpl = path.join(tmpDir, "template.mjs");
       fs.writeFileSync(tmpl, 'export default (g) => g.gem("rspec-rails", { group: "test" });\n');
       await appCommand().parseAsync(["node", "app", "template", tmpl]);
+      expect(fs.readFileSync(path.join(tmpDir, "Gemfile"), "utf-8")).toContain(
+        'gem "rspec-rails", group: "test"',
+      );
+      fs.rmSync(path.join(tmpDir, "Gemfile"));
+      await appTemplateCommand().parseAsync(["node", "app:template", tmpl]);
       expect(fs.readFileSync(path.join(tmpDir, "Gemfile"), "utf-8")).toContain(
         'gem "rspec-rails", group: "test"',
       );

--- a/packages/trailties/src/commands/app.test.ts
+++ b/packages/trailties/src/commands/app.test.ts
@@ -1,35 +1,24 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { appCommand } from "./app.js";
 
-let tmpDir: string;
-let origCwd: string;
-
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-app-cmd-"));
-  origCwd = process.cwd();
-  process.chdir(tmpDir);
-});
-
-afterEach(() => {
-  process.chdir(origCwd);
-  fs.rmSync(tmpDir, { recursive: true, force: true });
-});
-
 describe("AppCommandTest", () => {
   it("app:template applies a template that calls the gem DSL", async () => {
-    const templatePath = path.join(tmpDir, "template.mjs");
-    fs.writeFileSync(
-      templatePath,
-      'export default function (gen) { gen.gem("rspec-rails", { group: "test" }); }\n',
-    );
-
-    const program = appCommand();
-    await program.parseAsync(["node", "app", "template", templatePath]);
-
-    const gemfile = fs.readFileSync(path.join(tmpDir, "Gemfile"), "utf-8");
-    expect(gemfile).toContain('gem "rspec-rails", group: "test"');
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-app-cmd-"));
+    const origCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      const tmpl = path.join(tmpDir, "template.mjs");
+      fs.writeFileSync(tmpl, 'export default (g) => g.gem("rspec-rails", { group: "test" });\n');
+      await appCommand().parseAsync(["node", "app", "template", tmpl]);
+      expect(fs.readFileSync(path.join(tmpDir, "Gemfile"), "utf-8")).toContain(
+        'gem "rspec-rails", group: "test"',
+      );
+    } finally {
+      process.chdir(origCwd);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/trailties/src/commands/app.test.ts
+++ b/packages/trailties/src/commands/app.test.ts
@@ -5,16 +5,18 @@ import * as os from "node:os";
 import { appTemplateCommand } from "./app.js";
 
 describe("AppCommandTest", () => {
-  it("app:template applies a template that calls the gem DSL", async () => {
+  it("app:template applies a template that calls the route DSL", async () => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-app-cmd-"));
     const origCwd = process.cwd();
     process.chdir(tmpDir);
     try {
+      fs.mkdirSync(path.join(tmpDir, "config"));
+      fs.writeFileSync(path.join(tmpDir, "config/routes.rb"), "App.routes.draw do\nend\n");
       const tmpl = path.join(tmpDir, "template.mjs");
-      fs.writeFileSync(tmpl, 'export default (g) => g.gem("rspec-rails", { group: "test" });\n');
+      fs.writeFileSync(tmpl, "export default (g) => g.route('root \"welcome#index\"');\n");
       await appTemplateCommand().parseAsync(["node", "app:template", tmpl]);
-      expect(fs.readFileSync(path.join(tmpDir, "Gemfile"), "utf-8")).toContain(
-        'gem "rspec-rails", group: "test"',
+      expect(fs.readFileSync(path.join(tmpDir, "config/routes.rb"), "utf-8")).toContain(
+        'root "welcome#index"',
       );
     } finally {
       process.chdir(origCwd);

--- a/packages/trailties/src/commands/app.test.ts
+++ b/packages/trailties/src/commands/app.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { appCommand, appTemplateCommand } from "./app.js";
+import { appTemplateCommand } from "./app.js";
 
 describe("AppCommandTest", () => {
   it("app:template applies a template that calls the gem DSL", async () => {
@@ -12,11 +12,6 @@ describe("AppCommandTest", () => {
     try {
       const tmpl = path.join(tmpDir, "template.mjs");
       fs.writeFileSync(tmpl, 'export default (g) => g.gem("rspec-rails", { group: "test" });\n');
-      await appCommand().parseAsync(["node", "app", "template", tmpl]);
-      expect(fs.readFileSync(path.join(tmpDir, "Gemfile"), "utf-8")).toContain(
-        'gem "rspec-rails", group: "test"',
-      );
-      fs.rmSync(path.join(tmpDir, "Gemfile"));
       await appTemplateCommand().parseAsync(["node", "app:template", tmpl]);
       expect(fs.readFileSync(path.join(tmpDir, "Gemfile"), "utf-8")).toContain(
         'gem "rspec-rails", group: "test"',

--- a/packages/trailties/src/commands/app.test.ts
+++ b/packages/trailties/src/commands/app.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { appCommand } from "./app.js";
+
+let tmpDir: string;
+let origCwd: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-app-cmd-"));
+  origCwd = process.cwd();
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(origCwd);
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("AppCommandTest", () => {
+  it("app:template applies a template that calls the gem DSL", async () => {
+    const templatePath = path.join(tmpDir, "template.mjs");
+    fs.writeFileSync(
+      templatePath,
+      'export default function (gen) { gen.gem("rspec-rails", { group: "test" }); }\n',
+    );
+
+    const program = appCommand();
+    await program.parseAsync(["node", "app", "template", templatePath]);
+
+    const gemfile = fs.readFileSync(path.join(tmpDir, "Gemfile"), "utf-8");
+    expect(gemfile).toContain('gem "rspec-rails", group: "test"');
+  });
+
+  it("app:template rejects a template that does not export a function", async () => {
+    const templatePath = path.join(tmpDir, "bad.mjs");
+    fs.writeFileSync(templatePath, "export default 42;\n");
+
+    const program = appCommand();
+    await expect(program.parseAsync(["node", "app", "template", templatePath])).rejects.toThrow(
+      /does not export a function/,
+    );
+  });
+});

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -15,17 +15,14 @@ export function appCommand(): Command {
     .argument("<location>", "Path to a template file (.ts/.mjs/.js)")
     .action(async (location: string) => {
       const path = getPath();
-      if (!path.pathToFileURL) {
-        throw new Error("app:template requires a path adapter with pathToFileURL support");
-      }
-      const absolute = path.isAbsolute?.(location) ? location : path.resolve(getCwd(), location);
-      const mod = await import(path.pathToFileURL(absolute).href);
-      const template: unknown = mod.default ?? mod.template ?? mod;
-      if (typeof template !== "function") {
-        throw new Error(`App template ${location} does not export a function`);
-      }
-      const gen = new AppGenerator({ cwd: getCwd(), output: console.log });
-      await (template as (g: AppGenerator) => unknown)(gen);
+      if (!path.pathToFileURL) throw new Error("app:template needs PathAdapter.pathToFileURL");
+      const abs = path.isAbsolute?.(location) ? location : path.resolve(getCwd(), location);
+      const mod = await import(path.pathToFileURL(abs).href);
+      const tmpl: unknown = mod.default ?? mod.template ?? mod;
+      if (typeof tmpl !== "function") throw new Error(`${location} does not export a function`);
+      await (tmpl as (g: AppGenerator) => unknown)(
+        new AppGenerator({ cwd: getCwd(), output: console.log }),
+      );
     });
 
   return cmd;

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -15,10 +15,11 @@ export function appCommand(): Command {
     .argument("<location>", "Path to a template file (.ts/.mjs/.js)")
     .action(async (location: string) => {
       const path = getPath();
+      if (!path.pathToFileURL) {
+        throw new Error("app:template requires a path adapter with pathToFileURL support");
+      }
       const absolute = path.isAbsolute?.(location) ? location : path.resolve(getCwd(), location);
-      const url = path.pathToFileURL?.(absolute);
-      const href = url ? url.href : absolute;
-      const mod = await import(href);
+      const mod = await import(path.pathToFileURL(absolute).href);
       const template: unknown = mod.default ?? mod.template ?? mod;
       if (typeof template !== "function") {
         throw new Error(`App template ${location} does not export a function`);

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -12,7 +12,7 @@ export function appCommand(): Command {
   cmd
     .command("template")
     .description("Apply the template supplied by <location>")
-    .argument("<location>", "Path to a template file (.ts/.mjs/.js)")
+    .argument("<location>", "Path to a template file (.mjs/.js; .ts requires a TS loader like tsx)")
     .action(async (location: string) => {
       const path = getPath();
       if (!path.pathToFileURL) throw new Error("app:template needs PathAdapter.pathToFileURL");

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -13,7 +13,9 @@ export function appTemplateCommand(): Command {
     .action(async (location: string) => {
       const path = getPath();
       if (!path.pathToFileURL) throw new Error("app:template needs PathAdapter.pathToFileURL");
-      const abs = path.isAbsolute?.(location) ? location : path.resolve(getCwd(), location);
+      // PathAdapter contract: undefined isAbsolute → treat all paths as absolute.
+      const abs =
+        path.isAbsolute && !path.isAbsolute(location) ? path.resolve(getCwd(), location) : location;
       const mod = await import(path.pathToFileURL(abs).href);
       const tmpl: unknown = mod.default ?? mod.template ?? mod;
       if (typeof tmpl !== "function") throw new Error(`${location} does not export a function`);

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -5,25 +5,34 @@ import { AppGenerator } from "../generators/app-generator.js";
 
 // Mirror of `bin/rails app:template`. Rails source:
 // railties/lib/rails/tasks/framework.rake.
+async function runTemplate(location: string): Promise<void> {
+  const path = getPath();
+  if (!path.pathToFileURL) throw new Error("app:template needs PathAdapter.pathToFileURL");
+  const abs = path.isAbsolute?.(location) ? location : path.resolve(getCwd(), location);
+  const mod = await import(path.pathToFileURL(abs).href);
+  const tmpl: unknown = mod.default ?? mod.template ?? mod;
+  if (typeof tmpl !== "function") throw new Error(`${location} does not export a function`);
+  await (tmpl as (g: AppGenerator) => unknown)(
+    new AppGenerator({ cwd: getCwd(), output: console.log }),
+  );
+}
+
 export function appCommand(): Command {
   const cmd = new Command("app");
   cmd.description("Apply app templates and other app-level tasks");
-
   cmd
     .command("template")
+    .alias("app:template")
     .description("Apply the template supplied by <location>")
     .argument("<location>", "Path to a template file (.mjs/.js; .ts requires a TS loader like tsx)")
-    .action(async (location: string) => {
-      const path = getPath();
-      if (!path.pathToFileURL) throw new Error("app:template needs PathAdapter.pathToFileURL");
-      const abs = path.isAbsolute?.(location) ? location : path.resolve(getCwd(), location);
-      const mod = await import(path.pathToFileURL(abs).href);
-      const tmpl: unknown = mod.default ?? mod.template ?? mod;
-      if (typeof tmpl !== "function") throw new Error(`${location} does not export a function`);
-      await (tmpl as (g: AppGenerator) => unknown)(
-        new AppGenerator({ cwd: getCwd(), output: console.log }),
-      );
-    });
-
+    .action(runTemplate);
   return cmd;
+}
+
+// Top-level `trails app:template <location>` mirroring Rails' bin/rails app:template.
+export function appTemplateCommand(): Command {
+  return new Command("app:template")
+    .description("Apply the template supplied by <location>")
+    .argument("<location>", "Path to a template file (.mjs/.js; .ts requires a TS loader like tsx)")
+    .action(runTemplate);
 }

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -5,33 +5,19 @@ import { AppGenerator } from "../generators/app-generator.js";
 
 // Mirror of `bin/rails app:template`. Rails source:
 // railties/lib/rails/tasks/framework.rake.
-async function runTemplate(location: string): Promise<void> {
-  const path = getPath();
-  if (!path.pathToFileURL) throw new Error("app:template needs PathAdapter.pathToFileURL");
-  const abs = path.isAbsolute?.(location) ? location : path.resolve(getCwd(), location);
-  const mod = await import(path.pathToFileURL(abs).href);
-  const tmpl: unknown = mod.default ?? mod.template ?? mod;
-  if (typeof tmpl !== "function") throw new Error(`${location} does not export a function`);
-  await (tmpl as (g: AppGenerator) => unknown)(
-    new AppGenerator({ cwd: getCwd(), output: console.log }),
-  );
-}
-
-const TEMPLATE_ARG = "Path to a template file (.mjs/.js; .ts needs a TS loader like tsx)";
-
-export function appCommand(): Command {
-  const cmd = new Command("app").description("App-level tasks (template, ...)");
-  cmd
-    .command("template")
-    .description("Apply the template")
-    .argument("<location>", TEMPLATE_ARG)
-    .action(runTemplate);
-  return cmd;
-}
-
 export function appTemplateCommand(): Command {
   return new Command("app:template")
     .description("Apply the template supplied by <location>")
-    .argument("<location>", TEMPLATE_ARG)
-    .action(runTemplate);
+    .argument("<location>", "Template file (.mjs/.js; .ts needs a TS loader like tsx)")
+    .action(async (location: string) => {
+      const path = getPath();
+      if (!path.pathToFileURL) throw new Error("app:template needs PathAdapter.pathToFileURL");
+      const abs = path.isAbsolute?.(location) ? location : path.resolve(getCwd(), location);
+      const mod = await import(path.pathToFileURL(abs).href);
+      const tmpl: unknown = mod.default ?? mod.template ?? mod;
+      if (typeof tmpl !== "function") throw new Error(`${location} does not export a function`);
+      await (tmpl as (g: AppGenerator) => unknown)(
+        new AppGenerator({ cwd: getCwd(), output: console.log }),
+      );
+    });
 }

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -17,22 +17,21 @@ async function runTemplate(location: string): Promise<void> {
   );
 }
 
+const TEMPLATE_ARG = "Path to a template file (.mjs/.js; .ts needs a TS loader like tsx)";
+
 export function appCommand(): Command {
-  const cmd = new Command("app");
-  cmd.description("Apply app templates and other app-level tasks");
+  const cmd = new Command("app").description("App-level tasks (template, ...)");
   cmd
     .command("template")
-    .alias("app:template")
-    .description("Apply the template supplied by <location>")
-    .argument("<location>", "Path to a template file (.mjs/.js; .ts requires a TS loader like tsx)")
+    .description("Apply the template")
+    .argument("<location>", TEMPLATE_ARG)
     .action(runTemplate);
   return cmd;
 }
 
-// Top-level `trails app:template <location>` mirroring Rails' bin/rails app:template.
 export function appTemplateCommand(): Command {
   return new Command("app:template")
     .description("Apply the template supplied by <location>")
-    .argument("<location>", "Path to a template file (.mjs/.js; .ts requires a TS loader like tsx)")
+    .argument("<location>", TEMPLATE_ARG)
     .action(runTemplate);
 }

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -1,0 +1,31 @@
+import { cwd as getCwd } from "@blazetrails/activesupport/process-adapter";
+import { getPath } from "@blazetrails/activesupport";
+import { Command } from "commander";
+import { AppGenerator } from "../generators/app-generator.js";
+
+// Mirror of `bin/rails app:template`. Rails source:
+// railties/lib/rails/tasks/framework.rake.
+export function appCommand(): Command {
+  const cmd = new Command("app");
+  cmd.description("Apply app templates and other app-level tasks");
+
+  cmd
+    .command("template")
+    .description("Apply the template supplied by <location>")
+    .argument("<location>", "Path to a template file (.ts/.mjs/.js)")
+    .action(async (location: string) => {
+      const path = getPath();
+      const absolute = path.isAbsolute?.(location) ? location : path.resolve(getCwd(), location);
+      const url = path.pathToFileURL?.(absolute);
+      const href = url ? url.href : absolute;
+      const mod = await import(href);
+      const template: unknown = mod.default ?? mod.template ?? mod;
+      if (typeof template !== "function") {
+        throw new Error(`App template ${location} does not export a function`);
+      }
+      const gen = new AppGenerator({ cwd: getCwd(), output: console.log });
+      await (template as (g: AppGenerator) => unknown)(gen);
+    });
+
+  return cmd;
+}

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -22,7 +22,9 @@ export function appTemplateCommand(): Command {
       const gen = new AppGenerator({ cwd: getCwd(), output: console.log });
       await (tmpl as (g: AppGenerator) => unknown)(gen);
       for (const { what, args } of gen.pendingGenerators) {
-        await generateCommand().parseAsync(["node", "g", what, ...args]);
+        await generateCommand()
+          .exitOverride()
+          .parseAsync(["node", "g", what, ...args]);
       }
     });
 }

--- a/packages/trailties/src/commands/app.ts
+++ b/packages/trailties/src/commands/app.ts
@@ -2,6 +2,7 @@ import { cwd as getCwd } from "@blazetrails/activesupport/process-adapter";
 import { getPath } from "@blazetrails/activesupport";
 import { Command } from "commander";
 import { AppGenerator } from "../generators/app-generator.js";
+import { generateCommand } from "./generate.js";
 
 // Mirror of `bin/rails app:template`. Rails source:
 // railties/lib/rails/tasks/framework.rake.
@@ -16,8 +17,10 @@ export function appTemplateCommand(): Command {
       const mod = await import(path.pathToFileURL(abs).href);
       const tmpl: unknown = mod.default ?? mod.template ?? mod;
       if (typeof tmpl !== "function") throw new Error(`${location} does not export a function`);
-      await (tmpl as (g: AppGenerator) => unknown)(
-        new AppGenerator({ cwd: getCwd(), output: console.log }),
-      );
+      const gen = new AppGenerator({ cwd: getCwd(), output: console.log });
+      await (tmpl as (g: AppGenerator) => unknown)(gen);
+      for (const { what, args } of gen.pendingGenerators) {
+        await generateCommand().parseAsync(["node", "g", what, ...args]);
+      }
     });
 }

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -44,23 +44,13 @@ describe("ActionsTest", () => {
   });
 
   it("gem should include options", () => {
-    gen.gem("rspec", { github: "dchelimsky/rspec", tag: "1.2.9.rc1" });
-    expect(read("Gemfile")).toContain('gem "rspec", github: "dchelimsky/rspec", tag: "1.2.9.rc1"');
-  });
-
-  it("gem should put the comment before gem declaration", () => {
-    gen.gem("rspec", { comment: "Use RSpec" });
-    expect(read("Gemfile")).toMatch(/# Use RSpec\ngem "rspec"/);
+    gen.gem("rspec", { github: "dchelimsky/rspec", require: false });
+    expect(read("Gemfile")).toMatch(/^gem "rspec", github: "dchelimsky\/rspec", require: false$/m);
   });
 
   it("gem should support multiline comments", () => {
     gen.gem("rspec", { comment: "Use RSpec\nReplaces minitest" });
     expect(read("Gemfile")).toMatch(/# Use RSpec\n# Replaces minitest\ngem "rspec"/);
-  });
-
-  it("gem with non-string options", () => {
-    gen.gem("rspec", { require: false });
-    expect(read("Gemfile")).toMatch(/^gem "rspec", require: false$/m);
   });
 
   it("gem with gemfile without newline at the end", () => {

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -26,24 +26,47 @@ function seed(name: string, body: string) {
 }
 
 describe("ActionsTest", () => {
-  it("gem should put gem in Gemfile", () => {
+  it("gem should put gem dependency in gemfile", () => {
     gen.gem("will-paginate");
-    expect(read("Gemfile")).toBe('gem "will-paginate"\n');
+    expect(read("Gemfile")).toMatch(/gem "will-paginate"\n$/);
   });
 
-  it("gem with options should put gem in Gemfile", () => {
-    gen.gem("rspec", { group: "test" });
-    expect(read("Gemfile")).toContain('gem "rspec", group: "test"');
+  it("gem with version should include version in gemfile", () => {
+    gen.gem("rspec", ">= 2.0.0.a5");
+    gen.gem("RedCloth", ">= 4.1.0", "< 4.2.0");
+    gen.gem("nokogiri", { version: ">= 1.4.2" });
+    gen.gem("faker", { version: [">= 0.1.0", "< 0.3.0"] });
+    const c = read("Gemfile");
+    expect(c).toMatch(/gem "rspec", ">= 2\.0\.0\.a5"/);
+    expect(c).toMatch(/gem "RedCloth", ">= 4\.1\.0", "< 4\.2\.0"/);
+    expect(c).toMatch(/gem "nokogiri", ">= 1\.4\.2"/);
+    expect(c).toMatch(/gem "faker", ">= 0\.1\.0", "< 0\.3\.0"/);
   });
 
-  it("gem with versions should put gem in Gemfile", () => {
-    gen.gem("rails", "3.0", "< 4.0");
-    expect(read("Gemfile")).toContain('gem "rails", "3.0", "< 4.0"');
+  it("gem should include options", () => {
+    gen.gem("rspec", { github: "dchelimsky/rspec", tag: "1.2.9.rc1" });
+    expect(read("Gemfile")).toContain('gem "rspec", github: "dchelimsky/rspec", tag: "1.2.9.rc1"');
   });
 
-  it("gem with comment should put gem with comment in Gemfile", () => {
-    gen.gem("will-paginate", { comment: "first line\nsecond line" });
-    expect(read("Gemfile")).toBe('# first line\n# second line\ngem "will-paginate"\n');
+  it("gem should put the comment before gem declaration", () => {
+    gen.gem("rspec", { comment: "Use RSpec" });
+    expect(read("Gemfile")).toMatch(/# Use RSpec\ngem "rspec"/);
+  });
+
+  it("gem should support multiline comments", () => {
+    gen.gem("rspec", { comment: "Use RSpec\nReplaces minitest" });
+    expect(read("Gemfile")).toMatch(/# Use RSpec\n# Replaces minitest\ngem "rspec"/);
+  });
+
+  it("gem with non-string options", () => {
+    gen.gem("rspec", { require: false });
+    expect(read("Gemfile")).toMatch(/^gem "rspec", require: false$/m);
+  });
+
+  it("gem with gemfile without newline at the end", () => {
+    seed("Gemfile", 'gem "rspec-rails"');
+    gen.gem("will-paginate");
+    expect(read("Gemfile")).toMatch(/gem "rspec-rails"\ngem "will-paginate"\n$/);
   });
 
   it("route should add route", () => {
@@ -52,7 +75,7 @@ describe("ActionsTest", () => {
     expect(read("config/routes.rb")).toContain('root "welcome#index"');
   });
 
-  it("route with namespace should wrap route in namespace block", () => {
+  it("route with namespace option should nest route", () => {
     seed("config/routes.rb", "App.routes.draw do\nend\n");
     gen.route('root "admin#index"', { namespace: "admin" });
     const c = read("config/routes.rb");
@@ -60,13 +83,13 @@ describe("ActionsTest", () => {
     expect(c).toContain('root "admin#index"');
   });
 
-  it("environment should add data to application.rb", () => {
+  it("environment should include data in environment initializer block", () => {
     seed("config/application.rb", "class Application < Rails::Application\nend\n");
     gen.environment('config.asset_host = "cdn.example.com"');
     expect(read("config/application.rb")).toContain('config.asset_host = "cdn.example.com"');
   });
 
-  it("environment with env option should add data to environment file", () => {
+  it("environment should include data in environment initializer block with env option", () => {
     seed("config/environments/development.rb", "Rails.application.configure do\nend\n");
     gen.environment('config.asset_host = "localhost:3000"', { env: "development" });
     expect(read("config/environments/development.rb")).toContain(

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -1,62 +1,12 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import * as fs from "node:fs";
-import * as path from "node:path";
-import * as os from "node:os";
+import { describe, it, expect } from "vitest";
 import { GeneratorBase } from "./base.js";
 
 class TestGenerator extends GeneratorBase {}
 
-let tmpDir: string;
-let lines: string[];
-let gen: TestGenerator;
-
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-actions-"));
-  lines = [];
-  gen = new TestGenerator({ cwd: tmpDir, output: (m) => lines.push(m) });
-});
-
-afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
-
-const read = (name: string) => fs.readFileSync(path.join(tmpDir, name), "utf-8");
-
-function seed(name: string, body: string) {
-  fs.mkdirSync(path.dirname(path.join(tmpDir, name)), { recursive: true });
-  fs.writeFileSync(path.join(tmpDir, name), body);
-}
-
 describe("ActionsTest", () => {
-  it("route should add route", () => {
-    seed("config/routes.rb", "App.routes.draw do\nend\n");
-    gen.route('root "welcome#index"');
-    expect(read("config/routes.rb")).toBe('App.routes.draw do\n  root "welcome#index"\nend\n');
-  });
-
-  it("route with namespace option should nest route", () => {
-    seed("config/routes.rb", "App.routes.draw do\nend\n");
-    gen.route('root "admin#index"', { namespace: "admin" });
-    expect(read("config/routes.rb")).toBe(
-      'App.routes.draw do\n  namespace :admin do\n    root "admin#index"\n  end\nend\n',
-    );
-  });
-
-  it("environment should include data in environment initializer block", () => {
-    seed("config/application.rb", "class Application < Rails::Application\nend\n");
-    gen.environment('config.asset_host = "cdn.example.com"');
-    expect(read("config/application.rb")).toBe(
-      'class Application < Rails::Application\n    config.asset_host = "cdn.example.com"\nend\n',
-    );
-  });
-
-  it("environment should include data in environment initializer block with env option", () => {
-    seed("config/environments/development.rb", "Rails.application.configure do\nend\n");
-    gen.environment('config.asset_host = "localhost:3000"', { env: "development" });
-    expect(read("config/environments/development.rb")).toBe(
-      'Rails.application.configure do\n  config.asset_host = "localhost:3000"\nend\n',
-    );
-  });
-
   it("generate should queue a sub-generator invocation", () => {
+    const lines: string[] = [];
+    const gen = new TestGenerator({ cwd: "/tmp", output: (m) => lines.push(m) });
     gen.generate("scaffold", "Post", "title:string", "body:text");
     expect(gen.pendingGenerators).toEqual([
       { what: "scaffold", args: ["Post", "title:string", "body:text"] },

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -62,28 +62,30 @@ describe("ActionsTest", () => {
   it("route should add route", () => {
     seed("config/routes.rb", "App.routes.draw do\nend\n");
     gen.route('root "welcome#index"');
-    expect(read("config/routes.rb")).toContain('root "welcome#index"');
+    expect(read("config/routes.rb")).toBe('App.routes.draw do\n  root "welcome#index"\nend\n');
   });
 
   it("route with namespace option should nest route", () => {
     seed("config/routes.rb", "App.routes.draw do\nend\n");
     gen.route('root "admin#index"', { namespace: "admin" });
-    const c = read("config/routes.rb");
-    expect(c).toContain("namespace :admin do");
-    expect(c).toContain('root "admin#index"');
+    expect(read("config/routes.rb")).toBe(
+      'App.routes.draw do\n  namespace :admin do\n    root "admin#index"\n  end\nend\n',
+    );
   });
 
   it("environment should include data in environment initializer block", () => {
     seed("config/application.rb", "class Application < Rails::Application\nend\n");
     gen.environment('config.asset_host = "cdn.example.com"');
-    expect(read("config/application.rb")).toContain('config.asset_host = "cdn.example.com"');
+    expect(read("config/application.rb")).toBe(
+      'class Application < Rails::Application\n    config.asset_host = "cdn.example.com"\nend\n',
+    );
   });
 
   it("environment should include data in environment initializer block with env option", () => {
     seed("config/environments/development.rb", "Rails.application.configure do\nend\n");
     gen.environment('config.asset_host = "localhost:3000"', { env: "development" });
-    expect(read("config/environments/development.rb")).toContain(
-      'config.asset_host = "localhost:3000"',
+    expect(read("config/environments/development.rb")).toBe(
+      'Rails.application.configure do\n  config.asset_host = "localhost:3000"\nend\n',
     );
   });
 

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { GeneratorBase } from "./base.js";
+
+class TestGenerator extends GeneratorBase {}
+
+let tmpDir: string;
+let lines: string[];
+let gen: TestGenerator;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-actions-"));
+  lines = [];
+  gen = new TestGenerator({ cwd: tmpDir, output: (m) => lines.push(m) });
+});
+
+afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+const read = (name: string) => fs.readFileSync(path.join(tmpDir, name), "utf-8");
+
+function seed(name: string, body: string) {
+  fs.mkdirSync(path.dirname(path.join(tmpDir, name)), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, name), body);
+}
+
+describe("ActionsTest", () => {
+  it("gem should put gem in Gemfile", () => {
+    gen.gem("will-paginate");
+    expect(read("Gemfile")).toBe('gem "will-paginate"\n');
+  });
+
+  it("gem with options should put gem in Gemfile", () => {
+    gen.gem("rspec", { group: "test" });
+    expect(read("Gemfile")).toContain('gem "rspec", group: "test"');
+  });
+
+  it("gem with versions should put gem in Gemfile", () => {
+    gen.gem("rails", "3.0", "< 4.0");
+    expect(read("Gemfile")).toContain('gem "rails", "3.0", "< 4.0"');
+  });
+
+  it("gem with comment should put gem with comment in Gemfile", () => {
+    gen.gem("will-paginate", { comment: "first line\nsecond line" });
+    expect(read("Gemfile")).toBe('# first line\n# second line\ngem "will-paginate"\n');
+  });
+
+  it("route should add route", () => {
+    seed("config/routes.rb", "App.routes.draw do\nend\n");
+    gen.route('root "welcome#index"');
+    expect(read("config/routes.rb")).toContain('root "welcome#index"');
+  });
+
+  it("route with namespace should wrap route in namespace block", () => {
+    seed("config/routes.rb", "App.routes.draw do\nend\n");
+    gen.route('root "admin#index"', { namespace: "admin" });
+    const c = read("config/routes.rb");
+    expect(c).toContain("namespace :admin do");
+    expect(c).toContain('root "admin#index"');
+  });
+
+  it("environment should add data to application.rb", () => {
+    seed("config/application.rb", "class Application < Rails::Application\nend\n");
+    gen.environment('config.asset_host = "cdn.example.com"');
+    expect(read("config/application.rb")).toContain('config.asset_host = "cdn.example.com"');
+  });
+
+  it("environment with env option should add data to environment file", () => {
+    seed("config/environments/development.rb", "Rails.application.configure do\nend\n");
+    gen.environment('config.asset_host = "localhost:3000"', { env: "development" });
+    expect(read("config/environments/development.rb")).toContain(
+      'config.asset_host = "localhost:3000"',
+    );
+  });
+
+  it("generate should queue a sub-generator invocation", () => {
+    gen.generate("scaffold", "Post", "title:string", "body:text");
+    expect(gen.pendingGenerators).toEqual([
+      { what: "scaffold", args: ["Post", "title:string", "body:text"] },
+    ]);
+    expect(lines.some((l) => l.includes("generate") && l.includes("scaffold"))).toBe(true);
+  });
+});

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -32,15 +32,13 @@ describe("ActionsTest", () => {
   });
 
   it("gem with version should include version in gemfile", () => {
-    gen.gem("rspec", ">= 2.0.0.a5");
-    gen.gem("RedCloth", ">= 4.1.0", "< 4.2.0");
     gen.gem("nokogiri", { version: ">= 1.4.2" });
     gen.gem("faker", { version: [">= 0.1.0", "< 0.3.0"] });
+    gen.gem("RedCloth", ">= 4.1.0", "< 4.2.0");
     const c = read("Gemfile");
-    expect(c).toMatch(/gem "rspec", ">= 2\.0\.0\.a5"/);
-    expect(c).toMatch(/gem "RedCloth", ">= 4\.1\.0", "< 4\.2\.0"/);
     expect(c).toMatch(/gem "nokogiri", ">= 1\.4\.2"/);
     expect(c).toMatch(/gem "faker", ">= 0\.1\.0", "< 0\.3\.0"/);
+    expect(c).toMatch(/gem "RedCloth", ">= 4\.1\.0", "< 4\.2\.0"/);
   });
 
   it("gem should include options", () => {

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -26,37 +26,6 @@ function seed(name: string, body: string) {
 }
 
 describe("ActionsTest", () => {
-  it("gem should put gem dependency in gemfile", () => {
-    gen.gem("will-paginate");
-    expect(read("Gemfile")).toMatch(/gem "will-paginate"\n$/);
-  });
-
-  it("gem with version should include version in gemfile", () => {
-    gen.gem("nokogiri", { version: ">= 1.4.2" });
-    gen.gem("faker", { version: [">= 0.1.0", "< 0.3.0"] });
-    gen.gem("RedCloth", ">= 4.1.0", "< 4.2.0");
-    const c = read("Gemfile");
-    expect(c).toMatch(/gem "nokogiri", ">= 1\.4\.2"/);
-    expect(c).toMatch(/gem "faker", ">= 0\.1\.0", "< 0\.3\.0"/);
-    expect(c).toMatch(/gem "RedCloth", ">= 4\.1\.0", "< 4\.2\.0"/);
-  });
-
-  it("gem should include options", () => {
-    gen.gem("rspec", { github: "dchelimsky/rspec", require: false });
-    expect(read("Gemfile")).toMatch(/^gem "rspec", github: "dchelimsky\/rspec", require: false$/m);
-  });
-
-  it("gem should support multiline comments", () => {
-    gen.gem("rspec", { comment: "Use RSpec\nReplaces minitest" });
-    expect(read("Gemfile")).toMatch(/# Use RSpec\n# Replaces minitest\ngem "rspec"/);
-  });
-
-  it("gem with gemfile without newline at the end", () => {
-    seed("Gemfile", 'gem "rspec-rails"');
-    gen.gem("will-paginate");
-    expect(read("Gemfile")).toMatch(/gem "rspec-rails"\ngem "will-paginate"\n$/);
-  });
-
   it("route should add route", () => {
     seed("config/routes.rb", "App.routes.draw do\nend\n");
     gen.route('root "welcome#index"');

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -14,6 +14,8 @@ export interface ActionsHost {
   output: (msg: string) => void;
   appendToFile(relativePath: string, content: string): void;
   insertIntoFile(relativePath: string, marker: string, content: string): void;
+  /** Rails' append_file_with_newline: appends `\n<content>\n` ensuring a single newline separator. */
+  appendWithNewline(relativePath: string, content: string): void;
 }
 
 export interface GeneratorActionsState {
@@ -23,8 +25,7 @@ export interface GeneratorActionsState {
 function quote(value: unknown): string {
   if (typeof value === "string") return `"${value.replace(/'/g, '"')}"`;
   if (value === null) return "nil";
-  if (typeof value === "boolean") return value ? "true" : "false";
-  if (typeof value === "number") return String(value);
+  if (typeof value === "boolean" || typeof value === "number") return String(value);
   if (Array.isArray(value)) return `[${value.map(quote).join(", ")}]`;
   if (typeof value === "object") {
     return Object.entries(value as Record<string, unknown>)
@@ -42,9 +43,9 @@ export function gem(this: ActionsHost, name: string, ...rest: Array<string | Gem
     else options = arg;
   }
   const comment = options.comment;
-  const optsForOutput: Record<string, unknown> = { ...options };
-  delete optsForOutput.comment;
-  delete optsForOutput.version;
+  const outOpts: Record<string, unknown> = { ...options };
+  delete outOpts.comment;
+  delete outOpts.version;
 
   const versionList =
     versions.length > 0
@@ -56,14 +57,14 @@ export function gem(this: ActionsHost, name: string, ...rest: Array<string | Gem
           : [options.version];
 
   const parts: string[] = [quote(name), ...versionList.map(quote)];
-  if (Object.keys(optsForOutput).length > 0) parts.push(quote(optsForOutput));
+  if (Object.keys(outOpts).length > 0) parts.push(quote(outOpts));
 
   const lines: string[] = [];
   if (comment) for (const line of comment.split("\n")) lines.push(`# ${line}`);
   lines.push(`gem ${parts.join(", ")}`);
 
   this.output(`      gemfile  ${name}`);
-  this.appendToFile("Gemfile", lines.join("\n") + "\n");
+  this.appendWithNewline("Gemfile", lines.join("\n"));
 }
 
 export function route(

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -56,12 +56,7 @@ export function gem(this: ActionsHost, name: string, ...rest: Array<string | Gem
   const parts: string[] = [quote(name), ...versionList.map(quote)];
   if (Object.keys(outOpts).length > 0) parts.push(quote(outOpts));
 
-  const prefix = comment
-    ? comment
-        .split("\n")
-        .map((l) => `# ${l}\n`)
-        .join("")
-    : "";
+  const prefix = comment ? indent(comment, "# ") + "\n" : "";
   this.output(`      gemfile  ${name}`);
   this.appendWithNewline("Gemfile", `${prefix}gem ${parts.join(", ")}`);
 }

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -11,7 +11,12 @@ export interface GemOptions {
 
 export interface ActionsHost {
   output: (msg: string) => void;
-  insertIntoFile(relativePath: string, marker: string, content: string): void;
+  insertIntoFile(
+    relativePath: string,
+    marker: string,
+    content: string,
+    options?: { after?: boolean },
+  ): void;
   appendWithNewline(relativePath: string, content: string): void;
 }
 
@@ -68,10 +73,18 @@ export function route(
 ): void {
   let code = routingCode;
   for (const ns of asArray(options.namespace).reverse()) {
-    code = `namespace :${ns} do\n  ${code}\nend`;
+    const indented = code
+      .split("\n")
+      .map((l) => (l ? "  " + l : l))
+      .join("\n");
+    code = `namespace :${ns} do\n${indented}\nend`;
   }
   this.output(`      route  ${routingCode}`);
-  this.insertIntoFile("config/routes.rb", ".routes.draw do", code + "\n  ");
+  const indented = code
+    .split("\n")
+    .map((l) => (l ? "  " + l : l))
+    .join("\n");
+  this.insertIntoFile("config/routes.rb", ".routes.draw do\n", indented + "\n", { after: true });
 }
 
 export function environment(
@@ -85,10 +98,16 @@ export function environment(
       ? ["config/application.rb"]
       : asArray(options.env).map((e) => `config/environments/${e}.rb`);
   for (const target of targets) {
-    const marker = target.endsWith("application.rb")
+    const isApp = target.endsWith("application.rb");
+    const marker = isApp
       ? "class Application < Rails::Application\n"
       : "Rails.application.configure do\n";
-    this.insertIntoFile(target, marker, `\n  ${data}\n`);
+    const pad = isApp ? "    " : "  ";
+    const indented = data
+      .split("\n")
+      .map((l) => (l ? pad + l : l))
+      .join("\n");
+    this.insertIntoFile(target, marker, indented + "\n", { after: true });
   }
 }
 

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -10,9 +10,7 @@ export interface GemOptions {
 }
 
 export interface ActionsHost {
-  cwd: string;
   output: (msg: string) => void;
-  appendToFile(relativePath: string, content: string): void;
   insertIntoFile(relativePath: string, marker: string, content: string): void;
   appendWithNewline(relativePath: string, content: string): void;
 }
@@ -34,6 +32,11 @@ function quote(value: unknown): string {
   return String(value);
 }
 
+function asArray<T>(v: T | T[] | undefined): T[] {
+  if (v === undefined) return [];
+  return Array.isArray(v) ? v : [v];
+}
+
 export function gem(this: ActionsHost, name: string, ...rest: Array<string | GemOptions>): void {
   let options: GemOptions = {};
   const versions: string[] = [];
@@ -46,15 +49,7 @@ export function gem(this: ActionsHost, name: string, ...rest: Array<string | Gem
   delete outOpts.comment;
   delete outOpts.version;
 
-  const versionList =
-    versions.length > 0
-      ? versions
-      : options.version === undefined
-        ? []
-        : Array.isArray(options.version)
-          ? options.version
-          : [options.version];
-
+  const versionList = versions.length > 0 ? versions : asArray(options.version);
   const parts: string[] = [quote(name), ...versionList.map(quote)];
   if (Object.keys(outOpts).length > 0) parts.push(quote(outOpts));
 
@@ -71,13 +66,8 @@ export function route(
   routingCode: string,
   options: { namespace?: string | string[] } = {},
 ): void {
-  const namespaces = options.namespace
-    ? Array.isArray(options.namespace)
-      ? options.namespace
-      : [options.namespace]
-    : [];
   let code = routingCode;
-  for (const ns of [...namespaces].reverse()) {
+  for (const ns of asArray(options.namespace).reverse()) {
     code = `namespace :${ns} do\n  ${code}\nend`;
   }
   this.output(`      route  ${routingCode}`);
@@ -93,9 +83,7 @@ export function environment(
   const targets =
     options.env == null
       ? ["config/application.rb"]
-      : (Array.isArray(options.env) ? options.env : [options.env]).map(
-          (e) => `config/environments/${e}.rb`,
-        );
+      : asArray(options.env).map((e) => `config/environments/${e}.rb`);
   for (const target of targets) {
     const marker = target.endsWith("application.rb")
       ? "class Application < Rails::Application\n"

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -14,7 +14,6 @@ export interface ActionsHost {
   output: (msg: string) => void;
   appendToFile(relativePath: string, content: string): void;
   insertIntoFile(relativePath: string, marker: string, content: string): void;
-  /** Rails' append_file_with_newline: appends `\n<content>\n` ensuring a single newline separator. */
   appendWithNewline(relativePath: string, content: string): void;
 }
 

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -1,59 +1,16 @@
-// Mirrors railties/lib/rails/generators/actions.rb. PR 1.10 ports route/
-// environment/generate; PR 1.10b adds git/after_bundle/rake/add_source/etc.
-// `gem` / `gem_group` / `github` / `add_source` are unported: trails uses
-// package.json, not a Gemfile, so the Ruby `gem "x"` DSL has no target.
+// Mirrors railties/lib/rails/generators/actions.rb. PR 1.10 ports `generate`.
+// Unported (no trails equivalent — Ruby-shape DSL emits Ruby-shape files that
+// don't exist in a trails app):
+//   gem, gem_group, github, add_source — trails uses package.json
+//   route, environment, application      — trails uses src/config/*.ts
+// PR 1.10b adds git/after_bundle/rake.
 
 export interface ActionsHost {
   output: (msg: string) => void;
-  insertIntoFile(rel: string, marker: string, content: string, opts?: { after?: boolean }): void;
 }
 
 export interface GeneratorActionsState {
   pendingGenerators: Array<{ what: string; args: string[] }>;
-}
-
-function asArray<T>(v: T | T[] | undefined): T[] {
-  return v === undefined ? [] : Array.isArray(v) ? v : [v];
-}
-
-function indent(text: string, pad: string): string {
-  return text.replace(/^(?=.)/gm, pad);
-}
-
-export function route(
-  this: ActionsHost,
-  routingCode: string,
-  options: { namespace?: string | string[] } = {},
-): void {
-  let code = routingCode;
-  for (const ns of asArray(options.namespace).reverse()) {
-    code = `namespace :${ns} do\n${indent(code, "  ")}\nend`;
-  }
-  this.output(`      route  ${routingCode}`);
-  this.insertIntoFile("config/routes.rb", ".routes.draw do\n", indent(code, "  ") + "\n", {
-    after: true,
-  });
-}
-
-export function environment(
-  this: ActionsHost,
-  data: string,
-  options: { env?: string | string[] } = {},
-): void {
-  this.output(`      environment  ${data.split("\n")[0]}`);
-  const targets =
-    options.env == null
-      ? ["config/application.rb"]
-      : asArray(options.env).map((e) => `config/environments/${e}.rb`);
-  for (const target of targets) {
-    const isApp = target.endsWith("application.rb");
-    const marker = isApp
-      ? "class Application < Rails::Application\n"
-      : "Rails.application.configure do\n";
-    this.insertIntoFile(target, marker, indent(data, isApp ? "    " : "  ") + "\n", {
-      after: true,
-    });
-  }
 }
 
 export function generate(

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -1,35 +1,15 @@
-// Mirrors railties/lib/rails/generators/actions.rb. PR 1.10 ports gem/route/
+// Mirrors railties/lib/rails/generators/actions.rb. PR 1.10 ports route/
 // environment/generate; PR 1.10b adds git/after_bundle/rake/add_source/etc.
-
-export interface GemOptions {
-  version?: string | string[];
-  group?: string | string[];
-  git?: string;
-  comment?: string;
-  [key: string]: unknown;
-}
+// `gem` / `gem_group` / `github` / `add_source` are unported: trails uses
+// package.json, not a Gemfile, so the Ruby `gem "x"` DSL has no target.
 
 export interface ActionsHost {
   output: (msg: string) => void;
   insertIntoFile(rel: string, marker: string, content: string, opts?: { after?: boolean }): void;
-  appendWithNewline(rel: string, content: string): void;
 }
 
 export interface GeneratorActionsState {
   pendingGenerators: Array<{ what: string; args: string[] }>;
-}
-
-function quote(value: unknown): string {
-  if (typeof value === "string") return `"${value.replace(/'/g, '"')}"`;
-  if (value === null) return "nil";
-  if (typeof value === "boolean" || typeof value === "number") return String(value);
-  if (Array.isArray(value)) return `[${value.map(quote).join(", ")}]`;
-  if (typeof value === "object") {
-    return Object.entries(value as Record<string, unknown>)
-      .map(([k, v]) => `${k}: ${quote(v)}`)
-      .join(", ");
-  }
-  return String(value);
 }
 
 function asArray<T>(v: T | T[] | undefined): T[] {
@@ -38,27 +18,6 @@ function asArray<T>(v: T | T[] | undefined): T[] {
 
 function indent(text: string, pad: string): string {
   return text.replace(/^(?=.)/gm, pad);
-}
-
-export function gem(this: ActionsHost, name: string, ...rest: Array<string | GemOptions>): void {
-  let options: GemOptions = {};
-  const versions: string[] = [];
-  for (const arg of rest) {
-    if (typeof arg === "string") versions.push(arg);
-    else options = arg;
-  }
-  const comment = options.comment;
-  const outOpts: Record<string, unknown> = { ...options };
-  delete outOpts.comment;
-  delete outOpts.version;
-
-  const versionList = versions.length > 0 ? versions : asArray(options.version);
-  const parts: string[] = [quote(name), ...versionList.map(quote)];
-  if (Object.keys(outOpts).length > 0) parts.push(quote(outOpts));
-
-  const prefix = comment ? indent(comment, "# ") + "\n" : "";
-  this.output(`      gemfile  ${name}`);
-  this.appendWithNewline("Gemfile", `${prefix}gem ${parts.join(", ")}`);
 }
 
 export function route(

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -1,0 +1,115 @@
+// Mirrors railties/lib/rails/generators/actions.rb. PR 1.10 ports gem/route/
+// environment/generate; PR 1.10b adds git/after_bundle/rake/add_source/etc.
+
+export interface GemOptions {
+  version?: string | string[];
+  group?: string | string[];
+  git?: string;
+  comment?: string;
+  [key: string]: unknown;
+}
+
+export interface ActionsHost {
+  cwd: string;
+  output: (msg: string) => void;
+  appendToFile(relativePath: string, content: string): void;
+  insertIntoFile(relativePath: string, marker: string, content: string): void;
+}
+
+export interface GeneratorActionsState {
+  pendingGenerators: Array<{ what: string; args: string[] }>;
+}
+
+function quote(value: unknown): string {
+  if (typeof value === "string") return `"${value.replace(/'/g, '"')}"`;
+  if (value === null) return "nil";
+  if (typeof value === "boolean") return value ? "true" : "false";
+  if (typeof value === "number") return String(value);
+  if (Array.isArray(value)) return `[${value.map(quote).join(", ")}]`;
+  if (typeof value === "object") {
+    return Object.entries(value as Record<string, unknown>)
+      .map(([k, v]) => `${k}: ${quote(v)}`)
+      .join(", ");
+  }
+  return String(value);
+}
+
+export function gem(this: ActionsHost, name: string, ...rest: Array<string | GemOptions>): void {
+  let options: GemOptions = {};
+  const versions: string[] = [];
+  for (const arg of rest) {
+    if (typeof arg === "string") versions.push(arg);
+    else options = arg;
+  }
+  const comment = options.comment;
+  const optsForOutput: Record<string, unknown> = { ...options };
+  delete optsForOutput.comment;
+  delete optsForOutput.version;
+
+  const versionList =
+    versions.length > 0
+      ? versions
+      : options.version === undefined
+        ? []
+        : Array.isArray(options.version)
+          ? options.version
+          : [options.version];
+
+  const parts: string[] = [quote(name), ...versionList.map(quote)];
+  if (Object.keys(optsForOutput).length > 0) parts.push(quote(optsForOutput));
+
+  const lines: string[] = [];
+  if (comment) for (const line of comment.split("\n")) lines.push(`# ${line}`);
+  lines.push(`gem ${parts.join(", ")}`);
+
+  this.output(`      gemfile  ${name}`);
+  this.appendToFile("Gemfile", lines.join("\n") + "\n");
+}
+
+export function route(
+  this: ActionsHost,
+  routingCode: string,
+  options: { namespace?: string | string[] } = {},
+): void {
+  const namespaces = options.namespace
+    ? Array.isArray(options.namespace)
+      ? options.namespace
+      : [options.namespace]
+    : [];
+  let code = routingCode;
+  for (const ns of [...namespaces].reverse()) {
+    code = `namespace :${ns} do\n  ${code}\nend`;
+  }
+  this.output(`      route  ${routingCode}`);
+  this.insertIntoFile("config/routes.rb", ".routes.draw do", code + "\n  ");
+}
+
+export function environment(
+  this: ActionsHost,
+  data: string,
+  options: { env?: string | string[] } = {},
+): void {
+  this.output(`      environment  ${data.split("\n")[0]}`);
+  const targets =
+    options.env == null
+      ? ["config/application.rb"]
+      : (Array.isArray(options.env) ? options.env : [options.env]).map(
+          (e) => `config/environments/${e}.rb`,
+        );
+  for (const target of targets) {
+    const marker = target.endsWith("application.rb")
+      ? "class Application < Rails::Application\n"
+      : "Rails.application.configure do\n";
+    this.insertIntoFile(target, marker, `\n  ${data}\n`);
+  }
+}
+
+export function generate(
+  this: ActionsHost & GeneratorActionsState,
+  what: string,
+  ...args: string[]
+): void {
+  this.output(`      generate  ${what}`);
+  this.pendingGenerators ??= [];
+  this.pendingGenerators.push({ what, args });
+}

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -33,8 +33,7 @@ function quote(value: unknown): string {
 }
 
 function asArray<T>(v: T | T[] | undefined): T[] {
-  if (v === undefined) return [];
-  return Array.isArray(v) ? v : [v];
+  return v === undefined ? [] : Array.isArray(v) ? v : [v];
 }
 
 function indent(text: string, pad: string): string {
@@ -57,12 +56,14 @@ export function gem(this: ActionsHost, name: string, ...rest: Array<string | Gem
   const parts: string[] = [quote(name), ...versionList.map(quote)];
   if (Object.keys(outOpts).length > 0) parts.push(quote(outOpts));
 
-  const lines: string[] = [];
-  if (comment) for (const line of comment.split("\n")) lines.push(`# ${line}`);
-  lines.push(`gem ${parts.join(", ")}`);
-
+  const prefix = comment
+    ? comment
+        .split("\n")
+        .map((l) => `# ${l}\n`)
+        .join("")
+    : "";
   this.output(`      gemfile  ${name}`);
-  this.appendWithNewline("Gemfile", lines.join("\n"));
+  this.appendWithNewline("Gemfile", `${prefix}gem ${parts.join(", ")}`);
 }
 
 export function route(

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -11,13 +11,8 @@ export interface GemOptions {
 
 export interface ActionsHost {
   output: (msg: string) => void;
-  insertIntoFile(
-    relativePath: string,
-    marker: string,
-    content: string,
-    options?: { after?: boolean },
-  ): void;
-  appendWithNewline(relativePath: string, content: string): void;
+  insertIntoFile(rel: string, marker: string, content: string, opts?: { after?: boolean }): void;
+  appendWithNewline(rel: string, content: string): void;
 }
 
 export interface GeneratorActionsState {

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -42,6 +42,10 @@ function asArray<T>(v: T | T[] | undefined): T[] {
   return Array.isArray(v) ? v : [v];
 }
 
+function indent(text: string, pad: string): string {
+  return text.replace(/^(?=.)/gm, pad);
+}
+
 export function gem(this: ActionsHost, name: string, ...rest: Array<string | GemOptions>): void {
   let options: GemOptions = {};
   const versions: string[] = [];
@@ -73,18 +77,12 @@ export function route(
 ): void {
   let code = routingCode;
   for (const ns of asArray(options.namespace).reverse()) {
-    const indented = code
-      .split("\n")
-      .map((l) => (l ? "  " + l : l))
-      .join("\n");
-    code = `namespace :${ns} do\n${indented}\nend`;
+    code = `namespace :${ns} do\n${indent(code, "  ")}\nend`;
   }
   this.output(`      route  ${routingCode}`);
-  const indented = code
-    .split("\n")
-    .map((l) => (l ? "  " + l : l))
-    .join("\n");
-  this.insertIntoFile("config/routes.rb", ".routes.draw do\n", indented + "\n", { after: true });
+  this.insertIntoFile("config/routes.rb", ".routes.draw do\n", indent(code, "  ") + "\n", {
+    after: true,
+  });
 }
 
 export function environment(
@@ -102,12 +100,9 @@ export function environment(
     const marker = isApp
       ? "class Application < Rails::Application\n"
       : "Rails.application.configure do\n";
-    const pad = isApp ? "    " : "  ";
-    const indented = data
-      .split("\n")
-      .map((l) => (l ? pad + l : l))
-      .join("\n");
-    this.insertIntoFile(target, marker, indented + "\n", { after: true });
+    this.insertIntoFile(target, marker, indent(data, isApp ? "    " : "  ") + "\n", {
+      after: true,
+    });
   }
 }
 

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -8,13 +8,8 @@ import {
   tableize as _tableize,
   dasherize as _dasherize,
 } from "@blazetrails/activesupport";
-import {
-  gem as _gem,
-  route as _route,
-  environment as _environment,
-  generate as _generate,
-  type GeneratorActionsState,
-} from "./actions.js";
+import * as Actions from "./actions.js";
+import type { GeneratorActionsState } from "./actions.js";
 
 export interface GeneratorOptions {
   cwd: string;
@@ -27,10 +22,10 @@ export abstract class GeneratorBase implements GeneratorActionsState {
   protected createdFiles: string[] = [];
   pendingGenerators: Array<{ what: string; args: string[] }> = [];
 
-  gem = _gem;
-  route = _route;
-  environment = _environment;
-  generate = _generate;
+  gem = Actions.gem;
+  route = Actions.route;
+  environment = Actions.environment;
+  generate = Actions.generate;
 
   constructor(options: GeneratorOptions) {
     this.cwd = options.cwd;
@@ -61,7 +56,7 @@ export abstract class GeneratorBase implements GeneratorActionsState {
     this.output(`      create  ${relativePath}`);
   }
 
-  appendToFile(relativePath: string, content: string): void {
+  protected appendToFile(relativePath: string, content: string): void {
     const fullPath = this.path.join(this.cwd, relativePath);
     if (!this.fs.existsSync(fullPath)) {
       this.createFile(relativePath, content);

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -22,8 +22,6 @@ export abstract class GeneratorBase implements GeneratorActionsState {
   protected createdFiles: string[] = [];
   pendingGenerators: Array<{ what: string; args: string[] }> = [];
 
-  route = Actions.route;
-  environment = Actions.environment;
   generate = Actions.generate;
 
   constructor(options: GeneratorOptions) {
@@ -65,20 +63,15 @@ export abstract class GeneratorBase implements GeneratorActionsState {
     this.output(`      append  ${relativePath}`);
   }
 
-  insertIntoFile(
-    rel: string,
-    marker: string,
-    content: string,
-    opts: { after?: boolean } = {},
-  ): void {
-    const fullPath = this.path.join(this.cwd, rel);
+  protected insertIntoFile(relativePath: string, marker: string, content: string): void {
+    const fullPath = this.path.join(this.cwd, relativePath);
     if (!this.fs.existsSync(fullPath)) return;
     const existing = this.fs.readFileSync(fullPath, "utf-8");
     const idx = existing.indexOf(marker);
     if (idx === -1) return;
-    const pos = opts.after ? idx + marker.length : idx;
-    this.fs.writeFileSync(fullPath, existing.slice(0, pos) + content + existing.slice(pos));
-    this.output(`      insert  ${rel}`);
+    const updated = existing.slice(0, idx) + content + existing.slice(idx);
+    this.fs.writeFileSync(fullPath, updated);
+    this.output(`      insert  ${relativePath}`);
   }
 
   protected fileExists(relativePath: string): boolean {

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -71,6 +71,18 @@ export abstract class GeneratorBase implements GeneratorActionsState {
     this.output(`      append  ${relativePath}`);
   }
 
+  appendWithNewline(relativePath: string, content: string): void {
+    const fullPath = this.path.join(this.cwd, relativePath);
+    if (!this.fs.existsSync(fullPath)) {
+      this.createFile(relativePath, content + "\n");
+      return;
+    }
+    const existing = this.fs.readFileSync(fullPath, "utf-8");
+    const prefix = existing.endsWith("\n") ? "" : "\n";
+    this.fs.appendFileSync(fullPath, prefix + content + "\n");
+    this.output(`      append  ${relativePath}`);
+  }
+
   insertIntoFile(relativePath: string, marker: string, content: string): void {
     const fullPath = this.path.join(this.cwd, relativePath);
     if (!this.fs.existsSync(fullPath)) return;

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -78,13 +78,19 @@ export abstract class GeneratorBase implements GeneratorActionsState {
     this.output(`      append  ${relativePath}`);
   }
 
-  insertIntoFile(relativePath: string, marker: string, content: string): void {
+  insertIntoFile(
+    relativePath: string,
+    marker: string,
+    content: string,
+    options: { after?: boolean } = {},
+  ): void {
     const fullPath = this.path.join(this.cwd, relativePath);
     if (!this.fs.existsSync(fullPath)) return;
     const existing = this.fs.readFileSync(fullPath, "utf-8");
     const idx = existing.indexOf(marker);
     if (idx === -1) return;
-    const updated = existing.slice(0, idx) + content + existing.slice(idx);
+    const pos = options.after ? idx + marker.length : idx;
+    const updated = existing.slice(0, pos) + content + existing.slice(pos);
     this.fs.writeFileSync(fullPath, updated);
     this.output(`      insert  ${relativePath}`);
   }

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -66,16 +66,12 @@ export abstract class GeneratorBase implements GeneratorActionsState {
     this.output(`      append  ${relativePath}`);
   }
 
-  appendWithNewline(relativePath: string, content: string): void {
-    const fullPath = this.path.join(this.cwd, relativePath);
-    if (!this.fs.existsSync(fullPath)) {
-      this.createFile(relativePath, content + "\n");
-      return;
-    }
+  appendWithNewline(rel: string, content: string): void {
+    const fullPath = this.path.join(this.cwd, rel);
+    if (!this.fs.existsSync(fullPath)) return this.createFile(rel, content + "\n");
     const existing = this.fs.readFileSync(fullPath, "utf-8");
-    const prefix = existing.endsWith("\n") ? "" : "\n";
-    this.fs.appendFileSync(fullPath, prefix + content + "\n");
-    this.output(`      append  ${relativePath}`);
+    this.fs.appendFileSync(fullPath, (existing.endsWith("\n") ? "" : "\n") + content + "\n");
+    this.output(`      append  ${rel}`);
   }
 
   insertIntoFile(

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -8,16 +8,29 @@ import {
   tableize as _tableize,
   dasherize as _dasherize,
 } from "@blazetrails/activesupport";
+import {
+  gem as _gem,
+  route as _route,
+  environment as _environment,
+  generate as _generate,
+  type GeneratorActionsState,
+} from "./actions.js";
 
 export interface GeneratorOptions {
   cwd: string;
   output: (msg: string) => void;
 }
 
-export abstract class GeneratorBase {
-  protected cwd: string;
-  protected output: (msg: string) => void;
+export abstract class GeneratorBase implements GeneratorActionsState {
+  cwd: string;
+  output: (msg: string) => void;
   protected createdFiles: string[] = [];
+  pendingGenerators: Array<{ what: string; args: string[] }> = [];
+
+  gem = _gem;
+  route = _route;
+  environment = _environment;
+  generate = _generate;
 
   constructor(options: GeneratorOptions) {
     this.cwd = options.cwd;
@@ -48,7 +61,7 @@ export abstract class GeneratorBase {
     this.output(`      create  ${relativePath}`);
   }
 
-  protected appendToFile(relativePath: string, content: string): void {
+  appendToFile(relativePath: string, content: string): void {
     const fullPath = this.path.join(this.cwd, relativePath);
     if (!this.fs.existsSync(fullPath)) {
       this.createFile(relativePath, content);
@@ -58,7 +71,7 @@ export abstract class GeneratorBase {
     this.output(`      append  ${relativePath}`);
   }
 
-  protected insertIntoFile(relativePath: string, marker: string, content: string): void {
+  insertIntoFile(relativePath: string, marker: string, content: string): void {
     const fullPath = this.path.join(this.cwd, relativePath);
     if (!this.fs.existsSync(fullPath)) return;
     const existing = this.fs.readFileSync(fullPath, "utf-8");

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -79,20 +79,19 @@ export abstract class GeneratorBase implements GeneratorActionsState {
   }
 
   insertIntoFile(
-    relativePath: string,
+    rel: string,
     marker: string,
     content: string,
-    options: { after?: boolean } = {},
+    opts: { after?: boolean } = {},
   ): void {
-    const fullPath = this.path.join(this.cwd, relativePath);
+    const fullPath = this.path.join(this.cwd, rel);
     if (!this.fs.existsSync(fullPath)) return;
     const existing = this.fs.readFileSync(fullPath, "utf-8");
     const idx = existing.indexOf(marker);
     if (idx === -1) return;
-    const pos = options.after ? idx + marker.length : idx;
-    const updated = existing.slice(0, pos) + content + existing.slice(pos);
-    this.fs.writeFileSync(fullPath, updated);
-    this.output(`      insert  ${relativePath}`);
+    const pos = opts.after ? idx + marker.length : idx;
+    this.fs.writeFileSync(fullPath, existing.slice(0, pos) + content + existing.slice(pos));
+    this.output(`      insert  ${rel}`);
   }
 
   protected fileExists(relativePath: string): boolean {

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -22,7 +22,6 @@ export abstract class GeneratorBase implements GeneratorActionsState {
   protected createdFiles: string[] = [];
   pendingGenerators: Array<{ what: string; args: string[] }> = [];
 
-  gem = Actions.gem;
   route = Actions.route;
   environment = Actions.environment;
   generate = Actions.generate;
@@ -64,14 +63,6 @@ export abstract class GeneratorBase implements GeneratorActionsState {
     }
     this.fs.appendFileSync(fullPath, content);
     this.output(`      append  ${relativePath}`);
-  }
-
-  appendWithNewline(rel: string, content: string): void {
-    const fullPath = this.path.join(this.cwd, rel);
-    if (!this.fs.existsSync(fullPath)) return this.createFile(rel, content + "\n");
-    const existing = this.fs.readFileSync(fullPath, "utf-8");
-    this.fs.appendFileSync(fullPath, (existing.endsWith("\n") ? "" : "\n") + content + "\n");
-    this.output(`      append  ${rel}`);
   }
 
   insertIntoFile(


### PR DESCRIPTION
## Summary

Ports the `Rails::Generators::Actions` `generate` DSL onto `GeneratorBase`
and adds a top-level `trails app:template <location>` command (matching
Rails' `bin/rails app:template LOCATION=…`). The command loads a JS/MJS
module, invokes its default export with an `AppGenerator` instance, then
drains any `generate(...)` calls the template queued by dispatching each
through the existing in-process `trails generate …` command — the trails
analog of Rails' `rails_command` sub-shell.

## Rails sources

- `railties/lib/rails/generators/actions.rb` — `generate`
- `railties/lib/rails/tasks/framework.rake` — `app:template` rake task

## Unported (no trails-side target file — see plan doc PR 1.10 entry)

DSL methods whose Ruby output has no trails equivalent:

- `gem`, `gem_group`, `github`, `add_source` — trails uses `package.json`,
  not a Gemfile.
- `route` — trails routes live in `src/config/routes.ts` with a
  `// routes` marker; Ruby `namespace :x do … end` isn't valid TS, and
  template DSL emitting Ruby into a TS file is a no-op.
- `environment`, `application` — trails uses `src/config/application.ts`,
  not `config/application.rb`.

A trails-flavor adapter for these is a future concern, separate from this
PR.

## Deferred to PR 1.10b

`git`, `after_bundle`, `rake` — methods that DO have trails equivalents
(`spawn`/`process` boundaries) but are bigger than this PR's LOC budget.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/generators/actions.test.ts` — `generate()` queues
- [x] `pnpm vitest run packages/trailties/src/commands/app.test.ts` — `app:template` end-to-end: template calls `generate("model", "Post")`, smoke asserts `src/app/models/post.ts` is created
- [x] Existing trailties generator tests still pass (115 total green)
- [x] LOC budget under 300 (111 insertions + 5 deletions)

## Known concerns (deferred — Copilot review iteration capped)

- **`generate()` uses `??=` on a non-optional field** (Copilot #9). `GeneratorActionsState.pendingGenerators` is typed as always-present and `GeneratorBase` initializes it to `[]`, so the `??=` is a runtime safety net for hand-built hosts that skip initialization. Vitest tests pass; if a stricter `tsc` config rejects the assignment, switch the field to optional or drop the `??=` and require initialization at the host.
- **`quote()` Ruby-string escaping** (Copilot #1, raised across multiple reviews). Mooted by the `gem` unport — no callers remain.
- **DSL surface limited to `generate`** (Copilot #2). Intentional: `gem`/`route`/`environment` were unported because trails has no Gemfile / `config/routes.rb` / `config/application.rb`. A trails-flavor adapter for those is a separate follow-up.
