### PR TITLE
feat(trailties): NamedBase + GeneratedAttribute + Base reconciliation (PR 1.12)

### DIFF
--- a/packages/trailties/src/generators/generated-attribute.test.ts
+++ b/packages/trailties/src/generators/generated-attribute.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { GeneratedAttribute, GeneratorError } from "./generated-attribute.js";
+
+describe("GeneratedAttribute", () => {
+  it("test_field_name_with_dangerous_attribute_raises_error", () => {
+    expect(() => GeneratedAttribute.parse("save:string")).toThrow(GeneratorError);
+  });
+
+  it("test_field_type_returns_number_field", () => {
+    const ft = (s: string) => GeneratedAttribute.parse(s).fieldType();
+    expect(ft("age:integer")).toBe("number_field");
+    expect(ft("body:text")).toBe("textarea");
+    expect(ft("body:rich_text")).toBe("rich_textarea");
+    expect(ft("avatar:attachment")).toBe("file_field");
+    expect(ft("photos:attachments")).toBe("file_field");
+    expect(ft("born:date")).toBe("date_field");
+    expect(ft("at:datetime")).toBe("datetime_field");
+    expect(ft("when:time")).toBe("time_field");
+    expect(ft("admin:boolean")).toBe("checkbox");
+    expect(ft("title:string")).toBe("text_field");
+  });
+
+  it("test_decimal_precision_and_scale_options", () => {
+    const dec = GeneratedAttribute.parse("price:decimal{10,2}");
+    expect([dec.type, dec.attrOptions.precision, dec.attrOptions.scale, dec.toString()]).toEqual([
+      "decimal",
+      10,
+      2,
+      "price:decimal{10,2}",
+    ]);
+    expect(GeneratedAttribute.parse("title:string!").attrOptions.null).toBe(false);
+    const email = GeneratedAttribute.parse("email:index");
+    expect([email.type, email.hasIndex()]).toEqual(["string", true]);
+    const uniq = GeneratedAttribute.parse("post:references:uniq");
+    expect([uniq.attrOptions.index, uniq.hasUniqIndex()]).toEqual([{ unique: true }, true]);
+  });
+
+  it("test_virtual_password_digest_token_and_foreign_key", () => {
+    expect(GeneratedAttribute.parse("body:rich_text").virtual()).toBe(true);
+    expect(GeneratedAttribute.parse("title:string").virtual()).toBe(false);
+    expect(GeneratedAttribute.parse("password:digest").passwordDigest()).toBe(true);
+    expect(GeneratedAttribute.parse("api:token").token()).toBe(true);
+    expect(GeneratedAttribute.parse("post_id:integer").foreignKey()).toBe(true);
+    const a = GeneratedAttribute.parse("post_id:integer");
+    expect([a.singularName(), a.pluralName()]).toEqual(["post", "posts"]);
+  });
+
+  it("test_field_type_with_unknown_type_raises_error", () => {
+    expect(() => GeneratedAttribute.parse("title:bogus")).toThrow(GeneratorError);
+    expect(() => GeneratedAttribute.parse("title:string:bogus")).toThrow(GeneratorError);
+  });
+
+  it("test_human_name", () => {
+    expect(GeneratedAttribute.parse("first_name:string").humanName()).toBe("First name");
+    expect(GeneratedAttribute.parse("title").type).toBe("string");
+  });
+
+  it("test_size_option_can_be_passed_to_string_text_and_binary", () => {
+    expect(GeneratedAttribute.parse("notes:text{medium}").attrOptions.size).toBe("medium");
+    expect(GeneratedAttribute.parse("title:string{40}").attrOptions.limit).toBe(40);
+  });
+
+  it("test_reference_is_true", () => {
+    expect(GeneratedAttribute.parse("post:references").reference()).toBe(true);
+    expect(GeneratedAttribute.parse("title:string").reference()).toBe(false);
+    expect(GeneratedAttribute.parse("post:references{polymorphic}").polymorphic()).toBe(true);
+  });
+
+  it("test_handles_index_names_for_references", () => {
+    const p = GeneratedAttribute.parse("post:references");
+    expect([p.indexName(), p.columnName()]).toEqual(["post_id", "post_id"]);
+    expect(GeneratedAttribute.parse("post:references{polymorphic}").indexName()).toEqual([
+      "post_id",
+      "post_type",
+    ]);
+    expect(GeneratedAttribute.parse("title:string").columnName()).toBe("title");
+    expect(GeneratedAttribute.parse("title:string").toString()).toBe("title:string");
+    expect(GeneratedAttribute.parse("title:string:index").toString()).toBe("title:string:index");
+    expect(GeneratedAttribute.parse("title:string:uniq").toString()).toBe("title:string:uniq");
+  });
+});

--- a/packages/trailties/src/generators/generated-attribute.ts
+++ b/packages/trailties/src/generators/generated-attribute.ts
@@ -1,0 +1,129 @@
+import { humanize, pluralize, singularize } from "@blazetrails/activesupport";
+
+export class GeneratorError extends Error {}
+
+export type AttrOptions = Record<string, unknown>;
+export type IndexType = "index" | "uniq" | undefined;
+
+const INDEX_OPTIONS = ["index", "uniq"];
+const UNIQ_INDEX_OPTIONS = ["uniq"];
+const DEFAULT_TYPES = new Set(
+  "attachment attachments belongs_to boolean date datetime decimal digest float integer references rich_text string text time timestamp token".split(
+    " ",
+  ),
+);
+const DANGEROUS = new Set(["id", "type", "save", "destroy", "errors", "attributes"]);
+const FIELD_TYPES = Object.fromEntries(
+  "integer:number_field time:time_field datetime:datetime_field timestamp:datetime_field date:date_field text:textarea rich_text:rich_textarea boolean:checkbox attachment:file_field attachments:file_field"
+    .split(" ")
+    .map((p) => p.split(":")),
+);
+
+export class GeneratedAttribute {
+  name: string;
+  type: string;
+  attrOptions: AttrOptions;
+  private _hasIndex: boolean;
+  private _hasUniqIndex: boolean;
+
+  static parse(columnDefinition: string): GeneratedAttribute {
+    const [name, rawType, rawIndex] = columnDefinition.split(":");
+    let type: string | undefined = rawType;
+    let indexType: string | undefined = rawIndex;
+    if (type && GeneratedAttribute.validIndexType(type)) {
+      indexType = type;
+      type = undefined;
+    }
+    const [parsedType, opts] = parseTypeAndOptions(type);
+    const finalType = parsedType ?? "string";
+    if (DANGEROUS.has(name!)) {
+      throw new GeneratorError(
+        `Could not generate field '${name}', as it is already defined by Active Record.`,
+      );
+    }
+    if (parsedType && !GeneratedAttribute.validType(parsedType)) {
+      throw new GeneratorError(
+        `Could not generate field '${name}' with unknown type '${parsedType}'.`,
+      );
+    }
+    if (indexType && !GeneratedAttribute.validIndexType(indexType)) {
+      throw new GeneratorError(
+        `Could not generate field '${name}' with unknown index '${indexType}'.`,
+      );
+    }
+    if (parsedType && GeneratedAttribute.reference(finalType) && indexType === "uniq") {
+      opts.index = { unique: true };
+    }
+    return new GeneratedAttribute(name!, finalType, indexType as IndexType, opts);
+  }
+
+  static validType = (t: string): boolean => DEFAULT_TYPES.has(t);
+  static validIndexType = (t: string | undefined): boolean => INDEX_OPTIONS.includes(t ?? "");
+  static reference = (t: string): boolean => t === "references" || t === "belongs_to";
+
+  constructor(name: string, type = "string", indexType?: IndexType, attrOptions: AttrOptions = {}) {
+    this.name = name;
+    this.type = type;
+    this._hasIndex = INDEX_OPTIONS.includes(indexType ?? "");
+    this._hasUniqIndex = UNIQ_INDEX_OPTIONS.includes(indexType ?? "");
+    this.attrOptions = attrOptions;
+  }
+
+  humanName = (): string => humanize(this.name);
+  pluralName = (): string => pluralize(this.name.replace(/_id$/, ""));
+  singularName = (): string => singularize(this.name.replace(/_id$/, ""));
+  columnName = (): string => (this.reference() ? `${this.name}_id` : this.name);
+  indexName = (): string | string[] =>
+    this.polymorphic() ? [`${this.name}_id`, `${this.name}_type`] : this.columnName();
+  foreignKey = (): boolean => this.name.endsWith("_id");
+  reference = (): boolean => GeneratedAttribute.reference(this.type);
+  polymorphic = (): boolean => Boolean(this.attrOptions.polymorphic);
+  hasIndex = (): boolean => this._hasIndex;
+  hasUniqIndex = (): boolean => this._hasUniqIndex;
+  passwordDigest = (): boolean => this.name === "password" && this.type === "digest";
+  token = (): boolean => this.type === "token";
+  richText = (): boolean => this.type === "rich_text";
+  attachment = (): boolean => this.type === "attachment";
+  attachments = (): boolean => this.type === "attachments";
+  virtual = (): boolean => this.richText() || this.attachment() || this.attachments();
+
+  fieldType(): string {
+    return FIELD_TYPES[this.type] ?? "text_field";
+  }
+
+  toString(): string {
+    const opts = printOptions(this.attrOptions);
+    if (this.hasUniqIndex()) return `${this.name}:${this.type}${opts}:uniq`;
+    if (this.hasIndex()) return `${this.name}:${this.type}${opts}:index`;
+    return `${this.name}:${this.type}${opts}`;
+  }
+}
+
+function parseTypeAndOptions(type: string | undefined): [string | undefined, AttrOptions] {
+  if (!type) return [undefined, {}];
+  let parsedType: string | undefined;
+  const opts: AttrOptions = {};
+  let m: RegExpMatchArray | null;
+  if ((m = type.match(/^(text|binary)\{([a-z]+)\}$/))) [parsedType, opts.size] = [m[1], m[2]];
+  else if ((m = type.match(/^(string|text|binary|integer)\{(\d+)\}$/))) {
+    [parsedType, opts.limit] = [m[1], parseInt(m[2]!, 10)];
+  } else if ((m = type.match(/^decimal\{(\d+)[,.-](\d+)\}$/))) {
+    parsedType = "decimal";
+    opts.precision = parseInt(m[1]!, 10);
+    opts.scale = parseInt(m[2]!, 10);
+  } else if ((m = type.match(/^(references|belongs_to)\{(.+)\}$/))) {
+    parsedType = m[1];
+    for (const o of m[2]!.split(/[,.-]/)) opts[o] = true;
+  } else parsedType = type.replace(/!/g, "");
+  if (type.endsWith("!")) opts.null = false;
+  return [parsedType, opts];
+}
+
+function printOptions(opts: AttrOptions): string {
+  const k = Object.keys(opts);
+  if (k.length === 0) return "";
+  if (opts.size) return `{${opts.size}}`;
+  if (opts.limit != null) return `{${opts.limit}}`;
+  if (opts.precision != null && opts.scale != null) return `{${opts.precision},${opts.scale}}`;
+  return `{${k.join(",")}}`;
+}

--- a/packages/trailties/src/generators/index.ts
+++ b/packages/trailties/src/generators/index.ts
@@ -7,3 +7,7 @@ export { ControllerGenerator } from "./controller-generator.js";
 export { ScaffoldGenerator } from "./scaffold-generator.js";
 export { GeneratorBase } from "./base.js";
 export type { GeneratorOptions } from "./base.js";
+export { NamedBase } from "./named-base.js";
+export type { NamedBaseOptions } from "./named-base.js";
+export { GeneratedAttribute, GeneratorError } from "./generated-attribute.js";
+export type { AttrOptions, IndexType } from "./generated-attribute.js";

--- a/packages/trailties/src/generators/named-base.test.ts
+++ b/packages/trailties/src/generators/named-base.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { NamedBase } from "./named-base.js";
+
+function build(name: string, attributes: string[] = []): NamedBase {
+  return new NamedBase({ cwd: "/", output: () => {}, name, attributes });
+}
+
+describe("NamedBase", () => {
+  it("test_named_generator_with_underscore", () => {
+    const g = build("admin_user");
+    expect(g.fileName).toBe("admin_user");
+    expect(g.className()).toBe("AdminUser");
+    expect(g.tableName()).toBe("admin_users");
+  });
+
+  it("test_named_generator_attributes", () => {
+    const g = build("post", ["title:string", "body:text"]);
+    expect(g.attributes.map((a) => a.name)).toEqual(["title", "body"]);
+  });
+
+  it("test_namespaced_scaffold_plural_names", () => {
+    const g = build("admin/post");
+    expect(g.className()).toBe("Admin::Post");
+    expect(g.filePath()).toBe("admin/post");
+    expect(g.tableName()).toBe("admin_posts");
+  });
+
+  it("test_scaffold_plural_names", () => {
+    const g = build("post");
+    expect([g.pluralName(), g.singularName(), g.pluralTableName(), g.singularTableName()]).toEqual([
+      "posts",
+      "post",
+      "posts",
+      "post",
+    ]);
+  });
+});

--- a/packages/trailties/src/generators/named-base.ts
+++ b/packages/trailties/src/generators/named-base.ts
@@ -1,0 +1,49 @@
+import { underscore, camelize, pluralize, singularize, humanize } from "@blazetrails/activesupport";
+import { GeneratorBase, type GeneratorOptions } from "./base.js";
+import { GeneratedAttribute } from "./generated-attribute.js";
+
+export interface NamedBaseOptions extends GeneratorOptions {
+  name: string;
+  attributes?: string[];
+}
+
+export class NamedBase extends GeneratorBase {
+  name: string;
+  attributes: GeneratedAttribute[];
+  classPathParts: string[];
+  fileName: string;
+
+  constructor(options: NamedBaseOptions) {
+    super(options);
+    this.name = options.name;
+    const parts = this.name.includes("/") ? this.name.split("/") : this.name.split("::");
+    const underscored = parts.map((p) => underscore(p));
+    this.fileName = underscored.pop()!;
+    this.classPathParts = underscored;
+    this.attributes = (options.attributes ?? []).map((a) => GeneratedAttribute.parse(a));
+  }
+
+  singularName = (): string => this.fileName;
+  pluralName = (): string => pluralize(this.fileName);
+  humanName = (): string => humanize(this.singularName());
+  uncountable = (): boolean => this.singularName() === this.pluralName();
+  filePath = (): string => [...this.classPathParts, this.fileName].join("/");
+  className = (): string =>
+    [...this.classPathParts, this.fileName].map((s) => camelize(s)).join("::");
+  i18nScope = (): string => this.filePath().replace(/\//g, ".");
+  tableName = (): string => [...this.classPathParts, this.pluralName()].join("_");
+  singularTableName = (): string => singularize(this.tableName());
+  pluralTableName = (): string => this.tableName();
+  pluralFileName = (): string => pluralize(this.fileName);
+  fixtureFileName = (): string => this.pluralFileName();
+
+  attributesNames(): string[] {
+    const names: string[] = [];
+    for (const a of this.attributes) {
+      names.push(a.columnName());
+      if (a.passwordDigest()) names.push("password_confirmation");
+      if (a.polymorphic()) names.push(`${a.name}_type`);
+    }
+    return names;
+  }
+}


### PR DESCRIPTION
## Summary

First of three splits for PR 1.12 (generator infrastructure reconciliation).

- New `GeneratedAttribute` ports `railties/lib/rails/generators/generated_attribute.rb`: parse + type/index/options dispatch, `fieldType`, `columnName`, `indexName`, `virtual?`/`passwordDigest?`/`token?`/`richText?`/`attachment?`/`attachments?`, `reference?`/`polymorphic?`, `hasIndex?`/`hasUniqIndex?`, `foreignKey?`, `pluralName`/`singularName`/`humanName`, `toString`. 9 tests, Rails-verbatim names.
- New `NamedBase` extends `GeneratorBase` and ports the core naming helpers from `railties/lib/rails/generators/named_base.rb`: `className`, `tableName`/`singularTableName`/`pluralTableName`, `filePath`, `classPath`, `fileName`, `singular`/`plural`/`human` name, `fixtureFileName`, `i18nScope`, `attributesNames`, attribute parsing in constructor. 4 tests, Rails-verbatim names.

Existing generators (`model-generator.ts` etc.) still use their local `parseColumns` helpers; their refactor onto `GeneratedAttribute.parse` is explicitly slotted for 1.12c so the file-overlap stays minimal in this PR.

## Rails sources kept

- `railties/lib/rails/generators/named_base.rb` (core naming helpers)
- `railties/lib/rails/generators/generated_attribute.rb` (full surface used by Rails generators today)

## Intentionally skipped here

- Thor argument plumbing, `source_root`/`source_paths`
- `hook_for`/`remove_hook_for`, `class_option`
- `class_collisions`, `namespaced?`/`wrap_with_namespace`/`module_namespacing`
- `field_type` ERB helpers beyond the dispatch table; `default` value helper (deferred to 1.14 with view-template generators)
- `Base.rb` class-side helpers (`base_name`, `generator_name`, `indent`, …) — moved into 1.12c so they land alongside the refactor that actually consumes them
- Scaffold route helpers (`indexHelper`, `showHelper`, `editHelper`, `newHelper`, `singularRouteName`, `pluralRouteName`) — land with `resource_helpers` in 1.12b

## Remaining 1.12 scope

- **1.12b** — `Migration` + `actions/create_migration` + `model_helpers` + `resource_helpers` + `active_model`
- **1.12c** — `app_base` + `database` + `Base.rb` class-side reconciliation + refactor existing generators to extend `NamedBase` and replace their parallel `parseColumns*` impls with `GeneratedAttribute.parse`

## Test plan

- [x] `pnpm vitest run --project other packages/trailties/src/generators/` — 116 passed, 74 pre-existing skipped (no regressions in app/model/migration/controller/scaffold generators)
- [x] `pnpm tsc -p packages/trailties/tsconfig.json --noEmit` — clean for new files
- [x] LOC: 300 (at the ceiling)
- [x] No `node:*` imports added; no `process.*` references; no new third-party deps; no sync fs added