### PR TITLE
fix(activerecord): route JoinDependency identifier quoting through the adapter

### DIFF
--- a/packages/activerecord/src/associations/join-dependency-quoting.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-quoting.test.ts
@@ -101,6 +101,41 @@ describe("JoinDependency adapter-aware quoting", () => {
     expect(node!.joinSql).toContain(`"owner_type" = 'Owner'`);
   });
 
+  it("routes JOIN identifiers through the adapter's quoteTableName/quoteColumnName", () => {
+    const tcalls: string[] = [];
+    const ccalls: string[] = [];
+    stubConnection(Owner, {
+      quote: (v: unknown) => `'${String(v)}'`,
+      quoteTableName: (n: string) => (tcalls.push(n), `[T:${n}]`),
+      quoteColumnName: (n: string) => (ccalls.push(n), `[C:${n}]`),
+    } as any);
+
+    Associations.hasMany.call(Owner, "assets", { className: "Asset", foreignKey: "owner_id" });
+
+    const jd = new JoinDependency(Owner);
+    const node = jd.addAssociation("assets");
+    expect(node).not.toBeNull();
+    // Both table and column identifiers in the ON predicate are quoted by the
+    // adapter, not by the ANSI fallback.
+    expect(node!.joinSql).toContain("[T:assets].[C:owner_id] = [T:owners].[C:id]");
+    expect(tcalls).toContain("assets");
+    expect(tcalls).toContain("owners");
+    expect(ccalls).toContain("owner_id");
+    expect(ccalls).toContain("id");
+  });
+
+  it("falls back to the abstract identifier quoter when the adapter lacks quoteTableName/quoteColumnName", () => {
+    // Stub a quote()-only adapter (resolves through _resolveAdapter but has no
+    // identifier-quoting methods). Should still produce ANSI identifiers.
+    stubConnection(Owner, { quote: (v: unknown) => `'${String(v)}'` } as any);
+    Associations.hasMany.call(Owner, "assets", { className: "Asset", foreignKey: "owner_id" });
+
+    const jd = new JoinDependency(Owner);
+    const node = jd.addAssociation("assets");
+    expect(node).not.toBeNull();
+    expect(node!.joinSql).toContain(`"assets"."owner_id" = "owners"."id"`);
+  });
+
   it("propagates non-ConnectionNotDefined errors from connection()", () => {
     stubConnection(Owner, () => {
       throw new Error("pool exhausted");

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -295,7 +295,10 @@ export class JoinDependency {
     this._usedTableNames.add(targetTable!);
 
     // Substitute the PLACEHOLDER with the effective SQL name
-    joinOn = joinOn.replace(/PLACEHOLDER/g, this._qt(effectiveName));
+    // Function replacer avoids `$&`/`$'`/`` $` ``/`$N` expansion in the
+    // replacement string when an identifier contains `$`.
+    const effectiveQuoted = this._qt(effectiveName);
+    joinOn = joinOn.replace(/PLACEHOLDER/g, () => effectiveQuoted);
 
     // Apply association scope as additional ON conditions
     if (assocDef.options.scope && typeof assocDef.options.scope === "function") {
@@ -304,10 +307,8 @@ export class JoinDependency {
       if (scopeSql) {
         const whereMatch = scopeSql.match(/\bWHERE\s+(.+?)(?:\s+ORDER|\s+LIMIT|\s*$)/i);
         if (whereMatch) {
-          const scopeWhere = whereMatch[1].replaceAll(
-            this._qt(targetTable!),
-            this._qt(effectiveName),
-          );
+          const toQ = this._qt(effectiveName);
+          const scopeWhere = whereMatch[1].replaceAll(this._qt(targetTable!), () => toQ);
           joinOn += ` AND ${scopeWhere}`;
         }
       }
@@ -831,7 +832,8 @@ export class JoinDependency {
     // tN alias rather than colliding on the same unaliased identifier.
     const targetCollides = this._usedTableNames.has(targetTable) || targetTable === throughTable;
     const targetEffective = targetCollides ? targetAlias : targetTable;
-    targetJoinOn = targetJoinOn.replaceAll("TARGET_PLACEHOLDER", this._qt(targetEffective));
+    const targetEffectiveQuoted = this._qt(targetEffective);
+    targetJoinOn = targetJoinOn.replaceAll("TARGET_PLACEHOLDER", () => targetEffectiveQuoted);
 
     // Apply association scope
     if (assocDef.options.scope && typeof assocDef.options.scope === "function") {
@@ -840,10 +842,8 @@ export class JoinDependency {
       if (scopeSql) {
         const whereMatch = scopeSql.match(/\bWHERE\s+(.+?)(?:\s+ORDER|\s+LIMIT|\s*$)/i);
         if (whereMatch) {
-          const scopeWhere = whereMatch[1].replaceAll(
-            this._qt(targetTable),
-            this._qt(targetEffective),
-          );
+          const toQ = this._qt(targetEffective);
+          const scopeWhere = whereMatch[1].replaceAll(this._qt(targetTable), () => toQ);
           targetJoinOn += ` AND ${scopeWhere}`;
         }
       }

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -22,7 +22,11 @@ import { modelRegistry } from "../associations.js";
 import { reflectOnAssociation } from "../reflection.js";
 import { getInheritanceColumn, isStiSubclass } from "../inheritance.js";
 import { ConnectionNotDefined } from "../errors.js";
-import { quote as abstractQuote } from "../connection-adapters/abstract/quoting.js";
+import {
+  quote as abstractQuote,
+  quoteTableName as abstractQuoteTableName,
+  quoteColumnName as abstractQuoteColumnName,
+} from "../connection-adapters/abstract/quoting.js";
 
 export interface JoinNode {
   tableIndex: number;
@@ -176,6 +180,24 @@ export class JoinDependency {
     return abstractQuote(value);
   }
 
+  /**
+   * Adapter-aware table identifier quoting for JOIN SQL construction.
+   * Mirrors `_quoteString` resolution: delegate to the active adapter so
+   * MySQL emits backticks (avoids mixed-quote SQL when the MySQL Arel
+   * visitor is active), fall back to the ANSI portable form otherwise.
+   * @internal
+   */
+  private _qt(name: string): string {
+    const fn = (this._adapter as any)?.quoteTableName;
+    return typeof fn === "function" ? fn.call(this._adapter, name) : abstractQuoteTableName(name);
+  }
+
+  /** @internal */
+  private _qc(name: string): string {
+    const fn = (this._adapter as any)?.quoteColumnName;
+    return typeof fn === "function" ? fn.call(this._adapter, name) : abstractQuoteColumnName(name);
+  }
+
   get nodes(): JoinNode[] {
     return this._nodes;
   }
@@ -222,7 +244,7 @@ export class JoinDependency {
       const targetPk = assocDef.options.primaryKey ?? (targetModel as any).primaryKey ?? "id";
       if (Array.isArray(targetPk)) return null;
       // effectiveName resolved below after targetTable is known
-      joinOn = `PLACEHOLDER."${targetPk}" = "${sourceAlias}"."${foreignKey}"`;
+      joinOn = `PLACEHOLDER.${this._qc(targetPk)} = ${this._qt(sourceAlias)}.${this._qc(foreignKey)}`;
     } else if (
       assocDef.type === "hasMany" ||
       assocDef.type === "hasOne" ||
@@ -252,11 +274,11 @@ export class JoinDependency {
       if (Array.isArray(foreignKey)) return null;
       const primaryKey = assocDef.options.primaryKey ?? sourcePk;
       if (Array.isArray(primaryKey)) return null;
-      joinOn = `PLACEHOLDER."${foreignKey}" = "${sourceAlias}"."${primaryKey}"`;
+      joinOn = `PLACEHOLDER.${this._qc(foreignKey)} = ${this._qt(sourceAlias)}.${this._qc(primaryKey)}`;
 
       if (assocDef.options.as) {
         const typeCol = `${_toUnderscore(assocDef.options.as)}_type`;
-        joinOn += ` AND PLACEHOLDER."${typeCol}" = ${this._quoteString(modelClass.name)}`;
+        joinOn += ` AND PLACEHOLDER.${this._qc(typeCol)} = ${this._quoteString(modelClass.name)}`;
       }
     } else {
       return null;
@@ -273,7 +295,7 @@ export class JoinDependency {
     this._usedTableNames.add(targetTable!);
 
     // Substitute the PLACEHOLDER with the effective SQL name
-    joinOn = joinOn.replace(/PLACEHOLDER/g, `"${effectiveName}"`);
+    joinOn = joinOn.replace(/PLACEHOLDER/g, this._qt(effectiveName));
 
     // Apply association scope as additional ON conditions
     if (assocDef.options.scope && typeof assocDef.options.scope === "function") {
@@ -282,7 +304,10 @@ export class JoinDependency {
       if (scopeSql) {
         const whereMatch = scopeSql.match(/\bWHERE\s+(.+?)(?:\s+ORDER|\s+LIMIT|\s*$)/i);
         if (whereMatch) {
-          const scopeWhere = whereMatch[1].replaceAll(`"${targetTable!}"`, `"${effectiveName}"`);
+          const scopeWhere = whereMatch[1].replaceAll(
+            this._qt(targetTable!),
+            this._qt(effectiveName),
+          );
           joinOn += ` AND ${scopeWhere}`;
         }
       }
@@ -300,7 +325,9 @@ export class JoinDependency {
     // Build JOIN SQL: only emit the alias clause when effectiveName differs
     // from the real table name (i.e. there was a collision and we used tN).
     const joinTableExpr =
-      effectiveName === targetTable! ? `"${targetTable!}"` : `"${targetTable!}" "${effectiveName}"`;
+      effectiveName === targetTable!
+        ? this._qt(targetTable!)
+        : `${this._qt(targetTable!)} ${this._qt(effectiveName)}`;
 
     const node: JoinNode = {
       tableIndex,
@@ -381,7 +408,7 @@ export class JoinDependency {
     return this._aliases.map((a) => {
       const effectiveName = effectiveNameByIndex.get(a.tableIndex)!;
       // Rails emits column aliases as SqlLiteral (bare, not quoted).
-      return `"${effectiveName}"."${a.column}" AS ${a.alias}`;
+      return `${this._qt(effectiveName)}.${this._qc(a.column)} AS ${a.alias}`;
     });
   }
 
@@ -446,7 +473,10 @@ export class JoinDependency {
     }
     const selectExprs = this.aliases()
       .columns()
-      .map((a) => `"${effectiveNameByIndex.get(a.tableIndex)!}"."${a.column}" AS ${a.alias}`);
+      .map(
+        (a) =>
+          `${this._qt(effectiveNameByIndex.get(a.tableIndex)!)}.${this._qc(a.column)} AS ${a.alias}`,
+      );
     if (typeof relation.reselectBang === "function") {
       relation.reselectBang(...selectExprs);
       return relation;
@@ -491,7 +521,7 @@ export class JoinDependency {
     if (inheritanceCol && isStiSubclass(model)) {
       const stiNames = [model.name, ...((model as any).descendants ?? []).map((d: any) => d.name)];
       const inList = stiNames.map((n: string) => this._quoteString(n)).join(", ");
-      joinOn += ` AND "${alias}"."${inheritanceCol}" IN (${inList})`;
+      joinOn += ` AND ${this._qt(alias)}.${this._qc(inheritanceCol)} IN (${inList})`;
     }
     return joinOn;
   }
@@ -653,15 +683,15 @@ export class JoinDependency {
     // the set with tables we never actually joined.
     const throughEffective = this._usedTableNames.has(throughTable) ? throughAlias : throughTable;
 
-    let throughJoinOn = `"${throughEffective}"."${throughFk}" = "${sourceAlias}"."${sourcePk}"`;
+    let throughJoinOn = `${this._qt(throughEffective)}.${this._qc(throughFk)} = ${this._qt(sourceAlias)}.${this._qc(sourcePk)}`;
     if (throughAssocDef.options.as) {
       const typeCol = `${_toUnderscore(throughAssocDef.options.as)}_type`;
-      throughJoinOn += ` AND "${throughEffective}"."${typeCol}" = ${this._quoteString(String(modelClass.name))}`;
+      throughJoinOn += ` AND ${this._qt(throughEffective)}.${this._qc(typeCol)} = ${this._quoteString(String(modelClass.name))}`;
     }
     const throughJoinTableExpr =
       throughEffective === throughTable
-        ? `"${throughTable}"`
-        : `"${throughTable}" "${throughEffective}"`;
+        ? this._qt(throughTable)
+        : `${this._qt(throughTable)} ${this._qt(throughEffective)}`;
     const throughJoinSql = `LEFT OUTER JOIN ${throughJoinTableExpr} ON ${throughJoinOn}`;
 
     const sourceName = assocDef.options.source ?? _singularize(assocDef.name);
@@ -772,13 +802,13 @@ export class JoinDependency {
       targetTable = (targetModel as any).tableName;
       const targetPk = sourceAssocDef.options.primaryKey ?? (targetModel as any).primaryKey ?? "id";
       if (Array.isArray(targetPk)) return null;
-      targetJoinOn = `"TARGET_PLACEHOLDER"."${targetPk}" = "${throughEffective}"."${targetFk}"`;
+      targetJoinOn = `TARGET_PLACEHOLDER.${this._qc(targetPk)} = ${this._qt(throughEffective)}.${this._qc(targetFk)}`;
       if (isPoly) {
         // Mirrors Rails ThroughReflection / BelongsToReflection: the
         // polymorphic type column is `foreign_type` (options[:foreign_type]
         // || "#{name}_type"), and the value is the literal :source_type.
         const typeCol = sourceAssocDef.options.foreignType ?? `${_toUnderscore(sourceName)}_type`;
-        targetJoinOn += ` AND "${throughEffective}"."${typeCol}" = ${this._quoteString(String(assocDef.options.sourceType))}`;
+        targetJoinOn += ` AND ${this._qt(throughEffective)}.${this._qc(typeCol)} = ${this._quoteString(String(assocDef.options.sourceType))}`;
       }
     } else {
       const className = sourceAssocDef?.options?.className ?? _camelize(_singularize(sourceName));
@@ -790,7 +820,7 @@ export class JoinDependency {
       if (Array.isArray(targetFk)) return null;
       const throughPk = (throughModel as any).primaryKey ?? "id";
       if (Array.isArray(throughPk)) return null;
-      targetJoinOn = `"TARGET_PLACEHOLDER"."${targetFk}" = "${throughEffective}"."${throughPk}"`;
+      targetJoinOn = `TARGET_PLACEHOLDER.${this._qc(targetFk)} = ${this._qt(throughEffective)}.${this._qc(throughPk)}`;
     }
 
     // Mirror addAssociation collision-check for the target table too.
@@ -801,7 +831,7 @@ export class JoinDependency {
     // tN alias rather than colliding on the same unaliased identifier.
     const targetCollides = this._usedTableNames.has(targetTable) || targetTable === throughTable;
     const targetEffective = targetCollides ? targetAlias : targetTable;
-    targetJoinOn = targetJoinOn.replaceAll("TARGET_PLACEHOLDER", targetEffective);
+    targetJoinOn = targetJoinOn.replaceAll("TARGET_PLACEHOLDER", this._qt(targetEffective));
 
     // Apply association scope
     if (assocDef.options.scope && typeof assocDef.options.scope === "function") {
@@ -810,7 +840,10 @@ export class JoinDependency {
       if (scopeSql) {
         const whereMatch = scopeSql.match(/\bWHERE\s+(.+?)(?:\s+ORDER|\s+LIMIT|\s*$)/i);
         if (whereMatch) {
-          const scopeWhere = whereMatch[1].replaceAll(`"${targetTable}"`, `"${targetEffective}"`);
+          const scopeWhere = whereMatch[1].replaceAll(
+            this._qt(targetTable),
+            this._qt(targetEffective),
+          );
           targetJoinOn += ` AND ${scopeWhere}`;
         }
       }
@@ -844,8 +877,8 @@ export class JoinDependency {
 
     const targetJoinTableExpr =
       targetEffective === targetTable
-        ? `"${targetTable}"`
-        : `"${targetTable}" "${targetEffective}"`;
+        ? this._qt(targetTable)
+        : `${this._qt(targetTable)} ${this._qt(targetEffective)}`;
     const node: JoinNode = {
       tableIndex: targetTableIndex,
       tableAlias: targetAlias,


### PR DESCRIPTION
## Summary

`JoinDependency` built LEFT OUTER JOIN / column-alias SQL with hardcoded ANSI `\"...\"` identifier quoting. After TM Phase 9b-2b activates the MySQL Arel visitor (#2155), the FROM clause renders with backticks (visitor output) while the JOIN clause — constructed here as a pre-baked string — keeps ANSI quotes. The result is mixed-quote SQL that MariaDB/MySQL rejects.

Same family of bug as #2141's original blocker, in a different code path. Fixed at the construction site (mirrors #2144 routing `Table#star` through `Attribute` so the visitor handles quoting): every identifier quote in `join-dependency.ts` now delegates to the active adapter's `quoteTableName` / `quoteColumnName` via two new helpers (`_qt` / `_qc`) that mirror the resolution logic of the existing `_quoteString`. When the adapter lacks those methods (some mock test adapters), the helpers fall back to the ANSI portable form, preserving prior behavior.

## Sites covered

- simple `belongs_to` / `has_many` / `has_one` ON predicates
- polymorphic `as:` type predicate
- through-association ON predicate
- polymorphic through `source_type:` predicate
- STI subclass IN-list
- table-alias expressions (`real_name alias_name`)
- scope-WHERE table-name substitution
- eager-load SELECT projection (`tN.col AS tN_rN`)
- `applyColumnAliases`

## Behavior

- SQLite / PostgreSQL: no change — their `quoteTableName` / `quoteColumnName` return the same `\"...\"` form.
- MySQL once #2155 lands: identifiers render with backticks throughout the eager-load / includes+references join SQL, eliminating the mixed-quote SQL flagged in #2155's known-failures list (items 2 and 4 — eager-load JOIN quoting).

## Test plan

- [x] `packages/activerecord/src/relation.test.ts` — 117/117 on SQLite
- [x] `packages/activerecord/src/associations/**/*.test.ts` — 1525 pass
- [ ] MySQL CI after #2155 gate flip — should clear the eager-load mixed-quote failures listed there

## Diff size

47 / 21 (additions / deletions) — well under the 300 LOC ceiling.