### PR TITLE
fix(activerecord): bare quoted column for unknown order under from(subquery)

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3732,17 +3732,30 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * Quote a bare column identifier using the active adapter. Mirrors Rails'
-   * `arel_column` fallback (`yield field` → `connection.quote_table_name(name)`):
-   * an unknown column under a `from(subquery)` context must emit as bare
-   * `"col"` / `` `col` ``, not `table.col`. We can't use
-   * `Nodes.UnqualifiedColumn(table.get(col))` here because the MySQL visitor
-   * overrides that to delegate to the inner Attribute (needed for `UPDATE
-   * SET t.x = t.x + 1`), which re-qualifies the name.
+   * Quote a bare column identifier so an unknown column under a `from(subquery)`
+   * context emits as bare `"col"` / `` `col` `` rather than `table.col`.
+   * Mirrors Rails' `order_column` fallback (query_methods.rb): `Arel.sql(
+   * model.adapter_class.quote_table_name(attr_name), retryable: true)`.
+   * (Rails uses `quote_table_name` for a bare identifier; we use the
+   * adapter's `quoteColumnName` — same emission for a single identifier
+   * on all three dialects.)
+   *
+   * We can't use `Nodes.UnqualifiedColumn(table.get(col))` here: the MySQL
+   * visitor — matching Rails' `arel/visitors/mysql.rb` — overrides that node
+   * to delegate to the inner Attribute (Rails needs the table prefix for
+   * `UPDATE t SET t.x = t.x + 1`), so MySQL would re-qualify.
+   *
+   * Quote against the visitor that will actually emit the SELECT so the
+   * bare identifier matches the rest of the SQL's identifier quoting.
+   * `_compileSelectSql` uses `_selectVisitor()` when defined, else
+   * `manager.toSql()` (which is the global ANSI ToSql).
    * @internal
    */
   private _quoteBareColumn(name: string): string {
-    return this._modelClass.adapter.quoteColumnName(name);
+    if (this._selectVisitor() !== null) {
+      return this._modelClass.adapter.quoteColumnName(name);
+    }
+    return `"${name.replace(/"/g, '""')}"`;
   }
 
   private _applyOrderToManager(manager: SelectManager, table: Table): void {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3731,6 +3731,20 @@ export class Relation<T extends Base> {
     return Array.isArray(pk) ? pk.includes(col) : pk === col;
   }
 
+  /**
+   * Quote a bare column identifier using the active adapter. Mirrors Rails'
+   * `arel_column` fallback (`yield field` → `connection.quote_table_name(name)`):
+   * an unknown column under a `from(subquery)` context must emit as bare
+   * `"col"` / `` `col` ``, not `table.col`. We can't use
+   * `Nodes.UnqualifiedColumn(table.get(col))` here because the MySQL visitor
+   * overrides that to delegate to the inner Attribute (needed for `UPDATE
+   * SET t.x = t.x + 1`), which re-qualifies the name.
+   * @internal
+   */
+  private _quoteBareColumn(name: string): string {
+    return this._modelClass.adapter.quoteColumnName(name);
+  }
+
   private _applyOrderToManager(manager: SelectManager, table: Table): void {
     // Raw order clauses (from inOrderOf)
     for (const rawClause of this._rawOrderClauses) {
@@ -3755,11 +3769,11 @@ export class Relation<T extends Base> {
             // Any dotted identifier (one or more dots) passes through as raw SQL.
             if (rawCol.includes(".")) {
               manager.order(new Nodes.SqlLiteral(trimmed));
+            } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(rawCol)) {
+              const lit = new Nodes.SqlLiteral(this._quoteBareColumn(rawCol));
+              manager.order(dir === "DESC" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
             } else {
-              const node =
-                !this._fromClause.isEmpty() && !this._isKnownColumn(rawCol)
-                  ? new Nodes.UnqualifiedColumn(table.get(rawCol))
-                  : table.get(rawCol);
+              const node = table.get(rawCol);
               manager.order(
                 dir === "DESC" ? new Nodes.Descending(node) : new Nodes.Ascending(node),
               );
@@ -3768,11 +3782,13 @@ export class Relation<T extends Base> {
             // Not "col DIR" form. Only wrap plain letter-start identifiers;
             // everything else (positional "1", NULLS FIRST, commas, etc.) is raw SQL.
             if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
-              const node =
-                !this._fromClause.isEmpty() && !this._isKnownColumn(trimmed)
-                  ? new Nodes.UnqualifiedColumn(table.get(trimmed))
-                  : table.get(trimmed);
-              manager.order(new Nodes.Ascending(node));
+              if (!this._fromClause.isEmpty() && !this._isKnownColumn(trimmed)) {
+                manager.order(
+                  new Nodes.Ascending(new Nodes.SqlLiteral(this._quoteBareColumn(trimmed))),
+                );
+              } else {
+                manager.order(new Nodes.Ascending(table.get(trimmed)));
+              }
             } else {
               manager.order(new Nodes.SqlLiteral(trimmed));
             }
@@ -3786,10 +3802,8 @@ export class Relation<T extends Base> {
           const lit = new Nodes.SqlLiteral(col);
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(col)) {
-          const unqual = new Nodes.UnqualifiedColumn(table.get(col));
-          manager.order(
-            dir === "desc" ? new Nodes.Descending(unqual) : new Nodes.Ascending(unqual),
-          );
+          const lit = new Nodes.SqlLiteral(this._quoteBareColumn(col));
+          manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else {
           manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());
         }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3783,7 +3783,7 @@ export class Relation<T extends Base> {
             if (rawCol.includes(".")) {
               manager.order(new Nodes.SqlLiteral(trimmed));
             } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(rawCol)) {
-              const lit = new Nodes.SqlLiteral(this._quoteBareColumn(rawCol));
+              const lit = new Nodes.SqlLiteral(this._quoteBareColumn(rawCol), { retryable: true });
               manager.order(dir === "DESC" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
             } else {
               const node = table.get(rawCol);
@@ -3797,7 +3797,9 @@ export class Relation<T extends Base> {
             if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
               if (!this._fromClause.isEmpty() && !this._isKnownColumn(trimmed)) {
                 manager.order(
-                  new Nodes.Ascending(new Nodes.SqlLiteral(this._quoteBareColumn(trimmed))),
+                  new Nodes.Ascending(
+                    new Nodes.SqlLiteral(this._quoteBareColumn(trimmed), { retryable: true }),
+                  ),
                 );
               } else {
                 manager.order(new Nodes.Ascending(table.get(trimmed)));
@@ -3815,7 +3817,7 @@ export class Relation<T extends Base> {
           const lit = new Nodes.SqlLiteral(col);
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(col)) {
-          const lit = new Nodes.SqlLiteral(this._quoteBareColumn(col));
+          const lit = new Nodes.SqlLiteral(this._quoteBareColumn(col), { retryable: true });
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else {
           manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());


### PR DESCRIPTION
## Summary

`Relation#_applyOrderToManager` wraps unknown columns in `Nodes.UnqualifiedColumn(table.get(col))` to strip the table qualifier when ordering by a name that isn't on the model's table — typical under `from(subquery)`. The base `ToSql` visitor's `UnqualifiedColumn` handler emits the bare quoted name, so PG/SQLite produced the expected `ORDER BY "hotness" DESC`. The MySQL visitor, mirroring Rails' `arel/visitors/mysql.rb`, **overrides** `UnqualifiedColumn` to delegate to its inner expression — Rails needs that override for `UPDATE t SET t.x = t.x + 1`. As a side effect, MySQL re-qualifies the column and emits ``ORDER BY `developers`.`hotness` DESC`` for an unknown column in a subquery-aliased FROM.

Rails doesn't hit this because `preprocess_order_args` flows through `arel_column(field) { |name| connection.quote_table_name(name) }`, which for the unknown-column path yields a bare quoted identifier — never an `UnqualifiedColumn`. The `UnqualifiedColumn` node is only ever constructed by Arel for UPDATE assignments.

Fix: replace the `UnqualifiedColumn(table.get(col))` workaround in `_applyOrderToManager`'s three branches with `SqlLiteral(adapter.quoteColumnName(col))`. All three adapters now produce identical bare-quoted output, and the MySQL `UnqualifiedColumn` override stays correct for its real UPDATE-set callers (covered by `packages/arel/src/update-manager.test.ts` + `mysql.test.ts`).

Surfaces under TM Phase 9b-2b (MySQL Arel visitor activation, #2155). PG/SQLite SQL unchanged.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/relation.test.ts` — 117/117 SQLite
- [x] `PG_TEST_URL=... pnpm vitest run packages/activerecord/src/relation.test.ts` — 117/117 PG
- [x] `MYSQL_TEST_URL=... pnpm vitest run packages/activerecord/src/relation.test.ts -t "order by unknown column"` — passes (was failing)
- [x] `MYSQL_TEST_URL=... pnpm vitest run packages/activerecord/src/relation.test.ts -t "string ORDER BY in"` — passes (was failing, gated on Q() wrapping in #2155)
- [x] arel UnqualifiedColumn tests (UPDATE-set semantics, MySQL visitor delegation): 79/79
- [ ] CI green

## Out of scope

The other failing MySQL tests called out in #2155's description — eagerLoad LEFT OUTER JOIN mixed quoting, joins() insertion-order — are separate bugs in different code paths. They block #2155 merge but not this fix.