### PR TITLE
docs(tm-unification): capture 9b-1/9b-2a closures + 9b-2c followup

### DIFF
--- a/docs/tm-unification-plan.md
+++ b/docs/tm-unification-plan.md
@@ -102,10 +102,10 @@ logic:
 
 ### Phase 9a — activate `Visitors::SQLite`, delete `fixSqliteCompat` — closed (#2127, #2132)
 
-- `SchemaAdapter.arelVisitor` (test-adapter.ts:709-719) now delegates
-  to the inner adapter **for SQLite only**. The gate at line 718
-  (`if (this.inner?.adapterName !== "sqlite") return undefined`) and
-  its comment reserve the PG/MySQL flip for Phase 9b.
+- `SchemaAdapter.arelVisitor` flipped from hard-coded `undefined` to
+  delegating to the inner adapter, **gated on `sqlite`**. PG/MySQL
+  remained on the dormant fallback (PG was added in 9b-1; MySQL
+  pending in 9b-2).
 - `fixSqliteCompat` and `unwrapCompoundSelect` deleted
 - `Relation#_toSql` set-op path simplified to plain
   `${left} ${op} ${right}` concatenation

--- a/docs/tm-unification-plan.md
+++ b/docs/tm-unification-plan.md
@@ -7,8 +7,10 @@ once-per-file schema setup with transactional fixtures.
 
 Phases 1–4, 7, 8 are closed. Phase 5 (universal `defineSchema`) is
 complete. Phase 6 mechanical bulk migration is complete; the
-remainder is sized per-file surgery. Phase 9a is merged for SQLite;
-Phase 9b extends it to PG/MySQL and deletes `SchemaAdapter`.
+remainder is sized per-file surgery. Phase 9a (SQLite visitor) is
+merged. Phase 9b-1 (PG visitor) is merged. Phase 9b-2 is in flight:
+9b-2a (arel `Table.star` fix) merged, 9b-2b (MySQL gate flip +
+assertion sweep) in review.
 
 For closed-phase narrative and the original Path 1/Path 2 fallback
 diagnosis, see the merged PRs cited in each phase header and the
@@ -122,18 +124,51 @@ the dormant fallback in `relation.ts:3614-3619` emitted generic
 all-ANSI SQL. Each adapter is its own PR; bundling risks a CI failure
 that's hard to triage.
 
-**9b-1 — activate PG `arelVisitor` delegation.** Flip the gate at
-`test-adapter.ts:718` to also pass `postgres`. Audit
-`Visitors::PostgreSQL` against
-`vendor/rails/.../arel/visitors/postgresql.rb` for parity. Triage
-surfaced failures: fix the visitor where it diverges from Rails; gate
-test assertions where they hardcode dormant-fallback output.
-Estimated ~200-300 LOC.
+**9b-1 — activate PG `arelVisitor` delegation — closed (#2139).** The
+gate at `test-adapter.ts:715` now passes both `sqlite` and `postgres`.
+Smaller surface than 9a (3 files, +41/-27). 3 PG-bytea encryption
+tests skipped pending a `type.serialize` follow-up; that work is
+tracked in 9b-2d below.
 
-**9b-2 — activate MySQL `arelVisitor` delegation.** Same pattern.
-MariaDB CI is the canary; expect identifier-quote-style assertion
-fails since the dormant fallback emits ANSI `"` quotes but
-`Visitors::MySQL` emits backticks. Estimated ~150-250 LOC.
+**9b-2 — activate MySQL `arelVisitor` delegation.** Split into a
+prerequisite arel fix and the gate flip proper:
+
+- **9b-2a — `Table.star` → `Attribute` — closed (#2144).** First
+  attempt (#2141, closed) surfaced 56 MariaDB failures rooted in
+  mixed-quote SQL: `Table.star` was a pre-baked ANSI `SqlLiteral` at
+  `packages/arel/src/table.ts:197` that bypassed the adapter visitor.
+  Rails uses `table[Arel.star]` (an `Attribute`) so the visitor
+  handles dialect quoting. #2144 restored that shape; SQLite/PG
+  unchanged, MySQL now emits backticks via the visitor.
+- **9b-2b — gate flip + assertion sweep — in flight (#2155).** Drops
+  the adapter conditional from `test-adapter.ts:715` so all three
+  adapters delegate. Sweep of ~50 hardcoded `'"name"'` assertions in
+  `relation.test.ts` via a `Q(...)` helper that rewrites to backticks
+  on MySQL. Split-out fixes already merged (each surfaced as the
+  sweep proceeded):
+  - **#2156** — `JoinDependency` identifier quoting routed through
+    adapter helpers (LEFT OUTER JOIN clauses were hardcoded ANSI;
+    same bug family as #2141 in a different code path).
+  - **#2157** — `Relation#_applyOrderToManager` swapped `UnqualifiedColumn(table.get(col))` for `SqlLiteral(adapter.quoteColumnName(col))` to fix subquery-alias ORDER BY of unknown columns (MySQL's `UnqualifiedColumn` visitor override re-qualified). Tactical fix, not Rails-shaped — see 9b-2c.
+
+**9b-2c — Rails-shape #2157's ORDER BY path — ~30-50 LOC followup.**
+Rails' `preprocess_order_args` (`active_record/relation/query_methods.rb`)
+routes unknown columns through
+`arel_column(field) { |name| connection.quote_table_name(name) }`.
+The yield returns a bare-quoted identifier, so Rails never constructs
+an `UnqualifiedColumn` for ORDER BY — that node is reserved for
+UPDATE-set semantics. #2157's fix emits equivalent SQL but bypasses
+`arel_column`. Mirror that path so node construction matches Rails.
+([[project_pr2157_followup_arel_column_path]])
+
+**9b-2d — PG-bytea encryption `type.serialize` followup — ~30 LOC.**
+3 encryption tests remain skipped on PG bytea after #2139. Route
+`EncryptedAttribute` writes through `type.serialize` before reaching
+`adapter.quote()`. Same root cause as 9a's SQLite encryption skips —
+#2132 fixed those at the `quote()` layer (`Type::Binary::Data`
+branch). The PG-bytea case needs the parallel fix at the
+type-serialize layer, not at `quote()`. Likely also resolves any
+MySQL BLOB skips 9b-2b surfaces.
 
 **9b-3 + 9b-4 — delete the dormant-visitor fallback and
 `SchemaAdapter`.** Bundled because the fallback deletion is small (~50

--- a/docs/tm-unification-plan.md
+++ b/docs/tm-unification-plan.md
@@ -125,7 +125,7 @@ all-ANSI SQL. Each adapter is its own PR; bundling risks a CI failure
 that's hard to triage.
 
 **9b-1 — activate PG `arelVisitor` delegation — closed (#2139).** The
-gate at `test-adapter.ts:715` now passes both `sqlite` and `postgres`.
+gate at `test-adapter.ts:716` now passes both `sqlite` and `postgres`.
 Smaller surface than 9a (3 files, +41/-27). 3 PG-bytea encryption
 tests skipped pending a `type.serialize` follow-up; that work is
 tracked in 9b-2d below.
@@ -135,13 +135,13 @@ prerequisite arel fix and the gate flip proper:
 
 - **9b-2a — `Table.star` → `Attribute` — closed (#2144).** First
   attempt (#2141, closed) surfaced 56 MariaDB failures rooted in
-  mixed-quote SQL: `Table.star` was a pre-baked ANSI `SqlLiteral` at
-  `packages/arel/src/table.ts:197` that bypassed the adapter visitor.
+  mixed-quote SQL: `Table.star` in `packages/arel/src/table.ts` was
+  a pre-baked ANSI `SqlLiteral` that bypassed the adapter visitor.
   Rails uses `table[Arel.star]` (an `Attribute`) so the visitor
   handles dialect quoting. #2144 restored that shape; SQLite/PG
   unchanged, MySQL now emits backticks via the visitor.
 - **9b-2b — gate flip + assertion sweep — in flight (#2155).** Drops
-  the adapter conditional from `test-adapter.ts:715` so all three
+  the adapter conditional from `test-adapter.ts:716` so all three
   adapters delegate. Sweep of ~50 hardcoded `'"name"'` assertions in
   `relation.test.ts` via a `Q(...)` helper that rewrites to backticks
   on MySQL. Split-out fixes already merged (each surfaced as the

--- a/docs/tm-unification-plan.md
+++ b/docs/tm-unification-plan.md
@@ -170,6 +170,36 @@ branch). The PG-bytea case needs the parallel fix at the
 type-serialize layer, not at `quote()`. Likely also resolves any
 MySQL BLOB skips 9b-2b surfaces.
 
+**9b-2e — re-enable #2155's skips via Rails-idiomatic assertions —
+sized per file, no shared helper.** 9b-2b (#2155) `.skip`s the ~50
+tests in `relation.test.ts` (and any other files surfaced by CI)
+whose assertions hardcode ANSI `"name"` quoting. **The `.skip` with
+rationale is itself the correct Rails idiom** — Rails has no shared
+adapter-quote-rewriting helper ([[feedback_no_q_wrap_helper]]).
+
+Two options per skipped test, picked individually:
+
+1. **Inline `Regexp.escape(quote_*_name(name))` in the assertion** —
+   Rails' canonical pattern, no exported helper. From
+   `vendor/rails/activerecord/test/cases/relation/predicate_builder_test.rb`:
+   ```ruby
+   assert_match %r{#{Regexp.escape(quote_table_name("topics.title"))} ~ 'rails'}i, ...to_sql
+   ```
+   In trails: `expect(sql).toMatch(new RegExp(escapeRegExp(adapter.quoteColumnName("name"))))`
+   — full names, no abbreviation, no exported helper. If a single
+   test has many quoted identifiers, a local
+   `const escaped = (name) => escapeRegExp(adapter.quoteColumnName(name))`
+   binding scoped to that test mirrors Rails' local lambda — but it
+   stays local.
+2. **Rewrite to behavior-based assertion** — assert the SQL
+   _outcome_ (returned rows, computed values) instead of the SQL
+   string structure. Often cleaner; some `.toSql()` assertions are
+   really testing query construction that's better verified by
+   executing the query and checking results.
+
+When neither fits cleanly, the `.skip` stays. Don't ship a shared
+helper; don't ship a post-hoc rewriter.
+
 **9b-3 + 9b-4 — delete the dormant-visitor fallback and
 `SchemaAdapter`.** Bundled because the fallback deletion is small (~50
 LOC) and the dependent class deletion is the natural follow-on:


### PR DESCRIPTION
## Summary

- 9b-1 (#2139) and 9b-2a (#2144) merged since the last refresh; mark them closed.
- 9b-2 is now structured as 9b-2a (Table.star fix) + 9b-2b (gate flip + sweep, in flight as #2155 with split-out fixes #2156 and #2157).
- Adds a **9b-2c follow-up** entry: #2157 swapped `UnqualifiedColumn(table.get(col))` → `SqlLiteral(adapter.quoteColumnName(col))` to fix subquery-alias ORDER BY under MySQL. Functionally equivalent SQL, but bypasses Rails' \`arel_column(field) { |name| quote_table_name(name) }\` yield-block path. Rails never constructs \`UnqualifiedColumn\` for ORDER BY — that node is reserved for UPDATE-set semantics. Restore the Rails-shape post-9b-2b.

## Test plan

- [x] Doc-only change