### PR TITLE
feat(trailties): Bootstrap initializers (PR 2.3)

### DIFF
--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -303,6 +303,7 @@ export { benchmark } from "./benchmarkable.js";
 export type { BenchmarkLogger, BenchmarkOptions } from "./benchmarkable.js";
 
 export { Logger, taggedLogging, SimpleFormatter } from "./logger.js";
+export { NullLogger, nullLogger } from "./null-logger.js";
 export { BroadcastLogger } from "./broadcast-logger.js";
 export type { LogLevel, LoggerOutput, TaggedLogger } from "./logger.js";
 export { Subscriber } from "./subscriber.js";

--- a/packages/activesupport/src/null-logger.test.ts
+++ b/packages/activesupport/src/null-logger.test.ts
@@ -24,4 +24,16 @@ describe("NullLogger", () => {
     expect(log.warnEnabled).toBe(true);
     expect(log.debugEnabled).toBe(false);
   });
+
+  it("short-circuits add/log without invoking the formatter", () => {
+    const log = nullLogger();
+    let formatterCalls = 0;
+    log.formatter = () => {
+      formatterCalls += 1;
+      return "";
+    };
+    log.info("hot path");
+    log.add(Logger.ERROR, "boom");
+    expect(formatterCalls).toBe(0);
+  });
 });

--- a/packages/activesupport/src/null-logger.test.ts
+++ b/packages/activesupport/src/null-logger.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { Logger } from "./logger.js";
+import { NullLogger, nullLogger } from "./null-logger.js";
+
+describe("NullLogger", () => {
+  it("is a Logger", () => {
+    expect(new NullLogger()).toBeInstanceOf(Logger);
+  });
+
+  it("discards writes without throwing", () => {
+    const log = nullLogger();
+    expect(() => {
+      log.info("hello");
+      log.warn("world");
+      log.error("boom");
+      log.append("raw");
+      log.close();
+    }).not.toThrow();
+  });
+
+  it("still honors level filtering", () => {
+    const log = nullLogger();
+    log.level = Logger.WARN;
+    expect(log.warnEnabled).toBe(true);
+    expect(log.debugEnabled).toBe(false);
+  });
+});

--- a/packages/activesupport/src/null-logger.ts
+++ b/packages/activesupport/src/null-logger.ts
@@ -1,7 +1,8 @@
 /**
  * No-op Logger — discards all output while honoring the Logger interface
  * (level filtering, silence blocks, tagged logging). Used as a safe default
- * before applications wire up real logging (e.g. `Trails.logger` pre-init).
+ * before an application wires up real logging (e.g. as the fallback in
+ * `Application::Bootstrap`'s `:initialize_logger` initializer).
  *
  * `add` / `log` short-circuit to avoid formatter calls and
  * `Temporal.Now.instant()` allocations on the boot hot path; level

--- a/packages/activesupport/src/null-logger.ts
+++ b/packages/activesupport/src/null-logger.ts
@@ -1,0 +1,20 @@
+/**
+ * No-op Logger — discards all output while honoring the Logger interface
+ * (level filtering, silence blocks, tagged logging). Used as a safe default
+ * before applications wire up real logging (e.g. `Trails.logger` pre-init).
+ */
+import { Logger } from "./logger.js";
+
+export class NullLogger extends Logger {
+  constructor() {
+    super(null);
+  }
+
+  override append(_s: string): void {}
+  override close(): void {}
+}
+
+/** Convenience factory matching the `nullStore()` style used elsewhere. */
+export function nullLogger(): NullLogger {
+  return new NullLogger();
+}

--- a/packages/activesupport/src/null-logger.ts
+++ b/packages/activesupport/src/null-logger.ts
@@ -2,6 +2,10 @@
  * No-op Logger — discards all output while honoring the Logger interface
  * (level filtering, silence blocks, tagged logging). Used as a safe default
  * before applications wire up real logging (e.g. `Trails.logger` pre-init).
+ *
+ * `add` / `log` short-circuit to avoid formatter calls and
+ * `Temporal.Now.instant()` allocations on the boot hot path; level
+ * predicates (`debugEnabled`, `warnEnabled`, …) still reflect `this.level`.
  */
 import { Logger } from "./logger.js";
 
@@ -10,11 +14,19 @@ export class NullLogger extends Logger {
     super(null);
   }
 
+  override add(_severity: number, _message?: string | null, _progname?: string): boolean {
+    return true;
+  }
+
+  override log(_severity: number, _message?: string | (() => string), _progname?: string): boolean {
+    return true;
+  }
+
   override append(_s: string): void {}
   override close(): void {}
 }
 
-/** Convenience factory matching the `nullStore()` style used elsewhere. */
+/** Convenience factory; equivalent to `new NullLogger()`. */
 export function nullLogger(): NullLogger {
   return new NullLogger();
 }

--- a/packages/trailties/src/application/bootstrap.test.ts
+++ b/packages/trailties/src/application/bootstrap.test.ts
@@ -7,6 +7,7 @@ import {
   resetLoadHooks,
 } from "@blazetrails/activesupport";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Initializable } from "../initializable.js";
 import { Bootstrap, type BootstrapConfig, type BootstrapHost } from "./bootstrap.js";
 
 class TestApp extends Bootstrap implements BootstrapHost {
@@ -23,9 +24,9 @@ describe("Bootstrap", () => {
     resetLoadHooks();
   });
 
-  describe("default logger", () => {
-    it("returns a NullLogger before :initialize_logger runs", () => {
-      expect(Bootstrap.defaultLogger()).toBeInstanceOf(NullLogger);
+  describe("class shape", () => {
+    it("extends Initializable", () => {
+      expect(new TestApp()).toBeInstanceOf(Initializable);
     });
   });
 
@@ -97,14 +98,26 @@ describe("Bootstrap", () => {
   });
 
   describe("initializer order", () => {
+    const expected = [
+      "load_environment_config",
+      "initialize_logger",
+      "initialize_cache",
+      "bootstrap_hook",
+    ];
+
     it("declares the four initializers in Rails order", () => {
-      const names = Bootstrap._ownInitializers().map((i) => i.name);
-      expect(names).toEqual([
-        "load_environment_config",
-        "initialize_logger",
-        "initialize_cache",
-        "bootstrap_hook",
-      ]);
+      expect(Bootstrap._ownInitializers().map((i) => i.name)).toEqual(expected);
+    });
+
+    it("tsorts to the same Rails order via implicit chaining", () => {
+      const app = new TestApp();
+      expect(app.initializers.tsort().map((i) => i.name)).toEqual(expected);
+    });
+
+    it("places every initializer in the :all group", () => {
+      for (const init of Bootstrap._ownInitializers()) {
+        expect(init.belongsTo("all")).toBe(true);
+      }
     });
   });
 });

--- a/packages/trailties/src/application/bootstrap.test.ts
+++ b/packages/trailties/src/application/bootstrap.test.ts
@@ -1,0 +1,110 @@
+import {
+  type CacheStore,
+  Logger,
+  NullLogger,
+  NullStore,
+  onLoad,
+  resetLoadHooks,
+} from "@blazetrails/activesupport";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { Bootstrap, type BootstrapConfig, type BootstrapHost } from "./bootstrap.js";
+
+class TestApp extends Bootstrap implements BootstrapHost {
+  logger: Logger | null = null;
+  cache: CacheStore | null = null;
+  config: BootstrapConfig = {};
+}
+
+describe("Bootstrap", () => {
+  beforeEach(() => {
+    resetLoadHooks();
+  });
+  afterEach(() => {
+    resetLoadHooks();
+  });
+
+  describe("default logger", () => {
+    it("returns a NullLogger before :initialize_logger runs", () => {
+      expect(Bootstrap.defaultLogger()).toBeInstanceOf(NullLogger);
+    });
+  });
+
+  describe(":initialize_logger", () => {
+    it("uses config.logger when provided", () => {
+      const app = new TestApp();
+      const custom = new Logger(null);
+      app.config = { logger: custom };
+      app.runInitializers("all");
+      expect(app.logger).toBe(custom);
+    });
+
+    it("falls back to a NullLogger when config.logger is unset", () => {
+      const app = new TestApp();
+      app.runInitializers("all");
+      expect(app.logger).toBeInstanceOf(NullLogger);
+    });
+
+    it("applies config.logLevel to the resulting logger", () => {
+      const app = new TestApp();
+      app.config = { logLevel: "warn" };
+      app.runInitializers("all");
+      expect(app.logger?.level).toBe(Logger.WARN);
+    });
+
+    it("preserves a pre-existing logger", () => {
+      const app = new TestApp();
+      const preset = new Logger(null);
+      app.logger = preset;
+      app.runInitializers("all");
+      expect(app.logger).toBe(preset);
+    });
+  });
+
+  describe(":initialize_cache", () => {
+    it("uses config.cacheStore when provided", () => {
+      const app = new TestApp();
+      const store = new NullStore();
+      app.config = { cacheStore: store };
+      app.runInitializers("all");
+      expect(app.cache).toBe(store);
+    });
+
+    it("invokes config.cacheStore when given as a factory", () => {
+      const app = new TestApp();
+      const store = new NullStore();
+      app.config = { cacheStore: () => store };
+      app.runInitializers("all");
+      expect(app.cache).toBe(store);
+    });
+
+    it("falls back to a NullStore when cacheStore is unset", () => {
+      const app = new TestApp();
+      app.runInitializers("all");
+      expect(app.cache).toBeInstanceOf(NullStore);
+    });
+  });
+
+  describe(":bootstrap_hook", () => {
+    it("runs the :before_initialize load hooks against the app", () => {
+      const app = new TestApp();
+      let captured: unknown = null;
+      onLoad("before_initialize", (base) => {
+        captured = base;
+      });
+      app.runInitializers("all");
+      expect(captured).toBe(app);
+    });
+  });
+
+  describe("initializer order", () => {
+    it("declares the four initializers in Rails order", () => {
+      const names = Bootstrap._ownInitializers().map((i) => i.name);
+      expect(names).toEqual([
+        "load_environment_config",
+        "initialize_logger",
+        "initialize_cache",
+        "bootstrap_hook",
+      ]);
+    });
+  });
+});

--- a/packages/trailties/src/application/bootstrap.ts
+++ b/packages/trailties/src/application/bootstrap.ts
@@ -18,7 +18,7 @@
  */
 import {
   type CacheStore,
-  Logger,
+  type Logger,
   type LogLevel,
   NullLogger,
   NullStore,
@@ -38,15 +38,7 @@ export interface BootstrapHost {
   config: BootstrapConfig;
 }
 
-export class Bootstrap extends Initializable {
-  /**
-   * Default logger returned before `:initialize_logger` runs. Mirrors the
-   * Rails guarantee that `Rails.logger` is never nil at import time.
-   */
-  static defaultLogger(): Logger {
-    return new NullLogger();
-  }
-}
+export class Bootstrap extends Initializable {}
 
 Bootstrap.initializer("load_environment_config", { group: "all" }, function () {
   // Empty placeholder. Rails loads `config/environments/*.rb` here; trailties

--- a/packages/trailties/src/application/bootstrap.ts
+++ b/packages/trailties/src/application/bootstrap.ts
@@ -38,7 +38,11 @@ export interface BootstrapHost {
   config: BootstrapConfig;
 }
 
-export class Bootstrap extends Initializable {}
+export abstract class Bootstrap extends Initializable implements BootstrapHost {
+  abstract logger: Logger | null;
+  abstract cache: CacheStore | null;
+  abstract config: BootstrapConfig;
+}
 
 Bootstrap.initializer("load_environment_config", { group: "all" }, function () {
   // Empty placeholder. Rails loads `config/environments/*.rb` here; trailties

--- a/packages/trailties/src/application/bootstrap.ts
+++ b/packages/trailties/src/application/bootstrap.ts
@@ -1,0 +1,73 @@
+/**
+ * Port of `Rails::Application::Bootstrap` from
+ * `railties/lib/rails/application/bootstrap.rb`.
+ *
+ * Rails-mirrored initializers kept here:
+ *   - `:load_environment_config` — placeholder hook, run before user config.
+ *   - `:initialize_logger`       — wire `host.logger` from `config.logger` or
+ *                                  fall back to a `NullLogger`.
+ *   - `:initialize_cache`        — wire `host.cache` from `config.cacheStore`
+ *                                  or fall back to a `NullStore`.
+ *   - `:bootstrap_hook`          — fires the `before_initialize` load hook.
+ *
+ * Intentionally skipped (see docs/trailties-plan.md):
+ *   - `:set_load_path`, `:set_autoload_paths`,
+ *     `:initialize_dependency_mechanism`, `:set_eager_load_paths`,
+ *     `:load_environment_hook` — autoload / eager-load only;
+ *     ESM + bundlers cover this in trailties.
+ */
+import {
+  type CacheStore,
+  Logger,
+  type LogLevel,
+  NullLogger,
+  NullStore,
+  runLoadHooks,
+} from "@blazetrails/activesupport";
+import { Initializable } from "../initializable.js";
+
+export interface BootstrapConfig {
+  logger?: Logger | null;
+  logLevel?: LogLevel | number;
+  cacheStore?: CacheStore | (() => CacheStore);
+}
+
+export interface BootstrapHost {
+  logger: Logger | null;
+  cache: CacheStore | null;
+  config: BootstrapConfig;
+}
+
+export class Bootstrap extends Initializable {
+  /**
+   * Default logger returned before `:initialize_logger` runs. Mirrors the
+   * Rails guarantee that `Rails.logger` is never nil at import time.
+   */
+  static defaultLogger(): Logger {
+    return new NullLogger();
+  }
+}
+
+Bootstrap.initializer("load_environment_config", { group: "all" }, function () {
+  // Empty placeholder. Rails loads `config/environments/*.rb` here; trailties
+  // applications load environment modules through `config_for` (PR 2.5).
+});
+
+Bootstrap.initializer<BootstrapHost>("initialize_logger", { group: "all" }, function () {
+  if (!this.logger) {
+    this.logger = this.config.logger ?? new NullLogger();
+  }
+  const level = this.config.logLevel;
+  if (level !== undefined) this.logger.level = level;
+});
+
+Bootstrap.initializer<BootstrapHost>("initialize_cache", { group: "all" }, function () {
+  if (!this.cache) {
+    const store = this.config.cacheStore;
+    this.cache = typeof store === "function" ? store() : (store ?? new NullStore());
+  }
+});
+
+Bootstrap.initializer<BootstrapHost>("bootstrap_hook", { group: "all" }, function () {
+  runLoadHooks("before_initialize", this);
+});


### PR DESCRIPTION
## Summary

Port `Rails::Application::Bootstrap` from `railties/lib/rails/application/bootstrap.rb` (PR 2.3 of the trailties plan).

- New `Bootstrap` class (extends `Initializable`) at `packages/trailties/src/application/bootstrap.ts` registers the four kept initializers; tests in `bootstrap.test.ts` exercise each.
- Adds `NullLogger` / `nullLogger()` to activesupport — resolves open question #4 (the plan doc requires a real no-op logger primitive before `:initialize_logger` runs).

## Rails sources

- `railties/lib/rails/application/bootstrap.rb`

### Initializers kept

- `:load_environment_config` — empty placeholder; trailties apps load environment modules via `config_for` (PR 2.5).
- `:initialize_logger` — wires `host.logger` from `config.logger` or falls back to `NullLogger`; honors `config.logLevel`.
- `:initialize_cache` — wires `host.cache` from `config.cacheStore` (value or factory) or falls back to `NullStore`.
- `:bootstrap_hook` — fires `before_initialize` lazy-load hooks.

### Initializers intentionally skipped

- `:set_load_path`
- `:set_autoload_paths`
- `:initialize_dependency_mechanism`
- `:set_eager_load_paths`
- `:load_environment_hook`

All five are autoload / eager-load only; trailties relies on ESM and bundlers (per docs/trailties-plan.md "What we are NOT building").

## Test plan

- [x] `pnpm vitest run packages/trailties/src/application/bootstrap.test.ts packages/activesupport/src/null-logger.test.ts`
- [x] `pnpm build` clean
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] No `node:*` imports added in `packages/trailties/src/`
- [x] No `process.*` references added
- [x] 231 LOC (under 300 ceiling)