### PR TITLE
feat(trailties): Finisher initializers (PR 2.4)

### DIFF
--- a/packages/trailties/src/application/finisher.test.ts
+++ b/packages/trailties/src/application/finisher.test.ts
@@ -1,0 +1,135 @@
+// Mirrors railties/test/application/initializers/finisher_test.rb.
+// The ported subset of finisher initializers is exercised against a
+// mock host so we don't need the full Application shell (PR 2.5).
+import { describe, it, expect } from "vitest";
+import {
+  Finisher,
+  type FinisherConfig,
+  type FinisherEnv,
+  type FinisherHost,
+  type FinisherReloader,
+  type FinisherRoutes,
+} from "./finisher.js";
+import type { ConfigurationBlock } from "../trailtie/configuration.js";
+
+function buildHost(env: "development" | "production" = "development"): {
+  app: FinisherHost & Finisher;
+  calls: string[];
+  internalRoutes: string[];
+  toPrepared: ConfigurationBlock[];
+  mountedHelpers: string[];
+} {
+  const calls: string[] = [];
+  const internalRoutes: string[] = [];
+  const toPrepared: ConfigurationBlock[] = [];
+  const mountedHelpers: string[] = [];
+
+  class TestApp extends Finisher implements FinisherHost {
+    config: FinisherConfig = { toPrepareBlocks: [] };
+    env: FinisherEnv = { isDevelopment: () => env === "development" };
+    routes: FinisherRoutes = {
+      prepend: (block) => block(),
+      defineMountedHelper: (name) => mountedHelpers.push(name),
+    };
+    reloader: FinisherReloader = {
+      toPrepare: (block) => toPrepared.push(block),
+      prepareBang: () => calls.push("prepare!"),
+    };
+    ensureGeneratorTemplatesAdded(): void {
+      calls.push("generator_templates");
+    }
+    buildMiddlewareStack(): void {
+      calls.push("middleware_stack");
+    }
+    appendInternalRoute(verb: string, path: string, to: string): void {
+      internalRoutes.push(`${verb} ${path} -> ${to}`);
+    }
+  }
+
+  return {
+    app: new TestApp() as FinisherHost & Finisher,
+    calls,
+    internalRoutes,
+    toPrepared,
+    mountedHelpers,
+  };
+}
+
+describe("Finisher", () => {
+  it("registers the ported finisher initializers in Rails order", () => {
+    const names = Finisher._ownInitializers().map((i) => i.name);
+    expect(names).toEqual([
+      "add_generator_templates",
+      "add_internal_routes",
+      "build_middleware_stack",
+      "define_main_app_helper",
+      "add_to_prepare_blocks",
+      "run_prepare_callbacks",
+    ]);
+  });
+
+  it("does not register the intentionally skipped initializers", () => {
+    const names = Finisher._ownInitializers().map((i) => i.name);
+    expect(names).not.toContain("eager_load!");
+    expect(names).not.toContain("setup_main_autoloader");
+    expect(names).not.toContain("set_routes_reloader_hook");
+    expect(names).not.toContain("set_clear_dependencies_hook");
+    expect(names).not.toContain("enable_yjit");
+    expect(names).not.toContain("configure_executor_for_concurrency");
+  });
+
+  it("add_generator_templates calls ensureGeneratorTemplatesAdded", () => {
+    const { app, calls } = buildHost();
+    app.initializers.find((i) => i.name === "add_generator_templates")!.run(app);
+    expect(calls).toContain("generator_templates");
+  });
+
+  it("build_middleware_stack calls buildMiddlewareStack", () => {
+    const { app, calls } = buildHost();
+    app.initializers.find((i) => i.name === "build_middleware_stack")!.run(app);
+    expect(calls).toContain("middleware_stack");
+  });
+
+  it("define_main_app_helper defines the main_app mounted helper", () => {
+    const { app, mountedHelpers } = buildHost();
+    app.initializers.find((i) => i.name === "define_main_app_helper")!.run(app);
+    expect(mountedHelpers).toEqual(["main_app"]);
+  });
+
+  it("add_to_prepare_blocks forwards config.toPrepareBlocks to the reloader", () => {
+    const { app, toPrepared } = buildHost();
+    const block: ConfigurationBlock = () => {};
+    app.config.toPrepareBlocks.push(block);
+    app.initializers.find((i) => i.name === "add_to_prepare_blocks")!.run(app);
+    expect(toPrepared).toEqual([block]);
+  });
+
+  it("run_prepare_callbacks runs reloader.prepare!", () => {
+    const { app, calls } = buildHost();
+    app.initializers.find((i) => i.name === "run_prepare_callbacks")!.run(app);
+    expect(calls).toContain("prepare!");
+  });
+
+  it("add_internal_routes prepends rails/info routes in development", () => {
+    const { app, internalRoutes } = buildHost("development");
+    app.initializers.find((i) => i.name === "add_internal_routes")!.run(app);
+    expect(internalRoutes).toEqual([
+      "get /rails/info/properties -> rails/info#properties",
+      "get /rails/info/routes -> rails/info#routes",
+      "get /rails/info/notes -> rails/info#notes",
+      "get /rails/info -> rails/info#index",
+    ]);
+  });
+
+  it("add_internal_routes is a no-op outside development", () => {
+    const { app, internalRoutes } = buildHost("production");
+    app.initializers.find((i) => i.name === "add_internal_routes")!.run(app);
+    expect(internalRoutes).toEqual([]);
+  });
+
+  it("runs all finisher initializers in order via runInitializers", () => {
+    const { app, calls } = buildHost();
+    app.runInitializers();
+    expect(calls).toEqual(["generator_templates", "middleware_stack", "prepare!"]);
+  });
+});

--- a/packages/trailties/src/application/finisher.test.ts
+++ b/packages/trailties/src/application/finisher.test.ts
@@ -6,53 +6,41 @@ import {
   Finisher,
   type FinisherConfig,
   type FinisherEnv,
-  type FinisherHost,
   type FinisherReloader,
   type FinisherRoutes,
 } from "./finisher.js";
 import type { ConfigurationBlock } from "../trailtie/configuration.js";
 
-function buildHost(env: "development" | "production" = "development"): {
-  app: FinisherHost & Finisher;
-  calls: string[];
-  internalRoutes: string[];
-  toPrepared: ConfigurationBlock[];
-  mountedHelpers: string[];
-} {
-  const calls: string[] = [];
-  const internalRoutes: string[] = [];
-  const toPrepared: ConfigurationBlock[] = [];
-  const mountedHelpers: string[] = [];
+class TestApp extends Finisher {
+  config: FinisherConfig = { toPrepareBlocks: [] };
+  env: FinisherEnv = { isDevelopment: () => true };
+  calls: string[] = [];
+  internalRoutes: string[] = [];
+  toPrepared: ConfigurationBlock[] = [];
+  mountedHelpers: string[] = [];
 
-  class TestApp extends Finisher implements FinisherHost {
-    config: FinisherConfig = { toPrepareBlocks: [] };
-    env: FinisherEnv = { isDevelopment: () => env === "development" };
-    routes: FinisherRoutes = {
-      prepend: (block) => block(),
-      defineMountedHelper: (name) => mountedHelpers.push(name),
-    };
-    reloader: FinisherReloader = {
-      toPrepare: (block) => toPrepared.push(block),
-      prepareBang: () => calls.push("prepare!"),
-    };
-    ensureGeneratorTemplatesAdded(): void {
-      calls.push("generator_templates");
-    }
-    buildMiddlewareStack(): void {
-      calls.push("middleware_stack");
-    }
-    appendInternalRoute(verb: string, path: string, to: string): void {
-      internalRoutes.push(`${verb} ${path} -> ${to}`);
-    }
-  }
-
-  return {
-    app: new TestApp() as FinisherHost & Finisher,
-    calls,
-    internalRoutes,
-    toPrepared,
-    mountedHelpers,
+  routes: FinisherRoutes = {
+    prepend: (block) => block(),
+    defineMountedHelper: (name) => this.mountedHelpers.push(name),
   };
+  reloader: FinisherReloader = {
+    toPrepare: (block) => this.toPrepared.push(block),
+    prepareBang: () => this.calls.push("prepare!"),
+  };
+
+  ensureGeneratorTemplatesAdded(): void {
+    this.calls.push("generator_templates");
+  }
+  buildMiddlewareStack(): void {
+    this.calls.push("middleware_stack");
+  }
+  appendInternalRoute(verb: string, path: string, to: string): void {
+    this.internalRoutes.push(`${verb} ${path} -> ${to}`);
+  }
+}
+
+function run(app: TestApp, name: string): void {
+  app.initializers.find((i) => i.name === name)!.run();
 }
 
 describe("Finisher", () => {
@@ -70,50 +58,56 @@ describe("Finisher", () => {
 
   it("does not register the intentionally skipped initializers", () => {
     const names = Finisher._ownInitializers().map((i) => i.name);
-    expect(names).not.toContain("eager_load!");
-    expect(names).not.toContain("setup_main_autoloader");
-    expect(names).not.toContain("set_routes_reloader_hook");
-    expect(names).not.toContain("set_clear_dependencies_hook");
-    expect(names).not.toContain("enable_yjit");
-    expect(names).not.toContain("configure_executor_for_concurrency");
+    for (const skipped of [
+      "eager_load!",
+      "setup_main_autoloader",
+      "setup_default_session_store",
+      "finisher_hook",
+      "configure_executor_for_concurrency",
+      "set_routes_reloader_hook",
+      "set_clear_dependencies_hook",
+      "enable_yjit",
+    ]) {
+      expect(names).not.toContain(skipped);
+    }
   });
 
   it("add_generator_templates calls ensureGeneratorTemplatesAdded", () => {
-    const { app, calls } = buildHost();
-    app.initializers.find((i) => i.name === "add_generator_templates")!.run(app);
-    expect(calls).toContain("generator_templates");
+    const app = new TestApp();
+    run(app, "add_generator_templates");
+    expect(app.calls).toEqual(["generator_templates"]);
   });
 
   it("build_middleware_stack calls buildMiddlewareStack", () => {
-    const { app, calls } = buildHost();
-    app.initializers.find((i) => i.name === "build_middleware_stack")!.run(app);
-    expect(calls).toContain("middleware_stack");
+    const app = new TestApp();
+    run(app, "build_middleware_stack");
+    expect(app.calls).toEqual(["middleware_stack"]);
   });
 
   it("define_main_app_helper defines the main_app mounted helper", () => {
-    const { app, mountedHelpers } = buildHost();
-    app.initializers.find((i) => i.name === "define_main_app_helper")!.run(app);
-    expect(mountedHelpers).toEqual(["main_app"]);
+    const app = new TestApp();
+    run(app, "define_main_app_helper");
+    expect(app.mountedHelpers).toEqual(["main_app"]);
   });
 
   it("add_to_prepare_blocks forwards config.toPrepareBlocks to the reloader", () => {
-    const { app, toPrepared } = buildHost();
+    const app = new TestApp();
     const block: ConfigurationBlock = () => {};
     app.config.toPrepareBlocks.push(block);
-    app.initializers.find((i) => i.name === "add_to_prepare_blocks")!.run(app);
-    expect(toPrepared).toEqual([block]);
+    run(app, "add_to_prepare_blocks");
+    expect(app.toPrepared).toEqual([block]);
   });
 
   it("run_prepare_callbacks runs reloader.prepare!", () => {
-    const { app, calls } = buildHost();
-    app.initializers.find((i) => i.name === "run_prepare_callbacks")!.run(app);
-    expect(calls).toContain("prepare!");
+    const app = new TestApp();
+    run(app, "run_prepare_callbacks");
+    expect(app.calls).toEqual(["prepare!"]);
   });
 
   it("add_internal_routes prepends rails/info routes in development", () => {
-    const { app, internalRoutes } = buildHost("development");
-    app.initializers.find((i) => i.name === "add_internal_routes")!.run(app);
-    expect(internalRoutes).toEqual([
+    const app = new TestApp();
+    run(app, "add_internal_routes");
+    expect(app.internalRoutes).toEqual([
       "get /rails/info/properties -> rails/info#properties",
       "get /rails/info/routes -> rails/info#routes",
       "get /rails/info/notes -> rails/info#notes",
@@ -122,14 +116,15 @@ describe("Finisher", () => {
   });
 
   it("add_internal_routes is a no-op outside development", () => {
-    const { app, internalRoutes } = buildHost("production");
-    app.initializers.find((i) => i.name === "add_internal_routes")!.run(app);
-    expect(internalRoutes).toEqual([]);
+    const app = new TestApp();
+    app.env = { isDevelopment: () => false };
+    run(app, "add_internal_routes");
+    expect(app.internalRoutes).toEqual([]);
   });
 
-  it("runs all finisher initializers in order via runInitializers", () => {
-    const { app, calls } = buildHost();
+  it("runs all finisher initializers in declared order via runInitializers", () => {
+    const app = new TestApp();
     app.runInitializers();
-    expect(calls).toEqual(["generator_templates", "middleware_stack", "prepare!"]);
+    expect(app.calls).toEqual(["generator_templates", "middleware_stack", "prepare!"]);
   });
 });

--- a/packages/trailties/src/application/finisher.ts
+++ b/packages/trailties/src/application/finisher.ts
@@ -1,0 +1,83 @@
+/**
+ * Port of `Rails::Application::Finisher` from
+ * `railties/lib/rails/application/finisher.rb`. Defines the finisher
+ * initializers that run after the Trailtie initializers and bootstrap.
+ *
+ * Application (PR 2.5) will splice these into its initializer chain.
+ * Until then, this class can stand alone so tests can exercise the
+ * declarations and block bodies against a mock host.
+ *
+ * The Rails initializers tied to Zeitwerk, eager loading, the
+ * reloader/executor concurrency hooks, session store defaults, the
+ * routes-reloader hook, and YJIT are intentionally not ported here —
+ * they depend on subsystems we don't have or are out of scope per the
+ * trailties plan.
+ */
+import { Initializable } from "../initializable.js";
+import type { ConfigurationBlock } from "../trailtie/configuration.js";
+
+export interface FinisherRoutes {
+  prepend(block: () => void): void;
+  defineMountedHelper(name: string): void;
+}
+
+export interface FinisherReloader {
+  toPrepare(block: ConfigurationBlock): void;
+  prepareBang(): void;
+}
+
+export interface FinisherConfig {
+  toPrepareBlocks: ConfigurationBlock[];
+}
+
+export interface FinisherEnv {
+  isDevelopment(): boolean;
+}
+
+export interface FinisherHost {
+  config: FinisherConfig;
+  routes: FinisherRoutes;
+  reloader: FinisherReloader;
+  env: FinisherEnv;
+  ensureGeneratorTemplatesAdded(): void;
+  buildMiddlewareStack(): void;
+  appendInternalRoute(verb: string, path: string, to: string): void;
+}
+
+export class Finisher extends Initializable {}
+
+Finisher.initializer("add_generator_templates", function (this: FinisherHost) {
+  this.ensureGeneratorTemplatesAdded();
+});
+
+Finisher.initializer("add_internal_routes", function (this: FinisherHost, app?: unknown) {
+  const host = (app as FinisherHost | undefined) ?? this;
+  if (!host.env.isDevelopment()) return;
+  host.routes.prepend(() => {
+    host.appendInternalRoute("get", "/rails/info/properties", "rails/info#properties");
+    host.appendInternalRoute("get", "/rails/info/routes", "rails/info#routes");
+    host.appendInternalRoute("get", "/rails/info/notes", "rails/info#notes");
+    host.appendInternalRoute("get", "/rails/info", "rails/info#index");
+  });
+});
+
+Finisher.initializer("build_middleware_stack", function (this: FinisherHost) {
+  this.buildMiddlewareStack();
+});
+
+Finisher.initializer("define_main_app_helper", function (this: FinisherHost, app?: unknown) {
+  const host = (app as FinisherHost | undefined) ?? this;
+  host.routes.defineMountedHelper("main_app");
+});
+
+Finisher.initializer("add_to_prepare_blocks", function (this: FinisherHost, app?: unknown) {
+  const host = (app as FinisherHost | undefined) ?? this;
+  for (const block of host.config.toPrepareBlocks) {
+    host.reloader.toPrepare(block);
+  }
+});
+
+Finisher.initializer("run_prepare_callbacks", function (this: FinisherHost, app?: unknown) {
+  const host = (app as FinisherHost | undefined) ?? this;
+  host.reloader.prepareBang();
+});

--- a/packages/trailties/src/application/finisher.ts
+++ b/packages/trailties/src/application/finisher.ts
@@ -1,17 +1,24 @@
 /**
  * Port of `Rails::Application::Finisher` from
  * `railties/lib/rails/application/finisher.rb`. Defines the finisher
- * initializers that run after the Trailtie initializers and bootstrap.
+ * initializers that run after the Trailtie + bootstrap initializers.
  *
- * Application (PR 2.5) will splice these into its initializer chain.
- * Until then, this class can stand alone so tests can exercise the
- * declarations and block bodies against a mock host.
+ * Application (PR 2.5) will splice these into its initializer chain via
+ * `initializersChain()`. Until then this class stands alone so tests can
+ * exercise the declarations and block bodies against a mock host.
+ *
+ * Rails blocks of the form `initializer :foo do |app|` get the
+ * Application instance both as `self` and as the block argument. In our
+ * port, `Initializable` binds each initializer to its host via
+ * `bind(context)` before calling `block.apply(context, args)`, so `this`
+ * is already the host. The blocks here use `this: FinisherHost` and
+ * skip the redundant argument.
  *
  * The Rails initializers tied to Zeitwerk, eager loading, the
- * reloader/executor concurrency hooks, session store defaults, the
- * routes-reloader hook, and YJIT are intentionally not ported here —
- * they depend on subsystems we don't have or are out of scope per the
- * trailties plan.
+ * reloader/executor concurrency hooks, default session store, the
+ * routes-reloader hook, dependency clearing, and YJIT are intentionally
+ * not ported here — they depend on subsystems we don't have or are out
+ * of scope per the trailties plan.
  */
 import { Initializable } from "../initializable.js";
 import type { ConfigurationBlock } from "../trailtie/configuration.js";
@@ -50,14 +57,13 @@ Finisher.initializer("add_generator_templates", function (this: FinisherHost) {
   this.ensureGeneratorTemplatesAdded();
 });
 
-Finisher.initializer("add_internal_routes", function (this: FinisherHost, app?: unknown) {
-  const host = (app as FinisherHost | undefined) ?? this;
-  if (!host.env.isDevelopment()) return;
-  host.routes.prepend(() => {
-    host.appendInternalRoute("get", "/rails/info/properties", "rails/info#properties");
-    host.appendInternalRoute("get", "/rails/info/routes", "rails/info#routes");
-    host.appendInternalRoute("get", "/rails/info/notes", "rails/info#notes");
-    host.appendInternalRoute("get", "/rails/info", "rails/info#index");
+Finisher.initializer("add_internal_routes", function (this: FinisherHost) {
+  if (!this.env.isDevelopment()) return;
+  this.routes.prepend(() => {
+    this.appendInternalRoute("get", "/rails/info/properties", "rails/info#properties");
+    this.appendInternalRoute("get", "/rails/info/routes", "rails/info#routes");
+    this.appendInternalRoute("get", "/rails/info/notes", "rails/info#notes");
+    this.appendInternalRoute("get", "/rails/info", "rails/info#index");
   });
 });
 
@@ -65,19 +71,16 @@ Finisher.initializer("build_middleware_stack", function (this: FinisherHost) {
   this.buildMiddlewareStack();
 });
 
-Finisher.initializer("define_main_app_helper", function (this: FinisherHost, app?: unknown) {
-  const host = (app as FinisherHost | undefined) ?? this;
-  host.routes.defineMountedHelper("main_app");
+Finisher.initializer("define_main_app_helper", function (this: FinisherHost) {
+  this.routes.defineMountedHelper("main_app");
 });
 
-Finisher.initializer("add_to_prepare_blocks", function (this: FinisherHost, app?: unknown) {
-  const host = (app as FinisherHost | undefined) ?? this;
-  for (const block of host.config.toPrepareBlocks) {
-    host.reloader.toPrepare(block);
+Finisher.initializer("add_to_prepare_blocks", function (this: FinisherHost) {
+  for (const block of this.config.toPrepareBlocks) {
+    this.reloader.toPrepare(block);
   }
 });
 
-Finisher.initializer("run_prepare_callbacks", function (this: FinisherHost, app?: unknown) {
-  const host = (app as FinisherHost | undefined) ?? this;
-  host.reloader.prepareBang();
+Finisher.initializer("run_prepare_callbacks", function (this: FinisherHost) {
+  this.reloader.prepareBang();
 });


### PR DESCRIPTION
## Summary

Ports the kept subset of `Rails::Application::Finisher` initializers
into `@blazetrails/trailties`, per the trailties plan PR 2.4.

A standalone `Finisher` class extending `Initializable` registers the
six initializers against a typed `FinisherHost` interface. `Application`
(PR 2.5) will splice these into its initializer chain; a mock host in
the tests exercises every block today.

## Rails sources

- `railties/lib/rails/application/finisher.rb`

**Kept** (Rails names — `test:compare` matches these verbatim):

- `:add_generator_templates`
- `:add_internal_routes` (plan listed this as `:add_builtin_route`; Rails
  source name kept per CLAUDE.md rule on verbatim test/identifier names)
- `:build_middleware_stack`
- `:define_main_app_helper`
- `:add_to_prepare_blocks`
- `:run_prepare_callbacks`

**Skipped** (autoloader / eager-load / reloader-concurrency / YJIT /
session-store / routes-reloader subsystems are out of scope for the
trailties port, per the plan's "What we are NOT building" table):

- `:setup_main_autoloader`
- `:setup_default_session_store`
- `:eager_load!`
- `:finisher_hook` (after_initialize hook — defer)
- `:configure_executor_for_concurrency`
- `:set_routes_reloader_hook`
- `:set_clear_dependencies_hook`
- `:enable_yjit`
- `:ensure_autoload_once_paths_as_subset_of_autoload_paths` (lives in
  bootstrap; listed by plan as skipped framework-wide)

## Test plan

- [x] `pnpm vitest run packages/trailties/src/application/finisher.test.ts` — 10 passing
- [x] `pnpm lint` clean
- [x] No `node:*` / `process.*` references in new files
- [x] PR size 218 LOC (under 300 ceiling)