### PR TITLE
feat(trailties): per-framework Trailtie wiring (PR 2.7b + 2.7e)

### DIFF
--- a/packages/actionview/src/deprecator.ts
+++ b/packages/actionview/src/deprecator.ts
@@ -1,0 +1,14 @@
+/**
+ * Deprecator — handles deprecation warnings for ActionView.
+ *
+ * Mirrors: ActionView.deprecator (ActiveSupport::Deprecation instance).
+ */
+import { Deprecation } from "@blazetrails/activesupport";
+
+export { Deprecation as Deprecator };
+
+const _deprecator = new Deprecation({ gem: "actionview" });
+
+export function deprecator(): Deprecation {
+  return _deprecator;
+}

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -56,5 +56,5 @@ export {
 
 export * from "./helpers/index.js";
 
-export { Trailtie, defaultActionViewConfig, type ActionViewConfig } from "./trailtie.js";
+export { Trailtie, type ActionViewConfig } from "./trailtie.js";
 export { deprecator, Deprecator } from "./deprecator.js";

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -55,3 +55,6 @@ export {
 } from "./template-details.js";
 
 export * from "./helpers/index.js";
+
+export { Trailtie, defaultActionViewConfig, type ActionViewConfig } from "./trailtie.js";
+export { deprecator, Deprecator } from "./deprecator.js";

--- a/packages/actionview/src/trailtie.test.ts
+++ b/packages/actionview/src/trailtie.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { Trailtie, defaultActionViewConfig } from "./trailtie.js";
+import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
+import { deprecator } from "./deprecator.js";
+
+const { deprecators } = BaseRailtie;
+
+describe("RailtieTest", () => {
+  let savedSubclasses: (typeof BaseRailtie)[];
+
+  beforeEach(() => {
+    savedSubclasses = [...BaseRailtie.subclasses];
+  });
+
+  afterEach(() => {
+    (BaseRailtie.subclasses as (typeof BaseRailtie)[]).length = 0;
+    (BaseRailtie.subclasses as (typeof BaseRailtie)[]).push(...savedSubclasses);
+    for (const key of Object.keys(deprecators)) {
+      delete deprecators[key];
+    }
+  });
+
+  it("ActionView::Railtie is registered in the global subclasses list", () => {
+    expect(BaseRailtie.subclasses).toContain(Trailtie);
+  });
+
+  it("seeds the actionView config slot with Rails-matching defaults", () => {
+    expect(Trailtie.config["actionView"]).toEqual(defaultActionViewConfig());
+  });
+
+  it("runInitializers registers the ActionView deprecator", () => {
+    Trailtie.runInitializers();
+    expect(deprecators["actionView"]).toBe(deprecator());
+  });
+});

--- a/packages/actionview/src/trailtie.ts
+++ b/packages/actionview/src/trailtie.ts
@@ -1,0 +1,55 @@
+/**
+ * Trailtie — initialization hooks for ActionView.
+ *
+ * Mirrors: ActionView::Railtie < ::Rails::Engine
+ * (actionview/lib/action_view/railtie.rb)
+ *
+ * Extends the base Railtie exported from `@blazetrails/activesupport` and
+ * registers itself in the global initialization pipeline. Seeds the
+ * `actionView` config slot with the same defaults Rails establishes at the
+ * top of `railtie.rb`.
+ *
+ * Skipped initializers (deferred until the underlying helpers / resolver
+ * caching surface are ported): `action_view.logger`, `action_view.caching`,
+ * `action_view.setup_action_pack`, `action_view.collection_caching`, and
+ * every `config.after_initialize` block that mutates AssetTagHelper /
+ * FormHelper / FormTagHelper / SanitizeHelper / UrlHelper / Template /
+ * ContentExfiltrationPreventionHelper / Resolver. The matching helper
+ * setters either don't exist yet or live in unported namespaces.
+ */
+import { Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
+import { deprecator } from "./deprecator.js";
+
+export interface ActionViewConfig {
+  embedAuthenticityTokenInRemoteForms: boolean | null;
+  debugMissingTranslation: boolean;
+  defaultEnforceUtf8: boolean | null;
+  imageLoading: string | null;
+  imageDecoding: string | null;
+  applyStylesheetMediaDefault: boolean;
+  prependContentExfiltrationPrevention: boolean;
+}
+
+export function defaultActionViewConfig(): ActionViewConfig {
+  return {
+    embedAuthenticityTokenInRemoteForms: null,
+    debugMissingTranslation: true,
+    defaultEnforceUtf8: null,
+    imageLoading: null,
+    imageDecoding: null,
+    applyStylesheetMediaDefault: true,
+    prependContentExfiltrationPrevention: false,
+  };
+}
+
+export class Trailtie extends BaseRailtie {
+  static {
+    registerRailtie(this);
+
+    this.config["actionView"] = defaultActionViewConfig();
+
+    this.initializer("action_view.deprecator", () => {
+      BaseRailtie.deprecators["actionView"] = deprecator();
+    });
+  }
+}

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -47,7 +47,7 @@ export { LazyAttributeSet, LazyAttributeHash } from "./attribute-set/builder.js"
 export { AttributeSetCoder, AttributeSetCoderError } from "./attribute-set/coder.js";
 export type { AttributeSetCodec, AttributeSetEnvelope } from "./attribute-set/coder.js";
 export { jsonCodec } from "./attribute-set/codecs/json.js";
-export { Railtie } from "./railtie.js";
+export { Trailtie } from "./trailtie.js";
 export { WithValidator } from "./validations/with.js";
 export { AbsenceValidator } from "./validations/absence.js";
 export { PresenceValidator } from "./validations/presence.js";

--- a/packages/activemodel/src/trailtie.test.ts
+++ b/packages/activemodel/src/trailtie.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { env as processEnv, setEnv } from "@blazetrails/activesupport/process-adapter";
-import { Railtie } from "./railtie.js";
+import { Trailtie } from "./trailtie.js";
 import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
 const { deprecators } = BaseRailtie;
 import { SecurePassword } from "./secure-password.js";
@@ -18,10 +18,10 @@ describe("RailtieTest", () => {
     try {
       savedConfig =
         typeof structuredClone === "function"
-          ? structuredClone(Railtie.config)
-          : { ...Railtie.config };
+          ? structuredClone(Trailtie.config)
+          : { ...Trailtie.config };
     } catch {
-      savedConfig = { ...Railtie.config };
+      savedConfig = { ...Trailtie.config };
     }
   });
 
@@ -31,10 +31,10 @@ describe("RailtieTest", () => {
     (BaseRailtie.subclasses as (typeof BaseRailtie)[]).length = 0;
     (BaseRailtie.subclasses as (typeof BaseRailtie)[]).push(...savedSubclasses);
     // Reset per-class config to saved snapshot
-    for (const key of Object.keys(Railtie.config)) {
-      delete (Railtie.config as Record<string, unknown>)[key];
+    for (const key of Object.keys(Trailtie.config)) {
+      delete (Trailtie.config as Record<string, unknown>)[key];
     }
-    Object.assign(Railtie.config, savedConfig);
+    Object.assign(Trailtie.config, savedConfig);
     // Clear deprecators registry
     for (const key of Object.keys(deprecators)) {
       delete deprecators[key];
@@ -42,39 +42,39 @@ describe("RailtieTest", () => {
   });
 
   it("secure password min_cost is false in the development environment", () => {
-    Railtie.initialize({ env: "development" });
+    Trailtie.initialize({ env: "development" });
     expect(SecurePassword.minCost).toBe(false);
   });
 
   it("secure password min_cost is true in the test environment", () => {
-    Railtie.initialize({ env: "test" });
+    Trailtie.initialize({ env: "test" });
     expect(SecurePassword.minCost).toBe(true);
   });
 
   it("i18n customize full message defaults to false", () => {
-    Railtie.initialize();
+    Trailtie.initialize();
     expect(ActiveModelError.i18nCustomizeFullMessage).toBe(false);
   });
 
   it("i18n customize full message can be disabled", () => {
     ActiveModelError.i18nCustomizeFullMessage = true;
-    Railtie.initialize();
+    Trailtie.initialize();
     expect(ActiveModelError.i18nCustomizeFullMessage).toBe(false);
   });
 
   it("i18n customize full message can be enabled", () => {
-    Railtie.initialize({ i18nCustomizeFullMessage: true });
+    Trailtie.initialize({ i18nCustomizeFullMessage: true });
     expect(ActiveModelError.i18nCustomizeFullMessage).toBe(true);
   });
 
   it("i18n customize full message can be enabled via nested activeModel config", () => {
-    Railtie.initialize({ activeModel: { i18nCustomizeFullMessage: true } });
+    Trailtie.initialize({ activeModel: { i18nCustomizeFullMessage: true } });
     expect(ActiveModelError.i18nCustomizeFullMessage).toBe(true);
   });
 
   it("ActiveModel::Railtie is registered in the global subclasses list", () => {
     // Mirrors Rails::Railtie.subclasses which auto-populates via `inherited`.
-    expect(BaseRailtie.subclasses).toContain(Railtie);
+    expect(BaseRailtie.subclasses).toContain(Trailtie);
   });
 
   it("runInitializers applies the active_model.secure_password setting", () => {
@@ -85,7 +85,7 @@ describe("RailtieTest", () => {
     const prev = processEnv.TRAILS_ENV;
     setEnv("TRAILS_ENV", "test");
     try {
-      Railtie.runInitializers();
+      Trailtie.runInitializers();
       expect(SecurePassword.minCost).toBe(true);
     } finally {
       setEnv("TRAILS_ENV", prev);
@@ -93,26 +93,26 @@ describe("RailtieTest", () => {
   });
 
   it("runInitializers registers the ActiveModel deprecator", () => {
-    Railtie.runInitializers();
+    Trailtie.runInitializers();
     expect(deprecators["activeModel"]).toBe(deprecator());
   });
 
   it("runInitializers applies i18nCustomizeFullMessage from Railtie.config.activeModel", () => {
-    (Railtie.config as Record<string, unknown>)["activeModel"] = {
+    (Trailtie.config as Record<string, unknown>)["activeModel"] = {
       i18nCustomizeFullMessage: true,
     };
-    Railtie.runInitializers();
+    Trailtie.runInitializers();
     expect(ActiveModelError.i18nCustomizeFullMessage).toBe(true);
   });
 
   it("runInitializers applies i18nCustomizeFullMessage from flat Railtie.config (backwards-compat)", () => {
-    (Railtie.config as Record<string, unknown>)["i18nCustomizeFullMessage"] = true;
-    Railtie.runInitializers();
+    (Trailtie.config as Record<string, unknown>)["i18nCustomizeFullMessage"] = true;
+    Trailtie.runInitializers();
     expect(ActiveModelError.i18nCustomizeFullMessage).toBe(true);
   });
 
   it("runInitializers defaults i18nCustomizeFullMessage to false when config is absent", () => {
-    Railtie.runInitializers();
+    Trailtie.runInitializers();
     expect(ActiveModelError.i18nCustomizeFullMessage).toBe(false);
   });
 });

--- a/packages/activemodel/src/trailtie.ts
+++ b/packages/activemodel/src/trailtie.ts
@@ -16,7 +16,7 @@ export interface RailtieConfig {
 }
 
 /**
- * Railtie — initialization hooks for ActiveModel.
+ * Trailtie — initialization hooks for ActiveModel.
  *
  * Mirrors: ActiveModel::Railtie < ::Rails::Railtie
  * (activemodel/lib/active_model/railtie.rb)
@@ -25,7 +25,7 @@ export interface RailtieConfig {
  * matching the Rails inheritance pattern, and registers itself so it
  * participates in the global initialization pipeline.
  */
-export class Railtie extends BaseRailtie {
+export class Trailtie extends BaseRailtie {
   static {
     registerRailtie(this);
 
@@ -34,12 +34,12 @@ export class Railtie extends BaseRailtie {
     });
 
     this.initializer("active_model.secure_password", () => {
-      SecurePassword.minCost = Railtie.detectEnv() === "test";
+      SecurePassword.minCost = Trailtie.detectEnv() === "test";
     });
 
     this.initializer("active_model.i18n_customize_full_message", () => {
-      ActiveModelError.i18nCustomizeFullMessage = Railtie.resolveI18nCustomizeFullMessage(
-        Railtie.config as RailtieConfig,
+      ActiveModelError.i18nCustomizeFullMessage = Trailtie.resolveI18nCustomizeFullMessage(
+        Trailtie.config as RailtieConfig,
       );
     });
   }
@@ -49,9 +49,9 @@ export class Railtie extends BaseRailtie {
    * backwards-compat with existing callers).
    */
   static initialize(config?: RailtieConfig): void {
-    const env = config?.env ?? Railtie.detectEnv();
+    const env = config?.env ?? Trailtie.detectEnv();
     SecurePassword.minCost = env === "test";
-    ActiveModelError.i18nCustomizeFullMessage = Railtie.resolveI18nCustomizeFullMessage(config);
+    ActiveModelError.i18nCustomizeFullMessage = Trailtie.resolveI18nCustomizeFullMessage(config);
   }
 
   private static resolveI18nCustomizeFullMessage(cfg?: RailtieConfig): boolean {

--- a/packages/activemodel/src/trailtie.ts
+++ b/packages/activemodel/src/trailtie.ts
@@ -8,7 +8,7 @@ export interface ActiveModelConfig {
   i18nCustomizeFullMessage?: boolean;
 }
 
-export interface RailtieConfig {
+export interface TrailtieConfig {
   env?: string;
   /** @deprecated Use `activeModel.i18nCustomizeFullMessage` instead. Kept for backwards compat. */
   i18nCustomizeFullMessage?: boolean;
@@ -39,7 +39,7 @@ export class Trailtie extends BaseRailtie {
 
     this.initializer("active_model.i18n_customize_full_message", () => {
       ActiveModelError.i18nCustomizeFullMessage = Trailtie.resolveI18nCustomizeFullMessage(
-        Trailtie.config as RailtieConfig,
+        Trailtie.config as TrailtieConfig,
       );
     });
   }
@@ -48,13 +48,13 @@ export class Trailtie extends BaseRailtie {
    * One-shot configuration helper (non-Rails convenience kept for
    * backwards-compat with existing callers).
    */
-  static initialize(config?: RailtieConfig): void {
+  static initialize(config?: TrailtieConfig): void {
     const env = config?.env ?? Trailtie.detectEnv();
     SecurePassword.minCost = env === "test";
     ActiveModelError.i18nCustomizeFullMessage = Trailtie.resolveI18nCustomizeFullMessage(config);
   }
 
-  private static resolveI18nCustomizeFullMessage(cfg?: RailtieConfig): boolean {
+  private static resolveI18nCustomizeFullMessage(cfg?: TrailtieConfig): boolean {
     return cfg?.activeModel?.i18nCustomizeFullMessage ?? cfg?.i18nCustomizeFullMessage ?? false;
   }
 
@@ -63,7 +63,7 @@ export class Trailtie extends BaseRailtie {
     // populated at module load on Node, empty on browser hosts. Either
     // way, no `typeof process !== "undefined"` guard needed. Aliased to
     // avoid shadowing the local `env` variable in `initialize()` and
-    // the `RailtieConfig.env` property.
+    // the `TrailtieConfig.env` property.
     //
     // Mirrors Rails' RAILS_ENV: TRAILS_ENV only. We deliberately do
     // NOT fall back to NODE_ENV — the JS ecosystem treats NODE_ENV as


### PR DESCRIPTION
## Summary

Per-framework `Trailtie` wiring for **activemodel** and **actionview**, completing the PR 2.7 row of `docs/trailties-plan.md` (the activerecord + actionpack rows already landed in earlier PRs).

### PR 2.7b — activemodel
Rename `packages/activemodel/src/railtie.ts` → `trailtie.ts` and `class Railtie` → `class Trailtie` to match the per-framework naming convention established in PR 2.1 (`railtie.rb` → `trailtie.ts`, `Railtie` → `Trailtie`) and already followed by activerecord and actionpack. Behavior unchanged.

### PR 2.7e — actionview
Add a minimal `Trailtie` + `deprecator` for actionview:
- registers itself via `registerRailtie`
- seeds `config.actionView` with the Rails defaults from `railtie.rb` (embedAuthenticityTokenInRemoteForms, debugMissingTranslation, defaultEnforceUtf8, imageLoading, imageDecoding, applyStylesheetMediaDefault, prependContentExfiltrationPrevention)
- wires the `action_view.deprecator` initializer

### Rails sources mirrored
- `activemodel/lib/active_model/railtie.rb`
- `actionview/lib/action_view/railtie.rb`

### Intentionally skipped (actionview)
Deferred until the matching helper / resolver surface is ported:
- `config.after_initialize` blocks mutating `AssetTagHelper`, `FormHelper`, `FormTagHelper`, `SanitizeHelper`, `UrlHelper`, `Template`, `ContentExfiltrationPreventionHelper`
- `action_view.logger`, `action_view.caching`, `action_view.setup_action_pack`, `action_view.collection_caching` — depend on `ActionView::Resolver.caching`, `Rails.logger`, `ActionDispatch::Routing::UrlFor`, and `PartialRenderer.collection_cache`, none yet ported.
- `rake_tasks { cache_digests.rake }`

## Test plan
- [x] `pnpm vitest run packages/activemodel/src/trailtie.test.ts packages/actionview/src/trailtie.test.ts` — 15 tests pass
- [x] `pnpm --filter @blazetrails/activemodel --filter @blazetrails/actionview build`
- [x] `pnpm lint`