### PR TITLE
refactor(activerecord): route order-by unknown columns through arelColumn (TM Phase 9b-2c)

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3758,6 +3758,23 @@ export class Relation<T extends Base> {
     return `"${name.replace(/"/g, '""')}"`;
   }
 
+  /**
+   * Rails `Relation#order_column`. Routes ORDER BY column resolution through
+   * `arelColumn` with a quoted-identifier fallback for unknown columns, so
+   * an `UnqualifiedColumn` node is never constructed for ORDER BY — Rails
+   * reserves that node for UPDATE-set semantics (see arel/visitors/mysql.rb,
+   * which delegates `UnqualifiedColumn` to the inner attribute and would
+   * re-qualify the column).
+   * @internal
+   */
+  private _orderColumn(field: string): unknown {
+    return this.arelColumn(
+      field,
+      (attrName: string) =>
+        new Nodes.SqlLiteral(this._quoteBareColumn(attrName), { retryable: true }),
+    );
+  }
+
   private _applyOrderToManager(manager: SelectManager, table: Table): void {
     // Raw order clauses (from inOrderOf)
     for (const rawClause of this._rawOrderClauses) {
@@ -3783,7 +3800,7 @@ export class Relation<T extends Base> {
             if (rawCol.includes(".")) {
               manager.order(new Nodes.SqlLiteral(trimmed));
             } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(rawCol)) {
-              const lit = new Nodes.SqlLiteral(this._quoteBareColumn(rawCol), { retryable: true });
+              const lit = this._orderColumn(rawCol) as Nodes.Node;
               manager.order(dir === "DESC" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
             } else {
               const node = table.get(rawCol);
@@ -3796,11 +3813,7 @@ export class Relation<T extends Base> {
             // everything else (positional "1", NULLS FIRST, commas, etc.) is raw SQL.
             if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
               if (!this._fromClause.isEmpty() && !this._isKnownColumn(trimmed)) {
-                manager.order(
-                  new Nodes.Ascending(
-                    new Nodes.SqlLiteral(this._quoteBareColumn(trimmed), { retryable: true }),
-                  ),
-                );
+                manager.order(new Nodes.Ascending(this._orderColumn(trimmed) as Nodes.Node));
               } else {
                 manager.order(new Nodes.Ascending(table.get(trimmed)));
               }
@@ -3817,7 +3830,7 @@ export class Relation<T extends Base> {
           const lit = new Nodes.SqlLiteral(col);
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(col)) {
-          const lit = new Nodes.SqlLiteral(this._quoteBareColumn(col), { retryable: true });
+          const lit = this._orderColumn(col) as Nodes.Node;
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else {
           manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3758,24 +3758,6 @@ export class Relation<T extends Base> {
     return `"${name.replace(/"/g, '""')}"`;
   }
 
-  /**
-   * Rails `Relation#order_column`. Routes ORDER BY column resolution through
-   * `arelColumn` with a quoted-identifier fallback for unknown columns, so
-   * an `UnqualifiedColumn` node is never constructed for ORDER BY — Rails
-   * reserves that node for UPDATE-set semantics (see arel/visitors/mysql.rb,
-   * which delegates `UnqualifiedColumn` to the inner attribute and would
-   * re-qualify the column).
-   * @internal
-   */
-  private _orderColumn(field: string): unknown {
-    return this.arelColumn(field, (attrName: string) => {
-      if (attrName === "count" && this._groupColumns.length > 0) {
-        return this._modelClass.arelTable.get(attrName);
-      }
-      return new Nodes.SqlLiteral(this._quoteBareColumn(attrName), { retryable: true });
-    });
-  }
-
   private _applyOrderToManager(manager: SelectManager, table: Table): void {
     // Raw order clauses (from inOrderOf)
     for (const rawClause of this._rawOrderClauses) {
@@ -3801,7 +3783,7 @@ export class Relation<T extends Base> {
             if (rawCol.includes(".")) {
               manager.order(new Nodes.SqlLiteral(trimmed));
             } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(rawCol)) {
-              const lit = this._orderColumn(rawCol) as Nodes.Node;
+              const lit = this.orderColumn(rawCol) as Nodes.Node;
               manager.order(dir === "DESC" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
             } else {
               const node = table.get(rawCol);
@@ -3814,7 +3796,7 @@ export class Relation<T extends Base> {
             // everything else (positional "1", NULLS FIRST, commas, etc.) is raw SQL.
             if (/^[A-Za-z_$][\w$]*$/.test(trimmed)) {
               if (!this._fromClause.isEmpty() && !this._isKnownColumn(trimmed)) {
-                manager.order(new Nodes.Ascending(this._orderColumn(trimmed) as Nodes.Node));
+                manager.order(new Nodes.Ascending(this.orderColumn(trimmed) as Nodes.Node));
               } else {
                 manager.order(new Nodes.Ascending(table.get(trimmed)));
               }
@@ -3831,7 +3813,7 @@ export class Relation<T extends Base> {
           const lit = new Nodes.SqlLiteral(col);
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else if (!this._fromClause.isEmpty() && !this._isKnownColumn(col)) {
-          const lit = this._orderColumn(col) as Nodes.Node;
+          const lit = this.orderColumn(col) as Nodes.Node;
           manager.order(dir === "desc" ? new Nodes.Descending(lit) : new Nodes.Ascending(lit));
         } else {
           manager.order(dir === "desc" ? table.get(col).desc() : table.get(col).asc());

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3768,11 +3768,12 @@ export class Relation<T extends Base> {
    * @internal
    */
   private _orderColumn(field: string): unknown {
-    return this.arelColumn(
-      field,
-      (attrName: string) =>
-        new Nodes.SqlLiteral(this._quoteBareColumn(attrName), { retryable: true }),
-    );
+    return this.arelColumn(field, (attrName: string) => {
+      if (attrName === "count" && this._groupColumns.length > 0) {
+        return this._modelClass.arelTable.get(attrName);
+      }
+      return new Nodes.SqlLiteral(this._quoteBareColumn(attrName), { retryable: true });
+    });
   }
 
   private _applyOrderToManager(manager: SelectManager, table: Table): void {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1852,7 +1852,7 @@ export function orderColumn(this: QueryMethodsHost, field: string): unknown {
       return table?.get(attrName) ?? arelSql(attrName);
     }
     const quoted = safeQuoteColumnName(modelClass, attrName);
-    return arelSql(quoted);
+    return new Nodes.SqlLiteral(quoted, { retryable: true });
   });
 }
 


### PR DESCRIPTION
## Summary

#2157's tactical fix swapped `Nodes.UnqualifiedColumn(table.get(col))` for `Nodes.SqlLiteral(adapter.quoteColumnName(col))` inline at three sites in `Relation#_applyOrderToManager` so bare-identifier emission stayed consistent across PG/SQLite/MySQL.

Rails reaches the same emission via dispatch: `preprocess_order_args` → `order_column(field)` → `arel_column(field) { |name| adapter.quote_table_name(name) }`. The yield-block fires only for unknown columns and returns a bare quoted identifier — so `UnqualifiedColumn` is never constructed for ORDER BY (it's reserved for UPDATE-set semantics, which the MySQL visitor's `UnqualifiedColumn` override preserves).

This PR routes `_applyOrderToManager`'s three unknown-column branches through the existing `Relation#orderColumn` delegate (relation.ts → relation/query-methods.ts), which already mirrors Rails' `order_column` shape (including the `count` + `group_values` special-case). Also fixes one Rails-fidelity gap in that delegate: its fallback emitted `Arel.sql(quoted)` without the `retryable: true` flag Rails' yield block passes — switched to `Nodes.SqlLiteral(quoted, { retryable: true })`.

Behavior unchanged on all three adapters — same `SqlLiteral` with the same quoted name, now also carrying `retryable: true` to match Rails. The construction goes via the Rails-shaped dispatch path so future ORDER BY edge cases get fixed once at `arelColumn` rather than scattered across callers.

Net: +4/-9 LOC across two files.

## Rails parity

Rails (`active_record/relation/query_methods.rb:2153`):
```ruby
def order_column(field)
  arel_column(field) do |attr_name|
    if attr_name == "count" && !group_values.empty?
      table[attr_name]
    else
      Arel.sql(model.adapter_class.quote_table_name(attr_name), retryable: true)
    end
  end
end
```

trails `orderColumn` after this PR (relation/query-methods.ts:1847) mirrors that block — count+group returns `table.get(attrName)`, else returns a `retryable` `SqlLiteral` of the adapter-quoted name. (`quoteColumnName` and `quote_table_name` emit the same SQL for a single bare identifier on all three dialects.)

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/relation.test.ts` — 88/88 passing on SQLite (29 skipped, unchanged)
- [x] `pnpm api:compare --package activerecord` — 4956/4958 (100%), no regression
- [x] `pnpm test:compare` — 12967/21714, no regression (no test changes)
- [ ] CI green across PG/SQLite/MySQL