### PR TITLE
test(activerecord): unskip 13 cross-adapter assertions (TM Phase 9b-2e)

### DIFF
--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -14,6 +14,7 @@ import {
 } from "../associations.js";
 import { CollectionProxy } from "./collection-proxy.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
+import { quoteTableName } from "../test-helpers/quote-regex.js";
 
 const TEST_SCHEMA: Schema = {
   acc_posts: { title: "string" },
@@ -3688,7 +3689,7 @@ describe("HasManyThroughAssociationsTest", () => {
     expect(count).toBe(2);
   });
 
-  it.skip("inner join with quoted table name", async () => {
+  it("inner join with quoted table name", async () => {
     class IjqPerson extends Base {
       static {
         this.attribute("first_name", "string");
@@ -3730,8 +3731,8 @@ describe("HasManyThroughAssociationsTest", () => {
 
     // Verify through join SQL properly quotes table names
     const sql = IjqPerson.joins("ijqJobs").toSql();
-    expect(sql).toContain('"ijq_references"');
-    expect(sql).toContain('"ijq_jobs"');
+    expect(sql).toContain(quoteTableName("ijq_references"));
+    expect(sql).toContain(quoteTableName("ijq_jobs"));
 
     const jobs = await loadHasManyThrough(person, "ijqJobs", {
       through: "ijqReferences",

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -16,6 +16,7 @@ import { SubclassNotFound, NameError } from "./errors.js";
 import { quoteSqlValue } from "./base.js";
 
 import { createTestAdapter, adapterType, type TestDatabaseAdapter } from "./test-adapter.js";
+import { quoteColumnName } from "./test-helpers/quote-regex.js";
 import { registerModel } from "./associations.js";
 import { connectedToStack } from "./core.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -2424,7 +2425,7 @@ describe("BasicsTest", () => {
   it.skip("connection in utc time", () => {
     // BLOCKED: connection-pool — establish_connection: same as "connection in local time"
   });
-  it.skip("column name properly quoted", () => {
+  it("column name properly quoted", () => {
     class User extends Base {
       static {
         this.attribute("name", "string");
@@ -2432,7 +2433,7 @@ describe("BasicsTest", () => {
       }
     }
     const sql = User.where({ name: "test" }).toSql();
-    expect(sql).toContain('"name"');
+    expect(sql).toContain(quoteColumnName("name"));
   });
   it("quoting arrays", async () => {
     class Reply extends Base {

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -795,15 +795,18 @@ describe("FinderTest", () => {
     expect(Array.isArray(results)).toBe(true);
   });
 
-  it.skip("hash condition find with escaped characters", async () => {
+  it("hash condition find with escaped characters", async () => {
     class Topic extends Base {
       static {
         this.attribute("title", "string");
         this.adapter = adapter;
       }
     }
-    const sql = Topic.where({ title: "it's" }).toSql();
-    expect(sql).toContain("it''s");
+    const value = "Ain't noth'n like' #stuff";
+    await Topic.create({ title: value });
+    const found = await Topic.where({ title: value }).first();
+    expect(found).not.toBeNull();
+    expect((found as Topic).title).toBe(value);
   });
 
   it("model class responds to second bang", async () => {

--- a/packages/activerecord/src/inheritance.test.ts
+++ b/packages/activerecord/src/inheritance.test.ts
@@ -7,6 +7,7 @@ import { Base, registerModel, enableSti, registerSubclass, SubclassNotFound } fr
 import { getStiBase, isStiSubclass, setBaseClass } from "./inheritance.js";
 
 import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
+import { quoteTableName } from "./test-helpers/quote-regex.js";
 import { defineSchema, type Schema } from "./test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "./adapter.js";
@@ -253,10 +254,10 @@ describe("InheritanceTest", () => {
     expect(cars.length).toBe(1);
   });
 
-  it.skip("eager load belongs to primary key quoting", async () => {
+  it("eager load belongs to primary key quoting", async () => {
     const { Vehicle } = makeHierarchy();
     const sql = Vehicle.all().toSql();
-    expect(sql).toContain('"vehicles"');
+    expect(sql).toContain(quoteTableName("vehicles"));
   });
 
   // -------------------------------------------------------------------------

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -28,6 +28,7 @@ import { Associations, resolveAssocClass } from "./associations.js";
 import { Table } from "@blazetrails/arel";
 
 import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
+import { quoteTableName, escapeRegExp } from "./test-helpers/quote-regex.js";
 import { UnknownPrimaryKey } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { defineSchema, type Schema } from "./test-helpers/define-schema.js";
@@ -1132,7 +1133,7 @@ describe("ReflectionTest", () => {
     expect(() => bad.joinPrimaryKey).toThrow(/source association/i);
     expect(() => bad.joinForeignKey).toThrow(/source association/i);
   });
-  it.skip("join scope builds arel predicate for has many", () => {
+  it("join scope builds arel predicate for has many", () => {
     const { Author } = makeModels();
     const ref = reflectOnAssociation(Author, "books") as AssociationReflection;
     const booksTable = new Table("books");
@@ -1140,9 +1141,13 @@ describe("ReflectionTest", () => {
     const scope = ref.joinScope(booksTable, authorsTable, Author);
     const sql = scope.toSql();
     // has_many: books.author_id = authors.id
-    expect(sql).toMatch(/"books"\."author_id" = "authors"\."id"/);
+    expect(sql).toMatch(
+      new RegExp(
+        `${escapeRegExp(quoteTableName("books.author_id"))} = ${escapeRegExp(quoteTableName("authors.id"))}`,
+      ),
+    );
   });
-  it.skip("join scope builds arel predicate for belongs to", () => {
+  it("join scope builds arel predicate for belongs to", () => {
     const { Book, Author } = makeModels();
     const ref = reflectOnAssociation(Book, "author") as AssociationReflection;
     const authorsTable = new Table("authors");
@@ -1150,7 +1155,11 @@ describe("ReflectionTest", () => {
     const scope = ref.joinScope(authorsTable, booksTable, Book);
     const sql = scope.toSql();
     // belongs_to: authors.id = books.author_id
-    expect(sql).toMatch(/"authors"\."id" = "books"\."author_id"/);
+    expect(sql).toMatch(
+      new RegExp(
+        `${escapeRegExp(quoteTableName("authors.id"))} = ${escapeRegExp(quoteTableName("books.author_id"))}`,
+      ),
+    );
   });
   it.skip("scope chain", () => {
     // BLOCKED: associations — reflection feature gap (macros / options inspection)

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -9,6 +9,7 @@ import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js"
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { dropAllTables } from "../test-helpers/drop-all-tables.js";
+import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
 
 describe("PredicateBuilderTest", () => {
   // Rails setup: Topic.predicate_builder.register_handler(Regexp, proc { |col, val| col ~ val.source })
@@ -33,7 +34,7 @@ describe("PredicateBuilderTest", () => {
     await dropAllTables(adapter);
   });
 
-  it.skip("registering new handlers", () => {
+  it("registering new handlers", () => {
     class PbTopic extends Base {
       static {
         this.tableName = "topics";
@@ -50,13 +51,15 @@ describe("PredicateBuilderTest", () => {
     });
     try {
       const sql = PbTopic.where({ title: new RegexFilter("rails") }).toSql();
-      expect(sql).toMatch(/"topics"."title" ~ 'rails'/i);
+      expect(sql).toMatch(
+        new RegExp(`${escapeRegExp(quoteTableName("topics.title"))} ~ 'rails'`, "i"),
+      );
     } finally {
       (PbTopic as any)._predicateBuilder = null;
     }
   });
 
-  it.skip("registering new handlers for association", () => {
+  it("registering new handlers for association", () => {
     class PbTopic2 extends Base {
       static {
         this.tableName = "topics";
@@ -84,7 +87,9 @@ describe("PredicateBuilderTest", () => {
     try {
       const sql = PbReply2.where({ pbTopic2: { title: new RegexFilter2("rails") } }).toSql();
       // Handler propagates to associated table — column uses association-resolved table name.
-      expect(sql).toMatch(/"pbTopic2"."title" ~ 'rails'/i);
+      expect(sql).toMatch(
+        new RegExp(`${escapeRegExp(quoteTableName("pbTopic2.title"))} ~ 'rails'`, "i"),
+      );
     } finally {
       modelRegistry.delete("PbTopic2");
       modelRegistry.delete("PbReply2");

--- a/packages/activerecord/src/relation/select-star-join-collision.test.ts
+++ b/packages/activerecord/src/relation/select-star-join-collision.test.ts
@@ -23,6 +23,7 @@ import { Associations, loadHasMany } from "../associations.js";
 import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
+import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
 
 describe("SELECT * column collision in joined relations", () => {
   let adapter: TestDatabaseAdapter;
@@ -88,20 +89,21 @@ describe("SELECT * column collision in joined relations", () => {
     ]);
   });
 
-  it.skip("default projection is `<target>.*` always (matches Rails — never bare `*`)", async () => {
+  it("default projection is `<target>.*` always (matches Rails — never bare `*`)", async () => {
     // Always-qualified projection matches Rails'
     // `klass.arel_table[Arel.star]`. Holds with or without joins
     // so the no-joins case isn't a special case the user has to
     // know about.
+    const qUsers = escapeRegExp(quoteTableName("ssj_users"));
     const noJoins = (SsjUser as any).all().toSql();
-    expect(noJoins).toMatch(/SELECT\s+"ssj_users"\.\*/i);
+    expect(noJoins).toMatch(new RegExp(`SELECT\\s+${qUsers}\\.\\*`, "i"));
     expect(noJoins).not.toMatch(/SELECT\s+\*/i);
 
     const withJoins = (SsjUser as any).all().joins("INNER JOIN ssj_friendships ON 1 = 1").toSql();
-    expect(withJoins).toMatch(/SELECT\s+"ssj_users"\.\*/i);
+    expect(withJoins).toMatch(new RegExp(`SELECT\\s+${qUsers}\\.\\*`, "i"));
   });
 
-  it.skip("keeps qualified projection even when from() replaces the FROM source (Rails behavior)", async () => {
+  it("keeps qualified projection even when from() replaces the FROM source (Rails behavior)", async () => {
     // Rails' `Relation#build_select` (query_methods.rb:1909)
     // projects `table[Arel.star]` unconditionally — it doesn't
     // special-case `from()`. The resulting SQL is the caller's
@@ -110,6 +112,8 @@ describe("SELECT * column collision in joined relations", () => {
     // `.select("*")`. We match Rails here rather than silently
     // downgrading to bare `*`.
     const sql = (SsjUser as any).all().from("(SELECT * FROM ssj_users) AS sub").toSql();
-    expect(sql).toMatch(/SELECT\s+"ssj_users"\.\*/i);
+    expect(sql).toMatch(
+      new RegExp(`SELECT\\s+${escapeRegExp(quoteTableName("ssj_users"))}\\.\\*`, "i"),
+    );
   });
 });

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -8,6 +8,7 @@ import { Base } from "../index.js";
 import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
+import { quoteColumnName } from "../test-helpers/quote-regex.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 let _adapter: TestDatabaseAdapter;
@@ -48,7 +49,7 @@ describe("SelectTest", () => {
     expect(sql).toContain("title");
   });
 
-  it.skip("reselect replaces previous select", () => {
+  it("reselect replaces previous select", () => {
     class Post extends Base {
       static {
         this.attribute("title", "string");
@@ -227,11 +228,11 @@ describe("SelectTest", () => {
     /* needs default_scope with select */
   });
 
-  it.skip("enumerate columns in select statements", () => {
+  it("enumerate columns in select statements", () => {
     const { Developer } = makeModel();
     const sql = Developer.select("name", "salary").toSql();
-    expect(sql).toContain('"name"');
-    expect(sql).toContain('"salary"');
+    expect(sql).toContain(quoteColumnName("name"));
+    expect(sql).toContain(quoteColumnName("salary"));
   });
 
   it.skip("select with block without any arguments", () => {
@@ -348,7 +349,7 @@ describe("Relation Select (Rails-guided)", () => {
     adapter = freshAdapter();
   });
 
-  it.skip("select specific columns in SQL", () => {
+  it("select specific columns in SQL", () => {
     class User extends Base {
       static {
         this.attribute("name", "string");
@@ -357,7 +358,7 @@ describe("Relation Select (Rails-guided)", () => {
       }
     }
     const sql = User.all().select("name").toSql();
-    expect(sql).toContain('"name"');
+    expect(sql).toContain(quoteColumnName("name"));
     expect(sql).not.toContain("*");
   });
 
@@ -375,7 +376,7 @@ describe("Relation Select (Rails-guided)", () => {
     expect(result).toHaveLength(2);
   });
 
-  it.skip("reselect replaces previous select", () => {
+  it("reselect replaces previous select", () => {
     class User extends Base {
       static {
         this.attribute("name", "string");
@@ -384,8 +385,8 @@ describe("Relation Select (Rails-guided)", () => {
       }
     }
     const sql = User.all().select("name").reselect("email").toSql();
-    expect(sql).toContain('"email"');
-    expect(sql).not.toContain('"name"');
+    expect(sql).toContain(quoteColumnName("email"));
+    expect(sql).not.toContain(quoteColumnName("name"));
   });
 
   it("distinct generates DISTINCT SQL", () => {

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -7,6 +7,7 @@ import { Base, Range, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
 import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { quoteTableName } from "../test-helpers/quote-regex.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
@@ -70,14 +71,14 @@ describe("WhereChainTest", () => {
     expect(sql).toContain("author_id");
     expect(sql).toMatch(/!=\s*NULL|IS NOT NULL/);
   });
-  it.skip("associated merged with scope on association", () => {
+  it("associated merged with scope on association", () => {
     const sql = Post.all()
       .whereAssociated("author")
       .merge(Author.where({ id: 1 }))
       .toSql();
     expect(sql).toContain("INNER JOIN");
     expect(sql).not.toMatch(/IS NOT NULL/);
-    expect(sql).toContain('"authors"');
+    expect(sql).toContain(quoteTableName("authors"));
   });
 
   it("associated unscoped merged with scope on association", () => {
@@ -334,14 +335,14 @@ describe("WhereChainTest", () => {
     expect(sql).toContain("author_id");
     expect(sql).toContain("IS NULL");
   });
-  it.skip("missing merged with scope on association", () => {
+  it("missing merged with scope on association", () => {
     const sql = Post.all()
       .whereMissing("author")
       .merge(Author.where({ id: 1 }))
       .toSql();
     expect(sql).toMatch(/LEFT.*JOIN/);
     expect(sql).not.toMatch(/IS NULL/);
-    expect(sql).toContain('"authors"');
+    expect(sql).toContain(quoteTableName("authors"));
   });
 
   it("missing unscoped merged with scope on association", () => {

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -9,6 +9,7 @@ import { Associations } from "../associations.js";
 import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
+import { quoteTableName, quoteColumnName } from "../test-helpers/quote-regex.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 // -- Helpers --
@@ -251,7 +252,7 @@ describe("WhereTest", () => {
     expect(sql2).toContain("hello");
     expect(sql2).toContain("world");
   });
-  it.skip("where with table name and target table", () => {
+  it("where with table name and target table", () => {
     class Post extends Base {
       static {
         this._tableName = "posts";
@@ -260,7 +261,7 @@ describe("WhereTest", () => {
       }
     }
     const sql = Post.where({ title: "hello" }).toSql();
-    expect(sql).toContain('"posts"');
+    expect(sql).toContain(quoteTableName("posts"));
     expect(sql).toContain("title");
   });
   it.skip("where with table name and target table joined", () => {
@@ -557,7 +558,7 @@ describe("WhereTest", () => {
     expect(result).toHaveLength(1);
     expect(result[0].author_id).toBe(author.id);
   });
-  it.skip("where with numeric comparison", () => {
+  it("where with numeric comparison", () => {
     class Post extends Base {
       static {
         this.attribute("views", "integer");
@@ -565,7 +566,7 @@ describe("WhereTest", () => {
       }
     }
     const sql = Post.where({ views: 5 }).toSql();
-    expect(sql).toContain('"views"');
+    expect(sql).toContain(quoteColumnName("views"));
     expect(sql).toContain("5");
   });
   it("where with multiple numeric comparisons", () => {


### PR DESCRIPTION
## Summary

Converts a first batch of `.skip` markers added by #2155 (MySQL Arel visitor activation) into adapter-agnostic assertions using the `quoteTableName` / `quoteColumnName` / `escapeRegExp` helpers shipped in #2161. Follows Rails' canonical inline pattern — call sites read identifier quoting from the active adapter rather than hardcoding ANSI `\"name\"`.

13 conversions across 10 smaller test files:

- `base.test.ts` — column name properly quoted
- `finder.test.ts` — hash condition find with escaped characters (converted to behavior assertion, matching Rails' `test_hash_condition_find_with_escaped_characters` shape)
- `inheritance.test.ts` — eager load belongs to primary key quoting
- `reflection.test.ts` — join scope arel predicate (has_many, belongs_to)
- `relation/predicate-builder.test.ts` — registering new handlers (×2)
- `relation/select-star-join-collision.test.ts` — default projection / from() (×2)
- `relation/select.test.ts` — reselect, enumerate columns, select specific (×4)
- `relation/where-chain.test.ts` — associated/missing merged with scope (×2)
- `relation/where.test.ts` — where with table name, where with numeric (×2)
- `associations/has-many-through-associations.test.ts` — inner join with quoted table name

## Follow-ups (deferred to keep this PR under the 300 LOC ceiling)

The larger skip pools added by #2155 are left for follow-up PRs:

- `relation.test.ts` — ~29 skips
- `relations.test.ts` — 9 skips added by #2155 (file has many older skips too)
- `associations/association-scope.test.ts` — 9 skips

Each follow-up will mechanically convert via the same helper pattern.

## Test plan

- [x] SQLite suite passes for all converted files
- [x] PostgreSQL suite passes for all converted files
- [ ] MariaDB CI green (authoritative)
- [ ] `api:compare` non-negative
- [ ] `test:compare` non-negative (no renames; only `.skip` → `it`)