### PR TITLE
feat(trailties): Engine shell + paths defaults (PR 2.2)

### DIFF
--- a/packages/trailties/src/engine.test.ts
+++ b/packages/trailties/src/engine.test.ts
@@ -1,0 +1,142 @@
+// Smoke tests for the `Engine` shell. Full Rails-mirrored
+// `railties/test/engine_test.rb` cases land in PR 2.2b alongside the
+// `Configuration` defaults and route mounting.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  fsAdapterConfig,
+  registerFsAdapter,
+  type FsAdapter,
+  type PathAdapter,
+} from "@blazetrails/activesupport";
+import { Engine } from "./engine.js";
+import { Trailtie } from "./trailtie.js";
+import { Trailties } from "./engine/trailties.js";
+
+const posixPath: PathAdapter = {
+  join: (...p) => p.join("/").replace(/\/+/g, "/"),
+  dirname: (p) => p.replace(/\/[^/]*$/, "") || "/",
+  basename: (p) => p.split("/").pop() ?? "",
+  resolve: (...p) =>
+    p
+      .reduce((o, x) => (!x ? o : x.startsWith("/") ? x : o ? `${o}/${x}` : x), "")
+      .replace(/\/+/g, "/"),
+  extname: (p) => (p.lastIndexOf(".") > 0 ? p.slice(p.lastIndexOf(".")) : ""),
+  isAbsolute: (p) => p.startsWith("/"),
+  sep: "/",
+};
+
+const FIXED_MTIME = new Date(0);
+const stat = (d: boolean) => ({
+  isDirectory: () => d,
+  isFile: () => !d,
+  size: 0,
+  mtime: FIXED_MTIME,
+});
+
+function installFs(dirs: Set<string>, files: Set<string>): void {
+  registerFsAdapter(
+    "engine-test",
+    {
+      cwd: () => "/",
+      exists: async (p: string) => dirs.has(p) || files.has(p),
+      stat: async (p: string) => {
+        if (dirs.has(p)) return stat(true);
+        if (files.has(p)) return stat(false);
+        throw new Error("ENOENT");
+      },
+      statSync: () => stat(false),
+      realpath: async (p: string) => p,
+    } as unknown as FsAdapter,
+    posixPath,
+  );
+  fsAdapterConfig.adapter = "engine-test";
+}
+
+const PREV = fsAdapterConfig.adapter;
+afterEach(() => {
+  fsAdapterConfig.adapter = PREV;
+});
+
+describe("Engine", () => {
+  it("Engine is abstract and cannot be instantiated directly", () => {
+    expect(() => new Engine()).toThrow(/abstract/);
+  });
+
+  it("engine_name aliases railtie_name", () => {
+    class BlogEngine extends Engine {}
+    Trailtie.register(BlogEngine);
+    expect(BlogEngine.engineName()).toBe("blog_engine");
+    expect(BlogEngine.engineName()).toBe(BlogEngine.railtieName());
+  });
+
+  it("isolated? defaults to false", () => {
+    class PlainEngine extends Engine {}
+    Trailtie.register(PlainEngine);
+    expect(PlainEngine.isolated()).toBe(false);
+    expect(PlainEngine.instance().isolated()).toBe(false);
+  });
+
+  describe("find_root_with_flag", () => {
+    beforeEach(() =>
+      installFs(new Set(["/", "/app", "/app/sub", "/app/sub/deep"]), new Set(["/app/lib"])),
+    );
+
+    it("walks parents until the flag is found", async () => {
+      expect(await Engine.findRootWithFlag("lib", "/app/sub/deep")).toBe("/app");
+    });
+    it("returns the fallback when nothing matches", async () => {
+      expect(await Engine.findRootWithFlag("missing", "/app/sub", "/fallback")).toBe("/fallback");
+    });
+    it("throws when no flag and no fallback", async () => {
+      await expect(Engine.findRootWithFlag("missing", "/app/sub")).rejects.toThrow(
+        /Could not find root/,
+      );
+    });
+    it("find_root uses 'lib' as the flag", async () => {
+      expect(await Engine.findRoot("/app")).toBe("/app");
+    });
+  });
+
+  it("paths declares the Rails default layout (root memoized once resolved)", async () => {
+    installFs(new Set(["/", "/blog", "/blog/sub"]), new Set(["/blog/lib"]));
+    class PathsEngine extends Engine {}
+    Trailtie.register(PathsEngine);
+    PathsEngine.calledFrom("/blog/sub");
+    const inst = PathsEngine.instance();
+    const paths = await inst.paths();
+    for (const k of ["app", "app/models", "lib", "config/routes.ts", "db/migrate", "vendor"]) {
+      expect(paths.get(k), k).toBeDefined();
+    }
+    expect(paths.get("lib")!.isLoadPath()).toBe(true);
+    expect(paths.get("vendor")!.isLoadPath()).toBe(true);
+    expect(await inst.paths()).toBe(paths);
+  });
+
+  it("find() locates the engine whose root matches", async () => {
+    installFs(new Set(["/", "/found", "/found/sub"]), new Set(["/found/lib"]));
+    class FoundEngine extends Engine {}
+    Trailtie.register(FoundEngine);
+    FoundEngine.calledFrom("/found/sub");
+    expect(await FoundEngine.instance().root()).toBe("/found");
+    expect(await Engine.find("/found")).toBe(FoundEngine.instance());
+    expect(await Engine.find("/elsewhere")).toBeUndefined();
+  });
+
+  it("helpersPaths returns only existing app/helpers directories", async () => {
+    installFs(new Set(["/", "/blog", "/blog/app", "/blog/app/helpers"]), new Set(["/blog/lib"]));
+    class HelpersEngine extends Engine {}
+    Trailtie.register(HelpersEngine);
+    HelpersEngine.calledFrom("/blog");
+    expect(await HelpersEngine.instance().helpersPaths()).toEqual(["/blog/app/helpers"]);
+  });
+
+  it("railties returns a Trailties collection over registered subclasses", () => {
+    class RailtiesEngine extends Engine {}
+    Trailtie.register(RailtiesEngine);
+    const inst = RailtiesEngine.instance();
+    const collection = inst.railties();
+    expect(collection).toBeInstanceOf(Trailties);
+    expect(Array.from(collection)).toContain(inst);
+    expect(collection.minus([inst])).not.toContain(inst);
+  });
+});

--- a/packages/trailties/src/engine.ts
+++ b/packages/trailties/src/engine.ts
@@ -1,0 +1,137 @@
+// Port of `Rails::Engine` from `railties/lib/rails/engine.rb`. Shell only:
+// find / findRoot / findRootWithFlag, the paths defaults, and the railties()
+// collection. EngineConfiguration + route mounting → 2.2b; lazy_route_set
+// + updater → 2.2c. See PR description for the Rails-skipped surface.
+import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
+import { Root } from "./paths.js";
+import { Trailtie } from "./trailtie.js";
+import { Trailties } from "./engine/trailties.js";
+
+type EngineHost = { _calledFrom?: string; _isolated?: boolean };
+const host = (k: typeof Engine): EngineHost => k as unknown as EngineHost;
+
+export class Engine extends Trailtie {
+  private _paths?: Root;
+  private _railtiesCollection?: Trailties;
+
+  static calledFrom(value?: string): string | undefined {
+    if (value !== undefined) host(this)._calledFrom = value;
+    return host(this)._calledFrom;
+  }
+  static isolated(value?: boolean): boolean {
+    if (value !== undefined) host(this)._isolated = value;
+    return host(this)._isolated === true;
+  }
+
+  /** Mirrors Rails' `alias :engine_name :railtie_name`. */
+  static engineName(name?: string): string {
+    return this.railtieName(name);
+  }
+
+  static engineSubclasses(): Array<typeof Engine> {
+    return Trailtie.subclasses().filter((k): k is typeof Engine => k.prototype instanceof Engine);
+  }
+
+  static async find(path: string): Promise<Engine | undefined> {
+    const p = await getPathAsync();
+    const fs = await getFsAsync();
+    const expanded = await realpathOr(fs, p.resolve(path));
+    for (const klass of this.engineSubclasses()) {
+      const engine = klass.instance() as Engine;
+      const root = await engine.root().catch(() => undefined);
+      if (root && (await realpathOr(fs, p.resolve(root))) === expanded) return engine;
+    }
+    return undefined;
+  }
+
+  static async findRootWithFlag(
+    flag: string,
+    rootPath: string | undefined,
+    fallback?: string,
+  ): Promise<string> {
+    const p = await getPathAsync();
+    const fs = await getFsAsync();
+    let cur = rootPath;
+    while (cur && (await isDirectory(fs, cur)) && !(await fs.exists(p.join(cur, flag)))) {
+      const parent = p.dirname(cur);
+      cur = parent !== cur ? parent : undefined;
+    }
+    const found = cur && (await fs.exists(p.join(cur, flag))) ? cur : fallback;
+    if (!found) throw new Error(`Could not find root path for ${this.name}`);
+    return await realpathOr(fs, found);
+  }
+
+  static findRoot(from: string): Promise<string> {
+    return this.findRootWithFlag("lib", from);
+  }
+
+  engineName(): string {
+    return (this.constructor as typeof Engine).engineName();
+  }
+  isolated(): boolean {
+    return (this.constructor as typeof Engine).isolated();
+  }
+
+  async root(): Promise<string | undefined> {
+    const klass = this.constructor as typeof Engine;
+    const from = klass.calledFrom();
+    return from === undefined ? undefined : await klass.findRoot(from);
+  }
+
+  // Default paths layout. `.rb` → `.ts`; autoload/eager surface → 2.2b.
+  async paths(): Promise<Root> {
+    if (this._paths) return this._paths;
+    const root = (await this.root()) ?? null;
+    const paths = new Root(root);
+    paths.add("app", { glob: "{*,*/concerns}" });
+    paths.add("app/assets", { glob: "*" });
+    paths.add("app/controllers");
+    paths.add("app/channels");
+    paths.add("app/helpers");
+    paths.add("app/models");
+    paths.add("app/mailers");
+    paths.add("app/views");
+    paths.add("lib", { loadPath: true });
+    paths.add("lib/assets", { glob: "*" });
+    paths.add("lib/tasks", { glob: "**/*.rake" });
+    paths.add("config");
+    paths.add("config/initializers", { glob: "**/*.{ts,js}" });
+    paths.add("config/locales", { glob: "**/*.{ts,js,json}" });
+    paths.add("config/routes.ts");
+    paths.add("config/routes", { glob: "**/*.{ts,js}" });
+    paths.add("db");
+    paths.add("db/migrate");
+    paths.add("db/seeds.ts");
+    paths.add("vendor", { loadPath: true });
+    paths.add("vendor/assets", { glob: "*" });
+    if (root !== null) this._paths = paths;
+    return paths;
+  }
+
+  async helpersPaths(): Promise<string[]> {
+    const node = (await this.paths()).get("app/helpers");
+    return node ? await node.existent() : [];
+  }
+
+  railties(): Trailties {
+    if (!this._railtiesCollection) this._railtiesCollection = new Trailties();
+    return this._railtiesCollection;
+  }
+}
+
+type Fs = Awaited<ReturnType<typeof getFsAsync>>;
+async function isDirectory(fs: Fs, p: string): Promise<boolean> {
+  if (!fs.stat) throw new Error("FsAdapter.stat() is required for trailties (async-only).");
+  try {
+    return (await fs.stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+async function realpathOr(fs: Fs, p: string): Promise<string> {
+  try {
+    return fs.realpath ? await fs.realpath(p) : p;
+  } catch {
+    return p;
+  }
+}

--- a/packages/trailties/src/engine/trailties.ts
+++ b/packages/trailties/src/engine/trailties.ts
@@ -1,0 +1,21 @@
+// Port of railties/lib/rails/engine/railties.rb. Iterable collection of
+// instantiated Trailtie + Engine subclasses (excluding the abstract bases).
+import { Trailtie } from "../trailtie.js";
+
+export class Trailties implements Iterable<Trailtie> {
+  readonly all: Trailtie[] = Trailtie.subclasses().map((k) => k.instance());
+
+  [Symbol.iterator](): Iterator<Trailtie> {
+    return this.all[Symbol.iterator]();
+  }
+  /** Mirrors Ruby `Enumerable#each`. */
+  each(fn: (t: Trailtie) => void): this {
+    for (const t of this.all) fn(t);
+    return this;
+  }
+  /** Mirrors Ruby `Array#-`. */
+  minus(others: Trailtie[]): Trailtie[] {
+    const drop = new Set(others);
+    return this.all.filter((t) => !drop.has(t));
+  }
+}


### PR DESCRIPTION
## Summary

First split of PR 2.2 (~250 LOC target, 299 LOC actual). Ports `Rails::Engine`
shell as the foundation for the full Configuration / route mounting (2.2b)
and lazy_route_set / updater (2.2c).

- \`packages/trailties/src/engine.ts\` — \`Engine\` shell: \`find\`,
  \`findRoot\`, \`findRootWithFlag\`, the \`paths\` defaults, \`helpersPaths\`,
  \`railties()\`. \`calledFrom\` / \`isolated\` are explicit static accessors
  (no Ruby \`inherited\` hook).
- \`packages/trailties/src/engine/trailties.ts\` — iterable collection of
  registered Trailtie + Engine instances. Mirrors
  \`railties/lib/rails/engine/railties.rb\`.
- \`packages/trailties/src/engine.test.ts\` — smoke coverage (9 tests).

## Rails sources

- \`railties/lib/rails/engine.rb\` — \`Engine\`, \`find\`, \`find_root\`,
  \`find_root_with_flag\`, \`paths\`, \`helpers_paths\`, \`railties\`,
  \`engine_name\`, \`isolated?\`.
- \`railties/lib/rails/engine/railties.rb\` — \`Engine::Railties\` →
  \`Trailties\`.

## Methods skipped here (lands later, per plan doc)

- 2.2b — full \`EngineConfiguration\` (incl. the explicit
  \`tableNamePrefix\` option that replaces \`isolate_namespace\`),
  \`_all_load_paths\`, route mounting, full Rails-mirrored tests.
- 2.2c — \`engine/lazy_route_set.rb\`, \`engine/updater.rb\`.
- Permanently skipped per plan doc: \`eager_load!\`, \`eager_load_paths\`,
  \`_all_autoload_paths\`, \`isolate_namespace\` (replaced by
  \`tableNamePrefix\` config), \`config\` / \`generators\` /
  \`MiddlewareStackProxy\` wiring (PR 2.5 covers \`app\` / \`endpoint\` /
  \`call\`), block runners \`load_console\` / \`load_runner\` / \`load_tasks\`
  / \`load_generators\` / \`load_server\` (PR 2.1b), \`load_seed\`,
  \`load_config_initializer\`, \`has_migrations?\`, \`build_request\`,
  \`fixtures_in_root_and_not_in_vendor_or_dot_dir?\`,
  \`default_middleware_stack\` (PR 2.5).

## Test plan

- [x] \`pnpm vitest run packages/trailties/src/engine.test.ts\` — 9/9
- [x] \`pnpm typecheck\` — clean
- [x] \`pnpm lint\` on the new files — clean
- [x] No \`node:*\` / \`process.*\` imports in the new files
- [x] LOC under 300 ceiling (299 insertions)