### PR TITLE
feat(trailties): app template DSL — git, after_bundle, rake (PR 1.10b)

### DIFF
--- a/packages/trailties/src/cli.ts
+++ b/packages/trailties/src/cli.ts
@@ -11,6 +11,15 @@ import { appTemplateCommand } from "./commands/app.js";
 import { notesCommand } from "./commands/notes.js";
 import { statsCommand } from "./commands/stats.js";
 
+export {
+  registerPackageManagerAdapter,
+  packageManagerAdapterConfig,
+  detectPackageManager,
+  getPackageManager,
+  packageManagerInstall,
+  type PackageManagerAdapter,
+} from "./package-manager.js";
+
 export function createProgram(): Command {
   const program = new Command();
 

--- a/packages/trailties/src/commands/new.ts
+++ b/packages/trailties/src/commands/new.ts
@@ -3,6 +3,7 @@ import { Command } from "commander";
 import path from "node:path";
 import { execSync } from "node:child_process";
 import { AppGenerator } from "../generators/app-generator.js";
+import { getPackageManager, packageManagerInstall } from "../package-manager.js";
 
 export function newCommand(): Command {
   const cmd = new Command("new");
@@ -37,12 +38,13 @@ export function newCommand(): Command {
       }
 
       if (!options.skipInstall) {
-        console.log("  Installing dependencies...");
-        try {
-          execSync("pnpm install", { cwd: appDir, stdio: "pipe" });
+        const pm = getPackageManager(appDir);
+        console.log(`  Installing dependencies with ${pm.name}...`);
+        const result = packageManagerInstall(appDir);
+        if (result.status === 0) {
           console.log("  Dependencies installed");
-        } catch {
-          console.log("  Could not install dependencies — run 'pnpm install' manually");
+        } else {
+          console.log(`  Could not install dependencies — run '${pm.name} install' manually`);
         }
       }
 

--- a/packages/trailties/src/commands/new.ts
+++ b/packages/trailties/src/commands/new.ts
@@ -38,9 +38,14 @@ export function newCommand(): Command {
       }
 
       if (!options.skipInstall) {
-        const pm = getPackageManager(appDir);
+        // Detect from the *caller* cwd, not appDir: a freshly generated app
+        // has no lockfile, so detecting in appDir always falls back to npm
+        // and silently downgrades anyone who invoked `trails new` from a
+        // pnpm/yarn/bun workspace. Falls back to pnpm (the historical
+        // trails default) when caller cwd has no lockfile either.
+        const pm = getPackageManager(cwd, { fallback: "pnpm" });
         console.log(`  Installing dependencies with ${pm.name}...`);
-        const result = packageManagerInstall(appDir);
+        const result = packageManagerInstall(appDir, pm);
         if (result.status === 0) {
           console.log("  Dependencies installed");
         } else {

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -77,6 +77,14 @@ describe("ActionsTest", () => {
     expect(calls[0].options?.env?.RAILS_ENV).toBe("production");
   });
 
+  it("rake env option should be passed per-call and not mutate adapter env", () => {
+    const gen = makeGen();
+    gen.rake("log:clear", { env: "production" });
+    gen.rake("log:clear");
+    expect(calls[0].options?.env?.RAILS_ENV).toBe("production");
+    expect(calls[1].options?.env?.RAILS_ENV).toBe("development");
+  });
+
   it("rake with sudo option should run rake with sudo", () => {
     makeGen().rake("log:clear", { sudo: true });
     expect(calls[0].cmd).toBe("sudo");

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -1,7 +1,47 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  registerChildProcessAdapter,
+  childProcessAdapterConfig,
+  type ChildProcessAdapter,
+  type SpawnSyncOptions,
+  type SpawnSyncResult,
+} from "@blazetrails/activesupport";
 import { GeneratorBase } from "./base.js";
 
 class TestGenerator extends GeneratorBase {}
+
+interface SpawnCall {
+  cmd: string;
+  args: string[];
+  options?: SpawnSyncOptions;
+}
+
+let calls: SpawnCall[] = [];
+let nextResult: SpawnSyncResult = { status: 0, signal: null, stdout: "", stderr: "" };
+let previousAdapter: string | null;
+
+const testAdapter: ChildProcessAdapter = {
+  spawnSync(cmd, args, options) {
+    calls.push({ cmd, args, options });
+    return nextResult;
+  },
+};
+
+beforeEach(() => {
+  calls = [];
+  nextResult = { status: 0, signal: null, stdout: "", stderr: "" };
+  registerChildProcessAdapter("trailties-actions-test", testAdapter);
+  previousAdapter = childProcessAdapterConfig.adapter;
+  childProcessAdapterConfig.adapter = "trailties-actions-test";
+});
+
+afterEach(() => {
+  childProcessAdapterConfig.adapter = previousAdapter;
+});
+
+function makeGen(): TestGenerator {
+  return new TestGenerator({ cwd: "/tmp", output: () => {} });
+}
 
 describe("ActionsTest", () => {
   it("generate should queue a sub-generator invocation", () => {
@@ -12,5 +52,59 @@ describe("ActionsTest", () => {
       { what: "scaffold", args: ["Post", "title:string", "body:text"] },
     ]);
     expect(lines.some((l) => l.includes("generate") && l.includes("scaffold"))).toBe(true);
+  });
+
+  it("git with symbol should run command using git scm", () => {
+    makeGen().git("init");
+    expect(calls).toEqual([{ cmd: "git", args: ["init"], options: { cwd: "/tmp" } }]);
+  });
+
+  it("git with hash should run each command using git scm", () => {
+    makeGen().git({ rm: "README", add: "." });
+    expect(calls.map((c) => [c.cmd, ...c.args].join(" "))).toEqual(["git rm README", "git add ."]);
+  });
+
+  it("rake should run rake with the default environment", () => {
+    makeGen().rake("log:clear");
+    expect(calls).toHaveLength(1);
+    expect(calls[0].cmd).toBe("rake");
+    expect(calls[0].args).toEqual(["log:clear"]);
+    expect(calls[0].options?.env?.RAILS_ENV).toBe("development");
+  });
+
+  it("rake with env option should run rake with the env environment", () => {
+    makeGen().rake("log:clear", { env: "production" });
+    expect(calls[0].options?.env?.RAILS_ENV).toBe("production");
+  });
+
+  it("rake with sudo option should run rake with sudo", () => {
+    makeGen().rake("log:clear", { sudo: true });
+    expect(calls[0].cmd).toBe("sudo");
+    expect(calls[0].args).toEqual(["rake", "log:clear"]);
+  });
+
+  it("rake with capture option should run rake with capture", () => {
+    nextResult = { status: 0, signal: null, stdout: "captured output", stderr: "" };
+    const out = makeGen().rake("log:clear", { capture: true });
+    expect(out).toBe("captured output");
+  });
+
+  it("rake with abort_on_failure option should raise on failure", () => {
+    nextResult = { status: 1, signal: null, stdout: "", stderr: "boom" };
+    expect(() => makeGen().rake("invalid", { abortOnFailure: true })).toThrow(/aborted/);
+  });
+
+  it("after_bundle should queue callbacks for later invocation", () => {
+    const gen = makeGen();
+    const order: number[] = [];
+    gen.afterBundle(() => {
+      order.push(1);
+    });
+    gen.afterBundle(() => {
+      order.push(2);
+    });
+    expect(gen.afterBundleCallbacks).toHaveLength(2);
+    for (const cb of gen.afterBundleCallbacks) cb();
+    expect(order).toEqual([1, 2]);
   });
 });

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -69,20 +69,20 @@ describe("ActionsTest", () => {
     expect(calls).toHaveLength(1);
     expect(calls[0].cmd).toBe("rake");
     expect(calls[0].args).toEqual(["log:clear"]);
-    expect(calls[0].options?.env?.RAILS_ENV).toBe("development");
+    expect(calls[0].options?.env?.TRAILS_ENV).toBe("development");
   });
 
   it("rake with env option should run rake with the env environment", () => {
     makeGen().rake("log:clear", { env: "production" });
-    expect(calls[0].options?.env?.RAILS_ENV).toBe("production");
+    expect(calls[0].options?.env?.TRAILS_ENV).toBe("production");
   });
 
   it("rake env option should be passed per-call and not mutate adapter env", () => {
     const gen = makeGen();
     gen.rake("log:clear", { env: "production" });
     gen.rake("log:clear");
-    expect(calls[0].options?.env?.RAILS_ENV).toBe("production");
-    expect(calls[1].options?.env?.RAILS_ENV).toBe("development");
+    expect(calls[0].options?.env?.TRAILS_ENV).toBe("production");
+    expect(calls[1].options?.env?.TRAILS_ENV).toBe("development");
   });
 
   it("rake with sudo option should run rake with sudo", () => {
@@ -100,6 +100,17 @@ describe("ActionsTest", () => {
   it("rake with abort_on_failure option should raise on failure", () => {
     nextResult = { status: 1, signal: null, stdout: "", stderr: "boom" };
     expect(() => makeGen().rake("invalid", { abortOnFailure: true })).toThrow(/aborted/);
+  });
+
+  it("rake with abort_on_failure should raise when spawn errored (status null)", () => {
+    nextResult = {
+      status: null,
+      signal: null,
+      stdout: "",
+      stderr: "",
+      error: new Error("ENOENT: command not found"),
+    };
+    expect(() => makeGen().rake("missing-bin", { abortOnFailure: true })).toThrow(/ENOENT/);
   });
 
   it("after_bundle should queue callbacks for later invocation", () => {

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -113,17 +113,17 @@ describe("ActionsTest", () => {
     expect(() => makeGen().rake("missing-bin", { abortOnFailure: true })).toThrow(/ENOENT/);
   });
 
-  it("after_bundle should queue callbacks for later invocation", () => {
+  it("after_install should queue callbacks for later invocation", () => {
     const gen = makeGen();
     const order: number[] = [];
-    gen.afterBundle(() => {
+    gen.afterInstall(() => {
       order.push(1);
     });
-    gen.afterBundle(() => {
+    gen.afterInstall(() => {
       order.push(2);
     });
-    expect(gen.afterBundleCallbacks).toHaveLength(2);
-    for (const cb of gen.afterBundleCallbacks) cb();
+    expect(gen.afterInstallCallbacks).toHaveLength(2);
+    for (const cb of gen.afterInstallCallbacks) cb();
     expect(order).toEqual([1, 2]);
   });
 });

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -102,6 +102,11 @@ describe("ActionsTest", () => {
     expect(() => makeGen().rake("invalid", { abortOnFailure: true })).toThrow(/aborted/);
   });
 
+  it("rake with abort_on_failure should include signal name when killed by signal", () => {
+    nextResult = { status: null, signal: "SIGTERM", stdout: "", stderr: "" };
+    expect(() => makeGen().rake("slow", { abortOnFailure: true })).toThrow(/SIGTERM/);
+  });
+
   it("rake with abort_on_failure should raise when spawn errored (status null)", () => {
     nextResult = {
       status: null,

--- a/packages/trailties/src/generators/actions.test.ts
+++ b/packages/trailties/src/generators/actions.test.ts
@@ -59,6 +59,20 @@ describe("ActionsTest", () => {
     expect(calls).toEqual([{ cmd: "git", args: ["init"], options: { cwd: "/tmp" } }]);
   });
 
+  it("git with multi-arg string should split into argv", () => {
+    makeGen().git("checkout -b feature/new");
+    expect(calls).toEqual([
+      { cmd: "git", args: ["checkout", "-b", "feature/new"], options: { cwd: "/tmp" } },
+    ]);
+  });
+
+  it("git with hash containing multi-arg options should split each", () => {
+    makeGen().git({ commit: "-m initial" });
+    expect(calls).toEqual([
+      { cmd: "git", args: ["commit", "-m", "initial"], options: { cwd: "/tmp" } },
+    ]);
+  });
+
   it("git with hash should run each command using git scm", () => {
     makeGen().git({ rm: "README", add: "." });
     expect(calls.map((c) => [c.cmd, ...c.args].join(" "))).toEqual(["git rm README", "git add ."]);

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -1,16 +1,19 @@
-// Mirrors railties/lib/rails/generators/actions.rb. PR 1.10 ports `generate`.
-// Unported (no trails equivalent — Ruby-shape DSL emits Ruby-shape files that
-// don't exist in a trails app):
+// Mirrors railties/lib/rails/generators/actions.rb. Ports generate, git,
+// rake, after_bundle. Unported (no trails equivalent — Ruby-shape DSL emits
+// Ruby-shape files that don't exist in a trails app):
 //   gem, gem_group, github, add_source — trails uses package.json
 //   route, environment, application      — trails uses src/config/*.ts
-// PR 1.10b adds git/after_bundle/rake.
+
+import { getChildProcess, env as processEnv } from "@blazetrails/activesupport";
 
 export interface ActionsHost {
+  cwd: string;
   output: (msg: string) => void;
 }
 
 export interface GeneratorActionsState {
   pendingGenerators: Array<{ what: string; args: string[] }>;
+  afterBundleCallbacks: Array<() => void | Promise<void>>;
 }
 
 export function generate(
@@ -21,4 +24,71 @@ export function generate(
   this.output(`      generate  ${what}`);
   this.pendingGenerators ??= [];
   this.pendingGenerators.push({ what, args });
+}
+
+export function git(this: ActionsHost, commands: string | Record<string, string>): void {
+  if (typeof commands === "string") {
+    runGitCommand(this, commands, "");
+  } else {
+    for (const [cmd, options] of Object.entries(commands)) {
+      runGitCommand(this, cmd, options);
+    }
+  }
+}
+
+function runGitCommand(host: ActionsHost, cmd: string, options: string): void {
+  const optionParts = options ? splitArgs(options) : [];
+  const args = [cmd, ...optionParts];
+  host.output(`         run  git ${[cmd, options].filter(Boolean).join(" ")}`);
+  getChildProcess().spawnSync("git", args, { cwd: host.cwd });
+}
+
+export function afterBundle(
+  this: GeneratorActionsState,
+  callback: () => void | Promise<void>,
+): void {
+  this.afterBundleCallbacks ??= [];
+  this.afterBundleCallbacks.push(callback);
+}
+
+export interface RakeOptions {
+  env?: string;
+  sudo?: boolean;
+  capture?: boolean;
+  abortOnFailure?: boolean;
+}
+
+export function rake(
+  this: ActionsHost,
+  command: string,
+  options: RakeOptions = {},
+): string | undefined {
+  return executeCommand(this, "rake", command, options);
+}
+
+function executeCommand(
+  host: ActionsHost,
+  name: string,
+  command: string,
+  opts: RakeOptions,
+): string | undefined {
+  const envName = opts.env ?? processEnv.RAILS_ENV ?? "development";
+  const parts: string[] = [];
+  if (opts.sudo) parts.push("sudo");
+  parts.push(name, ...splitArgs(command));
+  const [bin, ...args] = parts;
+  host.output(`         ${name}  ${command}`);
+  const result = getChildProcess().spawnSync(bin, args, {
+    cwd: host.cwd,
+    env: { ...processEnv, RAILS_ENV: envName } as NodeJS.ProcessEnv,
+  });
+  if (opts.abortOnFailure && (result.status ?? 0) !== 0) {
+    throw new Error(`${name} ${command} aborted: exit status ${result.status}`);
+  }
+  if (opts.capture) return result.stdout;
+  return undefined;
+}
+
+function splitArgs(s: string): string[] {
+  return s.split(/\s+/).filter(Boolean);
 }

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -1,6 +1,9 @@
 // Mirrors railties/lib/rails/generators/actions.rb. Ports generate, git,
-// rake, after_bundle. Unported (no trails equivalent — Ruby-shape DSL emits
-// Ruby-shape files that don't exist in a trails app):
+// rake, and after_install (Rails' after_bundle — renamed for the JS
+// ecosystem; trails apps run a package-manager install, not `bundle`).
+//
+// Unported (no trails equivalent — Ruby-shape DSL emits Ruby-shape files
+// that don't exist in a trails app):
 //   gem, gem_group, github, add_source — trails uses package.json
 //   route, environment, application      — trails uses src/config/*.ts
 
@@ -13,7 +16,7 @@ export interface ActionsHost {
 
 export interface GeneratorActionsState {
   pendingGenerators: Array<{ what: string; args: string[] }>;
-  afterBundleCallbacks: Array<() => void | Promise<void>>;
+  afterInstallCallbacks: Array<() => void | Promise<void>>;
 }
 
 export function generate(
@@ -41,11 +44,11 @@ function runGitCommand(host: ActionsHost, cmd: string, options: string): void {
   getChildProcess().spawnSync("git", args, { cwd: host.cwd });
 }
 
-export function afterBundle(
+export function afterInstall(
   this: GeneratorActionsState,
   callback: () => void | Promise<void>,
 ): void {
-  this.afterBundleCallbacks.push(callback);
+  this.afterInstallCallbacks.push(callback);
 }
 
 export interface RakeOptions {

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -22,7 +22,6 @@ export function generate(
   ...args: string[]
 ): void {
   this.output(`      generate  ${what}`);
-  this.pendingGenerators ??= [];
   this.pendingGenerators.push({ what, args });
 }
 
@@ -37,9 +36,8 @@ export function git(this: ActionsHost, commands: string | Record<string, string>
 }
 
 function runGitCommand(host: ActionsHost, cmd: string, options: string): void {
-  const optionParts = options ? splitArgs(options) : [];
-  const args = [cmd, ...optionParts];
-  host.output(`         run  git ${[cmd, options].filter(Boolean).join(" ")}`);
+  const args = [cmd, ...splitArgs(options)];
+  host.output(`           git  ${[cmd, options].filter(Boolean).join(" ")}`);
   getChildProcess().spawnSync("git", args, { cwd: host.cwd });
 }
 
@@ -47,7 +45,6 @@ export function afterBundle(
   this: GeneratorActionsState,
   callback: () => void | Promise<void>,
 ): void {
-  this.afterBundleCallbacks ??= [];
   this.afterBundleCallbacks.push(callback);
 }
 
@@ -77,7 +74,7 @@ function executeCommand(
   if (opts.sudo) parts.push("sudo");
   parts.push(name, ...splitArgs(command));
   const [bin, ...args] = parts;
-  host.output(`         ${name}  ${command}`);
+  host.output(`          ${name}  ${command}`);
   const result = getChildProcess().spawnSync(bin, args, {
     cwd: host.cwd,
     env: { ...processEnv, RAILS_ENV: envName } as NodeJS.ProcessEnv,

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -69,7 +69,11 @@ function executeCommand(
   command: string,
   opts: RakeOptions,
 ): string | undefined {
-  const envName = opts.env ?? processEnv.RAILS_ENV ?? "development";
+  // Mirrors Rails' RAILS_ENV resolution but defaults from TRAILS_ENV
+  // (the trailties runtime convention, see database.ts:resolveEnv). Set
+  // both vars in the spawned env: TRAILS_ENV for trails children, plus
+  // RAILS_ENV so a literal `rake` task that reads RAILS_ENV still works.
+  const envName = opts.env ?? processEnv.TRAILS_ENV ?? processEnv.RAILS_ENV ?? "development";
   const parts: string[] = [];
   if (opts.sudo) parts.push("sudo");
   parts.push(name, ...splitArgs(command));
@@ -77,10 +81,11 @@ function executeCommand(
   host.output(`          ${name}  ${command}`);
   const result = getChildProcess().spawnSync(bin, args, {
     cwd: host.cwd,
-    env: { ...processEnv, RAILS_ENV: envName } as NodeJS.ProcessEnv,
+    env: { ...processEnv, TRAILS_ENV: envName, RAILS_ENV: envName } as NodeJS.ProcessEnv,
   });
-  if (opts.abortOnFailure && (result.status ?? 0) !== 0) {
-    throw new Error(`${name} ${command} aborted: exit status ${result.status}`);
+  if (opts.abortOnFailure && (result.status !== 0 || result.error)) {
+    const detail = result.error ? `: ${result.error.message}` : ` exit status ${result.status}`;
+    throw new Error(`${name} ${command} aborted${detail}`);
   }
   if (opts.capture) return result.stdout;
   return undefined;

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -87,7 +87,11 @@ function executeCommand(
     env: { ...processEnv, TRAILS_ENV: envName, RAILS_ENV: envName } as NodeJS.ProcessEnv,
   });
   if (opts.abortOnFailure && (result.status !== 0 || result.error)) {
-    const detail = result.error ? `: ${result.error.message}` : ` exit status ${result.status}`;
+    const detail = result.error
+      ? `: ${result.error.message}`
+      : result.signal
+        ? ` signal ${result.signal}`
+        : ` exit status ${result.status}`;
     throw new Error(`${name} ${command} aborted${detail}`);
   }
   if (opts.capture) return result.stdout;

--- a/packages/trailties/src/generators/actions.ts
+++ b/packages/trailties/src/generators/actions.ts
@@ -30,17 +30,20 @@ export function generate(
 
 export function git(this: ActionsHost, commands: string | Record<string, string>): void {
   if (typeof commands === "string") {
-    runGitCommand(this, commands, "");
+    // String form is the whole subcommand line: `git("checkout -b foo")`
+    // must spawn ["checkout", "-b", "foo"], not [<the whole string>].
+    const parts = splitArgs(commands);
+    runGitCommand(this, parts[0] ?? "", parts.slice(1));
   } else {
     for (const [cmd, options] of Object.entries(commands)) {
-      runGitCommand(this, cmd, options);
+      runGitCommand(this, cmd, splitArgs(options));
     }
   }
 }
 
-function runGitCommand(host: ActionsHost, cmd: string, options: string): void {
-  const args = [cmd, ...splitArgs(options)];
-  host.output(`           git  ${[cmd, options].filter(Boolean).join(" ")}`);
+function runGitCommand(host: ActionsHost, cmd: string, optionArgs: string[]): void {
+  const args = [cmd, ...optionArgs];
+  host.output(`           git  ${[cmd, ...optionArgs].join(" ").trim()}`);
   getChildProcess().spawnSync("git", args, { cwd: host.cwd });
 }
 

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -21,8 +21,12 @@ export abstract class GeneratorBase implements GeneratorActionsState {
   output: (msg: string) => void;
   protected createdFiles: string[] = [];
   pendingGenerators: Array<{ what: string; args: string[] }> = [];
+  afterBundleCallbacks: Array<() => void | Promise<void>> = [];
 
   generate = Actions.generate;
+  git = Actions.git;
+  afterBundle = Actions.afterBundle;
+  rake = Actions.rake;
 
   constructor(options: GeneratorOptions) {
     this.cwd = options.cwd;

--- a/packages/trailties/src/generators/base.ts
+++ b/packages/trailties/src/generators/base.ts
@@ -21,11 +21,11 @@ export abstract class GeneratorBase implements GeneratorActionsState {
   output: (msg: string) => void;
   protected createdFiles: string[] = [];
   pendingGenerators: Array<{ what: string; args: string[] }> = [];
-  afterBundleCallbacks: Array<() => void | Promise<void>> = [];
+  afterInstallCallbacks: Array<() => void | Promise<void>> = [];
 
   generate = Actions.generate;
   git = Actions.git;
-  afterBundle = Actions.afterBundle;
+  afterInstall = Actions.afterInstall;
   rake = Actions.rake;
 
   constructor(options: GeneratorOptions) {

--- a/packages/trailties/src/package-manager.test.ts
+++ b/packages/trailties/src/package-manager.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  registerFsAdapter,
+  fsAdapterConfig,
+  registerChildProcessAdapter,
+  childProcessAdapterConfig,
+  type FsAdapter,
+  type PathAdapter,
+  type ChildProcessAdapter,
+} from "@blazetrails/activesupport";
+import {
+  registerPackageManagerAdapter,
+  packageManagerAdapterConfig,
+  detectPackageManager,
+  getPackageManager,
+  packageManagerInstall,
+} from "./package-manager.js";
+
+let lockFiles: Set<string>;
+let spawnCalls: Array<{ cmd: string; args: string[] }>;
+let previousFs: string | null;
+let previousCp: string | null;
+let previousPm: string | null;
+
+const stubFs = {
+  existsSync: (p: string) => lockFiles.has(p),
+} as unknown as FsAdapter;
+
+const stubCp: ChildProcessAdapter = {
+  spawnSync(cmd, args) {
+    spawnCalls.push({ cmd, args });
+    return { status: 0, signal: null, stdout: "", stderr: "" };
+  },
+};
+
+beforeEach(() => {
+  lockFiles = new Set();
+  spawnCalls = [];
+  registerFsAdapter("pm-test", stubFs, {} as PathAdapter);
+  registerChildProcessAdapter("pm-test", stubCp);
+  previousFs = fsAdapterConfig.adapter;
+  previousCp = childProcessAdapterConfig.adapter;
+  previousPm = packageManagerAdapterConfig.adapter;
+  fsAdapterConfig.adapter = "pm-test";
+  childProcessAdapterConfig.adapter = "pm-test";
+  packageManagerAdapterConfig.adapter = null;
+});
+
+afterEach(() => {
+  fsAdapterConfig.adapter = previousFs;
+  childProcessAdapterConfig.adapter = previousCp;
+  packageManagerAdapterConfig.adapter = previousPm;
+});
+
+describe("detectPackageManager", () => {
+  it("prefers pnpm when pnpm-lock.yaml is present", () => {
+    lockFiles.add("/app/pnpm-lock.yaml");
+    expect(detectPackageManager("/app").name).toBe("pnpm");
+  });
+
+  it("picks yarn when yarn.lock is present and no pnpm lock", () => {
+    lockFiles.add("/app/yarn.lock");
+    expect(detectPackageManager("/app").name).toBe("yarn");
+  });
+
+  it("picks bun when bun.lockb is present and no pnpm/yarn lock", () => {
+    lockFiles.add("/app/bun.lockb");
+    expect(detectPackageManager("/app").name).toBe("bun");
+  });
+
+  it("falls back to npm when no lockfile is present", () => {
+    expect(detectPackageManager("/app").name).toBe("npm");
+  });
+
+  it("resolves pnpm before yarn when both lockfiles coexist", () => {
+    lockFiles.add("/app/pnpm-lock.yaml");
+    lockFiles.add("/app/yarn.lock");
+    expect(detectPackageManager("/app").name).toBe("pnpm");
+  });
+});
+
+describe("getPackageManager", () => {
+  it("honors an explicit adapter override", () => {
+    packageManagerAdapterConfig.adapter = "yarn";
+    expect(getPackageManager("/app").name).toBe("yarn");
+  });
+
+  it("falls back to detection when no override is set", () => {
+    lockFiles.add("/app/pnpm-lock.yaml");
+    expect(getPackageManager("/app").name).toBe("pnpm");
+  });
+
+  it("throws when override names an unregistered adapter", () => {
+    packageManagerAdapterConfig.adapter = "does-not-exist";
+    expect(() => getPackageManager("/app")).toThrow(/is not registered/);
+  });
+});
+
+describe("registerPackageManagerAdapter", () => {
+  it("makes a custom adapter selectable via the override", () => {
+    registerPackageManagerAdapter({
+      name: "deno",
+      installArgs: ["install"],
+      addArgs: ["add"],
+      runArgs: ["task"],
+    });
+    packageManagerAdapterConfig.adapter = "deno";
+    expect(getPackageManager("/app").name).toBe("deno");
+  });
+});
+
+describe("packageManagerInstall", () => {
+  it("invokes the active package manager's install command in cwd", () => {
+    packageManagerAdapterConfig.adapter = "npm";
+    packageManagerInstall("/app");
+    expect(spawnCalls).toEqual([{ cmd: "npm", args: ["install"] }]);
+  });
+});

--- a/packages/trailties/src/package-manager.test.ts
+++ b/packages/trailties/src/package-manager.test.ts
@@ -26,6 +26,10 @@ const stubFs = {
   existsSync: (p: string) => lockFiles.has(p),
 } as unknown as FsAdapter;
 
+const stubPath = {
+  join: (...parts: string[]) => parts.join("/"),
+} as unknown as PathAdapter;
+
 const stubCp: ChildProcessAdapter = {
   spawnSync(cmd, args) {
     spawnCalls.push({ cmd, args });
@@ -36,7 +40,7 @@ const stubCp: ChildProcessAdapter = {
 beforeEach(() => {
   lockFiles = new Set();
   spawnCalls = [];
-  registerFsAdapter("pm-test", stubFs, {} as PathAdapter);
+  registerFsAdapter("pm-test", stubFs, stubPath);
   registerChildProcessAdapter("pm-test", stubCp);
   previousFs = fsAdapterConfig.adapter;
   previousCp = childProcessAdapterConfig.adapter;
@@ -70,6 +74,10 @@ describe("detectPackageManager", () => {
 
   it("falls back to npm when no lockfile is present", () => {
     expect(detectPackageManager("/app").name).toBe("npm");
+  });
+
+  it("uses the fallback option when no lockfile is present", () => {
+    expect(detectPackageManager("/app", { fallback: "pnpm" }).name).toBe("pnpm");
   });
 
   it("resolves pnpm before yarn when both lockfiles coexist", () => {

--- a/packages/trailties/src/package-manager.ts
+++ b/packages/trailties/src/package-manager.ts
@@ -1,0 +1,105 @@
+// Pluggable package-manager adapter. Mirrors the activesupport
+// child-process / fs adapter pattern: a registry of named implementations
+// plus a default-detection path that picks one based on lock-file presence.
+//
+// Why pluggable: trails apps may use pnpm, npm, yarn, or bun. Hardcoding
+// any single one in generator code locks users out of the others. Adapter
+// at the boundary, hardcoded only at registration time.
+
+import { getChildProcess, getFs } from "@blazetrails/activesupport";
+
+export interface PackageManagerAdapter {
+  /** CLI binary name (`pnpm`, `npm`, `yarn`, `bun`). */
+  name: string;
+  /** Argv for `<name> install` — the trails equivalent of `bundle install`. */
+  installArgs: string[];
+  /** Argv prefix for adding a dependency, e.g. `["add"]` or `["install"]`. */
+  addArgs: string[];
+  /** Argv prefix for running a package.json script. */
+  runArgs: string[];
+}
+
+const registry = new Map<string, PackageManagerAdapter>();
+let currentAdapterName: string | null = null;
+
+export function registerPackageManagerAdapter(adapter: PackageManagerAdapter): void {
+  registry.set(adapter.name, adapter);
+}
+
+// Built-in adapters. These are pure data; they don't import anything.
+registerPackageManagerAdapter({
+  name: "pnpm",
+  installArgs: ["install"],
+  addArgs: ["add"],
+  runArgs: ["run"],
+});
+registerPackageManagerAdapter({
+  name: "npm",
+  installArgs: ["install"],
+  addArgs: ["install"],
+  runArgs: ["run"],
+});
+registerPackageManagerAdapter({
+  name: "yarn",
+  installArgs: ["install"],
+  addArgs: ["add"],
+  runArgs: ["run"],
+});
+registerPackageManagerAdapter({
+  name: "bun",
+  installArgs: ["install"],
+  addArgs: ["add"],
+  runArgs: ["run"],
+});
+
+export const packageManagerAdapterConfig = {
+  get adapter(): string | null {
+    return currentAdapterName;
+  },
+  set adapter(name: string | null) {
+    currentAdapterName = name;
+  },
+};
+
+/**
+ * Detect the active package manager from lock-file presence in `cwd`.
+ *
+ * Order: pnpm → yarn → bun → npm. Mirrors how the JS ecosystem itself
+ * resolves conflicts when multiple lockfiles exist (pnpm wins because
+ * its lockfile is the most-recent convention and the most authoritative
+ * about hoisting). Falls back to `npm` since every Node install ships it.
+ */
+export function detectPackageManager(cwd: string): PackageManagerAdapter {
+  const fs = getFs();
+  if (fs.existsSync(`${cwd}/pnpm-lock.yaml`)) return registry.get("pnpm")!;
+  if (fs.existsSync(`${cwd}/yarn.lock`)) return registry.get("yarn")!;
+  if (fs.existsSync(`${cwd}/bun.lockb`)) return registry.get("bun")!;
+  return registry.get("npm")!;
+}
+
+/**
+ * Resolve the active package manager. Honors an explicit
+ * `packageManagerAdapterConfig.adapter` override; otherwise auto-detects
+ * from `cwd`.
+ */
+export function getPackageManager(cwd: string): PackageManagerAdapter {
+  if (currentAdapterName) {
+    const adapter = registry.get(currentAdapterName);
+    if (!adapter) throw new Error(`Package manager "${currentAdapterName}" is not registered.`);
+    return adapter;
+  }
+  return detectPackageManager(cwd);
+}
+
+/**
+ * Run the active package manager's install command in `cwd`. Returns the
+ * spawn result so callers can decide whether non-zero exit aborts.
+ */
+export function packageManagerInstall(cwd: string): {
+  status: number | null;
+  stderr: string;
+} {
+  const pm = getPackageManager(cwd);
+  const result = getChildProcess().spawnSync(pm.name, pm.installArgs, { cwd });
+  return { status: result.status, stderr: result.stderr };
+}

--- a/packages/trailties/src/package-manager.ts
+++ b/packages/trailties/src/package-manager.ts
@@ -6,7 +6,7 @@
 // any single one in generator code locks users out of the others. Adapter
 // at the boundary, hardcoded only at registration time.
 
-import { getChildProcess, getFs } from "@blazetrails/activesupport";
+import { getChildProcess, getFs, getPath } from "@blazetrails/activesupport";
 
 export interface PackageManagerAdapter {
   /** CLI binary name (`pnpm`, `npm`, `yarn`, `bun`). */
@@ -69,37 +69,49 @@ export const packageManagerAdapterConfig = {
  * its lockfile is the most-recent convention and the most authoritative
  * about hoisting). Falls back to `npm` since every Node install ships it.
  */
-export function detectPackageManager(cwd: string): PackageManagerAdapter {
+export interface DetectOptions {
+  /** Adapter name to return when no lockfile is found. Defaults to `npm`. */
+  fallback?: string;
+}
+
+export function detectPackageManager(cwd: string, opts: DetectOptions = {}): PackageManagerAdapter {
   const fs = getFs();
-  if (fs.existsSync(`${cwd}/pnpm-lock.yaml`)) return registry.get("pnpm")!;
-  if (fs.existsSync(`${cwd}/yarn.lock`)) return registry.get("yarn")!;
-  if (fs.existsSync(`${cwd}/bun.lockb`)) return registry.get("bun")!;
-  return registry.get("npm")!;
+  const path = getPath();
+  if (fs.existsSync(path.join(cwd, "pnpm-lock.yaml"))) return registry.get("pnpm")!;
+  if (fs.existsSync(path.join(cwd, "yarn.lock"))) return registry.get("yarn")!;
+  if (fs.existsSync(path.join(cwd, "bun.lockb"))) return registry.get("bun")!;
+  const fallback = opts.fallback ?? "npm";
+  const adapter = registry.get(fallback);
+  if (!adapter) throw new Error(`Package manager "${fallback}" is not registered.`);
+  return adapter;
 }
 
 /**
  * Resolve the active package manager. Honors an explicit
  * `packageManagerAdapterConfig.adapter` override; otherwise auto-detects
- * from `cwd`.
+ * from `cwd` (with optional `fallback`).
  */
-export function getPackageManager(cwd: string): PackageManagerAdapter {
+export function getPackageManager(cwd: string, opts: DetectOptions = {}): PackageManagerAdapter {
   if (currentAdapterName) {
     const adapter = registry.get(currentAdapterName);
     if (!adapter) throw new Error(`Package manager "${currentAdapterName}" is not registered.`);
     return adapter;
   }
-  return detectPackageManager(cwd);
+  return detectPackageManager(cwd, opts);
 }
 
 /**
- * Run the active package manager's install command in `cwd`. Returns the
- * spawn result so callers can decide whether non-zero exit aborts.
+ * Run a package manager's install command in `cwd`. If `pm` is omitted,
+ * resolves via {@link getPackageManager}.
  */
-export function packageManagerInstall(cwd: string): {
+export function packageManagerInstall(
+  cwd: string,
+  pm?: PackageManagerAdapter,
+): {
   status: number | null;
   stderr: string;
 } {
-  const pm = getPackageManager(cwd);
-  const result = getChildProcess().spawnSync(pm.name, pm.installArgs, { cwd });
+  const resolved = pm ?? getPackageManager(cwd);
+  const result = getChildProcess().spawnSync(resolved.name, resolved.installArgs, { cwd });
   return { status: result.status, stderr: result.stderr };
 }


### PR DESCRIPTION
## Summary

Extends `packages/trailties/src/generators/actions.ts` with the remaining
Rails app-template DSL methods that have a trails equivalent:

- `git(commands)` — shells out via `childProcessAdapter`; accepts a string
  (`gen.git(\"init\")`) or a hash (`gen.git({ rm: \"README\", add: \".\" })`).
- `afterBundle(callback)` — queues callbacks for later invocation.
- `rake(command, options)` — runs `rake` with `env` / `sudo` / `capture` /
  `abortOnFailure` options, mirroring `execute_command` in Rails.

Mixed into `GeneratorBase` alongside the existing `generate` method.

## Rails sources

- `railties/lib/rails/generators/actions.rb` — `git`, `rake`,
  `execute_command`.
- `railties/lib/rails/generators/rails/app/app_generator.rb` —
  `after_bundle`.

## Skipped (no trails equivalent)

Documented inline at the top of `actions.ts`:

- `gem`, `gem_group`, `github`, `add_source` — trails uses `package.json`,
  not a Gemfile. (PR 1.10b spec listed `add_source`; per the plan and the
  existing actions.ts header, these remain unported.)
- `route`, `environment`, `application` — trails uses `src/config/*.ts`,
  not `config/routes.rb` / `config/application.rb`.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/generators/actions.test.ts`
  — 9/9 pass (1 existing `generate` test + 8 new Rails-mirrored tests).
- [x] No `node:*` imports added (uses `getChildProcess` from activesupport).
- [x] No `process.*` references (uses activesupport `env`).
- [x] LOC within ~100-LOC target.