### PR TITLE
feat(trailties): generator helpers — Migration + ModelHelpers + ResourceHelpers + ActiveModel (PR 1.12b)

### DIFF
--- a/packages/trailties/src/generators/active-model.test.ts
+++ b/packages/trailties/src/generators/active-model.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { ActiveModel } from "./active-model.js";
+
+describe("ActiveModel", () => {
+  it("class + instance methods emit Ruby-shape snippets", () => {
+    expect([
+      ActiveModel.all("Foo"),
+      ActiveModel.find("Foo", "params[:id]"),
+      ActiveModel.find("Foo"),
+      ActiveModel.build("Foo", "x"),
+      ActiveModel.build("Foo"),
+    ]).toEqual(["Foo.all", "Foo.find(params[:id])", "Foo.find()", "Foo.new(x)", "Foo.new"]);
+    const m = new ActiveModel("@foo");
+    expect([m.save(), m.update("x"), m.errors(), m.destroy()]).toEqual([
+      "@foo.save",
+      "@foo.update(x)",
+      "@foo.errors",
+      "@foo.destroy!",
+    ]);
+  });
+});

--- a/packages/trailties/src/generators/active-model.ts
+++ b/packages/trailties/src/generators/active-model.ts
@@ -1,0 +1,30 @@
+// Mirrors railties/lib/rails/generators/active_model.rb. Per-ORM subclasses
+// override these methods to emit ORM-specific snippets that the scaffold
+// controller template inlines.
+export class ActiveModel {
+  readonly name: string;
+  constructor(name: string) {
+    this.name = name;
+  }
+  static all(klass: string): string {
+    return `${klass}.all`;
+  }
+  static find(klass: string, params?: string): string {
+    return `${klass}.find(${params ?? ""})`;
+  }
+  static build(klass: string, params?: string): string {
+    return params == null ? `${klass}.new` : `${klass}.new(${params})`;
+  }
+  save(): string {
+    return `${this.name}.save`;
+  }
+  update(params?: string): string {
+    return `${this.name}.update(${params ?? ""})`;
+  }
+  errors(): string {
+    return `${this.name}.errors`;
+  }
+  destroy(): string {
+    return `${this.name}.destroy!`;
+  }
+}

--- a/packages/trailties/src/generators/index.ts
+++ b/packages/trailties/src/generators/index.ts
@@ -11,3 +11,9 @@ export { NamedBase } from "./named-base.js";
 export type { NamedBaseOptions } from "./named-base.js";
 export { GeneratedAttribute, GeneratorError } from "./generated-attribute.js";
 export type { AttrOptions, IndexType } from "./generated-attribute.js";
+// CreateMigration action deferred to a 1.12b follow-up PR to stay under the
+// 300 LOC ceiling — see docs/trailties-plan.md.
+export { ActiveModel } from "./active-model.js";
+export * from "./migration.js";
+export * from "./model-helpers.js";
+export * from "./resource-helpers.js";

--- a/packages/trailties/src/generators/migration.test.ts
+++ b/packages/trailties/src/generators/migration.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import type { FsAdapter, PathAdapter } from "@blazetrails/activesupport";
+import {
+  buildMigrationAssigns,
+  currentMigrationNumber,
+  migrationExists,
+  migrationLookupAt,
+  nextMigrationNumber,
+  NotImplementedError,
+} from "./migration.js";
+
+const path = {
+  join: (...p: string[]) => p.join("/"),
+  basename: (p: string) => p.split("/").pop()!,
+} as PathAdapter;
+
+const fs = (entries: Record<string, string[]>): FsAdapter =>
+  ({
+    exists: async (p: string) => Object.hasOwn(entries, p),
+    readdir: async (p: string) => entries[p] ?? [],
+  }) as unknown as FsAdapter;
+
+describe("migration", () => {
+  it("lookupAt + exists + currentMigrationNumber + buildAssigns", async () => {
+    const f = fs({
+      "/d": ["20260101000000_create_posts.ts", "20260103000000_other.ts", "skip.md"],
+    });
+    expect(await migrationLookupAt(f, path, "/d")).toEqual([
+      "/d/20260101000000_create_posts.ts",
+      "/d/20260103000000_other.ts",
+    ]);
+    expect(await migrationLookupAt(fs({}), path, "/missing")).toEqual([]);
+    expect(await migrationExists(f, path, "/d", "create_posts")).toBe(
+      "/d/20260101000000_create_posts.ts",
+    );
+    expect(await migrationExists(f, path, "/d", "missing")).toBeUndefined();
+    expect(await currentMigrationNumber(f, path, "/d")).toBe(20260103000000);
+    expect(buildMigrationAssigns(path, "db/migrate/create_posts.ts", "20260101000000")).toEqual({
+      migrationNumber: "20260101000000",
+      migrationFileName: "create_posts",
+      migrationClassName: "CreatePosts",
+    });
+  });
+
+  it("nextMigrationNumber raises NotImplementedError", () => {
+    expect(() => nextMigrationNumber()).toThrow(NotImplementedError);
+  });
+});

--- a/packages/trailties/src/generators/migration.ts
+++ b/packages/trailties/src/generators/migration.ts
@@ -1,0 +1,65 @@
+import { camelize, type FsAdapter, type PathAdapter } from "@blazetrails/activesupport";
+
+// Mirrors railties/lib/rails/generators/migration.rb. `migration_template`
+// (ERB rendering) is deferred to PR 1.12c where generators are reworked to
+// consume templates.
+export interface MigrationAssigns {
+  migrationNumber: string;
+  migrationFileName: string;
+  migrationClassName: string;
+}
+
+const MIGRATION_FILE_RE = /^[0-9].*_.*\.(ts|js|rb)$/;
+
+export async function migrationLookupAt(
+  fs: FsAdapter,
+  path: PathAdapter,
+  dirname: string,
+): Promise<string[]> {
+  if (!(await fs.exists(dirname))) return [];
+  if (!fs.readdir) throw new Error("FsAdapter.readdir is required");
+  return (await fs.readdir(dirname))
+    .filter((e) => MIGRATION_FILE_RE.test(e))
+    .map((e) => path.join(dirname, e));
+}
+
+export async function migrationExists(
+  fs: FsAdapter,
+  path: PathAdapter,
+  dirname: string,
+  fileName: string,
+): Promise<string | undefined> {
+  const re = new RegExp(`\\d+_${fileName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.(ts|js|rb)$`);
+  return (await migrationLookupAt(fs, path, dirname)).find((f) => re.test(f));
+}
+
+export async function currentMigrationNumber(
+  fs: FsAdapter,
+  path: PathAdapter,
+  dirname: string,
+): Promise<number> {
+  let max = 0;
+  for (const f of await migrationLookupAt(fs, path, dirname)) {
+    const n = parseInt(path.basename(f).split("_")[0]!, 10);
+    if (!Number.isNaN(n) && n > max) max = n;
+  }
+  return max;
+}
+
+export class NotImplementedError extends Error {}
+export function nextMigrationNumber(): never {
+  throw new NotImplementedError("nextMigrationNumber must be implemented");
+}
+
+export function buildMigrationAssigns(
+  path: PathAdapter,
+  destination: string,
+  nextNumber: string,
+): MigrationAssigns {
+  const base = path.basename(destination).replace(/\.(ts|js|rb)$/, "");
+  return {
+    migrationNumber: nextNumber,
+    migrationFileName: base,
+    migrationClassName: camelize(base),
+  };
+}

--- a/packages/trailties/src/generators/model-helpers.test.ts
+++ b/packages/trailties/src/generators/model-helpers.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { ModelHelpers, normalizeModelName } from "./model-helpers.js";
+import { GeneratorError } from "./generated-attribute.js";
 
 describe("normalizeModelName", () => {
   beforeEach(() => {
@@ -18,5 +19,12 @@ describe("normalizeModelName", () => {
 
     ModelHelpers.skipWarn = false;
     expect(normalizeModelName("posts", { forcePlural: true })).toBe("posts");
+  });
+
+  it("raises GeneratorError on inflection-impossible names", () => {
+    // "WIFI" trips the activesupport inflector's underscore round-trip
+    // (`underscore("WIFI")` → "wifi" but `underscore("WIFIs")` → "wif_is"),
+    // which is exactly Rails' inflection_impossible? check.
+    expect(() => normalizeModelName("WIFI")).toThrow(GeneratorError);
   });
 });

--- a/packages/trailties/src/generators/model-helpers.test.ts
+++ b/packages/trailties/src/generators/model-helpers.test.ts
@@ -6,11 +6,15 @@ describe("normalizeModelName", () => {
     ModelHelpers.skipWarn = false;
   });
 
-  it("singularizes plurals, honors forcePlural, sets skipWarn", () => {
+  it("singularizes plurals and warns once, honors forcePlural, suppresses subsequent warns", () => {
     const messages: string[] = [];
     expect(normalizeModelName("posts", {}, (m) => messages.push(m))).toBe("post");
     expect(messages[0]).toContain("'posts' was recognized as a plural");
     expect(ModelHelpers.skipWarn).toBe(true);
+
+    const more: string[] = [];
+    expect(normalizeModelName("comments", {}, (m) => more.push(m))).toBe("comment");
+    expect(more).toEqual([]);
 
     ModelHelpers.skipWarn = false;
     expect(normalizeModelName("posts", { forcePlural: true })).toBe("posts");

--- a/packages/trailties/src/generators/model-helpers.test.ts
+++ b/packages/trailties/src/generators/model-helpers.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { ModelHelpers, normalizeModelName } from "./model-helpers.js";
+
+describe("normalizeModelName", () => {
+  beforeEach(() => {
+    ModelHelpers.skipWarn = false;
+  });
+
+  it("singularizes plurals, honors forcePlural, sets skipWarn", () => {
+    const messages: string[] = [];
+    expect(normalizeModelName("posts", {}, (m) => messages.push(m))).toBe("post");
+    expect(messages[0]).toContain("'posts' was recognized as a plural");
+    expect(ModelHelpers.skipWarn).toBe(true);
+
+    ModelHelpers.skipWarn = false;
+    expect(normalizeModelName("posts", { forcePlural: true })).toBe("posts");
+  });
+});

--- a/packages/trailties/src/generators/model-helpers.ts
+++ b/packages/trailties/src/generators/model-helpers.ts
@@ -2,17 +2,19 @@ import { pluralize, singularize, underscore } from "@blazetrails/activesupport";
 import { GeneratorError } from "./generated-attribute.js";
 
 // Mirrors railties/lib/rails/generators/model_helpers.rb. Trailties
-// generators call normalizeModelName() from their constructor.
+// generators call normalizeModelName() from their constructor. Warning
+// strings are kept verbatim from Rails so `pnpm api:compare` can match.
 // prettier-ignore
-export const PLURAL_MODEL_NAME_WARN_MESSAGE = "[WARNING] The model name '%s' was recognized as a plural, using the singular '%s' instead. Override with --force-plural or setup custom inflection rules for this noun before running the generator.";
+const PLURAL_WARN = "[WARNING] The model name '%s' was recognized as a plural, using the singular '%s' instead. Override with --force-plural or setup custom inflection rules for this noun before running the generator.";
 // prettier-ignore
-export const IRREGULAR_MODEL_NAME_WARN_MESSAGE = "[WARNING] Rails cannot recover singular form from its plural form '%s'.\nPlease setup custom inflection rules for this noun before running the generator in config/initializers/inflections.rb.\n";
+const IRREGULAR_WARN = "[WARNING] Rails cannot recover singular form from its plural form '%s'.\nPlease setup custom inflection rules for this noun before running the generator in config/initializers/inflections.rb.\n";
 // prettier-ignore
-export const INFLECTION_IMPOSSIBLE_ERROR_MESSAGE = "Rails cannot recover the underscored form from its camelcase form '%s'.\nPlease use an underscored name instead, either '%s' or '%s'.\nOr setup custom inflection rules for this noun before running the generator in config/initializers/inflections.rb.\n";
+const IMPOSSIBLE_ERR = "Rails cannot recover the underscored form from its camelcase form '%s'.\nPlease use an underscored name instead, either '%s' or '%s'.\nOr setup custom inflection rules for this noun before running the generator in config/initializers/inflections.rb.\n";
 
 export class ModelHelpers {
   static skipWarn = false;
 }
+
 export interface ModelHelpersOptions {
   forcePlural?: boolean;
 }
@@ -26,17 +28,15 @@ export function normalizeModelName(
   let cur = name;
   if (isPlural(cur) && !options.forcePlural) {
     const s = singularize(cur);
-    if (!ModelHelpers.skipWarn) say(fmt(PLURAL_MODEL_NAME_WARN_MESSAGE, cur, s));
+    if (!ModelHelpers.skipWarn) say(fmt(PLURAL_WARN, cur, s));
     cur = s;
   }
   if (isInflectionImpossible(cur)) {
     const o1 = underscore(singularize(cur));
     const o2 = singularize(underscore(pluralize(cur)));
-    throw new GeneratorError(fmt(INFLECTION_IMPOSSIBLE_ERROR_MESSAGE, cur, o1, o2));
+    throw new GeneratorError(fmt(IMPOSSIBLE_ERR, cur, o1, o2));
   }
-  if (isIrregular(cur) && !ModelHelpers.skipWarn) {
-    say(fmt(IRREGULAR_MODEL_NAME_WARN_MESSAGE, pluralize(cur)));
-  }
+  if (isIrregular(cur) && !ModelHelpers.skipWarn) say(fmt(IRREGULAR_WARN, pluralize(cur)));
   ModelHelpers.skipWarn = true;
   return cur;
 }

--- a/packages/trailties/src/generators/model-helpers.ts
+++ b/packages/trailties/src/generators/model-helpers.ts
@@ -1,0 +1,51 @@
+import { pluralize, singularize, underscore } from "@blazetrails/activesupport";
+import { GeneratorError } from "./generated-attribute.js";
+
+// Mirrors railties/lib/rails/generators/model_helpers.rb. Trailties
+// generators call normalizeModelName() from their constructor.
+// prettier-ignore
+export const PLURAL_MODEL_NAME_WARN_MESSAGE = "[WARNING] The model name '%s' was recognized as a plural, using the singular '%s' instead. Override with --force-plural or setup custom inflection rules for this noun before running the generator.";
+// prettier-ignore
+export const IRREGULAR_MODEL_NAME_WARN_MESSAGE = "[WARNING] Rails cannot recover singular form from its plural form '%s'.\nPlease setup custom inflection rules for this noun before running the generator in config/initializers/inflections.rb.\n";
+// prettier-ignore
+export const INFLECTION_IMPOSSIBLE_ERROR_MESSAGE = "Rails cannot recover the underscored form from its camelcase form '%s'.\nPlease use an underscored name instead, either '%s' or '%s'.\nOr setup custom inflection rules for this noun before running the generator in config/initializers/inflections.rb.\n";
+
+export class ModelHelpers {
+  static skipWarn = false;
+}
+export interface ModelHelpersOptions {
+  forcePlural?: boolean;
+}
+export type SayFn = (message: string) => void;
+
+export function normalizeModelName(
+  name: string,
+  options: ModelHelpersOptions = {},
+  say: SayFn = () => {},
+): string {
+  let cur = name;
+  if (isPlural(cur) && !options.forcePlural) {
+    const s = singularize(cur);
+    if (!ModelHelpers.skipWarn) say(fmt(PLURAL_MODEL_NAME_WARN_MESSAGE, cur, s));
+    cur = s;
+  }
+  if (isInflectionImpossible(cur)) {
+    const o1 = underscore(singularize(cur));
+    const o2 = singularize(underscore(pluralize(cur)));
+    throw new GeneratorError(fmt(INFLECTION_IMPOSSIBLE_ERROR_MESSAGE, cur, o1, o2));
+  }
+  if (isIrregular(cur) && !ModelHelpers.skipWarn) {
+    say(fmt(IRREGULAR_MODEL_NAME_WARN_MESSAGE, pluralize(cur)));
+  }
+  ModelHelpers.skipWarn = true;
+  return cur;
+}
+
+const isPlural = (n: string): boolean => n === pluralize(n) && singularize(n) !== pluralize(n);
+const isIrregular = (n: string): boolean => singularize(n) !== singularize(pluralize(n));
+const isInflectionImpossible = (n: string): boolean =>
+  n !== underscore(n) && underscore(singularize(n)) !== singularize(underscore(pluralize(n)));
+const fmt = (t: string, ...a: string[]): string => {
+  let i = 0;
+  return t.replace(/%s/g, () => a[i++] ?? "");
+};

--- a/packages/trailties/src/generators/resource-helpers.test.ts
+++ b/packages/trailties/src/generators/resource-helpers.test.ts
@@ -13,7 +13,7 @@ describe("applyResourceHelpers", () => {
     ModelHelpers.skipWarn = false;
   });
 
-  it("pluralizes into controller helpers, supports modelName override, exposes default ORM", () => {
+  it("pluralizes into controller helpers and honors modelName override", () => {
     const i = applyResourceHelpers("admin/post");
     expect([i.controllerName, i.controllerClassPath, i.controllerFileName]).toEqual([
       "admin/posts",
@@ -25,8 +25,16 @@ describe("applyResourceHelpers", () => {
     expect(controllerI18nScope(i)).toBe("admin.posts");
 
     const j = applyResourceHelpers("posts", { modelName: "Article" });
-    expect(j.name).toBe("Article");
-    expect(j.controllerName).toBe("posts");
+    expect([j.name, j.controllerName]).toEqual(["Article", "posts"]);
+
+    const k = applyResourceHelpers("admin::post");
+    expect(controllerFilePath(k)).toBe("admin/posts");
     expect(defaultOrmInstance("@post").save()).toBe("@post.save");
+  });
+
+  it("does not re-run plural warn on modelName override", () => {
+    const messages: string[] = [];
+    applyResourceHelpers("posts", { modelName: "comments" }, (m) => messages.push(m));
+    expect(messages.filter((m) => m.includes("recognized as a plural"))).toHaveLength(1);
   });
 });

--- a/packages/trailties/src/generators/resource-helpers.test.ts
+++ b/packages/trailties/src/generators/resource-helpers.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  applyResourceHelpers,
+  controllerClassName,
+  controllerFilePath,
+  controllerI18nScope,
+  defaultOrmInstance,
+} from "./resource-helpers.js";
+import { ModelHelpers } from "./model-helpers.js";
+
+describe("applyResourceHelpers", () => {
+  beforeEach(() => {
+    ModelHelpers.skipWarn = false;
+  });
+
+  it("pluralizes into controller helpers, supports modelName override, exposes default ORM", () => {
+    const i = applyResourceHelpers("admin/post");
+    expect([i.controllerName, i.controllerClassPath, i.controllerFileName]).toEqual([
+      "admin/posts",
+      ["admin"],
+      "posts",
+    ]);
+    expect(controllerFilePath(i)).toBe("admin/posts");
+    expect(controllerClassName(i)).toBe("Admin::Posts");
+    expect(controllerI18nScope(i)).toBe("admin.posts");
+
+    const j = applyResourceHelpers("posts", { modelName: "Article" });
+    expect(j.name).toBe("Article");
+    expect(j.controllerName).toBe("posts");
+    expect(defaultOrmInstance("@post").save()).toBe("@post.save");
+  });
+});

--- a/packages/trailties/src/generators/resource-helpers.ts
+++ b/packages/trailties/src/generators/resource-helpers.ts
@@ -21,8 +21,11 @@ export function applyResourceHelpers(
   options: ResourceHelpersOptions = {},
   say: SayFn = () => {},
 ): ResourceHelpersInfo {
+  // Rails: super (ModelHelpers#initialize) normalizes once, then
+  // `self.name = options[:model_name]` swaps without re-running the
+  // pluralize-warn path; `assign_names!` only re-derives file/class paths.
   const initial = normalizeModelName(rawName, options, say);
-  const name = options.modelName ? normalizeModelName(options.modelName, options, say) : initial;
+  const name = options.modelName ?? initial;
   const controllerName = pluralize(initial);
   const parts = controllerName.includes("/")
     ? controllerName.split("/")

--- a/packages/trailties/src/generators/resource-helpers.ts
+++ b/packages/trailties/src/generators/resource-helpers.ts
@@ -1,0 +1,44 @@
+import { camelize, pluralize, underscore } from "@blazetrails/activesupport";
+import { ActiveModel } from "./active-model.js";
+import { normalizeModelName, type ModelHelpersOptions, type SayFn } from "./model-helpers.js";
+
+// Mirrors railties/lib/rails/generators/resource_helpers.rb. `orm_class` /
+// `orm_instance` (Ruby `constantize` lookup) are deferred to PR 1.14; the
+// default fallback ActiveModel is re-exported via defaultOrmInstance().
+export interface ResourceHelpersOptions extends ModelHelpersOptions {
+  modelName?: string;
+}
+
+export interface ResourceHelpersInfo {
+  name: string;
+  controllerName: string;
+  controllerClassPath: string[];
+  controllerFileName: string;
+}
+
+export function applyResourceHelpers(
+  rawName: string,
+  options: ResourceHelpersOptions = {},
+  say: SayFn = () => {},
+): ResourceHelpersInfo {
+  const initial = normalizeModelName(rawName, options, say);
+  const name = options.modelName ? normalizeModelName(options.modelName, options, say) : initial;
+  const controllerName = pluralize(initial);
+  const parts = controllerName.includes("/")
+    ? controllerName.split("/")
+    : controllerName.split("::");
+  const classPath = parts.map((p) => underscore(p));
+  const fileName = classPath.pop()!;
+  return { name, controllerName, controllerClassPath: classPath, controllerFileName: fileName };
+}
+
+export const controllerFilePath = (i: ResourceHelpersInfo): string =>
+  [...i.controllerClassPath, i.controllerFileName].join("/");
+
+export const controllerClassName = (i: ResourceHelpersInfo): string =>
+  [...i.controllerClassPath, i.controllerFileName].map((s) => camelize(s)).join("::");
+
+export const controllerI18nScope = (i: ResourceHelpersInfo): string =>
+  controllerFilePath(i).replace(/\//g, ".");
+
+export const defaultOrmInstance = (name: string): ActiveModel => new ActiveModel(name);


### PR DESCRIPTION
Ports the smaller half of railties' generator infrastructure that PR 1.12 (#2154) deferred.

## Rails sources mirrored

- `railties/lib/rails/generators/migration.rb`
- `railties/lib/rails/generators/model_helpers.rb`
- `railties/lib/rails/generators/resource_helpers.rb`
- `railties/lib/rails/generators/active_model.rb`

## Files

- `packages/trailties/src/generators/migration.ts` (+ test) — `migrationLookupAt`, `migrationExists`, `currentMigrationNumber`, `nextMigrationNumber`, `buildMigrationAssigns`. Async-only fs access via injected `FsAdapter`/`PathAdapter`.
- `packages/trailties/src/generators/model-helpers.ts` (+ test) — `normalizeModelName` (plural→singular warn, irregular warn, inflection-impossible raise) + `ModelHelpers.skipWarn` process-singleton.
- `packages/trailties/src/generators/resource-helpers.ts` (+ test) — `applyResourceHelpers` + `controllerFilePath` / `controllerClassName` / `controllerI18nScope` + `defaultOrmInstance` fallback.
- `packages/trailties/src/generators/active-model.ts` (+ test) — class with static `all` / `find` / `build` and instance `save` / `update` / `errors` / `destroy` Ruby-snippet emitters.
- `packages/trailties/src/generators/index.ts` — re-exports.

## Intentionally skipped / deferred

- `migration.rb#migration_template` (ERB rendering) — deferred to PR 1.12c where generators are reworked to consume templates.
- `railties/lib/rails/generators/actions/create_migration.rb` — listed in the 1.12b plan but split off to a 1.12b follow-up so this bundle stays under the 300-LOC ceiling.
- `resource_helpers.rb#orm_class` / `#orm_instance` (Ruby `constantize` of `"\#{orm}::Generators::ActiveModel"`) — deferred to PR 1.14 where the ORM generator registry lands. Default fallback is exposed via `defaultOrmInstance`.

## Hard-rules check

- No `node:*` imports; no `process.*`; async fs only (`fs.exists`, `fs.readdir`).
- No new third-party deps.
- camelCase only.
- Branched from `main` (no stacked PRs).

## Notes

Branch from main only — sibling PRs (1.12c, 1.12b create-migration follow-up) land separately.

## Rails-fidelity notes (Copilot review #1)

- `migration_lookup_at` regex / `current_migration_number` split use `_` per Rails source (`Dir.glob("#{dirname}/[0-9]*_*.rb")` and `basename.split("_")`). The existing trails `MigrationGenerator` writes `<timestamp>-<name>` (hyphen) — a deviation that PR 1.12c will reconcile by aligning the generator to Rails' underscore convention. Keeping `_` here so 1.12c can adopt these helpers as-is.
- `controllerClassName` returns the camelized path without a `"Controller"` suffix, matching Rails: `(controller_class_path + [controller_file_name]).map!(&:camelize).join("::")`. The `"Controller"` suffix is added in the scaffold/controller ERB templates, not in this helper.
