### PR TITLE
feat(trailties): Application shell + find_root + initialize! happy path (PR 2.5a)

### DIFF
--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -95,6 +95,31 @@ describe("Application", () => {
       Application.register(MyApp3);
       expect(Trailtie.subclasses()).toContain(MyApp3);
     });
+
+    it("is idempotent — :before_configuration fires once per subclass", () => {
+      class MyApp4 extends Application {}
+      const seen: unknown[] = [];
+      onLoad("before_configuration", (base) => {
+        seen.push(base);
+      });
+      Application.register(MyApp4);
+      Application.register(MyApp4);
+      expect(seen).toEqual([MyApp4]);
+    });
+  });
+
+  describe("name", () => {
+    it("dasherizes the class name and strips a trailing /application", () => {
+      class MyBlogApplication extends Application {}
+      Application.register(MyBlogApplication);
+      expect(MyBlogApplication.instance().name()).toBe("my-blog");
+    });
+
+    it("dasherizes without the suffix when the class has no Application name", () => {
+      class WidgetShop extends Application {}
+      Application.register(WidgetShop);
+      expect(WidgetShop.instance().name()).toBe("widget-shop");
+    });
   });
 
   describe("find_root", () => {

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -1,0 +1,165 @@
+// Smoke tests for the `Application` shell (PR 2.5a). Full Rails-mirrored
+// `railties/test/application/*` cases land in PR 2.5b alongside
+// `Configuration` defaults and the default middleware stack.
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  fsAdapterConfig,
+  NullLogger,
+  NullStore,
+  onLoad,
+  registerFsAdapter,
+  resetLoadHooks,
+  type FsAdapter,
+  type PathAdapter,
+} from "@blazetrails/activesupport";
+import { Application } from "./application.js";
+import { Engine } from "./engine.js";
+import { Trailtie } from "./trailtie.js";
+
+const posixPath: PathAdapter = {
+  join: (...p) => p.join("/").replace(/\/+/g, "/"),
+  dirname: (p) => p.replace(/\/[^/]*$/, "") || "/",
+  basename: (p) => p.split("/").pop() ?? "",
+  resolve: (...p) =>
+    p
+      .reduce((o, x) => (!x ? o : x.startsWith("/") ? x : o ? `${o}/${x}` : x), "")
+      .replace(/\/+/g, "/"),
+  extname: (p) => (p.lastIndexOf(".") > 0 ? p.slice(p.lastIndexOf(".")) : ""),
+  isAbsolute: (p) => p.startsWith("/"),
+  sep: "/",
+};
+
+const FIXED_MTIME = new Date(0);
+const stat = (d: boolean) => ({
+  isDirectory: () => d,
+  isFile: () => !d,
+  size: 0,
+  mtime: FIXED_MTIME,
+});
+
+function installFs(dirs: Set<string>, files: Set<string>, cwd = "/"): void {
+  registerFsAdapter(
+    "application-test",
+    {
+      cwd: () => cwd,
+      exists: async (p: string) => dirs.has(p) || files.has(p),
+      stat: async (p: string) => {
+        if (dirs.has(p)) return stat(true);
+        if (files.has(p)) return stat(false);
+        throw new Error("ENOENT");
+      },
+      statSync: () => stat(false),
+      realpath: async (p: string) => p,
+    } as unknown as FsAdapter,
+    posixPath,
+  );
+  fsAdapterConfig.adapter = "application-test";
+}
+
+const PREV = fsAdapterConfig.adapter;
+beforeEach(() => resetLoadHooks());
+afterEach(() => {
+  fsAdapterConfig.adapter = PREV;
+  resetLoadHooks();
+  Application.appClass = null;
+});
+
+describe("Application", () => {
+  it("is a subclass of Engine", () => {
+    expect(Application.prototype).toBeInstanceOf(Engine);
+  });
+
+  it("Application is abstract and cannot be instantiated directly", () => {
+    expect(() => new Application()).toThrow(/abstract/);
+  });
+
+  describe("register", () => {
+    it("sets appClass to the registered subclass", () => {
+      class MyApp extends Application {}
+      Application.register(MyApp);
+      expect(Application.appClass).toBe(MyApp);
+    });
+
+    it("fires :before_configuration load hooks with the subclass", () => {
+      class MyApp2 extends Application {}
+      const seen: unknown[] = [];
+      onLoad("before_configuration", (base) => {
+        seen.push(base);
+      });
+      Application.register(MyApp2);
+      expect(seen).toEqual([MyApp2]);
+    });
+
+    it("registers the subclass in the Trailtie registry", () => {
+      class MyApp3 extends Application {}
+      Application.register(MyApp3);
+      expect(Trailtie.subclasses()).toContain(MyApp3);
+    });
+  });
+
+  describe("find_root", () => {
+    it("walks parents looking for config.ts (trails' config.ru analog)", async () => {
+      installFs(new Set(["/", "/app", "/app/src", "/app/src/inner"]), new Set(["/app/config.ts"]));
+      class RootApp extends Application {}
+      Application.register(RootApp);
+      expect(await RootApp.findRoot("/app/src/inner")).toBe("/app");
+    });
+
+    it("falls back to fs.cwd() when no flag is found", async () => {
+      installFs(new Set(["/", "/cwd", "/elsewhere"]), new Set(["/cwd/config.ts"]), "/cwd");
+      class CwdApp extends Application {}
+      Application.register(CwdApp);
+      expect(await CwdApp.findRoot("/elsewhere")).toBe("/cwd");
+    });
+  });
+
+  describe("initialize!", () => {
+    it("returns false from initialized? before initialize() is called", () => {
+      class IApp extends Application {}
+      Application.register(IApp);
+      expect(IApp.instance().initialized()).toBe(false);
+    });
+
+    it("runs the Bootstrap initializer chain and flips initialized?", async () => {
+      class IApp2 extends Application {}
+      Application.register(IApp2);
+      const app = IApp2.instance();
+      await app.initialize();
+      expect(app.initialized()).toBe(true);
+      // Bootstrap.initialize_logger wired a default NullLogger.
+      expect(app.logger).toBeInstanceOf(NullLogger);
+      // Bootstrap.initialize_cache wired a default NullStore.
+      expect(app.cache).toBeInstanceOf(NullStore);
+    });
+
+    it("fires :after_initialize load hooks once initialization completes", async () => {
+      class IApp3 extends Application {}
+      Application.register(IApp3);
+      const seen: unknown[] = [];
+      onLoad("after_initialize", (base) => {
+        seen.push(base);
+      });
+      const app = IApp3.instance();
+      await app.initialize();
+      expect(seen).toEqual([app]);
+    });
+
+    it("raises when called twice", async () => {
+      class IApp4 extends Application {}
+      Application.register(IApp4);
+      const app = IApp4.instance();
+      await app.initialize();
+      await expect(app.initialize()).rejects.toThrow(/already initialized/);
+    });
+
+    it("splices Bootstrap initializers ahead of inherited Engine ones", () => {
+      class IApp5 extends Application {}
+      Application.register(IApp5);
+      const names = IApp5.instance().initializers.map((i) => i.name);
+      expect(names).toContain("load_environment_config");
+      expect(names).toContain("initialize_logger");
+      expect(names).toContain("initialize_cache");
+      expect(names).toContain("bootstrap_hook");
+    });
+  });
+});

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -1,36 +1,17 @@
-/**
- * Port of `Rails::Application` from `railties/lib/rails/application.rb`.
- *
- * PR 2.5a (this file): the Application shell — class identity, findRoot
- * happy path, `initialize!` happy path that runs the initializer chain
- * (Bootstrap + Trailtie/Engine + Finisher), `initialized?`, and the
- * `appClass` accessor that PR 2.6's `Rails.application` will read.
- *
- * Deferred:
- *   - PR 2.5b: `application/configuration.ts` defaults +
- *     `application/default-middleware-stack.ts` + full Rails-mirrored
- *     tests.
- *   - PR 2.5c: `application/routes-reloader.ts` + `config_for("database")`
- *     dynamic import + credentials/key_generator/message_verifier wiring.
- *
- * Intentionally skipped from upstream (see docs/trailties-plan.md):
- *   - `secrets` (pre-credentials back-compat), `eager_load!`,
- *     `assets`, `sandbox`, `executor`, `reloader`, `autoloaders` —
- *     blocked on subsystems we do not have or that are explicitly out
- *     of scope (Zeitwerk, eager loading).
- *   - `console`/`runner`/`generators`/`server` block runners —
- *     PR 2.1b's Configurable mixin work.
- *   - `migration_railties`, `load_generators`, `helpers_paths`,
- *     `to_app`, `console` block, `require_environment!` — follow-ups.
- *
- * Trailties differences from Rails:
- *   - `findRoot` looks for `config.ts` (the trails equivalent of Rails'
- *     `config.ru` — see `generators/app-generator.ts`).
- *   - Subclasses register explicitly via `Application.register(klass)`
- *     instead of Ruby's `inherited` hook. `register` doubles as Rails'
- *     `Rails.app_class = base` wiring.
- */
-import { getFsAsync, runLoadHooks } from "@blazetrails/activesupport";
+// Port of `Rails::Application` from `railties/lib/rails/application.rb`.
+// PR 2.5a: the Application shell — findRoot, `initialize!` happy path
+// (Bootstrap + inherited Engine/Trailtie chain), `initialized?`, `name`,
+// and the `appClass` accessor that PR 2.6's `Rails.application` reads.
+// Configuration defaults + default middleware stack + Finisher splicing
+// land in PR 2.5b; routes-reloader + config_for + credentials in PR 2.5c.
+// Skipped from upstream (see docs/trailties-plan.md): secrets, eager_load!,
+// assets, sandbox, executor, reloader, autoloaders, helpers_paths, to_app,
+// migration_railties, load_generators, require_environment!, console/
+// runner/generators/server block runners (PR 2.1b Configurable work).
+// Trailties differs from Rails by using `config.ts` as the root flag
+// (trails' rackup analog) and explicit `Application.register(klass)`
+// instead of Ruby's `inherited` hook.
+import { dasherize, getFsAsync, runLoadHooks, underscore } from "@blazetrails/activesupport";
 import { Engine } from "./engine.js";
 import { Trailtie } from "./trailtie.js";
 import { Bootstrap } from "./application/bootstrap.js";
@@ -38,6 +19,8 @@ import { Collection, type InitializerGroup } from "./initializable.js";
 import type { CacheStore, Logger } from "@blazetrails/activesupport";
 
 let _appClass: typeof Application | null = null;
+/** @internal Tracks which subclasses have fired `:before_configuration`. */
+const _registered = new WeakSet<typeof Application>();
 
 export class Application extends Engine {
   private _initialized = false;
@@ -58,9 +41,13 @@ export class Application extends Engine {
    * `:before_configuration` load hooks.
    */
   static register(subclass: typeof Application): void {
+    const fresh = !_registered.has(subclass);
     Trailtie.register(subclass);
     _appClass = subclass;
-    runLoadHooks("before_configuration", subclass);
+    if (fresh) {
+      _registered.add(subclass);
+      runLoadHooks("before_configuration", subclass);
+    }
   }
 
   /**
@@ -76,6 +63,15 @@ export class Application extends Engine {
   /** Returns true once {@link Application#initialize} has completed. */
   initialized(): boolean {
     return this._initialized;
+  }
+
+  /**
+   * Dasherized application name — mirrors Rails' `def name`. Strips a
+   * trailing `/application` segment so `MyApp::Application#name` returns
+   * `"my-app"`.
+   */
+  name(): string {
+    return dasherize(underscore(this.constructor.name)).replace(/-application$/, "");
   }
 
   /**

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -1,0 +1,104 @@
+/**
+ * Port of `Rails::Application` from `railties/lib/rails/application.rb`.
+ *
+ * PR 2.5a (this file): the Application shell — class identity, findRoot
+ * happy path, `initialize!` happy path that runs the initializer chain
+ * (Bootstrap + Trailtie/Engine + Finisher), `initialized?`, and the
+ * `appClass` accessor that PR 2.6's `Rails.application` will read.
+ *
+ * Deferred:
+ *   - PR 2.5b: `application/configuration.ts` defaults +
+ *     `application/default-middleware-stack.ts` + full Rails-mirrored
+ *     tests.
+ *   - PR 2.5c: `application/routes-reloader.ts` + `config_for("database")`
+ *     dynamic import + credentials/key_generator/message_verifier wiring.
+ *
+ * Intentionally skipped from upstream (see docs/trailties-plan.md):
+ *   - `secrets` (pre-credentials back-compat), `eager_load!`,
+ *     `assets`, `sandbox`, `executor`, `reloader`, `autoloaders` —
+ *     blocked on subsystems we do not have or that are explicitly out
+ *     of scope (Zeitwerk, eager loading).
+ *   - `console`/`runner`/`generators`/`server` block runners —
+ *     PR 2.1b's Configurable mixin work.
+ *   - `migration_railties`, `load_generators`, `helpers_paths`,
+ *     `to_app`, `console` block, `require_environment!` — follow-ups.
+ *
+ * Trailties differences from Rails:
+ *   - `findRoot` looks for `config.ts` (the trails equivalent of Rails'
+ *     `config.ru` — see `generators/app-generator.ts`).
+ *   - Subclasses register explicitly via `Application.register(klass)`
+ *     instead of Ruby's `inherited` hook. `register` doubles as Rails'
+ *     `Rails.app_class = base` wiring.
+ */
+import { getFsAsync, runLoadHooks } from "@blazetrails/activesupport";
+import { Engine } from "./engine.js";
+import { Trailtie } from "./trailtie.js";
+import { Bootstrap } from "./application/bootstrap.js";
+import { Collection, type InitializerGroup } from "./initializable.js";
+import type { CacheStore, Logger } from "@blazetrails/activesupport";
+
+let _appClass: typeof Application | null = null;
+
+export class Application extends Engine {
+  private _initialized = false;
+  logger: Logger | null = null;
+  cache: CacheStore | null = null;
+
+  /** Mirrors Rails' `Rails.app_class`. Set by {@link Application.register}. */
+  static get appClass(): typeof Application | null {
+    return _appClass;
+  }
+  static set appClass(klass: typeof Application | null) {
+    _appClass = klass;
+  }
+
+  /**
+   * Register a concrete Application subclass. Replaces Rails' `inherited`
+   * hook; mirrors `Rails.app_class = base` and runs the
+   * `:before_configuration` load hooks.
+   */
+  static register(subclass: typeof Application): void {
+    Trailtie.register(subclass);
+    _appClass = subclass;
+    runLoadHooks("before_configuration", subclass);
+  }
+
+  /**
+   * Trailties equivalent of Rails' `find_root_with_flag "config.ru"`:
+   * walks parents from `from` looking for `config.ts`, falling back to
+   * the fs adapter's cwd.
+   */
+  static async findRoot(from: string): Promise<string> {
+    const fs = await getFsAsync();
+    return this.findRootWithFlag("config.ts", from, fs.cwd());
+  }
+
+  /** Returns true once {@link Application#initialize} has completed. */
+  initialized(): boolean {
+    return this._initialized;
+  }
+
+  /**
+   * Splice Bootstrap + Engine/Trailtie + Finisher initializers — mirrors
+   * Rails' `Application#initializers`. Finisher splicing lands in PR 2.5b
+   * once `Configuration` + the middleware stack supply the host methods
+   * Finisher requires.
+   */
+  get initializers(): Collection {
+    const bootstrap = Bootstrap.initializersFor(this);
+    const inherited = super.initializers;
+    return bootstrap.plus(inherited);
+  }
+
+  /**
+   * Run the initializer chain — Rails' `initialize!`. Idempotency mirrors
+   * Rails: re-entry raises rather than silently returning.
+   */
+  async initialize(group: InitializerGroup = "default"): Promise<this> {
+    if (this._initialized) throw new Error("Application has been already initialized.");
+    this.runInitializers(group, this);
+    this._initialized = true;
+    runLoadHooks("after_initialize", this);
+    return this;
+  }
+}


### PR DESCRIPTION
## Summary

First split of PR 2.5 — the `Application` shell.

- `Application` class extending `Engine`
- `Application.register(klass)` — replaces Rails' `inherited` hook; sets `appClass` and fires `:before_configuration` load hook
- `Application.findRoot(from)` — walks parents looking for `config.ts` (trails' equivalent of `config.ru`), falling back to `fs.cwd()`
- `Application#initialize()` — runs the initializer chain (Bootstrap + Engine/Trailtie), flips `initialized?`, fires `:after_initialize` load hook, raises on re-entry
- `Application#initializers` — splices Bootstrap initializers ahead of the inherited chain

## Rails source

- `railties/lib/rails/application.rb` — `Application`, `find_root`, `initialize!`

## Methods/initializers intentionally skipped

- `secrets` (pre-credentials back-compat)
- `eager_load!`, `assets`, `sandbox`
- `executor`, `reloader`, `autoloaders`
- `migration_railties`, `load_generators`, `helpers_paths`, `to_app`
- `require_environment!`
- `console`, `runner`, `generators`, `server` block runners (deferred to PR 2.1b Configurable work)
- Finisher initializer splicing — Finisher requires host methods (`routes`, `reloader`, `env`, `ensureGeneratorTemplatesAdded`, `buildMiddlewareStack`, `appendInternalRoute`) that depend on the full Configuration + middleware stack; deferred to PR 2.5b

## Remaining scope

PR 2.5b (separate from-main PR):
- `application/configuration.ts` defaults
- `application/default-middleware-stack.ts`
- Full Rails-mirrored tests
- Finisher splicing into the initializer chain

PR 2.5c (separate from-main PR):
- `application/routes-reloader.ts`
- `config_for("database")` dynamic import
- `credentials` wiring + `key_generator` + `message_verifier`

## Test plan

- [x] `pnpm vitest run packages/trailties/src/application.test.ts` — 12 passing
- [x] No `node:*` imports outside bin.ts
- [x] No `process.*` references
- [x] Async fs only
- [x] 272 LOC (under 300 ceiling)