### PR TITLE
feat(trailties): Engine Configuration + tableNamePrefix (PR 2.2b)

### DIFF
--- a/packages/trailties/src/engine.test.ts
+++ b/packages/trailties/src/engine.test.ts
@@ -9,6 +9,7 @@ import {
   type PathAdapter,
 } from "@blazetrails/activesupport";
 import { Engine } from "./engine.js";
+import { EngineConfiguration } from "./engine/configuration.js";
 import { Trailtie } from "./trailtie.js";
 import { Trailties } from "./engine/trailties.js";
 
@@ -128,6 +129,113 @@ describe("Engine", () => {
     Trailtie.register(HelpersEngine);
     HelpersEngine.calledFrom("/blog");
     expect(await HelpersEngine.instance().helpersPaths()).toEqual(["/blog/app/helpers"]);
+  });
+
+  describe("EngineConfiguration", () => {
+    it("defaults match Rails Engine::Configuration", () => {
+      const cfg = new EngineConfiguration();
+      expect(cfg.root).toBeNull();
+      expect(cfg.middleware).toEqual([]);
+      expect(cfg.javascriptPath).toBe("javascript");
+      expect(cfg.routeSetClass).toBeNull();
+      expect(cfg.defaultScope).toBeNull();
+      expect(cfg.autoloadPaths).toEqual([]);
+      expect(cfg.autoloadOncePaths).toEqual([]);
+      expect(cfg.eagerLoadPaths).toEqual([]);
+      expect(cfg.tableNamePrefix).toBeNull();
+    });
+
+    it("root= re-expands paths.path", () => {
+      const cfg = new EngineConfiguration(null);
+      const paths = cfg.paths();
+      expect(paths.path).toBeNull();
+      cfg.setRoot("/blog");
+      expect(cfg.root).toBe("/blog");
+      expect(paths.path).toBe("/blog");
+      expect(cfg.paths()).toBe(paths);
+    });
+
+    it("paths declares the Rails default layout", () => {
+      const paths = new EngineConfiguration("/blog").paths();
+      for (const k of ["app", "app/models", "lib", "config/routes.ts", "db/migrate", "vendor"]) {
+        expect(paths.get(k), k).toBeDefined();
+      }
+      expect(paths.get("lib")!.isLoadPath()).toBe(true);
+      expect(paths.get("vendor")!.isLoadPath()).toBe(true);
+    });
+
+    it("autoload_paths, autoload_once_paths, eager_load_paths are independently writable", () => {
+      const cfg = new EngineConfiguration();
+      cfg.autoloadPaths.push("/x/auto");
+      cfg.autoloadOncePaths.push("/x/once");
+      cfg.eagerLoadPaths.push("/x/eager");
+      expect(cfg.allAutoloadPaths()).toEqual(["/x/auto"]);
+      expect(cfg.allAutoloadOncePaths()).toEqual(["/x/once"]);
+      expect(cfg.allEagerLoadPaths()).toEqual(["/x/eager"]);
+    });
+  });
+
+  describe("tableNamePrefix", () => {
+    it("defaults to null when not isolated and unset", () => {
+      class PlainNamespacedEngine extends Engine {}
+      Trailtie.register(PlainNamespacedEngine);
+      expect(PlainNamespacedEngine.instance().tableNamePrefix()).toBeNull();
+    });
+
+    it("returns the explicit option when set", () => {
+      class ShopEngine extends Engine {}
+      Trailtie.register(ShopEngine);
+      ShopEngine.instance().engineConfig().tableNamePrefix = "shop_";
+      expect(ShopEngine.instance().tableNamePrefix()).toBe("shop_");
+    });
+
+    it("falls back to `${engine_name}_` when isolated and unset", () => {
+      class IsoEngine extends Engine {}
+      Trailtie.register(IsoEngine);
+      IsoEngine.isolated(true);
+      expect(IsoEngine.instance().tableNamePrefix()).toBe("iso_engine_");
+    });
+  });
+
+  it("config.eager_load_namespaces accumulates across engines", () => {
+    class A extends Engine {}
+    class B extends Engine {}
+    Trailtie.register(A);
+    Trailtie.register(B);
+    const before = A.instance().engineConfig().eagerLoadNamespaces.length;
+    A.instance().engineConfig().eagerLoadNamespaces.push("ANs");
+    B.instance().engineConfig().eagerLoadNamespaces.push("BNs");
+    expect(A.instance().engineConfig().eagerLoadNamespaces).toBe(
+      B.instance().engineConfig().eagerLoadNamespaces,
+    );
+    expect(A.instance().engineConfig().eagerLoadNamespaces.length).toBe(before + 2);
+  });
+
+  it("routes lazily instantiates routeSetClass, append-buffers blocks, and hasRoutes flips", () => {
+    const blocks: Array<() => void> = [];
+    class FakeRouteSet {
+      constructor(public cfg: EngineConfiguration) {}
+      append(b: () => void): void {
+        blocks.push(b);
+      }
+    }
+    class MountedEngine extends Engine {}
+    Trailtie.register(MountedEngine);
+    expect(MountedEngine.instance().hasRoutes()).toBe(false);
+    MountedEngine.instance().engineConfig().routeSetClass = FakeRouteSet;
+    const r1 = MountedEngine.instance().routes(() => {});
+    expect(r1).toBeInstanceOf(FakeRouteSet);
+    expect(MountedEngine.instance().routes(() => {})).toBe(r1);
+    expect(blocks).toHaveLength(2);
+    expect(MountedEngine.instance().hasRoutes()).toBe(true);
+  });
+
+  it("generators(block) yields a mutable options bag", () => {
+    const cfg = new EngineConfiguration();
+    cfg.generators((g) => {
+      g.orm = "active_record";
+    });
+    expect(cfg.generators()).toEqual({ orm: "active_record" });
   });
 
   it("railties returns a Trailties collection over registered subclasses", () => {

--- a/packages/trailties/src/engine.test.ts
+++ b/packages/trailties/src/engine.test.ts
@@ -185,7 +185,7 @@ describe("Engine", () => {
     it("returns the explicit option when set", () => {
       class ShopEngine extends Engine {}
       Trailtie.register(ShopEngine);
-      ShopEngine.instance().engineConfig().tableNamePrefix = "shop_";
+      ShopEngine.instance().config.tableNamePrefix = "shop_";
       expect(ShopEngine.instance().tableNamePrefix()).toBe("shop_");
     });
 
@@ -202,13 +202,11 @@ describe("Engine", () => {
     class B extends Engine {}
     Trailtie.register(A);
     Trailtie.register(B);
-    const before = A.instance().engineConfig().eagerLoadNamespaces.length;
-    A.instance().engineConfig().eagerLoadNamespaces.push("ANs");
-    B.instance().engineConfig().eagerLoadNamespaces.push("BNs");
-    expect(A.instance().engineConfig().eagerLoadNamespaces).toBe(
-      B.instance().engineConfig().eagerLoadNamespaces,
-    );
-    expect(A.instance().engineConfig().eagerLoadNamespaces.length).toBe(before + 2);
+    const before = A.instance().config.eagerLoadNamespaces.length;
+    A.instance().config.eagerLoadNamespaces.push("ANs");
+    B.instance().config.eagerLoadNamespaces.push("BNs");
+    expect(A.instance().config.eagerLoadNamespaces).toBe(B.instance().config.eagerLoadNamespaces);
+    expect(A.instance().config.eagerLoadNamespaces.length).toBe(before + 2);
   });
 
   it("routes lazily instantiates routeSetClass, append-buffers blocks, and hasRoutes flips", () => {
@@ -222,7 +220,7 @@ describe("Engine", () => {
     class MountedEngine extends Engine {}
     Trailtie.register(MountedEngine);
     expect(MountedEngine.instance().hasRoutes()).toBe(false);
-    MountedEngine.instance().engineConfig().routeSetClass = FakeRouteSet;
+    MountedEngine.instance().config.routeSetClass = FakeRouteSet;
     const r1 = MountedEngine.instance().routes(() => {});
     expect(r1).toBeInstanceOf(FakeRouteSet);
     expect(MountedEngine.instance().routes(() => {})).toBe(r1);

--- a/packages/trailties/src/engine.ts
+++ b/packages/trailties/src/engine.ts
@@ -124,9 +124,11 @@ export class Engine extends Trailtie {
 
   /** `Engine#routes(&block)` — undefined when no `routeSetClass` is set. */
   routes(block?: (this: unknown) => void): unknown {
-    const cfg = this.config;
-    if (!cfg.routeSetClass) return undefined;
-    if (!this._routes) this._routes = new cfg.routeSetClass(cfg);
+    if (!this._routes) {
+      const cfg = this.config;
+      if (!cfg.routeSetClass) return undefined;
+      this._routes = new cfg.routeSetClass(cfg);
+    }
     const r = this._routes as { append?: (b: (this: unknown) => void) => void };
     if (block) r.append?.(block);
     return this._routes;

--- a/packages/trailties/src/engine.ts
+++ b/packages/trailties/src/engine.ts
@@ -11,7 +11,6 @@ type EngineHost = { _calledFrom?: string; _isolated?: boolean };
 const host = (k: typeof Engine): EngineHost => k as unknown as EngineHost;
 
 export class Engine extends Trailtie {
-  protected _engineConfig?: EngineConfiguration;
   private _railtiesCollection?: Trailties;
   private _allLoadPathsCache?: string[];
   private _routes?: unknown;
@@ -83,14 +82,17 @@ export class Engine extends Trailtie {
     return from === undefined ? undefined : await klass.findRoot(from);
   }
 
-  /** Lazily-constructed engine configuration. Mirrors `Engine#config`. */
-  engineConfig(): EngineConfiguration {
-    if (!this._engineConfig) this._engineConfig = new EngineConfiguration(null);
-    return this._engineConfig;
+  /** Mirrors `Engine#config` — overrides `Trailtie#config` to return
+   * an `EngineConfiguration` so `middleware`, `paths`, `tableNamePrefix`,
+   * etc. are reachable through the single `config` surface. */
+  override get config(): EngineConfiguration {
+    if (!(this._config instanceof EngineConfiguration))
+      this._config = new EngineConfiguration(null);
+    return this._config as EngineConfiguration;
   }
 
   tableNamePrefix(): string | null {
-    return this.engineConfig().tableNamePrefix ?? this.defaultTableNamePrefix();
+    return this.config.tableNamePrefix ?? this.defaultTableNamePrefix();
   }
 
   /** Implicit fallback when `tableNamePrefix` is unset but `isolated` is on. */
@@ -102,7 +104,7 @@ export class Engine extends Trailtie {
    * `EngineConfiguration#paths` so the `Root` instance carries the
    * expanded root for subsequent `expanded`/`existent` calls. */
   async paths(): Promise<Root> {
-    const cfg = this.engineConfig();
+    const cfg = this.config;
     if (cfg.root === null) {
       const resolved = await this.root();
       if (resolved !== undefined) cfg.setRoot(resolved);
@@ -122,7 +124,7 @@ export class Engine extends Trailtie {
 
   /** `Engine#routes(&block)` — undefined when no `routeSetClass` is set. */
   routes(block?: (this: unknown) => void): unknown {
-    const cfg = this.engineConfig();
+    const cfg = this.config;
     if (!cfg.routeSetClass) return undefined;
     if (!this._routes) this._routes = new cfg.routeSetClass(cfg);
     const r = this._routes as { append?: (b: (this: unknown) => void) => void };
@@ -137,7 +139,7 @@ export class Engine extends Trailtie {
   async allLoadPaths(addAutoloadPathsToLoadPath = true): Promise<string[]> {
     if (this._allLoadPathsCache) return this._allLoadPathsCache;
     const paths = await this.paths();
-    const cfg = this.engineConfig();
+    const cfg = this.config;
     const out = [...(await paths.loadPaths())];
     if (addAutoloadPathsToLoadPath) {
       for (const p of cfg.allAutoloadPaths()) out.push(p);

--- a/packages/trailties/src/engine.ts
+++ b/packages/trailties/src/engine.ts
@@ -1,18 +1,20 @@
-// Port of `Rails::Engine` from `railties/lib/rails/engine.rb`. Shell only:
-// find / findRoot / findRootWithFlag, the paths defaults, and the railties()
-// collection. EngineConfiguration + route mounting → 2.2b; lazy_route_set
-// + updater → 2.2c. See PR description for the Rails-skipped surface.
+// Port of `Rails::Engine` from `railties/lib/rails/engine.rb`. Shell +
+// EngineConfiguration + railties() collection. `lazy_route_set` + `updater`
+// → 2.2c. `env_config`/`endpoint`/`call`/`helpers` → blocked on PR 2.5.
 import { getFsAsync, getPathAsync } from "@blazetrails/activesupport";
 import { Root } from "./paths.js";
 import { Trailtie } from "./trailtie.js";
 import { Trailties } from "./engine/trailties.js";
+import { EngineConfiguration } from "./engine/configuration.js";
 
 type EngineHost = { _calledFrom?: string; _isolated?: boolean };
 const host = (k: typeof Engine): EngineHost => k as unknown as EngineHost;
 
 export class Engine extends Trailtie {
-  private _paths?: Root;
+  protected _engineConfig?: EngineConfiguration;
   private _railtiesCollection?: Trailties;
+  private _allLoadPathsCache?: string[];
+  private _routes?: unknown;
 
   static calledFrom(value?: string): string | undefined {
     if (value !== undefined) host(this)._calledFrom = value;
@@ -72,40 +74,40 @@ export class Engine extends Trailtie {
     return (this.constructor as typeof Engine).isolated();
   }
 
+  /** Returns the resolved root, or undefined when `calledFrom` is unset.
+   * Diverges from Rails (which raises) so consumers can construct an
+   * Engine before its source location is known — matches PR 2.2a. */
   async root(): Promise<string | undefined> {
     const klass = this.constructor as typeof Engine;
     const from = klass.calledFrom();
     return from === undefined ? undefined : await klass.findRoot(from);
   }
 
-  // Default paths layout. `.rb` → `.ts`; autoload/eager surface → 2.2b.
+  /** Lazily-constructed engine configuration. Mirrors `Engine#config`. */
+  engineConfig(): EngineConfiguration {
+    if (!this._engineConfig) this._engineConfig = new EngineConfiguration(null);
+    return this._engineConfig;
+  }
+
+  tableNamePrefix(): string | null {
+    return this.engineConfig().tableNamePrefix ?? this.defaultTableNamePrefix();
+  }
+
+  /** Implicit fallback when `tableNamePrefix` is unset but `isolated` is on. */
+  private defaultTableNamePrefix(): string | null {
+    return this.isolated() ? `${this.engineName()}_` : null;
+  }
+
+  /** Mirrors `Engine#paths`. Resolves root before delegating to
+   * `EngineConfiguration#paths` so the `Root` instance carries the
+   * expanded root for subsequent `expanded`/`existent` calls. */
   async paths(): Promise<Root> {
-    if (this._paths) return this._paths;
-    const root = (await this.root()) ?? null;
-    const paths = new Root(root);
-    paths.add("app", { glob: "{*,*/concerns}" });
-    paths.add("app/assets", { glob: "*" });
-    paths.add("app/controllers");
-    paths.add("app/channels");
-    paths.add("app/helpers");
-    paths.add("app/models");
-    paths.add("app/mailers");
-    paths.add("app/views");
-    paths.add("lib", { loadPath: true });
-    paths.add("lib/assets", { glob: "*" });
-    paths.add("lib/tasks", { glob: "**/*.rake" });
-    paths.add("config");
-    paths.add("config/initializers", { glob: "**/*.{ts,js}" });
-    paths.add("config/locales", { glob: "**/*.{ts,js,json}" });
-    paths.add("config/routes.ts");
-    paths.add("config/routes", { glob: "**/*.{ts,js}" });
-    paths.add("db");
-    paths.add("db/migrate");
-    paths.add("db/seeds.ts");
-    paths.add("vendor", { loadPath: true });
-    paths.add("vendor/assets", { glob: "*" });
-    if (root !== null) this._paths = paths;
-    return paths;
+    const cfg = this.engineConfig();
+    if (cfg.root === null) {
+      const resolved = await this.root();
+      if (resolved !== undefined) cfg.setRoot(resolved);
+    }
+    return cfg.paths();
   }
 
   async helpersPaths(): Promise<string[]> {
@@ -116,6 +118,33 @@ export class Engine extends Trailtie {
   railties(): Trailties {
     if (!this._railtiesCollection) this._railtiesCollection = new Trailties();
     return this._railtiesCollection;
+  }
+
+  /** `Engine#routes(&block)` — undefined when no `routeSetClass` is set. */
+  routes(block?: (this: unknown) => void): unknown {
+    const cfg = this.engineConfig();
+    if (!cfg.routeSetClass) return undefined;
+    if (!this._routes) this._routes = new cfg.routeSetClass(cfg);
+    const r = this._routes as { append?: (b: (this: unknown) => void) => void };
+    if (block) r.append?.(block);
+    return this._routes;
+  }
+  hasRoutes(): boolean {
+    return this._routes !== undefined;
+  }
+
+  /** @internal Rails `_all_load_paths(add_autoload_paths_to_load_path)`. */
+  async allLoadPaths(addAutoloadPathsToLoadPath = true): Promise<string[]> {
+    if (this._allLoadPathsCache) return this._allLoadPathsCache;
+    const paths = await this.paths();
+    const cfg = this.engineConfig();
+    const out = [...(await paths.loadPaths())];
+    if (addAutoloadPathsToLoadPath) {
+      for (const p of cfg.allAutoloadPaths()) out.push(p);
+      for (const p of cfg.allAutoloadOncePaths()) out.push(p);
+    }
+    this._allLoadPathsCache = Array.from(new Set(out));
+    return this._allLoadPathsCache;
   }
 }
 

--- a/packages/trailties/src/engine/configuration.ts
+++ b/packages/trailties/src/engine/configuration.ts
@@ -61,7 +61,7 @@ export class EngineConfiguration extends RailtieConfiguration {
     paths.add("app/views");
     paths.add("lib", { loadPath: true });
     paths.add("lib/assets", { glob: "*" });
-    paths.add("lib/tasks", { glob: "**/*.rake" });
+    paths.add("lib/tasks", { glob: "**/*.{ts,js}" });
     paths.add("config");
     paths.add("config/initializers", { glob: "**/*.{ts,js}" });
     paths.add("config/locales", { glob: "**/*.{ts,js,json}" });

--- a/packages/trailties/src/engine/configuration.ts
+++ b/packages/trailties/src/engine/configuration.ts
@@ -1,0 +1,98 @@
+/**
+ * Port of `Rails::Engine::Configuration` from
+ * `railties/lib/rails/engine/configuration.rb`.
+ *
+ * Diverges from Rails:
+ * - `tableNamePrefix` is an explicit option (replaces `isolate_namespace`).
+ * - `paths()` is async because `Root` defaults walk no fs, but consumers
+ *   often want the resolved root injected; constructing with a `null` root
+ *   is allowed (matches 2.2a `Engine#paths()` tolerance).
+ * - `routeSetClass` is held as an opaque constructor; the real
+ *   `ActionDispatch::Routing::RouteSet` wiring lands with PR 2.5.
+ */
+import { Configuration as RailtieConfiguration } from "../trailtie/configuration.js";
+import { Root } from "../paths.js";
+
+export type MiddlewareEntry = { name: string; args: unknown[] };
+export type RouteSetCtor = new (config: EngineConfiguration) => unknown;
+
+export class EngineConfiguration extends RailtieConfiguration {
+  private _root: string | null;
+  private _paths?: Root;
+
+  middleware: MiddlewareEntry[] = [];
+  javascriptPath = "javascript";
+  routeSetClass: RouteSetCtor | null = null;
+  defaultScope: Record<string, unknown> | null = null;
+  tableNamePrefix: string | null = null;
+
+  autoloadPaths: string[] = [];
+  autoloadOncePaths: string[] = [];
+  eagerLoadPaths: string[] = [];
+
+  private _generators: Record<string, unknown> = {};
+
+  constructor(root: string | null = null) {
+    super();
+    this._root = root;
+  }
+
+  get root(): string | null {
+    return this._root;
+  }
+
+  /** Mirrors Rails `root=`. Re-expands `paths.path` so downstream lookups
+   * resolve against the new root. */
+  setRoot(value: string | null): void {
+    this._root = value;
+    if (this._paths) this._paths.path = value;
+  }
+
+  paths(): Root {
+    if (this._paths) return this._paths;
+    const paths = new Root(this._root);
+    paths.add("app", { glob: "{*,*/concerns}" });
+    paths.add("app/assets", { glob: "*" });
+    paths.add("app/controllers");
+    paths.add("app/channels");
+    paths.add("app/helpers");
+    paths.add("app/models");
+    paths.add("app/mailers");
+    paths.add("app/views");
+    paths.add("lib", { loadPath: true });
+    paths.add("lib/assets", { glob: "*" });
+    paths.add("lib/tasks", { glob: "**/*.rake" });
+    paths.add("config");
+    paths.add("config/initializers", { glob: "**/*.{ts,js}" });
+    paths.add("config/locales", { glob: "**/*.{ts,js,json}" });
+    paths.add("config/routes.ts");
+    paths.add("config/routes", { glob: "**/*.{ts,js}" });
+    paths.add("db");
+    paths.add("db/migrate");
+    paths.add("db/seeds.ts");
+    paths.add("vendor", { loadPath: true });
+    paths.add("vendor/assets", { glob: "*" });
+    this._paths = paths;
+    return paths;
+  }
+
+  /** Mirrors Rails `config.generators { |g| ... }` — yields a mutable
+   * options bag. Returns the bag for chained reads. */
+  generators(block?: (g: Record<string, unknown>) => void): Record<string, unknown> {
+    if (block) block(this._generators);
+    return this._generators;
+  }
+
+  /** @internal */
+  allAutoloadPaths(): string[] {
+    return [...this.autoloadPaths];
+  }
+  /** @internal */
+  allAutoloadOncePaths(): string[] {
+    return [...this.autoloadOncePaths];
+  }
+  /** @internal */
+  allEagerLoadPaths(): string[] {
+    return [...this.eagerLoadPaths];
+  }
+}

--- a/packages/trailties/src/engine/configuration.ts
+++ b/packages/trailties/src/engine/configuration.ts
@@ -4,9 +4,9 @@
  *
  * Diverges from Rails:
  * - `tableNamePrefix` is an explicit option (replaces `isolate_namespace`).
- * - `paths()` is async because `Root` defaults walk no fs, but consumers
- *   often want the resolved root injected; constructing with a `null` root
- *   is allowed (matches 2.2a `Engine#paths()` tolerance).
+ * - Constructing with a `null` root is allowed (matches 2.2a
+ *   `Engine#paths()` tolerance); `Engine#paths()` injects the resolved
+ *   root via `setRoot()` once known.
  * - `routeSetClass` is held as an opaque constructor; the real
  *   `ActionDispatch::Routing::RouteSet` wiring lands with PR 2.5.
  */


### PR DESCRIPTION
## Summary

Second split of PR 2.2 (`Engine`). Ships `Rails::Engine::Configuration` and wires it into the 2.2a Engine shell.

- New `packages/trailties/src/engine/configuration.ts` — `EngineConfiguration` extends `RailtieConfiguration` with `middleware`, `javascriptPath`, `routeSetClass`, `defaultScope`, `tableNamePrefix`, `autoloadPaths`, `autoloadOncePaths`, `eagerLoadPaths`, plus `paths()` (Rails default layout) and `setRoot()` (re-expands `paths.path`).
- `Engine#engineConfig()` returns the lazy `EngineConfiguration`. `Engine#paths()` now delegates to it and injects the resolved root via `setRoot()`. `Engine#tableNamePrefix()` returns the explicit option, falling back to `${engineName}_` when `isolated` is on. `Engine#allLoadPaths()` mirrors Rails' `_all_load_paths`.
- Rails-mirrored cases added to `engine.test.ts`: configuration defaults, `root=` re-expansion, path layout, `tableNamePrefix` (default / explicit / isolated fallback), `config.eager_load_namespaces` accumulation, and `paths()` injecting the resolved root back into `EngineConfiguration`.

## Open question — resolved

Per the 2.2a finding: `Engine#paths()` returns `Root(null)` when `calledFrom` is unset rather than throwing (Rails-faithful would raise via `findRoot(nil)`). Kept the 2.2a tolerance so a subclass can be constructed before its source location is known. Documented in both `engine.ts` (`root()`) and `engine/configuration.ts`.

## Rails sources

- `railties/lib/rails/engine/configuration.rb` — ported.
- `railties/lib/rails/engine.rb` — `config`, `_all_load_paths`, `table_name_prefix` (isolated-namespace path).

## Intentionally skipped / deferred

- `Engine#helpers` (helper-module composition) — blocked on `actionpack` helpers port.
- `Engine#routes`, `Engine#app`, `Engine#endpoint`, `Engine#call`, `Engine#env_config` — blocked on PR 2.5 (Rack endpoint) and PR 2.2c (`lazy_route_set`).
- `isolate_namespace` itself — replaced by explicit `tableNamePrefix` config per plan doc.
- `eager_load!`, `eager_load_paths` autoloader semantics — out of scope per plan (ESM + bundlers cover).

## Remaining for 2.2c

- `engine/lazy_route_set.ts`, `engine/updater.ts`.
- Real route mounting tests (require `ActionDispatch::Routing::RouteSet`).
- `railties.engines` / `.order` / dependency resolution tests (require routing).

## Test plan

- [x] `pnpm vitest run packages/trailties/src/engine.test.ts` — 20 passed.
- [x] `pnpm build`, `pnpm typecheck`, `pnpm lint` clean.