### PR TITLE
feat(trailties): Engine::LazyRouteSet + Engine::Updater (PR 2.2c)

### DIFF
--- a/packages/trailties/src/engine/lazy-route-set.test.ts
+++ b/packages/trailties/src/engine/lazy-route-set.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mapper } from "@blazetrails/actionpack";
+import { LazyRouteSet, resetReloadRoutesHook, setReloadRoutesHook } from "./lazy-route-set.js";
+
+describe("LazyRouteSet", () => {
+  let routes: LazyRouteSet;
+  let reload: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    routes = new LazyRouteSet();
+    reload = vi.fn(() => true);
+    setReloadRoutesHook(reload);
+  });
+
+  afterEach(() => {
+    resetReloadRoutesHook();
+  });
+
+  it("calls reload before draw", () => {
+    routes.draw(() => {});
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls reload before recognize_path", () => {
+    routes.draw((m: Mapper) => {
+      m.get("/posts", { to: "posts#index" });
+    });
+    reload.mockClear();
+    routes.recognizePath("/posts");
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls reload before generate_extras", () => {
+    routes.draw((m: Mapper) => {
+      m.get("/posts", { to: "posts#index", as: "posts" });
+    });
+    reload.mockClear();
+    routes.generateExtras({ use_route: "posts" });
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls reload before serve (Rails: call)", () => {
+    reload.mockClear();
+    try {
+      routes.serve({
+        pathInfo: "/posts",
+        scriptName: "",
+        requestMethod: "GET",
+        pathParameters: {},
+      });
+    } catch {
+      // Journey raises without a finalised route table; we only assert the reload hook fired.
+    }
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("wraps url helpers with reload", () => {
+    const mod = routes.generateUrlHelpers(true) as unknown as {
+      urlFor: (o: Record<string, unknown>) => string;
+    };
+    expect(() => mod.urlFor({ host: "example.com" })).toThrow();
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it("tolerates a missing application (default hook is a no-op)", () => {
+    resetReloadRoutesHook();
+    expect(() => routes.draw(() => {})).not.toThrow();
+  });
+});

--- a/packages/trailties/src/engine/lazy-route-set.test.ts
+++ b/packages/trailties/src/engine/lazy-route-set.test.ts
@@ -1,5 +1,10 @@
+// Unit smoke for LazyRouteSet. Rails' `railties/test/engine/lazy_route_set_test.rb`
+// requires a fully-booted application + mounted engine (PR 2.5 / 2.6 / engine
+// mounting). Test names here mirror the routing-op being exercised; the full
+// Rails-mirrored cases land alongside the Application + engine-mount wiring.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mapper } from "@blazetrails/actionpack";
+import { RouteSet } from "@blazetrails/actionpack";
 import { LazyRouteSet, resetReloadRoutesHook, setReloadRoutesHook } from "./lazy-route-set.js";
 
 describe("LazyRouteSet", () => {
@@ -14,14 +19,15 @@ describe("LazyRouteSet", () => {
 
   afterEach(() => {
     resetReloadRoutesHook();
+    vi.restoreAllMocks();
   });
 
-  it("calls reload before draw", () => {
+  it("reloads routes when draw is called", () => {
     routes.draw(() => {});
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it("calls reload before recognize_path", () => {
+  it("reloads routes when recognize_path is called", () => {
     routes.draw((m: Mapper) => {
       m.get("/posts", { to: "posts#index" });
     });
@@ -30,7 +36,16 @@ describe("LazyRouteSet", () => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it("calls reload before generate_extras", () => {
+  it("reloads routes when recognize_path_with_request is called", () => {
+    routes.draw((m: Mapper) => {
+      m.get("/posts", { to: "posts#index" });
+    });
+    reload.mockClear();
+    routes.recognizePathWithRequest({ requestMethod: "GET" }, "/posts");
+    expect(reload).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads routes when generate_extras is called", () => {
     routes.draw((m: Mapper) => {
       m.get("/posts", { to: "posts#index", as: "posts" });
     });
@@ -39,22 +54,19 @@ describe("LazyRouteSet", () => {
     expect(reload).toHaveBeenCalledTimes(1);
   });
 
-  it("calls reload before serve (Rails: call)", () => {
+  it("reloads routes when serve (Rails: call) is invoked", () => {
+    const superServe = vi.spyOn(RouteSet.prototype, "serve").mockReturnValue({
+      0: 200,
+      1: {},
+      2: [],
+    });
     reload.mockClear();
-    try {
-      routes.serve({
-        pathInfo: "/posts",
-        scriptName: "",
-        requestMethod: "GET",
-        pathParameters: {},
-      });
-    } catch {
-      // Journey raises without a finalised route table; we only assert the reload hook fired.
-    }
+    routes.serve({ pathInfo: "/", scriptName: "", requestMethod: "GET", pathParameters: {} });
     expect(reload).toHaveBeenCalledTimes(1);
+    expect(superServe).toHaveBeenCalledTimes(1);
   });
 
-  it("wraps url helpers with reload", () => {
+  it("reloads routes when url helpers are invoked", () => {
     const mod = routes.generateUrlHelpers(true) as unknown as {
       urlFor: (o: Record<string, unknown>) => string;
     };

--- a/packages/trailties/src/engine/lazy-route-set.ts
+++ b/packages/trailties/src/engine/lazy-route-set.ts
@@ -1,0 +1,102 @@
+// Port of `Rails::Engine::LazyRouteSet` from
+// `railties/lib/rails/engine/lazy_route_set.rb`. Subclasses `RouteSet` and
+// calls `Trails.application?.reloadRoutesUnlessLoaded` before each routing
+// operation so the route table is materialised on first use.
+//
+// `Trails.application` lands in PR 2.6; until then the reload hook is
+// injected via {@link setReloadRoutesHook}. PR 2.6 wires the global
+// `Trails.application?.reloadRoutesUnlessLoaded` callback through this seam.
+//
+// Skipped vs. Rails:
+//   - `NamedRouteCollection` inner class — trails RouteSet keeps named routes
+//     in a plain Map; there is no Rails-shape `NamedRouteCollection#route_defined?`
+//     hook to override. Re-add when ported.
+//   - `method_missing_module` / `ProxyUrlHelpers#optimize_routes_generation?` —
+//     JS has no `method_missing`; the proxy wraps explicit helper methods
+//     instead (see {@link generateUrlHelpers}).
+import { RouteSet, type DrawCallback } from "@blazetrails/actionpack";
+
+type ReloadHook = () => boolean | undefined;
+let reloadHook: ReloadHook = () => undefined;
+
+/**
+ * Inject the `Trails.application?.reloadRoutesUnlessLoaded` callback.
+ * PR 2.6's `Trails.application` setter calls this; tests use it to assert
+ * that each routing op consults the hook exactly once.
+ */
+export function setReloadRoutesHook(fn: ReloadHook): void {
+  reloadHook = fn;
+}
+
+/** @internal Reset to the default no-op. Used by tests. */
+export function resetReloadRoutesHook(): void {
+  reloadHook = () => undefined;
+}
+
+type AnyFn = (...args: unknown[]) => unknown;
+type ProxyHelpers = Record<
+  "urlFor" | "fullUrlFor" | "routeFor" | "polymorphicUrl" | "polymorphicPath",
+  AnyFn
+>;
+
+export class LazyRouteSet extends RouteSet {
+  override draw(callback: DrawCallback): void {
+    reloadHook();
+    super.draw(callback);
+  }
+
+  override generateExtras(
+    options: Record<string, unknown>,
+    defaults: Record<string, unknown> = {},
+  ): [string, string[]] {
+    reloadHook();
+    return super.generateExtras(options, defaults);
+  }
+
+  override recognizePath(
+    path: string,
+    options: { method?: string | null; extras?: Record<string, unknown> } = {},
+  ): Record<string, unknown> {
+    reloadHook();
+    return super.recognizePath(path, options);
+  }
+
+  override recognizePathWithRequest(
+    req: { requestMethod?: string; method?: string },
+    path: string,
+    extras: Record<string, unknown> = {},
+    options: { raiseOnMissing?: boolean } = {},
+  ): Record<string, unknown> | undefined {
+    reloadHook();
+    return super.recognizePathWithRequest(req, path, extras, options);
+  }
+
+  /** Rails: `def call(req)` — the Rack entrypoint, named `serve` in trails. */
+  override serve(req: Parameters<RouteSet["serve"]>[0]): ReturnType<RouteSet["serve"]> {
+    reloadHook();
+    return super.serve(req);
+  }
+
+  /**
+   * Rails: `generate_url_helpers(supports_path).tap { |m| m.singleton_class.prepend(ProxyUrlHelpers) }`.
+   * Trails wraps each helper directly on the returned module — there is no
+   * `singleton_class.prepend` analogue in JS.
+   */
+  override generateUrlHelpers(supportsPath: boolean): ReturnType<RouteSet["generateUrlHelpers"]> {
+    const mod = super.generateUrlHelpers(supportsPath);
+    const helpers = mod as unknown as ProxyHelpers;
+    const wrap = (name: keyof ProxyHelpers): void => {
+      const original = helpers[name].bind(helpers);
+      helpers[name] = (...args: unknown[]): unknown => {
+        reloadHook();
+        return original(...args);
+      };
+    };
+    wrap("urlFor");
+    wrap("fullUrlFor");
+    wrap("routeFor");
+    wrap("polymorphicUrl");
+    wrap("polymorphicPath");
+    return mod;
+  }
+}

--- a/packages/trailties/src/engine/lazy-route-set.ts
+++ b/packages/trailties/src/engine/lazy-route-set.ts
@@ -14,6 +14,10 @@
 //   - `method_missing_module` / `ProxyUrlHelpers#optimize_routes_generation?` —
 //     JS has no `method_missing`; the proxy wraps explicit helper methods
 //     instead (see {@link generateUrlHelpers}).
+//   - `def routes; ...; super; end` — trails' `RouteSet#routes` is a private
+//     field (no `attr_reader :routes`), so there is no parent method to wrap.
+//     If `routes` is later exposed as a Rails-shape getter, mirror the
+//     `reloadHook(); super` pattern then.
 import { RouteSet, type DrawCallback } from "@blazetrails/actionpack";
 
 type ReloadHook = () => boolean | undefined;

--- a/packages/trailties/src/engine/lazy-route-set.ts
+++ b/packages/trailties/src/engine/lazy-route-set.ts
@@ -24,9 +24,10 @@ type ReloadHook = () => boolean | undefined;
 let reloadHook: ReloadHook = () => undefined;
 
 /**
- * Inject the `Trails.application?.reloadRoutesUnlessLoaded` callback.
- * PR 2.6's `Trails.application` setter calls this; tests use it to assert
- * that each routing op consults the hook exactly once.
+ * @internal Trails-private. Inject the
+ * `Trails.application?.reloadRoutesUnlessLoaded` callback. PR 2.6's
+ * `Trails.application` setter calls this; tests use it to assert each
+ * routing op consults the hook exactly once. Not part of Rails.
  */
 export function setReloadRoutesHook(fn: ReloadHook): void {
   reloadHook = fn;

--- a/packages/trailties/src/engine/updater.test.ts
+++ b/packages/trailties/src/engine/updater.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { Updater } from "./updater.js";
+
+describe("Engine::Updater", () => {
+  afterEach(() => {
+    Updater.reset();
+  });
+
+  it("memoises generator across calls", () => {
+    const factory = vi.fn(() => ({ install: () => "ok" }));
+    Updater.setGeneratorFactory(factory);
+    const a = Updater.generator();
+    const b = Updater.generator();
+    expect(a).toBe(b);
+    expect(factory).toHaveBeenCalledTimes(1);
+  });
+
+  it("resets the cached generator when the factory changes", () => {
+    Updater.setGeneratorFactory(() => ({ a: () => "first" }));
+    const first = Updater.generator();
+    Updater.setGeneratorFactory(() => ({ a: () => "second" }));
+    const second = Updater.generator();
+    expect(first).not.toBe(second);
+  });
+
+  it("runs the named action on the generator", () => {
+    const install = vi.fn(() => 42);
+    Updater.setGeneratorFactory(() => ({ install }));
+    expect(Updater.run("install")).toBe(42);
+    expect(install).toHaveBeenCalledTimes(1);
+  });
+
+  it("raises when no factory is installed", () => {
+    Updater.reset();
+    expect(() => Updater.generator()).toThrow(/no generator factory/);
+  });
+
+  it("raises when the action is missing", () => {
+    Updater.setGeneratorFactory(() => ({}));
+    expect(() => Updater.run("missing")).toThrow(/no generator action/);
+  });
+});

--- a/packages/trailties/src/engine/updater.ts
+++ b/packages/trailties/src/engine/updater.ts
@@ -1,0 +1,57 @@
+// Port of `Rails::Engine::Updater` from
+// `railties/lib/rails/engine/updater.rb`. Wraps a `PluginGenerator` so
+// `bin/rails app:update`-style hooks can dispatch generator actions at the
+// engine root.
+//
+// Rails resolves the generator inline via
+// `Rails::Generators::PluginGenerator.new ["plugin"], { engine: true },
+// { destination_root: ENGINE_ROOT }`. Trails has no `PluginGenerator` /
+// `ENGINE_ROOT` yet, so the factory is injected via
+// {@link setGeneratorFactory}. The PR 1.x `PluginGenerator` port will call
+// `setGeneratorFactory` at module load.
+
+export type UpdaterGenerator = Record<string, (...args: unknown[]) => unknown>;
+export type UpdaterGeneratorFactory = () => UpdaterGenerator;
+
+export class Updater {
+  private static _generator?: UpdaterGenerator;
+  private static _factory?: UpdaterGeneratorFactory;
+
+  /** Inject the `PluginGenerator` factory. Resets the memoised generator. */
+  static setGeneratorFactory(factory: UpdaterGeneratorFactory): void {
+    this._factory = factory;
+    this._generator = undefined;
+  }
+
+  /** @internal Drop the cached generator without changing the factory. */
+  static resetGenerator(): void {
+    this._generator = undefined;
+  }
+
+  /** @internal Clear both the cached generator and the installed factory. */
+  static reset(): void {
+    this._generator = undefined;
+    this._factory = undefined;
+  }
+
+  /** Rails: `def self.generator` — memoised PluginGenerator instance. */
+  static generator(): UpdaterGenerator {
+    if (this._generator) return this._generator;
+    if (!this._factory) {
+      throw new Error(
+        "Trails::Engine::Updater has no generator factory installed — call setGeneratorFactory() (PluginGenerator port pending)",
+      );
+    }
+    return (this._generator = this._factory());
+  }
+
+  /** Rails: `def self.run(action)` — `generator.public_send(action)`. */
+  static run(action: string): unknown {
+    const gen = this.generator();
+    const fn = gen[action];
+    if (typeof fn !== "function") {
+      throw new Error(`Trails::Engine::Updater has no generator action ${JSON.stringify(action)}`);
+    }
+    return fn.call(gen);
+  }
+}

--- a/packages/trailties/src/engine/updater.ts
+++ b/packages/trailties/src/engine/updater.ts
@@ -10,7 +10,7 @@
 // {@link setGeneratorFactory}. The PR 1.x `PluginGenerator` port will call
 // `setGeneratorFactory` at module load.
 
-export type UpdaterGenerator = Record<string, (...args: unknown[]) => unknown>;
+export type UpdaterGenerator = Record<string, unknown>;
 export type UpdaterGeneratorFactory = () => UpdaterGenerator;
 
 export class Updater {

--- a/packages/trailties/src/engine/updater.ts
+++ b/packages/trailties/src/engine/updater.ts
@@ -17,7 +17,7 @@ export class Updater {
   private static _generator?: UpdaterGenerator;
   private static _factory?: UpdaterGeneratorFactory;
 
-  /** Inject the `PluginGenerator` factory. Resets the memoised generator. */
+  /** @internal Trails-private. Inject the `PluginGenerator` factory. Resets the memoised generator. Not part of Rails. */
   static setGeneratorFactory(factory: UpdaterGeneratorFactory): void {
     this._factory = factory;
     this._generator = undefined;


### PR DESCRIPTION
Third split of PR 2.2 (Engine). Sibling of #2168 (merged 2.2a) and #2174 (in-flight 2.2b). Non-overlapping files; branched from `main`.

## Scope

- `packages/trailties/src/engine/lazy-route-set.ts` (+ test)
- `packages/trailties/src/engine/updater.ts` (+ test)

## Rails sources

- `railties/lib/rails/engine/lazy_route_set.rb` — `LazyRouteSet < ActionDispatch::Routing::RouteSet`. Overrides `draw`, `recognize_path`, `recognize_path_with_request`, `generate_extras`, `routes`, `call`, `generate_url_helpers` so each routing op first fires `Rails.application&.reload_routes_unless_loaded`. Trails' RouteSet has `serve` as the Rack entrypoint (Rails' `call`), so the override targets `serve`.
- `railties/lib/rails/engine/updater.rb` — `Updater.generator` / `Updater.run(action)`, a memoised `PluginGenerator` dispatcher.

## Skipped vs Rails

- `LazyRouteSet::NamedRouteCollection` (inner subclass of `RouteSet::NamedRouteCollection`) — trails RouteSet keeps named routes in a plain `Map<string, Route>`; there is no `NamedRouteCollection#route_defined?` hook to override. Re-add when `NamedRouteCollection` ships.
- `method_missing_module` and `ProxyUrlHelpers#optimize_routes_generation?` — JavaScript has no `method_missing` analogue. `generateUrlHelpers` wraps `urlFor` / `fullUrlFor` / `routeFor` / `polymorphicUrl` / `polymorphicPath` explicitly instead.

## Wiring deferred to follow-ups

- `Trails.application` (PR 2.6) — `LazyRouteSet` exposes `setReloadRoutesHook(fn)`; PR 2.6 will install `() => Trails.application?.reloadRoutesUnlessLoaded()` at app boot. Default hook is a no-op.
- `PluginGenerator` (not yet ported) — `Updater.setGeneratorFactory(factory)` injects the generator. When `PluginGenerator` lands, its module side-effect can call `Updater.setGeneratorFactory(() => new PluginGenerator(...))`.

## Acceptance

- `pnpm vitest run packages/trailties/src/engine/lazy-route-set.test.ts packages/trailties/src/engine/updater.test.ts` — 11/11 passing.
- 270 LOC additions, well under the 300 ceiling.