### PR TITLE
feat(trailties): AppBase + Database (no Trilogy) + migration filename underscore (PR 1.12c)

### DIFF
--- a/packages/trailties/src/commands/db.test.ts
+++ b/packages/trailties/src/commands/db.test.ts
@@ -626,9 +626,11 @@ describe("discoverMigrations", () => {
     const migrations = await discoverMigrations(tmpDir);
     expect(migrations).toHaveLength(2);
     expect(migrations[0].version).toBe("20260101000000");
-    expect(migrations[0].name).toBe("create-users");
+    // discoverMigrations canonicalizes proxy.name to the underscore form
+    // (Rails-faithful) regardless of the on-disk separator.
+    expect(migrations[0].name).toBe("create_users");
     expect(migrations[1].version).toBe("20260102000000");
-    expect(migrations[1].name).toBe("add-email-to-users");
+    expect(migrations[1].name).toBe("add_email_to_users");
   });
 
   it("sorts migrations by version", async () => {
@@ -976,8 +978,9 @@ export class CreatePosts extends Migration {
     const joined = errs.join("\n");
     expect(joined).toContain("You have 1 pending migration:");
     expect(joined).toContain("20260101000000");
-    // migration-loader derives the display name from the filename suffix.
-    expect(joined).toContain("create-posts");
+    // migration-loader derives the display name from the filename suffix
+    // and canonicalizes hyphen separators to underscores (Rails-faithful).
+    expect(joined).toContain("create_posts");
     expect(joined).toContain("Run `trails db migrate` to resolve this issue.");
   });
 

--- a/packages/trailties/src/commands/destroy.test.ts
+++ b/packages/trailties/src/commands/destroy.test.ts
@@ -3,14 +3,18 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { createProgram } from "../cli.js";
+import { destroyCommand } from "./destroy.js";
 
 let tmpDir: string;
+let originalCwd: string;
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-test-"));
+  originalCwd = process.cwd();
 });
 
 afterEach(() => {
+  process.chdir(originalCwd);
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
@@ -42,5 +46,20 @@ describe("DestroyCommand", () => {
     const program = createProgram();
     const cmd = program.commands.find((c) => c.name() === "destroy");
     expect(cmd?.commands.some((c) => c.name() === "scaffold")).toBe(true);
+  });
+
+  it("destroy migration anchors the filename match", async () => {
+    const migrationsDir = path.join(tmpDir, "db", "migrations");
+    fs.mkdirSync(migrationsDir, { recursive: true });
+    const target = path.join(migrationsDir, "20260101000000_create_posts.ts");
+    const decoy = path.join(migrationsDir, "20260202000000_add_create_posts_flag.ts");
+    fs.writeFileSync(target, "");
+    fs.writeFileSync(decoy, "");
+
+    process.chdir(tmpDir);
+    await destroyCommand().parseAsync(["migration", "create_posts"], { from: "user" });
+
+    expect(fs.existsSync(target)).toBe(false);
+    expect(fs.existsSync(decoy)).toBe(true);
   });
 });

--- a/packages/trailties/src/commands/destroy.ts
+++ b/packages/trailties/src/commands/destroy.ts
@@ -30,7 +30,10 @@ export function destroyCommand(): Command {
         // user-derived tableName so regex metacharacters can't widen
         // the match.
         const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const pattern = new RegExp(`create[_-]${escaped}\\.(ts|js)$`);
+        // Anchor to the start of the filename and require the timestamp
+        // + separator so names like `..._recreate_posts.ts` cannot match
+        // `create_posts.ts`.
+        const pattern = new RegExp(`^\\d+[_-]create[_-]${escaped}\\.(ts|js)$`);
         for (const f of fs.readdirSync(migrationsDir)) {
           if (pattern.test(f)) {
             removeFile(cwd, `db/migrations/${f}`);
@@ -89,8 +92,10 @@ export function destroyCommand(): Command {
       // Migration
       const migrationsDir = path.join(cwd, "db", "migrations");
       if (fs.existsSync(migrationsDir)) {
+        const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const pattern = new RegExp(`^\\d+[_-]create[_-]${escaped}\\.(ts|js)$`);
         for (const f of fs.readdirSync(migrationsDir)) {
-          if (f.includes(`create-${tableName}`) || f.includes(`create_${tableName}`)) {
+          if (pattern.test(f)) {
             removeFile(cwd, `db/migrations/${f}`);
           }
         }

--- a/packages/trailties/src/commands/destroy.ts
+++ b/packages/trailties/src/commands/destroy.ts
@@ -26,8 +26,11 @@ export function destroyCommand(): Command {
       const migrationsDir = path.join(cwd, "db", "migrations");
       if (fs.existsSync(migrationsDir)) {
         // Match both the underscore form (post-1.12c, Rails-faithful)
-        // and the hyphen form (pre-1.12c transitional).
-        const pattern = new RegExp(`create[_-]${tableName}\\.ts$`);
+        // and the hyphen form (pre-1.12c transitional). Escape the
+        // user-derived tableName so regex metacharacters can't widen
+        // the match.
+        const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const pattern = new RegExp(`create[_-]${escaped}\\.ts$`);
         for (const f of fs.readdirSync(migrationsDir)) {
           if (pattern.test(f)) {
             removeFile(cwd, `db/migrations/${f}`);

--- a/packages/trailties/src/commands/destroy.ts
+++ b/packages/trailties/src/commands/destroy.ts
@@ -62,10 +62,16 @@ export function destroyCommand(): Command {
       const migrationsDir = path.join(cwd, "db", "migrations");
       if (!fs.existsSync(migrationsDir)) return;
 
-      const dashed = dasherize(name);
+      // Anchor on `^<timestamp>[_-]<name>\.(ts|js)$` so a name like
+      // `create_posts` does not also match `..._add_create_posts_flag.ts`.
+      // Escape first so regex metacharacters in the user-supplied name
+      // can't widen the match.
+      const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const dashed = dasherize(escaped);
       const underscored = dashed.replace(/-/g, "_");
+      const pattern = new RegExp(`^\\d+[_-](${dashed}|${underscored})\\.(ts|js)$`);
       for (const f of fs.readdirSync(migrationsDir)) {
-        if (f.includes(dashed) || f.includes(underscored)) {
+        if (pattern.test(f)) {
           removeFile(cwd, `db/migrations/${f}`);
         }
       }

--- a/packages/trailties/src/commands/destroy.ts
+++ b/packages/trailties/src/commands/destroy.ts
@@ -30,7 +30,7 @@ export function destroyCommand(): Command {
         // user-derived tableName so regex metacharacters can't widen
         // the match.
         const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-        const pattern = new RegExp(`create[_-]${escaped}\\.ts$`);
+        const pattern = new RegExp(`create[_-]${escaped}\\.(ts|js)$`);
         for (const f of fs.readdirSync(migrationsDir)) {
           if (pattern.test(f)) {
             removeFile(cwd, `db/migrations/${f}`);

--- a/packages/trailties/src/commands/destroy.ts
+++ b/packages/trailties/src/commands/destroy.ts
@@ -25,7 +25,9 @@ export function destroyCommand(): Command {
       // Find and remove migration
       const migrationsDir = path.join(cwd, "db", "migrations");
       if (fs.existsSync(migrationsDir)) {
-        const pattern = new RegExp(`create-${tableName}\\.ts$`);
+        // Match both the underscore form (post-1.12c, Rails-faithful)
+        // and the hyphen form (pre-1.12c transitional).
+        const pattern = new RegExp(`create[_-]${tableName}\\.ts$`);
         for (const f of fs.readdirSync(migrationsDir)) {
           if (pattern.test(f)) {
             removeFile(cwd, `db/migrations/${f}`);
@@ -55,8 +57,9 @@ export function destroyCommand(): Command {
       if (!fs.existsSync(migrationsDir)) return;
 
       const dashed = dasherize(name);
+      const underscored = dashed.replace(/-/g, "_");
       for (const f of fs.readdirSync(migrationsDir)) {
-        if (f.includes(dashed)) {
+        if (f.includes(dashed) || f.includes(underscored)) {
           removeFile(cwd, `db/migrations/${f}`);
         }
       }

--- a/packages/trailties/src/generators/app-base.test.ts
+++ b/packages/trailties/src/generators/app-base.test.ts
@@ -40,6 +40,14 @@ describe("AppBase", () => {
     expect(g.skip("ActiveStorage")).toBe(false);
   });
 
+  it("destinationRoot joins relative appPath, keeps absolute as-is", () => {
+    expect(build({ cwd: "/work", appPath: "blog" }).destinationRoot).toBe("/work/blog");
+    expect(build({ cwd: "/work", appPath: "/elsewhere/blog" }).destinationRoot).toBe(
+      "/elsewhere/blog",
+    );
+    expect(build({ cwd: "/work", appPath: "blog" }).cwd).toBe("/work/blog");
+  });
+
   it("dependsOnSystemTest false when api or skipTest", () => {
     expect(build({ api: true }).dependsOnSystemTest()).toBe(false);
     expect(build({ skipTest: true }).dependsOnSystemTest()).toBe(false);

--- a/packages/trailties/src/generators/app-base.test.ts
+++ b/packages/trailties/src/generators/app-base.test.ts
@@ -3,52 +3,41 @@ import { AppBase, type AppBaseOptions } from "./app-base.js";
 
 class T extends AppBase {}
 const build = (o: Partial<AppBaseOptions> = {}) =>
-  new T({ cwd: "/tmp/x", output: () => {}, appPath: "myapp", ...o });
+  new T({ cwd: "/work", output: () => {}, appPath: "blog", ...o });
 
 describe("AppBase", () => {
-  it("defaults to sqlite3 with keeps and system tests", () => {
+  it("defaults: sqlite3, keeps, system tests, destinationRoot joins cwd+appPath", () => {
     const g = build();
     expect(g.sqlite3()).toBe(true);
     expect(g.database.name).toBe("sqlite3");
     expect(g.keeps()).toBe(true);
     expect(g.dependsOnSystemTest()).toBe(true);
+    expect(g.destinationRoot).toBe("/work/blog");
+    expect(g.cwd).toBe("/work/blog");
+    expect(build({ appPath: "/abs/blog" }).destinationRoot).toBe("/abs/blog");
   });
 
-  it("skip(what) reads skip<What> options", () => {
+  it("skip(what), devcontainer, postgres delegate", () => {
     const g = build({ skipActionCable: true, skipKeeps: true, devcontainer: true });
     expect(g.skip("ActionCable")).toBe(true);
     expect(g.keeps()).toBe(false);
     expect(g.devcontainer()).toBe(true);
     expect(g.skipDevcontainer()).toBe(false);
+    expect(build({ database: "postgresql" }).database.name).toBe("postgres");
+    expect(build({ database: "postgresql" }).sqlite3()).toBe(false);
   });
 
-  it("postgres database delegate", () => {
-    const g = build({ database: "postgresql" });
-    expect(g.database.name).toBe("postgres");
-    expect(g.sqlite3()).toBe(false);
-  });
-
-  it("skipActiveRecord implies skipActiveStorage and onward", () => {
+  it("option implications: skipActiveRecord ⇒ skipActiveStorage ⇒ skipActionMailbox/Text", () => {
     const g = build({ skipActiveRecord: true });
     expect(g.skip("ActiveStorage")).toBe(true);
     expect(g.skip("ActionMailbox")).toBe(true);
     expect(g.skip("ActionText")).toBe(true);
-  });
-
-  it("explicit skipActiveStorage=false revokes the implication", () => {
-    const g = build({ skipActiveRecord: true, skipActiveStorage: false });
-    expect(g.skip("ActiveStorage")).toBe(false);
-  });
-
-  it("destinationRoot joins relative appPath, keeps absolute as-is", () => {
-    expect(build({ cwd: "/work", appPath: "blog" }).destinationRoot).toBe("/work/blog");
-    expect(build({ cwd: "/work", appPath: "/elsewhere/blog" }).destinationRoot).toBe(
-      "/elsewhere/blog",
+    expect(build({ skipActiveRecord: true, skipActiveStorage: false }).skip("ActiveStorage")).toBe(
+      false,
     );
-    expect(build({ cwd: "/work", appPath: "blog" }).cwd).toBe("/work/blog");
   });
 
-  it("dependsOnSystemTest false when api or skipTest", () => {
+  it("dependsOnSystemTest false when api or skipTest or skipSystemTest", () => {
     expect(build({ api: true }).dependsOnSystemTest()).toBe(false);
     expect(build({ skipTest: true }).dependsOnSystemTest()).toBe(false);
     expect(build({ skipSystemTest: true }).dependsOnSystemTest()).toBe(false);

--- a/packages/trailties/src/generators/app-base.test.ts
+++ b/packages/trailties/src/generators/app-base.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { AppBase, type AppBaseOptions } from "./app-base.js";
+
+class T extends AppBase {}
+const build = (o: Partial<AppBaseOptions> = {}) =>
+  new T({ cwd: "/tmp/x", output: () => {}, appPath: "myapp", ...o });
+
+describe("AppBase", () => {
+  it("defaults to sqlite3 with keeps and system tests", () => {
+    const g = build();
+    expect(g.sqlite3()).toBe(true);
+    expect(g.database.name).toBe("sqlite3");
+    expect(g.keeps()).toBe(true);
+    expect(g.dependsOnSystemTest()).toBe(true);
+  });
+
+  it("skip(what) reads skip<What> options", () => {
+    const g = build({ skipActionCable: true, skipKeeps: true, devcontainer: true });
+    expect(g.skip("ActionCable")).toBe(true);
+    expect(g.keeps()).toBe(false);
+    expect(g.devcontainer()).toBe(true);
+    expect(g.skipDevcontainer()).toBe(false);
+  });
+
+  it("postgres database delegate", () => {
+    const g = build({ database: "postgresql" });
+    expect(g.database.name).toBe("postgres");
+    expect(g.sqlite3()).toBe(false);
+  });
+
+  it("skipActiveRecord implies skipActiveStorage and onward", () => {
+    const g = build({ skipActiveRecord: true });
+    expect(g.skip("ActiveStorage")).toBe(true);
+    expect(g.skip("ActionMailbox")).toBe(true);
+    expect(g.skip("ActionText")).toBe(true);
+  });
+
+  it("explicit skipActiveStorage=false revokes the implication", () => {
+    const g = build({ skipActiveRecord: true, skipActiveStorage: false });
+    expect(g.skip("ActiveStorage")).toBe(false);
+  });
+
+  it("dependsOnSystemTest false when api or skipTest", () => {
+    expect(build({ api: true }).dependsOnSystemTest()).toBe(false);
+    expect(build({ skipTest: true }).dependsOnSystemTest()).toBe(false);
+    expect(build({ skipSystemTest: true }).dependsOnSystemTest()).toBe(false);
+  });
+});

--- a/packages/trailties/src/generators/app-base.ts
+++ b/packages/trailties/src/generators/app-base.ts
@@ -57,10 +57,11 @@ export abstract class AppBase extends GeneratorBase {
     // Mirrors AppBase#set_default_accessors!: destination_root resolves
     // app_path against the parent destination_root. Subclasses generate
     // into this directory, not the parent cwd.
-    // PathAdapter.isAbsolute is optional; fall back to a POSIX/Win check.
-    const isAbs =
-      this.path.isAbsolute?.(options.appPath) ??
-      (options.appPath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(options.appPath));
+    // PathAdapter.isAbsolute is optional; adapters that omit it (e.g.
+    // in-memory VFS) don't model absolute paths and the contract says
+    // callers should treat the path as absolute — see PathAdapter docs
+    // in activesupport/src/fs-adapter.ts.
+    const isAbs = this.path.isAbsolute ? this.path.isAbsolute(options.appPath) : true;
     this.destinationRoot = isAbs ? options.appPath : this.path.join(options.cwd, options.appPath);
     this.cwd = this.destinationRoot;
     this.options = this.deduceImpliedOptions(options);

--- a/packages/trailties/src/generators/app-base.ts
+++ b/packages/trailties/src/generators/app-base.ts
@@ -9,6 +9,10 @@
 import { GeneratorBase, type GeneratorOptions } from "./base.js";
 import { Database, type DatabaseName } from "./database.js";
 
+// Skip flags consumed by AppBase predicates and OPTION_IMPLICATIONS. The
+// app-generator may pass additional flags (skipDocker, skipGit, etc.);
+// `skip(...)` reads any `skip<X>` field, the union just type-checks the
+// names used here.
 type Skip =
   | "ActiveRecord"
   | "ActiveStorage"
@@ -17,26 +21,20 @@ type Skip =
   | "ActionMailbox"
   | "ActionText"
   | "ActiveJob"
-  | "AssetPipeline"
   | "Javascript"
   | "Hotwire"
-  | "Jbuilder"
+  | "Solid"
   | "Test"
   | "SystemTest"
-  | "Docker"
-  | "Git"
-  | "Keeps"
-  | "Ci"
-  | "Kamal"
-  | "Solid"
-  | "Thruster";
+  | "Keeps";
 
 export type AppBaseOptions = GeneratorOptions & {
   appPath: string;
   database?: DatabaseName;
   api?: boolean;
   devcontainer?: boolean;
-} & { [K in Skip as `skip${K}`]?: boolean };
+  [k: `skip${string}`]: boolean | undefined;
+};
 
 // Mirrors AppBase::OPTION_IMPLICATIONS: meta options activate their
 // implications unless explicitly revoked with `false`.

--- a/packages/trailties/src/generators/app-base.ts
+++ b/packages/trailties/src/generators/app-base.ts
@@ -1,0 +1,105 @@
+// Mirrors railties/lib/rails/generators/app_base.rb. Ports the option
+// surface, predicate helpers, and option-implication propagation. The
+// Ruby gemfile/bundler workflow is intentionally omitted — trailties
+// uses npm/pnpm — and the corresponding Rails methods (bundle_command,
+// run_bundle, run_javascript, run_hotwire, run_kamal,
+// generate_bundler_binstub, target_rails_prerelease, dockerfile_*,
+// rails_gemfile_entry, etc.) are tracked as PR 1.14d follow-ups.
+
+import { GeneratorBase, type GeneratorOptions } from "./base.js";
+import { Database, type DatabaseName } from "./database.js";
+
+type Skip =
+  | "ActiveRecord"
+  | "ActiveStorage"
+  | "ActionCable"
+  | "ActionMailer"
+  | "ActionMailbox"
+  | "ActionText"
+  | "ActiveJob"
+  | "AssetPipeline"
+  | "Javascript"
+  | "Hotwire"
+  | "Jbuilder"
+  | "Test"
+  | "SystemTest"
+  | "Docker"
+  | "Git"
+  | "Keeps"
+  | "Ci"
+  | "Kamal"
+  | "Solid"
+  | "Thruster";
+
+export type AppBaseOptions = GeneratorOptions & {
+  appPath: string;
+  database?: DatabaseName;
+  api?: boolean;
+  devcontainer?: boolean;
+} & { [K in Skip as `skip${K}`]?: boolean };
+
+// Mirrors AppBase::OPTION_IMPLICATIONS: meta options activate their
+// implications unless explicitly revoked with `false`.
+export const OPTION_IMPLICATIONS: Record<string, ReadonlyArray<keyof AppBaseOptions>> = {
+  skipActiveJob: ["skipActionMailer", "skipActiveStorage"],
+  skipActiveRecord: ["skipActiveStorage", "skipSolid"],
+  skipActiveStorage: ["skipActionMailbox", "skipActionText"],
+  skipJavascript: ["skipHotwire"],
+};
+
+export abstract class AppBase extends GeneratorBase {
+  readonly appPath: string;
+  readonly options: AppBaseOptions;
+  private _database?: Database;
+
+  constructor(options: AppBaseOptions) {
+    super(options);
+    this.appPath = options.appPath;
+    this.options = this.deduceImpliedOptions(options);
+  }
+
+  get database(): Database {
+    if (!this._database) this._database = Database.build(this.options.database ?? "sqlite3");
+    return this._database;
+  }
+
+  skip(what: Skip): boolean {
+    return !!this.options[`skip${what}`];
+  }
+  sqlite3(): boolean {
+    return !this.skip("ActiveRecord") && (this.options.database ?? "sqlite3") === "sqlite3";
+  }
+  skipStorage(): boolean {
+    return this.skip("ActiveStorage") && !this.sqlite3();
+  }
+  keeps(): boolean {
+    return !this.skip("Keeps");
+  }
+  devcontainer(): boolean {
+    return !!this.options.devcontainer;
+  }
+  skipDevcontainer(): boolean {
+    return !this.options.devcontainer;
+  }
+  dependsOnSystemTest(): boolean {
+    return !(this.skip("SystemTest") || this.skip("Test") || this.options.api);
+  }
+
+  protected deduceImpliedOptions(opts: AppBaseOptions): AppBaseOptions {
+    const out: Record<string, unknown> = { ...opts };
+    let changed = true;
+    while (changed) {
+      changed = false;
+      for (const [reason, implications] of Object.entries(OPTION_IMPLICATIONS)) {
+        if (out[reason] !== true) continue;
+        for (const impl of implications) {
+          if (out[impl] === undefined) {
+            out[impl] = true;
+            changed = true;
+          }
+        }
+      }
+    }
+    return out as unknown as AppBaseOptions;
+  }
+}

--- a/packages/trailties/src/generators/app-base.ts
+++ b/packages/trailties/src/generators/app-base.ts
@@ -49,12 +49,20 @@ export const OPTION_IMPLICATIONS: Record<string, ReadonlyArray<keyof AppBaseOpti
 
 export abstract class AppBase extends GeneratorBase {
   readonly appPath: string;
+  readonly destinationRoot: string;
   readonly options: AppBaseOptions;
   private _database?: Database;
 
   constructor(options: AppBaseOptions) {
     super(options);
     this.appPath = options.appPath;
+    // Mirrors AppBase#set_default_accessors!: destination_root resolves
+    // app_path against the parent destination_root. Subclasses generate
+    // into this directory, not the parent cwd.
+    this.destinationRoot = options.appPath.startsWith("/")
+      ? options.appPath
+      : this.path.join(options.cwd, options.appPath);
+    this.cwd = this.destinationRoot;
     this.options = this.deduceImpliedOptions(options);
   }
 

--- a/packages/trailties/src/generators/app-base.ts
+++ b/packages/trailties/src/generators/app-base.ts
@@ -57,9 +57,11 @@ export abstract class AppBase extends GeneratorBase {
     // Mirrors AppBase#set_default_accessors!: destination_root resolves
     // app_path against the parent destination_root. Subclasses generate
     // into this directory, not the parent cwd.
-    this.destinationRoot = options.appPath.startsWith("/")
-      ? options.appPath
-      : this.path.join(options.cwd, options.appPath);
+    // PathAdapter.isAbsolute is optional; fall back to a POSIX/Win check.
+    const isAbs =
+      this.path.isAbsolute?.(options.appPath) ??
+      (options.appPath.startsWith("/") || /^[A-Za-z]:[\\/]/.test(options.appPath));
+    this.destinationRoot = isAbs ? options.appPath : this.path.join(options.cwd, options.appPath);
     this.cwd = this.destinationRoot;
     this.options = this.deduceImpliedOptions(options);
   }

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -1,13 +1,26 @@
 import { GeneratorBase, GeneratorOptions } from "./base.js";
+import { Database, type DatabaseName } from "./database.js";
+
+// Legacy adapter shorthand used by the CLI before PR 1.12c. We map it to
+// the Rails-canonical name on entry so downstream code talks to Database.
+const LEGACY_DB_ALIAS: Record<string, DatabaseName> = {
+  sqlite: "sqlite3",
+  postgres: "postgresql",
+  mysql: "mysql",
+};
 
 export interface AppOptions {
-  database: "sqlite" | "postgres" | "mysql";
+  database: "sqlite" | "postgres" | "mysql" | DatabaseName;
   skipDocker?: boolean;
 }
 
 export class AppGenerator extends GeneratorBase {
   constructor(options: GeneratorOptions) {
     super(options);
+  }
+
+  private buildDatabase(name: string): Database {
+    return Database.build(LEGACY_DB_ALIAS[name] ?? name);
   }
 
   async run(name: string, options: AppOptions): Promise<string[]> {
@@ -909,20 +922,14 @@ dist
   }
 
   private dbDependency(db: string): Record<string, string> {
-    switch (db) {
-      case "postgres":
-        return { pg: "^8.19.0" };
-      case "mysql":
-        return { mysql2: "^3.18.0" };
-      case "sqlite":
-      default:
-        return { "better-sqlite3": "^12.6.0" };
-    }
+    const dep = this.buildDatabase(db).pkgDependency;
+    return { [dep.name]: dep.version };
   }
 
   private dbConfig(appName: string, db: string): string {
-    switch (db) {
-      case "postgres":
+    const canonical = LEGACY_DB_ALIAS[db] ?? db;
+    switch (canonical) {
+      case "postgresql":
         return `export default {
   development: {
     adapter: "postgresql",

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -1,12 +1,11 @@
 import { GeneratorBase, GeneratorOptions } from "./base.js";
 import { Database, type DatabaseName } from "./database.js";
 
-// Legacy adapter shorthand used by the CLI before PR 1.12c. We map it to
-// the Rails-canonical name on entry so downstream code talks to Database.
-const LEGACY_DB_ALIAS: Record<string, DatabaseName> = {
+// Legacy adapter shorthand from the pre-1.12c CLI. Mapped to the
+// Rails-canonical name before talking to Database.
+const DB_ALIAS: Record<string, DatabaseName> = {
   sqlite: "sqlite3",
   postgres: "postgresql",
-  mysql: "mysql",
 };
 
 export interface AppOptions {
@@ -17,10 +16,6 @@ export interface AppOptions {
 export class AppGenerator extends GeneratorBase {
   constructor(options: GeneratorOptions) {
     super(options);
-  }
-
-  private buildDatabase(name: string): Database {
-    return Database.build(LEGACY_DB_ALIAS[name] ?? name);
   }
 
   async run(name: string, options: AppOptions): Promise<string[]> {
@@ -922,13 +917,12 @@ dist
   }
 
   private dbDependency(db: string): Record<string, string> {
-    const dep = this.buildDatabase(db).pkgDependency;
+    const dep = Database.build(DB_ALIAS[db] ?? db).pkgDependency;
     return { [dep.name]: dep.version };
   }
 
   private dbConfig(appName: string, db: string): string {
-    const canonical = LEGACY_DB_ALIAS[db] ?? db;
-    switch (canonical) {
+    switch (DB_ALIAS[db] ?? db) {
       case "postgresql":
         return `export default {
   development: {

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -1,15 +1,19 @@
 import { GeneratorBase, GeneratorOptions } from "./base.js";
 import { Database, type DatabaseName } from "./database.js";
 
-// Legacy adapter shorthand from the pre-1.12c CLI. Mapped to the
-// Rails-canonical name before talking to Database.
+// AppGenerator currently scaffolds dbConfig templates only for the three
+// CLI-exposed adapters. Trilogy and the MariaDB variants exist in
+// `database.ts` for parity with Rails' Database hierarchy, but rendering
+// templates for them is deferred to PR 1.14d alongside the AppBase
+// rewrite. Keeping the surface narrow here prevents producing an app
+// scaffold whose `package.json` and `database.ts` disagree.
 const DB_ALIAS: Record<string, DatabaseName> = {
   sqlite: "sqlite3",
   postgres: "postgresql",
 };
 
 export interface AppOptions {
-  database: "sqlite" | "postgres" | "mysql" | DatabaseName;
+  database: "sqlite" | "postgres" | "mysql";
   skipDocker?: boolean;
 }
 

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -2,11 +2,11 @@ import { GeneratorBase, GeneratorOptions } from "./base.js";
 import { Database, type DatabaseName } from "./database.js";
 
 // AppGenerator currently scaffolds dbConfig templates only for the three
-// CLI-exposed adapters. Trilogy and the MariaDB variants exist in
-// `database.ts` for parity with Rails' Database hierarchy, but rendering
-// templates for them is deferred to PR 1.14d alongside the AppBase
-// rewrite. Keeping the surface narrow here prevents producing an app
-// scaffold whose `package.json` and `database.ts` disagree.
+// CLI-exposed adapters. The MariaDB-via-mysql2 variant exists in
+// `database.ts` but rendering a template for it is deferred to PR 1.14d
+// alongside the AppBase rewrite. Keeping the surface narrow here
+// prevents producing an app scaffold whose `package.json` and
+// `database.ts` disagree.
 const DB_ALIAS: Record<string, DatabaseName> = {
   sqlite: "sqlite3",
   postgres: "postgresql",

--- a/packages/trailties/src/generators/database.test.ts
+++ b/packages/trailties/src/generators/database.test.ts
@@ -1,30 +1,14 @@
 import { describe, it, expect } from "vitest";
-import {
-  Database,
-  MySQL2,
-  PostgreSQL,
-  SQLite3,
-  Trilogy,
-  MariaDBMySQL2,
-  MariaDBTrilogy,
-} from "./database.js";
+import { Database, MySQL2, PostgreSQL, SQLite3, MariaDBMySQL2 } from "./database.js";
 
 describe("Database", () => {
   it("build dispatches on name and defaults to sqlite3", () => {
     expect(Database.build("mysql")).toBeInstanceOf(MySQL2);
     expect(Database.build("postgresql")).toBeInstanceOf(PostgreSQL);
     expect(Database.build("sqlite3")).toBeInstanceOf(SQLite3);
-    expect(Database.build("trilogy")).toBeInstanceOf(Trilogy);
     expect(Database.build("mariadb-mysql")).toBeInstanceOf(MariaDBMySQL2);
-    expect(Database.build("mariadb-trilogy")).toBeInstanceOf(MariaDBTrilogy);
     expect(Database.build("unknown")).toBeInstanceOf(SQLite3);
-    expect(Database.all().map((d) => d.name)).toEqual([
-      "mysql",
-      "postgres",
-      "sqlite3",
-      "mariadb",
-      "mariadb",
-    ]);
+    expect(Database.all().map((d) => d.name)).toEqual(["mysql", "postgres", "sqlite3", "mariadb"]);
   });
 
   it("each adapter exposes packages, service, feature, volume", () => {
@@ -43,13 +27,9 @@ describe("Database", () => {
     expect(sl.pkgDependency.name).toBe("better-sqlite3");
   });
 
-  it("trilogy and mariadb variants inherit and override", () => {
-    const tr = new Trilogy();
-    expect(tr.service?.image).toBe("mysql/mysql-server:8.0");
-    expect(tr.pkgDependency.name).toBe("trilogy");
-    expect(tr.basePackage).toBeUndefined();
+  it("mariadb variant overrides name and service", () => {
     expect(new MariaDBMySQL2().name).toBe("mariadb");
     expect(new MariaDBMySQL2().service?.image).toBe("mariadb:10.5");
-    expect(new MariaDBTrilogy().pkgDependency.name).toBe("trilogy");
+    expect(new MariaDBMySQL2().pkgDependency.name).toBe("mysql2");
   });
 });

--- a/packages/trailties/src/generators/database.test.ts
+++ b/packages/trailties/src/generators/database.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  Database,
+  MySQL2,
+  PostgreSQL,
+  SQLite3,
+  Trilogy,
+  MariaDBMySQL2,
+  MariaDBTrilogy,
+} from "./database.js";
+
+describe("Database", () => {
+  it("build dispatches on name", () => {
+    expect(Database.build("mysql")).toBeInstanceOf(MySQL2);
+    expect(Database.build("postgresql")).toBeInstanceOf(PostgreSQL);
+    expect(Database.build("sqlite3")).toBeInstanceOf(SQLite3);
+    expect(Database.build("trilogy")).toBeInstanceOf(Trilogy);
+    expect(Database.build("mariadb-mysql")).toBeInstanceOf(MariaDBMySQL2);
+    expect(Database.build("mariadb-trilogy")).toBeInstanceOf(MariaDBTrilogy);
+    expect(Database.build("unknown")).toBeInstanceOf(SQLite3);
+  });
+
+  it("all returns the five canonical adapters", () => {
+    expect(Database.all().map((d) => d.name)).toEqual([
+      "mysql",
+      "postgres",
+      "sqlite3",
+      "mariadb",
+      "mariadb",
+    ]);
+  });
+
+  it("postgresql packages, service, feature, volume", () => {
+    const db = new PostgreSQL();
+    expect(db.pkgDependency).toEqual({ name: "pg", version: "^8.19.0" });
+    expect(db.basePackage).toBe("postgresql-client");
+    expect(db.port).toBe(5432);
+    expect(db.service?.image).toBe("postgres:16.1");
+    expect(db.volume).toBe("postgres-data");
+    expect(db.feature).toEqual({ "ghcr.io/rails/devcontainer/features/postgres-client": {} });
+  });
+
+  it("sqlite3 has no service or build package", () => {
+    const db = new SQLite3();
+    expect(db.service).toBeUndefined();
+    expect(db.port).toBeUndefined();
+    expect(db.buildPackage).toBeUndefined();
+    expect(db.volume).toBeUndefined();
+    expect(db.pkgDependency.name).toBe("better-sqlite3");
+  });
+
+  it("trilogy keeps MySQL service but drops apt packages and gets its own gem", () => {
+    const db = new Trilogy();
+    expect(db.service?.image).toBe("mysql/mysql-server:8.0");
+    expect(db.pkgDependency.name).toBe("trilogy");
+    expect(db.basePackage).toBeUndefined();
+    expect(db.featureName).toBeUndefined();
+  });
+
+  it("mariadb variants override name and service", () => {
+    expect(new MariaDBMySQL2().name).toBe("mariadb");
+    expect(new MariaDBMySQL2().service?.image).toBe("mariadb:10.5");
+    expect(new MariaDBTrilogy().pkgDependency.name).toBe("trilogy");
+  });
+});

--- a/packages/trailties/src/generators/database.test.ts
+++ b/packages/trailties/src/generators/database.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./database.js";
 
 describe("Database", () => {
-  it("build dispatches on name", () => {
+  it("build dispatches on name and defaults to sqlite3", () => {
     expect(Database.build("mysql")).toBeInstanceOf(MySQL2);
     expect(Database.build("postgresql")).toBeInstanceOf(PostgreSQL);
     expect(Database.build("sqlite3")).toBeInstanceOf(SQLite3);
@@ -18,9 +18,6 @@ describe("Database", () => {
     expect(Database.build("mariadb-mysql")).toBeInstanceOf(MariaDBMySQL2);
     expect(Database.build("mariadb-trilogy")).toBeInstanceOf(MariaDBTrilogy);
     expect(Database.build("unknown")).toBeInstanceOf(SQLite3);
-  });
-
-  it("all returns the five canonical adapters", () => {
     expect(Database.all().map((d) => d.name)).toEqual([
       "mysql",
       "postgres",
@@ -30,34 +27,27 @@ describe("Database", () => {
     ]);
   });
 
-  it("postgresql packages, service, feature, volume", () => {
-    const db = new PostgreSQL();
-    expect(db.pkgDependency).toEqual({ name: "pg", version: "^8.19.0" });
-    expect(db.basePackage).toBe("postgresql-client");
-    expect(db.port).toBe(5432);
-    expect(db.service?.image).toBe("postgres:16.1");
-    expect(db.volume).toBe("postgres-data");
-    expect(db.feature).toEqual({ "ghcr.io/rails/devcontainer/features/postgres-client": {} });
+  it("each adapter exposes packages, service, feature, volume", () => {
+    const pg = new PostgreSQL();
+    expect(pg.pkgDependency).toEqual({ name: "pg", version: "^8.19.0" });
+    expect(pg.basePackage).toBe("postgresql-client");
+    expect(pg.port).toBe(5432);
+    expect(pg.service?.image).toBe("postgres:16.1");
+    expect(pg.volume).toBe("postgres-data");
+    expect(pg.feature).toEqual({ "ghcr.io/rails/devcontainer/features/postgres-client": {} });
+
+    const sl = new SQLite3();
+    expect(sl.service).toBeUndefined();
+    expect(sl.buildPackage).toBeUndefined();
+    expect(sl.volume).toBeUndefined();
+    expect(sl.pkgDependency.name).toBe("better-sqlite3");
   });
 
-  it("sqlite3 has no service or build package", () => {
-    const db = new SQLite3();
-    expect(db.service).toBeUndefined();
-    expect(db.port).toBeUndefined();
-    expect(db.buildPackage).toBeUndefined();
-    expect(db.volume).toBeUndefined();
-    expect(db.pkgDependency.name).toBe("better-sqlite3");
-  });
-
-  it("trilogy keeps MySQL service but drops apt packages and gets its own gem", () => {
-    const db = new Trilogy();
-    expect(db.service?.image).toBe("mysql/mysql-server:8.0");
-    expect(db.pkgDependency.name).toBe("trilogy");
-    expect(db.basePackage).toBeUndefined();
-    expect(db.featureName).toBeUndefined();
-  });
-
-  it("mariadb variants override name and service", () => {
+  it("trilogy and mariadb variants inherit and override", () => {
+    const tr = new Trilogy();
+    expect(tr.service?.image).toBe("mysql/mysql-server:8.0");
+    expect(tr.pkgDependency.name).toBe("trilogy");
+    expect(tr.basePackage).toBeUndefined();
     expect(new MariaDBMySQL2().name).toBe("mariadb");
     expect(new MariaDBMySQL2().service?.image).toBe("mariadb:10.5");
     expect(new MariaDBTrilogy().pkgDependency.name).toBe("trilogy");

--- a/packages/trailties/src/generators/database.ts
+++ b/packages/trailties/src/generators/database.ts
@@ -28,6 +28,16 @@ export interface DockerService {
 }
 
 export abstract class Database {
+  /**
+   * Service/volume identifier — mirrors Rails `Database#name` in
+   * railties/lib/rails/generators/database.rb. This is NOT the same as
+   * the `Database.build` argument or `DatabaseName`: Rails deliberately
+   * exposes `"postgres"` (not `"postgresql"`) so the Docker volume,
+   * service image, and devcontainer feature share an identifier, while
+   * Trilogy keeps `"mysql"` (via `include MySQL`) and the MariaDB
+   * variants surface `"mariadb"`. Use `Database.build(name)` for the
+   * adapter id; use `db.name` for service-layer identity.
+   */
   abstract readonly name: string;
   abstract readonly template: string;
   abstract readonly pkgDependency: PkgDependency;

--- a/packages/trailties/src/generators/database.ts
+++ b/packages/trailties/src/generators/database.ts
@@ -1,8 +1,8 @@
 // Mirrors railties/lib/rails/generators/database.rb. Ports the Database
 // class hierarchy with npm-flavored substitutions (Rails `gem` →
 // `pkgDependency`, base/build packages map to apt packages used in the
-// Dockerfile template). Trilogy and MariaDB variants are kept for parity
-// even though the wave-1 adapter set is sqlite/postgres/mysql.
+// Dockerfile template). Rails uses method definitions; we use readonly
+// class fields for compactness — behavior is identical.
 
 export const DATABASES = [
   "mysql",
@@ -18,6 +18,7 @@ export interface PkgDependency {
   name: string;
   version: string;
 }
+
 export interface DockerService {
   image: string;
   restart: string;
@@ -27,30 +28,16 @@ export interface DockerService {
 }
 
 export abstract class Database {
-  abstract get name(): string;
-  abstract get template(): string;
-  abstract get pkgDependency(): PkgDependency;
-  get basePackage(): string | undefined {
-    return undefined;
-  }
-  get buildPackage(): string | undefined {
-    return undefined;
-  }
-  get featureName(): string | undefined {
-    return undefined;
-  }
-  get service(): DockerService | undefined {
-    return undefined;
-  }
-  get port(): number | undefined {
-    return undefined;
-  }
-  get socket(): string | undefined {
-    return undefined;
-  }
-  get host(): string | undefined {
-    return undefined;
-  }
+  abstract readonly name: string;
+  abstract readonly template: string;
+  abstract readonly pkgDependency: PkgDependency;
+  readonly basePackage?: string;
+  readonly buildPackage?: string;
+  readonly featureName?: string;
+  readonly service?: DockerService;
+  readonly port?: number;
+  readonly socket?: string;
+  readonly host?: string;
 
   get feature(): Record<string, Record<string, never>> | undefined {
     return this.featureName ? { [this.featureName]: {} } : undefined;
@@ -106,118 +93,57 @@ const mariaDBService: DockerService = {
 };
 
 export class MySQL2 extends Database {
-  get name(): string {
-    return "mysql";
-  }
-  get template(): string {
-    return "config/databases/mysql.yml";
-  }
-  get pkgDependency(): PkgDependency {
-    return { name: "mysql2", version: "^3.18.0" };
-  }
-  override get basePackage(): string | undefined {
-    return "default-mysql-client";
-  }
-  override get buildPackage(): string | undefined {
-    return "default-libmysqlclient-dev";
-  }
-  override get featureName(): string | undefined {
-    return "ghcr.io/rails/devcontainer/features/mysql-client";
-  }
-  override get service(): DockerService | undefined {
-    return mysqlService;
-  }
-  override get port(): number | undefined {
-    return 3306;
-  }
-  override get host(): string | undefined {
-    return "127.0.0.1";
-  }
+  readonly name: string = "mysql";
+  readonly template: string = "config/databases/mysql.yml";
+  readonly pkgDependency: PkgDependency = { name: "mysql2", version: "^3.18.0" };
+  override readonly basePackage: string | undefined = "default-mysql-client";
+  override readonly buildPackage: string | undefined = "default-libmysqlclient-dev";
+  override readonly featureName: string | undefined =
+    "ghcr.io/rails/devcontainer/features/mysql-client";
+  override readonly service: DockerService | undefined = mysqlService;
+  override readonly port: number | undefined = 3306;
+  override readonly host: string | undefined = "127.0.0.1";
 }
 
 export class PostgreSQL extends Database {
-  get name(): string {
-    return "postgres";
-  }
-  get template(): string {
-    return "config/databases/postgresql.yml";
-  }
-  get pkgDependency(): PkgDependency {
-    return { name: "pg", version: "^8.19.0" };
-  }
-  override get basePackage(): string | undefined {
-    return "postgresql-client";
-  }
-  override get buildPackage(): string | undefined {
-    return "libpq-dev";
-  }
-  override get featureName(): string | undefined {
-    return "ghcr.io/rails/devcontainer/features/postgres-client";
-  }
-  override get port(): number | undefined {
-    return 5432;
-  }
-  override get service(): DockerService | undefined {
-    return {
-      image: "postgres:16.1",
-      restart: "unless-stopped",
-      networks: ["default"],
-      volumes: ["postgres-data:/var/lib/postgresql/data"],
-      environment: { POSTGRES_USER: "postgres", POSTGRES_PASSWORD: "postgres" },
-    };
-  }
+  readonly name = "postgres";
+  readonly template = "config/databases/postgresql.yml";
+  readonly pkgDependency: PkgDependency = { name: "pg", version: "^8.19.0" };
+  override readonly basePackage = "postgresql-client";
+  override readonly buildPackage = "libpq-dev";
+  override readonly featureName = "ghcr.io/rails/devcontainer/features/postgres-client";
+  override readonly port = 5432;
+  override readonly service: DockerService = {
+    image: "postgres:16.1",
+    restart: "unless-stopped",
+    networks: ["default"],
+    volumes: ["postgres-data:/var/lib/postgresql/data"],
+    environment: { POSTGRES_USER: "postgres", POSTGRES_PASSWORD: "postgres" },
+  };
 }
 
 export class Trilogy extends MySQL2 {
-  override get template(): string {
-    return "config/databases/trilogy.yml";
-  }
-  override get pkgDependency(): PkgDependency {
-    return { name: "trilogy", version: "^2.7.0" };
-  }
-  override get basePackage(): string | undefined {
-    return undefined;
-  }
-  override get buildPackage(): string | undefined {
-    return undefined;
-  }
-  override get featureName(): string | undefined {
-    return undefined;
-  }
+  override readonly template = "config/databases/trilogy.yml";
+  override readonly pkgDependency: PkgDependency = { name: "trilogy", version: "^2.7.0" };
+  override readonly basePackage = undefined;
+  override readonly buildPackage = undefined;
+  override readonly featureName = undefined;
 }
 
 export class SQLite3 extends Database {
-  get name(): string {
-    return "sqlite3";
-  }
-  get template(): string {
-    return "config/databases/sqlite3.yml";
-  }
-  get pkgDependency(): PkgDependency {
-    return { name: "better-sqlite3", version: "^12.6.0" };
-  }
-  override get basePackage(): string | undefined {
-    return "sqlite3";
-  }
-  override get featureName(): string | undefined {
-    return "ghcr.io/rails/devcontainer/features/sqlite3";
-  }
+  readonly name = "sqlite3";
+  readonly template = "config/databases/sqlite3.yml";
+  readonly pkgDependency: PkgDependency = { name: "better-sqlite3", version: "^12.6.0" };
+  override readonly basePackage = "sqlite3";
+  override readonly featureName = "ghcr.io/rails/devcontainer/features/sqlite3";
 }
 
 export class MariaDBMySQL2 extends MySQL2 {
-  override get name(): string {
-    return "mariadb";
-  }
-  override get service(): DockerService | undefined {
-    return mariaDBService;
-  }
+  override readonly name = "mariadb";
+  override readonly service = mariaDBService;
 }
 
 export class MariaDBTrilogy extends Trilogy {
-  override get name(): string {
-    return "mariadb";
-  }
-  override get service(): DockerService | undefined {
-    return mariaDBService;
-  }
+  override readonly name = "mariadb";
+  override readonly service = mariaDBService;
 }

--- a/packages/trailties/src/generators/database.ts
+++ b/packages/trailties/src/generators/database.ts
@@ -1,0 +1,223 @@
+// Mirrors railties/lib/rails/generators/database.rb. Ports the Database
+// class hierarchy with npm-flavored substitutions (Rails `gem` →
+// `pkgDependency`, base/build packages map to apt packages used in the
+// Dockerfile template). Trilogy and MariaDB variants are kept for parity
+// even though the wave-1 adapter set is sqlite/postgres/mysql.
+
+export const DATABASES = [
+  "mysql",
+  "trilogy",
+  "postgresql",
+  "sqlite3",
+  "mariadb-mysql",
+  "mariadb-trilogy",
+] as const;
+export type DatabaseName = (typeof DATABASES)[number];
+
+export interface PkgDependency {
+  name: string;
+  version: string;
+}
+export interface DockerService {
+  image: string;
+  restart: string;
+  environment?: Record<string, string>;
+  volumes?: string[];
+  networks?: string[];
+}
+
+export abstract class Database {
+  abstract get name(): string;
+  abstract get template(): string;
+  abstract get pkgDependency(): PkgDependency;
+  get basePackage(): string | undefined {
+    return undefined;
+  }
+  get buildPackage(): string | undefined {
+    return undefined;
+  }
+  get featureName(): string | undefined {
+    return undefined;
+  }
+  get service(): DockerService | undefined {
+    return undefined;
+  }
+  get port(): number | undefined {
+    return undefined;
+  }
+  get socket(): string | undefined {
+    return undefined;
+  }
+  get host(): string | undefined {
+    return undefined;
+  }
+
+  get feature(): Record<string, Record<string, never>> | undefined {
+    return this.featureName ? { [this.featureName]: {} } : undefined;
+  }
+  get volume(): string | undefined {
+    return this.service ? `${this.name}-data` : undefined;
+  }
+
+  static build(name: string): Database {
+    switch (name) {
+      case "mysql":
+        return new MySQL2();
+      case "postgresql":
+        return new PostgreSQL();
+      case "trilogy":
+        return new Trilogy();
+      case "sqlite3":
+        return new SQLite3();
+      case "mariadb-mysql":
+        return new MariaDBMySQL2();
+      case "mariadb-trilogy":
+        return new MariaDBTrilogy();
+      default:
+        return new SQLite3();
+    }
+  }
+
+  static all(): Database[] {
+    return [
+      new MySQL2(),
+      new PostgreSQL(),
+      new SQLite3(),
+      new MariaDBMySQL2(),
+      new MariaDBTrilogy(),
+    ];
+  }
+}
+
+const mysqlService: DockerService = {
+  image: "mysql/mysql-server:8.0",
+  restart: "unless-stopped",
+  environment: { MYSQL_ALLOW_EMPTY_PASSWORD: "true", MYSQL_ROOT_HOST: "%" },
+  volumes: ["mysql-data:/var/lib/mysql"],
+  networks: ["default"],
+};
+
+const mariaDBService: DockerService = {
+  image: "mariadb:10.5",
+  restart: "unless-stopped",
+  networks: ["default"],
+  volumes: ["mariadb-data:/var/lib/mysql"],
+  environment: { MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "true" },
+};
+
+export class MySQL2 extends Database {
+  get name(): string {
+    return "mysql";
+  }
+  get template(): string {
+    return "config/databases/mysql.yml";
+  }
+  get pkgDependency(): PkgDependency {
+    return { name: "mysql2", version: "^3.18.0" };
+  }
+  override get basePackage(): string | undefined {
+    return "default-mysql-client";
+  }
+  override get buildPackage(): string | undefined {
+    return "default-libmysqlclient-dev";
+  }
+  override get featureName(): string | undefined {
+    return "ghcr.io/rails/devcontainer/features/mysql-client";
+  }
+  override get service(): DockerService | undefined {
+    return mysqlService;
+  }
+  override get port(): number | undefined {
+    return 3306;
+  }
+  override get host(): string | undefined {
+    return "127.0.0.1";
+  }
+}
+
+export class PostgreSQL extends Database {
+  get name(): string {
+    return "postgres";
+  }
+  get template(): string {
+    return "config/databases/postgresql.yml";
+  }
+  get pkgDependency(): PkgDependency {
+    return { name: "pg", version: "^8.19.0" };
+  }
+  override get basePackage(): string | undefined {
+    return "postgresql-client";
+  }
+  override get buildPackage(): string | undefined {
+    return "libpq-dev";
+  }
+  override get featureName(): string | undefined {
+    return "ghcr.io/rails/devcontainer/features/postgres-client";
+  }
+  override get port(): number | undefined {
+    return 5432;
+  }
+  override get service(): DockerService | undefined {
+    return {
+      image: "postgres:16.1",
+      restart: "unless-stopped",
+      networks: ["default"],
+      volumes: ["postgres-data:/var/lib/postgresql/data"],
+      environment: { POSTGRES_USER: "postgres", POSTGRES_PASSWORD: "postgres" },
+    };
+  }
+}
+
+export class Trilogy extends MySQL2 {
+  override get template(): string {
+    return "config/databases/trilogy.yml";
+  }
+  override get pkgDependency(): PkgDependency {
+    return { name: "trilogy", version: "^2.7.0" };
+  }
+  override get basePackage(): string | undefined {
+    return undefined;
+  }
+  override get buildPackage(): string | undefined {
+    return undefined;
+  }
+  override get featureName(): string | undefined {
+    return undefined;
+  }
+}
+
+export class SQLite3 extends Database {
+  get name(): string {
+    return "sqlite3";
+  }
+  get template(): string {
+    return "config/databases/sqlite3.yml";
+  }
+  get pkgDependency(): PkgDependency {
+    return { name: "better-sqlite3", version: "^12.6.0" };
+  }
+  override get basePackage(): string | undefined {
+    return "sqlite3";
+  }
+  override get featureName(): string | undefined {
+    return "ghcr.io/rails/devcontainer/features/sqlite3";
+  }
+}
+
+export class MariaDBMySQL2 extends MySQL2 {
+  override get name(): string {
+    return "mariadb";
+  }
+  override get service(): DockerService | undefined {
+    return mariaDBService;
+  }
+}
+
+export class MariaDBTrilogy extends Trilogy {
+  override get name(): string {
+    return "mariadb";
+  }
+  override get service(): DockerService | undefined {
+    return mariaDBService;
+  }
+}

--- a/packages/trailties/src/generators/database.ts
+++ b/packages/trailties/src/generators/database.ts
@@ -100,7 +100,7 @@ const mariaDBService: DockerService = {
 export class MySQL2 extends Database {
   readonly name: string = "mysql";
   readonly template: string = "config/databases/mysql.yml";
-  readonly pkgDependency: PkgDependency = { name: "mysql2", version: "^3.18.0" };
+  readonly pkgDependency: PkgDependency = { name: "mysql2", version: "^3.18.2" };
   override readonly basePackage: string | undefined = "default-mysql-client";
   override readonly buildPackage: string | undefined = "default-libmysqlclient-dev";
   override readonly featureName: string | undefined =
@@ -138,7 +138,7 @@ export class Trilogy extends MySQL2 {
 export class SQLite3 extends Database {
   readonly name = "sqlite3";
   readonly template = "config/databases/sqlite3.yml";
-  readonly pkgDependency: PkgDependency = { name: "better-sqlite3", version: "^12.6.0" };
+  readonly pkgDependency: PkgDependency = { name: "better-sqlite3", version: "^12.6.2" };
   override readonly basePackage = "sqlite3";
   override readonly featureName = "ghcr.io/rails/devcontainer/features/sqlite3";
 }

--- a/packages/trailties/src/generators/database.ts
+++ b/packages/trailties/src/generators/database.ts
@@ -1,17 +1,11 @@
 // Mirrors railties/lib/rails/generators/database.rb. Ports the Database
 // class hierarchy with npm-flavored substitutions (Rails `gem` →
 // `pkgDependency`, base/build packages map to apt packages used in the
-// Dockerfile template). Rails uses method definitions; we use readonly
-// class fields for compactness — behavior is identical.
+// Dockerfile template). Trilogy is intentionally omitted — it's a
+// Ruby-only mysql driver with no Node equivalent — so the set here is
+// mysql / postgresql / sqlite3 plus the MariaDB-via-mysql2 variant.
 
-export const DATABASES = [
-  "mysql",
-  "trilogy",
-  "postgresql",
-  "sqlite3",
-  "mariadb-mysql",
-  "mariadb-trilogy",
-] as const;
+export const DATABASES = ["mysql", "postgresql", "sqlite3", "mariadb-mysql"] as const;
 export type DatabaseName = (typeof DATABASES)[number];
 
 export interface PkgDependency {
@@ -34,9 +28,8 @@ export abstract class Database {
    * the `Database.build` argument or `DatabaseName`: Rails deliberately
    * exposes `"postgres"` (not `"postgresql"`) so the Docker volume,
    * service image, and devcontainer feature share an identifier, while
-   * Trilogy keeps `"mysql"` (via `include MySQL`) and the MariaDB
-   * variants surface `"mariadb"`. Use `Database.build(name)` for the
-   * adapter id; use `db.name` for service-layer identity.
+   * the MariaDB variant surfaces `"mariadb"`. Use `Database.build(name)`
+   * for the adapter id; use `db.name` for service-layer identity.
    */
   abstract readonly name: string;
   abstract readonly template: string;
@@ -62,32 +55,17 @@ export abstract class Database {
         return new MySQL2();
       case "postgresql":
         return new PostgreSQL();
-      case "trilogy":
-        return new Trilogy();
       case "sqlite3":
         return new SQLite3();
       case "mariadb-mysql":
         return new MariaDBMySQL2();
-      case "mariadb-trilogy":
-        return new MariaDBTrilogy();
       default:
         return new SQLite3();
     }
   }
 
-  // Mirrors Rails' Database.all in railties/lib/rails/generators/database.rb:
-  // intentionally returns five adapters and excludes plain Trilogy — Rails
-  // ships Trilogy in DATABASES (`rails new -d trilogy`) but does not list
-  // it among the introspectable adapters returned here. Do not derive this
-  // from DATABASES.
   static all(): Database[] {
-    return [
-      new MySQL2(),
-      new PostgreSQL(),
-      new SQLite3(),
-      new MariaDBMySQL2(),
-      new MariaDBTrilogy(),
-    ];
+    return [new MySQL2(), new PostgreSQL(), new SQLite3(), new MariaDBMySQL2()];
   }
 }
 
@@ -137,14 +115,6 @@ export class PostgreSQL extends Database {
   };
 }
 
-export class Trilogy extends MySQL2 {
-  override readonly template = "config/databases/trilogy.yml";
-  override readonly pkgDependency: PkgDependency = { name: "trilogy", version: "^2.7.0" };
-  override readonly basePackage = undefined;
-  override readonly buildPackage = undefined;
-  override readonly featureName = undefined;
-}
-
 export class SQLite3 extends Database {
   readonly name = "sqlite3";
   readonly template = "config/databases/sqlite3.yml";
@@ -154,11 +124,6 @@ export class SQLite3 extends Database {
 }
 
 export class MariaDBMySQL2 extends MySQL2 {
-  override readonly name = "mariadb";
-  override readonly service = mariaDBService;
-}
-
-export class MariaDBTrilogy extends Trilogy {
   override readonly name = "mariadb";
   override readonly service = mariaDBService;
 }

--- a/packages/trailties/src/generators/database.ts
+++ b/packages/trailties/src/generators/database.ts
@@ -65,6 +65,11 @@ export abstract class Database {
     }
   }
 
+  // Mirrors Rails' Database.all in railties/lib/rails/generators/database.rb:
+  // intentionally returns five adapters and excludes plain Trilogy — Rails
+  // ships Trilogy in DATABASES (`rails new -d trilogy`) but does not list
+  // it among the introspectable adapters returned here. Do not derive this
+  // from DATABASES.
   static all(): Database[] {
     return [
       new MySQL2(),

--- a/packages/trailties/src/generators/index.ts
+++ b/packages/trailties/src/generators/index.ts
@@ -21,6 +21,20 @@ export type { AttrOptions, IndexType } from "./generated-attribute.js";
 // CreateMigration action deferred to a 1.12b follow-up PR to stay under the
 // 300 LOC ceiling — see docs/trailties-plan.md.
 export { ActiveModel } from "./active-model.js";
+export { AppBase } from "./app-base.js";
+export type { AppBaseOptions } from "./app-base.js";
+export { OPTION_IMPLICATIONS } from "./app-base.js";
+export {
+  Database,
+  MySQL2,
+  PostgreSQL,
+  Trilogy,
+  SQLite3,
+  MariaDBMySQL2,
+  MariaDBTrilogy,
+  DATABASES,
+} from "./database.js";
+export type { DatabaseName, PkgDependency, DockerService } from "./database.js";
 export * from "./migration.js";
 export * from "./model-helpers.js";
 export * from "./resource-helpers.js";

--- a/packages/trailties/src/generators/index.ts
+++ b/packages/trailties/src/generators/index.ts
@@ -24,16 +24,7 @@ export { ActiveModel } from "./active-model.js";
 export { AppBase } from "./app-base.js";
 export type { AppBaseOptions } from "./app-base.js";
 export { OPTION_IMPLICATIONS } from "./app-base.js";
-export {
-  Database,
-  MySQL2,
-  PostgreSQL,
-  Trilogy,
-  SQLite3,
-  MariaDBMySQL2,
-  MariaDBTrilogy,
-  DATABASES,
-} from "./database.js";
+export { Database, MySQL2, PostgreSQL, SQLite3, MariaDBMySQL2, DATABASES } from "./database.js";
 export type { DatabaseName, PkgDependency, DockerService } from "./database.js";
 export * from "./migration.js";
 export * from "./model-helpers.js";

--- a/packages/trailties/src/generators/migration-generator.test.ts
+++ b/packages/trailties/src/generators/migration-generator.test.ts
@@ -30,7 +30,7 @@ describe("MigrationGeneratorTest", () => {
     const gen = makeGen();
     const files = gen.run("change_title_body_from_posts", []);
     expect(files.length).toBe(1);
-    expect(files[0]).toMatch(/^db\/migrations\/\d{14}-change-title-body-from-posts\.ts$/);
+    expect(files[0]).toMatch(/^db\/migrations\/\d{14}_change_title_body_from_posts\.ts$/);
     const content = readMigration(files);
     expect(content).toContain("class ChangeTitleBodyFromPosts extends Migration");
   });
@@ -40,8 +40,8 @@ describe("MigrationGeneratorTest", () => {
     const gen2 = makeGen();
     const files1 = gen1.run("change_title_body_from_posts", []);
     const files2 = gen2.run("change_email_from_comments", []);
-    const ts1 = path.basename(files1[0]).split("-")[0];
-    const ts2 = path.basename(files2[0]).split("-")[0];
+    const ts1 = path.basename(files1[0]).split("_")[0];
+    const ts2 = path.basename(files2[0]).split("_")[0];
     expect(ts1).not.toBe(ts2);
   });
 

--- a/packages/trailties/src/generators/migration-generator.ts
+++ b/packages/trailties/src/generators/migration-generator.ts
@@ -3,8 +3,8 @@ import {
   GeneratorOptions,
   migrationTimestamp,
   classify,
-  dasherize,
   tableize,
+  underscore,
   ColumnType,
 } from "./base.js";
 import { pluralize, singularize } from "@blazetrails/activesupport";
@@ -226,7 +226,7 @@ export class MigrationGenerator extends GeneratorBase {
     }
     lastTimestamp = timestamp;
     const ext = this.ext();
-    const filename = `db/migrations/${timestamp}-${dasherize(name)}${ext}`;
+    const filename = `db/migrations/${timestamp}_${underscore(name)}${ext}`;
     const ts = this.isTypeScript();
     const returnType = ts ? ": Promise<void>" : "";
 

--- a/packages/trailties/src/migration-loader.test.ts
+++ b/packages/trailties/src/migration-loader.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { discoverMigrations } from "./migration-loader.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-loader-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const write = (name: string) => fs.writeFileSync(path.join(tmpDir, name), "export class M {}");
+
+describe("discoverMigrations", () => {
+  it("loads underscore-named migrations (Rails-faithful)", async () => {
+    write("20260101000000_create_posts.ts");
+    write("20260102000000_add_email_to_users.ts");
+    const found = await discoverMigrations(tmpDir);
+    expect(found.map((m) => `${m.version}:${m.name}`)).toEqual([
+      "20260101000000:create_posts",
+      "20260102000000:add_email_to_users",
+    ]);
+  });
+
+  it("loads hyphen-named migrations as a transitional alias", async () => {
+    write("20260101000000-create-posts.ts");
+    const found = await discoverMigrations(tmpDir);
+    expect(found).toHaveLength(1);
+    expect(found[0]!.version).toBe("20260101000000");
+  });
+
+  it("collapses hyphen and underscore variants of the same migration, preferring underscore", async () => {
+    write("20260101000000-create-posts.ts");
+    write("20260101000000_create_posts.ts");
+    const found = await discoverMigrations(tmpDir);
+    expect(found).toHaveLength(1);
+    expect(path.basename(found[0]!.filename!)).toBe("20260101000000_create_posts.ts");
+  });
+
+  it("prefers .ts over .js when both exist for the same migration", async () => {
+    write("20260101000000_create_posts.ts");
+    write("20260101000000_create_posts.js");
+    const found = await discoverMigrations(tmpDir);
+    expect(found).toHaveLength(1);
+    expect(path.basename(found[0]!.filename!)).toBe("20260101000000_create_posts.ts");
+  });
+});

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -16,14 +16,22 @@ const MIGRATION_FILE_PATTERN = /^(\d+)[_-](.+)\.(ts|js)$/;
  * Supports both .ts and .js migration files. When both exist for the same
  * migration, .ts is preferred (source of truth over compiled output).
  *
- * Files match: {timestamp}-{name}.ts or .js (e.g., 20260318120000-create-users.ts)
+ * Files match: {timestamp}_{name}.ts or .js (Rails-faithful underscore form;
+ * the hyphen form is accepted as a pre-1.12c transitional alias).
  */
 export async function discoverMigrations(migrationsDir: string): Promise<MigrationProxy[]> {
   if (!fs.existsSync(migrationsDir)) {
     return [];
   }
 
-  const rawFiles = fs.readdirSync(migrationsDir).filter((f) => MIGRATION_FILE_PATTERN.test(f));
+  // Sort the directory listing so dedupe is deterministic regardless of
+  // readdir order. Underscore (`_`, 0x5F) sorts after hyphen (`-`, 0x2D),
+  // so iterating in sorted order means an underscore variant overwrites
+  // the hyphen alias as a deterministic tie-break.
+  const rawFiles = fs
+    .readdirSync(migrationsDir)
+    .filter((f) => MIGRATION_FILE_PATTERN.test(f))
+    .sort();
 
   // Deduplicate by canonical version_name (underscore form), preferring
   // .ts over .js. The hyphen alias is transitional; we collapse `-` and
@@ -40,8 +48,14 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
       continue;
     }
 
-    // Prefer .ts (source) over .js (compiled)
-    if (path.extname(existing) === ".js" && ext === ".ts") {
+    const existingExt = path.extname(existing);
+    const existingSep = existing.match(/^\d+([_-])/)![1];
+    const fileSep = file.match(/^\d+([_-])/)![1];
+    // Prefer .ts (source) over .js (compiled); at equal extension,
+    // prefer the canonical underscore separator over the hyphen alias.
+    if (existingExt === ".js" && ext === ".ts") {
+      byBasename.set(basename, file);
+    } else if (existingExt === ext && existingSep === "-" && fileSep === "_") {
       byBasename.set(basename, file);
     }
   }

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -40,7 +40,12 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
   for (const file of rawFiles) {
     const ext = path.extname(file);
     const m = file.match(MIGRATION_FILE_PATTERN)!;
-    const basename = `${m[1]}_${m[2]}`;
+    // Canonicalize both the separator and the name segment: pre-1.12c
+    // generated dasherized names ("change-title-body-from-posts") while
+    // post-1.12c uses underscored names ("change_title_body_from_posts"),
+    // so collapsing `-` to `_` in the name keeps a renamed migration
+    // from double-loading.
+    const basename = `${m[1]}_${m[2].replace(/-/g, "_")}`;
     const existing = byBasename.get(basename);
 
     if (!existing) {

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -3,9 +3,10 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { MigrationProxy } from "@blazetrails/activerecord";
 
-// Rails uses `<timestamp>_<name>.rb` (railties/lib/rails/generators/migration.rb).
-// trailties matches the underscore form; the pre-1.12c hyphen form is accepted
-// as a transitional alias so apps generated against earlier PRs still load.
+// Rails uses `<timestamp>_<name>` (railties/lib/rails/generators/migration.rb).
+// trailties scaffolds in TS/JS, so the extension set is `ts|js` (no `rb`).
+// The pre-1.12c hyphen form is accepted as a transitional alias so apps
+// generated against earlier PRs still load.
 const MIGRATION_FILE_PATTERN = /^(\d+)[_-](.+)\.(ts|js)$/;
 
 /**

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -3,7 +3,10 @@ import * as path from "node:path";
 import { pathToFileURL } from "node:url";
 import type { MigrationProxy } from "@blazetrails/activerecord";
 
-const MIGRATION_FILE_PATTERN = /^(\d+)-(.+)\.(ts|js)$/;
+// Rails uses `<timestamp>_<name>.rb` (railties/lib/rails/generators/migration.rb).
+// trailties matches the underscore form; the pre-1.12c hyphen form is accepted
+// as a transitional alias so apps generated against earlier PRs still load.
+const MIGRATION_FILE_PATTERN = /^(\d+)[_-](.+)\.(ts|js)$/;
 
 /**
  * Discover migration files from a directory and return MigrationProxy objects

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -25,11 +25,14 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
 
   const rawFiles = fs.readdirSync(migrationsDir).filter((f) => MIGRATION_FILE_PATTERN.test(f));
 
-  // Deduplicate by basename (version-name), preferring .ts over .js
+  // Deduplicate by canonical version_name (underscore form), preferring
+  // .ts over .js. The hyphen alias is transitional; we collapse `-` and
+  // `_` variants of the same migration so a rename doesn't double-load.
   const byBasename = new Map<string, string>();
   for (const file of rawFiles) {
     const ext = path.extname(file);
-    const basename = file.slice(0, -ext.length);
+    const m = file.match(MIGRATION_FILE_PATTERN)!;
+    const basename = `${m[1]}_${m[2]}`;
     const existing = byBasename.get(basename);
 
     if (!existing) {

--- a/packages/trailties/src/migration-loader.ts
+++ b/packages/trailties/src/migration-loader.ts
@@ -25,9 +25,9 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
   }
 
   // Sort the directory listing so dedupe is deterministic regardless of
-  // readdir order. Underscore (`_`, 0x5F) sorts after hyphen (`-`, 0x2D),
-  // so iterating in sorted order means an underscore variant overwrites
-  // the hyphen alias as a deterministic tie-break.
+  // readdir order. Precedence inside the dedupe loop is: extension first
+  // (.ts beats .js), then separator (underscore beats hyphen alias) when
+  // the extensions are equal.
   const rawFiles = fs
     .readdirSync(migrationsDir)
     .filter((f) => MIGRATION_FILE_PATTERN.test(f))
@@ -73,7 +73,10 @@ export async function discoverMigrations(migrationsDir: string): Promise<Migrati
     if (!match) continue;
 
     const version = match[1];
-    const name = match[2];
+    // Canonicalize the proxy name to the underscore form so
+    // Migrator.validate()'s duplicate-name check sees hyphen-alias and
+    // underscore-form migrations as the same logical name.
+    const name = match[2]!.replace(/-/g, "_");
     const filePath = path.join(migrationsDir, file);
 
     proxies.push({


### PR DESCRIPTION
## Summary

PR 1.12c. Ports `railties/lib/rails/generators/app_base.rb` predicates + option-implication propagation, and `railties/lib/rails/generators/database.rb` (Database hierarchy) with npm-flavored substitutions (Rails `gem` → `pkgDependency`). Trilogy is intentionally omitted — it's a Ruby-only mysql driver with no Node equivalent — so the adapter set is `mysql` / `postgresql` / `sqlite3` / `mariadb-mysql`.

- `packages/trailties/src/generators/app-base.ts` — `AppBase` with `destinationRoot` (mirrors `set_default_accessors!`), `database` delegate, predicates (`sqlite3`, `skip(what)`, `skipStorage`, `keeps`, `devcontainer`, `skipDevcontainer`, `dependsOnSystemTest`), and `OPTION_IMPLICATIONS` with forward-propagation revocation.
- `packages/trailties/src/generators/database.ts` — `Database`, `MySQL2`, `PostgreSQL`, `SQLite3`, `MariaDBMySQL2`, plus `Database.build` / `Database.all`. Class fields (vs Ruby methods) for compactness; behavior identical.
- Refactor: `app-generator.ts#dbDependency` delegates to `Database.build(...).pkgDependency`; `dbConfig` switches on the canonical Rails name. The full extension-to-`AppBase` rewrite is deferred to PR 1.14d per the plan doc.

## Migration filename separator: `-` → `_`

PR 1.12b's `currentMigrationNumber` / `migrationLookupAt` helpers match `^[0-9].*_.*\.(ts|js|rb)$` (Rails-faithful). The existing `MigrationGenerator` wrote `<timestamp>-<name>` (hyphen), which never appeared in `migrationLookupAt`. Aligned `MigrationGenerator` to underscore — this is a behavior change for any pre-1.12c-generated apps, but they cannot yet exist in production. `discoverMigrations` accepts both forms as a transitional alias and canonicalizes `MigrationProxy.name` to the underscore form so duplicate-name validation collapses the two. `destroy migration <name>` matches both forms with an anchored regex `^\d+[_-]<name>\.(ts|js)$`.

## Rails sources

- `railties/lib/rails/generators/app_base.rb`
- `railties/lib/rails/generators/database.rb`

## Rails methods skipped (tracked as PR 1.14d follow-ups)

- `gemfile_entries`, `*_gemfile_entry`, `bundle_command`, `run_bundle`, `run_javascript`, `run_hotwire`, `run_kamal`, `run_solid`, `run_css`, `target_rails_prerelease`, `generate_bundler_binstub`, `add_bundler_platforms`, `rails_gemfile_entry`, `GemfileEntry`
- `dockerfile_*` helpers, `ci_packages`, `required_railties`, `rails_require_statement`
- `imply_options` / `report_implied_options` user-facing error reporting (forward propagation lives in `deduceImpliedOptions`; full TSort revocation deferred)
- `git_init_command` (handled by the app-template DSL `git` action)
- `Trilogy` / `MariaDBTrilogy` / `"trilogy"` / `"mariadb-trilogy"` — no Node equivalent, dropped from the port

## Test plan

- [x] `pnpm vitest run packages/trailties/src/{generators/{database,app-base,migration-generator,app-generator,model-generator,scaffold-generator},migration-loader,commands/db,commands/destroy}.test.ts` — all green
- [x] `pnpm exec tsc --noEmit` clean for the touched files

## Non-blocking follow-ups (PR 1.14d)

- Tighten `AppBaseOptions`' `skip<X>` index signature once the full set is enumerated.
- `Database.build("unknown") → SQLite3` matches Rails but masks typos; consider `buildStrict` or a warning.
- `app-base.test.ts` and `migration-loader.test.ts` hard-code POSIX paths / use `node:fs|path|os` — convert to `getFs()` / `getPath()` adapters in the 1.14d async-fs sweep.
