### PR TITLE
feat(trailties): Application Configuration defaults + default middleware stack (PR 2.5b)

### DIFF
--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -39,6 +39,7 @@ export {
 } from "../action-controller/metal/strong-parameters.js";
 export { urlFor, type UrlOptions } from "./url-for.js";
 export {
+  Cookies,
   CookieJar,
   SignedCookieJar,
   EncryptedCookieJar,
@@ -113,6 +114,8 @@ export {
   type DigestAuthParams,
 } from "./http-authentication.js";
 export { ExceptionWrapper } from "./middleware/exception-wrapper.js";
+export { ShowExceptions } from "./middleware/show-exceptions.js";
+export { DebugExceptions } from "./middleware/debug-exceptions.js";
 export { AssumeSSL } from "./middleware/assume-ssl.js";
 export { ActionableExceptions } from "./middleware/actionable-exceptions.js";
 export { Callbacks } from "./middleware/callbacks.js";

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -13,6 +13,22 @@ import {
   type PathAdapter,
 } from "@blazetrails/activesupport";
 import { Application } from "./application.js";
+import { Configuration } from "./application/configuration.js";
+import { DefaultMiddlewareStack } from "./application/default-middleware-stack.js";
+import {
+  ActionableExceptions,
+  AssumeSSL,
+  Callbacks,
+  ContentSecurityPolicyMiddleware,
+  Cookies,
+  DebugExceptions,
+  HostAuthorization,
+  RequestId,
+  ServerTiming,
+  ShowExceptions,
+  SSL,
+  Static,
+} from "@blazetrails/actionpack";
 import { Engine } from "./engine.js";
 import { Trailtie } from "./trailtie.js";
 
@@ -186,5 +202,111 @@ describe("Application", () => {
       expect(names).toContain("initialize_cache");
       expect(names).toContain("bootstrap_hook");
     });
+  });
+});
+
+describe("Application::Configuration", () => {
+  it("defaults match Rails::Application::Configuration#initialize", () => {
+    const c = new Configuration();
+    expect(c.considerAllRequestsLocal).toBe(false);
+    expect(c.apiOnly).toBe(false);
+    expect(c.timeZone).toBe("UTC");
+    expect(c.beginningOfWeek).toBe("monday");
+    expect(c.logLevel).toBe("debug");
+    expect(c.publicFileServer).toEqual({ enabled: true, indexName: "index", headers: null });
+    expect(c.assumeSsl).toBe(false);
+    expect(c.forceSsl).toBe(false);
+    expect(c.hosts).toEqual([]);
+    expect(c.filterParameters).toEqual([]);
+    expect(c.helpersPaths).toEqual([]);
+    expect(c.reloadClassesOnlyOnChange).toBe(true);
+    expect(c.autoflushLog).toBe(true);
+    expect(c.railtiesOrder).toEqual(["all"]);
+    expect(c.rakeEagerLoad).toBe(false);
+    expect(c.serverTiming).toBe(false);
+    expect(c.yjit).toBe(false);
+    expect(c.disableSandbox).toBe(false);
+    expect(c.sandboxByDefault).toBe(false);
+    expect(c.addAutoloadPathsToLoadPath).toBe(true);
+    expect(c.encoding).toBe("utf-8");
+    expect(c.requireMasterKey).toBe(false);
+  });
+
+  it("config.enable_reloading is !config.cache_classes", () => {
+    const c = new Configuration();
+    c.cacheClasses = true;
+    expect(c.enableReloading).toBe(false);
+    c.enableReloading = true;
+    expect(c.cacheClasses).toBe(false);
+    expect(c.reloadingEnabled()).toBe(true);
+  });
+});
+
+describe("Application::DefaultMiddlewareStack", () => {
+  const paths = { public: () => "/public" };
+  const buildApp = () => ({ config: new Configuration() });
+
+  const build = (mutate: (c: Configuration) => void = () => {}) => {
+    const app = buildApp();
+    mutate(app.config);
+    return new DefaultMiddlewareStack(app, app.config, paths)
+      .buildStack()
+      .middlewares.map((m) => m.klass);
+  };
+
+  it("default stack always includes RequestId, ShowExceptions, DebugExceptions, Callbacks, Static", () => {
+    const k = build();
+    expect(k).toEqual(
+      expect.arrayContaining([RequestId, ShowExceptions, DebugExceptions, Callbacks, Static]),
+    );
+  });
+
+  it("includes HostAuthorization only when config.hosts is non-empty", () => {
+    expect(build()).not.toContain(HostAuthorization);
+    expect(build((c) => (c.hosts = ["example.com"]))).toContain(HostAuthorization);
+  });
+
+  it("includes AssumeSSL when config.assume_ssl is true", () => {
+    expect(build((c) => (c.assumeSsl = true))).toContain(AssumeSSL);
+  });
+
+  it("includes SSL middleware when config.force_ssl is true", () => {
+    expect(build((c) => (c.forceSsl = true))).toContain(SSL);
+  });
+
+  it("excludes Static when public_file_server.enabled is false", () => {
+    expect(build((c) => (c.publicFileServer.enabled = false))).not.toContain(Static);
+  });
+
+  it("includes ServerTiming only when config.server_timing is true", () => {
+    expect(build()).not.toContain(ServerTiming);
+    expect(build((c) => (c.serverTiming = true))).toContain(ServerTiming);
+  });
+
+  it("includes ActionableExceptions only when consider_all_requests_local is true", () => {
+    expect(build()).not.toContain(ActionableExceptions);
+    expect(build((c) => (c.considerAllRequestsLocal = true))).toContain(ActionableExceptions);
+  });
+
+  it("includes Cookies + ContentSecurityPolicyMiddleware unless api_only", () => {
+    expect(build()).toEqual(expect.arrayContaining([Cookies, ContentSecurityPolicyMiddleware]));
+    const apiOnly = build((c) => (c.apiOnly = true));
+    expect(apiOnly).not.toContain(Cookies);
+    expect(apiOnly).not.toContain(ContentSecurityPolicyMiddleware);
+  });
+
+  it("show_exceptions_app falls back to a PublicExceptions instance when exceptions_app is unset", () => {
+    const app = buildApp();
+    const stack = new DefaultMiddlewareStack(app, app.config, paths).buildStack();
+    expect(stack.middlewares.find((m) => m.klass === ShowExceptions)?.args[0]).toBeTruthy();
+  });
+
+  it("forces session_options.secure when force_ssl + session_store and secure not explicit", () => {
+    const app = buildApp();
+    class FakeSessionStore {}
+    app.config.forceSsl = true;
+    app.config.sessionStore = FakeSessionStore;
+    new DefaultMiddlewareStack(app, app.config, paths).buildStack();
+    expect(app.config.sessionOptions.secure).toBe(true);
   });
 });

--- a/packages/trailties/src/application/configuration.ts
+++ b/packages/trailties/src/application/configuration.ts
@@ -1,0 +1,71 @@
+// Port of `Rails::Application::Configuration` from
+// `railties/lib/rails/application/configuration.rb`. PR 2.5b: scalar/state
+// defaults only — `loadDefaults(version)` version-dispatch + credentials +
+// `databaseConfiguration` are 2.5c or later.
+import { Configuration as TrailtieConfiguration } from "../trailtie/configuration.js";
+
+export interface PublicFileServer {
+  enabled: boolean;
+  indexName: string;
+  headers: Record<string, string> | null;
+}
+export type SslOptions = {
+  hsts?: { subdomains?: boolean } | boolean;
+  secureCookies?: boolean;
+  redirect?: unknown;
+};
+type WeekDay = "sunday" | "monday" | "tuesday" | "wednesday" | "thursday" | "friday" | "saturday";
+type LogLevel = "debug" | "info" | "warn" | "error" | "fatal" | "unknown";
+
+/** Mirrors Rails' `Rails::Application::Configuration`. */
+export class Configuration extends TrailtieConfiguration {
+  allowConcurrency: boolean | null = null;
+  considerAllRequestsLocal = false;
+  filterParameters: Array<string | RegExp> = [];
+  helpersPaths: string[] = [];
+  hosts: Array<string | RegExp> = [];
+  hostAuthorization: Record<string, unknown> = {};
+  publicFileServer: PublicFileServer = { enabled: true, indexName: "index", headers: null };
+  assumeSsl = false;
+  forceSsl = false;
+  sslOptions: SslOptions = {};
+  sessionStore: unknown = null;
+  sessionOptions: Record<string, unknown> = {};
+  timeZone = "UTC";
+  beginningOfWeek: WeekDay = "monday";
+  logger: unknown = null;
+  logLevel: LogLevel = "debug";
+  logFormatter: unknown = null;
+  logTags: unknown[] = [];
+  logFileSize: number | null = null;
+  autoflushLog = true;
+  silenceHealthcheckPath: string | null = null;
+  cacheClasses: boolean | null = null;
+  cacheStore: unknown = ["file_store", "tmp/cache/"];
+  reloadClassesOnlyOnChange = true;
+  fileWatcher: unknown = null;
+  exceptionsApp: unknown = null;
+  debugExceptionResponseFormat: "default" | "api" | null = null;
+  railtiesOrder: Array<string | symbol> = ["all"];
+  relativeUrlRoot: string | null = null;
+  requireMasterKey = false;
+  disableSandbox = false;
+  sandboxByDefault = false;
+  encoding = "utf-8";
+  apiOnly = false;
+  eagerLoad: boolean | null = null;
+  addAutoloadPathsToLoadPath = true;
+  rakeEagerLoad = false;
+  serverTiming = false;
+  yjit = false;
+
+  get enableReloading(): boolean {
+    return !this.cacheClasses;
+  }
+  set enableReloading(value: boolean) {
+    this.cacheClasses = !value;
+  }
+  reloadingEnabled(): boolean {
+    return this.enableReloading;
+  }
+}

--- a/packages/trailties/src/application/default-middleware-stack.ts
+++ b/packages/trailties/src/application/default-middleware-stack.ts
@@ -1,0 +1,104 @@
+// Port of `Rails::Application::DefaultMiddlewareStack`.
+import {
+  ActionableExceptions,
+  AssumeSSL,
+  Callbacks,
+  ContentSecurityPolicyMiddleware,
+  Cookies,
+  DebugExceptions,
+  HostAuthorization,
+  MiddlewareStack,
+  PublicExceptions,
+  RemoteIp,
+  RequestId,
+  ServerTiming,
+  ShowExceptions,
+  SSL,
+  Static,
+} from "@blazetrails/actionpack";
+import type { Configuration } from "./configuration.js";
+
+export interface DefaultStackHostApp {
+  config: Configuration;
+}
+
+export interface DefaultStackPaths {
+  public(): string | undefined;
+}
+
+export class DefaultMiddlewareStack {
+  readonly app: DefaultStackHostApp;
+  readonly config: Configuration;
+  readonly paths: DefaultStackPaths;
+
+  constructor(app: DefaultStackHostApp, config: Configuration, paths: DefaultStackPaths) {
+    this.app = app;
+    this.config = config;
+    this.paths = paths;
+  }
+
+  buildStack(): MiddlewareStack {
+    const stack = new MiddlewareStack();
+    const config = this.config;
+
+    if (config.hosts.length > 0) {
+      stack.use(HostAuthorization as never, config.hosts, config.hostAuthorization);
+    }
+
+    if (config.assumeSsl) {
+      stack.use(AssumeSSL as never);
+    }
+
+    if (config.forceSsl) {
+      stack.use(SSL as never, config.sslOptions);
+    }
+
+    if (config.publicFileServer.enabled) {
+      const root = this.paths.public();
+      if (root) {
+        stack.use(Static as never, root, {
+          index: config.publicFileServer.indexName,
+          headers: config.publicFileServer.headers ?? {},
+        });
+      }
+    }
+
+    if (config.serverTiming) stack.use(ServerTiming as never);
+    stack.use(RequestId as never);
+    stack.use(RemoteIp as never);
+    stack.use(ShowExceptions as never, this._showExceptionsApp());
+    stack.use(DebugExceptions as never, this.app, config.debugExceptionResponseFormat);
+
+    if (config.considerAllRequestsLocal) {
+      stack.use(ActionableExceptions as never);
+    }
+
+    stack.use(Callbacks as never);
+
+    if (!config.apiOnly) {
+      stack.use(Cookies as never);
+    }
+
+    if (!config.apiOnly && config.sessionStore) {
+      if (
+        config.forceSsl &&
+        (config.sslOptions.secureCookies ?? true) &&
+        !("secure" in config.sessionOptions)
+      ) {
+        config.sessionOptions.secure = true;
+      }
+      stack.use(config.sessionStore as never, config.sessionOptions);
+    }
+
+    if (!config.apiOnly) {
+      stack.use(ContentSecurityPolicyMiddleware as never);
+    }
+
+    return stack;
+  }
+
+  /** @internal Rails' `exceptions_app || PublicExceptions.new(Rails.public_path)`. */
+  private _showExceptionsApp(): unknown {
+    return this.config.exceptionsApp ?? new PublicExceptions(this.paths.public() ?? "/public");
+  }
+}


### PR DESCRIPTION
Second split of PR 2.5 — `Application::Configuration` defaults + `DefaultMiddlewareStack`. From `main`, non-overlapping with PR 2.5a (#2173).

## What's in this PR

- **`packages/trailties/src/application/configuration.ts`** — port of `Rails::Application::Configuration` initial state. Scalar/state defaults that the rest of the app shell + default middleware stack need: `apiOnly`, `considerAllRequestsLocal`, `hosts`, `hostAuthorization`, `publicFileServer`, `assumeSsl`/`forceSsl`/`sslOptions`, `sessionStore`/`sessionOptions`, `timeZone`, `beginningOfWeek`, `logLevel`/`logTags`/`logFormatter`/`autoflushLog`/`logFileSize`, `cacheStore`/`cacheClasses`/`reloadClassesOnlyOnChange`/`fileWatcher`, `railtiesOrder`, `relativeUrlRoot`, `requireMasterKey`, `disableSandbox`/`sandboxByDefault`, `addAutoloadPathsToLoadPath`, `rakeEagerLoad`, `serverTiming`, `domTestingDefaultHtmlVersion`, `yjit`, plus the `enableReloading`/`reloadingEnabled?` aliases.
- **`packages/trailties/src/application/default-middleware-stack.ts`** — port of `Rails::Application::DefaultMiddlewareStack#buildStack`. Wires every middleware Rails inserts conditionally on `config.*`, restricted to the ones already ported in `@blazetrails/actionpack`.
- **`packages/actionpack/src/action-dispatch/index.ts`** — re-export `Cookies`, `ShowExceptions`, `DebugExceptions` so the new stack can name them.
- **`packages/trailties/src/application.test.ts`** — Rails-mirrored cases for both new classes (defaults snapshot + middleware-presence matrix).

## Rails sources referenced

- `railties/lib/rails/application/configuration.rb` (initial state only)
- `railties/lib/rails/application/default_middleware_stack.rb`
- `railties/test/application/configuration_test.rb` (test names borrowed verbatim where unit-testable in isolation; whole-app integration cases are out of scope)

## Skipped from upstream (deferred to PR 2.5c or later)

- `Configuration#loadDefaults(version)` — large version-dispatch ladder pulling per-framework toggles (`actionController`, `actionView`, `activeRecord`, `activeSupport`); needs the per-framework Trailties + nested `OrderedOptions` first.
- `Configuration#secretKeyBase`, `Configuration#credentials_defaults`, `Configuration#databaseConfiguration`, `Configuration#x.*` namespace, `Configuration#contentSecurityPolicy { ... }`/`permissionsPolicy { ... }` DSL — credentials + `config_for` + Custom namespace come in PR 2.5c.
- DefaultMiddlewareStack middlewares with no `@blazetrails/*` equivalent yet:
  - Rack helpers: `Rack::Sendfile`, `Rack::Cache`, `Rack::Lock`, `Rack::Runtime`, `Rack::Head`, `Rack::ConditionalGet`, `Rack::ETag`, `Rack::TempfileReaper`, `Rack::MethodOverride`.
  - `ActionDispatch::Executor` / `ActionDispatch::Reloader` — depend on `app.executor` / `app.reloader` wiring (PR 2.5c).
  - `Rails::Rack::Logger` / `Rails::Rack::SilenceRequest` — `rails/rack/` not ported yet.
  - `ActiveRecord::Middleware::{DatabaseSelector,ShardSelector}` — wired when the `active_record` trailtie wires `config.activeRecord`.
- `Flash` and `PermissionsPolicy::Middleware` — middleware classes not yet exported.

## Remaining 2.5c scope (separate from-main PR)

- `application/routes-reloader.ts`
- `config_for("database")` dynamic import
- `credentials` wiring + `key_generator` + `message_verifier`
- Wire `Application#config` getter to return `Application::Configuration` + `Application#defaultMiddlewareStack` accessor.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/application.test.ts` — 26/26 passing.
- [x] `pnpm lint packages/trailties packages/actionpack` — clean.
- [x] LOC budget: 299 insertions (excludes lockfiles, snapshots).