### PR TITLE
feat(activerecord): PG bind-path `type_casted_binds` infra (TM Phase 9b-2d, partial)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1111,10 +1111,7 @@ export function highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#type_casted_binds
  */
-export function typeCastedBinds(
-  binds: unknown[] | undefined,
-  typeCast?: (value: unknown) => unknown,
-): unknown[] {
+export function typeCastedBinds(binds: unknown[] | undefined): unknown[] {
   return (binds ?? []).map((b: any) => {
     // Rails: `ActiveModel::Attribute === value ? type_cast(value.value_for_database) : type_cast(value)`
     // valueForDatabase is a getter on real Attribute instances; handle both getter and
@@ -1126,7 +1123,7 @@ export function typeCastedBinds(
     } else {
       v = b && typeof b === "object" && "value" in b ? b.value : b;
     }
-    return typeCast ? typeCast(v) : temporalToBindString(v);
+    return temporalToBindString(v);
   });
 }
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1111,7 +1111,10 @@ export function highPrecisionCurrentTimestamp(): Nodes.SqlLiteral {
  *
  * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#type_casted_binds
  */
-export function typeCastedBinds(binds: unknown[] | undefined): unknown[] {
+export function typeCastedBinds(
+  binds: unknown[] | undefined,
+  typeCast?: (value: unknown) => unknown,
+): unknown[] {
   return (binds ?? []).map((b: any) => {
     // Rails: `ActiveModel::Attribute === value ? type_cast(value.value_for_database) : type_cast(value)`
     // valueForDatabase is a getter on real Attribute instances; handle both getter and
@@ -1123,7 +1126,7 @@ export function typeCastedBinds(binds: unknown[] | undefined): unknown[] {
     } else {
       v = b && typeof b === "object" && "value" in b ? b.value : b;
     }
-    return temporalToBindString(v);
+    return typeCast ? typeCast(v) : temporalToBindString(v);
   });
 }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -703,7 +703,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // Type-cast bind objects (QueryAttribute) → primitives, then run each
     // through `_bindForPg` for Temporal / BinaryData normalization before
     // pg sees them.
-    const bindArray = typeCastedBinds(binds, (v) => this._bindForPg(v));
+    const bindArray = typeCastedBinds(binds).map((v) => this._bindForPg(v));
     const rewritten = this.rewriteBinds(sql, bindArray);
     this._noticeReceiverSqlWarnings = [];
     const payload: Record<string, unknown> = {
@@ -1114,7 +1114,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     name: string,
     binds: unknown[],
   ): Promise<Result> {
-    const bindArray = typeCastedBinds(binds, (v) => this._bindForPg(v));
+    const bindArray = typeCastedBinds(binds).map((v) => this._bindForPg(v));
     const rewritten = this.rewriteBinds(sql, bindArray);
     this._noticeReceiverSqlWarnings = [];
     const payload: Record<string, unknown> = {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,5 +1,5 @@
 import pg from "pg";
-import { type Type, ValueType, ArgumentError, BinaryData } from "@blazetrails/activemodel";
+import { type Type, ValueType, ArgumentError } from "@blazetrails/activemodel";
 import {
   singularize,
   underscore,
@@ -2525,7 +2525,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * @internal
    */
   private _bindForPg(value: unknown): unknown {
-    if (value instanceof BinaryData) return this.typeCast(value);
+    // Duck-type BinaryData detection: instanceof would silently miss across
+    // module-identity splits (e.g. duplicated @blazetrails/activemodel copies
+    // in the dep tree), in which case the wrapper would slip past as a plain
+    // object and pg would JSON.stringify it. Checking the Uint8Array `bytes`
+    // shape directly is robust to that.
+    if (
+      value !== null &&
+      typeof value === "object" &&
+      (value as { bytes?: unknown }).bytes instanceof Uint8Array &&
+      !(value instanceof Uint8Array)
+    ) {
+      return Buffer.from((value as { bytes: Uint8Array }).bytes);
+    }
     return temporalToBindString(value, "postgres");
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1607,7 +1607,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // re-EXPLAIN'd. Bind values pass through to pg as the values
       // array so `EXPLAIN` with parameters doesn't error with
       // "there is no parameter $1".
-      const pgBinds = binds.map((v) => temporalToBindString(v, "postgres"));
+      const pgBinds = binds.map((v) => this._bindForPg(v));
       const rewritten = this.rewriteBinds(sql, pgBinds);
       const result = await client.query(`${clause} ${rewritten}`, pgBinds);
       const printer = new ExplainPrettyPrinter();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2514,14 +2514,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * Normalize a single bind value before handing it to node-postgres.
    *
    * BinaryData wrappers (produced by `Type::Binary::Data`-shape serializers
-   * like `EncryptedAttributeType` on binary columns) are unwrapped via
-   * `typeCast` to a Buffer so pg binds them as bytea; pg has no built-in
-   * coercion for BinaryData and would `JSON.stringify` it otherwise,
-   * corrupting bytes 128–255 (the PG-only encryption binary round-trip
-   * failure surfaced by Phase 9b-1). Other values flow through
-   * `temporalToBindString` for Temporal / infinity sentinel handling.
+   * like `EncryptedAttributeType` on binary columns) are unwrapped to a
+   * Buffer so pg binds them as bytea; pg has no built-in coercion for
+   * BinaryData and would `JSON.stringify` it otherwise, corrupting bytes
+   * 128–255 (the PG-only encryption binary round-trip failure surfaced
+   * by Phase 9b-1). Other values flow through `temporalToBindString` for
+   * Temporal / infinity sentinel handling.
    *
    * Mirrors Rails' `type_casted_binds` calling `type_cast` per value.
+   * Detection is duck-typed (`bytes: Uint8Array`) rather than delegating
+   * to `this.typeCast` so the gate survives split module identity in the
+   * dep tree (`pgTypeCast`'s `instanceof BinaryData` check would silently
+   * miss when the encryption module and the adapter resolve different
+   * copies of `@blazetrails/activemodel`).
    * @internal
    */
   private _bindForPg(value: unknown): unknown {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1,5 +1,5 @@
 import pg from "pg";
-import { type Type, ValueType, ArgumentError } from "@blazetrails/activemodel";
+import { type Type, ValueType, ArgumentError, BinaryData } from "@blazetrails/activemodel";
 import {
   singularize,
   underscore,
@@ -700,10 +700,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       fields: Array<{ name: string; dataTypeID: number }>;
       rows: unknown[][];
     }
-    // Type-cast bind objects (QueryAttribute) → primitives, then convert
-    // Temporal values to SQL strings before pg sees them.
-    const castBinds = typeCastedBinds(binds);
-    const bindArray = castBinds.map((v) => temporalToBindString(v, "postgres"));
+    // Type-cast bind objects (QueryAttribute) → primitives, then run each
+    // through `_bindForPg` for Temporal / BinaryData normalization before
+    // pg sees them.
+    const bindArray = typeCastedBinds(binds, (v) => this._bindForPg(v));
     const rewritten = this.rewriteBinds(sql, bindArray);
     this._noticeReceiverSqlWarnings = [];
     const payload: Record<string, unknown> = {
@@ -1114,8 +1114,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     name: string,
     binds: unknown[],
   ): Promise<Result> {
-    const castBinds = typeCastedBinds(binds);
-    const bindArray = castBinds.map((v) => temporalToBindString(v, "postgres"));
+    const bindArray = typeCastedBinds(binds, (v) => this._bindForPg(v));
     const rewritten = this.rewriteBinds(sql, bindArray);
     this._noticeReceiverSqlWarnings = [];
     const payload: Record<string, unknown> = {
@@ -1197,7 +1196,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   ): Promise<Record<string, unknown>[]> {
     this.checkIfWriteQuery(sql);
     await this.materializeTransactions();
-    binds = binds.map((v) => temporalToBindString(v, "postgres"));
+    binds = binds.map((v) => this._bindForPg(v));
     const rewritten = this.rewriteBinds(sql, binds);
     // payload.sql is the rewritten SQL (`$1` not `?`) so ExplainSubscriber
     // stores something that can be re-EXPLAIN'd on the same adapter
@@ -1240,7 +1239,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async executeMutation(sql: string, binds: unknown[] = [], name: string = "SQL"): Promise<number> {
     this.checkIfWriteQuery(sql);
     await this.materializeTransactions();
-    binds = binds.map((v) => temporalToBindString(v, "postgres"));
+    binds = binds.map((v) => this._bindForPg(v));
     const pgSql = this.rewriteBinds(sql, binds);
     this._noticeReceiverSqlWarnings = [];
     // payload.sql records the rewritten SQL — ExplainSubscriber captures
@@ -2509,6 +2508,25 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   override typeCast(value: unknown): unknown {
     return pgTypeCast(value);
+  }
+
+  /**
+   * Normalize a single bind value before handing it to node-postgres.
+   *
+   * BinaryData wrappers (produced by `Type::Binary::Data`-shape serializers
+   * like `EncryptedAttributeType` on binary columns) are unwrapped via
+   * `typeCast` to a Buffer so pg binds them as bytea; pg has no built-in
+   * coercion for BinaryData and would `JSON.stringify` it otherwise,
+   * corrupting bytes 128–255 (the PG-only encryption binary round-trip
+   * failure surfaced by Phase 9b-1). Other values flow through
+   * `temporalToBindString` for Temporal / infinity sentinel handling.
+   *
+   * Mirrors Rails' `type_casted_binds` calling `type_cast` per value.
+   * @internal
+   */
+  private _bindForPg(value: unknown): unknown {
+    if (value instanceof BinaryData) return this.typeCast(value);
+    return temporalToBindString(value, "postgres");
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2541,7 +2541,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       (value as { bytes?: unknown }).bytes instanceof Uint8Array &&
       !(value instanceof Uint8Array)
     ) {
-      return Buffer.from((value as { bytes: Uint8Array }).bytes);
+      const u8 = (value as { bytes: Uint8Array }).bytes;
+      return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
     }
     return temporalToBindString(value, "postgres");
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.test.ts
@@ -35,8 +35,13 @@ describe("PostgreSQL quoting", () => {
     expect(quoteIdentifier('foo"bar')).toBe('"foo""bar"');
   });
 
-  it("type casts binary data using the PG binary bind shape", () => {
-    expect(typeCast(new BinaryData("hello"))).toEqual({ value: "hello", format: 1 });
+  it("type casts binary data to a Buffer for node-postgres bytea binding", () => {
+    // node-postgres natively binds Buffer as bytea (hex literal in text mode).
+    // Returning a Buffer preserves bytes 128–255 that the prior
+    // `{ value: value.toString(), format: 1 }` shape corrupted via UTF-8 decode.
+    const cast = typeCast(new BinaryData(new Uint8Array([0xde, 0xad, 0xbe, 0xef])));
+    expect(Buffer.isBuffer(cast)).toBe(true);
+    expect(Array.from(cast as Buffer)).toEqual([0xde, 0xad, 0xbe, 0xef]);
   });
 
   it("quotes PostgreSQL OID wrapper values before delegating other values", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -213,10 +213,18 @@ export function quoteDefaultExpression(
 export function typeCast(value: unknown): unknown {
   if (value instanceof BinaryData) {
     // node-postgres binds Buffer as bytea natively (text-format hex literal).
-    // Returning a Buffer of the raw bytes preserves bytes 128–255 that the
-    // prior `value.toString()` path corrupted via UTF-8 decode — the source
-    // of the PG-only encryption binary round-trip failures.
-    return Buffer.from(value.bytes);
+    // Returning a Buffer over the existing ArrayBuffer preserves bytes
+    // 128–255 that the prior `value.toString()` path corrupted via UTF-8
+    // decode — the source of the PG-only encryption binary round-trip
+    // failures — without allocating a copy for potentially large
+    // encrypted payloads. Note: Rails' PG adapter returns
+    // `{ value: value.to_s, format: 1 }` here; that bind-param hash is a
+    // pg-ruby contract (binary format mode), and node-postgres does not
+    // honor it (a `{value, format}` object is JSON-stringified into
+    // garbage). The Rails-equivalent functional behavior in this driver
+    // is a bare Buffer.
+    const u8 = value.bytes;
+    return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
   }
   if (value instanceof Uint8Array) return value;
   if (value instanceof XmlData || value instanceof BitData) {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -212,8 +212,13 @@ export function quoteDefaultExpression(
 
 export function typeCast(value: unknown): unknown {
   if (value instanceof BinaryData) {
-    return { value: value.toString(), format: 1 } satisfies BinaryBind;
+    // node-postgres binds Buffer as bytea natively (text-format hex literal).
+    // Returning a Buffer of the raw bytes preserves bytes 128–255 that the
+    // prior `value.toString()` path corrupted via UTF-8 decode — the source
+    // of the PG-only encryption binary round-trip failures.
+    return Buffer.from(value.bytes);
   }
+  if (value instanceof Uint8Array) return value;
   if (value instanceof XmlData || value instanceof BitData) {
     return value.toString();
   }

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -213,15 +213,17 @@ export function quoteDefaultExpression(
 export function typeCast(value: unknown): unknown {
   if (value instanceof BinaryData) {
     // node-postgres binds Buffer as bytea natively (text-format hex literal).
-    // Returning a Buffer of the raw bytes preserves bytes 128–255 that the
-    // prior `value.toString()` path corrupted via UTF-8 decode — the source
-    // of the PG-only encryption binary round-trip failures. Rails' PG
-    // adapter returns `{ value: value.to_s, format: 1 }` here; that
-    // bind-param hash is a pg-ruby contract (binary format mode), and
-    // node-postgres does not honor it (a `{value, format}` object is
-    // JSON-stringified into garbage). The Rails-equivalent functional
-    // behavior in this driver is a bare Buffer.
-    return Buffer.from(value.bytes);
+    // Returning a Buffer over the existing Uint8Array preserves bytes
+    // 128–255 that the prior `value.toString()` path corrupted via UTF-8
+    // decode, and matches MySQL `quotedBinary`'s view-form treatment of
+    // Uint8Array at `mysql/quoting.ts:97-98`. Rails' PG adapter returns
+    // `{ value: value.to_s, format: 1 }` here; that bind-param hash is a
+    // pg-ruby contract (binary format mode), and node-postgres does not
+    // honor it (a `{value, format}` object is JSON-stringified into
+    // garbage). The Rails-equivalent functional behavior in this driver
+    // is a bare Buffer.
+    const u8 = value.bytes;
+    return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
   }
   if (value instanceof Uint8Array) return value;
   if (value instanceof XmlData || value instanceof BitData) {

--- a/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/quoting.ts
@@ -213,18 +213,15 @@ export function quoteDefaultExpression(
 export function typeCast(value: unknown): unknown {
   if (value instanceof BinaryData) {
     // node-postgres binds Buffer as bytea natively (text-format hex literal).
-    // Returning a Buffer over the existing ArrayBuffer preserves bytes
-    // 128–255 that the prior `value.toString()` path corrupted via UTF-8
-    // decode — the source of the PG-only encryption binary round-trip
-    // failures — without allocating a copy for potentially large
-    // encrypted payloads. Note: Rails' PG adapter returns
-    // `{ value: value.to_s, format: 1 }` here; that bind-param hash is a
-    // pg-ruby contract (binary format mode), and node-postgres does not
-    // honor it (a `{value, format}` object is JSON-stringified into
-    // garbage). The Rails-equivalent functional behavior in this driver
-    // is a bare Buffer.
-    const u8 = value.bytes;
-    return Buffer.from(u8.buffer, u8.byteOffset, u8.byteLength);
+    // Returning a Buffer of the raw bytes preserves bytes 128–255 that the
+    // prior `value.toString()` path corrupted via UTF-8 decode — the source
+    // of the PG-only encryption binary round-trip failures. Rails' PG
+    // adapter returns `{ value: value.to_s, format: 1 }` here; that
+    // bind-param hash is a pg-ruby contract (binary format mode), and
+    // node-postgres does not honor it (a `{value, format}` object is
+    // JSON-stringified into garbage). The Rails-equivalent functional
+    // behavior in this driver is a bare Buffer.
+    return Buffer.from(value.bytes);
   }
   if (value instanceof Uint8Array) return value;
   if (value instanceof XmlData || value instanceof BitData) {

--- a/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
@@ -8,7 +8,7 @@ import {
   makeMsgPackTextBook,
   assertEncryptedAttribute,
 } from "./test-helpers.js";
-import { type TestDatabaseAdapter, adapterType } from "../test-adapter.js";
+import { type TestDatabaseAdapter } from "../test-adapter.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { Encoding as EncodingError } from "./errors.js";
 
@@ -31,34 +31,23 @@ describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest",
     restoreEncryptionConfig(configSnapshot);
   });
 
-  // Phase 9b-1: PG bytea round-trip for encrypted binary columns produces
-  // invalid JSON in the decryptor. Same Category B follow-up as 9a's SQLite
-  // skips — encryption type/serialize layer needs to route writes through
-  // type.serialize so the encrypted string reaches adapter.quote, not the
-  // EncryptedMessage object. Tracked alongside the 9a follow-up.
-  it.skipIf(adapterType === "postgres")(
-    "binary data can be serialized with message pack",
-    async () => {
-      const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
-      const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
-      const book = await Book.create({ logo: allBytes });
-      await assertEncryptedAttribute(book, "logo", allBytes);
-    },
-  );
+  it("binary data can be serialized with message pack", async () => {
+    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
+    const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
+    const book = await Book.create({ logo: allBytes });
+    await assertEncryptedAttribute(book, "logo", allBytes);
+  });
 
-  it.skipIf(adapterType === "postgres")(
-    "binary data can be encrypted uncompressed and serialized with message pack",
-    async () => {
-      const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
-      // Rails: both ranges are 128 bytes (< 140 threshold) so neither is compressed.
-      // TS note: highBytes (128–255) encoded as Latin-1 measures as 256 UTF-8 bytes so
-      // it may be compressed; the round-trip is correct either way.
-      const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
-      const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
-      await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
-      await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
-    },
-  );
+  it("binary data can be encrypted uncompressed and serialized with message pack", async () => {
+    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
+    // Rails: both ranges are 128 bytes (< 140 threshold) so neither is compressed.
+    // TS note: highBytes (128–255) encoded as Latin-1 measures as 256 UTF-8 bytes so
+    // it may be compressed; the round-trip is correct either way.
+    const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
+    const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
+    await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
+    await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
+  });
 
   it("text columns cannot be serialized with message pack", async () => {
     const MsgPackTextBook = makeMsgPackTextBook(adapter);

--- a/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
@@ -8,7 +8,7 @@ import {
   makeMsgPackTextBook,
   assertEncryptedAttribute,
 } from "./test-helpers.js";
-import { type TestDatabaseAdapter } from "../test-adapter.js";
+import { type TestDatabaseAdapter, adapterType } from "../test-adapter.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { Encoding as EncodingError } from "./errors.js";
 
@@ -31,23 +31,34 @@ describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest",
     restoreEncryptionConfig(configSnapshot);
   });
 
-  it("binary data can be serialized with message pack", async () => {
-    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
-    const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
-    const book = await Book.create({ logo: allBytes });
-    await assertEncryptedAttribute(book, "logo", allBytes);
-  });
+  // Phase 9b-2d: PG bytea round-trip of encrypted binary attributes is still
+  // broken after the bind-path fix in this PR. Write completes; reload's
+  // decrypt fails at `JSON.parse` on the Latin-1-decoded bytes — bytes
+  // stored ≠ bytes sent. Needs reproduction against a live PG instance to
+  // diagnose. Tracked as the remaining Phase 9b-2 follow-up.
+  it.skipIf(adapterType === "postgres")(
+    "binary data can be serialized with message pack",
+    async () => {
+      const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
+      const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
+      const book = await Book.create({ logo: allBytes });
+      await assertEncryptedAttribute(book, "logo", allBytes);
+    },
+  );
 
-  it("binary data can be encrypted uncompressed and serialized with message pack", async () => {
-    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
-    // Rails: both ranges are 128 bytes (< 140 threshold) so neither is compressed.
-    // TS note: highBytes (128–255) encoded as Latin-1 measures as 256 UTF-8 bytes so
-    // it may be compressed; the round-trip is correct either way.
-    const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
-    const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
-    await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
-    await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
-  });
+  it.skipIf(adapterType === "postgres")(
+    "binary data can be encrypted uncompressed and serialized with message pack",
+    async () => {
+      const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
+      // Rails: both ranges are 128 bytes (< 140 threshold) so neither is compressed.
+      // TS note: highBytes (128–255) encoded as Latin-1 measures as 256 UTF-8 bytes so
+      // it may be compressed; the round-trip is correct either way.
+      const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
+      const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
+      await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
+      await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
+    },
+  );
 
   it("text columns cannot be serialized with message pack", async () => {
     const MsgPackTextBook = makeMsgPackTextBook(adapter);

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -31,7 +31,6 @@ import { Configurable } from "./configurable.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { EncryptableRecord } from "./encryptable-record.js";
 import { isEncryptedAttribute } from "../encryption.js";
-import { adapterType } from "../test-adapter.js";
 
 describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
@@ -593,11 +592,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     expect((await Book.create({ logo: null })).logo).toBeNull();
     expect((await Book.create({ logo: new Uint8Array(0) })).logo).toEqual(new Uint8Array(0));
   });
-  // Phase 9b-1: PG bytea round-trip of encrypted binary attributes — see
-  // encryptable-record-message-pack-serialized.test.ts for the shared
-  // follow-up. The compressed variant above passes because its assertion
-  // is in-memory only.
-  it.skipIf(adapterType === "postgres")("binary data can be encrypted uncompressed", async () => {
+  it("binary data can be encrypted uncompressed", async () => {
     const Book = makeEncryptedBookWithBinary(await freshAdapter());
     const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
     const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -31,6 +31,7 @@ import { Configurable } from "./configurable.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { EncryptableRecord } from "./encryptable-record.js";
 import { isEncryptedAttribute } from "../encryption.js";
+import { adapterType } from "../test-adapter.js";
 
 describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
@@ -592,7 +593,14 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     expect((await Book.create({ logo: null })).logo).toBeNull();
     expect((await Book.create({ logo: new Uint8Array(0) })).logo).toEqual(new Uint8Array(0));
   });
-  it("binary data can be encrypted uncompressed", async () => {
+  // Phase 9b-2d: PG bytea round-trip of encrypted binary attributes is still
+  // broken even after routing the bind path through `_bindForPg` (BinaryData
+  // → Buffer for node-postgres). Write completes; reload's decrypt fails at
+  // `JSON.parse` on the Latin-1-decoded bytes from PG, meaning the bytes
+  // stored ≠ bytes sent. Needs reproduction against a live PG instance to
+  // diagnose (suspect pg-node param encoding for bytea). Tracked as the
+  // remaining Phase 9b-2 follow-up.
+  it.skipIf(adapterType === "postgres")("binary data can be encrypted uncompressed", async () => {
     const Book = makeEncryptedBookWithBinary(await freshAdapter());
     const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
     const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);


### PR DESCRIPTION
## Summary

**Scope reduced from original goal.** The original target was unblocking 3 encryption binary tests still skipped on PG after 9b-1. This PR ships the bind-path infrastructure that should be the foundation of the fix — but two CI rounds confirmed it doesn't actually unblock the round-trip on PG. Without a local PG instance I can't diagnose further. Restoring the `it.skipIf(adapterType === "postgres")` markers with sharper rationale; the round-trip gap stays open as the final 9b-2 follow-up.

## What this PR does ship

- Adds a private `_bindForPg(value)` on `PostgreSQLAdapter` that duck-types `BinaryData` (Uint8Array-bearing wrapper from `Type::Binary::Data`-shape serializers like `EncryptedAttributeType`) and unwraps to a `Buffer` so pg can bind it as bytea. Without this, pg `JSON.stringify`s the wrapper. Duck-typing rather than `instanceof` to survive split `@blazetrails/activemodel` module identity in the dep tree.
- Wires `_bindForPg` at every PG bind boundary — `executeArray`, `execute`, `executeMutation`, `_instrumentedQueryOnClient`, and `explain()` — so the contract is consistent. This mirrors Rails' `type_casted_binds` calling `type_cast` per bind on every adapter path.
- Updates `pgTypeCast(BinaryData)` to return `Buffer.from(value.bytes)` (was `{ value: value.toString(), format: 1 }`, a pg-ruby bind-hash contract that node-postgres doesn't honor — would be JSON-stringified into garbage). Documented inline.

## What this PR does NOT fix

- PG bytea round-trip of encrypted binary attributes. CI confirms `Book.create({logo: bytes})` completes (write reaches pg) but `Book.reload()` fails decryption — `JSON.parse` on the Latin-1-decoded bytes throws. Bytes stored ≠ bytes sent.
- The 3 tests stay skipped on PG with a sharper rationale comment pointing at the open gap:
  - `encryptable-record.test.ts > binary data can be encrypted uncompressed`
  - `encryptable-record-message-pack-serialized.test.ts > binary data can be serialized with message pack`
  - `encryptable-record-message-pack-serialized.test.ts > binary data can be encrypted uncompressed and serialized with message pack`

## Diagnosis state for the follow-up

Suspect node-postgres param encoding for bytea (it should accept `Buffer` natively as bytea and emit `\\x{hex}` in the text-protocol bind, but somehow round-trip corrupts). Needs a live PG instance to instrument the actual bind frame and the bytes pg stores. Same code path on SQLite works (290 tests green, including the same encryption binary round-trips when SQLite is the adapter), so the gap is PG-specific.

## Test plan

- [x] `pnpm exec vitest run packages/activerecord/src/encryption/` clean on SQLite (30 files, 289 pass, 1 unrelated skip)
- [x] `pnpm api:compare --package activerecord` delta non-negative (4956/4958, unchanged)
- [x] `pnpm test:compare --package activerecord` delta non-negative (6669/7870, unchanged)
- [ ] PG + MariaDB clean via CI (the 3 PG-blocked tests are skipped again so CI should now go green)