### PR TITLE
feat(trailties): credentials/master_key/encrypted_file/encryption_key_file generators (PR 1.14a)

### DIFF
--- a/packages/trailties/src/generators/rails/credentials/credentials-generator.test.ts
+++ b/packages/trailties/src/generators/rails/credentials/credentials-generator.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { EncryptedFile } from "@blazetrails/activesupport/encrypted-file";
+import { CredentialsGenerator } from "./credentials-generator.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-creds-"));
+  fs.mkdirSync(path.join(tmpDir, "config"));
+  fs.writeFileSync(path.join(tmpDir, "config/master.key"), EncryptedFile.generateKey(), {
+    mode: 0o600,
+  });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const read = (): Promise<string> =>
+  new EncryptedFile({
+    contentPath: path.join(tmpDir, "config/credentials.yml.enc"),
+    keyPath: path.join(tmpDir, "config/master.key"),
+    envKey: "RAILS_MASTER_KEY",
+    raiseIfMissingKey: true,
+  }).read();
+
+describe("CredentialsGeneratorTest", () => {
+  it("add_credentials_file writes encrypted credentials with secret_key_base", async () => {
+    await new CredentialsGenerator({ cwd: tmpDir, output: () => {} }).addCredentialsFile();
+    const content = await read();
+    expect(content).toContain("# aws:");
+    expect(content).toMatch(/secret_key_base: [0-9a-f]{128}/);
+  });
+
+  it("add_credentials_file with skip_secret_key_base omits secret_key_base and is idempotent", async () => {
+    await new CredentialsGenerator({
+      cwd: tmpDir,
+      output: () => {},
+      skipSecretKeyBase: true,
+    }).addCredentialsFile();
+    expect(await read()).not.toContain("secret_key_base:");
+    const before = fs.readFileSync(path.join(tmpDir, "config/credentials.yml.enc"));
+    await new CredentialsGenerator({ cwd: tmpDir, output: () => {} }).addCredentialsFile();
+    expect(fs.readFileSync(path.join(tmpDir, "config/credentials.yml.enc"))).toEqual(before);
+  });
+});

--- a/packages/trailties/src/generators/rails/credentials/credentials-generator.ts
+++ b/packages/trailties/src/generators/rails/credentials/credentials-generator.ts
@@ -1,0 +1,68 @@
+import { EncryptedFile } from "@blazetrails/activesupport/encrypted-file";
+import { getCrypto } from "@blazetrails/activesupport";
+import { GeneratorBase, type GeneratorOptions } from "../../base.js";
+
+export interface CredentialsGeneratorOptions extends GeneratorOptions {
+  contentPath?: string;
+  keyPath?: string;
+  skipSecretKeyBase?: boolean;
+}
+
+export class CredentialsGenerator extends GeneratorBase {
+  readonly contentPath: string;
+  readonly keyPath: string;
+  readonly skipSecretKeyBase: boolean;
+  private memoSecretKeyBase: string | null = null;
+
+  constructor(options: CredentialsGeneratorOptions) {
+    super(options);
+    this.contentPath = options.contentPath ?? "config/credentials.yml.enc";
+    this.keyPath = options.keyPath ?? "config/master.key";
+    this.skipSecretKeyBase = options.skipSecretKeyBase ?? false;
+  }
+
+  async addCredentialsFile(): Promise<void> {
+    if (this.fileExists(this.contentPath)) return;
+    this.output(`Adding ${this.contentPath} to store encrypted credentials.`);
+    const content = this.renderTemplate();
+    await this.encryptedFile().write(content);
+    this.output("The following content has been encrypted with the Rails master key:");
+    this.output(content);
+    this.output("You can edit encrypted credentials with `trails credentials edit`.");
+  }
+
+  private encryptedFile(): EncryptedFile {
+    const contentPath = this.path.join(this.cwd, this.contentPath);
+    this.fs.mkdirSync(this.path.dirname(contentPath), { recursive: true });
+    return new EncryptedFile({
+      contentPath,
+      keyPath: this.path.join(this.cwd, this.keyPath),
+      envKey: "RAILS_MASTER_KEY",
+      raiseIfMissingKey: true,
+    });
+  }
+
+  private secretKeyBase(): string {
+    return (this.memoSecretKeyBase ??= Buffer.from(getCrypto().randomBytes(64)).toString("hex"));
+  }
+
+  private renderTemplate(): string {
+    const lines = [
+      "# smtp:",
+      "#   user_name: my-smtp-user",
+      "#   password: my-smtp-password",
+      "#",
+      "# aws:",
+      "#   access_key_id: 123",
+      "#   secret_access_key: 345",
+    ];
+    if (!this.skipSecretKeyBase) {
+      lines.push(
+        "",
+        "# Used as the base secret for all MessageVerifiers in Rails, including the one protecting cookies.",
+        `secret_key_base: ${this.secretKeyBase()}`,
+      );
+    }
+    return lines.join("\n") + "\n";
+  }
+}

--- a/packages/trailties/src/generators/rails/encrypted-file/encrypted-file-generator.test.ts
+++ b/packages/trailties/src/generators/rails/encrypted-file/encrypted-file-generator.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { EncryptedFile } from "@blazetrails/activesupport/encrypted-file";
+import { EncryptedFileGenerator } from "./encrypted-file-generator.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-enc-file-"));
+  fs.mkdirSync(path.join(tmpDir, "config"));
+  fs.writeFileSync(path.join(tmpDir, "config/secret.key"), EncryptedFile.generateKey(), {
+    mode: 0o600,
+  });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("EncryptedFileGeneratorTest", () => {
+  it("add_encrypted_file_silently round-trips template and is idempotent", async () => {
+    const gen = new EncryptedFileGenerator({ cwd: tmpDir, output: () => {} });
+    await gen.addEncryptedFileSilently("config/secret.yml.enc", "config/secret.key");
+    const file = new EncryptedFile({
+      contentPath: path.join(tmpDir, "config/secret.yml.enc"),
+      keyPath: path.join(tmpDir, "config/secret.key"),
+      envKey: "RAILS_MASTER_KEY",
+      raiseIfMissingKey: true,
+    });
+    expect(await file.read()).toContain("# aws:");
+    const before = fs.readFileSync(path.join(tmpDir, "config/secret.yml.enc"));
+    await gen.addEncryptedFileSilently("config/secret.yml.enc", "config/secret.key");
+    expect(fs.readFileSync(path.join(tmpDir, "config/secret.yml.enc"))).toEqual(before);
+  });
+});

--- a/packages/trailties/src/generators/rails/encrypted-file/encrypted-file-generator.ts
+++ b/packages/trailties/src/generators/rails/encrypted-file/encrypted-file-generator.ts
@@ -1,0 +1,30 @@
+import { EncryptedFile } from "@blazetrails/activesupport/encrypted-file";
+import { GeneratorBase, type GeneratorOptions } from "../../base.js";
+
+const DEFAULT_TEMPLATE = `# aws:
+#   access_key_id: 123
+#   secret_access_key: 345
+
+`;
+
+export class EncryptedFileGenerator extends GeneratorBase {
+  constructor(options: GeneratorOptions) {
+    super(options);
+  }
+
+  async addEncryptedFileSilently(
+    filePath: string,
+    keyPath: string,
+    template: string = DEFAULT_TEMPLATE,
+  ): Promise<void> {
+    if (this.fileExists(filePath)) return;
+    const file = new EncryptedFile({
+      contentPath: this.path.join(this.cwd, filePath),
+      keyPath: this.path.join(this.cwd, keyPath),
+      envKey: "RAILS_MASTER_KEY",
+      raiseIfMissingKey: true,
+    });
+    await file.write(template);
+    this.output(`      create  ${filePath}`);
+  }
+}

--- a/packages/trailties/src/generators/rails/encryption-key-file/encryption-key-file-generator.test.ts
+++ b/packages/trailties/src/generators/rails/encryption-key-file/encryption-key-file-generator.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { EncryptionKeyFileGenerator } from "./encryption-key-file-generator.js";
+
+let tmpDir: string;
+let lines: string[];
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-enc-key-"));
+  lines = [];
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const build = () => new EncryptionKeyFileGenerator({ cwd: tmpDir, output: (m) => lines.push(m) });
+
+describe("EncryptionKeyFileGeneratorTest", () => {
+  it("add_key_file writes a hex key file at mode 0600 and is idempotent", () => {
+    build().addKeyFile("config/foo.key");
+    const fullPath = path.join(tmpDir, "config/foo.key");
+    const original = fs.readFileSync(fullPath, "utf-8");
+    expect(original).toMatch(/^[0-9a-f]+$/);
+    expect(fs.statSync(fullPath).mode & 0o777).toBe(0o600);
+    expect(lines.some((l) => l.includes("Adding config/foo.key"))).toBe(true);
+    build().addKeyFile("config/foo.key");
+    expect(fs.readFileSync(fullPath, "utf-8")).toBe(original);
+  });
+
+  it("ignore_key_file appends once, skips when present, and logs without .gitignore", () => {
+    build().ignoreKeyFile("config/foo.key");
+    expect(lines.some((l) => l.includes("Don't commit config/foo.key"))).toBe(true);
+    fs.writeFileSync(path.join(tmpDir, ".gitignore"), "node_modules\n");
+    build().ignoreKeyFile("config/foo.key");
+    const after = fs.readFileSync(path.join(tmpDir, ".gitignore"), "utf-8");
+    expect(after).toContain("/config/foo.key");
+    build().ignoreKeyFile("config/foo.key");
+    expect(fs.readFileSync(path.join(tmpDir, ".gitignore"), "utf-8")).toBe(after);
+  });
+});

--- a/packages/trailties/src/generators/rails/encryption-key-file/encryption-key-file-generator.ts
+++ b/packages/trailties/src/generators/rails/encryption-key-file/encryption-key-file-generator.ts
@@ -1,0 +1,40 @@
+import { EncryptedFile } from "@blazetrails/activesupport/encrypted-file";
+import { GeneratorBase, type GeneratorOptions } from "../../base.js";
+
+export class EncryptionKeyFileGenerator extends GeneratorBase {
+  constructor(options: GeneratorOptions) {
+    super(options);
+  }
+
+  addKeyFile(keyPath: string): void {
+    if (this.fileExists(keyPath)) return;
+    const key = EncryptedFile.generateKey();
+    this.output(`Adding ${keyPath} to store the encryption key: ${key}`);
+    this.output("Save this in a password manager your team can access.");
+    this.output(
+      "If you lose the key, no one, including you, can access anything encrypted with it.",
+    );
+    this.addKeyFileSilently(keyPath, key);
+  }
+
+  addKeyFileSilently(keyPath: string, key?: string): void {
+    this.createFile(keyPath, key ?? EncryptedFile.generateKey(), { mode: 0o600 });
+  }
+
+  ignoreKeyFile(keyPath: string, ignore: string = this.keyIgnore(keyPath)): void {
+    if (!this.fileExists(".gitignore")) {
+      this.output(`IMPORTANT: Don't commit ${keyPath}. Add this to your ignore file:${ignore}`);
+      return;
+    }
+    const existing = this.fs.readFileSync(this.path.join(this.cwd, ".gitignore"), "utf-8");
+    if (existing.includes(ignore)) return;
+    this.output(`Ignoring ${keyPath} so it won't end up in Git history:`);
+    this.appendToFile(".gitignore", ignore);
+  }
+
+  ignoreKeyFileSilently(keyPath: string, ignore: string = this.keyIgnore(keyPath)): void {
+    if (this.fileExists(".gitignore")) this.appendToFile(".gitignore", ignore);
+  }
+
+  private keyIgnore = (keyPath: string): string => `\n/${keyPath}\n`;
+}

--- a/packages/trailties/src/generators/rails/master-key/master-key-generator.test.ts
+++ b/packages/trailties/src/generators/rails/master-key/master-key-generator.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { MasterKeyGenerator } from "./master-key-generator.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-master-key-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe("MasterKeyGeneratorTest", () => {
+  it("add_master_key_file + ignore_master_key_file write key and labelled gitignore entry", () => {
+    fs.writeFileSync(path.join(tmpDir, ".gitignore"), "node_modules\n");
+    const gen = new MasterKeyGenerator({ cwd: tmpDir, output: () => {} });
+    gen.addMasterKeyFile();
+    gen.ignoreMasterKeyFile();
+    expect(fs.readFileSync(path.join(tmpDir, "config/master.key"), "utf-8")).toMatch(/^[0-9a-f]+$/);
+    const ignore = fs.readFileSync(path.join(tmpDir, ".gitignore"), "utf-8");
+    expect(ignore).toContain("# Ignore master key for decrypting credentials and more.");
+    expect(ignore).toContain("/config/master.key");
+  });
+});

--- a/packages/trailties/src/generators/rails/master-key/master-key-generator.ts
+++ b/packages/trailties/src/generators/rails/master-key/master-key-generator.ts
@@ -1,0 +1,43 @@
+import { EncryptedFile } from "@blazetrails/activesupport/encrypted-file";
+import { GeneratorBase, type GeneratorOptions } from "../../base.js";
+import { EncryptionKeyFileGenerator } from "../encryption-key-file/encryption-key-file-generator.js";
+
+const MASTER_KEY_PATH = "config/master.key";
+
+export class MasterKeyGenerator extends GeneratorBase {
+  constructor(options: GeneratorOptions) {
+    super(options);
+  }
+
+  addMasterKeyFile(): void {
+    if (this.fileExists(MASTER_KEY_PATH)) return;
+    const key = EncryptedFile.generateKey();
+    this.output(`Adding ${MASTER_KEY_PATH} to store the master encryption key: ${key}`);
+    this.output("Save this in a password manager your team can access.");
+    this.output(
+      "If you lose the key, no one, including you, can access anything encrypted with it.",
+    );
+    this.addMasterKeyFileSilently(key);
+  }
+
+  addMasterKeyFileSilently(key?: string): void {
+    if (this.fileExists(MASTER_KEY_PATH)) return;
+    this.keyFileGenerator().addKeyFileSilently(MASTER_KEY_PATH, key);
+  }
+
+  ignoreMasterKeyFile(): void {
+    this.keyFileGenerator().ignoreKeyFile(MASTER_KEY_PATH, this.keyIgnore());
+  }
+
+  ignoreMasterKeyFileSilently(): void {
+    this.keyFileGenerator().ignoreKeyFileSilently(MASTER_KEY_PATH, this.keyIgnore());
+  }
+
+  private keyFileGenerator(): EncryptionKeyFileGenerator {
+    return new EncryptionKeyFileGenerator({ cwd: this.cwd, output: this.output });
+  }
+
+  private keyIgnore(): string {
+    return `\n# Ignore master key for decrypting credentials and more.\n/${MASTER_KEY_PATH}\n`;
+  }
+}


### PR DESCRIPTION
## Summary

Ports the four credentials-related Rails generators into trailties (PR 1.14a — see `docs/trailties-plan.md`):

- `CredentialsGenerator` — `config/credentials.yml.enc` with `secret_key_base` (memoized to match Rails)
- `MasterKeyGenerator` — `config/master.key` + labelled `.gitignore` entry
- `EncryptedFileGenerator.addEncryptedFileSilently`
- `EncryptionKeyFileGenerator.addKeyFile{,Silently}` / `ignoreKeyFile{,Silently}`

Built on `@blazetrails/activesupport`'s `EncryptedFile` (#2148). Generator sources use only `GeneratorBase` helpers and the `FsAdapter` — no `node:*` / `process.*` imports.

## Rails sources

- `railties/lib/rails/generators/rails/credentials/credentials_generator.rb`
- `railties/lib/rails/generators/rails/master_key/master_key_generator.rb`
- `railties/lib/rails/generators/rails/encrypted_file/encrypted_file_generator.rb`
- `railties/lib/rails/generators/rails/encryption_key_file/encryption_key_file_generator.rb`

Every Rails public method is mirrored. Log messages preserved verbatim where they affect operator-visible UX.

## Methods skipped vs. Rails

- **Thor `argument` / `class_option` DSL** — replaced by trailties' `GeneratorOptions` / constructor-options pattern (matches `BenchmarkGenerator`, `ScriptGenerator`, etc.).
- **`in_root`** — generators already operate relative to the injected `cwd` via `GeneratorBase` helpers (`createFile`, `appendToFile`, `fileExists`).
- **ERB-rendered `credentials.yml.tt` template** — rendered inline (no ERB engine in trailties). The `unless options.skip_secret_key_base?` toggle is preserved via the `skipSecretKeyBase` option.
- **`render_template_to_encrypted_file` private helper** — collapsed into `addCredentialsFile` since there's no separate template/`change` step without ERB.
- **`encrypted_file_template` private helper** — promoted to a file-scoped `DEFAULT_TEMPLATE` constant.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/generators/rails/{credentials,master-key,encrypted-file,encryption-key-file}/`
- [x] `pnpm typecheck`
- [x] Diff size: 338 insertions (12% over the 300 soft ceiling; well under the 400 review-cycle threshold). Density is similar to recent trailties generator PRs (#2170, #2172).