### PR TITLE
feat(trailties): activerecord + action-controller config namespaces (PR 2.7c + 2.7d)

### DIFF
--- a/packages/actionpack/src/action-controller/trailtie.test.ts
+++ b/packages/actionpack/src/action-controller/trailtie.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { Trailtie, type ActionControllerConfig } from "./trailtie.js";
+import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
+import { deprecator } from "./deprecator.js";
+
+const { deprecators } = BaseRailtie;
+
+describe("ActionController::Trailtie", () => {
+  let savedSubclasses: (typeof BaseRailtie)[];
+  let savedConfig: ActionControllerConfig;
+
+  beforeEach(() => {
+    savedSubclasses = [...BaseRailtie.subclasses];
+    savedConfig = { ...(Trailtie.config["actionController"] as ActionControllerConfig) };
+  });
+
+  afterEach(() => {
+    (BaseRailtie.subclasses as (typeof BaseRailtie)[]).length = 0;
+    (BaseRailtie.subclasses as (typeof BaseRailtie)[]).push(...savedSubclasses);
+    Trailtie.config["actionController"] = savedConfig;
+    for (const key of Object.keys(deprecators)) {
+      delete deprecators[key];
+    }
+  });
+
+  it("ActionController::Railtie is registered in the global subclasses list", () => {
+    expect(BaseRailtie.subclasses).toContain(Trailtie);
+  });
+
+  it("runInitializers registers the ActionController deprecator", () => {
+    Trailtie.runInitializers();
+    expect(deprecators["actionController"]).toBe(deprecator());
+  });
+
+  it("seeds config.actionController with the Rails default OrderedOptions block", () => {
+    const cfg = Trailtie.config["actionController"] as ActionControllerConfig;
+    expect(cfg.raiseOnOpenRedirects).toBe(false);
+    expect(cfg.logQueryTagsAroundActions).toBe(true);
+    expect(cfg.wrapParametersByDefault).toBe(false);
+  });
+});

--- a/packages/actionpack/src/action-controller/trailtie.test.ts
+++ b/packages/actionpack/src/action-controller/trailtie.test.ts
@@ -11,7 +11,7 @@ describe("ActionController::Trailtie", () => {
 
   beforeEach(() => {
     savedSubclasses = [...BaseRailtie.subclasses];
-    savedConfig = { ...(Trailtie.config["actionController"] as ActionControllerConfig) };
+    savedConfig = structuredClone(Trailtie.config["actionController"] as ActionControllerConfig);
   });
 
   afterEach(() => {

--- a/packages/actionpack/src/action-controller/trailtie.ts
+++ b/packages/actionpack/src/action-controller/trailtie.ts
@@ -3,17 +3,49 @@
  *
  * Mirrors: ActionController::Railtie < Rails::Railtie (railtie.rb)
  *
- * Extends the base Railtie from `@blazetrails/activesupport` and registers
- * itself in the global initialization pipeline.
+ * Extends the base Railtie from `@blazetrails/activesupport`, registers
+ * itself in the global initialization pipeline, and seeds the
+ * `config.actionController` namespace with the same defaults Rails sets at
+ * the top of `actionpack/lib/action_controller/railtie.rb` (the
+ * `ActiveSupport::OrderedOptions` block).
+ *
+ * Unported targets (assets_config — paths["public"] not ported; helpers
+ * path wiring; parameters_config — needs on_load + ActionController
+ * ::Parameters; set_configs setter-dispatch; compile_config_methods;
+ * request_forgery_protection — needs RequestForgeryProtection.protect_from_forgery
+ * wiring; query_log_tags — needs ActiveRecord QueryLogs wiring;
+ * test_case — needs ActiveSupport executor) are left out and will land as
+ * those frameworks gain the matching surface — see docs/trailties-plan.md
+ * PR 2.7 follow-ups.
  *
  * @see https://api.rubyonrails.org/classes/ActionController/Railtie.html
  */
 import { Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
 import { deprecator } from "./deprecator.js";
 
+/**
+ * Shape of `config.actionController` — mirrors the
+ * `ActiveSupport::OrderedOptions` block at the top of Rails' railtie.rb.
+ */
+export interface ActionControllerConfig {
+  raiseOnOpenRedirects: boolean;
+  logQueryTagsAroundActions: boolean;
+  wrapParametersByDefault: boolean;
+}
+
+function defaultActionControllerConfig(): ActionControllerConfig {
+  return {
+    raiseOnOpenRedirects: false,
+    logQueryTagsAroundActions: true,
+    wrapParametersByDefault: false,
+  };
+}
+
 export class Trailtie extends BaseRailtie {
   static {
     registerRailtie(this);
+
+    this.config["actionController"] = defaultActionControllerConfig();
 
     this.initializer("action_controller.deprecator", () => {
       BaseRailtie.deprecators["actionController"] = deprecator();

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -13,7 +13,7 @@ describe("RailtieTest", () => {
 
   beforeEach(() => {
     savedSubclasses = [...BaseRailtie.subclasses];
-    savedConfig = { ...(Trailtie.config["activeRecord"] as ActiveRecordConfig) };
+    savedConfig = structuredClone(Trailtie.config["activeRecord"] as ActiveRecordConfig);
     savedTimeZoneAware = Base.timeZoneAwareAttributes;
   });
 

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { Trailtie } from "./trailtie.js";
+import { Trailtie, type ActiveRecordConfig } from "./trailtie.js";
 import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
 import { deprecator } from "./deprecator.js";
 
@@ -27,5 +27,22 @@ describe("RailtieTest", () => {
   it("runInitializers registers the ActiveRecord deprecator", () => {
     Trailtie.runInitializers();
     expect(deprecators["activeRecord"]).toBe(deprecator());
+  });
+
+  it("seeds config.activeRecord with the Rails default OrderedOptions block", () => {
+    const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
+    expect(cfg.useSchemaCacheDump).toBe(true);
+    expect(cfg.checkSchemaCacheDumpVersion).toBe(true);
+    expect(cfg.maintainTestSchema).toBe(true);
+    expect(cfg.hasManyInversing).toBe(false);
+    expect(cfg.queryLogTagsEnabled).toBe(false);
+    expect(cfg.queryLogTags).toEqual(["application"]);
+    expect(cfg.queryLogTagsFormat).toBe("legacy");
+    expect(cfg.cacheQueryLogTags).toBe(false);
+    expect(cfg.raiseOnAssignToAttrReadonly).toBe(false);
+    expect(cfg.belongsToRequiredValidatesForeignKey).toBe(true);
+    expect(cfg.generateSecureTokenOn).toBe("create");
+    expect(cfg.encryption).toEqual({});
+    expect(cfg.queues).toEqual({});
   });
 });

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { Trailtie, type ActiveRecordConfig } from "./trailtie.js";
+import { Base } from "./base.js";
 import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
 import { deprecator } from "./deprecator.js";
 
@@ -7,14 +8,20 @@ const { deprecators } = BaseRailtie;
 
 describe("RailtieTest", () => {
   let savedSubclasses: (typeof BaseRailtie)[];
+  let savedConfig: ActiveRecordConfig;
+  let savedTimeZoneAware: boolean;
 
   beforeEach(() => {
     savedSubclasses = [...BaseRailtie.subclasses];
+    savedConfig = { ...(Trailtie.config["activeRecord"] as ActiveRecordConfig) };
+    savedTimeZoneAware = Base.timeZoneAwareAttributes;
   });
 
   afterEach(() => {
     (BaseRailtie.subclasses as (typeof BaseRailtie)[]).length = 0;
     (BaseRailtie.subclasses as (typeof BaseRailtie)[]).push(...savedSubclasses);
+    Trailtie.config["activeRecord"] = savedConfig;
+    Base.timeZoneAwareAttributes = savedTimeZoneAware;
     for (const key of Object.keys(deprecators)) {
       delete deprecators[key];
     }
@@ -44,5 +51,11 @@ describe("RailtieTest", () => {
     expect(cfg.generateSecureTokenOn).toBe("create");
     expect(cfg.encryption).toEqual({});
     expect(cfg.queues).toEqual({});
+  });
+
+  it("runInitializers enables time_zone_aware_attributes on Base", () => {
+    Base.timeZoneAwareAttributes = false;
+    Trailtie.runInitializers();
+    expect(Base.timeZoneAwareAttributes).toBe(true);
   });
 });

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -51,7 +51,7 @@ export interface ActiveRecordConfig {
   maintainTestSchema: boolean;
   hasManyInversing: boolean;
   queryLogTagsEnabled: boolean;
-  queryLogTags: readonly (string | symbol)[];
+  queryLogTags: readonly string[];
   queryLogTagsFormat: "legacy" | "sqlcommenter";
   cacheQueryLogTags: boolean;
   raiseOnAssignToAttrReadonly: boolean;

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -3,13 +3,25 @@
  *
  * Mirrors: ActiveRecord::Railtie < Rails::Railtie (railtie.rb)
  *
- * Extends the base Railtie from `@blazetrails/activesupport` and registers
- * itself in the global initialization pipeline.
+ * Extends the base Railtie from `@blazetrails/activesupport`, registers
+ * itself in the global initialization pipeline, and seeds the
+ * `config.activeRecord` namespace with the same defaults Rails sets at the
+ * top of `activerecord/lib/active_record/railtie.rb` (the
+ * `ActiveSupport::OrderedOptions` block).
  *
  * Also re-exports the ActionController and ActiveJob mixin objects that
  * `railtie.rb` wires into those frameworks:
  *   - `ControllerRuntime` — SQL runtime tracking per request
  *   - `JobRuntime` — SQL runtime tracking per job
+ *
+ * Unported targets (rake tasks, console/runner hooks, on_load callback
+ * registry, migration_error middleware insertion, schema-cache-config
+ * copy, define_attribute_methods, sqlite3/postgresql adapter strict
+ * defaults, set_configs setter-dispatch loop, set_reloader_hooks,
+ * set_executor_hooks, watchable_files, encryption.configuration,
+ * query_log_tags_config, log_runtime subscriber) are intentionally left
+ * out for now — they each depend on Rails infrastructure that has not yet
+ * been ported to trails. See docs/trailties-plan.md PR 2.7 follow-ups.
  */
 import { Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
 import { deprecator } from "./deprecator.js";
@@ -23,13 +35,53 @@ import { instrument } from "./trailties/job-runtime.js";
 export const ControllerRuntime = { processAction, cleanupViewRuntime, appendInfoToPayload };
 export const JobRuntime = { instrument };
 
-export class Trailtie extends BaseRailtie {
-  constructor() {
-    super();
-  }
+/**
+ * Shape of `config.activeRecord` — mirrors the
+ * `ActiveSupport::OrderedOptions` block at the top of Rails' railtie.rb.
+ */
+export interface ActiveRecordEncryptionConfig {
+  [key: string]: unknown;
+}
 
+export interface ActiveRecordConfig {
+  encryption: ActiveRecordEncryptionConfig;
+  useSchemaCacheDump: boolean;
+  checkSchemaCacheDumpVersion: boolean;
+  maintainTestSchema: boolean;
+  hasManyInversing: boolean;
+  queryLogTagsEnabled: boolean;
+  queryLogTags: readonly (string | symbol)[];
+  queryLogTagsFormat: "legacy" | "sqlcommenter";
+  cacheQueryLogTags: boolean;
+  raiseOnAssignToAttrReadonly: boolean;
+  belongsToRequiredValidatesForeignKey: boolean;
+  generateSecureTokenOn: "create" | "initialize";
+  queues: Record<string, unknown>;
+}
+
+function defaultActiveRecordConfig(): ActiveRecordConfig {
+  return {
+    encryption: {},
+    useSchemaCacheDump: true,
+    checkSchemaCacheDumpVersion: true,
+    maintainTestSchema: true,
+    hasManyInversing: false,
+    queryLogTagsEnabled: false,
+    queryLogTags: ["application"],
+    queryLogTagsFormat: "legacy",
+    cacheQueryLogTags: false,
+    raiseOnAssignToAttrReadonly: false,
+    belongsToRequiredValidatesForeignKey: true,
+    generateSecureTokenOn: "create",
+    queues: {},
+  };
+}
+
+export class Trailtie extends BaseRailtie {
   static {
     registerRailtie(this);
+
+    this.config["activeRecord"] = defaultActiveRecordConfig();
 
     this.initializer("active_record.deprecator", () => {
       BaseRailtie.deprecators["activeRecord"] = deprecator();

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -24,6 +24,7 @@
  * been ported to trails. See docs/trailties-plan.md PR 2.7 follow-ups.
  */
 import { Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
+import { Base } from "./base.js";
 import { deprecator } from "./deprecator.js";
 import {
   processAction,
@@ -85,6 +86,12 @@ export class Trailtie extends BaseRailtie {
 
     this.initializer("active_record.deprecator", () => {
       BaseRailtie.deprecators["activeRecord"] = deprecator();
+    });
+
+    this.initializer("active_record.initialize_timezone", () => {
+      // Rails: `ActiveSupport.on_load(:active_record) { self.time_zone_aware_attributes = true }`.
+      // The on_load registry isn't ported yet, so apply directly to Base.
+      Base.timeZoneAwareAttributes = true;
     });
   }
 }

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -51,7 +51,7 @@ export interface ActiveRecordConfig {
   maintainTestSchema: boolean;
   hasManyInversing: boolean;
   queryLogTagsEnabled: boolean;
-  queryLogTags: readonly string[];
+  queryLogTags: string[];
   queryLogTagsFormat: "legacy" | "sqlcommenter";
   cacheQueryLogTags: boolean;
   raiseOnAssignToAttrReadonly: boolean;


### PR DESCRIPTION
## Summary

Bundles **PR 2.7c** (activerecord Trailtie) + **PR 2.7d** (actionpack action-controller Trailtie) from `docs/trailties-plan.md`. The action-dispatch half of 2.7d already shipped its config namespace in #2007; this PR brings activerecord + action-controller up to parity by seeding their config namespaces with the `ActiveSupport::OrderedOptions` defaults Rails sets at the top of each `railtie.rb`.

- `packages/activerecord/src/trailtie.ts` — adds `ActiveRecordConfig` interface + `defaultActiveRecordConfig()` and registers it as `Trailtie.config["activeRecord"]`. Mirrors lines 17–42 of Rails' `active_record/railtie.rb`. Wires `active_record.initialize_timezone` to flip `Base.timeZoneAwareAttributes = true` (the `on_load` callback registry isn't ported, so the assignment is applied directly to `Base`).
- `packages/actionpack/src/action-controller/trailtie.ts` — adds `ActionControllerConfig` interface + `defaultActionControllerConfig()` and registers it as `Trailtie.config["actionController"]`. Mirrors lines 14–17 of Rails' `action_controller/railtie.rb`.

PR 2.7a (activesupport Trailtie) is **skipped** — blocked on open question #2 in the plan doc.

## Rails sources

- `vendor/rails/activerecord/lib/active_record/railtie.rb`
- `vendor/rails/actionpack/lib/action_controller/railtie.rb`
- `vendor/rails/actionpack/lib/action_dispatch/railtie.rb` (already shipped in #2007 + #2165)

## Initializers / blocks wired

- `active_record.deprecator`
- `active_record.initialize_timezone` — direct assignment to `Base.timeZoneAwareAttributes`; will switch to the `on_load` registry when that lands.
- `action_controller.deprecator`

## Initializers / blocks intentionally skipped

These depend on Rails infrastructure that has not yet been ported to trails and will land as separate follow-ups against the plan doc:

**activerecord:**
- `app_generators.orm`, `action_dispatch.rescue_responses.merge!`, `eager_load_namespaces` — no equivalent registries yet
- `rake_tasks`, `console`, `runner` — Rails-only hooks
- `postgresql_time_zone_aware_types`, `logger`, `backtrace_cleaner` — need `ActiveSupport.on_load` registry
- `migration_error` — needs `app_middleware.insert_after` API + `Migration::CheckPending`
- `cache_versioning_support`, `copy_schema_cache_config`, `define_attribute_methods`, `sqlite3_adapter_strict_strings_by_default`, `postgresql_adapter_decode_dates`
- `set_configs`, `initialize_database`, `log_runtime`, `set_reloader_hooks`, `set_executor_hooks`, `add_watchable_files`, `clear_active_connections`, `set_filter_attributes`, `set_signed_id_verifier_secret`, `generated_token_verifier`
- `active_record_encryption.configuration`, `query_log_tags_config`

**action-controller:**
- `eager_load_namespaces`
- `assets_config` — needs `paths["public"]`
- `set_helpers_path` — needs `helpers_paths`
- `parameters_config` — needs `ActionController::Parameters` + `on_load(:action_controller)`
- `set_configs`, `compile_config_methods`, `request_forgery_protection`, `query_log_tags`, `test_case`

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/trailtie.test.ts` — passes (4 tests)
- [x] `pnpm vitest run packages/actionpack/src/action-controller/trailtie.test.ts` — passes (3 tests)
- [x] `tsc --build` — clean