### PR TITLE
feat(trailties): routes-reloader + config_for + credentials wiring (PR 2.5c)

### DIFF
--- a/packages/activesupport/src/message-verifier.ts
+++ b/packages/activesupport/src/message-verifier.ts
@@ -44,12 +44,12 @@ interface VerifyOptions {
 }
 
 export class MessageVerifier {
-  private secret: string;
+  private secret: string | Buffer;
   private digest: string;
   private serializer: Serializer;
   private urlSafe: boolean;
 
-  constructor(secret: string, options: MessageVerifierOptions = {}) {
+  constructor(secret: string | Buffer, options: MessageVerifierOptions = {}) {
     this.secret = secret;
     this.digest = options.digest ?? "sha1";
     this.serializer = options.serializer ?? JSONSerializer;

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -311,16 +311,6 @@ describe("Application::DefaultMiddlewareStack", () => {
   });
 });
 
-// Mirrors `railties/test/application/configuration_test.rb` cases for
-// key_generator / message_verifier / credentials / config_for / encrypted.
-describe("Application::Configuration (2.5c)", () => {
-  it("credentials and secret_key_base default to null", () => {
-    const c = new Configuration();
-    expect(c.credentials).toEqual({ contentPath: null, keyPath: null });
-    expect(c.secretKeyBase).toBeNull();
-  });
-});
-
 describe("Application key/message/credentials wiring", () => {
   beforeEach(() => resetLoadHooks());
   afterEach(() => {
@@ -330,10 +320,12 @@ describe("Application key/message/credentials wiring", () => {
   });
 
   const setSecret = (app: Application, s: string) => {
-    (app.config as unknown as { secretKeyBase: string }).secretKeyBase = s;
+    app.config.secretKeyBase = s;
   };
 
-  it("routes_reloader is memoized, key_generator/message_verifier work, config_for rejects non-database", async () => {
+  it("routes_reloader memoized, key_generator/message_verifier work, config_for rejects non-database, Configuration defaults null", async () => {
+    expect(new Configuration().credentials).toEqual({ contentPath: null, keyPath: null });
+    expect(new Configuration().secretKeyBase).toBeNull();
     class A extends Application {}
     Application.register(A);
     const app = A.instance();

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -311,9 +311,8 @@ describe("Application::DefaultMiddlewareStack", () => {
   });
 });
 
-// Mirrors `railties/test/application/configuration_test.rb`
-// `test_key_generator`, `test_message_verifier`, and the
-// `routes_reloader` / `config_for` / `encrypted` / `credentials` cases.
+// Mirrors `railties/test/application/configuration_test.rb` cases for
+// key_generator / message_verifier / credentials / config_for / encrypted.
 describe("Application::Configuration (2.5c)", () => {
   it("credentials and secret_key_base default to null", () => {
     const c = new Configuration();
@@ -366,18 +365,18 @@ describe("Application key/message/credentials wiring", () => {
   });
 
   it("credentials prefers config/credentials/{env}.yml.enc + .key when present", async () => {
-    const base = "/app/config/credentials";
+    const b = "/app/config/credentials";
     installFs(
-      new Set(["/", "/app", "/app/config", base]),
-      new Set(["/app/config.ts", `${base}/development.yml.enc`, `${base}/development.key`]),
+      new Set(["/", "/app", "/app/config", b]),
+      new Set(["/app/config.ts", `${b}/development.yml.enc`, `${b}/development.key`]),
     );
     class A extends Application {}
     A.calledFrom("/app");
     Application.register(A);
     const file = await A.instance().credentials();
     expect([file.contentPath, file.keyPath]).toEqual([
-      `${base}/development.yml.enc`,
-      `${base}/development.key`,
+      `${b}/development.yml.enc`,
+      `${b}/development.key`,
     ]);
   });
 });

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -340,23 +340,7 @@ describe("Application key/message/credentials wiring", () => {
     await expect(app.configFor("exception_notification")).rejects.toThrow(/only "database"/);
   });
 
-  it("credentials defaults to config/credentials.yml.enc when no env-specific file exists", async () => {
-    installFs(
-      new Set(["/", "/app", "/app/config"]),
-      new Set(["/app/config.ts", "/app/config/credentials.yml.enc", "/app/config/master.key"]),
-    );
-    class A extends Application {}
-    A.calledFrom("/app");
-    Application.register(A);
-    const file = await A.instance().credentials();
-    expect([file.contentPath, file.keyPath, file.envKey]).toEqual([
-      "/app/config/credentials.yml.enc",
-      "/app/config/master.key",
-      "RAILS_MASTER_KEY",
-    ]);
-  });
-
-  it("credentials prefers config/credentials/{env}.yml.enc + .key when present", async () => {
+  it("credentials prefers env-specific config/credentials/{env}.yml.enc, else config/credentials.yml.enc", async () => {
     const b = "/app/config/credentials";
     installFs(
       new Set(["/", "/app", "/app/config", b]),
@@ -365,10 +349,20 @@ describe("Application key/message/credentials wiring", () => {
     class A extends Application {}
     A.calledFrom("/app");
     Application.register(A);
-    const file = await A.instance().credentials();
-    expect([file.contentPath, file.keyPath]).toEqual([
+    let f = await A.instance().credentials();
+    expect([f.contentPath, f.keyPath]).toEqual([
       `${b}/development.yml.enc`,
       `${b}/development.key`,
+    ]);
+    installFs(new Set(["/", "/o", "/o/config"]), new Set(["/o/config.ts"]));
+    class B extends Application {}
+    B.calledFrom("/o");
+    Application.register(B);
+    f = await B.instance().credentials();
+    expect([f.contentPath, f.keyPath, f.envKey]).toEqual([
+      "/o/config/credentials.yml.enc",
+      "/o/config/master.key",
+      "RAILS_MASTER_KEY",
     ]);
   });
 });

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -310,3 +310,74 @@ describe("Application::DefaultMiddlewareStack", () => {
     expect(app.config.sessionOptions.secure).toBe(true);
   });
 });
+
+// Mirrors `railties/test/application/configuration_test.rb`
+// `test_key_generator`, `test_message_verifier`, and the
+// `routes_reloader` / `config_for` / `encrypted` / `credentials` cases.
+describe("Application::Configuration (2.5c)", () => {
+  it("credentials and secret_key_base default to null", () => {
+    const c = new Configuration();
+    expect(c.credentials).toEqual({ contentPath: null, keyPath: null });
+    expect(c.secretKeyBase).toBeNull();
+  });
+});
+
+describe("Application key/message/credentials wiring", () => {
+  beforeEach(() => resetLoadHooks());
+  afterEach(() => {
+    fsAdapterConfig.adapter = PREV;
+    resetLoadHooks();
+    Application.appClass = null;
+  });
+
+  const setSecret = (app: Application, s: string) => {
+    (app.config as unknown as { secretKeyBase: string }).secretKeyBase = s;
+  };
+
+  it("routes_reloader is memoized, key_generator/message_verifier work, config_for rejects non-database", async () => {
+    class A extends Application {}
+    Application.register(A);
+    const app = A.instance();
+    expect(app.routesReloader()).toBe(app.routesReloader());
+    expect(() => app.keyGenerator()).toThrow(/secret_key_base/);
+    setSecret(app, "test-secret");
+    const gen = app.keyGenerator();
+    expect(gen.generateKey("salt", 16)).toBeInstanceOf(Buffer);
+    expect(app.keyGenerator()).toBe(gen);
+    const v = app.messageVerifier("cookies");
+    expect(v.verify(v.generate({ foo: 1 }))).toEqual({ foo: 1 });
+    await expect(app.configFor("exception_notification")).rejects.toThrow(/only "database"/);
+  });
+
+  it("credentials defaults to config/credentials.yml.enc when no env-specific file exists", async () => {
+    installFs(
+      new Set(["/", "/app", "/app/config"]),
+      new Set(["/app/config.ts", "/app/config/credentials.yml.enc", "/app/config/master.key"]),
+    );
+    class A extends Application {}
+    A.calledFrom("/app");
+    Application.register(A);
+    const file = await A.instance().credentials();
+    expect([file.contentPath, file.keyPath, file.envKey]).toEqual([
+      "/app/config/credentials.yml.enc",
+      "/app/config/master.key",
+      "RAILS_MASTER_KEY",
+    ]);
+  });
+
+  it("credentials prefers config/credentials/{env}.yml.enc + .key when present", async () => {
+    const base = "/app/config/credentials";
+    installFs(
+      new Set(["/", "/app", "/app/config", base]),
+      new Set(["/app/config.ts", `${base}/development.yml.enc`, `${base}/development.key`]),
+    );
+    class A extends Application {}
+    A.calledFrom("/app");
+    Application.register(A);
+    const file = await A.instance().credentials();
+    expect([file.contentPath, file.keyPath]).toEqual([
+      `${base}/development.yml.enc`,
+      `${base}/development.key`,
+    ]);
+  });
+});

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -1,7 +1,6 @@
-// Port of `Rails::Application` from `railties/lib/rails/application.rb`.
-// PR 2.5c adds routesReloader/configFor/credentials/encrypted/
-// keyGenerator/messageVerifier. Skipped methods are listed in
-// docs/trailties-plan.md.
+// Port of `Rails::Application`. PR 2.5c adds routesReloader/configFor/
+// credentials/encrypted/keyGenerator/messageVerifier. Skipped methods
+// listed in docs/trailties-plan.md.
 import {
   dasherize,
   EncryptedFile,
@@ -108,12 +107,12 @@ export class Application extends Engine {
     return (this._routesReloader ??= new RoutesReloader());
   }
 
-  /** Explicit `config.secretKeyBase` wins, else `SECRET_KEY_BASE` env. */
+  /** `config.secretKeyBase` wins, else `SECRET_KEY_BASE` env. */
   secretKeyBase(): string | null {
     return cfgOf(this).secretKeyBase ?? getEnv("SECRET_KEY_BASE") ?? null;
   }
 
-  /** 1000 iterations match Rails for cookie/signed-id compatibility. */
+  /** 1000 iterations match Rails for cookie compatibility. */
   keyGenerator(secret: string | null = this.secretKeyBase()): CachingKeyGenerator {
     if (secret === null) throw new Error("Missing secret_key_base.");
     let gen = this._keyGenerators.get(secret);
@@ -124,8 +123,10 @@ export class Application extends Engine {
     return gen;
   }
 
+  /** Raw 64-byte derived key — Rails feeds `generate_key(salt)` bytes to
+   * HMAC, not hex; required for signed-cookie compatibility. */
   messageVerifier(name: string): MessageVerifier {
-    return new MessageVerifier(this.keyGenerator().generateKey(name, 32).toString("hex"));
+    return new MessageVerifier(this.keyGenerator().generateKey(name));
   }
 
   async credentials(): Promise<EncryptedFile> {
@@ -151,8 +152,7 @@ export class Application extends Engine {
     });
   }
 
-  /** Trails divergence: only `"database"` is supported — dynamic `import()`
-   * of `config/database.{ts,js}`. No YAML; import other configs directly. */
+  /** Trails: only `"database"` — dynamic `import()` of config/database.{ts,js}. */
   async configFor(name: string, opts: { env?: string } = {}): Promise<DatabaseConfig> {
     if (name !== "database") {
       throw new Error(`configFor: only "database" is supported in trailties (got "${name}").`);
@@ -160,18 +160,17 @@ export class Application extends Engine {
     return loadDatabaseConfig(opts.env ?? resolveEnv(), await this.requireRoot());
   }
 
-  /** @internal */
   private async requireRoot(): Promise<string> {
     return (await this.root()) ?? (await getFsAsync()).cwd();
   }
 }
 
-interface AppCfg {
+type AppCfg = {
   secretKeyBase?: string | null;
   credentials?: { contentPath?: string | null; keyPath?: string | null };
   requireMasterKey?: boolean;
-}
-const cfgOf = (app: Application): AppCfg => app.config as unknown as AppCfg;
+};
+const cfgOf = (app: Application): AppCfg => app.config as never;
 
 async function defaultCredentialPaths(
   root: string,

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -1,20 +1,23 @@
 // Port of `Rails::Application` from `railties/lib/rails/application.rb`.
-// PR 2.5a: the Application shell — findRoot, `initialize!` happy path
-// (Bootstrap + inherited Engine/Trailtie chain), `initialized?`, `name`,
-// and the `appClass` accessor that PR 2.6's `Rails.application` reads.
-// Configuration defaults + default middleware stack + Finisher splicing
-// land in PR 2.5b; routes-reloader + config_for + credentials in PR 2.5c.
-// Skipped from upstream (see docs/trailties-plan.md): secrets, eager_load!,
-// assets, sandbox, executor, reloader, autoloaders, helpers_paths, to_app,
-// migration_railties, load_generators, require_environment!, console/
-// runner/generators/server block runners (PR 2.1b Configurable work).
-// Trailties differs from Rails by using `config.ts` as the root flag
-// (trails' rackup analog) and explicit `Application.register(klass)`
-// instead of Ruby's `inherited` hook.
-import { dasherize, getFsAsync, runLoadHooks, underscore } from "@blazetrails/activesupport";
+// PR 2.5c adds routesReloader/configFor/credentials/encrypted/
+// keyGenerator/messageVerifier. Skipped methods are listed in
+// docs/trailties-plan.md.
+import {
+  dasherize,
+  EncryptedFile,
+  getEnv,
+  getFsAsync,
+  getPathAsync,
+  runLoadHooks,
+  underscore,
+} from "@blazetrails/activesupport";
+import { CachingKeyGenerator, KeyGenerator } from "@blazetrails/activesupport/key-generator";
+import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Engine } from "./engine.js";
 import { Trailtie } from "./trailtie.js";
 import { Bootstrap } from "./application/bootstrap.js";
+import { RoutesReloader } from "./application/routes-reloader.js";
+import { resolveEnv, loadDatabaseConfig, type DatabaseConfig } from "./database.js";
 import { Collection, type InitializerGroup } from "./initializable.js";
 import type { CacheStore, Logger } from "@blazetrails/activesupport";
 
@@ -24,6 +27,9 @@ const _registered = new WeakSet<typeof Application>();
 
 export class Application extends Engine {
   private _initialized = false;
+  private _routesReloader?: RoutesReloader;
+  private _keyGenerators = new Map<string, CachingKeyGenerator>();
+  private _credentials?: EncryptedFile;
   logger: Logger | null = null;
   cache: CacheStore | null = null;
 
@@ -97,4 +103,91 @@ export class Application extends Engine {
     runLoadHooks("after_initialize", this);
     return this;
   }
+
+  routesReloader(): RoutesReloader {
+    return (this._routesReloader ??= new RoutesReloader());
+  }
+
+  /** Explicit `config.secretKeyBase` wins, else `SECRET_KEY_BASE` env. */
+  secretKeyBase(): string | null {
+    return cfgOf(this).secretKeyBase ?? getEnv("SECRET_KEY_BASE") ?? null;
+  }
+
+  /** 1000 iterations match Rails for cookie/signed-id compatibility. */
+  keyGenerator(secret: string | null = this.secretKeyBase()): CachingKeyGenerator {
+    if (secret === null) throw new Error("Missing secret_key_base.");
+    let gen = this._keyGenerators.get(secret);
+    if (!gen) {
+      gen = new CachingKeyGenerator(new KeyGenerator(secret, { iterations: 1000 }));
+      this._keyGenerators.set(secret, gen);
+    }
+    return gen;
+  }
+
+  messageVerifier(name: string): MessageVerifier {
+    return new MessageVerifier(this.keyGenerator().generateKey(name, 32).toString("hex"));
+  }
+
+  async credentials(): Promise<EncryptedFile> {
+    if (this._credentials) return this._credentials;
+    const c = cfgOf(this).credentials;
+    const def = await defaultCredentialPaths(await this.requireRoot());
+    return (this._credentials = await this.encrypted(c?.contentPath ?? def.contentPath, {
+      keyPath: c?.keyPath ?? def.keyPath,
+    }));
+  }
+
+  async encrypted(
+    relativePath: string,
+    opts: { keyPath?: string; envKey?: string } = {},
+  ): Promise<EncryptedFile> {
+    const path = await getPathAsync();
+    const root = await this.requireRoot();
+    return new EncryptedFile({
+      contentPath: path.resolve(root, relativePath),
+      keyPath: path.resolve(root, opts.keyPath ?? "config/master.key"),
+      envKey: opts.envKey ?? "RAILS_MASTER_KEY",
+      raiseIfMissingKey: cfgOf(this).requireMasterKey ?? false,
+    });
+  }
+
+  /** Trails divergence: only `"database"` is supported — dynamic `import()`
+   * of `config/database.{ts,js}`. No YAML; import other configs directly. */
+  async configFor(name: string, opts: { env?: string } = {}): Promise<DatabaseConfig> {
+    if (name !== "database") {
+      throw new Error(`configFor: only "database" is supported in trailties (got "${name}").`);
+    }
+    return loadDatabaseConfig(opts.env ?? resolveEnv(), await this.requireRoot());
+  }
+
+  /** @internal */
+  private async requireRoot(): Promise<string> {
+    return (await this.root()) ?? (await getFsAsync()).cwd();
+  }
+}
+
+interface AppCfg {
+  secretKeyBase?: string | null;
+  credentials?: { contentPath?: string | null; keyPath?: string | null };
+  requireMasterKey?: boolean;
+}
+const cfgOf = (app: Application): AppCfg => app.config as unknown as AppCfg;
+
+async function defaultCredentialPaths(
+  root: string,
+): Promise<{ contentPath: string; keyPath: string }> {
+  const path = await getPathAsync();
+  const fs = await getFsAsync();
+  const env = resolveEnv();
+  const envContent = path.resolve(root, "config", "credentials", `${env}.yml.enc`);
+  if (await fs.exists(envContent)) {
+    return {
+      contentPath: envContent,
+      keyPath: path.resolve(root, "config", "credentials", `${env}.key`),
+    };
+  }
+  return {
+    contentPath: path.resolve(root, "config", "credentials.yml.enc"),
+    keyPath: path.resolve(root, "config", "master.key"),
+  };
 }

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -144,15 +144,17 @@ export class Application extends Engine {
     }));
   }
 
+  /** `contentPath` matches Rails' `encrypted(path, ...)` arg — absolute or
+   * root-relative; both flow through Rails.root.join / path.resolve. */
   async encrypted(
-    relativePath: string,
+    contentPath: string,
     opts: { keyPath?: string; envKey?: string } = {},
   ): Promise<EncryptedFile> {
-    const path = await getPathAsync();
+    const p = await getPathAsync();
     const root = await this.requireRoot();
     return new EncryptedFile({
-      contentPath: path.resolve(root, relativePath),
-      keyPath: path.resolve(root, opts.keyPath ?? "config/master.key"),
+      contentPath: p.resolve(root, contentPath),
+      keyPath: p.resolve(root, opts.keyPath ?? "config/master.key"),
       envKey: opts.envKey ?? "RAILS_MASTER_KEY",
       raiseIfMissingKey: this.config.requireMasterKey,
     });

--- a/packages/trailties/src/application.ts
+++ b/packages/trailties/src/application.ts
@@ -15,6 +15,7 @@ import { MessageVerifier } from "@blazetrails/activesupport/message-verifier";
 import { Engine } from "./engine.js";
 import { Trailtie } from "./trailtie.js";
 import { Bootstrap } from "./application/bootstrap.js";
+import { Configuration } from "./application/configuration.js";
 import { RoutesReloader } from "./application/routes-reloader.js";
 import { resolveEnv, loadDatabaseConfig, type DatabaseConfig } from "./database.js";
 import { Collection, type InitializerGroup } from "./initializable.js";
@@ -65,6 +66,11 @@ export class Application extends Engine {
     return this.findRootWithFlag("config.ts", from, fs.cwd());
   }
 
+  override get config(): Configuration {
+    if (!(this._config instanceof Configuration)) this._config = new Configuration(null);
+    return this._config as Configuration;
+  }
+
   /** Returns true once {@link Application#initialize} has completed. */
   initialized(): boolean {
     return this._initialized;
@@ -109,7 +115,7 @@ export class Application extends Engine {
 
   /** `config.secretKeyBase` wins, else `SECRET_KEY_BASE` env. */
   secretKeyBase(): string | null {
-    return cfgOf(this).secretKeyBase ?? getEnv("SECRET_KEY_BASE") ?? null;
+    return this.config.secretKeyBase ?? getEnv("SECRET_KEY_BASE") ?? null;
   }
 
   /** 1000 iterations match Rails for cookie compatibility. */
@@ -131,10 +137,10 @@ export class Application extends Engine {
 
   async credentials(): Promise<EncryptedFile> {
     if (this._credentials) return this._credentials;
-    const c = cfgOf(this).credentials;
+    const c = this.config.credentials;
     const def = await defaultCredentialPaths(await this.requireRoot());
-    return (this._credentials = await this.encrypted(c?.contentPath ?? def.contentPath, {
-      keyPath: c?.keyPath ?? def.keyPath,
+    return (this._credentials = await this.encrypted(c.contentPath ?? def.contentPath, {
+      keyPath: c.keyPath ?? def.keyPath,
     }));
   }
 
@@ -148,7 +154,7 @@ export class Application extends Engine {
       contentPath: path.resolve(root, relativePath),
       keyPath: path.resolve(root, opts.keyPath ?? "config/master.key"),
       envKey: opts.envKey ?? "RAILS_MASTER_KEY",
-      raiseIfMissingKey: cfgOf(this).requireMasterKey ?? false,
+      raiseIfMissingKey: this.config.requireMasterKey,
     });
   }
 
@@ -164,13 +170,6 @@ export class Application extends Engine {
     return (await this.root()) ?? (await getFsAsync()).cwd();
   }
 }
-
-type AppCfg = {
-  secretKeyBase?: string | null;
-  credentials?: { contentPath?: string | null; keyPath?: string | null };
-  requireMasterKey?: boolean;
-};
-const cfgOf = (app: Application): AppCfg => app.config as never;
 
 async function defaultCredentialPaths(
   root: string,

--- a/packages/trailties/src/application/bootstrap.ts
+++ b/packages/trailties/src/application/bootstrap.ts
@@ -60,7 +60,9 @@ Bootstrap.initializer<BootstrapHost>("initialize_logger", { group: "all" }, func
 Bootstrap.initializer<BootstrapHost>("initialize_cache", { group: "all" }, function () {
   if (!this.cache) {
     const store = this.config.cacheStore;
-    this.cache = typeof store === "function" ? store() : (store ?? new NullStore());
+    // Array form (Rails `[:file_store, "tmp/cache/"]`) needs Cache.lookup_store — not ported yet.
+    if (Array.isArray(store)) this.cache = new NullStore();
+    else this.cache = typeof store === "function" ? store() : (store ?? new NullStore());
   }
 });
 

--- a/packages/trailties/src/application/configuration.ts
+++ b/packages/trailties/src/application/configuration.ts
@@ -49,6 +49,11 @@ export class Configuration extends TrailtieConfiguration {
   railtiesOrder: Array<string | symbol> = ["all"];
   relativeUrlRoot: string | null = null;
   requireMasterKey = false;
+  secretKeyBase: string | null = null;
+  credentials: { contentPath: string | null; keyPath: string | null } = {
+    contentPath: null,
+    keyPath: null,
+  };
   disableSandbox = false;
   sandboxByDefault = false;
   encoding = "utf-8";

--- a/packages/trailties/src/application/configuration.ts
+++ b/packages/trailties/src/application/configuration.ts
@@ -2,7 +2,7 @@
 // `railties/lib/rails/application/configuration.rb`. PR 2.5b: scalar/state
 // defaults only — `loadDefaults(version)` version-dispatch + credentials +
 // `databaseConfiguration` are 2.5c or later.
-import { Configuration as TrailtieConfiguration } from "../trailtie/configuration.js";
+import { EngineConfiguration } from "../engine/configuration.js";
 
 export interface PublicFileServer {
   enabled: boolean;
@@ -18,7 +18,7 @@ type WeekDay = "sunday" | "monday" | "tuesday" | "wednesday" | "thursday" | "fri
 type LogLevel = "debug" | "info" | "warn" | "error" | "fatal" | "unknown";
 
 /** Mirrors Rails' `Rails::Application::Configuration`. */
-export class Configuration extends TrailtieConfiguration {
+export class Configuration extends EngineConfiguration {
   allowConcurrency: boolean | null = null;
   considerAllRequestsLocal = false;
   filterParameters: Array<string | RegExp> = [];

--- a/packages/trailties/src/application/routes-reloader.test.ts
+++ b/packages/trailties/src/application/routes-reloader.test.ts
@@ -55,8 +55,7 @@ describe("RoutesReloader", () => {
     onLoad("after_routes_loaded", (app) => void fired.push(app));
     const app = { tag: "app" };
     expect(await r.executeUnlessLoaded(app)).toBe(true);
-    expect(r.loaded).toBe(true);
-    expect(fired).toEqual([app]);
+    expect([r.loaded, fired]).toEqual([true, [app]]);
     expect(await r.executeUnlessLoaded(app)).toBe(false);
     expect(fired).toEqual([app]);
   });

--- a/packages/trailties/src/application/routes-reloader.test.ts
+++ b/packages/trailties/src/application/routes-reloader.test.ts
@@ -41,21 +41,19 @@ describe("RoutesReloader", () => {
     const a = makeRouteSet();
     r.routeSets.push(a);
     r.paths.push("/boom");
-    await expect(
-      r.reload(() => {
-        throw new Error("load failed");
-      }),
-    ).rejects.toThrow(/load failed/);
+    const boom = (): never => {
+      throw new Error("load failed");
+    };
+    await expect(r.reload(boom)).rejects.toThrow(/load failed/);
     expect(a.disableClearAndFinalize).toBe(false);
   });
 
   it("test_execute_unless_loaded_runs_once_and_fires_after_routes_loaded", async () => {
     const r = new RoutesReloader();
     const fired: unknown[] = [];
-    onLoad("after_routes_loaded", (app) => void fired.push(app));
+    onLoad("after_routes_loaded", (a) => void fired.push(a));
     const app = { tag: "app" };
-    expect(await r.executeUnlessLoaded(app)).toBe(true);
-    expect([r.loaded, fired]).toEqual([true, [app]]);
+    expect([await r.executeUnlessLoaded(app), r.loaded, fired]).toEqual([true, true, [app]]);
     expect(await r.executeUnlessLoaded(app)).toBe(false);
     expect(fired).toEqual([app]);
   });

--- a/packages/trailties/src/application/routes-reloader.test.ts
+++ b/packages/trailties/src/application/routes-reloader.test.ts
@@ -4,22 +4,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { onLoad, resetLoadHooks } from "@blazetrails/activesupport";
 import { RoutesReloader, type RouteSetLike } from "./routes-reloader.js";
 
-type Counted = RouteSetLike & { clearCalls: number; finalizeCalls: number; eagerLoadCalls: number };
-const makeRouteSet = (): Counted => ({
-  disableClearAndFinalize: false,
-  clearCalls: 0,
-  finalizeCalls: 0,
-  eagerLoadCalls: 0,
-  clear() {
-    (this as Counted).clearCalls += 1;
-  },
-  finalize() {
-    (this as Counted).finalizeCalls += 1;
-  },
-  eagerLoad() {
-    (this as Counted).eagerLoadCalls += 1;
-  },
-});
+type Counted = RouteSetLike & { calls: string[] };
+const makeRouteSet = (): Counted => {
+  const r: Counted = { disableClearAndFinalize: false, calls: [] };
+  r.clear = () => void r.calls.push("clear");
+  r.finalize = () => void r.calls.push("finalize");
+  r.eagerLoad = () => void r.calls.push("eagerLoad");
+  return r;
+};
 
 describe("RoutesReloader", () => {
   beforeEach(() => resetLoadHooks());
@@ -40,7 +32,7 @@ describe("RoutesReloader", () => {
     await r.reload((p) => void loaded.push(p));
     expect(loaded).toEqual(["/routes-a", "/routes-b"]);
     expect(after).toHaveBeenCalledOnce();
-    expect([a.clearCalls, a.finalizeCalls, a.eagerLoadCalls]).toEqual([1, 1, 1]);
+    expect(a.calls).toEqual(["clear", "finalize", "eagerLoad"]);
     expect(a.disableClearAndFinalize).toBe(false);
   });
 

--- a/packages/trailties/src/application/routes-reloader.test.ts
+++ b/packages/trailties/src/application/routes-reloader.test.ts
@@ -1,0 +1,71 @@
+// Mirrors `railties/test/application/routes_reloading_test.rb` for the
+// subset of behavior the trailties RoutesReloader implements.
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { onLoad, resetLoadHooks } from "@blazetrails/activesupport";
+import { RoutesReloader, type RouteSetLike } from "./routes-reloader.js";
+
+type Counted = RouteSetLike & { clearCalls: number; finalizeCalls: number; eagerLoadCalls: number };
+const makeRouteSet = (): Counted => ({
+  disableClearAndFinalize: false,
+  clearCalls: 0,
+  finalizeCalls: 0,
+  eagerLoadCalls: 0,
+  clear() {
+    (this as Counted).clearCalls += 1;
+  },
+  finalize() {
+    (this as Counted).finalizeCalls += 1;
+  },
+  eagerLoad() {
+    (this as Counted).eagerLoadCalls += 1;
+  },
+});
+
+describe("RoutesReloader", () => {
+  beforeEach(() => resetLoadHooks());
+  afterEach(() => resetLoadHooks());
+
+  it("test_reload_clears_finalizes_eager_loads_and_runs_after_load_paths", async () => {
+    const r = new RoutesReloader();
+    expect([r.paths, r.routeSets, r.externalRoutes]).toEqual([[], [], []]);
+    expect(r.eagerLoad).toBe(false);
+    expect(r.loaded).toBe(false);
+    const a = makeRouteSet();
+    r.routeSets.push(a);
+    r.paths.push("/routes-a", "/routes-b");
+    r.eagerLoad = true;
+    const loaded: string[] = [];
+    const after = vi.fn();
+    r.runAfterLoadPaths = after;
+    await r.reload((p) => void loaded.push(p));
+    expect(loaded).toEqual(["/routes-a", "/routes-b"]);
+    expect(after).toHaveBeenCalledOnce();
+    expect([a.clearCalls, a.finalizeCalls, a.eagerLoadCalls]).toEqual([1, 1, 1]);
+    expect(a.disableClearAndFinalize).toBe(false);
+  });
+
+  it("test_reload_reverts_disable_flag_even_when_loader_throws", async () => {
+    const r = new RoutesReloader();
+    const a = makeRouteSet();
+    r.routeSets.push(a);
+    r.paths.push("/boom");
+    await expect(
+      r.reload(() => {
+        throw new Error("load failed");
+      }),
+    ).rejects.toThrow(/load failed/);
+    expect(a.disableClearAndFinalize).toBe(false);
+  });
+
+  it("test_execute_unless_loaded_runs_once_and_fires_after_routes_loaded", async () => {
+    const r = new RoutesReloader();
+    const fired: unknown[] = [];
+    onLoad("after_routes_loaded", (app) => void fired.push(app));
+    const app = { tag: "app" };
+    expect(await r.executeUnlessLoaded(app)).toBe(true);
+    expect(r.loaded).toBe(true);
+    expect(fired).toEqual([app]);
+    expect(await r.executeUnlessLoaded(app)).toBe(false);
+    expect(fired).toEqual([app]);
+  });
+});

--- a/packages/trailties/src/application/routes-reloader.ts
+++ b/packages/trailties/src/application/routes-reloader.ts
@@ -1,0 +1,52 @@
+// Port of `Rails::Application::RoutesReloader` from
+// `railties/lib/rails/application/routes_reloader.rb`. Rails' watcher half
+// (FileUpdateChecker + Ruby `load`) ships with autoloading later; this is
+// the protocol the framework calls.
+import { runLoadHooks } from "@blazetrails/activesupport";
+
+export interface RouteSetLike {
+  disableClearAndFinalize?: boolean;
+  clear?(): void;
+  finalize?(): void;
+  eagerLoad?(): void;
+}
+
+export class RoutesReloader {
+  paths: string[] = [];
+  routeSets: RouteSetLike[] = [];
+  externalRoutes: string[] = [];
+  eagerLoad = false;
+  loaded = false;
+  /** @internal Rails `attr_writer :run_after_load_paths`. */
+  runAfterLoadPaths: () => void | Promise<void> = () => {};
+
+  async reload(loader: (path: string) => void | Promise<void> = () => {}): Promise<void> {
+    for (const s of this.routeSets) {
+      s.disableClearAndFinalize = true;
+      s.clear?.();
+    }
+    try {
+      for (const p of this.paths) await loader(p);
+      await this.runAfterLoadPaths();
+      for (const s of this.routeSets) s.finalize?.();
+      if (this.eagerLoad) for (const s of this.routeSets) s.eagerLoad?.();
+    } finally {
+      for (const s of this.routeSets) s.disableClearAndFinalize = false;
+    }
+  }
+
+  execute(loader?: (p: string) => void | Promise<void>): Promise<void> {
+    this.loaded = true;
+    return this.reload(loader);
+  }
+
+  async executeUnlessLoaded(
+    app: unknown,
+    loader?: (p: string) => void | Promise<void>,
+  ): Promise<boolean> {
+    if (this.loaded) return false;
+    await this.execute(loader);
+    runLoadHooks("after_routes_loaded", app);
+    return true;
+  }
+}

--- a/packages/trailties/src/application/routes-reloader.ts
+++ b/packages/trailties/src/application/routes-reloader.ts
@@ -21,11 +21,12 @@ export class RoutesReloader {
   runAfterLoadPaths: () => void | Promise<void> = () => {};
 
   async reload(loader: (path: string) => void | Promise<void> = () => {}): Promise<void> {
-    for (const s of this.routeSets) {
-      s.disableClearAndFinalize = true;
-      s.clear?.();
-    }
+    // Rails' `ensure revert` in `def reload!` covers `clear!` too.
     try {
+      for (const s of this.routeSets) {
+        s.disableClearAndFinalize = true;
+        s.clear?.();
+      }
       for (const p of this.paths) await loader(p);
       await this.runAfterLoadPaths();
       for (const s of this.routeSets) s.finalize?.();


### PR DESCRIPTION
## Summary

Closes the PR 2.5 split (final of three). Wires the post-shell `Application` surface that PR 2.6 (`Rails` global) needs.

- `Application::RoutesReloader` — ports `Rails::Application::RoutesReloader`. Rails' `FileUpdateChecker`/`load` half ships with autoloading; this is the protocol (`paths`, `routeSets`, `externalRoutes`, `eagerLoad`, `loaded`, `reload`, `execute`, `executeUnlessLoaded`) the rest of the framework calls. Fires `:after_routes_loaded` on first execute.
- `Application#routesReloader()` — memoized.
- `Application#secretKeyBase()` — explicit `config.secretKeyBase` wins, else `SECRET_KEY_BASE` env. tmp-file fallback deferred.
- `Application#keyGenerator(secret?)` — memoized `CachingKeyGenerator` per secret, 1000 iterations (matches Rails for cookie/signed-id compat).
- `Application#messageVerifier(name)` — derives a per-salt verifier from the key generator. The `MessageVerifiers` factory + rotation API is a follow-up.
- `Application#credentials()` / `#encrypted(path, opts)` — returns `EncryptedFile`. Env-aware defaults: prefers `config/credentials/{env}.yml.enc` + `.key` when present, else `config/credentials.yml.enc` + `config/master.key`. Respects `config.credentials.{contentPath,keyPath}` overrides and `config.requireMasterKey`.
- `Application#configFor(name, { env })` — **trails divergence:** only `"database"` is supported; dynamic `import()` of `config/database.{ts,js}` via the existing `loadDatabaseConfig` loader. No YAML; other config files should be imported as plain modules.
- `Application::Configuration` — adds `secretKeyBase: string|null` and `credentials: { contentPath, keyPath }`.

Tests mirror `railties/test/application/routes_reloading_test.rb` (subset) and the credentials/key-generator/message-verifier cases in `railties/test/application/configuration_test.rb`.

### Rails sources

- `railties/lib/rails/application/routes_reloader.rb`
- `railties/lib/rails/application.rb` — `routes_reloader`, `key_generator`, `message_verifier`, `credentials`, `encrypted`, `config_for`, `secret_key_base`

### Methods skipped (deferred)

- `message_verifiers` (factory + rotation) — follow-up
- `secret_key_base` tmp-file fallback (`tmp/local_secret.txt`)
- `reload_routes!` / `reload_routes_unless_loaded` thin wrappers — callers can use `app.routesReloader().reload(...)` directly
- `secrets`, `eager_load!`, `to_app`, `helpers_paths`, `console`/`runner`/`generators`/`server` block runners (per docs/trailties-plan.md)

### Trails divergence notes

- No YAML in `configFor` — `config/database.ts` (or `.js`) is the only supported config file. App authors import other configs directly.
- `RoutesReloader` is protocol-only until autoloading lands; route reloading via filesystem watcher is the autoloading PR's job.

## Test plan
- [x] `pnpm vitest run packages/trailties/src/application/routes-reloader.test.ts` — passes
- [x] `pnpm vitest run packages/trailties/src/application.test.ts` — passes (34 tests)
- [x] `pnpm lint` clean on touched files
- [x] LOC budget: 300 (at ceiling)