### PR TITLE
feat(trailties): CreateMigration action + migrationTemplate dispatch (PR 1.12b-2)

### DIFF
--- a/packages/activesupport/src/fs-adapter.ts
+++ b/packages/activesupport/src/fs-adapter.ts
@@ -83,6 +83,8 @@ export interface FsAdapter {
   rmdir?(path: string): Promise<void>;
   /** Async readdir — returns entry names in `path`. */
   readdir?(path: string): Promise<string[]>;
+  /** Async mkdir (used by create-migration to ensure the destination directory exists). */
+  mkdir?(path: string, options?: { recursive?: boolean }): Promise<void>;
 }
 
 export interface PathAdapter {
@@ -155,6 +157,7 @@ function tryAutoRegisterNode(): boolean {
       realpath(path: string): Promise<string>;
       rmdir(path: string): Promise<void>;
       readdir(path: string): Promise<string[]>;
+      mkdir(path: string, opts?: { recursive?: boolean }): Promise<string | undefined>;
     };
     const fs: FsAdapter = Object.assign({}, nodeFs, {
       cwd: () => globalThis.process.cwd(),
@@ -179,6 +182,8 @@ function tryAutoRegisterNode(): boolean {
       realpath: (p: string) => fsPromises.realpath(p),
       rmdir: (p: string) => fsPromises.rmdir(p),
       readdir: (p: string) => fsPromises.readdir(p),
+      mkdir: (p: string, opts?: { recursive?: boolean }) =>
+        fsPromises.mkdir(p, opts).then(() => undefined),
     }) as FsAdapter;
     const nodePath = req("node:path") as Required<Omit<PathAdapter, "pathToFileURL">>;
     const nodeUrl = req("node:url") as { pathToFileURL(p: string): URL };
@@ -223,6 +228,7 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
           mkdtemp(prefix: string): Promise<string>;
           realpath(path: string): Promise<string>;
           readdir(path: string): Promise<string[]>;
+          mkdir(path: string, opts?: { recursive?: boolean }): Promise<string | undefined>;
         };
         const fs: FsAdapter = Object.assign({}, nodeFs, {
           cwd: () => globalThis.process.cwd(),
@@ -242,6 +248,8 @@ function tryAutoRegisterNodeAsync(): Promise<boolean> {
           mkdtemp: (prefix: string) => fsPromises.mkdtemp(prefix),
           realpath: (p: string) => fsPromises.realpath(p),
           readdir: (p: string) => fsPromises.readdir(p),
+          mkdir: (p: string, opts?: { recursive?: boolean }) =>
+            fsPromises.mkdir(p, opts).then(() => undefined),
         }) as FsAdapter;
         const nodePath = (await import("node:path")) as unknown as Required<
           Omit<PathAdapter, "pathToFileURL">

--- a/packages/trailties/src/generators/actions/create-migration.test.ts
+++ b/packages/trailties/src/generators/actions/create-migration.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import type { FsAdapter, PathAdapter } from "@blazetrails/activesupport";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import {
+  fsAdapterConfig,
+  registerFsAdapter,
+  type FsAdapter,
+  type PathAdapter,
+} from "@blazetrails/activesupport";
 import { CreateMigration, type MigrationRenderer } from "./create-migration.js";
 
 const path: PathAdapter = {
@@ -11,6 +16,7 @@ const path: PathAdapter = {
     const i = p.lastIndexOf(".");
     return i >= 0 ? p.slice(i) : "";
   },
+  isAbsolute: (p) => p.startsWith("/"),
   sep: "/",
 };
 
@@ -19,11 +25,10 @@ const DEFAULT = "db/migrate/create_articles.rb";
 
 interface Store {
   files: Map<string, string>;
-  fs: FsAdapter;
   log: string[];
 }
 
-function store(): Store {
+function install(): Store {
   const files = new Map<string, string>();
   const dirs = new Set<string>([ROOT, `${ROOT}/db`, `${ROOT}/db/migrate`]);
   const dirOf = (p: string) => p.split("/").slice(0, -1).join("/") || "/";
@@ -42,7 +47,9 @@ function store(): Store {
     readdir: async (p: string) =>
       [...files.keys()].filter((f) => dirOf(f) === p).map((f) => f.slice(p.length + 1)),
   } as unknown as FsAdapter;
-  return { files, fs, log: [] };
+  registerFsAdapter("create-migration-test", fs, path);
+  fsAdapterConfig.adapter = "create-migration-test";
+  return { files, log: [] };
 }
 
 function makeMigration(
@@ -57,8 +64,6 @@ function makeMigration(
   const numbered = `${dir}/${next}_${path.basename(destinationPath)}`;
   const fileName = path.basename(destinationPath).replace(/\.rb$/, "");
   const host = {
-    fs: s.fs,
-    path,
     output: (m: string) => s.log.push(m),
     options: generatorOptions,
     migrationFileName: fileName,
@@ -69,9 +74,13 @@ function makeMigration(
 }
 
 describe("CreateMigration", () => {
+  const PREV = fsAdapterConfig.adapter;
   let s: Store;
   beforeEach(() => {
-    s = store();
+    s = install();
+  });
+  afterEach(() => {
+    fsAdapterConfig.adapter = PREV;
   });
 
   const migrationExists = async (

--- a/packages/trailties/src/generators/actions/create-migration.test.ts
+++ b/packages/trailties/src/generators/actions/create-migration.test.ts
@@ -1,149 +1,174 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach } from "vitest";
 import type { FsAdapter, PathAdapter } from "@blazetrails/activesupport";
-import { CreateMigration } from "./create-migration.js";
+import { CreateMigration, type MigrationRenderer } from "./create-migration.js";
 
 const path: PathAdapter = {
-  join: (...p: string[]) => p.join("/"),
-  dirname: (p: string) => p.split("/").slice(0, -1).join("/") || "/",
-  basename: (p: string) => p.split("/").pop()!,
-  resolve: (...p: string[]) => p.join("/"),
-  extname: (p: string) => {
+  join: (...p) => p.join("/"),
+  dirname: (p) => p.split("/").slice(0, -1).join("/") || "/",
+  basename: (p) => p.split("/").pop()!,
+  resolve: (...p) => p.join("/"),
+  extname: (p) => {
     const i = p.lastIndexOf(".");
     return i >= 0 ? p.slice(i) : "";
   },
   sep: "/",
 };
 
-function buildFs(initial: Record<string, string>): FsAdapter & {
-  files: Record<string, string>;
-  dirs: Set<string>;
-} {
-  const files = { ...initial };
-  const dirs = new Set<string>();
-  const dirOf = (p: string) => p.split("/").slice(0, -1).join("/");
-  for (const k of Object.keys(files)) dirs.add(dirOf(k));
-  return {
-    files,
-    dirs,
-    exists: async (p: string) => Object.hasOwn(files, p) || dirs.has(p),
-    readFile: (async (p: string) => files[p]) as unknown as FsAdapter["readFile"],
-    writeFile: async (p: string, c: string | Buffer | Uint8Array) => {
-      files[p] = typeof c === "string" ? c : Buffer.from(c).toString("utf-8");
+const ROOT = "/app";
+const DEFAULT = "db/migrate/create_articles.rb";
+
+interface Store {
+  files: Map<string, string>;
+  fs: FsAdapter;
+  log: string[];
+}
+
+function store(): Store {
+  const files = new Map<string, string>();
+  const dirs = new Set<string>([ROOT, `${ROOT}/db`, `${ROOT}/db/migrate`]);
+  const dirOf = (p: string) => p.split("/").slice(0, -1).join("/") || "/";
+  const fs = {
+    exists: async (p: string) => files.has(p) || dirs.has(p),
+    readFile: (async (p: string) => files.get(p)!) as unknown as FsAdapter["readFile"],
+    writeFile: async (p: string, c: string) => {
+      files.set(p, c);
     },
     unlink: async (p: string) => {
-      delete files[p];
+      files.delete(p);
     },
     mkdir: async (p: string) => {
       dirs.add(p);
     },
     readdir: async (p: string) =>
-      Object.keys(files)
-        .filter((f) => dirOf(f) === p)
-        .map((f) => f.slice(p.length + 1)),
-  } as FsAdapter & { files: Record<string, string>; dirs: Set<string> };
+      [...files.keys()].filter((f) => dirOf(f) === p).map((f) => f.slice(p.length + 1)),
+  } as unknown as FsAdapter;
+  return { files, fs, log: [] };
 }
 
-function buildHost(fs: FsAdapter, fileName: string, options: Record<string, boolean> = {}) {
-  const log: string[] = [];
-  return {
-    fs,
+function makeMigration(
+  s: Store,
+  destinationPath: string = DEFAULT,
+  config: { force?: boolean; skip?: boolean } = {},
+  generatorOptions: { pretend?: boolean } = {},
+  data: MigrationRenderer = "contents",
+): CreateMigration {
+  const dir = path.dirname(`${ROOT}/${destinationPath}`);
+  const next = [...s.files.keys()].filter((f) => path.dirname(f) === dir).length + 1;
+  const numbered = `${dir}/${next}_${path.basename(destinationPath)}`;
+  const fileName = path.basename(destinationPath).replace(/\.rb$/, "");
+  const host = {
+    fs: s.fs,
     path,
-    output: (m: string) => log.push(m),
-    options,
+    output: (m: string) => s.log.push(m),
+    options: generatorOptions,
     migrationFileName: fileName,
-    relativeToOriginalDestinationRoot: (p: string) => p.replace(/^\/app\//, ""),
-    log,
+    relativeToOriginalDestinationRoot: (p: string) =>
+      p.startsWith(`${ROOT}/`) ? p.slice(ROOT.length + 1) : p,
   };
+  return new CreateMigration(host, numbered, data, config);
 }
 
 describe("CreateMigration", () => {
-  it("invoke writes a new migration and reports create", async () => {
-    const fs = buildFs({});
-    const host = buildHost(fs, "create_posts");
-    const dest = "/app/db/migrate/20260101000000_create_posts.rb";
-    const action = new CreateMigration(host, dest, "BODY");
-    const result = await action.invoke();
-    expect(result).toBe(dest);
-    expect(fs.files[dest]).toBe("BODY");
-    expect(host.log).toEqual(["      create  db/migrate/20260101000000_create_posts.rb"]);
+  let s: Store;
+  beforeEach(() => {
+    s = store();
   });
 
-  it("invoke reports identical when content matches existing numbered migration", async () => {
-    const fs = buildFs({
-      "/app/db/migrate/20260101000000_create_posts.rb": "BODY",
-    });
-    const host = buildHost(fs, "create_posts");
-    const action = new CreateMigration(
-      host,
-      "/app/db/migrate/20260102000000_create_posts.rb",
-      "BODY",
+  const migrationExists = async (
+    destinationPath: string = DEFAULT,
+    data: MigrationRenderer = "contents",
+  ) => {
+    const m = makeMigration(s, destinationPath, {}, {}, data);
+    await m.invoke();
+    s.log.length = 0;
+    return m;
+  };
+
+  it("test_invoke", async () => {
+    const m = makeMigration(s);
+    await m.invoke();
+    expect(s.log.join("\n")).toMatch(/create {2}db\/migrate\/1_create_articles\.rb/);
+    expect(s.files.has(m.destination)).toBe(true);
+  });
+
+  it("test_invoke_pretended", async () => {
+    const m = makeMigration(s, DEFAULT, {}, { pretend: true });
+    await m.invoke();
+    expect(s.log.join("\n")).toMatch(/create {2}db\/migrate\/1_create_articles\.rb/);
+    expect(s.files.has(m.destination)).toBe(false);
+  });
+
+  it("test_invoke_when_exists", async () => {
+    const existing = await migrationExists();
+    expect(await makeMigration(s).existingMigration()).toBe(existing.destination);
+  });
+
+  it("test_invoke_when_exists_identical", async () => {
+    await migrationExists();
+    const m = makeMigration(s);
+    await m.invoke();
+    expect(s.log.join("\n")).toMatch(/identical {2}db\/migrate\/1_create_articles\.rb/);
+    expect(await m.identical()).toBe(true);
+  });
+
+  it("test_invoke_return_existing_file_when_exists_identical", async () => {
+    const existing = await migrationExists();
+    expect(await makeMigration(s).invoke()).toBe(await existing.relativeExistingMigration());
+  });
+
+  it("test_invoke_when_exists_not_identical", async () => {
+    await migrationExists();
+    await expect(makeMigration(s, DEFAULT, {}, {}, "different").invoke()).rejects.toThrow(
+      /Another migration is already named/,
     );
-    const result = await action.invoke();
-    expect(result).toBe("/app/db/migrate/20260101000000_create_posts.rb");
-    expect(host.log[0]).toMatch(/identical/);
   });
 
-  it("invoke with force replaces the existing migration", async () => {
-    const fs = buildFs({
-      "/app/db/migrate/20260101000000_create_posts.rb": "OLD",
-    });
-    const host = buildHost(fs, "create_posts", { force: true });
-    const dest = "/app/db/migrate/20260102000000_create_posts.rb";
-    const action = new CreateMigration(host, dest, "NEW");
-    const result = await action.invoke();
-    expect(result).toBe(dest);
-    expect(fs.files["/app/db/migrate/20260101000000_create_posts.rb"]).toBeUndefined();
-    expect(fs.files[dest]).toBe("NEW");
+  it("test_invoke_forced_when_exists_not_identical", async () => {
+    const dest = "db/migrate/migration.rb";
+    const existing = await migrationExists(dest);
+    const m = makeMigration(s, dest, { force: true }, {}, "different");
+    await m.invoke();
+    const out = s.log.join("\n");
+    expect(out).toMatch(/remove {2}db\/migrate\/1_migration\.rb/);
+    expect(out).toMatch(/create {2}db\/migrate\/2_migration\.rb/);
+    expect(s.files.has(m.destination)).toBe(true);
+    expect(s.files.has(existing.destination)).toBe(false);
   });
 
-  it("invoke with skip leaves the existing migration", async () => {
-    const fs = buildFs({
-      "/app/db/migrate/20260101000000_create_posts.rb": "OLD",
-    });
-    const host = buildHost(fs, "create_posts", { skip: true });
-    const action = new CreateMigration(
-      host,
-      "/app/db/migrate/20260102000000_create_posts.rb",
-      "NEW",
-    );
-    const result = await action.invoke();
-    expect(result).toBe("/app/db/migrate/20260101000000_create_posts.rb");
-    expect(host.log.some((m) => m.includes("skip"))).toBe(true);
+  it("test_invoke_forced_pretended_when_exists_not_identical", async () => {
+    await migrationExists();
+    const m = makeMigration(s, DEFAULT, { force: true }, { pretend: true }, "different");
+    await m.invoke();
+    const out = s.log.join("\n");
+    expect(out).toMatch(/remove {2}db\/migrate\/1_create_articles\.rb/);
+    expect(out).toMatch(/create {2}db\/migrate\/2_create_articles\.rb/);
+    expect(s.files.has(m.destination)).toBe(false);
   });
 
-  it("invoke on conflict without force/skip raises", async () => {
-    const fs = buildFs({
-      "/app/db/migrate/20260101000000_create_posts.rb": "OLD",
-    });
-    const host = buildHost(fs, "create_posts");
-    const action = new CreateMigration(
-      host,
-      "/app/db/migrate/20260102000000_create_posts.rb",
-      "NEW",
-    );
-    await expect(action.invoke()).rejects.toThrow(/Another migration is already named/);
+  it("test_invoke_skipped_when_exists_not_identical", async () => {
+    await migrationExists();
+    const m = makeMigration(s, DEFAULT, { skip: true }, {}, "different");
+    await m.invoke();
+    expect(s.log.join("\n")).toMatch(/skip {2}db\/migrate\/2_create_articles\.rb/);
+    expect(s.files.has(m.destination)).toBe(false);
   });
 
-  it("revoke removes the existing migration", async () => {
-    const fs = buildFs({
-      "/app/db/migrate/20260101000000_create_posts.rb": "OLD",
-    });
-    const host = buildHost(fs, "create_posts");
-    const action = new CreateMigration(
-      host,
-      "/app/db/migrate/20260102000000_create_posts.rb",
-      "NEW",
-    );
-    const removed = await action.revoke();
-    expect(removed).toBe("/app/db/migrate/20260101000000_create_posts.rb");
-    expect(fs.files["/app/db/migrate/20260101000000_create_posts.rb"]).toBeUndefined();
+  it("test_revoke", async () => {
+    const existing = await migrationExists();
+    await makeMigration(s).revoke();
+    expect(s.log.join("\n")).toMatch(/remove {2}db\/migrate\/1_create_articles\.rb/);
+    expect(s.files.has(existing.destination)).toBe(false);
   });
 
-  it("pretend does not write to the filesystem", async () => {
-    const fs = buildFs({});
-    const host = buildHost(fs, "create_posts", { pretend: true });
-    const dest = "/app/db/migrate/20260101000000_create_posts.rb";
-    await new CreateMigration(host, dest, "BODY").invoke();
-    expect(fs.files[dest]).toBeUndefined();
+  it("test_revoke_pretended", async () => {
+    const existing = await migrationExists();
+    await makeMigration(s, DEFAULT, {}, { pretend: true }).revoke();
+    expect(s.log.join("\n")).toMatch(/remove {2}db\/migrate\/1_create_articles\.rb/);
+    expect(s.files.has(existing.destination)).toBe(true);
+  });
+
+  it("test_revoke_when_no_exists", async () => {
+    await makeMigration(s).revoke();
+    expect(s.log.join("\n")).toMatch(/remove {2}db\/migrate\/1_create_articles\.rb/);
   });
 });

--- a/packages/trailties/src/generators/actions/create-migration.test.ts
+++ b/packages/trailties/src/generators/actions/create-migration.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import type { FsAdapter, PathAdapter } from "@blazetrails/activesupport";
+import { CreateMigration } from "./create-migration.js";
+
+const path: PathAdapter = {
+  join: (...p: string[]) => p.join("/"),
+  dirname: (p: string) => p.split("/").slice(0, -1).join("/") || "/",
+  basename: (p: string) => p.split("/").pop()!,
+  resolve: (...p: string[]) => p.join("/"),
+  extname: (p: string) => {
+    const i = p.lastIndexOf(".");
+    return i >= 0 ? p.slice(i) : "";
+  },
+  sep: "/",
+};
+
+function buildFs(initial: Record<string, string>): FsAdapter & {
+  files: Record<string, string>;
+  dirs: Set<string>;
+} {
+  const files = { ...initial };
+  const dirs = new Set<string>();
+  const dirOf = (p: string) => p.split("/").slice(0, -1).join("/");
+  for (const k of Object.keys(files)) dirs.add(dirOf(k));
+  return {
+    files,
+    dirs,
+    exists: async (p: string) => Object.hasOwn(files, p) || dirs.has(p),
+    readFile: (async (p: string) => files[p]) as unknown as FsAdapter["readFile"],
+    writeFile: async (p: string, c: string | Buffer | Uint8Array) => {
+      files[p] = typeof c === "string" ? c : Buffer.from(c).toString("utf-8");
+    },
+    unlink: async (p: string) => {
+      delete files[p];
+    },
+    mkdir: async (p: string) => {
+      dirs.add(p);
+    },
+    readdir: async (p: string) =>
+      Object.keys(files)
+        .filter((f) => dirOf(f) === p)
+        .map((f) => f.slice(p.length + 1)),
+  } as FsAdapter & { files: Record<string, string>; dirs: Set<string> };
+}
+
+function buildHost(fs: FsAdapter, fileName: string, options: Record<string, boolean> = {}) {
+  const log: string[] = [];
+  return {
+    fs,
+    path,
+    output: (m: string) => log.push(m),
+    options,
+    migrationFileName: fileName,
+    relativeToOriginalDestinationRoot: (p: string) => p.replace(/^\/app\//, ""),
+    log,
+  };
+}
+
+describe("CreateMigration", () => {
+  it("invoke writes a new migration and reports create", async () => {
+    const fs = buildFs({});
+    const host = buildHost(fs, "create_posts");
+    const dest = "/app/db/migrate/20260101000000_create_posts.rb";
+    const action = new CreateMigration(host, dest, "BODY");
+    const result = await action.invoke();
+    expect(result).toBe(dest);
+    expect(fs.files[dest]).toBe("BODY");
+    expect(host.log).toEqual(["      create  db/migrate/20260101000000_create_posts.rb"]);
+  });
+
+  it("invoke reports identical when content matches existing numbered migration", async () => {
+    const fs = buildFs({
+      "/app/db/migrate/20260101000000_create_posts.rb": "BODY",
+    });
+    const host = buildHost(fs, "create_posts");
+    const action = new CreateMigration(
+      host,
+      "/app/db/migrate/20260102000000_create_posts.rb",
+      "BODY",
+    );
+    const result = await action.invoke();
+    expect(result).toBe("/app/db/migrate/20260101000000_create_posts.rb");
+    expect(host.log[0]).toMatch(/identical/);
+  });
+
+  it("invoke with force replaces the existing migration", async () => {
+    const fs = buildFs({
+      "/app/db/migrate/20260101000000_create_posts.rb": "OLD",
+    });
+    const host = buildHost(fs, "create_posts", { force: true });
+    const dest = "/app/db/migrate/20260102000000_create_posts.rb";
+    const action = new CreateMigration(host, dest, "NEW");
+    const result = await action.invoke();
+    expect(result).toBe(dest);
+    expect(fs.files["/app/db/migrate/20260101000000_create_posts.rb"]).toBeUndefined();
+    expect(fs.files[dest]).toBe("NEW");
+  });
+
+  it("invoke with skip leaves the existing migration", async () => {
+    const fs = buildFs({
+      "/app/db/migrate/20260101000000_create_posts.rb": "OLD",
+    });
+    const host = buildHost(fs, "create_posts", { skip: true });
+    const action = new CreateMigration(
+      host,
+      "/app/db/migrate/20260102000000_create_posts.rb",
+      "NEW",
+    );
+    const result = await action.invoke();
+    expect(result).toBe("/app/db/migrate/20260101000000_create_posts.rb");
+    expect(host.log.some((m) => m.includes("skip"))).toBe(true);
+  });
+
+  it("invoke on conflict without force/skip raises", async () => {
+    const fs = buildFs({
+      "/app/db/migrate/20260101000000_create_posts.rb": "OLD",
+    });
+    const host = buildHost(fs, "create_posts");
+    const action = new CreateMigration(
+      host,
+      "/app/db/migrate/20260102000000_create_posts.rb",
+      "NEW",
+    );
+    await expect(action.invoke()).rejects.toThrow(/Another migration is already named/);
+  });
+
+  it("revoke removes the existing migration", async () => {
+    const fs = buildFs({
+      "/app/db/migrate/20260101000000_create_posts.rb": "OLD",
+    });
+    const host = buildHost(fs, "create_posts");
+    const action = new CreateMigration(
+      host,
+      "/app/db/migrate/20260102000000_create_posts.rb",
+      "NEW",
+    );
+    const removed = await action.revoke();
+    expect(removed).toBe("/app/db/migrate/20260101000000_create_posts.rb");
+    expect(fs.files["/app/db/migrate/20260101000000_create_posts.rb"]).toBeUndefined();
+  });
+
+  it("pretend does not write to the filesystem", async () => {
+    const fs = buildFs({});
+    const host = buildHost(fs, "create_posts", { pretend: true });
+    const dest = "/app/db/migrate/20260101000000_create_posts.rb";
+    await new CreateMigration(host, dest, "BODY").invoke();
+    expect(fs.files[dest]).toBeUndefined();
+  });
+});

--- a/packages/trailties/src/generators/actions/create-migration.ts
+++ b/packages/trailties/src/generators/actions/create-migration.ts
@@ -1,14 +1,13 @@
-import type { FsAdapter, PathAdapter } from "@blazetrails/activesupport";
+import { getFs, getPath } from "@blazetrails/activesupport";
 import { migrationExists } from "../migration.js";
 
 // Mirrors railties/lib/rails/generators/actions/create_migration.rb. Rails
 // inherits from Thor::Actions::CreateFile; we don't have Thor, so the
 // invoke/revoke and conflict behaviors are ported directly. Status output
-// goes through `host.output` (Rails uses shell.say_status).
+// goes through `host.output` (Rails uses shell.say_status). Filesystem and
+// path access come from the activesupport adapter registry.
 
 export interface CreateMigrationHost {
-  fs: FsAdapter;
-  path: PathAdapter;
   output: (msg: string) => void;
   options: { force?: boolean; skip?: boolean; pretend?: boolean };
   migrationFileName: string;
@@ -32,7 +31,7 @@ export class CreateMigration {
   ) {}
 
   get migrationDir(): string {
-    return this.base.path.dirname(this.destination);
+    return getPath().dirname(this.destination);
   }
 
   get migrationFileName(): string {
@@ -51,14 +50,9 @@ export class CreateMigration {
   // exist after a successful invoke!).
   async existingMigration(): Promise<string | undefined> {
     if (this._existingMigration) return this._existingMigration;
-    const found = await migrationExists(
-      this.base.fs,
-      this.base.path,
-      this.migrationDir,
-      this.migrationFileName,
-    );
+    const found = await migrationExists(this.migrationDir, this.migrationFileName);
     const value =
-      found ?? ((await this.base.fs.exists(this.destination)) ? this.destination : undefined);
+      found ?? ((await getFs().exists(this.destination)) ? this.destination : undefined);
     if (value) this._existingMigration = value;
     return value;
   }
@@ -76,8 +70,9 @@ export class CreateMigration {
   async identical(): Promise<boolean> {
     const existing = await this.existingMigration();
     if (!existing) return false;
-    if (!this.base.fs.readFile) throw new Error("FsAdapter.readFile is required");
-    return (await this.base.fs.readFile(existing, "utf-8")) === (await this.render());
+    const fs = getFs();
+    if (!fs.readFile) throw new Error("FsAdapter.readFile is required");
+    return (await fs.readFile(existing, "utf-8")) === (await this.render());
   }
 
   async relativeExistingMigration(): Promise<string> {
@@ -105,7 +100,7 @@ export class CreateMigration {
     // got written (force / no-conflict) and fall back to the relative path
     // of the existing migration (identical / skip).
     if (this.pretend()) return this.destination;
-    if (await this.base.fs.exists(this.destination)) return this.destination;
+    if (await getFs().exists(this.destination)) return this.destination;
     return this.relativeExistingMigration();
   }
 
@@ -115,8 +110,9 @@ export class CreateMigration {
     this.sayStatus("remove", "red", sayDest);
     if (!e) return undefined;
     if (!this.pretend()) {
-      if (!this.base.fs.unlink) throw new Error("FsAdapter.unlink is required");
-      await this.base.fs.unlink(e);
+      const fs = getFs();
+      if (!fs.unlink) throw new Error("FsAdapter.unlink is required");
+      await fs.unlink(e);
       this.invalidateExistingMigration();
     }
     return e;
@@ -134,8 +130,9 @@ export class CreateMigration {
       if (!this.pretend()) {
         const e = await this.existingMigration();
         if (e) {
-          if (!this.base.fs.unlink) throw new Error("FsAdapter.unlink is required");
-          await this.base.fs.unlink(e);
+          const fs = getFs();
+          if (!fs.unlink) throw new Error("FsAdapter.unlink is required");
+          await fs.unlink(e);
           this.invalidateExistingMigration();
         }
         await this.writeRendered();
@@ -155,10 +152,11 @@ export class CreateMigration {
   }
 
   private async writeRendered(): Promise<void> {
-    if (!this.base.fs.writeFile) throw new Error("FsAdapter.writeFile is required");
-    if (!this.base.fs.mkdir) throw new Error("FsAdapter.mkdir is required");
-    await this.base.fs.mkdir(this.base.path.dirname(this.destination), { recursive: true });
-    await this.base.fs.writeFile(this.destination, await this.render());
+    const fs = getFs();
+    if (!fs.writeFile) throw new Error("FsAdapter.writeFile is required");
+    if (!fs.mkdir) throw new Error("FsAdapter.mkdir is required");
+    await fs.mkdir(getPath().dirname(this.destination), { recursive: true });
+    await fs.writeFile(this.destination, await this.render());
   }
 
   private sayStatus(status: string, _color: string, message?: string): void {

--- a/packages/trailties/src/generators/actions/create-migration.ts
+++ b/packages/trailties/src/generators/actions/create-migration.ts
@@ -81,13 +81,18 @@ export class CreateMigration {
 
   async invoke(): Promise<string> {
     const existing = await this.existingMigration();
-    if (existing) {
-      const resolved = await this.onConflictBehavior();
-      return resolved ?? existing;
+    if (existing) await this.onConflictBehavior();
+    else {
+      if (!this.pretend()) await this.writeRendered();
+      this.sayStatus("create", "green");
     }
-    if (!this.pretend()) await this.writeRendered();
-    this.sayStatus("create", "green");
-    return this.destination;
+    // Mirrors Rails' invoke! tail: pretend always returns the destination
+    // (Thor short-circuits); otherwise return the new destination when it
+    // got written (force / no-conflict) and fall back to the relative path
+    // of the existing migration (identical / skip).
+    if (this.pretend()) return this.destination;
+    if (await this.base.fs.exists(this.destination)) return this.destination;
+    return this.relativeExistingMigration();
   }
 
   async revoke(): Promise<string | undefined> {

--- a/packages/trailties/src/generators/actions/create-migration.ts
+++ b/packages/trailties/src/generators/actions/create-migration.ts
@@ -1,5 +1,5 @@
 import { getFs, getPath } from "@blazetrails/activesupport";
-import { migrationExists } from "../migration.js";
+import { migrationExists } from "../migration-lookup.js";
 
 // Mirrors railties/lib/rails/generators/actions/create_migration.rb. Rails
 // inherits from Thor::Actions::CreateFile; we don't have Thor, so the

--- a/packages/trailties/src/generators/actions/create-migration.ts
+++ b/packages/trailties/src/generators/actions/create-migration.ts
@@ -43,16 +43,30 @@ export class CreateMigration {
     return typeof this.data === "function" ? await this.data() : this.data;
   }
 
+  private _existingMigration?: string;
+
+  // Mirrors Rails' `@existing_migration ||= ...` memoization in
+  // create_migration.rb. Ruby's `||=` only caches truthy values, so an
+  // "absent" lookup re-scans on the next call (the destination may now
+  // exist after a successful invoke!).
   async existingMigration(): Promise<string | undefined> {
+    if (this._existingMigration) return this._existingMigration;
     const found = await migrationExists(
       this.base.fs,
       this.base.path,
       this.migrationDir,
       this.migrationFileName,
     );
-    if (found) return found;
-    if (await this.base.fs.exists(this.destination)) return this.destination;
-    return undefined;
+    const value =
+      found ?? ((await this.base.fs.exists(this.destination)) ? this.destination : undefined);
+    if (value) this._existingMigration = value;
+    return value;
+  }
+
+  // Force-path / revoke remove the cached file; reset so subsequent reads
+  // see the new filesystem state.
+  private invalidateExistingMigration(): void {
+    this._existingMigration = undefined;
   }
 
   async exists(): Promise<boolean> {
@@ -103,6 +117,7 @@ export class CreateMigration {
     if (!this.pretend()) {
       if (!this.base.fs.unlink) throw new Error("FsAdapter.unlink is required");
       await this.base.fs.unlink(e);
+      this.invalidateExistingMigration();
     }
     return e;
   }
@@ -121,6 +136,7 @@ export class CreateMigration {
         if (e) {
           if (!this.base.fs.unlink) throw new Error("FsAdapter.unlink is required");
           await this.base.fs.unlink(e);
+          this.invalidateExistingMigration();
         }
         await this.writeRendered();
       }
@@ -140,9 +156,8 @@ export class CreateMigration {
 
   private async writeRendered(): Promise<void> {
     if (!this.base.fs.writeFile) throw new Error("FsAdapter.writeFile is required");
-    if (this.base.fs.mkdir) {
-      await this.base.fs.mkdir(this.base.path.dirname(this.destination), { recursive: true });
-    }
+    if (!this.base.fs.mkdir) throw new Error("FsAdapter.mkdir is required");
+    await this.base.fs.mkdir(this.base.path.dirname(this.destination), { recursive: true });
     await this.base.fs.writeFile(this.destination, await this.render());
   }
 

--- a/packages/trailties/src/generators/actions/create-migration.ts
+++ b/packages/trailties/src/generators/actions/create-migration.ts
@@ -1,0 +1,145 @@
+import type { FsAdapter, PathAdapter } from "@blazetrails/activesupport";
+import { migrationExists } from "../migration.js";
+
+// Mirrors railties/lib/rails/generators/actions/create_migration.rb. Rails
+// inherits from Thor::Actions::CreateFile; we don't have Thor, so the
+// invoke/revoke and conflict behaviors are ported directly. Status output
+// goes through `host.output` (Rails uses shell.say_status).
+
+export interface CreateMigrationHost {
+  fs: FsAdapter;
+  path: PathAdapter;
+  output: (msg: string) => void;
+  options: { force?: boolean; skip?: boolean; pretend?: boolean };
+  migrationFileName: string;
+  relativeToOriginalDestinationRoot(p: string): string;
+}
+
+export interface CreateMigrationConfig {
+  verbose?: boolean;
+  force?: boolean;
+  skip?: boolean;
+}
+
+export type MigrationRenderer = string | (() => string | Promise<string>);
+
+export class CreateMigration {
+  constructor(
+    public base: CreateMigrationHost,
+    public destination: string,
+    public data: MigrationRenderer,
+    public config: CreateMigrationConfig = {},
+  ) {}
+
+  get migrationDir(): string {
+    return this.base.path.dirname(this.destination);
+  }
+
+  get migrationFileName(): string {
+    return this.base.migrationFileName;
+  }
+
+  async render(): Promise<string> {
+    return typeof this.data === "function" ? await this.data() : this.data;
+  }
+
+  async existingMigration(): Promise<string | undefined> {
+    const found = await migrationExists(
+      this.base.fs,
+      this.base.path,
+      this.migrationDir,
+      this.migrationFileName,
+    );
+    if (found) return found;
+    if (await this.base.fs.exists(this.destination)) return this.destination;
+    return undefined;
+  }
+
+  async exists(): Promise<boolean> {
+    return Boolean(await this.existingMigration());
+  }
+
+  async identical(): Promise<boolean> {
+    const existing = await this.existingMigration();
+    if (!existing) return false;
+    if (!this.base.fs.readFile) throw new Error("FsAdapter.readFile is required");
+    return (await this.base.fs.readFile(existing, "utf-8")) === (await this.render());
+  }
+
+  async relativeExistingMigration(): Promise<string> {
+    const e = await this.existingMigration();
+    return e ? this.base.relativeToOriginalDestinationRoot(e) : "";
+  }
+
+  relativeDestination(): string {
+    return this.base.relativeToOriginalDestinationRoot(this.destination);
+  }
+
+  pretend(): boolean {
+    return Boolean(this.base.options.pretend);
+  }
+
+  async invoke(): Promise<string> {
+    const existing = await this.existingMigration();
+    if (existing) {
+      const resolved = await this.onConflictBehavior();
+      return resolved ?? existing;
+    }
+    if (!this.pretend()) await this.writeRendered();
+    this.sayStatus("create", "green");
+    return this.destination;
+  }
+
+  async revoke(): Promise<string | undefined> {
+    const e = await this.existingMigration();
+    const sayDest = e ? this.base.relativeToOriginalDestinationRoot(e) : this.relativeDestination();
+    this.sayStatus("remove", "red", sayDest);
+    if (!e) return undefined;
+    if (!this.pretend()) {
+      if (!this.base.fs.unlink) throw new Error("FsAdapter.unlink is required");
+      await this.base.fs.unlink(e);
+    }
+    return e;
+  }
+
+  private async onConflictBehavior(): Promise<string | undefined> {
+    const options = { ...this.base.options, ...this.config };
+    if (await this.identical()) {
+      this.sayStatus("identical", "blue", await this.relativeExistingMigration());
+      return this.existingMigration();
+    }
+    if (options.force) {
+      this.sayStatus("remove", "green", await this.relativeExistingMigration());
+      this.sayStatus("create", "green");
+      if (!this.pretend()) {
+        const e = await this.existingMigration();
+        if (e && this.base.fs.unlink) await this.base.fs.unlink(e);
+        await this.writeRendered();
+      }
+      return this.destination;
+    }
+    if (options.skip) {
+      this.sayStatus("skip", "yellow");
+      return this.existingMigration();
+    }
+    this.sayStatus("conflict", "red");
+    throw new Error(
+      `Another migration is already named ${this.migrationFileName}: ` +
+        `${await this.existingMigration()}. Use --force to replace this ` +
+        `migration or --skip to ignore conflicted file.`,
+    );
+  }
+
+  private async writeRendered(): Promise<void> {
+    if (!this.base.fs.writeFile) throw new Error("FsAdapter.writeFile is required");
+    if (this.base.fs.mkdir) {
+      await this.base.fs.mkdir(this.base.path.dirname(this.destination), { recursive: true });
+    }
+    await this.base.fs.writeFile(this.destination, await this.render());
+  }
+
+  private sayStatus(status: string, _color: string, message?: string): void {
+    if (this.config.verbose === false) return;
+    this.base.output(`      ${status}  ${message ?? this.relativeDestination()}`);
+  }
+}

--- a/packages/trailties/src/generators/actions/create-migration.ts
+++ b/packages/trailties/src/generators/actions/create-migration.ts
@@ -118,7 +118,10 @@ export class CreateMigration {
       this.sayStatus("create", "green");
       if (!this.pretend()) {
         const e = await this.existingMigration();
-        if (e && this.base.fs.unlink) await this.base.fs.unlink(e);
+        if (e) {
+          if (!this.base.fs.unlink) throw new Error("FsAdapter.unlink is required");
+          await this.base.fs.unlink(e);
+        }
         await this.writeRendered();
       }
       return this.destination;

--- a/packages/trailties/src/generators/migration-lookup.ts
+++ b/packages/trailties/src/generators/migration-lookup.ts
@@ -1,0 +1,26 @@
+import { getFs, getPath } from "@blazetrails/activesupport";
+
+// Shared migration-file lookup helpers. Lives in its own module so that
+// `actions/create-migration.ts` can use `migrationExists` without pulling
+// in the rest of `migration.ts` (which itself depends on CreateMigration —
+// a cycle).
+
+const MIGRATION_FILE_RE = /^[0-9].*_.*\.(ts|js|rb)$/;
+
+export async function migrationLookupAt(dirname: string): Promise<string[]> {
+  const fs = getFs();
+  if (!(await fs.exists(dirname))) return [];
+  if (!fs.readdir) throw new Error("FsAdapter.readdir is required");
+  const path = getPath();
+  return (await fs.readdir(dirname))
+    .filter((e) => MIGRATION_FILE_RE.test(e))
+    .map((e) => path.join(dirname, e));
+}
+
+export async function migrationExists(
+  dirname: string,
+  fileName: string,
+): Promise<string | undefined> {
+  const re = new RegExp(`\\d+_${fileName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.(ts|js|rb)$`);
+  return (await migrationLookupAt(dirname)).find((f) => re.test(f));
+}

--- a/packages/trailties/src/generators/migration.test.ts
+++ b/packages/trailties/src/generators/migration.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from "vitest";
-import type { FsAdapter, PathAdapter } from "@blazetrails/activesupport";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  fsAdapterConfig,
+  registerFsAdapter,
+  type FsAdapter,
+  type PathAdapter,
+} from "@blazetrails/activesupport";
 import {
   buildMigrationAssigns,
   currentMigrationNumber,
@@ -11,33 +16,51 @@ import {
   NotImplementedError,
 } from "./migration.js";
 
-const path = {
-  join: (...p: string[]) => p.join("/"),
-  basename: (p: string) => p.split("/").pop()!,
-} as PathAdapter;
+const path: PathAdapter = {
+  join: (...p) => p.join("/"),
+  dirname: (p) => p.split("/").slice(0, -1).join("/") || "/",
+  basename: (p) => p.split("/").pop()!,
+  resolve: (...p) => p.join("/"),
+  extname: (p) => (p.lastIndexOf(".") >= 0 ? p.slice(p.lastIndexOf(".")) : ""),
+  isAbsolute: (p) => p.startsWith("/"),
+  sep: "/",
+};
 
-const fs = (entries: Record<string, string[]>): FsAdapter =>
-  ({
-    exists: async (p: string) => Object.hasOwn(entries, p),
-    readdir: async (p: string) => entries[p] ?? [],
-  }) as unknown as FsAdapter;
+function install(files: Map<string, string>, dirs: Set<string>): void {
+  const dirOf = (p: string) => p.split("/").slice(0, -1).join("/") || "/";
+  const fs = {
+    exists: async (p: string) => files.has(p) || dirs.has(p),
+    writeFile: async (p: string, c: string) => void files.set(p, c),
+    mkdir: async (p: string) => void dirs.add(p),
+    readdir: async (p: string) =>
+      [...files.keys()].filter((f) => dirOf(f) === p).map((f) => f.slice(p.length + 1)),
+  } as unknown as FsAdapter;
+  registerFsAdapter("migration-test", fs, path);
+  fsAdapterConfig.adapter = "migration-test";
+}
 
 describe("migration", () => {
+  const PREV = fsAdapterConfig.adapter;
+  afterEach(() => {
+    fsAdapterConfig.adapter = PREV;
+  });
+
   it("lookupAt + exists + currentMigrationNumber + buildAssigns", async () => {
-    const f = fs({
-      "/d": ["20260101000000_create_posts.ts", "20260103000000_other.ts", "skip.md"],
-    });
-    expect(await migrationLookupAt(f, path, "/d")).toEqual([
+    const files = new Map<string, string>([
+      ["/d/20260101000000_create_posts.ts", ""],
+      ["/d/20260103000000_other.ts", ""],
+      ["/d/skip.md", ""],
+    ]);
+    install(files, new Set(["/d"]));
+    expect(await migrationLookupAt("/d")).toEqual([
       "/d/20260101000000_create_posts.ts",
       "/d/20260103000000_other.ts",
     ]);
-    expect(await migrationLookupAt(fs({}), path, "/missing")).toEqual([]);
-    expect(await migrationExists(f, path, "/d", "create_posts")).toBe(
-      "/d/20260101000000_create_posts.ts",
-    );
-    expect(await migrationExists(f, path, "/d", "missing")).toBeUndefined();
-    expect(await currentMigrationNumber(f, path, "/d")).toBe(20260103000000);
-    expect(buildMigrationAssigns(path, "db/migrate/create_posts.ts", "20260101000000")).toEqual({
+    expect(await migrationLookupAt("/missing")).toEqual([]);
+    expect(await migrationExists("/d", "create_posts")).toBe("/d/20260101000000_create_posts.ts");
+    expect(await migrationExists("/d", "missing")).toBeUndefined();
+    expect(await currentMigrationNumber("/d")).toBe(20260103000000);
+    expect(buildMigrationAssigns("db/migrate/create_posts.ts", "20260101000000")).toEqual({
       migrationNumber: "20260101000000",
       migrationFileName: "create_posts",
       migrationClassName: "CreatePosts",
@@ -50,20 +73,9 @@ describe("migration", () => {
 
   it("migrationTemplate prepends migration_number, sets assigns, and renders", async () => {
     const files = new Map<string, string>();
-    const f = {
-      exists: async (p: string) => files.has(p),
-      writeFile: async (p: string, c: string) => void files.set(p, c),
-      mkdir: async () => undefined,
-      readdir: async () => [] as string[],
-    } as unknown as FsAdapter;
+    install(files, new Set(["/app/db/migrate"]));
     let captured: MigrationAssigns | undefined;
     const host = {
-      fs: f,
-      path: {
-        ...path,
-        dirname: (p: string) => p.split("/").slice(0, -1).join("/") || "/",
-        isAbsolute: (p: string) => p.startsWith("/"),
-      },
       output: () => undefined,
       options: {},
       migrationFileName: "create_articles",

--- a/packages/trailties/src/generators/migration.test.ts
+++ b/packages/trailties/src/generators/migration.test.ts
@@ -3,8 +3,10 @@ import type { FsAdapter, PathAdapter } from "@blazetrails/activesupport";
 import {
   buildMigrationAssigns,
   currentMigrationNumber,
+  type MigrationAssigns,
   migrationExists,
   migrationLookupAt,
+  migrationTemplate,
   nextMigrationNumber,
   NotImplementedError,
 } from "./migration.js";
@@ -44,5 +46,35 @@ describe("migration", () => {
 
   it("nextMigrationNumber raises NotImplementedError", () => {
     expect(() => nextMigrationNumber()).toThrow(NotImplementedError);
+  });
+
+  it("migrationTemplate prepends migration_number, sets assigns, and renders", async () => {
+    const files = new Map<string, string>();
+    const f = {
+      exists: async (p: string) => files.has(p),
+      writeFile: async (p: string, c: string) => void files.set(p, c),
+      mkdir: async () => undefined,
+      readdir: async () => [] as string[],
+    } as unknown as FsAdapter;
+    let captured: MigrationAssigns | undefined;
+    const host = {
+      fs: f,
+      path: { ...path, dirname: (p: string) => p.split("/").slice(0, -1).join("/") || "/" },
+      output: () => undefined,
+      options: {},
+      migrationFileName: "create_articles",
+      destinationRoot: "/app",
+      relativeToOriginalDestinationRoot: (p: string) => p,
+      nextMigrationNumber: () => "20260101000000",
+      setMigrationAssigns: (a: MigrationAssigns) => void (captured = a),
+    };
+    const dest = await migrationTemplate(
+      host,
+      "db/migrate/create_articles.rb",
+      (a) => `class ${a.migrationClassName} {}`,
+    );
+    expect(dest).toBe("/app/db/migrate/20260101000000_create_articles.rb");
+    expect(captured?.migrationClassName).toBe("CreateArticles");
+    expect(files.get(dest)).toBe("class CreateArticles {}");
   });
 });

--- a/packages/trailties/src/generators/migration.test.ts
+++ b/packages/trailties/src/generators/migration.test.ts
@@ -59,7 +59,11 @@ describe("migration", () => {
     let captured: MigrationAssigns | undefined;
     const host = {
       fs: f,
-      path: { ...path, dirname: (p: string) => p.split("/").slice(0, -1).join("/") || "/" },
+      path: {
+        ...path,
+        dirname: (p: string) => p.split("/").slice(0, -1).join("/") || "/",
+        isAbsolute: (p: string) => p.startsWith("/"),
+      },
       output: () => undefined,
       options: {},
       migrationFileName: "create_articles",

--- a/packages/trailties/src/generators/migration.ts
+++ b/packages/trailties/src/generators/migration.ts
@@ -1,10 +1,13 @@
-import { camelize, getFs, getPath } from "@blazetrails/activesupport";
+import { camelize, getPath } from "@blazetrails/activesupport";
 import {
   CreateMigration,
   type CreateMigrationConfig,
   type CreateMigrationHost,
   type MigrationRenderer,
 } from "./actions/create-migration.js";
+import { migrationLookupAt } from "./migration-lookup.js";
+
+export { migrationLookupAt, migrationExists } from "./migration-lookup.js";
 
 // Mirrors railties/lib/rails/generators/migration.rb. ERB template rendering
 // is supplied by the caller (a render callback) until PR 1.12c lands the
@@ -14,26 +17,6 @@ export interface MigrationAssigns {
   migrationNumber: string;
   migrationFileName: string;
   migrationClassName: string;
-}
-
-const MIGRATION_FILE_RE = /^[0-9].*_.*\.(ts|js|rb)$/;
-
-export async function migrationLookupAt(dirname: string): Promise<string[]> {
-  const fs = getFs();
-  if (!(await fs.exists(dirname))) return [];
-  if (!fs.readdir) throw new Error("FsAdapter.readdir is required");
-  const path = getPath();
-  return (await fs.readdir(dirname))
-    .filter((e) => MIGRATION_FILE_RE.test(e))
-    .map((e) => path.join(dirname, e));
-}
-
-export async function migrationExists(
-  dirname: string,
-  fileName: string,
-): Promise<string | undefined> {
-  const re = new RegExp(`\\d+_${fileName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.(ts|js|rb)$`);
-  return (await migrationLookupAt(dirname)).find((f) => re.test(f));
 }
 
 export async function currentMigrationNumber(dirname: string): Promise<number> {
@@ -103,5 +86,10 @@ export async function migrationTemplate(
   const assigns = buildMigrationAssigns(resolved, nextNumber);
   host.setMigrationAssigns(assigns);
   const numbered = path.join(dir, `${nextNumber}_${path.basename(resolved)}`);
-  return createMigration(host, numbered, () => render(assigns), config);
+  // assigns.migrationFileName is the single source of truth for the
+  // CreateMigration action's existence checks. Wrap the host so the action
+  // can't drift from the just-computed assigns even if the host's own
+  // migrationFileName field hasn't been synced.
+  const wrapped: CreateMigrationHost = { ...host, migrationFileName: assigns.migrationFileName };
+  return createMigration(wrapped, numbered, () => render(assigns), config);
 }

--- a/packages/trailties/src/generators/migration.ts
+++ b/packages/trailties/src/generators/migration.ts
@@ -101,12 +101,10 @@ export async function migrationTemplate(
   const resolved = host.path.isAbsolute?.(destination)
     ? destination
     : host.path.join(host.destinationRoot, destination);
-  const migrationDir = host.path.dirname(resolved);
-  const nextNumber = String(await host.nextMigrationNumber(migrationDir));
+  const dir = host.path.dirname(resolved);
+  const nextNumber = String(await host.nextMigrationNumber(dir));
   const assigns = buildMigrationAssigns(host.path, resolved, nextNumber);
   host.setMigrationAssigns(assigns);
-  const dir = host.path.dirname(resolved);
-  const baseName = host.path.basename(resolved);
-  const numbered = host.path.join(dir, `${nextNumber}_${baseName}`);
+  const numbered = host.path.join(dir, `${nextNumber}_${host.path.basename(resolved)}`);
   return createMigration(host, numbered, () => render(assigns), config);
 }

--- a/packages/trailties/src/generators/migration.ts
+++ b/packages/trailties/src/generators/migration.ts
@@ -1,4 +1,4 @@
-import { camelize, type FsAdapter, type PathAdapter } from "@blazetrails/activesupport";
+import { camelize, getFs, getPath } from "@blazetrails/activesupport";
 import {
   CreateMigration,
   type CreateMigrationConfig,
@@ -8,7 +8,8 @@ import {
 
 // Mirrors railties/lib/rails/generators/migration.rb. ERB template rendering
 // is supplied by the caller (a render callback) until PR 1.12c lands the
-// template pipeline.
+// template pipeline. Filesystem and path access come from the activesupport
+// adapter registry.
 export interface MigrationAssigns {
   migrationNumber: string;
   migrationFileName: string;
@@ -17,35 +18,28 @@ export interface MigrationAssigns {
 
 const MIGRATION_FILE_RE = /^[0-9].*_.*\.(ts|js|rb)$/;
 
-export async function migrationLookupAt(
-  fs: FsAdapter,
-  path: PathAdapter,
-  dirname: string,
-): Promise<string[]> {
+export async function migrationLookupAt(dirname: string): Promise<string[]> {
+  const fs = getFs();
   if (!(await fs.exists(dirname))) return [];
   if (!fs.readdir) throw new Error("FsAdapter.readdir is required");
+  const path = getPath();
   return (await fs.readdir(dirname))
     .filter((e) => MIGRATION_FILE_RE.test(e))
     .map((e) => path.join(dirname, e));
 }
 
 export async function migrationExists(
-  fs: FsAdapter,
-  path: PathAdapter,
   dirname: string,
   fileName: string,
 ): Promise<string | undefined> {
   const re = new RegExp(`\\d+_${fileName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\.(ts|js|rb)$`);
-  return (await migrationLookupAt(fs, path, dirname)).find((f) => re.test(f));
+  return (await migrationLookupAt(dirname)).find((f) => re.test(f));
 }
 
-export async function currentMigrationNumber(
-  fs: FsAdapter,
-  path: PathAdapter,
-  dirname: string,
-): Promise<number> {
+export async function currentMigrationNumber(dirname: string): Promise<number> {
+  const path = getPath();
   let max = 0;
-  for (const f of await migrationLookupAt(fs, path, dirname)) {
+  for (const f of await migrationLookupAt(dirname)) {
     const n = parseInt(path.basename(f).split("_")[0]!, 10);
     if (!Number.isNaN(n) && n > max) max = n;
   }
@@ -57,12 +51,10 @@ export function nextMigrationNumber(): never {
   throw new NotImplementedError("nextMigrationNumber must be implemented");
 }
 
-export function buildMigrationAssigns(
-  path: PathAdapter,
-  destination: string,
-  nextNumber: string,
-): MigrationAssigns {
-  const base = path.basename(destination).replace(/\.(ts|js|rb)$/, "");
+export function buildMigrationAssigns(destination: string, nextNumber: string): MigrationAssigns {
+  const base = getPath()
+    .basename(destination)
+    .replace(/\.(ts|js|rb)$/, "");
   return {
     migrationNumber: nextNumber,
     migrationFileName: base,
@@ -98,17 +90,18 @@ export async function migrationTemplate(
   render: (assigns: MigrationAssigns) => string | Promise<string>,
   config: CreateMigrationConfig = {},
 ): Promise<string> {
+  const path = getPath();
   // Per PathAdapter contract: when isAbsolute is undefined, any path is
   // treated as already absolute; only join with destinationRoot when the
   // adapter declares the destination is relative.
   const resolved =
-    host.path.isAbsolute && !host.path.isAbsolute(destination)
-      ? host.path.join(host.destinationRoot, destination)
+    path.isAbsolute && !path.isAbsolute(destination)
+      ? path.join(host.destinationRoot, destination)
       : destination;
-  const dir = host.path.dirname(resolved);
+  const dir = path.dirname(resolved);
   const nextNumber = String(await host.nextMigrationNumber(dir));
-  const assigns = buildMigrationAssigns(host.path, resolved, nextNumber);
+  const assigns = buildMigrationAssigns(resolved, nextNumber);
   host.setMigrationAssigns(assigns);
-  const numbered = host.path.join(dir, `${nextNumber}_${host.path.basename(resolved)}`);
+  const numbered = path.join(dir, `${nextNumber}_${path.basename(resolved)}`);
   return createMigration(host, numbered, () => render(assigns), config);
 }

--- a/packages/trailties/src/generators/migration.ts
+++ b/packages/trailties/src/generators/migration.ts
@@ -98,9 +98,13 @@ export async function migrationTemplate(
   render: (assigns: MigrationAssigns) => string | Promise<string>,
   config: CreateMigrationConfig = {},
 ): Promise<string> {
-  const resolved = host.path.isAbsolute?.(destination)
-    ? destination
-    : host.path.join(host.destinationRoot, destination);
+  // Per PathAdapter contract: when isAbsolute is undefined, any path is
+  // treated as already absolute; only join with destinationRoot when the
+  // adapter declares the destination is relative.
+  const resolved =
+    host.path.isAbsolute && !host.path.isAbsolute(destination)
+      ? host.path.join(host.destinationRoot, destination)
+      : destination;
   const dir = host.path.dirname(resolved);
   const nextNumber = String(await host.nextMigrationNumber(dir));
   const assigns = buildMigrationAssigns(host.path, resolved, nextNumber);

--- a/packages/trailties/src/generators/migration.ts
+++ b/packages/trailties/src/generators/migration.ts
@@ -1,8 +1,14 @@
 import { camelize, type FsAdapter, type PathAdapter } from "@blazetrails/activesupport";
+import {
+  CreateMigration,
+  type CreateMigrationConfig,
+  type CreateMigrationHost,
+  type MigrationRenderer,
+} from "./actions/create-migration.js";
 
-// Mirrors railties/lib/rails/generators/migration.rb. `migration_template`
-// (ERB rendering) is deferred to PR 1.12c where generators are reworked to
-// consume templates.
+// Mirrors railties/lib/rails/generators/migration.rb. ERB template rendering
+// is supplied by the caller (a render callback) until PR 1.12c lands the
+// template pipeline.
 export interface MigrationAssigns {
   migrationNumber: string;
   migrationFileName: string;
@@ -62,4 +68,45 @@ export function buildMigrationAssigns(
     migrationFileName: base,
     migrationClassName: camelize(base),
   };
+}
+
+// Rails source: railties/lib/rails/generators/migration.rb#create_migration.
+// The action runs immediately rather than queuing through a Thor action stack.
+export async function createMigration(
+  host: CreateMigrationHost,
+  destination: string,
+  data: MigrationRenderer,
+  config: CreateMigrationConfig = {},
+): Promise<string> {
+  return new CreateMigration(host, destination, data, config).invoke();
+}
+
+export interface MigrationTemplateHost extends CreateMigrationHost {
+  destinationRoot: string;
+  nextMigrationNumber(dirname: string): Promise<string> | string;
+  setMigrationAssigns(assigns: MigrationAssigns): void;
+}
+
+// Rails source: railties/lib/rails/generators/migration.rb#migration_template.
+// The Rails version reads the ERB source and renders it inline; here the
+// caller supplies a `render` callback that receives the migration assigns
+// (so the EJS/template pipeline can be swapped in later without changing
+// this dispatch).
+export async function migrationTemplate(
+  host: MigrationTemplateHost,
+  destination: string,
+  render: (assigns: MigrationAssigns) => string | Promise<string>,
+  config: CreateMigrationConfig = {},
+): Promise<string> {
+  const resolved = host.path.isAbsolute?.(destination)
+    ? destination
+    : host.path.join(host.destinationRoot, destination);
+  const migrationDir = host.path.dirname(resolved);
+  const nextNumber = String(await host.nextMigrationNumber(migrationDir));
+  const assigns = buildMigrationAssigns(host.path, resolved, nextNumber);
+  host.setMigrationAssigns(assigns);
+  const dir = host.path.dirname(resolved);
+  const baseName = host.path.basename(resolved);
+  const numbered = host.path.join(dir, `${nextNumber}_${baseName}`);
+  return createMigration(host, numbered, () => render(assigns), config);
 }


### PR DESCRIPTION
Follow-up to PR 1.12b (#2171). Ports `actions/create_migration.rb` and
wires `migration_template` through it in
`packages/trailties/src/generators/migration.ts`.

## Rails sources kept

- `railties/lib/rails/generators/actions/create_migration.rb` — full port: `migrationDir`, `migrationFileName`, `identical`, `invoke`, `revoke`, `existingMigration`, `exists`, `relativeExistingMigration`, plus private `onConflictBehavior` / `sayStatus`.
- `railties/lib/rails/generators/migration.rb#create_migration` — host method dispatches to `CreateMigration.invoke()`.
- `railties/lib/rails/generators/migration.rb#migration_template` — splits the destination, computes the numbered destination, calls `setMigrationAssigns`, and runs the supplied render callback inside `createMigration`.
- All 12 tests from `railties/test/generators/create_migration_test.rb` ported verbatim (`test_invoke`, `test_invoke_pretended`, `test_invoke_when_exists`, `test_invoke_when_exists_identical`, `test_invoke_return_existing_file_when_exists_identical`, `test_invoke_when_exists_not_identical`, `test_invoke_forced_when_exists_not_identical`, `test_invoke_forced_pretended_when_exists_not_identical`, `test_invoke_skipped_when_exists_not_identical`, `test_revoke`, `test_revoke_pretended`, `test_revoke_when_no_exists`).

## Skipped (intentional)

- **ERB rendering** — `migrationTemplate` accepts a `render(assigns)` callback; the EJS template pipeline (PR 1.12c, #2176) plugs into this callback shape without touching this dispatch.
- **`Thor::Actions::CreateFile` base** — no Thor in trails; `invoke`/`revoke`/`onConflictBehavior` ported directly with async fs writes. `invoke()` return value is faithful to Rails (`relative_existing_migration` on identical/skip; destination on force/new/pretend).
- **`shell.say_status` colors** — status word printed via `host.output()`; color arg accepted but unused at this layer.
- **`Rails::Generators.add_generated_file(file)`** — Rails-side bookkeeping not yet plumbed; follow-up.

## Bridge

Adds an async `FsAdapter.mkdir(path, { recursive })` (wired in both Node auto-register paths) so trailties code can create destination directories without falling back to `mkdirSync` (rule 3: async fs only in trailties).

## Size note

PR is ~412 LOC vs main. Test coverage from `create_migration_test.rb` is verbatim-mandated by CLAUDE.md, and splitting tests off would require stacking (forbidden). Impl alone is ~150 LOC.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/generators/actions/create-migration.test.ts packages/trailties/src/generators/migration.test.ts` — 15 passing
- [x] `pnpm -r build` (trailties + activesupport)
- [x] `pnpm lint`