### PR TITLE
feat(trailties): activesupport Trailtie (PR 2.7a)

### DIFF
--- a/packages/trailties/src/trailties/active-support.test.ts
+++ b/packages/trailties/src/trailties/active-support.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { Railtie as BaseRailtie, deprecator } from "@blazetrails/activesupport";
+import { Digest } from "@blazetrails/activesupport/digest";
+import { Trailtie, type TrailtieConfig } from "./active-support.js";
+
+const { deprecators } = BaseRailtie;
+
+describe("RailtieTest", () => {
+  let savedSubclasses: (typeof BaseRailtie)[];
+  let savedConfig: Record<string, unknown>;
+  let savedHashDigestClass: typeof Digest.hashDigestClass;
+
+  beforeEach(() => {
+    savedSubclasses = [...BaseRailtie.subclasses];
+    savedHashDigestClass = Digest.hashDigestClass;
+    try {
+      savedConfig =
+        typeof structuredClone === "function"
+          ? structuredClone(Trailtie.config)
+          : { ...Trailtie.config };
+    } catch {
+      savedConfig = { ...Trailtie.config };
+    }
+  });
+
+  afterEach(() => {
+    (BaseRailtie.subclasses as (typeof BaseRailtie)[]).length = 0;
+    (BaseRailtie.subclasses as (typeof BaseRailtie)[]).push(...savedSubclasses);
+    for (const key of Object.keys(Trailtie.config)) {
+      delete (Trailtie.config as Record<string, unknown>)[key];
+    }
+    Object.assign(Trailtie.config, savedConfig);
+    for (const key of Object.keys(deprecators)) {
+      delete deprecators[key];
+    }
+    Digest.hashDigestClass = savedHashDigestClass;
+  });
+
+  it("ActiveSupport::Railtie is registered in the global subclasses list", () => {
+    expect(BaseRailtie.subclasses).toContain(Trailtie);
+  });
+
+  it("seeds config.activeSupport on load", () => {
+    expect((Trailtie.config as TrailtieConfig).activeSupport).toBeDefined();
+  });
+
+  it("runInitializers registers the ActiveSupport deprecator", () => {
+    Trailtie.runInitializers();
+    expect(deprecators["activeSupport"]).toBe(deprecator);
+  });
+
+  it("runInitializers applies hashDigestClass from Railtie.config.activeSupport", () => {
+    const custom = { hexdigest: (data: string): string => `custom:${data}` };
+    (Trailtie.config as TrailtieConfig).activeSupport = { hashDigestClass: custom };
+    Trailtie.runInitializers();
+    expect(Digest.hashDigestClass).toBe(custom);
+  });
+
+  it("runInitializers leaves hashDigestClass untouched when config is absent", () => {
+    const before = Digest.hashDigestClass;
+    Trailtie.runInitializers();
+    expect(Digest.hashDigestClass).toBe(before);
+  });
+});

--- a/packages/trailties/src/trailties/active-support.test.ts
+++ b/packages/trailties/src/trailties/active-support.test.ts
@@ -1,35 +1,31 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { Railtie as BaseRailtie, Deprecation, deprecator } from "@blazetrails/activesupport";
 import { Digest } from "@blazetrails/activesupport/digest";
-import { Trailtie, type TrailtieConfig } from "./active-support.js";
+import { Trailtie, type ActiveSupportConfig } from "./active-support.js";
 
 const { deprecators } = BaseRailtie;
 
 describe("RailtieTest", () => {
   let savedSubclasses: (typeof BaseRailtie)[];
-  let savedConfig: Record<string, unknown>;
+  let savedActiveSupport: unknown;
   let savedHashDigestClass: typeof Digest.hashDigestClass;
 
   beforeEach(() => {
     savedSubclasses = [...BaseRailtie.subclasses];
     savedHashDigestClass = Digest.hashDigestClass;
+    const cur = Trailtie.config["activeSupport"];
     try {
-      savedConfig =
-        typeof structuredClone === "function"
-          ? structuredClone(Trailtie.config)
-          : { ...Trailtie.config };
+      savedActiveSupport =
+        typeof structuredClone === "function" ? structuredClone(cur) : { ...(cur as object) };
     } catch {
-      savedConfig = { ...Trailtie.config };
+      savedActiveSupport = { ...(cur as object) };
     }
   });
 
   afterEach(() => {
     (BaseRailtie.subclasses as (typeof BaseRailtie)[]).length = 0;
     (BaseRailtie.subclasses as (typeof BaseRailtie)[]).push(...savedSubclasses);
-    for (const key of Object.keys(Trailtie.config)) {
-      delete (Trailtie.config as Record<string, unknown>)[key];
-    }
-    Object.assign(Trailtie.config, savedConfig);
+    Trailtie.config["activeSupport"] = savedActiveSupport;
     for (const key of Object.keys(deprecators)) {
       delete deprecators[key];
     }
@@ -41,7 +37,7 @@ describe("RailtieTest", () => {
   });
 
   it("seeds config.activeSupport on load", () => {
-    expect((Trailtie.config as TrailtieConfig).activeSupport).toBeDefined();
+    expect(Trailtie.config["activeSupport"]).toBeDefined();
   });
 
   it("runInitializers registers the ActiveSupport deprecator", () => {
@@ -51,7 +47,7 @@ describe("RailtieTest", () => {
 
   it("runInitializers applies hashDigestClass from Railtie.config.activeSupport", () => {
     const custom = { hexdigest: (data: string): string => `custom:${data}` };
-    (Trailtie.config as TrailtieConfig).activeSupport = { hashDigestClass: custom };
+    Trailtie.config["activeSupport"] = { hashDigestClass: custom } satisfies ActiveSupportConfig;
     Trailtie.runInitializers();
     expect(Digest.hashDigestClass).toBe(custom);
   });
@@ -59,7 +55,7 @@ describe("RailtieTest", () => {
   it("runInitializers silences all deprecators when reportDeprecations is false", () => {
     const other = new Deprecation();
     deprecators["other"] = other;
-    (Trailtie.config as TrailtieConfig).activeSupport = { reportDeprecations: false };
+    Trailtie.config["activeSupport"] = { reportDeprecations: false } satisfies ActiveSupportConfig;
     const savedBehavior = deprecator.behavior;
     const savedSilenced = deprecator.silenced;
     const savedDisallowed = deprecator.disallowedBehavior;
@@ -80,11 +76,11 @@ describe("RailtieTest", () => {
   it("runInitializers applies deprecation behavior to all registered deprecators", () => {
     const other = new Deprecation();
     deprecators["other"] = other;
-    (Trailtie.config as TrailtieConfig).activeSupport = {
+    Trailtie.config["activeSupport"] = {
       deprecation: "raise",
       disallowedDeprecation: "raise",
       disallowedDeprecationWarnings: ["bad"],
-    };
+    } satisfies ActiveSupportConfig;
     const savedBehavior = deprecator.behavior;
     const savedDisallowed = deprecator.disallowedBehavior;
     const savedWarnings = [...deprecator.disallowedWarnings];

--- a/packages/trailties/src/trailties/active-support.test.ts
+++ b/packages/trailties/src/trailties/active-support.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
-import { Railtie as BaseRailtie, deprecator } from "@blazetrails/activesupport";
+import { Railtie as BaseRailtie, Deprecation, deprecator } from "@blazetrails/activesupport";
 import { Digest } from "@blazetrails/activesupport/digest";
 import { Trailtie, type TrailtieConfig } from "./active-support.js";
 
@@ -54,6 +54,52 @@ describe("RailtieTest", () => {
     (Trailtie.config as TrailtieConfig).activeSupport = { hashDigestClass: custom };
     Trailtie.runInitializers();
     expect(Digest.hashDigestClass).toBe(custom);
+  });
+
+  it("runInitializers silences all deprecators when reportDeprecations is false", () => {
+    const other = new Deprecation();
+    deprecators["other"] = other;
+    (Trailtie.config as TrailtieConfig).activeSupport = { reportDeprecations: false };
+    const savedBehavior = deprecator.behavior;
+    const savedSilenced = deprecator.silenced;
+    const savedDisallowed = deprecator.disallowedBehavior;
+    try {
+      Trailtie.runInitializers();
+      for (const d of [deprecator, other]) {
+        expect(d.silenced).toBe(true);
+        expect(d.behavior).toBe("silence");
+        expect(d.disallowedBehavior).toBe("silence");
+      }
+    } finally {
+      deprecator.behavior = savedBehavior;
+      deprecator.silenced = savedSilenced;
+      deprecator.disallowedBehavior = savedDisallowed;
+    }
+  });
+
+  it("runInitializers applies deprecation behavior to all registered deprecators", () => {
+    const other = new Deprecation();
+    deprecators["other"] = other;
+    (Trailtie.config as TrailtieConfig).activeSupport = {
+      deprecation: "raise",
+      disallowedDeprecation: "raise",
+      disallowedDeprecationWarnings: ["bad"],
+    };
+    const savedBehavior = deprecator.behavior;
+    const savedDisallowed = deprecator.disallowedBehavior;
+    const savedWarnings = [...deprecator.disallowedWarnings];
+    try {
+      Trailtie.runInitializers();
+      for (const d of [deprecator, other]) {
+        expect(d.behavior).toBe("raise");
+        expect(d.disallowedBehavior).toBe("raise");
+        expect(d.disallowedWarnings).toEqual(["bad"]);
+      }
+    } finally {
+      deprecator.behavior = savedBehavior;
+      deprecator.disallowedBehavior = savedDisallowed;
+      deprecator.disallowedWarnings = savedWarnings;
+    }
   });
 
   it("runInitializers leaves hashDigestClass untouched when config is absent", () => {

--- a/packages/trailties/src/trailties/active-support.ts
+++ b/packages/trailties/src/trailties/active-support.ts
@@ -83,6 +83,18 @@ export class Trailtie extends BaseRailtie {
       BaseRailtie.deprecators["activeSupport"] = deprecator;
     });
 
+    // ORDERING CAVEAT: in Rails, every `<framework>.deprecator` initializer
+    // is annotated `before: :load_environment_config`, while
+    // `active_support.deprecation_behavior` carries no `before:` — so by the
+    // time this fires, *every* framework's deprecator has been registered
+    // and Rails' `app.deprecators` proxy iterates them all. Our BaseRailtie
+    // does not yet support `before:`/`after:` initializer ordering, and
+    // `app.deprecators` is a plain `Record`, not a proxy that tracks future
+    // additions. This means a framework whose `.deprecator` initializer
+    // runs *after* this block (registration order) won't get these
+    // settings applied. The Rails-shaped fix lives on BaseRailtie
+    // (ordering + DeprecatorsProxy) and is a follow-up on PR 2.7a, not a
+    // local patch here.
     this.initializer("active_support.deprecation_behavior", () => {
       const cfg = (Trailtie.config as TrailtieConfig).activeSupport ?? {};
       const all = Object.values(BaseRailtie.deprecators).filter((d): d is Deprecation => d != null);

--- a/packages/trailties/src/trailties/active-support.ts
+++ b/packages/trailties/src/trailties/active-support.ts
@@ -1,0 +1,81 @@
+/**
+ * Trailtie — initialization hooks for ActiveSupport.
+ *
+ * Mirrors: ActiveSupport::Railtie < ::Rails::Railtie
+ * (activesupport/lib/active_support/railtie.rb)
+ *
+ * Resolves docs/trailties-plan.md open question #2: the activesupport
+ * trailtie lives **inside the trailties package** (not in activesupport
+ * itself) so the dependency direction stays trailties → activesupport.
+ * Putting it under `packages/activesupport/src/` would force activesupport
+ * to depend on `@blazetrails/activesupport`'s own Railtie base via a
+ * self-import, and worse, would couple the leaf framework to the
+ * application-runner concept it should stay agnostic of.
+ *
+ * Only the initializers whose targets are already ported to trails are
+ * wired here. The rest are documented as skipped on the PR (and become
+ * follow-ups as the underlying helpers land):
+ *
+ *   - active_support.isolation_level — IsolatedExecutionState has no
+ *     `isolationLevel` setter yet
+ *   - active_support.raise_on_invalid_cache_expiration_time — Cache::Store
+ *     has no equivalent flag
+ *   - active_support.set_authenticated_message_encryption — MessageEncryptor
+ *     has no `useAuthenticatedMessageEncryption` toggle
+ *   - active_support.reset_execution_context — no reloader/executor in trails
+ *   - active_support.reset_all_current_attributes_instances — same
+ *   - active_support.deprecation_behavior — Deprecation has no
+ *     `silenced`/`behavior` setters wired through Application
+ *   - active_support.initialize_time_zone — no TZInfo binding
+ *   - active_support.to_time_preserves_timezone — flag not ported
+ *   - active_support.initialize_beginning_of_week — Date.beginning_of_week
+ *     not ported
+ *   - active_support.require_master_key — credentials key lookup runs
+ *     elsewhere
+ *   - active_support.set_configs — generic setter-dispatch loop;
+ *     intentionally deferred until each target landed
+ *   - active_support.set_key_generator_hash_digest_class — KeyGenerator's
+ *     hashDigestClass is per-instance, not class-level
+ *   - active_support.set_default_message_serializer — Messages::Codec not
+ *     ported
+ *   - active_support.set_use_message_serializer_for_metadata — same
+ */
+import { Railtie as BaseRailtie, registerRailtie, deprecator } from "@blazetrails/activesupport";
+import { Digest } from "@blazetrails/activesupport/digest";
+
+export interface HashDigestClass {
+  hexdigest(data: string): string;
+}
+
+export interface ActiveSupportConfig {
+  hashDigestClass?: HashDigestClass;
+}
+
+export interface TrailtieConfig {
+  activeSupport?: ActiveSupportConfig;
+}
+
+/**
+ * Trailtie wiring for ActiveSupport.
+ *
+ * Mirrors: ActiveSupport::Railtie (activesupport/lib/active_support/railtie.rb)
+ */
+export class Trailtie extends BaseRailtie {
+  static {
+    registerRailtie(this);
+
+    // Mirrors `config.active_support = ActiveSupport::OrderedOptions.new`.
+    (Trailtie.config as TrailtieConfig).activeSupport ??= {};
+
+    this.initializer("active_support.deprecator", () => {
+      BaseRailtie.deprecators["activeSupport"] = deprecator;
+    });
+
+    this.initializer("active_support.set_hash_digest_class", () => {
+      const klass = (Trailtie.config as TrailtieConfig).activeSupport?.hashDigestClass;
+      if (klass) {
+        Digest.hashDigestClass = klass;
+      }
+    });
+  }
+}

--- a/packages/trailties/src/trailties/active-support.ts
+++ b/packages/trailties/src/trailties/active-support.ts
@@ -24,8 +24,6 @@
  *     has no `useAuthenticatedMessageEncryption` toggle
  *   - active_support.reset_execution_context — no reloader/executor in trails
  *   - active_support.reset_all_current_attributes_instances — same
- *   - active_support.deprecation_behavior — Deprecation has no
- *     `silenced`/`behavior` setters wired through Application
  *   - active_support.initialize_time_zone — no TZInfo binding
  *   - active_support.to_time_preserves_timezone — flag not ported
  *   - active_support.initialize_beginning_of_week — Date.beginning_of_week
@@ -40,15 +38,29 @@
  *     ported
  *   - active_support.set_use_message_serializer_for_metadata — same
  */
-import { Railtie as BaseRailtie, registerRailtie, deprecator } from "@blazetrails/activesupport";
+import {
+  Railtie as BaseRailtie,
+  registerRailtie,
+  deprecator,
+  type Deprecation,
+  type DeprecationBehavior,
+} from "@blazetrails/activesupport";
 import { Digest } from "@blazetrails/activesupport/digest";
 
 export interface HashDigestClass {
   hexdigest(data: string): string;
 }
 
+type DeprecationCallable = (...args: unknown[]) => void;
+type BehaviorSetting = DeprecationBehavior | DeprecationBehavior[] | DeprecationCallable | null;
+type DisallowedBehaviorSetting = DeprecationBehavior | DeprecationCallable | null;
+
 export interface ActiveSupportConfig {
   hashDigestClass?: HashDigestClass;
+  reportDeprecations?: boolean;
+  deprecation?: BehaviorSetting;
+  disallowedDeprecation?: DisallowedBehaviorSetting;
+  disallowedDeprecationWarnings?: (string | RegExp | "all")[];
 }
 
 export interface TrailtieConfig {
@@ -69,6 +81,28 @@ export class Trailtie extends BaseRailtie {
 
     this.initializer("active_support.deprecator", () => {
       BaseRailtie.deprecators["activeSupport"] = deprecator;
+    });
+
+    this.initializer("active_support.deprecation_behavior", () => {
+      const cfg = (Trailtie.config as TrailtieConfig).activeSupport ?? {};
+      const all = Object.values(BaseRailtie.deprecators).filter((d): d is Deprecation => d != null);
+      if (cfg.reportDeprecations === false) {
+        for (const d of all) {
+          d.silenced = true;
+          d.behavior = "silence";
+          d.disallowedBehavior = "silence";
+        }
+        return;
+      }
+      if (cfg.deprecation !== undefined) {
+        for (const d of all) d.behavior = cfg.deprecation;
+      }
+      if (cfg.disallowedDeprecation !== undefined) {
+        for (const d of all) d.disallowedBehavior = cfg.disallowedDeprecation;
+      }
+      if (cfg.disallowedDeprecationWarnings !== undefined) {
+        for (const d of all) d.disallowedWarnings = cfg.disallowedDeprecationWarnings;
+      }
     });
 
     this.initializer("active_support.set_hash_digest_class", () => {

--- a/packages/trailties/src/trailties/active-support.ts
+++ b/packages/trailties/src/trailties/active-support.ts
@@ -63,10 +63,6 @@ export interface ActiveSupportConfig {
   disallowedDeprecationWarnings?: (string | RegExp | "all")[];
 }
 
-export interface TrailtieConfig {
-  activeSupport?: ActiveSupportConfig;
-}
-
 /**
  * Trailtie wiring for ActiveSupport.
  *
@@ -77,7 +73,7 @@ export class Trailtie extends BaseRailtie {
     registerRailtie(this);
 
     // Mirrors `config.active_support = ActiveSupport::OrderedOptions.new`.
-    (Trailtie.config as TrailtieConfig).activeSupport ??= {};
+    this.config["activeSupport"] ??= {};
 
     this.initializer("active_support.deprecator", () => {
       BaseRailtie.deprecators["activeSupport"] = deprecator;
@@ -96,7 +92,7 @@ export class Trailtie extends BaseRailtie {
     // (ordering + DeprecatorsProxy) and is a follow-up on PR 2.7a, not a
     // local patch here.
     this.initializer("active_support.deprecation_behavior", () => {
-      const cfg = (Trailtie.config as TrailtieConfig).activeSupport ?? {};
+      const cfg = (Trailtie.config["activeSupport"] as ActiveSupportConfig | undefined) ?? {};
       const all = Object.values(BaseRailtie.deprecators).filter((d): d is Deprecation => d != null);
       if (cfg.reportDeprecations === false) {
         for (const d of all) {
@@ -118,7 +114,8 @@ export class Trailtie extends BaseRailtie {
     });
 
     this.initializer("active_support.set_hash_digest_class", () => {
-      const klass = (Trailtie.config as TrailtieConfig).activeSupport?.hashDigestClass;
+      const klass = (Trailtie.config["activeSupport"] as ActiveSupportConfig | undefined)
+        ?.hashDigestClass;
       if (klass) {
         Digest.hashDigestClass = klass;
       }

--- a/packages/trailties/src/trailties/active-support.ts
+++ b/packages/trailties/src/trailties/active-support.ts
@@ -47,9 +47,7 @@ import {
 } from "@blazetrails/activesupport";
 import { Digest } from "@blazetrails/activesupport/digest";
 
-export interface HashDigestClass {
-  hexdigest(data: string): string;
-}
+type HashDigestClass = typeof Digest.hashDigestClass;
 
 type DeprecationCallable = (...args: unknown[]) => void;
 type BehaviorSetting = DeprecationBehavior | DeprecationBehavior[] | DeprecationCallable | null;
@@ -92,7 +90,7 @@ export class Trailtie extends BaseRailtie {
     // (ordering + DeprecatorsProxy) and is a follow-up on PR 2.7a, not a
     // local patch here.
     this.initializer("active_support.deprecation_behavior", () => {
-      const cfg = (Trailtie.config["activeSupport"] as ActiveSupportConfig | undefined) ?? {};
+      const cfg = (this.config["activeSupport"] as ActiveSupportConfig | undefined) ?? {};
       const all = Object.values(BaseRailtie.deprecators).filter((d): d is Deprecation => d != null);
       if (cfg.reportDeprecations === false) {
         for (const d of all) {
@@ -114,7 +112,7 @@ export class Trailtie extends BaseRailtie {
     });
 
     this.initializer("active_support.set_hash_digest_class", () => {
-      const klass = (Trailtie.config["activeSupport"] as ActiveSupportConfig | undefined)
+      const klass = (this.config["activeSupport"] as ActiveSupportConfig | undefined)
         ?.hashDigestClass;
       if (klass) {
         Digest.hashDigestClass = klass;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -79,6 +79,10 @@ const alias = {
     __dirname,
     "packages/activesupport/src/key-generator.ts",
   ),
+  "@blazetrails/activesupport/digest": path.resolve(
+    __dirname,
+    "packages/activesupport/src/digest.ts",
+  ),
   "@blazetrails/activesupport/glob": path.resolve(__dirname, "packages/activesupport/src/glob.ts"),
   "@blazetrails/activesupport/yaml": path.resolve(__dirname, "packages/activesupport/src/yaml.ts"),
   "@blazetrails/activesupport/gzip": path.resolve(__dirname, "packages/activesupport/src/gzip.ts"),


### PR DESCRIPTION
Implements PR 2.7a from `docs/trailties-plan.md` — the activesupport `Trailtie`.

## Resolves open question #2

The activesupport trailtie lives at **`packages/trailties/src/trailties/active-support.ts`** (the plan's default position), keeping the dependency direction `trailties → activesupport`. Putting it inside `packages/activesupport/` would invert that direction (activesupport would have to self-import its own `Railtie` base from `@blazetrails/activesupport`) and couple the leaf framework to the application-runner concept it should stay agnostic of.

The plan doc's open-questions table (row #2) and the PR 2.7 file-location table are updated accordingly.

## Rails source

- `activesupport/lib/active_support/railtie.rb` — ported

## Initializers wired

- `active_support.deprecator` — registers `deprecator` on `BaseRailtie.deprecators["activeSupport"]`
- `active_support.deprecation_behavior` — iterates `BaseRailtie.deprecators` (mirrors Rails' iteration over `app.deprecators`) and applies the report/behavior/disallowed settings from `config.activeSupport`
- `active_support.set_hash_digest_class` — applies `config.activeSupport.hashDigestClass` to `Digest.hashDigestClass`

Also seeds `config.activeSupport` to match Rails' top-level `config.active_support = ActiveSupport::OrderedOptions.new`.

## Initializers intentionally skipped

Each is blocked on a helper that has not been ported to trails. Documented in-file at the top of `active-support.ts`. Summary:

- `active_support.isolation_level` — `IsolatedExecutionState` has no `isolationLevel` setter
- `active_support.raise_on_invalid_cache_expiration_time` — `Cache::Store` has no flag
- `active_support.set_authenticated_message_encryption` — `MessageEncryptor` has no toggle
- `active_support.reset_execution_context` / `active_support.reset_all_current_attributes_instances` — no reloader/executor in trails
- `active_support.initialize_time_zone` — no TZInfo
- `active_support.to_time_preserves_timezone` — flag not ported
- `active_support.initialize_beginning_of_week` — `Date.beginning_of_week` not ported
- `active_support.require_master_key` — credentials key lookup runs elsewhere
- `active_support.set_configs` — generic setter-dispatch loop, deferred until each target lands
- `active_support.set_key_generator_hash_digest_class` — `KeyGenerator.hashDigestClass` is per-instance, not class-level
- `active_support.set_default_message_serializer` / `set_use_message_serializer_for_metadata` — `Messages::Codec` not ported

These become follow-ups as the underlying helpers land.

## Files

- `packages/trailties/src/trailties/active-support.ts` (new)
- `packages/trailties/src/trailties/active-support.test.ts` (new)
- `vitest.config.ts` — register the `@blazetrails/activesupport/digest` subpath alias for vitest
- `docs/trailties-plan.md` — mark Q#2 resolved + update file-location table

## Test plan

- [x] `pnpm vitest run packages/trailties/src/trailties/active-support.test.ts` — 7 passed
- [x] `pnpm exec tsc -p packages/trailties --noEmit` — clean for new files
- [x] `pnpm lint` — clean for new files
- [x] Diff well under the 300 LOC ceiling