### PR TITLE
refactor(activerecord): delete dormant arelVisitor fallback (TM Phase 9b-3)

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3613,9 +3613,15 @@ export class Relation<T extends Base> {
 
   private _arelVisitor(): Visitors.ToSql {
     const adapter = (this._modelClass as any)._adapter as
-      | (Visitors.ArelQuoter & { arelVisitor?: Visitors.ToSql })
-      | null;
-    return adapter?.arelVisitor ?? new Visitors.ToSql(adapter ?? undefined);
+      | { arelVisitor?: Visitors.ToSql }
+      | null
+      | undefined;
+    if (!adapter?.arelVisitor) {
+      throw new Error(
+        "Relation requires a model class with an adapter exposing arelVisitor to compile SQL",
+      );
+    }
+    return adapter.arelVisitor;
   }
 
   /**

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -707,9 +707,9 @@ class SchemaAdapter implements DatabaseAdapter {
   }
 
   get arelVisitor(): Visitors.ToSql | undefined {
-    // Phase 9b-2b: all three adapters now delegate. The dormant
-    // `new Visitors.ToSql` fallback in `Relation#_arelVisitor` is dead
-    // code; Phase 9b-3+4 will delete the fallback and this wrapper class.
+    // Phase 9b-3 deleted the dormant `new Visitors.ToSql` fallback in
+    // `Relation#_arelVisitor`; this wrapper still delegates. Phase 9b-4
+    // (follow-up) will delete this wrapper class entirely.
     return (this.inner as { arelVisitor?: Visitors.ToSql }).arelVisitor;
   }
 


### PR DESCRIPTION
## Summary

- Delete the dormant `new Visitors.ToSql(adapter ?? undefined)` fallback in `Relation#_arelVisitor` — all three real adapters now expose `arelVisitor` (PG #2139, MySQL #2155, SQLite pre-9b) and `AbstractAdapter` provides a default. Replace with a hard throw so a misconfigured relation surfaces loudly instead of silently emitting mixed-quote ANSI SQL.

## Scope split — 9b-4 deferred as follow-up

The original task was 9b-3 (fallback) + 9b-4 (delete `SchemaAdapter` wrapper). I'm shipping **9b-3 only** here.

Despite the plan doc framing `SchemaAdapter` as \"pure delegation,\" it isn't. The wrapper carries real behavior that tests rely on:

- **Async-chain transaction visibility filtering** (`_txVisible` / `_txLockStorage`) — hides the inner adapter's transaction state from foreign async chains. Without this, `Promise.all` top-level transactions would observe each other's TM frame as joinable and bypass the TM mutex.
- **Manual transaction depth tracking** (`_manualTxDepth`) — direct `beginTransaction()`/`commit()`/`rollback()` callers (migrations, fixtures, query-cache tests) don't go through `withinNewTransaction`, so without this counter the chain-aware delegations would hide tx state from them.
- **DDL tracking** (`recordDdlTracking` on `executeMutation` and `exec`) — drives `defineSchema`'s cache-invalidation logic via `adapterKnownTables`.

Deleting the wrapper requires migrating each of these concerns (likely into TM and/or test-helpers) and sweeping ~148 consumers. That's substantially more than the ~300 LOC PR ceiling and warrants its own design pass. Leaving the wrapper in place; updated the `arelVisitor` comment to flag 9b-3 done and 9b-4 deferred.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/relation.test.ts` — 88 pass / 29 skipped
- [x] `pnpm vitest run packages/activerecord/src/relations.test.ts` — 655 pass / 27 skipped
- [ ] CI green across all three adapters