### PR TITLE
feat(tse-compiler): new package — lexer, AST, JS emitter (Phase 2a-0)

### DIFF
--- a/packages/tse-compiler/package.json
+++ b/packages/tse-compiler/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@blazetrails/tse-compiler",
+  "version": "0.1.0",
+  "description": "TSE (Trails Server Embedded) compiler — lexer, AST, JS emitter. Rails analogue: the erubi gem.",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc"
+  },
+  "files": [
+    "dist"
+  ],
+  "license": "MIT"
+}

--- a/packages/tse-compiler/src/emit-js.test.ts
+++ b/packages/tse-compiler/src/emit-js.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { compileJs } from "./emit-js.js";
+
+describe("compileJs", () => {
+  it("emits a render function with the Rails-shaped dispatch", () => {
+    const { code } = compileJs("<h1><%= name %></h1>");
+    expect(code).toBe(
+      [
+        "export default function render(context, locals) {",
+        "  const _ob = context.outputBuffer;",
+        '  _ob.safeAppend("<h1>");',
+        "  _ob.append(name);",
+        '  _ob.safeAppend("</h1>");',
+        "  return _ob;",
+        "}",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("dispatches expression sites by escape mode and indicator", () => {
+    expect(compileJs("<%= n %>").code).toContain("_ob.append(n);");
+    expect(compileJs("<%= n %>", { escapeIgnore: true }).code).toContain("_ob.safeExprAppend(n);");
+    expect(compileJs("<%== n %>").code).toContain("_ob.safeExprAppend(n);");
+    expect(compileJs("<% const x = 1 %>").code).toContain("const x = 1;");
+  });
+});

--- a/packages/tse-compiler/src/emit-js.ts
+++ b/packages/tse-compiler/src/emit-js.ts
@@ -1,0 +1,51 @@
+/** JS runtime emitter — TseAst → ES module. Mirrors actionview-flavored Erubi
+ * (plan §2.6): static text → `safeAppend`; `<%= %>` → `append` (escapes unless
+ * SafeString) or `safeExprAppend` when format is in `escape_ignore_list`;
+ * `<%== %>` always `safeExprAppend`. */
+
+import { parse, type TseAst, type TseNode } from "./parser.js";
+
+export interface EmitJsOptions {
+  escapeIgnore?: boolean;
+}
+
+export interface EmitResult {
+  code: string;
+  localsSignature: string | null;
+  typesAnnotation: string | null;
+}
+
+export function compileJs(source: string, options: EmitJsOptions = {}): EmitResult {
+  const ast = parse(source);
+  return {
+    code: emit(ast, options),
+    localsSignature: ast.localsSignature,
+    typesAnnotation: ast.typesAnnotation,
+  };
+}
+
+function emit(ast: TseAst, options: EmitJsOptions): string {
+  const exprAppend = options.escapeIgnore === true ? "safeExprAppend" : "append";
+  const lines = [
+    "export default function render(context, locals) {",
+    "  const _ob = context.outputBuffer;",
+  ];
+  for (const node of ast.nodes) lines.push("  " + emitNode(node, exprAppend));
+  lines.push("  return _ob;", "}");
+  return lines.join("\n") + "\n";
+}
+
+function emitNode(node: TseNode, exprAppend: string): string {
+  switch (node.kind) {
+    case "text":
+      return `_ob.safeAppend(${JSON.stringify(node.value)});`;
+    case "code": {
+      const t = node.value.trimEnd();
+      return node.value + (t.endsWith(";") || t.endsWith("{") || t.endsWith("}") ? "" : ";");
+    }
+    case "expr":
+      return `_ob.${exprAppend}(${node.value});`;
+    case "rawExpr":
+      return `_ob.safeExprAppend(${node.value});`;
+  }
+}

--- a/packages/tse-compiler/src/index.ts
+++ b/packages/tse-compiler/src/index.ts
@@ -1,0 +1,4 @@
+export { tokenize, TseSyntaxError, type Token, type TokenKind } from "./lexer.js";
+export { parse, type TseAst, type TseNode } from "./parser.js";
+export { compileJs, type EmitJsOptions, type EmitResult } from "./emit-js.js";
+export { parseFilename, type ParsedFilename } from "./parse-filename.js";

--- a/packages/tse-compiler/src/lexer.test.ts
+++ b/packages/tse-compiler/src/lexer.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { tokenize, TseSyntaxError } from "./lexer.js";
+
+describe("tokenize", () => {
+  it("splits text and recognizes every tag indicator", () => {
+    const t = tokenize("a<% x %>b<%= e %><%== r %><%# c %><%! types: T !%>");
+    expect(t.map((x) => x.kind)).toEqual([
+      "text",
+      "code",
+      "text",
+      "expr",
+      "rawExpr",
+      "comment",
+      "typesMagic",
+    ]);
+  });
+
+  it("honors <%- and -%> trim modes and <%% / %%> literals", () => {
+    const left = tokenize("a\n   <%- x %>b");
+    expect(left[0].value).toBe("a\n");
+    expect(left[1].trimLeft).toBe(true);
+    const right = tokenize("<% x -%>   \nb");
+    expect(right[1].value).toBe("b");
+    expect(tokenize("<%% %%>")[0].value).toBe("<% %>");
+  });
+
+  it("throws on unterminated tags", () => {
+    expect(() => tokenize("<% never closed")).toThrow(TseSyntaxError);
+    expect(() => tokenize("<%! never closed")).toThrow(TseSyntaxError);
+  });
+});

--- a/packages/tse-compiler/src/lexer.ts
+++ b/packages/tse-compiler/src/lexer.ts
@@ -1,0 +1,48 @@
+/** TSE lexer. Rails analogue: the `erubi` gem scanner. Single divergence:
+ * `<%! ... !%>` magic blocks for TS-only type annotations (plan §2.10.1). */
+
+export type TokenKind = "text" | "code" | "expr" | "rawExpr" | "comment" | "typesMagic";
+export interface Token {
+  kind: TokenKind;
+  value: string;
+  trimLeft: boolean;
+  trimRight: boolean;
+}
+export class TseSyntaxError extends Error {}
+
+const TAG_RE = /<%%|%%>|<%!([\s\S]*?)!%>|<%(-)?(==|=|#)?([\s\S]*?)(-)?%>/g;
+const KIND: Record<string, TokenKind> = { "=": "expr", "==": "rawExpr", "#": "comment" };
+const text = (value: string): Token => ({ kind: "text", value, trimLeft: false, trimRight: false });
+
+export function tokenize(source: string): Token[] {
+  const tokens: Token[] = [];
+  let buf = "";
+  let last = 0;
+  const flush = (): void => {
+    if (buf.length > 0) tokens.push(text(buf));
+    buf = "";
+  };
+
+  for (const m of source.matchAll(TAG_RE)) {
+    buf += source.slice(last, m.index);
+    last = m.index + m[0].length;
+    if (m[0] === "<%%") buf += "<%";
+    else if (m[0] === "%%>") buf += "%>";
+    else if (m[1] !== undefined) {
+      flush();
+      tokens.push({ kind: "typesMagic", value: m[1], trimLeft: false, trimRight: false });
+    } else {
+      const trimLeft = m[2] === "-";
+      const trimRight = m[5] === "-";
+      if (trimLeft) buf = buf.replace(/[ \t]*$/, "");
+      flush();
+      tokens.push({ kind: KIND[m[3] ?? ""] ?? "code", value: m[4], trimLeft, trimRight });
+      if (trimRight) last += (/^[ \t]*\r?\n/.exec(source.slice(last))?.[0] ?? "").length;
+    }
+  }
+  buf += source.slice(last);
+  flush();
+
+  if (/<%/.test(source.replace(TAG_RE, ""))) throw new TseSyntaxError("unterminated TSE tag");
+  return tokens;
+}

--- a/packages/tse-compiler/src/parse-filename.test.ts
+++ b/packages/tse-compiler/src/parse-filename.test.ts
@@ -1,0 +1,14 @@
+import { describe, it, expect } from "vitest";
+import { parseFilename } from "./parse-filename.js";
+
+describe("parseFilename", () => {
+  it("splits `<name>.<format>.tse` and handles missing format", () => {
+    expect(parseFilename("users/show.html.tse")).toEqual({
+      name: "users/show",
+      format: "html",
+      handler: "tse",
+    });
+    expect(parseFilename("users/show.json.tse").format).toBe("json");
+    expect(parseFilename("show.tse")).toEqual({ name: "show", format: null, handler: "tse" });
+  });
+});

--- a/packages/tse-compiler/src/parse-filename.ts
+++ b/packages/tse-compiler/src/parse-filename.ts
@@ -1,0 +1,21 @@
+/** Splits `<name>.<format>.<handler>` per Rails' filename grammar (plan §2.2).
+ * Locale folds into `name` (`show.en.html.tse` → `show.en`); variant stays
+ * glued to `format` (`show.html+phone.tse` → `html+phone`). Splitting these
+ * into their own fields is a follow-up tied to the LookupContext port. */
+
+export interface ParsedFilename {
+  name: string;
+  format: string | null;
+  handler: string | null;
+}
+
+export function parseFilename(path: string): ParsedFilename {
+  const slash = path.lastIndexOf("/");
+  const dir = slash === -1 ? "" : path.slice(0, slash + 1);
+  const base = slash === -1 ? path : path.slice(slash + 1);
+  const segments = base.split(".");
+  if (segments.length < 2) return { name: dir + base, format: null, handler: null };
+  const handler = segments.pop()!;
+  const format = segments.length > 1 ? segments.pop()! : null;
+  return { name: dir + segments.join("."), format, handler };
+}

--- a/packages/tse-compiler/src/parser.test.ts
+++ b/packages/tse-compiler/src/parser.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import { parse } from "./parser.js";
+import { TseSyntaxError } from "./lexer.js";
+
+describe("parse", () => {
+  it("lifts locals: and types: magic comments off the node stream", () => {
+    const ast = parse(
+      "<%# locals: (name:, count: 0) %><%! types: { name: string } !%>hi<%= name %>",
+    );
+    expect(ast.localsSignature).toBe("name:, count: 0");
+    expect(ast.typesAnnotation).toBe("{ name: string }");
+    expect(ast.nodes).toEqual([
+      { kind: "text", value: "hi" },
+      { kind: "expr", value: "name" },
+    ]);
+  });
+
+  it("normalizes empty `locals: ()` to `**nil` and keeps the first directive on duplicates", () => {
+    expect(parse("<%# locals: () %>").localsSignature).toBe("**nil");
+    expect(parse("<%# locals: (a:) %><%# locals: (b:) %>").localsSignature).toBe("a:");
+  });
+
+  it("rejects unknown <%! ... !%> directives", () => {
+    expect(() => parse("<%! foo: bar !%>")).toThrow(TseSyntaxError);
+  });
+});

--- a/packages/tse-compiler/src/parser.ts
+++ b/packages/tse-compiler/src/parser.ts
@@ -1,0 +1,41 @@
+/** Builds a TseAst from the token stream. Lifts `<%# locals: (...) %>` and
+ * `<%! types: ... !%>` magic comments onto the AST root — mirrors Rails'
+ * `Template#strict_locals!` mutating source before Erubi compiles it. */
+
+import { tokenize, TseSyntaxError } from "./lexer.js";
+
+export type TseNode =
+  | { kind: "text"; value: string }
+  | { kind: "code"; value: string }
+  | { kind: "expr"; value: string }
+  | { kind: "rawExpr"; value: string };
+
+export interface TseAst {
+  nodes: TseNode[];
+  localsSignature: string | null;
+  typesAnnotation: string | null;
+}
+
+const LOCALS_RE = /^\s*locals:\s*\((.*)\)\s*$/s;
+
+export function parse(source: string): TseAst {
+  const nodes: TseNode[] = [];
+  let localsSignature: string | null = null;
+  let typesAnnotation: string | null = null;
+
+  for (const tok of tokenize(source)) {
+    if (tok.kind === "text") {
+      if (tok.value.length > 0) nodes.push({ kind: "text", value: tok.value });
+    } else if (tok.kind === "comment") {
+      const m = LOCALS_RE.exec(tok.value);
+      if (m && localsSignature === null) localsSignature = m[1].trim() || "**nil";
+    } else if (tok.kind === "typesMagic") {
+      const m = /^\s*types:\s*/.exec(tok.value);
+      if (!m) throw new TseSyntaxError(`unknown <%! ... !%> directive: ${tok.value.trim()}`);
+      if (typesAnnotation === null) typesAnnotation = tok.value.slice(m[0].length).trim();
+    } else {
+      nodes.push({ kind: tok.kind, value: tok.value.trim() } as TseNode);
+    }
+  }
+  return { nodes, localsSignature, typesAnnotation };
+}

--- a/packages/tse-compiler/tsconfig.json
+++ b/packages/tse-compiler/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,6 +226,8 @@ importers:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)
 
+  packages/tse-compiler: {}
+
   packages/website:
     devDependencies:
       '@sveltejs/adapter-static':
@@ -321,6 +323,9 @@ importers:
       '@blazetrails/trailties':
         specifier: workspace:*
         version: link:../../packages/trailties
+      '@blazetrails/tse-compiler':
+        specifier: workspace:*
+        version: link:../../packages/tse-compiler
 
   scripts/parity:
     dependencies:

--- a/scripts/guides-typecheck/package.json
+++ b/scripts/guides-typecheck/package.json
@@ -16,6 +16,7 @@
     "@blazetrails/did-you-mean": "workspace:*",
     "@blazetrails/globalid": "workspace:*",
     "@blazetrails/html-sanitizer": "workspace:*",
-    "@blazetrails/trails-tsc": "workspace:*"
+    "@blazetrails/trails-tsc": "workspace:*",
+    "@blazetrails/tse-compiler": "workspace:*"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
   "files": [],
   "references": [
     { "path": "packages/activesupport" },
+    { "path": "packages/tse-compiler" },
     { "path": "packages/arel" },
     { "path": "packages/activemodel" },
     { "path": "packages/trails-tsc" },


### PR DESCRIPTION
## Summary

Introduces `@blazetrails/tse-compiler`, the leaf compiler package that
underpins both the actionview TSE handler and the trails-tsc plugin
(see [`docs/tse-plan.md` §2.3](docs/tse-plan.md)). Rails analogue: the
[`erubi` gem](https://github.com/jeremyevans/erubi).

This is the first of several Phase 2a PRs; everything after this one
depends on the lexer + AST landing.

## What lands

- **Lexer** — full Erubi tag set: `<% %>`, `<%= %>`, `<%== %>`, `<%# %>`,
  `<%- -%>` trim modes (right-trim consumes `[ \t]*\r?\n` per Erubi
  `DEFAULT_REGEXP`), `<%% / %%>` literals, plus the TSE-only
  `<%! types: ... !%>` magic block (single divergence from Erubi,
  per plan §2.10.1). Unterminated tags raise `TseSyntaxError`.
- **Parser** — builds a typed AST and lifts both magic comments off
  the node stream:
  - `<%# locals: (name:, count: 0) %>` → `localsSignature`
  - `<%! types: { name: string } !%>` → `typesAnnotation`

  Unknown `<%! ... !%>` directives raise `TseSyntaxError` so future
  block kinds (e.g. `format:`) can't silently misclassify as `types:`.
  Mirrors Rails `Template#strict_locals!` which mutates source via
  `sub!` before Erubi compiles it.
- **JS runtime emitter** — `TseAst → ES module` with Rails-shaped
  dispatch (plan §2.6):
  - static text → `_ob.safeAppend(...)`
  - `<%= %>` → `_ob.append(...)` (HTML-escapes unless `SafeString`)
  - `<%= %>` flips to `_ob.safeExprAppend(...)` when
    `escapeIgnore: true` — mirrors `Template::Handlers::ERB.escape_ignore_list`
    (e.g. `text/plain`)
  - `<%== %>` → `_ob.safeExprAppend(...)` unconditionally
  - emitted module returns `_ob` (the OutputBuffer, a `SafeString`)
- **`parseFilename`** — splits the minimum `<name>.<format>.<handler>`
  shape from Rails' filename grammar (plan §2.3). Locale/variant
  parsing is a follow-up tied to the LookupContext port.

## Method names match Rails Erubi, not the current `OutputBuffer`

The emitter writes `_ob.safeAppend(...)` / `_ob.append(...)` because
that's what actionview's Erubi adapter emits in Rails. Source:

- `vendor/rails/actionview/lib/action_view/buffers.rb:54,60` —
  `alias :append= :<<` and `alias :safe_append= :safe_concat`
- `vendor/rails/actionview/lib/action_view/template/handlers/erb/erubi.rb:37,54` —
  emits `.safe_append=` for static text and `.append=` for `<%= %>`

Today our `packages/actionview/src/buffers.ts` exposes the canonical
`concat` / `safeConcat` / `safeExprAppend` but lacks the `append` /
`safeAppend` aliases. **Phase 2a-1 (the `Tse` handler PR) will add
the aliases**, restoring the same alias pattern Rails uses. Keeping the
emitter Rails-faithful here means Phase 2a-1 is a pure add — no churn
back through the compiler.

## Deferred (separate PRs, per plan §4)

- **Strict-locals binding emission** — the runtime half of Rails
  `Template#strict_locals!` (plan §1.3, §2.5): when `localsSignature`
  is present, the emitted function should destructure the named keys
  out of `locals` so bare `<%= name %>` resolves, mirroring Rails'
  kwarg-spliced method signature. Pairs naturally with the
  `StrictLocalsMismatch` runtime check planned for Phase 2a-1.
  Today, templates can write `<%= locals.name %>` explicitly.
- **Phase 2a-0b** — TS shim emitter (`.tse.ts` typecheck artifact).
- **Phase 2a-0c** — `.d.ts` + `.d.ts.map` emitter (invokes the
  TypeScript compiler API on the emitted `.tse.ts`).
- **Block-form `<%= helper do %>...<% end %>`** dispatch
  (plan §2.4 / §2.10.3) — needs the `capture(...)` wrapper around the
  block callback. Lands alongside the actionview `Tse` handler.
- **Source maps** (plan §2.6 / §2.9) — the JS emitter emits code only;
  `.tse.js.map` is part of Phase 2a-1.
- **Phase 2a-1** — `Tse` handler class in `@blazetrails/actionview`
  (also adds the `safeAppend` / `append` aliases on `OutputBuffer`
  and the strict-locals destructure prologue).
- **Phase 2b** — trails-tsc plugin file I/O + `views-manifest.ts`
  generation.

## Rails sources referenced for fidelity

- `vendor/rails/actionview/lib/action_view/template/handlers/erb.rb`
- `vendor/rails/actionview/lib/action_view/template/handlers/erb/erubi.rb`
- `vendor/rails/actionview/lib/action_view/buffers.rb`
- `erubi-1.12.0/lib/erubi.rb` — `DEFAULT_REGEXP` (right-trim shape)

## Notes

- 298 net LOC (under the 300 ceiling).
- No third-party runtime deps.
- No `node:*` imports, no `process.*`, no async fs required.
- camelCase throughout; conventional commits.

## Test plan

- [x] `pnpm exec tsc -b packages/tse-compiler` — clean
- [x] `pnpm vitest run packages/tse-compiler/` — 9/9 passing
- [x] `pnpm eslint packages/tse-compiler` — clean
- [x] `pnpm guides:typecheck` — clean
- [ ] CI green