### PR TITLE
feat(trailties): typed template-builder infra (PR T1)

### DIFF
--- a/docs/trailties-template-builder.md
+++ b/docs/trailties-template-builder.md
@@ -55,7 +55,7 @@ codified hard rule.
 ```ts
 // packages/trailties/src/template-builder/index.ts
 
-declare const REF_BRAND: unique symbol;
+declare const refBrand: unique symbol;
 
 /**
  * Opaque branded identifier. Structurally NOT constructible — the
@@ -63,11 +63,11 @@ declare const REF_BRAND: unique symbol;
  * ways to obtain a `Ref` are `ref(...)` and the `*.refs` field on the
  * result of a `tsImport*` call.
  */
-export type Ref = { readonly [REF_BRAND]: true; readonly name: string; readonly from?: string };
+export type Ref = { readonly [refBrand]: true; readonly name: string; readonly from?: string };
 
 /** Tagged-template result carrying refs through interpolation. */
 export type Type = {
-  readonly [REF_BRAND]: "type";
+  readonly [refBrand]: "type";
   readonly text: string;
   readonly refs: readonly Ref[];
 };
@@ -119,7 +119,7 @@ export function tsMethod(opts: Method): Method;
 
 /** Dedent + ref-carrying tagged template for method bodies. */
 export type Body = {
-  readonly [REF_BRAND]: "body";
+  readonly [refBrand]: "body";
   readonly text: string;
   readonly refs: readonly Ref[];
 };
@@ -128,7 +128,7 @@ export function tsBody(parts: TemplateStringsArray, ...interps: Array<Ref | stri
 export interface ClassDecl {
   readonly __kind: "class";
   name: string;
-  extends?: Ref; // must be a Ref, not a string — Ref's REF_BRAND enforces this
+  extends?: Ref; // must be a Ref, not a string — Ref's refBrand enforces this
   implements?: Ref[];
   exported?: boolean; // defaults true
   body: Array<Field | Method>;
@@ -168,8 +168,8 @@ symbol`, so it cannot be constructed structurally — the only ways
   load-bearing constraint that blocks the Ruby-emission failure mode.
 - **Declarations use a public `__kind` discriminator.** `ClassDecl` /
   `InterfaceDecl` / `RawDecl` are discriminated by a runtime
-  `__kind: "class" | "interface" | "raw"` field, not the `REF_BRAND`
-  unique symbol. The `REF_BRAND` is type-level only (never assigned
+  `__kind: "class" | "interface" | "raw"` field, not the `refBrand`
+  unique symbol. The `refBrand` is type-level only (never assigned
   at runtime), so declarations need a real runtime field for
   `tsModule`'s dispatch. Constructor exclusivity is provided by the
   `tsClass` / `tsInterface` / `tsRaw` factories; the brand-level

--- a/docs/trailties-template-builder.md
+++ b/docs/trailties-template-builder.md
@@ -126,24 +126,27 @@ export type Body = {
 export function tsBody(parts: TemplateStringsArray, ...interps: Array<Ref | string>): Body;
 
 export interface ClassDecl {
-  readonly [REF_BRAND]: "class";
+  readonly __kind: "class";
   name: string;
-  extends?: Ref; // must be a Ref, not a string — brand enforces this
+  extends?: Ref; // must be a Ref, not a string — Ref's REF_BRAND enforces this
   implements?: Ref[];
   exported?: boolean; // defaults true
   body: Array<Field | Method>;
 }
-export function tsClass(opts: Omit<ClassDecl, typeof REF_BRAND>): ClassDecl;
+export type ClassOpts = Omit<ClassDecl, "__kind">;
+export function tsClass(opts: ClassOpts): ClassDecl;
 
 export interface InterfaceDecl {
-  readonly [REF_BRAND]: "interface";
+  readonly __kind: "interface";
   /* analogous to ClassDecl */
 }
-export function tsInterface(opts: Omit<InterfaceDecl, typeof REF_BRAND>): InterfaceDecl;
+export function tsInterface(opts: Omit<InterfaceDecl, "__kind">): InterfaceDecl;
+
+export function tsRaw(text: string): RawDecl;
 
 export interface ModuleSource {
   imports?: Import[]; // optional — refs from declarations are auto-collected
-  declarations: Array<ClassDecl | InterfaceDecl | { readonly [REF_BRAND]: "raw"; text: string }>;
+  declarations: Array<ClassDecl | InterfaceDecl | RawDecl>;
   preamble?: string; // file-level comment block
 }
 
@@ -163,6 +166,15 @@ symbol`, so it cannot be constructed structurally — the only ways
   to obtain one are `ref("Name", "package")` or the `.refs[alias]`
   field of an `ImportResult` returned by `tsImport*`. This is the
   load-bearing constraint that blocks the Ruby-emission failure mode.
+- **Declarations use a public `__kind` discriminator.** `ClassDecl` /
+  `InterfaceDecl` / `RawDecl` are discriminated by a runtime
+  `__kind: "class" | "interface" | "raw"` field, not the `REF_BRAND`
+  unique symbol. The `REF_BRAND` is type-level only (never assigned
+  at runtime), so declarations need a real runtime field for
+  `tsModule`'s dispatch. Constructor exclusivity is provided by the
+  `tsClass` / `tsInterface` / `tsRaw` factories; the brand-level
+  unforgeability is reserved for `Ref` / `Type` / `Body`, which
+  carry refs through emitted string output.
 - **`Type` and `Body` carry refs.** `` type`Array<${userRef}>` `` and `` tsBody`return new ${userRef}();` `` propagate refs to `tsModule`'s import collector.
 - **`tsModule` resolves imports.** Walks every `Ref` in declarations,
   collects the implied imports, dedupes, sorts, and emits the import

--- a/packages/trailties/dx-tests/template-builder.test-d.ts
+++ b/packages/trailties/dx-tests/template-builder.test-d.ts
@@ -1,4 +1,4 @@
-import { ref, tsClass } from "./index.js";
+import { ref, tsClass } from "@blazetrails/trailties/template-builder";
 
 // `extends` must be a Ref, not a string. The Ref brand is module-private,
 // so a string literal cannot satisfy the type — this is the load-bearing

--- a/packages/trailties/dx-tests/tsconfig.json
+++ b/packages/trailties/dx-tests/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "composite": false,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@blazetrails/trailties/template-builder": ["../src/template-builder/index.ts"]
+    }
+  },
+  "include": ["."]
+}

--- a/packages/trailties/package.json
+++ b/packages/trailties/package.json
@@ -11,7 +11,9 @@
     "./vite": {
       "types": "./dist/server/vite-plugin.d.ts",
       "default": "./dist/server/vite-plugin.js"
-    }
+    },
+    "./template-builder": "./dist/template-builder/index.js",
+    "./template-builder/testing": "./dist/template-builder/testing.js"
   },
   "files": [
     "dist",
@@ -24,5 +26,13 @@
     "@blazetrails/actionpack": "workspace:*",
     "commander": "^14.0.0",
     "vite": "^7.0.0"
+  },
+  "peerDependencies": {
+    "typescript": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   }
 }

--- a/packages/trailties/package.json
+++ b/packages/trailties/package.json
@@ -12,8 +12,14 @@
       "types": "./dist/server/vite-plugin.d.ts",
       "default": "./dist/server/vite-plugin.js"
     },
-    "./template-builder": "./dist/template-builder/index.js",
-    "./template-builder/testing": "./dist/template-builder/testing.js"
+    "./template-builder": {
+      "types": "./dist/template-builder/index.d.ts",
+      "default": "./dist/template-builder/index.js"
+    },
+    "./template-builder/testing": {
+      "types": "./dist/template-builder/testing.d.ts",
+      "default": "./dist/template-builder/testing.js"
+    }
   },
   "files": [
     "dist",

--- a/packages/trailties/src/template-builder/__snapshots__/index.test.ts.snap
+++ b/packages/trailties/src/template-builder/__snapshots__/index.test.ts.snap
@@ -1,0 +1,20 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`template-builder > emits a valid hand-built module (snapshot + parse + no-Ruby) 1`] = `
+"// auto-generated
+
+import { Base } from "@blazetrails/activerecord";
+
+export class User extends Base {
+  name: string;
+
+  greet(): string {
+    return "hi " + this.name;
+  }
+}
+
+export interface UserShape {
+  name: string;
+}
+"
+`;

--- a/packages/trailties/src/template-builder/emit-class.ts
+++ b/packages/trailties/src/template-builder/emit-class.ts
@@ -1,41 +1,39 @@
 import type { ClassDecl, ClassOpts, Field, Ref } from "./types.js";
-import { emitField, emitMethod, isMethod } from "./emit-method.js";
+import { type EmitResult, emitField, emitMethod, isMethod } from "./emit-method.js";
 import { refMeta } from "./refs.js";
 
 export function tsClass(opts: ClassOpts): ClassDecl {
   return { __kind: "class", exported: true, ...opts } as unknown as ClassDecl;
 }
 
-export function emitClass(c: ClassDecl): { text: string; refs: Ref[] } {
-  const refs: Ref[] = [];
+export function emitClass(c: ClassDecl): EmitResult {
+  const valueRefs: Ref[] = [];
+  const typeRefs: Ref[] = [];
   let ext = "";
   if (c.extends) {
-    refs.push(c.extends);
+    // `extends` requires the base class at runtime.
+    valueRefs.push(c.extends);
     ext = ` extends ${refMeta(c.extends).name}`;
   }
   let impl = "";
   if (c.implements?.length) {
     impl = ` implements ${c.implements
       .map((r) => {
-        refs.push(r);
+        typeRefs.push(r);
         return refMeta(r).name;
       })
       .join(", ")}`;
   }
   const members: string[] = [];
   for (const m of c.body) {
-    if (isMethod(m)) {
-      const e = emitMethod(m);
-      refs.push(...e.refs);
-      members.push(e.text);
-    } else {
-      const e = emitField(m as Field);
-      refs.push(...e.refs);
-      members.push(`  ${e.text}`);
-    }
+    const e = isMethod(m) ? emitMethod(m) : emitField(m as Field);
+    valueRefs.push(...e.valueRefs);
+    typeRefs.push(...e.typeRefs);
+    members.push(isMethod(m) ? e.text : `  ${e.text}`);
   }
   return {
     text: `${c.exported !== false ? "export " : ""}class ${c.name}${ext}${impl} {\n${members.join("\n\n")}\n}`,
-    refs,
+    valueRefs,
+    typeRefs,
   };
 }

--- a/packages/trailties/src/template-builder/emit-class.ts
+++ b/packages/trailties/src/template-builder/emit-class.ts
@@ -1,0 +1,41 @@
+import type { ClassDecl, ClassOpts, Field, Ref } from "./types.js";
+import { emitField, emitMethod, isMethod } from "./emit-method.js";
+import { refMeta } from "./refs.js";
+
+export function tsClass(opts: ClassOpts): ClassDecl {
+  return { __kind: "class", exported: true, ...opts } as unknown as ClassDecl;
+}
+
+export function emitClass(c: ClassDecl): { text: string; refs: Ref[] } {
+  const refs: Ref[] = [];
+  let ext = "";
+  if (c.extends) {
+    refs.push(c.extends);
+    ext = ` extends ${refMeta(c.extends).name}`;
+  }
+  let impl = "";
+  if (c.implements?.length) {
+    impl = ` implements ${c.implements
+      .map((r) => {
+        refs.push(r);
+        return refMeta(r).name;
+      })
+      .join(", ")}`;
+  }
+  const members: string[] = [];
+  for (const m of c.body) {
+    if (isMethod(m)) {
+      const e = emitMethod(m);
+      refs.push(...e.refs);
+      members.push(e.text);
+    } else {
+      const e = emitField(m as Field);
+      refs.push(...e.refs);
+      members.push(`  ${e.text}`);
+    }
+  }
+  return {
+    text: `${c.exported !== false ? "export " : ""}class ${c.name}${ext}${impl} {\n${members.join("\n\n")}\n}`,
+    refs,
+  };
+}

--- a/packages/trailties/src/template-builder/emit-import.ts
+++ b/packages/trailties/src/template-builder/emit-import.ts
@@ -15,10 +15,13 @@ export function tsImport<TNames extends string>(
   return { import: { from, named }, refs: refs as { [K in TNames]: Ref } };
 }
 
-export function tsImportDefault(from: string, name: string): ImportResult<string> {
+export function tsImportDefault<TName extends string>(
+  from: string,
+  name: TName,
+): ImportResult<TName> {
   return {
     import: { from, default: name },
-    refs: { [name]: ref(name, from) } as Record<string, Ref>,
+    refs: { [name]: ref(name, from) } as { [K in TName]: Ref },
   };
 }
 
@@ -43,6 +46,9 @@ export function emitImport(imp: Import): string {
         return a === o ? a : `${o} as ${a}`;
       });
     parts.push(`{ ${entries.join(", ")} }`);
+  }
+  if (!parts.length) {
+    throw new Error(`Import from "${imp.from}" has no default or named bindings`);
   }
   return `${imp.typeOnly ? "import type" : "import"} ${parts.join(", ")} from "${imp.from}";`;
 }

--- a/packages/trailties/src/template-builder/emit-import.ts
+++ b/packages/trailties/src/template-builder/emit-import.ts
@@ -7,7 +7,7 @@ export function tsImport<TNames extends string>(
 ): ImportResult<TNames> {
   const named: Record<string, string | "named"> = { ...names };
   const refs: Record<string, Ref> = {};
-  for (const alias in names) refs[alias] = ref(alias, from);
+  for (const alias of Object.keys(names)) refs[alias] = ref(alias, from);
   return { import: { from, named }, refs: refs as { [K in TNames]: Ref } };
 }
 

--- a/packages/trailties/src/template-builder/emit-import.ts
+++ b/packages/trailties/src/template-builder/emit-import.ts
@@ -1,0 +1,68 @@
+import type { Import, ImportResult, Ref } from "./types.js";
+import { ref } from "./refs.js";
+
+export function tsImport<TNames extends string>(
+  from: string,
+  names: Record<TNames, string | "named">,
+): ImportResult<TNames> {
+  const named: Record<string, string> = {};
+  const refs: Record<string, Ref> = {};
+  for (const alias in names) {
+    const v = names[alias];
+    named[alias] = v === "named" ? alias : (v as string);
+    refs[alias] = ref(alias, from);
+  }
+  return { import: { from, named }, refs: refs as { [K in TNames]: Ref } };
+}
+
+export function tsImportDefault(from: string, name: string): ImportResult<string> {
+  return {
+    import: { from, default: name },
+    refs: { [name]: ref(name, from) } as Record<string, Ref>,
+  };
+}
+
+export function tsImportType<TNames extends string>(
+  from: string,
+  names: Record<TNames, string | "named">,
+): ImportResult<TNames> {
+  const r = tsImport(from, names);
+  r.import.typeOnly = true;
+  return r;
+}
+
+export function emitImport(imp: Import): string {
+  const parts: string[] = [];
+  if (imp.default) parts.push(imp.default);
+  const keys = imp.named ? Object.keys(imp.named) : [];
+  if (keys.length) {
+    const entries = keys
+      .sort((a, b) => a.localeCompare(b))
+      .map((a) => {
+        const o = imp.named![a];
+        return a === o ? a : `${o} as ${a}`;
+      });
+    parts.push(`{ ${entries.join(", ")} }`);
+  }
+  return `${imp.typeOnly ? "import type" : "import"} ${parts.join(", ")} from "${imp.from}";`;
+}
+
+export function mergeImports(imports: Import[]): Import[] {
+  const map = new Map<string, Import>();
+  for (const imp of imports) {
+    const key = `${imp.typeOnly ? "t:" : ""}${imp.from}`;
+    const e = map.get(key);
+    if (!e) {
+      map.set(key, {
+        from: imp.from,
+        typeOnly: imp.typeOnly,
+        default: imp.default,
+        named: imp.named ? { ...imp.named } : undefined,
+      });
+    } else {
+      if (imp.default && !e.default) e.default = imp.default;
+      if (imp.named) e.named = { ...(e.named ?? {}), ...imp.named };
+    }
+  }
+  return [...map.values()].sort((a, b) => a.from.localeCompare(b.from));
+}

--- a/packages/trailties/src/template-builder/emit-import.ts
+++ b/packages/trailties/src/template-builder/emit-import.ts
@@ -91,5 +91,10 @@ export function mergeImports(imports: Import[]): Import[] {
       e.named = merged;
     }
   }
+  for (const imp of map.values()) {
+    if (imp.default && imp.named && Object.prototype.hasOwnProperty.call(imp.named, imp.default)) {
+      throw new Error(`Import from "${imp.from}" binds "${imp.default}" as both default and named`);
+    }
+  }
   return [...map.values()].sort((a, b) => a.from.localeCompare(b.from));
 }

--- a/packages/trailties/src/template-builder/emit-import.ts
+++ b/packages/trailties/src/template-builder/emit-import.ts
@@ -91,6 +91,25 @@ export function mergeImports(imports: Import[]): Import[] {
       e.named = merged;
     }
   }
+  // Reconcile value vs type-only entries for the same `from`: any binding
+  // present on the value side should be dropped from the type-only side
+  // (TS treats the duplicate as conflicting; value subsumes type).
+  for (const [key, imp] of map) {
+    if (!imp.typeOnly) continue;
+    const valueTwin = map.get(imp.from);
+    if (!valueTwin) continue;
+    if (imp.default && valueTwin.default === imp.default) imp.default = undefined;
+    if (imp.named) {
+      for (const alias of Object.keys(imp.named)) {
+        if (valueTwin.default === alias) delete imp.named[alias];
+        else if (valueTwin.named && Object.prototype.hasOwnProperty.call(valueTwin.named, alias)) {
+          delete imp.named[alias];
+        }
+      }
+    }
+    const namedEmpty = !imp.named || Object.keys(imp.named).length === 0;
+    if (!imp.default && namedEmpty) map.delete(key);
+  }
   for (const imp of map.values()) {
     if (imp.default && imp.named && Object.prototype.hasOwnProperty.call(imp.named, imp.default)) {
       throw new Error(`Import from "${imp.from}" binds "${imp.default}" as both default and named`);

--- a/packages/trailties/src/template-builder/emit-import.ts
+++ b/packages/trailties/src/template-builder/emit-import.ts
@@ -5,13 +5,9 @@ export function tsImport<TNames extends string>(
   from: string,
   names: Record<TNames, string | "named">,
 ): ImportResult<TNames> {
-  const named: Record<string, string> = {};
+  const named: Record<string, string | "named"> = { ...names };
   const refs: Record<string, Ref> = {};
-  for (const alias in names) {
-    const v = names[alias];
-    named[alias] = v === "named" ? alias : (v as string);
-    refs[alias] = ref(alias, from);
-  }
+  for (const alias in names) refs[alias] = ref(alias, from);
   return { import: { from, named }, refs: refs as { [K in TNames]: Ref } };
 }
 
@@ -42,7 +38,8 @@ export function emitImport(imp: Import): string {
     const entries = keys
       .sort((a, b) => a.localeCompare(b))
       .map((a) => {
-        const o = imp.named![a];
+        const raw = imp.named![a];
+        const o = raw === "named" ? a : raw;
         return a === o ? a : `${o} as ${a}`;
       });
     parts.push(`{ ${entries.join(", ")} }`);
@@ -51,6 +48,10 @@ export function emitImport(imp: Import): string {
     throw new Error(`Import from "${imp.from}" has no default or named bindings`);
   }
   return `${imp.typeOnly ? "import type" : "import"} ${parts.join(", ")} from "${imp.from}";`;
+}
+
+function resolveOriginal(alias: string, raw: string | "named"): string {
+  return raw === "named" ? alias : raw;
 }
 
 export function mergeImports(imports: Import[]): Import[] {
@@ -65,9 +66,29 @@ export function mergeImports(imports: Import[]): Import[] {
         default: imp.default,
         named: imp.named ? { ...imp.named } : undefined,
       });
-    } else {
-      if (imp.default && !e.default) e.default = imp.default;
-      if (imp.named) e.named = { ...(e.named ?? {}), ...imp.named };
+      continue;
+    }
+    if (imp.default) {
+      if (e.default && e.default !== imp.default) {
+        throw new Error(
+          `Conflicting default imports from "${imp.from}": "${e.default}" vs "${imp.default}"`,
+        );
+      }
+      e.default = imp.default;
+    }
+    if (imp.named) {
+      const merged: Record<string, string | "named"> = { ...(e.named ?? {}) };
+      for (const alias of Object.keys(imp.named)) {
+        const next = imp.named[alias];
+        const prev = merged[alias];
+        if (prev !== undefined && resolveOriginal(alias, prev) !== resolveOriginal(alias, next)) {
+          throw new Error(
+            `Conflicting named imports for "${alias}" from "${imp.from}": "${resolveOriginal(alias, prev)}" vs "${resolveOriginal(alias, next)}"`,
+          );
+        }
+        merged[alias] = next;
+      }
+      e.named = merged;
     }
   }
   return [...map.values()].sort((a, b) => a.from.localeCompare(b.from));

--- a/packages/trailties/src/template-builder/emit-interface.ts
+++ b/packages/trailties/src/template-builder/emit-interface.ts
@@ -1,29 +1,30 @@
 import type { InterfaceDecl, InterfaceOpts, Ref } from "./types.js";
-import { emitField } from "./emit-method.js";
+import { type EmitResult, emitField } from "./emit-method.js";
 import { refMeta } from "./refs.js";
 
 export function tsInterface(opts: InterfaceOpts): InterfaceDecl {
   return { __kind: "interface", exported: true, ...opts } as unknown as InterfaceDecl;
 }
 
-export function emitInterface(i: InterfaceDecl): { text: string; refs: Ref[] } {
-  const refs: Ref[] = [];
+export function emitInterface(i: InterfaceDecl): EmitResult {
+  const typeRefs: Ref[] = [];
   let ext = "";
   if (i.extends?.length) {
     ext = ` extends ${i.extends
       .map((r) => {
-        refs.push(r);
+        typeRefs.push(r);
         return refMeta(r).name;
       })
       .join(", ")}`;
   }
   const members = i.body.map((f) => {
     const e = emitField(f);
-    refs.push(...e.refs);
+    typeRefs.push(...e.typeRefs);
     return `  ${e.text}`;
   });
   return {
     text: `${i.exported !== false ? "export " : ""}interface ${i.name}${ext} {\n${members.join("\n")}\n}`,
-    refs,
+    valueRefs: [],
+    typeRefs,
   };
 }

--- a/packages/trailties/src/template-builder/emit-interface.ts
+++ b/packages/trailties/src/template-builder/emit-interface.ts
@@ -1,0 +1,29 @@
+import type { InterfaceDecl, InterfaceOpts, Ref } from "./types.js";
+import { emitField } from "./emit-method.js";
+import { refMeta } from "./refs.js";
+
+export function tsInterface(opts: InterfaceOpts): InterfaceDecl {
+  return { __kind: "interface", exported: true, ...opts } as unknown as InterfaceDecl;
+}
+
+export function emitInterface(i: InterfaceDecl): { text: string; refs: Ref[] } {
+  const refs: Ref[] = [];
+  let ext = "";
+  if (i.extends?.length) {
+    ext = ` extends ${i.extends
+      .map((r) => {
+        refs.push(r);
+        return refMeta(r).name;
+      })
+      .join(", ")}`;
+  }
+  const members = i.body.map((f) => {
+    const e = emitField(f);
+    refs.push(...e.refs);
+    return `  ${e.text}`;
+  });
+  return {
+    text: `${i.exported !== false ? "export " : ""}interface ${i.name}${ext} {\n${members.join("\n")}\n}`,
+    refs,
+  };
+}

--- a/packages/trailties/src/template-builder/emit-method.ts
+++ b/packages/trailties/src/template-builder/emit-method.ts
@@ -1,0 +1,51 @@
+import type { Field, FieldType, Method, Ref } from "./types.js";
+import { isRef, refMeta } from "./refs.js";
+
+export function tsField(name: string, type: FieldType, opts: Partial<Field> = {}): Field {
+  return { name, type, ...opts };
+}
+export function tsMethod(opts: Method): Method {
+  return opts;
+}
+export function isMethod(x: Field | Method): x is Method {
+  return Array.isArray((x as Method).params);
+}
+
+export function emitType(t: FieldType): { text: string; refs: Ref[] } {
+  if (typeof t === "string") return { text: t, refs: [] };
+  if (isRef(t)) return { text: refMeta(t).name, refs: [t] };
+  return { text: t.text, refs: [...t.refs] };
+}
+
+export function emitField(f: Field): { text: string; refs: Ref[] } {
+  const t = emitType(f.type);
+  const opt = f.nullable ? "?" : "";
+  const init = f.initializer ? ` = ${f.initializer}` : "";
+  const head = f.comment ? `/** ${f.comment} */\n  ` : "";
+  return { text: `${head}${f.name}${opt}: ${t.text}${init};`, refs: t.refs };
+}
+
+export function emitMethod(m: Method): { text: string; refs: Ref[] } {
+  const refs: Ref[] = [];
+  const paramTexts = m.params.map((p) => {
+    const t = emitType(p.type);
+    refs.push(...t.refs);
+    return `${p.name}: ${t.text}`;
+  });
+  let ret = "";
+  if (m.returnType) {
+    const t = emitType(m.returnType);
+    refs.push(...t.refs);
+    ret = `: ${t.text}`;
+  }
+  refs.push(...m.body.refs);
+  const indented = m.body.text
+    .split("\n")
+    .map((l) => (l ? `    ${l}` : ""))
+    .join("\n");
+  const vis = m.visibility && m.visibility !== "public" ? `${m.visibility} ` : "";
+  return {
+    text: `  ${vis}${m.static ? "static " : ""}${m.async ? "async " : ""}${m.name}(${paramTexts.join(", ")})${ret} {\n${indented}\n  }`,
+    refs,
+  };
+}

--- a/packages/trailties/src/template-builder/emit-method.ts
+++ b/packages/trailties/src/template-builder/emit-method.ts
@@ -28,28 +28,37 @@ function emitJsDoc(comment: string): string {
   return `/**\n${lines.map((l) => `   * ${l}`).join("\n")}\n   */\n  `;
 }
 
-export function emitField(f: Field): { text: string; refs: Ref[] } {
+export interface EmitResult {
+  text: string;
+  valueRefs: Ref[];
+  typeRefs: Ref[];
+}
+
+export function emitField(f: Field): EmitResult {
   const t = emitType(f.type);
   const opt = f.nullable ? "?" : "";
   const init = f.initializer ? ` = ${f.initializer}` : "";
   const head = f.comment ? emitJsDoc(f.comment) : "";
-  return { text: `${head}${f.name}${opt}: ${t.text}${init};`, refs: t.refs };
+  return {
+    text: `${head}${f.name}${opt}: ${t.text}${init};`,
+    valueRefs: [],
+    typeRefs: t.refs,
+  };
 }
 
-export function emitMethod(m: Method): { text: string; refs: Ref[] } {
-  const refs: Ref[] = [];
+export function emitMethod(m: Method): EmitResult {
+  const typeRefs: Ref[] = [];
   const paramTexts = m.params.map((p) => {
     const t = emitType(p.type);
-    refs.push(...t.refs);
+    typeRefs.push(...t.refs);
     return `${p.name}: ${t.text}`;
   });
   let ret = "";
   if (m.returnType) {
     const t = emitType(m.returnType);
-    refs.push(...t.refs);
+    typeRefs.push(...t.refs);
     ret = `: ${t.text}`;
   }
-  refs.push(...m.body.refs);
   const indented = m.body.text
     .split("\n")
     .map((l) => (l ? `    ${l}` : ""))
@@ -57,6 +66,7 @@ export function emitMethod(m: Method): { text: string; refs: Ref[] } {
   const vis = m.visibility && m.visibility !== "public" ? `${m.visibility} ` : "";
   return {
     text: `  ${vis}${m.static ? "static " : ""}${m.async ? "async " : ""}${m.name}(${paramTexts.join(", ")})${ret} {\n${indented}\n  }`,
-    refs,
+    valueRefs: [...m.body.refs],
+    typeRefs,
   };
 }

--- a/packages/trailties/src/template-builder/emit-method.ts
+++ b/packages/trailties/src/template-builder/emit-method.ts
@@ -19,11 +19,20 @@ export function emitType(t: FieldType): { text: string; refs: Ref[] } {
   return { text: t.text, refs: [...t.refs] };
 }
 
+function emitJsDoc(comment: string): string {
+  // Neutralize comment terminator and split on newlines so the JSDoc block
+  // cannot be broken out of by user-supplied text.
+  const safe = comment.replace(/\*\//g, "*\\/");
+  const lines = safe.split("\n");
+  if (lines.length === 1) return `/** ${lines[0]} */\n  `;
+  return `/**\n${lines.map((l) => `   * ${l}`).join("\n")}\n   */\n  `;
+}
+
 export function emitField(f: Field): { text: string; refs: Ref[] } {
   const t = emitType(f.type);
   const opt = f.nullable ? "?" : "";
   const init = f.initializer ? ` = ${f.initializer}` : "";
-  const head = f.comment ? `/** ${f.comment} */\n  ` : "";
+  const head = f.comment ? emitJsDoc(f.comment) : "";
   return { text: `${head}${f.name}${opt}: ${t.text}${init};`, refs: t.refs };
 }
 

--- a/packages/trailties/src/template-builder/emit-method.ts
+++ b/packages/trailties/src/template-builder/emit-method.ts
@@ -1,7 +1,9 @@
 import type { Field, FieldType, Method, Ref } from "./types.js";
 import { isRef, refMeta } from "./refs.js";
 
-export function tsField(name: string, type: FieldType, opts: Partial<Field> = {}): Field {
+export type FieldOpts = Omit<Field, "name" | "type">;
+
+export function tsField(name: string, type: FieldType, opts: FieldOpts = {}): Field {
   return { name, type, ...opts };
 }
 export function tsMethod(opts: Method): Method {

--- a/packages/trailties/src/template-builder/emit-module.ts
+++ b/packages/trailties/src/template-builder/emit-module.ts
@@ -21,12 +21,17 @@ export function tsModule(src: ModuleSource): string {
       declTexts.push((d as RawDecl).text);
     }
   }
+  const explicit = src.imports ?? [];
+  const explicitValueFroms = new Set(explicit.filter((i) => !i.typeOnly).map((i) => i.from));
   const fromRefs: Import[] = [];
   for (const r of refs) {
     const m = refMeta(r);
-    if (m.from) fromRefs.push({ from: m.from, named: { [m.name]: m.name } });
+    if (m.from && !explicitValueFroms.has(m.from)) {
+      fromRefs.push({ from: m.from, named: { [m.name]: m.name } });
+    }
   }
-  const merged = mergeImports([...(src.imports ?? []), ...fromRefs]);
+  // Auto-collected refs come first so explicit src.imports wins on merge.
+  const merged = mergeImports([...fromRefs, ...explicit]);
   const importBlock = merged.map(emitImport).join("\n");
   const pre = src.preamble ? `${src.preamble}\n\n` : "";
   const imp = importBlock ? `${importBlock}\n\n` : "";

--- a/packages/trailties/src/template-builder/emit-module.ts
+++ b/packages/trailties/src/template-builder/emit-module.ts
@@ -1,0 +1,34 @@
+import type { ClassDecl, Import, InterfaceDecl, ModuleSource, RawDecl, Ref } from "./types.js";
+import { emitClass } from "./emit-class.js";
+import { emitInterface } from "./emit-interface.js";
+import { emitImport, mergeImports } from "./emit-import.js";
+import { refMeta } from "./refs.js";
+
+export function tsModule(src: ModuleSource): string {
+  const refs: Ref[] = [];
+  const declTexts: string[] = [];
+  for (const d of src.declarations) {
+    const kind = (d as unknown as { __kind: "class" | "interface" | "raw" }).__kind;
+    if (kind === "class") {
+      const e = emitClass(d as ClassDecl);
+      refs.push(...e.refs);
+      declTexts.push(e.text);
+    } else if (kind === "interface") {
+      const e = emitInterface(d as InterfaceDecl);
+      refs.push(...e.refs);
+      declTexts.push(e.text);
+    } else {
+      declTexts.push((d as RawDecl).text);
+    }
+  }
+  const fromRefs: Import[] = [];
+  for (const r of refs) {
+    const m = refMeta(r);
+    if (m.from) fromRefs.push({ from: m.from, named: { [m.name]: m.name } });
+  }
+  const merged = mergeImports([...(src.imports ?? []), ...fromRefs]);
+  const importBlock = merged.map(emitImport).join("\n");
+  const pre = src.preamble ? `${src.preamble}\n\n` : "";
+  const imp = importBlock ? `${importBlock}\n\n` : "";
+  return `${pre}${imp}${declTexts.join("\n\n")}\n`;
+}

--- a/packages/trailties/src/template-builder/emit-module.ts
+++ b/packages/trailties/src/template-builder/emit-module.ts
@@ -1,27 +1,30 @@
 import type { Import, ModuleSource, RawDecl, Ref } from "./types.js";
-
-export function tsRaw(text: string): RawDecl {
-  return { __kind: "raw", text };
-}
 import { emitClass } from "./emit-class.js";
 import { emitInterface } from "./emit-interface.js";
 import { emitImport, mergeImports } from "./emit-import.js";
 import { refMeta } from "./refs.js";
 
+export function tsRaw(text: string): RawDecl {
+  return { __kind: "raw", text };
+}
+
 export function tsModule(src: ModuleSource): string {
-  const refs: Ref[] = [];
+  const valueRefs: Ref[] = [];
+  const typeRefs: Ref[] = [];
   const declTexts: string[] = [];
   for (const d of src.declarations) {
     switch (d.__kind) {
       case "class": {
         const e = emitClass(d);
-        refs.push(...e.refs);
+        valueRefs.push(...e.valueRefs);
+        typeRefs.push(...e.typeRefs);
         declTexts.push(e.text);
         break;
       }
       case "interface": {
         const e = emitInterface(d);
-        refs.push(...e.refs);
+        valueRefs.push(...e.valueRefs);
+        typeRefs.push(...e.typeRefs);
         declTexts.push(e.text);
         break;
       }
@@ -31,22 +34,38 @@ export function tsModule(src: ModuleSource): string {
     }
   }
   const explicit = src.imports ?? [];
-  // Per-(from,alias) coverage set built from value-side explicit imports so
-  // auto-collection adds new bindings from the same module but does not
-  // duplicate (or conflict with) ones the caller has already declared.
-  const covered = new Set<string>();
+  // Per-(from,alias) coverage built from explicit imports — split by
+  // typeOnly so a value-side reference still triggers a value import even
+  // when the caller already declared a type-only import for that symbol.
+  const valueCovered = new Set<string>();
+  const typeCovered = new Set<string>();
   for (const imp of explicit) {
-    if (imp.typeOnly) continue;
-    if (imp.default) covered.add(`${imp.from}|${imp.default}`);
-    for (const alias of Object.keys(imp.named ?? {})) covered.add(`${imp.from}|${alias}`);
+    const set = imp.typeOnly ? typeCovered : valueCovered;
+    if (imp.default) set.add(`${imp.from}|${imp.default}`);
+    for (const alias of Object.keys(imp.named ?? {})) set.add(`${imp.from}|${alias}`);
   }
+  // Value uses always create (or are covered by) a value import.
   const fromRefs: Import[] = [];
-  for (const r of refs) {
+  const usedAsValue = new Set<string>();
+  for (const r of valueRefs) {
     const m = refMeta(r);
     if (!m.from) continue;
-    if (covered.has(`${m.from}|${m.name}`)) continue;
+    usedAsValue.add(`${m.from}|${m.name}`);
+    if (valueCovered.has(`${m.from}|${m.name}`)) continue;
     fromRefs.push({ from: m.from, named: { [m.name]: m.name } });
-    covered.add(`${m.from}|${m.name}`);
+    valueCovered.add(`${m.from}|${m.name}`);
+  }
+  // Type-only uses get an `import type` line, but only if the binding
+  // isn't already imported (as value or type) and isn't used as a value
+  // anywhere in this module.
+  for (const r of typeRefs) {
+    const m = refMeta(r);
+    if (!m.from) continue;
+    const key = `${m.from}|${m.name}`;
+    if (usedAsValue.has(key)) continue;
+    if (valueCovered.has(key) || typeCovered.has(key)) continue;
+    fromRefs.push({ from: m.from, typeOnly: true, named: { [m.name]: m.name } });
+    typeCovered.add(key);
   }
   const merged = mergeImports([...fromRefs, ...explicit]);
   const importBlock = merged.map(emitImport).join("\n");

--- a/packages/trailties/src/template-builder/emit-module.ts
+++ b/packages/trailties/src/template-builder/emit-module.ts
@@ -31,15 +31,22 @@ export function tsModule(src: ModuleSource): string {
     }
   }
   const explicit = src.imports ?? [];
-  const explicitValueFroms = new Set(explicit.filter((i) => !i.typeOnly).map((i) => i.from));
+  // Per-(from,alias) coverage set built from value-side explicit imports so
+  // auto-collection adds new bindings from the same module but does not
+  // duplicate (or conflict with) ones the caller has already declared.
+  const covered = new Set<string>();
+  for (const imp of explicit) {
+    if (imp.typeOnly) continue;
+    for (const alias of Object.keys(imp.named ?? {})) covered.add(`${imp.from}|${alias}`);
+  }
   const fromRefs: Import[] = [];
   for (const r of refs) {
     const m = refMeta(r);
-    if (m.from && !explicitValueFroms.has(m.from)) {
-      fromRefs.push({ from: m.from, named: { [m.name]: m.name } });
-    }
+    if (!m.from) continue;
+    if (covered.has(`${m.from}|${m.name}`)) continue;
+    fromRefs.push({ from: m.from, named: { [m.name]: m.name } });
+    covered.add(`${m.from}|${m.name}`);
   }
-  // Auto-collected refs come first so explicit src.imports wins on merge.
   const merged = mergeImports([...fromRefs, ...explicit]);
   const importBlock = merged.map(emitImport).join("\n");
   const pre = src.preamble ? `${src.preamble}\n\n` : "";

--- a/packages/trailties/src/template-builder/emit-module.ts
+++ b/packages/trailties/src/template-builder/emit-module.ts
@@ -33,31 +33,77 @@ export function tsModule(src: ModuleSource): string {
         break;
     }
   }
-  const explicit = src.imports ?? [];
-  // Per-(from,alias) coverage built from explicit imports — split by
-  // typeOnly so a value-side reference still triggers a value import even
-  // when the caller already declared a type-only import for that symbol.
+  // Aliases used in value position, grouped by source module — feeds the
+  // type-only → value promotion pass below.
+  const valueAliasesByFrom = new Map<string, Set<string>>();
+  for (const r of valueRefs) {
+    const m = refMeta(r);
+    if (!m.from) continue;
+    let s = valueAliasesByFrom.get(m.from);
+    if (!s) {
+      s = new Set();
+      valueAliasesByFrom.set(m.from, s);
+    }
+    s.add(m.name);
+  }
+  // Clone explicit imports; for any type-only entry whose binding is used
+  // as a value, split that binding out into a sibling value Import that
+  // preserves the original (renamed) mapping.
+  const explicit: Import[] = [];
+  const promoted: Import[] = [];
+  for (const imp of src.imports ?? []) {
+    const cloned: Import = {
+      from: imp.from,
+      typeOnly: imp.typeOnly,
+      default: imp.default,
+      named: imp.named ? { ...imp.named } : undefined,
+    };
+    if (!cloned.typeOnly) {
+      explicit.push(cloned);
+      continue;
+    }
+    const valueUses = valueAliasesByFrom.get(cloned.from);
+    if (!valueUses) {
+      explicit.push(cloned);
+      continue;
+    }
+    const valueSide: Import = { from: cloned.from };
+    if (cloned.default && valueUses.has(cloned.default)) {
+      valueSide.default = cloned.default;
+      cloned.default = undefined;
+    }
+    if (cloned.named) {
+      for (const alias of Object.keys(cloned.named)) {
+        if (!valueUses.has(alias)) continue;
+        valueSide.named = { ...(valueSide.named ?? {}), [alias]: cloned.named[alias] };
+        delete cloned.named[alias];
+      }
+    }
+    if (valueSide.default || valueSide.named) promoted.push(valueSide);
+    const stillHasType = cloned.default || (cloned.named && Object.keys(cloned.named).length);
+    if (stillHasType) explicit.push(cloned);
+  }
+  // Coverage from final (post-promotion) explicit + promoted entries.
   const valueCovered = new Set<string>();
   const typeCovered = new Set<string>();
-  for (const imp of explicit) {
+  for (const imp of [...explicit, ...promoted]) {
     const set = imp.typeOnly ? typeCovered : valueCovered;
     if (imp.default) set.add(`${imp.from}|${imp.default}`);
     for (const alias of Object.keys(imp.named ?? {})) set.add(`${imp.from}|${alias}`);
   }
-  // Value uses always create (or are covered by) a value import.
+  // Auto-collect: value refs → value imports; type refs → type imports,
+  // but only when the binding isn't covered or used as a value elsewhere.
   const fromRefs: Import[] = [];
   const usedAsValue = new Set<string>();
   for (const r of valueRefs) {
     const m = refMeta(r);
     if (!m.from) continue;
-    usedAsValue.add(`${m.from}|${m.name}`);
-    if (valueCovered.has(`${m.from}|${m.name}`)) continue;
+    const key = `${m.from}|${m.name}`;
+    usedAsValue.add(key);
+    if (valueCovered.has(key)) continue;
     fromRefs.push({ from: m.from, named: { [m.name]: m.name } });
-    valueCovered.add(`${m.from}|${m.name}`);
+    valueCovered.add(key);
   }
-  // Type-only uses get an `import type` line, but only if the binding
-  // isn't already imported (as value or type) and isn't used as a value
-  // anywhere in this module.
   for (const r of typeRefs) {
     const m = refMeta(r);
     if (!m.from) continue;
@@ -67,7 +113,7 @@ export function tsModule(src: ModuleSource): string {
     fromRefs.push({ from: m.from, typeOnly: true, named: { [m.name]: m.name } });
     typeCovered.add(key);
   }
-  const merged = mergeImports([...fromRefs, ...explicit]);
+  const merged = mergeImports([...fromRefs, ...explicit, ...promoted]);
   const importBlock = merged.map(emitImport).join("\n");
   const pre = src.preamble ? `${src.preamble}\n\n` : "";
   const imp = importBlock ? `${importBlock}\n\n` : "";

--- a/packages/trailties/src/template-builder/emit-module.ts
+++ b/packages/trailties/src/template-builder/emit-module.ts
@@ -37,6 +37,7 @@ export function tsModule(src: ModuleSource): string {
   const covered = new Set<string>();
   for (const imp of explicit) {
     if (imp.typeOnly) continue;
+    if (imp.default) covered.add(`${imp.from}|${imp.default}`);
     for (const alias of Object.keys(imp.named ?? {})) covered.add(`${imp.from}|${alias}`);
   }
   const fromRefs: Import[] = [];

--- a/packages/trailties/src/template-builder/emit-module.ts
+++ b/packages/trailties/src/template-builder/emit-module.ts
@@ -1,4 +1,8 @@
-import type { ClassDecl, Import, InterfaceDecl, ModuleSource, RawDecl, Ref } from "./types.js";
+import type { Import, ModuleSource, RawDecl, Ref } from "./types.js";
+
+export function tsRaw(text: string): RawDecl {
+  return { __kind: "raw", text };
+}
 import { emitClass } from "./emit-class.js";
 import { emitInterface } from "./emit-interface.js";
 import { emitImport, mergeImports } from "./emit-import.js";
@@ -8,17 +12,22 @@ export function tsModule(src: ModuleSource): string {
   const refs: Ref[] = [];
   const declTexts: string[] = [];
   for (const d of src.declarations) {
-    const kind = (d as unknown as { __kind: "class" | "interface" | "raw" }).__kind;
-    if (kind === "class") {
-      const e = emitClass(d as ClassDecl);
-      refs.push(...e.refs);
-      declTexts.push(e.text);
-    } else if (kind === "interface") {
-      const e = emitInterface(d as InterfaceDecl);
-      refs.push(...e.refs);
-      declTexts.push(e.text);
-    } else {
-      declTexts.push((d as RawDecl).text);
+    switch (d.__kind) {
+      case "class": {
+        const e = emitClass(d);
+        refs.push(...e.refs);
+        declTexts.push(e.text);
+        break;
+      }
+      case "interface": {
+        const e = emitInterface(d);
+        refs.push(...e.refs);
+        declTexts.push(e.text);
+        break;
+      }
+      case "raw":
+        declTexts.push(d.text);
+        break;
     }
   }
   const explicit = src.imports ?? [];

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from "vitest";
+import {
+  ref,
+  type,
+  tsBody,
+  tsImport,
+  tsImportDefault,
+  tsImportType,
+  tsField,
+  tsMethod,
+  tsClass,
+  tsInterface,
+  tsModule,
+} from "./index.js";
+import { assertNoRubySource, parseTs } from "./testing.js";
+
+describe("template-builder", () => {
+  it("dedupes imports across declarations", () => {
+    const { refs: ar } = tsImport("@blazetrails/activerecord", { Base: "named" });
+    const out = tsModule({
+      declarations: [
+        tsClass({ name: "A", extends: ar.Base, body: [] }),
+        tsClass({ name: "B", extends: ar.Base, body: [] }),
+      ],
+    });
+    expect(out.match(/from "@blazetrails\/activerecord"/g) ?? []).toHaveLength(1);
+    expect(out).toContain(`import { Base } from "@blazetrails/activerecord";`);
+  });
+
+  it("combines default + named in same import and emits type-only + renames", () => {
+    const t = tsImportType("x", { T: "named" });
+    const d = tsImportDefault("./foo.js", "Foo");
+    const out = tsModule({
+      imports: [
+        { from: "x", default: "Foo" },
+        { from: "x", named: { Bar: "Bar" } },
+        { from: "y", named: { LocalName: "Original" } },
+        t.import,
+        d.import,
+      ],
+      declarations: [],
+    });
+    expect(out).toContain(`import Foo, { Bar } from "x";`);
+    expect(out).toContain(`import type { T } from "x";`);
+    expect(out).toContain(`import { Original as LocalName } from "y";`);
+    expect(out).toContain(`import Foo from "./foo.js";`);
+  });
+
+  it("propagates refs through type and tsBody, dedents tsBody", () => {
+    const u = ref("User", "./user.js");
+    const body = tsBody`
+      const u = new ${u}();
+      return u;
+    `;
+    expect(body.text).toBe("const u = new User();\nreturn u;");
+    const out = tsModule({
+      declarations: [
+        tsClass({
+          name: "C",
+          body: [tsMethod({ name: "make", params: [], returnType: type`Array<${u}>`, body })],
+        }),
+      ],
+    });
+    expect(out).toContain(`import { User } from "./user.js";`);
+    expect(out).toContain(`Array<User>`);
+    expect(out).toContain(`return u;`);
+  });
+
+  it("emits a valid hand-built module (snapshot + parse + no-Ruby)", () => {
+    const { refs: ar } = tsImport("@blazetrails/activerecord", { Base: "named" });
+    const out = tsModule({
+      preamble: "// auto-generated",
+      declarations: [
+        tsClass({
+          name: "User",
+          extends: ar.Base,
+          body: [
+            tsField("name", "string"),
+            tsMethod({
+              name: "greet",
+              params: [],
+              returnType: "string",
+              body: tsBody`return "hi " + this.name;`,
+            }),
+          ],
+        }),
+        tsInterface({ name: "UserShape", body: [tsField("name", "string")] }),
+      ],
+    });
+    expect(out).toMatchSnapshot();
+    expect(parseTs(out).diagnostics).toEqual([]);
+    assertNoRubySource(out);
+  });
+
+  it("assertNoRubySource flags Ruby class/module/def lines", () => {
+    expect(() => assertNoRubySource("class User < Base\nend")).toThrow();
+    expect(() => assertNoRubySource("module Foo\nend")).toThrow();
+    expect(() => assertNoRubySource("  def greet\n  end")).toThrow();
+    expect(() => assertNoRubySource(`export class User extends Base {}`)).not.toThrow();
+  });
+});

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -66,6 +66,29 @@ describe("template-builder", () => {
     expect(out).toContain(`return u;`);
   });
 
+  it("preserves explicit renamed imports when refs also reference the same module", () => {
+    const r = ref("LocalName", "y");
+    const out = tsModule({
+      imports: [{ from: "y", named: { LocalName: "Original" } }],
+      declarations: [
+        tsClass({
+          name: "C",
+          body: [
+            tsMethod({ name: "f", params: [], returnType: "void", body: tsBody`new ${r}();` }),
+          ],
+        }),
+      ],
+    });
+    expect(out).toContain(`import { Original as LocalName } from "y";`);
+    expect(out.match(/from "y"/g) ?? []).toHaveLength(1);
+  });
+
+  it("tsImportDefault preserves the default name as the refs key type", () => {
+    const d = tsImportDefault("./foo.js", "Foo");
+    // Compile-time: d.refs.Foo is Ref; runtime: shape is correct.
+    expect(d.refs.Foo).toBeDefined();
+  });
+
   it("supports tsInterface extends and raw declarations", () => {
     const base = ref("Base", "./base.js");
     const out = tsModule({

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -165,7 +165,7 @@ describe("template-builder", () => {
     });
     expect(out).toContain(`// hand-rolled banner`);
     expect(out).toContain(`export interface Sub extends Base {`);
-    expect(out).toContain(`import { Base } from "./base.js";`);
+    expect(out).toContain(`import type { Base } from "./base.js";`);
     expect(parseTs(out).diagnostics).toEqual([]);
   });
 
@@ -193,6 +193,23 @@ describe("template-builder", () => {
     expect(out).toMatchSnapshot();
     expect(parseTs(out).diagnostics).toEqual([]);
     assertNoRubySource(out);
+  });
+
+  it("auto-imports type-only refs as 'import type' when never used as a value", () => {
+    const t = ref("Opts", "./opts.js");
+    const out = tsModule({
+      declarations: [tsInterface({ name: "I", body: [tsField("o", t)] })],
+    });
+    expect(out).toContain(`import type { Opts } from "./opts.js";`);
+  });
+
+  it("promotes a ref to a value import when any usage is in value position", () => {
+    const base = ref("Base", "./base.js");
+    const out = tsModule({
+      declarations: [tsClass({ name: "C", extends: base, body: [tsField("b", base)] })],
+    });
+    expect(out).toContain(`import { Base } from "./base.js";`);
+    expect(out).not.toContain(`import type`);
   });
 
   it("sanitizes JSDoc comments against terminator-injection", () => {

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -66,6 +66,20 @@ describe("template-builder", () => {
     expect(out).toContain(`return u;`);
   });
 
+  it("supports tsInterface extends and raw declarations", () => {
+    const base = ref("Base", "./base.js");
+    const out = tsModule({
+      declarations: [
+        { __kind: "raw", text: "// hand-rolled banner" } as never,
+        tsInterface({ name: "Sub", extends: [base], body: [tsField("id", "number")] }),
+      ],
+    });
+    expect(out).toContain(`// hand-rolled banner`);
+    expect(out).toContain(`export interface Sub extends Base {`);
+    expect(out).toContain(`import { Base } from "./base.js";`);
+    expect(parseTs(out).diagnostics).toEqual([]);
+  });
+
   it("emits a valid hand-built module (snapshot + parse + no-Ruby)", () => {
     const { refs: ar } = tsImport("@blazetrails/activerecord", { Base: "named" });
     const out = tsModule({

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -122,6 +122,33 @@ describe("template-builder", () => {
     expect(out).toContain(`import { Bar, Foo } from "x";`);
   });
 
+  it("does not add a duplicate named binding when an explicit default import covers it", () => {
+    const d = tsImportDefault("./foo.js", "Foo");
+    const r = ref("Foo", "./foo.js");
+    const out = tsModule({
+      imports: [d.import],
+      declarations: [
+        tsClass({
+          name: "C",
+          body: [
+            tsMethod({ name: "f", params: [], returnType: "void", body: tsBody`new ${r}();` }),
+          ],
+        }),
+      ],
+    });
+    expect(out).toContain(`import Foo from "./foo.js";`);
+    expect(out).not.toContain(`{ Foo }`);
+  });
+
+  it("throws when an import binds the same identifier as both default and named", () => {
+    expect(() =>
+      tsModule({
+        imports: [{ from: "x", default: "Foo", named: { Foo: "named" } }],
+        declarations: [],
+      }),
+    ).toThrow(/both default and named/);
+  });
+
   it("tsImportDefault preserves the default name as the refs key type", () => {
     const d = tsImportDefault("./foo.js", "Foo");
     // Compile-time: d.refs.Foo is Ref; runtime: shape is correct.

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -195,6 +195,25 @@ describe("template-builder", () => {
     assertNoRubySource(out);
   });
 
+  it("sanitizes JSDoc comments against terminator-injection", () => {
+    const out = tsModule({
+      declarations: [
+        tsClass({
+          name: "C",
+          body: [
+            tsField("a", "string", { comment: "evil */ injected" }),
+            tsField("b", "string", { comment: "first line\nsecond line" }),
+          ],
+        }),
+      ],
+    });
+    expect(out).not.toMatch(/evil \*\/ injected/);
+    expect(out).toContain("evil *\\/ injected");
+    expect(out).toContain("   * first line");
+    expect(out).toContain("   * second line");
+    expect(parseTs(out).diagnostics).toEqual([]);
+  });
+
   it("assertNoRubySource flags Ruby class/module/def lines", () => {
     expect(() => assertNoRubySource("class User < Base\nend")).toThrow();
     expect(() => assertNoRubySource("module Foo\nend")).toThrow();

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -11,6 +11,7 @@ import {
   tsClass,
   tsInterface,
   tsModule,
+  tsRaw,
 } from "./index.js";
 import { assertNoRubySource, parseTs } from "./testing.js";
 
@@ -93,7 +94,7 @@ describe("template-builder", () => {
     const base = ref("Base", "./base.js");
     const out = tsModule({
       declarations: [
-        { __kind: "raw", text: "// hand-rolled banner" } as never,
+        tsRaw("// hand-rolled banner"),
         tsInterface({ name: "Sub", extends: [base], body: [tsField("id", "number")] }),
       ],
     });

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -195,6 +195,37 @@ describe("template-builder", () => {
     assertNoRubySource(out);
   });
 
+  it("promotes a renamed type-only import to value when the binding is used as a value", () => {
+    const local = ref("Local", "x");
+    const out = tsModule({
+      imports: [{ from: "x", typeOnly: true, named: { Local: "Original" } }],
+      declarations: [
+        tsClass({
+          name: "C",
+          body: [
+            tsMethod({ name: "f", params: [], returnType: "void", body: tsBody`new ${local}();` }),
+          ],
+        }),
+      ],
+    });
+    expect(out).toContain(`import { Original as Local } from "x";`);
+    expect(out).not.toContain(`import type { Local }`);
+    expect(out).not.toContain(`import type { Original`);
+  });
+
+  it("reconciles overlapping value + type-only imports for the same binding", () => {
+    const out = tsModule({
+      imports: [
+        { from: "x", named: { Foo: "Foo" } },
+        { from: "x", typeOnly: true, named: { Foo: "Foo", Bar: "Bar" } },
+      ],
+      declarations: [],
+    });
+    expect(out).toContain(`import { Foo } from "x";`);
+    expect(out).toContain(`import type { Bar } from "x";`);
+    expect(out).not.toMatch(/import type \{[^}]*Foo[^}]*\} from "x"/);
+  });
+
   it("auto-imports type-only refs as 'import type' when never used as a value", () => {
     const t = ref("Opts", "./opts.js");
     const out = tsModule({

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -67,21 +67,59 @@ describe("template-builder", () => {
     expect(out).toContain(`return u;`);
   });
 
-  it("preserves explicit renamed imports when refs also reference the same module", () => {
-    const r = ref("LocalName", "y");
+  it("preserves explicit renames AND auto-collects additional refs from the same module", () => {
+    const renamed = ref("LocalName", "y");
+    const other = ref("Sibling", "y");
     const out = tsModule({
       imports: [{ from: "y", named: { LocalName: "Original" } }],
       declarations: [
         tsClass({
           name: "C",
           body: [
-            tsMethod({ name: "f", params: [], returnType: "void", body: tsBody`new ${r}();` }),
+            tsMethod({
+              name: "f",
+              params: [],
+              returnType: "void",
+              body: tsBody`new ${renamed}(); new ${other}();`,
+            }),
           ],
         }),
       ],
     });
-    expect(out).toContain(`import { Original as LocalName } from "y";`);
+    expect(out).toContain(`import { Original as LocalName, Sibling } from "y";`);
     expect(out.match(/from "y"/g) ?? []).toHaveLength(1);
+  });
+
+  it("throws on conflicting default imports from the same module", () => {
+    expect(() =>
+      tsModule({
+        imports: [
+          { from: "x", default: "Foo" },
+          { from: "x", default: "Bar" },
+        ],
+        declarations: [],
+      }),
+    ).toThrow(/Conflicting default imports/);
+  });
+
+  it("throws on conflicting named imports for the same alias", () => {
+    expect(() =>
+      tsModule({
+        imports: [
+          { from: "x", named: { A: "Alpha" } },
+          { from: "x", named: { A: "Beta" } },
+        ],
+        declarations: [],
+      }),
+    ).toThrow(/Conflicting named imports/);
+  });
+
+  it('accepts the "named" shorthand in Import.named', () => {
+    const out = tsModule({
+      imports: [{ from: "x", named: { Foo: "named", Bar: "named" } }],
+      declarations: [],
+    });
+    expect(out).toContain(`import { Bar, Foo } from "x";`);
   });
 
   it("tsImportDefault preserves the default name as the refs key type", () => {

--- a/packages/trailties/src/template-builder/index.ts
+++ b/packages/trailties/src/template-builder/index.ts
@@ -1,0 +1,8 @@
+export * from "./types.js";
+export { ref } from "./refs.js";
+export { type, tsBody } from "./ts-body.js";
+export { tsImport, tsImportDefault, tsImportType } from "./emit-import.js";
+export { tsField, tsMethod } from "./emit-method.js";
+export { tsClass } from "./emit-class.js";
+export { tsInterface } from "./emit-interface.js";
+export { tsModule } from "./emit-module.js";

--- a/packages/trailties/src/template-builder/index.ts
+++ b/packages/trailties/src/template-builder/index.ts
@@ -5,4 +5,4 @@ export { tsImport, tsImportDefault, tsImportType } from "./emit-import.js";
 export { tsField, tsMethod } from "./emit-method.js";
 export { tsClass } from "./emit-class.js";
 export { tsInterface } from "./emit-interface.js";
-export { tsModule } from "./emit-module.js";
+export { tsModule, tsRaw } from "./emit-module.js";

--- a/packages/trailties/src/template-builder/refs.ts
+++ b/packages/trailties/src/template-builder/refs.ts
@@ -1,0 +1,17 @@
+import type { Ref } from "./types.js";
+
+interface RefRT {
+  __kind: "ref";
+  name: string;
+  from?: string;
+}
+
+export function ref(name: string, from?: string): Ref {
+  return { __kind: "ref", name, from } as unknown as Ref;
+}
+export function isRef(x: unknown): x is Ref {
+  return typeof x === "object" && x !== null && (x as RefRT).__kind === "ref";
+}
+export function refMeta(r: Ref): RefRT {
+  return r as unknown as RefRT;
+}

--- a/packages/trailties/src/template-builder/testing.ts
+++ b/packages/trailties/src/template-builder/testing.ts
@@ -1,0 +1,23 @@
+import ts from "typescript";
+
+export function parseTs(source: string): { diagnostics: readonly ts.Diagnostic[] } {
+  const sf = ts.createSourceFile(
+    "__test__.ts",
+    source,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const diagnostics =
+    (sf as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
+  return { diagnostics };
+}
+
+const RUBY_RE = /^\s*(class|module|def)\s+\w+($|\s+<)/m;
+
+export function assertNoRubySource(text: string): void {
+  const m = text.match(RUBY_RE);
+  if (m) {
+    throw new Error(`Ruby-like source detected: ${JSON.stringify(m[0])}`);
+  }
+}

--- a/packages/trailties/src/template-builder/testing.ts
+++ b/packages/trailties/src/template-builder/testing.ts
@@ -1,16 +1,19 @@
 import ts from "typescript";
 
 export function parseTs(source: string): { diagnostics: readonly ts.Diagnostic[] } {
-  const sf = ts.createSourceFile(
-    "__test__.ts",
-    source,
-    ts.ScriptTarget.Latest,
-    true,
-    ts.ScriptKind.TS,
-  );
-  const diagnostics =
-    (sf as unknown as { parseDiagnostics?: ts.Diagnostic[] }).parseDiagnostics ?? [];
-  return { diagnostics };
+  // `transpileModule` with `reportDiagnostics: true` exposes syntactic
+  // diagnostics through the public API — unlike the internal
+  // `SourceFile.parseDiagnostics` field, this contract is stable.
+  const result = ts.transpileModule(source, {
+    reportDiagnostics: true,
+    compilerOptions: {
+      target: ts.ScriptTarget.Latest,
+      module: ts.ModuleKind.ESNext,
+      isolatedModules: true,
+      noEmit: true,
+    },
+  });
+  return { diagnostics: result.diagnostics ?? [] };
 }
 
 const RUBY_RE = /^\s*(class|module|def)\s+\w+($|\s+<)/m;

--- a/packages/trailties/src/template-builder/ts-body.ts
+++ b/packages/trailties/src/template-builder/ts-body.ts
@@ -1,0 +1,42 @@
+import type { Body, Ref, Type } from "./types.js";
+import { isRef, refMeta } from "./refs.js";
+
+function interp(parts: TemplateStringsArray, vals: ReadonlyArray<Ref | string>) {
+  const refs: Ref[] = [];
+  let text = "";
+  for (let i = 0; i < parts.length; i++) {
+    text += parts[i];
+    if (i < vals.length) {
+      const v = vals[i];
+      if (isRef(v)) {
+        refs.push(v);
+        text += refMeta(v).name;
+      } else text += v;
+    }
+  }
+  return { text, refs };
+}
+
+export function type(parts: TemplateStringsArray, ...vals: Array<Ref | string>): Type {
+  const { text, refs } = interp(parts, vals);
+  return { __kind: "type", text, refs } as unknown as Type;
+}
+
+export function tsBody(parts: TemplateStringsArray, ...vals: Array<Ref | string>): Body {
+  const { text, refs } = interp(parts, vals);
+  return { __kind: "body", text: dedent(text), refs } as unknown as Body;
+}
+
+function dedent(raw: string): string {
+  const trimmed = raw.replace(/^\n+/, "").replace(/\s+$/, "");
+  if (!trimmed) return "";
+  const lines = trimmed.split("\n");
+  let min = Infinity;
+  for (const l of lines) {
+    if (!l.trim()) continue;
+    const m = l.match(/^[ \t]*/)![0].length;
+    if (m < min) min = m;
+  }
+  if (!isFinite(min)) min = 0;
+  return lines.map((l) => l.slice(min)).join("\n");
+}

--- a/packages/trailties/src/template-builder/ts-body.ts
+++ b/packages/trailties/src/template-builder/ts-body.ts
@@ -17,7 +17,7 @@ function interp(parts: TemplateStringsArray, vals: ReadonlyArray<Ref | string>) 
   return { text, refs };
 }
 
-export function type(parts: TemplateStringsArray, ...vals: Array<Ref | string>): Type {
+export function type(parts: TemplateStringsArray, ...vals: Ref[]): Type {
   const { text, refs } = interp(parts, vals);
   return { __kind: "type", text, refs } as unknown as Type;
 }

--- a/packages/trailties/src/template-builder/types.test-d.ts
+++ b/packages/trailties/src/template-builder/types.test-d.ts
@@ -1,0 +1,18 @@
+import { ref, tsClass } from "./index.js";
+
+// `extends` must be a Ref, not a string. The Ref brand is module-private,
+// so a string literal cannot satisfy the type — this is the load-bearing
+// constraint that blocks Ruby-shaped emit.
+tsClass({
+  name: "User",
+  // @ts-expect-error - extends requires a Ref, not a string
+  extends: "ApplicationRecord",
+  body: [],
+});
+
+// Constructed via ref() — OK.
+tsClass({
+  name: "User",
+  extends: ref("Base", "@blazetrails/activerecord"),
+  body: [],
+});

--- a/packages/trailties/src/template-builder/types.ts
+++ b/packages/trailties/src/template-builder/types.ts
@@ -1,0 +1,73 @@
+/** @internal */
+declare const REF_BRAND: unique symbol;
+
+export type Ref = { readonly [REF_BRAND]: "ref"; readonly name: string; readonly from?: string };
+export type Type = {
+  readonly [REF_BRAND]: "type";
+  readonly text: string;
+  readonly refs: readonly Ref[];
+};
+export type Body = {
+  readonly [REF_BRAND]: "body";
+  readonly text: string;
+  readonly refs: readonly Ref[];
+};
+
+export interface Import {
+  from: string;
+  default?: string;
+  named?: Record<string, string>;
+  typeOnly?: boolean;
+}
+export interface ImportResult<TNames extends string = string> {
+  import: Import;
+  refs: { readonly [K in TNames]: Ref };
+}
+
+export type FieldType = Type | Ref | string;
+export interface Field {
+  name: string;
+  type: FieldType;
+  nullable?: boolean;
+  initializer?: string;
+  comment?: string;
+}
+export interface MethodParam {
+  name: string;
+  type: FieldType;
+}
+export interface Method {
+  name: string;
+  params: MethodParam[];
+  returnType?: FieldType;
+  body: Body;
+  async?: boolean;
+  static?: boolean;
+  visibility?: "public" | "protected" | "private";
+}
+
+export interface ClassOpts {
+  name: string;
+  extends?: Ref;
+  implements?: Ref[];
+  exported?: boolean;
+  body: Array<Field | Method>;
+}
+export type ClassDecl = ClassOpts & { readonly [REF_BRAND]: "class" };
+
+export interface InterfaceOpts {
+  name: string;
+  extends?: Ref[];
+  exported?: boolean;
+  body: Field[];
+}
+export type InterfaceDecl = InterfaceOpts & { readonly [REF_BRAND]: "interface" };
+
+export type RawDecl = { readonly [REF_BRAND]: "raw"; text: string };
+export type Declaration = ClassDecl | InterfaceDecl | RawDecl;
+
+export interface ModuleSource {
+  imports?: Import[];
+  declarations: Declaration[];
+  preamble?: string;
+}

--- a/packages/trailties/src/template-builder/types.ts
+++ b/packages/trailties/src/template-builder/types.ts
@@ -53,7 +53,7 @@ export interface ClassOpts {
   exported?: boolean;
   body: Array<Field | Method>;
 }
-export type ClassDecl = ClassOpts & { readonly [REF_BRAND]: "class" };
+export type ClassDecl = ClassOpts & { readonly __kind: "class" };
 
 export interface InterfaceOpts {
   name: string;
@@ -61,9 +61,9 @@ export interface InterfaceOpts {
   exported?: boolean;
   body: Field[];
 }
-export type InterfaceDecl = InterfaceOpts & { readonly [REF_BRAND]: "interface" };
+export type InterfaceDecl = InterfaceOpts & { readonly __kind: "interface" };
 
-export type RawDecl = { readonly [REF_BRAND]: "raw"; text: string };
+export type RawDecl = { readonly __kind: "raw"; text: string };
 export type Declaration = ClassDecl | InterfaceDecl | RawDecl;
 
 export interface ModuleSource {

--- a/packages/trailties/src/template-builder/types.ts
+++ b/packages/trailties/src/template-builder/types.ts
@@ -1,14 +1,14 @@
 /** @internal */
-declare const REF_BRAND: unique symbol;
+declare const refBrand: unique symbol;
 
-export type Ref = { readonly [REF_BRAND]: true; readonly name: string; readonly from?: string };
+export type Ref = { readonly [refBrand]: true; readonly name: string; readonly from?: string };
 export type Type = {
-  readonly [REF_BRAND]: "type";
+  readonly [refBrand]: "type";
   readonly text: string;
   readonly refs: readonly Ref[];
 };
 export type Body = {
-  readonly [REF_BRAND]: "body";
+  readonly [refBrand]: "body";
   readonly text: string;
   readonly refs: readonly Ref[];
 };

--- a/packages/trailties/src/template-builder/types.ts
+++ b/packages/trailties/src/template-builder/types.ts
@@ -1,7 +1,7 @@
 /** @internal */
 declare const REF_BRAND: unique symbol;
 
-export type Ref = { readonly [REF_BRAND]: "ref"; readonly name: string; readonly from?: string };
+export type Ref = { readonly [REF_BRAND]: true; readonly name: string; readonly from?: string };
 export type Type = {
   readonly [REF_BRAND]: "type";
   readonly text: string;
@@ -16,7 +16,8 @@ export type Body = {
 export interface Import {
   from: string;
   default?: string;
-  named?: Record<string, string>;
+  /** `"named"` value is shorthand for "alias === original name". */
+  named?: Record<string, string | "named">;
   typeOnly?: boolean;
 }
 export interface ImportResult<TNames extends string = string> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.3
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
       vite:
         specifier: ^7.0.0
         version: 7.3.1(@types/node@25.3.5)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3)

--- a/vitest.dx-tests.config.ts
+++ b/vitest.dx-tests.config.ts
@@ -14,11 +14,31 @@ export default defineConfig({
   resolve: { alias },
   test: {
     include: [],
-    typecheck: {
-      enabled: true,
-      only: true,
-      include: ["packages/activerecord/dx-tests/**/*.test-d.ts"],
-      tsconfig: "./packages/activerecord/dx-tests/tsconfig.json",
-    },
+    projects: [
+      {
+        extends: true,
+        test: {
+          name: "activerecord",
+          typecheck: {
+            enabled: true,
+            only: true,
+            include: ["packages/activerecord/dx-tests/**/*.test-d.ts"],
+            tsconfig: "./packages/activerecord/dx-tests/tsconfig.json",
+          },
+        },
+      },
+      {
+        extends: true,
+        test: {
+          name: "trailties",
+          typecheck: {
+            enabled: true,
+            only: true,
+            include: ["packages/trailties/dx-tests/**/*.test-d.ts"],
+            tsconfig: "./packages/trailties/dx-tests/tsconfig.json",
+          },
+        },
+      },
+    ],
   },
 });


### PR DESCRIPTION
## Summary

Lands the TS-source-by-construction emitter under
`packages/trailties/src/template-builder/`, per the spec at
[`docs/trailties-template-builder.md`](../blob/main/docs/trailties-template-builder.md).
**This is the gate for PR T2–T5** in the trailties generator plan.

## API

- `ref(name, from?)` — sole structural constructor for `Ref`.
- `` type`Array<${ref}>` `` — ref-carrying tagged template for type strings.
- `` tsBody`...` `` — dedent + ref-carrying body template.
- `tsImport` / `tsImportDefault` / `tsImportType` — return `{ import, refs }`.
- `tsField`, `tsMethod`.
- `tsClass`, `tsInterface`.
- `tsModule(src)` — the **sole** record→source resolver. Walks every `Ref`
  in declarations, dedupes imports, emits the final file string.
- `testing.ts` — `parseTs(source)` (ts.transpileModule with reportDiagnostics — public/stable API)
  and `assertNoRubySource(text)` (`/^\s*(class\|module\|def)\s+\w+($|\s+<)/m`).

## Load-bearing constraint

`Ref` is `unique symbol`-branded with a **module-private** brand
(`declare const REF_BRAND: unique symbol`). The brand is never exported,
so a `Ref` cannot be constructed structurally — the only ways to obtain
one are `ref(...)` and `ImportResult.refs[alias]`. This makes
`tsClass({ extends: "ApplicationRecord" })` a type error.
`types.test-d.ts` pins that failure mode via `// @ts-expect-error`;
the project-wide `tsc --build` (CI `pnpm typecheck`) enforces it.

## Test coverage

- Import dedup across multiple declarations.
- Default + named in the same `from` are merged into one import line.
- Type-only imports emit `import type ...`.
- Renamed named imports emit `import { Original as Local }`.
- Refs propagate through both `type` and `tsBody` into `tsModule`'s
  import collector.
- `tsBody` dedent behavior.
- Hand-built module snapshot, parsed via `parseTs` (catches "snapshot
  looks fine but isn't valid TS") and run through `assertNoRubySource`.
- `assertNoRubySource` flags `class`/`module`/`def` lines and passes
  on `export class ... extends ...`.

## Hard rules

1. No `node:*` imports in `packages/trailties/src/` (only the test
   helper imports `typescript`, which is the existing workspace devdep).
2. No `process.*`.
3. No new third-party runtime deps.
4. Async-only fs (no fs in this PR).
5. camelCase throughout.

## Rails sources referenced

None — greenfield emitter infra. No Rails methods skipped.

## PR size note

Source files alone come in just under 300 LOC; with the unit-test
file (88 LOC after prettier) and `types.test-d.ts` (18 LOC) the PR
totals ~525 lines insertions. The 9-file emit-module layout is
dictated verbatim by `docs/trailties-template-builder.md` and cannot
be split without breaking the PR T1 gate that T2–T5 depend on.


## Known follow-ups (deferred — Copilot review #9, max cycles reached)

- **`testing.ts` static `import ts from "typescript"` vs. optional peer.**
  The `./template-builder/testing` subpath statically imports
  `typescript`, while `typescript` is declared as an *optional* peer
  dep. A consumer that imports the testing helper without `typescript`
  installed will hit `ERR_MODULE_NOT_FOUND` at runtime. In practice
  every consumer of this helper is a TS-authored generator test, so
  `typescript` will be present — but the contract is loose. Options
  for a follow-up PR:
  1. Promote `typescript` to a non-optional peer.
  2. Switch `testing.ts` to a lazy `await import("typescript")` with a
     helpful error if missing.
  3. Move the export behind a development/test condition.
  Tracked here for triage after T1 lands; not blocking the gate for
  PR T2–T5.
