### PR TITLE
feat(trailties): Trails global + Rails→Trails api-compare rename (PR 2.6)

### DIFF
--- a/docs/trailties-plan.md
+++ b/docs/trailties-plan.md
@@ -92,6 +92,7 @@ think one is wrong.
 | User code STI subclass / `Concern.included` registration | User app maintains a central index file (e.g. `app/models/index.ts`). Future tooling in `trails-tsc` will auto-manage these.                                      |
 | `Engine` namespacing replacement                         | Explicit `tableNamePrefix` config option. Module/helper namespacing handled by where the user imports from.                                                       |
 | `Rails.logger` before init                               | `NullLogger` in activesupport (shipped). Wiring into a `Trails` global is PR 2.6.                                                                                 |
+| `Trails.version` source                                  | Trailties `package.json` (via `packages/trailties/src/version.ts`). Trails versions independently from upstream Rails. Resolved in PR 2.6.                        |
 | Activesupport `Trailtie` file location                   | Likely **inside trailties** (`packages/trailties/src/trailties/active-support.ts`) to avoid inverting the trailties → activesupport dependency. PR 2.7a confirms. |
 | Application root-flag file                               | `config.ts` (trails analog of Rails' `config.ru`). `Application.findRoot` walks parents looking for it. See `app-generator.ts:177`.                               |
 
@@ -109,7 +110,6 @@ Every PR must pass:
 | #   | Question                                                                                                                                   | Decide before |
 | --- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------- |
 | 2   | Where does the activesupport `Trailtie` live (in trailties subdir vs activesupport itself)?                                                | PR 2.7a       |
-| 3   | What does `Rails.version` return — trailties `package.json` version or tracked Rails upstream version?                                     | PR 2.6        |
 | 5   | Convert remaining sync `readdir`/`readFile`/`writeFile` callers to async; promote optional `FsAdapter` async surface to required?          | PR 1.12c      |
 | 6   | Should `Engine#paths()` THROW (Rails-faithful) when `calledFrom` is unset? (Currently returns `Root(null)` per 2.2a/b deviation.)          | PR 2.5c       |
 | 7   | Migration filename separator: align `MigrationGenerator` to Rails `_` (preferred) or broaden helper regexes to accept `_` and `-`?         | PR 1.12c      |

--- a/packages/trailties/src/__fixtures__/hello-world/app.ts
+++ b/packages/trailties/src/__fixtures__/hello-world/app.ts
@@ -1,0 +1,17 @@
+// PR 2.6 integration fixture — minimal Application subclass + Rack-style
+// hello-world handler dispatched through actionpack's `RouteSet`. Used by
+// `application.test.ts` to verify `Trails.application.initialize()` + a
+// route serves end-to-end through actionpack.
+import { bodyFromString } from "@blazetrails/rack";
+import { RouteSet } from "@blazetrails/actionpack";
+import { Application } from "../../application.js";
+
+export class HelloWorldApp extends Application {}
+
+export function buildRoutes(): RouteSet {
+  const routes = new RouteSet();
+  const hello = (_env: Record<string, unknown>) =>
+    [200, { "content-type": "text/plain" }, bodyFromString("hello world")] as const;
+  routes.draw((r) => r.mount(hello, { at: "/hello" }));
+  return routes;
+}

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -31,6 +31,9 @@ import {
 } from "@blazetrails/actionpack";
 import { Engine } from "./engine.js";
 import { Trailtie } from "./trailtie.js";
+import { Trails } from "./rails.js";
+import { HelloWorldApp, buildRoutes } from "./__fixtures__/hello-world/app.js";
+import { bodyToString } from "@blazetrails/rack";
 
 const posixPath: PathAdapter = {
   join: (...p) => p.join("/").replace(/\/+/g, "/"),
@@ -206,19 +209,21 @@ describe("Application", () => {
 });
 
 describe("Trails.application integration (PR 2.6 hello-world fixture)", () => {
+  afterEach(() => {
+    Trails.application = null;
+  });
+
   it("initializes a registered Application subclass and serves a route through actionpack", async () => {
-    const { HelloWorldApp, buildRoutes } = await import("./__fixtures__/hello-world/app.js");
-    const { Trails } = await import("./rails.js");
     Application.register(HelloWorldApp);
     expect(Trails.application).toBeInstanceOf(HelloWorldApp);
-    await Trails.application!.initialize();
-    expect(Trails.application!.initialized()).toBe(true);
-    const routes = buildRoutes();
-    const { bodyToString } = await import("@blazetrails/rack");
-    const [status, , body] = await routes.call({ REQUEST_METHOD: "GET", PATH_INFO: "/hello" });
+    await Trails.initialize();
+    expect(Trails.initialized()).toBe(true);
+    const [status, , body] = await buildRoutes().call({
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/hello",
+    });
     expect(status).toBe(200);
     expect(await bodyToString(body)).toBe("hello world");
-    Trails.application = null;
   });
 });
 

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -254,6 +254,13 @@ describe("Application::Configuration", () => {
     expect(c.requireMasterKey).toBe(false);
   });
 
+  it("paths() appends the application-only 'public' entry on top of EngineConfiguration", () => {
+    // Rails: application/configuration.rb#paths adds public, tmp, log, etc.
+    // Trails only ports `public` today (the rest follow in PR 2.7-followups).
+    const c = new Configuration();
+    expect(c.paths().get("public")).toBeDefined();
+  });
+
   it("config.enable_reloading is !config.cache_classes", () => {
     const c = new Configuration();
     c.cacheClasses = true;

--- a/packages/trailties/src/application.test.ts
+++ b/packages/trailties/src/application.test.ts
@@ -205,6 +205,23 @@ describe("Application", () => {
   });
 });
 
+describe("Trails.application integration (PR 2.6 hello-world fixture)", () => {
+  it("initializes a registered Application subclass and serves a route through actionpack", async () => {
+    const { HelloWorldApp, buildRoutes } = await import("./__fixtures__/hello-world/app.js");
+    const { Trails } = await import("./rails.js");
+    Application.register(HelloWorldApp);
+    expect(Trails.application).toBeInstanceOf(HelloWorldApp);
+    await Trails.application!.initialize();
+    expect(Trails.application!.initialized()).toBe(true);
+    const routes = buildRoutes();
+    const { bodyToString } = await import("@blazetrails/rack");
+    const [status, , body] = await routes.call({ REQUEST_METHOD: "GET", PATH_INFO: "/hello" });
+    expect(status).toBe(200);
+    expect(await bodyToString(body)).toBe("hello world");
+    Trails.application = null;
+  });
+});
+
 describe("Application::Configuration", () => {
   it("defaults match Rails::Application::Configuration#initialize", () => {
     const c = new Configuration();

--- a/packages/trailties/src/application/configuration.ts
+++ b/packages/trailties/src/application/configuration.ts
@@ -3,6 +3,7 @@
 // defaults only — `loadDefaults(version)` version-dispatch + credentials +
 // `databaseConfiguration` are 2.5c or later.
 import { EngineConfiguration } from "../engine/configuration.js";
+import type { Root } from "../paths.js";
 
 export interface PublicFileServer {
   enabled: boolean;
@@ -72,5 +73,18 @@ export class Configuration extends EngineConfiguration {
   }
   reloadingEnabled(): boolean {
     return this.enableReloading;
+  }
+
+  /**
+   * Mirrors `Rails::Application::Configuration#paths`: appends the app-only
+   * path entries (`public`, `tmp`, `log`, …) on top of `EngineConfiguration#paths`.
+   * Only `public` is added today; the remaining Rails entries land with their
+   * respective consumers (PR 2.7-followups). See
+   * `vendor/rails/railties/lib/rails/application/configuration.rb:396`.
+   */
+  override paths(): Root {
+    const paths = super.paths();
+    if (!paths.get("public")) paths.add("public");
+    return paths;
   }
 }

--- a/packages/trailties/src/cli.ts
+++ b/packages/trailties/src/cli.ts
@@ -13,6 +13,11 @@ import { statsCommand } from "./commands/stats.js";
 import { credentialsCommand } from "./commands/credentials.js";
 import { encryptedCommand } from "./commands/encrypted.js";
 
+export { Trails } from "./rails.js";
+export { Application } from "./application.js";
+export { Engine } from "./engine.js";
+export { Trailtie } from "./trailtie.js";
+
 export {
   registerPackageManagerAdapter,
   packageManagerAdapterConfig,

--- a/packages/trailties/src/index.ts
+++ b/packages/trailties/src/index.ts
@@ -1,0 +1,5 @@
+export { Trails } from "./rails.js";
+export { Application } from "./application.js";
+export { Engine } from "./engine.js";
+export { Trailtie } from "./trailtie.js";
+export { VERSION } from "./version.js";

--- a/packages/trailties/src/index.ts
+++ b/packages/trailties/src/index.ts
@@ -1,5 +1,0 @@
-export { Trails } from "./rails.js";
-export { Application } from "./application.js";
-export { Engine } from "./engine.js";
-export { Trailtie } from "./trailtie.js";
-export { VERSION } from "./version.js";

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { EnvironmentInquirer, NullLogger } from "@blazetrails/activesupport";
+import { EnvironmentInquirer, NullLogger, setEnv } from "@blazetrails/activesupport";
 import { Trails, _resetTrailsEnv } from "./rails.js";
 import { Application } from "./application.js";
 import { BacktraceCleaner } from "./backtrace-cleaner.js";
@@ -49,10 +49,19 @@ describe("Trails", () => {
     expect(Trails.configuration).toBe(CApp.instance().config);
   });
 
-  it("Trails.env returns an EnvironmentInquirer wrapping TRAILS_ENV/NODE_ENV", () => {
-    expect(Trails.env).toBeInstanceOf(EnvironmentInquirer);
-    // Vitest sets NODE_ENV=test by default; the fallback chain picks it up.
-    expect(["development", "test"]).toContain(Trails.env.toString());
+  it("Trails.env returns an EnvironmentInquirer wrapping TRAILS_ENV (NOT NODE_ENV)", () => {
+    // `resolveEnv()` in database.ts deliberately ignores NODE_ENV.
+    // Set TRAILS_ENV explicitly via the processAdapter so this assertion
+    // is decoupled from vitest's default `NODE_ENV=test`.
+    setEnv("TRAILS_ENV", "staging");
+    try {
+      _resetTrailsEnv();
+      expect(Trails.env).toBeInstanceOf(EnvironmentInquirer);
+      expect(Trails.env.toString()).toBe("staging");
+    } finally {
+      setEnv("TRAILS_ENV", undefined);
+      _resetTrailsEnv();
+    }
   });
 
   it("Trails.env= accepts a string and wraps it in EnvironmentInquirer", () => {

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { EnvironmentInquirer, NullLogger } from "@blazetrails/activesupport";
-import { Trails } from "./rails.js";
+import { Trails, _resetTrailsEnv } from "./rails.js";
 import { Application } from "./application.js";
 import { BacktraceCleaner } from "./backtrace-cleaner.js";
 import { VERSION } from "./version.js";
@@ -9,12 +9,12 @@ beforeEach(() => {
   Trails.application = null;
   Trails.cache = null;
   Trails.logger = null;
-  Trails._resetEnv();
+  _resetTrailsEnv();
   Application.appClass = null;
 });
 afterEach(() => {
   Trails.application = null;
-  Trails._resetEnv();
+  _resetTrailsEnv();
   Application.appClass = null;
 });
 
@@ -49,9 +49,10 @@ describe("Trails", () => {
     expect(Trails.configuration).toBe(CApp.instance().config);
   });
 
-  it("Trails.env returns an EnvironmentInquirer defaulting to development", () => {
+  it("Trails.env returns an EnvironmentInquirer wrapping TRAILS_ENV/NODE_ENV", () => {
     expect(Trails.env).toBeInstanceOf(EnvironmentInquirer);
-    expect(Trails.env.is("development")).toBe(true);
+    // Vitest sets NODE_ENV=test by default; the fallback chain picks it up.
+    expect(["development", "test"]).toContain(Trails.env.toString());
   });
 
   it("Trails.env= accepts a string and wraps it in EnvironmentInquirer", () => {
@@ -85,5 +86,17 @@ describe("Trails", () => {
 
   it("Trails.root resolves to undefined when no app is registered", async () => {
     expect(await Trails.root()).toBeUndefined();
+  });
+
+  it("Trails.initialized() is false before initialize, true after", async () => {
+    class InitApp extends Application {}
+    Application.register(InitApp);
+    expect(Trails.initialized()).toBe(false);
+    await Trails.initialize();
+    expect(Trails.initialized()).toBe(true);
+  });
+
+  it("Trails.initialize() throws when no application is registered", async () => {
+    await expect(Trails.initialize()).rejects.toThrow(/Trails.application is not set/);
   });
 });

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -148,6 +148,10 @@ describe("Trails", () => {
     await expect(Trails.initialize()).rejects.toThrow(/Trails.application is not set/);
   });
 
+  it("Trails.initialized() throws when no application is registered (Rails: no allow_nil:)", () => {
+    expect(() => Trails.initialized()).toThrow(/Trails.application is not set/);
+  });
+
   it("Trails.publicPath returns null when no application is registered", async () => {
     expect(await Trails.publicPath()).toBeNull();
   });

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -14,6 +14,8 @@ beforeEach(() => {
 });
 afterEach(() => {
   Trails.application = null;
+  Trails.cache = null;
+  Trails.logger = null;
   _resetTrailsEnv();
   Application.appClass = null;
 });

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -33,6 +33,17 @@ describe("Trails", () => {
     expect(Trails.application).toBeInstanceOf(MyApp);
   });
 
+  it("Trails.application memoizes the first non-null result (Rails: @application ||= ...)", () => {
+    class MyApp extends Application {}
+    Application.register(MyApp);
+    const first = Trails.application;
+    class OtherApp extends Application {}
+    Application.register(OtherApp);
+    // Even though appClass is now OtherApp, the memoized application sticks.
+    expect(Trails.application).toBe(first);
+    expect(Trails.application).toBeInstanceOf(MyApp);
+  });
+
   it("Trails.application= overrides the appClass-derived instance", () => {
     class MyApp extends Application {}
     Application.register(MyApp);
@@ -94,12 +105,26 @@ describe("Trails", () => {
   });
 
   it("Trails.groups concatenates TRAILS_GROUPS env entries (Rails-faithful: no trim)", () => {
-    // Rails: `groups.concat ENV["RAILS_GROUPS"].to_s.split(",")`. No trim,
-    // empty segments dropped. Trails mirrors that on TRAILS_GROUPS.
+    // Rails: `groups.concat ENV["RAILS_GROUPS"].to_s.split(",")`. No trim;
+    // Ruby `split(",")` preserves middle empties and drops trailing
+    // empties. Trails mirrors that on TRAILS_GROUPS.
     Trails.env = "development";
     setEnv("TRAILS_GROUPS", "assets,workers");
     try {
       expect(Trails.groups()).toEqual(["default", "development", "assets", "workers"]);
+    } finally {
+      setEnv("TRAILS_GROUPS", undefined);
+    }
+  });
+
+  it("Trails.groups TRAILS_GROUPS drops trailing empties but keeps middle ones (Ruby split semantics)", () => {
+    Trails.env = "development";
+    setEnv("TRAILS_GROUPS", "assets,,workers,,");
+    try {
+      // Trailing two empties dropped; the middle empty between assets and
+      // workers is preserved (matches `"assets,,workers,,".split(",")` in
+      // Ruby → `["assets", "", "workers"]`).
+      expect(Trails.groups()).toEqual(["default", "development", "assets", "", "workers"]);
     } finally {
       setEnv("TRAILS_GROUPS", undefined);
     }

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -152,11 +152,20 @@ describe("Trails", () => {
     expect(await Trails.publicPath()).toBeNull();
   });
 
+  it("Trails.publicPath returns null when app.root() is unresolved (no throw)", async () => {
+    class UnrootedApp extends Application {}
+    Application.register(UnrootedApp);
+    const app = UnrootedApp.instance();
+    app.root = async () => undefined;
+    await expect(Trails.publicPath()).resolves.toBeNull();
+  });
+
   it('Trails.publicPath returns the first expanded entry of paths["public"]', async () => {
     class PubApp extends Application {}
     Application.register(PubApp);
     const app = PubApp.instance();
     const stubPath = { expanded: async () => ["/srv/app/public", "/srv/app/public-alt"] };
+    app.root = async () => "/srv/app";
     app.paths = async () =>
       ({ get: (k: string) => (k === "public" ? stubPath : undefined) }) as unknown as Awaited<
         ReturnType<typeof app.paths>

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { EnvironmentInquirer, NullLogger } from "@blazetrails/activesupport";
+import { Trails } from "./rails.js";
+import { Application } from "./application.js";
+import { BacktraceCleaner } from "./backtrace-cleaner.js";
+import { VERSION } from "./version.js";
+
+beforeEach(() => {
+  Trails.application = null;
+  Trails.cache = null;
+  Trails.logger = null;
+  Trails._resetEnv();
+  Application.appClass = null;
+});
+afterEach(() => {
+  Trails.application = null;
+  Trails._resetEnv();
+  Application.appClass = null;
+});
+
+describe("Trails", () => {
+  it("Trails.version returns the trailties package version", () => {
+    expect(Trails.version).toBe(VERSION);
+  });
+
+  it("Trails.application returns null when no app is registered", () => {
+    expect(Trails.application).toBeNull();
+  });
+
+  it("Trails.application returns the registered Application instance", () => {
+    class MyApp extends Application {}
+    Application.register(MyApp);
+    expect(Trails.application).toBeInstanceOf(MyApp);
+  });
+
+  it("Trails.application= overrides the appClass-derived instance", () => {
+    class MyApp extends Application {}
+    Application.register(MyApp);
+    class OtherApp extends Application {}
+    Application.register(OtherApp);
+    const other = OtherApp.instance();
+    Trails.application = other;
+    expect(Trails.application).toBe(other);
+  });
+
+  it("Trails.configuration delegates to application.config", () => {
+    class CApp extends Application {}
+    Application.register(CApp);
+    expect(Trails.configuration).toBe(CApp.instance().config);
+  });
+
+  it("Trails.env returns an EnvironmentInquirer defaulting to development", () => {
+    expect(Trails.env).toBeInstanceOf(EnvironmentInquirer);
+    expect(Trails.env.is("development")).toBe(true);
+  });
+
+  it("Trails.env= accepts a string and wraps it in EnvironmentInquirer", () => {
+    Trails.env = "test";
+    expect(Trails.env.is("test")).toBe(true);
+    expect(Trails.env.toString()).toBe("test");
+  });
+
+  it("Trails.backtraceCleaner returns a memoized BacktraceCleaner", () => {
+    expect(Trails.backtraceCleaner).toBeInstanceOf(BacktraceCleaner);
+    expect(Trails.backtraceCleaner).toBe(Trails.backtraceCleaner);
+  });
+
+  it("Trails.logger is null by default and accepts assignment", () => {
+    expect(Trails.logger).toBeNull();
+    const logger = new NullLogger();
+    Trails.logger = logger;
+    expect(Trails.logger).toBe(logger);
+  });
+
+  it("Trails.groups includes :default, current env, and option-matched keys", () => {
+    Trails.env = "development";
+    expect(Trails.groups()).toEqual(["default", "development"]);
+    expect(Trails.groups({ assets: ["development", "test"] })).toEqual([
+      "default",
+      "development",
+      "assets",
+    ]);
+    expect(Trails.groups({ assets: ["production"] })).toEqual(["default", "development"]);
+  });
+
+  it("Trails.root resolves to undefined when no app is registered", async () => {
+    expect(await Trails.root()).toBeUndefined();
+  });
+});

--- a/packages/trailties/src/rails.test.ts
+++ b/packages/trailties/src/rails.test.ts
@@ -93,6 +93,18 @@ describe("Trails", () => {
     expect(Trails.groups({ assets: ["production"] })).toEqual(["default", "development"]);
   });
 
+  it("Trails.groups concatenates TRAILS_GROUPS env entries (Rails-faithful: no trim)", () => {
+    // Rails: `groups.concat ENV["RAILS_GROUPS"].to_s.split(",")`. No trim,
+    // empty segments dropped. Trails mirrors that on TRAILS_GROUPS.
+    Trails.env = "development";
+    setEnv("TRAILS_GROUPS", "assets,workers");
+    try {
+      expect(Trails.groups()).toEqual(["default", "development", "assets", "workers"]);
+    } finally {
+      setEnv("TRAILS_GROUPS", undefined);
+    }
+  });
+
   it("Trails.root resolves to undefined when no app is registered", async () => {
     expect(await Trails.root()).toBeUndefined();
   });
@@ -107,5 +119,21 @@ describe("Trails", () => {
 
   it("Trails.initialize() throws when no application is registered", async () => {
     await expect(Trails.initialize()).rejects.toThrow(/Trails.application is not set/);
+  });
+
+  it("Trails.publicPath returns null when no application is registered", async () => {
+    expect(await Trails.publicPath()).toBeNull();
+  });
+
+  it('Trails.publicPath returns the first expanded entry of paths["public"]', async () => {
+    class PubApp extends Application {}
+    Application.register(PubApp);
+    const app = PubApp.instance();
+    const stubPath = { expanded: async () => ["/srv/app/public", "/srv/app/public-alt"] };
+    app.paths = async () =>
+      ({ get: (k: string) => (k === "public" ? stubPath : undefined) }) as unknown as Awaited<
+        ReturnType<typeof app.paths>
+      >;
+    expect(await Trails.publicPath()).toBe("/srv/app/public");
   });
 });

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -5,6 +5,7 @@ import { EnvironmentInquirer, getEnv } from "@blazetrails/activesupport";
 import type { CacheStore, Logger } from "@blazetrails/activesupport";
 import { Application } from "./application.js";
 import { BacktraceCleaner } from "./backtrace-cleaner.js";
+import type { Configuration } from "./application/configuration.js";
 import { VERSION } from "./version.js";
 
 let _application: Application | null = null;
@@ -13,8 +14,12 @@ let _logger: Logger | null = null;
 let _env: EnvironmentInquirer | undefined;
 let _backtraceCleaner: BacktraceCleaner | undefined;
 
+function resolveDefaultEnv(): string {
+  return getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? "development";
+}
+
 /**
- * Trails-renamed `Rails` module. Exposed as a frozen object literal with
+ * Trails-renamed `Rails` module. Exposed as an object literal with
  * accessors because TS has no module-singleton pattern. Mutations flow
  * through explicit setters (`Trails.application = app`,
  * `Trails.env = "test"`).
@@ -52,23 +57,34 @@ export const Trails = {
   },
 
   /** Rails: `Rails.configuration` → `application.config`. */
-  get configuration() {
-    const app = Trails.application;
-    return app ? app.config : null;
+  get configuration(): Configuration | null {
+    return Trails.application?.config ?? null;
   },
 
   /**
-   * Rails: `@_env ||= ActiveSupport::EnvironmentInquirer.new(...)`. Checks
-   * `TRAILS_ENV`, `RAILS_ENV`, then `RACK_ENV`, defaulting to
-   * `"development"`.
+   * Rails: `@_env ||= ActiveSupport::EnvironmentInquirer.new(...)`.
+   * Trails env precedence: `TRAILS_ENV`, then `NODE_ENV`, defaulting to
+   * `"development"` — matches `resolveEnv()` in `database.ts`.
    */
   get env(): EnvironmentInquirer {
-    return (_env ??= new EnvironmentInquirer(
-      getEnv("TRAILS_ENV") ?? getEnv("RAILS_ENV") ?? getEnv("RACK_ENV") ?? "development",
-    ));
+    return (_env ??= new EnvironmentInquirer(resolveDefaultEnv()));
   },
   set env(value: string | EnvironmentInquirer) {
     _env = typeof value === "string" ? new EnvironmentInquirer(value) : value;
+  },
+
+  /** Rails: `delegate :initialize!, to: :application`. Throws when no app
+   * is registered, matching Rails' `NoMethodError` on `nil.initialize!`. */
+  async initialize(group?: string): Promise<Application> {
+    const app = Trails.application;
+    if (!app)
+      throw new Error("Trails.application is not set — register an Application subclass first.");
+    return app.initialize(group as Parameters<Application["initialize"]>[0]);
+  },
+
+  /** Rails: `delegate :initialized?, to: :application`. */
+  initialized(): boolean {
+    return Trails.application?.initialized() ?? false;
   },
 
   get backtraceCleaner(): BacktraceCleaner {
@@ -90,29 +106,26 @@ export const Trails = {
   },
 
   /**
-   * Rails: `Rails.groups(*groups)`. Combines `:default`, current env, the
-   * `RAILS_GROUPS` env var, and any extra group dependencies from the
-   * optional trailing options hash.
+   * Rails: `Rails.groups(*groups)`. Combines `"default"`, current env, the
+   * `TRAILS_GROUPS` env var, and option-hash keys whose value array
+   * includes the current env. Result is deduped, preserving insertion
+   * order.
    */
-  groups(...args: Array<string | symbol | Record<string, string[]>>): string[] {
+  groups(...args: Array<string | Record<string, string[]>>): string[] {
     const last = args[args.length - 1];
-    const opts =
-      last && typeof last === "object" && !Array.isArray(last)
-        ? (args.pop() as Record<string, string[]>)
-        : {};
+    const opts = last && typeof last === "object" ? (args.pop() as Record<string, string[]>) : {};
     const env = Trails.env.toString();
-    const out: string[] = ["default", env];
-    for (const g of args) out.push(String(g));
-    const envGroups = getEnv("RAILS_GROUPS");
+    const out: string[] = ["default", env, ...(args as string[])];
+    const envGroups = getEnv("TRAILS_GROUPS");
     if (envGroups) for (const g of envGroups.split(",")) if (g) out.push(g);
     for (const [k, envs] of Object.entries(opts)) {
-      if (envs.map(String).includes(env)) out.push(k);
+      if (envs.includes(env)) out.push(k);
     }
     return [...new Set(out)];
   },
-
-  /** @internal Test-only — drops the cached EnvironmentInquirer. */
-  _resetEnv(): void {
-    _env = undefined;
-  },
 };
+
+/** @internal Test-only — drops the cached EnvironmentInquirer. */
+export function _resetTrailsEnv(): void {
+  _env = undefined;
+}

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -6,6 +6,7 @@ import type { CacheStore, Logger } from "@blazetrails/activesupport";
 import { Application } from "./application.js";
 import { BacktraceCleaner } from "./backtrace-cleaner.js";
 import type { Configuration } from "./application/configuration.js";
+import type { InitializerGroup } from "./initializable.js";
 import { VERSION } from "./version.js";
 
 let _application: Application | null = null;
@@ -75,11 +76,11 @@ export const Trails = {
 
   /** Rails: `delegate :initialize!, to: :application`. Throws when no app
    * is registered, matching Rails' `NoMethodError` on `nil.initialize!`. */
-  async initialize(group?: string): Promise<Application> {
+  async initialize(group: InitializerGroup = "default"): Promise<Application> {
     const app = Trails.application;
     if (!app)
       throw new Error("Trails.application is not set — register an Application subclass first.");
-    return app.initialize(group as Parameters<Application["initialize"]>[0]);
+    return app.initialize(group);
   },
 
   /** Rails: `delegate :initialized?, to: :application`. */

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -100,9 +100,14 @@ export class Trails {
     return app.initialize(group);
   }
 
-  /** Rails: `delegate :initialized?, to: :application`. */
+  /** Rails: `delegate :initialized?, to: :application`. Rails has no
+   * `allow_nil:` on the delegate, so this throws when no app is
+   * registered — matching the symmetric behavior of `initialize()`. */
   static initialized(): boolean {
-    return Trails.application?.initialized() ?? false;
+    const app = Trails.application;
+    if (!app)
+      throw new Error("Trails.application is not set — register an Application subclass first.");
+    return app.initialized();
   }
 
   static get backtraceCleaner(): BacktraceCleaner {

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -6,6 +6,7 @@ import type { CacheStore, Logger } from "@blazetrails/activesupport";
 import { Application } from "./application.js";
 import { BacktraceCleaner } from "./backtrace-cleaner.js";
 import type { Configuration } from "./application/configuration.js";
+import { resolveEnv } from "./database.js";
 import type { InitializerGroup } from "./initializable.js";
 import { VERSION } from "./version.js";
 
@@ -14,10 +15,6 @@ let _cache: CacheStore | null = null;
 let _logger: Logger | null = null;
 let _env: EnvironmentInquirer | undefined;
 let _backtraceCleaner: BacktraceCleaner | undefined;
-
-function resolveDefaultEnv(): string {
-  return getEnv("TRAILS_ENV") ?? getEnv("NODE_ENV") ?? "development";
-}
 
 /**
  * Trails-renamed `Rails` module. Exposed as an object literal with
@@ -64,11 +61,14 @@ export const Trails = {
 
   /**
    * Rails: `@_env ||= ActiveSupport::EnvironmentInquirer.new(...)`.
-   * Trails env precedence: `TRAILS_ENV`, then `NODE_ENV`, defaulting to
-   * `"development"` — matches `resolveEnv()` in `database.ts`.
+   * Delegates to `resolveEnv()` in `database.ts` for a single source of
+   * truth — reads `TRAILS_ENV`, defaults to `"development"`. Deliberately
+   * does NOT fall back to `NODE_ENV` (see `database.ts:resolveEnv` for
+   * the rationale: JS ecosystem treats `NODE_ENV` as a build-time hint,
+   * not a runtime selector).
    */
   get env(): EnvironmentInquirer {
-    return (_env ??= new EnvironmentInquirer(resolveDefaultEnv()));
+    return (_env ??= new EnvironmentInquirer(resolveEnv()));
   },
   set env(value: string | EnvironmentInquirer) {
     _env = typeof value === "string" ? new EnvironmentInquirer(value) : value;

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -156,7 +156,9 @@ export class Trails {
   }
 }
 
-/** @internal Test-only — drops the cached EnvironmentInquirer. */
+/** @internal Test-only — drops cached module-private singletons that
+ * leak across vitest tests (EnvironmentInquirer, BacktraceCleaner). */
 export function _resetTrailsEnv(): void {
   _env = undefined;
+  _backtraceCleaner = undefined;
 }

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -2,8 +2,10 @@
 // Renamed `Rails` → `Trails`; `api:compare` wires the alias via the
 // `Rails: "Trails"` entry in `TS_CLASS_RENAMES` (compare.ts).
 //
-// Modeled as a class with static accessors (cf. `log-subscriber.ts`,
-// `digest.ts`) so the api-compare extractor harvests getters/setters —
+// Modeled as a class with static accessors (cf.
+// `packages/activesupport/src/log-subscriber.ts`,
+// `packages/activesupport/src/digest.ts`) so the api-compare extractor
+// harvests getters/setters —
 // `harvestObjectLiteralMethods` ignores accessors on object literals, but
 // the class extractor walks `ts.isGetAccessorDeclaration` for static
 // members. `Trails` is never instantiated.
@@ -132,9 +134,12 @@ export class Trails {
    * order.
    */
   static groups(...args: Array<string | Record<string, string[]>>): string[] {
-    // Rails' `extract_options!` only pops a plain Hash; arrays and other
-    // objects fall through as group identifiers. Require a plain Object
-    // prototype (or null) to mirror that.
+    // Rails' `extract_options!` only pops a plain Hash. The TS signature
+    // restricts callers to `string` group identifiers + an optional
+    // trailing plain object, but at runtime someone could still pass an
+    // array (`String(arr)` would yield a comma-joined identifier). The
+    // plain-Object-prototype check is the defensive guard that mirrors
+    // `extract_options!` exactly.
     const last = args[args.length - 1];
     const isPlainObject =
       last !== null &&

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -112,10 +112,14 @@ export class Trails {
     return Trails.application?.root();
   }
 
-  /** Rails: `application && Pathname.new(application.paths["public"].first)`. */
+  /** Rails: `application && Pathname.new(application.paths["public"].first)`.
+   * Returns null when no app is registered OR when the app's root is still
+   * unresolved (Engine.calledFrom unset) — `Path#expanded` throws on a null
+   * root, so we short-circuit before reaching it. */
   static async publicPath(): Promise<string | null> {
     const app = Trails.application;
     if (!app) return null;
+    if ((await app.root()) === undefined) return null;
     const paths = await app.paths();
     const expanded = await paths.get("public")?.expanded();
     return expanded?.[0] ?? null;

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -38,9 +38,14 @@ export class Trails {
   }
 
   static get application(): Application | null {
+    // Rails: `@application ||= (app_class.instance if app_class)`. The `||=`
+    // caches the first non-nil result, so a later `Application.appClass =`
+    // does not retroactively change `Trails.application`.
     if (_application) return _application;
     const klass = Application.appClass;
-    return klass ? (klass.instance() as Application) : null;
+    if (!klass) return null;
+    _application = klass.instance() as Application;
+    return _application;
   }
   static set application(app: Application | null) {
     _application = app;
@@ -123,12 +128,27 @@ export class Trails {
    * order.
    */
   static groups(...args: Array<string | Record<string, string[]>>): string[] {
+    // Rails' `extract_options!` only pops a plain Hash; arrays and other
+    // objects fall through as group identifiers. Require a plain Object
+    // prototype (or null) to mirror that.
     const last = args[args.length - 1];
-    const opts = last && typeof last === "object" ? (args.pop() as Record<string, string[]>) : {};
+    const isPlainObject =
+      last !== null &&
+      typeof last === "object" &&
+      !Array.isArray(last) &&
+      (Object.getPrototypeOf(last) === Object.prototype || Object.getPrototypeOf(last) === null);
+    const opts = isPlainObject ? (args.pop() as Record<string, string[]>) : {};
     const env = Trails.env.toString();
     const out: string[] = ["default", env, ...(args as string[])];
+    // Rails: `groups.concat ENV["RAILS_GROUPS"].to_s.split(",")`.
+    // Ruby's `String#split(",")` (no -1 limit) drops trailing empty
+    // segments but preserves middle ones — mirror exactly.
     const envGroups = getEnv("TRAILS_GROUPS");
-    if (envGroups) for (const g of envGroups.split(",")) if (g) out.push(g);
+    if (envGroups) {
+      const parts = envGroups.split(",");
+      while (parts.length > 0 && parts[parts.length - 1] === "") parts.pop();
+      for (const g of parts) out.push(g);
+    }
     for (const [k, envs] of Object.entries(opts)) {
       if (envs.includes(env)) out.push(k);
     }

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -1,7 +1,14 @@
 // Port of `Rails` module from `railties/lib/rails.rb`.
 // Renamed `Rails` → `Trails`; `api:compare` wires the alias via the
 // `Rails: "Trails"` entry in `TS_CLASS_RENAMES` (compare.ts).
-import { EnvironmentInquirer, getEnv } from "@blazetrails/activesupport";
+//
+// Modeled as a class with static accessors (cf. `log-subscriber.ts`,
+// `digest.ts`) so the api-compare extractor harvests getters/setters —
+// `harvestObjectLiteralMethods` ignores accessors on object literals, but
+// the class extractor walks `ts.isGetAccessorDeclaration` for static
+// members. `Trails` is never instantiated.
+import { EnvironmentInquirer } from "@blazetrails/activesupport";
+import { getEnv } from "@blazetrails/activesupport";
 import type { CacheStore, Logger } from "@blazetrails/activesupport";
 import { Application } from "./application.js";
 import { BacktraceCleaner } from "./backtrace-cleaner.js";
@@ -17,47 +24,50 @@ let _env: EnvironmentInquirer | undefined;
 let _backtraceCleaner: BacktraceCleaner | undefined;
 
 /**
- * Trails-renamed `Rails` module. Exposed as an object literal with
- * accessors because TS has no module-singleton pattern. Mutations flow
- * through explicit setters (`Trails.application = app`,
+ * Trails-renamed `Rails` module from `railties/lib/rails.rb`. Mutations
+ * flow through explicit setters (`Trails.application = app`,
  * `Trails.env = "test"`).
  *
  * `Trails.version` returns the `@blazetrails/trailties` package version
  * (`packages/trailties/src/version.ts`), NOT the tracked Rails upstream
  * version — resolves open question #3 in `docs/trailties-plan.md`.
  */
-export const Trails = {
-  get application(): Application | null {
+export class Trails {
+  private constructor() {
+    throw new Error("Trails is a static-only namespace; do not instantiate.");
+  }
+
+  static get application(): Application | null {
     if (_application) return _application;
     const klass = Application.appClass;
     return klass ? (klass.instance() as Application) : null;
-  },
-  set application(app: Application | null) {
+  }
+  static set application(app: Application | null) {
     _application = app;
-  },
+  }
 
-  get cache(): CacheStore | null {
+  static get cache(): CacheStore | null {
     return _cache;
-  },
-  set cache(value: CacheStore | null) {
+  }
+  static set cache(value: CacheStore | null) {
     _cache = value;
-  },
+  }
 
-  get logger(): Logger | null {
+  static get logger(): Logger | null {
     return _logger;
-  },
-  set logger(value: Logger | null) {
+  }
+  static set logger(value: Logger | null) {
     _logger = value;
-  },
+  }
 
-  get version(): string {
+  static get version(): string {
     return VERSION;
-  },
+  }
 
   /** Rails: `Rails.configuration` → `application.config`. */
-  get configuration(): Configuration | null {
+  static get configuration(): Configuration | null {
     return Trails.application?.config ?? null;
-  },
+  }
 
   /**
    * Rails: `@_env ||= ActiveSupport::EnvironmentInquirer.new(...)`.
@@ -67,44 +77,44 @@ export const Trails = {
    * the rationale: JS ecosystem treats `NODE_ENV` as a build-time hint,
    * not a runtime selector).
    */
-  get env(): EnvironmentInquirer {
+  static get env(): EnvironmentInquirer {
     return (_env ??= new EnvironmentInquirer(resolveEnv()));
-  },
-  set env(value: string | EnvironmentInquirer) {
+  }
+  static set env(value: string | EnvironmentInquirer) {
     _env = typeof value === "string" ? new EnvironmentInquirer(value) : value;
-  },
+  }
 
   /** Rails: `delegate :initialize!, to: :application`. Throws when no app
    * is registered, matching Rails' `NoMethodError` on `nil.initialize!`. */
-  async initialize(group: InitializerGroup = "default"): Promise<Application> {
+  static async initialize(group: InitializerGroup = "default"): Promise<Application> {
     const app = Trails.application;
     if (!app)
       throw new Error("Trails.application is not set — register an Application subclass first.");
     return app.initialize(group);
-  },
+  }
 
   /** Rails: `delegate :initialized?, to: :application`. */
-  initialized(): boolean {
+  static initialized(): boolean {
     return Trails.application?.initialized() ?? false;
-  },
+  }
 
-  get backtraceCleaner(): BacktraceCleaner {
+  static get backtraceCleaner(): BacktraceCleaner {
     return (_backtraceCleaner ??= new BacktraceCleaner());
-  },
+  }
 
   /** Rails: `application && application.config.root`. */
-  async root(): Promise<string | undefined> {
+  static async root(): Promise<string | undefined> {
     return Trails.application?.root();
-  },
+  }
 
   /** Rails: `application && Pathname.new(application.paths["public"].first)`. */
-  async publicPath(): Promise<string | null> {
+  static async publicPath(): Promise<string | null> {
     const app = Trails.application;
     if (!app) return null;
     const paths = await app.paths();
     const expanded = await paths.get("public")?.expanded();
     return expanded?.[0] ?? null;
-  },
+  }
 
   /**
    * Rails: `Rails.groups(*groups)`. Combines `"default"`, current env, the
@@ -112,7 +122,7 @@ export const Trails = {
    * includes the current env. Result is deduped, preserving insertion
    * order.
    */
-  groups(...args: Array<string | Record<string, string[]>>): string[] {
+  static groups(...args: Array<string | Record<string, string[]>>): string[] {
     const last = args[args.length - 1];
     const opts = last && typeof last === "object" ? (args.pop() as Record<string, string[]>) : {};
     const env = Trails.env.toString();
@@ -123,8 +133,8 @@ export const Trails = {
       if (envs.includes(env)) out.push(k);
     }
     return [...new Set(out)];
-  },
-};
+  }
+}
 
 /** @internal Test-only — drops the cached EnvironmentInquirer. */
 export function _resetTrailsEnv(): void {

--- a/packages/trailties/src/rails.ts
+++ b/packages/trailties/src/rails.ts
@@ -1,0 +1,118 @@
+// Port of `Rails` module from `railties/lib/rails.rb`.
+// Renamed `Rails` → `Trails`; `api:compare` wires the alias via the
+// `Rails: "Trails"` entry in `TS_CLASS_RENAMES` (compare.ts).
+import { EnvironmentInquirer, getEnv } from "@blazetrails/activesupport";
+import type { CacheStore, Logger } from "@blazetrails/activesupport";
+import { Application } from "./application.js";
+import { BacktraceCleaner } from "./backtrace-cleaner.js";
+import { VERSION } from "./version.js";
+
+let _application: Application | null = null;
+let _cache: CacheStore | null = null;
+let _logger: Logger | null = null;
+let _env: EnvironmentInquirer | undefined;
+let _backtraceCleaner: BacktraceCleaner | undefined;
+
+/**
+ * Trails-renamed `Rails` module. Exposed as a frozen object literal with
+ * accessors because TS has no module-singleton pattern. Mutations flow
+ * through explicit setters (`Trails.application = app`,
+ * `Trails.env = "test"`).
+ *
+ * `Trails.version` returns the `@blazetrails/trailties` package version
+ * (`packages/trailties/src/version.ts`), NOT the tracked Rails upstream
+ * version — resolves open question #3 in `docs/trailties-plan.md`.
+ */
+export const Trails = {
+  get application(): Application | null {
+    if (_application) return _application;
+    const klass = Application.appClass;
+    return klass ? (klass.instance() as Application) : null;
+  },
+  set application(app: Application | null) {
+    _application = app;
+  },
+
+  get cache(): CacheStore | null {
+    return _cache;
+  },
+  set cache(value: CacheStore | null) {
+    _cache = value;
+  },
+
+  get logger(): Logger | null {
+    return _logger;
+  },
+  set logger(value: Logger | null) {
+    _logger = value;
+  },
+
+  get version(): string {
+    return VERSION;
+  },
+
+  /** Rails: `Rails.configuration` → `application.config`. */
+  get configuration() {
+    const app = Trails.application;
+    return app ? app.config : null;
+  },
+
+  /**
+   * Rails: `@_env ||= ActiveSupport::EnvironmentInquirer.new(...)`. Checks
+   * `TRAILS_ENV`, `RAILS_ENV`, then `RACK_ENV`, defaulting to
+   * `"development"`.
+   */
+  get env(): EnvironmentInquirer {
+    return (_env ??= new EnvironmentInquirer(
+      getEnv("TRAILS_ENV") ?? getEnv("RAILS_ENV") ?? getEnv("RACK_ENV") ?? "development",
+    ));
+  },
+  set env(value: string | EnvironmentInquirer) {
+    _env = typeof value === "string" ? new EnvironmentInquirer(value) : value;
+  },
+
+  get backtraceCleaner(): BacktraceCleaner {
+    return (_backtraceCleaner ??= new BacktraceCleaner());
+  },
+
+  /** Rails: `application && application.config.root`. */
+  async root(): Promise<string | undefined> {
+    return Trails.application?.root();
+  },
+
+  /** Rails: `application && Pathname.new(application.paths["public"].first)`. */
+  async publicPath(): Promise<string | null> {
+    const app = Trails.application;
+    if (!app) return null;
+    const paths = await app.paths();
+    const expanded = await paths.get("public")?.expanded();
+    return expanded?.[0] ?? null;
+  },
+
+  /**
+   * Rails: `Rails.groups(*groups)`. Combines `:default`, current env, the
+   * `RAILS_GROUPS` env var, and any extra group dependencies from the
+   * optional trailing options hash.
+   */
+  groups(...args: Array<string | symbol | Record<string, string[]>>): string[] {
+    const last = args[args.length - 1];
+    const opts =
+      last && typeof last === "object" && !Array.isArray(last)
+        ? (args.pop() as Record<string, string[]>)
+        : {};
+    const env = Trails.env.toString();
+    const out: string[] = ["default", env];
+    for (const g of args) out.push(String(g));
+    const envGroups = getEnv("RAILS_GROUPS");
+    if (envGroups) for (const g of envGroups.split(",")) if (g) out.push(g);
+    for (const [k, envs] of Object.entries(opts)) {
+      if (envs.map(String).includes(env)) out.push(k);
+    }
+    return [...new Set(out)];
+  },
+
+  /** @internal Test-only — drops the cached EnvironmentInquirer. */
+  _resetEnv(): void {
+    _env = undefined;
+  },
+};

--- a/scripts/api-compare/compare.test.ts
+++ b/scripts/api-compare/compare.test.ts
@@ -205,6 +205,12 @@ describe("resolveTsClassForRuby", () => {
     expect(resolveTsClassForRuby("Railtie", "trailtie.ts", map)).toBe(trailtie);
   });
 
+  it("resolves Rails → Trails (global trails convention)", () => {
+    const trails = cls("rails.ts", "Trails");
+    const map = new Map([["rails.ts::Trails", trails]]);
+    expect(resolveTsClassForRuby("Rails", "rails.ts", map)).toBe(trails);
+  });
+
   it("returns undefined when nothing resolves", () => {
     expect(resolveTsClassForRuby("Nothing", "nowhere.ts", new Map())).toBeUndefined();
   });

--- a/scripts/api-compare/compare.ts
+++ b/scripts/api-compare/compare.ts
@@ -246,10 +246,13 @@ const TS_ROOT_INTERMEDIATE = new Map<string, string>([
 //   too generic in TS, so the flattened class keeps the `Model` prefix.
 // - `Railtie` → `Trailtie`: Trails railties are not Rails::Railtie subclasses;
 //   the pun name signals that distinction across all packages.
+// - `Rails` → `Trails`: top-level `module Rails` in `railties/lib/rails.rb`
+//   maps to the `Trails` global in `packages/trailties/src/rails.ts`.
 // - `Registry` → `TypeRegistry`: same rationale for `ActiveModel::Type::Registry`.
 const TS_CLASS_RENAMES: Record<string, string> = {
   Name: "ModelName",
   Railtie: "Trailtie",
+  Rails: "Trails",
   Registry: "TypeRegistry",
 };
 


### PR DESCRIPTION
## Summary

Ports `module Rails` from `railties/lib/rails.rb` to the `Trails` global in trailties. Modeled as a class with **static accessors** (cf. `log-subscriber.ts`, `digest.ts`) — TS has no module-singleton pattern, and the api-compare extractor only harvests getters/setters from classes, not object literals. `Trails` is never instantiated (the private constructor throws).

Adds `Rails: "Trails"` to `TS_CLASS_RENAMES` so `api:compare` resolves the Ruby `Rails` module against TS `Trails`, mirroring the `Railtie → Trailtie` entry from PR 2.1. Verified — `Trails` extracts as `rails.ts:Trails` with all 16 accessors + methods harvested by the class extractor.

## Open question #3 resolved

**`Trails.version` returns the trailties `package.json` version** (via `packages/trailties/src/version.ts`), **not** the tracked Rails upstream version. Rationale: Trails versions independently of upstream Rails. The plan doc moves Q#3 into "Decisions already made."

## Rails sources

Ported (`railties/lib/rails.rb`):
- `application` / `application=` with Rails-faithful `||=` memoization (`@application ||= (app_class.instance if app_class)`)
- `cache` / `cache=`, `logger` / `logger=` (attr_accessor)
- `version`, `configuration`, `backtraceCleaner`
- `env` / `env=` — delegates to `database.ts:resolveEnv` for single source of truth; `TRAILS_ENV` or `"development"`, deliberately ignoring `NODE_ENV` per documented rationale
- `root`, `publicPath` (safe when root unresolved), `groups` (Ruby `extract_options!` + `split(",")` semantics)
- `initialize` / `initialized` (Rails: `delegate :initialize!, :initialized?, to: :application`)

Also wires `Application::Configuration#paths()` to add the `public` entry (Rails: `application/configuration.rb:403`) so `Trails.publicPath()` actually resolves on real apps. Remaining Rails app-only entries (`tmp`, `log`, `public/javascripts`, `public/stylesheets`, `lib/templates`) follow with their consumers in PR 2.7-followups.

Intentionally skipped:
- `Rails.error` — defer until `ActiveSupport.errorReporter` is wired.
- `Rails.autoloaders` — Zeitwerk-equivalent autoloader is not ported (see plan doc).
- `BacktraceCleaner.setRoot(Trails.root)` lazy wiring — listed under "Wiring this PR drives" in the plan doc as a small follow-up.

## Scope

- `packages/trailties/src/rails.ts` + `rails.test.ts` (Trails class + 19 unit tests)
- `packages/trailties/src/__fixtures__/hello-world/app.ts` — integration fixture (`HelloWorldApp extends Application` + `buildRoutes()`)
- `packages/trailties/src/application.test.ts` — integration test: register `HelloWorldApp`, `await Trails.initialize()`, dispatch `GET /hello` through actionpack `RouteSet`, assert `200 "hello world"`; plus a config unit test locking the new `paths["public"]` entry
- `packages/trailties/src/application/configuration.ts` — `paths()` override adding `public`
- `packages/trailties/src/cli.ts` — re-exports `Trails`, `Application`, `Engine`, `Trailtie` from the package's `.` entrypoint (`./dist/cli.js` per `package.json`). No separate `index.ts` — would have been unreachable through the package exports map.
- `scripts/api-compare/compare.ts` — `Rails: "Trails"` rename entry
- `scripts/api-compare/compare.test.ts` — coverage for the alias
- `docs/trailties-plan.md` — Q#3 moved to decisions-made table

## Test plan

- [x] `pnpm typecheck` clean
- [x] `pnpm vitest run packages/trailties/src/rails.test.ts packages/trailties/src/application.test.ts scripts/api-compare/compare.test.ts` — all pass
- [x] Integration test boots an `Application` subclass, calls `Trails.initialize()`, and serves `GET /hello` via actionpack `RouteSet.call`
- [x] `pnpm tsx scripts/api-compare/extract-ts-api.ts` extracts `rails.ts:Trails` with all accessors as class methods
- [ ] `pnpm tsx scripts/api-compare/compare.ts --package trailties` matches `Trails` to Ruby `Rails` via the rename map (CI)
- [ ] `pnpm test:compare` continues to match Rails test names through the rename (CI)

## Deferred Copilot feedback (max review cycles reached)

Copilot review #9 raised one concern that is not blocking and is being deferred as a follow-up:

- **`Trails.publicPath()` may call `app.root()` twice on a cold cache.** When `config.root` is still null, `await app.root()` triggers a `findRootWithFlag` filesystem walk; then `await app.paths()` resolves root again before delegating to `EngineConfiguration#paths`. On the first call this can double the work. Mitigation: call `await app.paths()` once and check `paths.path` for null before invoking `expanded()`. Not shipping in this PR because (a) `paths()` already memoizes after the first call (`engine.ts:107`), so subsequent reads are cheap, and (b) `findRootWithFlag` is itself one-shot per Application instance. Will be folded into the `BacktraceCleaner.setRoot(Trails.root)` follow-up listed under "Wiring this PR drives" in `docs/trailties-plan.md`.
