### PR TITLE
ci: per-package gates for trailties, trails-tsc, tse-compiler

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,9 @@ jobs:
           # here affects all packages: workspace topology, root tooling
           # config, shared scripts, this workflow, composite actions.
           INFRA_RE='^(pnpm-lock\.yaml$|pnpm-workspace\.yaml$|package\.json$|tsconfig[^/]*\.json$|vitest[^/]*\.config\.ts$|scripts/|\.github/workflows/ci\.yml$|\.github/actions/)'
-          # AR consumes @blazetrails/trails-tsc at runtime via the tsc-wrapper
+          # AR workspace deps: arel/activemodel/activesupport/globalid/
+          # did-you-mean (per packages/activerecord/package.json). Also
+          # consumes @blazetrails/trails-tsc at runtime via the tsc-wrapper
           # CLI + type-virtualization modules (see packages/activerecord/src/
           # tsc-wrapper, schema-columns-dump.test.ts), so trails-tsc changes
           # can fail AR vitest suites — include it in the gate.
@@ -92,12 +94,15 @@ jobs:
           # actionpack/actionview/activerecord/rack/activesupport, so any of
           # their workspace upstreams also flips this on.
           TRAILTIES_PKGS_RE='^packages/(trailties|actionpack|actionview|activerecord|arel|activemodel|activesupport|globalid|rack|did-you-mean|trails-tsc)/'
-          # trails_tsc_affected gates the virtualized DX type tests, which
-          # are activerecord's only consumer of @blazetrails/trails-tsc.
+          # trails_tsc_affected gates the virtualized DX type tests.
+          # Workspace consumers of @blazetrails/trails-tsc today: activerecord
+          # (tsc-wrapper + type-virtualization) and scripts/guides-typecheck;
+          # AR consumption is the reason trails-tsc is also in AR_PKGS_RE.
           TRAILS_TSC_PKGS_RE='^packages/trails-tsc/'
-          # tse_compiler_affected gates tse-compiler-tests. Own package +
-          # activesupport (its only workspace dep).
-          TSE_COMPILER_PKGS_RE='^packages/(tse-compiler|activesupport)/'
+          # tse_compiler_affected gates tse-compiler-tests. The package has
+          # no workspace dependencies today (no activesupport import), so
+          # the gate matches the package path only.
+          TSE_COMPILER_PKGS_RE='^packages/tse-compiler/'
           force_all_affected() {
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
             echo "actionpack_affected=true"   >> "$GITHUB_OUTPUT"
@@ -132,7 +137,9 @@ jobs:
             else
               echo "docs_only=true" >> "$GITHUB_OUTPUT"
             fi
-            # On push to main / schedule / workflow_dispatch always run everything.
+            # On push to main / schedule / workflow_dispatch force every
+            # package gate true. Downstream jobs still honor docs_only, so a
+            # docs-only push to main still short-circuits the matrix.
             case "${{ github.event_name }}" in
               push|schedule|workflow_dispatch)
                 force_all_affected

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,9 +95,11 @@ jobs:
           # trails_tsc_affected gates the virtualized DX type tests, which
           # are activerecord's only consumer of @blazetrails/trails-tsc.
           TRAILS_TSC_PKGS_RE='^packages/trails-tsc/'
-          # tse_compiler_affected gates tse-compiler-tests. Only depends on
-          # activesupport today. The package may not exist on the base ref
-          # yet — when absent, the gate is simply never tripped by paths.
+          # tse_compiler_affected gates tse-compiler-tests. Own package +
+          # activesupport (its only workspace dep). Note: activesupport
+          # changes flip this on even when packages/tse-compiler is absent
+          # on the base ref — the job itself short-circuits in that case
+          # via the directory-presence check after checkout.
           TSE_COMPILER_PKGS_RE='^packages/(tse-compiler|activesupport)/'
           force_all_affected() {
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,11 @@ jobs:
           # here affects all packages: workspace topology, root tooling
           # config, shared scripts, this workflow, composite actions.
           INFRA_RE='^(pnpm-lock\.yaml$|pnpm-workspace\.yaml$|package\.json$|tsconfig[^/]*\.json$|vitest[^/]*\.config\.ts$|scripts/|\.github/workflows/ci\.yml$|\.github/actions/)'
-          AR_PKGS_RE='^packages/(activerecord|arel|activemodel|activesupport|globalid|did-you-mean)/'
+          # AR consumes @blazetrails/trails-tsc at runtime via the tsc-wrapper
+          # CLI + type-virtualization modules (see packages/activerecord/src/
+          # tsc-wrapper, schema-columns-dump.test.ts), so trails-tsc changes
+          # can fail AR vitest suites — include it in the gate.
+          AR_PKGS_RE='^packages/(activerecord|arel|activemodel|activesupport|globalid|did-you-mean|trails-tsc)/'
           # actionpack_affected gates actionpack-tests. True for actionpack +
           # its runtime deps (actionview/activemodel/activesupport/rack/did-you-mean).
           AP_PKGS_RE='^packages/(actionpack|actionview|activemodel|activesupport|rack|did-you-mean)/'
@@ -87,7 +91,7 @@ jobs:
           # trailties_affected gates trailties-tests. Trailties consumes
           # actionpack/actionview/activerecord/rack/activesupport, so any of
           # their workspace upstreams also flips this on.
-          TRAILTIES_PKGS_RE='^packages/(trailties|actionpack|actionview|activerecord|arel|activemodel|activesupport|globalid|rack|did-you-mean)/'
+          TRAILTIES_PKGS_RE='^packages/(trailties|actionpack|actionview|activerecord|arel|activemodel|activesupport|globalid|rack|did-you-mean|trails-tsc)/'
           # trails_tsc_affected gates the virtualized DX type tests, which
           # are activerecord's only consumer of @blazetrails/trails-tsc.
           TRAILS_TSC_PKGS_RE='^packages/trails-tsc/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,10 +96,7 @@ jobs:
           # are activerecord's only consumer of @blazetrails/trails-tsc.
           TRAILS_TSC_PKGS_RE='^packages/trails-tsc/'
           # tse_compiler_affected gates tse-compiler-tests. Own package +
-          # activesupport (its only workspace dep). Note: activesupport
-          # changes flip this on even when packages/tse-compiler is absent
-          # on the base ref — the job itself short-circuits in that case
-          # via the directory-presence check after checkout.
+          # activesupport (its only workspace dep).
           TSE_COMPILER_PKGS_RE='^packages/(tse-compiler|activesupport)/'
           force_all_affected() {
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
@@ -358,22 +355,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      # Package may not exist on the base ref yet; short-circuit before
-      # paying for pnpm setup + install. Remove this guard once #2190 lands.
-      - id: present
-        run: |
-          if [ -d packages/tse-compiler ]; then
-            echo "ok=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "ok=false" >> "$GITHUB_OUTPUT"
-            echo "packages/tse-compiler not present on this ref — skipping setup + tests"
-          fi
-      - if: steps.present.outputs.ok == 'true'
-        uses: ./.github/actions/setup-pnpm
-      - if: steps.present.outputs.ok == 'true'
-        run: pnpm install --frozen-lockfile
-      - if: steps.present.outputs.ok == 'true'
-        run: pnpm vitest run packages/tse-compiler
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm vitest run packages/tse-compiler
 
   sqlite-tests:
     name: SQLite Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,9 +77,9 @@ jobs:
           # here affects all packages: workspace topology, root tooling
           # config, shared scripts, this workflow, composite actions.
           INFRA_RE='^(pnpm-lock\.yaml$|pnpm-workspace\.yaml$|package\.json$|tsconfig[^/]*\.json$|vitest[^/]*\.config\.ts$|scripts/|\.github/workflows/ci\.yml$|\.github/actions/)'
-          AR_PKGS_RE='^packages/(activerecord|arel|activemodel|activesupport|globalid)/'
+          AR_PKGS_RE='^packages/(activerecord|arel|activemodel|activesupport|globalid|did-you-mean)/'
           # actionpack_affected gates actionpack-tests. True for actionpack +
-          # its runtime deps (actionview/activemodel/activesupport/rack).
+          # its runtime deps (actionview/activemodel/activesupport/rack/did-you-mean).
           AP_PKGS_RE='^packages/(actionpack|actionview|activemodel|activesupport|rack|did-you-mean)/'
           # actionview_affected gates actionview-tests. ActionView's only
           # workspace dependency is activesupport (see actionview/package.json).
@@ -352,17 +352,22 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-pnpm
-      - run: pnpm install --frozen-lockfile
-      # Package may not exist on the base ref yet; skip cleanly so the gate
-      # can land independent of the package PR.
-      - name: Run tse-compiler tests
+      # Package may not exist on the base ref yet; short-circuit before
+      # paying for pnpm setup + install. Remove this guard once #2190 lands.
+      - id: present
         run: |
           if [ -d packages/tse-compiler ]; then
-            pnpm vitest run packages/tse-compiler
+            echo "ok=true" >> "$GITHUB_OUTPUT"
           else
-            echo "packages/tse-compiler not present on this ref — skipping"
+            echo "ok=false" >> "$GITHUB_OUTPUT"
+            echo "packages/tse-compiler not present on this ref — skipping setup + tests"
           fi
+      - if: steps.present.outputs.ok == 'true'
+        uses: ./.github/actions/setup-pnpm
+      - if: steps.present.outputs.ok == 'true'
+        run: pnpm install --frozen-lockfile
+      - if: steps.present.outputs.ok == 'true'
+        run: pnpm vitest run packages/tse-compiler
 
   sqlite-tests:
     name: SQLite Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,17 +80,16 @@ jobs:
           AR_PKGS_RE='^packages/(activerecord|arel|activemodel|activesupport|globalid)/'
           # actionpack_affected gates actionpack-tests. True for actionpack +
           # its runtime deps (actionview/activemodel/activesupport/rack).
-          AP_PKGS_RE='^packages/(actionpack|actionview|activemodel|activesupport|rack)/'
-          # actionview_affected gates actionview-tests. True for actionview +
-          # its runtime deps (activemodel/activesupport/rack/html-sanitizer).
-          AV_PKGS_RE='^packages/(actionview|activemodel|activesupport|rack|html-sanitizer)/'
+          AP_PKGS_RE='^packages/(actionpack|actionview|activemodel|activesupport|rack|did-you-mean)/'
+          # actionview_affected gates actionview-tests. ActionView's only
+          # workspace dependency is activesupport (see actionview/package.json).
+          AV_PKGS_RE='^packages/(actionview|activesupport)/'
           # trailties_affected gates trailties-tests. Trailties consumes
-          # actionpack/actionview/activerecord, so any of their upstreams
-          # also flips this on.
-          TRAILTIES_PKGS_RE='^packages/(trailties|actionpack|actionview|activerecord|arel|activemodel|activesupport|globalid|rack|html-sanitizer)/'
-          # trails_tsc_affected gates the trails-tsc build/type check and the
-          # virtualized DX type tests (activerecord consumes trails-tsc as a
-          # dev/build dep for those tests).
+          # actionpack/actionview/activerecord/rack/activesupport, so any of
+          # their workspace upstreams also flips this on.
+          TRAILTIES_PKGS_RE='^packages/(trailties|actionpack|actionview|activerecord|arel|activemodel|activesupport|globalid|rack|did-you-mean)/'
+          # trails_tsc_affected gates the virtualized DX type tests, which
+          # are activerecord's only consumer of @blazetrails/trails-tsc.
           TRAILS_TSC_PKGS_RE='^packages/trails-tsc/'
           # tse_compiler_affected gates tse-compiler-tests. Only depends on
           # activesupport today. The package may not exist on the base ref

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
       docs_only: ${{ steps.filter.outputs.docs_only }}
       activerecord_affected: ${{ steps.filter.outputs.activerecord_affected }}
       actionpack_affected: ${{ steps.filter.outputs.actionpack_affected }}
+      actionview_affected: ${{ steps.filter.outputs.actionview_affected }}
+      trailties_affected: ${{ steps.filter.outputs.trailties_affected }}
+      trails_tsc_affected: ${{ steps.filter.outputs.trails_tsc_affected }}
+      tse_compiler_affected: ${{ steps.filter.outputs.tse_compiler_affected }}
       parity_sqlite: ${{ steps.filter.outputs.parity_sqlite }}
       parity_postgres: ${{ steps.filter.outputs.parity_postgres }}
       parity_mysql: ${{ steps.filter.outputs.parity_mysql }}
@@ -77,10 +81,32 @@ jobs:
           # actionpack_affected gates actionpack-tests. True for actionpack +
           # its runtime deps (actionview/activemodel/activesupport/rack).
           AP_PKGS_RE='^packages/(actionpack|actionview|activemodel|activesupport|rack)/'
+          # actionview_affected gates actionview-tests. True for actionview +
+          # its runtime deps (activemodel/activesupport/rack/html-sanitizer).
+          AV_PKGS_RE='^packages/(actionview|activemodel|activesupport|rack|html-sanitizer)/'
+          # trailties_affected gates trailties-tests. Trailties consumes
+          # actionpack/actionview/activerecord, so any of their upstreams
+          # also flips this on.
+          TRAILTIES_PKGS_RE='^packages/(trailties|actionpack|actionview|activerecord|arel|activemodel|activesupport|globalid|rack|html-sanitizer)/'
+          # trails_tsc_affected gates the trails-tsc build/type check and the
+          # virtualized DX type tests (activerecord consumes trails-tsc as a
+          # dev/build dep for those tests).
+          TRAILS_TSC_PKGS_RE='^packages/trails-tsc/'
+          # tse_compiler_affected gates tse-compiler-tests. Only depends on
+          # activesupport today. The package may not exist on the base ref
+          # yet — when absent, the gate is simply never tripped by paths.
+          TSE_COMPILER_PKGS_RE='^packages/(tse-compiler|activesupport)/'
+          force_all_affected() {
+            echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
+            echo "actionpack_affected=true"   >> "$GITHUB_OUTPUT"
+            echo "actionview_affected=true"   >> "$GITHUB_OUTPUT"
+            echo "trailties_affected=true"    >> "$GITHUB_OUTPUT"
+            echo "trails_tsc_affected=true"   >> "$GITHUB_OUTPUT"
+            echo "tse_compiler_affected=true" >> "$GITHUB_OUTPUT"
+          }
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
-            echo "actionpack_affected=true" >> "$GITHUB_OUTPUT"
+            force_all_affected
           # Triple-dot: diff against the merge-base of $base and $head, not
           # against the current tip of the base branch. Using `$base $head`
           # would also include every commit merged to main since this branch
@@ -89,8 +115,7 @@ jobs:
           elif ! files=$(git diff --name-only "$base"..."$head" 2>/dev/null); then
             echo "git diff failed (base may be unreachable after force-push) — running full matrix"
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
-            echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
-            echo "actionpack_affected=true" >> "$GITHUB_OUTPUT"
+            force_all_affected
           else
             echo "Changed files:"
             echo "$files"
@@ -108,24 +133,31 @@ jobs:
             # On push to main / schedule / workflow_dispatch always run everything.
             case "${{ github.event_name }}" in
               push|schedule|workflow_dispatch)
-                echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
-                echo "actionpack_affected=true" >> "$GITHUB_OUTPUT"
+                force_all_affected
                 ;;
               *)
                 if [ -z "$files" ]; then
                   echo "activerecord_affected=false" >> "$GITHUB_OUTPUT"
-                  echo "actionpack_affected=false" >> "$GITHUB_OUTPUT"
+                  echo "actionpack_affected=false"   >> "$GITHUB_OUTPUT"
+                  echo "actionview_affected=false"   >> "$GITHUB_OUTPUT"
+                  echo "trailties_affected=false"    >> "$GITHUB_OUTPUT"
+                  echo "trails_tsc_affected=false"   >> "$GITHUB_OUTPUT"
+                  echo "tse_compiler_affected=false" >> "$GITHUB_OUTPUT"
                 else
-                  if echo "$files" | grep -qE "$INFRA_RE|$AR_PKGS_RE"; then
-                    echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "activerecord_affected=false" >> "$GITHUB_OUTPUT"
-                  fi
-                  if echo "$files" | grep -qE "$INFRA_RE|$AP_PKGS_RE"; then
-                    echo "actionpack_affected=true" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "actionpack_affected=false" >> "$GITHUB_OUTPUT"
-                  fi
+                  set_gate() {
+                    local name="$1" re="$2"
+                    if echo "$files" | grep -qE "$INFRA_RE|$re"; then
+                      echo "${name}=true"  >> "$GITHUB_OUTPUT"
+                    else
+                      echo "${name}=false" >> "$GITHUB_OUTPUT"
+                    fi
+                  }
+                  set_gate activerecord_affected "$AR_PKGS_RE"
+                  set_gate actionpack_affected   "$AP_PKGS_RE"
+                  set_gate actionview_affected   "$AV_PKGS_RE"
+                  set_gate trailties_affected    "$TRAILTIES_PKGS_RE"
+                  set_gate trails_tsc_affected   "$TRAILS_TSC_PKGS_RE"
+                  set_gate tse_compiler_affected "$TSE_COMPILER_PKGS_RE"
                 fi
                 ;;
             esac
@@ -227,7 +259,10 @@ jobs:
   virtualized-dx-type-tests:
     name: Virtualized DX Type Tests
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      (needs.changes.outputs.activerecord_affected == 'true' ||
+       needs.changes.outputs.trails_tsc_affected == 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -264,7 +299,6 @@ jobs:
           packages/activemodel
           packages/activesupport
           packages/rack
-          packages/trailties
           scripts/guides-typecheck
 
   actionpack-tests:
@@ -284,7 +318,9 @@ jobs:
   actionview-tests:
     name: Action View Tests
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.actionview_affected == 'true'
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -292,6 +328,42 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm vitest run packages/actionview
+
+  trailties-tests:
+    name: Trailties Tests
+    needs: changes
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.trailties_affected == 'true'
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm vitest run packages/trailties
+
+  tse-compiler-tests:
+    name: TSE Compiler Tests
+    needs: changes
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.tse_compiler_affected == 'true'
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm install --frozen-lockfile
+      # Package may not exist on the base ref yet; skip cleanly so the gate
+      # can land independent of the package PR.
+      - name: Run tse-compiler tests
+        run: |
+          if [ -d packages/tse-compiler ]; then
+            pnpm vitest run packages/tse-compiler
+          else
+            echo "packages/tse-compiler not present on this ref — skipping"
+          fi
 
   sqlite-tests:
     name: SQLite Tests
@@ -735,6 +807,8 @@ jobs:
       - unit-tests
       - actionpack-tests
       - actionview-tests
+      - trailties-tests
+      - tse-compiler-tests
       - sqlite-tests
       - postgres-tests
       - mariadb-tests
@@ -757,6 +831,10 @@ jobs:
           DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
           AR_AFFECTED: ${{ needs.changes.outputs.activerecord_affected }}
           AP_AFFECTED: ${{ needs.changes.outputs.actionpack_affected }}
+          AV_AFFECTED: ${{ needs.changes.outputs.actionview_affected }}
+          TRAILTIES_AFFECTED: ${{ needs.changes.outputs.trailties_affected }}
+          TRAILS_TSC_AFFECTED: ${{ needs.changes.outputs.trails_tsc_affected }}
+          TSE_COMPILER_AFFECTED: ${{ needs.changes.outputs.tse_compiler_affected }}
           PARITY_SQLITE: ${{ needs.changes.outputs.parity_sqlite }}
           PARITY_POSTGRES: ${{ needs.changes.outputs.parity_postgres }}
           PARITY_MYSQL: ${{ needs.changes.outputs.parity_mysql }}
@@ -794,13 +872,28 @@ jobs:
                   # Actionpack test skip is legitimate when no actionpack-affecting paths changed.
                   [ "$AP_AFFECTED" = "false" ] && continue
                   ;;
+                actionview-tests)
+                  [ "$AV_AFFECTED" = "false" ] && continue
+                  ;;
+                trailties-tests)
+                  [ "$TRAILTIES_AFFECTED" = "false" ] && continue
+                  ;;
+                tse-compiler-tests)
+                  [ "$TSE_COMPILER_AFFECTED" = "false" ] && continue
+                  ;;
+                virtualized-dx-type-tests)
+                  # Legitimate skip when neither activerecord nor trails-tsc paths changed.
+                  if [ "$AR_AFFECTED" = "false" ] && [ "$TRAILS_TSC_AFFECTED" = "false" ]; then
+                    continue
+                  fi
+                  ;;
                 schema-parity-rails|schema-parity-trails|schema-parity-diff|\
                 query-parity-frozen-at|query-parity-rails|query-parity-trails|query-parity-diff)
                   # Parity skip is legitimate when no parity gate is on.
                   [ "$any_parity" = "false" ] && continue
                   ;;
               esac
-              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL)"
+              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL)"
               unexpected=1
             done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
           fi


### PR DESCRIPTION
## Summary

Tightens CI path-filtering so a PR touching only `packages/trailties`, `packages/trails-tsc`, or `packages/tse-compiler` runs only the relevant test job plus genuine downstream dependents — instead of dragging the actionview + trailties + virtualized DX suites along on every PR.

- Splits `trailties` out of the always-on `unit-tests` job into a gated `Trailties Tests` job.
- Adds a `TSE Compiler Tests` job (sibling to `Action View Tests` etc.) gated on `tse_compiler_affected`.
- Gates `Action View Tests` on `actionview_affected` (was always-on).
- Gates `Virtualized DX Type Tests` on `activerecord_affected || trails_tsc_affected`.
- Adds path-filter outputs for `trailties_affected`, `trails_tsc_affected`, `tse_compiler_affected`, `actionview_affected`. Refactors the AR/AP gate-setting into a shared `set_gate` shell helper and a `force_all_affected` helper.
- Updates the aggregate `CI` job's skip allow-list and `needs:` set.

## Dependency map (own + workspace upstreams that trip the gate)

| Package | Gate inputs | Downstream jobs that also re-run |
|---|---|---|
| `actionview` (new gate) | `actionview` + `activesupport` | `actionpack-tests`, `trailties-tests` |
| `actionpack` (existing) | `actionpack` + `actionview` + `activemodel` + `activesupport` + `rack` + `did-you-mean` | `trailties-tests` |
| `activerecord` (existing, expanded) | `activerecord` + `arel` + `activemodel` + `activesupport` + `globalid` + `did-you-mean` + `trails-tsc` | `trailties-tests`, `virtualized-dx-type-tests` |
| `trailties` | `trailties` + `actionpack` + `actionview` + `activerecord` + `arel` + `activemodel` + `activesupport` + `globalid` + `rack` + `did-you-mean` + `trails-tsc` | (none — leaf) |
| `trails-tsc` | `trails-tsc` only | AR DB suites (AR's `tsc-wrapper/` + `type-virtualization/` import it at runtime), `virtualized-dx-type-tests`, `trailties-tests` |
| `tse-compiler` | `tse-compiler` only (no workspace deps) | (future: actionview TSE handler — wire when it lands) |

The shared `INFRA_RE` (lockfile, root tsconfig, vitest config, shared scripts, this workflow, composite actions) still forces every gate true.

`AV_PKGS_RE` intentionally only matches `actionview|activesupport`: `packages/actionview/package.json` declares no other workspace dependency. `activemodel`/`rack`/`did-you-mean` are pulled in by `actionpack`, not `actionview`, and are already covered by `AP_PKGS_RE`.

## Verification (regex simulated against representative diffs)

```
only trailties        → trailties=true (rest false)
only trails-tsc       → trails_tsc=true, ar=true (AR consumes trails-tsc), trailties=true
only tse-compiler     → tse_compiler=true (rest false)
only activerecord     → ar=true, trailties=true
only actionview       → ap=true, av=true, trailties=true
only activesupport    → ar=true, ap=true, av=true, trailties=true
only did-you-mean     → ar=true, ap=true, trailties=true
only html-sanitizer   → no gate trips (no workspace consumer today)
pnpm-lock.yaml        → every gate true (INFRA_RE force)
docs/foo.md           → handled by docs_only short-circuit; no gates trip
```

## Test plan

- [ ] PR touching only `packages/tse-compiler/src/lexer.ts` → `tse-compiler-tests` runs; `trailties-tests`, `actionview-tests`, AR tests all skipped.
- [ ] PR touching only `packages/trailties/src/paths.ts` → `trailties-tests` runs; `actionview-tests`, AR tests, `tse-compiler-tests` skipped.
- [ ] PR touching only `packages/trails-tsc/src/host.ts` → AR DB suites + `virtualized-dx-type-tests` + `trailties-tests` all run (AR depends on trails-tsc at runtime); `actionview-tests`, `tse-compiler-tests` skipped.
- [ ] PR touching `packages/activerecord/src/foo.ts` → AR tests + `trailties-tests` + `virtualized-dx-type-tests` all run.
- [ ] PR touching `pnpm-lock.yaml` only → every gate forces true (INFRA_RE).
- [ ] Push to `main` / `schedule` / `workflow_dispatch` → every gate true via `force_all_affected`.
- [ ] Aggregate `CI` job passes with the new skip allow-list entries (no "Unexpectedly skipped" lines).

## Follow-up

- When the actionview TSE handler wires in `@blazetrails/tse-compiler`, add `tse-compiler` to `AV_PKGS_RE` so `actionview-tests` re-run on tse-compiler changes.

