### PR TITLE
fix(activerecord): use binary column for encrypted binary fixtures on PG (Phase 9b-2d)

### DIFF
--- a/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-message-pack-serialized.test.ts
@@ -8,7 +8,7 @@ import {
   makeMsgPackTextBook,
   assertEncryptedAttribute,
 } from "./test-helpers.js";
-import { type TestDatabaseAdapter, adapterType } from "../test-adapter.js";
+import { type TestDatabaseAdapter } from "../test-adapter.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { Encoding as EncodingError } from "./errors.js";
 
@@ -31,34 +31,23 @@ describe("ActiveRecord::Encryption::EncryptableRecordMessagePackSerializedTest",
     restoreEncryptionConfig(configSnapshot);
   });
 
-  // Phase 9b-2d: PG bytea round-trip of encrypted binary attributes is still
-  // broken after the bind-path fix in this PR. Write completes; reload's
-  // decrypt fails at `JSON.parse` on the Latin-1-decoded bytes — bytes
-  // stored ≠ bytes sent. Needs reproduction against a live PG instance to
-  // diagnose. Tracked as the remaining Phase 9b-2 follow-up.
-  it.skipIf(adapterType === "postgres")(
-    "binary data can be serialized with message pack",
-    async () => {
-      const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
-      const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
-      const book = await Book.create({ logo: allBytes });
-      await assertEncryptedAttribute(book, "logo", allBytes);
-    },
-  );
+  it("binary data can be serialized with message pack", async () => {
+    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
+    const allBytes = Uint8Array.from({ length: 256 }, (_, i) => i);
+    const book = await Book.create({ logo: allBytes });
+    await assertEncryptedAttribute(book, "logo", allBytes);
+  });
 
-  it.skipIf(adapterType === "postgres")(
-    "binary data can be encrypted uncompressed and serialized with message pack",
-    async () => {
-      const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
-      // Rails: both ranges are 128 bytes (< 140 threshold) so neither is compressed.
-      // TS note: highBytes (128–255) encoded as Latin-1 measures as 256 UTF-8 bytes so
-      // it may be compressed; the round-trip is correct either way.
-      const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
-      const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
-      await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
-      await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
-    },
-  );
+  it("binary data can be encrypted uncompressed and serialized with message pack", async () => {
+    const Book = makeEncryptedBookWithBinaryMessagePackSerialized(adapter);
+    // Rails: both ranges are 128 bytes (< 140 threshold) so neither is compressed.
+    // TS note: highBytes (128–255) encoded as Latin-1 measures as 256 UTF-8 bytes so
+    // it may be compressed; the round-trip is correct either way.
+    const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
+    const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);
+    await assertEncryptedAttribute(await Book.create({ logo: lowBytes }), "logo", lowBytes);
+    await assertEncryptedAttribute(await Book.create({ logo: highBytes }), "logo", highBytes);
+  });
 
   it("text columns cannot be serialized with message pack", async () => {
     const MsgPackTextBook = makeMsgPackTextBook(adapter);

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -31,7 +31,6 @@ import { Configurable } from "./configurable.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { EncryptableRecord } from "./encryptable-record.js";
 import { isEncryptedAttribute } from "../encryption.js";
-import { adapterType } from "../test-adapter.js";
 
 describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
@@ -593,14 +592,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     expect((await Book.create({ logo: null })).logo).toBeNull();
     expect((await Book.create({ logo: new Uint8Array(0) })).logo).toEqual(new Uint8Array(0));
   });
-  // Phase 9b-2d: PG bytea round-trip of encrypted binary attributes is still
-  // broken even after routing the bind path through `_bindForPg` (BinaryData
-  // → Buffer for node-postgres). Write completes; reload's decrypt fails at
-  // `JSON.parse` on the Latin-1-decoded bytes from PG, meaning the bytes
-  // stored ≠ bytes sent. Needs reproduction against a live PG instance to
-  // diagnose (suspect pg-node param encoding for bytea). Tracked as the
-  // remaining Phase 9b-2 follow-up.
-  it.skipIf(adapterType === "postgres")("binary data can be encrypted uncompressed", async () => {
+  it("binary data can be encrypted uncompressed", async () => {
     const Book = makeEncryptedBookWithBinary(await freshAdapter());
     const lowBytes = Uint8Array.from({ length: 128 }, (_, i) => i);
     const highBytes = Uint8Array.from({ length: 128 }, (_, i) => i + 128);

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -166,15 +166,14 @@ const ENCRYPTION_SCHEMA: Schema = {
   encrypted_book_with_custom_compressors: { name: { type: "string", limit: 1024 } },
   book_that_will_fail_to_encrypt_names: { name: { type: "string", limit: 1024 } },
   encrypted_traffic_light_with_store_states: { state: "text" },
-  // Encrypted binary payloads (ciphertext + IV + auth tag, JSON-wrapped and
-  // base64-encoded) exceed VARCHAR(255) — defineSchema maps `binary` →
-  // VARCHAR on MySQL, which truncates. Rails' fixture schema uses a single
-  // shared `encrypted_books` table with `t.binary :logo` (= BLOB on MySQL);
-  // we approximate with `text` to give MariaDB enough room.
-  encrypted_book_with_binaries: { logo: "text" },
+  // Mirrors Rails' `t.binary :logo` on `encrypted_books`. Maps to BYTEA on
+  // PG and BLOB on MySQL/SQLite via defineSchema's `binary` mapping. A TEXT
+  // column does not round-trip on PG: BinaryData-wrapped ciphertext binds
+  // as bytea and pg stores the `\x{hex}` literal in the TEXT column.
+  encrypted_book_with_binaries: { logo: "binary" },
   encrypted_book_with_serialized_first_binaries: { logo: "text" },
   encrypted_book_with_serialized_second_binaries: { logo: "text" },
-  encrypted_book_with_binary_message_pack_serializeds: { logo: "text" },
+  encrypted_book_with_binary_message_pack_serializeds: { logo: "binary" },
 };
 
 export async function installEncryptionSchema(adapter: DatabaseAdapter): Promise<void> {

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -186,7 +186,9 @@ const PG_ONLY_TYPES = new Set<string>(["citext", "hstore", "uuid", "interval", "
 
 // MySQL/MariaDB accepts native DATETIME columns with "YYYY-MM-DD HH:MM:SS" format
 // (no T/Z suffix). AR DateTime.serialize now emits this format, so datetime can
-// use the native column type. date/time/binary/json still use "string" (VARCHAR).
+// use the native column type. date/time/json still use "string" (VARCHAR);
+// `binary` routes through the native BLOB mapping so encrypted binary
+// attributes round-trip (BinaryData-wrapped ciphertext needs a binary column).
 // PG-only types are deliberately absent: defineSchema throws when one is used
 // against MySQL or SQLite.
 /** @internal */
@@ -201,7 +203,7 @@ const COLUMN_TYPE_MAP_MYSQL: Record<PrimitiveColumnSpec, string> = {
   datetime: "datetime",
   date: "string",
   time: "string",
-  binary: "string",
+  binary: "binary",
   json: "string",
 };
 

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -207,7 +207,8 @@ const COLUMN_TYPE_MAP_MYSQL: Record<PrimitiveColumnSpec, string> = {
   json: "string",
 };
 
-// SQLite stores temporal and binary types as TEXT.
+// SQLite stores temporal types as TEXT; `binary` routes through the native
+// BLOB mapping (inherited from MYSQL) so encrypted binary attributes round-trip.
 /** @internal */
 const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
   ...COLUMN_TYPE_MAP_MYSQL,


### PR DESCRIPTION
## Summary

Phase 9b-2d follow-up — closes the 3 encryption binary tests still skipped on PG after #2179.

Diagnosis (live PG): the bytea bind-path infra shipped in #2179 is correct. The actual gap was the **fixture schema**: `encrypted_book_with_binaries` and `encrypted_book_with_binary_message_pack_serializeds` declared `logo: \"text\"` to dodge a stale MySQL VARCHAR-truncation note. On PG, EncryptedAttributeType with a binary cast type wraps the ciphertext string in `BinaryData`; `_bindForPg` correctly unwraps to a Buffer, but pg then sends a bytea hex literal that PG inserts verbatim into the TEXT column (`\\x7b22...`). Reload returns that hex string instead of the original JSON ciphertext, so `JSON.parse` throws.

## Fix

- Switch the two truly-binary fixtures to `logo: \"binary\"` — mirrors Rails' `t.binary :logo` on `encrypted_books`. Maps to BYTEA on PG and BLOB on MySQL/SQLite.
- Fix the stale `defineSchema` mapping so `binary` resolves to the native BLOB column on MySQL/SQLite (`NATIVE_DATABASE_TYPES` already maps `binary → blob` on both adapters) instead of being downgraded to VARCHAR.
- The two serialized-binary fixtures keep TEXT columns because their AR attribute is `string`, not binary — their ciphertext is a plain string and TEXT is correct.
- Remove the 3 `it.skipIf(adapterType === \"postgres\")` markers added by #2179 and their `adapterType` imports.

No changes to the `_bindForPg` infra — it's load-bearing for the BYTEA case and stays intact.

## Test plan

- [x] `PG_TEST_URL=… pnpm exec vitest run packages/activerecord/src/encryption/ --no-file-parallelism` — 289 pass, 1 unrelated skip (the 3 PG-skipped tests are gone)
- [x] `pnpm exec vitest run packages/activerecord/src/encryption/` (SQLite) — 289 pass, 1 unrelated skip
- [x] `pnpm api:compare` — 4955/4958 (unchanged)
- [ ] MariaDB clean via CI