### PR TITLE
fix(activerecord): use native datetime/date/time/json columns on SQLite (Phase 9b-2e)

### DIFF
--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -211,7 +211,7 @@ const COLUMN_TYPE_MAP_MYSQL: Record<PrimitiveColumnSpec, string> = {
 // type names — they store as TEXT/BLOB under the hood while preserving the
 // declared type for schema reflection (so the type registry resolves to
 // SQLiteDateTimeType/DateType/TimeType/JsonType on load). `binary` inherits
-// from MYSQL (BLOB).
+// from `COLUMN_TYPE_MAP_MYSQL` (BLOB).
 /** @internal */
 const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
   ...COLUMN_TYPE_MAP_MYSQL,

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -207,12 +207,18 @@ const COLUMN_TYPE_MAP_MYSQL: Record<PrimitiveColumnSpec, string> = {
   json: "string",
 };
 
-// SQLite stores temporal types as TEXT; `binary` routes through the native
-// BLOB mapping (inherited from MYSQL) so encrypted binary attributes round-trip.
+// SQLite has type affinity rules but accepts native datetime/date/time/json
+// type names — they store as TEXT/BLOB under the hood while preserving the
+// declared type for schema reflection (so the type registry resolves to
+// SQLiteDateTimeType/DateType/TimeType/JsonType on load). `binary` inherits
+// from MYSQL (BLOB).
 /** @internal */
 const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
   ...COLUMN_TYPE_MAP_MYSQL,
-  datetime: "string",
+  datetime: "datetime",
+  date: "date",
+  time: "time",
+  json: "json",
 };
 
 /**


### PR DESCRIPTION
## Summary

Phase 9b-2e follow-up to #2197. `defineSchema` downgraded `date`/`time`/`datetime`/`json` to VARCHAR on SQLite even though SQLite has native type names for all four — that downgrade was masking what could be real serialize bugs by storing everything as strings.

SQLite has type affinity (not strict types), so the native column names store as TEXT/BLOB under the hood while preserving the declared type for schema reflection. The type registry then resolves the column to `SQLiteDateTimeType` / `DateType` / `TimeType` / `JsonType` on load — matching the AR attribute type the model already declares.

## Diagnostic

Mirrored the loop from #2197:
1. Flip the mapping
2. Run targeted SQLite suites
3. Check for breakage

No breakage. Targeted tests all pass:

- `dirty` (90)
- `persistence` (389)
- `serialization` (16)
- `relations` (682)
- `calculations` (546)
- `attributes` (55)
- `attribute-methods` (185)
- `type/*`
- `type-virtualization/virtualize` (64)
- `adapters/sqlite3/json` (2)
- `connection-adapters/sqlite3/schema-statements` (41)

## Deferred (follow-ups)

MySQL `date` / `time` / `json` downgrades. Each is plausibly fixable:

- `date` — Rails' `Date#to_s` produces `"YYYY-MM-DD"` which MySQL DATE accepts.
- `time` — Rails' `Time#to_s` likewise produces a MySQL-compatible literal.
- `json` — `Json.serialize` is `JSON.stringify`; MySQL's JSON column validates input on INSERT.

Each needs the same diagnostic loop as #2197 against live MySQL/MariaDB to confirm and to surface any real serialize bugs hidden by the VARCHAR fallback. Skipped in this PR because the worktree didn't have a clean live MySQL fixture DB available.

PG mappings are already native; not touched. `binary`/`string`/`text`/`integer`/`big_integer`/`float`/`decimal`/`boolean` mappings unchanged.

## Test plan

- [x] Targeted SQLite suites listed above pass locally
- [ ] CI green across all adapters