### PR TITLE
refactor(activerecord): relocate test-helper concerns out of test-adapter.ts

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -21,6 +21,11 @@ import { inspectExplainOption } from "./adapter.js";
 import type { AdapterName, DatabaseAdapter, ExplainOption } from "./adapter.js";
 import type { SchemaCache } from "./connection-adapters/schema-cache.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import {
+  clearDdlTrackers,
+  getCreatedTables,
+  recordDdlTracking,
+} from "./test-helpers/ddl-tracker.js";
 import { Base } from "./base.js";
 import { Visitors } from "@blazetrails/arel";
 import { DatabaseStatements } from "./connection-adapters/abstract/database-statements.js";
@@ -42,13 +47,6 @@ export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL
 
 let _sharedAdapter: any = null;
 
-// Schema tracking — what tables/columns have been created. Maintained
-// passively by `recordDdlTracking` after successful CREATE/DROP TABLE,
-// and consumed by `defineSchema`'s cache-invalidation logic
-// (`adapterKnownTables` in test-helpers/define-schema.ts).
-const _createdTables = new Set<string>();
-const _createdColumns = new Map<string, Set<string>>();
-
 // Async-chain visibility flag for `currentTransaction()` / `inTransaction` /
 // `openTransactions` on the wrapper. Set while a `withinNewTransaction` body
 // is executing on this chain so callers in OUR chain see the inner adapter's
@@ -66,225 +64,6 @@ function _txLockStorage(): AsyncContext<true> {
     _txLockHeldAdapter = asyncContext;
   }
   return _txLockHeld;
-}
-
-// Refcount of active `withTransactionalFixtures` scopes. When > 0, the
-// global beforeEach in test-setup-ar.ts skips resetTestAdapterState() so a
-// one-time schema set up in `beforeAll` survives across tests in the file.
-// Refcounted (not a bool) so nested describes / multiple suites that each
-// call withTransactionalFixtures don't clobber an outer scope's skip when
-// an inner scope's afterAll runs. Mirrors Rails ConnectionPool's
-// `@pinned_connections_depth` (connection_pool.rb:327, 345).
-let _skipGlobalResetDepth = 0;
-
-/**
- * Snapshot the global DDL trackers so a wrapping `withTransactionalFixtures`
- * scope can restore them after the outer transaction rolls back. DDL parsed
- * during an `it()` body adds entries to `_createdTables` / `_createdColumns`
- * (via `recordDdlTracking`); the rollback reverts the DDL on the DB side, but
- * the trackers would otherwise report the rolled-back table as still-created.
- *
- * Today this is harmless because `defineSchema` consults its signature cache
- * first (which is snapshot/restored via `_snapshotAppliedSchemaSignaturesForAdapter`).
- * But a future test pattern — `defineSchema` in `beforeAll` plus raw
- * `createTable` inside an `it()` body — would leak. Snapshot/restore plugs
- * that gap before it surfaces.
- *
- * @internal
- */
-export function _snapshotDdlTrackers(): {
-  tables: Set<string>;
-  columns: Map<string, Set<string>>;
-} {
-  const columns = new Map<string, Set<string>>();
-  for (const [k, v] of _createdColumns) columns.set(k, new Set(v));
-  return { tables: new Set(_createdTables), columns };
-}
-
-/** @internal */
-export function _restoreDdlTrackers(snapshot: {
-  tables: Set<string>;
-  columns: Map<string, Set<string>>;
-}): void {
-  _createdTables.clear();
-  for (const t of snapshot.tables) _createdTables.add(t);
-  _createdColumns.clear();
-  for (const [k, v] of snapshot.columns) _createdColumns.set(k, new Set(v));
-}
-
-/** @internal */
-export function pushSkipGlobalReset(): void {
-  _skipGlobalResetDepth += 1;
-}
-
-/** @internal */
-export function popSkipGlobalReset(): number {
-  if (_skipGlobalResetDepth > 0) _skipGlobalResetDepth -= 1;
-  return _skipGlobalResetDepth;
-}
-
-/** @internal */
-export function shouldSkipGlobalReset(): boolean {
-  return _skipGlobalResetDepth > 0;
-}
-
-// Per-adapter opt-out for the Phase 6.3 global BEGIN/ROLLBACK wrap.
-// Mirrors Rails' `self.use_transactional_tests = false` (per-test-class
-// in Rails; per-adapter here since adapters are the per-test-file unit
-// in trails). Written by `defineSchema(..., { useTransactionalTests })`,
-// read by the global `beforeEach` in `test-setup-ar.ts` (B6.3) and by
-// any future helper that needs to know whether transactional fixtures
-// are active. A WeakMap keeps the flag off the adapter's public surface
-// (it's purely a test concern) and avoids leaking adapters across
-// test files.
-const _useTransactionalTests = new WeakMap<object, boolean>();
-
-/** @internal */
-export function setUseTransactionalTests(adapter: object, value: boolean): void {
-  _useTransactionalTests.set(adapter, value);
-}
-
-/**
- * Read the per-adapter opt-out for transactional fixtures. Defaults to
- * `true` when the adapter has never been seen — the Phase 6.3 wrap is
- * on-by-default, and `defineSchema` always records an explicit value
- * before any DDL runs, so an unseen adapter means the file never called
- * `defineSchema` (e.g. test-helper unit tests) and the wrap is harmless.
- *
- * @internal
- */
-export function getUseTransactionalTests(adapter: object): boolean {
-  return _useTransactionalTests.get(adapter) ?? true;
-}
-
-/**
- * Extract the top-level column names from a `CREATE TABLE ... (...)` body.
- * Used to seed `_createdColumns` so `defineSchema`'s cache-invalidation
- * logic has accurate per-table column sets.
- *
- * Tracks paren depth so a nested type like `DECIMAL(10,2)` doesn't count
- * as a top-level comma; identifiers may be quoted with `"`, `` ` ``, or
- * unquoted. Skips quoted SQL literals so a default like `DEFAULT ')'`
- * doesn't close the column list. Returns `Set(["id"])` if no body is found.
- *
- * @internal exported for unit testing.
- */
-export function parseCreateTableColumns(sql: string): Set<string> {
-  const m = sql.match(/CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+["`]?\w+["`]?\s*\(/i);
-  if (!m) return new Set(["id"]);
-  const start = m.index! + m[0].length;
-
-  // Walk the body tracking paren depth, but skip over quoted literals so a
-  // `DEFAULT ')'` in a column definition doesn't close the column list.
-  // Supports single-quoted SQL strings (with `''` escape), double/backtick-
-  // quoted identifiers (which may legitimately contain parens), and MySQL's
-  // `\)` escape inside single-quoted strings.
-  const skipQuoted = (i: number, quote: string): number => {
-    i++;
-    while (i < sql.length) {
-      const ch = sql[i];
-      if (quote === "'" && ch === "\\" && i + 1 < sql.length) {
-        i += 2;
-        continue;
-      }
-      if (ch === quote) {
-        if (quote === "'" && sql[i + 1] === "'") {
-          i += 2;
-          continue;
-        }
-        return i + 1;
-      }
-      i++;
-    }
-    return i;
-  };
-
-  let depth = 1;
-  let end = -1;
-  let i = start;
-  while (i < sql.length) {
-    const ch = sql[i];
-    if (ch === "'" || ch === '"' || ch === "`") {
-      i = skipQuoted(i, ch);
-      continue;
-    }
-    if (ch === "(") depth++;
-    else if (ch === ")") {
-      depth--;
-      if (depth === 0) {
-        end = i;
-        break;
-      }
-    }
-    i++;
-  }
-  if (end < 0) return new Set(["id"]);
-
-  const cols = new Set<string>();
-  const body = sql.slice(start, end);
-  let part = "";
-  let pd = 0;
-  const flush = () => {
-    const piece = part.trim();
-    part = "";
-    if (!piece) return;
-    // Skip table-level constraints: PRIMARY KEY (...), FOREIGN KEY, UNIQUE, INDEX, KEY, CHECK, CONSTRAINT.
-    if (/^(PRIMARY\s+KEY|FOREIGN\s+KEY|UNIQUE\b|INDEX\b|KEY\b|CHECK\b|CONSTRAINT\b)/i.test(piece))
-      return;
-    const colMatch = piece.match(/^(?:["`](\w+)["`]|(\w+))/);
-    if (colMatch) cols.add(colMatch[1] ?? colMatch[2]);
-  };
-  let j = 0;
-  while (j < body.length) {
-    const ch = body[j];
-    if (ch === "'" || ch === '"' || ch === "`") {
-      const next = skipQuoted(start + j, ch) - start;
-      part += body.slice(j, next);
-      j = next;
-      continue;
-    }
-    if (ch === "(") pd++;
-    else if (ch === ")") pd--;
-    if (ch === "," && pd === 0) {
-      flush();
-      j++;
-      continue;
-    }
-    part += ch;
-    j++;
-  }
-  flush();
-  if (cols.size === 0) cols.add("id");
-  return cols;
-}
-
-/**
- * Update `_createdTables`/`_createdColumns` after a CREATE TABLE or DROP TABLE
- * has successfully executed. For CREATE: when the table was already tracked,
- * the CREATE was likely `IF NOT EXISTS` against a pre-existing table whose
- * real column set may differ from the SQL we're parsing — fall back to
- * `{id}` rather than recording columns that might not exist.
- *
- * @internal
- */
-function recordDdlTracking(
-  sql: string,
-  createMatch: RegExpMatchArray | null,
-  dropMatch: RegExpMatchArray | null,
-): void {
-  if (createMatch) {
-    const table = createMatch[1] ?? createMatch[2];
-    const wasTracked = _createdTables.has(table);
-    _createdTables.add(table);
-    if (!_createdColumns.has(table)) {
-      _createdColumns.set(table, wasTracked ? new Set(["id"]) : parseCreateTableColumns(sql));
-    }
-  }
-  if (dropMatch) {
-    const table = dropMatch[1] ?? dropMatch[2];
-    _createdTables.delete(table);
-    _createdColumns.delete(table);
-  }
 }
 
 let _factory: () => TestAdapterFixtures;
@@ -370,8 +149,7 @@ export async function resetTestAdapterState(): Promise<void> {
     await dropAllTables(_sharedAdapter);
     _sharedAdapter.schemaCache?.clear();
   }
-  _createdTables.clear();
-  _createdColumns.clear();
+  clearDdlTrackers();
   Base._modelsByName.clear();
 }
 
@@ -485,7 +263,7 @@ class TestAdapterFixtures implements DatabaseAdapter {
 
   /** Expose created tables for test introspection. */
   get tables(): Set<string> {
-    return _createdTables;
+    return getCreatedTables();
   }
 
   async execute(sql: string, binds?: unknown[], name?: string): Promise<Record<string, unknown>[]> {

--- a/packages/activerecord/src/test-helpers/ddl-tracker.test.ts
+++ b/packages/activerecord/src/test-helpers/ddl-tracker.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseCreateTableColumns } from "./test-adapter.js";
+import { parseCreateTableColumns } from "./ddl-tracker.js";
 
 describe("parseCreateTableColumns", () => {
   it("extracts simple columns from a MySQL CREATE TABLE", () => {

--- a/packages/activerecord/src/test-helpers/ddl-tracker.ts
+++ b/packages/activerecord/src/test-helpers/ddl-tracker.ts
@@ -1,0 +1,190 @@
+/**
+ * Module-level DDL tracking for the shared test adapter.
+ *
+ * Maintained passively by {@link recordDdlTracking} after a successful
+ * CREATE/DROP TABLE on the wrapper (`TestAdapterFixtures.executeMutation`
+ * and `exec`). Consumed by `defineSchema`'s cache-invalidation logic via
+ * `adapterKnownTables` (reads through the wrapper's `tables` getter) and
+ * snapshot/restored by `withTransactionalFixtures` so DDL applied inside
+ * an `it()` body doesn't leak across a rolled-back outer transaction.
+ *
+ * @internal
+ */
+
+const _createdTables = new Set<string>();
+const _createdColumns = new Map<string, Set<string>>();
+
+/** @internal */
+export function getCreatedTables(): Set<string> {
+  return _createdTables;
+}
+
+/** @internal */
+export function getCreatedColumns(): Map<string, Set<string>> {
+  return _createdColumns;
+}
+
+/** @internal */
+export function clearDdlTrackers(): void {
+  _createdTables.clear();
+  _createdColumns.clear();
+}
+
+/**
+ * Snapshot the global DDL trackers so a wrapping `withTransactionalFixtures`
+ * scope can restore them after the outer transaction rolls back. DDL parsed
+ * during an `it()` body adds entries to `_createdTables` / `_createdColumns`
+ * (via `recordDdlTracking`); the rollback reverts the DDL on the DB side, but
+ * the trackers would otherwise report the rolled-back table as still-created.
+ *
+ * Today this is harmless because `defineSchema` consults its signature cache
+ * first (which is snapshot/restored via `_snapshotAppliedSchemaSignaturesForAdapter`).
+ * But a future test pattern — `defineSchema` in `beforeAll` plus raw
+ * `createTable` inside an `it()` body — would leak. Snapshot/restore plugs
+ * that gap before it surfaces.
+ *
+ * @internal
+ */
+export function snapshotDdlTrackers(): {
+  tables: Set<string>;
+  columns: Map<string, Set<string>>;
+} {
+  const columns = new Map<string, Set<string>>();
+  for (const [k, v] of _createdColumns) columns.set(k, new Set(v));
+  return { tables: new Set(_createdTables), columns };
+}
+
+/** @internal */
+export function restoreDdlTrackers(snapshot: {
+  tables: Set<string>;
+  columns: Map<string, Set<string>>;
+}): void {
+  _createdTables.clear();
+  for (const t of snapshot.tables) _createdTables.add(t);
+  _createdColumns.clear();
+  for (const [k, v] of snapshot.columns) _createdColumns.set(k, new Set(v));
+}
+
+/**
+ * Extract the top-level column names from a `CREATE TABLE ... (...)` body.
+ * Used to seed `_createdColumns` so `defineSchema`'s cache-invalidation
+ * logic has accurate per-table column sets.
+ *
+ * Tracks paren depth so a nested type like `DECIMAL(10,2)` doesn't count
+ * as a top-level comma; identifiers may be quoted with `"`, `` ` ``, or
+ * unquoted. Skips quoted SQL literals so a default like `DEFAULT ')'`
+ * doesn't close the column list. Returns `Set(["id"])` if no body is found.
+ *
+ * @internal exported for unit testing.
+ */
+export function parseCreateTableColumns(sql: string): Set<string> {
+  const m = sql.match(/CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+["`]?\w+["`]?\s*\(/i);
+  if (!m) return new Set(["id"]);
+  const start = m.index! + m[0].length;
+
+  const skipQuoted = (i: number, quote: string): number => {
+    i++;
+    while (i < sql.length) {
+      const ch = sql[i];
+      if (quote === "'" && ch === "\\" && i + 1 < sql.length) {
+        i += 2;
+        continue;
+      }
+      if (ch === quote) {
+        if (quote === "'" && sql[i + 1] === "'") {
+          i += 2;
+          continue;
+        }
+        return i + 1;
+      }
+      i++;
+    }
+    return i;
+  };
+
+  let depth = 1;
+  let end = -1;
+  let i = start;
+  while (i < sql.length) {
+    const ch = sql[i];
+    if (ch === "'" || ch === '"' || ch === "`") {
+      i = skipQuoted(i, ch);
+      continue;
+    }
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth === 0) {
+        end = i;
+        break;
+      }
+    }
+    i++;
+  }
+  if (end < 0) return new Set(["id"]);
+
+  const cols = new Set<string>();
+  const body = sql.slice(start, end);
+  let part = "";
+  let pd = 0;
+  const flush = () => {
+    const piece = part.trim();
+    part = "";
+    if (!piece) return;
+    if (/^(PRIMARY\s+KEY|FOREIGN\s+KEY|UNIQUE\b|INDEX\b|KEY\b|CHECK\b|CONSTRAINT\b)/i.test(piece))
+      return;
+    const colMatch = piece.match(/^(?:["`](\w+)["`]|(\w+))/);
+    if (colMatch) cols.add(colMatch[1] ?? colMatch[2]);
+  };
+  let j = 0;
+  while (j < body.length) {
+    const ch = body[j];
+    if (ch === "'" || ch === '"' || ch === "`") {
+      const next = skipQuoted(start + j, ch) - start;
+      part += body.slice(j, next);
+      j = next;
+      continue;
+    }
+    if (ch === "(") pd++;
+    else if (ch === ")") pd--;
+    if (ch === "," && pd === 0) {
+      flush();
+      j++;
+      continue;
+    }
+    part += ch;
+    j++;
+  }
+  flush();
+  if (cols.size === 0) cols.add("id");
+  return cols;
+}
+
+/**
+ * Update `_createdTables`/`_createdColumns` after a CREATE TABLE or DROP TABLE
+ * has successfully executed. For CREATE: when the table was already tracked,
+ * the CREATE was likely `IF NOT EXISTS` against a pre-existing table whose
+ * real column set may differ from the SQL we're parsing — fall back to
+ * `{id}` rather than recording columns that might not exist.
+ *
+ * @internal
+ */
+export function recordDdlTracking(
+  sql: string,
+  createMatch: RegExpMatchArray | null,
+  dropMatch: RegExpMatchArray | null,
+): void {
+  if (createMatch) {
+    const table = createMatch[1] ?? createMatch[2];
+    const wasTracked = _createdTables.has(table);
+    _createdTables.add(table);
+    if (!_createdColumns.has(table)) {
+      _createdColumns.set(table, wasTracked ? new Set(["id"]) : parseCreateTableColumns(sql));
+    }
+  }
+  if (dropMatch) {
+    const table = dropMatch[1] ?? dropMatch[2];
+    _createdTables.delete(table);
+    _createdColumns.delete(table);
+  }
+}

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { createTestAdapter, getUseTransactionalTests } from "../test-adapter.js";
+import { createTestAdapter } from "../test-adapter.js";
+import { getUseTransactionalTests } from "./use-transactional-tests.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import { defineSchema, type ColumnSpec } from "./define-schema.js";
 

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseAdapter } from "../adapter.js";
 import { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
-import { setUseTransactionalTests } from "../test-adapter.js";
+import { setUseTransactionalTests } from "./use-transactional-tests.js";
 
 export type PrimitiveColumnSpec =
   | "string"

--- a/packages/activerecord/src/test-helpers/skip-global-reset.ts
+++ b/packages/activerecord/src/test-helpers/skip-global-reset.ts
@@ -1,0 +1,29 @@
+/**
+ * Refcount of active `withTransactionalFixtures` scopes. When > 0, the
+ * global beforeEach in test-setup-ar.ts skips resetTestAdapterState() so a
+ * one-time schema set up in `beforeAll` survives across tests in the file.
+ * Refcounted (not a bool) so nested describes / multiple suites that each
+ * call withTransactionalFixtures don't clobber an outer scope's skip when
+ * an inner scope's afterAll runs. Mirrors Rails ConnectionPool's
+ * `@pinned_connections_depth` (connection_pool.rb:327, 345).
+ *
+ * @internal
+ */
+
+let _skipGlobalResetDepth = 0;
+
+/** @internal */
+export function pushSkipGlobalReset(): void {
+  _skipGlobalResetDepth += 1;
+}
+
+/** @internal */
+export function popSkipGlobalReset(): number {
+  if (_skipGlobalResetDepth > 0) _skipGlobalResetDepth -= 1;
+  return _skipGlobalResetDepth;
+}
+
+/** @internal */
+export function shouldSkipGlobalReset(): boolean {
+  return _skipGlobalResetDepth > 0;
+}

--- a/packages/activerecord/src/test-helpers/use-transactional-tests.ts
+++ b/packages/activerecord/src/test-helpers/use-transactional-tests.ts
@@ -3,9 +3,10 @@
  * Mirrors Rails' `self.use_transactional_tests = false` (per-test-class
  * in Rails; per-adapter here since adapters are the per-test-file unit
  * in trails). Written by `defineSchema(..., { useTransactionalTests })`,
- * read by the global `beforeEach` in `test-setup-ar.ts` (B6.3) and by
- * any future helper that needs to know whether transactional fixtures
- * are active. A WeakMap keeps the flag off the adapter's public surface
+ * read by `withTransactionalFixtures`'s `beforeAll` to decide whether to
+ * activate the BEGIN/ROLLBACK wrap for that file (and by any future
+ * helper that needs the same signal). A WeakMap keeps the flag off the
+ * adapter's public surface
  * (it's purely a test concern) and avoids leaking adapters across
  * test files.
  *

--- a/packages/activerecord/src/test-helpers/use-transactional-tests.ts
+++ b/packages/activerecord/src/test-helpers/use-transactional-tests.ts
@@ -1,0 +1,33 @@
+/**
+ * Per-adapter opt-out for the Phase 6.3 global BEGIN/ROLLBACK wrap.
+ * Mirrors Rails' `self.use_transactional_tests = false` (per-test-class
+ * in Rails; per-adapter here since adapters are the per-test-file unit
+ * in trails). Written by `defineSchema(..., { useTransactionalTests })`,
+ * read by the global `beforeEach` in `test-setup-ar.ts` (B6.3) and by
+ * any future helper that needs to know whether transactional fixtures
+ * are active. A WeakMap keeps the flag off the adapter's public surface
+ * (it's purely a test concern) and avoids leaking adapters across
+ * test files.
+ *
+ * @internal
+ */
+
+const _useTransactionalTests = new WeakMap<object, boolean>();
+
+/** @internal */
+export function setUseTransactionalTests(adapter: object, value: boolean): void {
+  _useTransactionalTests.set(adapter, value);
+}
+
+/**
+ * Read the per-adapter opt-out for transactional fixtures. Defaults to
+ * `true` when the adapter has never been seen — the Phase 6.3 wrap is
+ * on-by-default, and `defineSchema` always records an explicit value
+ * before any DDL runs, so an unseen adapter means the file never called
+ * `defineSchema` (e.g. test-helper unit tests) and the wrap is harmless.
+ *
+ * @internal
+ */
+export function getUseTransactionalTests(adapter: object): boolean {
+  return _useTransactionalTests.get(adapter) ?? true;
+}

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -1,11 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import {
-  _snapshotDdlTrackers,
-  adapterType,
-  createTestAdapter,
-  shouldSkipGlobalReset,
-  type TestDatabaseAdapter,
-} from "../test-adapter.js";
+import { adapterType, createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { snapshotDdlTrackers } from "./ddl-tracker.js";
+import { shouldSkipGlobalReset } from "./skip-global-reset.js";
 import { SQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
 import { defineSchema } from "./define-schema.js";
 import { withTransactionalFixtures } from "./with-transactional-fixtures.js";
@@ -278,7 +274,7 @@ describe.skipIf(adapterType === "mysql")(
       // entry to preserve across rollback — without this, the
       // preservation assertion below would be vacuous.
       await defineSchema(adapter, { ddl_tracker_outer: { name: "string" } });
-      outerTables = _snapshotDdlTrackers().tables;
+      outerTables = snapshotDdlTrackers().tables;
       expect(outerTables.has("ddl_tracker_outer")).toBe(true);
     });
 
@@ -288,13 +284,13 @@ describe.skipIf(adapterType === "mysql")(
       await (adapter as unknown as AdapterWithExec).exec(
         `CREATE TABLE ddl_tracker_inner (id INTEGER PRIMARY KEY)`,
       );
-      const tables = _snapshotDdlTrackers().tables;
+      const tables = snapshotDdlTrackers().tables;
       expect(tables.has("ddl_tracker_inner")).toBe(true);
       expect(tables.has("ddl_tracker_outer")).toBe(true);
     });
 
     it("next test sees the inner tracker reset but outer entries preserved", () => {
-      const tables = _snapshotDdlTrackers().tables;
+      const tables = snapshotDdlTrackers().tables;
       expect(tables.has("ddl_tracker_inner")).toBe(false);
       expect(tables.has("ddl_tracker_outer")).toBe(true);
       for (const t of outerTables) expect(tables.has(t)).toBe(true);

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -1,14 +1,9 @@
 import { beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import type { DatabaseAdapter } from "../adapter.js";
-import {
-  _restoreDdlTrackers,
-  _snapshotDdlTrackers,
-  getUseTransactionalTests,
-  popSkipGlobalReset,
-  pushSkipGlobalReset,
-  resetTestAdapterState,
-  type TestDatabaseAdapter,
-} from "../test-adapter.js";
+import { resetTestAdapterState, type TestDatabaseAdapter } from "../test-adapter.js";
+import { restoreDdlTrackers, snapshotDdlTrackers } from "./ddl-tracker.js";
+import { popSkipGlobalReset, pushSkipGlobalReset } from "./skip-global-reset.js";
+import { getUseTransactionalTests } from "./use-transactional-tests.js";
 import {
   _restoreAppliedSchemaSignaturesForAdapter,
   _snapshotAppliedSchemaSignaturesForAdapter,
@@ -166,7 +161,7 @@ export function withTransactionalFixtures(
   // `it()` body (whose DDL was rolled back at the DB).
   let outerSig: Map<string, string> | null = null;
   let innerSig: Map<string, string> | null = null;
-  let ddlSnapshot: ReturnType<typeof _snapshotDdlTrackers> | null = null;
+  let ddlSnapshot: ReturnType<typeof snapshotDdlTrackers> | null = null;
 
   beforeAll(() => {
     active = getUseTransactionalTests(getAdapter());
@@ -187,7 +182,7 @@ export function withTransactionalFixtures(
     const [outer, inner] = adapterAndInner(getAdapter());
     outerSig = _snapshotAppliedSchemaSignaturesForAdapter(outer);
     innerSig = inner ? _snapshotAppliedSchemaSignaturesForAdapter(inner) : null;
-    ddlSnapshot = _snapshotDdlTrackers();
+    ddlSnapshot = snapshotDdlTrackers();
     // Mirrors Rails ConnectionPool#pin_connection!:
     //   @pinned_connection.begin_transaction joinable: false, _lazy: false
     await tm(getAdapter()).beginTransaction({ joinable: false, _lazy: false });
@@ -201,7 +196,7 @@ export function withTransactionalFixtures(
     const [outer, inner] = adapterAndInner(getAdapter());
     if (outerSig) _restoreAppliedSchemaSignaturesForAdapter(outer, outerSig);
     if (inner && innerSig) _restoreAppliedSchemaSignaturesForAdapter(inner, innerSig);
-    if (ddlSnapshot) _restoreDdlTrackers(ddlSnapshot);
+    if (ddlSnapshot) restoreDdlTrackers(ddlSnapshot);
     outerSig = null;
     innerSig = null;
     ddlSnapshot = null;

--- a/packages/activerecord/src/test-setup-ar.ts
+++ b/packages/activerecord/src/test-setup-ar.ts
@@ -12,7 +12,8 @@
 // for non-test consumers.
 import "@blazetrails/activesupport/sqlite/better-sqlite3";
 import { beforeEach } from "vitest";
-import { resetTestAdapterState, shouldSkipGlobalReset } from "./test-adapter.js";
+import { resetTestAdapterState } from "./test-adapter.js";
+import { shouldSkipGlobalReset } from "./test-helpers/skip-global-reset.js";
 
 // Wipe shared test-adapter state before every test. The previous lazy
 // "clean up on first DB op of next test" model left a window where a


### PR DESCRIPTION
## Summary

Path 1 of the `test-adapter.ts` cleanup: mechanical relocation of three independent test-helper concerns currently colocated with the adapter wrapper into dedicated files under `test-helpers/`. Zero semantic change.

`test-adapter.ts`: **769 → 547 LOC**.

## What moved

| New file | Concern moved out of `test-adapter.ts` |
| --- | --- |
| `test-helpers/ddl-tracker.ts` | `_createdTables`/`_createdColumns` module state, `parseCreateTableColumns` SQL DDL parser, `recordDdlTracking`, and the snapshot/restore pair used by `withTransactionalFixtures`. Public surface: `recordDdlTracking`, `snapshotDdlTrackers`/`restoreDdlTrackers` (underscore dropped — module-public now), `getCreatedTables()`/`getCreatedColumns()`/`clearDdlTrackers()`. `parseCreateTableColumns` stays `@internal` and exported only for unit testing. |
| `test-helpers/skip-global-reset.ts` | `_skipGlobalResetDepth` + `pushSkipGlobalReset`/`popSkipGlobalReset`/`shouldSkipGlobalReset`. |
| `test-helpers/use-transactional-tests.ts` | `_useTransactionalTests` WeakMap + `setUseTransactionalTests`/`getUseTransactionalTests`. |

`test-adapter.ts` keeps the factory glue (`adapterType`, `_sharedAdapter`, env-URL parsing, `createTestAdapter`, `cleanupTestAdapter`, `resetTestAdapterState`) and the `TestAdapterFixtures` wrapper class. The wrapper's `tables` getter and `resetTestAdapterState` route through `getCreatedTables()`/`clearDdlTrackers()`, and `executeMutation`/`exec` still call the same `recordDdlTracking` (now imported from `./test-helpers/ddl-tracker.js`).

## Consumer import updates

- `test-setup-ar.ts` → `shouldSkipGlobalReset` from `./test-helpers/skip-global-reset.js`
- `test-helpers/with-transactional-fixtures.ts` → split imports across the three new modules; `_snapshotDdlTrackers`/`_restoreDdlTrackers` → `snapshotDdlTrackers`/`restoreDdlTrackers`
- `test-helpers/define-schema.ts` → `setUseTransactionalTests` from `./use-transactional-tests.js`
- `test-helpers/define-schema.test.ts` → `getUseTransactionalTests` from `./use-transactional-tests.js`
- `test-helpers/with-transactional-fixtures.test.ts` → split imports + rename
- Unit test for the parser moves: `src/test-adapter.test.ts` → `src/test-helpers/ddl-tracker.test.ts` (tests now live next to the parser they exercise).

## What did NOT change

- `TestAdapterFixtures` class structure — path 3 (delete ~30 pure-delegation methods, update 18 `.innerAdapter` callers) is the natural follow-up.
- Load-bearing concerns in the wrapper: TX visibility (`_txLockHeld`), manual TX depth, the DDL recording calls inside `executeMutation`/`exec` (state moved, call sites stay).
- Behavior — pure relocation. If something's broken downstream after this lands it was broken before.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/test-helpers/` — 54 tests pass locally (ddl-tracker, define-schema, with-transactional-fixtures)
- [x] `pnpm vitest run packages/activerecord/src/base.test.ts` — 315 tests pass locally (broader wrapper smoke)
- [x] `pnpm build` + `pnpm typecheck` (lint-staged hooks)
- [ ] CI on SQLite / PG / MariaDB
- [ ] `pnpm api:compare` delta non-negative