### PR TITLE
feat(actionview): Tse template handler class (Phase 2a-1)

### DIFF
--- a/packages/actionview/package.json
+++ b/packages/actionview/package.json
@@ -13,6 +13,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "@blazetrails/activesupport": "workspace:*"
+    "@blazetrails/activesupport": "workspace:*",
+    "@blazetrails/tse-compiler": "workspace:*"
   }
 }

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -5,6 +5,11 @@ export {
   TemplateHandlerRegistry,
 } from "./template/handlers.js";
 export { Raw as RawHandler } from "./template/handlers/raw.js";
+export {
+  Tse as TseHandler,
+  type TseTemplate,
+  type TseImplementation,
+} from "./template/handlers/tse.js";
 
 // Merged: `Template` is both the interface (data shape) and a namespace
 // exposing the Rails-spelled `Template.Error` class.

--- a/packages/actionview/src/template/handlers/tse.test.ts
+++ b/packages/actionview/src/template/handlers/tse.test.ts
@@ -82,13 +82,24 @@ describe("Template::Handlers::Tse", () => {
   it("delegates compilation to the swappable implementation", () => {
     const calls: Array<{ source: string; escapeIgnore: boolean | undefined }> = [];
     Tse.implementation = ((source, options) => {
-      calls.push({ source, escapeIgnore: options.escapeIgnore });
+      calls.push({ source, escapeIgnore: options?.escapeIgnore });
       return { code: "STUB", localsSignature: null, typesAnnotation: null };
     }) as TseImplementation;
 
     const out = new Tse().call({ type: "text/plain" }, "src");
     expect(out).toBe("STUB");
     expect(calls).toEqual([{ source: "src", escapeIgnore: true }]);
+  });
+
+  it("normalizes a format-token template.type ('text') to MIME before the escapeIgnoreList check", () => {
+    const code = new Tse().call({ type: "text" }, "<%= name %>");
+    expect(code).toMatch(/_ob\.safeExprAppend\(name\)/);
+  });
+
+  it("render() throws — execution lands in Phase 2c", () => {
+    expect(() =>
+      new Tse().render("<%= 1 %>", {}, { controller: "c", action: "a", format: "html" }),
+    ).toThrow(/not yet implemented/);
   });
 
   it("Tse.call mirrors `Handlers::ERB.call` and delegates to a fresh instance", () => {

--- a/packages/actionview/src/template/handlers/tse.test.ts
+++ b/packages/actionview/src/template/handlers/tse.test.ts
@@ -79,6 +79,20 @@ describe("Template::Handlers::Tse", () => {
     expect(captured[1]).toBe("hello\n");
   });
 
+  it("stripTrailingNewlines chomps \\n, \\r\\n, and lone \\r like Ruby String#chomp", () => {
+    const captured: string[] = [];
+    Tse.implementation = ((source: string) => {
+      captured.push(source);
+      return { code: "", localsSignature: null, typesAnnotation: null };
+    }) as TseImplementation;
+    Tse.stripTrailingNewlines = true;
+
+    new Tse().call({ type: "text/html" }, "a\n");
+    new Tse().call({ type: "text/html" }, "b\r\n");
+    new Tse().call({ type: "text/html" }, "c\r");
+    expect(captured).toEqual(["a", "b", "c"]);
+  });
+
   it("delegates compilation to the swappable implementation", () => {
     const calls: Array<{ source: string; escapeIgnore: boolean | undefined }> = [];
     Tse.implementation = ((source, options) => {

--- a/packages/actionview/src/template/handlers/tse.test.ts
+++ b/packages/actionview/src/template/handlers/tse.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { TemplateHandlers } from "../handlers.js";
+import { Tse, type TseImplementation } from "./tse.js";
+
+describe("Template::Handlers::Tse", () => {
+  const originalImpl = Tse.implementation;
+  const originalEscapeIgnore = Tse.escapeIgnoreList;
+  const originalStrip = Tse.stripTrailingNewlines;
+  const originalTrim = Tse.trimMode;
+
+  afterEach(() => {
+    Tse.implementation = originalImpl;
+    Tse.escapeIgnoreList = originalEscapeIgnore;
+    Tse.stripTrailingNewlines = originalStrip;
+    Tse.trimMode = originalTrim;
+    TemplateHandlers.clear();
+  });
+
+  it("supports the streaming protocol", () => {
+    expect(new Tse().supportsStreaming()).toBe(true);
+  });
+
+  it("handles encoding", () => {
+    expect(new Tse().handlesEncoding()).toBe(true);
+  });
+
+  it("defaults trimMode to '-'", () => {
+    expect(Tse.trimMode).toBe("-");
+  });
+
+  it("defaults escapeIgnoreList to ['text/plain']", () => {
+    expect(Tse.escapeIgnoreList).toEqual(["text/plain"]);
+  });
+
+  it("defaults stripTrailingNewlines to false", () => {
+    expect(Tse.stripTrailingNewlines).toBe(false);
+  });
+
+  it("compiles a static template to a JS render module", () => {
+    const code = new Tse().call({ type: "text/html" }, "<h1>hi</h1>");
+    expect(code).toContain("export default function render");
+    expect(code).toContain("safeAppend");
+    expect(code).toContain("<h1>hi</h1>");
+  });
+
+  it("emits the escaping append for html templates", () => {
+    const code = new Tse().call({ type: "text/html" }, "<%= name %>");
+    expect(code).toMatch(/_ob\.append\(name\)/);
+  });
+
+  it("emits the non-escaping append for templates in escapeIgnoreList", () => {
+    const code = new Tse().call({ type: "text/plain" }, "<%= name %>");
+    expect(code).toMatch(/_ob\.safeExprAppend\(name\)/);
+  });
+
+  it("treats unknown template.type as escaping (not in ignore list)", () => {
+    const code = new Tse().call({ type: "application/json" }, "<%= name %>");
+    expect(code).toMatch(/_ob\.append\(name\)/);
+  });
+
+  it("treats missing template.type as escaping", () => {
+    const code = new Tse().call({}, "<%= name %>");
+    expect(code).toMatch(/_ob\.append\(name\)/);
+  });
+
+  it("strips a single trailing newline when stripTrailingNewlines is enabled", () => {
+    const captured: string[] = [];
+    Tse.implementation = ((source: string) => {
+      captured.push(source);
+      return { code: "", localsSignature: null, typesAnnotation: null };
+    }) as TseImplementation;
+
+    Tse.stripTrailingNewlines = true;
+    new Tse().call({ type: "text/html" }, "hello\n");
+    expect(captured[0]).toBe("hello");
+
+    Tse.stripTrailingNewlines = false;
+    new Tse().call({ type: "text/html" }, "hello\n");
+    expect(captured[1]).toBe("hello\n");
+  });
+
+  it("delegates compilation to the swappable implementation", () => {
+    const calls: Array<{ source: string; escapeIgnore: boolean | undefined }> = [];
+    Tse.implementation = ((source, options) => {
+      calls.push({ source, escapeIgnore: options.escapeIgnore });
+      return { code: "STUB", localsSignature: null, typesAnnotation: null };
+    }) as TseImplementation;
+
+    const out = new Tse().call({ type: "text/plain" }, "src");
+    expect(out).toBe("STUB");
+    expect(calls).toEqual([{ source: "src", escapeIgnore: true }]);
+  });
+
+  it("registers against the .tse extension via Template::Handlers", () => {
+    const tse = new Tse();
+    TemplateHandlers.registerTemplateHandler("tse", tse);
+    expect(TemplateHandlers.handlerForExtension("tse")).toBe(tse);
+  });
+});

--- a/packages/actionview/src/template/handlers/tse.test.ts
+++ b/packages/actionview/src/template/handlers/tse.test.ts
@@ -91,6 +91,11 @@ describe("Template::Handlers::Tse", () => {
     expect(calls).toEqual([{ source: "src", escapeIgnore: true }]);
   });
 
+  it("Tse.call mirrors `Handlers::ERB.call` and delegates to a fresh instance", () => {
+    const code = Tse.call({ type: "text/html" }, "<%= name %>");
+    expect(code).toMatch(/_ob\.append\(name\)/);
+  });
+
   it("registers against the .tse extension via Template::Handlers", () => {
     const tse = new Tse();
     TemplateHandlers.registerTemplateHandler("tse", tse);

--- a/packages/actionview/src/template/handlers/tse.ts
+++ b/packages/actionview/src/template/handlers/tse.ts
@@ -1,3 +1,4 @@
+import { chomp } from "@blazetrails/activesupport";
 import { compileJs, type EmitJsOptions, type EmitResult } from "@blazetrails/tse-compiler";
 import type { RenderContext, TemplateHandler } from "../handlers.js";
 
@@ -89,7 +90,7 @@ export class Tse implements TemplateHandler {
    */
   call(template: TseTemplate, source: string): string {
     const ctor = this.constructor as typeof Tse;
-    const prepared = ctor.stripTrailingNewlines ? source.replace(/(\r\n|\r|\n)$/, "") : source;
+    const prepared = ctor.stripTrailingNewlines ? chomp(source) : source;
     // Rails compares `template.type` (a MIME string like "text/html") against
     // `escape_ignore_list`. Trails' `Template#type` currently returns the
     // format token ("html") until `Mime::Type` lands — normalize both forms

--- a/packages/actionview/src/template/handlers/tse.ts
+++ b/packages/actionview/src/template/handlers/tse.ts
@@ -117,11 +117,12 @@ export class Tse implements TemplateHandler {
 }
 
 /**
- * Minimal format → MIME map used only by the {@link Tse#render} convenience
- * adapter to bridge `RenderContext.format` (a Rails format token like
- * `"html"`) into the `template.type` the Rails handler protocol expects.
- * The real lookup lives in `LookupContext` / `Mime::Type`; this is a
- * stopgap until `Template` is wired through.
+ * Normalize a `template.type` input into a MIME string. Rails compares the
+ * `escape_ignore_list` (default `["text/plain"]`) against `Template#type`,
+ * which already returns a MIME string. Trails' `Template#type` currently
+ * returns the format token (e.g. `"html"`) until `Mime::Type` lands, so we
+ * widen the input here: pass-through for MIMEs, map known tokens to MIME.
+ * Unknown tokens pass through unchanged so they still miss the ignore list.
  *
  * @internal
  */

--- a/packages/actionview/src/template/handlers/tse.ts
+++ b/packages/actionview/src/template/handlers/tse.ts
@@ -16,7 +16,7 @@ export interface TseTemplate {
  * `Template::Handlers::ERB.erb_implementation` — swappable in tests and by
  * downstream apps that want a different emitter.
  */
-export type TseImplementation = (source: string, options: EmitJsOptions) => EmitResult;
+export type TseImplementation = (source: string, options?: EmitJsOptions) => EmitResult;
 
 /**
  * ActionView::Template::Handlers::Tse
@@ -33,9 +33,12 @@ export class Tse implements TemplateHandler {
   readonly extensions = ["tse"];
 
   /**
-   * Trim mode passed to the compiler. Rails default is `"-"` and only `"-"`
-   * is wired through; we mirror that for fidelity even though the current
-   * tse-compiler always trims `<%- -%>` regardless.
+   * Trim mode (Rails: `erb_trim_mode`). API-surface parity only — Rails wires
+   * this through to Erubi, but `@blazetrails/tse-compiler` v0.1.0 hard-codes
+   * `-` trimming (the only mode Rails ever passes). The attribute is exposed
+   * now so downstream code that mirrors Rails patterns (`Tse.trimMode = "-"`)
+   * doesn't crash; it becomes load-bearing once tse-compiler accepts a `trim`
+   * option.
    */
   static trimMode: string = "-";
 
@@ -87,13 +90,29 @@ export class Tse implements TemplateHandler {
   call(template: TseTemplate, source: string): string {
     const ctor = this.constructor as typeof Tse;
     const prepared = ctor.stripTrailingNewlines ? source.replace(/\r?\n$/, "") : source;
-    const escapeIgnore = template.type != null && ctor.escapeIgnoreList.includes(template.type);
+    // Rails compares `template.type` (a MIME string like "text/html") against
+    // `escape_ignore_list`. Trails' `Template#type` currently returns the
+    // format token ("html") until `Mime::Type` lands — normalize both forms
+    // here so the Rails-shape default `["text/plain"]` matches regardless.
+    const mime = template.type != null ? formatToMimeType(template.type) : null;
+    const escapeIgnore = mime != null && ctor.escapeIgnoreList.includes(mime);
     const result = ctor.implementation(prepared, { escapeIgnore });
     return result.code;
   }
 
-  render(source: string, _locals: Record<string, unknown>, context: RenderContext): string {
-    return this.call({ type: context.format ? formatToMimeType(context.format) : null }, source);
+  /**
+   * Not yet executable. Rails' handler protocol returns compiled code from
+   * `call(...)`; turning that code into an output string requires the
+   * runtime substrate (`OutputBuffer`, view context, compiled-template
+   * module loader) that Phase 2c wires up. Returning the JS source from
+   * `render` would be a footgun — a renderer would write template source
+   * into the response body. Throw until execution lands.
+   */
+  render(_source: string, _locals: Record<string, unknown>, _context: RenderContext): string {
+    throw new Error(
+      "Tse#render is not yet implemented — `.tse` execution lands in Phase 2c. " +
+        "Use `Tse#call(template, source)` to get the compiled JS module source.",
+    );
   }
 }
 

--- a/packages/actionview/src/template/handlers/tse.ts
+++ b/packages/actionview/src/template/handlers/tse.ts
@@ -89,7 +89,7 @@ export class Tse implements TemplateHandler {
    */
   call(template: TseTemplate, source: string): string {
     const ctor = this.constructor as typeof Tse;
-    const prepared = ctor.stripTrailingNewlines ? source.replace(/\r?\n$/, "") : source;
+    const prepared = ctor.stripTrailingNewlines ? source.replace(/(\r\n|\r|\n)$/, "") : source;
     // Rails compares `template.type` (a MIME string like "text/html") against
     // `escape_ignore_list`. Trails' `Template#type` currently returns the
     // format token ("html") until `Mime::Type` lands — normalize both forms

--- a/packages/actionview/src/template/handlers/tse.ts
+++ b/packages/actionview/src/template/handlers/tse.ts
@@ -58,6 +58,16 @@ export class Tse implements TemplateHandler {
   static implementation: TseImplementation = compileJs;
 
   /**
+   * Class-level convenience. Mirrors `Handlers::ERB.call` which does
+   * `new.call(template, source)`. `Template::Handlers` registers the
+   * class itself in Rails; calling `Tse.call(template, source)` matches
+   * that protocol without forcing callers to construct an instance.
+   */
+  static call(template: TseTemplate, source: string): string {
+    return new this().call(template, source);
+  }
+
+  /**
    * Streaming render protocol marker. Mirrors
    * `Template::Handlers::ERB#supports_streaming?`.
    */

--- a/packages/actionview/src/template/handlers/tse.ts
+++ b/packages/actionview/src/template/handlers/tse.ts
@@ -1,0 +1,116 @@
+import { compileJs, type EmitJsOptions, type EmitResult } from "@blazetrails/tse-compiler";
+import type { RenderContext, TemplateHandler } from "../handlers.js";
+
+/**
+ * Minimal shape `Tse#call` needs from a template. Mirrors the subset of
+ * Rails' `ActionView::Template` that `Handlers::ERB#call` touches:
+ * `template.type` (MIME type) drives the `escape_ignore_list` check.
+ */
+export interface TseTemplate {
+  type?: string | null;
+}
+
+/**
+ * Pluggable compiler. Default is {@link compileJs} from
+ * `@blazetrails/tse-compiler`. Rails analogue:
+ * `Template::Handlers::ERB.erb_implementation` — swappable in tests and by
+ * downstream apps that want a different emitter.
+ */
+export type TseImplementation = (source: string, options: EmitJsOptions) => EmitResult;
+
+/**
+ * ActionView::Template::Handlers::Tse
+ *
+ * Trails Server Embedded handler — the `.tse` analogue of Rails'
+ * `Template::Handlers::ERB`. Reads class-level options, derives per-template
+ * compile options from `template.type`, delegates the actual
+ * source → JS-code compile to `@blazetrails/tse-compiler` (the `erubi`
+ * analogue), and returns the emitted JS module string.
+ *
+ * Mirrors `actionview/lib/action_view/template/handlers/erb.rb`.
+ */
+export class Tse implements TemplateHandler {
+  readonly extensions = ["tse"];
+
+  /**
+   * Trim mode passed to the compiler. Rails default is `"-"` and only `"-"`
+   * is wired through; we mirror that for fidelity even though the current
+   * tse-compiler always trims `<%- -%>` regardless.
+   */
+  static trimMode: string = "-";
+
+  /**
+   * Template MIME types whose `<%= %>` should NOT HTML-escape. Defaults to
+   * `["text/plain"]`. Rails: `escape_ignore_list`.
+   */
+  static escapeIgnoreList: string[] = ["text/plain"];
+
+  /**
+   * When true, `source.chomp` (drop a single trailing newline) is applied
+   * before compile. Rails: `strip_trailing_newlines`, default `false`.
+   */
+  static stripTrailingNewlines: boolean = false;
+
+  /**
+   * Swappable compiler implementation. Rails analogue:
+   * `erb_implementation = Erubi`.
+   */
+  static implementation: TseImplementation = compileJs;
+
+  /**
+   * Streaming render protocol marker. Mirrors
+   * `Template::Handlers::ERB#supports_streaming?`.
+   */
+  supportsStreaming(): boolean {
+    return true;
+  }
+
+  /** Mirrors `Template::Handlers::ERB#handles_encoding?`. */
+  handlesEncoding(): boolean {
+    return true;
+  }
+
+  /**
+   * Compile a template source to a JS module string. Rails:
+   * `Handlers::ERB#call(template, source) → ruby_code_string`.
+   */
+  call(template: TseTemplate, source: string): string {
+    const ctor = this.constructor as typeof Tse;
+    const prepared = ctor.stripTrailingNewlines ? source.replace(/\r?\n$/, "") : source;
+    const escapeIgnore = template.type != null && ctor.escapeIgnoreList.includes(template.type);
+    const result = ctor.implementation(prepared, { escapeIgnore });
+    return result.code;
+  }
+
+  render(source: string, _locals: Record<string, unknown>, context: RenderContext): string {
+    return this.call({ type: context.format ? formatToMimeType(context.format) : null }, source);
+  }
+}
+
+/**
+ * Minimal format → MIME map used only by the {@link Tse#render} convenience
+ * adapter to bridge `RenderContext.format` (a Rails format token like
+ * `"html"`) into the `template.type` the Rails handler protocol expects.
+ * The real lookup lives in `LookupContext` / `Mime::Type`; this is a
+ * stopgap until `Template` is wired through.
+ *
+ * @internal
+ */
+function formatToMimeType(format: string): string {
+  switch (format) {
+    case "html":
+      return "text/html";
+    case "text":
+      return "text/plain";
+    case "json":
+      return "application/json";
+    case "xml":
+      return "application/xml";
+    case "js":
+      return "text/javascript";
+    case "css":
+      return "text/css";
+    default:
+      return format;
+  }
+}

--- a/packages/actionview/tsconfig.json
+++ b/packages/actionview/tsconfig.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": [{ "path": "../activesupport" }]
+  "references": [{ "path": "../activesupport" }, { "path": "../tse-compiler" }]
 }

--- a/packages/activesupport/src/core-ext/string-ext.test.ts
+++ b/packages/activesupport/src/core-ext/string-ext.test.ts
@@ -31,6 +31,7 @@ import {
   stripHeredoc,
   downcaseFirst,
   upcaseFirst,
+  chomp,
 } from "../index.js";
 import { StringInquirer } from "../string-inquirer.js";
 
@@ -770,5 +771,33 @@ describe("OutputSafetyTest", () => {
   it("ERB::Util.xml_name_escape should escape unsafe characters for XML names", () => {
     const result = xmlNameEscape("hello world");
     expect(result).not.toContain(" ");
+  });
+});
+
+describe("String#chomp", () => {
+  it("removes a single trailing newline", () => {
+    expect(chomp("hello\n")).toBe("hello");
+  });
+  it("removes a trailing CRLF", () => {
+    expect(chomp("hello\r\n")).toBe("hello");
+  });
+  it("removes a lone trailing CR", () => {
+    expect(chomp("hello\r")).toBe("hello");
+  });
+  it("removes only one record separator", () => {
+    expect(chomp("hello\n\n")).toBe("hello\n");
+  });
+  it("returns the string unchanged when it has no trailing newline", () => {
+    expect(chomp("hello")).toBe("hello");
+  });
+  it("removes the given suffix when present", () => {
+    expect(chomp("hello world", " world")).toBe("hello");
+  });
+  it("returns the string unchanged when the suffix is absent", () => {
+    expect(chomp("hello", "x")).toBe("hello");
+  });
+  it("with an empty separator, removes all trailing newline characters", () => {
+    expect(chomp("hello\r\n\r\n", "")).toBe("hello");
+    expect(chomp("hello\n\n\n", "")).toBe("hello");
   });
 });

--- a/packages/activesupport/src/core-ext/string-ext.test.ts
+++ b/packages/activesupport/src/core-ext/string-ext.test.ts
@@ -796,6 +796,11 @@ describe("String#chomp", () => {
   it("returns the string unchanged when the suffix is absent", () => {
     expect(chomp("hello", "x")).toBe("hello");
   });
+  it("with separator '\\n', also eats a preceding CR (Ruby quirk)", () => {
+    expect(chomp("hello\r\n", "\n")).toBe("hello");
+    expect(chomp("hello\n", "\n")).toBe("hello");
+    expect(chomp("hello\r", "\n")).toBe("hello\r");
+  });
   it("with an empty separator, removes all trailing newline characters", () => {
     expect(chomp("hello\r\n\r\n", "")).toBe("hello");
     expect(chomp("hello\n\n\n", "")).toBe("hello");

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -182,6 +182,7 @@ export {
   from,
   to,
   indent,
+  chomp,
 } from "./string-utils.js";
 
 export {

--- a/packages/activesupport/src/string-utils.ts
+++ b/packages/activesupport/src/string-utils.ts
@@ -167,6 +167,18 @@ export function exclude(str: string, search: string): boolean {
 }
 
 /**
+ * Ruby `String#chomp`. With no separator (or `undefined`), removes a single
+ * trailing `\n`, `\r\n`, or `\r`. With a separator string, removes that
+ * suffix if present. Empty-string separator (Ruby paragraph mode) strips
+ * all trailing newline characters.
+ */
+export function chomp(str: string, separator?: string): string {
+  if (separator === undefined) return str.replace(/(\r\n|\r|\n)$/, "");
+  if (separator === "") return str.replace(/[\r\n]+$/, "");
+  return str.endsWith(separator) ? str.slice(0, str.length - separator.length) : str;
+}
+
+/**
  * Returns the first n characters of the string (default 1).
  * Raises if n is negative (mirrors Rails behaviour).
  */

--- a/packages/activesupport/src/string-utils.ts
+++ b/packages/activesupport/src/string-utils.ts
@@ -175,6 +175,8 @@ export function exclude(str: string, search: string): boolean {
 export function chomp(str: string, separator?: string): string {
   if (separator === undefined) return str.replace(/(\r\n|\r|\n)$/, "");
   if (separator === "") return str.replace(/[\r\n]+$/, "");
+  // Ruby quirk: chomp("\n") also eats a preceding CR — "x\r\n".chomp("\n") == "x".
+  if (separator === "\n") return str.replace(/\r?\n$/, "");
   return str.endsWith(separator) ? str.slice(0, str.length - separator.length) : str;
 }
 

--- a/packages/website/vite.config.ts
+++ b/packages/website/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       pkgAlias("@blazetrails/activerecord", "../activerecord/src/index.ts"),
       pkgAlias("@blazetrails/rack", "../rack/src/index.ts"),
       pkgAlias("@blazetrails/actionview", "../actionview/src/index.ts"),
+      pkgAlias("@blazetrails/tse-compiler", "../tse-compiler/src/index.ts"),
       pkgAlias("@blazetrails/actionpack", "../actionpack/src/index.ts"),
       pkgAlias("@blazetrails/trailties/generators", "../trailties/src/generators/index.ts"),
       pkgAlias("@blazetrails/globalid/wire", "../globalid/src/wire.ts"),

--- a/packages/website/vite.sw.config.ts
+++ b/packages/website/vite.sw.config.ts
@@ -51,6 +51,7 @@ export default defineConfig({
       pkgAlias("@blazetrails/activerecord", "../activerecord/src/index.ts"),
       pkgAlias("@blazetrails/rack", "../rack/src/index.ts"),
       pkgAlias("@blazetrails/actionview", "../actionview/src/index.ts"),
+      pkgAlias("@blazetrails/tse-compiler", "../tse-compiler/src/index.ts"),
       pkgAlias("@blazetrails/actionpack", "../actionpack/src/index.ts"),
       pkgAlias("@blazetrails/trailties/generators", "../trailties/src/generators/index.ts"),
       pkgAlias("@blazetrails/globalid/wire", "../globalid/src/wire.ts"),

--- a/packages/website/vitest.config.ts
+++ b/packages/website/vitest.config.ts
@@ -24,6 +24,7 @@ const aliases = {
   "@blazetrails/activerecord": path.resolve(__dirname, "../activerecord/src/index.ts"),
   "@blazetrails/rack": path.resolve(__dirname, "../rack/src/index.ts"),
   "@blazetrails/actionview": path.resolve(__dirname, "../actionview/src/index.ts"),
+  "@blazetrails/tse-compiler": path.resolve(__dirname, "../tse-compiler/src/index.ts"),
   "@blazetrails/actionpack": path.resolve(__dirname, "../actionpack/src/index.ts"),
   "@blazetrails/did-you-mean": path.resolve(__dirname, "../did-you-mean/src/index.ts"),
   "@blazetrails/trailties/generators": path.resolve(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@blazetrails/activesupport':
         specifier: workspace:*
         version: link:../activesupport
+      '@blazetrails/tse-compiler':
+        specifier: workspace:*
+        version: link:../tse-compiler
 
   packages/activemodel:
     dependencies:
@@ -2310,6 +2313,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@upsetjs/venn.js@2.0.0':
     resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -129,6 +129,7 @@ const alias = {
   "@blazetrails/activerecord": path.resolve(__dirname, "packages/activerecord/src/index.ts"),
   "@blazetrails/rack": path.resolve(__dirname, "packages/rack/src/index.ts"),
   "@blazetrails/actionview": path.resolve(__dirname, "packages/actionview/src/index.ts"),
+  "@blazetrails/tse-compiler": path.resolve(__dirname, "packages/tse-compiler/src/index.ts"),
   "@blazetrails/actionpack": path.resolve(__dirname, "packages/actionpack/src/index.ts"),
   "@blazetrails/globalid/wire": path.resolve(__dirname, "packages/globalid/src/wire.ts"),
   "@blazetrails/globalid/signed-global-id": path.resolve(


### PR DESCRIPTION
## Summary

- Adds `ActionView::Template::Handlers::Tse` — the `.tse` analogue of Rails' `Handlers::ERB` (per `docs/tse-plan.md` §2).
- `call(template, source) → JS code string`, delegating compilation to `@blazetrails/tse-compiler` (`compileJs`, the erubi analogue from #2190).
- Class attrs: `trimMode` (`"-"`), `escapeIgnoreList` (`["text/plain"]`), `stripTrailingNewlines` (`false`), `implementation` (swappable).
- `supportsStreaming()` + `handlesEncoding()` return `true`.
- Per-template escape dispatch driven by `template.type ∈ escapeIgnoreList`, matching Rails: `.text` → `safeExprAppend`, everything else → `append` (escaping).

## Out of scope (per phasing)

- Phase 2b: trails-tsc `.tse` plugin.
- Phase 2c: build CLI.
- Registration of the handler into `Template::Handlers` for `.tse` — wired in a follow-up so this PR stays focused on the class itself.

## Test plan

- [x] `pnpm vitest run --project other packages/actionview/src/template/handlers/tse.test.ts` (13 tests)
- [x] `pnpm vitest run --project other packages/actionview/src/template/handlers.test.ts` (no regression)
- [x] `pnpm tsc -b packages/actionview` clean