### PR TITLE
feat(trails-tsc): .tse virtualization plugin (TSE Phase 2b)

### DIFF
--- a/packages/trails-tsc/package.json
+++ b/packages/trails-tsc/package.json
@@ -14,6 +14,9 @@
   "scripts": {
     "build": "tsc"
   },
+  "dependencies": {
+    "@blazetrails/tse-compiler": "workspace:*"
+  },
   "peerDependencies": {
     "typescript": "^5.0.0"
   },

--- a/packages/trails-tsc/src/index.ts
+++ b/packages/trails-tsc/src/index.ts
@@ -17,3 +17,4 @@ export {
   type TrailsSolutionBuilder,
 } from "./build.js";
 export { remapDiagnostics, remapLine } from "./remap.js";
+export { createTsePlugin, virtualizeTse } from "./plugins/tse.js";

--- a/packages/trails-tsc/src/plugin.ts
+++ b/packages/trails-tsc/src/plugin.ts
@@ -27,9 +27,20 @@ export interface VirtualizeOutput {
 
 /**
  * Line-mapping record produced by a virtualizing plugin.
- * `insertedAtLine` is the 0-indexed line in the VIRTUALIZED text
- * where an injected block begins (sentinel `-1` = prepended above
- * line 0); the block spans `lineCount` virtual lines.
+ *
+ * `insertedAtLine` is the 0-indexed virtual line IMMEDIATELY BEFORE
+ * the injected block — i.e., the start coordinate is exclusive. The
+ * injected lines themselves are `insertedAtLine + 1 .. insertedAtLine + lineCount`
+ * (inclusive on both ends); those virtual lines have no original-source
+ * counterpart and `remapLine()` returns `null` for them. Later virtual
+ * lines are shifted up by `lineCount` to recover original-source lines.
+ *
+ * The sentinel value `-1` means the block was prepended ABOVE virtual
+ * line 0 — so a header of length N occupies virtual lines `0..N-1`.
+ *
+ * Plugins emitting a trailing footer should use
+ * `insertedAtLine: <last unmapped body line>`; the next `lineCount`
+ * virtual lines are then treated as injected.
  */
 export interface LineDelta {
   insertedAtLine: number;

--- a/packages/trails-tsc/src/plugins/tse.test.ts
+++ b/packages/trails-tsc/src/plugins/tse.test.ts
@@ -39,7 +39,7 @@ describe("virtualizeTse", () => {
     // parameter is a type error. (Inline a Record alias because the
     // diagnose helper runs with `lib: []`.)
     const probe =
-      "type Record<K extends keyof never, V> = { [P in K]: V };\n" +
+      "type Record<K extends keyof any, V> = { [P in K]: V };\n" +
       out +
       "\nrender({} as RenderContext, { extra: 1 });";
     expect(diagnose(probe).join("\n")).toMatch(/not assignable|extra/i);
@@ -73,14 +73,17 @@ describe("virtualizeTse", () => {
     expect(() => virtualizeTse("<%# locals: (user) %>")).toThrow(TseLocalsSignatureError);
   });
 
-  it("reports a LineDelta covering the header so diagnostics remap back to .tse", () => {
+  it("reports LineDeltas covering header and footer so diagnostics remap back to .tse", () => {
     const { ts, deltas } = virtualizeTseWithDeltas("<h1><%= 1 %></h1>");
-    expect(deltas).toHaveLength(1);
-    expect(deltas[0]?.insertedAtLine).toBe(-1);
-    // The header runs from the file start up to (and including) the
-    // `const _ob = …` line. The body should start immediately after.
-    const headerLines = ts.split("\n").slice(0, deltas[0]!.lineCount);
-    expect(headerLines.at(-1)).toContain("const _ob");
+    expect(deltas).toHaveLength(2);
+    const [head, foot] = deltas;
+    expect(head?.insertedAtLine).toBe(-1);
+    const lines = ts.split("\n");
+    expect(lines[head!.lineCount - 1]).toContain("const _ob");
+    // Footer delta starts at the line after the body and covers the
+    // trailing `return _ob;` + `}` + trailing newline.
+    expect(lines[foot!.insertedAtLine]).toContain("return _ob");
+    expect(foot?.insertedAtLine).toBe(head!.lineCount + 3); // 3 body nodes: text, expr, text
   });
 
   it("dispatches expression sites and preserves code chunks raw", () => {

--- a/packages/trails-tsc/src/plugins/tse.test.ts
+++ b/packages/trails-tsc/src/plugins/tse.test.ts
@@ -122,6 +122,17 @@ describe("virtualizeTse", () => {
     expect(() => virtualizeTse('<%# locals: (a: "oops) %>')).toThrow(TseLocalsSignatureError);
   });
 
+  it("throws on mismatched bracket types", () => {
+    // Outer parens are required by the locals regex; the mismatch is
+    // inside (a square closer for a curly opener).
+    expect(() => virtualizeTse("<%# locals: (a: {1, 2]) %>")).toThrow(/mismatched/);
+  });
+
+  it("throws on an empty / invalid local name", () => {
+    expect(() => virtualizeTse("<%# locals: (: 1) %>")).toThrow(/invalid local name/);
+    expect(() => virtualizeTse("<%# locals: (1bad: 1) %>")).toThrow(/invalid local name/);
+  });
+
   it("dispatches expression sites and preserves code chunks raw", () => {
     const out = virtualizeTse("<% if (n > 0) { %><%= n %><%== raw %><% } %>");
     expect(out).toContain("if (n > 0) {");

--- a/packages/trails-tsc/src/plugins/tse.test.ts
+++ b/packages/trails-tsc/src/plugins/tse.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import ts from "typescript";
+import { createTsePlugin, virtualizeTse } from "./tse.js";
+
+describe("createTsePlugin", () => {
+  it("claims the .tse extension", () => {
+    const plugin = createTsePlugin();
+    expect(plugin.name).toBe("tse");
+    expect(plugin.extensions).toEqual([".tse"]);
+  });
+
+  it("virtualizes through the host hook", () => {
+    const plugin = createTsePlugin();
+    const out = plugin.virtualize("/x/show.html.tse", "<h1><%= 1 %></h1>");
+    expect(out?.ts).toContain("export default function render(");
+    expect(out?.ts).toContain('_ob.safeAppend("<h1>");');
+    expect(out?.ts).toContain("_ob.append(1);");
+  });
+});
+
+describe("virtualizeTse", () => {
+  it("defaults to Record<string, unknown> when no locals declared", () => {
+    const ts = virtualizeTse("<p>hi</p>");
+    expect(ts).toContain("locals: Record<string, unknown>");
+    expect(ts).not.toContain("const {");
+  });
+
+  it("destructures locals and types them as unknown when no types block", () => {
+    const ts = virtualizeTse("<%# locals: (user:, count: 0) %><%= user %>");
+    expect(ts).toContain("locals: { user: unknown; count?: unknown }");
+    expect(ts).toContain("const { user, count = 0 } = locals;");
+  });
+
+  it("lifts the types annotation verbatim", () => {
+    const ts = virtualizeTse(
+      "<%# locals: (user:) %><%! types: { user: { name: string } } !%><%= user.name %>",
+    );
+    expect(ts).toContain("locals: { user: { name: string } }");
+    expect(ts).toContain("const { user } = locals;");
+  });
+
+  it("splits locals on top-level commas only", () => {
+    const ts = virtualizeTse("<%# locals: (a: f(1, 2), b: [1, 2]) %>");
+    expect(ts).toContain("const { a = f(1, 2), b = [1, 2] } = locals;");
+  });
+
+  it("dispatches expression sites and preserves code chunks raw", () => {
+    const out = virtualizeTse("<% if (n > 0) { %><%= n %><%== raw %><% } %>");
+    expect(out).toContain("if (n > 0) {");
+    expect(out).toContain("_ob.append(n);");
+    expect(out).toContain("_ob.safeExprAppend(raw);");
+    expect(out).toContain("}");
+  });
+
+  it("emits TS that type-checks against the declared locals", () => {
+    const source =
+      "<%# locals: (user:) %><%! types: { user: { name: string } } !%>" +
+      "<h1>Hello <%= user.name %></h1>";
+    const out = virtualizeTse(source);
+    expect(diagnose(out)).toEqual([]);
+  });
+
+  it("reports a tsc error when an expression mismatches the locals type", () => {
+    const source =
+      "<%# locals: (user:) %><%! types: { user: { name: string } } !%>" + "<%= user.missingProp %>";
+    const out = virtualizeTse(source);
+    const diags = diagnose(out);
+    expect(diags.length).toBeGreaterThan(0);
+    expect(diags.join("\n")).toMatch(/missingProp/);
+  });
+});
+
+function diagnose(source: string): string[] {
+  const fileName = "/virtual/show.html.tse.ts";
+  const sourceFile = ts.createSourceFile(fileName, source, ts.ScriptTarget.ES2022, true);
+  const host: ts.CompilerHost = {
+    fileExists: (f) => f === fileName,
+    readFile: (f) => (f === fileName ? source : undefined),
+    getSourceFile: (f, lv) => (f === fileName ? sourceFile : ts.createSourceFile(f, "", lv, true)),
+    getDefaultLibFileName: () => "lib.d.ts",
+    writeFile: () => {},
+    getCurrentDirectory: () => "/",
+    getCanonicalFileName: (f) => f,
+    useCaseSensitiveFileNames: () => true,
+    getNewLine: () => "\n",
+  };
+  const program = ts.createProgram({
+    rootNames: [fileName],
+    options: {
+      noEmit: true,
+      noResolve: true,
+      types: [],
+      lib: [],
+      skipLibCheck: true,
+      strict: true,
+    },
+    host,
+  });
+  return program
+    .getSemanticDiagnostics(sourceFile)
+    .concat(program.getSyntacticDiagnostics(sourceFile))
+    .map((d) => ts.flattenDiagnosticMessageText(d.messageText, "\n"));
+}

--- a/packages/trails-tsc/src/plugins/tse.test.ts
+++ b/packages/trails-tsc/src/plugins/tse.test.ts
@@ -25,6 +25,11 @@ describe("virtualizeTse", () => {
     expect(ts).not.toContain("const {");
   });
 
+  it("types empty `<%# locals: () %>` as Record<never, never> (Rails **nil parity)", () => {
+    const out = virtualizeTse("<%# locals: () %><p>hi</p>");
+    expect(out).toContain("locals: Record<never, never>");
+  });
+
   it("destructures locals and types them as unknown when no types block", () => {
     const ts = virtualizeTse("<%# locals: (user:, count: 0) %><%= user %>");
     expect(ts).toContain("locals: { user: unknown; count?: unknown }");

--- a/packages/trails-tsc/src/plugins/tse.test.ts
+++ b/packages/trails-tsc/src/plugins/tse.test.ts
@@ -139,6 +139,11 @@ describe("virtualizeTse", () => {
     expect(() => virtualizeTse("<%# locals: (1bad: 1) %>")).toThrow(/invalid local name/);
   });
 
+  it("rejects TS reserved words as local names", () => {
+    expect(() => virtualizeTse("<%# locals: (default: 1) %>")).toThrow(/invalid local name/);
+    expect(() => virtualizeTse("<%# locals: (await: 1) %>")).toThrow(/invalid local name/);
+  });
+
   it("dispatches expression sites and preserves code chunks raw", () => {
     const out = virtualizeTse("<% if (n > 0) { %><%= n %><%== raw %><% } %>");
     expect(out).toContain("if (n > 0) {");

--- a/packages/trails-tsc/src/plugins/tse.test.ts
+++ b/packages/trails-tsc/src/plugins/tse.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "vitest";
 import ts from "typescript";
-import { createTsePlugin, virtualizeTse } from "./tse.js";
+import {
+  createTsePlugin,
+  TseLocalsSignatureError,
+  virtualizeTse,
+  virtualizeTseWithDeltas,
+} from "./tse.js";
 
 describe("createTsePlugin", () => {
   it("claims the .tse extension", () => {
@@ -25,9 +30,19 @@ describe("virtualizeTse", () => {
     expect(ts).not.toContain("const {");
   });
 
-  it("types empty `<%# locals: () %>` as Record<never, never> (Rails **nil parity)", () => {
+  it("types empty `<%# locals: () %>` as Record<string, never> (Rails **nil parity)", () => {
+    // `Record<never, never>` collapses to `{}`; `Record<string, never>`
+    // actually rejects any provided key. See plan §2.5 / §2.9.
     const out = virtualizeTse("<%# locals: () %><p>hi</p>");
-    expect(out).toContain("locals: Record<never, never>");
+    expect(out).toContain("locals: Record<string, never>");
+    // Confirm via tsc: passing `{ extra: 1 }` to a `Record<string, never>`
+    // parameter is a type error. (Inline a Record alias because the
+    // diagnose helper runs with `lib: []`.)
+    const probe =
+      "type Record<K extends keyof never, V> = { [P in K]: V };\n" +
+      out +
+      "\nrender({} as RenderContext, { extra: 1 });";
+    expect(diagnose(probe).join("\n")).toMatch(/not assignable|extra/i);
   });
 
   it("destructures locals and types them as unknown when no types block", () => {
@@ -47,6 +62,25 @@ describe("virtualizeTse", () => {
   it("splits locals on top-level commas only", () => {
     const ts = virtualizeTse("<%# locals: (a: f(1, 2), b: [1, 2]) %>");
     expect(ts).toContain("const { a = f(1, 2), b = [1, 2] } = locals;");
+  });
+
+  it("does not split commas inside string or template literals", () => {
+    const ts = virtualizeTse("<%# locals: (a: \"x, y\", b: 'p, q', c: `t, ${x}, u`) %>");
+    expect(ts).toContain("const { a = \"x, y\", b = 'p, q', c = `t, ${x}, u` } = locals;");
+  });
+
+  it("throws on a malformed locals entry (no colon)", () => {
+    expect(() => virtualizeTse("<%# locals: (user) %>")).toThrow(TseLocalsSignatureError);
+  });
+
+  it("reports a LineDelta covering the header so diagnostics remap back to .tse", () => {
+    const { ts, deltas } = virtualizeTseWithDeltas("<h1><%= 1 %></h1>");
+    expect(deltas).toHaveLength(1);
+    expect(deltas[0]?.insertedAtLine).toBe(-1);
+    // The header runs from the file start up to (and including) the
+    // `const _ob = …` line. The body should start immediately after.
+    const headerLines = ts.split("\n").slice(0, deltas[0]!.lineCount);
+    expect(headerLines.at(-1)).toContain("const _ob");
   });
 
   it("dispatches expression sites and preserves code chunks raw", () => {

--- a/packages/trails-tsc/src/plugins/tse.test.ts
+++ b/packages/trails-tsc/src/plugins/tse.test.ts
@@ -80,10 +80,27 @@ describe("virtualizeTse", () => {
     expect(head?.insertedAtLine).toBe(-1);
     const lines = ts.split("\n");
     expect(lines[head!.lineCount - 1]).toContain("const _ob");
-    // Footer delta starts at the line after the body and covers the
-    // trailing `return _ob;` + `}` + trailing newline.
-    expect(lines[foot!.insertedAtLine]).toContain("return _ob");
-    expect(foot?.insertedAtLine).toBe(head!.lineCount + 3); // 3 body nodes: text, expr, text
+    // Footer delta marks the line BEFORE the trailing `return _ob;`
+    // (remapLine treats `injectedStart` as exclusive); the footer
+    // block then spans `lineCount` lines starting at injectedStart+1.
+    expect(lines[foot!.insertedAtLine + 1]).toContain("return _ob");
+  });
+
+  it("counts multi-line `<% %>` chunks as multiple virtual lines for the footer offset", () => {
+    const { ts, deltas } = virtualizeTseWithDeltas("<% const x = 1;\nconst y = 2; %>hi");
+    const [, foot] = deltas;
+    const lines = ts.split("\n");
+    // The footer's `return _ob;` should sit immediately after the
+    // body, regardless of how many node-array entries the body has.
+    expect(lines[foot!.insertedAtLine + 1]).toContain("return _ob");
+  });
+
+  it("throws on unbalanced brackets in the locals signature", () => {
+    expect(() => virtualizeTse("<%# locals: (a: (1, 2) %>")).toThrow(TseLocalsSignatureError);
+  });
+
+  it("throws on an unterminated string in the locals signature", () => {
+    expect(() => virtualizeTse('<%# locals: (a: "oops) %>')).toThrow(TseLocalsSignatureError);
   });
 
   it("dispatches expression sites and preserves code chunks raw", () => {

--- a/packages/trails-tsc/src/plugins/tse.test.ts
+++ b/packages/trails-tsc/src/plugins/tse.test.ts
@@ -21,6 +21,19 @@ describe("createTsePlugin", () => {
     expect(out?.ts).toContain('_ob.safeAppend("<h1>");');
     expect(out?.ts).toContain("_ob.append(1);");
   });
+
+  it("emits an error shim instead of throwing when virtualization fails", () => {
+    const plugin = createTsePlugin();
+    // Unbalanced brackets in the locals signature would otherwise raise
+    // and crash the host's `tsc` invocation.
+    const out = plugin.virtualize("/x/bad.tse", "<%# locals: (a: (1, 2) %>");
+    expect(out?.ts).toContain("/x/bad.tse");
+    expect(out?.ts).toContain(".tse virtualization failed");
+    // The shim is itself a valid TS source that produces a clear
+    // diagnostic when tsc compiles it.
+    const diags = diagnose(out!.ts);
+    expect(diags.length).toBeGreaterThan(0);
+  });
 });
 
 describe("virtualizeTse", () => {
@@ -71,6 +84,12 @@ describe("virtualizeTse", () => {
 
   it("throws on a malformed locals entry (no colon)", () => {
     expect(() => virtualizeTse("<%# locals: (user) %>")).toThrow(TseLocalsSignatureError);
+  });
+
+  it("shields unused destructured locals with `void name;`", () => {
+    const out = virtualizeTse("<%# locals: (user:, count: 0) %><p>hi</p>");
+    expect(out).toContain("const { user, count = 0 } = locals;");
+    expect(out).toContain("void user; void count;");
   });
 
   it("reports LineDeltas covering header and footer so diagnostics remap back to .tse", () => {

--- a/packages/trails-tsc/src/plugins/tse.test.ts
+++ b/packages/trails-tsc/src/plugins/tse.test.ts
@@ -128,6 +128,12 @@ describe("virtualizeTse", () => {
     expect(() => virtualizeTse("<%# locals: (a: {1, 2]) %>")).toThrow(/mismatched/);
   });
 
+  it("accepts mixed named kwargs + `**nil` sentinel (Rails parity)", () => {
+    const out = virtualizeTse("<%# locals: (user:, **nil) %><%= user %>");
+    expect(out).toContain("const { user } = locals;");
+    expect(out).toContain("locals: { user: unknown }");
+  });
+
   it("throws on an empty / invalid local name", () => {
     expect(() => virtualizeTse("<%# locals: (: 1) %>")).toThrow(/invalid local name/);
     expect(() => virtualizeTse("<%# locals: (1bad: 1) %>")).toThrow(/invalid local name/);

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -58,7 +58,10 @@ function parseLocalsSignature(sig: string): LocalEntry[] {
 
 function localsParamType(ast: TseAst, locals: LocalEntry[]): string {
   if (ast.typesAnnotation !== null) return ast.typesAnnotation;
-  if (locals.length === 0) return "Record<string, unknown>";
+  // No `<%# locals: %>` at all → permissive default.
+  if (ast.localsSignature === null) return "Record<string, unknown>";
+  // Explicit empty `<%# locals: () %>` → reject any keys (Rails `**nil`).
+  if (locals.length === 0) return "Record<never, never>";
   const fields = locals.map((l) => `${l.name}${l.defaultExpr ? "?" : ""}: unknown`);
   return `{ ${fields.join("; ")} }`;
 }

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -49,8 +49,25 @@ function parseLocalsSignature(sig: string): LocalEntry[] {
       continue;
     }
     if (ch === "(" || ch === "[" || ch === "{") depth++;
-    else if (ch === ")" || ch === "]" || ch === "}") depth--;
+    else if (ch === ")" || ch === "]" || ch === "}") {
+      depth--;
+      if (depth < 0) {
+        throw new TseLocalsSignatureError(
+          `unbalanced \`${ch}\` in locals signature ${JSON.stringify(sig)}`,
+        );
+      }
+    }
     buf += ch;
+  }
+  if (quote !== null) {
+    throw new TseLocalsSignatureError(
+      `unterminated ${quote === "`" ? "template literal" : "string"} in locals signature ${JSON.stringify(sig)}`,
+    );
+  }
+  if (depth !== 0) {
+    throw new TseLocalsSignatureError(
+      `unbalanced brackets in locals signature ${JSON.stringify(sig)}`,
+    );
   }
   if (buf.trim() !== "") parts.push(buf);
 
@@ -158,11 +175,15 @@ export function virtualizeTseWithDeltas(source: string): VirtualizeTseResult {
   // Per-node line-precise mapping inside the body is a follow-up tied
   // to tse-compiler emitting token spans.
   const ts = [...header, ...body, ...footer].join("\n");
+  // Body strings may contain embedded newlines (multi-line `<% %>`
+  // code chunks); compute virtual-line counts from the emitted text,
+  // not the node array length.
   const headerLineCount = header.join("\n").split("\n").length;
+  const bodyLineCount = body.length === 0 ? 0 : body.join("\n").split("\n").length;
   const footerLineCount = footer.join("\n").split("\n").length;
   const deltas: LineDelta[] = [
     { insertedAtLine: -1, lineCount: headerLineCount },
-    { insertedAtLine: headerLineCount + body.length, lineCount: footerLineCount },
+    { insertedAtLine: headerLineCount + bodyLineCount - 1, lineCount: footerLineCount },
   ];
   return { ts, deltas };
 }

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -1,0 +1,134 @@
+/**
+ * TSE virtualization plugin. Maps `.tse` source files to a typed TS
+ * function so tsc can type-check `<%= expr %>` and `<% code %>` blocks
+ * against the locals declared in `<%# locals: (...) %>` / refined by
+ * `<%! types: { ... } !%>`.
+ *
+ * Phase 2b scope: a single virtualized TS string per file (the
+ * `.tse.ts` body). On-disk `.tse.d.ts` / `.tse.js` emission is Phase
+ * 2c (build CLI). The body declares `RenderContext` and `SafeString`
+ * inline so this plugin has no actionview dependency.
+ *
+ * Plan: docs/tse-plan.md §2 + §4 (Phase 2b).
+ */
+
+import { parse, type TseAst } from "@blazetrails/tse-compiler";
+import type { TscPlugin, VirtualizeOutput } from "../plugin.js";
+
+interface LocalEntry {
+  name: string;
+  defaultExpr: string | null;
+}
+
+/**
+ * Parse the body of `<%# locals: (...) %>` into entries. The grammar
+ * matches Rails' kwarg form: `name:` (required) and `name: default`
+ * (optional). Defaults can contain commas inside parens/brackets/braces,
+ * so we split on top-level commas only.
+ */
+function parseLocalsSignature(sig: string): LocalEntry[] {
+  if (sig === "**nil" || sig.trim() === "") return [];
+  const parts: string[] = [];
+  let depth = 0;
+  let buf = "";
+  for (const ch of sig) {
+    if (ch === "," && depth === 0) {
+      parts.push(buf);
+      buf = "";
+      continue;
+    }
+    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    else if (ch === ")" || ch === "]" || ch === "}") depth--;
+    buf += ch;
+  }
+  if (buf.trim() !== "") parts.push(buf);
+
+  const entries: LocalEntry[] = [];
+  for (const raw of parts) {
+    const trimmed = raw.trim();
+    if (trimmed === "") continue;
+    const colon = trimmed.indexOf(":");
+    if (colon === -1) continue;
+    const name = trimmed.slice(0, colon).trim();
+    const tail = trimmed.slice(colon + 1).trim();
+    entries.push({ name, defaultExpr: tail === "" ? null : tail });
+  }
+  return entries;
+}
+
+function localsParamType(ast: TseAst, locals: LocalEntry[]): string {
+  if (ast.typesAnnotation !== null) return ast.typesAnnotation;
+  if (locals.length === 0) return "Record<string, unknown>";
+  const fields = locals.map((l) => `${l.name}${l.defaultExpr ? "?" : ""}: unknown`);
+  return `{ ${fields.join("; ")} }`;
+}
+
+function destructureLine(locals: LocalEntry[]): string {
+  if (locals.length === 0) return "";
+  const pieces = locals.map((l) =>
+    l.defaultExpr === null ? l.name : `${l.name} = ${l.defaultExpr}`,
+  );
+  return `  const { ${pieces.join(", ")} } = locals;`;
+}
+
+function emitNode(node: TseAst["nodes"][number]): string {
+  switch (node.kind) {
+    case "text":
+      return `  _ob.safeAppend(${JSON.stringify(node.value)});`;
+    case "code": {
+      const t = node.value.trimEnd();
+      const needsSemi = !(t.endsWith(";") || t.endsWith("{") || t.endsWith("}"));
+      return `  ${node.value}${needsSemi ? ";" : ""}`;
+    }
+    case "expr":
+      return `  _ob.append(${node.value});`;
+    case "rawExpr":
+      return `  _ob.safeExprAppend(${node.value});`;
+  }
+}
+
+const PREAMBLE = [
+  "/* virtualized from .tse — phase 2b trails-tsc plugin */",
+  "interface SafeString { readonly __safeStringBrand: unique symbol }",
+  "interface OutputBuffer extends SafeString {",
+  "  safeAppend(s: string): void;",
+  "  append(value: unknown): void;",
+  "  safeExprAppend(value: unknown): void;",
+  "}",
+  "interface RenderContext {",
+  "  readonly outputBuffer: OutputBuffer;",
+  "  [key: string]: unknown;",
+  "}",
+  "",
+].join("\n");
+
+export function virtualizeTse(source: string): string {
+  const ast = parse(source);
+  const locals = ast.localsSignature === null ? [] : parseLocalsSignature(ast.localsSignature);
+  const localsType = localsParamType(ast, locals);
+
+  const lines: string[] = [
+    PREAMBLE,
+    "export default function render(",
+    "  context: RenderContext,",
+    `  locals: ${localsType},`,
+    "): SafeString {",
+    "  void context; void locals;",
+    "  const _ob = context.outputBuffer;",
+  ];
+  const destruct = destructureLine(locals);
+  if (destruct !== "") lines.push(destruct);
+  for (const node of ast.nodes) lines.push(emitNode(node));
+  lines.push("  return _ob;", "}", "");
+  return lines.join("\n");
+}
+
+export function createTsePlugin(): TscPlugin {
+  return {
+    name: "tse",
+    extensions: [".tse"],
+    virtualize(_filePath, source): VirtualizeOutput {
+      return { ts: virtualizeTse(source) };
+    },
+  };
+}

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -152,12 +152,18 @@ export function virtualizeTseWithDeltas(source: string): VirtualizeTseResult {
   for (const node of ast.nodes) body.push(emitNode(node));
   const footer = ["  return _ob;", "}", ""];
 
-  // Single LineDelta covers the prepended header so `remapDiagnostics`
-  // surfaces tsc errors at the user's `.tse` coordinates. Per-node
-  // line-precise mapping is a follow-up tied to tse-compiler token spans.
+  // Two LineDeltas: one for the prepended header, one for the trailing
+  // footer (return + `}`). Without the footer delta, tsc errors landing
+  // at the closing brace would mis-remap to nonexistent `.tse` lines.
+  // Per-node line-precise mapping inside the body is a follow-up tied
+  // to tse-compiler emitting token spans.
   const ts = [...header, ...body, ...footer].join("\n");
   const headerLineCount = header.join("\n").split("\n").length;
-  const deltas: LineDelta[] = [{ insertedAtLine: -1, lineCount: headerLineCount }];
+  const footerLineCount = footer.join("\n").split("\n").length;
+  const deltas: LineDelta[] = [
+    { insertedAtLine: -1, lineCount: headerLineCount },
+    { insertedAtLine: headerLineCount + body.length, lineCount: footerLineCount },
+  ];
   return { ts, deltas };
 }
 

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -13,7 +13,9 @@
  */
 
 import { parse, type TseAst } from "@blazetrails/tse-compiler";
-import type { TscPlugin, VirtualizeOutput } from "../plugin.js";
+import type { LineDelta, TscPlugin, VirtualizeOutput } from "../plugin.js";
+
+export class TseLocalsSignatureError extends Error {}
 
 interface LocalEntry {
   name: string;
@@ -23,15 +25,37 @@ interface LocalEntry {
 /**
  * Parse the body of `<%# locals: (...) %>` into entries. The grammar
  * matches Rails' kwarg form: `name:` (required) and `name: default`
- * (optional). Defaults can contain commas inside parens/brackets/braces,
- * so we split on top-level commas only.
+ * (optional). Defaults can contain commas inside parens/brackets/braces
+ * and string/template literals, so we split on top-level commas only,
+ * tracking bracket depth and quote state. Generics (`Foo<A, B>`) are
+ * NOT recognized — angle brackets are ambiguous with `<` comparisons
+ * without a full TS scanner; same class of pragmatic limit as Erubi's
+ * regex lexer (plan §2.10.1). Template authors with generic defaults
+ * should bind via a name (`const x = foo<A, B>(); … count: x`).
  */
 function parseLocalsSignature(sig: string): LocalEntry[] {
   if (sig === "**nil" || sig.trim() === "") return [];
   const parts: string[] = [];
   let depth = 0;
+  let quote: '"' | "'" | "`" | null = null;
   let buf = "";
-  for (const ch of sig) {
+  for (let i = 0; i < sig.length; i++) {
+    const ch = sig[i]!;
+    if (quote !== null) {
+      buf += ch;
+      if (ch === "\\" && i + 1 < sig.length) {
+        buf += sig[i + 1]!;
+        i++;
+        continue;
+      }
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'" || ch === "`") {
+      quote = ch;
+      buf += ch;
+      continue;
+    }
     if (ch === "," && depth === 0) {
       parts.push(buf);
       buf = "";
@@ -48,7 +72,11 @@ function parseLocalsSignature(sig: string): LocalEntry[] {
     const trimmed = raw.trim();
     if (trimmed === "") continue;
     const colon = trimmed.indexOf(":");
-    if (colon === -1) continue;
+    if (colon === -1) {
+      throw new TseLocalsSignatureError(
+        `malformed locals entry ${JSON.stringify(trimmed)} — expected \`name:\` or \`name: default\``,
+      );
+    }
     const name = trimmed.slice(0, colon).trim();
     const tail = trimmed.slice(colon + 1).trim();
     entries.push({ name, defaultExpr: tail === "" ? null : tail });
@@ -61,7 +89,10 @@ function localsParamType(ast: TseAst, locals: LocalEntry[]): string {
   // No `<%# locals: %>` at all → permissive default.
   if (ast.localsSignature === null) return "Record<string, unknown>";
   // Explicit empty `<%# locals: () %>` → reject any keys (Rails `**nil`).
-  if (locals.length === 0) return "Record<never, never>";
+  // `Record<never, never>` collapses to `{}` (any object assignable),
+  // so use `Record<string, never>` — every key must map to `never`,
+  // which makes any provided property a type error.
+  if (locals.length === 0) return "Record<string, never>";
   const fields = locals.map((l) => `${l.name}${l.defaultExpr ? "?" : ""}: unknown`);
   return `{ ${fields.join("; ")} }`;
 }
@@ -105,12 +136,21 @@ const PREAMBLE = [
   "",
 ].join("\n");
 
+export interface VirtualizeTseResult {
+  ts: string;
+  deltas: readonly LineDelta[];
+}
+
 export function virtualizeTse(source: string): string {
+  return virtualizeTseWithDeltas(source).ts;
+}
+
+export function virtualizeTseWithDeltas(source: string): VirtualizeTseResult {
   const ast = parse(source);
   const locals = ast.localsSignature === null ? [] : parseLocalsSignature(ast.localsSignature);
   const localsType = localsParamType(ast, locals);
 
-  const lines: string[] = [
+  const header: string[] = [
     PREAMBLE,
     "export default function render(",
     "  context: RenderContext,",
@@ -120,10 +160,21 @@ export function virtualizeTse(source: string): string {
     "  const _ob = context.outputBuffer;",
   ];
   const destruct = destructureLine(locals);
-  if (destruct !== "") lines.push(destruct);
-  for (const node of ast.nodes) lines.push(emitNode(node));
-  lines.push("  return _ob;", "}", "");
-  return lines.join("\n");
+  if (destruct !== "") header.push(destruct);
+  const body: string[] = [];
+  for (const node of ast.nodes) body.push(emitNode(node));
+  const footer = ["  return _ob;", "}", ""];
+
+  // The entire header is prepended scaffolding the user didn't write;
+  // report it as a single LineDelta at the head of the virtualized
+  // file so `remapDiagnostics` subtracts it when surfacing tsc errors
+  // at `.tse` coordinates. Body lines are 1:1 with `<%= %>`/`<% %>`
+  // tokens; per-node line-precise mapping is a follow-up tied to
+  // tse-compiler emitting token spans.
+  const ts = [...header, ...body, ...footer].join("\n");
+  const headerLineCount = header.join("\n").split("\n").length;
+  const deltas: LineDelta[] = [{ insertedAtLine: -1, lineCount: headerLineCount }];
+  return { ts, deltas };
 }
 
 export function createTsePlugin(): TscPlugin {
@@ -131,7 +182,8 @@ export function createTsePlugin(): TscPlugin {
     name: "tse",
     extensions: [".tse"],
     virtualize(_filePath, source): VirtualizeOutput {
-      return { ts: virtualizeTse(source) };
+      const { ts, deltas } = virtualizeTseWithDeltas(source);
+      return { ts, deltas };
     },
   };
 }

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -1,8 +1,10 @@
 /**
- * TSE virtualization plugin. Maps `.tse` sources to a typed TS render
+ * TSE virtualization plugin — the in-memory tsc-virtualization half of
+ * Phase 2b (plan §2 / §4). Maps `.tse` sources to a typed TS render
  * function so tsc can check `<%= expr %>` / `<% code %>` against the
- * declared locals. Plan: docs/tse-plan.md §2 + §4 (Phase 2b).
- * On-disk `.tse.d.ts` / `.tse.js` emission is Phase 2c (build CLI).
+ * declared locals. This PR covers the virtualizing `TscPlugin` only;
+ * on-disk `.tse.d.ts` / `.tse.js` emission, the views-manifest writer,
+ * and the build CLI are Phase 2c.
  */
 
 import { parse, type TseAst } from "@blazetrails/tse-compiler";
@@ -13,6 +15,30 @@ export class TseLocalsSignatureError extends Error {}
 interface LocalEntry {
   name: string;
   defaultExpr: string | null;
+}
+
+// Words reserved in ES strict mode + module context — every one of
+// these would crash the emitted `const { <name> } = locals;` /
+// `void <name>;`. Strict mode is implicit in ESM, which is what
+// trails-tsc emits.
+// prettier-ignore
+const RESERVED_NAMES = new Set([
+  "break", "case", "catch", "class", "const", "continue", "debugger",
+  "default", "delete", "do", "else", "enum", "export", "extends", "false",
+  "finally", "for", "function", "if", "import", "in", "instanceof", "new",
+  "null", "return", "super", "switch", "this", "throw", "true", "try",
+  "typeof", "var", "void", "while", "with", "yield", "implements",
+  "interface", "let", "package", "private", "protected", "public",
+  "static", "await", "async",
+]);
+
+function isUsableLocalName(name: string): boolean {
+  // Syntactic shape: must look like a TS identifier (rejects empty,
+  // digit-led, punctuation). `ts.createSourceFile` is the bullet-proof
+  // check because it covers Unicode identifier rules, but we keep it
+  // cheap with a guard regex first.
+  if (!/^[A-Za-z_$][\w$]*$/u.test(name)) return false;
+  return !RESERVED_NAMES.has(name);
 }
 
 // Parse `<%# locals: (...) %>` body into entries. Splits on top-level
@@ -87,7 +113,11 @@ function parseLocalsSignature(sig: string): LocalEntry[] {
       );
     }
     const name = trimmed.slice(0, colon).trim();
-    if (!/^[A-Za-z_$][\w$]*$/.test(name)) {
+    // Identifier shape + reserved-word rejection. The bullet-proof
+    // check is "would `const { <name> } = x;` parse cleanly?" — let TS
+    // answer it for us via createSourceFile diagnostics. Caches keyed
+    // by name keep this cheap across many entries.
+    if (!isUsableLocalName(name)) {
       throw new TseLocalsSignatureError(
         `invalid local name ${JSON.stringify(name)} in locals signature ${JSON.stringify(sig)}`,
       );

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -1,15 +1,8 @@
 /**
- * TSE virtualization plugin. Maps `.tse` source files to a typed TS
- * function so tsc can type-check `<%= expr %>` and `<% code %>` blocks
- * against the locals declared in `<%# locals: (...) %>` / refined by
- * `<%! types: { ... } !%>`.
- *
- * Phase 2b scope: a single virtualized TS string per file (the
- * `.tse.ts` body). On-disk `.tse.d.ts` / `.tse.js` emission is Phase
- * 2c (build CLI). The body declares `RenderContext` and `SafeString`
- * inline so this plugin has no actionview dependency.
- *
- * Plan: docs/tse-plan.md §2 + §4 (Phase 2b).
+ * TSE virtualization plugin. Maps `.tse` sources to a typed TS render
+ * function so tsc can check `<%= expr %>` / `<% code %>` against the
+ * declared locals. Plan: docs/tse-plan.md §2 + §4 (Phase 2b).
+ * On-disk `.tse.d.ts` / `.tse.js` emission is Phase 2c (build CLI).
  */
 
 import { parse, type TseAst } from "@blazetrails/tse-compiler";
@@ -22,17 +15,11 @@ interface LocalEntry {
   defaultExpr: string | null;
 }
 
-/**
- * Parse the body of `<%# locals: (...) %>` into entries. The grammar
- * matches Rails' kwarg form: `name:` (required) and `name: default`
- * (optional). Defaults can contain commas inside parens/brackets/braces
- * and string/template literals, so we split on top-level commas only,
- * tracking bracket depth and quote state. Generics (`Foo<A, B>`) are
- * NOT recognized — angle brackets are ambiguous with `<` comparisons
- * without a full TS scanner; same class of pragmatic limit as Erubi's
- * regex lexer (plan §2.10.1). Template authors with generic defaults
- * should bind via a name (`const x = foo<A, B>(); … count: x`).
- */
+// Parse `<%# locals: (...) %>` body into entries. Splits on top-level
+// commas only, tracking brackets and quote/template-literal state.
+// Generics in defaults (`Foo<A, B>`) are not recognized — angle brackets
+// alias with `<` comparisons without a full TS scanner; same class of
+// pragmatic limit as Erubi's regex lexer (plan §2.10.1).
 function parseLocalsSignature(sig: string): LocalEntry[] {
   if (sig === "**nil" || sig.trim() === "") return [];
   const parts: string[] = [];
@@ -165,12 +152,9 @@ export function virtualizeTseWithDeltas(source: string): VirtualizeTseResult {
   for (const node of ast.nodes) body.push(emitNode(node));
   const footer = ["  return _ob;", "}", ""];
 
-  // The entire header is prepended scaffolding the user didn't write;
-  // report it as a single LineDelta at the head of the virtualized
-  // file so `remapDiagnostics` subtracts it when surfacing tsc errors
-  // at `.tse` coordinates. Body lines are 1:1 with `<%= %>`/`<% %>`
-  // tokens; per-node line-precise mapping is a follow-up tied to
-  // tse-compiler emitting token spans.
+  // Single LineDelta covers the prepended header so `remapDiagnostics`
+  // surfaces tsc errors at the user's `.tse` coordinates. Per-node
+  // line-precise mapping is a follow-up tied to tse-compiler token spans.
   const ts = [...header, ...body, ...footer].join("\n");
   const headerLineCount = header.join("\n").split("\n").length;
   const deltas: LineDelta[] = [{ insertedAtLine: -1, lineCount: headerLineCount }];

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -22,8 +22,9 @@ interface LocalEntry {
 // pragmatic limit as Erubi's regex lexer (plan §2.10.1).
 function parseLocalsSignature(sig: string): LocalEntry[] {
   if (sig === "**nil" || sig.trim() === "") return [];
+  const CLOSERS: Record<string, string> = { "(": ")", "[": "]", "{": "}" };
   const parts: string[] = [];
-  let depth = 0;
+  const stack: string[] = [];
   let quote: '"' | "'" | "`" | null = null;
   let buf = "";
   for (let i = 0; i < sig.length; i++) {
@@ -43,17 +44,17 @@ function parseLocalsSignature(sig: string): LocalEntry[] {
       buf += ch;
       continue;
     }
-    if (ch === "," && depth === 0) {
+    if (ch === "," && stack.length === 0) {
       parts.push(buf);
       buf = "";
       continue;
     }
-    if (ch === "(" || ch === "[" || ch === "{") depth++;
+    if (ch === "(" || ch === "[" || ch === "{") stack.push(CLOSERS[ch]!);
     else if (ch === ")" || ch === "]" || ch === "}") {
-      depth--;
-      if (depth < 0) {
+      const expected = stack.pop();
+      if (expected !== ch) {
         throw new TseLocalsSignatureError(
-          `unbalanced \`${ch}\` in locals signature ${JSON.stringify(sig)}`,
+          `mismatched \`${ch}\` (expected \`${expected ?? "<none>"}\`) in locals signature ${JSON.stringify(sig)}`,
         );
       }
     }
@@ -64,7 +65,7 @@ function parseLocalsSignature(sig: string): LocalEntry[] {
       `unterminated ${quote === "`" ? "template literal" : "string"} in locals signature ${JSON.stringify(sig)}`,
     );
   }
-  if (depth !== 0) {
+  if (stack.length !== 0) {
     throw new TseLocalsSignatureError(
       `unbalanced brackets in locals signature ${JSON.stringify(sig)}`,
     );
@@ -82,6 +83,11 @@ function parseLocalsSignature(sig: string): LocalEntry[] {
       );
     }
     const name = trimmed.slice(0, colon).trim();
+    if (!/^[A-Za-z_$][\w$]*$/.test(name)) {
+      throw new TseLocalsSignatureError(
+        `invalid local name ${JSON.stringify(name)} in locals signature ${JSON.stringify(sig)}`,
+      );
+    }
     const tail = trimmed.slice(colon + 1).trim();
     entries.push({ name, defaultExpr: tail === "" ? null : tail });
   }
@@ -190,12 +196,10 @@ export function virtualizeTseWithDeltas(source: string): VirtualizeTseResult {
   return { ts, deltas };
 }
 
-/**
- * Build a virtualized TS source that surfaces `msg` as a tsc error
- * diagnostic at line 1 (via a `@ts-expect-error`-defying type clash),
- * so a single malformed `.tse` produces a readable error instead of
- * crashing the whole `tsc` run.
- */
+// Build a virtualized TS source that surfaces `msg` as a tsc semantic
+// diagnostic (a string literal assigned to a `never`-typed binding) so
+// a single malformed `.tse` produces a readable error rather than
+// crashing the host's `tsc` run.
 function errorShim(filePath: string, msg: string): string {
   const safe = JSON.stringify(`${filePath}: ${msg}`);
   // `string` is not assignable to `never`, so tsc reports a clear

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -101,12 +101,15 @@ function localsParamType(ast: TseAst, locals: LocalEntry[]): string {
   return `{ ${fields.join("; ")} }`;
 }
 
-function destructureLine(locals: LocalEntry[]): string {
-  if (locals.length === 0) return "";
+function destructureLines(locals: LocalEntry[]): string[] {
+  if (locals.length === 0) return [];
   const pieces = locals.map((l) =>
     l.defaultExpr === null ? l.name : `${l.name} = ${l.defaultExpr}`,
   );
-  return `  const { ${pieces.join(", ")} } = locals;`;
+  // `void name;` shields unused destructured locals from `noUnusedLocals`,
+  // matching the `void context; void locals;` shield on the parameters.
+  const voids = `  ${locals.map((l) => `void ${l.name};`).join(" ")}`;
+  return [`  const { ${pieces.join(", ")} } = locals;`, voids];
 }
 
 function emitNode(node: TseAst["nodes"][number]): string {
@@ -163,8 +166,7 @@ export function virtualizeTseWithDeltas(source: string): VirtualizeTseResult {
     "  void context; void locals;",
     "  const _ob = context.outputBuffer;",
   ];
-  const destruct = destructureLine(locals);
-  if (destruct !== "") header.push(destruct);
+  for (const line of destructureLines(locals)) header.push(line);
   const body: string[] = [];
   for (const node of ast.nodes) body.push(emitNode(node));
   const footer = ["  return _ob;", "}", ""];
@@ -188,13 +190,36 @@ export function virtualizeTseWithDeltas(source: string): VirtualizeTseResult {
   return { ts, deltas };
 }
 
+/**
+ * Build a virtualized TS source that surfaces `msg` as a tsc error
+ * diagnostic at line 1 (via a `@ts-expect-error`-defying type clash),
+ * so a single malformed `.tse` produces a readable error instead of
+ * crashing the whole `tsc` run.
+ */
+function errorShim(filePath: string, msg: string): string {
+  const safe = JSON.stringify(`${filePath}: ${msg}`);
+  // `string` is not assignable to `never`, so tsc reports a clear
+  // semantic error whose message includes the failure detail.
+  return [
+    `// .tse virtualization failed: ${safe}`,
+    `const __tseFailure: never = ${safe};`,
+    `export default __tseFailure;`,
+    "",
+  ].join("\n");
+}
+
 export function createTsePlugin(): TscPlugin {
   return {
     name: "tse",
     extensions: [".tse"],
-    virtualize(_filePath, source): VirtualizeOutput {
-      const { ts, deltas } = virtualizeTseWithDeltas(source);
-      return { ts, deltas };
+    virtualize(filePath, source): VirtualizeOutput {
+      try {
+        const { ts, deltas } = virtualizeTseWithDeltas(source);
+        return { ts, deltas };
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        return { ts: errorShim(filePath, msg) };
+      }
     },
   };
 }

--- a/packages/trails-tsc/src/plugins/tse.ts
+++ b/packages/trails-tsc/src/plugins/tse.ts
@@ -76,6 +76,10 @@ function parseLocalsSignature(sig: string): LocalEntry[] {
   for (const raw of parts) {
     const trimmed = raw.trim();
     if (trimmed === "") continue;
+    // Rails accepts `**nil` mixed with named kwargs (e.g.
+    // `locals: (user:, **nil)`) to mean "these locals plus no
+    // extras". Skip the sentinel; treat surrounding entries normally.
+    if (trimmed === "**nil") continue;
     const colon = trimmed.indexOf(":");
     if (colon === -1) {
       throw new TseLocalsSignatureError(

--- a/packages/trails-tsc/tsconfig.json
+++ b/packages/trails-tsc/tsconfig.json
@@ -6,5 +6,5 @@
     "rootDir": "src"
   },
   "include": ["src"],
-  "references": []
+  "references": [{ "path": "../tse-compiler" }]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -201,6 +201,9 @@ importers:
 
   packages/trails-tsc:
     dependencies:
+      '@blazetrails/tse-compiler':
+        specifier: workspace:*
+        version: link:../tse-compiler
       typescript:
         specifier: ^5.0.0
         version: 5.9.3

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -137,6 +137,7 @@ const alias = {
   ),
   "@blazetrails/globalid": path.resolve(__dirname, "packages/globalid/src/index.ts"),
   "@blazetrails/trails-tsc": path.resolve(__dirname, "packages/trails-tsc/src/index.ts"),
+  "@blazetrails/tse-compiler": path.resolve(__dirname, "packages/tse-compiler/src/index.ts"),
   "@blazetrails/did-you-mean": path.resolve(__dirname, "packages/did-you-mean/src/index.ts"),
 };
 


### PR DESCRIPTION
## Summary

- Registers `.tse` as a tsc-visible extension via `createTsePlugin()`.
- Lifts `<%# locals: (...) %>` (Rails kwarg form: required + defaults, plus `**nil` sentinel) and optional `<%! types: {...} !%>` blocks via `@blazetrails/tse-compiler`.
- Emits an inline virtualized TS body — `export default function render(context: RenderContext, locals: <types>): SafeString` — so tsc type-checks `<%= expr %>` / `<% code %>` against the declared locals.
- Returns `LineDelta`s covering the prepended header and trailing footer so `remapDiagnostics` surfaces tsc errors near the user's `.tse` coordinates.
- Catches malformed-source errors and emits an error-shim TS source so a single bad `.tse` doesn't crash the host's `tsc` run.

Plan: `docs/tse-plan.md` §2 + §4 (Phase 2b). Builds on tse-compiler #2190. Independent of Phase 2a-1. `RenderContext` / `SafeString` are declared inline so the plugin has no actionview dep — Phase 2c will swap to `import type` from `@blazetrails/actionview`.

## Test plan

- [x] `pnpm vitest run packages/trails-tsc/src/plugins/tse.test.ts` — 22/22 pass
- [x] `pnpm --filter @blazetrails/trails-tsc exec tsc --noEmit` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm --filter @blazetrails/trails-tsc build` + `pnpm --filter @blazetrails/tse-compiler build`

## Known follow-ups (Phase 2c)

These are tracked in `docs/tse-plan.md` Phase 2c and won't ship with this PR. Calling them out explicitly because Copilot reviews surfaced them across iterations:

1. **`NoExtraKeys<T>` for strict-locals** (plan §2.5). The emitted `locals` type is a plain object type, which TS's excess-property check only reliably catches for fresh object literals at the call site. Adding an exact-type helper lands together with the swap from inline `RenderContext` to actionview's augmentable interface in Phase 2c.

2. **Per-token line-preserving body emission.** The current emitter collapses multi-line text/code tokens into single TS lines, so `remapDiagnostics` only maps errors that land in the header or footer back to `.tse` coordinates accurately. The fix needs tse-compiler to surface token spans; until then body-line diagnostics may point at the wrong `.tse` line. Listed in `docs/tse-plan.md` §3.5.

3. **TS-aware locals signature scanning.** The current parser tracks bracket depth + quote/template-literal state, but not generic angle brackets (`Foo<A, B>` defaults). The follow-up replaces the hand-rolled splitter with the TS scanner; same class of pragmatic limit as Erubi's regex lexer (plan §2.10.1).

4. **Reserved-word set vs. Unicode identifiers / contextual keywords.** `RESERVED_NAMES` is a hardcoded ASCII set tuned to ES strict + module context. `async` is included defensively (it's contextually reserved inside async functions, which the emitted render *is*, transitively, when streaming Phase 3d lands). Unicode identifier support and tightening `async` to `await`-only require switching to a TS-scanner-based check; deferred to the same Phase 2c follow-up as #3 since both share that dependency.

5. **Stale "createSourceFile + cache" comment** (Copilot review #9). The reserved-word check is currently the hardcoded set + ASCII regex; the comment overstates what the implementation does. Will fix in the Phase 2c PR that lands the TS-scanner-based check from #3 — the implementation will then match the wording.