### PR TITLE
refactor(activerecord): add sidecar test-adapter shape (Path 2a)

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -21,6 +21,7 @@ import { inspectExplainOption } from "./adapter.js";
 import type { AdapterName, DatabaseAdapter, ExplainOption } from "./adapter.js";
 import type { SchemaCache } from "./connection-adapters/schema-cache.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { SidecarFixtures } from "./test-helpers/sidecar-fixtures.js";
 import {
   clearDdlTrackers,
   getCreatedTables,
@@ -37,6 +38,8 @@ import type { Result } from "./result.js";
 // test-setup-worker-db.ts (a setupFile that runs before this module loads).
 const PG_TEST_URL = process.env.PG_TEST_URL;
 const MYSQL_TEST_URL = process.env.MYSQL_TEST_URL;
+
+export { SidecarFixtures };
 
 /** Which adapter backend is active. */
 export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL
@@ -110,6 +113,25 @@ export interface TestDatabaseAdapter extends DatabaseAdapter {
  */
 export function createTestAdapter(): TestDatabaseAdapter {
   return _factory();
+}
+
+/**
+ * Path 2 sidecar factory: returns the shared real {@link DatabaseAdapter}
+ * directly alongside a fresh {@link SidecarFixtures} handle. Use this
+ * when migrating off the `TestAdapterFixtures` wrapper — callers can
+ * issue DB ops on `adapter` directly (no delegation overhead) and use
+ * `fixtures` for the test-only TX visibility / DDL tracking concerns.
+ *
+ * Additive in sub-PR (a); consumers migrate in sub-PR (b); the wrapper
+ * is deleted in sub-PR (c).
+ *
+ * @internal
+ */
+export function createSidecarTestAdapter(): {
+  adapter: DatabaseAdapter;
+  fixtures: SidecarFixtures;
+} {
+  return { adapter: _sharedAdapter, fixtures: new SidecarFixtures(_sharedAdapter) };
 }
 
 /**

--- a/packages/activerecord/src/test-helpers/sidecar-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/sidecar-fixtures.test.ts
@@ -63,7 +63,17 @@ describe("createSidecarTestAdapter (path 2 sidecar)", () => {
     await fixtures.beginTransaction();
     expect(fixtures.inTransaction).toBe(true);
     expect(fixtures.openTransactions).toBeGreaterThan(0);
+    await fixtures.commit();
+    expect(fixtures.inTransaction).toBe(false);
+    expect(fixtures.openTransactions).toBe(0);
+  });
+
+  it("manual beginTransaction/rollback also clears depth and hides state", async () => {
+    const { fixtures } = createSidecarTestAdapter();
+    await fixtures.beginTransaction();
+    expect(fixtures.inTransaction).toBe(true);
     await fixtures.rollback();
     expect(fixtures.inTransaction).toBe(false);
+    expect(fixtures.openTransactions).toBe(0);
   });
 });

--- a/packages/activerecord/src/test-helpers/sidecar-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/sidecar-fixtures.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { createSidecarTestAdapter, resetTestAdapterState } from "../test-adapter.js";
+
+describe("createSidecarTestAdapter (path 2 sidecar)", () => {
+  beforeEach(async () => {
+    await resetTestAdapterState();
+  });
+
+  it("returns the real adapter and a fresh SidecarFixtures handle", () => {
+    const { adapter, fixtures } = createSidecarTestAdapter();
+    expect(typeof adapter.adapterName).toBe("string");
+    expect(fixtures.adapter).toBe(adapter);
+    expect(fixtures.inTransaction).toBe(false);
+    expect(fixtures.openTransactions).toBe(0);
+  });
+
+  it("each call returns a distinct fixtures handle but the same shared adapter", () => {
+    const a = createSidecarTestAdapter();
+    const b = createSidecarTestAdapter();
+    expect(a.adapter).toBe(b.adapter);
+    expect(a.fixtures).not.toBe(b.fixtures);
+  });
+
+  it("records CREATE/DROP TABLE via fixtures.exec for defineSchema cache invalidation", async () => {
+    const { adapter, fixtures } = createSidecarTestAdapter();
+    const table = "sidecar_smoke_test";
+    const q = adapter.adapterName === "mysql" ? "`" : '"';
+    await fixtures.exec(`CREATE TABLE ${q}${table}${q} (id INTEGER PRIMARY KEY)`);
+    const { getCreatedTables } = await import("./ddl-tracker.js");
+    expect(getCreatedTables().has(table)).toBe(true);
+    await fixtures.exec(`DROP TABLE ${q}${table}${q}`);
+    expect(getCreatedTables().has(table)).toBe(false);
+  });
+
+  it("hides transaction state from foreign async chains", async () => {
+    const { fixtures } = createSidecarTestAdapter();
+    expect(fixtures.currentTransaction()).toBeNull();
+    let insideTx: unknown = null;
+    await fixtures.withinNewTransaction({ joinable: false }, async () => {
+      insideTx = fixtures.currentTransaction();
+    });
+    expect(insideTx).not.toBeNull();
+    expect(fixtures.currentTransaction()).toBeNull();
+  });
+
+  it("manual beginTransaction/commit bumps depth and exposes state to the caller", async () => {
+    const { fixtures } = createSidecarTestAdapter();
+    await fixtures.beginTransaction();
+    expect(fixtures.inTransaction).toBe(true);
+    expect(fixtures.openTransactions).toBeGreaterThan(0);
+    await fixtures.rollback();
+    expect(fixtures.inTransaction).toBe(false);
+  });
+});

--- a/packages/activerecord/src/test-helpers/sidecar-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/sidecar-fixtures.test.ts
@@ -35,11 +35,26 @@ describe("createSidecarTestAdapter (path 2 sidecar)", () => {
   it("hides transaction state from foreign async chains", async () => {
     const { fixtures } = createSidecarTestAdapter();
     expect(fixtures.currentTransaction()).toBeNull();
-    let insideTx: unknown = null;
-    await fixtures.withinNewTransaction({ joinable: false }, async () => {
-      insideTx = fixtures.currentTransaction();
+
+    let foreignSawTx: unknown = "unset";
+    let releaseForeign!: () => void;
+    const foreignReady = new Promise<void>((resolve) => {
+      releaseForeign = resolve;
     });
-    expect(insideTx).not.toBeNull();
+    const foreignChain = (async () => {
+      await foreignReady;
+      foreignSawTx = fixtures.currentTransaction();
+    })();
+
+    let ownChainSawTx: unknown = null;
+    await fixtures.withinNewTransaction({ joinable: false }, async () => {
+      ownChainSawTx = fixtures.currentTransaction();
+      releaseForeign();
+      await foreignChain;
+    });
+
+    expect(ownChainSawTx).not.toBeNull();
+    expect(foreignSawTx).toBeNull();
     expect(fixtures.currentTransaction()).toBeNull();
   });
 

--- a/packages/activerecord/src/test-helpers/sidecar-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/sidecar-fixtures.ts
@@ -1,0 +1,161 @@
+/**
+ * Sidecar fixtures handle for path 2 of the test-adapter cleanup.
+ *
+ * Path 2 splits the historical `TestAdapterFixtures` wrapper into two pieces:
+ *   - The real {@link DatabaseAdapter} (used directly by callers for DB ops)
+ *   - A {@link SidecarFixtures} handle holding the three load-bearing
+ *     test-only concerns: async-chain TX visibility, manual TX depth
+ *     tracking, and CREATE/DROP TABLE recording for `defineSchema` cache
+ *     invalidation.
+ *
+ * This file is additive — the existing wrapper in `test-adapter.ts` is
+ * untouched. Sub-PR (b) migrates callers; sub-PR (c) deletes the wrapper.
+ *
+ * Unlike the wrapper, this is NOT a Proxy and does not delegate the full
+ * {@link DatabaseAdapter} surface. Production DB operations go straight to
+ * the real adapter; only fixture-aware code touches this handle.
+ *
+ * @internal
+ */
+
+import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
+import type { DatabaseAdapter } from "../adapter.js";
+import { recordDdlTracking } from "./ddl-tracker.js";
+
+let _txLockHeld: AsyncContext<true> | null = null;
+let _txLockHeldAdapter: ReturnType<typeof getAsyncContext> | null = null;
+
+/**
+ * Lazy async-context storage that tracks whether the current async chain
+ * entered through a sidecar `withinNewTransaction`. Recreated when the
+ * ActiveSupport asyncContextAdapter is swapped at runtime (DI / browser
+ * compat), matching the pattern in `test-adapter.ts` and `transactions.ts`.
+ */
+function _txLockStorage(): AsyncContext<true> {
+  const asyncContext = getAsyncContext();
+  if (!_txLockHeld || _txLockHeldAdapter !== asyncContext) {
+    _txLockHeld = asyncContext.create<true>();
+    _txLockHeldAdapter = asyncContext;
+  }
+  return _txLockHeld;
+}
+
+const CREATE_TABLE_RE = /CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+(?:["`](\w+)["`]|(\w+))/i;
+const DROP_TABLE_RE = /DROP\s+TABLE(?:\s+IF\s+EXISTS)?\s+(?:["`](\w+)["`]|(\w+))/i;
+
+/**
+ * Test-only sidecar handle. Carries the three concerns that the wrapper
+ * provides today:
+ *
+ *   1. Async-chain TX visibility — `currentTransaction()`, `inTransaction`,
+ *      and `openTransactions` only expose state when the caller's async
+ *      chain entered through this handle's `withinNewTransaction` (or
+ *      manually opened a transaction via `beginTransaction`). Foreign
+ *      concurrent chains see an empty handle so they don't observe each
+ *      other's TM frame as joinable.
+ *   2. Manual TX depth — direct callers that don't go through
+ *      `withinNewTransaction` still need their state visible; the counter
+ *      makes `_txVisible()` true for them.
+ *   3. DDL tracking — `exec()` and `executeMutation()` wrap the inner
+ *      adapter and call {@link recordDdlTracking} after success so
+ *      `defineSchema`'s cache-invalidation logic sees the same set of
+ *      created/dropped tables it does under the wrapper.
+ *
+ * @internal
+ */
+export class SidecarFixtures {
+  /** The real database adapter this handle is tracking. */
+  readonly adapter: DatabaseAdapter;
+  private _manualTxDepth = 0;
+
+  constructor(adapter: DatabaseAdapter) {
+    this.adapter = adapter;
+  }
+
+  /**
+   * True when this caller should see the inner adapter's transaction state.
+   * Either we entered through `withinNewTransaction` (storage set on this
+   * async chain) or the caller manually opened a transaction on this
+   * handle.
+   */
+  private _txVisible(): boolean {
+    return _txLockStorage().getStore() === true || this._manualTxDepth > 0;
+  }
+
+  async withinNewTransaction<T>(
+    opts: { isolation?: string | null; joinable?: boolean },
+    fn: (tx?: unknown) => Promise<T> | T,
+  ): Promise<T> {
+    const adapter = this.adapter as DatabaseAdapter & {
+      withinNewTransaction: (o: typeof opts, f: typeof fn) => Promise<T>;
+      transactionManager?: { synchronize?<R>(fn: () => Promise<R> | R): Promise<R> };
+    };
+    const storage = _txLockStorage();
+    const run = () => adapter.withinNewTransaction(opts, fn);
+    const tm = adapter.transactionManager;
+    const wrapped = storage.getStore() === true ? run : () => storage.run(true, run);
+    if (tm?.synchronize) return tm.synchronize(wrapped);
+    return wrapped();
+  }
+
+  currentTransaction(): unknown {
+    if (!this._txVisible()) return null;
+    return (this.adapter as { currentTransaction?: () => unknown }).currentTransaction?.();
+  }
+
+  get inTransaction(): boolean {
+    if (!this._txVisible()) return false;
+    return this.adapter.inTransaction;
+  }
+
+  get openTransactions(): number {
+    if (!this._txVisible()) return 0;
+    return this.adapter.openTransactions ?? 0;
+  }
+
+  async beginTransaction(): Promise<void> {
+    await this.adapter.beginTransaction();
+    this._manualTxDepth++;
+  }
+
+  async commit(): Promise<void> {
+    // Only decrement on success — failed COMMIT can leave PG/MySQL in an
+    // unresolved transaction (the driver clears `inTransaction` only when
+    // COMMIT succeeds). Decrementing in `finally` would report no tx while
+    // the adapter is still mid-transaction.
+    await this.adapter.commit();
+    if (this._manualTxDepth > 0) this._manualTxDepth--;
+  }
+
+  async rollback(): Promise<void> {
+    await this.adapter.rollback();
+    if (this._manualTxDepth > 0) this._manualTxDepth--;
+  }
+
+  /**
+   * Run a mutation through the adapter and record any CREATE/DROP TABLE
+   * for `defineSchema`'s cache-invalidation. Fixture-aware code (i.e.
+   * `defineSchema` itself) routes DDL through this method; production
+   * code goes straight to `adapter.executeMutation()` and skips the
+   * regex scan.
+   */
+  async executeMutation(sql: string, binds?: unknown[], name?: string): Promise<number> {
+    const createMatch = sql.match(CREATE_TABLE_RE);
+    const dropMatch = sql.match(DROP_TABLE_RE);
+    const result = await this.adapter.executeMutation(sql, binds, name);
+    recordDdlTracking(sql, createMatch, dropMatch);
+    return result;
+  }
+
+  /**
+   * Run a raw SQL statement through the adapter and record any
+   * CREATE/DROP TABLE for `defineSchema`'s cache-invalidation. Same
+   * routing contract as {@link executeMutation}.
+   */
+  async exec(sql: string): Promise<void> {
+    const createMatch = sql.match(CREATE_TABLE_RE);
+    const dropMatch = sql.match(DROP_TABLE_RE);
+    await (this.adapter as unknown as { exec(sql: string): Promise<void> }).exec(sql);
+    recordDdlTracking(sql, createMatch, dropMatch);
+  }
+}

--- a/packages/activerecord/src/test-helpers/sidecar-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/sidecar-fixtures.ts
@@ -74,9 +74,16 @@ export class SidecarFixtures {
 
   /**
    * True when this caller should see the inner adapter's transaction state.
-   * Either we entered through `withinNewTransaction` (storage set on this
-   * async chain) or the caller manually opened a transaction on this
-   * handle.
+   * Either *some* SidecarFixtures' `withinNewTransaction` set the flag on
+   * this async chain, or the caller manually opened a transaction on this
+   * specific handle.
+   *
+   * The async-chain flag is shared across all SidecarFixtures instances
+   * by design — matches the wrapper in `test-adapter.ts` (sub-PR (a) is
+   * additive-only). Because `createSidecarTestAdapter()` returns a fresh
+   * handle wrapping the *same* shared inner adapter, the underlying
+   * transaction state is single-source and "leaking" visibility between
+   * sibling handles on the same chain is the intended behavior.
    */
   private _txVisible(): boolean {
     return _txLockStorage().getStore() === true || this._manualTxDepth > 0;


### PR DESCRIPTION
## Summary

Sub-PR (a) of three for the test-adapter Path 2 cleanup. **Purely additive.** No consumers migrate yet.

Introduces `createSidecarTestAdapter()` returning `{ adapter, fixtures }` alongside the existing `TestAdapterFixtures` wrapper:

- `adapter` — the real `DatabaseAdapter`, used directly for DB ops
- `fixtures` — a new `SidecarFixtures` standalone class holding the three load-bearing test-only concerns

## Shape choice — tuple over intersection

Surveyed the 18 `.innerAdapter` reach-in sites. They already destructure or locally rebind the inner adapter (`const inner = testAdapter.innerAdapter`, `const realAdapter = testAdapter.innerAdapter`, etc.). A tuple `{ adapter, fixtures }` matches the call-site shape (b) will adopt without requiring an intersection type that would mask which surface each call uses (real adapter vs. test-only fixtures).

## What `SidecarFixtures` holds

The three concerns from the wrapper, intact:

1. **Async-chain TX visibility** for `currentTransaction()`, `inTransaction`, `openTransactions` — foreign chains see an empty handle (prevents Promise.all top-level tx from observing each other's frame as joinable)
2. **Manual TX depth counter** for direct `beginTransaction`/`commit`/`rollback` callers (migrations, fixtures, query-cache tests)
3. **CREATE/DROP TABLE recording** via `recordDdlTracking` on `exec` / `executeMutation` for `defineSchema`'s cache invalidation

## Not a Proxy

The 9b-4 attempt failed under Proxy-based delegation (encryption-uniqueness regressions). This is a clean structural split — the sidecar does **not** delegate the full `DatabaseAdapter` surface. Production DB ops route to the real adapter; only fixture-aware code (`defineSchema`, `withTransactionalFixtures`) touches the sidecar.

## DDL routing

Fixture-aware code routes DDL through `fixtures.exec(...)` / `fixtures.executeMutation(...)`. Production code goes straight to `adapter.executeMutation(...)` with no DDL-tracking regex overhead. Step 4's `AbstractAdapter.onDdl` hook is deferred — sub-PR (b) can adopt it if migrating `defineSchema` proves easier with an adapter-level hook than with explicit fixtures routing.

## Verification

- New `sidecar-fixtures.test.ts` smoke test: 5 cases, all green on SQLite (factory shape, distinct handles, DDL tracking, async-chain TX visibility, manual TX depth)
- Wrapper + 18 `.innerAdapter` callers untouched — existing suite unaffected
- 237 LOC additions, 0 deletions

## Follow-ups

- Sub-PR (b): migrate the 18 `.innerAdapter` callers to the sidecar shape
- Sub-PR (c): delete the `TestAdapterFixtures` wrapper

## Test plan

- [ ] CI green on SQLite / PG / MariaDB
- [ ] api:compare delta non-negative
- [ ] test:compare delta non-negative