### PR TITLE
feat(actionview): capture_helper (Phase 5 T2)

### DIFF
--- a/packages/actionview/src/flows.ts
+++ b/packages/actionview/src/flows.ts
@@ -1,0 +1,34 @@
+import { SafeBuffer, htmlSafe } from "@blazetrails/activesupport";
+
+/**
+ * OutputFlow — buffered storage for `content_for` / `provide`.
+ * Mirrors `ActionView::OutputFlow`. Missing keys lazily create an empty
+ * `SafeBuffer` so `<<` appends are well-defined.
+ */
+export class OutputFlow {
+  readonly content: Map<string, SafeBuffer> = new Map();
+
+  get(key: string): SafeBuffer {
+    let buf = this.content.get(key);
+    if (!buf) {
+      buf = htmlSafe("");
+      this.content.set(key, buf);
+    }
+    return buf;
+  }
+
+  set(key: string, value: unknown): void {
+    this.content.set(key, htmlSafe(value == null ? "" : String(value)));
+  }
+
+  append(key: string, value: unknown): void {
+    if (value == null) return;
+    const current = this.get(key);
+    const piece: string | SafeBuffer = value instanceof SafeBuffer ? value : String(value);
+    this.content.set(key, current.concat(piece));
+  }
+
+  appendBang(key: string, value: unknown): void {
+    this.append(key, value);
+  }
+}

--- a/packages/actionview/src/flows.ts
+++ b/packages/actionview/src/flows.ts
@@ -26,7 +26,13 @@ export class OutputFlow {
   append(key: string, value: unknown): void {
     if (value == null) return;
     const current = this.get(key);
-    const piece: string | SafeBuffer = value instanceof SafeBuffer ? value : toS(value);
+    // Rails: `@content[key] << value.to_s`. SafeBuffer and OutputBuffer
+    // both report html_safe via `to_s`, so they append verbatim; plain
+    // strings escape through SafeBuffer#concat.
+    let piece: string | SafeBuffer;
+    if (value instanceof SafeBuffer) piece = value;
+    else if (value instanceof OutputBuffer) piece = value.toString();
+    else piece = toS(value);
     this.content.set(key, current.concat(piece));
   }
 

--- a/packages/actionview/src/flows.ts
+++ b/packages/actionview/src/flows.ts
@@ -1,5 +1,7 @@
 import { SafeBuffer, htmlSafe } from "@blazetrails/activesupport";
 
+import { OutputBuffer } from "./buffers.js";
+
 /**
  * OutputFlow — buffered storage for `content_for` / `provide`.
  * Mirrors `ActionView::OutputFlow`. Missing keys lazily create an empty
@@ -18,17 +20,25 @@ export class OutputFlow {
   }
 
   set(key: string, value: unknown): void {
-    this.content.set(key, htmlSafe(value == null ? "" : String(value)));
+    this.content.set(key, htmlSafe(toS(value)));
   }
 
   append(key: string, value: unknown): void {
     if (value == null) return;
     const current = this.get(key);
-    const piece: string | SafeBuffer = value instanceof SafeBuffer ? value : String(value);
+    const piece: string | SafeBuffer = value instanceof SafeBuffer ? value : toS(value);
     this.content.set(key, current.concat(piece));
   }
 
   appendBang(key: string, value: unknown): void {
     this.append(key, value);
   }
+}
+
+/** Mirrors Ruby `value.to_s` for the values OutputFlow stores. */
+function toS(value: unknown): string {
+  if (value == null) return "";
+  if (value instanceof SafeBuffer) return value.toString();
+  if (value instanceof OutputBuffer) return value.toStr();
+  return String(value);
 }

--- a/packages/actionview/src/helpers/capture-helper.test.ts
+++ b/packages/actionview/src/helpers/capture-helper.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, beforeEach } from "vitest";
+
+import { OutputBuffer } from "../buffers.js";
+import { OutputFlow } from "../flows.js";
+import {
+  capture,
+  contentFor,
+  contentForQuestion,
+  provide,
+  withOutputBuffer,
+  type CaptureHelperHost,
+} from "./capture-helper.js";
+import { contentTag } from "./tag-helper.js";
+import { raw } from "./output-safety-helper.js";
+
+interface Host extends CaptureHelperHost {
+  capture: typeof capture;
+  contentFor: typeof contentFor;
+  contentForQuestion: typeof contentForQuestion;
+  provide: typeof provide;
+  withOutputBuffer: typeof withOutputBuffer;
+}
+
+function makeHost(): Host {
+  return {
+    outputBuffer: new OutputBuffer(),
+    viewFlow: new OutputFlow(),
+    capture,
+    contentFor,
+    contentForQuestion,
+    provide,
+    withOutputBuffer,
+  };
+}
+
+describe("CaptureHelperTest", () => {
+  let av: Host;
+
+  beforeEach(() => {
+    av = makeHost();
+  });
+
+  it("test_capture_captures_the_temporary_output_buffer_in_its_block", () => {
+    expect(av.outputBuffer!.isEmpty()).toBe(true);
+    const string = av.capture(() => {
+      av.outputBuffer!.concat("foo");
+      av.outputBuffer!.concat("bar");
+    });
+    expect(av.outputBuffer!.isEmpty()).toBe(true);
+    expect(string?.toString()).toBe("foobar");
+  });
+
+  it("test_capture_captures_the_value_returned_by_the_block_if_the_temporary_buffer_is_blank", () => {
+    const string = av.capture((a: string, b: string) => a + b, "foo", "bar");
+    expect(string?.toString()).toBe("foobar");
+  });
+
+  it("test_capture_returns_nil_if_the_returned_value_is_not_a_string", () => {
+    expect(av.capture(() => 1)).toBeNull();
+  });
+
+  it("test_capture_escapes_html", () => {
+    const string = av.capture(() => "<em>bar</em>");
+    expect(string?.toString()).toBe("&lt;em&gt;bar&lt;/em&gt;");
+  });
+
+  it("test_capture_doesnt_escape_twice", () => {
+    const string = av.capture(() => raw("&lt;em&gt;bar&lt;/em&gt;"));
+    expect(string?.toString()).toBe("&lt;em&gt;bar&lt;/em&gt;");
+  });
+
+  it("test_capture_does_not_reassign_buffer", () => {
+    const original = av.outputBuffer;
+    av.capture(() => {
+      expect(av.outputBuffer).toBe(original);
+    });
+  });
+
+  it("test_content_for_used_for_read", () => {
+    av.contentFor("foo", "foo");
+    expect(av.contentFor("foo")?.toString()).toBe("foo");
+
+    av.contentFor("bar", undefined, undefined, () => "bar");
+    expect(av.contentFor("bar")?.toString()).toBe("bar");
+  });
+
+  it("test_content_for_with_multiple_calls", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", "foo");
+    av.contentFor("title", "bar");
+    expect(av.contentFor("title")?.toString()).toBe("foobar");
+  });
+
+  it("test_content_for_with_multiple_calls_and_flush", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", "foo");
+    av.contentFor("title", "bar", { flush: true });
+    expect(av.contentFor("title")?.toString()).toBe("bar");
+  });
+
+  it("test_content_for_with_block", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", undefined, undefined, () => {
+      av.outputBuffer!.concat("foo");
+      av.outputBuffer!.concat("bar");
+      return null;
+    });
+    expect(av.contentFor("title")?.toString()).toBe("foobar");
+  });
+
+  it("test_content_for_with_block_and_multiple_calls_with_flush", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", undefined, undefined, () => "foo");
+    av.contentFor("title", undefined, { flush: true }, () => "bar");
+    expect(av.contentFor("title")?.toString()).toBe("bar");
+  });
+
+  it("test_content_for_with_block_and_multiple_calls_with_flush_nil_content", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", undefined, undefined, () => "foo");
+    av.contentFor("title", null, { flush: true }, () => "bar");
+    expect(av.contentFor("title")?.toString()).toBe("bar");
+  });
+
+  it("test_content_for_with_block_and_multiple_calls_without_flush", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", undefined, undefined, () => "foo");
+    av.contentFor("title", undefined, { flush: false }, () => "bar");
+    expect(av.contentFor("title")?.toString()).toBe("foobar");
+  });
+
+  it("test_content_for_with_whitespace_block", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", "foo");
+    av.contentFor("title", undefined, undefined, () => {
+      av.outputBuffer!.concat("  \n  ");
+      return null;
+    });
+    av.contentFor("title", "bar");
+    expect(av.contentFor("title")?.toString()).toBe("foobar");
+  });
+
+  it("test_content_for_with_whitespace_block_and_flush", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", "foo");
+    av.contentFor("title", undefined, { flush: true }, () => {
+      av.outputBuffer!.concat("  \n  ");
+      return null;
+    });
+    av.contentFor("title", "bar", { flush: true });
+    expect(av.contentFor("title")?.toString()).toBe("bar");
+  });
+
+  it("test_content_for_returns_nil_when_writing", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    expect(av.contentFor("title", "foo")).toBeNull();
+    expect(
+      av.contentFor("title", undefined, undefined, () => {
+        av.outputBuffer!.concat("bar");
+        return null;
+      }),
+    ).toBeNull();
+    expect(
+      av.contentFor("title", undefined, undefined, () => {
+        av.outputBuffer!.concat("  \n  ");
+        return null;
+      }),
+    ).toBeNull();
+    expect(av.contentFor("title")?.toString()).toBe("foobar");
+    expect(av.contentFor("title", "foo", { flush: true })).toBeNull();
+    expect(
+      av.contentFor("title", undefined, { flush: true }, () => {
+        av.outputBuffer!.concat("bar");
+        return null;
+      }),
+    ).toBeNull();
+    expect(
+      av.contentFor("title", undefined, { flush: true }, () => {
+        av.outputBuffer!.concat("  \n  ");
+        return null;
+      }),
+    ).toBeNull();
+    expect(av.contentFor("title")?.toString()).toBe("bar");
+  });
+
+  it("test_content_for_returns_nil_when_content_missing", () => {
+    expect(av.contentFor("some_missing_key")).toBeNull();
+  });
+
+  it("test_content_for_question_mark", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", "title");
+    expect(av.contentForQuestion("title")).toBe(true);
+    expect(av.contentForQuestion("something_else")).toBe(false);
+  });
+
+  it("test_content_for_should_be_html_safe_after_flush_empty", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.contentFor("title", undefined, undefined, () => contentTag("p", "title"));
+    expect(av.contentFor("title")!.htmlSafe).toBe(true);
+    av.contentFor("title", "", { flush: true });
+    av.contentFor("title", undefined, undefined, () => contentTag("p", "title"));
+    expect(av.contentFor("title")!.htmlSafe).toBe(true);
+  });
+
+  it("test_provide", () => {
+    expect(av.contentForQuestion("title")).toBe(false);
+    av.provide("title", "hi");
+    expect(av.contentForQuestion("title")).toBe(true);
+    expect(av.contentFor("title")?.toString()).toBe("hi");
+    av.provide("title", "<p>title</p>");
+    expect(av.contentFor("title")?.toString()).toBe("hi&lt;p&gt;title&lt;/p&gt;");
+
+    av.viewFlow = new OutputFlow();
+    av.provide("title", "hi");
+    av.provide("title", raw("<p>title</p>"));
+    expect(av.contentFor("title")?.toString()).toBe("hi<p>title</p>");
+  });
+
+  it("test_with_output_buffer_swaps_the_output_buffer_given_no_argument", () => {
+    expect(av.outputBuffer!.isEmpty()).toBe(true);
+    const buffer = av.withOutputBuffer(null, () => {
+      av.outputBuffer!.concat(".");
+    });
+    expect(buffer.toString().toString()).toBe(".");
+    expect(av.outputBuffer!.isEmpty()).toBe(true);
+  });
+
+  it("test_with_output_buffer_swaps_the_output_buffer_with_an_argument", () => {
+    expect(av.outputBuffer!.isEmpty()).toBe(true);
+    const buffer = new OutputBuffer(".");
+    av.withOutputBuffer(buffer, () => {
+      av.outputBuffer!.concat(".");
+    });
+    expect(buffer.toString().toString()).toBe("..");
+    expect(av.outputBuffer!.isEmpty()).toBe(true);
+  });
+
+  it("test_with_output_buffer_restores_the_output_buffer", () => {
+    const buffer = new OutputBuffer();
+    av.outputBuffer = buffer;
+    av.withOutputBuffer(null, () => {
+      av.outputBuffer!.concat(".");
+    });
+    expect(buffer).toBe(av.outputBuffer);
+  });
+
+  it("test_with_output_buffer_does_not_assume_there_is_an_output_buffer", () => {
+    expect(av.outputBuffer!.isEmpty()).toBe(true);
+    expect(
+      av
+        .withOutputBuffer(null, () => {})
+        .toString()
+        .toString(),
+    ).toBe("");
+  });
+
+  it("test_ignore_the_block_return_if_its_the_buffer", () => {
+    av.outputBuffer!.safeConcat("something");
+    const string = av.capture(() => {
+      av.outputBuffer!.concat("foo");
+      av.outputBuffer!.concat("bar");
+      return av.outputBuffer;
+    });
+    expect(string?.toString()).toBe("foobar");
+  });
+});

--- a/packages/actionview/src/helpers/capture-helper.ts
+++ b/packages/actionview/src/helpers/capture-helper.ts
@@ -61,13 +61,8 @@ export function contentFor(
     let opts = options;
     let body: unknown = content;
     if (block) {
-      if (
-        content !== undefined &&
-        typeof content === "object" &&
-        content !== null &&
-        options === undefined
-      ) {
-        opts = content as { flush?: boolean };
+      if (options === undefined && isPlainOptions(content)) {
+        opts = content;
       }
       body = capture.call(this, block);
     }
@@ -82,6 +77,13 @@ export function contentFor(
   }
   const stored = this.viewFlow.get(name);
   return isPresent(stored.toString()) ? stored : null;
+}
+
+/** Mirrors Ruby's `Hash === value` for the options-vs-content disambiguation. */
+function isPlainOptions(value: unknown): value is { flush?: boolean } {
+  return (
+    typeof value === "object" && value !== null && Object.getPrototypeOf(value) === Object.prototype
+  );
 }
 
 /**

--- a/packages/actionview/src/helpers/capture-helper.ts
+++ b/packages/actionview/src/helpers/capture-helper.ts
@@ -1,0 +1,135 @@
+import { SafeBuffer, htmlEscape, isPresent } from "@blazetrails/activesupport";
+
+import { OutputBuffer } from "../buffers.js";
+import { OutputFlow } from "../flows.js";
+
+/**
+ * Host shape required by capture-helper. Mixed into ActionView::Base
+ * (and ActionView::TestCase) via `this`-typed function assignment.
+ */
+export interface CaptureHelperHost {
+  outputBuffer: OutputBuffer | null;
+  viewFlow: OutputFlow;
+}
+
+/**
+ * capture — runs `block`, returning what it appended to the output buffer
+ * as an HTML-safe string. If the block's return value is itself a string
+ * (and the buffer stayed empty), that value is HTML-escaped and returned.
+ * Mirrors `ActionView::Helpers::CaptureHelper#capture`.
+ */
+export function capture<TArgs extends unknown[]>(
+  this: CaptureHelperHost,
+  block: (...args: TArgs) => unknown,
+  ...args: TArgs
+): SafeBuffer | null {
+  let value: unknown = null;
+  if (!this.outputBuffer) this.outputBuffer = new OutputBuffer();
+  const buf = this.outputBuffer;
+  const buffer = buf.capture(() => {
+    value = block(...args);
+  });
+
+  let string: unknown;
+  if (buf === value) {
+    string = buffer;
+  } else {
+    string = isPresent(buffer.toString()) ? buffer : value;
+  }
+
+  if (string instanceof OutputBuffer) return string.toString();
+  if (string instanceof SafeBuffer) return string;
+  if (typeof string === "string") return htmlEscape(string);
+  return null;
+}
+
+/**
+ * contentFor — stores or retrieves a block of markup keyed by `name`.
+ * With `content` or a block: appends (or replaces, when `flush: true`)
+ * into the view flow and returns `null`. Without either: returns the
+ * stored content if any, else `null`. Mirrors
+ * `ActionView::Helpers::CaptureHelper#content_for`.
+ */
+export function contentFor(
+  this: CaptureHelperHost,
+  name: string,
+  content?: unknown,
+  options?: { flush?: boolean },
+  block?: () => unknown,
+): SafeBuffer | null {
+  if (content !== undefined || block) {
+    let opts = options;
+    let body: unknown = content;
+    if (block) {
+      if (
+        content !== undefined &&
+        typeof content === "object" &&
+        content !== null &&
+        options === undefined
+      ) {
+        opts = content as { flush?: boolean };
+      }
+      body = capture.call(this, block);
+    }
+    if (body !== undefined && body !== null) {
+      if (opts?.flush) {
+        this.viewFlow.set(name, body);
+      } else {
+        this.viewFlow.append(name, body);
+      }
+    }
+    return null;
+  }
+  const stored = this.viewFlow.get(name);
+  return isPresent(stored.toString()) ? stored : null;
+}
+
+/**
+ * provide — like `contentFor`, but for streaming responses flushes back
+ * to the layout immediately. Mirrors
+ * `ActionView::Helpers::CaptureHelper#provide`.
+ */
+export function provide(
+  this: CaptureHelperHost,
+  name: string,
+  content?: unknown,
+  block?: () => unknown,
+): SafeBuffer | null {
+  let body: unknown = content;
+  if (block) body = capture.call(this, block);
+  if (body !== undefined && body !== null) {
+    this.viewFlow.appendBang(name, body);
+    return null;
+  }
+  return null;
+}
+
+/**
+ * contentForQuestion — `content_for?(name)`. True if any content has been
+ * captured for `name`. Mirrors `CaptureHelper#content_for?`.
+ */
+export function contentForQuestion(this: CaptureHelperHost, name: string): boolean {
+  return isPresent(this.viewFlow.get(name).toString());
+}
+
+/**
+ * withOutputBuffer — swaps the output buffer for the duration of `block`,
+ * returning the swapped-in buffer. Mirrors `CaptureHelper#with_output_buffer`.
+ *
+ * @internal
+ */
+export function withOutputBuffer(
+  this: CaptureHelperHost,
+  buf: OutputBuffer | null,
+  block: () => void,
+): OutputBuffer {
+  const next = buf ?? new OutputBuffer();
+  const old = this.outputBuffer;
+  this.outputBuffer = next;
+  try {
+    block();
+    return next;
+  } finally {
+    this.outputBuffer = old;
+  }
+}

--- a/packages/actionview/src/helpers/capture-helper.ts
+++ b/packages/actionview/src/helpers/capture-helper.ts
@@ -57,7 +57,7 @@ export function contentFor(
   options?: { flush?: boolean },
   block?: () => unknown,
 ): SafeBuffer | null {
-  if (content !== undefined || block) {
+  if (content != null || block) {
     let opts = options;
     let body: unknown = content;
     if (block) {

--- a/packages/actionview/src/helpers/index.ts
+++ b/packages/actionview/src/helpers/index.ts
@@ -23,6 +23,15 @@ export { htmlEscape, h, htmlEscapeOnce, jsonEscape } from "./output-safety-helpe
 export { escapeJavascript, j, javascriptCdataSection, javascriptTag } from "./javascript-helper.js";
 
 export {
+  capture,
+  contentFor,
+  contentForQuestion,
+  provide,
+  withOutputBuffer,
+} from "./capture-helper.js";
+export type { CaptureHelperHost } from "./capture-helper.js";
+
+export {
   numberToPhone,
   numberToCurrency,
   numberToPercentage,

--- a/packages/actionview/src/index.ts
+++ b/packages/actionview/src/index.ts
@@ -45,6 +45,8 @@ export {
 
 export { OutputBuffer, RawOutputBuffer, StreamingBuffer, RawStreamingBuffer } from "./buffers.js";
 
+export { OutputFlow } from "./flows.js";
+
 export { PathSet, type PathSetResolver } from "./path-set.js";
 export { TemplatePath } from "./template-path.js";
 export {

--- a/packages/actionview/src/template/capture-helper.test.ts
+++ b/packages/actionview/src/template/capture-helper.test.ts
@@ -9,9 +9,9 @@ import {
   provide,
   withOutputBuffer,
   type CaptureHelperHost,
-} from "./capture-helper.js";
-import { contentTag } from "./tag-helper.js";
-import { raw } from "./output-safety-helper.js";
+} from "../helpers/capture-helper.js";
+import { contentTag } from "../helpers/tag-helper.js";
+import { raw } from "../helpers/output-safety-helper.js";
 
 interface Host extends CaptureHelperHost {
   capture: typeof capture;
@@ -40,7 +40,7 @@ describe("CaptureHelperTest", () => {
     av = makeHost();
   });
 
-  it("test_capture_captures_the_temporary_output_buffer_in_its_block", () => {
+  it("capture captures the temporary output buffer in its block", () => {
     expect(av.outputBuffer!.isEmpty()).toBe(true);
     const string = av.capture(() => {
       av.outputBuffer!.concat("foo");
@@ -50,33 +50,33 @@ describe("CaptureHelperTest", () => {
     expect(string?.toString()).toBe("foobar");
   });
 
-  it("test_capture_captures_the_value_returned_by_the_block_if_the_temporary_buffer_is_blank", () => {
+  it("capture captures the value returned by the block if the temporary buffer is blank", () => {
     const string = av.capture((a: string, b: string) => a + b, "foo", "bar");
     expect(string?.toString()).toBe("foobar");
   });
 
-  it("test_capture_returns_nil_if_the_returned_value_is_not_a_string", () => {
+  it("capture returns nil if the returned value is not a string", () => {
     expect(av.capture(() => 1)).toBeNull();
   });
 
-  it("test_capture_escapes_html", () => {
+  it("capture escapes html", () => {
     const string = av.capture(() => "<em>bar</em>");
     expect(string?.toString()).toBe("&lt;em&gt;bar&lt;/em&gt;");
   });
 
-  it("test_capture_doesnt_escape_twice", () => {
+  it("capture doesnt escape twice", () => {
     const string = av.capture(() => raw("&lt;em&gt;bar&lt;/em&gt;"));
     expect(string?.toString()).toBe("&lt;em&gt;bar&lt;/em&gt;");
   });
 
-  it("test_capture_does_not_reassign_buffer", () => {
+  it("capture does not reassign buffer", () => {
     const original = av.outputBuffer;
     av.capture(() => {
       expect(av.outputBuffer).toBe(original);
     });
   });
 
-  it("test_content_for_used_for_read", () => {
+  it("content for used for read", () => {
     av.contentFor("foo", "foo");
     expect(av.contentFor("foo")?.toString()).toBe("foo");
 
@@ -84,21 +84,21 @@ describe("CaptureHelperTest", () => {
     expect(av.contentFor("bar")?.toString()).toBe("bar");
   });
 
-  it("test_content_for_with_multiple_calls", () => {
+  it("content for with multiple calls", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", "foo");
     av.contentFor("title", "bar");
     expect(av.contentFor("title")?.toString()).toBe("foobar");
   });
 
-  it("test_content_for_with_multiple_calls_and_flush", () => {
+  it("content for with multiple calls and flush", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", "foo");
     av.contentFor("title", "bar", { flush: true });
     expect(av.contentFor("title")?.toString()).toBe("bar");
   });
 
-  it("test_content_for_with_block", () => {
+  it("content for with block", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", undefined, undefined, () => {
       av.outputBuffer!.concat("foo");
@@ -108,28 +108,28 @@ describe("CaptureHelperTest", () => {
     expect(av.contentFor("title")?.toString()).toBe("foobar");
   });
 
-  it("test_content_for_with_block_and_multiple_calls_with_flush", () => {
+  it("content for with block and multiple calls with flush", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", undefined, undefined, () => "foo");
     av.contentFor("title", undefined, { flush: true }, () => "bar");
     expect(av.contentFor("title")?.toString()).toBe("bar");
   });
 
-  it("test_content_for_with_block_and_multiple_calls_with_flush_nil_content", () => {
+  it("content for with block and multiple calls with flush nil content", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", undefined, undefined, () => "foo");
     av.contentFor("title", null, { flush: true }, () => "bar");
     expect(av.contentFor("title")?.toString()).toBe("bar");
   });
 
-  it("test_content_for_with_block_and_multiple_calls_without_flush", () => {
+  it("content for with block and multiple calls without flush", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", undefined, undefined, () => "foo");
     av.contentFor("title", undefined, { flush: false }, () => "bar");
     expect(av.contentFor("title")?.toString()).toBe("foobar");
   });
 
-  it("test_content_for_with_whitespace_block", () => {
+  it("content for with whitespace block", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", "foo");
     av.contentFor("title", undefined, undefined, () => {
@@ -140,7 +140,7 @@ describe("CaptureHelperTest", () => {
     expect(av.contentFor("title")?.toString()).toBe("foobar");
   });
 
-  it("test_content_for_with_whitespace_block_and_flush", () => {
+  it("content for with whitespace block and flush", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", "foo");
     av.contentFor("title", undefined, { flush: true }, () => {
@@ -151,7 +151,7 @@ describe("CaptureHelperTest", () => {
     expect(av.contentFor("title")?.toString()).toBe("bar");
   });
 
-  it("test_content_for_returns_nil_when_writing", () => {
+  it("content for returns nil when writing", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     expect(av.contentFor("title", "foo")).toBeNull();
     expect(
@@ -183,18 +183,18 @@ describe("CaptureHelperTest", () => {
     expect(av.contentFor("title")?.toString()).toBe("bar");
   });
 
-  it("test_content_for_returns_nil_when_content_missing", () => {
+  it("content for returns nil when content missing", () => {
     expect(av.contentFor("some_missing_key")).toBeNull();
   });
 
-  it("test_content_for_question_mark", () => {
+  it("content for question mark", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", "title");
     expect(av.contentForQuestion("title")).toBe(true);
     expect(av.contentForQuestion("something_else")).toBe(false);
   });
 
-  it("test_content_for_should_be_html_safe_after_flush_empty", () => {
+  it("content for should be html safe after flush empty", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.contentFor("title", undefined, undefined, () => contentTag("p", "title"));
     expect(av.contentFor("title")!.htmlSafe).toBe(true);
@@ -203,7 +203,7 @@ describe("CaptureHelperTest", () => {
     expect(av.contentFor("title")!.htmlSafe).toBe(true);
   });
 
-  it("test_provide", () => {
+  it("provide", () => {
     expect(av.contentForQuestion("title")).toBe(false);
     av.provide("title", "hi");
     expect(av.contentForQuestion("title")).toBe(true);
@@ -217,7 +217,7 @@ describe("CaptureHelperTest", () => {
     expect(av.contentFor("title")?.toString()).toBe("hi<p>title</p>");
   });
 
-  it("test_with_output_buffer_swaps_the_output_buffer_given_no_argument", () => {
+  it("with output buffer swaps the output buffer given no argument", () => {
     expect(av.outputBuffer!.isEmpty()).toBe(true);
     const buffer = av.withOutputBuffer(null, () => {
       av.outputBuffer!.concat(".");
@@ -226,7 +226,7 @@ describe("CaptureHelperTest", () => {
     expect(av.outputBuffer!.isEmpty()).toBe(true);
   });
 
-  it("test_with_output_buffer_swaps_the_output_buffer_with_an_argument", () => {
+  it("with output buffer swaps the output buffer with an argument", () => {
     expect(av.outputBuffer!.isEmpty()).toBe(true);
     const buffer = new OutputBuffer(".");
     av.withOutputBuffer(buffer, () => {
@@ -236,7 +236,7 @@ describe("CaptureHelperTest", () => {
     expect(av.outputBuffer!.isEmpty()).toBe(true);
   });
 
-  it("test_with_output_buffer_restores_the_output_buffer", () => {
+  it("with output buffer restores the output buffer", () => {
     const buffer = new OutputBuffer();
     av.outputBuffer = buffer;
     av.withOutputBuffer(null, () => {
@@ -245,7 +245,12 @@ describe("CaptureHelperTest", () => {
     expect(buffer).toBe(av.outputBuffer);
   });
 
-  it("test_with_output_buffer_does_not_assume_there_is_an_output_buffer", () => {
+  it.skip("with output buffer sets proper encoding", () => {
+    // SKIPPED: TS strings are always UTF-16 — no per-string encoding
+    // to swap, so Rails' force_encoding propagation has no analogue.
+  });
+
+  it("with output buffer does not assume there is an output buffer", () => {
     expect(av.outputBuffer!.isEmpty()).toBe(true);
     expect(
       av
@@ -255,7 +260,7 @@ describe("CaptureHelperTest", () => {
     ).toBe("");
   });
 
-  it("test_ignore_the_block_return_if_its_the_buffer", () => {
+  it("ignore the block return if its the buffer", () => {
     av.outputBuffer!.safeConcat("something");
     const string = av.capture(() => {
       av.outputBuffer!.concat("foo");


### PR DESCRIPTION
## Summary
- Implements `ActionView::Helpers::CaptureHelper` — `capture`, `contentFor`, `contentForQuestion`, `provide`, `withOutputBuffer`.
- Adds `ActionView::OutputFlow` (`src/flows.ts`) with SafeBuffer-aware `append` so `provide(name, rawSafe)` round-trips html_safe content verbatim while plain strings are HTML-escaped. `OutputBuffer` is also treated as html_safe (matching Rails `OutputBuffer#to_s → SafeBuffer`).
- Helpers are `this`-typed module functions per CLAUDE.md, expecting a host that exposes `outputBuffer` + `viewFlow`.
- 26 tests mirror Rails verbatim from `vendor/rails/actionview/test/template/capture_helper_test.rb` (25 active + 1 skipped for the `force_encoding` case, which has no TS analogue).

## Scope note (size)
Plan doc Phase 5 T2 bundled capture + csp + csrf. csp_helper / csrf_helper are **deferred to a separate from-main PR** — capture-helper alone with its full Rails-mirrored test suite lands at ~415 LOC, already over the 300-LOC ceiling; bundling csp/csrf pushed it to ~560.

## Test plan
- [x] `pnpm vitest run packages/actionview/src/template/capture-helper.test.ts` — 25 passed, 1 skipped
- [x] `pnpm api:compare --package actionview` — `helpers/capture-helper.ts` 5/5 (100%)
- [x] `pnpm test:compare --package actionview` — `template/capture-helper.test.ts` 25 matched + 1 skipped
- [ ] CI green