### PR TITLE
refactor(trailties): AppGenerator extends AppBase (PR 1.14d)

### DIFF
--- a/packages/trailties/src/commands/new.ts
+++ b/packages/trailties/src/commands/new.ts
@@ -20,11 +20,11 @@ export function newCommand(): Command {
       const gen = new AppGenerator({
         cwd,
         output: console.log,
-      });
-      await gen.run(name, {
+        appPath: name,
         database: options.database,
         skipDocker: options.skipDocker,
       });
+      await gen.run();
 
       const appDir = path.join(cwd, name);
 

--- a/packages/trailties/src/generators/app-generator.test.ts
+++ b/packages/trailties/src/generators/app-generator.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { AppGenerator } from "./app-generator.js";
+import { AppGenerator, type AppDatabase } from "./app-generator.js";
 
 let tmpDir: string;
 let lines: string[];
@@ -16,8 +16,14 @@ afterEach(() => {
   fs.rmSync(tmpDir, { recursive: true, force: true });
 });
 
-function makeGen() {
-  return new AppGenerator({ cwd: tmpDir, output: (m) => lines.push(m) });
+function makeGen(database: AppDatabase = "sqlite", opts: { skipDocker?: boolean } = {}) {
+  return new AppGenerator({
+    cwd: tmpDir,
+    output: (m) => lines.push(m),
+    appPath: "my-app",
+    database,
+    ...opts,
+  });
 }
 
 function appPath(...segments: string[]) {
@@ -30,10 +36,8 @@ function exists(...segments: string[]) {
 
 describe("AppGenerator", () => {
   it("creates application directory structure", async () => {
-    const gen = makeGen();
-    await gen.run("my-app", { database: "sqlite" });
+    await makeGen().run();
 
-    // Root files
     expect(exists("package.json")).toBe(true);
     expect(exists("tsconfig.json")).toBe(true);
     expect(exists(".gitignore")).toBe(true);
@@ -44,12 +48,10 @@ describe("AppGenerator", () => {
     expect(exists("Dockerfile")).toBe(true);
     expect(exists(".dockerignore")).toBe(true);
 
-    // Bin
     expect(exists("bin/trails")).toBe(true);
     expect(exists("bin/setup")).toBe(true);
     expect(exists("bin/dev")).toBe(true);
 
-    // Config
     expect(exists("src/config/application.ts")).toBe(true);
     expect(exists("src/config/environment.ts")).toBe(true);
     expect(exists("src/config/routes.ts")).toBe(true);
@@ -66,7 +68,6 @@ describe("AppGenerator", () => {
     expect(exists("src/config/initializers/permissions-policy.ts")).toBe(true);
     expect(exists("src/config/locales/en.json")).toBe(true);
 
-    // App
     expect(exists("src/app/controllers/application-controller.ts")).toBe(true);
     expect(exists("src/app/controllers/concerns/.gitkeep")).toBe(true);
     expect(exists("src/app/models/application-record.ts")).toBe(true);
@@ -83,12 +84,10 @@ describe("AppGenerator", () => {
     expect(exists("src/app/assets/images/.gitkeep")).toBe(true);
     expect(exists("vite.config.ts")).toBe(true);
 
-    // Database
     expect(exists("db/migrations/.gitkeep")).toBe(true);
     expect(exists("db/seeds.ts")).toBe(true);
     expect(exists("db/schema.ts")).toBe(true);
 
-    // Test
     expect(exists("test/test-helper.ts")).toBe(true);
     expect(exists("test/models/.gitkeep")).toBe(true);
     expect(exists("test/controllers/.gitkeep")).toBe(true);
@@ -96,14 +95,12 @@ describe("AppGenerator", () => {
     expect(exists("test/integration/.gitkeep")).toBe(true);
     expect(exists("test/fixtures/files/.gitkeep")).toBe(true);
 
-    // Public
     expect(exists("public/404.html")).toBe(true);
     expect(exists("public/422.html")).toBe(true);
     expect(exists("public/500.html")).toBe(true);
     expect(exists("public/robots.txt")).toBe(true);
     expect(exists("public/favicon.ico")).toBe(true);
 
-    // Directories
     expect(exists("lib/tasks/.gitkeep")).toBe(true);
     expect(exists("log/.gitkeep")).toBe(true);
     expect(exists("storage/.gitkeep")).toBe(true);
@@ -113,8 +110,7 @@ describe("AppGenerator", () => {
   });
 
   it("generates valid package.json", async () => {
-    const gen = makeGen();
-    await gen.run("my-app", { database: "sqlite" });
+    await makeGen().run();
     const pkg = JSON.parse(fs.readFileSync(appPath("package.json"), "utf-8"));
     expect(pkg.name).toBe("my-app");
     expect(pkg.dependencies["better-sqlite3"]).toBeDefined();
@@ -127,8 +123,7 @@ describe("AppGenerator", () => {
   });
 
   it("configures postgres database", async () => {
-    const gen = makeGen();
-    await gen.run("my-app", { database: "postgres" });
+    await makeGen("postgres").run();
     const pkg = JSON.parse(fs.readFileSync(appPath("package.json"), "utf-8"));
     expect(pkg.dependencies.pg).toBeDefined();
     const dbConfig = fs.readFileSync(appPath("src/config/database.ts"), "utf-8");
@@ -136,8 +131,7 @@ describe("AppGenerator", () => {
   });
 
   it("configures mysql database", async () => {
-    const gen = makeGen();
-    await gen.run("my-app", { database: "mysql" });
+    await makeGen("mysql").run();
     const pkg = JSON.parse(fs.readFileSync(appPath("package.json"), "utf-8"));
     expect(pkg.dependencies.mysql2).toBeDefined();
     const dbConfig = fs.readFileSync(appPath("src/config/database.ts"), "utf-8");
@@ -145,26 +139,19 @@ describe("AppGenerator", () => {
   });
 
   it("configures sqlite database by default", async () => {
-    const gen = makeGen();
-    await gen.run("my-app", { database: "sqlite" });
+    await makeGen("sqlite").run();
     const dbConfig = fs.readFileSync(appPath("src/config/database.ts"), "utf-8");
     expect(dbConfig).toContain("sqlite3");
   });
 
   it("skips docker files when --skip-docker", async () => {
-    const gen = makeGen();
-    await gen.run("my-app", {
-      database: "sqlite",
-
-      skipDocker: true,
-    });
+    await makeGen("sqlite", { skipDocker: true }).run();
     expect(exists("Dockerfile")).toBe(false);
     expect(exists(".dockerignore")).toBe(false);
   });
 
   it("includes app name in generated files", async () => {
-    const gen = makeGen();
-    await gen.run("my-app", { database: "sqlite" });
+    await makeGen().run();
 
     const readme = fs.readFileSync(appPath("README.md"), "utf-8");
     expect(readme).toContain("my-app");

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -1,45 +1,47 @@
-import { GeneratorBase, GeneratorOptions } from "./base.js";
-import { Database, type DatabaseName } from "./database.js";
+import { AppBase, type AppBaseOptions } from "./app-base.js";
+import { type DatabaseName } from "./database.js";
 
-// AppGenerator currently scaffolds dbConfig templates only for the three
-// CLI-exposed adapters. The MariaDB-via-mysql2 variant exists in
-// `database.ts` but rendering a template for it is deferred to PR 1.14d
-// alongside the AppBase rewrite. Keeping the surface narrow here
-// prevents producing an app scaffold whose `package.json` and
-// `database.ts` disagree.
+// CLI-friendly DB aliases — `trails new -d sqlite|postgres|mysql` maps
+// onto the canonical Rails `DatabaseName`. MariaDB is exposed via the
+// canonical `mariadb-mysql` adapter id only (no short alias).
 const DB_ALIAS: Record<string, DatabaseName> = {
   sqlite: "sqlite3",
   postgres: "postgresql",
 };
 
-export interface AppOptions {
-  database: "sqlite" | "postgres" | "mysql";
+export type AppDatabase = "sqlite" | "postgres" | "mysql" | DatabaseName;
+
+export interface AppGeneratorOptions extends Omit<AppBaseOptions, "database" | "appPath"> {
+  appPath?: string;
+  database?: AppDatabase;
   skipDocker?: boolean;
 }
 
-export class AppGenerator extends GeneratorBase {
-  constructor(options: GeneratorOptions) {
-    super(options);
+export class AppGenerator extends AppBase {
+  constructor(options: AppGeneratorOptions) {
+    const database = options.database
+      ? ((DB_ALIAS[options.database] ?? options.database) as DatabaseName)
+      : undefined;
+    super({ ...options, appPath: options.appPath ?? options.cwd, database });
   }
 
-  async run(name: string, options: AppOptions): Promise<string[]> {
-    const appDir = this.path.join(this.cwd, name);
-    this.cwd = appDir;
+  async run(): Promise<string[]> {
+    const name = this.path.basename(this.appPath);
 
     this.output(`Creating new trails application: ${name}`);
     this.output("");
 
-    this.createRootFiles(name, options);
-    this.createBinFiles(name);
-    this.createConfigFiles(name, options);
+    this.createRootFiles(name);
+    this.createBinFiles();
+    this.createConfigFiles(name);
     this.createAppFiles(name);
-    this.createDbFiles(name);
+    this.createDbFiles();
     this.createTestFiles();
     this.createPublicFiles(name);
     this.createDirectoryPlaceholders();
 
-    if (!options.skipDocker) {
-      this.createDockerFiles(name);
+    if (!this.options.skipDocker) {
+      this.createDockerFiles();
     }
 
     this.output("");
@@ -47,8 +49,8 @@ export class AppGenerator extends GeneratorBase {
     return this.getCreatedFiles();
   }
 
-  private createRootFiles(name: string, options: AppOptions): void {
-    // package.json
+  private createRootFiles(name: string): void {
+    const dep = this.database.pkgDependency;
     this.createFile(
       "package.json",
       JSON.stringify(
@@ -74,7 +76,7 @@ export class AppGenerator extends GeneratorBase {
             "@blazetrails/rack": "*",
             "@blazetrails/actionpack": "*",
             "@blazetrails/trailties": "*",
-            ...this.dbDependency(options.database),
+            [dep.name]: dep.version,
           },
           devDependencies: {
             typescript: "^5.7.0",
@@ -87,7 +89,6 @@ export class AppGenerator extends GeneratorBase {
       ) + "\n",
     );
 
-    // tsconfig.json
     this.createFile(
       "tsconfig.json",
       JSON.stringify(
@@ -110,7 +111,6 @@ export class AppGenerator extends GeneratorBase {
       ) + "\n",
     );
 
-    // .gitignore
     this.createFile(
       ".gitignore",
       `/node_modules/
@@ -139,7 +139,6 @@ export class AppGenerator extends GeneratorBase {
 `,
     );
 
-    // .gitattributes
     this.createFile(
       ".gitattributes",
       `# Mark the database schema as having been generated.
@@ -149,10 +148,8 @@ db/schema.ts linguist-generated
 `,
     );
 
-    // .node-version
     this.createFile(".node-version", "22.0.0\n");
 
-    // README.md
     this.createFile(
       "README.md",
       `# ${name}
@@ -186,7 +183,6 @@ This application was generated with [trails](https://github.com/blazetrailsdev/b
 `,
     );
 
-    // config.ts — equivalent to config.ru (rackup file)
     this.createFile(
       "config.ts",
       `import { app } from "./src/config/application.js";
@@ -195,7 +191,6 @@ export default app;
 `,
     );
 
-    // vite.config.ts — Vite dev server with trails Rack adapter
     this.createFile(
       "vite.config.ts",
       `import { defineConfig } from "vite";
@@ -220,8 +215,7 @@ export default defineConfig({
     );
   }
 
-  private createBinFiles(name: string): void {
-    // bin/trails — binstub
+  private createBinFiles(): void {
     this.createFile(
       "bin/trails",
       `#!/usr/bin/env node
@@ -233,7 +227,6 @@ program.parse(process.argv);
       { mode: 0o755 },
     );
 
-    // bin/setup
     this.createFile(
       "bin/setup",
       `#!/usr/bin/env node
@@ -263,7 +256,6 @@ console.log("\\n== Done! ==");
       { mode: 0o755 },
     );
 
-    // bin/dev
     this.createFile(
       "bin/dev",
       `#!/usr/bin/env node
@@ -275,8 +267,7 @@ execSync("trails server", { stdio: "inherit" });
     );
   }
 
-  private createConfigFiles(name: string, options: AppOptions): void {
-    // src/config/application.ts — equivalent to config/application.rb
+  private createConfigFiles(name: string): void {
     this.createFile(
       "src/config/application.ts",
       `import { ActiveRecord } from "@blazetrails/activerecord";
@@ -294,7 +285,6 @@ export const app = {
 `,
     );
 
-    // src/config/environment.ts — equivalent to config/environment.rb
     this.createFile(
       "src/config/environment.ts",
       `import { app } from "./application.js";
@@ -303,7 +293,6 @@ export default app;
 `,
     );
 
-    // src/config/routes.ts
     this.createFile(
       "src/config/routes.ts",
       `// Define your application routes here.
@@ -317,10 +306,8 @@ export function drawRoutes(router: any): void {
 `,
     );
 
-    // src/config/database.ts
-    this.createFile("src/config/database.ts", this.dbConfig(name, options.database));
+    this.createFile("src/config/database.ts", this.dbConfig(name));
 
-    // src/config/puma.ts — equivalent to config/puma.rb
     this.createFile(
       "src/config/puma.ts",
       `const port = parseInt(process.env.PORT || "3000", 10);
@@ -337,7 +324,6 @@ export default {
 `,
     );
 
-    // src/config/cable.ts — equivalent to config/cable.yml
     this.createFile(
       "src/config/cable.ts",
       `export default {
@@ -355,7 +341,6 @@ export default {
 `,
     );
 
-    // src/config/storage.ts — equivalent to config/storage.yml
     this.createFile(
       "src/config/storage.ts",
       `export default {
@@ -371,7 +356,6 @@ export default {
 `,
     );
 
-    // Environment configs
     this.createFile(
       "src/config/environments/development.ts",
       `export default {
@@ -408,7 +392,6 @@ export default {
 `,
     );
 
-    // Initializers
     this.createFile(
       "src/config/initializers/content-security-policy.ts",
       `// Define an application-wide content security policy.
@@ -466,7 +449,6 @@ export const filterParameters = [
 `,
     );
 
-    // Locales
     this.createFile(
       "src/config/locales/en.json",
       JSON.stringify(
@@ -482,7 +464,6 @@ export const filterParameters = [
   }
 
   private createAppFiles(name: string): void {
-    // Application controller
     this.createFile(
       "src/app/controllers/application-controller.ts",
       `import { ActionController } from "@blazetrails/actionpack";
@@ -494,7 +475,6 @@ export class ApplicationController extends ActionController.Base {
 
     this.createFile("src/app/controllers/concerns/.gitkeep", "");
 
-    // Application record — equivalent to application_record.rb
     this.createFile(
       "src/app/models/application-record.ts",
       `import { ActiveRecord } from "@blazetrails/activerecord";
@@ -506,7 +486,6 @@ export class ApplicationRecord extends ActiveRecord.Base {
 
     this.createFile("src/app/models/concerns/.gitkeep", "");
 
-    // Application helper
     this.createFile(
       "src/app/helpers/application-helper.ts",
       `export const ApplicationHelper = {
@@ -514,7 +493,6 @@ export class ApplicationRecord extends ActiveRecord.Base {
 `,
     );
 
-    // Application job — equivalent to application_job.rb
     this.createFile(
       "src/app/jobs/application-job.ts",
       `export class ApplicationJob {
@@ -523,7 +501,6 @@ export class ApplicationRecord extends ActiveRecord.Base {
 `,
     );
 
-    // Application mailer — equivalent to application_mailer.rb
     this.createFile(
       "src/app/mailers/application-mailer.ts",
       `export class ApplicationMailer {
@@ -533,7 +510,6 @@ export class ApplicationRecord extends ActiveRecord.Base {
 `,
     );
 
-    // Channels
     this.createFile(
       "src/app/channels/application-cable/connection.ts",
       `export class Connection {
@@ -548,7 +524,6 @@ export class ApplicationRecord extends ActiveRecord.Base {
 `,
     );
 
-    // Views — layouts
     this.createFile(
       "src/app/views/layouts/application.html.tse",
       `<!DOCTYPE html>
@@ -589,7 +564,6 @@ export class ApplicationRecord extends ActiveRecord.Base {
 `,
     );
 
-    // Assets
     this.createFile(
       "src/app/assets/stylesheets/application.css",
       `/*
@@ -605,7 +579,7 @@ export class ApplicationRecord extends ActiveRecord.Base {
     this.createFile("src/app/assets/images/.gitkeep", "");
   }
 
-  private createDbFiles(name: string): void {
+  private createDbFiles(): void {
     this.createFile("db/migrations/.gitkeep", "");
 
     this.createFile(
@@ -645,7 +619,6 @@ export async function setupTestDatabase(): Promise<void> {
   }
 
   private createPublicFiles(name: string): void {
-    // Welcome page — equivalent to Rails' "Yay! You're on Rails!" page
     this.createFile(
       "public/index.html",
       `<!DOCTYPE html>
@@ -874,7 +847,7 @@ export async function setupTestDatabase(): Promise<void> {
     this.createFile("vendor/.gitkeep", "");
   }
 
-  private createDockerFiles(name: string): void {
+  private createDockerFiles(): void {
     this.createFile(
       "Dockerfile",
       `# syntax=docker/dockerfile:1
@@ -920,14 +893,9 @@ dist
     );
   }
 
-  private dbDependency(db: string): Record<string, string> {
-    const dep = Database.build(DB_ALIAS[db] ?? db).pkgDependency;
-    return { [dep.name]: dep.version };
-  }
-
-  private dbConfig(appName: string, db: string): string {
-    switch (DB_ALIAS[db] ?? db) {
-      case "postgresql":
+  private dbConfig(appName: string): string {
+    switch (this.database.name) {
+      case "postgres":
         return `export default {
   development: {
     adapter: "postgresql",
@@ -948,6 +916,7 @@ dist
 };
 `;
       case "mysql":
+      case "mariadb":
         return `export default {
   development: {
     adapter: "mysql2",

--- a/packages/trailties/src/generators/index.ts
+++ b/packages/trailties/src/generators/index.ts
@@ -1,5 +1,5 @@
 export { AppGenerator } from "./app-generator.js";
-export type { AppOptions } from "./app-generator.js";
+export type { AppGeneratorOptions, AppDatabase } from "./app-generator.js";
 export { ModelGenerator } from "./model-generator.js";
 export { MigrationGenerator } from "./migration-generator.js";
 export type { MigrationRunOptions } from "./migration-generator.js";

--- a/packages/website/src/lib/frontiers/trail-cli.ts
+++ b/packages/website/src/lib/frontiers/trail-cli.ts
@@ -164,8 +164,8 @@ export function createTrailCLI(deps: TrailCliDeps) {
         dropUserTables(adapter, deps.getTables);
         deps.clearMigrations();
 
-        const gen = new VfsAppGenerator({ vfs, output: log });
-        await gen.run(name, { database: "sqlite" });
+        const gen = new VfsAppGenerator({ vfs, output: log, appPath: name, database: "sqlite" });
+        await gen.run();
       },
 
       generate: async (args) => {

--- a/packages/website/src/lib/frontiers/tutorials/generator-fixtures.test.ts
+++ b/packages/website/src/lib/frontiers/tutorials/generator-fixtures.test.ts
@@ -16,8 +16,13 @@ beforeAll(async () => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-fixtures-"));
   output = [];
 
-  const appGen = new AppGenerator({ cwd: tmpDir, output: (m) => output.push(m) });
-  await appGen.run("docs", { database: "sqlite" });
+  const appGen = new AppGenerator({
+    cwd: tmpDir,
+    output: (m) => output.push(m),
+    appPath: "docs",
+    database: "sqlite",
+  });
+  await appGen.run();
 });
 
 afterAll(() => {

--- a/packages/website/src/lib/frontiers/vfs-generator.ts
+++ b/packages/website/src/lib/frontiers/vfs-generator.ts
@@ -3,7 +3,7 @@ import {
   ModelGenerator,
   MigrationGenerator,
 } from "@blazetrails/trailties/generators";
-import type { AppOptions } from "@blazetrails/trailties/generators";
+import type { AppDatabase } from "@blazetrails/trailties/generators";
 import {
   registerFsAdapter,
   ActiveSupport,
@@ -140,22 +140,21 @@ export class VfsModelGenerator extends ModelGenerator {
   }
 }
 
-export class VfsAppGenerator extends AppGenerator {
-  constructor(options: VfsGeneratorOptions) {
-    ensureVfsAdapter(options.vfs);
-    super({ cwd: "/", output: options.output });
-    applyVfsOverrides(this, options.vfs);
-  }
+export interface VfsAppGeneratorOptions extends VfsGeneratorOptions {
+  appPath: string;
+  database?: AppDatabase;
+}
 
-  override async run(name: string, options: AppOptions): Promise<string[]> {
-    const originalCwd = this.cwd;
-    try {
-      return await super.run(name, {
-        ...options,
-        skipDocker: true,
-      });
-    } finally {
-      this.cwd = originalCwd;
-    }
+export class VfsAppGenerator extends AppGenerator {
+  constructor(options: VfsAppGeneratorOptions) {
+    ensureVfsAdapter(options.vfs);
+    super({
+      cwd: "/",
+      output: options.output,
+      appPath: options.appPath,
+      database: options.database,
+      skipDocker: true,
+    });
+    applyVfsOverrides(this, options.vfs);
   }
 }


### PR DESCRIPTION
## Summary

Wires `AppGenerator` onto the `AppBase` class from PR 1.12c (#2176). The name + database + skipDocker options move into the constructor (matching `AppBase`'s shape); `run()` now takes no arguments. `dbDependency()` private helper deleted — `this.database.pkgDependency` is used directly. `dbConfig()` switches on `this.database.name`.

Net diff is ~56/-100 LOC.

## Rails sources

- `railties/lib/rails/generators/rails/app/app_generator.rb`
- `railties/lib/rails/generators/app_base.rb` (already ported in PR 1.12c)

## Methods / scope deferred (tracked in `docs/trailties-plan.md` PR 1.14d-b)

- Builder migration of the ~900 LOC of raw-string template emits.
- `--package-manager <pnpm|npm|yarn>` flag on `trails new` + threading.
- `--sqlite-driver <better-sqlite3|node-sqlite|expo-sqlite>` flag + threading.
- `default()` view-template helper on `GeneratedAttribute` and Rails-verbatim `test_default_value_*` tests.
- `required?` predicate (waiting on AR `belongs_to_required_by_default` config port).
- Bundler/gemfile workflow (Ruby-only — `bundle_command`, `run_bundle`, `run_hotwire`, `run_kamal`, `dockerfile_*`, etc.) — already noted as N/A in `app-base.ts`.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/generators/app-generator.test.ts packages/trailties/src/generators/app-base.test.ts packages/trailties/src/commands/app.test.ts` — 12 passed
- [x] `pnpm tsc -b packages/trailties` clean