### PR TITLE
test(activerecord): port cluster 1 fixtures second half (PR 1b)

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/author-favorites.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/author-favorites.ts
@@ -1,0 +1,10 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/author_favorites.yml
+export const authorFavoriteFixtureData = {
+  david_mary: {
+    id: 1,
+    author_id: ref("authors", "david"),
+    favorite_author_id: ref("authors", "mary"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/bad-posts.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/bad-posts.ts
@@ -1,0 +1,11 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/bad_posts.yml
+// Rails sets `_fixture: model_class: BadPostModel`; load with set_fixture_class.
+export const badPostFixtureData = {
+  bad_welcome: {
+    author_id: ref("authors", "david"),
+    title: "Welcome to the another weblog",
+    body: "It's really nice today",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/other-books.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/other-books.ts
@@ -1,0 +1,18 @@
+// activerecord/test/fixtures/other_books.yml
+// Rails sets `_fixture: model_class: Book` and ignores the PUBLISHED*
+// YAML-anchor rows; only `awdr` and `rfr` materialize. Enum symbols expanded
+// to the integer values from books.ts (status :published = 2, language
+// :english = 0).
+export const otherBookFixtureData = {
+  awdr: {
+    status: 2,
+    format: "paperback",
+    language: 0,
+    name: "Agile Web Development with Rails",
+  },
+  rfr: {
+    status: 2,
+    format: "ebook",
+    name: "Ruby for Rails",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/other-comments.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/other-comments.ts
@@ -1,0 +1,11 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/other_comments.yml
+// Rails sets `_fixture: model_class: Comment`. The YAML uses association-name
+// shorthand `post: second_welcome`; translated to the FK column `post_id`.
+export const otherCommentFixtureData = {
+  second_greetings: {
+    post_id: ref("other_posts", "second_welcome"),
+    body: "Thank you for the second welcome",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/other-comments.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/other-comments.ts
@@ -3,9 +3,11 @@ import { ref } from "../define-fixtures.js";
 // activerecord/test/fixtures/other_comments.yml
 // Rails sets `_fixture: model_class: Comment`. The YAML uses association-name
 // shorthand `post: second_welcome`; translated to the FK column `post_id`.
+// The target loads into the `posts` table (other_posts is itself
+// `_fixture.model_class: Post`), so the ref uses tableName `posts`.
 export const otherCommentFixtureData = {
   second_greetings: {
-    post_id: ref("other_posts", "second_welcome"),
+    post_id: ref("posts", "second_welcome"),
     body: "Thank you for the second welcome",
   },
 };

--- a/packages/activerecord/src/test-helpers/fixtures/other-posts.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/other-posts.ts
@@ -1,0 +1,12 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/other_posts.yml
+// Rails sets `_fixture: model_class: Post`.
+export const otherPostFixtureData = {
+  second_welcome: {
+    author_id: ref("authors", "david"),
+    title: "Welcome to the another weblog",
+    body: "It's really nice today",
+    legacy_comments_count: 1,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/other-topics.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/other-topics.ts
@@ -1,0 +1,47 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/other_topics.yml
+export const otherTopicFixtureData = {
+  first: {
+    id: 1,
+    title: "The First Topic",
+    author_name: "David",
+    author_email_address: "david@loudthinking.com",
+    written_on: "2003-07-16 14:28:11",
+    last_read: "2004-04-15",
+    bonus_time: "14:28:00",
+    content: "Have a nice day",
+    approved: false,
+    replies_count: 1,
+  },
+  second: {
+    id: 2,
+    title: "The Second Topic of the day",
+    author_name: "Mary",
+    written_on: "2004-07-15 14:28:00",
+    content: "Have a nice day",
+    approved: true,
+    replies_count: 0,
+    parent_id: ref("other_topics", "first"),
+    type: "Reply",
+  },
+  third: {
+    id: 3,
+    title: "The Third Topic of the day",
+    author_name: "Carl",
+    written_on: "2005-07-15 14:28:00",
+    content: "I'm a troll",
+    approved: true,
+    replies_count: 1,
+  },
+  fourth: {
+    id: 4,
+    title: "The Fourth Topic of the day",
+    author_name: "Carl",
+    written_on: "2006-07-15 14:28:00",
+    content: "Why not?",
+    approved: true,
+    type: "Reply",
+    parent_id: ref("other_topics", "third"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/other-topics.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/other-topics.ts
@@ -1,6 +1,10 @@
 import { ref } from "../define-fixtures.js";
 
 // activerecord/test/fixtures/other_topics.yml
+// Loaded into the `topics` table under Topic (Rails uses `set_fixture_class`
+// to map the other_topics fixture file onto Topic). Intra-set refs use
+// `ref("topics", ...)` because the loader keys the declared-id registry by
+// destination tableName, not by fixture-file name.
 export const otherTopicFixtureData = {
   first: {
     id: 1,
@@ -22,7 +26,7 @@ export const otherTopicFixtureData = {
     content: "Have a nice day",
     approved: true,
     replies_count: 0,
-    parent_id: ref("other_topics", "first"),
+    parent_id: ref("topics", "first"),
     type: "Reply",
   },
   third: {
@@ -42,6 +46,6 @@ export const otherTopicFixtureData = {
     content: "Why not?",
     approved: true,
     type: "Reply",
-    parent_id: ref("other_topics", "third"),
+    parent_id: ref("topics", "third"),
   },
 };

--- a/packages/activerecord/src/test-helpers/fixtures/references.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/references.ts
@@ -1,0 +1,23 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/references.yml
+export const referenceFixtureData = {
+  michael_magician: {
+    id: 1,
+    person_id: ref("people", "michael"),
+    job_id: ref("jobs", "magician"),
+    favorite: false,
+  },
+  michael_unicyclist: {
+    id: 2,
+    person_id: ref("people", "michael"),
+    job_id: ref("jobs", "unicyclist"),
+    favorite: true,
+  },
+  david_unicyclist: {
+    id: 3,
+    person_id: ref("people", "david"),
+    job_id: ref("jobs", "unicyclist"),
+    favorite: false,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/subscribers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/subscribers.ts
@@ -1,0 +1,16 @@
+// activerecord/test/fixtures/subscribers.yml
+// Subscriber uses `nick` as its string primary key; no integer id column.
+export const subscriberFixtureData = {
+  first: {
+    nick: "alterself",
+    name: "Luke Holden",
+  },
+  second: {
+    nick: "webster132",
+    name: "David Heinemeier Hansson",
+  },
+  third: {
+    nick: "swistak",
+    name: "Marcin Raczkowski",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/subscribers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/subscribers.ts
@@ -1,5 +1,7 @@
 // activerecord/test/fixtures/subscribers.yml
-// Subscriber uses `nick` as its string primary key; no integer id column.
+// Subscriber sets `self.primary_key = "nick"` (string PK). The subscribers
+// table still has an integer `id` column in the schema, but it is not the PK
+// and the Rails YAML never declares one.
 export const subscriberFixtureData = {
   first: {
     nick: "alterself",

--- a/packages/activerecord/src/test-helpers/fixtures/subscriptions.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/subscriptions.ts
@@ -1,0 +1,23 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/subscriptions.yml
+// subscriber_id holds the Subscriber#nick string PK directly (not a fixture
+// row-name ref); book_id is numeric in Rails YAML and resolves to the
+// book row carrying that id.
+export const subscriptionFixtureData = {
+  webster_awdr: {
+    id: 1,
+    subscriber_id: "webster132",
+    book_id: ref("books", "awdr"),
+  },
+  webster_rfr: {
+    id: 2,
+    subscriber_id: "webster132",
+    book_id: ref("books", "rfr"),
+  },
+  alterself_awdr: {
+    id: 3,
+    subscriber_id: "alterself",
+    book_id: ref("books", "awdr"),
+  },
+};


### PR DESCRIPTION
## Summary

Ports 9 Rails YAML fixtures to TS per `docs/fixtures-port-plan.md` PR 1b
(cluster 1 second half):

- `author-favorites.ts`, `bad-posts.ts`, `other-posts.ts`, `other-comments.ts`
- `other-topics.ts`, `other-books.ts`, `subscribers.ts`, `subscriptions.ts`
- `references.ts`

All rows carry the Rails `id` verbatim where the Rails YAML declares one
(Decision 1); FKs use `ref(table, row)` against the target's declared id.

## Notes per file

- **bad-posts / other-posts / other-comments / other-books / subscribers** —
  Rails YAML omits `id` so the TS omits it too. `_fixture: model_class: ...`
  metadata is captured as a header comment.
- **other-books** — the YAML anchors `PUBLISHED` / `PUBLISHED_PAPERBACK` /
  `PUBLISHED_EBOOK` are expanded inline into the two materialized rows
  (`awdr`, `rfr`). Rails `_fixture.ignore` removes the anchor-only rows
  from load. Book enum symbols (`:published`, `:english`) are normalized to
  the integer values used in `books.ts`.
- **subscribers** — `Subscriber` uses `nick` as a string PK; no integer id.
- **subscriptions.subscriber_id** holds the literal nick string (no
  subscribers row label matches a nick); `book_id` is numeric and resolves
  through `ref("books", ...)`.
- **other-comments** — Rails YAML association shorthand `post: second_welcome`
  is translated to the FK column `post_id: ref("other_posts", "second_welcome")`
  expected by the loader.
- **references / author-favorites** — FKs into `people`, `jobs`, `authors`;
  `people` and `jobs` aren't ported yet (cluster 3) but `ref()` is a lazy
  lookup so the refs resolve once those land.

## Verification

`pnpm fixtures:compare` (soft-fail per PR 0). New files surface as
`MATCH` (subscribers), `DIFF` (other-books — `_fixture.ignore` / anchors
aren't modeled by the comparer), or `TS-IMPORT-ERR` (the pre-existing
comparer limitation that also affects already-merged PR 1a fixtures
importing `ref`). No regressions.

## LOC

9 files, 171 insertions — well under the 300-LOC ceiling.