### PR TITLE
refactor(activerecord): migrate .innerAdapter callers to sidecar (Path 2b)

### DIFF
--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -15,7 +15,7 @@ import {
 import { SubclassNotFound, NameError } from "./errors.js";
 import { quoteSqlValue } from "./base.js";
 
-import { createTestAdapter, adapterType } from "./test-adapter.js";
+import { createSidecarTestAdapter, createTestAdapter, adapterType } from "./test-adapter.js";
 import { quoteColumnName } from "./test-helpers/quote-regex.js";
 import { registerModel } from "./associations.js";
 import { connectedToStack } from "./core.js";
@@ -2631,7 +2631,8 @@ describe("BasicsTest", () => {
   });
   it("column types on queries on postgresql", async () => {
     if (adapterType !== "postgres") return;
-    const result = await adapter.execQuery("SELECT 1 AS test");
+    const { adapter: pgAdapter } = createSidecarTestAdapter();
+    const result = await pgAdapter.execQuery("SELECT 1 AS test");
     expect(result.columnTypes["test"]).toBeInstanceOf(IntegerType);
   });
   it.skip("connection_handler can be overridden", () => {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -15,7 +15,7 @@ import {
 import { SubclassNotFound, NameError } from "./errors.js";
 import { quoteSqlValue } from "./base.js";
 
-import { createTestAdapter, adapterType, type TestDatabaseAdapter } from "./test-adapter.js";
+import { createTestAdapter, adapterType } from "./test-adapter.js";
 import { quoteColumnName } from "./test-helpers/quote-regex.js";
 import { registerModel } from "./associations.js";
 import { connectedToStack } from "./core.js";
@@ -2631,9 +2631,7 @@ describe("BasicsTest", () => {
   });
   it("column types on queries on postgresql", async () => {
     if (adapterType !== "postgres") return;
-    const result = await (adapter as TestDatabaseAdapter).innerAdapter.execQuery(
-      "SELECT 1 AS test",
-    );
+    const result = await adapter.execQuery("SELECT 1 AS test");
     expect(result.columnTypes["test"]).toBeInstanceOf(IntegerType);
   });
   it.skip("connection_handler can be overridden", () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -2237,24 +2237,23 @@ describe("MigrationTest", () => {
     //   (1) acquire/release are called symmetrically, and
     //   (2) _advisoryLockClient is null after migration — the pinned pool client
     //       was actually returned (not just nulled without release).
-    const { adapter: testAdapter } = createSidecarTestAdapter();
-    const inner = testAdapter as any;
-    const getSpy = vi.spyOn(inner, "getAdvisoryLock");
-    const releaseSpy = vi.spyOn(inner, "releaseAdvisoryLock");
+    const { adapter: realAdapter } = createSidecarTestAdapter();
+    const getSpy = vi.spyOn(realAdapter as any, "getAdvisoryLock");
+    const releaseSpy = vi.spyOn(realAdapter as any, "releaseAdvisoryLock");
     try {
       const proxy: MigrationProxy = {
         version: "200",
         name: "NoOp",
         migration: () => ({ up: async () => {}, down: async () => {} }),
       };
-      const migrator = new Migrator(testAdapter, [proxy]);
+      const migrator = new Migrator(realAdapter, [proxy]);
       await migrator.migrate();
       expect(getSpy).toHaveBeenCalledTimes(1);
       expect(releaseSpy).toHaveBeenCalledWith(getSpy.mock.calls[0][0]);
       // The pinned advisory-lock client must be released back to the pool.
       // A null _advisoryLockClient after migration means the pool client was
       // not leaked — the connection was closed as Rails expects.
-      expect(inner._advisoryLockClient).toBeNull();
+      expect((realAdapter as any)._advisoryLockClient).toBeNull();
       expect(await migrator.getAllVersions()).toContain("200");
     } finally {
       getSpy.mockRestore();

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -8,7 +8,7 @@ import { Base, MigrationContext, MigrationRunner, Migrator } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
 import { ConcurrentMigrationError } from "./migration.js";
-import { createTestAdapter, adapterType } from "./test-adapter.js";
+import { createSidecarTestAdapter, createTestAdapter, adapterType } from "./test-adapter.js";
 import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { Migration } from "./migration.js";
@@ -2171,8 +2171,7 @@ describe("MigrationTest", () => {
   );
 
   it.skipIf(adapterType === "sqlite")("migrator generates valid lock id", async () => {
-    const testAdapter = createTestAdapter();
-    const realAdapter = testAdapter.innerAdapter;
+    const { adapter: realAdapter } = createSidecarTestAdapter();
     const migrator = new Migrator(realAdapter, []);
     const lockId = await migrator.generateMigratorAdvisoryLockId();
     const acquired = await (realAdapter as any).getAdvisoryLock(lockId);
@@ -2238,8 +2237,8 @@ describe("MigrationTest", () => {
     //   (1) acquire/release are called symmetrically, and
     //   (2) _advisoryLockClient is null after migration — the pinned pool client
     //       was actually returned (not just nulled without release).
-    const testAdapter = createTestAdapter();
-    const inner = testAdapter.innerAdapter as any;
+    const { adapter: testAdapter } = createSidecarTestAdapter();
+    const inner = testAdapter as any;
     const getSpy = vi.spyOn(inner, "getAdvisoryLock");
     const releaseSpy = vi.spyOn(inner, "releaseAdvisoryLock");
     try {

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -2,12 +2,18 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
 import { cleanDefault, cleanRawPgExpression } from "./schema-dumper.js";
-import { createTestAdapter, adapterType } from "./test-adapter.js";
+import { createSidecarTestAdapter, createTestAdapter, adapterType } from "./test-adapter.js";
 import type { TestDatabaseAdapter } from "./test-adapter.js";
 import type { DatabaseAdapter } from "./adapter.js";
 
 function freshCtx(): { adapter: TestDatabaseAdapter; ctx: MigrationContext } {
   const adapter = createTestAdapter();
+  const ctx = new MigrationContext(adapter);
+  return { adapter, ctx };
+}
+
+function freshSidecarCtx(): { adapter: DatabaseAdapter; ctx: MigrationContext } {
+  const { adapter } = createSidecarTestAdapter();
   const ctx = new MigrationContext(adapter);
   return { adapter, ctx };
 }
@@ -224,33 +230,33 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")("schema dumps check constraints", async () => {
     const { SchemaStatements } =
       await import("./connection-adapters/abstract/schema-statements.js");
-    const { adapter: testAdapter, ctx: testCtx } = freshCtx();
+    const { adapter: testAdapter, ctx: testCtx } = freshSidecarCtx();
     await testCtx.createTable("products", {}, (t) => {
       t.decimal("price");
       t.decimal("discounted_price");
     });
-    const ss = new SchemaStatements(testAdapter.innerAdapter as any);
+    const ss = new SchemaStatements(testAdapter as any);
     await ss.addCheckConstraint("products", "price > discounted_price", {
       name: "products_price_check",
     });
-    const output = await SchemaDumper.dump(testAdapter.innerAdapter);
+    const output = await SchemaDumper.dump(testAdapter);
     expect(output).toContain("products_price_check");
     expect(output).toContain("t.checkConstraint");
   });
   it.skipIf(adapterType !== "postgres")("schema dumps exclusion constraints", async () => {
     const { SchemaDumper: PgSchemaDumper } =
       await import("./connection-adapters/postgresql/schema-dumper.js");
-    const { adapter: testAdapter, ctx: testCtx } = freshCtx();
+    const { adapter: testAdapter, ctx: testCtx } = freshSidecarCtx();
     await testCtx.createTable("test_schema_exclusion", { id: false }, (t) => {
       t.date("start_date");
       t.date("end_date");
     });
-    await (testAdapter.innerAdapter as any).addExclusionConstraint(
+    await (testAdapter as any).addExclusionConstraint(
       "test_schema_exclusion",
       "daterange(start_date, end_date) WITH &&",
       { using: "gist", name: "test_schema_exclusion_date_overlap" },
     );
-    const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
+    const output = await PgSchemaDumper.dump(testAdapter);
     expect(output).toContain("addExclusionConstraint");
     expect(output).toContain("test_schema_exclusion_date_overlap");
     expect(output).toContain("daterange(start_date, end_date) WITH &&");
@@ -258,22 +264,19 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")("schema dumps unique constraints", async () => {
     const { SchemaDumper: PgSchemaDumper } =
       await import("./connection-adapters/postgresql/schema-dumper.js");
-    const { adapter: testAdapter, ctx: testCtx } = freshCtx();
+    const { adapter: testAdapter, ctx: testCtx } = freshSidecarCtx();
     await testCtx.createTable("test_schema_unique", {}, (t) => {
       t.integer("position_1");
       t.integer("position_2");
     });
-    await (testAdapter.innerAdapter as any).addUniqueConstraint(
-      "test_schema_unique",
-      ["position_1"],
-      { name: "test_schema_unique_position_1" },
-    );
-    await (testAdapter.innerAdapter as any).addUniqueConstraint(
-      "test_schema_unique",
-      ["position_2"],
-      { nullsNotDistinct: true, name: "test_schema_unique_position_2_nnd" },
-    );
-    const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
+    await (testAdapter as any).addUniqueConstraint("test_schema_unique", ["position_1"], {
+      name: "test_schema_unique_position_1",
+    });
+    await (testAdapter as any).addUniqueConstraint("test_schema_unique", ["position_2"], {
+      nullsNotDistinct: true,
+      name: "test_schema_unique_position_2_nnd",
+    });
+    const output = await PgSchemaDumper.dump(testAdapter);
     expect(output).toContain("addUniqueConstraint");
     expect(output).toContain("test_schema_unique_position_1");
     expect(output).toContain("test_schema_unique_position_2_nnd");
@@ -284,14 +287,14 @@ describe("SchemaDumperTest", () => {
     async () => {
       const { SchemaDumper: PgSchemaDumper } =
         await import("./connection-adapters/postgresql/schema-dumper.js");
-      const { adapter: testAdapter, ctx: testCtx } = freshCtx();
+      const { adapter: testAdapter, ctx: testCtx } = freshSidecarCtx();
       await testCtx.createTable("test_uc_no_idx", {}, (t) => {
         t.integer("position");
       });
-      await (testAdapter.innerAdapter as any).addUniqueConstraint("test_uc_no_idx", ["position"], {
+      await (testAdapter as any).addUniqueConstraint("test_uc_no_idx", ["position"], {
         name: "test_uc_no_idx_position",
       });
-      const output = await PgSchemaDumper.dump(testAdapter.innerAdapter);
+      const output = await PgSchemaDumper.dump(testAdapter);
       expect(output).toContain("addUniqueConstraint");
       // The backing index must not also appear as an addIndex call.
       expect(output).not.toMatch(/addIndex.*test_uc_no_idx.*test_uc_no_idx_position/);

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { adapterType, createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import {
+  adapterType,
+  createSidecarTestAdapter,
+  createTestAdapter,
+  type TestDatabaseAdapter,
+} from "../test-adapter.js";
 import { snapshotDdlTrackers } from "./ddl-tracker.js";
 import { shouldSkipGlobalReset } from "./skip-global-reset.js";
 import { SQLite3Adapter } from "../connection-adapters/sqlite3-adapter.js";
@@ -9,11 +14,14 @@ import { withTransactionalFixtures } from "./with-transactional-fixtures.js";
 interface AdapterWithExec {
   exec(sql: string): Promise<void>;
   execute(sql: string): Promise<unknown[]>;
-  innerAdapter: {
-    transactionManager: {
-      beginTransaction(opts: Record<string, unknown>): Promise<unknown>;
-      commitTransaction(): Promise<void>;
-    };
+}
+
+interface TmHandle {
+  transactionManager: {
+    beginTransaction(opts: Record<string, unknown>): Promise<unknown>;
+    commitTransaction(): Promise<void>;
+    rollbackTransaction(): Promise<void>;
+    openTransactions: number;
   };
 }
 
@@ -43,9 +51,10 @@ describe("withTransactionalFixtures", () => {
   });
 
   it("nested user transaction becomes a savepoint and still rolls back at teardown", async () => {
-    await a().innerAdapter.transactionManager.beginTransaction({});
+    const tm = (createSidecarTestAdapter().adapter as unknown as TmHandle).transactionManager;
+    await tm.beginTransaction({});
     await a().exec(`INSERT INTO fixture_users (id, name) VALUES (2, 'bob')`);
-    await a().innerAdapter.transactionManager.commitTransaction();
+    await tm.commitTransaction();
     const rows = await a().execute(`SELECT * FROM fixture_users`);
     expect(rows).toHaveLength(1);
   });
@@ -83,11 +92,7 @@ describe("withTransactionalFixtures (useTransactionalTests=false opt-out)", () =
   // (openTransactions==2); when inactive, openTransactions==1 after our
   // manual begin.
   it("does not open a transaction in beforeEach when opted out", async () => {
-    const tm = a().innerAdapter.transactionManager as unknown as {
-      openTransactions: number;
-      beginTransaction(opts: Record<string, unknown>): Promise<unknown>;
-      rollbackTransaction(): Promise<void>;
-    };
+    const tm = (createSidecarTestAdapter().adapter as unknown as TmHandle).transactionManager;
     expect(tm.openTransactions).toBe(0);
     await tm.beginTransaction({});
     expect(tm.openTransactions).toBe(1);

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -15,7 +15,7 @@ import {
   modelRegistry,
 } from "./index.js";
 
-import { createTestAdapter } from "./test-adapter.js";
+import { createSidecarTestAdapter, createTestAdapter } from "./test-adapter.js";
 import { defineSchema } from "./test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "./adapter.js";
 import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
@@ -2135,11 +2135,10 @@ describe("TransactionTest", () => {
 
     it("calls clearCacheBang and re-raises when the body throws the expired error", async () => {
       const { PreparedStatementCacheExpired } = await import("./errors.js");
-      // TM routes through this.inner (the real connection), so spy on innerAdapter.
-      // SchemaAdapter.clearCacheBang delegates to inner, and TM calls clearCacheBang
-      // on _connection (= inner) directly — spying on the wrapper would miss it.
-      const innerAdapter = (adapter as any).innerAdapter ?? adapter;
-      const spy = vi.spyOn(innerAdapter as Required<DatabaseAdapter>, "clearCacheBang");
+      // TM calls clearCacheBang on _connection (the real adapter) directly,
+      // so spy on the shared real adapter via the sidecar handle.
+      const { adapter: realAdapter } = createSidecarTestAdapter();
+      const spy = vi.spyOn(realAdapter as Required<DatabaseAdapter>, "clearCacheBang");
       await expect(
         transaction(Account, async () => {
           throw new PreparedStatementCacheExpired("cached plan expired");
@@ -2149,8 +2148,8 @@ describe("TransactionTest", () => {
     });
 
     it("does not call clearCacheBang for unrelated errors", async () => {
-      const innerAdapter = (adapter as any).innerAdapter ?? adapter;
-      const spy = vi.spyOn(innerAdapter as Required<DatabaseAdapter>, "clearCacheBang");
+      const { adapter: realAdapter } = createSidecarTestAdapter();
+      const spy = vi.spyOn(realAdapter as Required<DatabaseAdapter>, "clearCacheBang");
       await expect(
         transaction(Account, async () => {
           throw new Error("unrelated");
@@ -2343,10 +2342,9 @@ describe("SchemaAdapter TM delegation", () => {
   // DDL savepoints are released eagerly (releaseSavepoint right after exec);
   // TM does not track them and never tries to release them again.
   it("transaction() routes SchemaAdapter through TM (spy on inner.withinNewTransaction)", async () => {
-    const testAdapter = createTestAdapter();
+    const { adapter: testAdapter } = createSidecarTestAdapter();
     await defineSchema(testAdapter, { items: { name: "string" } });
-    const inner = (testAdapter as any).innerAdapter;
-    const spy = vi.spyOn(inner, "withinNewTransaction");
+    const spy = vi.spyOn(testAdapter as any, "withinNewTransaction");
     class Item extends Base {
       static {
         this.attribute("name", "string");

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -2342,9 +2342,14 @@ describe("SchemaAdapter TM delegation", () => {
   // DDL savepoints are released eagerly (releaseSavepoint right after exec);
   // TM does not track them and never tries to release them again.
   it("transaction() routes SchemaAdapter through TM (spy on inner.withinNewTransaction)", async () => {
-    const { adapter: testAdapter } = createSidecarTestAdapter();
+    // Keep the wrapper for defineSchema/Model.adapter so the per-wrapper
+    // signature cache stays isolated across tests in this describe; spy on
+    // the shared real adapter via the sidecar — that's what the wrapper's
+    // withinNewTransaction routes to and what TM dispatches against.
+    const testAdapter = createTestAdapter();
     await defineSchema(testAdapter, { items: { name: "string" } });
-    const spy = vi.spyOn(testAdapter as any, "withinNewTransaction");
+    const { adapter: realAdapter } = createSidecarTestAdapter();
+    const spy = vi.spyOn(realAdapter as any, "withinNewTransaction");
     class Item extends Base {
       static {
         this.attribute("name", "string");


### PR DESCRIPTION
## Summary

Path 2 sub-PR (b) of the test-adapter cleanup. Migrates the 18
test-level `.innerAdapter` reach-in callers from the
`TestAdapterFixtures` wrapper to the `createSidecarTestAdapter()` shape
introduced in #2202.

- `base.test.ts`: drop wrapper cast; call `adapter.execQuery` directly
- `schema-dumper.test.ts`: new `freshSidecarCtx()` for the four PG-only
  constraint-dump tests, so they hit `PostgreSQLAdapter` directly
- `transactions.test.ts`: spy on `clearCacheBang` /
  `withinNewTransaction` via the sidecar adapter (matches what TM
  actually calls)
- `migration.test.ts`: sidecar for the two advisory-lock tests
- `with-transactional-fixtures.test.ts`: pull `transactionManager` from
  the sidecar adapter

After this PR, every test-level `.innerAdapter` reach-in is gone. The
helper `withTransactionalFixtures` keeps its defensive `.innerAdapter ??
adapter` unwrap for one more PR; sub-PR (c) deletes both the unwrap and
the wrapper class.

## Test plan

- [x] `pnpm vitest run` for the five touched files passes on SQLite
- [ ] PG + MariaDB via CI (schema-dumper PG tests + transactions advisory lock)
- [ ] `pnpm api:compare` non-negative
- [ ] `pnpm test:compare` non-negative