### PR TITLE
test(activerecord): port pirates/ships, encryption, fk_ fixtures (PR 2)

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/dead-parrots.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/dead-parrots.ts
@@ -1,0 +1,11 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/dead_parrots.yml
+// STI rows for the parrots table.
+export const deadParrotFixtureData = {
+  deadbird: {
+    name: "Dusty DeadBird",
+    parrot_sti_class: "DeadParrot",
+    killer_id: ref("pirates", "blackbeard"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/doubloons.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/doubloons.ts
@@ -1,0 +1,9 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/doubloons.yml
+export const doubloonFixtureData = {
+  blackbeards_doubloon: {
+    pirate_id: ref("pirates", "blackbeard"),
+    weight: 2,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/encrypted-book-that-ignores-cases.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/encrypted-book-that-ignores-cases.ts
@@ -1,0 +1,8 @@
+// activerecord/test/fixtures/encrypted_book_that_ignores_cases.yml
+export const encryptedBookThatIgnoresCasesFixtureData = {
+  rfr: {
+    author_id: 1,
+    name: "Ruby for Rails",
+    format: "ebook",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/encrypted-books.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/encrypted-books.ts
@@ -1,0 +1,8 @@
+// activerecord/test/fixtures/encrypted_books.yml
+export const encryptedBookFixtureData = {
+  awdr: {
+    author_id: 1,
+    name: "Agile Web Development with Rails",
+    format: "paperback",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/fk-object-to-point-to.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fk-object-to-point-to.ts
@@ -1,0 +1,6 @@
+// activerecord/test/fixtures/fk_object_to_point_to.yml
+export const fkObjectToPointToFixtureData = {
+  first: {
+    id: 1,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/fk-test-has-fk.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fk-test-has-fk.ts
@@ -1,0 +1,7 @@
+// activerecord/test/fixtures/fk_test_has_fk.yml
+export const fkTestHasFkFixtureData = {
+  first: {
+    id: 1,
+    fk_id: 1,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/fk-test-has-pk.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/fk-test-has-pk.ts
@@ -1,0 +1,7 @@
+// activerecord/test/fixtures/fk_test_has_pk.yml
+// `fk_test_has_pk` uses pk_id as its declared primary key.
+export const fkTestHasPkFixtureData = {
+  first: {
+    pk_id: 1,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/friendships.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/friendships.ts
@@ -1,0 +1,8 @@
+// activerecord/test/fixtures/friendships.yml
+export const friendshipFixtureData = {
+  "Connection 1": {
+    id: 1,
+    friend_id: 1,
+    follower_id: 2,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/live-parrots.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/live-parrots.ts
@@ -1,0 +1,8 @@
+// activerecord/test/fixtures/live_parrots.yml
+// STI rows for the parrots table.
+export const liveParrotFixtureData = {
+  dusty: {
+    name: "Dusty Bluebird",
+    parrot_sti_class: "LiveParrot",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/mateys.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/mateys.ts
@@ -1,0 +1,10 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/mateys.yml
+export const mateyFixtureData = {
+  blackbeard_to_redbeard: {
+    pirate_id: ref("pirates", "blackbeard"),
+    target_id: ref("pirates", "redbeard"),
+    weight: 10,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/parrots-pirates.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/parrots-pirates.ts
@@ -1,0 +1,13 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/parrots_pirates.yml
+export const parrotsPiratesFixtureData = {
+  george_blackbeard: {
+    parrot_id: ref("parrots", "george"),
+    pirate_id: ref("pirates", "blackbeard"),
+  },
+  louis_blackbeard: {
+    parrot_id: ref("parrots", "louis"),
+    pirate_id: ref("pirates", "blackbeard"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/parrots.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/parrots.ts
@@ -1,0 +1,34 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/parrots.yml
+// `_fixture: ignore: DEAD_PARROT` and the DEFAULTS anchor row are YAML-only
+// scaffolding (Rails skips them); we expand the merge inline and omit them.
+// `treasures: ...` is a HABTM association declared in YAML — it doesn't map
+// to a column on parrots so it's not represented here.
+export const parrotFixtureData = {
+  george: {
+    name: "Curious George",
+    parrot_sti_class: "LiveParrot",
+    breed: "australian",
+  },
+  louis: {
+    name: "King Louis",
+    parrot_sti_class: "LiveParrot",
+    breed: "african",
+  },
+  frederick: {
+    name: "frederick",
+    parrot_sti_class: "LiveParrot",
+    breed: "african",
+  },
+  polly: {
+    id: 4,
+    name: "polly",
+    killer_id: ref("pirates", "blackbeard"),
+    parrot_sti_class: "DeadParrot",
+  },
+  davey: {
+    parrot_sti_class: "LiveParrot",
+    breed: "australian",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/parrots.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/parrots.ts
@@ -1,10 +1,11 @@
 import { ref } from "../define-fixtures.js";
 
 // activerecord/test/fixtures/parrots.yml
-// `_fixture: ignore: DEAD_PARROT` and the DEFAULTS anchor row are YAML-only
-// scaffolding (Rails skips them); we expand the merge inline and omit them.
-// `treasures: ...` is a HABTM association declared in YAML — it doesn't map
-// to a column on parrots so it's not represented here.
+// Rails' `_fixture: ignore: DEAD_PARROT` skips DEAD_PARROT only; the DEFAULTS
+// anchor row is also a real fixture row (Rails inserts it). YAML anchors and
+// merges (`<<: *DEAD_PARROT`, `*DEFAULTS`) are expanded inline. `treasures:`
+// is a HABTM association declared in YAML — it doesn't map to a column on
+// parrots, so it's not represented here.
 export const parrotFixtureData = {
   george: {
     name: "Curious George",
@@ -26,6 +27,10 @@ export const parrotFixtureData = {
     name: "polly",
     killer_id: ref("pirates", "blackbeard"),
     parrot_sti_class: "DeadParrot",
+  },
+  DEFAULTS: {
+    parrot_sti_class: "LiveParrot",
+    breed: "australian",
   },
   davey: {
     parrot_sti_class: "LiveParrot",

--- a/packages/activerecord/src/test-helpers/fixtures/peoples-treasures.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/peoples-treasures.ts
@@ -1,0 +1,9 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/peoples_treasures.yml
+export const peoplesTreasuresFixtureData = {
+  michael_diamond: {
+    rich_person_id: ref("people", "michael"),
+    treasure_id: ref("treasures", "diamond"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/pirates.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/pirates.ts
@@ -1,0 +1,24 @@
+import { Temporal } from "@blazetrails/activesupport/temporal";
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/pirates.yml
+const twoWeeksAgo = Temporal.Instant.fromEpochMilliseconds(Date.now() - 14 * 24 * 60 * 60 * 1000);
+
+export const pirateFixtureData = {
+  blackbeard: {
+    catchphrase: "Yar.",
+    parrot_id: ref("parrots", "george"),
+  },
+  redbeard: {
+    catchphrase: "Avast!",
+    parrot_id: ref("parrots", "louis"),
+    created_on: twoWeeksAgo,
+    updated_on: twoWeeksAgo,
+  },
+  mark: {
+    catchphrase: "X marks the spot!",
+  },
+  "1": {
+    catchphrase: "#1 pirate!",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/ships.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/ships.ts
@@ -1,0 +1,13 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/ships.yml
+export const shipFixtureData = {
+  black_pearl: {
+    name: "Black Pearl",
+    pirate_id: ref("pirates", "blackbeard"),
+  },
+  interceptor: {
+    id: 2,
+    name: "Interceptor",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/strict-zines.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/strict-zines.ts
@@ -1,0 +1,6 @@
+// activerecord/test/fixtures/strict_zines.yml
+export const strictZineFixtureData = {
+  going_out: {
+    title: "Hello",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/treasures.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/treasures.ts
@@ -1,0 +1,24 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/treasures.yml
+// `looter: <row> (<Type>)` is Rails' polymorphic shorthand → looter_id +
+// looter_type pair.
+export const treasureFixtureData = {
+  diamond: {
+    name: "diamond",
+  },
+  sapphire: {
+    name: "sapphire",
+    looter_id: ref("pirates", "redbeard"),
+    looter_type: "Pirate",
+  },
+  ruby: {
+    name: "ruby",
+    looter_id: ref("parrots", "louis"),
+    looter_type: "Parrot",
+  },
+  emerald: {
+    id: 1,
+    name: "emerald",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/zines.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/zines.ts
@@ -1,0 +1,9 @@
+// activerecord/test/fixtures/zines.yml
+export const zineFixtureData = {
+  staying_in: {
+    title: "Staying in '08",
+  },
+  going_out: {
+    title: "Outdoor Pursuits 2k+8",
+  },
+};


### PR DESCRIPTION
## Summary

PR 2 of the fixtures port plan ([docs/fixtures-port-plan.md](docs/fixtures-port-plan.md)). Translates 18 Rails YAML fixtures into TS under `packages/activerecord/src/test-helpers/fixtures/`:

- **Cluster 2** (pirates/ships HABTM + STI test bed): `pirates`, `ships`, `parrots`, `parrots-pirates`, `dead-parrots`, `live-parrots`, `treasures`, `peoples-treasures`, `doubloons`, `mateys`, `friendships`
- **Cluster 9** (encryption): `encrypted-books`, `encrypted-book-that-ignores-cases`
- **Cluster 10** (misc fk_*): `strict-zines`, `zines`, `fk-object-to-point-to`, `fk-test-has-fk`, `fk-test-has-pk`

Per plan translation rules: kebab-case filenames, `ref()` for FKs, Rails `id` carried verbatim where declared, polymorphic shorthand `looter: redbeard (Pirate)` expanded to `looter_id`/`looter_type`, YAML anchors (`<<: *DEFAULTS`, `*DEAD_PARROT`) and `$LABEL` substitution expanded inline. HABTM YAML shorthand (`parrots.treasures`) is association sugar that doesn't map to a column on `parrots`, so it's omitted.

Size: 213 LOC (under the 300 ceiling, matches the plan's ~190 estimate).

## Verification

`pnpm fixtures:compare` (soft-fail per Decision 4) reports MATCH for files without ERB and without Rails' belongs_to-shorthand. Remaining DIFFs are compare-script limitations to be addressed before PR 7 flips strictness:

- `parrot: george` (belongs_to shorthand) → script reports `missing-in-ts: parrot / extra-in-ts: parrot_id`
- `$LABEL` substitution → script reports `value-differs`
- ERB-bearing files (pirates/parrots-pirates/peoples-treasures/mateys) → `ERB-UNSUPPORTED` (skipped by compare entirely)

## Test plan

- [ ] CI green
- [ ] `pnpm fixtures:compare` runs cleanly (soft-fail; no new TS-IMPORT-ERR / YAML-PARSE-ERR)