### PR TITLE
test(activerecord): port cluster 5 STI fixtures (PR 4)

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/cake-designers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cake-designers.ts
@@ -1,0 +1,5 @@
+// activerecord/test/fixtures/cake_designers.yml
+export const cakeDesignerFixtureData = {
+  flora: { id: 1 },
+  frosty: { id: 2 },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/chefs.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/chefs.ts
@@ -1,0 +1,5 @@
+// activerecord/test/fixtures/chefs.yml
+export const chefFixtureData = {
+  gordon_ramsay: { id: 1 },
+  marco_pierre_white: { id: 2 },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/clothing-items.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/clothing-items.ts
@@ -1,0 +1,27 @@
+// activerecord/test/fixtures/clothing_items.yml
+export const clothingItemFixtureData = {
+  green_pants: {
+    color: "green",
+    clothing_type: "pants",
+    description: "Cool green pants",
+    type: "ClothingItem",
+  },
+  green_t_shirt: {
+    color: "green",
+    clothing_type: "t-shirt",
+    description: "Cool green t-shirt",
+    type: "ClothingItem",
+  },
+  red_t_shirt: {
+    color: "red",
+    clothing_type: "t-shirt",
+    description: "Cool red t-shirt",
+    type: "ClothingItem",
+  },
+  used_blue_jeans: {
+    color: "blue",
+    clothing_type: "pants",
+    description: "Cool blue jeans",
+    type: "ClothingItem::Used",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/collections.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/collections.ts
@@ -1,0 +1,7 @@
+// activerecord/test/fixtures/collections.yml
+export const collectionFixtureData = {
+  collection_1: {
+    id: 1,
+    name: "Collection",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/colleges.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/colleges.ts
@@ -1,0 +1,7 @@
+// activerecord/test/fixtures/colleges.yml
+export const collegeFixtureData = {
+  FIU: {
+    id: 1,
+    name: "Florida International University",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/content-positions.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/content-positions.ts
@@ -1,0 +1,9 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/content_positions.yml
+export const contentPositionFixtureData = {
+  content_positions: {
+    id: 1,
+    content_id: ref("content", "content"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/content.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/content.ts
@@ -1,0 +1,7 @@
+// activerecord/test/fixtures/content.yml
+export const contentFixtureData = {
+  content: {
+    id: 1,
+    title: "How to use Rails",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/courses.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/courses.ts
@@ -1,0 +1,15 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/courses.yml
+// Rails `college: FIU` is the belongs_to association name; it sets college_id.
+export const courseFixtureData = {
+  ruby: {
+    id: 1,
+    name: "Ruby Development",
+    college_id: ref("colleges", "FIU"),
+  },
+  java: {
+    id: 2,
+    name: "Java Development",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/customers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/customers.ts
@@ -1,0 +1,39 @@
+// activerecord/test/fixtures/customers.yml
+export const customerFixtureData = {
+  david: {
+    id: 1,
+    name: "David",
+    balance: 50,
+    address_street: "Funny Street",
+    address_city: "Scary Town",
+    address_country: "Loony Land",
+    gps_location: "35.544623640962634x-105.9309951055148",
+  },
+  zaphod: {
+    id: 2,
+    name: "Zaphod",
+    balance: 62,
+    address_street: "Avenue Road",
+    address_city: "Hamlet Town",
+    address_country: "Nation Land",
+    gps_location: null,
+  },
+  barney: {
+    id: 3,
+    name: "Barney Gumble",
+    balance: 1,
+    address_street: "Quiet Road",
+    address_city: "Peaceful Town",
+    address_country: "Tranquil Land",
+    gps_location: null,
+  },
+  mary: {
+    id: 4,
+    name: "Mary",
+    balance: 1,
+    address_street: "Funny Street",
+    address_city: "Peaceful Town",
+    address_country: "Nation Land",
+    gps_location: null,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/drink-designers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/drink-designers.ts
@@ -1,0 +1,5 @@
+// activerecord/test/fixtures/drink_designers.yml
+export const drinkDesignerFixtureData = {
+  turner: { id: 1 },
+  sparrow: { id: 3 },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/entrants.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/entrants.ts
@@ -1,0 +1,20 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/entrants.yml
+export const entrantFixtureData = {
+  first: {
+    id: 1,
+    course_id: ref("courses", "ruby"),
+    name: "Ruby Developer",
+  },
+  second: {
+    id: 2,
+    course_id: ref("courses", "ruby"),
+    name: "Ruby Guru",
+  },
+  third: {
+    id: 3,
+    course_id: ref("courses", "java"),
+    name: "Java Lover",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/items.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/items.ts
@@ -1,0 +1,7 @@
+// activerecord/test/fixtures/items.yml
+export const itemFixtureData = {
+  dvd: {
+    id: 1,
+    name: "Godfather",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/mixins.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/mixins.ts
@@ -1,0 +1,38 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/mixins.yml
+
+// Nested set mixins: set_1..set_10 with ids 3001..3010.
+const sets = Object.fromEntries(
+  Array.from({ length: 10 }, (_, i) => [`set_${i + 1}`, { id: i + 3001 }]),
+);
+
+// Big old set: [id, parent_id, lft, rgt].
+const treeRows: ReadonlyArray<readonly [number, number, number, number]> = [
+  [4001, 0, 1, 20],
+  [4002, 4001, 2, 7],
+  [4003, 4002, 3, 4],
+  [4004, 4002, 5, 6],
+  [4005, 4001, 14, 13],
+  [4006, 4005, 9, 10],
+  [4007, 4005, 11, 12],
+  [4008, 4001, 8, 19],
+  [4009, 4008, 15, 16],
+  [4010, 4008, 17, 18],
+];
+
+const trees = Object.fromEntries(
+  treeRows.map(([id, parentId, lft, rgt]) => [
+    `tree_${id}`,
+    {
+      id,
+      parent_id: parentId === 0 ? 0 : ref("mixins", `tree_${parentId}`),
+      type: "NestedSetWithStringScope",
+      lft,
+      rgt,
+      root_id: 42,
+    },
+  ]),
+);
+
+export const mixinFixtureData = { ...sets, ...trees };

--- a/packages/activerecord/src/test-helpers/fixtures/paragraphs.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/paragraphs.ts
@@ -1,0 +1,5 @@
+// activerecord/test/fixtures/paragraphs.yml
+// Rails ERB generates 1001 rows: fixture_no_<i> with id=i, book_id=i*i.
+export const paragraphFixtureData = Object.fromEntries(
+  Array.from({ length: 1001 }, (_, i) => [`fixture_no_${i}`, { id: i, book_id: i * i }]),
+);

--- a/packages/activerecord/src/test-helpers/fixtures/products.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/products.ts
@@ -1,0 +1,10 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/products.yml
+export const productFixtureData = {
+  product_1: {
+    id: 1,
+    collection_id: ref("collections", "collection_1"),
+    name: "Product",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/variants.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/variants.ts
@@ -1,0 +1,10 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/variants.yml
+export const variantFixtureData = {
+  variant_1: {
+    id: 1,
+    product_id: ref("products", "product_1"),
+    name: "Variant",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/vegetables.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/vegetables.ts
@@ -1,0 +1,26 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/vegetables.yml
+export const vegetableFixtureData = {
+  first_cucumber: {
+    id: 1,
+    custom_type: "Cucumber",
+    name: "my cucumber",
+  },
+  first_cabbage: {
+    id: 2,
+    custom_type: "Cabbage",
+    name: "my cabbage",
+  },
+  second_cabbage: {
+    id: 3,
+    custom_type: "Cabbage",
+    name: "his cabbage",
+  },
+  red_cabbage: {
+    id: 4,
+    custom_type: "RedCabbage",
+    name: "red cabbage",
+    seller_id: ref("vegetables", "second_cabbage"),
+  },
+};


### PR DESCRIPTION
## Summary

PR 4 of the fixtures port plan (docs/fixtures-port-plan.md) — Cluster 5
(STI / inheritance test bed). Ports 17 Rails fixtures to TS:

- `vegetables`, `mixins`, `chefs`, `cake-designers`, `drink-designers`
- `paragraphs`, `content`, `content-positions`
- `collections`, `colleges`, `courses`, `entrants`
- `customers`, `products`, `variants`
- `clothing-items`, `items`

Rails ids carried verbatim (Decision 1). FKs use `ref()`. ERB-rendered
fixtures (`mixins` tree set; `paragraphs` 1001 rows) are expanded via
`Object.fromEntries` loops rather than literal repetition — keeps the
file small while preserving Rails id mirroring.

For `courses`, Rails' `college: FIU` is a `belongs_to :college` shorthand
that sets `college_id`; ported as `college_id: ref("colleges", "FIU")`.

## Verification

`pnpm fixtures:compare`:
- All 10 ref-free files MATCH 100% (chefs, cake-designers, drink-designers,
  customers, items, content, collections, colleges, clothing-items).
- The 7 files using `ref()` report TS-IMPORT-ERR — consistent with
  baseline behavior on previously-merged ref-using fixtures (pre-existing
  limitation of the compare script's tsx import path; not introduced
  here).

LOC: 242 additions (under 300 ceiling).

## Test plan

- [ ] CI green