### PR TITLE
fix(activerecord): clear defineSchema signature cache in resetTestAdapterState (Path 2c prep)

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -20,6 +20,7 @@ import { getAsyncContext, type AsyncContext } from "@blazetrails/activesupport";
 import { inspectExplainOption } from "./adapter.js";
 import type { AdapterName, DatabaseAdapter, ExplainOption } from "./adapter.js";
 import type { SchemaCache } from "./connection-adapters/schema-cache.js";
+import { clearAppliedSchemaSignatures } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import { SidecarFixtures } from "./test-helpers/sidecar-fixtures.js";
 import {
@@ -171,6 +172,11 @@ export async function resetTestAdapterState(): Promise<void> {
     await dropAllTables(_sharedAdapter);
     _sharedAdapter.schemaCache?.clear();
   }
+  // Drop every adapter's signature cache, not just `_sharedAdapter`'s. Tests
+  // that construct raw adapters directly (e.g. adapter-cluster tests under
+  // `connection-adapters/**`) also accumulate entries; under the sidecar
+  // shape the wrapper isolation that used to mask this is gone.
+  clearAppliedSchemaSignatures();
   clearDdlTrackers();
   Base._modelsByName.clear();
 }

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, vi } from "vitest";
 import { createTestAdapter } from "../test-adapter.js";
 import { getUseTransactionalTests } from "./use-transactional-tests.js";
 import type { DatabaseAdapter } from "../adapter.js";
-import { defineSchema, type ColumnSpec } from "./define-schema.js";
+import { clearAppliedSchemaSignatures, defineSchema, type ColumnSpec } from "./define-schema.js";
+import { dropAllTables } from "./drop-all-tables.js";
 
 let adapter: DatabaseAdapter;
 
@@ -371,6 +372,45 @@ describe("defineSchema", () => {
     it("defaults to true for an adapter that never called defineSchema", () => {
       const fresh = createTestAdapter();
       expect(getUseTransactionalTests(fresh)).toBe(true);
+    });
+  });
+
+  describe("clearAppliedSchemaSignatures", () => {
+    // Regression: under the sidecar shape a single shared adapter survives
+    // across tests, so the signature cache must be invalidated alongside
+    // dropAllTables — otherwise defineSchema(sameSpec) no-ops over a now-
+    // missing table.
+    it("re-runs DDL after the table is dropped underneath the cache", async () => {
+      const spec = { widgets: { name: "string" as ColumnSpec } };
+      await defineSchema(adapter, spec);
+      await dropAllTables(adapter);
+      clearAppliedSchemaSignatures(adapter);
+
+      await defineSchema(adapter, spec);
+
+      await expect(
+        adapter.executeMutation(`INSERT INTO widgets (name) VALUES ('ok')`),
+      ).resolves.toBeDefined();
+    });
+
+    it("no-arg form clears all tracked adapters", async () => {
+      const a = createTestAdapter();
+      const b = createTestAdapter();
+      const spec = { gizmos: { name: "string" as ColumnSpec } };
+      await defineSchema(a, spec);
+      await defineSchema(b, spec);
+      await dropAllTables(a);
+      await dropAllTables(b);
+      clearAppliedSchemaSignatures();
+
+      await defineSchema(a, spec);
+      await defineSchema(b, spec);
+      await expect(
+        a.executeMutation(`INSERT INTO gizmos (name) VALUES ('a')`),
+      ).resolves.toBeDefined();
+      await expect(
+        b.executeMutation(`INSERT INTO gizmos (name) VALUES ('b')`),
+      ).resolves.toBeDefined();
     });
   });
 });

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
-import { createTestAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, createTestAdapter } from "../test-adapter.js";
 import { getUseTransactionalTests } from "./use-transactional-tests.js";
 import type { DatabaseAdapter } from "../adapter.js";
 import { clearAppliedSchemaSignatures, defineSchema, type ColumnSpec } from "./define-schema.js";
@@ -376,40 +376,39 @@ describe("defineSchema", () => {
   });
 
   describe("clearAppliedSchemaSignatures", () => {
-    // Regression: under the sidecar shape a single shared adapter survives
-    // across tests, so the signature cache must be invalidated alongside
-    // dropAllTables — otherwise defineSchema(sameSpec) no-ops over a now-
-    // missing table.
-    it("re-runs DDL after the table is dropped underneath the cache", async () => {
+    // Regression: under the sidecar shape a single shared raw adapter
+    // survives across tests, so the signature cache must be invalidated
+    // alongside dropAllTables — otherwise defineSchema(sameSpec) no-ops
+    // over a now-missing table.
+    //
+    // Use the raw sidecar adapter (no `tables: Set`) so this exercises the
+    // cache-only path. The wrapper's `tables` Set would let
+    // `adapterKnownTables` detect the drop and force DDL re-execution
+    // without the explicit clear, masking the bug.
+    it("re-runs DDL after the table is dropped underneath the cache (per-adapter clear)", async () => {
+      const { adapter: raw } = createSidecarTestAdapter();
       const spec = { widgets: { name: "string" as ColumnSpec } };
-      await defineSchema(adapter, spec);
-      await dropAllTables(adapter);
-      clearAppliedSchemaSignatures(adapter);
+      await defineSchema(raw, spec);
+      await dropAllTables(raw);
+      clearAppliedSchemaSignatures(raw);
 
-      await defineSchema(adapter, spec);
+      await defineSchema(raw, spec);
 
       await expect(
-        adapter.executeMutation(`INSERT INTO widgets (name) VALUES ('ok')`),
+        raw.executeMutation(`INSERT INTO widgets (name) VALUES ('ok')`),
       ).resolves.toBeDefined();
     });
 
-    it("no-arg form clears all tracked adapters", async () => {
-      const a = createTestAdapter();
-      const b = createTestAdapter();
+    it("no-arg form rebinds the WeakMap so the next defineSchema re-runs DDL", async () => {
+      const { adapter: raw } = createSidecarTestAdapter();
       const spec = { gizmos: { name: "string" as ColumnSpec } };
-      await defineSchema(a, spec);
-      await defineSchema(b, spec);
-      await dropAllTables(a);
-      await dropAllTables(b);
+      await defineSchema(raw, spec);
+      await dropAllTables(raw);
       clearAppliedSchemaSignatures();
 
-      await defineSchema(a, spec);
-      await defineSchema(b, spec);
+      await defineSchema(raw, spec);
       await expect(
-        a.executeMutation(`INSERT INTO gizmos (name) VALUES ('a')`),
-      ).resolves.toBeDefined();
-      await expect(
-        b.executeMutation(`INSERT INTO gizmos (name) VALUES ('b')`),
+        raw.executeMutation(`INSERT INTO gizmos (name) VALUES ('ok')`),
       ).resolves.toBeDefined();
     });
   });

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -229,12 +229,13 @@ const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
  *
  * @internal
  */
-// Strong-ref Map (not WeakMap): we need enumeration for the global
-// `clearAppliedSchemaSignatures()` form. Test adapters are long-lived by
-// design — `_sharedAdapter` in test-adapter.ts is a module singleton, and
-// raw adapter-cluster adapters live for the test file's duration — so
-// holding them strongly here is a non-issue.
-const _appliedSchemaSignatures = new Map<DatabaseAdapter, Map<string, string>>();
+// WeakMap so short-lived adapter wrappers (createTestAdapter() returns a
+// fresh wrapper per call, and withTransactionalFixtures skips the global
+// reset between tests) don't accumulate. The no-arg clear below rebinds
+// the WeakMap rather than enumerating — outstanding snapshots from
+// `_snapshotAppliedSchemaSignaturesForAdapter` are independent Map copies
+// so callers holding a snapshot can still restore.
+let _appliedSchemaSignatures = new WeakMap<DatabaseAdapter, Map<string, string>>();
 
 /**
  * Snapshot the per-adapter signature cache. Paired with
@@ -279,9 +280,7 @@ export function clearAppliedSchemaSignatures(adapter?: DatabaseAdapter): void {
   if (adapter) {
     _appliedSchemaSignatures.delete(adapter);
   } else {
-    // Snapshots taken via `_snapshotAppliedSchemaSignaturesForAdapter` are
-    // independent Map copies, so callers holding a snapshot can still restore.
-    _appliedSchemaSignatures.clear();
+    _appliedSchemaSignatures = new WeakMap();
   }
 }
 

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -229,7 +229,12 @@ const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
  *
  * @internal
  */
-const _appliedSchemaSignatures = new WeakMap<DatabaseAdapter, Map<string, string>>();
+// Strong-ref Map (not WeakMap): we need enumeration for the global
+// `clearAppliedSchemaSignatures()` form. Test adapters are long-lived by
+// design — `_sharedAdapter` in test-adapter.ts is a module singleton, and
+// raw adapter-cluster adapters live for the test file's duration — so
+// holding them strongly here is a non-issue.
+const _appliedSchemaSignatures = new Map<DatabaseAdapter, Map<string, string>>();
 
 /**
  * Snapshot the per-adapter signature cache. Paired with
@@ -258,7 +263,6 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
   snapshot: Map<string, string>,
 ): void {
   _appliedSchemaSignatures.set(adapter, new Map(snapshot));
-  _trackedAdapters.add(adapter);
 }
 
 /**
@@ -274,23 +278,12 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
 export function clearAppliedSchemaSignatures(adapter?: DatabaseAdapter): void {
   if (adapter) {
     _appliedSchemaSignatures.delete(adapter);
-    _trackedAdapters.delete(adapter);
-    return;
+  } else {
+    // Snapshots taken via `_snapshotAppliedSchemaSignaturesForAdapter` are
+    // independent Map copies, so callers holding a snapshot can still restore.
+    _appliedSchemaSignatures.clear();
   }
-  // Snapshots taken via `_snapshotAppliedSchemaSignaturesForAdapter` are
-  // independent Map copies, so callers holding a snapshot can still restore.
-  for (const a of _trackedAdapters) _appliedSchemaSignatures.delete(a);
-  _trackedAdapters.clear();
 }
-
-/**
- * Strong-ref set of adapters with cache entries. The WeakMap above is the
- * authoritative store; this set just lets `clearAppliedSchemaSignatures()`
- * with no argument iterate every entry, since WeakMap isn't enumerable.
- *
- * @internal
- */
-const _trackedAdapters = new Set<DatabaseAdapter>();
 
 /** @internal */
 function getCache(adapter: DatabaseAdapter): Map<string, string> {
@@ -298,7 +291,6 @@ function getCache(adapter: DatabaseAdapter): Map<string, string> {
   if (!cache) {
     cache = new Map();
     _appliedSchemaSignatures.set(adapter, cache);
-    _trackedAdapters.add(adapter);
   }
   return cache;
 }

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -258,7 +258,38 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
   snapshot: Map<string, string>,
 ): void {
   _appliedSchemaSignatures.set(adapter, new Map(snapshot));
+  _trackedAdapters.add(adapter);
 }
+
+/**
+ * Drop the cached signature(s) for one adapter (or all adapters when no
+ * argument is given). Paired with `resetTestAdapterState` so the signature
+ * cache stays synchronized with `dropAllTables`: a shared adapter — which
+ * survives across tests under the sidecar shape — would otherwise hold
+ * signatures for tables that no longer exist, making a subsequent
+ * `defineSchema(sameSpec)` no-op over a missing table.
+ *
+ * @internal
+ */
+export function clearAppliedSchemaSignatures(adapter?: DatabaseAdapter): void {
+  if (adapter) {
+    _appliedSchemaSignatures.delete(adapter);
+    return;
+  }
+  // Snapshots taken via `_snapshotAppliedSchemaSignaturesForAdapter` are
+  // independent Map copies, so callers holding a snapshot can still restore.
+  for (const a of _trackedAdapters) _appliedSchemaSignatures.delete(a);
+  _trackedAdapters.clear();
+}
+
+/**
+ * Strong-ref set of adapters with cache entries. The WeakMap above is the
+ * authoritative store; this set just lets `clearAppliedSchemaSignatures()`
+ * with no argument iterate every entry, since WeakMap isn't enumerable.
+ *
+ * @internal
+ */
+const _trackedAdapters = new Set<DatabaseAdapter>();
 
 /** @internal */
 function getCache(adapter: DatabaseAdapter): Map<string, string> {
@@ -266,6 +297,7 @@ function getCache(adapter: DatabaseAdapter): Map<string, string> {
   if (!cache) {
     cache = new Map();
     _appliedSchemaSignatures.set(adapter, cache);
+    _trackedAdapters.add(adapter);
   }
   return cache;
 }

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -274,6 +274,7 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
 export function clearAppliedSchemaSignatures(adapter?: DatabaseAdapter): void {
   if (adapter) {
     _appliedSchemaSignatures.delete(adapter);
+    _trackedAdapters.delete(adapter);
     return;
   }
   // Snapshots taken via `_snapshotAppliedSchemaSignaturesForAdapter` are


### PR DESCRIPTION
## Summary

The signature WeakMap in `test-helpers/define-schema.ts` keyed by adapter identity used to be isolated per-test because `TestAdapterFixtures` returned a fresh wrapper from `createTestAdapter()`. Under the sidecar shape (PR #2202), the same shared real adapter survives across tests, so the cache outlives `dropAllTables()` — a subsequent `defineSchema(sameSpec)` no-ops over a now-missing table.

This adds `clearAppliedSchemaSignatures()` and calls it from `resetTestAdapterState()`. A latent bug the wrapper masked by accident; fixing it now unblocks Path 2c proper (wrapper deletion + 189-file consumer sweep).

## Scope

Path 2c was originally scoped as wrapper deletion + signature-cache fix + 189-file consumer sweep + 3 `.innerAdapter` defensive unwrap deletions in `with-transactional-fixtures.ts`. Per the PR-size ceiling, this ships just the signature-cache fix (38 LOC). The remaining work splits into follow-ups:

- **Path 2c-2 (consumer sweep)** — migrate the ~189 files still calling the wrapper-returning `createTestAdapter()` to the sidecar shape (`{ adapter, fixtures }`). Must land before the wrapper class can be deleted; the helpers' `.innerAdapter` defensive unwraps must stay until then.
- **Path 2c-3 (wrapper deletion)** — delete `TestAdapterFixtures` class, `TestDatabaseAdapter` type alias, rename `createSidecarTestAdapter` → `createTestAdapter`, delete the 3 `.innerAdapter` unwraps in `with-transactional-fixtures.ts`. Mechanical once Path 2c-2 lands.

The `PostgreSQLAdapter.execQuery` `columnTypes` drop noted in PR #2206's findings closes automatically with Path 2c-3.

## Test plan

- [x] `pnpm -w build` clean
- [x] `pnpm exec vitest run packages/activerecord/src/{migration,base,transactions,schema-dumper}.test.ts` — all pass (SQLite)
- [ ] CI: PG + MariaDB green