### PR TITLE
test(activerecord): port cpk/sharded/dogs fixtures (PR 5)

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/cpk-authors.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cpk-authors.ts
@@ -1,0 +1,9 @@
+// activerecord/test/fixtures/cpk_authors.yml
+export const cpkAuthorFixtureData = {
+  cpk_great_author: {
+    name: "Alice",
+  },
+  cpk_famous_author_first_book: {
+    name: "Bob",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/cpk-books.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cpk-books.ts
@@ -1,0 +1,24 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/cpk_books.yml
+export const cpkBookFixtureData = {
+  cpk_great_author_first_book: {
+    author_id: ref("cpk_authors", "cpk_great_author"),
+    title: "The first book",
+    revision: 1,
+  },
+  cpk_great_author_second_book: {
+    author_id: ref("cpk_authors", "cpk_great_author"),
+    title: "The second book",
+    revision: 1,
+  },
+  cpk_famous_author_first_book: {
+    author_id: ref("cpk_authors", "cpk_famous_author"),
+    title: "Ruby on Rails",
+    revision: 1,
+  },
+  cpk_book_with_generated_pk: {
+    title: "Generated author's book",
+    revision: 1,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/cpk-order-agreements.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cpk-order-agreements.ts
@@ -1,0 +1,15 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/cpk_order_agreements.yml
+export const cpkOrderAgreementFixtureData = {
+  order_agreement_one: {
+    signature: "abc123",
+  },
+  order_agreement_two: {
+    signature: "xyz789",
+  },
+  order_agreement_three: {
+    order_id: ref("cpk_orders", "cpk_groceries_order_2"),
+    signature: "def321",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/cpk-order-tags.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cpk-order-tags.ts
@@ -1,0 +1,17 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/cpk_order_tags.yml
+export const cpkOrderTagFixtureData = {
+  cpk_first_order_loyal_customer: {
+    tag_id: ref("cpk_tags", "cpk_tag_loyal_customer"),
+    order_id: ref("cpk_orders", "cpk_groceries_order_1"),
+  },
+  cpk_second_order_loyal_customer: {
+    tag_id: ref("cpk_tags", "cpk_tag_loyal_customer"),
+    order_id: ref("cpk_orders", "cpk_groceries_order_2"),
+  },
+  cpk_first_order_digital_product: {
+    tag_id: ref("cpk_tags", "cpk_tag_digital_product"),
+    order_id: ref("cpk_orders", "cpk_groceries_order_1"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/cpk-orders.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cpk-orders.ts
@@ -1,0 +1,12 @@
+// activerecord/test/fixtures/cpk_orders.yml
+export const cpkOrderFixtureData = {
+  cpk_groceries_order_1: {
+    status: "paid",
+  },
+  cpk_groceries_order_2: {
+    status: "paid",
+  },
+  cpk_coffee_order_1: {
+    status: "cancelled",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/cpk-reviews.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cpk-reviews.ts
@@ -1,0 +1,16 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/cpk_reviews.yml
+export const cpkReviewFixtureData = {
+  first_book_review: {
+    book_id: ref("cpk_books", "cpk_book_with_generated_pk"),
+    rating: 5,
+    comment: "The first book was alright.",
+  },
+  second_book_review_for_book_with_partial_pk_defined: {
+    book_id: ref("cpk_books", "cpk_great_author_first_book"),
+    author_id: ref("cpk_authors", "cpk_great_author"),
+    rating: 5,
+    comment: "The first book was alright.",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/cpk-reviews.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cpk-reviews.ts
@@ -1,15 +1,20 @@
 import { ref } from "../define-fixtures.js";
 
 // activerecord/test/fixtures/cpk_reviews.yml
+//
+// Rails YAML uses the `book:` belongs_to shorthand; Cpk::Review declares
+// `belongs_to :book, foreign_key: [:author_id, :number]`, so Rails populates
+// the composite FK columns `author_id` + `number` (no `book_id` column
+// exists). Mirror that here directly.
 export const cpkReviewFixtureData = {
   first_book_review: {
-    book_id: ref("cpk_books", "cpk_book_with_generated_pk"),
+    number: ref("cpk_books", "cpk_book_with_generated_pk"),
     rating: 5,
     comment: "The first book was alright.",
   },
   second_book_review_for_book_with_partial_pk_defined: {
-    book_id: ref("cpk_books", "cpk_great_author_first_book"),
     author_id: ref("cpk_authors", "cpk_great_author"),
+    number: ref("cpk_books", "cpk_great_author_first_book"),
     rating: 5,
     comment: "The first book was alright.",
   },

--- a/packages/activerecord/src/test-helpers/fixtures/cpk-tags.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cpk-tags.ts
@@ -1,0 +1,12 @@
+// activerecord/test/fixtures/cpk_tags.yml
+export const cpkTagFixtureData = {
+  cpk_tag_loyal_customer: {
+    name: "Loyal customer",
+  },
+  cpk_tag_digital_product: {
+    name: "Digital product",
+  },
+  cpk_tag_ruby_on_rails: {
+    name: "Ruby on Rails",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/dog-lovers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/dog-lovers.ts
@@ -1,0 +1,12 @@
+// activerecord/test/fixtures/dog_lovers.yml
+export const dogLoverFixtureData = {
+  david: {
+    id: 1,
+    bred_dogs_count: 0,
+    trained_dogs_count: 1,
+  },
+  joanna: {
+    id: 2,
+    dogs_count: 1,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/dogs.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/dogs.ts
@@ -1,0 +1,10 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/dogs.yml
+export const dogFixtureData = {
+  sophie: {
+    id: 1,
+    trainer_id: 1,
+    dog_lover_id: ref("dog_lovers", "joanna"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/other-dogs.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/other-dogs.ts
@@ -1,0 +1,6 @@
+// activerecord/test/fixtures/other_dogs.yml
+export const otherDogFixtureData = {
+  lassie: {
+    id: 1,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/sharded-blog-posts-tags.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/sharded-blog-posts-tags.ts
@@ -1,0 +1,30 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/sharded_blog_posts_tags.yml
+export const shardedBlogPostTagFixtureData = {
+  short_read_first_post_blog_one: {
+    tag_id: ref("sharded_tags", "short_read_blog_one"),
+    blog_post_id: ref("sharded_blog_posts", "great_post_blog_one"),
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  technical_content_first_post_blog_one: {
+    tag_id: ref("sharded_tags", "technical_blog_one"),
+    blog_post_id: ref("sharded_blog_posts", "great_post_blog_one"),
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  short_read_second_post_blog_one: {
+    tag_id: ref("sharded_tags", "short_read_blog_one"),
+    blog_post_id: ref("sharded_blog_posts", "second_post_blog_one"),
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  beginner_content_first_post_blog_two: {
+    tag_id: ref("sharded_tags", "beginner_blog_two"),
+    blog_post_id: ref("sharded_blog_posts", "great_post_blog_two"),
+    blog_id: ref("sharded_blogs", "sharded_blog_two"),
+  },
+  short_read_first_post_blog_two: {
+    tag_id: ref("sharded_tags", "short_read_blog_two"),
+    blog_post_id: ref("sharded_blog_posts", "great_post_blog_two"),
+    blog_id: ref("sharded_blogs", "sharded_blog_two"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/sharded-blog-posts.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/sharded-blog-posts.ts
@@ -1,0 +1,17 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/sharded_blog_posts.yml
+export const shardedBlogPostFixtureData = {
+  great_post_blog_one: {
+    title: "My first post in my Blog1!",
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  second_post_blog_one: {
+    title: "This is my second post in my Blog1!",
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  great_post_blog_two: {
+    title: "My first post in my Blog2!",
+    blog_id: ref("sharded_blogs", "sharded_blog_two"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/sharded-blogs.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/sharded-blogs.ts
@@ -1,0 +1,9 @@
+// activerecord/test/fixtures/sharded_blogs.yml
+export const shardedBlogFixtureData = {
+  sharded_blog_one: {
+    name: "Blog One",
+  },
+  sharded_blog_two: {
+    name: "Blog two",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/sharded-comments.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/sharded-comments.ts
@@ -1,0 +1,25 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/sharded_comments.yml
+export const shardedCommentFixtureData = {
+  great_comment_blog_post_one: {
+    body: "I really enjoyed the post!",
+    blog_post_id: ref("sharded_blog_posts", "great_post_blog_one"),
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  wow_comment_blog_post_one: {
+    body: "Wow!",
+    blog_post_id: ref("sharded_blog_posts", "great_post_blog_one"),
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  unique_comment_blog_post_one: {
+    body: "Your first blog post is great!",
+    blog_post_id: ref("sharded_blog_posts", "great_post_blog_one"),
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  great_comment_blog_post_two: {
+    body: "I really enjoyed the post!",
+    blog_post_id: ref("sharded_blog_posts", "great_post_blog_two"),
+    blog_id: ref("sharded_blogs", "sharded_blog_two"),
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/sharded-tags.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/sharded-tags.ts
@@ -1,0 +1,37 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/sharded_tags.yml
+export const shardedTagFixtureData = {
+  short_read_blog_one: {
+    name: "short read",
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  long_read_blog_one: {
+    name: "long read",
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  technical_blog_one: {
+    name: "tech",
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  time_management_blog_one: {
+    name: "time management",
+    blog_id: ref("sharded_blogs", "sharded_blog_one"),
+  },
+  beginner_blog_two: {
+    name: "for beginners",
+    blog_id: ref("sharded_blogs", "sharded_blog_two"),
+  },
+  intermediate_blog_two: {
+    name: "for intermediate",
+    blog_id: ref("sharded_blogs", "sharded_blog_two"),
+  },
+  short_read_blog_two: {
+    name: "short read",
+    blog_id: ref("sharded_blogs", "sharded_blog_two"),
+  },
+  breaking_news_blog_2: {
+    name: "breaking news",
+    blog_id: ref("sharded_blogs", "sharded_blog_two"),
+  },
+};


### PR DESCRIPTION
## Summary
- Ports Cluster 6 (composite PK): `cpk_authors`, `cpk_books`, `cpk_orders`, `cpk_order_agreements`, `cpk_order_tags`, `cpk_reviews`, `cpk_tags`.
- Ports Cluster 7 (sharded): `sharded_blogs`, `sharded_blog_posts`, `sharded_blog_posts_tags`, `sharded_comments`, `sharded_tags`.
- Ports the C4 spillover deferred from PR 3: `dogs`, `other_dogs`, `dog_lovers`.

Per `docs/fixtures-port-plan.md`. Rails ERB `FixtureSet.identify` / `composite_identify` calls translate to `ref()` against the target row label — the resolver reads the target's declared `id` (or `fixtureId()` fallback) so cross-fixture lookups stay consistent without recomputing Rails' hash. Files carry the Rails `id` verbatim wherever the YAML declared one (only the `dogs` / `other_dogs` / `dog_lovers` rows do).

15 files, +251 LOC, under the 300-LOC ceiling.

## Test plan
- [ ] CI green
- [ ] `pnpm fixtures:compare` lists the new files (DIFF / ERB-UNSUPPORTED are soft warnings through PR 7 per Decision 4)

## Follow-ups
- `composite_identify(:label, [:shop_id, :id])[:id]` in `cpk_order_tags` / `cpk_order_agreements` resolves through the row's `id`-component only; if a downstream CPK test asserts the literal Rails-hashed value rather than the declared row, the fixture-compare script will flag it once PR 7 flips compare to hard-fail. Address by extending `ref()` to take a key path, or by declaring explicit composite-key columns on the affected rows.