### PR TITLE
test(activerecord): port cluster 8 first-half fixtures (PR 6a)

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/aircrafts.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/aircrafts.ts
@@ -1,0 +1,11 @@
+// activerecord/test/fixtures/aircrafts.yml
+export const aircraftFixtureData = {
+  no_wheels: {
+    name: "boeing-with-no-wheels",
+    manufactured_at: "2024-01-01",
+  },
+  no_manufactured_at: {
+    name: "boeing-with-no-manufactured-at",
+    wheels_count: 2,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/binaries.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/binaries.ts
@@ -1,0 +1,13 @@
+// activerecord/test/fixtures/binaries.yml
+// Rails YAML carries a `!binary` literal (flowers) and an `<%= binary(...) %>`
+// ERB helper (binary_helper). fixtures:compare reports the YAML as
+// ERB-UNSUPPORTED and skips it; the binary payload is intentionally
+// not mirrored here — tests that need real bytes should build them in-test.
+export const binaryFixtureData = {
+  flowers: {
+    id: 1,
+  },
+  binary_helper: {
+    id: 2,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/bulbs.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/bulbs.ts
@@ -1,0 +1,9 @@
+// activerecord/test/fixtures/bulbs.yml
+export const bulbFixtureData = {
+  defaulty: {
+    name: "defaulty",
+  },
+  special: {
+    name: "special",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/cars.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/cars.ts
@@ -1,0 +1,19 @@
+// activerecord/test/fixtures/cars.yml
+export const carFixtureData = {
+  honda: {
+    id: 1,
+    name: "honda",
+    engines_count: 0,
+    bulbs_count: 0,
+    custom_tyres_count: 0,
+    person_id: 1,
+  },
+  zyke: {
+    id: 2,
+    name: "zyke",
+    engines_count: 0,
+    bulbs_count: 0,
+    custom_tyres_count: 0,
+    person_id: 2,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/computers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/computers.ts
@@ -1,0 +1,16 @@
+// activerecord/test/fixtures/computers.yml
+export const computerFixtureData = {
+  workstation: {
+    id: 1,
+    system: "Linux",
+    developer: 1,
+    extendedWarranty: 1,
+    timezone: 1,
+  },
+  laptop: {
+    system: "MacOS 1",
+    developer: 1,
+    extendedWarranty: 1,
+    timezone: 1,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/dashboards.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/dashboards.ts
@@ -1,0 +1,11 @@
+// activerecord/test/fixtures/dashboards.yml
+export const dashboardFixtureData = {
+  cool_first: {
+    dashboard_id: "d1",
+    name: "my_dashboard",
+  },
+  second: {
+    dashboard_id: "d2",
+    name: "second",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/minivans.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/minivans.ts
@@ -1,0 +1,9 @@
+// activerecord/test/fixtures/minivans.yml
+export const minivanFixtureData = {
+  cool_first: {
+    minivan_id: "m1",
+    name: "my_minivan",
+    speedometer_id: "s1",
+    color: "blue",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/movies.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/movies.ts
@@ -1,0 +1,11 @@
+// activerecord/test/fixtures/movies.yml
+export const movieFixtureData = {
+  first: {
+    movieid: 1,
+    name: "Terminator",
+  },
+  second: {
+    movieid: 2,
+    name: "Gladiator",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/speedometers.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/speedometers.ts
@@ -1,0 +1,13 @@
+// activerecord/test/fixtures/speedometers.yml
+export const speedometerFixtureData = {
+  cool_first: {
+    speedometer_id: "s1",
+    name: "my_speedometer",
+    dashboard_id: "d1",
+  },
+  second: {
+    speedometer_id: "s2",
+    name: "second",
+    dashboard_id: "d2",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/traffic-lights.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/traffic-lights.ts
@@ -1,0 +1,10 @@
+// activerecord/test/fixtures/traffic_lights.yml
+// `state` / `long_state` are serialized array columns in Rails;
+// fixtures:compare uses strict `===` so the arrays soft-DIFF.
+export const trafficLightFixtureData = {
+  uk: {
+    location: "UK",
+    state: ["Green", "Red", "Orange"],
+    long_state: ["Green, go ahead", "Red, wait", "Orange, caution light is about to switch"],
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/uuid-children.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/uuid-children.ts
@@ -1,0 +1,9 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/uuid_children.yml
+export const uuidChildFixtureData = {
+  sonny: {
+    uuid_parent: ref("uuid_parents", "daddy"),
+    name: "Sonny",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/uuid-parents.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/uuid-parents.ts
@@ -1,0 +1,7 @@
+// activerecord/test/fixtures/uuid_parents.yml
+// PG-only in Rails; ids resolved by the loader from the fixture label.
+export const uuidParentFixtureData = {
+  daddy: {
+    name: "Daddy",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/virtual-columns.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/virtual-columns.ts
@@ -1,0 +1,9 @@
+// activerecord/test/fixtures/virtual_columns.yml
+export const virtualColumnFixtureData = {
+  one: {
+    name: "hello",
+  },
+  two: {
+    name: "world",
+  },
+};


### PR DESCRIPTION
## Summary

Ports 13 UUID/type/edge fixtures from `activerecord/test/fixtures/` per `docs/fixtures-port-plan.md` PR 6a.

Files: `uuid_parents`, `uuid_children`, `binaries`, `aircrafts`, `bulbs`, `cars`, `computers`, `minivans`, `speedometers`, `dashboards`, `movies`, `traffic_lights`, `virtual_columns`.

## fixtures:compare

- 11 MATCH (100%)
- 1 DIFF: `traffic_lights` — `state` / `long_state` are serialized array columns; `fixtures:compare` uses strict `===`, so arrays always soft-DIFF (rows: 1/1, attrs: 1/3). Comparator limitation, not a port gap.
- 1 ERB-UNSUPPORTED: `binaries` — Rails YAML carries a `!binary` literal (`flowers`) and an `<%= binary(...) %>` ERB helper (`binary_helper`). Comparator skips ERB; the binary payload is intentionally not mirrored — tests that need real bytes should build them in-test.

## Notes

- `uuid_parents` / `uuid_children` / `aircrafts` / `virtual_columns` show `schema:not-ported` (informational — those tables aren't in `TEST_SCHEMA` yet).
- `uuid_children.uuid_parent` uses `ref("uuid_parents", "daddy")` to match Rails' association-name → id resolution; comparator handles the string-vs-ref shape.

## Test plan

- [x] `pnpm fixtures:compare` — 12 MATCH, 1 DIFF (traffic_lights arrays, expected), 1 ERB-UNSUPPORTED (binaries, expected)
- [x] `pnpm build` clean