### PR TITLE
test(activerecord): enable vitest/no-conditional-tests

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -277,6 +277,21 @@ export default defineConfig(
     },
   },
 
+  // ── activerecord: only no-conditional-tests is clean today.
+  // no-conditional-in-test and no-conditional-expect have outstanding
+  // violations; enable them in follow-up PRs as they're driven to zero.
+  {
+    files: [
+      "packages/activerecord/src/**/*.test.ts",
+      "packages/activerecord/dx-tests/**/*.test.ts",
+      "packages/activerecord/virtualized-dx-tests/**/*.test.ts",
+    ],
+    plugins: { vitest },
+    rules: {
+      "vitest/no-conditional-tests": "error",
+    },
+  },
+
   // ── activesupport ──
   {
     files: ["packages/activesupport/src/**/*.ts"],

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -405,12 +405,9 @@ describe("DJAS — composite key support", () => {
     // No orders — through step plucks nothing, final step gets
     // composite `where([...], [])` which PredicateBuilder resolves to
     // none().
-    const observed: string[] = [];
+    const allSql: unknown[] = [];
     const sub = Notifications.subscribe("sql.active_record", (event: any) => {
-      const sql = event?.payload?.sql;
-      if (typeof sql === "string" && /\bFROM\b\s+["`]?ck_line_items\b/i.test(sql)) {
-        observed.push(sql);
-      }
+      allSql.push(event?.payload?.sql);
     });
     try {
       const reflection = (CkShop as any)._reflectOnAssociation("ckLineItemsEmpty");
@@ -421,6 +418,10 @@ describe("DJAS — composite key support", () => {
     }
     // The none() short-circuit means no SELECT against ck_line_items
     // at all. A full-table scan (regression) would show at least one.
+    const observed = allSql.filter(
+      (sql): sql is string =>
+        typeof sql === "string" && /\bFROM\b\s+["`]?ck_line_items\b/i.test(sql),
+    );
     expect(observed).toEqual([]);
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #2164. Enables `vitest/no-conditional-tests` for activerecord by clearing its one outstanding violation.

- Lifted the SQL filter in `disable-joins-composite-key.test.ts` out of the `Notifications.subscribe` callback (`if (… && regex.test(sql)) observed.push(sql)`) into a post-hoc `allSql.filter(…)` after the assertion block.
- Removed the per-package ignore of `vitest/no-conditional-tests` for activerecord; added a dedicated activerecord block that enables only this rule.

The other two rules from #2164 remain disabled in activerecord pending follow-ups:
- `vitest/no-conditional-in-test`: 32 violations remain
- `vitest/no-conditional-expect`: 82 violations remain

These will be enabled in separate from-main PRs as they're driven to zero.

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm vitest run packages/activerecord/src/associations/disable-joins-composite-key.test.ts` — 9/9 pass