### PR TITLE
feat(trailties): migrate model/migration/resource-route generators onto template-builder (PR T2)

### DIFF
--- a/packages/trailties/src/generators/rails/migration/__snapshots__/migration-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/migration/__snapshots__/migration-generator.test.ts.snap
@@ -4,11 +4,9 @@ exports[`MigrationGeneratorTest > emits valid TS (snapshot + parse + no-Ruby) 1`
 "import { Migration } from "@blazetrails/activerecord";
 
 export class AddTitleToPosts extends Migration {
-  static version: string = "20260521120000";
+  static version = "20260521120000";
 
-  async change(): Promise<void> {
-
-  }
+  async change(): Promise<void> {}
 }
 "
 `;

--- a/packages/trailties/src/generators/rails/migration/__snapshots__/migration-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/migration/__snapshots__/migration-generator.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`MigrationGeneratorTest > emits valid TS (snapshot + parse + no-Ruby) 1`] = `
+"import { Migration } from "@blazetrails/activerecord";
+
+export class AddTitleToPosts extends Migration {
+  static version: string = "20260521120000";
+
+  async change(): Promise<void> {
+
+  }
+}
+"
+`;

--- a/packages/trailties/src/generators/rails/migration/migration-generator.test.ts
+++ b/packages/trailties/src/generators/rails/migration/migration-generator.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { MigrationGenerator } from "./migration-generator.js";
+import { MigrationGenerator, emitMigrationSource } from "./migration-generator.js";
+import { assertNoRubySource, parseTs } from "../../../template-builder/testing.js";
 
 let tmpDir: string;
 beforeEach(() => {
@@ -38,5 +39,12 @@ describe("MigrationGeneratorTest", () => {
 
   it("exit on failure", () => {
     expect(MigrationGenerator.exitOnFailure()).toBe(true);
+  });
+
+  it("emits valid TS (snapshot + parse + no-Ruby)", () => {
+    const out = emitMigrationSource("AddTitleToPosts", "20260521120000");
+    expect(out).toMatchSnapshot();
+    expect(parseTs(out).diagnostics).toEqual([]);
+    assertNoRubySource(out);
   });
 });

--- a/packages/trailties/src/generators/rails/migration/migration-generator.ts
+++ b/packages/trailties/src/generators/rails/migration/migration-generator.ts
@@ -1,3 +1,11 @@
+import {
+  tsBody,
+  tsClass,
+  tsField,
+  tsImport,
+  tsMethod,
+  tsModule,
+} from "../../../template-builder/index.js";
 import { NamedBase } from "../../named-base.js";
 import { classify, dasherize, migrationTimestamp } from "../../base.js";
 
@@ -6,6 +14,28 @@ import { classify, dasherize, migrationTimestamp } from "../../base.js";
 // minimal Migration shell; CreateX/AddXToY inference lives in the existing
 // top-level MigrationGenerator and folds in when the ORM hook lands.
 let lastTimestamp: string | null = null;
+
+export function emitMigrationSource(className: string, timestamp: string): string {
+  const { refs } = tsImport("@blazetrails/activerecord", { Migration: "named" });
+  return tsModule({
+    declarations: [
+      tsClass({
+        name: className,
+        extends: refs.Migration,
+        body: [
+          tsField("static version", "string", { initializer: `"${timestamp}"` }),
+          tsMethod({
+            name: "change",
+            async: true,
+            params: [],
+            returnType: "Promise<void>",
+            body: tsBody``,
+          }),
+        ],
+      }),
+    ],
+  });
+}
 
 export class MigrationGenerator extends NamedBase {
   static exitOnFailure(): boolean {
@@ -22,18 +52,7 @@ export class MigrationGenerator extends NamedBase {
     }
     lastTimestamp = timestamp;
     const filename = `db/migrations/${timestamp}-${dasherize(this.fileName)}${this.ext()}`;
-    const className = classify(this.fileName);
-    this.createFile(
-      filename,
-      `import { Migration } from "@blazetrails/activerecord";
-
-export class ${className} extends Migration {
-  static version = "${timestamp}";
-
-  async change(): Promise<void> {}
-}
-`,
-    );
+    this.createFile(filename, emitMigrationSource(classify(this.fileName), timestamp));
     return this.getCreatedFiles();
   }
 }

--- a/packages/trailties/src/generators/rails/migration/migration-generator.ts
+++ b/packages/trailties/src/generators/rails/migration/migration-generator.ts
@@ -23,7 +23,11 @@ export function emitMigrationSource(className: string, timestamp: string): strin
         name: className,
         extends: refs.Migration,
         body: [
-          tsField("static version", "string", { initializer: `"${timestamp}"` }),
+          tsField("version", "string", {
+            static: true,
+            inferType: true,
+            initializer: `"${timestamp}"`,
+          }),
           tsMethod({
             name: "change",
             async: true,

--- a/packages/trailties/src/generators/rails/model/__snapshots__/model-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/model/__snapshots__/model-generator.test.ts.snap
@@ -1,0 +1,24 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ModelGeneratorTest > emits valid TS over the attribute-type matrix (snapshot + parse + no-Ruby) 1`] = `
+"import { Base } from "@blazetrails/activerecord";
+
+export class Post extends Base {
+  title!: string;
+
+  views!: number;
+
+  price!: number;
+
+  published!: boolean;
+
+  published_at!: Date;
+
+  payload!: Uint8Array;
+
+  author_id!: number;
+
+  password_digest!: string;
+}
+"
+`;

--- a/packages/trailties/src/generators/rails/model/model-generator.test.ts
+++ b/packages/trailties/src/generators/rails/model/model-generator.test.ts
@@ -2,8 +2,9 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { ModelGenerator } from "./model-generator.js";
+import { ModelGenerator, emitModelSource } from "./model-generator.js";
 import { ModelHelpers } from "../../model-helpers.js";
+import { assertNoRubySource, parseTs } from "../../../template-builder/testing.js";
 
 let tmpDir: string;
 beforeEach(() => {
@@ -40,5 +41,21 @@ describe("ModelGeneratorTest", () => {
     expect(fs.readFileSync(path.join(tmpDir, files[0]!), "utf-8")).toContain(
       "export class AdminUser extends Base",
     );
+  });
+
+  it("emits valid TS over the attribute-type matrix (snapshot + parse + no-Ruby)", () => {
+    const out = emitModelSource("Post", [
+      ["title", "string"],
+      ["views", "number"],
+      ["price", "number"],
+      ["published", "boolean"],
+      ["published_at", "Date"],
+      ["payload", "Uint8Array"],
+      ["author_id", "number"],
+      ["password_digest", "string"],
+    ]);
+    expect(out).toMatchSnapshot();
+    expect(parseTs(out).diagnostics).toEqual([]);
+    assertNoRubySource(out);
   });
 });

--- a/packages/trailties/src/generators/rails/model/model-generator.ts
+++ b/packages/trailties/src/generators/rails/model/model-generator.ts
@@ -20,7 +20,7 @@ export function emitModelSource(className: string, fields: Array<[string, string
       tsClass({
         name: className,
         extends: refs.Base,
-        body: fields.map(([name, type]) => tsField(`${name}!`, type)),
+        body: fields.map(([name, type]) => tsField(name, type, { definite: true })),
       }),
     ],
   });

--- a/packages/trailties/src/generators/rails/model/model-generator.ts
+++ b/packages/trailties/src/generators/rails/model/model-generator.ts
@@ -1,4 +1,5 @@
 import { camelize } from "@blazetrails/activesupport";
+import { tsClass, tsField, tsImport, tsModule } from "../../../template-builder/index.js";
 import { NamedBase, type NamedBaseOptions } from "../../named-base.js";
 import { normalizeModelName, type ModelHelpersOptions } from "../../model-helpers.js";
 
@@ -12,6 +13,19 @@ const TS_TYPES: Record<string, string> = { integer: "number", float: "number",
   timestamp: "Date", time: "Date", references: "number", belongs_to: "number",
   binary: "Uint8Array", digest: "string" };
 
+export function emitModelSource(className: string, fields: Array<[string, string]>): string {
+  const { refs } = tsImport("@blazetrails/activerecord", { Base: "named" });
+  return tsModule({
+    declarations: [
+      tsClass({
+        name: className,
+        extends: refs.Base,
+        body: fields.map(([name, type]) => tsField(`${name}!`, type)),
+      }),
+    ],
+  });
+}
+
 export class ModelGenerator extends NamedBase {
   constructor(options: ModelGeneratorOptions) {
     const normalized = normalizeModelName(options.name, options, options.output);
@@ -21,19 +35,10 @@ export class ModelGenerator extends NamedBase {
   run(): string[] {
     const filename = `app/models/${this.filePath()}${this.ext()}`;
     const className = [...this.classPathParts, this.fileName].map((p) => camelize(p)).join("");
-    const attrs = this.attributes
+    const fields: Array<[string, string]> = this.attributes
       .filter((a) => !a.virtual())
-      .map((a) => `  ${a.columnName()}!: ${TS_TYPES[a.type] ?? "string"};`)
-      .join("\n");
-    this.createFile(
-      filename,
-      `import { Base } from "@blazetrails/activerecord";
-
-export class ${className} extends Base {
-${attrs}
-}
-`,
-    );
+      .map((a) => [a.columnName(), TS_TYPES[a.type] ?? "string"]);
+    this.createFile(filename, emitModelSource(className, fields));
     return this.getCreatedFiles();
   }
 }

--- a/packages/trailties/src/generators/rails/resource-route/__snapshots__/resource-route-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/resource-route/__snapshots__/resource-route-generator.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`ResourceRouteGeneratorTest > snippet matrix (snapshot + no-Ruby) 1`] = `
+{
+  "flat": "  router.resources("products");
+",
+  "nested": "  router.namespace("admin", (router) => {
+    router.namespace("users", (router) => {
+      router.resources("products");
+    });
+  });
+",
+}
+`;

--- a/packages/trailties/src/generators/rails/resource-route/resource-route-generator.test.ts
+++ b/packages/trailties/src/generators/rails/resource-route/resource-route-generator.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
-import { ResourceRouteGenerator } from "./resource-route-generator.js";
+import { ResourceRouteGenerator, emitResourceRouteSnippet } from "./resource-route-generator.js";
+import { assertNoRubySource } from "../../../template-builder/testing.js";
 
 let tmpDir: string;
 const mk = (name: string): ResourceRouteGenerator =>
@@ -35,5 +36,13 @@ describe("ResourceRouteGeneratorTest", () => {
   it("skips when actions are present", () => {
     mk("product").addResourceRoute({ actions: ["index"] });
     expect(read()).not.toContain("router.resources");
+  });
+
+  it("snippet matrix (snapshot + no-Ruby)", () => {
+    const flat = emitResourceRouteSnippet([], "products");
+    const nested = emitResourceRouteSnippet(["admin", "users"], "products");
+    expect({ flat, nested }).toMatchSnapshot();
+    assertNoRubySource(flat);
+    assertNoRubySource(nested);
   });
 });

--- a/packages/trailties/src/generators/rails/resource-route/resource-route-generator.ts
+++ b/packages/trailties/src/generators/rails/resource-route/resource-route-generator.ts
@@ -3,9 +3,21 @@ import { NamedBase } from "../../named-base.js";
 
 // Mirrors railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb.
 // Inserts router.resources() at the `// routes` marker in src/config/routes.{ts,js}
-// (trails uses TS routes, not Ruby DSL); see generators/actions.ts.
+// (trails uses TS routes, not Ruby DSL); see generators/actions.ts. Unlike sibling
+// generators, this one does not emit a full TS module (insertIntoFile only), so
+// it does not flow through the template-builder.
 export interface ResourceRouteOptions {
   actions?: string[];
+}
+
+export function emitResourceRouteSnippet(namespaces: string[], resource: string): string {
+  const lines: string[] = [];
+  namespaces.forEach((n, i) =>
+    lines.push(`${"  ".repeat(i + 1)}router.namespace("${n}", (router) => {`),
+  );
+  lines.push(`${"  ".repeat(namespaces.length + 1)}router.resources("${resource}");`);
+  for (let i = namespaces.length; i > 0; i--) lines.push(`${"  ".repeat(i)}});`);
+  return lines.join("\n") + "\n";
 }
 
 export class ResourceRouteGenerator extends NamedBase {
@@ -15,11 +27,10 @@ export class ResourceRouteGenerator extends NamedBase {
       this.fileExists(f),
     );
     if (!routesFile) return;
-    const ns = this.classPathParts;
-    const lines: string[] = [];
-    ns.forEach((n, i) => lines.push(`${"  ".repeat(i + 1)}router.namespace("${n}", (router) => {`));
-    lines.push(`${"  ".repeat(ns.length + 1)}router.resources("${pluralize(this.fileName)}");`);
-    for (let i = ns.length; i > 0; i--) lines.push(`${"  ".repeat(i)}});`);
-    this.insertIntoFile(routesFile, "// routes", lines.join("\n") + "\n");
+    this.insertIntoFile(
+      routesFile,
+      "// routes",
+      emitResourceRouteSnippet(this.classPathParts, pluralize(this.fileName)),
+    );
   }
 }

--- a/packages/trailties/src/template-builder/emit-method.ts
+++ b/packages/trailties/src/template-builder/emit-method.ts
@@ -36,13 +36,15 @@ export interface EmitResult {
 
 export function emitField(f: Field): EmitResult {
   const t = emitType(f.type);
-  const opt = f.nullable ? "?" : "";
+  const suffix = f.nullable ? "?" : f.definite ? "!" : "";
   const init = f.initializer ? ` = ${f.initializer}` : "";
   const head = f.comment ? emitJsDoc(f.comment) : "";
+  const ann = f.inferType ? "" : `: ${t.text}`;
+  const staticPrefix = f.static ? "static " : "";
   return {
-    text: `${head}${f.name}${opt}: ${t.text}${init};`,
+    text: `${head}${staticPrefix}${f.name}${suffix}${ann}${init};`,
     valueRefs: [],
-    typeRefs: t.refs,
+    typeRefs: f.inferType ? [] : t.refs,
   };
 }
 
@@ -59,13 +61,17 @@ export function emitMethod(m: Method): EmitResult {
     typeRefs.push(...t.refs);
     ret = `: ${t.text}`;
   }
-  const indented = m.body.text
-    .split("\n")
-    .map((l) => (l ? `    ${l}` : ""))
-    .join("\n");
   const vis = m.visibility && m.visibility !== "public" ? `${m.visibility} ` : "";
+  const head = `  ${vis}${m.static ? "static " : ""}${m.async ? "async " : ""}${m.name}(${paramTexts.join(", ")})${ret}`;
+  const bodyText =
+    m.body.text === ""
+      ? `${head} {}`
+      : `${head} {\n${m.body.text
+          .split("\n")
+          .map((l) => (l ? `    ${l}` : ""))
+          .join("\n")}\n  }`;
   return {
-    text: `  ${vis}${m.static ? "static " : ""}${m.async ? "async " : ""}${m.name}(${paramTexts.join(", ")})${ret} {\n${indented}\n  }`,
+    text: bodyText,
     valueRefs: [...m.body.refs],
     typeRefs,
   };

--- a/packages/trailties/src/template-builder/emit-method.ts
+++ b/packages/trailties/src/template-builder/emit-method.ts
@@ -35,6 +35,11 @@ export interface EmitResult {
 }
 
 export function emitField(f: Field): EmitResult {
+  if (f.inferType && !f.initializer) {
+    throw new Error(
+      `tsField "${f.name}": inferType requires an initializer (otherwise the emitted property has no type).`,
+    );
+  }
   const t = emitType(f.type);
   const suffix = f.nullable ? "?" : f.definite ? "!" : "";
   const init = f.initializer ? ` = ${f.initializer}` : "";

--- a/packages/trailties/src/template-builder/emit-method.ts
+++ b/packages/trailties/src/template-builder/emit-method.ts
@@ -40,16 +40,22 @@ export function emitField(f: Field): EmitResult {
       `tsField "${f.name}": inferType requires an initializer (otherwise the emitted property has no type).`,
     );
   }
-  const t = emitType(f.type);
   const suffix = f.nullable ? "?" : f.definite ? "!" : "";
   const init = f.initializer ? ` = ${f.initializer}` : "";
   const head = f.comment ? emitJsDoc(f.comment) : "";
-  const ann = f.inferType ? "" : `: ${t.text}`;
   const staticPrefix = f.static ? "static " : "";
+  if (f.inferType) {
+    return {
+      text: `${head}${staticPrefix}${f.name}${suffix}${init};`,
+      valueRefs: [],
+      typeRefs: [],
+    };
+  }
+  const t = emitType(f.type);
   return {
-    text: `${head}${staticPrefix}${f.name}${suffix}${ann}${init};`,
+    text: `${head}${staticPrefix}${f.name}${suffix}: ${t.text}${init};`,
     valueRefs: [],
-    typeRefs: f.inferType ? [] : t.refs,
+    typeRefs: t.refs,
   };
 }
 

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -287,6 +287,14 @@ describe("template-builder", () => {
     expect(parseTs(out).diagnostics).toEqual([]);
   });
 
+  it("rejects inferType without an initializer", () => {
+    expect(() =>
+      tsModule({
+        declarations: [tsClass({ name: "C", body: [tsField("v", "string", { inferType: true })] })],
+      }),
+    ).toThrow(/inferType requires an initializer/);
+  });
+
   it("assertNoRubySource flags Ruby class/module/def lines", () => {
     expect(() => assertNoRubySource("class User < Base\nend")).toThrow();
     expect(() => assertNoRubySource("module Foo\nend")).toThrow();

--- a/packages/trailties/src/template-builder/index.test.ts
+++ b/packages/trailties/src/template-builder/index.test.ts
@@ -262,6 +262,31 @@ describe("template-builder", () => {
     expect(parseTs(out).diagnostics).toEqual([]);
   });
 
+  it("supports static, definite, and inferType field opts; empty method body emits {}", () => {
+    const out = tsModule({
+      declarations: [
+        tsClass({
+          name: "M",
+          body: [
+            tsField("version", "string", { static: true, inferType: true, initializer: `"1"` }),
+            tsField("name", "string", { definite: true }),
+            tsMethod({
+              name: "noop",
+              async: true,
+              params: [],
+              returnType: "Promise<void>",
+              body: tsBody``,
+            }),
+          ],
+        }),
+      ],
+    });
+    expect(out).toContain(`  static version = "1";`);
+    expect(out).toContain(`  name!: string;`);
+    expect(out).toContain(`async noop(): Promise<void> {}`);
+    expect(parseTs(out).diagnostics).toEqual([]);
+  });
+
   it("assertNoRubySource flags Ruby class/module/def lines", () => {
     expect(() => assertNoRubySource("class User < Base\nend")).toThrow();
     expect(() => assertNoRubySource("module Foo\nend")).toThrow();

--- a/packages/trailties/src/template-builder/types.ts
+++ b/packages/trailties/src/template-builder/types.ts
@@ -30,8 +30,12 @@ export interface Field {
   name: string;
   type: FieldType;
   nullable?: boolean;
+  definite?: boolean;
   initializer?: string;
   comment?: string;
+  static?: boolean;
+  /** Omit the `: type` annotation. Useful when the initializer is self-typed. */
+  inferType?: boolean;
 }
 export interface MethodParam {
   name: string;

--- a/packages/trailties/src/template-builder/types.ts
+++ b/packages/trailties/src/template-builder/types.ts
@@ -34,7 +34,10 @@ export interface Field {
   initializer?: string;
   comment?: string;
   static?: boolean;
-  /** Omit the `: type` annotation. Useful when the initializer is self-typed. */
+  /**
+   * Omit the `: type` annotation; rely on the initializer for typing.
+   * Requires `initializer` — `emitField` throws otherwise.
+   */
   inferType?: boolean;
 }
 export interface MethodParam {


### PR DESCRIPTION
## Summary

PR T2 from `docs/trailties-plan.md`. Migrates the three smallest Rails-layout generators to flow through `@blazetrails/trailties/template-builder` (landed by PR T1 / #2191).

- `model-generator` emits via `tsModule` + `tsClass` + `tsField`.
- `migration-generator` emits via `tsModule` + `tsClass` + `tsField` + `tsMethod`.
- `resource-route-generator` factors the inserted snippet into `emitResourceRouteSnippet`; it does **not** flow through the builder because it does `insertIntoFile` into an existing TS module, not `createFile` — the builder mandate in plan hard rule 0 targets full-module emission.
- Per-generator `__snapshots__/` covering the attribute-type matrix.
- `parseTs` + `assertNoRubySource` checks on emitted output.

## Rails sources referenced

- `railties/lib/rails/generators/rails/model/model_generator.rb`
- `railties/lib/rails/generators/rails/migration/migration_generator.rb`
- `railties/lib/rails/generators/rails/resource_route/resource_route_generator.rb`

## Methods / initializers skipped

- `hook_for :orm` — deferred until the ORM-provided generator hook lands.
- `CreateX` / `AddXToY` inference for migrations — still lives in the legacy top-level `MigrationGenerator`; folds in with the ORM hook.
- Ruby Bundler / migration shell-out and other Ruby-only concerns.

## Test plan

- [x] `pnpm vitest run` over the three migrated test files (10→13 tests, snapshots written)
- [x] `pnpm typecheck`
- [x] `pnpm lint`