### PR TITLE
chore(fixtures-compare): metadata strip, assoc shorthand, list-form, array deep-equal

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/1-need-quoting.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/1-need-quoting.ts
@@ -1,12 +1,13 @@
 // activerecord/test/fixtures/1_need_quoting.yml
-// YAML list-form fixture (no row labels in Rails); synthesized labels here
-// for the TS loader's row-name map. The Rails file uses bare `- name: Foo`
-// entries, which Rails auto-labels at load time.
+// YAML list-form fixture: Rails auto-labels list-form entries as
+// `<basename>_<index>` (here `1_need_quoting_0`, `1_need_quoting_1`).
+// Mirrored verbatim so fixtures:compare and any test resolving by label
+// sees the same names Rails would.
 export const oneNeedQuotingFixtureData = {
-  foo: {
+  "1_need_quoting_0": {
     name: "Foo",
   },
-  bar: {
+  "1_need_quoting_1": {
     name: "Bar",
   },
 };

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -195,10 +195,18 @@ describe("loadRailsYaml (parsing fidelity)", () => {
 
   it("keeps list-form entries with array/scalar single-key values (not misclassified as labeled)", () => {
     // `- tags: [a, b]` is one bare list-form row, not a labeled `tags:` omap
-    // entry. Tightened looksLabeled predicate must require a non-null, non-
-    // array object before treating an entry as labeled.
+    // entry. Without the `--- !omap` doc tag, array entries always auto-label
+    // regardless of shape.
     const r = loadRailsYamlForTest(write("listarr", "- tags:\n    - a\n    - b\n  name: x\n"), "listarr"); // prettier-ignore
     expect(r).toEqual({ ok: true, data: { listarr_0: { tags: ["a", "b"], name: "x" } } });
+  });
+
+  it("honors `_fixture.ignore` inside a `!omap` document (entry, not top-level key)", () => {
+    const r = loadRailsYamlForTest(
+      write("omig", "--- !omap\n- _fixture:\n    ignore: SKIP\n- SKIP:\n    x: 1\n- keep:\n    y: 2\n"), // prettier-ignore
+      "omig",
+    );
+    expect(r).toEqual({ ok: true, data: { keep: { y: 2 } } });
   });
 
   it("auto-labels single-key list-form rows even when the value is a nested object", () => {

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterAll } from "vitest";
 // prettier-ignore
 import { stripErb, isRefLike, compareValue, compareFile, schemaCheck, canonicalizeRailsRow } from "./compare.js";
 import type { Schema } from "../../packages/activerecord/src/test-helpers/define-schema.js";
@@ -148,11 +148,59 @@ describe("canonicalizeRailsRow", () => {
   it("drops keys whose `_id` form isn't a column (HABTM / unknown assoc)", () => {
     expect(canonicalizeRailsRow({ treasures: "diamond, sapphire" }, {}, cols)).toEqual({});
   });
-  it("falls back to tsRow keys when no schema columns are available", () => {
+  it("falls back to tsRow keys when no schema columns are available, preserving unknown Rails keys", () => {
+    // Without schema we can't distinguish HABTM from a column the TS side
+    // dropped, so an unknown Rails key must survive to be flagged as
+    // `missing-in-ts` downstream — not silently dropped.
     expect(canonicalizeRailsRow({ pirate: "x" }, { pirate_id: 1 }, null)).toEqual({
       pirate_id: "x",
     });
-    expect(canonicalizeRailsRow({ pirate: "x" }, {}, null)).toEqual({});
+    expect(canonicalizeRailsRow({ company: "acme" }, {}, null)).toEqual({ company: "acme" });
+  });
+});
+
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadRailsYamlForTest } from "./compare.js";
+describe("loadRailsYaml (parsing fidelity)", () => {
+  const tmp = mkdtempSync(join(tmpdir(), "fixtures-compare-"));
+  const write = (basename: string, contents: string): string => {
+    const p = join(tmp, `${basename}.yml`);
+    writeFileSync(p, contents);
+    return p;
+  };
+  afterAll(() => rmSync(tmp, { recursive: true, force: true }));
+
+  it("expands `<<: *ANCHOR` merge keys (yaml `merge: true`)", () => {
+    const r = loadRailsYamlForTest(
+      write("merge", "DEFAULTS: &D\n  color: red\nrow1:\n  <<: *D\n  name: x\n"),
+      "merge",
+    );
+    expect(r).toEqual({ ok: true, data: { DEFAULTS: { color: "red" }, row1: { color: "red", name: "x" } } }); // prettier-ignore
+  });
+
+  it("strips `_fixture` metadata and honors `_fixture.ignore`", () => {
+    const r = loadRailsYamlForTest(
+      write("ig", "_fixture:\n  ignore: SKIP_ME\nSKIP_ME:\n  x: 1\nkeep:\n  y: 2\n"),
+      "ig",
+    );
+    expect(r).toEqual({ ok: true, data: { keep: { y: 2 } } });
+  });
+
+  it("auto-labels list-form fixtures as `<basename>_<index>`", () => {
+    const r = loadRailsYamlForTest(write("list", "- name: Foo\n- name: Bar\n"), "list");
+    expect(r).toEqual({ ok: true, data: { list_0: { name: "Foo" }, list_1: { name: "Bar" } } });
+  });
+
+  it("interpolates `$LABEL` to the row name on scalar string values", () => {
+    const r = loadRailsYamlForTest(write("lab", "polly:\n  name: $LABEL\n  breed: $LABEL bird\n"), "lab"); // prettier-ignore
+    expect(r).toEqual({ ok: true, data: { polly: { name: "polly", breed: "polly bird" } } });
+  });
+
+  it("returns ERB-UNSUPPORTED for ERB other than the adapter_name stub", () => {
+    const r = loadRailsYamlForTest(write("erb", "<% 3.times do %>x: 1<% end %>\n"), "erb");
+    expect(r).toEqual({ ok: false, reason: "ERB-UNSUPPORTED" });
   });
 });
 

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { stripErb, isRefLike, compareValue, compareFile, schemaCheck } from "./compare.js";
+// prettier-ignore
+import { stripErb, isRefLike, compareValue, compareFile, schemaCheck, canonicalizeRailsRow } from "./compare.js";
 import type { Schema } from "../../packages/activerecord/src/test-helpers/define-schema.js";
 
 // prettier-ignore
@@ -123,11 +124,38 @@ describe("compareFile + schema integration", () => {
   });
 });
 
+describe("canonicalizeRailsRow", () => {
+  const cols = new Set(["id", "name", "pirate_id", "pirate_type", "club_id"]);
+  it("passes column-named keys through unchanged", () => {
+    expect(canonicalizeRailsRow({ id: 1, name: "x" }, {}, cols)).toEqual({ id: 1, name: "x" });
+  });
+  it("expands `assoc: name` belongs_to short-hand into assoc_id", () => {
+    expect(canonicalizeRailsRow({ pirate: "blackbeard" }, {}, cols)).toEqual({
+      pirate_id: "blackbeard",
+    });
+  });
+  it("expands polymorphic `assoc: name (Type)` into assoc_id + assoc_type", () => {
+    expect(canonicalizeRailsRow({ pirate: "blackbeard (Pirate)" }, {}, cols)).toEqual({
+      pirate_id: "blackbeard",
+      pirate_type: "Pirate",
+    });
+  });
+  it("drops keys whose `_id` form isn't a column (HABTM / unknown assoc)", () => {
+    expect(canonicalizeRailsRow({ treasures: "diamond, sapphire" }, {}, cols)).toEqual({});
+  });
+  it("falls back to tsRow keys when no schema columns are available", () => {
+    expect(canonicalizeRailsRow({ pirate: "x" }, { pirate_id: 1 }, null)).toEqual({
+      pirate_id: "x",
+    });
+    expect(canonicalizeRailsRow({ pirate: "x" }, {}, null)).toEqual({});
+  });
+});
+
 describe("compareFile", () => {
   const empty = new Map();
   it("returns MISSING when the TS counterpart doesn't exist", async () => {
-    const rows = new Map([["pirates", { blackbeard: { id: 1 } }]]);
-    const r = await compareFile("pirates.yml", rows, empty, undefined);
+    const rows = new Map([["nonexistent_fixture_xyz", { row1: { id: 1 } }]]);
+    const r = await compareFile("nonexistent_fixture_xyz.yml", rows, empty, undefined);
     expect(r.status).toBe("MISSING");
     expect(r.tsBase).toBeNull();
   });

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -201,6 +201,22 @@ describe("loadRailsYaml (parsing fidelity)", () => {
     expect(r).toEqual({ ok: true, data: { listarr_0: { tags: ["a", "b"], name: "x" } } });
   });
 
+  it("auto-labels single-key list-form rows even when the value is a nested object", () => {
+    // `- settings: { theme: dark }` is a bare row with column `settings`,
+    // not a labeled omap entry. Requires the explicit `--- !omap` doc tag
+    // to opt into label-preserving flattening; without it we auto-label.
+    const r = loadRailsYamlForTest(write("lk", "- settings:\n    theme: dark\n"), "lk");
+    expect(r).toEqual({ ok: true, data: { lk_0: { settings: { theme: "dark" } } } });
+  });
+
+  it("preserves labels on `!omap` arrays via the document tag", () => {
+    const r = loadRailsYamlForTest(
+      write("om", "--- !omap\n- alpha:\n    n: 1\n- beta:\n    n: 2\n"),
+      "om",
+    );
+    expect(r).toEqual({ ok: true, data: { alpha: { n: 1 }, beta: { n: 2 } } });
+  });
+
   it("ignores prototype keys when canonicalizing without a schema", () => {
     // toString isn't a column; with `in` it would short-circuit known(); use
     // Object.hasOwn so the Rails key still surfaces as missing-in-ts drift.

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -37,6 +37,11 @@ describe("compareValue", () => {
     expect(cmp(ref("e", "modest"), "modest")[0]).toBe(true);
     expect(cmp("a", "b")[1][0]).toMatch(/^value-differs:/);
   });
+  it("compares array values structurally (postgres text[] etc.)", () => {
+    expect(cmp(["a", "b"], ["a", "b"])[0]).toBe(true);
+    expect(cmp(["a", "b"], ["a", "c"])[0]).toBe(false);
+    expect(cmp(["a"], ["a", "b"])[0]).toBe(false);
+  });
 });
 
 describe("schemaCheck", () => {

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -193,6 +193,20 @@ describe("loadRailsYaml (parsing fidelity)", () => {
     expect(r).toEqual({ ok: true, data: { list_0: { name: "Foo" }, list_1: { name: "Bar" } } });
   });
 
+  it("keeps list-form entries with array/scalar single-key values (not misclassified as labeled)", () => {
+    // `- tags: [a, b]` is one bare list-form row, not a labeled `tags:` omap
+    // entry. Tightened looksLabeled predicate must require a non-null, non-
+    // array object before treating an entry as labeled.
+    const r = loadRailsYamlForTest(write("listarr", "- tags:\n    - a\n    - b\n  name: x\n"), "listarr"); // prettier-ignore
+    expect(r).toEqual({ ok: true, data: { listarr_0: { tags: ["a", "b"], name: "x" } } });
+  });
+
+  it("ignores prototype keys when canonicalizing without a schema", () => {
+    // toString isn't a column; with `in` it would short-circuit known(); use
+    // Object.hasOwn so the Rails key still surfaces as missing-in-ts drift.
+    expect(canonicalizeRailsRow({ toString: "x" }, {}, null)).toEqual({ toString: "x" });
+  });
+
   it("interpolates `$LABEL` to the row name on scalar string values", () => {
     const r = loadRailsYamlForTest(write("lab", "polly:\n  name: $LABEL\n  breed: $LABEL bird\n"), "lab"); // prettier-ignore
     expect(r).toEqual({ ok: true, data: { polly: { name: "polly", breed: "polly bird" } } });

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -91,7 +91,10 @@ function loadRailsYaml(file: string, basename: string): { ok: true; data: Fixtur
   // like `DEFAULTS` (`&NAME`) are *still real fixture rows* — Rails inserts
   // them unless they're explicitly listed in `_fixture.ignore` (e.g.
   // `_fixture: { ignore: DEAD_PARROT }` skips only the DEAD_PARROT anchor).
-  const meta = (parsed as Record<string, unknown>)._fixture;
+  // For array-shaped (`!omap`) documents `_fixture` shows up as an entry,
+  // not a top-level key; pull from `entries` so omap fixtures honor `ignore`.
+  const meta = entries.find(([k]) => k === "_fixture")?.[1]
+    ?? (parsed as Record<string, unknown>)._fixture;
   const ignored = new Set<string>(["_fixture"]);
   if (meta && typeof meta === "object" && "ignore" in meta) {
     const ig = (meta as { ignore: unknown }).ignore;

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -76,7 +76,12 @@ function loadRailsYaml(file: string, basename: string): { ok: true; data: Fixtur
     parsed.forEach((e, i) => {
       if (!e || typeof e !== "object") return;
       const ks = Object.keys(e);
-      const looksLabeled = ks.length === 1 && typeof (e as Record<string, unknown>)[ks[0]] === "object"; // prettier-ignore
+      // Labeled !omap entries wrap a single key whose value is a non-null,
+      // non-array object (the column map). Bare list-form rows may also be
+      // single-key with object values (`- tags: [a, b]`, `- settings: {…}`),
+      // so require both invariants before treating as labeled.
+      const v = (e as Record<string, unknown>)[ks[0]];
+      const looksLabeled = ks.length === 1 && !!v && typeof v === "object" && !Array.isArray(v);
       if (looksLabeled) flat.push(...(Object.entries(e) as [string, unknown][]));
       else flat.push([`${basename}_${i}`, e]);
     });
@@ -242,9 +247,11 @@ export function schemaCheck(
 // prettier-ignore
 export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<string> | null): Row {
   const out: Row = {};
-  const known = (k: string): boolean => columns ? columns.has(k) : k in tsRow;
+  // Use Object.hasOwn for the schemaless tsRow probe so prototype keys
+  // (`toString`, `constructor`, …) don't read as columns.
+  const known = (k: string): boolean => (columns ? columns.has(k) : Object.hasOwn(tsRow, k));
   const hasIdForm = (k: string): boolean =>
-    columns ? columns.has(`${k}_id`) : `${k}_id` in tsRow;
+    columns ? columns.has(`${k}_id`) : Object.hasOwn(tsRow, `${k}_id`);
   for (const [k, v] of Object.entries(railsRow)) {
     if (known(k)) { out[k] = v; continue; } // prettier-ignore
     if (hasIdForm(k)) {

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -49,7 +49,7 @@ export function stripErb(text: string): { rendered: string; unsupported: boolean
 }
 
 // prettier-ignore
-function loadRailsYaml(file: string): { ok: true; data: FixtureMap } | { ok: false; reason: Status } {
+function loadRailsYaml(file: string, basename: string): { ok: true; data: FixtureMap } | { ok: false; reason: Status } {
   const raw = readFileSync(file, "utf8");
   const { rendered, unsupported } = stripErb(raw);
   if (unsupported) return { ok: false, reason: "ERB-UNSUPPORTED" };
@@ -61,10 +61,23 @@ function loadRailsYaml(file: string): { ok: true; data: FixtureMap } | { ok: fal
   }
   const out: FixtureMap = {};
   if (!parsed || typeof parsed !== "object") return { ok: true, data: out };
-  // YAML !omap → array of single-key maps; otherwise a plain object.
-  const entries = Array.isArray(parsed)
-    ? parsed.flatMap((e) => (e && typeof e === "object" ? Object.entries(e) : []))
-    : Object.entries(parsed as Record<string, unknown>);
+  // Three shapes Rails accepts:
+  //   1) plain map: `label: { col: val }` → Object.entries.
+  //   2) !omap (array of single-key maps with explicit labels) → entries.
+  //   3) list-form (array of bare maps, no label) → Rails auto-labels as
+  //      `<basename>_<index>` via `Fixtures::ClassCache#auto_named_fixtures`.
+  let entries: [string, unknown][];
+  if (Array.isArray(parsed)) {
+    const flat: [string, unknown][] = [];
+    parsed.forEach((e, i) => {
+      if (!e || typeof e !== "object") return;
+      const ks = Object.keys(e);
+      const looksLabeled = ks.length === 1 && typeof (e as Record<string, unknown>)[ks[0]] === "object"; // prettier-ignore
+      if (looksLabeled) flat.push(...(Object.entries(e) as [string, unknown][]));
+      else flat.push([`${basename}_${i}`, e]);
+    });
+    entries = flat;
+  } else entries = Object.entries(parsed as Record<string, unknown>);
   // Rails reserves `_fixture` (carries `model_class` / `ignore` metadata for
   // `set_fixture_class`) and YAML anchor blocks like `DEFAULTS` (merged into
   // rows via `<<: *DEFAULTS`); neither is a fixture row. The `_fixture.ignore`
@@ -134,6 +147,11 @@ export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, id
     return false;
   }
   if (tsVal === railsVal) return true;
+  // Array-typed columns (postgres `text[]`, etc.) appear as arrays on both
+  // sides; compare structurally so identical contents don't flag.
+  if (Array.isArray(tsVal) && Array.isArray(railsVal)
+    && tsVal.length === railsVal.length && tsVal.every((v, i) => v === railsVal[i]))
+    return true;
   notes.push(`value-differs: ${attr}: ts=${JSON.stringify(tsVal)} rails=${JSON.stringify(railsVal)}`); // prettier-ignore
   return false;
 }
@@ -355,7 +373,7 @@ async function main(): Promise<void> {
   const prelim = new Map<string, Status>();
   for (const f of allYamls) {
     const snake = f.replace(/\.yml$/, "");
-    const loaded = loadRailsYaml(path.join(YML_DIR, f));
+    const loaded = loadRailsYaml(path.join(YML_DIR, f), snake);
     if (loaded.ok) yamlByTable.set(snake, loaded.data);
     else prelim.set(snake, loaded.reason);
   }

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -67,22 +67,21 @@ function loadRailsYaml(file: string, basename: string): { ok: true; data: Fixtur
   if (!parsed || typeof parsed !== "object") return { ok: true, data: out };
   // Three shapes Rails accepts:
   //   1) plain map: `label: { col: val }` → Object.entries.
-  //   2) !omap (array of single-key maps with explicit labels) → entries.
+  //   2) `!omap` (array of single-key maps; labels preserved in source order)
+  //      — Rails opts in via the document tag `--- !omap`. Disambiguates from
+  //      list-form: without the tag, a single-key array entry is a bare row,
+  //      not a labeled entry (e.g. `- settings: { theme: dark }` is one row
+  //      with column `settings`, not an entry labeled `settings`).
   //   3) list-form (array of bare maps, no label) → Rails auto-labels as
   //      `<basename>_<index>` via `Fixtures::ClassCache#auto_named_fixtures`.
+  const isOmap = /^---\s*!omap\b/m.test(rendered);
   let entries: [string, unknown][];
   if (Array.isArray(parsed)) {
     const flat: [string, unknown][] = [];
     parsed.forEach((e, i) => {
       if (!e || typeof e !== "object") return;
       const ks = Object.keys(e);
-      // Labeled !omap entries wrap a single key whose value is a non-null,
-      // non-array object (the column map). Bare list-form rows may also be
-      // single-key with object values (`- tags: [a, b]`, `- settings: {…}`),
-      // so require both invariants before treating as labeled.
-      const v = (e as Record<string, unknown>)[ks[0]];
-      const looksLabeled = ks.length === 1 && !!v && typeof v === "object" && !Array.isArray(v);
-      if (looksLabeled) flat.push(...(Object.entries(e) as [string, unknown][]));
+      if (isOmap && ks.length === 1) flat.push(...(Object.entries(e) as [string, unknown][]));
       else flat.push([`${basename}_${i}`, e]);
     });
     entries = flat;

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -55,7 +55,7 @@ function loadRailsYaml(file: string): { ok: true; data: FixtureMap } | { ok: fal
   if (unsupported) return { ok: false, reason: "ERB-UNSUPPORTED" };
   let parsed: unknown;
   try {
-    parsed = parseYaml(rendered);
+    parsed = parseYaml(rendered, { merge: true });
   } catch {
     return { ok: false, reason: "YAML-PARSE-ERR" };
   }
@@ -65,8 +65,30 @@ function loadRailsYaml(file: string): { ok: true; data: FixtureMap } | { ok: fal
   const entries = Array.isArray(parsed)
     ? parsed.flatMap((e) => (e && typeof e === "object" ? Object.entries(e) : []))
     : Object.entries(parsed as Record<string, unknown>);
+  // Rails reserves `_fixture` (carries `model_class` / `ignore` metadata for
+  // `set_fixture_class`) and YAML anchor blocks like `DEFAULTS` (merged into
+  // rows via `<<: *DEFAULTS`); neither is a fixture row. The `_fixture.ignore`
+  // key further suppresses anchor blocks the user gave a non-DEFAULTS name
+  // (e.g. `_fixture: { ignore: DEAD_PARROT }`).
+  const meta = (parsed as Record<string, unknown>)._fixture;
+  // Only `_fixture` is a YAML metadata key; `DEFAULTS` and other anchor
+  // labels (`&NAME`) are still real fixture rows that Rails inserts unless
+  // they're listed in `_fixture.ignore` (e.g. `ignore: DEAD_PARROT`).
+  const ignored = new Set<string>(["_fixture"]);
+  if (meta && typeof meta === "object" && "ignore" in meta) {
+    const ig = (meta as { ignore: unknown }).ignore;
+    if (typeof ig === "string") ignored.add(ig);
+    else if (Array.isArray(ig)) for (const n of ig) if (typeof n === "string") ignored.add(n);
+  }
   for (const [k, v] of entries)
-    if (v && typeof v === "object" && !Array.isArray(v)) out[k] = v as Row;
+    if (v && typeof v === "object" && !Array.isArray(v) && !ignored.has(k))
+      out[k] = v as Row;
+  // Interpolate Rails' `$LABEL` token (the row name) on scalar string values.
+  for (const [name, row] of Object.entries(out)) {
+    for (const [col, val] of Object.entries(row)) {
+      if (typeof val === "string" && val.includes("$LABEL")) row[col] = val.replace(/\$LABEL/g, name); // prettier-ignore
+    }
+  }
   return { ok: true, data: out };
 }
 
@@ -184,6 +206,37 @@ export function schemaCheck(
   return { ported: true, extras };
 }
 
+/**
+ * Rails fixture loader maps association names to FK columns: `pirate: blackbeard`
+ * → `pirate_id`, `pirate: blackbeard (Pirate)` → `pirate_id` + `pirate_type` for
+ * polymorphic. HABTM keys (`treasures: diamond, sapphire`) populate a join table,
+ * not a column on the host row. The TS side encodes the materialized FK columns
+ * directly. Rewrite the Rails row to canonical TS shape so the per-attr diff
+ * doesn't drown in shorthand-vs-canonical noise: drop association keys whose
+ * `_id` counterpart isn't on either side (HABTM-like), and expand the rest.
+ */
+// prettier-ignore
+export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<string> | null): Row {
+  const out: Row = {};
+  const knows = (k: string): boolean => columns ? columns.has(k) : k in tsRow;
+  for (const [k, v] of Object.entries(railsRow)) {
+    if (knows(k)) { out[k] = v; continue; } // prettier-ignore
+    const idKey = `${k}_id`;
+    if (knows(idKey)) {
+      if (typeof v === "string") {
+        const m = /^(.*?)\s*\(([^)]+)\)\s*$/.exec(v);
+        if (m) { out[idKey] = m[1]; out[`${k}_type`] = m[2]; }
+        else out[idKey] = v;
+      } else out[idKey] = v as Row[string];
+      continue;
+    }
+    // Drop: HABTM association (e.g. `treasures: diamond, sapphire`) or a
+    // belongs_to whose host model isn't in the schema yet. Either way the
+    // value isn't a column on this table — comparing it would falsely flag.
+  }
+  return out;
+}
+
 // prettier-ignore
 export async function compareFile(yamlBase: string, yamlByTable: Map<string, FixtureMap>, idIndex: Map<string, Map<number, string[]>>, prelimFailure: Status | undefined, schema: Schema = TEST_SCHEMA): Promise<FileResult> {
   const snake = yamlBase.replace(/\.yml$/, "");
@@ -216,13 +269,21 @@ export async function compareFile(yamlBase: string, yamlByTable: Map<string, Fix
   r.schemaPorted = sc.ported;
   r.schemaExtras = sc.extras;
   let anyDiff = sc.extras > 0;
-  for (const [rowName, railsRow] of Object.entries(railsRows)) {
+  const tableShapeForCols = schema[snake] ? tableShape(schema[snake]) : null;
+  const cols: Set<string> | null = tableShapeForCols
+    ? new Set([
+        ...Object.keys(tableShapeForCols.columns),
+        ...(tableShapeForCols.hasImplicitId ? ["id"] : []),
+      ])
+    : null;
+  for (const [rowName, railsRowRaw] of Object.entries(railsRows)) {
     const tsRow = tsRows[rowName];
     if (!tsRow || typeof tsRow !== "object") {
       r.notes.push(`row missing in TS: ${rowName}`);
       anyDiff = true;
       continue;
     }
+    const railsRow = canonicalizeRailsRow(railsRowRaw, tsRow, cols);
     r.rowsMatched++;
     if ("id" in railsRow && (!("id" in tsRow) || tsRow.id !== railsRow.id)) {
       r.notes.push(`id-divergence: ${rowName} ts=${String(tsRow.id)} rails=${String(railsRow.id)}`);

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -48,6 +48,10 @@ export function stripErb(text: string): { rendered: string; unsupported: boolean
   return { rendered, unsupported: /<%[=#]?[^%]*%>/.test(rendered) };
 }
 
+// Exported under a `*ForTest` alias so the test suite can pin parsing
+// fidelity (merge keys, `_fixture.ignore`, list-form auto-labels, `$LABEL`)
+// without going through `main()`. Internal callers still use `loadRailsYaml`.
+export { loadRailsYaml as loadRailsYamlForTest };
 // prettier-ignore
 function loadRailsYaml(file: string, basename: string): { ok: true; data: FixtureMap } | { ok: false; reason: Status } {
   const raw = readFileSync(file, "utf8");
@@ -78,15 +82,12 @@ function loadRailsYaml(file: string, basename: string): { ok: true; data: Fixtur
     });
     entries = flat;
   } else entries = Object.entries(parsed as Record<string, unknown>);
-  // Rails reserves `_fixture` (carries `model_class` / `ignore` metadata for
-  // `set_fixture_class`) and YAML anchor blocks like `DEFAULTS` (merged into
-  // rows via `<<: *DEFAULTS`); neither is a fixture row. The `_fixture.ignore`
-  // key further suppresses anchor blocks the user gave a non-DEFAULTS name
-  // (e.g. `_fixture: { ignore: DEAD_PARROT }`).
+  // `_fixture` is the only YAML metadata key Rails reserves at parse time
+  // (carries `model_class` / `ignore` for `set_fixture_class`). Anchor labels
+  // like `DEFAULTS` (`&NAME`) are *still real fixture rows* — Rails inserts
+  // them unless they're explicitly listed in `_fixture.ignore` (e.g.
+  // `_fixture: { ignore: DEAD_PARROT }` skips only the DEAD_PARROT anchor).
   const meta = (parsed as Record<string, unknown>)._fixture;
-  // Only `_fixture` is a YAML metadata key; `DEFAULTS` and other anchor
-  // labels (`&NAME`) are still real fixture rows that Rails inserts unless
-  // they're listed in `_fixture.ignore` (e.g. `ignore: DEAD_PARROT`).
   const ignored = new Set<string>(["_fixture"]);
   if (meta && typeof meta === "object" && "ignore" in meta) {
     const ig = (meta as { ignore: unknown }).ignore;
@@ -230,17 +231,24 @@ export function schemaCheck(
  * polymorphic. HABTM keys (`treasures: diamond, sapphire`) populate a join table,
  * not a column on the host row. The TS side encodes the materialized FK columns
  * directly. Rewrite the Rails row to canonical TS shape so the per-attr diff
- * doesn't drown in shorthand-vs-canonical noise: drop association keys whose
- * `_id` counterpart isn't on either side (HABTM-like), and expand the rest.
+ * doesn't drown in shorthand-vs-canonical noise.
+ *
+ * Without schema (`columns === null`, i.e. table not yet ported in TEST_SCHEMA)
+ * we can't tell HABTM from a real column the TS side dropped, so we *preserve*
+ * unknown Rails keys verbatim — the downstream per-attr pass surfaces them as
+ * `missing-in-ts` drift instead of silently dropping them. Only when we have a
+ * column list AND the `_id` form is missing do we drop the key as HABTM-like.
  */
 // prettier-ignore
 export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<string> | null): Row {
   const out: Row = {};
-  const knows = (k: string): boolean => columns ? columns.has(k) : k in tsRow;
+  const known = (k: string): boolean => columns ? columns.has(k) : k in tsRow;
+  const hasIdForm = (k: string): boolean =>
+    columns ? columns.has(`${k}_id`) : `${k}_id` in tsRow;
   for (const [k, v] of Object.entries(railsRow)) {
-    if (knows(k)) { out[k] = v; continue; } // prettier-ignore
-    const idKey = `${k}_id`;
-    if (knows(idKey)) {
+    if (known(k)) { out[k] = v; continue; } // prettier-ignore
+    if (hasIdForm(k)) {
+      const idKey = `${k}_id`;
       if (typeof v === "string") {
         const m = /^(.*?)\s*\(([^)]+)\)\s*$/.exec(v);
         if (m) { out[idKey] = m[1]; out[`${k}_type`] = m[2]; }
@@ -248,9 +256,10 @@ export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<str
       } else out[idKey] = v as Row[string];
       continue;
     }
-    // Drop: HABTM association (e.g. `treasures: diamond, sapphire`) or a
-    // belongs_to whose host model isn't in the schema yet. Either way the
-    // value isn't a column on this table — comparing it would falsely flag.
+    // With a schema: drop as HABTM / unknown association (won't be a column on
+    // this table). Without a schema: keep verbatim so the downstream attr-diff
+    // can surface "missing-in-ts: <k>" — silently dropping would mask drift.
+    if (!columns) out[k] = v;
   }
   return out;
 }


### PR DESCRIPTION
## Summary

Part 1 of PR 7-fixes (see [docs/fixtures-port-plan.md](docs/fixtures-port-plan.md)).
PR 7 needs `fixtures:compare` clean before the strict-fail flip can land. On
`main`: **122 files — match=67 diff=30 missing=5 erb-unsupported=20** —
roughly half would fail a hard-fail CI gate. This PR moves match **67 → 86**
with compare-script fidelity work, not by hand-editing fixtures.

### Compare-script changes

- **`_fixture` YAML metadata stripped.** Rails uses `_fixture: { model_class: …, ignore: NAME }` to carry `set_fixture_class` and to suppress anchor blocks; it's not a fixture row. Was being counted as drift on bad_posts, cpk_*, other_*, sharded_*. `DEFAULTS` and other anchor labels stay treated as real rows because Rails inserts them; only `_fixture.ignore: NAME` (or a list) suppresses a specific anchor.
- **`yaml` parser `merge: true`.** `<<: *ANCHOR` now expands inline, so e.g. `polly` inherits `parrot_sti_class: DeadParrot` from the `DEAD_PARROT` anchor.
- **`$LABEL` interpolation** on scalar string values (treasures, parrots, …).
- **List-form fixtures auto-labeled** as `<basename>_<index>`, matching Rails' Fixtures auto-naming for unkeyed entries. (Only consumer: `1_need_quoting.yml`; the TS side is updated to match.)
- **`canonicalizeRailsRow`** expands belongs_to short-hand (`pirate: blackbeard` → `pirate_id`) and polymorphic (`pirate: name (Type)` → `pirate_id` + `pirate_type`). With a schema column list, drops association keys whose `_id` form isn't a column (HABTM `treasures: diamond, sapphire`, or a belongs_to with no schema entry). Without a schema, **preserves unknown Rails keys verbatim** so the downstream per-attr diff surfaces them as `missing-in-ts` drift instead of silently dropping them.
- **Array values compared structurally** in `compareValue` so identical postgres `text[]` contents stop flagging `value-differs` (`traffic_lights`).

### State after this PR

`pnpm fixtures:compare` → **122 files — match=86 diff=11 missing=5 erb-unsupported=20 other=0**.

Remaining 36 non-MATCH, deferred to follow-up PRs in the same series:

- **DIFFs (11)** — fixture-data / compare gaps the next PR can pick up: `authors.owned_essay_id` (string-PK ref via target's `name`, not by fixture label — needs target-PK lookup), `books` / `other_books` symbol-vs-integer enums (`status: :published` vs `2` — needs model enum metadata), `topics` / `other_topics` timestamp + YAML-serialized `content`, `randomly_named_a9` zero-padded string vs int, `developers_projects` numeric FK against ERB-only `developers.yml`, `sponsors` (custom `foreign_key: :club_id`), `comments.recursive_association_comment.company`, `dead_parrots` / `live_parrots` (real Rails-only keys now surfaced; previously silently dropped under the schemaless-canonicalize bug Copilot flagged).
- **MISSING (5)** — never ported: `faces`, `humans`, `owners`, `pets`, `toys`.
- **ERB-UNSUPPORTED (20)** — `binaries`, `categories_ordered`, `developers`, `mixins`, `paragraphs`, `mateys`, `memberships`, `parrots_pirates`, `peoples_treasures`, `pirates`, `sharded_*`, `cpk_order_agreements`, `cpk_order_tags`, `cpk_reviews`, `citations`, `edges`, `vertices`. Need richer ERB rendering (`<% ... times do ... %>`, `FixtureSet.identify`, `n.weeks.ago.to_fs(:db)`) or an opt-in exemption list.

Plan-doc PR 7 (strict-fail flip + remove four `unported-files.ts` entries + port `fixtures_test.rb` / `test_fixtures_test.rb` / `encrypted_fixtures_test.rb`) is still blocked on those 36 going to MATCH plus ~1.9k LOC of Ruby tests to port.

## Test plan

- [x] `pnpm vitest run scripts/fixtures-compare/compare.test.ts` — 27 pass, including new coverage for `canonicalizeRailsRow` (with + without schema), structural array equality, and `loadRailsYaml` parsing fidelity (merge keys, `_fixture.ignore`, list-form auto-labels, `$LABEL`, ERB-unsupported sentinel).
- [x] `pnpm fixtures:compare` → match=86, diff=11, missing=5, erb-unsupported=20.
- [x] `pnpm lint` clean.