### PR TITLE
feat(trailties): DevcontainerGenerator (PR T5)

### DIFF
--- a/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.test.ts
+++ b/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { DevcontainerGenerator, TRAILS_DEV_PATH } from "./devcontainer-generator.js";
+let tmpDir: string;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-devcontainer-"));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+type Opts = Partial<ConstructorParameters<typeof DevcontainerGenerator>[0]>;
+const run = (o: Opts = {}) =>
+  new DevcontainerGenerator({ cwd: tmpDir, output: () => {}, ...o }).run();
+const read = (rel: string) => fs.readFileSync(path.join(tmpDir, rel), "utf-8");
+const exists = (rel: string) => fs.existsSync(path.join(tmpDir, rel));
+const dc = () => JSON.parse(read(".devcontainer/devcontainer.json")) as Record<string, unknown>;
+const cm = () => JSON.parse(read(".devcontainer/compose.yaml")) as Record<string, unknown>;
+const features = () => dc().features as Record<string, unknown>;
+const env = () => (dc().containerEnv as Record<string, string> | undefined) ?? {};
+const services = () => cm().services as Record<string, Record<string, unknown>>;
+describe("DevcontainerGeneratorTest", () => {
+  it("test_creates_devcontainer_files", () => {
+    run();
+    expect(exists(".devcontainer/compose.yaml")).toBe(true);
+    expect(exists(".devcontainer/Dockerfile")).toBe(true);
+    expect(exists(".devcontainer/devcontainer.json")).toBe(true);
+  });
+  it("test_active_storage_option_skip", () => {
+    run({ activeStorage: false });
+    expect(features()).not.toHaveProperty("ghcr.io/rails/devcontainer/features/activestorage");
+  });
+  it("test_app_name_option", () => {
+    run({ appName: "my-TestApp_name" });
+    expect(dc().name).toBe("my-TestApp_name");
+    expect(cm().name).toBe("my-TestApp_name");
+  });
+  it("test_database_default_sqlite3", () => {
+    run();
+    expect(exists("config/database.yml")).toBe(false);
+    expect(features()).toHaveProperty("ghcr.io/rails/devcontainer/features/sqlite3");
+  });
+  it("test_database_mariadb_mysql", () => {
+    run({ database: "mariadb-mysql" });
+    expect(services().mariadb).toEqual({
+      image: "mariadb:10.5",
+      restart: "unless-stopped",
+      networks: ["default"],
+      volumes: ["mariadb-data:/var/lib/mysql"],
+      environment: { MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: "true" },
+    });
+    expect(cm().volumes).toHaveProperty("mariadb-data");
+    expect(services()["rails-app"].depends_on).toContain("mariadb");
+    expect(env().DB_HOST).toBe("mariadb");
+    expect(features()).toHaveProperty("ghcr.io/rails/devcontainer/features/mysql-client");
+    expect(dc().forwardPorts).toContain(3306);
+  });
+  it("test_database_mysql", () => {
+    run({ database: "mysql" });
+    expect(services().mysql).toMatchObject({ image: "mysql/mysql-server:8.0" });
+    expect(cm().volumes).toHaveProperty("mysql-data");
+    expect(env().DB_HOST).toBe("mysql");
+    expect(dc().forwardPorts).toContain(3306);
+  });
+  it("test_database_postgresql", () => {
+    run({ database: "postgresql" });
+    expect(services().postgres).toMatchObject({ image: "postgres:16.1" });
+    expect(env().DB_HOST).toBe("postgres");
+    expect(features()).toHaveProperty("ghcr.io/rails/devcontainer/features/postgres-client");
+    expect(dc().forwardPorts).toContain(5432);
+  });
+  it("test_dev_option", () => {
+    run({ dev: true });
+    const m = (dc().mounts as Array<Record<string, string>>)[0];
+    expect(m).toEqual({ type: "bind", source: TRAILS_DEV_PATH, target: TRAILS_DEV_PATH });
+  });
+  it("test_node_option", () => {
+    run({ node: true });
+    expect(features()).toHaveProperty("ghcr.io/devcontainers/features/node:1");
+  });
+  it("test_redis_option_default", () => {
+    run();
+    expect(services()["rails-app"].depends_on).toContain("redis");
+    expect(services().redis).toEqual({
+      image: "redis:7.2",
+      restart: "unless-stopped",
+      volumes: ["redis-data:/data"],
+    });
+    expect(env().REDIS_URL).toBe("redis://redis:6379/1");
+    expect(dc().forwardPorts).toContain(6379);
+  });
+  it("test_redis_option_skip", () => {
+    run({ redis: false });
+    expect(services()["rails-app"].depends_on ?? []).not.toContain("redis");
+    expect(services().redis).toBeUndefined();
+    expect(dc().forwardPorts).not.toContain(6379);
+  });
+  it("test_kamal_option_skip", () => {
+    run({ kamal: false });
+    expect(features()).not.toHaveProperty(
+      "ghcr.io/devcontainers/features/docker-outside-of-docker:1",
+    );
+    expect(env()).not.toHaveProperty("KAMAL_REGISTRY_PASSWORD");
+  });
+  it("test_system_test_option_default", () => {
+    fs.mkdirSync(path.join(tmpDir, "test"), { recursive: true });
+    fs.writeFileSync(
+      path.join(tmpDir, "test/application_system_test_case.ts"),
+      '  drivenBy(":selenium", { using: ":headless_chrome" });\n',
+    );
+    run();
+    expect(env().CAPYBARA_SERVER_PORT).toBe("45678");
+    expect(env().SELENIUM_HOST).toBe("selenium");
+    expect(read("test/application_system_test_case.ts")).toMatch(/servedBy/);
+  });
+  it("test_system_test_option_does_not_create_new_file", () => {
+    run({ systemTest: true });
+    expect(exists("test/application_system_test_case.ts")).toBe(false);
+  });
+  it("test_system_test_option_skip", () => {
+    run({ systemTest: false });
+    expect(services()["rails-app"].depends_on ?? []).not.toContain("selenium");
+    expect(services().selenium).toBeUndefined();
+    expect(env().CAPYBARA_SERVER_PORT).toBeUndefined();
+  });
+});

--- a/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.test.ts
+++ b/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.test.ts
@@ -27,9 +27,18 @@ describe("DevcontainerGeneratorTest", () => {
     expect(exists(".devcontainer/Dockerfile")).toBe(true);
     expect(exists(".devcontainer/devcontainer.json")).toBe(true);
   });
+  it("test_active_storage_option_default", () => {
+    run();
+    expect(features()).toHaveProperty("ghcr.io/rails/devcontainer/features/activestorage");
+  });
   it("test_active_storage_option_skip", () => {
     run({ activeStorage: false });
     expect(features()).not.toHaveProperty("ghcr.io/rails/devcontainer/features/activestorage");
+  });
+  it("test_app_name_option_default", () => {
+    run();
+    expect(dc().name).toBe("rails_app");
+    expect(cm().name).toBe("rails_app");
   });
   it("test_app_name_option", () => {
     run({ appName: "my-TestApp_name" });
@@ -70,10 +79,18 @@ describe("DevcontainerGeneratorTest", () => {
     expect(features()).toHaveProperty("ghcr.io/rails/devcontainer/features/postgres-client");
     expect(dc().forwardPorts).toContain(5432);
   });
+  it("test_dev_option_default", () => {
+    run();
+    expect(dc().mounts).toBeUndefined();
+  });
   it("test_dev_option", () => {
     run({ dev: true });
     const m = (dc().mounts as Array<Record<string, string>>)[0];
     expect(m).toEqual({ type: "bind", source: TRAILS_DEV_PATH, target: TRAILS_DEV_PATH });
+  });
+  it("test_node_option_default", () => {
+    run();
+    expect(features()).not.toHaveProperty("ghcr.io/devcontainers/features/node:1");
   });
   it("test_node_option", () => {
     run({ node: true });
@@ -95,6 +112,11 @@ describe("DevcontainerGeneratorTest", () => {
     expect(services()["rails-app"].depends_on ?? []).not.toContain("redis");
     expect(services().redis).toBeUndefined();
     expect(dc().forwardPorts).not.toContain(6379);
+  });
+  it("test_kamal_option_default", () => {
+    run();
+    expect(features()).toHaveProperty("ghcr.io/devcontainers/features/docker-outside-of-docker:1");
+    expect(env().KAMAL_REGISTRY_PASSWORD).toBe("$KAMAL_REGISTRY_PASSWORD");
   });
   it("test_kamal_option_skip", () => {
     run({ kamal: false });

--- a/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.test.ts
+++ b/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.test.ts
@@ -66,11 +66,14 @@ describe("DevcontainerGeneratorTest", () => {
     expect(dc().forwardPorts).toContain(3306);
   });
   it("test_database_mysql", () => {
+    fs.mkdirSync(path.join(tmpDir, "src/config"), { recursive: true });
+    fs.writeFileSync(path.join(tmpDir, "src/config/database.ts"), 'host: "localhost"\n');
     run({ database: "mysql" });
     expect(services().mysql).toMatchObject({ image: "mysql/mysql-server:8.0" });
     expect(cm().volumes).toHaveProperty("mysql-data");
     expect(env().DB_HOST).toBe("mysql");
     expect(dc().forwardPorts).toContain(3306);
+    expect(read("src/config/database.ts")).toMatch(/process\.env\.DB_HOST/);
   });
   it("test_database_postgresql", () => {
     run({ database: "postgresql" });

--- a/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.ts
+++ b/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.ts
@@ -1,0 +1,171 @@
+// Mirrors railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb.
+// compose.yaml / devcontainer.json are emitted as JSON syntax (YAML 1.2
+// is a strict superset of JSON; Compose accepts it). Dockerfile is raw.
+
+import { GeneratorBase, type GeneratorOptions } from "../../base.js";
+import { Database, DATABASES, type DatabaseName } from "../../database.js";
+
+export const TRAILS_DEV_PATH = "/workspaces/trails";
+export type SqliteDriver = "better-sqlite3" | "node-sqlite" | "expo-sqlite";
+
+export interface DevcontainerGeneratorOptions extends GeneratorOptions {
+  appName?: string;
+  database?: DatabaseName;
+  redis?: boolean;
+  systemTest?: boolean;
+  activeStorage?: boolean;
+  node?: boolean;
+  dev?: boolean;
+  kamal?: boolean;
+  sqliteDriver?: SqliteDriver;
+  nodeVersion?: string;
+}
+
+type JsonObject = { [k: string]: JsonValue };
+type JsonValue = string | number | boolean | null | JsonValue[] | JsonObject;
+type ResolvedOptions = Required<Omit<DevcontainerGeneratorOptions, "cwd" | "output">>;
+
+export class DevcontainerGenerator extends GeneratorBase {
+  readonly opts: ResolvedOptions;
+  readonly database: Database;
+
+  constructor(options: DevcontainerGeneratorOptions) {
+    super(options);
+    const database = options.database ?? "sqlite3";
+    if (!(DATABASES as readonly string[]).includes(database)) {
+      throw new Error(`Unknown database: ${database}`);
+    }
+    this.opts = {
+      appName: options.appName ?? "rails_app",
+      database,
+      redis: options.redis !== false,
+      systemTest: options.systemTest !== false,
+      activeStorage: options.activeStorage !== false,
+      node: options.node === true,
+      dev: options.dev === true,
+      kamal: options.kamal !== false,
+      sqliteDriver: options.sqliteDriver ?? "better-sqlite3",
+      nodeVersion: options.nodeVersion ?? "22.0.0",
+    };
+    this.database = Database.build(database);
+  }
+
+  run(): string[] {
+    this.createFile(".devcontainer/devcontainer.json", this.devcontainerJson());
+    this.createFile(".devcontainer/Dockerfile", this.dockerfile());
+    this.createFile(".devcontainer/compose.yaml", this.composeYaml());
+    this.gsubFile(
+      "test/application_system_test_case.ts",
+      /^\s*drivenBy\b.*$/m,
+      this.systemTestConfiguration(),
+      this.opts.systemTest,
+    );
+    this.gsubFile(
+      "src/config/database.ts",
+      /host:\s*"localhost"/g,
+      'host: process.env.DB_HOST ?? "localhost"',
+      this.opts.database === "postgresql",
+    );
+    return this.getCreatedFiles();
+  }
+
+  private gsubFile(rel: string, re: RegExp, replacement: string, enabled: boolean): void {
+    if (!enabled || !this.fileExists(rel)) return;
+    const full = this.path.join(this.cwd, rel);
+    this.fs.writeFileSync(full, this.fs.readFileSync(full, "utf-8").replace(re, replacement));
+    this.output(`      update  ${rel}`);
+  }
+
+  private devcontainerJson(): string {
+    const { dev, appName } = this.opts;
+    const env = this.containerEnv();
+    const json: JsonObject = {
+      name: appName,
+      dockerComposeFile: "compose.yaml",
+      service: "rails-app",
+      workspaceFolder: "/workspaces/${localWorkspaceFolderBasename}",
+      features: this.features(),
+    };
+    if (Object.keys(env).length > 0) json.containerEnv = env;
+    json.forwardPorts = this.forwardPorts();
+    if (dev) json.mounts = [{ type: "bind", source: TRAILS_DEV_PATH, target: TRAILS_DEV_PATH }];
+    json.postCreateCommand = "bin/setup --skip-server";
+    return JSON.stringify(json, null, 2) + "\n";
+  }
+
+  private dockerfile(): string {
+    return `ARG NODE_VERSION=${this.opts.nodeVersion}\nFROM mcr.microsoft.com/devcontainers/javascript-node:1-\${NODE_VERSION}\n`;
+  }
+
+  private composeYaml(): string {
+    const { systemTest, redis, appName } = this.opts;
+    const dbName = this.database.name;
+    const dbService = this.database.service;
+    const deps: string[] = [];
+    if (systemTest) deps.push("selenium");
+    if (redis) deps.push("redis");
+    if (dbService) deps.push(dbName);
+    const railsApp: JsonObject = {
+      build: { context: "..", dockerfile: ".devcontainer/Dockerfile" },
+      volumes: ["../..:/workspaces:cached"],
+      command: "sleep infinity",
+    };
+    if (deps.length > 0) railsApp.depends_on = deps;
+    const services: JsonObject = { "rails-app": railsApp };
+    if (systemTest)
+      services.selenium = { image: "selenium/standalone-chromium", restart: "unless-stopped" };
+    if (redis)
+      services.redis = {
+        image: "redis:7.2",
+        restart: "unless-stopped",
+        volumes: ["redis-data:/data"],
+      };
+    if (dbService) services[dbName] = dbService as unknown as JsonObject;
+    const yaml: JsonObject = { name: appName, services };
+    const volumes: JsonObject = {};
+    if (redis) volumes["redis-data"] = null;
+    if (this.database.volume) volumes[this.database.volume] = null;
+    if (Object.keys(volumes).length > 0) yaml.volumes = volumes;
+    return JSON.stringify(yaml, null, 2) + "\n";
+  }
+
+  private containerEnv(): Record<string, string> {
+    const env: Record<string, string> = {};
+    if (this.opts.systemTest) {
+      env.CAPYBARA_SERVER_PORT = "45678";
+      env.SELENIUM_HOST = "selenium";
+    }
+    if (this.opts.redis) env.REDIS_URL = "redis://redis:6379/1";
+    if (this.opts.kamal) env.KAMAL_REGISTRY_PASSWORD = "$KAMAL_REGISTRY_PASSWORD";
+    if (this.database.service) env.DB_HOST = this.database.name;
+    return env;
+  }
+
+  private features(): JsonObject {
+    const f: JsonObject = { "ghcr.io/devcontainers/features/github-cli:1": {} };
+    if (this.opts.activeStorage) f["ghcr.io/rails/devcontainer/features/activestorage"] = {};
+    if (this.opts.node) f["ghcr.io/devcontainers/features/node:1"] = {};
+    if (this.opts.kamal) f["ghcr.io/devcontainers/features/docker-outside-of-docker:1"] = {};
+    const dbf = this.database.feature;
+    const includeDb =
+      this.opts.database !== "sqlite3" || this.opts.sqliteDriver === "better-sqlite3";
+    if (dbf && includeDb) Object.assign(f, dbf);
+    return f;
+  }
+
+  private forwardPorts(): number[] {
+    const ports = [3000];
+    if (this.database.port) ports.push(this.database.port);
+    if (this.opts.redis) ports.push(6379);
+    return ports;
+  }
+
+  private systemTestConfiguration(): string {
+    return `  if (process.env.CAPYBARA_SERVER_PORT) {
+    servedBy({ host: "rails-app", port: process.env.CAPYBARA_SERVER_PORT });
+    drivenBy(":selenium", { using: ":headless_chrome", screenSize: [1400, 1400], options: { browser: ":remote", url: \`http://\${process.env.SELENIUM_HOST}:4444\` } });
+  } else {
+    drivenBy(":selenium", { using: ":headless_chrome", screenSize: [1400, 1400] });
+  }`;
+  }
+}

--- a/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.ts
+++ b/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.ts
@@ -1,10 +1,8 @@
 // Mirrors railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb.
 import { GeneratorBase, type GeneratorOptions } from "../../base.js";
 import { Database, DATABASES, type DatabaseName } from "../../database.js";
-
 export const TRAILS_DEV_PATH = "/workspaces/trails";
 export type SqliteDriver = "better-sqlite3" | "node-sqlite" | "expo-sqlite";
-
 export interface DevcontainerGeneratorOptions extends GeneratorOptions {
   appName?: string;
   database?: DatabaseName;
@@ -29,9 +27,8 @@ export class DevcontainerGenerator extends GeneratorBase {
   constructor(options: DevcontainerGeneratorOptions) {
     super(options);
     const database = options.database ?? "sqlite3";
-    if (!(DATABASES as readonly string[]).includes(database)) {
+    if (!(DATABASES as readonly string[]).includes(database))
       throw new Error(`Unknown database: ${database}`);
-    }
     this.opts = {
       appName: options.appName ?? "rails_app",
       database,
@@ -64,7 +61,7 @@ export class DevcontainerGenerator extends GeneratorBase {
       "src/config/database.ts",
       /host:\s*"localhost"/g,
       'host: process.env.DB_HOST ?? "localhost"',
-      this.opts.database === "postgresql",
+      this.opts.database !== "sqlite3",
     );
     return this.getCreatedFiles();
   }

--- a/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.ts
+++ b/packages/trailties/src/generators/rails/devcontainer/devcontainer-generator.ts
@@ -1,7 +1,4 @@
 // Mirrors railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb.
-// compose.yaml / devcontainer.json are emitted as JSON syntax (YAML 1.2
-// is a strict superset of JSON; Compose accepts it). Dockerfile is raw.
-
 import { GeneratorBase, type GeneratorOptions } from "../../base.js";
 import { Database, DATABASES, type DatabaseName } from "../../database.js";
 
@@ -52,7 +49,10 @@ export class DevcontainerGenerator extends GeneratorBase {
 
   run(): string[] {
     this.createFile(".devcontainer/devcontainer.json", this.devcontainerJson());
-    this.createFile(".devcontainer/Dockerfile", this.dockerfile());
+    this.createFile(
+      ".devcontainer/Dockerfile",
+      `ARG NODE_VERSION=${this.opts.nodeVersion}\nFROM mcr.microsoft.com/devcontainers/javascript-node:1-\${NODE_VERSION}\n`,
+    );
     this.createFile(".devcontainer/compose.yaml", this.composeYaml());
     this.gsubFile(
       "test/application_system_test_case.ts",
@@ -77,30 +77,41 @@ export class DevcontainerGenerator extends GeneratorBase {
   }
 
   private devcontainerJson(): string {
-    const { dev, appName } = this.opts;
-    const env = this.containerEnv();
+    const { appName, dev, systemTest, redis, activeStorage, node, kamal } = this.opts;
+    const features: JsonObject = { "ghcr.io/devcontainers/features/github-cli:1": {} };
+    if (activeStorage) features["ghcr.io/rails/devcontainer/features/activestorage"] = {};
+    if (node) features["ghcr.io/devcontainers/features/node:1"] = {};
+    if (kamal) features["ghcr.io/devcontainers/features/docker-outside-of-docker:1"] = {};
+    const includeDb =
+      this.opts.database !== "sqlite3" || this.opts.sqliteDriver === "better-sqlite3";
+    if (this.database.feature && includeDb) Object.assign(features, this.database.feature);
+
+    const env: Record<string, string> = {};
+    if (systemTest)
+      Object.assign(env, { CAPYBARA_SERVER_PORT: "45678", SELENIUM_HOST: "selenium" });
+    if (redis) env.REDIS_URL = "redis://redis:6379/1";
+    if (kamal) env.KAMAL_REGISTRY_PASSWORD = "$KAMAL_REGISTRY_PASSWORD";
+    if (this.database.service) env.DB_HOST = this.database.name;
+    const ports: number[] = [3000];
+    if (this.database.port) ports.push(this.database.port);
+    if (redis) ports.push(6379);
     const json: JsonObject = {
       name: appName,
       dockerComposeFile: "compose.yaml",
       service: "rails-app",
       workspaceFolder: "/workspaces/${localWorkspaceFolderBasename}",
-      features: this.features(),
+      features,
     };
     if (Object.keys(env).length > 0) json.containerEnv = env;
-    json.forwardPorts = this.forwardPorts();
+    json.forwardPorts = ports;
     if (dev) json.mounts = [{ type: "bind", source: TRAILS_DEV_PATH, target: TRAILS_DEV_PATH }];
     json.postCreateCommand = "bin/setup --skip-server";
     return JSON.stringify(json, null, 2) + "\n";
   }
 
-  private dockerfile(): string {
-    return `ARG NODE_VERSION=${this.opts.nodeVersion}\nFROM mcr.microsoft.com/devcontainers/javascript-node:1-\${NODE_VERSION}\n`;
-  }
-
   private composeYaml(): string {
     const { systemTest, redis, appName } = this.opts;
-    const dbName = this.database.name;
-    const dbService = this.database.service;
+    const { name: dbName, service: dbService, volume: dbVolume } = this.database;
     const deps: string[] = [];
     if (systemTest) deps.push("selenium");
     if (redis) deps.push("redis");
@@ -124,40 +135,9 @@ export class DevcontainerGenerator extends GeneratorBase {
     const yaml: JsonObject = { name: appName, services };
     const volumes: JsonObject = {};
     if (redis) volumes["redis-data"] = null;
-    if (this.database.volume) volumes[this.database.volume] = null;
+    if (dbVolume) volumes[dbVolume] = null;
     if (Object.keys(volumes).length > 0) yaml.volumes = volumes;
     return JSON.stringify(yaml, null, 2) + "\n";
-  }
-
-  private containerEnv(): Record<string, string> {
-    const env: Record<string, string> = {};
-    if (this.opts.systemTest) {
-      env.CAPYBARA_SERVER_PORT = "45678";
-      env.SELENIUM_HOST = "selenium";
-    }
-    if (this.opts.redis) env.REDIS_URL = "redis://redis:6379/1";
-    if (this.opts.kamal) env.KAMAL_REGISTRY_PASSWORD = "$KAMAL_REGISTRY_PASSWORD";
-    if (this.database.service) env.DB_HOST = this.database.name;
-    return env;
-  }
-
-  private features(): JsonObject {
-    const f: JsonObject = { "ghcr.io/devcontainers/features/github-cli:1": {} };
-    if (this.opts.activeStorage) f["ghcr.io/rails/devcontainer/features/activestorage"] = {};
-    if (this.opts.node) f["ghcr.io/devcontainers/features/node:1"] = {};
-    if (this.opts.kamal) f["ghcr.io/devcontainers/features/docker-outside-of-docker:1"] = {};
-    const dbf = this.database.feature;
-    const includeDb =
-      this.opts.database !== "sqlite3" || this.opts.sqliteDriver === "better-sqlite3";
-    if (dbf && includeDb) Object.assign(f, dbf);
-    return f;
-  }
-
-  private forwardPorts(): number[] {
-    const ports = [3000];
-    if (this.database.port) ports.push(this.database.port);
-    if (this.opts.redis) ports.push(6379);
-    return ports;
   }
 
   private systemTestConfiguration(): string {


### PR DESCRIPTION
## Summary

Ports `railties/lib/rails/generators/rails/devcontainer/devcontainer_generator.rb` onto the existing `Database` registry (#2176). Emits:

- `.devcontainer/devcontainer.json` — `JSON.stringify(..., null, 2)`
- `.devcontainer/compose.yaml` — `JSON.stringify(..., null, 2)` (YAML 1.2 is a strict superset of JSON; Compose accepts it; resolves the YAML carve-out from the prior PR 1.14c-3 scope per `docs/trailties-plan.md` PR T5)
- `.devcontainer/Dockerfile` — raw string (surface too small to justify the builder)

Plus `updateApplicationSystemTestCase` (replaces `drivenBy` line when `test/application_system_test_case.ts` exists) and `updateDatabaseConfig` — runs for any non-sqlite database, rewriting `host: "localhost"` in `src/config/database.ts` to `host: process.env.DB_HOST ?? "localhost"`. Rails sidesteps this by emitting full `database.yml` templates that already reference `ENV["DB_HOST"]`; trailties' `app-generator` hardcodes `host: "localhost"` for mysql/mariadb/postgres, so the rewrite must fire for all of them.

Options: `appName`, `database`, `redis`, `systemTest`, `activeStorage`, `node`, `dev`, `kamal`, `sqliteDriver`, `nodeVersion`.

## Test plan

- [x] 20 ported Rails tests pass — names match `DevcontainerGeneratorTest` verbatim for `test:compare`
- [x] LOC 300 (at ceiling)
- [x] prettier + eslint clean
- [x] typecheck passes (pre-commit hook ran build + typecheck)

## Notes / follow-ups

- `gsubFile` uses sync `readFileSync`/`writeFileSync` consistent with the existing `GeneratorBase` (`createFile` etc. are all sync). PR 1.12c-b is the planned async migration.
- `sqliteDriver` defaults to `better-sqlite3`; `node-sqlite` / `expo-sqlite` skip the SQLite devcontainer feature. App-base wiring for the flag itself is a follow-up.
- `--skip-solid` option intentionally omitted — the trailties Solid stack isn't yet ported.
- `db/system/change` generator (PR 1.14c-4) is blocked on this PR per plan.
- `mariadb-trilogy` / `trilogy` tests omitted — trailties doesn't port the Ruby-only Trilogy driver (already reflected in `DATABASES`).