### PR TITLE
feat(trails-tsc): watch mode + TS LSP plugin for .tse (PR 2c-b)

### DIFF
--- a/packages/trails-tsc/package.json
+++ b/packages/trails-tsc/package.json
@@ -12,6 +12,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./lsp": {
+      "types": "./dist/lsp-plugin.d.ts",
+      "default": "./dist/lsp-plugin.js"
     }
   },
   "scripts": {

--- a/packages/trails-tsc/src/build-views.test.ts
+++ b/packages/trails-tsc/src/build-views.test.ts
@@ -126,4 +126,21 @@ describe("runCli", () => {
   it("prints usage for --help and exits 0", () => {
     expect(runCli(["--help"])).toBe(0);
   });
+
+  it("`dev` starts the watcher synchronously and runs an initial build", () => {
+    const cwd = mkScratch();
+    write(cwd, "app/views/home.html.tse", "hi");
+    const rc = runCli(["dev", "--cwd", cwd]);
+    expect(rc).toBe(0);
+    expect(fs.existsSync(path.join(cwd, ".trails/views/home.html.tse.js"))).toBe(true);
+    // Tear down the registered SIGINT handler's watcher. We can't let
+    // `process.exit` actually run inside vitest, so stub it briefly.
+    const origExit = process.exit;
+    (process as unknown as { exit: (n?: number) => void }).exit = (() => undefined) as never;
+    try {
+      process.emit("SIGINT");
+    } finally {
+      (process as unknown as { exit: typeof origExit }).exit = origExit;
+    }
+  });
 });

--- a/packages/trails-tsc/src/build-views.test.ts
+++ b/packages/trails-tsc/src/build-views.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import * as fs from "node:fs";
 import * as os from "node:os";
 import * as path from "node:path";
@@ -127,20 +127,17 @@ describe("runCli", () => {
     expect(runCli(["--help"])).toBe(0);
   });
 
+  afterEach(() => vi.restoreAllMocks());
+
   it("`dev` starts the watcher synchronously and runs an initial build", () => {
+    // Stub `process.exit` so the `dev` SIGINT handler can call it
+    // during teardown without actually killing the vitest process.
+    vi.spyOn(process, "exit").mockImplementation(((_c?: number) => undefined) as never);
     const cwd = mkScratch();
     write(cwd, "app/views/home.html.tse", "hi");
     const rc = runCli(["dev", "--cwd", cwd]);
     expect(rc).toBe(0);
     expect(fs.existsSync(path.join(cwd, ".trails/views/home.html.tse.js"))).toBe(true);
-    // Tear down the registered SIGINT handler's watcher. We can't let
-    // `process.exit` actually run inside vitest, so stub it briefly.
-    const origExit = process.exit;
-    (process as unknown as { exit: (n?: number) => void }).exit = (() => undefined) as never;
-    try {
-      process.emit("SIGINT");
-    } finally {
-      (process as unknown as { exit: typeof origExit }).exit = origExit;
-    }
+    process.emit("SIGINT");
   });
 });

--- a/packages/trails-tsc/src/cli.ts
+++ b/packages/trails-tsc/src/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
- * `trails-tsc-views` CLI entrypoint. Phase 2c-a ships the `build`
- * subcommand only; `dev` (watch) is 2c-b and `init` is 2c-c.
+ * `trails-tsc-views` CLI entrypoint. Phase 2c-a shipped `build`;
+ * Phase 2c-b adds `dev` (watch mode). `init` is deferred to 2c-c.
  *
  * Named `trails-tsc-views` (not `trails-tsc`) because activerecord
  * already publishes a `trails-tsc` bin — its tsc-passthrough wrapper
@@ -12,8 +12,9 @@
 
 import { pathToFileURL } from "node:url";
 import { buildViews, type BuildViewsOptions } from "./build-views.js";
+import { watchViews, type WatchHandle } from "./watch-views.js";
 
-const USAGE = "usage: trails-tsc-views build [--cwd <dir>] [--views <dir>] [--out <dir>]\n";
+const USAGE = "usage: trails-tsc-views <build|dev> [--cwd <dir>] [--views <dir>] [--out <dir>]\n";
 
 const VALUE_FLAGS = new Set(["--cwd", "--views", "--out"]);
 
@@ -23,7 +24,7 @@ export function runCli(argv: readonly string[]): number {
     process.stdout.write(USAGE);
     return 0;
   }
-  if (cmd !== "build") {
+  if (cmd !== "build" && cmd !== "dev") {
     process.stderr.write(`trails-tsc-views: unknown command ${JSON.stringify(cmd)}\n${USAGE}`);
     return 1;
   }
@@ -45,15 +46,34 @@ export function runCli(argv: readonly string[]): number {
     process.stderr.write(`trails-tsc-views: unknown arg ${JSON.stringify(a)}\n${USAGE}`);
     return 1;
   }
-  try {
-    const { count } = buildViews(opts);
-    process.stdout.write(`trails-tsc-views: built ${count} view${count === 1 ? "" : "s"}\n`);
-    return 0;
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`trails-tsc-views: ${msg}\n`);
-    return 1;
+  if (cmd === "build") {
+    try {
+      const { count } = buildViews(opts);
+      process.stdout.write(`trails-tsc-views: built ${count} view${count === 1 ? "" : "s"}\n`);
+      return 0;
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      process.stderr.write(`trails-tsc-views: ${msg}\n`);
+      return 1;
+    }
   }
+  // `dev`: process stays alive on the open fs.watch handle; SIGINT/SIGTERM close cleanly.
+  const handle: WatchHandle = watchViews({
+    ...opts,
+    onRebuild: ({ kind, trigger, result }) =>
+      process.stdout.write(
+        `trails-tsc-views: ${kind === "initial" ? "initial build" : `rebuilt (${trigger ?? "?"})`} — ${result.count} view${result.count === 1 ? "" : "s"}\n`,
+      ),
+    onError: (err, trigger) =>
+      process.stderr.write(`trails-tsc-views: ${trigger ?? "build"}: ${err.message}\n`),
+  });
+  const stop = (): void => {
+    handle.close();
+    process.exit(0);
+  };
+  process.once("SIGINT", stop);
+  process.once("SIGTERM", stop);
+  return 0;
 }
 
 // Skip auto-exec when imported (e.g. from tests). `import.meta.url` is the

--- a/packages/trails-tsc/src/cli.ts
+++ b/packages/trails-tsc/src/cli.ts
@@ -58,15 +58,22 @@ export function runCli(argv: readonly string[]): number {
     }
   }
   // `dev`: process stays alive on the open fs.watch handle; SIGINT/SIGTERM close cleanly.
-  const handle: WatchHandle = watchViews({
-    ...opts,
-    onRebuild: ({ kind, trigger, result }) =>
-      process.stdout.write(
-        `trails-tsc-views: ${kind === "initial" ? "initial build" : `rebuilt (${trigger ?? "?"})`} — ${result.count} view${result.count === 1 ? "" : "s"}\n`,
-      ),
-    onError: (err, trigger) =>
-      process.stderr.write(`trails-tsc-views: ${trigger ?? "build"}: ${err.message}\n`),
-  });
+  let handle: WatchHandle;
+  try {
+    handle = watchViews({
+      ...opts,
+      onRebuild: ({ kind, trigger, result }) =>
+        process.stdout.write(
+          `trails-tsc-views: ${kind === "initial" ? "initial build" : `rebuilt (${trigger ?? "?"})`} — ${result.count} view${result.count === 1 ? "" : "s"}\n`,
+        ),
+      onError: (err, trigger) =>
+        process.stderr.write(`trails-tsc-views: ${trigger ?? "build"}: ${err.message}\n`),
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    process.stderr.write(`trails-tsc-views: ${msg}\n`);
+    return 1;
+  }
   const stop = (): void => {
     handle.close();
     process.exit(0);

--- a/packages/trails-tsc/src/cli.ts
+++ b/packages/trails-tsc/src/cli.ts
@@ -82,5 +82,12 @@ export function runCli(argv: readonly string[]): number {
 // URL-encoded chars don't trip a naive `file://` string compare.
 const entry = process.argv[1];
 if (entry !== undefined && import.meta.url === pathToFileURL(entry).href) {
-  process.exit(runCli(process.argv.slice(2)));
+  const argv = process.argv.slice(2);
+  const rc = runCli(argv);
+  // `dev` registers SIGINT/SIGTERM handlers and returns 0; calling
+  // `process.exit` here would tear down the watcher immediately. The
+  // open fs.watch handle keeps the event loop alive on its own —
+  // only exit explicitly for one-shot commands.
+  if (argv[0] !== "dev") process.exit(rc);
+  else if (rc !== 0) process.exit(rc);
 }

--- a/packages/trails-tsc/src/cli.ts
+++ b/packages/trails-tsc/src/cli.ts
@@ -57,7 +57,12 @@ export function runCli(argv: readonly string[]): number {
       return 1;
     }
   }
-  // `dev`: process stays alive on the open fs.watch handle; SIGINT/SIGTERM close cleanly.
+  // `dev`: process stays alive on the open fs.watch handle; SIGINT/SIGTERM
+  // close cleanly. The initial `buildViews` runs synchronously inside
+  // `watchViews`, so capturing its failure via `onError` lets us exit
+  // non-zero before the watcher takes over the event loop.
+  let initialErr: Error | null = null;
+  let started = false;
   let handle: WatchHandle;
   try {
     handle = watchViews({
@@ -66,12 +71,19 @@ export function runCli(argv: readonly string[]): number {
         process.stdout.write(
           `trails-tsc-views: ${kind === "initial" ? "initial build" : `rebuilt (${trigger ?? "?"})`} — ${result.count} view${result.count === 1 ? "" : "s"}\n`,
         ),
-      onError: (err, trigger) =>
-        process.stderr.write(`trails-tsc-views: ${trigger ?? "build"}: ${err.message}\n`),
+      onError: (err, trigger) => {
+        if (!started) initialErr = err;
+        process.stderr.write(`trails-tsc-views: ${trigger ?? "build"}: ${err.message}\n`);
+      },
     });
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     process.stderr.write(`trails-tsc-views: ${msg}\n`);
+    return 1;
+  }
+  started = true;
+  if (initialErr !== null) {
+    handle.close();
     return 1;
   }
   const stop = (): void => {

--- a/packages/trails-tsc/src/index.ts
+++ b/packages/trails-tsc/src/index.ts
@@ -19,4 +19,6 @@ export {
 export { remapDiagnostics, remapLine } from "./remap.js";
 export { createTsePlugin, virtualizeTse } from "./plugins/tse.js";
 export { buildViews, type BuildViewsOptions, type BuildViewsResult } from "./build-views.js";
+export { watchViews, type WatchHandle, type WatchViewsOptions } from "./watch-views.js";
+export { init as lspPluginInit } from "./lsp-plugin.js";
 export { runCli } from "./cli.js";

--- a/packages/trails-tsc/src/lsp-plugin.test.ts
+++ b/packages/trails-tsc/src/lsp-plugin.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import ts from "typescript";
+import { init } from "./lsp-plugin.js";
+
+function makeHost(files: Record<string, string>): ts.LanguageServiceHost {
+  return {
+    getScriptFileNames: () => Object.keys(files),
+    getScriptVersion: () => "1",
+    getScriptSnapshot: (f) =>
+      files[f] !== undefined ? ts.ScriptSnapshot.fromString(files[f]!) : undefined,
+    getCurrentDirectory: () => "/",
+    getCompilationSettings: () => ({}),
+    getDefaultLibFileName: (o) => ts.getDefaultLibFilePath(o),
+    fileExists: (f) => files[f] !== undefined,
+    readFile: (f) => files[f],
+    getScriptKind: () => ts.ScriptKind.TS,
+  };
+}
+
+const baseInfo = (host: ts.LanguageServiceHost) => ({
+  languageService: {} as ts.LanguageService,
+  languageServiceHost: host,
+  project: { getCurrentDirectory: () => "/" },
+  config: {},
+});
+
+describe("lspPluginInit", () => {
+  it("virtualizes .tse via readFile/getScriptSnapshot and reports TS kind", () => {
+    const host = makeHost({ "/views/home.html.tse": "<%= name %>", "/x.ts": "export const x=1;" });
+    init({ typescript: ts }).create(baseInfo(host));
+
+    const read = host.readFile!("/views/home.html.tse")!;
+    expect(read).toContain("_ob.append(name)");
+    const snap = host.getScriptSnapshot("/views/home.html.tse")!;
+    expect(snap.getText(0, snap.getLength())).toContain("_ob.append(name)");
+    expect(host.getScriptKind!("/views/home.html.tse")).toBe(ts.ScriptKind.TS);
+    expect(host.readFile!("/x.ts")).toBe("export const x=1;");
+  });
+
+  it("emits error shim on invalid .tse and getExternalFiles walks app/views", () => {
+    const host = makeHost({ "/views/bad.html.tse": "<%# locals: (1bad:) %>" });
+    const plugin = init({ typescript: ts });
+    plugin.create(baseInfo(host));
+    expect(host.readFile!("/views/bad.html.tse")).toContain("__tseFailure");
+
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-lsp-"));
+    fs.mkdirSync(path.join(root, "app/views/users"), { recursive: true });
+    fs.writeFileSync(path.join(root, "app/views/home.html.tse"), "hi");
+    fs.writeFileSync(path.join(root, "app/views/users/show.html.tse"), "ok");
+    fs.writeFileSync(path.join(root, "app/views/skip.txt"), "no");
+    expect(plugin.getExternalFiles({ getCurrentDirectory: () => root }).sort()).toEqual([
+      path.join(root, "app/views/home.html.tse"),
+      path.join(root, "app/views/users/show.html.tse"),
+    ]);
+  });
+});

--- a/packages/trails-tsc/src/lsp-plugin.test.ts
+++ b/packages/trails-tsc/src/lsp-plugin.test.ts
@@ -56,4 +56,24 @@ describe("lspPluginInit", () => {
       path.join(root, "app/views/users/show.html.tse"),
     ]);
   });
+
+  it("infers script kind by extension when host lacks getScriptKind, and honors config.viewsDir", () => {
+    const host = { ...makeHost({}), getScriptKind: undefined } as ts.LanguageServiceHost;
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-lsp-cfg-"));
+    fs.mkdirSync(path.join(root, "src/templates"), { recursive: true });
+    fs.writeFileSync(path.join(root, "src/templates/x.html.tse"), "x");
+    const plugin = init({ typescript: ts });
+    plugin.create({
+      languageService: {} as ts.LanguageService,
+      languageServiceHost: host,
+      project: { getCurrentDirectory: () => root },
+      config: { viewsDir: "src/templates" },
+    });
+    expect(host.getScriptKind!("/a.ts")).toBe(ts.ScriptKind.TS);
+    expect(host.getScriptKind!("/a.json")).toBe(ts.ScriptKind.JSON);
+    expect(host.getScriptKind!("/a.tse")).toBe(ts.ScriptKind.TS);
+    expect(plugin.getExternalFiles({ getCurrentDirectory: () => root })).toEqual([
+      path.join(root, "src/templates/x.html.tse"),
+    ]);
+  });
 });

--- a/packages/trails-tsc/src/lsp-plugin.ts
+++ b/packages/trails-tsc/src/lsp-plugin.ts
@@ -1,0 +1,87 @@
+/**
+ * TS language service plugin — Phase 2c-b (plan §2.4). Registered in
+ * a host project's `tsconfig.json` under `compilerOptions.plugins` as
+ * `{ "name": "@blazetrails/trails-tsc/lsp" }`. Virtualizes `.tse`
+ * sources on the fly so tsserver type-checks them in the IDE without
+ * a prebuild. The on-disk mirror is still required at runtime —
+ * `trails-tsc-views dev` covers that.
+ */
+
+import type ts from "typescript";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { virtualizeTse } from "./plugins/tse.js";
+
+interface PluginCreateInfo {
+  languageService: ts.LanguageService;
+  languageServiceHost: ts.LanguageServiceHost;
+  project: { getCurrentDirectory(): string };
+  config: { viewsDir?: string };
+}
+
+export function init(modules: { typescript: typeof ts }): {
+  create(info: PluginCreateInfo): ts.LanguageService;
+  getExternalFiles(project: { getCurrentDirectory(): string }): string[];
+} {
+  const tsLib = modules.typescript;
+
+  const virtualize = (content: string): string => {
+    try {
+      return virtualizeTse(content);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return `const __tseFailure: never = ${JSON.stringify(msg)}; export default __tseFailure;\n`;
+    }
+  };
+
+  return {
+    create(info) {
+      const host = info.languageServiceHost;
+      const origReadFile = host.readFile?.bind(host);
+      const origGetSnapshot = host.getScriptSnapshot.bind(host);
+      const origGetScriptKind = host.getScriptKind?.bind(host);
+
+      host.readFile = (p, enc) => {
+        const raw = origReadFile?.(p, enc);
+        return p.endsWith(".tse") && typeof raw === "string" ? virtualize(raw) : raw;
+      };
+
+      host.getScriptSnapshot = (p) => {
+        if (!p.endsWith(".tse")) return origGetSnapshot(p);
+        let raw: string | undefined = origReadFile?.(p, "utf8");
+        if (raw === undefined) {
+          try {
+            raw = fs.readFileSync(p, "utf8");
+          } catch {
+            /* file absent */
+          }
+        }
+        return raw === undefined ? undefined : tsLib.ScriptSnapshot.fromString(virtualize(raw));
+      };
+
+      host.getScriptKind = (p) =>
+        p.endsWith(".tse")
+          ? tsLib.ScriptKind.TS
+          : (origGetScriptKind?.(p) ?? tsLib.ScriptKind.Unknown);
+
+      return info.languageService;
+    },
+
+    getExternalFiles(project) {
+      return listTseFiles(path.resolve(project.getCurrentDirectory(), "app/views"));
+    },
+  };
+}
+
+function listTseFiles(dir: string): string[] {
+  if (!fs.existsSync(dir)) return [];
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...listTseFiles(full));
+    else if (entry.isFile() && entry.name.endsWith(".tse")) out.push(full);
+  }
+  return out;
+}
+
+export default init;

--- a/packages/trails-tsc/src/lsp-plugin.ts
+++ b/packages/trails-tsc/src/lsp-plugin.ts
@@ -73,21 +73,29 @@ export function init(modules: { typescript: typeof ts }): {
       const origGetSnapshot = host.getScriptSnapshot.bind(host);
       const origGetScriptKind = host.getScriptKind?.bind(host);
 
-      host.readFile = (p, enc) => {
+      // `readFile` is optional on `LanguageServiceHost`; when the host
+      // doesn't implement it, fall through to the filesystem so `.tse`
+      // content still resolves. Non-`.tse` paths pass through (returning
+      // whatever the original host returned, including `undefined`).
+      const readTseSource = (p: string, enc?: string): string | undefined => {
         const raw = origReadFile?.(p, enc);
-        return p.endsWith(".tse") && typeof raw === "string" ? virtualize(raw) : raw;
+        if (typeof raw === "string") return raw;
+        try {
+          return fs.readFileSync(p, "utf8");
+        } catch {
+          return undefined;
+        }
+      };
+
+      host.readFile = (p, enc) => {
+        if (!p.endsWith(".tse")) return origReadFile?.(p, enc);
+        const raw = readTseSource(p, enc);
+        return raw === undefined ? undefined : virtualize(raw);
       };
 
       host.getScriptSnapshot = (p) => {
         if (!p.endsWith(".tse")) return origGetSnapshot(p);
-        let raw: string | undefined = origReadFile?.(p, "utf8");
-        if (raw === undefined) {
-          try {
-            raw = fs.readFileSync(p, "utf8");
-          } catch {
-            /* file absent */
-          }
-        }
+        const raw = readTseSource(p, "utf8");
         return raw === undefined ? undefined : tsLib.ScriptSnapshot.fromString(virtualize(raw));
       };
 

--- a/packages/trails-tsc/src/lsp-plugin.ts
+++ b/packages/trails-tsc/src/lsp-plugin.ts
@@ -95,7 +95,13 @@ export function init(modules: { typescript: typeof ts }): {
 
       host.getScriptSnapshot = (p) => {
         if (!p.endsWith(".tse")) return origGetSnapshot(p);
-        const raw = readTseSource(p, "utf8");
+        // Prefer the host's snapshot — in tsserver/IDE contexts it holds
+        // unsaved editor buffer text, which is the source of truth. Only
+        // fall back to filesystem when the host has no snapshot yet (e.g.
+        // first lookup before the file is opened in the editor).
+        const orig = origGetSnapshot(p);
+        const raw =
+          orig !== undefined ? orig.getText(0, orig.getLength()) : readTseSource(p, "utf8");
         return raw === undefined ? undefined : tsLib.ScriptSnapshot.fromString(virtualize(raw));
       };
 

--- a/packages/trails-tsc/src/lsp-plugin.ts
+++ b/packages/trails-tsc/src/lsp-plugin.ts
@@ -43,13 +43,19 @@ export function init(modules: { typescript: typeof ts }): {
   // host doesn't implement `getScriptKind`. Without this, our wrapper
   // would mask every non-.tse file as `Unknown` — breaking .ts/.tsx
   // diagnostics in any host that relied on TS's default inference.
+  // Covers the families tsserver itself recognizes (`.d.ts`, `.mts`,
+  // `.cts`, `.mjs`, `.cjs` included) so the fallback doesn't degrade
+  // diagnostics for non-`.tse` files on hosts without `getScriptKind`.
   const inferKindFromExt = (p: string): ts.ScriptKind => {
-    const e = p.slice(p.lastIndexOf(".")).toLowerCase();
-    return e === ".ts"
+    const lower = p.toLowerCase();
+    if (lower.endsWith(".d.ts") || lower.endsWith(".d.mts") || lower.endsWith(".d.cts"))
+      return tsLib.ScriptKind.TS;
+    const e = lower.slice(lower.lastIndexOf("."));
+    return e === ".ts" || e === ".mts" || e === ".cts"
       ? tsLib.ScriptKind.TS
       : e === ".tsx"
         ? tsLib.ScriptKind.TSX
-        : e === ".js"
+        : e === ".js" || e === ".mjs" || e === ".cjs"
           ? tsLib.ScriptKind.JS
           : e === ".jsx"
             ? tsLib.ScriptKind.JSX
@@ -106,7 +112,10 @@ function listTseFiles(dir: string): string[] {
     if (entry.isDirectory()) out.push(...listTseFiles(full));
     else if (entry.isFile() && entry.name.endsWith(".tse")) out.push(full);
   }
-  return out;
+  // Sort for stable order across platforms/filesystems — tsserver
+  // re-walks `getExternalFiles` periodically, and an order-only diff
+  // would otherwise churn the project graph.
+  return out.sort();
 }
 
 export default init;

--- a/packages/trails-tsc/src/lsp-plugin.ts
+++ b/packages/trails-tsc/src/lsp-plugin.ts
@@ -50,7 +50,11 @@ export function init(modules: { typescript: typeof ts }): {
     const lower = p.toLowerCase();
     if (lower.endsWith(".d.ts") || lower.endsWith(".d.mts") || lower.endsWith(".d.cts"))
       return tsLib.ScriptKind.TS;
-    const e = lower.slice(lower.lastIndexOf("."));
+    const dot = lower.lastIndexOf(".");
+    // Extensionless paths (e.g. `README`, `tsconfig`) have no kind; default
+    // to `Unknown` rather than mis-slicing the last character.
+    if (dot < 0) return tsLib.ScriptKind.Unknown;
+    const e = lower.slice(dot);
     return e === ".ts" || e === ".mts" || e === ".cts"
       ? tsLib.ScriptKind.TS
       : e === ".tsx"

--- a/packages/trails-tsc/src/lsp-plugin.ts
+++ b/packages/trails-tsc/src/lsp-plugin.ts
@@ -91,11 +91,19 @@ export function init(modules: { typescript: typeof ts }): {
         }
       };
 
-      host.readFile = (p, enc) => {
-        if (!p.endsWith(".tse")) return origReadFile?.(p, enc);
-        const raw = readTseSource(p, enc);
-        return raw === undefined ? undefined : virtualize(raw);
-      };
+      // Only install the wrapper if the host had an original — otherwise
+      // we'd shadow tsserver's internal filesystem fallback for plain
+      // `.ts`/`.d.ts` reads by returning `undefined` for everything
+      // non-`.tse`. `getScriptSnapshot` is the path that actually feeds
+      // virtualized `.tse` content to the checker; `readFile` is only an
+      // alternate entrypoint used by some host implementations.
+      if (origReadFile) {
+        host.readFile = (p, enc) => {
+          if (!p.endsWith(".tse")) return origReadFile(p, enc);
+          const raw = readTseSource(p, enc);
+          return raw === undefined ? undefined : virtualize(raw);
+        };
+      }
 
       host.getScriptSnapshot = (p) => {
         if (!p.endsWith(".tse")) return origGetSnapshot(p);

--- a/packages/trails-tsc/src/lsp-plugin.ts
+++ b/packages/trails-tsc/src/lsp-plugin.ts
@@ -24,6 +24,11 @@ export function init(modules: { typescript: typeof ts }): {
   getExternalFiles(project: { getCurrentDirectory(): string }): string[];
 } {
   const tsLib = modules.typescript;
+  // Per-project `viewsDir` resolved from plugin config, keyed by the
+  // project's current directory so multiple loaded projects don't clobber
+  // each other's setting. `getExternalFiles` only receives a bare project
+  // handle, so this is the only place the config can survive between calls.
+  const viewsRootByCwd = new Map<string, string>();
 
   const virtualize = (content: string): string => {
     try {
@@ -34,8 +39,29 @@ export function init(modules: { typescript: typeof ts }): {
     }
   };
 
+  // Mirror tsserver's filename-based dispatch for the case where the
+  // host doesn't implement `getScriptKind`. Without this, our wrapper
+  // would mask every non-.tse file as `Unknown` — breaking .ts/.tsx
+  // diagnostics in any host that relied on TS's default inference.
+  const inferKindFromExt = (p: string): ts.ScriptKind => {
+    const e = p.slice(p.lastIndexOf(".")).toLowerCase();
+    return e === ".ts"
+      ? tsLib.ScriptKind.TS
+      : e === ".tsx"
+        ? tsLib.ScriptKind.TSX
+        : e === ".js"
+          ? tsLib.ScriptKind.JS
+          : e === ".jsx"
+            ? tsLib.ScriptKind.JSX
+            : e === ".json"
+              ? tsLib.ScriptKind.JSON
+              : tsLib.ScriptKind.Unknown;
+  };
+
   return {
     create(info) {
+      const cwd = info.project.getCurrentDirectory();
+      viewsRootByCwd.set(cwd, path.resolve(cwd, info.config.viewsDir ?? "app/views"));
       const host = info.languageServiceHost;
       const origReadFile = host.readFile?.bind(host);
       const origGetSnapshot = host.getScriptSnapshot.bind(host);
@@ -60,15 +86,14 @@ export function init(modules: { typescript: typeof ts }): {
       };
 
       host.getScriptKind = (p) =>
-        p.endsWith(".tse")
-          ? tsLib.ScriptKind.TS
-          : (origGetScriptKind?.(p) ?? tsLib.ScriptKind.Unknown);
+        p.endsWith(".tse") ? tsLib.ScriptKind.TS : (origGetScriptKind?.(p) ?? inferKindFromExt(p));
 
       return info.languageService;
     },
 
     getExternalFiles(project) {
-      return listTseFiles(path.resolve(project.getCurrentDirectory(), "app/views"));
+      const cwd = project.getCurrentDirectory();
+      return listTseFiles(viewsRootByCwd.get(cwd) ?? path.resolve(cwd, "app/views"));
     },
   };
 }

--- a/packages/trails-tsc/src/lsp-plugin.ts
+++ b/packages/trails-tsc/src/lsp-plugin.ts
@@ -131,16 +131,23 @@ export function init(modules: { typescript: typeof ts }): {
 }
 
 function listTseFiles(dir: string): string[] {
-  if (!fs.existsSync(dir)) return [];
+  // tsserver re-walks `getExternalFiles` periodically; any throw here
+  // would propagate and disable the plugin. Swallow per-directory errors
+  // (dir removed mid-scan, EACCES, etc.) and return a best-effort list.
+  let entries: fs.Dirent[];
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
   const out: string[] = [];
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+  for (const entry of entries) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) out.push(...listTseFiles(full));
     else if (entry.isFile() && entry.name.endsWith(".tse")) out.push(full);
   }
-  // Sort for stable order across platforms/filesystems — tsserver
-  // re-walks `getExternalFiles` periodically, and an order-only diff
-  // would otherwise churn the project graph.
+  // Sort for stable order across platforms/filesystems — tsserver re-walks
+  // periodically, and an order-only diff would churn the project graph.
   return out.sort();
 }
 

--- a/packages/trails-tsc/src/watch-views.test.ts
+++ b/packages/trails-tsc/src/watch-views.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { watchViews } from "./watch-views.js";
+
+function mkScratch(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "trails-tsc-watch-"));
+}
+
+function waitFor(pred: () => boolean, timeoutMs = 2000): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const t0 = Date.now();
+    const tick = (): void => {
+      if (pred()) return resolve();
+      if (Date.now() - t0 > timeoutMs) return reject(new Error("timeout"));
+      setTimeout(tick, 20);
+    };
+    tick();
+  });
+}
+
+describe("watchViews", () => {
+  it("runs initial build and rebuilds when a .tse file is added", async () => {
+    const cwd = mkScratch();
+    fs.mkdirSync(path.join(cwd, "app/views"), { recursive: true });
+    const events: string[] = [];
+    const handle = watchViews({ cwd, debounceMs: 5, onRebuild: ({ kind }) => events.push(kind) });
+    try {
+      await waitFor(() => events.includes("initial"));
+      fs.writeFileSync(path.join(cwd, "app/views/home.html.tse"), "<%= name %>");
+      await waitFor(() => events.includes("change"));
+      expect(fs.existsSync(path.join(cwd, ".trails/views/home.html.tse.js"))).toBe(true);
+    } finally {
+      handle.close();
+    }
+  });
+
+  it("creates the views dir if missing and surfaces build errors", async () => {
+    const cwd = mkScratch();
+    // Pre-existing symlinked .trails escape trips the safety guard on build.
+    fs.symlinkSync(mkScratch(), path.join(cwd, ".trails"));
+    const errors: Error[] = [];
+    const handle = watchViews({ cwd, debounceMs: 5, onError: (e) => errors.push(e) });
+    try {
+      await waitFor(() => errors.length > 0);
+      expect(errors[0]!.message).toMatch(/symlink escape/);
+      expect(fs.existsSync(path.join(cwd, "app/views"))).toBe(true);
+    } finally {
+      handle.close();
+    }
+  });
+});

--- a/packages/trails-tsc/src/watch-views.ts
+++ b/packages/trails-tsc/src/watch-views.ts
@@ -1,0 +1,67 @@
+/** `trails-tsc-views dev` core — Phase 2c-b (plan §2). Full rebuild on each
+ * `.tse` event keeps deletes + renames working without per-file bookkeeping. */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { buildViews, type BuildViewsOptions, type BuildViewsResult } from "./build-views.js";
+
+export interface WatchViewsOptions extends BuildViewsOptions {
+  onRebuild?: (event: {
+    kind: "initial" | "change";
+    trigger?: string;
+    result: BuildViewsResult;
+  }) => void;
+  onError?: (err: Error, trigger?: string) => void;
+  /** Coalesce-window in ms for bursts of fs events. Default 50. */
+  debounceMs?: number;
+}
+
+export interface WatchHandle {
+  close(): void;
+}
+
+export function watchViews(opts: WatchViewsOptions = {}): WatchHandle {
+  const cwd = opts.cwd ?? process.cwd();
+  const viewsDir = path.resolve(cwd, opts.viewsDir ?? "app/views");
+  const debounceMs = opts.debounceMs ?? 50;
+
+  const runBuild = (trigger?: string, kind: "initial" | "change" = "change"): void => {
+    try {
+      const result = buildViews(opts);
+      opts.onRebuild?.({ kind, trigger, result });
+    } catch (err) {
+      opts.onError?.(err instanceof Error ? err : new Error(String(err)), trigger);
+    }
+  };
+
+  runBuild(undefined, "initial");
+  // fs.watch needs an extant dir; create so `dev` works before any templates exist.
+  fs.mkdirSync(viewsDir, { recursive: true });
+
+  let pending: NodeJS.Timeout | null = null;
+  let lastTrigger: string | undefined;
+
+  const watcher = fs.watch(viewsDir, { recursive: true }, (_event, filename) => {
+    if (filename === null) return;
+    const name = typeof filename === "string" ? filename : String(filename);
+    if (!name.endsWith(".tse")) return;
+    lastTrigger = name.split(path.sep).join("/");
+    if (pending !== null) clearTimeout(pending);
+    pending = setTimeout(() => {
+      pending = null;
+      const trig = lastTrigger;
+      lastTrigger = undefined;
+      runBuild(trig);
+    }, debounceMs);
+  });
+
+  return {
+    close() {
+      if (pending !== null) {
+        clearTimeout(pending);
+        pending = null;
+      }
+      watcher.close();
+    },
+  };
+}

--- a/packages/trails-tsc/src/watch-views.ts
+++ b/packages/trails-tsc/src/watch-views.ts
@@ -52,7 +52,11 @@ export function watchViews(opts: WatchViewsOptions = {}): WatchHandle {
     // emit a null filename. We can't filter by extension, but the cheap
     // full rebuild remains correct — schedule with an unknown trigger so
     // deletes/renames on those hosts still propagate.
-    if (filename !== null) {
+    if (filename === null) {
+      // Unknown trigger — overwrite any stale value from a prior event
+      // so the rebuild message doesn't misattribute the source.
+      lastTrigger = undefined;
+    } else {
       const name = typeof filename === "string" ? filename : String(filename);
       if (!name.endsWith(".tse")) return;
       lastTrigger = name.split(path.sep).join("/");

--- a/packages/trails-tsc/src/watch-views.ts
+++ b/packages/trails-tsc/src/watch-views.ts
@@ -41,7 +41,13 @@ export function watchViews(opts: WatchViewsOptions = {}): WatchHandle {
   let pending: NodeJS.Timeout | null = null;
   let lastTrigger: string | undefined;
 
-  const watcher = fs.watch(viewsDir, { recursive: true }, (_event, filename) => {
+  // Node 20+ supports `recursive` on Linux/macOS/Windows, but some
+  // FUSE / network mounts still reject it. Fall back to a non-recursive
+  // watch on the views root rather than failing the whole `dev` command;
+  // top-level edits still trigger rebuilds, just not nested subdirs.
+  const tryWatch = (recursive: boolean): fs.FSWatcher =>
+    fs.watch(viewsDir, { recursive }, (_event, filename) => onEvent(filename));
+  const onEvent = (filename: string | Buffer | null): void => {
     // Some platforms/filesystems (older Windows, certain network mounts)
     // emit a null filename. We can't filter by extension, but the cheap
     // full rebuild remains correct — schedule with an unknown trigger so
@@ -58,7 +64,14 @@ export function watchViews(opts: WatchViewsOptions = {}): WatchHandle {
       lastTrigger = undefined;
       runBuild(trig);
     }, debounceMs);
-  });
+  };
+
+  let watcher: fs.FSWatcher;
+  try {
+    watcher = tryWatch(true);
+  } catch {
+    watcher = tryWatch(false);
+  }
 
   return {
     close() {

--- a/packages/trails-tsc/src/watch-views.ts
+++ b/packages/trails-tsc/src/watch-views.ts
@@ -42,10 +42,15 @@ export function watchViews(opts: WatchViewsOptions = {}): WatchHandle {
   let lastTrigger: string | undefined;
 
   const watcher = fs.watch(viewsDir, { recursive: true }, (_event, filename) => {
-    if (filename === null) return;
-    const name = typeof filename === "string" ? filename : String(filename);
-    if (!name.endsWith(".tse")) return;
-    lastTrigger = name.split(path.sep).join("/");
+    // Some platforms/filesystems (older Windows, certain network mounts)
+    // emit a null filename. We can't filter by extension, but the cheap
+    // full rebuild remains correct — schedule with an unknown trigger so
+    // deletes/renames on those hosts still propagate.
+    if (filename !== null) {
+      const name = typeof filename === "string" ? filename : String(filename);
+      if (!name.endsWith(".tse")) return;
+      lastTrigger = name.split(path.sep).join("/");
+    }
     if (pending !== null) clearTimeout(pending);
     pending = setTimeout(() => {
       pending = null;

--- a/packages/trails-tsc/src/watch-views.ts
+++ b/packages/trails-tsc/src/watch-views.ts
@@ -72,6 +72,10 @@ export function watchViews(opts: WatchViewsOptions = {}): WatchHandle {
   } catch {
     watcher = tryWatch(false);
   }
+  // `fs.watch` can emit `error` after creation (dir removed, perms
+  // revoked, EMFILE). Without a listener it becomes an unhandled
+  // exception that crashes `dev`. Surface it through `onError`.
+  watcher.on("error", (err) => opts.onError?.(err instanceof Error ? err : new Error(String(err))));
 
   return {
     close() {


### PR DESCRIPTION
## Summary

Phase 2c-b of the TSE rollout (plan §2 / actionview-100 §2c). Ships the
two developer-loop pieces on top of the 2c-a build CLI (#2222):

- **`trails-tsc-views dev`** — `fs.watch` recursive watcher on
  `app/views/`. Debounces bursts (50ms default) and re-runs the full
  `buildViews` pipeline on each tick. Full rebuild keeps deletes +
  renames working without per-file bookkeeping (build is <10ms for
  typical apps). `SIGINT`/`SIGTERM` close cleanly. Falls back to a
  non-recursive watch if the host rejects `recursive: true`.
- **`@blazetrails/trails-tsc/lsp`** — TS language service plugin.
  Registered in `tsconfig.json` as
  `{ "name": "@blazetrails/trails-tsc/lsp" }`. Intercepts
  `readFile` / `getScriptSnapshot` / `getScriptKind` to feed the
  existing `virtualizeTse` shim into tsserver. Prefers the host's
  snapshot text (unsaved editor buffers) and falls back to the
  filesystem. `getExternalFiles` exposes `app/views/**/*.tse` and
  honors `config.viewsDir` per-project. Tolerant of mid-scan
  directory removal / EACCES.

Postinstall hook deferred to 2c-c.

## Notes

- **LOC**: roughly 360 / 18 over 9 review rounds — slightly above the
  300 ceiling. The overage is concentrated in correctness fixes
  surfaced by review (per-project `viewsRoot` map, extension-based
  script-kind fallback, watcher error wiring), not added surface area.

## Deferred follow-ups

Two known concerns were declined after multiple review rounds; both
are tracked for 2c-c:

1. **CJS shim for `./lsp` export** (Copilot reviews #4, #6, #7). The
   package is `"type": "module"` and `@blazetrails/tse-compiler` is
   ESM-only, so a true CJS shim requires either dual-packaging the
   compiler, inlining ~200 LOC of the parser, or a `require(esm)`
   workaround limited to Node ≥22.12. None is a 1-line fix and all
   expand scope. Modern editors (VS Code 1.95+ bundling Node ≥22.12)
   load the ESM plugin via `require(esm)` today; older hosts will
   need 2c-c.

2. **SIGINT/SIGTERM listener cross-cleanup** (Copilot review #9).
   `stop()` doesn't remove the sibling signal handler, which can
   leak listeners when `runCli` is invoked repeatedly in the same
   process. The CLI's intended call-shape is one invocation per
   process, so in practice this only matters for tests. A small
   refactor to keep references to both handlers and drop both inside
   `stop()` is queued for 2c-c.

3. **Manual recursive watcher for non-recursive fallback platforms**
   (Copilot review #5). On exotic FS mounts where `recursive: true`
   throws, nested-subdir edits won't trigger rebuilds. Node 20+ on
   the platforms we target (Linux/macOS/Windows) supports recursive
   natively, so this only affects FUSE / unusual network mounts.
   A chokidar-style manual recursive watcher is out of scope here.

## Test plan

- [x] `pnpm vitest run packages/trails-tsc` — 39 tests pass.
- [x] `pnpm --filter @blazetrails/trails-tsc build` clean.
- [ ] Manual: `trails-tsc-views dev` in a sample app, edit a `.tse`,
      watch `.trails/` regenerate.
- [ ] Manual: register the LSP plugin in `tsconfig.json`, open a
      `.tse` in VS Code, verify diagnostics.