### PR TITLE
feat(trailties): helper + scaffold_controller generators on builder (PR 1.14b-cont)

### DIFF
--- a/packages/trailties/src/generators/rails/helper/helper-generator.test.ts
+++ b/packages/trailties/src/generators/rails/helper/helper-generator.test.ts
@@ -42,6 +42,14 @@ describe("HelperGeneratorTest", () => {
     );
   });
 
+  it("strips a trailing dashed helper suffix", () => {
+    makeGen().run("account-helper");
+    expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/account-helper.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/account-helper-helper.ts"))).toBe(
+      false,
+    );
+  });
+
   it("nested namespace", () => {
     makeGen().run("admin/account");
     const c = fs.readFileSync(

--- a/packages/trailties/src/generators/rails/helper/helper-generator.test.ts
+++ b/packages/trailties/src/generators/rails/helper/helper-generator.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { HelperGenerator, helperPaths } from "./helper-generator.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-helper-"));
+  fs.writeFileSync(path.join(tmpDir, "tsconfig.json"), "{}");
+});
+
+afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+function makeGen(cwd = tmpDir) {
+  return new HelperGenerator({ cwd, output: () => {} });
+}
+
+describe("HelperGeneratorTest", () => {
+  it("helper", () => {
+    makeGen().run("Account");
+    const c = fs.readFileSync(path.join(tmpDir, "src/app/helpers/account-helper.ts"), "utf-8");
+    expect(c).toContain("AccountHelper");
+  });
+
+  it("invokes default test framework", () => {
+    makeGen().run("Account");
+    expect(fs.existsSync(path.join(tmpDir, "test/helpers/account-helper.test.ts"))).toBe(true);
+  });
+
+  it("does not invoke test framework if required", () => {
+    makeGen().run("Account", { test: false });
+    expect(fs.existsSync(path.join(tmpDir, "test/helpers/account-helper.test.ts"))).toBe(false);
+  });
+
+  it("strips a trailing helper suffix", () => {
+    makeGen().run("account_helper");
+    expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/account-helper.ts"))).toBe(true);
+    expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/account-helper-helper.ts"))).toBe(
+      false,
+    );
+  });
+
+  it("nested namespace", () => {
+    makeGen().run("admin/account");
+    const c = fs.readFileSync(
+      path.join(tmpDir, "src/app/helpers/admin/account-helper.ts"),
+      "utf-8",
+    );
+    expect(c).toContain("AdminAccountHelper");
+  });
+
+  it("generates .js helper for JS projects", () => {
+    const jsDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-helper-js-"));
+    try {
+      const files = new HelperGenerator({ cwd: jsDir, output: () => {} }).run("Posts");
+      expect(files).toContain("src/app/helpers/posts-helper.js");
+      expect(files).toContain("test/helpers/posts-helper.test.js");
+    } finally {
+      fs.rmSync(jsDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("helperPaths", () => {
+  it("derives canonical names", () => {
+    expect(helperPaths("Account")).toMatchObject({
+      helperName: "AccountHelper",
+      helperFile: "account-helper",
+    });
+    expect(helperPaths("admin/account").helperName).toBe("AdminAccountHelper");
+    expect(helperPaths("account_helper").helperFile).toBe("account-helper");
+  });
+});

--- a/packages/trailties/src/generators/rails/helper/helper-generator.ts
+++ b/packages/trailties/src/generators/rails/helper/helper-generator.ts
@@ -52,7 +52,7 @@ export interface HelperPaths {
 }
 
 export function helperPaths(name: string): HelperPaths {
-  const stripped = name.replace(/_?helper$/i, "");
+  const stripped = name.replace(/[_-]?helper$/i, "");
   const parts = stripped.split("/");
   const leaf = parts[parts.length - 1]!;
   const helperName =

--- a/packages/trailties/src/generators/rails/helper/helper-generator.ts
+++ b/packages/trailties/src/generators/rails/helper/helper-generator.ts
@@ -1,0 +1,67 @@
+import {
+  GeneratorBase,
+  type GeneratorOptions,
+  classify,
+  dasherize,
+  underscore,
+} from "../../base.js";
+
+export interface HelperRunOptions {
+  test?: boolean;
+}
+
+// Mirrors railties/lib/rails/generators/rails/helper/helper_generator.rb.
+export class HelperGenerator extends GeneratorBase {
+  constructor(options: GeneratorOptions) {
+    super(options);
+  }
+
+  run(name: string, options: HelperRunOptions = {}): string[] {
+    const { test = true } = options;
+    const ext = this.ext();
+    const paths = helperPaths(name);
+
+    this.createFile(
+      `src/app/helpers/${paths.helperFile}${ext}`,
+      `export const ${paths.helperName} = {\n};\n`,
+    );
+
+    if (test) {
+      const importPrefix = "../".repeat(paths.namespaceParts.length + 1);
+      this.createFile(
+        `test/helpers/${paths.helperFile}.test${ext}`,
+        `import { describe, it } from "vitest";
+import { ${paths.helperName} } from "${importPrefix}src/app/helpers/${paths.helperFile}.js";
+
+describe("${paths.helperName}", () => {
+  it("is defined", () => {
+    void ${paths.helperName};
+  });
+});
+`,
+      );
+    }
+    return this.getCreatedFiles();
+  }
+}
+
+export interface HelperPaths {
+  helperName: string;
+  helperFile: string;
+  namespaceParts: string[];
+}
+
+export function helperPaths(name: string): HelperPaths {
+  const stripped = name.replace(/_?helper$/i, "");
+  const parts = stripped.split("/");
+  const leaf = parts[parts.length - 1]!;
+  const helperName =
+    parts.length > 1
+      ? parts.map((p) => classify(p)).join("") + "Helper"
+      : classify(leaf) + "Helper";
+  const helperFile =
+    parts.length > 1
+      ? parts.map((p) => dasherize(underscore(p))).join("/") + "-helper"
+      : dasherize(underscore(leaf)) + "-helper";
+  return { helperName, helperFile, namespaceParts: parts };
+}

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
@@ -124,6 +124,16 @@ describe("ScaffoldControllerGeneratorTest", () => {
     expect(c).toContain('this.params.expect({ account: ["name"] })');
     expect(parseTs(c).diagnostics).toEqual([]);
     expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/admin/accounts-helper.ts"))).toBe(true);
-    expect(read("src/config/routes.ts")).toContain('router.resources("admin/accounts")');
+    const routes = read("src/config/routes.ts");
+    expect(routes).toContain('router.namespace("admin"');
+    expect(routes).toContain('router.resources("accounts")');
+    expect(routes).not.toContain('router.resources("admin/accounts")');
+  });
+
+  it("strips dashed controller suffix", () => {
+    makeGen().run("posts-controller");
+    const c = read("src/app/controllers/posts-controller.ts");
+    expect(c).toContain("class PostsController");
+    expect(c).not.toContain("PostsControllerController");
   });
 });

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
@@ -3,6 +3,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { ScaffoldControllerGenerator } from "./scaffold-controller-generator.js";
+import { parseTs, assertNoRubySource } from "../../../template-builder/testing.js";
 
 let tmpDir: string;
 
@@ -75,6 +76,26 @@ describe("ScaffoldControllerGeneratorTest", () => {
   it("skip routes", () => {
     makeGen().run("User", [], { skipRoutes: true });
     expect(read("src/config/routes.ts")).not.toContain('router.resources("users")');
+  });
+
+  it("permits the parameters passed", () => {
+    makeGen().run("User", ["name:string", "age:integer"]);
+    const c = read("src/app/controllers/users-controller.ts");
+    expect(c).toContain('this.params.expect("user", ["name", "age"])');
+    expect(c).toContain("userParams()");
+  });
+
+  it("with no attributes falls back to params.fetch", () => {
+    makeGen().run("User");
+    const c = read("src/app/controllers/users-controller.ts");
+    expect(c).toContain('this.params.fetch("user", {})');
+  });
+
+  it("emits valid TypeScript with no Ruby leakage", () => {
+    makeGen().run("User", ["name:string", "age:integer"]);
+    const c = read("src/app/controllers/users-controller.ts");
+    expect(parseTs(c).diagnostics).toEqual([]);
+    assertNoRubySource(c);
   });
 
   it("api controller", () => {

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
@@ -130,6 +130,23 @@ describe("ScaffoldControllerGeneratorTest", () => {
     expect(routes).not.toContain('router.resources("admin/accounts")');
   });
 
+  it("singularizes plural input for model + params key", () => {
+    makeGen().run("posts", ["title:string"]);
+    const c = read("src/app/controllers/posts-controller.ts");
+    expect(c).toContain("class PostsController");
+    expect(c).toContain("Post.all()");
+    expect(c).toContain('this.params.expect({ post: ["title"] })');
+    expect(c).toContain("postParams()");
+  });
+
+  it("uses underscored namespace in routes (not dasherized)", () => {
+    makeGen().run("admin_panel/users");
+    const routes = read("src/config/routes.ts");
+    expect(routes).toContain('router.namespace("admin_panel"');
+    expect(routes).not.toContain('router.namespace("admin-panel"');
+    expect(routes.match(/\n\n\n/)).toBeNull();
+  });
+
   it("strips dashed controller suffix", () => {
     makeGen().run("posts-controller");
     const c = read("src/app/controllers/posts-controller.ts");

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
@@ -104,6 +104,9 @@ describe("ScaffoldControllerGeneratorTest", () => {
     expect(c).toContain("renderJson");
     expect(c).not.toContain("async new_()");
     expect(c).not.toContain("async edit()");
+    expect(c).toContain('this.params.expect("user", ["name"])');
+    expect(parseTs(c).diagnostics).toEqual([]);
+    assertNoRubySource(c);
     expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/users-helper.ts"))).toBe(false);
   });
 });

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { ScaffoldControllerGenerator } from "./scaffold-controller-generator.js";
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sc-"));
+  fs.writeFileSync(path.join(tmpDir, "tsconfig.json"), "{}");
+  fs.mkdirSync(path.join(tmpDir, "src/config"), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, "src/config/routes.ts"), "// routes\n");
+});
+
+afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+function makeGen() {
+  return new ScaffoldControllerGenerator({ cwd: tmpDir, output: () => {} });
+}
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(tmpDir, rel), "utf-8");
+}
+
+describe("ScaffoldControllerGeneratorTest", () => {
+  it("controller content", () => {
+    makeGen().run("User", ["name:string", "age:integer"]);
+    const c = read("src/app/controllers/users-controller.ts");
+    expect(c).toContain("class UsersController extends ActionController.Base");
+    for (const action of ["index", "show", "new_", "create", "edit", "update", "destroy"]) {
+      expect(c).toContain(`async ${action}()`);
+    }
+  });
+
+  it("don't use require", () => {
+    makeGen().run("User");
+    expect(read("src/app/controllers/users-controller.ts")).not.toMatch(/\brequire\(/);
+  });
+
+  it("check class collision", () => {
+    makeGen().run("user_controller");
+    expect(fs.existsSync(path.join(tmpDir, "src/app/controllers/users-controller.ts"))).toBe(true);
+  });
+
+  it("invokes default test framework", () => {
+    makeGen().run("User");
+    expect(fs.existsSync(path.join(tmpDir, "test/controllers/users-controller.test.ts"))).toBe(
+      true,
+    );
+  });
+
+  it("does not invoke test framework if required", () => {
+    makeGen().run("User", [], { test: false });
+    expect(fs.existsSync(path.join(tmpDir, "test/controllers/users-controller.test.ts"))).toBe(
+      false,
+    );
+  });
+
+  it("invokes helper", () => {
+    makeGen().run("User");
+    expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/users-helper.ts"))).toBe(true);
+  });
+
+  it("does not invoke helper if required", () => {
+    makeGen().run("User", [], { helper: false });
+    expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/users-helper.ts"))).toBe(false);
+  });
+
+  it("add routes", () => {
+    makeGen().run("User");
+    expect(read("src/config/routes.ts")).toContain('router.resources("users")');
+  });
+
+  it("skip routes", () => {
+    makeGen().run("User", [], { skipRoutes: true });
+    expect(read("src/config/routes.ts")).not.toContain('router.resources("users")');
+  });
+
+  it("api controller", () => {
+    makeGen().run("User", ["name:string"], { api: true });
+    const c = read("src/app/controllers/users-controller.ts");
+    expect(c).toContain("renderJson");
+    expect(c).not.toContain("async new_()");
+    expect(c).not.toContain("async edit()");
+    expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/users-helper.ts"))).toBe(false);
+  });
+});

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.test.ts
@@ -81,7 +81,7 @@ describe("ScaffoldControllerGeneratorTest", () => {
   it("permits the parameters passed", () => {
     makeGen().run("User", ["name:string", "age:integer"]);
     const c = read("src/app/controllers/users-controller.ts");
-    expect(c).toContain('this.params.expect("user", ["name", "age"])');
+    expect(c).toContain('this.params.expect({ user: ["name", "age"] })');
     expect(c).toContain("userParams()");
   });
 
@@ -104,9 +104,26 @@ describe("ScaffoldControllerGeneratorTest", () => {
     expect(c).toContain("renderJson");
     expect(c).not.toContain("async new_()");
     expect(c).not.toContain("async edit()");
-    expect(c).toContain('this.params.expect("user", ["name"])');
+    expect(c).toContain('this.params.expect({ user: ["name"] })');
     expect(parseTs(c).diagnostics).toEqual([]);
     assertNoRubySource(c);
     expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/users-helper.ts"))).toBe(false);
+  });
+
+  it("generated test file parses as valid TypeScript", () => {
+    makeGen().run("User");
+    const t = read("test/controllers/users-controller.test.ts");
+    expect(parseTs(t).diagnostics).toEqual([]);
+  });
+
+  it("namespaced scaffold controller emits flattened class name and nested paths", () => {
+    makeGen().run("admin/account", ["name:string"]);
+    const c = read("src/app/controllers/admin/accounts-controller.ts");
+    expect(c).toContain("class AdminAccountsController");
+    expect(c).not.toMatch(/::/);
+    expect(c).toContain('this.params.expect({ account: ["name"] })');
+    expect(parseTs(c).diagnostics).toEqual([]);
+    expect(fs.existsSync(path.join(tmpDir, "src/app/helpers/admin/accounts-helper.ts"))).toBe(true);
+    expect(read("src/config/routes.ts")).toContain('router.resources("admin/accounts")');
   });
 });

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
@@ -118,7 +118,7 @@ function paramsMethod(singular: string, attrs: string[], ts: boolean): Method {
   return tsMethod({
     name: `${singular}Params`,
     params: [],
-    returnType: ts ? "Record<string, unknown>" : undefined,
+    returnType: ts ? "unknown" : undefined,
     body: tsBody`${list}`,
   });
 }
@@ -146,7 +146,7 @@ function crudMethods(
     mk("new_", `this.render({ action: "new", locals: { ${singular}: {} } });`, ts),
     mk(
       "create",
-      `// const ${singular} = await ${model}.create(${params});\nvoid ${params};\nthis.redirectTo("/${plural}");`,
+      `// const ${singular} = await ${model}.create(${params});\nthis.redirectTo("/${plural}");`,
       ts,
     ),
     mk(
@@ -156,7 +156,7 @@ function crudMethods(
     ),
     mk(
       "update",
-      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(${params});\nvoid ${params};\nthis.redirectTo("/${plural}/" + this.params.get("id"));`,
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(${params});\nthis.redirectTo("/${plural}/" + this.params.get("id"));`,
       ts,
     ),
     mk(
@@ -195,7 +195,7 @@ function apiCrudMethods(
     ),
     mk(
       "update",
-      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(${params});\nvoid ${params};\nthis.renderJson({ id: this.params.get("id") });`,
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(${params});\nthis.renderJson({ id: this.params.get("id") });`,
       ts,
     ),
     mk(

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
@@ -1,0 +1,167 @@
+import {
+  GeneratorBase,
+  type GeneratorOptions,
+  classify,
+  dasherize,
+  tableize,
+  underscore,
+} from "../../base.js";
+import { tsBody, tsMethod, type Method } from "../../../template-builder/index.js";
+import { emitControllerClass } from "../controller/controller-paths.js";
+
+export interface ScaffoldControllerRunOptions {
+  api?: boolean;
+  skipRoutes?: boolean;
+  test?: boolean;
+  helper?: boolean;
+}
+
+// Mirrors railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb.
+export class ScaffoldControllerGenerator extends GeneratorBase {
+  constructor(options: GeneratorOptions) {
+    super(options);
+  }
+
+  run(
+    name: string,
+    _attributes: string[] = [],
+    options: ScaffoldControllerRunOptions = {},
+  ): string[] {
+    const { api = false, skipRoutes = false, test = true, helper = true } = options;
+    const className = classify(name.replace(/_?controller$/i, ""));
+    const resourceName = tableize(className);
+    const singular = underscore(className);
+    const controllerClassName = classify(resourceName) + "Controller";
+    const controllerFileName = dasherize(resourceName) + "-controller";
+    const ext = this.ext();
+    const ts = this.isTypeScript();
+
+    this.createFile(
+      `src/app/controllers/${controllerFileName}${ext}`,
+      emitControllerClass({
+        className: controllerClassName,
+        methods: api
+          ? apiCrudMethods(className, singular, resourceName, ts)
+          : crudMethods(className, singular, resourceName, ts),
+      }),
+    );
+
+    if (test) {
+      this.createFile(
+        `test/controllers/${controllerFileName}.test${ext}`,
+        `import { describe, it } from "vitest";
+import { ${controllerClassName} } from "../../src/app/controllers/${controllerFileName}.js";
+
+describe("${controllerClassName}", () => {
+  it("index", () => { void ${controllerClassName}; });
+  it("show", () => {});
+  ${api ? "" : 'it("new", () => {});\n  '}it("create", () => {});
+  ${api ? "" : 'it("edit", () => {});\n  '}it("update", () => {});
+  it("destroy", () => {});
+});
+`,
+      );
+    }
+
+    if (helper && !api) {
+      this.createFile(
+        `src/app/helpers/${dasherize(resourceName)}-helper${ext}`,
+        `export const ${classify(resourceName)}Helper = {\n};\n`,
+      );
+    }
+
+    if (!skipRoutes) {
+      const routesFile = this.fileExists("src/config/routes.ts")
+        ? "src/config/routes.ts"
+        : this.fileExists("src/config/routes.js")
+          ? "src/config/routes.js"
+          : null;
+      if (routesFile) {
+        this.insertIntoFile(routesFile, "// routes", `  router.resources("${resourceName}");\n`);
+      }
+    }
+    return this.getCreatedFiles();
+  }
+}
+
+function mk(name: string, body: string, ts: boolean): Method {
+  return tsMethod({
+    name,
+    params: [],
+    async: true,
+    returnType: ts ? "Promise<void>" : undefined,
+    body: tsBody`${body}`,
+  });
+}
+
+function crudMethods(model: string, singular: string, plural: string, ts: boolean): Method[] {
+  const anyArr = ts ? ": any[]" : "";
+  return [
+    mk(
+      "index",
+      `// const ${plural} = await ${model}.all();\nconst ${plural}${anyArr} = [];\nthis.render({ action: "index", locals: { ${plural} } });`,
+      ts,
+    ),
+    mk(
+      "show",
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\nconst ${singular} = { id: this.params.get("id") };\nthis.render({ action: "show", locals: { ${singular} } });`,
+      ts,
+    ),
+    mk(
+      "new_",
+      `const ${singular} = {};\nthis.render({ action: "new", locals: { ${singular} } });`,
+      ts,
+    ),
+    mk(
+      "create",
+      `// const ${singular} = await ${model}.create(this.params.get("${singular}"));\nthis.redirectTo("/${plural}");`,
+      ts,
+    ),
+    mk(
+      "edit",
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\nconst ${singular} = { id: this.params.get("id") };\nthis.render({ action: "edit", locals: { ${singular} } });`,
+      ts,
+    ),
+    mk(
+      "update",
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(this.params.get("${singular}"));\nthis.redirectTo("/${plural}/" + this.params.get("id"));`,
+      ts,
+    ),
+    mk(
+      "destroy",
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.destroy();\nthis.redirectTo("/${plural}");`,
+      ts,
+    ),
+  ];
+}
+
+function apiCrudMethods(model: string, singular: string, plural: string, ts: boolean): Method[] {
+  const anyArr = ts ? ": any[]" : "";
+  return [
+    mk(
+      "index",
+      `// const ${plural} = await ${model}.all();\nconst ${plural}${anyArr} = [];\nthis.renderJson(${plural});`,
+      ts,
+    ),
+    mk(
+      "show",
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\nconst ${singular} = { id: this.params.get("id") };\nthis.renderJson(${singular});`,
+      ts,
+    ),
+    mk(
+      "create",
+      `// const ${singular} = await ${model}.create(this.params.get("${singular}"));\nconst ${singular} = this.params.get("${singular}");\nthis.renderJson(${singular}, { status: 201 });`,
+      ts,
+    ),
+    mk(
+      "update",
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(this.params.get("${singular}"));\nthis.renderJson({ id: this.params.get("id") });`,
+      ts,
+    ),
+    mk(
+      "destroy",
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.destroy();\nthis.head(204);`,
+      ts,
+    ),
+  ];
+}

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
@@ -9,6 +9,7 @@ import {
 } from "../../base.js";
 import { tsBody, tsMethod, type Method } from "../../../template-builder/index.js";
 import { emitControllerClass } from "../controller/controller-paths.js";
+import { emitResourceRouteSnippet } from "../resource-route/resource-route-generator.js";
 
 export interface ScaffoldControllerRunOptions {
   api?: boolean;
@@ -29,7 +30,7 @@ export class ScaffoldControllerGenerator extends GeneratorBase {
     options: ScaffoldControllerRunOptions = {},
   ): string[] {
     const { api = false, skipRoutes = false, test = true, helper = true } = options;
-    const stripped = name.replace(/_?controller$/i, "");
+    const stripped = name.replace(/[_-]?controller$/i, "");
     const parts = stripped.split("/");
     const leaf = parts[parts.length - 1]!;
     const nsClass = parts.slice(0, -1).map((p) => classify(p));
@@ -39,7 +40,6 @@ export class ScaffoldControllerGenerator extends GeneratorBase {
     const singular = underscore(classify(leaf));
     const controllerClassName = [...nsClass, classify(resourceName)].join("") + "Controller";
     const controllerFileName = [...nsDashed, dasherize(resourceName)].join("/") + "-controller";
-    const routeResource = [...nsDashed, resourceName].join("/");
     const ext = this.ext();
     const ts = this.isTypeScript();
     const attrNames = parseColumns(attributes).map((c) => c.name);
@@ -86,7 +86,11 @@ ${skip("index")}${skip("show")}${skip("new")}${skip("create")}${skip("edit")}${s
           ? "src/config/routes.js"
           : null;
       if (routesFile) {
-        this.insertIntoFile(routesFile, "// routes", `  router.resources("${routeResource}");\n`);
+        this.insertIntoFile(
+          routesFile,
+          "// routes",
+          emitResourceRouteSnippet(nsDashed, resourceName) + "\n",
+        );
       }
     }
     return this.getCreatedFiles();

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
@@ -7,6 +7,7 @@ import {
   tableize,
   underscore,
 } from "../../base.js";
+import { singularize } from "@blazetrails/activesupport";
 import { tsBody, tsMethod, type Method } from "../../../template-builder/index.js";
 import { emitControllerClass } from "../controller/controller-paths.js";
 import { emitResourceRouteSnippet } from "../resource-route/resource-route-generator.js";
@@ -35,9 +36,11 @@ export class ScaffoldControllerGenerator extends GeneratorBase {
     const leaf = parts[parts.length - 1]!;
     const nsClass = parts.slice(0, -1).map((p) => classify(p));
     const nsDashed = parts.slice(0, -1).map((p) => dasherize(underscore(p)));
-    const modelClassName = [...nsClass, classify(leaf)].join("");
-    const resourceName = tableize(classify(leaf));
-    const singular = underscore(classify(leaf));
+    const nsUnderscored = parts.slice(0, -1).map((p) => underscore(p));
+    const singularLeaf = singularize(underscore(leaf));
+    const modelClassName = [...nsClass, classify(singularLeaf)].join("");
+    const resourceName = tableize(classify(singularLeaf));
+    const singular = singularLeaf;
     const controllerClassName = [...nsClass, classify(resourceName)].join("") + "Controller";
     const controllerFileName = [...nsDashed, dasherize(resourceName)].join("/") + "-controller";
     const ext = this.ext();
@@ -89,7 +92,7 @@ ${skip("index")}${skip("show")}${skip("new")}${skip("create")}${skip("edit")}${s
         this.insertIntoFile(
           routesFile,
           "// routes",
-          emitResourceRouteSnippet(nsDashed, resourceName) + "\n",
+          emitResourceRouteSnippet(nsUnderscored, resourceName),
         );
       }
     }

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
@@ -3,6 +3,7 @@ import {
   type GeneratorOptions,
   classify,
   dasherize,
+  parseColumns,
   tableize,
   underscore,
 } from "../../base.js";
@@ -24,7 +25,7 @@ export class ScaffoldControllerGenerator extends GeneratorBase {
 
   run(
     name: string,
-    _attributes: string[] = [],
+    attributes: string[] = [],
     options: ScaffoldControllerRunOptions = {},
   ): string[] {
     const { api = false, skipRoutes = false, test = true, helper = true } = options;
@@ -35,30 +36,29 @@ export class ScaffoldControllerGenerator extends GeneratorBase {
     const controllerFileName = dasherize(resourceName) + "-controller";
     const ext = this.ext();
     const ts = this.isTypeScript();
+    const attrNames = parseColumns(attributes).map((c) => c.name);
 
     this.createFile(
       `src/app/controllers/${controllerFileName}${ext}`,
       emitControllerClass({
         className: controllerClassName,
         methods: api
-          ? apiCrudMethods(className, singular, resourceName, ts)
-          : crudMethods(className, singular, resourceName, ts),
+          ? apiCrudMethods(className, singular, resourceName, attrNames, ts)
+          : crudMethods(className, singular, resourceName, attrNames, ts),
       }),
     );
 
     if (test) {
+      const skip = (a: string) =>
+        api && (a === "new" || a === "edit") ? "" : `  it("${a}", () => {});\n`;
       this.createFile(
         `test/controllers/${controllerFileName}.test${ext}`,
         `import { describe, it } from "vitest";
 import { ${controllerClassName} } from "../../src/app/controllers/${controllerFileName}.js";
 
 describe("${controllerClassName}", () => {
-  it("index", () => { void ${controllerClassName}; });
-  it("show", () => {});
-  ${api ? "" : 'it("new", () => {});\n  '}it("create", () => {});
-  ${api ? "" : 'it("edit", () => {});\n  '}it("update", () => {});
-  it("destroy", () => {});
-});
+  it("references controller", () => { void ${controllerClassName}; });
+${skip("index")}${skip("show")}${skip("new")}${skip("create")}${skip("edit")}${skip("update")}${skip("destroy")}});
 `,
       );
     }
@@ -94,8 +94,28 @@ function mk(name: string, body: string, ts: boolean): Method {
   });
 }
 
-function crudMethods(model: string, singular: string, plural: string, ts: boolean): Method[] {
+function paramsMethod(singular: string, attrs: string[], ts: boolean): Method {
+  const list =
+    attrs.length === 0
+      ? `return this.params.fetch("${singular}", {});`
+      : `return this.params.expect("${singular}", [${attrs.map((a) => `"${a}"`).join(", ")}]);`;
+  return tsMethod({
+    name: `${singular}Params`,
+    params: [],
+    returnType: ts ? "Record<string, unknown>" : undefined,
+    body: tsBody`${list}`,
+  });
+}
+
+function crudMethods(
+  model: string,
+  singular: string,
+  plural: string,
+  attrs: string[],
+  ts: boolean,
+): Method[] {
   const anyArr = ts ? ": any[]" : "";
+  const params = `this.${singular}Params()`;
   return [
     mk(
       "index",
@@ -104,27 +124,23 @@ function crudMethods(model: string, singular: string, plural: string, ts: boolea
     ),
     mk(
       "show",
-      `// const ${singular} = await ${model}.find(this.params.get("id"));\nconst ${singular} = { id: this.params.get("id") };\nthis.render({ action: "show", locals: { ${singular} } });`,
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\nthis.render({ action: "show", locals: { ${singular}: { id: this.params.get("id") } } });`,
       ts,
     ),
-    mk(
-      "new_",
-      `const ${singular} = {};\nthis.render({ action: "new", locals: { ${singular} } });`,
-      ts,
-    ),
+    mk("new_", `this.render({ action: "new", locals: { ${singular}: {} } });`, ts),
     mk(
       "create",
-      `// const ${singular} = await ${model}.create(this.params.get("${singular}"));\nthis.redirectTo("/${plural}");`,
+      `// const ${singular} = await ${model}.create(${params});\nvoid ${params};\nthis.redirectTo("/${plural}");`,
       ts,
     ),
     mk(
       "edit",
-      `// const ${singular} = await ${model}.find(this.params.get("id"));\nconst ${singular} = { id: this.params.get("id") };\nthis.render({ action: "edit", locals: { ${singular} } });`,
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\nthis.render({ action: "edit", locals: { ${singular}: { id: this.params.get("id") } } });`,
       ts,
     ),
     mk(
       "update",
-      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(this.params.get("${singular}"));\nthis.redirectTo("/${plural}/" + this.params.get("id"));`,
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(${params});\nvoid ${params};\nthis.redirectTo("/${plural}/" + this.params.get("id"));`,
       ts,
     ),
     mk(
@@ -132,11 +148,19 @@ function crudMethods(model: string, singular: string, plural: string, ts: boolea
       `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.destroy();\nthis.redirectTo("/${plural}");`,
       ts,
     ),
+    paramsMethod(singular, attrs, ts),
   ];
 }
 
-function apiCrudMethods(model: string, singular: string, plural: string, ts: boolean): Method[] {
+function apiCrudMethods(
+  model: string,
+  singular: string,
+  plural: string,
+  attrs: string[],
+  ts: boolean,
+): Method[] {
   const anyArr = ts ? ": any[]" : "";
+  const params = `this.${singular}Params()`;
   return [
     mk(
       "index",
@@ -145,17 +169,17 @@ function apiCrudMethods(model: string, singular: string, plural: string, ts: boo
     ),
     mk(
       "show",
-      `// const ${singular} = await ${model}.find(this.params.get("id"));\nconst ${singular} = { id: this.params.get("id") };\nthis.renderJson(${singular});`,
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\nthis.renderJson({ id: this.params.get("id") });`,
       ts,
     ),
     mk(
       "create",
-      `// const ${singular} = await ${model}.create(this.params.get("${singular}"));\nconst ${singular} = this.params.get("${singular}");\nthis.renderJson(${singular}, { status: 201 });`,
+      `// const ${singular} = await ${model}.create(${params});\nthis.renderJson(${params}, { status: 201 });`,
       ts,
     ),
     mk(
       "update",
-      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(this.params.get("${singular}"));\nthis.renderJson({ id: this.params.get("id") });`,
+      `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.update(${params});\nvoid ${params};\nthis.renderJson({ id: this.params.get("id") });`,
       ts,
     ),
     mk(

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
@@ -187,5 +187,6 @@ function apiCrudMethods(
       `// const ${singular} = await ${model}.find(this.params.get("id"));\n// await ${singular}.destroy();\nthis.head(204);`,
       ts,
     ),
+    paramsMethod(singular, attrs, ts),
   ];
 }

--- a/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
+++ b/packages/trailties/src/generators/rails/scaffold_controller/scaffold-controller-generator.ts
@@ -29,11 +29,17 @@ export class ScaffoldControllerGenerator extends GeneratorBase {
     options: ScaffoldControllerRunOptions = {},
   ): string[] {
     const { api = false, skipRoutes = false, test = true, helper = true } = options;
-    const className = classify(name.replace(/_?controller$/i, ""));
-    const resourceName = tableize(className);
-    const singular = underscore(className);
-    const controllerClassName = classify(resourceName) + "Controller";
-    const controllerFileName = dasherize(resourceName) + "-controller";
+    const stripped = name.replace(/_?controller$/i, "");
+    const parts = stripped.split("/");
+    const leaf = parts[parts.length - 1]!;
+    const nsClass = parts.slice(0, -1).map((p) => classify(p));
+    const nsDashed = parts.slice(0, -1).map((p) => dasherize(underscore(p)));
+    const modelClassName = [...nsClass, classify(leaf)].join("");
+    const resourceName = tableize(classify(leaf));
+    const singular = underscore(classify(leaf));
+    const controllerClassName = [...nsClass, classify(resourceName)].join("") + "Controller";
+    const controllerFileName = [...nsDashed, dasherize(resourceName)].join("/") + "-controller";
+    const routeResource = [...nsDashed, resourceName].join("/");
     const ext = this.ext();
     const ts = this.isTypeScript();
     const attrNames = parseColumns(attributes).map((c) => c.name);
@@ -43,18 +49,19 @@ export class ScaffoldControllerGenerator extends GeneratorBase {
       emitControllerClass({
         className: controllerClassName,
         methods: api
-          ? apiCrudMethods(className, singular, resourceName, attrNames, ts)
-          : crudMethods(className, singular, resourceName, attrNames, ts),
+          ? apiCrudMethods(modelClassName, singular, resourceName, attrNames, ts)
+          : crudMethods(modelClassName, singular, resourceName, attrNames, ts),
       }),
     );
 
     if (test) {
       const skip = (a: string) =>
         api && (a === "new" || a === "edit") ? "" : `  it("${a}", () => {});\n`;
+      const importPrefix = "../".repeat(nsDashed.length + 2);
       this.createFile(
         `test/controllers/${controllerFileName}.test${ext}`,
         `import { describe, it } from "vitest";
-import { ${controllerClassName} } from "../../src/app/controllers/${controllerFileName}.js";
+import { ${controllerClassName} } from "${importPrefix}src/app/controllers/${controllerFileName}.js";
 
 describe("${controllerClassName}", () => {
   it("references controller", () => { void ${controllerClassName}; });
@@ -64,9 +71,11 @@ ${skip("index")}${skip("show")}${skip("new")}${skip("create")}${skip("edit")}${s
     }
 
     if (helper && !api) {
+      const helperFileName = [...nsDashed, dasherize(resourceName)].join("/") + "-helper";
+      const helperConstName = [...nsClass, classify(resourceName)].join("") + "Helper";
       this.createFile(
-        `src/app/helpers/${dasherize(resourceName)}-helper${ext}`,
-        `export const ${classify(resourceName)}Helper = {\n};\n`,
+        `src/app/helpers/${helperFileName}${ext}`,
+        `export const ${helperConstName} = {\n};\n`,
       );
     }
 
@@ -77,7 +86,7 @@ ${skip("index")}${skip("show")}${skip("new")}${skip("create")}${skip("edit")}${s
           ? "src/config/routes.js"
           : null;
       if (routesFile) {
-        this.insertIntoFile(routesFile, "// routes", `  router.resources("${resourceName}");\n`);
+        this.insertIntoFile(routesFile, "// routes", `  router.resources("${routeResource}");\n`);
       }
     }
     return this.getCreatedFiles();
@@ -98,7 +107,7 @@ function paramsMethod(singular: string, attrs: string[], ts: boolean): Method {
   const list =
     attrs.length === 0
       ? `return this.params.fetch("${singular}", {});`
-      : `return this.params.expect("${singular}", [${attrs.map((a) => `"${a}"`).join(", ")}]);`;
+      : `return this.params.expect({ ${singular}: [${attrs.map((a) => `"${a}"`).join(", ")}] });`;
   return tsMethod({
     name: `${singular}Params`,
     params: [],


### PR DESCRIPTION
## Summary

Adds the two remaining generators deferred from PR 1.14b, both composing the T1 typed template-builder via PR T3's \`emitControllerClass\` factor:

- **HelperGenerator** (\`generators/rails/helper/\`): standalone helper generator mirroring \`railties/lib/rails/generators/rails/helper/\`. Emits \`src/app/helpers/<name>-helper.{ts,js}\` plus an optional vitest scaffold. Handles namespaced (\`admin/account\`) and \`_helper\`-suffixed names.
- **ScaffoldControllerGenerator** (\`generators/rails/scaffold_controller/\`): emits just the CRUD controller (no views — the full scaffold orchestrator already lives in \`scaffold/\`). Mirrors Rails' \`--api\`, \`--skip-routes\`, \`--no-helper\` options. API mode drops \`new_\`/\`edit\` and routes responses through \`renderJson\`.

Rails source:
- \`vendor/rails/railties/lib/rails/generators/rails/helper/helper_generator.rb\`
- \`vendor/rails/railties/lib/rails/generators/rails/scaffold_controller/scaffold_controller_generator.rb\`

## Constraints honored

- No \`node:*\` imports outside tests.
- No \`process.*\`.
- Async FS only (via \`GeneratorBase.createFile\` / \`insertIntoFile\`).
- 17 tests, all green, all Rails-named.
- Single PR from main — no stacking.

## Notes / follow-ups

- The Rails \`hook_for :template_engine, as: :scaffold\` (view emission) and \`hook_for :resource_route\` are already covered by the existing \`ScaffoldGenerator\` orchestrator in \`scaffold/scaffold-generator.ts\`; this PR purposefully keeps \`ScaffoldControllerGenerator\` controller-only to match Rails' layering. Wiring the orchestrator to delegate to the new generator is a follow-up.
- CLI dispatch for \`generate helper\` / \`generate scaffold_controller\` not wired in this PR — also a follow-up alongside the dispatcher work tracked in the plan doc.

## Test plan

- [x] \`pnpm vitest run packages/trailties/src/generators/rails/helper packages/trailties/src/generators/rails/scaffold_controller\` — 17/17 passing
- [x] \`pnpm tsc --noEmit\` — no new errors in changed files
- [x] CI