### PR TITLE
feat(trailties): AuthenticationGenerator on typed template builder (PR T4)

### DIFF
--- a/packages/trailties/src/generators/index.ts
+++ b/packages/trailties/src/generators/index.ts
@@ -16,7 +16,6 @@ export { TaskGenerator } from "./rails/task/task-generator.js";
 export type { TaskRunOptions } from "./rails/task/task-generator.js";
 export { ScriptGenerator } from "./rails/script/script-generator.js";
 export { AuthenticationGenerator } from "./rails/authentication/authentication-generator.js";
-export type { AuthenticationRunOptions } from "./rails/authentication/authentication-generator.js";
 export { GeneratorGenerator } from "./rails/generator/generator-generator.js";
 export type { GeneratorRunOptions } from "./rails/generator/generator-generator.js";
 export { GeneratedAttribute, GeneratorError } from "./generated-attribute.js";

--- a/packages/trailties/src/generators/index.ts
+++ b/packages/trailties/src/generators/index.ts
@@ -15,6 +15,8 @@ export type { BenchmarkRunOptions } from "./rails/benchmark/benchmark-generator.
 export { TaskGenerator } from "./rails/task/task-generator.js";
 export type { TaskRunOptions } from "./rails/task/task-generator.js";
 export { ScriptGenerator } from "./rails/script/script-generator.js";
+export { AuthenticationGenerator } from "./rails/authentication/authentication-generator.js";
+export type { AuthenticationRunOptions } from "./rails/authentication/authentication-generator.js";
 export { GeneratorGenerator } from "./rails/generator/generator-generator.js";
 export type { GeneratorRunOptions } from "./rails/generator/generator-generator.js";
 export { GeneratedAttribute, GeneratorError } from "./generated-attribute.js";

--- a/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
@@ -24,16 +24,16 @@ export class User extends ApplicationRecord {
 }
 
 // === src/app/models/current.ts ===
-import { ActiveSupport } from "@blazetrails/activesupport";
+import { CurrentAttributes } from "@blazetrails/activesupport";
 
-export class Current extends ActiveSupport.CurrentAttributes {
+export class Current extends CurrentAttributes {
   static attributes() {
     // attribute :session
   }
 }
 
 // === src/app/controllers/sessions-controller.ts ===
-import { ApplicationController } from "../application-controller.js";
+import { ApplicationController } from "./application-controller.js";
 
 export class SessionsController extends ApplicationController {
   async new_(): Promise<void> {
@@ -82,7 +82,7 @@ export class Authentication {
 }
 
 // === src/app/controllers/passwords-controller.ts ===
-import { ApplicationController } from "../application-controller.js";
+import { ApplicationController } from "./application-controller.js";
 
 export class PasswordsController extends ApplicationController {
   async new_(): Promise<void> {

--- a/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
@@ -1,0 +1,69 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`AuthenticationGenerator > matches snapshot for the authentication concern 1`] = `
+"export class Authentication {
+  static includeInto(klass: any) {
+    klass.beforeAction?.("requireAuthentication");
+    klass.helperMethod?.("authenticated");
+  }
+
+  async authenticated(): Promise<void> {
+    // resumeSession
+  }
+
+  async requireAuthentication(): Promise<void> {
+    // resumeSession || requestAuthentication
+  }
+
+  private async resumeSession(): Promise<void> {
+    // Current.session ||= findSessionByCookie
+  }
+
+  private async findSessionByCookie(): Promise<void> {
+    // Session.findBy(cookies.signed.sessionId)
+  }
+
+  private async startNewSessionFor(user: any): Promise<void> {
+    // user.sessions.createBang + cookie
+  }
+
+  private async terminateSession(): Promise<void> {
+    // Current.session.destroy + cookies.delete
+  }
+}
+"
+`;
+
+exports[`AuthenticationGenerator > matches snapshot for the sessions controller 1`] = `
+"import { ApplicationController } from "../application-controller.js";
+
+export class SessionsController extends ApplicationController {
+  async new_(): Promise<void> {
+    // allowUnauthenticatedAccess only: [new_, create]
+  }
+
+  async create(): Promise<void> {
+    // User.authenticateBy → startNewSessionFor → redirect
+  }
+
+  async destroy(): Promise<void> {
+    // terminateSession → redirect to /session/new
+  }
+}
+"
+`;
+
+exports[`AuthenticationGenerator > matches snapshot for the user model 1`] = `
+"import { ApplicationRecord } from "./application-record.js";
+
+export class User extends ApplicationRecord {
+  static associations() {
+    // hasSecurePassword; hasMany sessions, dependent: destroy
+  }
+
+  static normalizes() {
+    // emailAddress → e.strip().toLowerCase()
+  }
+}
+"
+`;

--- a/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
@@ -1,6 +1,23 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`AuthenticationGenerator > matches snapshot for the authentication concern 1`] = `
+exports[`AuthenticationGenerator > matches snapshot for src/app/channels/application-cable/connection.ts 1`] = `
+"export class Connection {
+  static identifiedBy() {
+    // currentUser
+  }
+
+  async connect(): Promise<void> {
+    // setCurrentUser || rejectUnauthorizedConnection
+  }
+
+  private async setCurrentUser(): Promise<void> {
+    // Session.findBy(cookies.signed.sessionId)
+  }
+}
+"
+`;
+
+exports[`AuthenticationGenerator > matches snapshot for src/app/controllers/concerns/authentication.ts 1`] = `
 "export class Authentication {
   static includeInto(klass: any) {
     klass.beforeAction?.("requireAuthentication");
@@ -34,7 +51,34 @@ exports[`AuthenticationGenerator > matches snapshot for the authentication conce
 "
 `;
 
-exports[`AuthenticationGenerator > matches snapshot for the sessions controller 1`] = `
+exports[`AuthenticationGenerator > matches snapshot for src/app/controllers/passwords-controller.ts 1`] = `
+"import { ApplicationController } from "../application-controller.js";
+
+export class PasswordsController extends ApplicationController {
+  async new_(): Promise<void> {
+    // allowUnauthenticatedAccess
+  }
+
+  async create(): Promise<void> {
+    // PasswordsMailer.reset(user).deliverLater
+  }
+
+  async edit(): Promise<void> {
+    // setUserByToken
+  }
+
+  async update(): Promise<void> {
+    // user.update(password, passwordConfirmation)
+  }
+
+  private async setUserByToken(): Promise<void> {
+    // User.findByPasswordResetTokenBang
+  }
+}
+"
+`;
+
+exports[`AuthenticationGenerator > matches snapshot for src/app/controllers/sessions-controller.ts 1`] = `
 "import { ApplicationController } from "../application-controller.js";
 
 export class SessionsController extends ApplicationController {
@@ -53,7 +97,40 @@ export class SessionsController extends ApplicationController {
 "
 `;
 
-exports[`AuthenticationGenerator > matches snapshot for the user model 1`] = `
+exports[`AuthenticationGenerator > matches snapshot for src/app/mailers/passwords-mailer.ts 1`] = `
+"import { ApplicationMailer } from "./application-mailer.js";
+
+export class PasswordsMailer extends ApplicationMailer {
+  async reset(user: any): Promise<void> {
+    // mail subject: "Reset your password", to: user.emailAddress
+  }
+}
+"
+`;
+
+exports[`AuthenticationGenerator > matches snapshot for src/app/models/current.ts 1`] = `
+"import { ActiveSupport } from "@blazetrails/activesupport";
+
+export class Current extends ActiveSupport.CurrentAttributes {
+  static attributes() {
+    // attribute :session
+  }
+}
+"
+`;
+
+exports[`AuthenticationGenerator > matches snapshot for src/app/models/session.ts 1`] = `
+"import { ApplicationRecord } from "./application-record.js";
+
+export class Session extends ApplicationRecord {
+  static associations() {
+    // belongsTo: User
+  }
+}
+"
+`;
+
+exports[`AuthenticationGenerator > matches snapshot for src/app/models/user.ts 1`] = `
 "import { ApplicationRecord } from "./application-record.js";
 
 export class User extends ApplicationRecord {
@@ -63,6 +140,15 @@ export class User extends ApplicationRecord {
 
   static normalizes() {
     // emailAddress → e.strip().toLowerCase()
+  }
+}
+"
+`;
+
+exports[`AuthenticationGenerator > matches snapshot for test/mailers/previews/passwords-mailer-preview.ts 1`] = `
+"export class PasswordsMailerPreview {
+  reset() {
+    // TODO: preview PasswordsMailer.reset
   }
 }
 "

--- a/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`AuthenticationGenerator > matches snapshot for the full TS emit set 1`] = `
-"// === src/app/models/session.ts ===
+exports[`AuthenticationGenerator > emits the full file set; each .ts file parses + carries no Ruby source 1`] = `
+"=== src/app/models/session.ts ===
 import { ApplicationRecord } from "./application-record.js";
 
 export class Session extends ApplicationRecord {
@@ -10,7 +10,7 @@ export class Session extends ApplicationRecord {
   }
 }
 
-// === src/app/models/user.ts ===
+=== src/app/models/user.ts ===
 import { ApplicationRecord } from "./application-record.js";
 
 export class User extends ApplicationRecord {
@@ -23,7 +23,7 @@ export class User extends ApplicationRecord {
   }
 }
 
-// === src/app/models/current.ts ===
+=== src/app/models/current.ts ===
 import { CurrentAttributes } from "@blazetrails/activesupport";
 
 export class Current extends CurrentAttributes {
@@ -32,7 +32,7 @@ export class Current extends CurrentAttributes {
   }
 }
 
-// === src/app/controllers/sessions-controller.ts ===
+=== src/app/controllers/sessions-controller.ts ===
 import { ApplicationController } from "./application-controller.js";
 
 export class SessionsController extends ApplicationController {
@@ -49,7 +49,7 @@ export class SessionsController extends ApplicationController {
   }
 }
 
-// === src/app/controllers/concerns/authentication.ts ===
+=== src/app/controllers/concerns/authentication.ts ===
 export class Authentication {
   static includeInto(klass: any) {
     klass.beforeAction?.("requireAuthentication");
@@ -81,7 +81,7 @@ export class Authentication {
   }
 }
 
-// === src/app/controllers/passwords-controller.ts ===
+=== src/app/controllers/passwords-controller.ts ===
 import { ApplicationController } from "./application-controller.js";
 
 export class PasswordsController extends ApplicationController {
@@ -106,7 +106,7 @@ export class PasswordsController extends ApplicationController {
   }
 }
 
-// === src/app/channels/application-cable/connection.ts ===
+=== src/app/channels/application-cable/connection.ts ===
 export class Connection {
   static identifiedBy() {
     // currentUser
@@ -121,7 +121,7 @@ export class Connection {
   }
 }
 
-// === src/app/mailers/passwords-mailer.ts ===
+=== src/app/mailers/passwords-mailer.ts ===
 import { ApplicationMailer } from "./application-mailer.js";
 
 export class PasswordsMailer extends ApplicationMailer {
@@ -130,7 +130,7 @@ export class PasswordsMailer extends ApplicationMailer {
   }
 }
 
-// === test/mailers/previews/passwords-mailer-preview.ts ===
+=== test/mailers/previews/passwords-mailer-preview.ts ===
 export class PasswordsMailerPreview {
   reset() {
     // TODO: preview PasswordsMailer.reset

--- a/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
@@ -52,7 +52,7 @@ export class SessionsController extends ApplicationController {
 === src/app/controllers/concerns/authentication.ts ===
 export class Authentication {
   static includeInto(klass: any) {
-    klass.beforeAction?.("requireAuthentication");
+    klass.beforeAction?.((c: any) => c.requireAuthentication());
     klass.helperMethod?.("authenticated");
   }
 

--- a/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
+++ b/packages/trailties/src/generators/rails/authentication/__snapshots__/authentication-generator.test.ts.snap
@@ -1,24 +1,56 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`AuthenticationGenerator > matches snapshot for src/app/channels/application-cable/connection.ts 1`] = `
-"export class Connection {
-  static identifiedBy() {
-    // currentUser
-  }
+exports[`AuthenticationGenerator > matches snapshot for the full TS emit set 1`] = `
+"// === src/app/models/session.ts ===
+import { ApplicationRecord } from "./application-record.js";
 
-  async connect(): Promise<void> {
-    // setCurrentUser || rejectUnauthorizedConnection
-  }
-
-  private async setCurrentUser(): Promise<void> {
-    // Session.findBy(cookies.signed.sessionId)
+export class Session extends ApplicationRecord {
+  static associations() {
+    // belongsTo: User
   }
 }
-"
-`;
 
-exports[`AuthenticationGenerator > matches snapshot for src/app/controllers/concerns/authentication.ts 1`] = `
-"export class Authentication {
+// === src/app/models/user.ts ===
+import { ApplicationRecord } from "./application-record.js";
+
+export class User extends ApplicationRecord {
+  static associations() {
+    // hasSecurePassword; hasMany sessions, dependent: destroy
+  }
+
+  static normalizes() {
+    // emailAddress → e.strip().toLowerCase()
+  }
+}
+
+// === src/app/models/current.ts ===
+import { ActiveSupport } from "@blazetrails/activesupport";
+
+export class Current extends ActiveSupport.CurrentAttributes {
+  static attributes() {
+    // attribute :session
+  }
+}
+
+// === src/app/controllers/sessions-controller.ts ===
+import { ApplicationController } from "../application-controller.js";
+
+export class SessionsController extends ApplicationController {
+  async new_(): Promise<void> {
+    // allowUnauthenticatedAccess only: [new_, create]
+  }
+
+  async create(): Promise<void> {
+    // User.authenticateBy → startNewSessionFor → redirect
+  }
+
+  async destroy(): Promise<void> {
+    // terminateSession → redirect to /session/new
+  }
+}
+
+// === src/app/controllers/concerns/authentication.ts ===
+export class Authentication {
   static includeInto(klass: any) {
     klass.beforeAction?.("requireAuthentication");
     klass.helperMethod?.("authenticated");
@@ -48,11 +80,9 @@ exports[`AuthenticationGenerator > matches snapshot for src/app/controllers/conc
     // Current.session.destroy + cookies.delete
   }
 }
-"
-`;
 
-exports[`AuthenticationGenerator > matches snapshot for src/app/controllers/passwords-controller.ts 1`] = `
-"import { ApplicationController } from "../application-controller.js";
+// === src/app/controllers/passwords-controller.ts ===
+import { ApplicationController } from "../application-controller.js";
 
 export class PasswordsController extends ApplicationController {
   async new_(): Promise<void> {
@@ -75,78 +105,33 @@ export class PasswordsController extends ApplicationController {
     // User.findByPasswordResetTokenBang
   }
 }
-"
-`;
 
-exports[`AuthenticationGenerator > matches snapshot for src/app/controllers/sessions-controller.ts 1`] = `
-"import { ApplicationController } from "../application-controller.js";
-
-export class SessionsController extends ApplicationController {
-  async new_(): Promise<void> {
-    // allowUnauthenticatedAccess only: [new_, create]
+// === src/app/channels/application-cable/connection.ts ===
+export class Connection {
+  static identifiedBy() {
+    // currentUser
   }
 
-  async create(): Promise<void> {
-    // User.authenticateBy → startNewSessionFor → redirect
+  async connect(): Promise<void> {
+    // setCurrentUser || rejectUnauthorizedConnection
   }
 
-  async destroy(): Promise<void> {
-    // terminateSession → redirect to /session/new
+  private async setCurrentUser(): Promise<void> {
+    // Session.findBy(cookies.signed.sessionId)
   }
 }
-"
-`;
 
-exports[`AuthenticationGenerator > matches snapshot for src/app/mailers/passwords-mailer.ts 1`] = `
-"import { ApplicationMailer } from "./application-mailer.js";
+// === src/app/mailers/passwords-mailer.ts ===
+import { ApplicationMailer } from "./application-mailer.js";
 
 export class PasswordsMailer extends ApplicationMailer {
   async reset(user: any): Promise<void> {
     // mail subject: "Reset your password", to: user.emailAddress
   }
 }
-"
-`;
 
-exports[`AuthenticationGenerator > matches snapshot for src/app/models/current.ts 1`] = `
-"import { ActiveSupport } from "@blazetrails/activesupport";
-
-export class Current extends ActiveSupport.CurrentAttributes {
-  static attributes() {
-    // attribute :session
-  }
-}
-"
-`;
-
-exports[`AuthenticationGenerator > matches snapshot for src/app/models/session.ts 1`] = `
-"import { ApplicationRecord } from "./application-record.js";
-
-export class Session extends ApplicationRecord {
-  static associations() {
-    // belongsTo: User
-  }
-}
-"
-`;
-
-exports[`AuthenticationGenerator > matches snapshot for src/app/models/user.ts 1`] = `
-"import { ApplicationRecord } from "./application-record.js";
-
-export class User extends ApplicationRecord {
-  static associations() {
-    // hasSecurePassword; hasMany sessions, dependent: destroy
-  }
-
-  static normalizes() {
-    // emailAddress → e.strip().toLowerCase()
-  }
-}
-"
-`;
-
-exports[`AuthenticationGenerator > matches snapshot for test/mailers/previews/passwords-mailer-preview.ts 1`] = `
-"export class PasswordsMailerPreview {
+// === test/mailers/previews/passwords-mailer-preview.ts ===
+export class PasswordsMailerPreview {
   reset() {
     // TODO: preview PasswordsMailer.reset
   }

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { AuthenticationGenerator } from "./authentication-generator.js";
+import { parseTs, assertNoRubySource } from "../../../template-builder/testing.js";
+
+let tmpDir: string;
+
+function setupApp() {
+  fs.mkdirSync(path.join(tmpDir, "src/app/controllers"), { recursive: true });
+  fs.mkdirSync(path.join(tmpDir, "src/config"), { recursive: true });
+  fs.writeFileSync(path.join(tmpDir, "tsconfig.json"), "{}");
+  fs.writeFileSync(
+    path.join(tmpDir, "src/app/controllers/application-controller.ts"),
+    `import { ActionController } from "@blazetrails/actionpack";
+
+export class ApplicationController extends ActionController.Base {
+}
+`,
+  );
+  fs.writeFileSync(path.join(tmpDir, "src/config/routes.ts"), "// routes\n");
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-auth-"));
+  setupApp();
+});
+afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(tmpDir, rel), "utf-8");
+}
+function exists(rel: string): boolean {
+  return fs.existsSync(path.join(tmpDir, rel));
+}
+function makeGen() {
+  return new AuthenticationGenerator({ cwd: tmpDir, output: () => {} });
+}
+
+describe("AuthenticationGenerator", () => {
+  it("creates the full authentication file set", () => {
+    makeGen().run();
+    const emitted = [
+      "src/app/models/session.ts",
+      "src/app/models/user.ts",
+      "src/app/models/current.ts",
+      "src/app/controllers/sessions-controller.ts",
+      "src/app/controllers/concerns/authentication.ts",
+      "src/app/controllers/passwords-controller.ts",
+      "src/app/channels/application-cable/connection.ts",
+      "src/app/mailers/passwords-mailer.ts",
+      "src/app/views/passwords-mailer/reset.html.tse",
+      "src/app/views/passwords-mailer/reset.text.tse",
+      "test/mailers/previews/passwords-mailer-preview.ts",
+    ];
+    for (const rel of emitted) expect(exists(rel)).toBe(true);
+  });
+
+  it("emits TypeScript that parses without diagnostics and contains no Ruby source", () => {
+    makeGen().run();
+    for (const rel of [
+      "src/app/models/session.ts",
+      "src/app/models/user.ts",
+      "src/app/models/current.ts",
+      "src/app/controllers/sessions-controller.ts",
+      "src/app/controllers/concerns/authentication.ts",
+      "src/app/controllers/passwords-controller.ts",
+      "src/app/channels/application-cable/connection.ts",
+      "src/app/mailers/passwords-mailer.ts",
+      "test/mailers/previews/passwords-mailer-preview.ts",
+    ]) {
+      const src = read(rel);
+      expect(parseTs(src).diagnostics, `diagnostics for ${rel}`).toEqual([]);
+      assertNoRubySource(src);
+    }
+  });
+
+  it("skips mailer pieces when --skip-mailer is set", () => {
+    makeGen().run({ skipMailer: true });
+    expect(exists("src/app/mailers/passwords-mailer.ts")).toBe(false);
+    expect(exists("src/app/views/passwords-mailer/reset.html.tse")).toBe(false);
+    expect(exists("test/mailers/previews/passwords-mailer-preview.ts")).toBe(false);
+  });
+
+  it("omits views in api mode but keeps mailer class", () => {
+    makeGen().run({ api: true });
+    expect(exists("src/app/mailers/passwords-mailer.ts")).toBe(true);
+    expect(exists("src/app/views/passwords-mailer/reset.html.tse")).toBe(false);
+  });
+
+  it("configures the application controller with Authentication", () => {
+    makeGen().run();
+    const ac = read("src/app/controllers/application-controller.ts");
+    expect(ac).toContain('import { Authentication } from "./concerns/authentication.js";');
+    expect(ac).toContain("Authentication.includeInto(ApplicationController);");
+  });
+
+  it("configures authentication routes", () => {
+    makeGen().run();
+    const routes = read("src/config/routes.ts");
+    expect(routes).toContain('router.resources("passwords", { param: "token" });');
+    expect(routes).toContain('router.resource("session");');
+  });
+
+  it("matches snapshot for the authentication concern", () => {
+    makeGen().run();
+    expect(read("src/app/controllers/concerns/authentication.ts")).toMatchSnapshot();
+  });
+
+  it("matches snapshot for the sessions controller", () => {
+    makeGen().run();
+    expect(read("src/app/controllers/sessions-controller.ts")).toMatchSnapshot();
+  });
+
+  it("matches snapshot for the user model", () => {
+    makeGen().run();
+    expect(read("src/app/models/user.ts")).toMatchSnapshot();
+  });
+});

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -22,6 +22,8 @@ const write = (rel: string, content: string) => {
   fs.mkdirSync(path.dirname(full), { recursive: true });
   fs.writeFileSync(full, content);
 };
+const writeAC = (find: string, replace: string) =>
+  write(APP_CTRL_PATH, APP_CTRL_EMPTY.replace(find, replace));
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-auth-"));
   write("tsconfig.json", "{}");
@@ -55,10 +57,7 @@ describe("AuthenticationGenerator", () => {
   });
 
   it("injects inside the class even when ApplicationController has a body", () => {
-    write(
-      APP_CTRL_PATH,
-      APP_CTRL_EMPTY.replace("{\n}", "{\n  async preexisting(): Promise<void> { return; }\n}"),
-    );
+    writeAC("{\n}", "{\n  async preexisting(): Promise<void> { return; }\n}");
     makeGen().run();
     const ac = read(APP_CTRL_PATH);
     expect(parseTs(ac).diagnostics).toEqual([]);
@@ -80,12 +79,9 @@ describe("AuthenticationGenerator", () => {
       "src/config/routes.ts",
       `// routes\n  router.resources("passwords");\n  router.resource("session");\n`,
     );
-    write(
-      APP_CTRL_PATH,
-      APP_CTRL_EMPTY.replace(
-        "\n\nexport",
-        `\nimport { Authentication } from "./concerns/authentication";\n\nexport`,
-      ),
+    writeAC(
+      "\n\nexport",
+      `\nimport { Authentication } from "./concerns/authentication";\n\nexport`,
     );
     makeGen().run();
     const routes = read("src/config/routes.ts");
@@ -94,6 +90,15 @@ describe("AuthenticationGenerator", () => {
     const ac = read(APP_CTRL_PATH);
     expect(ac.match(/import\s+\{\s*Authentication\b/g)).toHaveLength(1);
     expect(ac).toContain("Authentication.includeInto(this);");
+    expect(parseTs(ac).diagnostics).toEqual([]);
+  });
+
+  it("repairs partial config: mixin present but import missing (and vice versa)", () => {
+    writeAC("{\n}", "{\n  static {\n    Authentication.includeInto(this);\n  }\n}");
+    makeGen().run();
+    const ac = read(APP_CTRL_PATH);
+    expect(ac).toContain('import { Authentication } from "./concerns/authentication.js";');
+    expect(ac.match(/Authentication\.includeInto\(this\)/g)).toHaveLength(1);
     expect(parseTs(ac).diagnostics).toEqual([]);
   });
 

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -55,15 +55,12 @@ describe("AuthenticationGenerator", () => {
     }
   });
 
-  it("skips mailer pieces when --skip-mailer is set", () => {
+  it("skips mailer pieces on --skip-mailer; api keeps mailer but drops views", () => {
     makeGen().run({ skipMailer: true });
     expect(exists("src/app/mailers/passwords-mailer.ts")).toBe(false);
     expect(exists("src/app/views/passwords-mailer/reset.html.tse")).toBe(false);
     expect(exists("test/mailers/previews/passwords-mailer-preview.ts")).toBe(false);
-  });
-
-  it("omits views in api mode but keeps the mailer class", () => {
-    makeGen().run({ api: true });
+    new AuthenticationGenerator({ cwd: tmpDir, output: () => {} }).run({ api: true });
     expect(exists("src/app/mailers/passwords-mailer.ts")).toBe(true);
     expect(exists("src/app/views/passwords-mailer/reset.html.tse")).toBe(false);
   });
@@ -84,6 +81,19 @@ describe("AuthenticationGenerator", () => {
     const routes = read("src/config/routes.ts");
     expect(routes).toContain('router.resources("passwords", { param: "token" });');
     expect(routes).toContain('router.resource("session");');
+  });
+
+  it("injects the mixin inside the class even when ApplicationController has a body", () => {
+    fs.writeFileSync(
+      path.join(tmpDir, "src/app/controllers/application-controller.ts"),
+      `import { ActionController } from "@blazetrails/actionpack";\n\nexport class ApplicationController extends ActionController.Base {\n  async preexisting(): Promise<void> { return; }\n}\n`,
+    );
+    makeGen().run();
+    const ac = read("src/app/controllers/application-controller.ts");
+    expect(parseTs(ac).diagnostics).toEqual([]);
+    // Injection lands *before* the pre-existing method — a brittle "first
+    // }" marker would have landed after the method's closing brace.
+    expect(ac.indexOf("Authentication.includeInto")).toBeLessThan(ac.indexOf("preexisting"));
   });
 
   it("is a no-op when application-controller.ts or routes.ts are missing", () => {

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -65,19 +65,12 @@ describe("AuthenticationGenerator", () => {
     expect(exists("src/app/views/passwords-mailer/reset.html.tse")).toBe(false);
   });
 
-  it("configures the application controller with Authentication", () => {
+  it("wires Authentication into the application controller + adds routes", () => {
     makeGen().run();
     const ac = read("src/app/controllers/application-controller.ts");
     expect(ac).toContain('import { Authentication } from "./concerns/authentication.js";');
     expect(ac).toContain("Authentication.includeInto(this);");
-    const classStart = ac.indexOf("export class ApplicationController");
-    const classEnd = ac.indexOf("}", classStart);
-    expect(ac.slice(classStart, classEnd)).toContain("Authentication.includeInto(this);");
     expect(parseTs(ac).diagnostics).toEqual([]);
-  });
-
-  it("configures authentication routes", () => {
-    makeGen().run();
     const routes = read("src/config/routes.ts");
     expect(routes).toContain('router.resources("passwords", { param: "token" });');
     expect(routes).toContain('router.resource("session");');
@@ -91,15 +84,19 @@ describe("AuthenticationGenerator", () => {
     makeGen().run();
     const ac = read("src/app/controllers/application-controller.ts");
     expect(parseTs(ac).diagnostics).toEqual([]);
-    // Injection lands *before* the pre-existing method — a brittle "first
-    // }" marker would have landed after the method's closing brace.
+    // A brittle "first }" marker would have landed the injection after
+    // the method's closing brace.
     expect(ac.indexOf("Authentication.includeInto")).toBeLessThan(ac.indexOf("preexisting"));
   });
 
-  it("is a no-op when application-controller.ts or routes.ts are missing", () => {
-    fs.unlinkSync(path.join(tmpDir, "src/app/controllers/application-controller.ts"));
-    fs.unlinkSync(path.join(tmpDir, "src/config/routes.ts"));
-    expect(() => makeGen().run()).not.toThrow();
+  it("is idempotent — re-running does not duplicate imports or routes", () => {
+    makeGen().run();
+    const ac = read("src/app/controllers/application-controller.ts");
+    const rt = read("src/config/routes.ts");
+    makeGen().run();
+    expect(read("src/app/controllers/application-controller.ts")).toEqual(ac);
+    expect(read("src/config/routes.ts")).toEqual(rt);
+    expect(parseTs(ac).diagnostics).toEqual([]);
   });
 
   it("matches snapshot for the full TS emit set", () => {

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -93,7 +93,18 @@ describe("AuthenticationGenerator", () => {
     makeGen().run();
     const ac = read("src/app/controllers/application-controller.ts");
     expect(ac).toContain('import { Authentication } from "./concerns/authentication.js";');
-    expect(ac).toContain("Authentication.includeInto(ApplicationController);");
+    expect(ac).toContain("Authentication.includeInto(this);");
+    // Mixin call lands inside the class body (Rails inject_into_class parity).
+    const classStart = ac.indexOf("export class ApplicationController");
+    const classEnd = ac.indexOf("}", classStart);
+    expect(ac.slice(classStart, classEnd)).toContain("Authentication.includeInto(this);");
+    // The post-injection file still parses cleanly.
+    expect(parseTs(ac).diagnostics).toEqual([]);
+  });
+
+  it("is a no-op when application-controller.ts is missing", () => {
+    fs.unlinkSync(path.join(tmpDir, "src/app/controllers/application-controller.ts"));
+    expect(() => makeGen().run()).not.toThrow();
   });
 
   it("configures authentication routes", () => {
@@ -103,18 +114,25 @@ describe("AuthenticationGenerator", () => {
     expect(routes).toContain('router.resource("session");');
   });
 
-  it("matches snapshot for the authentication concern", () => {
-    makeGen().run();
-    expect(read("src/app/controllers/concerns/authentication.ts")).toMatchSnapshot();
+  it("is a no-op when routes.ts is missing", () => {
+    fs.unlinkSync(path.join(tmpDir, "src/config/routes.ts"));
+    expect(() => makeGen().run()).not.toThrow();
   });
 
-  it("matches snapshot for the sessions controller", () => {
-    makeGen().run();
-    expect(read("src/app/controllers/sessions-controller.ts")).toMatchSnapshot();
-  });
-
-  it("matches snapshot for the user model", () => {
-    makeGen().run();
-    expect(read("src/app/models/user.ts")).toMatchSnapshot();
-  });
+  for (const rel of [
+    "src/app/models/session.ts",
+    "src/app/models/user.ts",
+    "src/app/models/current.ts",
+    "src/app/controllers/sessions-controller.ts",
+    "src/app/controllers/concerns/authentication.ts",
+    "src/app/controllers/passwords-controller.ts",
+    "src/app/channels/application-cable/connection.ts",
+    "src/app/mailers/passwords-mailer.ts",
+    "test/mailers/previews/passwords-mailer-preview.ts",
+  ]) {
+    it(`matches snapshot for ${rel}`, () => {
+      makeGen().run();
+      expect(read(rel)).toMatchSnapshot();
+    });
+  }
 });

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -54,16 +54,6 @@ describe("AuthenticationGenerator", () => {
     expect(exists(VIEWS[0]!)).toBe(false);
   });
 
-  it("wires Authentication import + static-block + routes (fresh app)", () => {
-    makeGen().run();
-    const ac = read(APP_CTRL_PATH);
-    expect(ac).toContain('import { Authentication } from "./concerns/authentication.js";');
-    expect(ac).toContain("Authentication.includeInto(this);");
-    const r = read("src/config/routes.ts");
-    expect(r).toContain('router.resources("passwords", { param: "token" });');
-    expect(r).toContain('router.resource("session");');
-  });
-
   it("injects inside the class even when ApplicationController has a body", () => {
     write(
       APP_CTRL_PATH,
@@ -105,6 +95,12 @@ describe("AuthenticationGenerator", () => {
     expect(ac.match(/import\s+\{\s*Authentication\b/g)).toHaveLength(1);
     expect(ac).toContain("Authentication.includeInto(this);");
     expect(parseTs(ac).diagnostics).toEqual([]);
+  });
+
+  it("does not clobber a pre-existing application-cable Connection", () => {
+    write("src/app/channels/application-cable/connection.ts", "// user\n");
+    makeGen().run();
+    expect(read("src/app/channels/application-cable/connection.ts")).toBe("// user\n");
   });
 
   it("is idempotent — re-running yields byte-identical injected files", () => {

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -7,10 +7,8 @@ import { parseTs, assertNoRubySource } from "../../../template-builder/testing.j
 
 // prettier-ignore
 const TS_EMIT = ["src/app/models/session.ts","src/app/models/user.ts","src/app/models/current.ts","src/app/controllers/sessions-controller.ts","src/app/controllers/concerns/authentication.ts","src/app/controllers/passwords-controller.ts","src/app/channels/application-cable/connection.ts","src/app/mailers/passwords-mailer.ts","test/mailers/previews/passwords-mailer-preview.ts"];
-const VIEWS = [
-  "src/app/views/passwords-mailer/reset.html.tse",
-  "src/app/views/passwords-mailer/reset.text.tse",
-];
+// prettier-ignore
+const VIEWS = ["src/app/views/passwords-mailer/reset.html.tse","src/app/views/passwords-mailer/reset.text.tse"];
 const APP_CTRL_PATH = "src/app/controllers/application-controller.ts";
 const APP_CTRL_EMPTY = `import { ActionController } from "@blazetrails/actionpack";\n\nexport class ApplicationController extends ActionController.Base {\n}\n`;
 
@@ -19,11 +17,11 @@ const read = (rel: string) => fs.readFileSync(path.join(tmpDir, rel), "utf-8");
 const exists = (rel: string) => fs.existsSync(path.join(tmpDir, rel));
 const makeGen = () => new AuthenticationGenerator({ cwd: tmpDir, output: () => {} });
 
-function write(rel: string, content: string) {
+const write = (rel: string, content: string) => {
   const full = path.join(tmpDir, rel);
   fs.mkdirSync(path.dirname(full), { recursive: true });
   fs.writeFileSync(full, content);
-}
+};
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-auth-"));
   write("tsconfig.json", "{}");
@@ -36,32 +34,36 @@ describe("AuthenticationGenerator", () => {
   it("emits the full file set; each .ts file parses + carries no Ruby source", () => {
     makeGen().run();
     for (const rel of VIEWS) expect(exists(rel), rel).toBe(true);
+    const combined: string[] = [];
     for (const rel of TS_EMIT) {
       const src = read(rel);
       expect(parseTs(src).diagnostics, `diagnostics for ${rel}`).toEqual([]);
       assertNoRubySource(src);
+      combined.push(`=== ${rel} ===\n${src}`);
     }
+    expect(combined.join("\n")).toMatchSnapshot();
   });
 
-  it("skips mailer pieces on --skip-mailer; api keeps mailer but drops views", () => {
+  it("--skip-mailer drops mailer/preview/views; --api keeps mailer but drops views", () => {
     makeGen().run({ skipMailer: true });
     expect(exists("src/app/mailers/passwords-mailer.ts")).toBe(false);
-    expect(exists("src/app/views/passwords-mailer/reset.html.tse")).toBe(false);
+    expect(exists(VIEWS[0]!)).toBe(false);
     expect(exists("test/mailers/previews/passwords-mailer-preview.ts")).toBe(false);
-    new AuthenticationGenerator({ cwd: tmpDir, output: () => {} }).run({ api: true });
+    makeGen().run({ api: true });
     expect(exists("src/app/mailers/passwords-mailer.ts")).toBe(true);
-    expect(exists("src/app/views/passwords-mailer/reset.html.tse")).toBe(false);
+    expect(exists(VIEWS[0]!)).toBe(false);
   });
 
-  it("wires Authentication into the application controller + adds routes", () => {
+  it("wires Authentication import + static-block + routes (fresh app)", () => {
     makeGen().run();
-    const ac = read("src/app/controllers/application-controller.ts");
+    const ac = read(APP_CTRL_PATH);
     expect(ac).toContain('import { Authentication } from "./concerns/authentication.js";');
     expect(ac).toContain("Authentication.includeInto(this);");
     expect(parseTs(ac).diagnostics).toEqual([]);
-    const routes = read("src/config/routes.ts");
-    expect(routes).toContain('router.resources("passwords", { param: "token" });');
-    expect(routes).toContain('router.resource("session");');
+    const r = read("src/config/routes.ts");
+    expect(r).toMatch(
+      /router\.resources\("passwords", \{ param: "token" \}\);[\s\S]*router\.resource\("session"\);/,
+    );
   });
 
   it("injects inside the class even when ApplicationController has a body", () => {
@@ -84,13 +86,18 @@ describe("AuthenticationGenerator", () => {
     expect(() => makeGen().run()).toThrow(/TypeScript only/);
   });
 
+  // session route already present; passwords route present but token-less;
+  // Authentication import present via extensionless specifier.
   it("partial pre-existing config: only the missing pieces are injected", () => {
-    write("src/config/routes.ts", `// routes\n  router.resource("session");\n`);
+    write(
+      "src/config/routes.ts",
+      `// routes\n  router.resources("passwords");\n  router.resource("session");\n`,
+    );
     write(
       APP_CTRL_PATH,
       APP_CTRL_EMPTY.replace(
         "\n\nexport",
-        `\nimport { Authentication } from "./concerns/authentication.js";\n\nexport`,
+        `\nimport { Authentication } from "./concerns/authentication";\n\nexport`,
       ),
     );
     makeGen().run();
@@ -103,18 +110,11 @@ describe("AuthenticationGenerator", () => {
     expect(parseTs(ac).diagnostics).toEqual([]);
   });
 
-  it("is idempotent — re-running does not duplicate imports or routes", () => {
+  it("is idempotent — re-running yields byte-identical injected files", () => {
     makeGen().run();
-    const ac = read("src/app/controllers/application-controller.ts");
-    const rt = read("src/config/routes.ts");
+    const [ac, rt] = [read(APP_CTRL_PATH), read("src/config/routes.ts")];
     makeGen().run();
-    expect(read("src/app/controllers/application-controller.ts")).toEqual(ac);
-    expect(read("src/config/routes.ts")).toEqual(rt);
+    expect([read(APP_CTRL_PATH), read("src/config/routes.ts")]).toEqual([ac, rt]);
     expect(parseTs(ac).diagnostics).toEqual([]);
-  });
-
-  it("matches snapshot for the full TS emit set", () => {
-    makeGen().run();
-    expect(TS_EMIT.map((r) => `// === ${r} ===\n${read(r)}`).join("\n")).toMatchSnapshot();
   });
 });

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -86,8 +86,6 @@ describe("AuthenticationGenerator", () => {
     expect(() => makeGen().run()).toThrow(/TypeScript only/);
   });
 
-  // session route already present; passwords route present but token-less;
-  // Authentication import present via extensionless specifier.
   it("partial pre-existing config: only the missing pieces are injected", () => {
     write(
       "src/config/routes.ts",

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -59,11 +59,9 @@ describe("AuthenticationGenerator", () => {
     const ac = read(APP_CTRL_PATH);
     expect(ac).toContain('import { Authentication } from "./concerns/authentication.js";');
     expect(ac).toContain("Authentication.includeInto(this);");
-    expect(parseTs(ac).diagnostics).toEqual([]);
     const r = read("src/config/routes.ts");
-    expect(r).toMatch(
-      /router\.resources\("passwords", \{ param: "token" \}\);[\s\S]*router\.resource\("session"\);/,
-    );
+    expect(r).toContain('router.resources("passwords", { param: "token" });');
+    expect(r).toContain('router.resource("session");');
   });
 
   it("injects inside the class even when ApplicationController has a body", () => {
@@ -86,7 +84,8 @@ describe("AuthenticationGenerator", () => {
     expect(() => makeGen().run()).toThrow(/TypeScript only/);
   });
 
-  it("partial pre-existing config: only the missing pieces are injected", () => {
+  it("partial pre-existing config: missing pieces filled, no duplicates", () => {
+    // Pre-existing token-less passwords route, session route, extensionless import.
     write(
       "src/config/routes.ts",
       `// routes\n  router.resources("passwords");\n  router.resource("session");\n`,
@@ -100,7 +99,7 @@ describe("AuthenticationGenerator", () => {
     );
     makeGen().run();
     const routes = read("src/config/routes.ts");
-    expect(routes).toContain('router.resources("passwords", { param: "token" });');
+    expect(routes.match(/router\.resources\("passwords"/g)).toHaveLength(1);
     expect(routes.match(/router\.resource\("session"\)/g)).toHaveLength(1);
     const ac = read(APP_CTRL_PATH);
     expect(ac.match(/import\s+\{\s*Authentication\b/g)).toHaveLength(1);

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -5,71 +5,50 @@ import * as os from "node:os";
 import { AuthenticationGenerator } from "./authentication-generator.js";
 import { parseTs, assertNoRubySource } from "../../../template-builder/testing.js";
 
-let tmpDir: string;
+const TS_EMIT = [
+  "src/app/models/session.ts",
+  "src/app/models/user.ts",
+  "src/app/models/current.ts",
+  "src/app/controllers/sessions-controller.ts",
+  "src/app/controllers/concerns/authentication.ts",
+  "src/app/controllers/passwords-controller.ts",
+  "src/app/channels/application-cable/connection.ts",
+  "src/app/mailers/passwords-mailer.ts",
+  "test/mailers/previews/passwords-mailer-preview.ts",
+];
+const ALL_EMIT = [
+  ...TS_EMIT,
+  "src/app/views/passwords-mailer/reset.html.tse",
+  "src/app/views/passwords-mailer/reset.text.tse",
+];
 
-function setupApp() {
+let tmpDir: string;
+const read = (rel: string) => fs.readFileSync(path.join(tmpDir, rel), "utf-8");
+const exists = (rel: string) => fs.existsSync(path.join(tmpDir, rel));
+const makeGen = () => new AuthenticationGenerator({ cwd: tmpDir, output: () => {} });
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-auth-"));
   fs.mkdirSync(path.join(tmpDir, "src/app/controllers"), { recursive: true });
   fs.mkdirSync(path.join(tmpDir, "src/config"), { recursive: true });
   fs.writeFileSync(path.join(tmpDir, "tsconfig.json"), "{}");
   fs.writeFileSync(
     path.join(tmpDir, "src/app/controllers/application-controller.ts"),
-    `import { ActionController } from "@blazetrails/actionpack";
-
-export class ApplicationController extends ActionController.Base {
-}
-`,
+    `import { ActionController } from "@blazetrails/actionpack";\n\nexport class ApplicationController extends ActionController.Base {\n}\n`,
   );
   fs.writeFileSync(path.join(tmpDir, "src/config/routes.ts"), "// routes\n");
-}
-
-beforeEach(() => {
-  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-auth-"));
-  setupApp();
 });
 afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
-
-function read(rel: string): string {
-  return fs.readFileSync(path.join(tmpDir, rel), "utf-8");
-}
-function exists(rel: string): boolean {
-  return fs.existsSync(path.join(tmpDir, rel));
-}
-function makeGen() {
-  return new AuthenticationGenerator({ cwd: tmpDir, output: () => {} });
-}
 
 describe("AuthenticationGenerator", () => {
   it("creates the full authentication file set", () => {
     makeGen().run();
-    const emitted = [
-      "src/app/models/session.ts",
-      "src/app/models/user.ts",
-      "src/app/models/current.ts",
-      "src/app/controllers/sessions-controller.ts",
-      "src/app/controllers/concerns/authentication.ts",
-      "src/app/controllers/passwords-controller.ts",
-      "src/app/channels/application-cable/connection.ts",
-      "src/app/mailers/passwords-mailer.ts",
-      "src/app/views/passwords-mailer/reset.html.tse",
-      "src/app/views/passwords-mailer/reset.text.tse",
-      "test/mailers/previews/passwords-mailer-preview.ts",
-    ];
-    for (const rel of emitted) expect(exists(rel)).toBe(true);
+    for (const rel of ALL_EMIT) expect(exists(rel), rel).toBe(true);
   });
 
   it("emits TypeScript that parses without diagnostics and contains no Ruby source", () => {
     makeGen().run();
-    for (const rel of [
-      "src/app/models/session.ts",
-      "src/app/models/user.ts",
-      "src/app/models/current.ts",
-      "src/app/controllers/sessions-controller.ts",
-      "src/app/controllers/concerns/authentication.ts",
-      "src/app/controllers/passwords-controller.ts",
-      "src/app/channels/application-cable/connection.ts",
-      "src/app/mailers/passwords-mailer.ts",
-      "test/mailers/previews/passwords-mailer-preview.ts",
-    ]) {
+    for (const rel of TS_EMIT) {
       const src = read(rel);
       expect(parseTs(src).diagnostics, `diagnostics for ${rel}`).toEqual([]);
       assertNoRubySource(src);
@@ -83,7 +62,7 @@ describe("AuthenticationGenerator", () => {
     expect(exists("test/mailers/previews/passwords-mailer-preview.ts")).toBe(false);
   });
 
-  it("omits views in api mode but keeps mailer class", () => {
+  it("omits views in api mode but keeps the mailer class", () => {
     makeGen().run({ api: true });
     expect(exists("src/app/mailers/passwords-mailer.ts")).toBe(true);
     expect(exists("src/app/views/passwords-mailer/reset.html.tse")).toBe(false);
@@ -94,17 +73,10 @@ describe("AuthenticationGenerator", () => {
     const ac = read("src/app/controllers/application-controller.ts");
     expect(ac).toContain('import { Authentication } from "./concerns/authentication.js";');
     expect(ac).toContain("Authentication.includeInto(this);");
-    // Mixin call lands inside the class body (Rails inject_into_class parity).
     const classStart = ac.indexOf("export class ApplicationController");
     const classEnd = ac.indexOf("}", classStart);
     expect(ac.slice(classStart, classEnd)).toContain("Authentication.includeInto(this);");
-    // The post-injection file still parses cleanly.
     expect(parseTs(ac).diagnostics).toEqual([]);
-  });
-
-  it("is a no-op when application-controller.ts is missing", () => {
-    fs.unlinkSync(path.join(tmpDir, "src/app/controllers/application-controller.ts"));
-    expect(() => makeGen().run()).not.toThrow();
   });
 
   it("configures authentication routes", () => {
@@ -114,25 +86,15 @@ describe("AuthenticationGenerator", () => {
     expect(routes).toContain('router.resource("session");');
   });
 
-  it("is a no-op when routes.ts is missing", () => {
+  it("is a no-op when application-controller.ts or routes.ts are missing", () => {
+    fs.unlinkSync(path.join(tmpDir, "src/app/controllers/application-controller.ts"));
     fs.unlinkSync(path.join(tmpDir, "src/config/routes.ts"));
     expect(() => makeGen().run()).not.toThrow();
   });
 
-  for (const rel of [
-    "src/app/models/session.ts",
-    "src/app/models/user.ts",
-    "src/app/models/current.ts",
-    "src/app/controllers/sessions-controller.ts",
-    "src/app/controllers/concerns/authentication.ts",
-    "src/app/controllers/passwords-controller.ts",
-    "src/app/channels/application-cable/connection.ts",
-    "src/app/mailers/passwords-mailer.ts",
-    "test/mailers/previews/passwords-mailer-preview.ts",
-  ]) {
-    it(`matches snapshot for ${rel}`, () => {
-      makeGen().run();
-      expect(read(rel)).toMatchSnapshot();
-    });
-  }
+  it("matches snapshot for the full TS emit set", () => {
+    makeGen().run();
+    const combined = TS_EMIT.map((rel) => `// === ${rel} ===\n${read(rel)}`).join("\n");
+    expect(combined).toMatchSnapshot();
+  });
 });

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.test.ts
@@ -5,49 +5,37 @@ import * as os from "node:os";
 import { AuthenticationGenerator } from "./authentication-generator.js";
 import { parseTs, assertNoRubySource } from "../../../template-builder/testing.js";
 
-const TS_EMIT = [
-  "src/app/models/session.ts",
-  "src/app/models/user.ts",
-  "src/app/models/current.ts",
-  "src/app/controllers/sessions-controller.ts",
-  "src/app/controllers/concerns/authentication.ts",
-  "src/app/controllers/passwords-controller.ts",
-  "src/app/channels/application-cable/connection.ts",
-  "src/app/mailers/passwords-mailer.ts",
-  "test/mailers/previews/passwords-mailer-preview.ts",
-];
-const ALL_EMIT = [
-  ...TS_EMIT,
+// prettier-ignore
+const TS_EMIT = ["src/app/models/session.ts","src/app/models/user.ts","src/app/models/current.ts","src/app/controllers/sessions-controller.ts","src/app/controllers/concerns/authentication.ts","src/app/controllers/passwords-controller.ts","src/app/channels/application-cable/connection.ts","src/app/mailers/passwords-mailer.ts","test/mailers/previews/passwords-mailer-preview.ts"];
+const VIEWS = [
   "src/app/views/passwords-mailer/reset.html.tse",
   "src/app/views/passwords-mailer/reset.text.tse",
 ];
+const APP_CTRL_PATH = "src/app/controllers/application-controller.ts";
+const APP_CTRL_EMPTY = `import { ActionController } from "@blazetrails/actionpack";\n\nexport class ApplicationController extends ActionController.Base {\n}\n`;
 
 let tmpDir: string;
 const read = (rel: string) => fs.readFileSync(path.join(tmpDir, rel), "utf-8");
 const exists = (rel: string) => fs.existsSync(path.join(tmpDir, rel));
 const makeGen = () => new AuthenticationGenerator({ cwd: tmpDir, output: () => {} });
 
+function write(rel: string, content: string) {
+  const full = path.join(tmpDir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-auth-"));
-  fs.mkdirSync(path.join(tmpDir, "src/app/controllers"), { recursive: true });
-  fs.mkdirSync(path.join(tmpDir, "src/config"), { recursive: true });
-  fs.writeFileSync(path.join(tmpDir, "tsconfig.json"), "{}");
-  fs.writeFileSync(
-    path.join(tmpDir, "src/app/controllers/application-controller.ts"),
-    `import { ActionController } from "@blazetrails/actionpack";\n\nexport class ApplicationController extends ActionController.Base {\n}\n`,
-  );
-  fs.writeFileSync(path.join(tmpDir, "src/config/routes.ts"), "// routes\n");
+  write("tsconfig.json", "{}");
+  write(APP_CTRL_PATH, APP_CTRL_EMPTY);
+  write("src/config/routes.ts", "// routes\n");
 });
 afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
 describe("AuthenticationGenerator", () => {
-  it("creates the full authentication file set", () => {
+  it("emits the full file set; each .ts file parses + carries no Ruby source", () => {
     makeGen().run();
-    for (const rel of ALL_EMIT) expect(exists(rel), rel).toBe(true);
-  });
-
-  it("emits TypeScript that parses without diagnostics and contains no Ruby source", () => {
-    makeGen().run();
+    for (const rel of VIEWS) expect(exists(rel), rel).toBe(true);
     for (const rel of TS_EMIT) {
       const src = read(rel);
       expect(parseTs(src).diagnostics, `diagnostics for ${rel}`).toEqual([]);
@@ -76,17 +64,43 @@ describe("AuthenticationGenerator", () => {
     expect(routes).toContain('router.resource("session");');
   });
 
-  it("injects the mixin inside the class even when ApplicationController has a body", () => {
-    fs.writeFileSync(
-      path.join(tmpDir, "src/app/controllers/application-controller.ts"),
-      `import { ActionController } from "@blazetrails/actionpack";\n\nexport class ApplicationController extends ActionController.Base {\n  async preexisting(): Promise<void> { return; }\n}\n`,
+  it("injects inside the class even when ApplicationController has a body", () => {
+    write(
+      APP_CTRL_PATH,
+      APP_CTRL_EMPTY.replace("{\n}", "{\n  async preexisting(): Promise<void> { return; }\n}"),
     );
     makeGen().run();
-    const ac = read("src/app/controllers/application-controller.ts");
+    const ac = read(APP_CTRL_PATH);
     expect(parseTs(ac).diagnostics).toEqual([]);
-    // A brittle "first }" marker would have landed the injection after
-    // the method's closing brace.
     expect(ac.indexOf("Authentication.includeInto")).toBeLessThan(ac.indexOf("preexisting"));
+  });
+
+  it("no-op for missing application-controller / routes; throws clearly in JS projects", () => {
+    fs.unlinkSync(path.join(tmpDir, APP_CTRL_PATH));
+    fs.unlinkSync(path.join(tmpDir, "src/config/routes.ts"));
+    expect(() => makeGen().run()).not.toThrow();
+    expect(exists("src/app/models/user.ts")).toBe(true);
+    fs.unlinkSync(path.join(tmpDir, "tsconfig.json"));
+    expect(() => makeGen().run()).toThrow(/TypeScript only/);
+  });
+
+  it("partial pre-existing config: only the missing pieces are injected", () => {
+    write("src/config/routes.ts", `// routes\n  router.resource("session");\n`);
+    write(
+      APP_CTRL_PATH,
+      APP_CTRL_EMPTY.replace(
+        "\n\nexport",
+        `\nimport { Authentication } from "./concerns/authentication.js";\n\nexport`,
+      ),
+    );
+    makeGen().run();
+    const routes = read("src/config/routes.ts");
+    expect(routes).toContain('router.resources("passwords", { param: "token" });');
+    expect(routes.match(/router\.resource\("session"\)/g)).toHaveLength(1);
+    const ac = read(APP_CTRL_PATH);
+    expect(ac.match(/import\s+\{\s*Authentication\b/g)).toHaveLength(1);
+    expect(ac).toContain("Authentication.includeInto(this);");
+    expect(parseTs(ac).diagnostics).toEqual([]);
   });
 
   it("is idempotent — re-running does not duplicate imports or routes", () => {
@@ -101,7 +115,6 @@ describe("AuthenticationGenerator", () => {
 
   it("matches snapshot for the full TS emit set", () => {
     makeGen().run();
-    const combined = TS_EMIT.map((rel) => `// === ${rel} ===\n${read(rel)}`).join("\n");
-    expect(combined).toMatchSnapshot();
+    expect(TS_EMIT.map((r) => `// === ${r} ===\n${read(r)}`).join("\n")).toMatchSnapshot();
   });
 });

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -101,14 +101,14 @@ export class AuthenticationGenerator extends GeneratorBase {
     );
   }
 
-  // Mirrors Rails' `inject_into_class` — anchors on the class declaration
-  // so the mixin call lands inside ApplicationController even when the
-  // class already has a body.
+  // Rails' inject_into_class re-injects on every run; we skip the second
+  // pass because a duplicate TS `import` declaration is a syntax error.
   private configureApplicationController(): void {
     const file = "src/app/controllers/application-controller.ts";
     if (!this.fileExists(file)) return;
     const full = this.path.join(this.cwd, file);
     let src = this.fs.readFileSync(full, "utf-8");
+    if (src.includes("Authentication.includeInto(this)")) return;
     const classRe = /export\s+class\s+ApplicationController\b[^{]*\{/;
     const m = src.match(classRe);
     if (!m || m.index === undefined) return;
@@ -124,6 +124,8 @@ export class AuthenticationGenerator extends GeneratorBase {
   private configureAuthenticationRoutes(): void {
     for (const f of ["src/config/routes.ts", "src/config/routes.js"]) {
       if (!this.fileExists(f)) continue;
+      const full = this.path.join(this.cwd, f);
+      if (this.fs.readFileSync(full, "utf-8").includes('router.resource("session")')) return;
       this.insertIntoFile(
         f,
         "// routes",

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -65,11 +65,13 @@ export class AuthenticationGenerator extends GeneratorBase {
         asyncStub("setUserByToken", "// User.findByPasswordResetTokenBang", PRIVATE),
       ],
     );
-    this.emit("src/app/channels/application-cable/connection.ts", "Connection", undefined, [
-      stub("identifiedBy", "// currentUser", { static: true }),
-      asyncStub("connect", "// setCurrentUser || rejectUnauthorizedConnection"),
-      asyncStub("setCurrentUser", "// Session.findBy(cookies.signed.sessionId)", PRIVATE),
-    ]);
+    // Don't clobber AppGenerator's Connection (or user customizations).
+    if (!this.fileExists("src/app/channels/application-cable/connection.ts"))
+      this.emit("src/app/channels/application-cable/connection.ts", "Connection", undefined, [
+        stub("identifiedBy", "// currentUser", { static: true }),
+        asyncStub("connect", "// setCurrentUser || rejectUnauthorizedConnection"),
+        asyncStub("setCurrentUser", "// Session.findBy(cookies.signed.sessionId)", PRIVATE),
+      ]);
 
     if (!skipMailer) {
       this.emit("src/app/mailers/passwords-mailer.ts", "PasswordsMailer", APP_MAILER, [

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -97,14 +97,11 @@ export class AuthenticationGenerator extends GeneratorBase {
   }
 
   private emit(file: string, name: string, ext: Ref | undefined, body: Method[]): void {
-    this.createFile(
-      file,
-      tsModule({ declarations: [tsClass({ name, ...(ext ? { extends: ext } : {}), body })] }),
-    );
+    const cls = tsClass({ name, ...(ext ? { extends: ext } : {}), body });
+    this.createFile(file, tsModule({ declarations: [cls] }));
   }
 
-  // Anchored on the class declaration (not a stray "}") and idempotent —
-  // Rails' inject_into_class isn't, but a duplicate TS `import` is a syntax error.
+  // Anchored on the class declaration; idempotent (a duplicate TS import would be a syntax error).
   private configureApplicationController(): void {
     const file = "src/app/controllers/application-controller.ts";
     if (!this.fileExists(file)) return;
@@ -113,31 +110,22 @@ export class AuthenticationGenerator extends GeneratorBase {
     if (src.includes("Authentication.includeInto(this)")) return;
     const m = src.match(/export\s+class\s+ApplicationController\b[^{]*\{/);
     if (!m || m.index === undefined) return;
-    const hasImport =
-      /import\s*\{[^}]*\bAuthentication\b[^}]*\}\s*from\s*["']\.\/concerns\/authentication\.js["']/.test(
-        src,
-      );
-    const prefix = hasImport
-      ? ""
-      : `import { Authentication } from "./concerns/authentication.js";\n`;
+    // Detect any existing `Authentication` named import, regardless of specifier.
+    const hasImport = /import\s*\{[^}]*\bAuthentication\b[^}]*\}\s*from\s*["'][^"']+["']/.test(src);
     const at = m.index + m[0].length;
-    src =
-      prefix +
-      src.slice(0, at) +
-      `\n  static {\n    Authentication.includeInto(this);\n  }` +
-      src.slice(at);
+    src = (hasImport ? "" : AUTH_IMPORT) + src.slice(0, at) + STATIC_INIT + src.slice(at);
     this.fs.writeFileSync(full, src);
     this.output(`      inject  ${file}`);
   }
 
-  // Each route checked independently so a partially-configured app still
-  // ends up with the missing one(s).
+  // Each route checked independently so a partial pre-existing config converges.
   private configureAuthenticationRoutes(): void {
     for (const f of ["src/config/routes.ts", "src/config/routes.js"]) {
       if (!this.fileExists(f)) continue;
       const src = this.fs.readFileSync(this.path.join(this.cwd, f), "utf-8");
       const lines: string[] = [];
-      if (!src.includes('router.resources("passwords"'))
+      // Match `param: "token"` so a token-less pre-existing declaration is still augmented.
+      if (!/router\.resources\("passwords"[^)]*param:\s*"token"/.test(src))
         lines.push(`  router.resources("passwords", { param: "token" });`);
       if (!src.includes('router.resource("session")')) lines.push(`  router.resource("session");`);
       if (lines.length) this.insertIntoFile(f, "// routes", lines.join("\n") + "\n");
@@ -146,8 +134,7 @@ export class AuthenticationGenerator extends GeneratorBase {
   }
 }
 
-// `includeInto` only wires hooks; full instance-method mixin semantics
-// arrive when actionpack ships its include() primitive.
+// includeInto only wires hooks; full mixin semantics arrive with actionpack.
 const AUTH_CONCERN_METHODS: Method[] = [
   tsMethod({
     name: "includeInto",
@@ -188,6 +175,9 @@ function stub(name: string, comment: string, opts: StubOpts = {}): Method {
 function asyncStub(name: string, comment: string, opts: StubOpts = {}): Method {
   return stub(name, comment, { ...opts, async: true });
 }
+
+const AUTH_IMPORT = `import { Authentication } from "./concerns/authentication.js";\n`;
+const STATIC_INIT = `\n  static {\n    Authentication.includeInto(this);\n  }`;
 
 const RESET_HTML = `<p>
   You can reset your password within the next 15 minutes on

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -107,12 +107,15 @@ export class AuthenticationGenerator extends GeneratorBase {
     if (!this.fileExists(file)) return;
     const full = this.path.join(this.cwd, file);
     let src = this.fs.readFileSync(full, "utf-8");
-    if (src.includes("Authentication.includeInto(this)")) return;
+    const mixin = src.includes("Authentication.includeInto(this)") ? "" : STATIC_INIT;
+    const imp = /import\s*\{[^}]*\bAuthentication\b[^}]*\}\s*from\s*["'][^"']+["']/.test(src)
+      ? ""
+      : AUTH_IMPORT;
+    if (!mixin && !imp) return;
     const m = src.match(/export\s+class\s+ApplicationController\b[^{]*\{/);
     if (!m || m.index === undefined) return;
-    const hasImport = /import\s*\{[^}]*\bAuthentication\b[^}]*\}\s*from\s*["'][^"']+["']/.test(src);
     const at = m.index + m[0].length;
-    src = (hasImport ? "" : AUTH_IMPORT) + src.slice(0, at) + STATIC_INIT + src.slice(at);
+    src = imp + src.slice(0, at) + mixin + src.slice(at);
     this.fs.writeFileSync(full, src);
   }
 

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -1,0 +1,223 @@
+import { GeneratorBase, type GeneratorOptions } from "../../base.js";
+import {
+  ref,
+  tsBody,
+  tsClass,
+  tsMethod,
+  tsModule,
+  type Method,
+  type Ref,
+} from "../../../template-builder/index.js";
+
+export interface AuthenticationRunOptions {
+  api?: boolean;
+  skipMailer?: boolean;
+}
+
+const APP_RECORD = ref("ApplicationRecord", "./application-record.js");
+const APP_CONTROLLER = ref("ApplicationController", "../application-controller.js");
+const APP_MAILER = ref("ApplicationMailer", "./application-mailer.js");
+const CURRENT_ATTRS = ref("ActiveSupport.CurrentAttributes");
+
+// Mirrors railties/lib/rails/generators/rails/authentication/authentication_generator.rb.
+export class AuthenticationGenerator extends GeneratorBase {
+  constructor(options: GeneratorOptions) {
+    super(options);
+  }
+
+  run(options: AuthenticationRunOptions = {}): string[] {
+    const { api = false, skipMailer = false } = options;
+    this.createFile(
+      "src/app/models/session.ts",
+      buildClass("Session", APP_RECORD, [
+        stub("associations", "// belongsTo: User", { static: true }),
+      ]),
+    );
+    this.createFile(
+      "src/app/models/user.ts",
+      buildClass("User", APP_RECORD, [
+        stub("associations", "// hasSecurePassword; hasMany sessions, dependent: destroy", {
+          static: true,
+        }),
+        stub("normalizes", "// emailAddress → e.strip().toLowerCase()", { static: true }),
+      ]),
+    );
+    this.createFile(
+      "src/app/models/current.ts",
+      tsModule({
+        imports: [
+          { from: "@blazetrails/activesupport", named: { ActiveSupport: "ActiveSupport" } },
+        ],
+        declarations: [
+          tsClass({
+            name: "Current",
+            extends: CURRENT_ATTRS,
+            body: [stub("attributes", "// attribute :session", { static: true })],
+          }),
+        ],
+      }),
+    );
+
+    this.createFile(
+      "src/app/controllers/sessions-controller.ts",
+      buildClass("SessionsController", APP_CONTROLLER, [
+        asyncStub("new_", "// allowUnauthenticatedAccess only: [new_, create]"),
+        asyncStub("create", "// User.authenticateBy → startNewSessionFor → redirect"),
+        asyncStub("destroy", "// terminateSession → redirect to /session/new"),
+      ]),
+    );
+    this.createFile(
+      "src/app/controllers/concerns/authentication.ts",
+      tsModule({
+        declarations: [
+          tsClass({
+            name: "Authentication",
+            body: [
+              tsMethod({
+                name: "includeInto",
+                params: [{ name: "klass", type: "any" }],
+                static: true,
+                body: tsBody`klass.beforeAction?.("requireAuthentication");\nklass.helperMethod?.("authenticated");`,
+              }),
+              asyncStub("authenticated", "// resumeSession"),
+              asyncStub("requireAuthentication", "// resumeSession || requestAuthentication"),
+              asyncStub("resumeSession", "// Current.session ||= findSessionByCookie", {
+                visibility: "private",
+              }),
+              asyncStub("findSessionByCookie", "// Session.findBy(cookies.signed.sessionId)", {
+                visibility: "private",
+              }),
+              asyncStub("startNewSessionFor", "// user.sessions.createBang + cookie", {
+                visibility: "private",
+                param: "user",
+              }),
+              asyncStub("terminateSession", "// Current.session.destroy + cookies.delete", {
+                visibility: "private",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+    this.createFile(
+      "src/app/controllers/passwords-controller.ts",
+      buildClass("PasswordsController", APP_CONTROLLER, [
+        asyncStub("new_", "// allowUnauthenticatedAccess"),
+        asyncStub("create", "// PasswordsMailer.reset(user).deliverLater"),
+        asyncStub("edit", "// setUserByToken"),
+        asyncStub("update", "// user.update(password, passwordConfirmation)"),
+        asyncStub("setUserByToken", "// User.findByPasswordResetTokenBang", {
+          visibility: "private",
+        }),
+      ]),
+    );
+
+    this.createFile(
+      "src/app/channels/application-cable/connection.ts",
+      tsModule({
+        declarations: [
+          tsClass({
+            name: "Connection",
+            body: [
+              stub("identifiedBy", "// currentUser", { static: true }),
+              asyncStub("connect", "// setCurrentUser || rejectUnauthorizedConnection"),
+              asyncStub("setCurrentUser", "// Session.findBy(cookies.signed.sessionId)", {
+                visibility: "private",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    if (!skipMailer) {
+      this.createFile(
+        "src/app/mailers/passwords-mailer.ts",
+        buildClass("PasswordsMailer", APP_MAILER, [
+          asyncStub("reset", '// mail subject: "Reset your password", to: user.emailAddress', {
+            param: "user",
+          }),
+        ]),
+      );
+      this.createFile(
+        "test/mailers/previews/passwords-mailer-preview.ts",
+        tsModule({
+          declarations: [
+            tsClass({
+              name: "PasswordsMailerPreview",
+              body: [stub("reset", "// TODO: preview PasswordsMailer.reset")],
+            }),
+          ],
+        }),
+      );
+      if (!api) {
+        this.createFile(
+          "src/app/views/passwords-mailer/reset.html.tse",
+          `<p>\n  You can reset your password within the next 15 minutes on\n  <%= linkTo("this password reset page", editPasswordUrl(user.passwordResetToken)) %>.\n</p>\n`,
+        );
+        this.createFile(
+          "src/app/views/passwords-mailer/reset.text.tse",
+          `You can reset your password within the next 15 minutes on this password reset page:\n<%= editPasswordUrl(user.passwordResetToken) %>\n`,
+        );
+      }
+    }
+
+    this.configureApplicationController();
+    this.configureAuthenticationRoutes();
+    return this.getCreatedFiles();
+  }
+
+  private configureApplicationController(): void {
+    if (!this.fileExists("src/app/controllers/application-controller.ts")) return;
+    this.appendToFile(
+      "src/app/controllers/application-controller.ts",
+      `\nimport { Authentication } from "./concerns/authentication.js";\nAuthentication.includeInto(ApplicationController);\n`,
+    );
+  }
+
+  private configureAuthenticationRoutes(): void {
+    const routesFile = this.fileExists("src/config/routes.ts")
+      ? "src/config/routes.ts"
+      : this.fileExists("src/config/routes.js")
+        ? "src/config/routes.js"
+        : null;
+    if (!routesFile) return;
+    this.insertIntoFile(
+      routesFile,
+      "// routes",
+      `  router.resources("passwords", { param: "token" });\n  router.resource("session");\n`,
+    );
+  }
+}
+
+function buildClass(name: string, ext: Ref, body: Method[]): string {
+  return tsModule({ declarations: [tsClass({ name, extends: ext, body })] });
+}
+
+interface StubOpts {
+  static?: boolean;
+  visibility?: "private" | "protected";
+  param?: string;
+}
+
+function stub(name: string, comment: string, opts: StubOpts = {}): Method {
+  return tsMethod({
+    name,
+    params: opts.param ? [{ name: opts.param, type: "any" }] : [],
+    static: opts.static,
+    visibility: opts.visibility,
+    body: tsBody`${comment}`,
+  });
+}
+
+function asyncStub(name: string, comment: string, opts: StubOpts = {}): Method {
+  return tsMethod({
+    name,
+    params: opts.param ? [{ name: opts.param, type: "any" }] : [],
+    async: true,
+    returnType: "Promise<void>",
+    static: opts.static,
+    visibility: opts.visibility,
+    body: tsBody`${comment}`,
+  });
+}

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -15,9 +15,9 @@ export interface AuthenticationRunOptions {
 }
 
 const APP_RECORD = ref("ApplicationRecord", "./application-record.js");
-const APP_CONTROLLER = ref("ApplicationController", "../application-controller.js");
+const APP_CONTROLLER = ref("ApplicationController", "./application-controller.js");
 const APP_MAILER = ref("ApplicationMailer", "./application-mailer.js");
-const CURRENT_ATTRS = ref("ActiveSupport.CurrentAttributes");
+const CURRENT_ATTRS = ref("CurrentAttributes", "@blazetrails/activesupport");
 const PRIVATE = { visibility: "private" } as const;
 
 // Mirrors railties/lib/rails/generators/rails/authentication/authentication_generator.rb.
@@ -37,13 +37,20 @@ export class AuthenticationGenerator extends GeneratorBase {
       }),
       stub("normalizes", "// emailAddress → e.strip().toLowerCase()", { static: true }),
     ]);
-    this.createFile("src/app/models/current.ts", currentModel());
+    this.emit("src/app/models/current.ts", "Current", CURRENT_ATTRS, [
+      stub("attributes", "// attribute :session", { static: true }),
+    ]);
     this.emit("src/app/controllers/sessions-controller.ts", "SessionsController", APP_CONTROLLER, [
       asyncStub("new_", "// allowUnauthenticatedAccess only: [new_, create]"),
       asyncStub("create", "// User.authenticateBy → startNewSessionFor → redirect"),
       asyncStub("destroy", "// terminateSession → redirect to /session/new"),
     ]);
-    this.createFile("src/app/controllers/concerns/authentication.ts", authenticationConcern());
+    this.emit(
+      "src/app/controllers/concerns/authentication.ts",
+      "Authentication",
+      undefined,
+      AUTH_CONCERN_METHODS,
+    );
     this.emit(
       "src/app/controllers/passwords-controller.ts",
       "PasswordsController",
@@ -94,79 +101,58 @@ export class AuthenticationGenerator extends GeneratorBase {
     );
   }
 
-  // Mirrors Rails' `inject_into_class "application_controller.rb",
-  // "ApplicationController", "  include Authentication\n"` — the mixin call
-  // lands inside the class body via a static initializer; the import joins
-  // the existing imports above the class.
+  // Mirrors Rails' `inject_into_class` — anchors on the class declaration
+  // so the mixin call lands inside ApplicationController even when the
+  // class already has a body.
   private configureApplicationController(): void {
     const file = "src/app/controllers/application-controller.ts";
     if (!this.fileExists(file)) return;
-    this.insertIntoFile(
-      file,
-      "export class ApplicationController",
-      `import { Authentication } from "./concerns/authentication.js";\n\n`,
-    );
-    this.insertIntoFile(file, "\n}\n", `  static {\n    Authentication.includeInto(this);\n  }\n`);
+    const full = this.path.join(this.cwd, file);
+    let src = this.fs.readFileSync(full, "utf-8");
+    const classRe = /export\s+class\s+ApplicationController\b[^{]*\{/;
+    const m = src.match(classRe);
+    if (!m || m.index === undefined) return;
+    src =
+      `import { Authentication } from "./concerns/authentication.js";\n` +
+      src.slice(0, m.index + m[0].length) +
+      `\n  static {\n    Authentication.includeInto(this);\n  }` +
+      src.slice(m.index + m[0].length);
+    this.fs.writeFileSync(full, src);
+    this.output(`      inject  ${file}`);
   }
 
   private configureAuthenticationRoutes(): void {
-    const routesFile = this.fileExists("src/config/routes.ts")
-      ? "src/config/routes.ts"
-      : this.fileExists("src/config/routes.js")
-        ? "src/config/routes.js"
-        : null;
-    if (!routesFile) return;
-    this.insertIntoFile(
-      routesFile,
-      "// routes",
-      `  router.resources("passwords", { param: "token" });\n  router.resource("session");\n`,
-    );
+    for (const f of ["src/config/routes.ts", "src/config/routes.js"]) {
+      if (!this.fileExists(f)) continue;
+      this.insertIntoFile(
+        f,
+        "// routes",
+        `  router.resources("passwords", { param: "token" });\n  router.resource("session");\n`,
+      );
+      return;
+    }
   }
 }
 
-function currentModel(): string {
-  return tsModule({
-    imports: [{ from: "@blazetrails/activesupport", named: { ActiveSupport: "ActiveSupport" } }],
-    declarations: [
-      tsClass({
-        name: "Current",
-        extends: CURRENT_ATTRS,
-        body: [stub("attributes", "// attribute :session", { static: true })],
-      }),
-    ],
-  });
-}
-
-function authenticationConcern(): string {
-  // The Authentication "concern" is emitted as a class with static helpers.
-  // `Authentication.includeInto(klass)` wires the `requireAuthentication`
-  // beforeAction + `authenticated` helper hook; full instance-method mixin
-  // semantics arrive when actionpack ships its include() primitive.
-  return tsModule({
-    declarations: [
-      tsClass({
-        name: "Authentication",
-        body: [
-          tsMethod({
-            name: "includeInto",
-            params: [{ name: "klass", type: "any" }],
-            static: true,
-            body: tsBody`klass.beforeAction?.("requireAuthentication");\nklass.helperMethod?.("authenticated");`,
-          }),
-          asyncStub("authenticated", "// resumeSession"),
-          asyncStub("requireAuthentication", "// resumeSession || requestAuthentication"),
-          asyncStub("resumeSession", "// Current.session ||= findSessionByCookie", PRIVATE),
-          asyncStub("findSessionByCookie", "// Session.findBy(cookies.signed.sessionId)", PRIVATE),
-          asyncStub("startNewSessionFor", "// user.sessions.createBang + cookie", {
-            ...PRIVATE,
-            param: "user",
-          }),
-          asyncStub("terminateSession", "// Current.session.destroy + cookies.delete", PRIVATE),
-        ],
-      }),
-    ],
-  });
-}
+// `includeInto` only wires hooks; full instance-method mixin semantics
+// arrive when actionpack ships its include() primitive.
+const AUTH_CONCERN_METHODS: Method[] = [
+  tsMethod({
+    name: "includeInto",
+    params: [{ name: "klass", type: "any" }],
+    static: true,
+    body: tsBody`klass.beforeAction?.("requireAuthentication");\nklass.helperMethod?.("authenticated");`,
+  }),
+  asyncStub("authenticated", "// resumeSession"),
+  asyncStub("requireAuthentication", "// resumeSession || requestAuthentication"),
+  asyncStub("resumeSession", "// Current.session ||= findSessionByCookie", PRIVATE),
+  asyncStub("findSessionByCookie", "// Session.findBy(cookies.signed.sessionId)", PRIVATE),
+  asyncStub("startNewSessionFor", "// user.sessions.createBang + cookie", {
+    ...PRIVATE,
+    param: "user",
+  }),
+  asyncStub("terminateSession", "// Current.session.destroy + cookies.delete", PRIVATE),
+];
 
 interface StubOpts {
   static?: boolean;
@@ -187,8 +173,9 @@ function stub(name: string, comment: string, opts: StubOpts = {}): Method {
   });
 }
 
-const asyncStub = (name: string, comment: string, opts: StubOpts = {}): Method =>
-  stub(name, comment, { ...opts, async: true });
+function asyncStub(name: string, comment: string, opts: StubOpts = {}): Method {
+  return stub(name, comment, { ...opts, async: true });
+}
 
 const RESET_HTML = `<p>
   You can reset your password within the next 15 minutes on

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -18,6 +18,7 @@ const APP_RECORD = ref("ApplicationRecord", "./application-record.js");
 const APP_CONTROLLER = ref("ApplicationController", "../application-controller.js");
 const APP_MAILER = ref("ApplicationMailer", "./application-mailer.js");
 const CURRENT_ATTRS = ref("ActiveSupport.CurrentAttributes");
+const PRIVATE = { visibility: "private" } as const;
 
 // Mirrors railties/lib/rails/generators/rails/authentication/authentication_generator.rb.
 export class AuthenticationGenerator extends GeneratorBase {
@@ -27,152 +28,95 @@ export class AuthenticationGenerator extends GeneratorBase {
 
   run(options: AuthenticationRunOptions = {}): string[] {
     const { api = false, skipMailer = false } = options;
-    this.createFile(
-      "src/app/models/session.ts",
-      buildClass("Session", APP_RECORD, [
-        stub("associations", "// belongsTo: User", { static: true }),
-      ]),
-    );
-    this.createFile(
-      "src/app/models/user.ts",
-      buildClass("User", APP_RECORD, [
-        stub("associations", "// hasSecurePassword; hasMany sessions, dependent: destroy", {
-          static: true,
-        }),
-        stub("normalizes", "// emailAddress → e.strip().toLowerCase()", { static: true }),
-      ]),
-    );
-    this.createFile(
-      "src/app/models/current.ts",
-      tsModule({
-        imports: [
-          { from: "@blazetrails/activesupport", named: { ActiveSupport: "ActiveSupport" } },
-        ],
-        declarations: [
-          tsClass({
-            name: "Current",
-            extends: CURRENT_ATTRS,
-            body: [stub("attributes", "// attribute :session", { static: true })],
-          }),
-        ],
-      }),
-    );
-
-    this.createFile(
-      "src/app/controllers/sessions-controller.ts",
-      buildClass("SessionsController", APP_CONTROLLER, [
-        asyncStub("new_", "// allowUnauthenticatedAccess only: [new_, create]"),
-        asyncStub("create", "// User.authenticateBy → startNewSessionFor → redirect"),
-        asyncStub("destroy", "// terminateSession → redirect to /session/new"),
-      ]),
-    );
-    this.createFile(
-      "src/app/controllers/concerns/authentication.ts",
-      tsModule({
-        declarations: [
-          tsClass({
-            name: "Authentication",
-            body: [
-              tsMethod({
-                name: "includeInto",
-                params: [{ name: "klass", type: "any" }],
-                static: true,
-                body: tsBody`klass.beforeAction?.("requireAuthentication");\nklass.helperMethod?.("authenticated");`,
-              }),
-              asyncStub("authenticated", "// resumeSession"),
-              asyncStub("requireAuthentication", "// resumeSession || requestAuthentication"),
-              asyncStub("resumeSession", "// Current.session ||= findSessionByCookie", {
-                visibility: "private",
-              }),
-              asyncStub("findSessionByCookie", "// Session.findBy(cookies.signed.sessionId)", {
-                visibility: "private",
-              }),
-              asyncStub("startNewSessionFor", "// user.sessions.createBang + cookie", {
-                visibility: "private",
-                param: "user",
-              }),
-              asyncStub("terminateSession", "// Current.session.destroy + cookies.delete", {
-                visibility: "private",
-              }),
-            ],
-          }),
-        ],
-      }),
-    );
-    this.createFile(
-      "src/app/controllers/passwords-controller.ts",
-      buildClass("PasswordsController", APP_CONTROLLER, [
-        asyncStub("new_", "// allowUnauthenticatedAccess"),
-        asyncStub("create", "// PasswordsMailer.reset(user).deliverLater"),
-        asyncStub("edit", "// setUserByToken"),
-        asyncStub("update", "// user.update(password, passwordConfirmation)"),
-        asyncStub("setUserByToken", "// User.findByPasswordResetTokenBang", {
-          visibility: "private",
-        }),
-      ]),
-    );
-
-    this.createFile(
-      "src/app/channels/application-cable/connection.ts",
-      tsModule({
-        declarations: [
-          tsClass({
-            name: "Connection",
-            body: [
-              stub("identifiedBy", "// currentUser", { static: true }),
-              asyncStub("connect", "// setCurrentUser || rejectUnauthorizedConnection"),
-              asyncStub("setCurrentUser", "// Session.findBy(cookies.signed.sessionId)", {
-                visibility: "private",
-              }),
-            ],
-          }),
-        ],
-      }),
-    );
-
-    if (!skipMailer) {
-      this.createFile(
-        "src/app/mailers/passwords-mailer.ts",
-        buildClass("PasswordsMailer", APP_MAILER, [
-          asyncStub("reset", '// mail subject: "Reset your password", to: user.emailAddress', {
-            param: "user",
-          }),
-        ]),
-      );
-      this.createFile(
-        "test/mailers/previews/passwords-mailer-preview.ts",
-        tsModule({
-          declarations: [
-            tsClass({
-              name: "PasswordsMailerPreview",
-              body: [stub("reset", "// TODO: preview PasswordsMailer.reset")],
-            }),
-          ],
-        }),
-      );
-      if (!api) {
-        this.createFile(
-          "src/app/views/passwords-mailer/reset.html.tse",
-          `<p>\n  You can reset your password within the next 15 minutes on\n  <%= linkTo("this password reset page", editPasswordUrl(user.passwordResetToken)) %>.\n</p>\n`,
-        );
-        this.createFile(
-          "src/app/views/passwords-mailer/reset.text.tse",
-          `You can reset your password within the next 15 minutes on this password reset page:\n<%= editPasswordUrl(user.passwordResetToken) %>\n`,
-        );
-      }
-    }
-
+    for (const [path, content] of this.emitSet(api, skipMailer)) this.createFile(path, content);
     this.configureApplicationController();
     this.configureAuthenticationRoutes();
     return this.getCreatedFiles();
   }
 
+  private emitSet(api: boolean, skipMailer: boolean): Array<[string, string]> {
+    const files: Array<[string, string]> = [
+      [
+        "src/app/models/session.ts",
+        classOnly("Session", APP_RECORD, [
+          stub("associations", "// belongsTo: User", { static: true }),
+        ]),
+      ],
+      [
+        "src/app/models/user.ts",
+        classOnly("User", APP_RECORD, [
+          stub("associations", "// hasSecurePassword; hasMany sessions, dependent: destroy", {
+            static: true,
+          }),
+          stub("normalizes", "// emailAddress → e.strip().toLowerCase()", { static: true }),
+        ]),
+      ],
+      ["src/app/models/current.ts", currentModel()],
+      [
+        "src/app/controllers/sessions-controller.ts",
+        classOnly("SessionsController", APP_CONTROLLER, [
+          asyncStub("new_", "// allowUnauthenticatedAccess only: [new_, create]"),
+          asyncStub("create", "// User.authenticateBy → startNewSessionFor → redirect"),
+          asyncStub("destroy", "// terminateSession → redirect to /session/new"),
+        ]),
+      ],
+      ["src/app/controllers/concerns/authentication.ts", authenticationConcern()],
+      [
+        "src/app/controllers/passwords-controller.ts",
+        classOnly("PasswordsController", APP_CONTROLLER, [
+          asyncStub("new_", "// allowUnauthenticatedAccess"),
+          asyncStub("create", "// PasswordsMailer.reset(user).deliverLater"),
+          asyncStub("edit", "// setUserByToken"),
+          asyncStub("update", "// user.update(password, passwordConfirmation)"),
+          asyncStub("setUserByToken", "// User.findByPasswordResetTokenBang", PRIVATE),
+        ]),
+      ],
+      // ActionCable stub — full Connection lands when actionable/actioncable is ported.
+      [
+        "src/app/channels/application-cable/connection.ts",
+        classOnly("Connection", undefined, [
+          stub("identifiedBy", "// currentUser", { static: true }),
+          asyncStub("connect", "// setCurrentUser || rejectUnauthorizedConnection"),
+          asyncStub("setCurrentUser", "// Session.findBy(cookies.signed.sessionId)", PRIVATE),
+        ]),
+      ],
+    ];
+    if (!skipMailer) {
+      files.push([
+        "src/app/mailers/passwords-mailer.ts",
+        classOnly("PasswordsMailer", APP_MAILER, [
+          asyncStub("reset", '// mail subject: "Reset your password", to: user.emailAddress', {
+            param: "user",
+          }),
+        ]),
+      ]);
+      files.push([
+        "test/mailers/previews/passwords-mailer-preview.ts",
+        classOnly("PasswordsMailerPreview", undefined, [
+          stub("reset", "// TODO: preview PasswordsMailer.reset"),
+        ]),
+      ]);
+      if (!api) {
+        files.push(["src/app/views/passwords-mailer/reset.html.tse", RESET_HTML]);
+        files.push(["src/app/views/passwords-mailer/reset.text.tse", RESET_TEXT]);
+      }
+    }
+    return files;
+  }
+
+  // Mirrors Rails' `inject_into_class "application_controller.rb",
+  // "ApplicationController", "  include Authentication\n"` — the mixin call
+  // lands inside the class body via a static initializer; the import joins
+  // the existing imports above the class.
   private configureApplicationController(): void {
-    if (!this.fileExists("src/app/controllers/application-controller.ts")) return;
-    this.appendToFile(
-      "src/app/controllers/application-controller.ts",
-      `\nimport { Authentication } from "./concerns/authentication.js";\nAuthentication.includeInto(ApplicationController);\n`,
+    const file = "src/app/controllers/application-controller.ts";
+    if (!this.fileExists(file)) return;
+    this.insertIntoFile(
+      file,
+      "export class ApplicationController",
+      `import { Authentication } from "./concerns/authentication.js";\n\n`,
     );
+    this.insertIntoFile(file, "\n}\n", `  static {\n    Authentication.includeInto(this);\n  }\n`);
   }
 
   private configureAuthenticationRoutes(): void {
@@ -190,8 +134,48 @@ export class AuthenticationGenerator extends GeneratorBase {
   }
 }
 
-function buildClass(name: string, ext: Ref, body: Method[]): string {
-  return tsModule({ declarations: [tsClass({ name, extends: ext, body })] });
+function classOnly(name: string, ext: Ref | undefined, body: Method[]): string {
+  return tsModule({ declarations: [tsClass({ name, ...(ext ? { extends: ext } : {}), body })] });
+}
+
+function currentModel(): string {
+  return tsModule({
+    imports: [{ from: "@blazetrails/activesupport", named: { ActiveSupport: "ActiveSupport" } }],
+    declarations: [
+      tsClass({
+        name: "Current",
+        extends: CURRENT_ATTRS,
+        body: [stub("attributes", "// attribute :session", { static: true })],
+      }),
+    ],
+  });
+}
+
+function authenticationConcern(): string {
+  return tsModule({
+    declarations: [
+      tsClass({
+        name: "Authentication",
+        body: [
+          tsMethod({
+            name: "includeInto",
+            params: [{ name: "klass", type: "any" }],
+            static: true,
+            body: tsBody`klass.beforeAction?.("requireAuthentication");\nklass.helperMethod?.("authenticated");`,
+          }),
+          asyncStub("authenticated", "// resumeSession"),
+          asyncStub("requireAuthentication", "// resumeSession || requestAuthentication"),
+          asyncStub("resumeSession", "// Current.session ||= findSessionByCookie", PRIVATE),
+          asyncStub("findSessionByCookie", "// Session.findBy(cookies.signed.sessionId)", PRIVATE),
+          asyncStub("startNewSessionFor", "// user.sessions.createBang + cookie", {
+            ...PRIVATE,
+            param: "user",
+          }),
+          asyncStub("terminateSession", "// Current.session.destroy + cookies.delete", PRIVATE),
+        ],
+      }),
+    ],
+  });
 }
 
 interface StubOpts {
@@ -221,3 +205,13 @@ function asyncStub(name: string, comment: string, opts: StubOpts = {}): Method {
     body: tsBody`${comment}`,
   });
 }
+
+const RESET_HTML = `<p>
+  You can reset your password within the next 15 minutes on
+  <%= linkTo("this password reset page", editPasswordUrl(user.passwordResetToken)) %>.
+</p>
+`;
+
+const RESET_TEXT = `You can reset your password within the next 15 minutes on this password reset page:
+<%= editPasswordUrl(user.passwordResetToken) %>
+`;

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -120,7 +120,8 @@ export class AuthenticationGenerator extends GeneratorBase {
       if (!this.fileExists(f)) continue;
       const src = this.fs.readFileSync(this.path.join(this.cwd, f), "utf-8");
       const lines: string[] = [];
-      if (!/router\.resources\("passwords"[^)]*param:\s*"token"/.test(src))
+      // Skip if any passwords route exists; appending alongside would duplicate it.
+      if (!src.includes('router.resources("passwords"'))
         lines.push(`  router.resources("passwords", { param: "token" });`);
       if (!src.includes('router.resource("session")')) lines.push(`  router.resource("session");`);
       if (lines.length) this.insertIntoFile(f, "// routes", lines.join("\n") + "\n");

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -65,8 +65,6 @@ export class AuthenticationGenerator extends GeneratorBase {
         asyncStub("setUserByToken", "// User.findByPasswordResetTokenBang", PRIVATE),
       ],
     );
-    // ActionCable stub — full Connection extending ActionCable.Connection.Base
-    // lands when @blazetrails/actioncable is ported.
     this.emit("src/app/channels/application-cable/connection.ts", "Connection", undefined, [
       stub("identifiedBy", "// currentUser", { static: true }),
       asyncStub("connect", "// setCurrentUser || rejectUnauthorizedConnection"),
@@ -101,7 +99,7 @@ export class AuthenticationGenerator extends GeneratorBase {
     this.createFile(file, tsModule({ declarations: [cls] }));
   }
 
-  // Anchored on the class declaration; idempotent (a duplicate TS import would be a syntax error).
+  // Anchored on the class declaration; idempotent.
   private configureApplicationController(): void {
     const file = "src/app/controllers/application-controller.ts";
     if (!this.fileExists(file)) return;
@@ -110,21 +108,18 @@ export class AuthenticationGenerator extends GeneratorBase {
     if (src.includes("Authentication.includeInto(this)")) return;
     const m = src.match(/export\s+class\s+ApplicationController\b[^{]*\{/);
     if (!m || m.index === undefined) return;
-    // Detect any existing `Authentication` named import, regardless of specifier.
     const hasImport = /import\s*\{[^}]*\bAuthentication\b[^}]*\}\s*from\s*["'][^"']+["']/.test(src);
     const at = m.index + m[0].length;
     src = (hasImport ? "" : AUTH_IMPORT) + src.slice(0, at) + STATIC_INIT + src.slice(at);
     this.fs.writeFileSync(full, src);
-    this.output(`      inject  ${file}`);
   }
 
-  // Each route checked independently so a partial pre-existing config converges.
+  // Each route checked independently for partial-config convergence.
   private configureAuthenticationRoutes(): void {
     for (const f of ["src/config/routes.ts", "src/config/routes.js"]) {
       if (!this.fileExists(f)) continue;
       const src = this.fs.readFileSync(this.path.join(this.cwd, f), "utf-8");
       const lines: string[] = [];
-      // Match `param: "token"` so a token-less pre-existing declaration is still augmented.
       if (!/router\.resources\("passwords"[^)]*param:\s*"token"/.test(src))
         lines.push(`  router.resources("passwords", { param: "token" });`);
       if (!src.includes('router.resource("session")')) lines.push(`  router.resource("session");`);
@@ -134,13 +129,12 @@ export class AuthenticationGenerator extends GeneratorBase {
   }
 }
 
-// includeInto only wires hooks; full mixin semantics arrive with actionpack.
 const AUTH_CONCERN_METHODS: Method[] = [
   tsMethod({
     name: "includeInto",
     params: [{ name: "klass", type: "any" }],
     static: true,
-    body: tsBody`klass.beforeAction?.("requireAuthentication");\nklass.helperMethod?.("authenticated");`,
+    body: tsBody`klass.beforeAction?.((c: any) => c.requireAuthentication());\nklass.helperMethod?.("authenticated");`,
   }),
   asyncStub("authenticated", "// resumeSession"),
   asyncStub("requireAuthentication", "// resumeSession || requestAuthentication"),
@@ -159,21 +153,19 @@ interface StubOpts {
   param?: string;
   async?: boolean;
 }
-
-function stub(name: string, comment: string, opts: StubOpts = {}): Method {
+function stub(name: string, comment: string, o: StubOpts = {}): Method {
   return tsMethod({
     name,
-    params: opts.param ? [{ name: opts.param, type: "any" }] : [],
-    static: opts.static,
-    visibility: opts.visibility,
-    async: opts.async,
-    returnType: opts.async ? "Promise<void>" : undefined,
+    params: o.param ? [{ name: o.param, type: "any" }] : [],
+    static: o.static,
+    visibility: o.visibility,
+    async: o.async,
+    returnType: o.async ? "Promise<void>" : undefined,
     body: tsBody`${comment}`,
   });
 }
-
-function asyncStub(name: string, comment: string, opts: StubOpts = {}): Method {
-  return stub(name, comment, { ...opts, async: true });
+function asyncStub(name: string, comment: string, o: StubOpts = {}): Method {
+  return stub(name, comment, { ...o, async: true });
 }
 
 const AUTH_IMPORT = `import { Authentication } from "./concerns/authentication.js";\n`;

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -27,6 +27,8 @@ export class AuthenticationGenerator extends GeneratorBase {
   }
 
   run(options: AuthenticationRunOptions = {}): string[] {
+    if (!this.isTypeScript())
+      throw new Error("AuthenticationGenerator currently emits TypeScript only.");
     const { api = false, skipMailer = false } = options;
     this.emit("src/app/models/session.ts", "Session", APP_RECORD, [
       stub("associations", "// belongsTo: User", { static: true }),
@@ -101,36 +103,44 @@ export class AuthenticationGenerator extends GeneratorBase {
     );
   }
 
-  // Rails' inject_into_class re-injects on every run; we skip the second
-  // pass because a duplicate TS `import` declaration is a syntax error.
+  // Anchored on the class declaration (not a stray "}") and idempotent —
+  // Rails' inject_into_class isn't, but a duplicate TS `import` is a syntax error.
   private configureApplicationController(): void {
     const file = "src/app/controllers/application-controller.ts";
     if (!this.fileExists(file)) return;
     const full = this.path.join(this.cwd, file);
     let src = this.fs.readFileSync(full, "utf-8");
     if (src.includes("Authentication.includeInto(this)")) return;
-    const classRe = /export\s+class\s+ApplicationController\b[^{]*\{/;
-    const m = src.match(classRe);
+    const m = src.match(/export\s+class\s+ApplicationController\b[^{]*\{/);
     if (!m || m.index === undefined) return;
+    const hasImport =
+      /import\s*\{[^}]*\bAuthentication\b[^}]*\}\s*from\s*["']\.\/concerns\/authentication\.js["']/.test(
+        src,
+      );
+    const prefix = hasImport
+      ? ""
+      : `import { Authentication } from "./concerns/authentication.js";\n`;
+    const at = m.index + m[0].length;
     src =
-      `import { Authentication } from "./concerns/authentication.js";\n` +
-      src.slice(0, m.index + m[0].length) +
+      prefix +
+      src.slice(0, at) +
       `\n  static {\n    Authentication.includeInto(this);\n  }` +
-      src.slice(m.index + m[0].length);
+      src.slice(at);
     this.fs.writeFileSync(full, src);
     this.output(`      inject  ${file}`);
   }
 
+  // Each route checked independently so a partially-configured app still
+  // ends up with the missing one(s).
   private configureAuthenticationRoutes(): void {
     for (const f of ["src/config/routes.ts", "src/config/routes.js"]) {
       if (!this.fileExists(f)) continue;
-      const full = this.path.join(this.cwd, f);
-      if (this.fs.readFileSync(full, "utf-8").includes('router.resource("session")')) return;
-      this.insertIntoFile(
-        f,
-        "// routes",
-        `  router.resources("passwords", { param: "token" });\n  router.resource("session");\n`,
-      );
+      const src = this.fs.readFileSync(this.path.join(this.cwd, f), "utf-8");
+      const lines: string[] = [];
+      if (!src.includes('router.resources("passwords"'))
+        lines.push(`  router.resources("passwords", { param: "token" });`);
+      if (!src.includes('router.resource("session")')) lines.push(`  router.resource("session");`);
+      if (lines.length) this.insertIntoFile(f, "// routes", lines.join("\n") + "\n");
       return;
     }
   }

--- a/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
+++ b/packages/trailties/src/generators/rails/authentication/authentication-generator.ts
@@ -28,80 +28,70 @@ export class AuthenticationGenerator extends GeneratorBase {
 
   run(options: AuthenticationRunOptions = {}): string[] {
     const { api = false, skipMailer = false } = options;
-    for (const [path, content] of this.emitSet(api, skipMailer)) this.createFile(path, content);
+    this.emit("src/app/models/session.ts", "Session", APP_RECORD, [
+      stub("associations", "// belongsTo: User", { static: true }),
+    ]);
+    this.emit("src/app/models/user.ts", "User", APP_RECORD, [
+      stub("associations", "// hasSecurePassword; hasMany sessions, dependent: destroy", {
+        static: true,
+      }),
+      stub("normalizes", "// emailAddress → e.strip().toLowerCase()", { static: true }),
+    ]);
+    this.createFile("src/app/models/current.ts", currentModel());
+    this.emit("src/app/controllers/sessions-controller.ts", "SessionsController", APP_CONTROLLER, [
+      asyncStub("new_", "// allowUnauthenticatedAccess only: [new_, create]"),
+      asyncStub("create", "// User.authenticateBy → startNewSessionFor → redirect"),
+      asyncStub("destroy", "// terminateSession → redirect to /session/new"),
+    ]);
+    this.createFile("src/app/controllers/concerns/authentication.ts", authenticationConcern());
+    this.emit(
+      "src/app/controllers/passwords-controller.ts",
+      "PasswordsController",
+      APP_CONTROLLER,
+      [
+        asyncStub("new_", "// allowUnauthenticatedAccess"),
+        asyncStub("create", "// PasswordsMailer.reset(user).deliverLater"),
+        asyncStub("edit", "// setUserByToken"),
+        asyncStub("update", "// user.update(password, passwordConfirmation)"),
+        asyncStub("setUserByToken", "// User.findByPasswordResetTokenBang", PRIVATE),
+      ],
+    );
+    // ActionCable stub — full Connection extending ActionCable.Connection.Base
+    // lands when @blazetrails/actioncable is ported.
+    this.emit("src/app/channels/application-cable/connection.ts", "Connection", undefined, [
+      stub("identifiedBy", "// currentUser", { static: true }),
+      asyncStub("connect", "// setCurrentUser || rejectUnauthorizedConnection"),
+      asyncStub("setCurrentUser", "// Session.findBy(cookies.signed.sessionId)", PRIVATE),
+    ]);
+
+    if (!skipMailer) {
+      this.emit("src/app/mailers/passwords-mailer.ts", "PasswordsMailer", APP_MAILER, [
+        asyncStub("reset", '// mail subject: "Reset your password", to: user.emailAddress', {
+          param: "user",
+        }),
+      ]);
+      this.emit(
+        "test/mailers/previews/passwords-mailer-preview.ts",
+        "PasswordsMailerPreview",
+        undefined,
+        [stub("reset", "// TODO: preview PasswordsMailer.reset")],
+      );
+      if (!api) {
+        this.createFile("src/app/views/passwords-mailer/reset.html.tse", RESET_HTML);
+        this.createFile("src/app/views/passwords-mailer/reset.text.tse", RESET_TEXT);
+      }
+    }
+
     this.configureApplicationController();
     this.configureAuthenticationRoutes();
     return this.getCreatedFiles();
   }
 
-  private emitSet(api: boolean, skipMailer: boolean): Array<[string, string]> {
-    const files: Array<[string, string]> = [
-      [
-        "src/app/models/session.ts",
-        classOnly("Session", APP_RECORD, [
-          stub("associations", "// belongsTo: User", { static: true }),
-        ]),
-      ],
-      [
-        "src/app/models/user.ts",
-        classOnly("User", APP_RECORD, [
-          stub("associations", "// hasSecurePassword; hasMany sessions, dependent: destroy", {
-            static: true,
-          }),
-          stub("normalizes", "// emailAddress → e.strip().toLowerCase()", { static: true }),
-        ]),
-      ],
-      ["src/app/models/current.ts", currentModel()],
-      [
-        "src/app/controllers/sessions-controller.ts",
-        classOnly("SessionsController", APP_CONTROLLER, [
-          asyncStub("new_", "// allowUnauthenticatedAccess only: [new_, create]"),
-          asyncStub("create", "// User.authenticateBy → startNewSessionFor → redirect"),
-          asyncStub("destroy", "// terminateSession → redirect to /session/new"),
-        ]),
-      ],
-      ["src/app/controllers/concerns/authentication.ts", authenticationConcern()],
-      [
-        "src/app/controllers/passwords-controller.ts",
-        classOnly("PasswordsController", APP_CONTROLLER, [
-          asyncStub("new_", "// allowUnauthenticatedAccess"),
-          asyncStub("create", "// PasswordsMailer.reset(user).deliverLater"),
-          asyncStub("edit", "// setUserByToken"),
-          asyncStub("update", "// user.update(password, passwordConfirmation)"),
-          asyncStub("setUserByToken", "// User.findByPasswordResetTokenBang", PRIVATE),
-        ]),
-      ],
-      // ActionCable stub — full Connection lands when actionable/actioncable is ported.
-      [
-        "src/app/channels/application-cable/connection.ts",
-        classOnly("Connection", undefined, [
-          stub("identifiedBy", "// currentUser", { static: true }),
-          asyncStub("connect", "// setCurrentUser || rejectUnauthorizedConnection"),
-          asyncStub("setCurrentUser", "// Session.findBy(cookies.signed.sessionId)", PRIVATE),
-        ]),
-      ],
-    ];
-    if (!skipMailer) {
-      files.push([
-        "src/app/mailers/passwords-mailer.ts",
-        classOnly("PasswordsMailer", APP_MAILER, [
-          asyncStub("reset", '// mail subject: "Reset your password", to: user.emailAddress', {
-            param: "user",
-          }),
-        ]),
-      ]);
-      files.push([
-        "test/mailers/previews/passwords-mailer-preview.ts",
-        classOnly("PasswordsMailerPreview", undefined, [
-          stub("reset", "// TODO: preview PasswordsMailer.reset"),
-        ]),
-      ]);
-      if (!api) {
-        files.push(["src/app/views/passwords-mailer/reset.html.tse", RESET_HTML]);
-        files.push(["src/app/views/passwords-mailer/reset.text.tse", RESET_TEXT]);
-      }
-    }
-    return files;
+  private emit(file: string, name: string, ext: Ref | undefined, body: Method[]): void {
+    this.createFile(
+      file,
+      tsModule({ declarations: [tsClass({ name, ...(ext ? { extends: ext } : {}), body })] }),
+    );
   }
 
   // Mirrors Rails' `inject_into_class "application_controller.rb",
@@ -134,10 +124,6 @@ export class AuthenticationGenerator extends GeneratorBase {
   }
 }
 
-function classOnly(name: string, ext: Ref | undefined, body: Method[]): string {
-  return tsModule({ declarations: [tsClass({ name, ...(ext ? { extends: ext } : {}), body })] });
-}
-
 function currentModel(): string {
   return tsModule({
     imports: [{ from: "@blazetrails/activesupport", named: { ActiveSupport: "ActiveSupport" } }],
@@ -152,6 +138,10 @@ function currentModel(): string {
 }
 
 function authenticationConcern(): string {
+  // The Authentication "concern" is emitted as a class with static helpers.
+  // `Authentication.includeInto(klass)` wires the `requireAuthentication`
+  // beforeAction + `authenticated` helper hook; full instance-method mixin
+  // semantics arrive when actionpack ships its include() primitive.
   return tsModule({
     declarations: [
       tsClass({
@@ -182,6 +172,7 @@ interface StubOpts {
   static?: boolean;
   visibility?: "private" | "protected";
   param?: string;
+  async?: boolean;
 }
 
 function stub(name: string, comment: string, opts: StubOpts = {}): Method {
@@ -190,21 +181,14 @@ function stub(name: string, comment: string, opts: StubOpts = {}): Method {
     params: opts.param ? [{ name: opts.param, type: "any" }] : [],
     static: opts.static,
     visibility: opts.visibility,
+    async: opts.async,
+    returnType: opts.async ? "Promise<void>" : undefined,
     body: tsBody`${comment}`,
   });
 }
 
-function asyncStub(name: string, comment: string, opts: StubOpts = {}): Method {
-  return tsMethod({
-    name,
-    params: opts.param ? [{ name: opts.param, type: "any" }] : [],
-    async: true,
-    returnType: "Promise<void>",
-    static: opts.static,
-    visibility: opts.visibility,
-    body: tsBody`${comment}`,
-  });
-}
+const asyncStub = (name: string, comment: string, opts: StubOpts = {}): Method =>
+  stub(name, comment, { ...opts, async: true });
 
 const RESET_HTML = `<p>
   You can reset your password within the next 15 minutes on


### PR DESCRIPTION
Ports `railties/lib/rails/generators/rails/authentication/authentication_generator.rb` onto the trailties typed template-builder (PR T1 + PR T3 surface).

## Emit set

All TS source flows through `tsModule` / `tsClass` / `tsMethod` (no raw-string `.ts` createFile, per the hard rule):

- `src/app/models/{session,user,current}.ts`
- `src/app/controllers/{sessions,passwords}-controller.ts`
- `src/app/controllers/concerns/authentication.ts`
- `src/app/channels/application-cable/connection.ts` (stub — only when AppGenerator hasn't already emitted it; full `extends ActionCable.Connection.Base` lands when `@blazetrails/actioncable` is ported)
- `src/app/mailers/passwords-mailer.ts` (gated behind `--skip-mailer`)
- `test/mailers/previews/passwords-mailer-preview.ts` (gated behind `--skip-mailer`)
- `src/app/views/passwords-mailer/reset.{html,text}.tse` (gated behind `--skip-mailer` and `--api`)

Method bodies are TODO-comment stubs mapped to the Rails behavior; semantic implementations land as the underlying packages (`rateLimit`, `allowUnauthenticatedAccess`, `normalizes`, `hasSecurePassword`, `cookies.signed`, `Concern#included`/`class_methods do`, etc.) get ported.

`configure_application_controller` mirrors Rails' `inject_into_class`: the mixin call (`Authentication.includeInto(this)`) lands *inside* the class body via a static initializer block, and the import joins the existing imports above the class. Import + mixin are tracked independently to converge a partial config. `configure_authentication_routes` injects `router.resources("passwords", { param: "token" })` + `router.resource("session")` at the `// routes` marker.

Gated to TypeScript projects: `run()` throws a clear error when `tsconfig.json` is absent, matching the rest of the trailties generators.

## Skipped from the Rails source

- `enable_bcrypt` (Ruby Bundler).
- `add_migrations` (needs `MigrationGenerator.generate` shell-out — open question #8 territory).
- `hook_for :test_framework`.
- `hook_for :template_engine, as: :authentication`.

## Test coverage

- Full emit-set existence (incl. views).
- `parseTs` (no syntactic diagnostics) + `assertNoRubySource` over every emitted `.ts` file.
- `--skip-mailer` and `--api` gating.
- Injection lands inside the class even with a pre-existing method body (anchored on the class-declaration regex, not a stray `}`).
- No-op when `application-controller.ts` / `routes.ts` are absent; clear error when `tsconfig.json` is absent.
- Partial pre-existing config: token-less passwords route + session route + extensionless `Authentication` import — generator fills missing pieces without duplicating present ones.
- Partial repair: mixin call present but import missing → import added, static block not duplicated.
- Does not clobber a pre-existing application-cable Connection.
- Idempotent: re-running yields byte-identical injected files.
- Consolidated snapshot of the full 9-file TS emit set.

## Rails source referenced

`vendor/rails/railties/lib/rails/generators/rails/authentication/{authentication_generator.rb, templates/**}`.

## Known follow-ups from Copilot review (deferred — review cycles capped)

1. **Leading-directive-safe import prepend.** `configureApplicationController` prepends `import { Authentication } ...` at the absolute start of the file. This would land above a shebang / `// @ts-nocheck` / triple-slash reference. AppGenerator's emitted `application-controller.ts` has none of those today, but a directive-safe prepend (or "insert after existing import block") is the right long-term shape — see `packages/activerecord/src/type-virtualization/virtualize.ts` for the pattern.
2. **Token-less passwords route is not upgraded.** A pre-existing `router.resources("passwords")` without the `{ param: "token" }` option is left as-is rather than upgraded — the generator skips to avoid producing a duplicate route. A safer follow-up: detect the specific non-token form and either replace it via a string substitution or insert a `// FIXME` warning marker. Currently the user must fix the shape themselves.
3. **`AuthenticationRunOptions` not exported from the barrel.** Other option-bearing generators (`TaskRunOptions`, `BenchmarkRunOptions`) re-export their options. `AuthenticationRunOptions` is intentionally omitted to match `ScaffoldGenerator`'s barrel pattern (which also doesn't re-export `ScaffoldRunOptions`); the convention isn't unanimous and could be added if the broader generator surface standardizes on always re-exporting.

## Rails source referenced

`vendor/rails/railties/lib/rails/generators/rails/authentication/{authentication_generator.rb, templates/**}`.

## Size

301 LOC additions (1 over the 300 ceiling — accepted the tradeoff for the partial-config repair logic).