### PR TITLE
feat(trailties): db/system/change generator (PR 1.14c-4)

### DIFF
--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
@@ -49,6 +49,7 @@ RUN apt-get update -qq && apt-get install --no-install-recommends -y curl libvip
 
 beforeEach(() => {
   tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-db-change-"));
+  fs.writeFileSync(path.join(tmpDir, "tsconfig.json"), "{}");
   seedPackageJson();
   seedDockerfile();
 });
@@ -144,6 +145,24 @@ describe("ChangeGeneratorTest", () => {
   it("editPackageJson throws on unparseable JSON", () => {
     write("package.json", "{ this is not json");
     expect(() => run("mysql")).toThrow(/Could not parse .*package\.json/);
+  });
+
+  it("editDatabaseConfig fallback honors isTypeScript()", () => {
+    fs.rmSync(path.join(tmpDir, "tsconfig.json"));
+    run("postgresql");
+    expect(exists("src/config/database.js")).toBe(true);
+    expect(exists("src/config/database.ts")).toBe(false);
+  });
+
+  it("editDockerfile prefers longest-match alternation", () => {
+    // sqlite's build list ("build-essential git") is a prefix of pg's
+    // ("build-essential git libpq-dev"); first-match alternation would
+    // truncate. Verify the full line is replaced.
+    write("Dockerfile", "RUN apt-get install -y build-essential git libpq-dev\n");
+    run("mysql");
+    expect(read("Dockerfile")).toBe(
+      "RUN apt-get install -y build-essential default-libmysqlclient-dev git\n",
+    );
   });
 
   it("editDockerfile is a no-op when no DB package lines match", () => {

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
@@ -165,6 +165,14 @@ describe("ChangeGeneratorTest", () => {
     );
   });
 
+  it("editDockerfile does not match inside a longer word token", () => {
+    // \b boundaries (mirroring Rails change_generator.rb) prevent matching
+    // when a canonical token is the prefix of a longer word like "gitlab-cli".
+    write("Dockerfile", "RUN apt-get install -y build-essential gitlab-cli\n");
+    run("postgresql");
+    expect(read("Dockerfile")).toBe("RUN apt-get install -y build-essential gitlab-cli\n");
+  });
+
   it("editDockerfile is a no-op when no DB package lines match", () => {
     write("Dockerfile", "FROM node:22-slim\nRUN echo hello\n");
     const calls: string[] = [];

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
@@ -57,8 +57,14 @@ afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 describe("ChangeGeneratorTest", () => {
   it("change to invalid database", () => {
     expect(() => new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "invalid-db" })).toThrow(
-      /Invalid value for --to option/,
+      /Invalid value for --to option\. Supported preconfigurations are: mysql, postgresql, sqlite3, mariadb-mysql\./,
     );
+  });
+
+  it("appName defaults to basename of cwd", () => {
+    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "postgresql" }).run();
+    const cfg = read("src/config/database.ts");
+    expect(cfg).toContain(`database: "${path.basename(tmpDir)}_development"`);
   });
 
   it("change to postgresql", () => {

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
@@ -54,6 +54,15 @@ beforeEach(() => {
 });
 afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
 
+function run(to: string, opts: { appName?: string; output?: (m: string) => void } = {}) {
+  return new ChangeGenerator({
+    cwd: tmpDir,
+    output: opts.output ?? (() => {}),
+    to,
+    appName: opts.appName ?? "tmp",
+  }).run();
+}
+
 describe("ChangeGeneratorTest", () => {
   it("change to invalid database", () => {
     expect(() => new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "invalid-db" })).toThrow(
@@ -63,79 +72,56 @@ describe("ChangeGeneratorTest", () => {
 
   it("appName defaults to basename of cwd", () => {
     new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "postgresql" }).run();
-    const cfg = read("src/config/database.ts");
-    expect(cfg).toContain(`database: "${path.basename(tmpDir)}_development"`);
+    expect(read("src/config/database.ts")).toContain(
+      `database: "${path.basename(tmpDir)}_development"`,
+    );
   });
 
   it("change to postgresql", () => {
-    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "postgresql", appName: "tmp" }).run();
-
+    run("postgresql");
     const cfg = read("src/config/database.ts");
     expect(cfg).toContain('adapter: "postgresql"');
     expect(cfg).toContain('database: "tmp_development"');
-
     const pkg = JSON.parse(read("package.json"));
     expect(pkg.dependencies.pg).toBe("^8.19.0");
     expect(pkg.dependencies["better-sqlite3"]).toBeUndefined();
-
     const dockerfile = read("Dockerfile");
     expect(dockerfile).toContain("build-essential git libpq-dev");
     expect(dockerfile).toContain("curl libvips postgresql-client");
   });
 
   it("change to mysql", () => {
-    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "mysql", appName: "tmp" }).run();
-
+    run("mysql");
     const cfg = read("src/config/database.ts");
     expect(cfg).toContain('adapter: "mysql2"');
     expect(cfg).toContain('database: "tmp_development"');
-
     const pkg = JSON.parse(read("package.json"));
     expect(pkg.dependencies.mysql2).toBe("^3.18.2");
     expect(pkg.dependencies["better-sqlite3"]).toBeUndefined();
-
     const dockerfile = read("Dockerfile");
     expect(dockerfile).toContain("build-essential default-libmysqlclient-dev git");
     expect(dockerfile).toContain("curl default-mysql-client libvips");
   });
 
   it("change to sqlite3", () => {
-    write(
-      "package.json",
-      JSON.stringify({ name: "tmp", dependencies: { pg: "^8.19.0" } }, null, 2) + "\n",
-    );
-    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "sqlite3", appName: "tmp" }).run();
-
-    const cfg = read("src/config/database.ts");
-    expect(cfg).toContain('adapter: "sqlite3"');
-    expect(cfg).toContain("db/development.sqlite3");
-
+    write("package.json", JSON.stringify({ dependencies: { pg: "^8.19.0" } }) + "\n");
+    run("sqlite3");
+    expect(read("src/config/database.ts")).toContain("db/development.sqlite3");
     const pkg = JSON.parse(read("package.json"));
     expect(pkg.dependencies["better-sqlite3"]).toBe("^12.6.2");
     expect(pkg.dependencies.pg).toBeUndefined();
   });
 
   it("change to mariadb", () => {
-    new ChangeGenerator({
-      cwd: tmpDir,
-      output: () => {},
-      to: "mariadb-mysql",
-      appName: "tmp",
-    }).run();
-
-    const cfg = read("src/config/database.ts");
-    expect(cfg).toContain('adapter: "mysql2"');
-
-    const pkg = JSON.parse(read("package.json"));
-    expect(pkg.dependencies.mysql2).toBe("^3.18.2");
-
-    const dockerfile = read("Dockerfile");
-    expect(dockerfile).toContain("default-libmysqlclient-dev");
+    run("mariadb-mysql");
+    expect(read("src/config/database.ts")).toContain('adapter: "mysql2"');
+    expect(JSON.parse(read("package.json")).dependencies.mysql2).toBe("^3.18.2");
+    expect(read("Dockerfile")).toContain("default-libmysqlclient-dev");
   });
 
   it("change from versioned dep to other versioned dep", () => {
-    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "postgresql", appName: "tmp" }).run();
-    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "mysql", appName: "tmp" }).run();
+    run("postgresql");
+    run("mysql");
     const pkg = JSON.parse(read("package.json"));
     expect(pkg.dependencies.mysql2).toBe("^3.18.2");
     expect(pkg.dependencies.pg).toBeUndefined();
@@ -143,8 +129,28 @@ describe("ChangeGeneratorTest", () => {
 
   it("no Dockerfile is a no-op", () => {
     fs.rmSync(path.join(tmpDir, "Dockerfile"));
-    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "mysql", appName: "tmp" }).run();
+    run("mysql");
     expect(exists("Dockerfile")).toBe(false);
     expect(exists("src/config/database.ts")).toBe(true);
+  });
+
+  it("editDatabaseConfig targets existing config/database.ts when present", () => {
+    write("config/database.ts", "// existing\n");
+    run("postgresql");
+    expect(read("config/database.ts")).toContain('adapter: "postgresql"');
+    expect(exists("src/config/database.ts")).toBe(false);
+  });
+
+  it("editPackageJson throws on unparseable JSON", () => {
+    write("package.json", "{ this is not json");
+    expect(() => run("mysql")).toThrow(/Could not parse .*package\.json/);
+  });
+
+  it("editDockerfile is a no-op when no DB package lines match", () => {
+    write("Dockerfile", "FROM node:22-slim\nRUN echo hello\n");
+    const calls: string[] = [];
+    run("mysql", { output: (m) => calls.push(m) });
+    expect(read("Dockerfile")).toBe("FROM node:22-slim\nRUN echo hello\n");
+    expect(calls.some((m) => m.includes("Dockerfile"))).toBe(false);
   });
 });

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as os from "node:os";
+import { ChangeGenerator } from "./change-generator.js";
+
+let tmpDir: string;
+
+function write(rel: string, content: string): void {
+  const full = path.join(tmpDir, rel);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, content);
+}
+
+function read(rel: string): string {
+  return fs.readFileSync(path.join(tmpDir, rel), "utf-8");
+}
+
+function exists(rel: string): boolean {
+  return fs.existsSync(path.join(tmpDir, rel));
+}
+
+function seedPackageJson(): void {
+  write(
+    "package.json",
+    JSON.stringify(
+      {
+        name: "tmp",
+        dependencies: {
+          "@blazetrails/activerecord": "*",
+          "better-sqlite3": "^12.6.2",
+        },
+      },
+      null,
+      2,
+    ) + "\n",
+  );
+}
+
+function seedDockerfile(): void {
+  write(
+    "Dockerfile",
+    `FROM node:22-slim AS base
+RUN apt-get update -qq && apt-get install --no-install-recommends -y build-essential git
+RUN apt-get update -qq && apt-get install --no-install-recommends -y curl libvips sqlite3
+`,
+  );
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-db-change-"));
+  seedPackageJson();
+  seedDockerfile();
+});
+afterEach(() => fs.rmSync(tmpDir, { recursive: true, force: true }));
+
+describe("ChangeGeneratorTest", () => {
+  it("change to invalid database", () => {
+    expect(() => new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "invalid-db" })).toThrow(
+      /Invalid value for --to option/,
+    );
+  });
+
+  it("change to postgresql", () => {
+    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "postgresql", appName: "tmp" }).run();
+
+    const cfg = read("src/config/database.ts");
+    expect(cfg).toContain('adapter: "postgresql"');
+    expect(cfg).toContain('database: "tmp_development"');
+
+    const pkg = JSON.parse(read("package.json"));
+    expect(pkg.dependencies.pg).toBe("^8.19.0");
+    expect(pkg.dependencies["better-sqlite3"]).toBeUndefined();
+
+    const dockerfile = read("Dockerfile");
+    expect(dockerfile).toContain("build-essential git libpq-dev");
+    expect(dockerfile).toContain("curl libvips postgresql-client");
+  });
+
+  it("change to mysql", () => {
+    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "mysql", appName: "tmp" }).run();
+
+    const cfg = read("src/config/database.ts");
+    expect(cfg).toContain('adapter: "mysql2"');
+    expect(cfg).toContain('database: "tmp_development"');
+
+    const pkg = JSON.parse(read("package.json"));
+    expect(pkg.dependencies.mysql2).toBe("^3.18.2");
+    expect(pkg.dependencies["better-sqlite3"]).toBeUndefined();
+
+    const dockerfile = read("Dockerfile");
+    expect(dockerfile).toContain("build-essential default-libmysqlclient-dev git");
+    expect(dockerfile).toContain("curl default-mysql-client libvips");
+  });
+
+  it("change to sqlite3", () => {
+    write(
+      "package.json",
+      JSON.stringify({ name: "tmp", dependencies: { pg: "^8.19.0" } }, null, 2) + "\n",
+    );
+    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "sqlite3", appName: "tmp" }).run();
+
+    const cfg = read("src/config/database.ts");
+    expect(cfg).toContain('adapter: "sqlite3"');
+    expect(cfg).toContain("db/development.sqlite3");
+
+    const pkg = JSON.parse(read("package.json"));
+    expect(pkg.dependencies["better-sqlite3"]).toBe("^12.6.2");
+    expect(pkg.dependencies.pg).toBeUndefined();
+  });
+
+  it("change to mariadb", () => {
+    new ChangeGenerator({
+      cwd: tmpDir,
+      output: () => {},
+      to: "mariadb-mysql",
+      appName: "tmp",
+    }).run();
+
+    const cfg = read("src/config/database.ts");
+    expect(cfg).toContain('adapter: "mysql2"');
+
+    const pkg = JSON.parse(read("package.json"));
+    expect(pkg.dependencies.mysql2).toBe("^3.18.2");
+
+    const dockerfile = read("Dockerfile");
+    expect(dockerfile).toContain("default-libmysqlclient-dev");
+  });
+
+  it("change from versioned dep to other versioned dep", () => {
+    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "postgresql", appName: "tmp" }).run();
+    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "mysql", appName: "tmp" }).run();
+    const pkg = JSON.parse(read("package.json"));
+    expect(pkg.dependencies.mysql2).toBe("^3.18.2");
+    expect(pkg.dependencies.pg).toBeUndefined();
+  });
+
+  it("no Dockerfile is a no-op", () => {
+    fs.rmSync(path.join(tmpDir, "Dockerfile"));
+    new ChangeGenerator({ cwd: tmpDir, output: () => {}, to: "mysql", appName: "tmp" }).run();
+    expect(exists("Dockerfile")).toBe(false);
+    expect(exists("src/config/database.ts")).toBe(true);
+  });
+});

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -82,6 +82,13 @@ export class ChangeGenerator extends GeneratorBase {
     this.writeOrUpdate("package.json", JSON.stringify(pkg, null, 2) + "\n");
   }
 
+  // Mirrors railties change_generator.rb's exact-string gsub against
+  // all_docker_bases_regex / all_docker_builds_regex: matches only the
+  // package lists `dockerPackages(...)` would emit for a known database.
+  // Trailties' current AppGenerator Dockerfile (app-generator.ts) doesn't
+  // emit those lines today, so on a default-generated app this is a no-op
+  // until AppGenerator's Dockerfile is aligned with the Database registry
+  // (tracked under PR 1.14d in docs/trailties-plan.md).
   editDockerfile(): void {
     if (!this.fileExists("Dockerfile")) return;
     const fullPath = this.path.join(this.cwd, "Dockerfile");

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -65,7 +65,7 @@ export class ChangeGenerator extends GeneratorBase {
     if (!this.fileExists("package.json")) return;
     const fullPath = this.path.join(this.cwd, "package.json");
     const raw = this.fs.readFileSync(fullPath, "utf-8");
-    let pkg: { dependencies?: Record<string, string> } & Record<string, unknown>;
+    let pkg: { dependencies?: unknown } & Record<string, unknown>;
     try {
       pkg = JSON.parse(raw);
     } catch (e) {
@@ -74,7 +74,17 @@ export class ChangeGenerator extends GeneratorBase {
         { cause: e },
       );
     }
-    const deps = (pkg.dependencies ?? {}) as Record<string, string>;
+    if (pkg === null || typeof pkg !== "object" || Array.isArray(pkg)) {
+      throw new Error(`Expected ${fullPath} to be a JSON object.`);
+    }
+    const rawDeps = pkg.dependencies;
+    if (
+      rawDeps !== undefined &&
+      (rawDeps === null || typeof rawDeps !== "object" || Array.isArray(rawDeps))
+    ) {
+      throw new Error(`Expected ${fullPath} "dependencies" to be an object.`);
+    }
+    const deps = (rawDeps ?? {}) as Record<string, string>;
     for (const d of Database.all()) delete deps[d.pkgDependency.name];
     const target = this.database.pkgDependency;
     deps[target.name] = target.version;
@@ -106,8 +116,12 @@ export class ChangeGenerator extends GeneratorBase {
   }
 
   private writeOrUpdate(relativePath: string, content: string): void {
-    const existed = this.fileExists(relativePath);
     const full = this.path.join(this.cwd, relativePath);
+    const existed = this.fileExists(relativePath);
+    if (existed && this.fs.readFileSync(full, "utf-8") === content) {
+      this.output(`   identical  ${relativePath}`);
+      return;
+    }
     this.fs.mkdirSync(this.path.dirname(full), { recursive: true });
     this.fs.writeFileSync(full, content);
     if (existed) {

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -31,7 +31,8 @@ export class ChangeGenerator extends GeneratorBase {
       );
     }
     this.to = options.to as DatabaseName;
-    this.appName = options.appName ?? "app";
+    // Mirrors railties' AppName module: derive from destination_root basename.
+    this.appName = options.appName ?? this.path.basename(this.cwd);
   }
 
   get database(): Database {

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -57,7 +57,7 @@ export class ChangeGenerator extends GeneratorBase {
         "config/database.js",
         "src/config/database.ts",
         "src/config/database.js",
-      ].find((p) => this.fileExists(p)) ?? "src/config/database.ts";
+      ].find((p) => this.fileExists(p)) ?? `src/config/database${this.ext()}`;
     this.writeOrUpdate(target, databaseConfigTs(this.database, this.appName));
   }
 
@@ -170,6 +170,12 @@ function dockerPackages(base: string[], extra: string | undefined): string {
 }
 
 function dockerPackagesRegex(base: string[], pick: (d: Database) => string | undefined): RegExp {
-  const alts = [...new Set(Database.all().map((d) => dockerPackages(base, pick(d))))];
+  // Sort by descending length so the longest match wins. JS regex alternation
+  // is first-match (not longest-match), so shorter prefixes like the
+  // base-only "build-essential git" would otherwise truncate a longer match
+  // like "build-essential git libpq-dev".
+  const alts = [...new Set(Database.all().map((d) => dockerPackages(base, pick(d))))].sort(
+    (a, b) => b.length - a.length,
+  );
   return new RegExp(alts.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|"), "g");
 }

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -172,12 +172,14 @@ function dockerPackages(base: string[], extra: string | undefined): string {
 }
 
 function dockerPackagesRegex(base: string[], pick: (d: Database) => string | undefined): RegExp {
-  // Sort by descending length so the longest match wins. JS regex alternation
-  // is first-match (not longest-match), so shorter prefixes like the
-  // base-only "build-essential git" would otherwise truncate a longer match
-  // like "build-essential git libpq-dev".
+  // Mirrors railties change_generator.rb: each alternation arm is wrapped in
+  // \b boundaries so the package list only matches as a whole word run
+  // (e.g. won't partial-match inside `build-essential git libfoo-dev` if the
+  // arm is `build-essential git`). Sort by descending length first because
+  // JS regex alternation is first-match, not longest-match.
   const alts = [...new Set(Database.all().map((d) => dockerPackages(base, pick(d))))].sort(
     (a, b) => b.length - a.length,
   );
-  return new RegExp(alts.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|"), "g");
+  const escaped = alts.map((s) => `\\b${s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`);
+  return new RegExp(escaped.join("|"), "g");
 }

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -58,11 +58,7 @@ export class ChangeGenerator extends GeneratorBase {
         "src/config/database.ts",
         "src/config/database.js",
       ].find((p) => this.fileExists(p)) ?? "src/config/database.ts";
-    const content = databaseConfigTs(this.database, this.appName);
-    const full = this.path.join(this.cwd, target);
-    this.fs.mkdirSync(this.path.dirname(full), { recursive: true });
-    this.fs.writeFileSync(full, content);
-    this.output(`     update  ${target}`);
+    this.writeOrUpdate(target, databaseConfigTs(this.database, this.appName));
   }
 
   editPackageJson(): void {
@@ -83,8 +79,7 @@ export class ChangeGenerator extends GeneratorBase {
     const target = this.database.pkgDependency;
     deps[target.name] = target.version;
     pkg.dependencies = deps;
-    this.fs.writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + "\n");
-    this.output(`     update  package.json`);
+    this.writeOrUpdate("package.json", JSON.stringify(pkg, null, 2) + "\n");
   }
 
   editDockerfile(): void {
@@ -100,8 +95,20 @@ export class ChangeGenerator extends GeneratorBase {
       dockerPackages(BUILD_PACKAGES, this.database.buildPackage),
     );
     if (after === before) return;
-    this.fs.writeFileSync(fullPath, after);
-    this.output(`     update  Dockerfile`);
+    this.writeOrUpdate("Dockerfile", after);
+  }
+
+  private writeOrUpdate(relativePath: string, content: string): void {
+    const existed = this.fileExists(relativePath);
+    const full = this.path.join(this.cwd, relativePath);
+    this.fs.mkdirSync(this.path.dirname(full), { recursive: true });
+    this.fs.writeFileSync(full, content);
+    if (existed) {
+      this.output(`      update  ${relativePath}`);
+    } else {
+      this.createdFiles.push(relativePath);
+      this.output(`      create  ${relativePath}`);
+    }
   }
 
   editDevcontainerFiles(): void {

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -49,7 +49,15 @@ export class ChangeGenerator extends GeneratorBase {
   }
 
   editDatabaseConfig(): void {
-    const target = "src/config/database.ts";
+    // Candidate order matches the runtime loader in trailties/src/database.ts
+    // so editing prefers the active config; fall back to src/config when none exist.
+    const target =
+      [
+        "config/database.ts",
+        "config/database.js",
+        "src/config/database.ts",
+        "src/config/database.js",
+      ].find((p) => this.fileExists(p)) ?? "src/config/database.ts";
     const content = databaseConfigTs(this.database, this.appName);
     const full = this.path.join(this.cwd, target);
     this.fs.mkdirSync(this.path.dirname(full), { recursive: true });
@@ -64,8 +72,11 @@ export class ChangeGenerator extends GeneratorBase {
     let pkg: { dependencies?: Record<string, string> } & Record<string, unknown>;
     try {
       pkg = JSON.parse(raw);
-    } catch {
-      return;
+    } catch (e) {
+      throw new Error(
+        `Could not parse ${fullPath}: ${(e as Error).message}. Fix the file and re-run.`,
+        { cause: e },
+      );
     }
     const deps = (pkg.dependencies ?? {}) as Record<string, string>;
     for (const d of Database.all()) delete deps[d.pkgDependency.name];
@@ -79,14 +90,17 @@ export class ChangeGenerator extends GeneratorBase {
   editDockerfile(): void {
     if (!this.fileExists("Dockerfile")) return;
     const fullPath = this.path.join(this.cwd, "Dockerfile");
-    let content = this.fs.readFileSync(fullPath, "utf-8");
-    content = gsub(content, allDockerBasesRegex(), dockerBasePackages(this.database.basePackage));
-    content = gsub(
-      content,
-      allDockerBuildsRegex(),
-      dockerBuildPackages(this.database.buildPackage),
+    const before = this.fs.readFileSync(fullPath, "utf-8");
+    let after = before.replace(
+      dockerPackagesRegex(BASE_PACKAGES, (d) => d.basePackage),
+      dockerPackages(BASE_PACKAGES, this.database.basePackage),
     );
-    this.fs.writeFileSync(fullPath, content);
+    after = after.replace(
+      dockerPackagesRegex(BUILD_PACKAGES, (d) => d.buildPackage),
+      dockerPackages(BUILD_PACKAGES, this.database.buildPackage),
+    );
+    if (after === before) return;
+    this.fs.writeFileSync(fullPath, after);
     this.output(`     update  Dockerfile`);
   }
 
@@ -123,32 +137,11 @@ function databaseConfigTs(database: Database, appName: string): string {
   ].join("\n");
 }
 
-function dockerBasePackages(databasePackage: string | undefined): string {
-  const set = databasePackage ? [databasePackage, ...BASE_PACKAGES].sort() : [...BASE_PACKAGES];
-  return set.join(" ");
+function dockerPackages(base: string[], extra: string | undefined): string {
+  return (extra ? [extra, ...base].sort() : [...base]).join(" ");
 }
 
-function dockerBuildPackages(databasePackage: string | undefined): string {
-  const set = databasePackage ? [databasePackage, ...BUILD_PACKAGES].sort() : [...BUILD_PACKAGES];
-  return set.join(" ");
-}
-
-function escapeRegex(s: string): string {
-  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-}
-
-function altRegex(values: string[]): RegExp {
-  return new RegExp([...new Set(values)].map(escapeRegex).join("|"), "g");
-}
-
-function allDockerBasesRegex(): RegExp {
-  return altRegex(Database.all().map((d) => dockerBasePackages(d.basePackage)));
-}
-
-function allDockerBuildsRegex(): RegExp {
-  return altRegex(Database.all().map((d) => dockerBuildPackages(d.buildPackage)));
-}
-
-function gsub(haystack: string, pattern: RegExp, replacement: string): string {
-  return haystack.replace(pattern, replacement);
+function dockerPackagesRegex(base: string[], pick: (d: Database) => string | undefined): RegExp {
+  const alts = [...new Set(Database.all().map((d) => dockerPackages(base, pick(d))))];
+  return new RegExp(alts.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")).join("|"), "g");
 }

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -58,7 +58,7 @@ export class ChangeGenerator extends GeneratorBase {
         "src/config/database.ts",
         "src/config/database.js",
       ].find((p) => this.fileExists(p)) ?? `src/config/database${this.ext()}`;
-    this.writeOrUpdate(target, databaseConfigTs(this.database, this.appName));
+    this.writeOrUpdate(target, databaseConfigTs(this.to, this.database, this.appName));
   }
 
   editPackageJson(): void {
@@ -140,8 +140,8 @@ export class ChangeGenerator extends GeneratorBase {
   }
 }
 
-function databaseConfigTs(database: Database, appName: string): string {
-  if (database.name === "sqlite3") {
+function databaseConfigTs(to: DatabaseName, database: Database, appName: string): string {
+  if (to === "sqlite3") {
     return [
       `export default {`,
       ...["development", "test", "production"].map(
@@ -151,7 +151,9 @@ function databaseConfigTs(database: Database, appName: string): string {
       ``,
     ].join("\n");
   }
-  const adapter = database.name === "postgres" ? "postgresql" : "mysql2";
+  // `to` is the adapter id (`postgresql` | `mysql` | `mariadb-mysql`);
+  // `Database#name` is a service/volume identifier and not safe to switch on.
+  const adapter = to === "postgresql" ? "postgresql" : "mysql2";
   const port = database.port!;
   const block = (env: string) =>
     `  ${env}: { adapter: "${adapter}", database: "${appName}_${env}", host: "localhost", port: ${port} },`;

--- a/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
+++ b/packages/trailties/src/generators/rails/db/system/change/change-generator.ts
@@ -1,0 +1,153 @@
+// Mirrors railties/lib/rails/generators/rails/db/system/change/change_generator.rb.
+// Trailties substitutions: the Rails generator rewrites `config/database.yml`
+// (ERB/YAML) and `Gemfile`. Trailties emits `src/config/database.ts` and
+// `package.json` instead, so `editDatabaseConfig` rewrites the TS module and
+// `editPackageJson` swaps the database dependency. Dockerfile rewriting
+// mirrors Rails when the Dockerfile carries db-specific apt packages.
+// Devcontainer file rewriting is deferred until trailties' devcontainer
+// generator (#2221) lands.
+
+import { GeneratorBase, type GeneratorOptions } from "../../../../base.js";
+import { Database, DATABASES, type DatabaseName } from "../../../../database.js";
+
+const BASE_PACKAGES = ["curl", "libvips"];
+const BUILD_PACKAGES = ["build-essential", "git"];
+
+export interface ChangeGeneratorOptions extends GeneratorOptions {
+  to: string;
+  appName?: string;
+}
+
+export class ChangeGenerator extends GeneratorBase {
+  readonly to: DatabaseName;
+  readonly appName: string;
+  private _database?: Database;
+
+  constructor(options: ChangeGeneratorOptions) {
+    super(options);
+    if (!(DATABASES as readonly string[]).includes(options.to)) {
+      throw new Error(
+        `Invalid value for --to option. Supported preconfigurations are: ${DATABASES.join(", ")}.`,
+      );
+    }
+    this.to = options.to as DatabaseName;
+    this.appName = options.appName ?? "app";
+  }
+
+  get database(): Database {
+    if (!this._database) this._database = Database.build(this.to);
+    return this._database;
+  }
+
+  run(): string[] {
+    this.editDatabaseConfig();
+    this.editPackageJson();
+    this.editDockerfile();
+    this.editDevcontainerFiles();
+    return this.getCreatedFiles();
+  }
+
+  editDatabaseConfig(): void {
+    const target = "src/config/database.ts";
+    const content = databaseConfigTs(this.database, this.appName);
+    const full = this.path.join(this.cwd, target);
+    this.fs.mkdirSync(this.path.dirname(full), { recursive: true });
+    this.fs.writeFileSync(full, content);
+    this.output(`     update  ${target}`);
+  }
+
+  editPackageJson(): void {
+    if (!this.fileExists("package.json")) return;
+    const fullPath = this.path.join(this.cwd, "package.json");
+    const raw = this.fs.readFileSync(fullPath, "utf-8");
+    let pkg: { dependencies?: Record<string, string> } & Record<string, unknown>;
+    try {
+      pkg = JSON.parse(raw);
+    } catch {
+      return;
+    }
+    const deps = (pkg.dependencies ?? {}) as Record<string, string>;
+    for (const d of Database.all()) delete deps[d.pkgDependency.name];
+    const target = this.database.pkgDependency;
+    deps[target.name] = target.version;
+    pkg.dependencies = deps;
+    this.fs.writeFileSync(fullPath, JSON.stringify(pkg, null, 2) + "\n");
+    this.output(`     update  package.json`);
+  }
+
+  editDockerfile(): void {
+    if (!this.fileExists("Dockerfile")) return;
+    const fullPath = this.path.join(this.cwd, "Dockerfile");
+    let content = this.fs.readFileSync(fullPath, "utf-8");
+    content = gsub(content, allDockerBasesRegex(), dockerBasePackages(this.database.basePackage));
+    content = gsub(
+      content,
+      allDockerBuildsRegex(),
+      dockerBuildPackages(this.database.buildPackage),
+    );
+    this.fs.writeFileSync(fullPath, content);
+    this.output(`     update  Dockerfile`);
+  }
+
+  editDevcontainerFiles(): void {
+    // Deferred: trailties' devcontainer generator (#2221) is in flight.
+    // Once its emission shape is known, this method will edit
+    // `.devcontainer/devcontainer.json` and `.devcontainer/compose.yaml`
+    // analogous to Rails' edit_devcontainer_json / edit_compose_yaml.
+  }
+}
+
+function databaseConfigTs(database: Database, appName: string): string {
+  if (database.name === "sqlite3") {
+    return [
+      `export default {`,
+      ...["development", "test", "production"].map(
+        (env) => `  ${env}: { adapter: "sqlite3", database: "db/${env}.sqlite3" },`,
+      ),
+      `};`,
+      ``,
+    ].join("\n");
+  }
+  const adapter = database.name === "postgres" ? "postgresql" : "mysql2";
+  const port = database.port!;
+  const block = (env: string) =>
+    `  ${env}: { adapter: "${adapter}", database: "${appName}_${env}", host: "localhost", port: ${port} },`;
+  return [
+    `export default {`,
+    block("development"),
+    block("test"),
+    `  production: { adapter: "${adapter}", url: process.env.DATABASE_URL },`,
+    `};`,
+    ``,
+  ].join("\n");
+}
+
+function dockerBasePackages(databasePackage: string | undefined): string {
+  const set = databasePackage ? [databasePackage, ...BASE_PACKAGES].sort() : [...BASE_PACKAGES];
+  return set.join(" ");
+}
+
+function dockerBuildPackages(databasePackage: string | undefined): string {
+  const set = databasePackage ? [databasePackage, ...BUILD_PACKAGES].sort() : [...BUILD_PACKAGES];
+  return set.join(" ");
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function altRegex(values: string[]): RegExp {
+  return new RegExp([...new Set(values)].map(escapeRegex).join("|"), "g");
+}
+
+function allDockerBasesRegex(): RegExp {
+  return altRegex(Database.all().map((d) => dockerBasePackages(d.basePackage)));
+}
+
+function allDockerBuildsRegex(): RegExp {
+  return altRegex(Database.all().map((d) => dockerBuildPackages(d.buildPackage)));
+}
+
+function gsub(haystack: string, pattern: RegExp, replacement: string): string {
+  return haystack.replace(pattern, replacement);
+}


### PR DESCRIPTION
## Summary

Mirrors `railties/lib/rails/generators/rails/db/system/change/change_generator.rb` with trailties substitutions.

- `editDatabaseConfig` rewrites the active TS database config (matches the runtime loader's candidate order: `config/database.{ts,js}`, then `src/config/...`; falls back to `src/config/database.ts`).
- `editPackageJson` is the Rails `editGemfile` analog — strips known DB deps (`pg` / `mysql2` / `better-sqlite3`) and adds the target adapter's dep. Throws with file path + parse error on unparseable JSON.
- `editDockerfile` uses Rails-shape exact-string substitution over the `BASE_PACKAGES` / `BUILD_PACKAGES` alternation; skips write/output when no substitution changes the file.
- `editDevcontainerFiles` is intentionally deferred (see follow-ups).

Test names mirror Rails `db_system_change_generator_test.rb` verbatim where applicable.

Plan doc entry: `docs/trailties-plan.md` PR 1.14c-4.

## Follow-ups

- **AppGenerator Dockerfile alignment (PR 1.14d):** trailties' current `AppGenerator` emits a Dockerfile whose `apt-get install` line doesn't match the `dockerPackages(BASE_PACKAGES, …)` / `dockerPackages(BUILD_PACKAGES, …)` shape, so on a default-generated app `editDockerfile` is a no-op. The Rails-faithful fix is to align AppGenerator's Dockerfile with the `Database` registry's `basePackage` / `buildPackage` fields (mirrors Rails `app/templates/Dockerfile.tt`). Diverging this generator to parse-and-recompute would break Rails fidelity, so the work lives upstream.
- **`editDevcontainerFiles` (#2221):** wire once the devcontainer generator lands its emission shape.
- **Dedupe `databaseConfigTs` with `AppGenerator#dbConfig`.**

## Test plan
- [x] `pnpm vitest run packages/trailties/src/generators/rails/db/system/change/change-generator.test.ts` — 11 tests pass
- [x] CI green (DX type tests, lint, etc.)