### PR TITLE
test(activerecord): port pets/animals cluster fixtures (PR 4-late)

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/faces.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/faces.ts
@@ -1,0 +1,18 @@
+import { ref } from "../define-fixtures.js";
+
+// activerecord/test/fixtures/faces.yml
+export const faceFixtureData = {
+  trusting: {
+    description: "trusting",
+    human_id: ref("humans", "gordon"),
+  },
+  weather_beaten: {
+    description: "weather beaten",
+    human_id: ref("humans", "steve"),
+  },
+  confused: {
+    description: "confused",
+    polymorphic_human_id: ref("humans", "gordon"),
+    polymorphic_human_type: "Human",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/humans.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/humans.ts
@@ -1,0 +1,9 @@
+// activerecord/test/fixtures/humans.yml
+export const humanFixtureData = {
+  gordon: {
+    name: "Gordon",
+  },
+  steve: {
+    name: "Steve",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/owners.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/owners.ts
@@ -1,0 +1,13 @@
+// activerecord/test/fixtures/owners.yml
+export const ownerFixtureData = {
+  blackbeard: {
+    owner_id: 1,
+    name: "blackbeard",
+    essay_id: "A Modest Proposal",
+    happy_at: "2150-10-10 16:00:00",
+  },
+  ashley: {
+    owner_id: 2,
+    name: "ashley",
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/pets.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/pets.ts
@@ -1,0 +1,23 @@
+// activerecord/test/fixtures/pets.yml
+export const petFixtureData = {
+  parrot: {
+    pet_id: 1,
+    name: "parrot",
+    owner_id: 1,
+  },
+  chew: {
+    pet_id: 2,
+    name: "chew",
+    owner_id: 2,
+  },
+  mochi: {
+    pet_id: 3,
+    name: "mochi",
+    owner_id: 2,
+  },
+  bulbul: {
+    pet_id: 4,
+    name: "bulbul",
+    owner_id: 1,
+  },
+};

--- a/packages/activerecord/src/test-helpers/fixtures/toys.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/toys.ts
@@ -1,0 +1,18 @@
+// activerecord/test/fixtures/toys.yml
+export const toyFixtureData = {
+  bone: {
+    toy_id: 1,
+    name: "Bone",
+    pet_id: 1,
+  },
+  doll: {
+    toy_id: 2,
+    name: "Doll",
+    pet_id: 2,
+  },
+  bulbuli: {
+    toy_id: 3,
+    name: "Bulbuli",
+    pet_id: 4,
+  },
+};


### PR DESCRIPTION
## Summary

Closes the 5 MISSING entries in `fixtures:compare`:

- `faces.yml` → `faces.ts` (polymorphic refs to humans)
- `humans.yml` → `humans.ts`
- `owners.yml` → `owners.ts` (composite-PK schema, `owner_id`)
- `pets.yml` → `pets.ts` (composite-PK schema, `pet_id`)
- `toys.yml` → `toys.ts` (composite-PK schema, `toy_id`)

This is cluster 4 from `docs/fixtures-port-plan.md`. `dogs` / `other_dogs` /
`dog_lovers` from the same cluster were already shipped under PR 5
(#2212); this finishes the cluster.

All five files match Rails YAML at 100% rows/attrs under
`pnpm fixtures:compare`. Local TS-IMPORT-ERR on `faces.ts` is the
already-known "needs full pnpm build of activesupport/globalid" issue,
identical to `dogs.ts` / `developers-projects.ts` — clears in CI.

## Why this PR

PR 7 (strict flip of `fixtures:compare` to hard-fail + remove
`fixtures.rb` / `fixture_set` / `test_fixtures.rb` /
`encrypted_fixtures.rb` from `unported-files.ts`) is blocked while
`MISSING` count is non-zero. Closing this cluster unblocks the next
step toward PR 7. Three `DIFF`-status fixtures remain (`live_parrots`,
`other_books`, `randomly_named_a9`) and are a separate PR.

## Test plan

- [ ] CI `Fixtures comparison` job stays green
- [ ] `pnpm fixtures:compare` shows `missing=0` (down from 5) after this lands