### PR TITLE
test(activerecord): reconcile 3 fixture DIFFs against Rails YAML

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures/authors.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/authors.ts
@@ -7,7 +7,7 @@ export const authorFixtureData = {
     name: "David",
     author_address_id: ref("author_addresses", "david_address"),
     author_address_extra_id: ref("author_addresses", "david_address_extra"),
-    owned_essay_id: ref("essays", "a modest proposal"),
+    owned_essay_id: "A Modest Proposal",
     organization_id: "No Such Agency",
   },
   mary: {

--- a/packages/activerecord/src/test-helpers/fixtures/comments.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/comments.ts
@@ -74,6 +74,6 @@ export const commentFixtureData = {
     body: "afrase",
     post_id: ref("posts", "sti_post_and_comments"),
     type: "Comment",
-    company_id: ref("companies", "recursive_association_fk"),
+    company: ref("companies", "recursive_association_fk"),
   },
 };

--- a/packages/activerecord/src/test-helpers/fixtures/randomly-named-a9.ts
+++ b/packages/activerecord/src/test-helpers/fixtures/randomly-named-a9.ts
@@ -2,10 +2,10 @@
 export const randomlyNamedA9FixtureData = {
   first_instance: {
     some_attribute: "AAA",
-    another_attribute: "000",
+    another_attribute: 0,
   },
   second_instance: {
     some_attribute: "BBB",
-    another_attribute: "999",
+    another_attribute: 999,
   },
 };


### PR DESCRIPTION
## Summary

Three Rails-faithful corrections to existing fixture ports, dropping
`fixtures:compare` DIFF count **11 → 8**.

1. **`authors.david.owned_essay_id`** — was `ref("essays", "a modest proposal")`,
   now literal `"A Modest Proposal"`. Rails YAML stores the essay's
   `name` column value directly (not a row-label ref), the same way
   `essays.ts` already handles `writer_id: "David"`, `category_id: "General"`,
   etc.

2. **`randomly_named_a9.{first,second}_instance.another_attribute`** —
   was string `"000"` / `"999"`, now integer `0` / `999`. YAML parses
   unquoted `000` / `999` as integers; the TS port had quoted them by
   mistake.

3. **`comments.recursive_association_comment.company_id`** → `company`.
   Rails `schema.rb` declares `t.integer :company` (no `_id` suffix) and
   YAML uses `company: 15` directly. Schema in `test-schema.ts` already
   names the column `company`, so the TS row had been writing to a
   nonexistent column.

## Remaining DIFFs (out of scope, follow-ups)

These need compare-script enhancements, not fixture edits:

- **books / other_books** — Rails YAML uses enum symbols (`:published`)
  but the TS port stores the integer the enum maps to. Needs an enum
  resolver in compare, or a per-column override.
- **topics / other_topics** — `written_on` / `bonus_time` datetime
  format differences (Rails Time-with-tz vs string), plus YAML-serialized
  `content` column. Needs serialization-aware comparison.
- **dead_parrots / live_parrots** — `treasures: [ruby, sapphire]` is a
  HABTM list; compare keeps the key when schema isn't ported and reports
  `missing-in-ts`. STI rows that point to a sibling table aren't picked
  up by the per-yml schema lookup either.
- **sponsors** — Rails declares `belongs_to :sponsor_club, class_name: "Club", foreign_key: "club_id"`,
  so YAML `sponsor_club: moustache_club` maps to column `club_id`.
  `canonicalizeRailsRow` only handles `assoc → assoc_id`, not custom
  `foreign_key:` overrides.
- **developers_projects** — relies on `developers.yml` ids; `developers.yml`
  is ERB-UNSUPPORTED so the id index is empty.

## Test plan

- [ ] CI `Fixtures comparison` job stays green
- [ ] `pnpm fixtures:compare` shows authors / comments / randomly-named-a9
      as MATCH (down from DIFF)