### PR TITLE
fix(activerecord): await caseInsensitiveComparison in uniqueness validator

### DIFF
--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -1722,4 +1722,33 @@ describe("UniquenessValidationTest", () => {
     const t3 = new Topic({ title: "world" });
     expect(await t3.save()).toBe(true);
   });
+
+  // Regression: PostgreSQLAdapter#caseInsensitiveComparison is async (OID
+  // lookup via pg_proc). buildRelation must await it — passing the bare
+  // Promise to Relation#where yields "Unsupported argument type:
+  // [object Promise]". Stubbed here so the contract is exercised without
+  // requiring a live PG connection.
+  it("awaits async adapter.caseInsensitiveComparison without leaking a Promise into where()", async () => {
+    const adp = await freshAdapterValidation2();
+    let wasAwaited = false;
+    (adp as any).caseInsensitiveComparison = async (attribute: any, value: unknown) => {
+      await Promise.resolve();
+      wasAwaited = true;
+      return attribute.lower().eq((attribute.relation as any).lower(value));
+    };
+
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+        this.adapter = adp;
+        this.validatesUniqueness("title", { caseSensitive: false });
+      }
+    }
+
+    await Topic.create({ title: "Hello" });
+    const t2 = new Topic({ title: "HELLO" });
+    expect(await t2.save()).toBe(false);
+    expect(wasAwaited).toBe(true);
+    expect(t2.errors.on("title")).toBeTruthy();
+  });
 });

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -32,7 +32,7 @@ const CLUSTER_A_SCHEMA = {
 } as const;
 
 async function freshAdapterA(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
+  const { adapter } = createSidecarTestAdapter();
   await defineSchema(adapter, CLUSTER_A_SCHEMA);
   return adapter;
 }
@@ -643,7 +643,7 @@ describe("UniquenessValidationTest", () => {
 });
 
 async function freshAdapterIndex(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
+  const { adapter } = createSidecarTestAdapter();
   await defineSchema(adapter, {
     posts: {
       title: "string",
@@ -870,7 +870,7 @@ describe("UniquenessValidationWithIndexTest", () => {
 });
 
 async function freshAdapterCompositeOrders(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
+  const { adapter } = createSidecarTestAdapter();
   await defineSchema(adapter, {
     orders: {
       shop_id: "integer",
@@ -896,7 +896,7 @@ async function freshAdapterCompositeOrders(): Promise<DatabaseAdapter> {
 }
 
 async function freshAdapterCompositeOrders2(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
+  const { adapter } = createSidecarTestAdapter();
   await defineSchema(adapter, {
     orders: { shop_id: "string", code: "string" },
   });
@@ -1539,7 +1539,7 @@ describe("UniquenessWithCompositeKey", () => {
 
 describe("UniquenessWithCompositeKey", () => {
   it("uniqueness validation for model with composite key duplicate check", async () => {
-    const adp = createTestAdapter();
+    const { adapter: adp } = createSidecarTestAdapter();
     await defineSchema(adp, { entries: { group_id: "integer", seq: "integer" } });
     class Entry extends Base {
       static {
@@ -1556,7 +1556,7 @@ describe("UniquenessWithCompositeKey", () => {
 });
 
 async function freshAdapterBindParams(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
+  const { adapter } = createSidecarTestAdapter();
   await defineSchema(adapter, {
     tokens: {
       columns: { token: "string", label: "string" },
@@ -1636,7 +1636,7 @@ describe("UniquenessBindParamsTest", () => {
 });
 
 async function freshAdapterValidation2(): Promise<DatabaseAdapter> {
-  const adapter = createTestAdapter();
+  const { adapter } = createSidecarTestAdapter();
   await defineSchema(adapter, {
     emails: { address: "string" },
     usernames: { name: "string" },

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "../index.js";
 
-import { createSidecarTestAdapter } from "../test-adapter.js";
+import { createTestAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -32,7 +32,7 @@ const CLUSTER_A_SCHEMA = {
 } as const;
 
 async function freshAdapterA(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, CLUSTER_A_SCHEMA);
   return adapter;
 }
@@ -643,7 +643,7 @@ describe("UniquenessValidationTest", () => {
 });
 
 async function freshAdapterIndex(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     posts: {
       title: "string",
@@ -870,7 +870,7 @@ describe("UniquenessValidationWithIndexTest", () => {
 });
 
 async function freshAdapterCompositeOrders(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     orders: {
       shop_id: "integer",
@@ -896,7 +896,7 @@ async function freshAdapterCompositeOrders(): Promise<DatabaseAdapter> {
 }
 
 async function freshAdapterCompositeOrders2(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     orders: { shop_id: "string", code: "string" },
   });
@@ -1539,7 +1539,7 @@ describe("UniquenessWithCompositeKey", () => {
 
 describe("UniquenessWithCompositeKey", () => {
   it("uniqueness validation for model with composite key duplicate check", async () => {
-    const { adapter: adp } = createSidecarTestAdapter();
+    const adp = createTestAdapter();
     await defineSchema(adp, { entries: { group_id: "integer", seq: "integer" } });
     class Entry extends Base {
       static {
@@ -1556,7 +1556,7 @@ describe("UniquenessWithCompositeKey", () => {
 });
 
 async function freshAdapterBindParams(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     tokens: {
       columns: { token: "string", label: "string" },
@@ -1636,7 +1636,7 @@ describe("UniquenessBindParamsTest", () => {
 });
 
 async function freshAdapterValidation2(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     emails: { address: "string" },
     usernames: { name: "string" },

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -101,41 +101,7 @@ export class UniquenessValidator extends EachValidator {
       return;
     }
 
-    let relation = buildRelation(
-      modelClass,
-      attribute,
-      mapped,
-      this.options as Record<string, unknown>,
-    );
-
-    if (record.isPersisted?.()) {
-      const pk = modelClass.primaryKey ?? "id";
-      if (Array.isArray(pk)) {
-        const dbVals = pk.map((col: string) =>
-          record._dirty?.attributeChanged(col)
-            ? record._dirty.attributeWas(col)
-            : record.readAttribute(col),
-        );
-        relation = relation.whereNot(pk, [dbVals]);
-      } else {
-        const dbVal = record._dirty?.attributeChanged(pk)
-          ? record._dirty.attributeWas(pk)
-          : record.readAttribute(pk);
-        relation = relation.whereNot({ [pk]: [dbVal] });
-      }
-    }
-
     const opts = this.options as any;
-
-    relation = scopeRelation(record, relation, this.options as Record<string, unknown>);
-
-    if (opts?.conditions && typeof opts.conditions === "function") {
-      const conditioned =
-        opts.conditions.length === 0
-          ? opts.conditions.call(relation)
-          : opts.conditions.call(relation, record);
-      if (conditioned != null) relation = conditioned;
-    }
 
     let asyncValidations = (record as any)._asyncValidationPromises as
       | Promise<unknown>[]
@@ -148,11 +114,46 @@ export class UniquenessValidator extends EachValidator {
     const errorOpts: Record<string, unknown> = { value };
     if (opts?.message != null) errorOpts.message = opts.message;
 
-    const validationPromise = relation.exists().then((exists: boolean) => {
+    const validationPromise = (async () => {
+      let [relation] = await buildRelation(
+        modelClass,
+        attribute,
+        mapped,
+        this.options as Record<string, unknown>,
+      );
+
+      if (record.isPersisted?.()) {
+        const pk = modelClass.primaryKey ?? "id";
+        if (Array.isArray(pk)) {
+          const dbVals = pk.map((col: string) =>
+            record._dirty?.attributeChanged(col)
+              ? record._dirty.attributeWas(col)
+              : record.readAttribute(col),
+          );
+          relation = relation.whereNot(pk, [dbVals]);
+        } else {
+          const dbVal = record._dirty?.attributeChanged(pk)
+            ? record._dirty.attributeWas(pk)
+            : record.readAttribute(pk);
+          relation = relation.whereNot({ [pk]: [dbVal] });
+        }
+      }
+
+      relation = scopeRelation(record, relation, this.options as Record<string, unknown>);
+
+      if (opts?.conditions && typeof opts.conditions === "function") {
+        const conditioned =
+          opts.conditions.length === 0
+            ? opts.conditions.call(relation)
+            : opts.conditions.call(relation, record);
+        if (conditioned != null) relation = conditioned;
+      }
+
+      const exists = await relation.exists();
       if (exists) {
         record.errors.add(attribute, "taken", errorOpts);
       }
-    });
+    })();
     asyncValidations.push(validationPromise);
   }
 }
@@ -287,12 +288,14 @@ function resolveAttributes(record: any, attributes: string[]): string[] {
  *
  * @internal
  */
-function buildRelation(
+async function buildRelation(
   klass: any,
   attribute: string,
   value: unknown,
   options: Record<string, unknown>,
-): any {
+): Promise<[any]> {
+  // Wrapped in a tuple because Relation is thenable — a bare `await` would
+  // execute the query and resolve to the row array.
   const base = typeof klass.unscoped === "function" ? klass.unscoped() : klass.where({});
   const arel = klass.arelTable as { get?: (n: string) => any } | null;
   const pb = (base as { predicateBuilder?: { buildBindAttribute(c: string, v: unknown): unknown } })
@@ -325,7 +328,7 @@ function buildRelation(
             ? (typeObj as any).type()
             : (typeObj as any).type;
       if (colType !== "uuid") {
-        comparison = adapter?.caseInsensitiveComparison?.(attr, bind) ?? null;
+        comparison = (await adapter?.caseInsensitiveComparison?.(attr, bind)) ?? null;
         if (comparison == null && typeof value === "string") {
           // No native CI form — fall back to LOWER() with a lowercased bind.
           // Keeps the bind parameterized so the prepared-statement cache
@@ -336,10 +339,10 @@ function buildRelation(
       }
     }
     if (comparison != null && typeof base.where === "function") {
-      return base.where(comparison);
+      return [base.where(comparison)];
     }
   }
-  return base.where({ [attribute]: value });
+  return [base.where({ [attribute]: value })];
 }
 
 /**


### PR DESCRIPTION
## Summary

- `UniquenessValidator#buildRelation` called `adapter.caseInsensitiveComparison?.(attr, bind)` without `await`. `PostgreSQLAdapter.caseInsensitiveComparison` is `async`, so the Promise leaked into `base.where()` → `Unsupported argument type: [object Promise]`.
- Made `buildRelation` async and moved the persisted-PK / scope / conditions chain into the existing async-validation promise body so the await fits naturally. Return value wrapped in a single-element tuple because `Relation` is thenable (a bare `await` would execute the query and resolve to a row array).

Closes Bug 1 from PR #2219 post-merge findings.

## Why the wrapper hid it

`TestAdapterFixtures` doesn't delegate `caseInsensitiveComparison`, so the optional chain returned `undefined` and the validator fell through to its `LOWER()`-bind fallback. The sidecar exposes the real adapter, surfacing the missing await.

## Test migration deferred

The original plan re-migrated `uniqueness-validation.test.ts` to `createSidecarTestAdapter`, but PG CI exposed a second gap: the sidecar PG adapter's `columnForAttribute` returns undefined for tables created via `defineSchema` (schema cache isn't warmed), so PG's `caseInsensitiveComparison` falls back to `attribute.eq(value)` — no `LOWER`, no match for `'HELLO'` vs `'Hello'`. Follow-up: wire schema-cache warming into `createSidecarTestAdapter`, then re-migrate.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/validations/uniqueness-validation.test.ts` — 100 passing on SQLite
- [ ] CI: PG + MySQL