### PR TITLE
test(activerecord): migrate relation/ consumers to sidecar test adapter (Path 2c-2 batch 2)

### DIFF
--- a/packages/activerecord/src/relation/and.test.ts
+++ b/packages/activerecord/src/relation/and.test.ts
@@ -5,13 +5,13 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let adapter: TestDatabaseAdapter;
+let adapter: SidecarAdapter;
 beforeAll(async () => {
-  adapter = createTestAdapter();
+  ({ adapter: adapter } = createSidecarTestAdapter());
   await defineSchema(adapter, {
     posts: { title: "string", body: "string", author: "string" },
     users: { name: "string", role: "string", active: "boolean" },

--- a/packages/activerecord/src/relation/annotations.test.ts
+++ b/packages/activerecord/src/relation/annotations.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, {
     posts: { title: "string" },
     items: {},

--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -9,7 +9,7 @@
 import { describe, it, expect } from "vitest";
 import { Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base, Relation, UnmodifiableRelation } from "../index.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter } from "../test-adapter.js";
 
 class Post extends Base {
   static _tableName = "posts";
@@ -17,7 +17,7 @@ class Post extends Base {
 Post.attribute("id", "integer");
 Post.attribute("title", "string");
 Post.attribute("body", "text");
-Post.adapter = createTestAdapter();
+Post.adapter = createSidecarTestAdapter().adapter;
 
 function relation(): Relation<Post> {
   return Post.all() as unknown as Relation<Post>;

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -12,12 +12,12 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("Relation#where — composite-key form", () => {
-  let adapter: TestDatabaseAdapter;
+  let adapter: SidecarAdapter;
 
   class CompOrder extends Base {
     static {
@@ -30,7 +30,7 @@ describe("Relation#where — composite-key form", () => {
   }
 
   beforeAll(async () => {
-    adapter = createTestAdapter();
+    ({ adapter: adapter } = createSidecarTestAdapter());
     await defineSchema(adapter, {
       comp_orders: {
         columns: {

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -1,13 +1,13 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let adapter: TestDatabaseAdapter;
+let adapter: SidecarAdapter;
 
 beforeAll(async () => {
-  adapter = createTestAdapter();
+  ({ adapter: adapter } = createSidecarTestAdapter());
   await defineSchema(adapter, {
     arel_posts: { title: "string" },
     posts: { title: "string" },

--- a/packages/activerecord/src/relation/delete-all.test.ts
+++ b/packages/activerecord/src/relation/delete-all.test.ts
@@ -14,14 +14,14 @@ function epochMs(v: unknown): number {
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany, processDependentAssociations } from "../associations.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, {
     posts: {
       title: "string",

--- a/packages/activerecord/src/relation/field-ordered-values.test.ts
+++ b/packages/activerecord/src/relation/field-ordered-values.test.ts
@@ -5,12 +5,12 @@
 import { describe, it, expect } from "vitest";
 import { Base, defineEnum } from "../index.js";
 
-import { createTestAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 // -- Helpers --
 function freshAdapter(): DatabaseAdapter {
-  return createTestAdapter();
+  return createSidecarTestAdapter().adapter;
 }
 
 // ==========================================================================

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, {
     posts: { title: "string", author: "string" },
     items: { name: "string", status: "string" },

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("RelationMutationTest", () => {
-  let adapter: TestDatabaseAdapter;
+  let adapter: SidecarAdapter;
   beforeAll(async () => {
-    adapter = createTestAdapter();
+    ({ adapter: adapter } = createSidecarTestAdapter());
     await defineSchema(adapter, {
       posts: { title: "string", author: "string" },
     });

--- a/packages/activerecord/src/relation/or.test.ts
+++ b/packages/activerecord/src/relation/or.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, {
     posts: {
       title: "string",

--- a/packages/activerecord/src/relation/order.test.ts
+++ b/packages/activerecord/src/relation/order.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, {
     posts: { title: "string", score: "integer" },
     items: { name: "string", price: "integer" },

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -5,7 +5,7 @@ import { Substitute } from "../statement-cache.js";
 import { Range } from "../connection-adapters/postgresql/oid/range.js";
 import { TableMetadata } from "../table-metadata.js";
 import { Base, registerModel, modelRegistry } from "../index.js";
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { dropAllTables } from "../test-helpers/drop-all-tables.js";
@@ -16,10 +16,10 @@ describe("PredicateBuilderTest", () => {
   // Teardown: Topic.class_eval { @predicate_builder = nil }
   // We use a local custom class instead of Regexp to keep the test self-contained.
 
-  let adapter: TestDatabaseAdapter;
+  let adapter: SidecarAdapter;
 
   beforeAll(async () => {
-    adapter = createTestAdapter();
+    ({ adapter: adapter } = createSidecarTestAdapter());
     await defineSchema(adapter, {
       topics: { title: "string" },
       replies: { parent_id: "integer" },

--- a/packages/activerecord/src/relation/select-star-join-collision.test.ts
+++ b/packages/activerecord/src/relation/select-star-join-collision.test.ts
@@ -20,13 +20,13 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
 
 describe("SELECT * column collision in joined relations", () => {
-  let adapter: TestDatabaseAdapter;
+  let adapter: SidecarAdapter;
 
   class SsjUser extends Base {
     static {
@@ -43,7 +43,7 @@ describe("SELECT * column collision in joined relations", () => {
   }
 
   beforeAll(async () => {
-    adapter = createTestAdapter();
+    ({ adapter: adapter } = createSidecarTestAdapter());
     await defineSchema(adapter, {
       ssj_users: { name: "string" },
       ssj_friendships: { ssj_user_id: "integer", ssj_friend_id: "integer" },

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -5,15 +5,15 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { quoteColumnName } from "../test-helpers/quote-regex.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, {
     posts: { title: "string", body: "string", status: "string" },
     items: { name: "string", status: "string", category: "string" },

--- a/packages/activerecord/src/relation/structural-compatibility.test.ts
+++ b/packages/activerecord/src/relation/structural-compatibility.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let adapter: TestDatabaseAdapter;
+let adapter: SidecarAdapter;
 
 beforeAll(async () => {
-  adapter = createTestAdapter();
+  ({ adapter: adapter } = createSidecarTestAdapter());
   await defineSchema(adapter, {
     posts: { title: "string", score: "integer" },
     users: { name: "string" },

--- a/packages/activerecord/src/relation/thenable.test.ts
+++ b/packages/activerecord/src/relation/thenable.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect, beforeAll, beforeEach, vi, afterEach } from "vitest";
 import { Base, Relation, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("Thenable", () => {
-  let adapter: SidecarAdapter;
+  let adapter: TestDatabaseAdapter;
   let ThenableUser: typeof Base;
 
   beforeAll(async () => {
-    ({ adapter: adapter } = createSidecarTestAdapter());
+    adapter = createTestAdapter();
     await defineSchema(adapter, {
       thenable_users: { name: "string", active: "integer" },
       thenable_posts: { title: "string" },

--- a/packages/activerecord/src/relation/thenable.test.ts
+++ b/packages/activerecord/src/relation/thenable.test.ts
@@ -1,16 +1,16 @@
 import { describe, it, expect, beforeAll, beforeEach, vi, afterEach } from "vitest";
 import { Base, Relation, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
 describe("Thenable", () => {
-  let adapter: TestDatabaseAdapter;
+  let adapter: SidecarAdapter;
   let ThenableUser: typeof Base;
 
   beforeAll(async () => {
-    adapter = createTestAdapter();
+    ({ adapter: adapter } = createSidecarTestAdapter());
     await defineSchema(adapter, {
       thenable_users: { name: "string", active: "integer" },
       thenable_posts: { title: "string" },

--- a/packages/activerecord/src/relation/unscope-coverage.test.ts
+++ b/packages/activerecord/src/relation/unscope-coverage.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { createTestAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter } from "../test-adapter.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 describe("Relation#unscope — full Rails key coverage", () => {
@@ -25,7 +25,7 @@ describe("Relation#unscope — full Rails key coverage", () => {
   }
 
   beforeEach(() => {
-    adapter = createTestAdapter();
+    ({ adapter } = createSidecarTestAdapter());
     UscAuthor.adapter = adapter;
     UscPost.adapter = adapter;
     registerModel("UscAuthor", UscAuthor);

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -14,14 +14,14 @@ function epochMs(v: unknown): number {
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, {
     posts: { title: "string", author: "string", views: "integer", updated_at: "datetime" },
   });

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -12,7 +12,7 @@ import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: SidecarAdapter = createSidecarTestAdapter().adapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
   ({ adapter: _adapter } = createSidecarTestAdapter());
   const authorCols = { name: "string" as const };

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -12,9 +12,8 @@ import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: SidecarAdapter = createSidecarTestAdapter().adapter;
+const _adapter: SidecarAdapter = createSidecarTestAdapter().adapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = createSidecarTestAdapter());
   const authorCols = { name: "string" as const };
   const postCols = {
     title: "string" as const,

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -12,7 +12,7 @@ import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: SidecarAdapter;
+let _adapter: SidecarAdapter = createSidecarTestAdapter().adapter;
 beforeAll(async () => {
   ({ adapter: _adapter } = createSidecarTestAdapter());
   const authorCols = { name: "string" as const };

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -6,15 +6,15 @@ import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { quoteTableName } from "../test-helpers/quote-regex.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter = createTestAdapter();
+let _adapter: SidecarAdapter = createSidecarTestAdapter().adapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   const authorCols = { name: "string" as const };
   const postCols = {
     title: "string" as const,

--- a/packages/activerecord/src/relation/where-clause.test.ts
+++ b/packages/activerecord/src/relation/where-clause.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, {
     posts: { title: "string", author: "string", status: "string" },
   });

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, defineEnum, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { quoteTableName, quoteColumnName } from "../test-helpers/quote-regex.js";
@@ -117,9 +117,9 @@ const SCHEMA: Schema = {
   },
 };
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, SCHEMA);
 });
 withTransactionalFixtures(() => _adapter);

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -5,13 +5,13 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = createSidecarTestAdapter());
   await defineSchema(_adapter, {
     posts: { title: "string", tags_count: "integer" },
     wj_posts: { title: "string" },
@@ -22,7 +22,7 @@ beforeAll(async () => {
   });
 });
 withTransactionalFixtures(() => _adapter);
-function freshAdapter(): TestDatabaseAdapter {
+function freshAdapter(): SidecarAdapter {
   return _adapter;
 }
 


### PR DESCRIPTION
## Summary

Path 2c-2 sweep — batch 2. Continues #2219. Migrates 21 of 22 consumers in `packages/activerecord/src/relation/*.test.ts` off the `TestAdapterFixtures` wrapper (`createTestAdapter()`) to the sidecar shape (`createSidecarTestAdapter()`). Wrapper, factory, and `TestDatabaseAdapter` type alias remain for path 2c-3 to delete after every consumer is migrated.

Files migrated (21): and, annotations, build-arel-helpers, composite-where, delegation, delete-all, field-ordered-values, merging, mutation, or, order, predicate-builder, select, select-star-join-collision, structural-compatibility, unscope-coverage, update-all, where, where-chain, where-clause, with.

### Deferred

- `thenable.test.ts` — surfaced a pre-existing wrapper-masked bug. The "does not eagerly evaluate on construction" test spies `adapter.execute`; the wrapper exposed a uniform `execute` so the spy fired on every backend, but the bare PG adapter routes SELECTs through a different method, so the spy never fires. SQLite still passes. Follow-up: migrate after the spy targets the real PG query method (or assert on a backend-agnostic hook).

`scoping/relation-scoping.test.ts` (Bug 2 from #2219 — concurrent-writes race) is in `scoping/`, not in this batch's scope.

## Test plan

- [x] `pnpm vitest run` on all 21 migrated files passes locally (SQLite)
- [x] PG + MariaDB via CI (after deferring thenable.test.ts)
- [x] `pnpm api:compare` delta non-negative
- [x] `pnpm test:compare` delta non-negative