### PR TITLE
docs(fixtures): audit plan + sized loose ends for PR 7 strict-fail

### DIFF
--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -15,8 +15,8 @@ PR 7 flips `fixtures:compare` MISSING/DIFF to hard-fail and removes the
 four fixtures-related entries from `scripts/api-compare/unported-files.ts`.
 Everything below is what must close (or move to an explicit allow-list)
 first. Cross-referenced to merged PRs; the source finding files this
-section was distilled from live in each PR's GitHub review thread and,
-for contributors running btwhooks locally, under
+section was distilled from are available in each PR's GitHub review
+thread and (for local runs of btwhooks) under
 `~/.btwhooks/data/github/blazetrailsdev/trails/<PR#>/post-pr/`.
 
 ### Compare-script enhancements blocking strict mode (~150 LOC total)
@@ -124,7 +124,7 @@ load:
   `packages/activerecord/src/test-helpers/define-fixtures.ts`. Blocks
   `subscribers.ts` (Rails `Subscriber.primary_key = "nick"`) and
   `string-key-objects.ts`. From #2205 + #2214 findings.
-- **~30–50 LOC — defineFixtures NOT NULL `created_at`/`updated_at`
+- **~30–50 LOC — `defineFixtures` NOT NULL `created_at`/`updated_at`
   auto-stamp.** Unblocks `people.ts` (Rails schema has
   `t.timestamps null: false`; YAML omits both — Rails' loader stamps
   them). From #2209.
@@ -132,7 +132,7 @@ load:
   `memberships.type: "CurrentMembership"` are model enums; loader
   needs to route through the attribute layer (or a small enum-lookup
   helper) before insert. From #2208, #2209.
-- **~80–150 LOC — defineFixtures belongs_to-reflection → FK-column
+- **~80–150 LOC — `defineFixtures` belongs_to-reflection → FK-column
   resolver.** Lets future fixture `.ts` stay byte-closer to YAML
   (write `club: foo` instead of `club_id: ref("clubs", "foo")`).
   From #2209.

--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -428,7 +428,7 @@ ceiling) and PR 7 (granted ceiling waiver — see entry).
 2. **Schema port lands as PR 0.5 (split into sibling PRs).**
    `vendor/rails/activerecord/test/schema/schema.rb` is 1462 LOC; the TS
    port is ~2200 LOC, well past the 300-LOC ceiling. Splits as
-   `0.5a` … `0.5h` (rough), sibling branches from `main` with
+   `0.5a` … `0.5g` (came in at 7 slots; original estimate was 6–8), sibling branches from `main` with
    non-overlapping table groups, merged in any order. The final
    split-suffix PR wires `test-schema.ts` into
    `setup-adapter-suite.ts`. Every fixture PR after that assumes the

--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -2,8 +2,147 @@
 
 Port the remaining Rails `activerecord/test/fixtures/*.yml` files to TS so
 that ported AR tests can call `useFixtures([...])` instead of inlining
-`defineSchema()` / row inserts in `beforeAll`. Currently 12 of 122
-translated.
+`defineSchema()` / row inserts in `beforeAll`. **All 122 fixtures
+translated** (PRs 0–6b + 0.5a–g + 0.75 + 4-late merged 2026-05-20…21).
+`pnpm fixtures:compare` reports **match=94 diff=8 missing=0
+erb-unsupported=20** under soft mode. PR 7's strict-fail flip is blocked
+on the 8 DIFF + 20 ERB-UNSUPPORTED + the test-body port; see "Loose ends"
+below.
+
+## Loose ends before PR 7 can ship
+
+PR 7 flips `fixtures:compare` MISSING/DIFF to hard-fail and removes the
+four fixtures-related entries from `scripts/api-compare/unported-files.ts`.
+Everything below is what must close (or move to an explicit allow-list)
+first. Cross-referenced to merged PRs and the source finding files under
+`~/.btwhooks/data/github/blazetrailsdev/trails/<PR#>/post-pr/`.
+
+### Compare-script enhancements blocking strict mode (~180 LOC total)
+
+The 8 remaining DIFFs are all `scripts/fixtures-compare/compare.ts`
+gaps, not fixture-data bugs. Per #2228 post-merge findings:
+
+1. **~40 LOC — enum-symbol comparator.** `books` / `other_books` use
+   Rails enum symbols (`:published`, `:english`) in YAML; TS stores
+   the mapped integer. Needs a per-column enum resolver (model metadata
+   lookup or configurable map) in `canonicalizeRailsRow` /
+   `compareValue`.
+2. **~30 LOC — HABTM key handling.**
+   `dead_parrots.deadbird.treasures: [ruby, sapphire]` and
+   `live_parrots.dusty.treasures` are HABTM list-form. canonicalize
+   keeps the key when `columns === null` (STI subclasses report
+   `schema:not-ported`); either look up the STI parent's schema or
+   drop array-valued association keys.
+3. **~30 LOC — custom `foreign_key:` override map.** `sponsors`:
+   `belongs_to :sponsor_club, class_name: "Club", foreign_key: "club_id"`,
+   so YAML `sponsor_club: moustache_club` maps to column `club_id`.
+   `canonicalizeRailsRow` only handles default `<assoc> → <assoc>_id`.
+4. **~50 LOC — datetime + YAML-coder serialization tolerance.**
+   `topics` / `other_topics` `written_on` / `bonus_time` diff because
+   Rails Time-with-tz format vs TS string; `content` is YAML-serialized.
+   Needs serialization-aware normalization in `compareValue`.
+5. **deps** — `developers_projects` DIFF is a numeric FK pointing into
+   `developers.yml` which is ERB-UNSUPPORTED. Resolves once item (8)
+   below lands or via an id-index fallback for ERB-skipped tables.
+
+### ERB-UNSUPPORTED files (20 — all 0 rows compared)
+
+These are skipped entirely under soft mode; strict mode will need a
+decision per the list below. From #2208, #2214, #2227 findings:
+
+- `pirates.yml`, `mateys.yml`, `parrots_pirates.yml`,
+  `peoples_treasures.yml`, `memberships.yml`, `sharded_blog_posts.yml`,
+  `sharded_blog_posts_tags.yml`, `sharded_comments.yml`,
+  `sharded_tags.yml`, `cpk_order_agreements.yml`, `cpk_order_tags.yml`,
+  `cpk_reviews.yml` — use `<%= FixtureSet.identify(:label) %>` or
+  `<%= composite_identify(...) %>`; the TS port stores the CRC32
+  equivalent via `fixtureId()`. Needs **~30 LOC** in `stripErb` to
+  reverse `identify(:label)` → `fixtureId("label")` and recognize
+  `composite_identify`.
+- `developers.yml`, `paragraphs.yml`, `mixins.yml`, `binaries.yml`,
+  `categories_ordered.yml`, `citations.yml`, `edges.yml`,
+  `vertices.yml` — use loop ERB (`<% (1..N).each %>`,
+  `<%= binary(...) %>`, `<%= 2.weeks.ago.to_fs(:db) %>`). Needs
+  **~30 LOC** loop expander in `stripErb` for the common
+  `<% N.times do |i| %>` / `<% (1..N).each %>` shapes, plus an
+  attr-level skip (rather than file-level) for ERB the comparer
+  can't resolve (#2208 item 3).
+
+(6) **~30 LOC — `stripErb` `FixtureSet.identify` reverse-resolution.**
+(7) **~30 LOC — `stripErb` simple-loop expander + attr-level skip.**
+(8) Either (6)+(7) clear the 20 ERB-UNSUPPORTED, OR PR 7 ships with
+an explicit ERB-allow-list (e.g. `scripts/fixtures-compare/erb-allowlist.txt`)
+that keeps the 20 soft while every other status hard-fails.
+
+### Test-body port (PR 7a — ceiling waiver section, ~1.9k LOC of Ruby)
+
+Per #2227 findings, the test bodies named in the existing PR 7 entry
+break out cleanly as `7a`:
+
+- `vendor/rails/activerecord/test/cases/fixtures_test.rb` — 1847 LOC,
+  153 tests.
+- `vendor/rails/activerecord/test/cases/test_fixtures_test.rb` — 74 LOC.
+- `vendor/rails/activerecord/test/cases/encryption/encrypted_fixtures_test.rb`
+  — 22 LOC.
+
+Once these land (with the 4 entries still in `unported-files.ts`), the
+**~30 LOC PR 7b** flips compare to hard-fail + removes those exclusions.
+
+### Loader gaps required by ported-but-not-yet-loadable fixtures
+
+These don't block compare strictness, but they block tests from actually
+calling `useFixtures([...])` against the ported data. Recorded here so
+PR 8 (PoC conversion) doesn't accidentally pick a fixture that can't
+load:
+
+- **~20 LOC — `resolveDeclaredPk` string-PK support** in
+  `packages/activerecord/src/test-helpers/define-fixtures.ts`. Blocks
+  `subscribers.ts` (Rails `Subscriber.primary_key = "nick"`) and
+  `string-key-objects.ts`. From #2205 + #2214 findings.
+- **~30–50 LOC — defineFixtures NOT NULL `created_at`/`updated_at`
+  auto-stamp.** Unblocks `people.ts` (Rails schema has
+  `t.timestamps null: false`; YAML omits both — Rails' loader stamps
+  them). From #2209.
+- **~40 LOC — enum-aware insert.** `parrots.breed: "australian"` and
+  `memberships.type: "CurrentMembership"` are model enums; loader
+  needs to route through the attribute layer (or a small enum-lookup
+  helper) before insert. From #2208, #2209.
+- **~80–150 LOC — defineFixtures belongs_to-reflection → FK-column
+  resolver.** Lets future fixture `.ts` stay byte-closer to YAML
+  (write `club: foo` instead of `club_id: ref("clubs", "foo")`).
+  From #2209.
+- **~20 LOC — `fixtures:compare` id-index keyed by the schema's
+  declared PK column, not hard-coded `id`.** Clears soft-fail noise
+  for non-`id`-PK tables (owners/pets/toys/keyboards). From #2209.
+- **~50 LOC — `ref()` accepts a key-path**
+  (`ref("cpk_orders", "label", "id")`) so composite-FK fixtures can
+  address a specific PK component. Required before strict mode for
+  the CPK cluster. From #2212.
+- **~5 LOC — `defineFixtures` registry rollback widening.** Commit
+  `adapterIds.set(tableName, tableIds)` after the row-building loop,
+  or widen the existing try/catch. Pre-existing #2125 finding,
+  unchanged.
+
+### Plan / doc clean-ups (small)
+
+- **~1–2 lines, Translation Rules.** Add: "when a fixture uses Rails
+  `_fixture: model_class:`, `ref()` arguments use the destination
+  model's `tableName`, not the fixture-file name." (#2205 finding #3,
+  bit `other-topics` and `other-comments`.)
+- Note in this doc that `pnpm fixtures:compare` requires
+  `@blazetrails/activesupport` + `@blazetrails/globalid` to be built
+  locally (`pnpm -r --filter '!website' build`); CI builds deps first
+  but a cold local run reports spurious `TS-IMPORT-ERR`. (#2227.)
+
+### Out of scope (recorded so they don't drift back in)
+
+- `aircrafts.yml` `schema:not-ported` because Rails table is
+  `:aircraft` (singular) — comparator-side alias map, ~10 LOC,
+  optional polish. (#2213.)
+- `_fixture.ignore` anchor-row support so `other_books` can promote
+  from "rows: 2/2 with anchors expanded" to anchor-aware MATCH —
+  cosmetic. (#2205.)
+- Local-only TS-IMPORT-ERR before a build — diagnostic message only.
 
 ## Why
 
@@ -27,17 +166,21 @@ translated.
 
 ## Current state
 
-- 12 translated under `packages/activerecord/src/test-helpers/fixtures/`:
-  `accounts`, `author-addresses`, `authors`, `books`, `comments`,
-  `companies`, `developers`, `developers-projects`, `posts`, `projects`,
-  `topics` (+ `fixtures.test.ts`). These were written under the
-  pre-decision CRC32 model and need an id backfill (PR 0.75).
-- 110 missing. Categorized below by usage cluster.
-- Loader is already in place: `defineFixtures()`, `useFixtures()`,
-  `fixtureId()`, `ref()`, `fixture-set.ts`. `useFixtures([...])` returns
-  typed accessors of the form `result.authors("david")` — that's the
-  callsite shape ported tests will use; no new `fixtureRow()` helper is
-  needed.
+- **All 122 Rails fixtures translated** under
+  `packages/activerecord/src/test-helpers/fixtures/`. Latest
+  `pnpm fixtures:compare`: match=94, diff=8, missing=0,
+  erb-unsupported=20. The 8 DIFFs and 20 ERB-UNSUPPORTED are
+  compare-script gaps (not fixture-data drift) — see "Loose ends
+  before PR 7 can ship" at the top of this doc.
+- Loader (`defineFixtures()`, `useFixtures()`, `fixtureId()`, `ref()`,
+  `fixture-set.ts`) is in place. `useFixtures([...])` returns typed
+  accessors of the form `result.authors("david")` — that's the
+  callsite shape ported tests will use; no new `fixtureRow()` helper
+  is needed. A handful of ported fixtures are not yet loadable at
+  runtime (string-PK, enum-bridge, NOT-NULL timestamp auto-stamp);
+  see "Loose ends → Loader gaps."
+- The gap table below remains as the rollout-time cluster map; cluster
+  rollout PRs are all closed (see Rollout section).
 
 ## Gap, by cluster
 
@@ -174,64 +317,60 @@ The two exceptions to the 300-LOC ceiling are called out explicitly
 below: the schema port (split into ~6–8 sibling PRs, each under
 ceiling) and PR 7 (granted ceiling waiver — see entry).
 
-1. **PR 0** — `scripts/fixtures-compare/` script + CI wiring (soft
-   failure). Lands first so subsequent PRs are self-checking.
-2. **PR 0.5a … 0.5h** — Port `vendor/rails/activerecord/test/schema/schema.rb`
-   (1462 LOC Ruby ≈ 2200 LOC TS) into
-   `packages/activerecord/src/test-helpers/test-schema.ts`. Splits as
-   ~6–8 sibling PRs off `main`, each with non-overlapping table groups
-   under the 300-LOC ceiling. Final split-suffix PR wires the schema
-   into `setup-adapter-suite.ts` once all tables are present.
-3. **PR 0.75** — Backfill explicit Rails ids onto the 12 already-translated
-   fixtures (`accounts`, `author-addresses`, `authors`, `books`,
-   `comments`, `companies`, `developers`, `developers-projects`,
-   `posts`, `projects`, `topics`). Land the `ref()` resolver change to
-   read declared `id`s here so the rest of the port runs against the
-   final API. Includes the `adapterName(adapter)` helper if any of the
-   12 need it.
-4. **PR 1a** — Cluster 1 first half: `categories`, `categorizations`,
-   `categories_posts`, `categories_ordered`, `taggings`, `tags`,
-   `essays`, `readers`. (~250 LOC) Highest test demand under
-   `relation/` / `associations/`.
-5. **PR 1b** — Cluster 1 second half: `author_favorites`, `bad_posts`,
-   `other_posts`, `other_comments`, `other_topics`, `other_books`,
-   `subscribers`, `subscriptions`, `references`. (~250 LOC)
-6. **PR 2** — Cluster 2 (pirates/ships) + Cluster 9 (encryption) +
-   Cluster 10 (misc fk\_\*). Three small clusters bundled. (~190 LOC)
-7. **PR 3** — Cluster 3 (people/clubs) + the C4 tail (`pets`, `toys`,
-   `owners`, `humans`, `faces`). Leaves `dogs` / `other_dogs` /
-   `dog_lovers` for PR 5 to stay under ceiling. (~280 LOC)
-8. **PR 4** — Cluster 5 (STI). (~260 LOC standalone)
-9. **PR 5** — Cluster 6 (CPK) + Cluster 7 (sharded) + C4 spillover
-   (`dogs`, `other_dogs`, `dog_lovers`). (~300 LOC)
-10. **PR 6a** — Cluster 8 first half: `uuid_parents`, `uuid_children`,
-    `binaries`, `aircrafts`, `bulbs`, `cars`, `computers`, `minivans`,
-    `speedometers`, `dashboards`, `movies`, `traffic_lights`,
-    `virtual_columns`. (~250 LOC)
-11. **PR 6b** — Cluster 8 second half: `mixed_case_monkeys`,
-    `legacy_things`, `minimalistics`, `funny_jokes`, `randomly_named_a9`,
-    `1_need_quoting`, `string_key_objects`, `warehouse-things`, `nodes`,
-    `trees`, `edges`, `vertices`, `citations`, `ratings`,
-    `price_estimates`. (~250 LOC)
-12. **PR 7 (300-LOC ceiling waived)** — Three coupled changes that must
-    land together so CI parity holds:
-    - flip `fixtures:compare` to hard-fail;
-    - remove `fixtures.rb` / `fixture_set/` / `test_fixtures.rb` /
-      `encryption/encrypted_fixtures.rb` from
-      `scripts/api-compare/unported-files.ts`;
-    - port the corresponding Rails test files
-      (`fixtures_test.rb` is 1847 LOC of Ruby tests;
-      `test_fixtures_test.rb` 74 LOC; plus the
-      `encryption/encrypted_fixtures_test.rb` body).
+1. **PR 0 closed (#2122)** — `scripts/fixtures-compare/` + CI wiring.
+   Schema-diff pass landed as **#2135**. Subsequent compare-script
+   fidelity work landed as **#2220** (metadata strip, assoc shorthand,
+   `$LABEL`, list-form, array deep-equal, merge keys); remaining
+   compare gaps are listed under "Loose ends" above.
+2. **PR 0.5a–g closed (#2124 #2128 #2130 #2131 #2133 #2134 #2140)** —
+   `vendor/rails/activerecord/test/schema/schema.rb` ported into
+   `packages/activerecord/src/test-helpers/test-schema.ts` across 7
+   sibling PRs; #2140 wired the schema into `setup-adapter-suite.ts`.
+   Final schema-port count came in under the planned 8 slots.
+3. **PR 0.75 closed (#2125)** — id backfill on the 12 originals;
+   `ref()` resolver reads declared `id`; `adapterName(adapter)` helper
+   landed in the same PR. One follow-up (registry rollback widening,
+   ~5 LOC) is in "Loose ends → Loader gaps" above.
+4. **PR 1a closed (#2143)** — cluster 1 first half. Surfaced the
+   `_fixture` metadata-row noise and the `set_fixture_class` ref()
+   tableName trap — both addressed in #2220 / "Loose ends → Plan
+   clean-ups."
+5. **PR 1b closed (#2205)** — cluster 1 second half. `subscribers.ts`
+   shipped but is non-loadable until string-PK loader support lands
+   (see Loose ends).
+6. **PR 2 closed (#2208)** — pirates/ships + encryption + fk\_\*. Most
+   ERB-UNSUPPORTED gaps remaining today live in this cluster.
+7. **PR 3 closed (#2209)** — cluster 3 (people/clubs). The C4 tail
+   (`pets`, `toys`, `owners`, `humans`, `faces`) was deferred over
+   ceiling; shipped separately as **PR 4-late closed (#2227)** out of
+   the original `<base>` / `<base>b` plan.
+8. **PR 4 closed (#2210)** — cluster 5 (STI), 17 fixtures.
+9. **PR 5 closed (#2212)** — CPK + sharded + C4 spillover
+   (`dogs`, `other_dogs`, `dog_lovers`).
+10. **PR 6a closed (#2213)** — cluster 8 first half.
+11. **PR 6b closed (#2214)** — cluster 8 second half.
+12. **DIFF reconcile closed (#2228)** — 3 fixture-side corrections
+    (`authors.owned_essay_id`, `randomly_named_a9` int vs string,
+    `comments.recursive_association_comment.company`). DIFF count
+    11 → 8; the residual 8 are compare-script gaps and now live in
+    "Loose ends."
+13. **PR 7 — split into 7a + 7b** (sub-split path chosen per the
+    original ceiling-waiver entry; see "Loose ends" above for the full
+    blocker list):
+    - **PR 7a (~1.9k LOC, ceiling waiver retained)** — port
+      `fixtures_test.rb` (1847 LOC / 153 tests),
+      `test_fixtures_test.rb` (74 LOC), and
+      `encryption/encrypted_fixtures_test.rb` (22 LOC). Exclusions in
+      `scripts/api-compare/unported-files.ts` stay in place until 7b.
+    - **PR 7b (~30 LOC, gated)** — flip `fixtures:compare` MISSING/DIFF
+      to hard-fail; remove `fixtures.rb` / `fixture_set/` /
+      `test_fixtures.rb` / `encryption/encrypted_fixtures.rb` from
+      `scripts/api-compare/unported-files.ts`. Gated on (a) the 8
+      remaining DIFFs flipping to MATCH or moving to an explicit
+      allow-list, (b) the 20 ERB-UNSUPPORTED clearing or being
+      allow-listed, and (c) 7a landed.
 
-    Splitting these breaks the `test:compare` counter mid-flight — once
-    the exclusions are removed but the tests aren't ported, CI shows a
-    regression. Ceiling waiver is explicit per user direction. Sub-split
-    only if a clean way emerges (e.g. translating `fixtures_test.rb` in
-    a `7a` that lands the file but leaves the exclusion in place, then
-    `7b` removes the exclusion + flips compare).
-
-13. **PR 8 — proof-of-concept conversion.** Pick one existing AR test
+14. **PR 8 — proof-of-concept conversion.** Pick one existing AR test
     file that currently inlines `defineSchema()` and whose data needs
     are met by the translated fixtures (candidates:
     `relations.test.ts`, `serialization.test.ts`,

--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -17,7 +17,7 @@ Everything below is what must close (or move to an explicit allow-list)
 first. Cross-referenced to merged PRs and the source finding files under
 `~/.btwhooks/data/github/blazetrailsdev/trails/<PR#>/post-pr/`.
 
-### Compare-script enhancements blocking strict mode (~180 LOC total)
+### Compare-script enhancements blocking strict mode (~150 LOC total)
 
 The 8 remaining DIFFs are all `scripts/fixtures-compare/compare.ts`
 gaps, not fixture-data bugs. Per #2228 post-merge findings:
@@ -29,8 +29,9 @@ gaps, not fixture-data bugs. Per #2228 post-merge findings:
    `compareValue`.
 2. **~30 LOC — HABTM key handling.**
    `dead_parrots.deadbird.treasures: [ruby, sapphire]` and
-   `live_parrots.dusty.treasures` are HABTM list-form. canonicalize
-   keeps the key when `columns === null` (STI subclasses report
+   `live_parrots.dusty.treasures` are HABTM list-form.
+   `canonicalizeRailsRow` keeps the key when `columns === null` (STI
+   subclasses report
    `schema:not-ported`); either look up the STI parent's schema or
    drop array-valued association keys.
 3. **~30 LOC — custom `foreign_key:` override map.** `sponsors`:
@@ -106,7 +107,8 @@ break out cleanly as `7a`:
 - `vendor/rails/activerecord/test/cases/encryption/encrypted_fixtures_test.rb`
   — 22 LOC.
 
-Once these land (with the 4 entries still in `unported-files.ts`), the
+Once these land (with the 4 entries still in
+`scripts/api-compare/unported-files.ts`), the
 **~30 LOC PR 7b** flips compare to hard-fail + removes those exclusions.
 
 ### Loader gaps required by ported-but-not-yet-loadable fixtures

--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -47,32 +47,53 @@ gaps, not fixture-data bugs. Per #2228 post-merge findings:
 
 ### ERB-UNSUPPORTED files (20 — all 0 rows compared)
 
-These are skipped entirely under soft mode; strict mode will need a
-decision per the list below. From #2208, #2214, #2227 findings:
+These are skipped entirely under soft mode; strict mode needs each
+either parseable by the compare script or covered by an explicit
+allow-list. From #2208, #2214, #2227 findings:
 
-- `pirates.yml`, `mateys.yml`, `parrots_pirates.yml`,
-  `peoples_treasures.yml`, `memberships.yml`, `sharded_blog_posts.yml`,
-  `sharded_blog_posts_tags.yml`, `sharded_comments.yml`,
-  `sharded_tags.yml`, `cpk_order_agreements.yml`, `cpk_order_tags.yml`,
-  `cpk_reviews.yml` — use `<%= FixtureSet.identify(:label) %>` or
-  `<%= composite_identify(...) %>`; the TS port stores the CRC32
-  equivalent via `fixtureId()`. Needs **~30 LOC** in `stripErb` to
-  reverse `identify(:label)` → `fixtureId("label")` and recognize
-  `composite_identify`.
-- `developers.yml`, `paragraphs.yml`, `mixins.yml`, `binaries.yml`,
-  `categories_ordered.yml`, `citations.yml`, `edges.yml`,
-  `vertices.yml` — use loop ERB (`<% (1..N).each %>`,
-  `<%= binary(...) %>`, `<%= 2.weeks.ago.to_fs(:db) %>`). Needs
-  **~30 LOC** loop expander in `stripErb` for the common
-  `<% N.times do |i| %>` / `<% (1..N).each %>` shapes, plus an
-  attr-level skip (rather than file-level) for ERB the comparer
-  can't resolve (#2208 item 3).
+6. **~30 LOC — `stripErb` `FixtureSet.identify` reverse-resolution.**
+   Affects `pirates.yml`, `mateys.yml`, `parrots_pirates.yml`,
+   `peoples_treasures.yml`, `memberships.yml`, `sharded_blog_posts.yml`,
+   `sharded_blog_posts_tags.yml`, `sharded_comments.yml`,
+   `sharded_tags.yml`, `cpk_order_agreements.yml`, `cpk_order_tags.yml`,
+   `cpk_reviews.yml`. These use
+   `<%= FixtureSet.identify(:label) %>` or
+   `<%= composite_identify(...) %>`; the TS port already stores the
+   CRC32-equivalent via `fixtureId()`. Teach `stripErb` to reverse
+   `identify(:label)` → `fixtureId("label")` and to recognize
+   `composite_identify`.
+7. **~30 LOC — `stripErb` simple-loop expander + attr-level skip.**
+   Affects `developers.yml`, `paragraphs.yml`, `mixins.yml`,
+   `binaries.yml`, `categories_ordered.yml`, `citations.yml`,
+   `edges.yml`, `vertices.yml`. These use loop ERB
+   (`<% (1..N).each %>`, `<%= binary(...) %>`,
+   `<%= 2.weeks.ago.to_fs(:db) %>`). Add a loop expander for the
+   common `<% N.times do |i| %>` / `<% (1..N).each %>` shapes, plus
+   an attr-level skip (rather than file-level) for residual
+   non-resolvable ERB (#2208 item 3).
+8. **Fallback (~10 LOC):** if (6)+(7) don't fully clear the 20 in
+   one PR cycle, PR 7b ships with an explicit allow-list
+   (e.g. `scripts/fixtures-compare/erb-allowlist.txt`) so the listed
+   files stay soft while every other status hard-fails.
 
-(6) **~30 LOC — `stripErb` `FixtureSet.identify` reverse-resolution.**
-(7) **~30 LOC — `stripErb` simple-loop expander + attr-level skip.**
-(8) Either (6)+(7) clear the 20 ERB-UNSUPPORTED, OR PR 7 ships with
-an explicit ERB-allow-list (e.g. `scripts/fixtures-compare/erb-allowlist.txt`)
-that keeps the 20 soft while every other status hard-fails.
+### Schema-side residuals (informational column, not a hard-fail blocker)
+
+`pnpm fixtures:compare` reports a `schema:…` token per file independent
+of the MATCH/DIFF status. Today: **`schema — ported=87/102
+extras-flagged=0 (skipped 20)`**. 15 fixtures still report
+`schema:not-ported` — most are STI subclasses sharing a parent table
+(`dead_parrots`, `live_parrots`, `other_*`, `bad_posts`,
+`encrypted_book_that_ignores_cases`) or a singular/plural mismatch
+(`aircrafts.yml` vs `:aircraft`). These are comparator lookup
+quirks, not real schema gaps, and current behavior doesn't hard-fail
+on the schema column. If PR 7b promotes `schema:not-ported` to
+hard-fail, address with:
+
+9. **~15 LOC — STI parent-table lookup + fixture-file → table alias
+   map** in `scripts/fixtures-compare/compare.ts` so STI children
+   pick up the parent's column list and `aircrafts.yml` validates
+   against `TEST_SCHEMA.aircraft`. (#2213.) Otherwise skip and keep
+   the schema column informational.
 
 ### Test-body port (PR 7a — ceiling waiver section, ~1.9k LOC of Ruby)
 

--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -1,7 +1,7 @@
 # Fixtures port plan
 
-Port the remaining Rails `activerecord/test/fixtures/*.yml` files to TS so
-that ported AR tests can call `useFixtures([...])` instead of inlining
+Tracks the port of Rails `activerecord/test/fixtures/*.yml` to TS so that
+ported AR tests can call `useFixtures([...])` instead of inlining
 `defineSchema()` / row inserts in `beforeAll`. **All 122 fixtures
 translated** (PRs 0–6b + 0.5a–g + 0.75 + 4-late merged 2026-05-20…21).
 `pnpm fixtures:compare` reports **match=94 diff=8 missing=0
@@ -14,7 +14,9 @@ below.
 PR 7 flips `fixtures:compare` MISSING/DIFF to hard-fail and removes the
 four fixtures-related entries from `scripts/api-compare/unported-files.ts`.
 Everything below is what must close (or move to an explicit allow-list)
-first. Cross-referenced to merged PRs and the source finding files under
+first. Cross-referenced to merged PRs; the source finding files this
+section was distilled from live in each PR's GitHub review thread and,
+for contributors running btwhooks locally, under
 `~/.btwhooks/data/github/blazetrailsdev/trails/<PR#>/post-pr/`.
 
 ### Compare-script enhancements blocking strict mode (~150 LOC total)

--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -13,8 +13,14 @@ below.
 
 PR 7 flips `fixtures:compare` MISSING/DIFF to hard-fail and removes the
 four fixtures-related entries from `scripts/api-compare/unported-files.ts`.
-Everything below is what must close (or move to an explicit allow-list)
-first. Cross-referenced to merged PRs; the source finding files this
+**Strict-mode blockers** (must close or move to an explicit allow-list
+before PR 7b can ship): the compare-script DIFF enhancements, the
+ERB-UNSUPPORTED handling, and the PR 7a test-body port. The remaining
+subsections — loader gaps and schema-side residuals — are _informational
+follow-ups_ recorded here so PR 8 (PoC conversion) doesn't pick a
+non-loadable fixture and so future schema-column policy changes have a
+sized list ready; neither blocks strict mode under current behavior.
+Cross-referenced to merged PRs; the source finding files this
 section was distilled from are available in each PR's GitHub review
 thread and (for local runs of btwhooks) under
 `~/.btwhooks/data/github/blazetrailsdev/trails/<PR#>/post-pr/`.


### PR DESCRIPTION
## Summary

Doc-only audit of `docs/fixtures-port-plan.md` before the PR 7 strict-fail flip.

- Marks merged PRs (0, 0.5a-g, 0.75, 1a-6b, 4-late #2227, DIFF-reconcile #2228) inline as closed.
- Replaces the stale "12 of 122 translated" intro with current `pnpm fixtures:compare` numbers (**match=94 diff=8 missing=0 erb-unsupported=20**).
- Adds a top-of-doc **"Loose ends before PR 7 can ship"** section as a contiguous 1→9 sized punch-list: compare-script DIFF enhancements (~150 LOC), ERB-UNSUPPORTED handling (~70 LOC or allow-list), loader gaps required for loadability, schema:not-ported residuals.
- Splits PR 7 into **7a** (~1.9k LOC Ruby test-body port, ceiling waiver retained) and **7b** (~30 LOC, gated).

## Biggest loose end

All 8 residual DIFFs are `scripts/fixtures-compare/compare.ts` gaps (enum-symbol, HABTM, custom `foreign_key:`, datetime/YAML-coder) — not fixture-data drift. Plus 20 ERB-UNSUPPORTED files at 0 rows compared.

## Test plan

- [ ] Doc renders on the website.
- [ ] Sanity-check sized LOC estimates against the cited finding files.