### PR TITLE
feat(trailties): postinstall hook builds .tse views (PR 2c-c)

### DIFF
--- a/packages/trailties/src/generators/app-generator.test.ts
+++ b/packages/trailties/src/generators/app-generator.test.ts
@@ -122,6 +122,13 @@ describe("AppGenerator", () => {
     expect(pkg.devDependencies.vite).toBeDefined();
   });
 
+  it("emits postinstall hook that builds .tse views", async () => {
+    await makeGen().run();
+    const pkg = JSON.parse(fs.readFileSync(appPath("package.json"), "utf-8"));
+    expect(pkg.scripts.postinstall).toBe("trails-tsc-views build");
+    expect(pkg.devDependencies["@blazetrails/trails-tsc"]).toBeDefined();
+  });
+
   it("configures postgres database", async () => {
     await makeGen("postgres").run();
     const pkg = JSON.parse(fs.readFileSync(appPath("package.json"), "utf-8"));

--- a/packages/trailties/src/generators/app-generator.test.ts
+++ b/packages/trailties/src/generators/app-generator.test.ts
@@ -125,8 +125,10 @@ describe("AppGenerator", () => {
   it("emits postinstall hook that builds .tse views", async () => {
     await makeGen().run();
     const pkg = JSON.parse(fs.readFileSync(appPath("package.json"), "utf-8"));
-    expect(pkg.scripts.postinstall).toBe("trails-tsc-views build");
+    expect(pkg.scripts.postinstall).toBe("trails-tsc-views build --views src/app/views");
     expect(pkg.devDependencies["@blazetrails/trails-tsc"]).toBeDefined();
+    const gitignore = fs.readFileSync(appPath(".gitignore"), "utf-8");
+    expect(gitignore).toContain("/.trails/");
   });
 
   it("configures postgres database", async () => {

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -68,7 +68,7 @@ export class AppGenerator extends AppBase {
             "db:seed": "trails db seed",
             "db:setup": "trails db create && trails db migrate && trails db seed",
             "db:reset": "trails db drop && trails db setup",
-            postinstall: "trails-tsc-views build",
+            postinstall: "trails-tsc-views build --views src/app/views",
           },
           dependencies: {
             "@blazetrails/activerecord": "*",
@@ -117,6 +117,7 @@ export class AppGenerator extends AppBase {
       ".gitignore",
       `/node_modules/
 /dist/
+/.trails/
 /.env*
 !/.env.example
 

--- a/packages/trailties/src/generators/app-generator.ts
+++ b/packages/trailties/src/generators/app-generator.ts
@@ -68,6 +68,7 @@ export class AppGenerator extends AppBase {
             "db:seed": "trails db seed",
             "db:setup": "trails db create && trails db migrate && trails db seed",
             "db:reset": "trails db drop && trails db setup",
+            postinstall: "trails-tsc-views build",
           },
           dependencies: {
             "@blazetrails/activerecord": "*",
@@ -79,6 +80,7 @@ export class AppGenerator extends AppBase {
             [dep.name]: dep.version,
           },
           devDependencies: {
+            "@blazetrails/trails-tsc": "*",
             typescript: "^5.7.0",
             vite: "^7.0.0",
             vitest: "^3.0.0",


### PR DESCRIPTION
## Summary

TSE Phase 2c-c — wires the trailties `AppGenerator` to emit a `postinstall` script in the generated `package.json` that runs `trails-tsc-views build --views src/app/views`, plus adds `@blazetrails/trails-tsc` as a devDependency and gitignores the `/.trails/` output dir. This ensures a freshly-generated trails app has its `.tse` views compiled (and IDE support working) before the user starts the dev server.

- Plan: `docs/tse-plan.md` §2, `docs/actionview-100-percent.md` Phase 2c
- Deps merged: #2190, #2200, #2201, #2222, #2223

The `--views src/app/views` flag is required because the generator places views under `src/app/views`, but `trails-tsc-views build` defaults to `app/views`.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/generators/app-generator.test.ts` (8/8 pass)
- New test asserts `scripts.postinstall === "trails-tsc-views build --views src/app/views"`, `devDependencies["@blazetrails/trails-tsc"]` present, and `.gitignore` contains `/.trails/`