### PR TITLE
feat(actionview): close javascript_helper toward 100%

### DIFF
--- a/packages/actionview/src/helpers/javascript-helper.ts
+++ b/packages/actionview/src/helpers/javascript-helper.ts
@@ -65,12 +65,11 @@ export function javascriptTag(
   let content: unknown;
 
   if (resolvedBlock) {
-    const isPlainOpts =
+    const isHash =
       contentOrOptions != null &&
       typeof contentOrOptions === "object" &&
-      !(contentOrOptions instanceof SafeBuffer) &&
-      !Array.isArray(contentOrOptions);
-    opts = isPlainOpts
+      Object.getPrototypeOf(contentOrOptions) === Object.prototype;
+    opts = isHash
       ? { ...(contentOrOptions as Record<string, unknown>) }
       : typeof htmlOptions === "object" && htmlOptions !== null
         ? { ...(htmlOptions as Record<string, unknown>) }

--- a/packages/actionview/src/helpers/javascript-helper.ts
+++ b/packages/actionview/src/helpers/javascript-helper.ts
@@ -1,12 +1,13 @@
 import { SafeBuffer, htmlSafe } from "@blazetrails/activesupport";
-import { contentTag } from "./tag-helper.js";
-import { cdataSection } from "./tag-helper.js";
+
+import { capture, type CaptureHelperHost } from "./capture-helper.js";
+import { cdataSection, contentTag } from "./tag-helper.js";
 
 /**
  * ActionView::Helpers::JavaScriptHelper
  */
 
-const JS_ESCAPE_MAP: Record<string, string> = {
+export const JS_ESCAPE_MAP: Record<string, string> = {
   "\\": "\\\\",
   "</": "<\\/",
   "\r\n": "\\n",
@@ -23,34 +24,65 @@ const JS_ESCAPE_MAP: Record<string, string> = {
 const JS_ESCAPE_PATTERN = /(\\|<\/|\r\n|\u2028|\u2029|[\n\r"']|[`]|[$])/g;
 
 /**
- * escapeJavascript — escapes carriage returns, quotes, and other characters
- * for safe embedding in JavaScript strings.
+ * Escapes carriage returns and single and double quotes for JavaScript
+ * segments. Also available through the alias {@link j}.
  */
 export function escapeJavascript(javascript: unknown): string | SafeBuffer {
-  const str = String(javascript ?? "");
-  if (str === "") {
-    const wasSafe = javascript instanceof SafeBuffer && javascript.htmlSafe;
-    return wasSafe ? htmlSafe("") : "";
-  }
-  const result = str.replace(JS_ESCAPE_PATTERN, (match) => JS_ESCAPE_MAP[match] ?? match);
+  const str = javascript == null ? "" : String(javascript);
+  const result =
+    str === "" ? "" : str.replace(JS_ESCAPE_PATTERN, (match) => JS_ESCAPE_MAP[match] ?? match);
   const wasSafe = javascript instanceof SafeBuffer && javascript.htmlSafe;
   return wasSafe ? htmlSafe(result) : result;
 }
 
 export const j = escapeJavascript;
 
-/**
- * javascriptCdataSection — wraps content in a JavaScript CDATA section.
- */
-export function javascriptCdataSection(content: string): SafeBuffer {
-  return htmlSafe(`\n//${cdataSection(`\n${content}\n//`).toString()}\n`);
+/** @internal */
+export function javascriptCdataSection(content: unknown): SafeBuffer {
+  return htmlSafe(`\n//${cdataSection(`\n${String(content ?? "")}\n//`).toString()}\n`);
 }
 
 /**
- * javascriptTag — returns a <script> tag wrapping the content.
+ * Returns a JavaScript `<script>` tag wrapping `content` in a CDATA section.
+ * Mirrors `ActionView::Helpers::JavaScriptHelper#javascript_tag`. Pass a
+ * block (with optional leading `htmlOptions`) to capture from the output
+ * buffer instead.
  */
-export function javascriptTag(content: string, htmlOptions?: Record<string, unknown>): SafeBuffer {
-  const opts = htmlOptions ? { ...htmlOptions } : {};
-  const cdataContent = javascriptCdataSection(content);
-  return contentTag("script", cdataContent, opts, true) as SafeBuffer;
+export function javascriptTag(
+  this: CaptureHelperHost | void,
+  contentOrOptions?: unknown,
+  htmlOptions?: Record<string, unknown> | (() => unknown),
+  block?: () => unknown,
+): SafeBuffer {
+  const resolvedBlock =
+    typeof htmlOptions === "function"
+      ? htmlOptions
+      : typeof block === "function"
+        ? block
+        : undefined;
+
+  let opts: Record<string, unknown>;
+  let content: unknown;
+
+  if (resolvedBlock) {
+    const isPlainOpts =
+      contentOrOptions != null &&
+      typeof contentOrOptions === "object" &&
+      !(contentOrOptions instanceof SafeBuffer) &&
+      !Array.isArray(contentOrOptions);
+    opts = isPlainOpts
+      ? { ...(contentOrOptions as Record<string, unknown>) }
+      : typeof htmlOptions === "object" && htmlOptions !== null
+        ? { ...(htmlOptions as Record<string, unknown>) }
+        : {};
+    content = capture.call(this as CaptureHelperHost, resolvedBlock);
+  } else {
+    content = contentOrOptions;
+    opts =
+      typeof htmlOptions === "object" && htmlOptions !== null
+        ? { ...(htmlOptions as Record<string, unknown>) }
+        : {};
+  }
+
+  return contentTag("script", javascriptCdataSection(content), opts, true) as SafeBuffer;
 }

--- a/packages/actionview/src/template/javascript-helper.test.ts
+++ b/packages/actionview/src/template/javascript-helper.test.ts
@@ -26,8 +26,8 @@ describe("JavaScriptHelperTest", () => {
     );
     expect(escapeJavascript("backslash\\test").toString()).toBe("backslash\\\\test");
     expect(escapeJavascript("don't </close> tags").toString()).toBe("don\\'t <\\/close> tags");
-    expect(escapeJavascript("unicode   newline").toString()).toBe("unicode &#x2028; newline");
-    expect(escapeJavascript("unicode   newline").toString()).toBe("unicode &#x2029; newline");
+    expect(escapeJavascript("unicode \u2028 newline").toString()).toBe("unicode &#x2028; newline");
+    expect(escapeJavascript("unicode \u2029 newline").toString()).toBe("unicode &#x2029; newline");
 
     expect(j("don't </close> tags").toString()).toBe("don\\'t <\\/close> tags");
   });

--- a/packages/actionview/src/template/javascript-helper.test.ts
+++ b/packages/actionview/src/template/javascript-helper.test.ts
@@ -1,11 +1,19 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
+import { htmlSafe, SafeBuffer } from "@blazetrails/activesupport";
+
+import { OutputBuffer } from "../buffers.js";
+import { OutputFlow } from "../flows.js";
+import { concat } from "../helpers/text-helper.js";
 import {
   escapeJavascript,
   j,
-  javascriptTag,
   javascriptCdataSection,
+  javascriptTag,
 } from "../helpers/javascript-helper.js";
-import { htmlSafe, SafeBuffer } from "@blazetrails/activesupport";
+
+function host() {
+  return { outputBuffer: null as OutputBuffer | null, viewFlow: new OutputFlow() };
+}
 
 describe("JavaScriptHelperTest", () => {
   it("escape javascript", () => {
@@ -18,8 +26,8 @@ describe("JavaScriptHelperTest", () => {
     );
     expect(escapeJavascript("backslash\\test").toString()).toBe("backslash\\\\test");
     expect(escapeJavascript("don't </close> tags").toString()).toBe("don\\'t <\\/close> tags");
-    expect(escapeJavascript("unicode \u2028 newline").toString()).toBe("unicode &#x2028; newline");
-    expect(escapeJavascript("unicode \u2029 newline").toString()).toBe("unicode &#x2029; newline");
+    expect(escapeJavascript("unicode   newline").toString()).toBe("unicode &#x2028; newline");
+    expect(escapeJavascript("unicode   newline").toString()).toBe("unicode &#x2029; newline");
 
     expect(j("don't </close> tags").toString()).toBe("don\\'t <\\/close> tags");
   });
@@ -37,26 +45,37 @@ describe("JavaScriptHelperTest", () => {
     const expectedStr = "\\'quoted\\' \\\"double-quoted\\\" new-line:\\n <\\/closed>";
     expect(escapeJavascript(given).toString()).toBe(expectedStr);
     expect(escapeJavascript(htmlSafe(given)).toString()).toBe(expectedStr);
-    // Unsafe string returns plain string
     const unsafeResult = escapeJavascript(given);
     expect(unsafeResult instanceof SafeBuffer).toBe(false);
-    // Safe string returns SafeBuffer
     const safeResult = escapeJavascript(htmlSafe(given));
     expect(safeResult instanceof SafeBuffer).toBe(true);
     expect((safeResult as SafeBuffer).htmlSafe).toBe(true);
   });
 
   it("javascript tag", () => {
-    const result = javascriptTag("alert('hello')").toString();
+    const ctx = host();
+    ctx.outputBuffer = new OutputBuffer("foo");
+    const result = javascriptTag.call(ctx, "alert('hello')").toString();
     expect(result).toBe("<script>\n//<![CDATA[\nalert('hello')\n//]]>\n</script>");
+    expect(ctx.outputBuffer.toString().toString()).toBe("foo");
   });
 
   it("javascript tag with options", () => {
-    const result = javascriptTag("alert('hello')", {
-      id: "the_js_tag",
-    }).toString();
+    const result = javascriptTag.call(undefined, "alert('hello')", { id: "the_js_tag" }).toString();
     expect(result).toBe(
       "<script id=\"the_js_tag\">\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
+    );
+  });
+
+  it("javascript tag with block", () => {
+    const ctx = { outputBuffer: new OutputBuffer(), viewFlow: new OutputFlow() };
+    const result = javascriptTag
+      .call(ctx, { type: "application/javascript" }, () => {
+        concat.call(ctx, htmlSafe("alert('hello')"));
+      })
+      .toString();
+    expect(result).toBe(
+      "<script type=\"application/javascript\">\n//<![CDATA[\nalert('hello')\n//]]>\n</script>",
     );
   });
 


### PR DESCRIPTION
## Summary

- Add block-form `javascriptTag` matching Rails' `javascript_tag(content_or_options_with_block = nil, html_options = {}, &block)` signature. Block form delegates to `capture()` to pull content from the output buffer.
- Mirror remaining Rails `JavaScriptHelperTest` cases verbatim (backtick, dollar sign, SafeBuffer round-trip, output_buffer untouched, block form).
- Tighten `escapeJavascript` early-return; tag `javascriptCdataSection` `@internal` to mirror Rails `:nodoc:`.

## Out of scope (follow-ups)

- `nonce: true` branch — needs `content_security_policy_nonce` (Request/CSP infra not ported).
- `javascript_include_tag` — lives in `asset_tag_helper.rb`, not `javascript_helper.rb`.

Plan doc: `docs/actionview-100-percent.md` Phase 5 T2 entry.

## Test plan

- [x] `pnpm vitest run packages/actionview/src/template/javascript-helper.test.ts` — 8/8 passing