### PR TITLE
test(activerecord): clear remaining no-conditional-in-test sites + enable rule

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -289,6 +289,7 @@ export default defineConfig(
     plugins: { vitest },
     rules: {
       "vitest/no-conditional-tests": "error",
+      "vitest/no-conditional-in-test": "error",
     },
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -277,9 +277,9 @@ export default defineConfig(
     },
   },
 
-  // ── activerecord: only no-conditional-tests is clean today.
-  // no-conditional-in-test and no-conditional-expect have outstanding
-  // violations; enable them in follow-up PRs as they're driven to zero.
+  // ── activerecord: no-conditional-tests and no-conditional-in-test are
+  // clean. no-conditional-expect still has outstanding violations; enable
+  // it in a follow-up PR as the sites are driven to zero.
   {
     files: [
       "packages/activerecord/src/**/*.test.ts",

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -13,11 +13,12 @@ import {
   MYSQL_TEST_URL,
 } from "./test-helper.js";
 
-// NO_TABLE_OPTIONS sql_mode was deprecated in MySQL 5.7.22, removed in 8+,
-// and never supported by MariaDB. Probed at module load via mysqlVersion.
-const supportsNoTableOptions =
-  !isMariaDb && mysqlVersion !== "" && new Version(mysqlVersion.replace(/-.*$/, "")).lt("5.7.22");
-const itIfNoTableOptions = supportsNoTableOptions ? it : it.skip;
+// Rails: `skip "..." if @connection.database_version >= "5.7.22"`. We add
+// MariaDB to the skip list since MariaDB never supported NO_TABLE_OPTIONS.
+// Probed at module load so the conditional can sit on it.skipIf instead of
+// inside the test body (which the lint rule forbids).
+const skipNoTableOptions =
+  isMariaDb || mysqlVersion === "" || new Version(mysqlVersion.replace(/-.*$/, "")).gte("5.7.22");
 
 const dumpTable = (adapter: Mysql2Adapter, tableName: string) =>
   SchemaDumper.dumpTableSchema(adapter as unknown as SchemaSource, tableName);
@@ -104,7 +105,7 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(output).toMatch(/PARTITION BY HASH/);
     });
 
-    itIfNoTableOptions("schema dump works with NO_TABLE_OPTIONS sql mode", async () => {
+    it.skipIf(skipNoTableOptions)("schema dump works with NO_TABLE_OPTIONS sql mode", async () => {
       const oldMode = await adapter.showVariable("sql_mode");
       expect(oldMode).not.toBeNull();
       await adapter.execute(`SET @@SESSION.sql_mode='${oldMode!},NO_TABLE_OPTIONS'`);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/table-options.test.ts
@@ -5,7 +5,19 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Version } from "../../connection-adapters/abstract-adapter.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
-import { describeIfMysql, isMariaDb, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
+import {
+  describeIfMysql,
+  isMariaDb,
+  mysqlVersion,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "./test-helper.js";
+
+// NO_TABLE_OPTIONS sql_mode was deprecated in MySQL 5.7.22, removed in 8+,
+// and never supported by MariaDB. Probed at module load via mysqlVersion.
+const supportsNoTableOptions =
+  !isMariaDb && mysqlVersion !== "" && new Version(mysqlVersion.replace(/-.*$/, "")).lt("5.7.22");
+const itIfNoTableOptions = supportsNoTableOptions ? it : it.skip;
 
 const dumpTable = (adapter: Mysql2Adapter, tableName: string) =>
   SchemaDumper.dumpTableSchema(adapter as unknown as SchemaSource, tableName);
@@ -92,20 +104,10 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(output).toMatch(/PARTITION BY HASH/);
     });
 
-    it("schema dump works with NO_TABLE_OPTIONS sql mode", async () => {
-      // As of MySQL 5.7.22, NO_TABLE_OPTIONS is deprecated and removed in MySQL 8+
-      // Skip on MariaDB and newer MySQL where the mode doesn't exist
-      if (!isMariaDb) {
-        const versionStr = await adapter.showVariable("version");
-        if (!versionStr) return;
-        if (new Version(versionStr.replace(/-.*$/, "")).gte("5.7.22")) return;
-      } else {
-        return; // MariaDB doesn't support NO_TABLE_OPTIONS
-      }
-
+    itIfNoTableOptions("schema dump works with NO_TABLE_OPTIONS sql mode", async () => {
       const oldMode = await adapter.showVariable("sql_mode");
-      if (!oldMode) return;
-      await adapter.execute(`SET @@SESSION.sql_mode='${oldMode},NO_TABLE_OPTIONS'`);
+      expect(oldMode).not.toBeNull();
+      await adapter.execute(`SET @@SESSION.sql_mode='${oldMode!},NO_TABLE_OPTIONS'`);
       try {
         await adapter.createTable("mysql_table_options", { force: true });
         const output = await dumpTable(adapter, "mysql_table_options");

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/test-helper.ts
@@ -35,24 +35,27 @@ export const MYSQL_TEST_URL =
 
 let mysqlAvailable = false;
 let mariaDb = false;
+let mysqlVersionStr = "";
 
-async function checkMysql(): Promise<{ available: boolean; isMariaDb: boolean }> {
+async function checkMysql(): Promise<{ available: boolean; isMariaDb: boolean; version: string }> {
   let conn: Awaited<ReturnType<typeof mysql.createConnection>> | undefined;
   try {
     conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
     const [rows] = await conn.query("SELECT VERSION() AS v");
     const ver = (rows as Array<{ v: string }>)[0]?.v ?? "";
-    return { available: true, isMariaDb: /mariadb/i.test(ver) };
+    return { available: true, isMariaDb: /mariadb/i.test(ver), version: ver };
   } catch {
-    return { available: false, isMariaDb: false };
+    return { available: false, isMariaDb: false, version: "" };
   } finally {
     await conn?.end().catch(() => {});
   }
 }
 
-({ available: mysqlAvailable, isMariaDb: mariaDb } = await checkMysql());
+({ available: mysqlAvailable, isMariaDb: mariaDb, version: mysqlVersionStr } = await checkMysql());
 
 export const describeIfMysql = mysqlAvailable ? describe : (describe.skip as typeof describe);
 /** true when the connected server is MariaDB; false on MySQL or when MySQL is unavailable. */
 export const isMariaDb = mariaDb;
+/** Raw VERSION() string from the connected MySQL/MariaDB server (empty when unavailable). */
+export const mysqlVersion = mysqlVersionStr;
 export { Mysql2Adapter };

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -30,9 +30,6 @@ import {
 import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-adapter.js";
 import { Result } from "../../result.js";
 
-// MariaDB does not include mismatched FK details in error messages.
-const itUnlessMariaDb = isMariaDb ? it.skip : it;
-
 // Fabricated-error translate_exception checks. These don't touch a live
 // MySQL server (they feed Object.assign(new Error(...), { errno/code })
 // straight into translateException), so they live outside describeIfMysql
@@ -293,7 +290,8 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(error.cause).toBeInstanceOf(Error);
     });
 
-    itUnlessMariaDb(
+    // Rails: `skip "MariaDB does not return mismatched foreign key in error message" if @conn.mariadb?`
+    it.skipIf(isMariaDb)(
       "errors for multiple fks on mismatched types for pk table in alter table",
       async () => {
         // Add matching FK first (cars.id is BIGINT, engines.id is BIGINT — OK)

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -4,6 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
   describeIfMysql,
+  isMariaDb,
   Mysql2Adapter,
   MYSQL_TEST_URL,
   withDbWarningsAction,
@@ -28,6 +29,9 @@ import {
 } from "../../errors.js";
 import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-adapter.js";
 import { Result } from "../../result.js";
+
+// MariaDB does not include mismatched FK details in error messages.
+const itUnlessMariaDb = isMariaDb ? it.skip : it;
 
 // Fabricated-error translate_exception checks. These don't touch a live
 // MySQL server (they feed Object.assign(new Error(...), { errno/code })
@@ -289,31 +293,30 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(error.cause).toBeInstanceOf(Error);
     });
 
-    it("errors for multiple fks on mismatched types for pk table in alter table", async () => {
-      // MariaDB does not include mismatched FK details in error message
-      const isMariaDb = adapter.isMariadb();
-      if (isMariaDb) return;
+    itUnlessMariaDb(
+      "errors for multiple fks on mismatched types for pk table in alter table",
+      async () => {
+        // Add matching FK first (cars.id is BIGINT, engines.id is BIGINT — OK)
+        await adapter.executeMutation(
+          "ALTER TABLE `engines` ADD COLUMN `car_id` BIGINT, ADD CONSTRAINT `fk_car` FOREIGN KEY (`car_id`) REFERENCES `cars` (`id`)",
+        );
 
-      // Add matching FK first (cars.id is BIGINT, engines.id is BIGINT — OK)
-      await adapter.executeMutation(
-        "ALTER TABLE `engines` ADD COLUMN `car_id` BIGINT, ADD CONSTRAINT `fk_car` FOREIGN KEY (`car_id`) REFERENCES `cars` (`id`)",
-      );
+        // Then add mismatched FK (old_cars.id is INT but old_car_id is BIGINT)
+        const error = await adapter
+          .executeMutation(
+            "ALTER TABLE `engines` ADD CONSTRAINT `fk_old_car` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
+          )
+          .then(() => null)
+          .catch((e) => e);
 
-      // Then add mismatched FK (old_cars.id is INT but old_car_id is BIGINT)
-      const error = await adapter
-        .executeMutation(
-          "ALTER TABLE `engines` ADD CONSTRAINT `fk_old_car` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
-        )
-        .then(() => null)
-        .catch((e) => e);
-
-      expect(error).toBeInstanceOf(MismatchedForeignKey);
-      expect(error.message).toMatch(
-        /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
-      );
-      expect(error.message).toMatch(/which has type `int/i);
-      expect(error.cause).toBeInstanceOf(Error);
-    });
+        expect(error).toBeInstanceOf(MismatchedForeignKey);
+        expect(error.message).toMatch(
+          /Column `old_car_id` on table `engines` does not match column `id` on `old_cars`/,
+        );
+        expect(error.message).toMatch(/which has type `int/i);
+        expect(error.cause).toBeInstanceOf(Error);
+      },
+    );
 
     it("errors for bigint fks on integer pk table in create table", async () => {
       // foos.old_car_id is BIGINT but old_cars.id is INT

--- a/packages/activerecord/src/adapters/postgresql/partitions.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/partitions.test.ts
@@ -2,7 +2,12 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/partitions_test.rb
  */
 import { describe, it, beforeEach, afterEach, expect } from "vitest";
-import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import {
+  describeIfPg,
+  pgSupportsNativePartitioning,
+  PostgreSQLAdapter,
+  PG_TEST_URL,
+} from "./test-helper.js";
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;
@@ -15,9 +20,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   });
 
   describe("PostgresqlPartitionsTest", () => {
-    it("partitions table exists", async () => {
-      await adapter.getDatabaseVersion();
-      if (!adapter.supportsNativePartitioning()) return;
+    it.skipIf(!pgSupportsNativePartitioning)("partitions table exists", async () => {
       await adapter.createTable(
         "partitioned_events",
         {

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -2,7 +2,12 @@
  * Mirrors Rails activerecord/test/cases/adapters/postgresql/schema_test.rb
  */
 import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach, vi } from "vitest";
-import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import {
+  describeIfPg,
+  pgSupportsNativePartitioning,
+  PostgreSQLAdapter,
+  PG_TEST_URL,
+} from "./test-helper.js";
 import { StatementInvalid } from "../../errors.js";
 import { makeThingModels, makeThing5Model, makeSongAlbumModels } from "./schema-ar-models.js";
 import { defineSchema } from "../../test-helpers/define-schema.js";
@@ -956,9 +961,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`DROP TABLE IF EXISTS vehicles`);
     });
 
-    it("list partition options is dumped", async () => {
-      await adapter.getDatabaseVersion();
-      if (!adapter.supportsNativePartitioning()) return;
+    it.skipIf(!pgSupportsNativePartitioning)("list partition options is dumped", async () => {
       const options = "PARTITION BY LIST (kind)";
       await adapter.schemaStatements().createTable("trains", { id: false, options }, (t) => {
         t.string("name");
@@ -969,9 +972,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(lines.join("\n")).toContain(`options: "${options}"`);
     });
 
-    it("range partition options is dumped", async () => {
-      await adapter.getDatabaseVersion();
-      if (!adapter.supportsNativePartitioning()) return;
+    it.skipIf(!pgSupportsNativePartitioning)("range partition options is dumped", async () => {
       const options = "PARTITION BY RANGE (created_at)";
       await adapter.schemaStatements().createTable("trains", { id: false, options }, (t) => {
         t.string("name");

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -8,22 +8,27 @@ import type { NotificationSubscriber, NotificationEvent } from "@blazetrails/act
 export const PG_TEST_URL = process.env.PG_TEST_URL ?? "postgres://localhost:5432/rails_js_test";
 
 let pgAvailable = false;
+let pgServerVersionNum = 0;
 
-async function checkPg(): Promise<boolean> {
+async function checkPg(): Promise<{ available: boolean; serverVersionNum: number }> {
   try {
     const client = new pg.Client({ connectionString: PG_TEST_URL });
     await client.connect();
-    await client.query("SELECT 1");
+    const res = await client.query<{ v: string }>("SHOW server_version_num");
     await client.end();
-    return true;
+    return { available: true, serverVersionNum: Number(res.rows[0]?.v ?? 0) };
   } catch {
-    return false;
+    return { available: false, serverVersionNum: 0 };
   }
 }
 
-pgAvailable = await checkPg();
+({ available: pgAvailable, serverVersionNum: pgServerVersionNum } = await checkPg());
 
 export const describeIfPg = pgAvailable ? describe : (describe.skip as typeof describe);
+/** PG server_version_num at module load (0 when unavailable). */
+export const pgServerVersion = pgServerVersionNum;
+/** Mirrors PostgreSQLAdapter#supportsNativePartitioning — PG 10+ (100000). */
+export const pgSupportsNativePartitioning = pgServerVersionNum >= 100000;
 
 /** Mirrors Rails' with_postgresql_datetime_type — temporarily changes the adapter's datetimeType. */
 export async function withPostgresqlDatetimeType<T>(

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -11,14 +11,15 @@ let pgAvailable = false;
 let pgServerVersionNum = 0;
 
 async function checkPg(): Promise<{ available: boolean; serverVersionNum: number }> {
+  const client = new pg.Client({ connectionString: PG_TEST_URL });
   try {
-    const client = new pg.Client({ connectionString: PG_TEST_URL });
     await client.connect();
     const res = await client.query<{ v: string }>("SHOW server_version_num");
-    await client.end();
     return { available: true, serverVersionNum: Number(res.rows[0]?.v ?? 0) };
   } catch {
     return { available: false, serverVersionNum: 0 };
+  } finally {
+    await client.end().catch(() => {});
   }
 }
 

--- a/packages/activerecord/src/adapters/postgresql/test-helper.ts
+++ b/packages/activerecord/src/adapters/postgresql/test-helper.ts
@@ -14,7 +14,9 @@ async function checkPg(): Promise<{ available: boolean; serverVersionNum: number
   const client = new pg.Client({ connectionString: PG_TEST_URL });
   try {
     await client.connect();
-    const res = await client.query<{ v: string }>("SHOW server_version_num");
+    const res = await client.query<{ v: string }>(
+      "SELECT current_setting('server_version_num') AS v",
+    );
     return { available: true, serverVersionNum: Number(res.rows[0]?.v ?? 0) };
   } catch {
     return { available: false, serverVersionNum: 0 };

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -18,21 +18,34 @@ import { NoDatabaseError } from "../errors.js";
 const MYSQL_TEST_URL = process.env.MYSQL_TEST_URL ?? "mysql://root@localhost:3306/rails_js_test";
 
 let mysqlAvailable = false;
+let mysqlHasExprIndexes = false;
+let mysqlRejectsZeroDate = false;
 
-async function checkMysql(): Promise<boolean> {
+async function checkMysql(): Promise<void> {
   try {
     const conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
-    await conn.query("SELECT 1");
+    const [exprRows] = await conn.query(
+      `SELECT 1 FROM information_schema.columns WHERE table_schema='information_schema' AND table_name='STATISTICS' AND column_name='EXPRESSION' LIMIT 1`,
+    );
+    const [modeRows] = await conn.query("SELECT @@SESSION.sql_mode AS m");
+    const mode = String((modeRows as Array<{ m: string }>)[0]?.m ?? "");
     await conn.end();
-    return true;
+    mysqlAvailable = true;
+    mysqlHasExprIndexes = (exprRows as Array<unknown>).length > 0;
+    mysqlRejectsZeroDate = mode.includes("NO_ZERO_DATE") || mode.includes("TRADITIONAL");
   } catch {
-    return false;
+    /* MySQL unavailable — describeIfMysql will skip everything. */
   }
 }
 
-mysqlAvailable = await checkMysql();
+await checkMysql();
 
 const describeIfMysql = mysqlAvailable ? describe : describe.skip;
+// STATISTICS.EXPRESSION column gates MySQL 8.0.13+ functional indexes;
+// default sql_mode containing NO_ZERO_DATE/TRADITIONAL rejects zero
+// datetimes. Both probed at module load so test bodies stay conditional-free.
+const itIfExprIndexes = mysqlHasExprIndexes ? it : it.skip;
+const itUnlessRejectsZeroDate = mysqlRejectsZeroDate ? it.skip : it;
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -611,38 +624,24 @@ describeIfMysql("Mysql2Adapter", () => {
       ]);
     });
 
-    it("indexes() represents MySQL 8+ functional indexes via their expression", async () => {
-      // MySQL 8+ supports `CREATE INDEX ... ON t((expr))`; those rows
-      // have NULL column_name in information_schema.statistics and the
-      // expression in `expression`. Surfacing "null" as a column name
-      // would poison SchemaCache; wrapping the expression in parens
-      // matches Rails' IndexDefinition display.
-      //
-      // Gate on a DB-side probe rather than try/catching CREATE (a
-      // blanket catch would also swallow permissions errors or a
-      // genuine syntax regression) and rather than reaching into a
-      // private adapter helper (couples the test to implementation
-      // details). Query information_schema.columns for
-      // STATISTICS.EXPRESSION directly — the column exists on MySQL
-      // 8.0.13+, absent on older MySQL and on MariaDB.
-      const capabilityRows = (await adapter.execute(
-        `SELECT 1 AS one FROM information_schema.columns
-           WHERE table_schema = 'information_schema'
-           AND table_name = 'STATISTICS'
-           AND column_name = 'EXPRESSION'
-           LIMIT 1`,
-      )) as Array<unknown>;
-      if (capabilityRows.length === 0) return;
-
-      await adapter.exec("CREATE INDEX `widgets_on_lower_name` ON `widgets` ((LOWER(`name`)))");
-      const idx = await adapter.indexes("widgets");
-      const functional = idx.find((i) => i.name === "widgets_on_lower_name");
-      expect(functional).toBeDefined();
-      // Either `(lower(`name`))` or similar — just assert it's parenthesized.
-      expect(functional!.columns).toHaveLength(1);
-      expect(functional!.columns[0].startsWith("(")).toBe(true);
-      expect(functional!.columns[0]).not.toBe("null");
-    });
+    itIfExprIndexes(
+      "indexes() represents MySQL 8+ functional indexes via their expression",
+      async () => {
+        // MySQL 8.0.13+ supports `CREATE INDEX ... ON t((expr))`; those
+        // rows have NULL column_name in information_schema.statistics
+        // and the expression in `expression`. Surfacing "null" as a
+        // column name would poison SchemaCache; wrapping the expression
+        // in parens matches Rails' IndexDefinition display.
+        await adapter.exec("CREATE INDEX `widgets_on_lower_name` ON `widgets` ((LOWER(`name`)))");
+        const idx = await adapter.indexes("widgets");
+        const functional = idx.find((i) => i.name === "widgets_on_lower_name");
+        expect(functional).toBeDefined();
+        // Either `(lower(`name`))` or similar — just assert it's parenthesized.
+        expect(functional!.columns).toHaveLength(1);
+        expect(functional!.columns[0].startsWith("(")).toBe(true);
+        expect(functional!.columns[0]).not.toBe("null");
+      },
+    );
 
     describe("foreignKeys", () => {
       beforeEach(async () => {
@@ -740,11 +739,7 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(zdt.microsecond).toBe(456);
     });
 
-    it("returns null for zero DATETIME '0000-00-00 00:00:00'", async () => {
-      // NO_ZERO_DATE in sql_mode rejects the insert. Check first and skip if set.
-      const modeRows = await adapter.execute("SELECT @@SESSION.sql_mode AS m");
-      const sqlMode = String(modeRows[0].m ?? "");
-      if (sqlMode.includes("NO_ZERO_DATE") || sqlMode.includes("TRADITIONAL")) return;
+    itUnlessRejectsZeroDate("returns null for zero DATETIME '0000-00-00 00:00:00'", async () => {
       await adapter.exec("INSERT INTO `temporal_test` (`dt`) VALUES ('0000-00-00 00:00:00')");
       const rows = await adapter.execute("SELECT `dt` FROM `temporal_test`");
       expect(rows[0].dt).toBeNull();

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -25,14 +25,26 @@ async function checkMysql(): Promise<void> {
   let conn: Awaited<ReturnType<typeof mysql.createConnection>> | undefined;
   try {
     conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
-    const [exprRows] = await conn.query(
-      `SELECT 1 FROM information_schema.columns WHERE table_schema='information_schema' AND table_name='STATISTICS' AND column_name='EXPRESSION' LIMIT 1`,
-    );
-    const [modeRows] = await conn.query("SELECT @@SESSION.sql_mode AS m");
-    const mode = String((modeRows as Array<{ m: string }>)[0]?.m ?? "");
+    await conn.query("SELECT 1");
     mysqlAvailable = true;
-    mysqlHasExprIndexes = (exprRows as Array<unknown>).length > 0;
-    mysqlRejectsZeroDate = mode.includes("NO_ZERO_DATE") || mode.includes("TRADITIONAL");
+    // Capability probes are best-effort; a failure here (e.g. restricted
+    // information_schema) leaves the defaults (false) without forcing
+    // the whole suite to skip.
+    try {
+      const [exprRows] = await conn.query(
+        `SELECT 1 FROM information_schema.columns WHERE table_schema='information_schema' AND table_name='STATISTICS' AND column_name='EXPRESSION' LIMIT 1`,
+      );
+      mysqlHasExprIndexes = (exprRows as Array<unknown>).length > 0;
+    } catch {
+      /* leave mysqlHasExprIndexes = false */
+    }
+    try {
+      const [modeRows] = await conn.query("SELECT @@SESSION.sql_mode AS m");
+      const mode = String((modeRows as Array<{ m: string }>)[0]?.m ?? "");
+      mysqlRejectsZeroDate = mode.includes("NO_ZERO_DATE") || mode.includes("TRADITIONAL");
+    } catch {
+      /* leave mysqlRejectsZeroDate = false */
+    }
   } catch {
     /* MySQL unavailable — describeIfMysql will skip everything. */
   } finally {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.test.ts
@@ -22,19 +22,21 @@ let mysqlHasExprIndexes = false;
 let mysqlRejectsZeroDate = false;
 
 async function checkMysql(): Promise<void> {
+  let conn: Awaited<ReturnType<typeof mysql.createConnection>> | undefined;
   try {
-    const conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
+    conn = await mysql.createConnection({ uri: MYSQL_TEST_URL });
     const [exprRows] = await conn.query(
       `SELECT 1 FROM information_schema.columns WHERE table_schema='information_schema' AND table_name='STATISTICS' AND column_name='EXPRESSION' LIMIT 1`,
     );
     const [modeRows] = await conn.query("SELECT @@SESSION.sql_mode AS m");
     const mode = String((modeRows as Array<{ m: string }>)[0]?.m ?? "");
-    await conn.end();
     mysqlAvailable = true;
     mysqlHasExprIndexes = (exprRows as Array<unknown>).length > 0;
     mysqlRejectsZeroDate = mode.includes("NO_ZERO_DATE") || mode.includes("TRADITIONAL");
   } catch {
     /* MySQL unavailable — describeIfMysql will skip everything. */
+  } finally {
+    await conn?.end().catch(() => {});
   }
 }
 

--- a/packages/activerecord/src/tsc-wrapper/cli.test.ts
+++ b/packages/activerecord/src/tsc-wrapper/cli.test.ts
@@ -14,6 +14,10 @@ const createBuilderWithArPlugin = createArSolutionBuilder;
 
 const CURRENT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const FIXTURES_DIR = path.resolve(CURRENT_DIR, "__fixtures__");
+const CLI_BIN_PATH = path.resolve(CURRENT_DIR, "../../dist/tsc-wrapper/cli.js");
+// CLI-binary tests skip when dist isn't built (CI jobs that skip
+// `pnpm build`). Probed at module load so test bodies stay conditional-free.
+const itIfCliBin = fs.existsSync(CLI_BIN_PATH) ? it : it.skip;
 
 describe("trails-tsc CLI — Phase 1b.1", () => {
   it("virtualizes a single-file model: post.title types as string with no declares", () => {
@@ -65,24 +69,23 @@ describe("trails-tsc CLI — Phase 1b.1", () => {
     expect(allDiags).toHaveLength(0);
   });
 
-  it("CLI binary exits 0 on clean fixture", async () => {
-    const binPath = path.resolve(CURRENT_DIR, "../../dist/tsc-wrapper/cli.js");
-    // Skip if dist hasn't been built (CI test jobs that skip `pnpm build`).
-    // The programmatic API tests above cover the same behavior; this test
-    // exercises the real binary entry path as an extra integration check.
-    if (!fs.existsSync(binPath)) return;
-    const { execFileSync } = await import("node:child_process");
-    const result = execFileSync(
-      "node",
-      [binPath, "-p", path.join(FIXTURES_DIR, "tsconfig.json"), "--noEmit"],
-      {
-        encoding: "utf8",
-        stdio: ["pipe", "pipe", "pipe"],
-      },
-    );
-    // Clean exit — no output expected on success.
-    expect(result).toBe("");
-  }, 30_000);
+  itIfCliBin(
+    "CLI binary exits 0 on clean fixture",
+    async () => {
+      const { execFileSync } = await import("node:child_process");
+      const result = execFileSync(
+        "node",
+        [CLI_BIN_PATH, "-p", path.join(FIXTURES_DIR, "tsconfig.json"), "--noEmit"],
+        {
+          encoding: "utf8",
+          stdio: ["pipe", "pipe", "pipe"],
+        },
+      );
+      // Clean exit — no output expected on success.
+      expect(result).toBe("");
+    },
+    30_000,
+  );
 });
 
 describe("trails-tsc diagnostic remap — Phase 1b.2", () => {
@@ -299,22 +302,26 @@ describe("trails-tsc --build composite projects — Phase 1b.5", () => {
   // routinely takes ~3–5s on warm machines and longer under load; the
   // Vitest default 5000ms timeout makes this flaky. Bump the per-test
   // timeout rather than leaving false-negatives in CI.
-  it("CLI binary --build exits 0 on the composite fixture", async () => {
-    const binPath = path.resolve(CURRENT_DIR, "../../dist/tsc-wrapper/cli.js");
-    // Same pattern as the Phase 1b.1 binary test: skip when dist
-    // isn't built (e.g., CI jobs that don't run `pnpm build`).
-    if (!fs.existsSync(binPath)) return;
-    const { execFileSync } = await import("node:child_process");
-    withTempComposite((dir) => {
-      const result = execFileSync("node", [binPath, "--build", path.join(dir, "tsconfig.json")], {
-        encoding: "utf8",
-        stdio: ["pipe", "pipe", "pipe"],
+  itIfCliBin(
+    "CLI binary --build exits 0 on the composite fixture",
+    async () => {
+      const { execFileSync } = await import("node:child_process");
+      withTempComposite((dir) => {
+        const result = execFileSync(
+          "node",
+          [CLI_BIN_PATH, "--build", path.join(dir, "tsconfig.json")],
+          {
+            encoding: "utf8",
+            stdio: ["pipe", "pipe", "pipe"],
+          },
+        );
+        // Solution builder prints no output on a clean build.
+        expect(result).toBe("");
+        expect(fs.existsSync(path.join(dir, "app", "dist", "post.d.ts"))).toBe(true);
       });
-      // Solution builder prints no output on a clean build.
-      expect(result).toBe("");
-      expect(fs.existsSync(path.join(dir, "app", "dist", "post.d.ts"))).toBe(true);
-    });
-  }, 30_000);
+    },
+    30_000,
+  );
 
   it("re-build after editing a model reflects the new declares in dependents", () => {
     withTempComposite((dir) => {


### PR DESCRIPTION
## Summary

Follow-up to #2218 / #2215 / #2164. Drives `vitest/no-conditional-in-test`
from **10 → 0** violations in activerecord and **enables the rule** in
`eslint.config.mjs` for activerecord.

All 10 remaining sites branched on async runtime probes (server
version, sql_mode, fs.existsSync). Each probe was lifted to module
load and replaced with a tiny aliased `const itIfX = cond ? it : it.skip`
so existing test bodies stay verbatim (no whole-block reindent).

### Sites cleared

- `adapters/abstract-mysql-adapter/table-options.test.ts × 2` — NO_TABLE_OPTIONS gated by `mysqlVersion < 5.7.22 && !isMariaDb`. `mysqlVersion` newly exported from the abstract-mysql test-helper.
- `adapters/postgresql/partitions.test.ts × 1` and `adapters/postgresql/schema.test.ts × 2` — `supportsNativePartitioning` probed once at module load (`SHOW server_version_num`); new `pgSupportsNativePartitioning` exported from the postgresql test-helper.
- `adapters/mysql2/mysql2-adapter.test.ts × 1` — multi-FK MariaDB skip now uses the shared `isMariaDb` constant.
- `connection-adapters/mysql2-adapter.test.ts × 2` — `STATISTICS.EXPRESSION` availability + default `@@SESSION.sql_mode` probed in the file's own `checkMysql()` (one extra connection at load, zero per-test cost).
- `tsc-wrapper/cli.test.ts × 2` — `fs.existsSync(CLI_BIN_PATH)` lifted to a module-level `itIfCliBin` alias.

### Rule flip

`packages/activerecord` now enables `vitest/no-conditional-in-test`
alongside `no-conditional-tests`. Eslint clean.

### Follow-up (not in this PR)

`vitest/no-conditional-expect` is still disabled in activerecord — ~93
sites in the #2164 baseline count. Separate cleanup PR.

## Test plan

- [x] `pnpm exec eslint .` clean
- [x] `pnpm exec tsc --build packages/activerecord` clean
- [x] `pnpm vitest run packages/activerecord/src/tsc-wrapper/cli.test.ts` (no DB needed) — 26 pass
- [ ] CI covers the live-DB tests (MySQL / MariaDB / PG)