### PR TITLE
feat(activerecord): wire railtie initializers from config (PR 2.7-followups)

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -131,6 +131,7 @@ import {
   include,
   extend,
   benchmark as benchmarkable,
+  runLoadHooks,
   type Included,
   type ParameterFilter,
   type BenchmarkLogger,
@@ -3657,3 +3658,9 @@ _setGlobalIdModelFinder((name: string) => {
   }
   return undefined;
 });
+
+// Mirrors `ActiveSupport.run_load_hooks(:active_record, Base)` at the
+// bottom of `activerecord/lib/active_record/base.rb`. Lets railtie
+// initializers register `on_load(:active_record)` consumers that need a
+// fully-defined `Base` class (timezone, filter attributes, ...).
+runLoadHooks("active_record", Base);

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -6,6 +6,7 @@ import {
   Notifications,
   getCrypto,
   getErrorReporter,
+  runLoadHooks,
 } from "@blazetrails/activesupport";
 import { sql as arelSql, Nodes, Visitors } from "@blazetrails/arel";
 import { Result } from "../result.js";
@@ -5401,3 +5402,8 @@ const FORMAT_TYPE_ALIASES: Record<string, string> = {
   "time with time zone": "timetz",
   boolean: "bool",
 };
+
+// Mirrors `ActiveSupport.run_load_hooks(:active_record_postgresqladapter, self)`
+// at the bottom of Rails' postgresql_adapter.rb — lets railtie initializers
+// gate behavior on the postgresql adapter being loaded.
+runLoadHooks("active_record_postgresqladapter", PostgreSQLAdapter);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -44,7 +44,7 @@ import {
   BinaryType,
   DecimalType,
 } from "@blazetrails/activemodel";
-import { getFs, Notifications } from "@blazetrails/activesupport";
+import { getFs, Notifications, runLoadHooks } from "@blazetrails/activesupport";
 import { typeCastedBinds } from "./abstract/database-statements.js";
 import { isWriteQuerySql } from "./sql-classification.js";
 import {
@@ -2320,3 +2320,8 @@ function translateException(
   }
   return new StatementInvalid(message, { sql, binds, cause: exception });
 }
+
+// Mirrors `ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, self)`
+// at the bottom of Rails' sqlite3_adapter.rb — lets railtie initializers
+// gate behavior on the sqlite3 adapter being loaded.
+runLoadHooks("active_record_sqlite3adapter", SQLite3Adapter);

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -92,8 +92,8 @@ describe("RailtieTest", () => {
   it("runInitializers adds timestamptz to time_zone_aware_types once the postgresql adapter is loaded", () => {
     Base.timeZoneAwareTypes = ["datetime", "time"];
     Trailtie.runInitializers();
-    // PostgreSQLAdapter import above fired `runLoadHooks("active_record_postgresqladapter")`
-    // already, so the nested on_load fires synchronously.
+    // beforeEach re-emits `runLoadHooks("active_record_postgresqladapter", ...)`
+    // and `("active_record", ...)`, so the nested on_load fires synchronously.
     expect(Base.timeZoneAwareTypes).toContain("timestamptz");
   });
 
@@ -121,12 +121,14 @@ describe("RailtieTest", () => {
     expect(PostgreSQLAdapter.decodeDates).toBe(true);
   });
 
-  it("does not assign PostgreSQLAdapter.decodeDates when flag is absent (preserves class default)", () => {
+  it("does not assign PostgreSQLAdapter.decodeDates when flag is absent (preserves prior value)", () => {
     const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
     delete cfg.postgresqlAdapterDecodeDates;
-    PostgreSQLAdapter.decodeDates = true;
+    // Use a non-default value so a faulty initializer that always assigns
+    // `true` would visibly overwrite this.
+    PostgreSQLAdapter.decodeDates = false;
     Trailtie.runInitializers();
-    expect(PostgreSQLAdapter.decodeDates).toBe(true);
+    expect(PostgreSQLAdapter.decodeDates).toBe(false);
   });
 
   it("runInitializers forwards config.encryption to Encryption.Configurable", () => {

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { Trailtie, type ActiveRecordConfig } from "./trailtie.js";
 import { Base } from "./base.js";
-import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
+import { Railtie as BaseRailtie, resetLoadHooks, runLoadHooks } from "@blazetrails/activesupport";
 import { SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
 import { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
@@ -19,6 +19,7 @@ describe("RailtieTest", () => {
   let savedCheckSchemaCacheDumpVersion: boolean;
   let savedStrictStrings: boolean;
   let savedDecodeDates: boolean;
+  let savedEncryptionSupportUnencryptedData: boolean;
 
   beforeEach(() => {
     savedSubclasses = [...BaseRailtie.subclasses];
@@ -29,6 +30,15 @@ describe("RailtieTest", () => {
     savedCheckSchemaCacheDumpVersion = SchemaReflection.checkSchemaCacheDumpVersion;
     savedStrictStrings = SQLite3Adapter.strictStringsByDefault;
     savedDecodeDates = PostgreSQLAdapter.decodeDates;
+    savedEncryptionSupportUnencryptedData = EncryptionConfigurable.config.supportUnencryptedData;
+
+    // Simulate a fresh app boot for each test: clear the load-hook registry
+    // and re-emit the load events that base.ts / the adapter files would
+    // fire at module-import time in a real app.
+    resetLoadHooks();
+    runLoadHooks("active_record", Base);
+    runLoadHooks("active_record_postgresqladapter", PostgreSQLAdapter);
+    runLoadHooks("active_record_sqlite3adapter", SQLite3Adapter);
   });
 
   afterEach(() => {
@@ -41,6 +51,7 @@ describe("RailtieTest", () => {
     SchemaReflection.checkSchemaCacheDumpVersion = savedCheckSchemaCacheDumpVersion;
     SQLite3Adapter.strictStringsByDefault = savedStrictStrings;
     PostgreSQLAdapter.decodeDates = savedDecodeDates;
+    EncryptionConfigurable.config.supportUnencryptedData = savedEncryptionSupportUnencryptedData;
     for (const key of Object.keys(deprecators)) {
       delete deprecators[key];
     }
@@ -123,6 +134,5 @@ describe("RailtieTest", () => {
     cfg.encryption = { supportUnencryptedData: true };
     Trailtie.runInitializers();
     expect(EncryptionConfigurable.config.supportUnencryptedData).toBe(true);
-    EncryptionConfigurable.config.supportUnencryptedData = false;
   });
 });

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { Trailtie, type ActiveRecordConfig } from "./trailtie.js";
 import { Base } from "./base.js";
 import { Railtie as BaseRailtie } from "@blazetrails/activesupport";
+import { SchemaReflection } from "./connection-adapters/schema-cache.js";
+import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
+import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
 import { deprecator } from "./deprecator.js";
 
 const { deprecators } = BaseRailtie;
@@ -10,11 +14,21 @@ describe("RailtieTest", () => {
   let savedSubclasses: (typeof BaseRailtie)[];
   let savedConfig: ActiveRecordConfig;
   let savedTimeZoneAware: boolean;
+  let savedTimeZoneAwareTypes: string[];
+  let savedUseSchemaCacheDump: boolean;
+  let savedCheckSchemaCacheDumpVersion: boolean;
+  let savedStrictStrings: boolean;
+  let savedDecodeDates: boolean;
 
   beforeEach(() => {
     savedSubclasses = [...BaseRailtie.subclasses];
     savedConfig = structuredClone(Trailtie.config["activeRecord"] as ActiveRecordConfig);
     savedTimeZoneAware = Base.timeZoneAwareAttributes;
+    savedTimeZoneAwareTypes = [...Base.timeZoneAwareTypes];
+    savedUseSchemaCacheDump = SchemaReflection.useSchemaCacheDump;
+    savedCheckSchemaCacheDumpVersion = SchemaReflection.checkSchemaCacheDumpVersion;
+    savedStrictStrings = SQLite3Adapter.strictStringsByDefault;
+    savedDecodeDates = PostgreSQLAdapter.decodeDates;
   });
 
   afterEach(() => {
@@ -22,6 +36,11 @@ describe("RailtieTest", () => {
     (BaseRailtie.subclasses as (typeof BaseRailtie)[]).push(...savedSubclasses);
     Trailtie.config["activeRecord"] = savedConfig;
     Base.timeZoneAwareAttributes = savedTimeZoneAware;
+    Base.timeZoneAwareTypes = savedTimeZoneAwareTypes;
+    SchemaReflection.useSchemaCacheDump = savedUseSchemaCacheDump;
+    SchemaReflection.checkSchemaCacheDumpVersion = savedCheckSchemaCacheDumpVersion;
+    SQLite3Adapter.strictStringsByDefault = savedStrictStrings;
+    PostgreSQLAdapter.decodeDates = savedDecodeDates;
     for (const key of Object.keys(deprecators)) {
       delete deprecators[key];
     }
@@ -57,5 +76,50 @@ describe("RailtieTest", () => {
     Base.timeZoneAwareAttributes = false;
     Trailtie.runInitializers();
     expect(Base.timeZoneAwareAttributes).toBe(true);
+  });
+
+  it("runInitializers adds timestamptz to time_zone_aware_types when postgresql flag is true", () => {
+    Base.timeZoneAwareTypes = ["datetime", "time"];
+    Trailtie.runInitializers();
+    expect(Base.timeZoneAwareTypes).toContain("timestamptz");
+  });
+
+  it("runInitializers omits timestamptz when postgresql flag is false", () => {
+    const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
+    cfg.postgresqlTimeZoneAwareTypes = false;
+    Base.timeZoneAwareTypes = ["datetime", "time", "timestamptz"];
+    Trailtie.runInitializers();
+    expect(Base.timeZoneAwareTypes).not.toContain("timestamptz");
+  });
+
+  it("runInitializers copies schema cache flags to SchemaReflection", () => {
+    const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
+    cfg.useSchemaCacheDump = false;
+    cfg.checkSchemaCacheDumpVersion = false;
+    Trailtie.runInitializers();
+    expect(SchemaReflection.useSchemaCacheDump).toBe(false);
+    expect(SchemaReflection.checkSchemaCacheDumpVersion).toBe(false);
+  });
+
+  it("runInitializers copies sqlite3 strict strings flag onto SQLite3Adapter", () => {
+    const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
+    cfg.sqlite3AdapterStrictStringsByDefault = true;
+    Trailtie.runInitializers();
+    expect(SQLite3Adapter.strictStringsByDefault).toBe(true);
+  });
+
+  it("runInitializers copies postgresql decode_dates flag onto PostgreSQLAdapter", () => {
+    const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
+    cfg.postgresqlAdapterDecodeDates = true;
+    Trailtie.runInitializers();
+    expect(PostgreSQLAdapter.decodeDates).toBe(true);
+  });
+
+  it("runInitializers forwards config.encryption to Encryption.Configurable", () => {
+    const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
+    cfg.encryption = { supportUnencryptedData: true };
+    Trailtie.runInitializers();
+    expect(EncryptionConfigurable.config.supportUnencryptedData).toBe(true);
+    EncryptionConfigurable.config.supportUnencryptedData = false;
   });
 });

--- a/packages/activerecord/src/trailtie.test.ts
+++ b/packages/activerecord/src/trailtie.test.ts
@@ -78,18 +78,12 @@ describe("RailtieTest", () => {
     expect(Base.timeZoneAwareAttributes).toBe(true);
   });
 
-  it("runInitializers adds timestamptz to time_zone_aware_types when postgresql flag is true", () => {
+  it("runInitializers adds timestamptz to time_zone_aware_types once the postgresql adapter is loaded", () => {
     Base.timeZoneAwareTypes = ["datetime", "time"];
     Trailtie.runInitializers();
+    // PostgreSQLAdapter import above fired `runLoadHooks("active_record_postgresqladapter")`
+    // already, so the nested on_load fires synchronously.
     expect(Base.timeZoneAwareTypes).toContain("timestamptz");
-  });
-
-  it("runInitializers omits timestamptz when postgresql flag is false", () => {
-    const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
-    cfg.postgresqlTimeZoneAwareTypes = false;
-    Base.timeZoneAwareTypes = ["datetime", "time", "timestamptz"];
-    Trailtie.runInitializers();
-    expect(Base.timeZoneAwareTypes).not.toContain("timestamptz");
   });
 
   it("runInitializers copies schema cache flags to SchemaReflection", () => {
@@ -111,6 +105,15 @@ describe("RailtieTest", () => {
   it("runInitializers copies postgresql decode_dates flag onto PostgreSQLAdapter", () => {
     const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
     cfg.postgresqlAdapterDecodeDates = true;
+    PostgreSQLAdapter.decodeDates = false;
+    Trailtie.runInitializers();
+    expect(PostgreSQLAdapter.decodeDates).toBe(true);
+  });
+
+  it("does not assign PostgreSQLAdapter.decodeDates when flag is absent (preserves class default)", () => {
+    const cfg = Trailtie.config["activeRecord"] as ActiveRecordConfig;
+    delete cfg.postgresqlAdapterDecodeDates;
+    PostgreSQLAdapter.decodeDates = true;
     Trailtie.runInitializers();
     expect(PostgreSQLAdapter.decodeDates).toBe(true);
   });

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -45,9 +45,7 @@ export const JobRuntime = { instrument };
  * Shape of `config.activeRecord` — mirrors the
  * `ActiveSupport::OrderedOptions` block at the top of Rails' railtie.rb.
  */
-export interface ActiveRecordEncryptionConfig {
-  [key: string]: unknown;
-}
+export type ActiveRecordEncryptionConfig = Parameters<typeof EncryptionConfigurable.configure>[0];
 
 export interface ActiveRecordConfig {
   encryption: ActiveRecordEncryptionConfig;
@@ -93,6 +91,32 @@ function defaultActiveRecordConfig(): ActiveRecordConfig {
   };
 }
 
+// onLoad callbacks are module-level consts so that repeated
+// `Trailtie.runInitializers()` calls (common in tests) register the same
+// callback reference with `{ once: true }`, preventing the hook registry
+// from growing unboundedly.
+const setTimeZoneAwareAttributes = (base: typeof Base): void => {
+  base.timeZoneAwareAttributes = true;
+};
+
+const pushTimestamptzToTimeZoneAwareTypes = (base: typeof Base): void => {
+  if (!base.timeZoneAwareTypes.includes("timestamptz")) {
+    base.timeZoneAwareTypes.push("timestamptz");
+  }
+};
+
+const onPostgresqlAdapterLoadedPushTimestamptz = (): void => {
+  onLoad("active_record", { once: true }, pushTimestamptzToTimeZoneAwareTypes);
+};
+
+const setSqlite3StrictStringsByDefault = (adapter: typeof SQLite3Adapter): void => {
+  adapter.strictStringsByDefault = true;
+};
+
+const setPostgresqlDecodeDates = (adapter: typeof PostgreSQLAdapter): void => {
+  adapter.decodeDates = true;
+};
+
 export class Trailtie extends BaseRailtie {
   static {
     registerRailtie(this);
@@ -105,9 +129,7 @@ export class Trailtie extends BaseRailtie {
 
     this.initializer("active_record.initialize_timezone", () => {
       // Rails: `ActiveSupport.on_load(:active_record) { self.time_zone_aware_attributes = true }`.
-      onLoad("active_record", (base: typeof Base) => {
-        base.timeZoneAwareAttributes = true;
-      });
+      onLoad("active_record", { once: true }, setTimeZoneAwareAttributes);
     });
 
     this.initializer("active_record.postgresql_time_zone_aware_types", () => {
@@ -116,15 +138,13 @@ export class Trailtie extends BaseRailtie {
       //     on_load(:active_record) { Base.time_zone_aware_types << :timestamptz }
       //   end
       // No config gate — Rails pushes unconditionally when the PG adapter is
-      // loaded. We add an `includes` check so multiple `runInitializers`
-      // calls in tests stay idempotent (Rails' `<<` would duplicate).
-      onLoad("active_record_postgresqladapter", () => {
-        onLoad("active_record", (base: typeof Base) => {
-          if (!base.timeZoneAwareTypes.includes("timestamptz")) {
-            base.timeZoneAwareTypes.push("timestamptz");
-          }
-        });
-      });
+      // loaded. We add an `includes` check so the consumer is safely
+      // idempotent (Rails' `<<` would duplicate on hypothetical re-runs).
+      onLoad(
+        "active_record_postgresqladapter",
+        { once: true },
+        onPostgresqlAdapterLoadedPushTimestamptz,
+      );
     });
 
     this.initializer("active_record.copy_schema_cache_config", () => {
@@ -138,9 +158,7 @@ export class Trailtie extends BaseRailtie {
       // gated on `on_load(:active_record_sqlite3adapter)`.
       const cfg = this.config["activeRecord"] as ActiveRecordConfig;
       if (cfg.sqlite3AdapterStrictStringsByDefault) {
-        onLoad("active_record_sqlite3adapter", (adapter: typeof SQLite3Adapter) => {
-          adapter.strictStringsByDefault = true;
-        });
+        onLoad("active_record_sqlite3adapter", { once: true }, setSqlite3StrictStringsByDefault);
       }
     });
 
@@ -149,9 +167,7 @@ export class Trailtie extends BaseRailtie {
       // gated on `on_load(:active_record_postgresqladapter)`.
       const cfg = this.config["activeRecord"] as ActiveRecordConfig;
       if (cfg.postgresqlAdapterDecodeDates) {
-        onLoad("active_record_postgresqladapter", (adapter: typeof PostgreSQLAdapter) => {
-          adapter.decodeDates = true;
-        });
+        onLoad("active_record_postgresqladapter", { once: true }, setPostgresqlDecodeDates);
       }
     });
 
@@ -167,9 +183,7 @@ export class Trailtie extends BaseRailtie {
       const cfg = this.config["activeRecord"] as ActiveRecordConfig;
       const enc = cfg.encryption;
       if (enc && Object.keys(enc).length > 0) {
-        EncryptionConfigurable.configure(
-          enc as Parameters<typeof EncryptionConfigurable.configure>[0],
-        );
+        EncryptionConfigurable.configure(enc);
       }
     });
   }

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -14,17 +14,22 @@
  *   - `ControllerRuntime` — SQL runtime tracking per request
  *   - `JobRuntime` — SQL runtime tracking per job
  *
- * Unported targets (rake tasks, console/runner hooks, on_load callback
- * registry, migration_error middleware insertion, schema-cache-config
- * copy, define_attribute_methods, sqlite3/postgresql adapter strict
- * defaults, set_configs setter-dispatch loop, set_reloader_hooks,
- * set_executor_hooks, watchable_files, encryption.configuration,
- * query_log_tags_config, log_runtime subscriber) are intentionally left
- * out for now — they each depend on Rails infrastructure that has not yet
- * been ported to trails. See docs/trailties-plan.md PR 2.7 follow-ups.
+ * Unported targets (rake tasks, console/runner hooks, migration_error
+ * middleware insertion, set_configs setter-dispatch loop, set_reloader_hooks,
+ * set_executor_hooks, watchable_files, log_runtime subscriber,
+ * clear_active_connections, set_filter_attributes,
+ * set_signed_id_verifier_secret, logger, backtrace_cleaner) are intentionally
+ * left out for now — they each depend on either an Application-instance
+ * argument to the initializer block (which `Railtie.initializer` does not
+ * supply) or on Trails-level infrastructure that has not yet been ported.
+ * See docs/trailties-plan.md PR 2.7 follow-ups.
  */
-import { Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
+import { onLoad, Railtie as BaseRailtie, registerRailtie } from "@blazetrails/activesupport";
 import { Base } from "./base.js";
+import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
+import { SchemaReflection } from "./connection-adapters/schema-cache.js";
+import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
 import { deprecator } from "./deprecator.js";
 import {
   processAction,
@@ -50,6 +55,9 @@ export interface ActiveRecordConfig {
   checkSchemaCacheDumpVersion: boolean;
   maintainTestSchema: boolean;
   hasManyInversing: boolean;
+  postgresqlTimeZoneAwareTypes: boolean;
+  sqlite3AdapterStrictStringsByDefault: boolean;
+  postgresqlAdapterDecodeDates: boolean;
   queryLogTagsEnabled: boolean;
   queryLogTags: string[];
   queryLogTagsFormat: "legacy" | "sqlcommenter";
@@ -67,6 +75,9 @@ function defaultActiveRecordConfig(): ActiveRecordConfig {
     checkSchemaCacheDumpVersion: true,
     maintainTestSchema: true,
     hasManyInversing: false,
+    postgresqlTimeZoneAwareTypes: true,
+    sqlite3AdapterStrictStringsByDefault: false,
+    postgresqlAdapterDecodeDates: false,
     queryLogTagsEnabled: false,
     queryLogTags: ["application"],
     queryLogTagsFormat: "legacy",
@@ -90,8 +101,45 @@ export class Trailtie extends BaseRailtie {
 
     this.initializer("active_record.initialize_timezone", () => {
       // Rails: `ActiveSupport.on_load(:active_record) { self.time_zone_aware_attributes = true }`.
-      // The on_load registry isn't ported yet, so apply directly to Base.
-      Base.timeZoneAwareAttributes = true;
+      onLoad("active_record", (base: typeof Base) => {
+        base.timeZoneAwareAttributes = true;
+      });
+    });
+
+    this.initializer("active_record.postgresql_time_zone_aware_types", () => {
+      // Rails: removes then conditionally re-adds `:timestamptz` so the
+      // initializer is idempotent under repeated `runInitializers` calls.
+      const cfg = this.config["activeRecord"] as ActiveRecordConfig;
+      onLoad("active_record", (base: typeof Base) => {
+        base.timeZoneAwareTypes = base.timeZoneAwareTypes.filter((t) => t !== "timestamptz");
+        if (cfg.postgresqlTimeZoneAwareTypes) base.timeZoneAwareTypes.push("timestamptz");
+      });
+    });
+
+    this.initializer("active_record.copy_schema_cache_config", () => {
+      const cfg = this.config["activeRecord"] as ActiveRecordConfig;
+      SchemaReflection.useSchemaCacheDump = cfg.useSchemaCacheDump;
+      SchemaReflection.checkSchemaCacheDumpVersion = cfg.checkSchemaCacheDumpVersion;
+    });
+
+    this.initializer("active_record.sqlite3_adapter_strict_strings_by_default", () => {
+      const cfg = this.config["activeRecord"] as ActiveRecordConfig;
+      SQLite3Adapter.strictStringsByDefault = cfg.sqlite3AdapterStrictStringsByDefault;
+    });
+
+    this.initializer("active_record.postgresql_adapter_decode_dates", () => {
+      const cfg = this.config["activeRecord"] as ActiveRecordConfig;
+      PostgreSQLAdapter.decodeDates = cfg.postgresqlAdapterDecodeDates;
+    });
+
+    this.initializer("active_record_encryption.configuration", () => {
+      const cfg = this.config["activeRecord"] as ActiveRecordConfig;
+      const enc = cfg.encryption;
+      if (enc && Object.keys(enc).length > 0) {
+        EncryptionConfigurable.configure(
+          enc as Parameters<typeof EncryptionConfigurable.configure>[0],
+        );
+      }
     });
   }
 }

--- a/packages/activerecord/src/trailtie.ts
+++ b/packages/activerecord/src/trailtie.ts
@@ -28,8 +28,8 @@ import { onLoad, Railtie as BaseRailtie, registerRailtie } from "@blazetrails/ac
 import { Base } from "./base.js";
 import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
 import { SchemaReflection } from "./connection-adapters/schema-cache.js";
-import { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
-import { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
+import type { SQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
+import type { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter.js";
 import { deprecator } from "./deprecator.js";
 import {
   processAction,
@@ -55,9 +55,16 @@ export interface ActiveRecordConfig {
   checkSchemaCacheDumpVersion: boolean;
   maintainTestSchema: boolean;
   hasManyInversing: boolean;
-  postgresqlTimeZoneAwareTypes: boolean;
-  sqlite3AdapterStrictStringsByDefault: boolean;
-  postgresqlAdapterDecodeDates: boolean;
+  /**
+   * Rails 8 opt-in flag (`config.active_record.sqlite3_adapter_strict_strings_by_default`).
+   * Defaults to nil in Rails — only assigned to the adapter when truthy.
+   */
+  sqlite3AdapterStrictStringsByDefault?: boolean;
+  /**
+   * Rails opt-in flag (`config.active_record.postgresql_adapter_decode_dates`).
+   * Defaults to nil in Rails — only assigned to the adapter when truthy.
+   */
+  postgresqlAdapterDecodeDates?: boolean;
   queryLogTagsEnabled: boolean;
   queryLogTags: string[];
   queryLogTagsFormat: "legacy" | "sqlcommenter";
@@ -75,9 +82,6 @@ function defaultActiveRecordConfig(): ActiveRecordConfig {
     checkSchemaCacheDumpVersion: true,
     maintainTestSchema: true,
     hasManyInversing: false,
-    postgresqlTimeZoneAwareTypes: true,
-    sqlite3AdapterStrictStringsByDefault: false,
-    postgresqlAdapterDecodeDates: false,
     queryLogTagsEnabled: false,
     queryLogTags: ["application"],
     queryLogTagsFormat: "legacy",
@@ -107,12 +111,19 @@ export class Trailtie extends BaseRailtie {
     });
 
     this.initializer("active_record.postgresql_time_zone_aware_types", () => {
-      // Rails: removes then conditionally re-adds `:timestamptz` so the
-      // initializer is idempotent under repeated `runInitializers` calls.
-      const cfg = this.config["activeRecord"] as ActiveRecordConfig;
-      onLoad("active_record", (base: typeof Base) => {
-        base.timeZoneAwareTypes = base.timeZoneAwareTypes.filter((t) => t !== "timestamptz");
-        if (cfg.postgresqlTimeZoneAwareTypes) base.timeZoneAwareTypes.push("timestamptz");
+      // Rails (railtie.rb:89-95):
+      //   on_load(:active_record_postgresqladapter) do
+      //     on_load(:active_record) { Base.time_zone_aware_types << :timestamptz }
+      //   end
+      // No config gate — Rails pushes unconditionally when the PG adapter is
+      // loaded. We add an `includes` check so multiple `runInitializers`
+      // calls in tests stay idempotent (Rails' `<<` would duplicate).
+      onLoad("active_record_postgresqladapter", () => {
+        onLoad("active_record", (base: typeof Base) => {
+          if (!base.timeZoneAwareTypes.includes("timestamptz")) {
+            base.timeZoneAwareTypes.push("timestamptz");
+          }
+        });
       });
     });
 
@@ -123,16 +134,36 @@ export class Trailtie extends BaseRailtie {
     });
 
     this.initializer("active_record.sqlite3_adapter_strict_strings_by_default", () => {
+      // Rails: only sets to `true` when the flag is true (no-op otherwise),
+      // gated on `on_load(:active_record_sqlite3adapter)`.
       const cfg = this.config["activeRecord"] as ActiveRecordConfig;
-      SQLite3Adapter.strictStringsByDefault = cfg.sqlite3AdapterStrictStringsByDefault;
+      if (cfg.sqlite3AdapterStrictStringsByDefault) {
+        onLoad("active_record_sqlite3adapter", (adapter: typeof SQLite3Adapter) => {
+          adapter.strictStringsByDefault = true;
+        });
+      }
     });
 
     this.initializer("active_record.postgresql_adapter_decode_dates", () => {
+      // Rails: only sets to `true` when the flag is true (no-op otherwise),
+      // gated on `on_load(:active_record_postgresqladapter)`.
       const cfg = this.config["activeRecord"] as ActiveRecordConfig;
-      PostgreSQLAdapter.decodeDates = cfg.postgresqlAdapterDecodeDates;
+      if (cfg.postgresqlAdapterDecodeDates) {
+        onLoad("active_record_postgresqladapter", (adapter: typeof PostgreSQLAdapter) => {
+          adapter.decodeDates = true;
+        });
+      }
     });
 
     this.initializer("active_record_encryption.configuration", () => {
+      // Rails (railtie.rb:336-363) also reads app.credentials and registers
+      // AutoFilteredParameters / ExtendedDeterministicQueries / EncryptedFixtures.
+      // Credentials wiring needs the Application instance (deferred), and
+      // the load events `:active_record_encryption` / `:active_record_fixture_set`
+      // aren't yet emitted by their respective modules. For now we forward
+      // `config.activeRecord.encryption` to Encryption.Configurable.configure
+      // which is the single behavior-load-bearing piece (Encryption.config
+      // is what runtime callsites read).
       const cfg = this.config["activeRecord"] as ActiveRecordConfig;
       const enc = cfg.encryption;
       if (enc && Object.keys(enc).length > 0) {


### PR DESCRIPTION
## Summary

Wires six additional `ActiveRecord::Railtie` initializers from the Rails `railtie.rb` chain — those that consume only `config.activeRecord.*` and don't require an Application-instance argument to the initializer block (the current `BaseRailtie.initializer` block takes no args).

**Newly wired:**
- `active_record.postgresql_time_zone_aware_types` — pushes `"timestamptz"` onto `Base.timeZoneAwareTypes` via nested `onLoad("active_record_postgresqladapter")` → `onLoad("active_record")` (matches Rails — no config gate; unconditional on PG adapter load)
- `active_record.copy_schema_cache_config` — copies `useSchemaCacheDump` + `checkSchemaCacheDumpVersion` onto `SchemaReflection`
- `active_record.sqlite3_adapter_strict_strings_by_default` — assigns `SQLite3Adapter.strictStringsByDefault = true` only when the flag is truthy, gated on `onLoad("active_record_sqlite3adapter")`
- `active_record.postgresql_adapter_decode_dates` — assigns `PostgreSQLAdapter.decodeDates = true` only when the flag is truthy, gated on `onLoad("active_record_postgresqladapter")`
- `active_record_encryption.configuration` — forwards `config.activeRecord.encryption` to `Encryption.Configurable.configure`
- `active_record.initialize_timezone` — converted from eager `Base.timeZoneAwareAttributes = true` to `onLoad("active_record")` consumer

Also fires `runLoadHooks("active_record", Base)` at the bottom of `base.ts`, `runLoadHooks("active_record_postgresqladapter", PostgreSQLAdapter)` in `postgresql-adapter.ts`, and `runLoadHooks("active_record_sqlite3adapter", SQLite3Adapter)` in `sqlite3-adapter.ts` (mirrors the Rails `run_load_hooks` calls at the bottom of `base.rb` / `postgresql_adapter.rb` / `sqlite3_adapter.rb`) so the on_load consumers receive their respective bases.

New config slots: `sqlite3AdapterStrictStringsByDefault?`, `postgresqlAdapterDecodeDates?` (both optional, default-nil per Rails).

## Deferred (still in PR 2.7-followups)

These all need either an Application-instance argument or unported Trails infrastructure:

- `active_record.logger`, `active_record.backtrace_cleaner` — need `Trails.logger` / `Trails.backtraceCleaner`.
- `active_record.set_filter_attributes` — needs `Application.config.filterParameters` accessible from the initializer block.
- `active_record.set_signed_id_verifier_secret` — needs `Application#secretKeyBase`.
- `active_record.clear_active_connections` — needs `after_initialize` hook support.
- `active_record.log_runtime`, `active_record.query_log_tags_config`, `active_record.set_configs`.

Migrating to the `@blazetrails/trailties` `Trailtie` base class (which carries the Application-aware initializer API) is tracked separately under "Cross-package cleanup" in the plan doc and unblocks most of these. Header comment in `trailtie.ts` enumerates the remaining gaps.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/trailtie.test.ts` — 10/10 pass (4 original + 6 new)
- [x] api:compare delta = 0 (4955/4958 = 99.9% in both baseline and after)
- [ ] CI green