### PR TITLE
feat(trailties): Trailtie Configurable + block runners + lifecycle hooks (PR 2.1b)

### DIFF
--- a/packages/trailties/src/engine.ts
+++ b/packages/trailties/src/engine.ts
@@ -6,9 +6,7 @@ import { Root } from "./paths.js";
 import { Trailtie } from "./trailtie.js";
 import { Trailties } from "./engine/trailties.js";
 import { EngineConfiguration } from "./engine/configuration.js";
-
-type EngineHost = { _calledFrom?: string; _isolated?: boolean };
-const host = (k: typeof Engine): EngineHost => k as unknown as EngineHost;
+import { readOwnState, writeOwnState } from "./trailtie/per-class-state.js";
 
 export class Engine extends Trailtie {
   private _railtiesCollection?: Trailties;
@@ -16,12 +14,12 @@ export class Engine extends Trailtie {
   private _routes?: unknown;
 
   static calledFrom(value?: string): string | undefined {
-    if (value !== undefined) host(this)._calledFrom = value;
-    return host(this)._calledFrom;
+    if (value !== undefined) writeOwnState(this, "_calledFrom", value);
+    return readOwnState<string>(this, "_calledFrom");
   }
   static isolated(value?: boolean): boolean {
-    if (value !== undefined) host(this)._isolated = value;
-    return host(this)._isolated === true;
+    if (value !== undefined) writeOwnState(this, "_isolated", value);
+    return readOwnState<boolean>(this, "_isolated") === true;
   }
 
   /** Mirrors Rails' `alias :engine_name :railtie_name`. */

--- a/packages/trailties/src/trailtie.test.ts
+++ b/packages/trailties/src/trailtie.test.ts
@@ -123,6 +123,14 @@ describe("Trailtie", () => {
     });
   }
 
+  it("Configurable seal sees through an anonymous intermediate class", () => {
+    class AnonSealed extends Trailtie {}
+    sealAgainstInheritance(AnonSealed);
+    const Anon = class extends AnonSealed {};
+    class Grand extends Anon {}
+    expect(() => Trailtie.register(Grand)).toThrow(/cannot inherit from a AnonSealed/);
+  });
+
   it("Configurable seals a class — single and multi-level inheritance", () => {
     class SealedTie extends Trailtie {}
     sealAgainstInheritance(SealedTie);

--- a/packages/trailties/src/trailtie.test.ts
+++ b/packages/trailties/src/trailtie.test.ts
@@ -77,6 +77,12 @@ describe("Trailtie", () => {
     expect(ran).toContain("child_tie");
   });
 
+  const RUNNERS = {
+    generators: "runGeneratorsBlocks",
+    console: "runConsoleBlocks",
+    server: "runServerBlocks",
+    runner: "runRunnerBlocks",
+  } as const;
   for (const kind of ["generators", "console", "server", "runner"] as const) {
     it(`${kind} block is executed when MyApp.load_${kind} is called`, () => {
       let ran = false;
@@ -85,32 +91,46 @@ describe("Trailtie", () => {
       T[kind](() => {
         ran = true;
       });
-      const runner = {
-        generators: "runGeneratorsBlocks",
-        console: "runConsoleBlocks",
-        server: "runServerBlocks",
-        runner: "runRunnerBlocks",
-      }[kind] as keyof Trailtie;
-      (T.instance()[runner] as (a: unknown) => void).call(T.instance(), {});
+      (T.instance()[RUNNERS[kind]] as (a: unknown) => void).call(T.instance(), {});
       expect(ran).toBe(true);
     });
   }
 
-  it("Configuration lifecycle hooks register and run", () => {
-    const order: string[] = [];
-    new Configuration().beforeInitialize(() => order.push("before"));
-    new Configuration().afterInitialize(() => order.push("after"));
-    Configuration.runHook("beforeInitialize");
-    Configuration.runHook("afterInitialize");
-    expect(order).toContain("before");
-    expect(order).toContain("after");
+  it("non-rake block defined in superclass of railtie is also executed", () => {
+    const ran: string[] = [];
+    class P extends Trailtie {}
+    Trailtie.register(P);
+    P.console(() => ran.push("p"));
+    class C extends P {}
+    Trailtie.register(C);
+    C.instance().runConsoleBlocks({});
+    expect(ran).toEqual(["p"]);
   });
 
-  it("Configurable seals a class against further subclassing", () => {
+  const HOOKS = [
+    "beforeConfiguration",
+    "beforeInitialize",
+    "beforeEagerLoad",
+    "afterInitialize",
+    "afterRoutesLoaded",
+  ] as const;
+  for (const hook of HOOKS) {
+    it(`Configuration#${hook} block runs when ${hook} hook fires`, () => {
+      const seen: unknown[] = [];
+      new Configuration()[hook]((arg) => seen.push(arg));
+      Configuration.runHook(hook, "marker");
+      expect(seen).toContain("marker");
+    });
+  }
+
+  it("Configurable seals a class — single and multi-level inheritance", () => {
     class SealedTie extends Trailtie {}
     sealAgainstInheritance(SealedTie);
-    class ShouldFail extends SealedTie {}
-    expect(() => Trailtie.register(ShouldFail)).toThrow(/cannot inherit from a SealedTie/);
+    class Direct extends SealedTie {}
+    class Mid extends SealedTie {}
+    class Deep extends Mid {}
+    expect(() => Trailtie.register(Direct)).toThrow(/cannot inherit from a SealedTie/);
+    expect(() => Trailtie.register(Deep)).toThrow(/cannot inherit from a SealedTie/);
   });
 
   it("returns registered subclasses sorted by load order, excluding abstract entries", () => {

--- a/packages/trailties/src/trailtie.test.ts
+++ b/packages/trailties/src/trailtie.test.ts
@@ -3,6 +3,7 @@
 import { describe, it, expect } from "vitest";
 import { Trailtie } from "./trailtie.js";
 import { Configuration } from "./trailtie/configuration.js";
+import { sealAgainstInheritance } from "./trailtie/configurable.js";
 
 describe("Trailtie", () => {
   it("cannot instantiate a Railtie object", () => {
@@ -48,6 +49,68 @@ describe("Trailtie", () => {
     });
     InitTrailtie.instance().runInitializers();
     expect(calls).toEqual(["one"]);
+  });
+
+  it("rake_tasks block is executed when MyApp.load_tasks is called", () => {
+    let ran = false;
+    class TaskTie extends Trailtie {}
+    Trailtie.register(TaskTie);
+    TaskTie.rakeTasks(() => {
+      ran = true;
+    });
+    expect(ran).toBe(false);
+    TaskTie.instance().runTasksBlocks({});
+    expect(ran).toBe(true);
+  });
+
+  it("rake_tasks block defined in superclass of railtie is also executed", () => {
+    const ran: string[] = [];
+    class ParentTie extends Trailtie {}
+    Trailtie.register(ParentTie);
+    ParentTie.rakeTasks(function () {
+      ran.push(this.railtieName);
+    });
+    class ChildTie extends ParentTie {}
+    Trailtie.register(ChildTie);
+    ChildTie.railtieName("child_tie");
+    ChildTie.instance().runTasksBlocks({});
+    expect(ran).toContain("child_tie");
+  });
+
+  for (const kind of ["generators", "console", "server", "runner"] as const) {
+    it(`${kind} block is executed when MyApp.load_${kind} is called`, () => {
+      let ran = false;
+      class T extends Trailtie {}
+      Trailtie.register(T);
+      T[kind](() => {
+        ran = true;
+      });
+      const runner = {
+        generators: "runGeneratorsBlocks",
+        console: "runConsoleBlocks",
+        server: "runServerBlocks",
+        runner: "runRunnerBlocks",
+      }[kind] as keyof Trailtie;
+      (T.instance()[runner] as (a: unknown) => void).call(T.instance(), {});
+      expect(ran).toBe(true);
+    });
+  }
+
+  it("Configuration lifecycle hooks register and run", () => {
+    const order: string[] = [];
+    new Configuration().beforeInitialize(() => order.push("before"));
+    new Configuration().afterInitialize(() => order.push("after"));
+    Configuration.runHook("beforeInitialize");
+    Configuration.runHook("afterInitialize");
+    expect(order).toContain("before");
+    expect(order).toContain("after");
+  });
+
+  it("Configurable seals a class against further subclassing", () => {
+    class SealedTie extends Trailtie {}
+    sealAgainstInheritance(SealedTie);
+    class ShouldFail extends SealedTie {}
+    expect(() => Trailtie.register(ShouldFail)).toThrow(/cannot inherit from a SealedTie/);
   });
 
   it("returns registered subclasses sorted by load order, excluding abstract entries", () => {

--- a/packages/trailties/src/trailtie.ts
+++ b/packages/trailties/src/trailtie.ts
@@ -1,21 +1,20 @@
 /**
- * Port of `Rails::Railtie` from `railties/lib/rails/railtie.rb`.
- * Subclasses opt in to the registry explicitly via `Trailtie.register(...)`
- * — there is no `inherited` hook in TS. The block runners
- * (rakeTasks/console/runner/generators/server) and the `Configurable`
- * mixin land in PR 2.1b.
+ * Port of `Rails::Railtie` from `railties/lib/rails/railtie.rb`. Subclasses
+ * opt in to the registry via `Trailtie.register(...)` — no `inherited`
+ * hook. Block runners (`rakeTasks`/`console`/`runner`/`generators`/
+ * `server`) walk ancestors like Rails' `each_registered_block`.
  */
 import { underscore } from "@blazetrails/activesupport";
 import { Initializable } from "./initializable.js";
 import { Configuration } from "./trailtie/configuration.js";
+import { ownState, readOwnState, writeOwnState } from "./trailtie/per-class-state.js";
+import { assertNotSealed } from "./trailtie/configurable.js";
 
 export const ABSTRACT_RAILTIES = ["Trailtie", "Engine", "Application"] as const;
-
-type Host = { _loadIndex?: number; _railtieName?: string; _instance?: Trailtie };
-
-/** @internal Module-wide load counter shared across subclasses. */
 let loadCounter = 0;
-const host = (k: typeof Trailtie): Host => k as unknown as Host;
+
+export type BlockRunnerKind = "rakeTasks" | "console" | "runner" | "generators" | "server";
+export type TrailtieBlock = (this: Trailtie, app: unknown) => void;
 
 export class Trailtie extends Initializable {
   /** @internal */
@@ -35,14 +34,19 @@ export class Trailtie extends Initializable {
   static subclasses(): Array<typeof Trailtie> {
     return [...Trailtie._registry]
       .filter((s) => !s.isAbstractRailtie())
-      .sort((a, b) => (host(a)._loadIndex ?? 0) - (host(b)._loadIndex ?? 0));
+      .sort(
+        (a, b) =>
+          (readOwnState<number>(a, "_loadIndex") ?? 0) -
+          (readOwnState<number>(b, "_loadIndex") ?? 0),
+      );
   }
 
   /** Explicit subclass registration — replaces Rails' `inherited` hook. */
   static register(subclass: typeof Trailtie): void {
     if (Trailtie._registry.includes(subclass)) return;
-    if (!Object.prototype.hasOwnProperty.call(subclass, "_loadIndex")) {
-      host(subclass)._loadIndex = ++loadCounter;
+    assertNotSealed(subclass);
+    if (readOwnState<number>(subclass, "_loadIndex") === undefined) {
+      writeOwnState(subclass, "_loadIndex", ++loadCounter);
     }
     Trailtie._registry.push(subclass);
   }
@@ -53,21 +57,18 @@ export class Trailtie extends Initializable {
 
   /** Set or get the short railtie name (defaults to underscored class name). */
   static railtieName(name?: string): string {
-    const h = host(this);
-    if (name !== undefined) h._railtieName = name;
-    if (!Object.prototype.hasOwnProperty.call(this, "_railtieName") || !h._railtieName) {
-      h._railtieName = underscore(this.name).replace(/\//g, "_");
+    if (name !== undefined) writeOwnState(this, "_railtieName", name);
+    let existing = readOwnState<string>(this, "_railtieName");
+    if (!existing) {
+      existing = underscore(this.name).replace(/\//g, "_");
+      writeOwnState(this, "_railtieName", existing);
     }
-    return h._railtieName;
+    return existing;
   }
 
   /** Lazily-created per-class singleton. */
   static instance<T extends typeof Trailtie>(this: T): InstanceType<T> {
-    const h = host(this) as { _instance?: InstanceType<T> };
-    if (!Object.prototype.hasOwnProperty.call(this, "_instance") || !h._instance) {
-      h._instance = new (this as unknown as new () => InstanceType<T>)();
-    }
-    return h._instance;
+    return ownState(this, "_instance", () => new (this as unknown as new () => InstanceType<T>)());
   }
 
   static get config(): Configuration {
@@ -76,6 +77,27 @@ export class Trailtie extends Initializable {
 
   static configure(block: (this: Trailtie) => void): void {
     (this as typeof Trailtie).instance().configure(block);
+  }
+
+  static rakeTasks(block: TrailtieBlock): void {
+    registerBlockFor(this, "rakeTasks", block);
+  }
+  static console(block: TrailtieBlock): void {
+    registerBlockFor(this, "console", block);
+  }
+  static runner(block: TrailtieBlock): void {
+    registerBlockFor(this, "runner", block);
+  }
+  static generators(block: TrailtieBlock): void {
+    registerBlockFor(this, "generators", block);
+  }
+  static server(block: TrailtieBlock): void {
+    registerBlockFor(this, "server", block);
+  }
+
+  /** @internal Read the blocks registered directly on `klass` for `kind`. */
+  static registeredBlocksFor(kind: BlockRunnerKind): TrailtieBlock[] {
+    return readOwnState<TrailtieBlock[]>(this, blockKey(kind)) ?? [];
   }
 
   get config(): Configuration {
@@ -93,5 +115,45 @@ export class Trailtie extends Initializable {
 
   inspect(): string {
     return `#<${this.constructor.name}>`;
+  }
+
+  runConsoleBlocks(app: unknown): void {
+    eachRegisteredBlock(this, "console", (b) => b.call(this, app));
+  }
+  runGeneratorsBlocks(app: unknown): void {
+    eachRegisteredBlock(this, "generators", (b) => b.call(this, app));
+  }
+  runRunnerBlocks(app: unknown): void {
+    eachRegisteredBlock(this, "runner", (b) => b.call(this, app));
+  }
+  runTasksBlocks(app: unknown): void {
+    eachRegisteredBlock(this, "rakeTasks", (b) => b.call(this, app));
+  }
+  runServerBlocks(app: unknown): void {
+    eachRegisteredBlock(this, "server", (b) => b.call(this, app));
+  }
+}
+
+function blockKey(kind: BlockRunnerKind): string {
+  return `_blocks_${kind}`;
+}
+
+function registerBlockFor(
+  klass: typeof Trailtie,
+  kind: BlockRunnerKind,
+  block: TrailtieBlock,
+): void {
+  ownState(klass, blockKey(kind), () => [] as TrailtieBlock[]).push(block);
+}
+
+function eachRegisteredBlock(
+  instance: Trailtie,
+  kind: BlockRunnerKind,
+  fn: (b: TrailtieBlock) => void,
+): void {
+  let klass: typeof Trailtie | null = instance.constructor as typeof Trailtie;
+  while (klass && "registeredBlocksFor" in klass) {
+    for (const block of klass.registeredBlocksFor(kind)) fn(block);
+    klass = Object.getPrototypeOf(klass) as typeof Trailtie | null;
   }
 }

--- a/packages/trailties/src/trailtie/configurable.ts
+++ b/packages/trailties/src/trailtie/configurable.ts
@@ -15,10 +15,12 @@ export function sealAgainstInheritance(klass: typeof Trailtie): void {
   ownState(klass, SEALED_KEY, () => true);
 }
 
-/** @internal Throws if any ancestor of `subclass` is sealed. */
+/** @internal Throws if any ancestor of `subclass` is sealed. Walks every
+ * prototype-chain step (no early termination on anonymous classes — an
+ * anonymous intermediate must not let a sealed grandparent slip past). */
 export function assertNotSealed(subclass: typeof Trailtie): void {
   let parent = Object.getPrototypeOf(subclass) as typeof Trailtie | null;
-  while (parent && parent !== Trailtie && parent.name !== "") {
+  while (parent && parent !== Function.prototype && parent !== Object.prototype) {
     if (readOwnState<boolean>(parent, SEALED_KEY) === true) {
       throw new Error(`You cannot inherit from a ${parent.name} child`);
     }

--- a/packages/trailties/src/trailtie/configurable.ts
+++ b/packages/trailties/src/trailtie/configurable.ts
@@ -1,0 +1,27 @@
+/**
+ * Port of `Rails::Railtie::Configurable` from
+ * `railties/lib/rails/railtie/configurable.rb`. The Rails module's other
+ * roles (delegating `config`, caching `instance`, `method_missing`) are
+ * already provided by `Trailtie` itself; what remains is the
+ * `inherited`-raises sealed-class guard, used by `Application`.
+ */
+import { Trailtie } from "../trailtie.js";
+import { ownState, readOwnState } from "./per-class-state.js";
+
+const SEALED_KEY = "_sealedFromInheritance";
+
+/** Seal `klass` against being a superclass of any future registration. */
+export function sealAgainstInheritance(klass: typeof Trailtie): void {
+  ownState(klass, SEALED_KEY, () => true);
+}
+
+/** @internal Throws if any ancestor of `subclass` is sealed. */
+export function assertNotSealed(subclass: typeof Trailtie): void {
+  let parent = Object.getPrototypeOf(subclass) as typeof Trailtie | null;
+  while (parent && parent !== Trailtie && parent.name !== "") {
+    if (readOwnState<boolean>(parent, SEALED_KEY) === true) {
+      throw new Error(`You cannot inherit from a ${parent.name} child`);
+    }
+    parent = Object.getPrototypeOf(parent) as typeof Trailtie | null;
+  }
+}

--- a/packages/trailties/src/trailtie/configuration.ts
+++ b/packages/trailties/src/trailtie/configuration.ts
@@ -1,11 +1,22 @@
 /**
  * Port of `Rails::Railtie::Configuration` from
  * `railties/lib/rails/railtie/configuration.rb`. Holds the shared config
- * accessed via `Trailtie.config`. This PR ships the base state and the
- * `toPrepare` block list; lifecycle hooks (`beforeConfiguration` etc.)
- * land alongside `Configurable` in the follow-up.
+ * accessed via `Trailtie.config`. Lifecycle hooks are stored on a
+ * class-side registry — Rails routes them through `ActiveSupport.on_load`
+ * with `yield: true`; a direct class-side array matches the observable
+ * behavior without coupling to a hook surface that doesn't expose that
+ * semantic yet.
  */
 export type ConfigurationBlock = (this: unknown, ...args: unknown[]) => void;
+
+const LIFECYCLE_HOOKS = [
+  "beforeConfiguration",
+  "beforeInitialize",
+  "beforeEagerLoad",
+  "afterInitialize",
+  "afterRoutesLoaded",
+] as const;
+export type LifecycleHook = (typeof LIFECYCLE_HOOKS)[number];
 
 export class Configuration {
   /** @internal Rails `@@`-style shared state. */
@@ -16,6 +27,14 @@ export class Configuration {
   static readonly _watchableDirs: Record<string, string[]> = {};
   /** @internal */
   static readonly _toPrepareBlocks: ConfigurationBlock[] = [];
+  /** @internal Per-hook block registries shared across subclasses. */
+  static readonly _lifecycleBlocks: Record<LifecycleHook, ConfigurationBlock[]> = {
+    beforeConfiguration: [],
+    beforeInitialize: [],
+    beforeEagerLoad: [],
+    afterInitialize: [],
+    afterRoutesLoaded: [],
+  };
 
   private readonly _options: Record<string, unknown> = {};
 
@@ -36,11 +55,46 @@ export class Configuration {
     if (block) Configuration._toPrepareBlocks.push(block);
   }
 
-  /** Read the free-form option bag (mirrors Ruby `method_missing` getter). */
+  beforeConfiguration(block: ConfigurationBlock): void {
+    Configuration._lifecycleBlocks.beforeConfiguration.push(block);
+  }
+  beforeInitialize(block: ConfigurationBlock): void {
+    Configuration._lifecycleBlocks.beforeInitialize.push(block);
+  }
+  beforeEagerLoad(block: ConfigurationBlock): void {
+    Configuration._lifecycleBlocks.beforeEagerLoad.push(block);
+  }
+  afterInitialize(block: ConfigurationBlock): void {
+    Configuration._lifecycleBlocks.afterInitialize.push(block);
+  }
+  afterRoutesLoaded(block: ConfigurationBlock): void {
+    Configuration._lifecycleBlocks.afterRoutesLoaded.push(block);
+  }
+
+  /** @internal Run every block registered for `hook` with `args`. */
+  static runHook(hook: LifecycleHook, ...args: unknown[]): void {
+    for (const block of Configuration._lifecycleBlocks[hook]) block(...args);
+  }
+
+  /** @internal All lifecycle hook names, in Rails' documented order. */
+  static lifecycleHooks(): readonly LifecycleHook[] {
+    return LIFECYCLE_HOOKS;
+  }
+
+  /** Stubs for `Configuration#appMiddleware` / `appGenerators` — wired
+   * when actionpack ships `MiddlewareStackProxy` and the generators
+   * config surface lands. Returning `undefined` keeps the gap loud. */
+  appMiddleware(): undefined {
+    return undefined;
+  }
+  appGenerators(): undefined {
+    return undefined;
+  }
+
+  /** Free-form option bag (mirrors Ruby `method_missing` get/set). */
   get(key: string): unknown {
     return this._options[key];
   }
-  /** Write the free-form option bag (mirrors Ruby `method_missing` setter). */
   set(key: string, value: unknown): void {
     this._options[key] = value;
   }

--- a/packages/trailties/src/trailtie/per-class-state.ts
+++ b/packages/trailties/src/trailtie/per-class-state.ts
@@ -1,0 +1,22 @@
+/**
+ * @internal Per-class own-state helper. Mirrors Ruby `@ivar` semantics on
+ * a class object: each subclass has its own value, never inherited via
+ * the prototype chain. Replaces the duplicated `host = (k) => k as
+ * unknown as Host` cast in `trailtie.ts` and `engine.ts`.
+ */
+export function ownState<T>(klass: object, key: string, factory: () => T): T {
+  const bag = klass as Record<string, unknown>;
+  if (!Object.prototype.hasOwnProperty.call(bag, key)) bag[key] = factory();
+  return bag[key] as T;
+}
+
+/** @internal Read own-state without initializing. */
+export function readOwnState<T>(klass: object, key: string): T | undefined {
+  const bag = klass as Record<string, unknown>;
+  return Object.prototype.hasOwnProperty.call(bag, key) ? (bag[key] as T) : undefined;
+}
+
+/** @internal Write own-state. */
+export function writeOwnState(klass: object, key: string, value: unknown): void {
+  (klass as Record<string, unknown>)[key] = value;
+}


### PR DESCRIPTION
## Summary

Implements the deferred pieces from PR 2.1 per `docs/trailties-plan.md` PR 2.1b:

- **`Configurable` sealed-class guard** (`packages/trailties/src/trailtie/configurable.ts`, recreated). `sealAgainstInheritance(klass)` marks a class; `Trailtie.register(sub)` walks the prototype chain and throws if any ancestor is sealed (mirrors Rails' `inherited` raise).
- **Framework block runners** — `Trailtie.rakeTasks` / `console` / `runner` / `generators` / `server` register class-side block lists; `runTasksBlocks(app)` / `runConsoleBlocks(app)` / etc. walk the prototype chain to invoke every ancestor's registered blocks (Rails' `each_registered_block`).
- **`Configuration` lifecycle hooks** — `beforeConfiguration` / `beforeInitialize` / `beforeEagerLoad` / `afterInitialize` / `afterRoutesLoaded` backed by a class-side `_lifecycleBlocks` registry + `Configuration.runHook(name, ...args)` (called by Application bootstrap once those phases are wired downstream).
- **`Configuration.appMiddleware` / `appGenerators` stubs** return `undefined` until actionpack `MiddlewareStackProxy` and the generators config surface land.
- **`_perClassState` extraction** — `ownState` / `readOwnState` / `writeOwnState` in `trailtie/per-class-state.ts` replace the duplicated `host = (k) => k as unknown as Host` cast in `trailtie.ts` and `engine.ts` (third call site = block-runner registries).

Test names from `vendor/rails/railties/test/railties/railtie_test.rb` are preserved verbatim.

## Test plan

- [x] `pnpm vitest run packages/trailties/src/trailtie.test.ts` — 15 pass
- [x] `pnpm vitest run packages/trailties` — 673 pass, 74 skipped, 0 fail
- [x] `pnpm typecheck` — only pre-existing errors in `trailties/active-support.ts` and `welcome-controller.ts` (unrelated)
- [x] LOC under ceiling (296 add+del excluding lockfiles)

## Follow-ups

- `Configuration.runHook` is exercised by tests but not yet called from `Application` bootstrap — wiring lands in PR 2.5c alongside the `Finisher.initializersFor` splice (already tracked in plan).
- `appMiddleware` / `appGenerators` stubs to be replaced once actionpack `MiddlewareStackProxy` ships (see PR 2.1b scope item (d)).
- `Engine#config` cast smell (per #2174) noted in plan as bundle-with-`_perClassState` — left as a follow-up to keep this PR under the ceiling.