### PR TITLE
revert: PR #2236 (sidecar rename + warm schema cache) — unbreak PG/SQLite

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -23,7 +23,7 @@ import type { TransactionManager } from "./connection-adapters/abstract/transact
 import type { SchemaCache } from "./connection-adapters/schema-cache.js";
 import { clearAppliedSchemaSignatures } from "./test-helpers/define-schema.js";
 import { dropAllTables } from "./test-helpers/drop-all-tables.js";
-import { TestFixtures } from "./test-helpers/test-fixtures.js";
+import { SidecarFixtures } from "./test-helpers/sidecar-fixtures.js";
 import {
   clearDdlTrackers,
   getCreatedTables,
@@ -41,7 +41,7 @@ import type { Result } from "./result.js";
 const PG_TEST_URL = process.env.PG_TEST_URL;
 const MYSQL_TEST_URL = process.env.MYSQL_TEST_URL;
 
-export { TestFixtures };
+export { SidecarFixtures };
 
 /** Which adapter backend is active. */
 export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL
@@ -130,7 +130,7 @@ export type SidecarAdapter = DatabaseAdapter & { transactionManager: Transaction
 
 /**
  * Path 2 sidecar factory: returns the shared real {@link DatabaseAdapter}
- * directly alongside a fresh {@link TestFixtures} handle. Use this
+ * directly alongside a fresh {@link SidecarFixtures} handle. Use this
  * when migrating off the `TestAdapterFixtures` wrapper — callers can
  * issue DB ops on `adapter` directly (no delegation overhead) and use
  * `fixtures` for the test-only TX visibility / DDL tracking concerns.
@@ -142,9 +142,9 @@ export type SidecarAdapter = DatabaseAdapter & { transactionManager: Transaction
  */
 export function createSidecarTestAdapter(): {
   adapter: SidecarAdapter;
-  fixtures: TestFixtures;
+  fixtures: SidecarFixtures;
 } {
-  return { adapter: _sharedAdapter, fixtures: new TestFixtures(_sharedAdapter) };
+  return { adapter: _sharedAdapter, fixtures: new SidecarFixtures(_sharedAdapter) };
 }
 
 /**

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -417,36 +417,5 @@ export async function defineSchema(
       }
     });
     cache.set(table, newSig);
-    invalidateSchemaCacheFor(adapter, table);
   }
-}
-
-/**
- * Drop any cached schema entries for `table` so the next
- * `columnForAttribute()` / `columnsHash()` lazy-loads against the freshly
- * created table. Without this, a prior `defineSchema` (or any earlier
- * introspection of a same-named table) can leave `_columns` /
- * `_columnsHash` populated; the cache then returns stale data when callers
- * read it — and on PG, `caseInsensitiveComparison` silently drops the
- * `LOWER()` wrap when `columnsHash` returns a column it can't recognize.
- *
- * Mirrors Rails' `clear_data_source_cache!(connection, name)` shape
- * (SchemaCache#clear_data_source_cache! in `schema_cache.rb`), used here
- * for the same reason: when DDL changes a table out from under the cache.
- *
- * Skips quietly when the adapter doesn't expose a schema cache (raw
- * connections in low-level adapter tests).
- *
- * @internal
- */
-function invalidateSchemaCacheFor(adapter: DatabaseAdapter, table: string): void {
-  const sc = (
-    adapter as {
-      schemaCache?: {
-        clearDataSourceCacheBang?(connection: unknown, name: string): void;
-      };
-    }
-  ).schemaCache;
-  const pool = (adapter as { pool?: unknown }).pool ?? adapter;
-  sc?.clearDataSourceCacheBang?.(pool, table);
 }

--- a/packages/activerecord/src/test-helpers/sidecar-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/sidecar-fixtures.test.ts
@@ -6,7 +6,7 @@ describe("createSidecarTestAdapter (path 2 sidecar)", () => {
     await resetTestAdapterState();
   });
 
-  it("returns the real adapter and a fresh TestFixtures handle", () => {
+  it("returns the real adapter and a fresh SidecarFixtures handle", () => {
     const { adapter, fixtures } = createSidecarTestAdapter();
     expect(typeof adapter.adapterName).toBe("string");
     expect(fixtures.adapter).toBe(adapter);

--- a/packages/activerecord/src/test-helpers/sidecar-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/sidecar-fixtures.ts
@@ -1,18 +1,19 @@
 /**
- * Test-only fixtures handle for path 2 of the test-adapter cleanup.
+ * Sidecar fixtures handle for path 2 of the test-adapter cleanup.
  *
- * Named after `ActiveRecord::TestFixtures` in Rails — same role (test-only
- * connection state paired with a real adapter), different mechanics. Rails
- * mixes it into test cases as a module; trails carries it as a class until
- * the connection-pool epic lets each test pin its own connection. At that
- * point the three concerns this class holds (async-chain TX visibility,
- * manual TX depth tracking, DDL tracking for `defineSchema` cache
- * invalidation) all retire and this wrapper deletes.
+ * Path 2 splits the historical `TestAdapterFixtures` wrapper into two pieces:
+ *   - The real {@link DatabaseAdapter} (used directly by callers for DB ops)
+ *   - A {@link SidecarFixtures} handle holding the three load-bearing
+ *     test-only concerns: async-chain TX visibility, manual TX depth
+ *     tracking, and CREATE/DROP TABLE recording for `defineSchema` cache
+ *     invalidation.
  *
- * Unlike the legacy `TestAdapterFixtures` Proxy, this is NOT a delegating
- * wrapper over the full {@link DatabaseAdapter} surface. Production DB
- * operations go straight to the real adapter; only fixture-aware code
- * touches this handle.
+ * This file is additive — the existing wrapper in `test-adapter.ts` is
+ * untouched. Sub-PR (b) migrates callers; sub-PR (c) deletes the wrapper.
+ *
+ * Unlike the wrapper, this is NOT a Proxy and does not delegate the full
+ * {@link DatabaseAdapter} surface. Production DB operations go straight to
+ * the real adapter; only fixture-aware code touches this handle.
  *
  * @internal
  */
@@ -62,7 +63,7 @@ const DROP_TABLE_RE = /DROP\s+TABLE(?:\s+IF\s+EXISTS)?\s+(?:["`](\w+)["`]|(\w+))
  *
  * @internal
  */
-export class TestFixtures {
+export class SidecarFixtures {
   /** The real database adapter this handle is tracking. */
   readonly adapter: DatabaseAdapter;
   private _manualTxDepth = 0;
@@ -73,11 +74,11 @@ export class TestFixtures {
 
   /**
    * True when this caller should see the inner adapter's transaction state.
-   * Either *some* TestFixtures' `withinNewTransaction` set the flag on
+   * Either *some* SidecarFixtures' `withinNewTransaction` set the flag on
    * this async chain, or the caller manually opened a transaction on this
    * specific handle.
    *
-   * The async-chain flag is shared across all TestFixtures instances
+   * The async-chain flag is shared across all SidecarFixtures instances
    * by design — matches the wrapper in `test-adapter.ts` (sub-PR (a) is
    * additive-only). Because `createSidecarTestAdapter()` returns a fresh
    * handle wrapping the *same* shared inner adapter, the underlying

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -6,7 +6,7 @@ import { describe, it, expect } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "../index.js";
 
-import { createSidecarTestAdapter } from "../test-adapter.js";
+import { createTestAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
@@ -32,7 +32,7 @@ const CLUSTER_A_SCHEMA = {
 } as const;
 
 async function freshAdapterA(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, CLUSTER_A_SCHEMA);
   return adapter;
 }
@@ -643,7 +643,7 @@ describe("UniquenessValidationTest", () => {
 });
 
 async function freshAdapterIndex(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     posts: {
       title: "string",
@@ -870,7 +870,7 @@ describe("UniquenessValidationWithIndexTest", () => {
 });
 
 async function freshAdapterCompositeOrders(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     orders: {
       shop_id: "integer",
@@ -896,7 +896,7 @@ async function freshAdapterCompositeOrders(): Promise<DatabaseAdapter> {
 }
 
 async function freshAdapterCompositeOrders2(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     orders: { shop_id: "string", code: "string" },
   });
@@ -1539,7 +1539,7 @@ describe("UniquenessWithCompositeKey", () => {
 
 describe("UniquenessWithCompositeKey", () => {
   it("uniqueness validation for model with composite key duplicate check", async () => {
-    const { adapter: adp } = createSidecarTestAdapter();
+    const adp = createTestAdapter();
     await defineSchema(adp, { entries: { group_id: "integer", seq: "integer" } });
     class Entry extends Base {
       static {
@@ -1556,7 +1556,7 @@ describe("UniquenessWithCompositeKey", () => {
 });
 
 async function freshAdapterBindParams(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     tokens: {
       columns: { token: "string", label: "string" },
@@ -1636,7 +1636,7 @@ describe("UniquenessBindParamsTest", () => {
 });
 
 async function freshAdapterValidation2(): Promise<DatabaseAdapter> {
-  const { adapter } = createSidecarTestAdapter();
+  const adapter = createTestAdapter();
   await defineSchema(adapter, {
     emails: { address: "string" },
     usernames: { name: "string" },


### PR DESCRIPTION
## Summary

Reverts c2cfa07d0 (#2236).

The PR advertised a schema-cache **warmup** in `defineSchema()` but the implementation only **invalidated** the cache and trusted lazy loading. On PG that race lost: `PostgreSQLAdapter#caseInsensitiveComparison` runs before the first reader, sees an empty hash, drops the `LOWER()` wrap, and `validates uniqueness case insensitive` fails — poisoning every PostgreSQL CI run on main.

I tried adding a real warmup in this branch (`SchemaCache#add` after each CREATE TABLE). That fixed PG but broke SQLite: populating `_columnsHash`/`_dataSourceExists` on the shared SQLite adapter interferes with `defineSchema`'s subsequent drop-recreate cycles, surfacing as "table X has no column Y" SQLITE_ERRORs across calculations / persistence / insert-all / date-time-precision / time-precision / json (~21 tests).

Reverting is the cleanest unblock. The follow-up plan should address the actual schema-loading gap (the sidecar-using model has no implicit `connection.columns()` warmup the way Rails models do) before re-attempting the test migration.

## Test plan

- [ ] CI green on PG, SQLite, MariaDB