### PR TITLE
test(activerecord): port missing EncryptedBook model variants

### DIFF
--- a/packages/activerecord/src/encryption/encryptable-record-api.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record-api.test.ts
@@ -6,7 +6,7 @@ import {
   restoreEncryptionConfig,
   makeEncryptedPost,
   makeEncryptedBook,
-  makeEncryptedBookIgnoreCase,
+  makeEncryptedBookThatIgnoresCase,
   makeFreshModel,
   makeKeyProvider,
   assertEncryptedAttribute,
@@ -233,7 +233,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
 
   it("encrypt will preserve case when :ignore_case option is used", async () => {
     Configurable.config.supportUnencryptedData = true;
-    const Book = makeEncryptedBookIgnoreCase(await freshAdapter());
+    const Book = makeEncryptedBookThatIgnoresCase(await freshAdapter());
     new Book();
     const book = await withoutEncryption(() => Book.create({ name: "Dune" }));
     // Before encryption, reads back the plaintext original case.
@@ -246,7 +246,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordApiTest", () => {
 
   it("re-encrypting will preserve case when :ignore_case option is used", async () => {
     Configurable.config.supportUnencryptedData = true;
-    const Book = makeEncryptedBookIgnoreCase(await freshAdapter());
+    const Book = makeEncryptedBookThatIgnoresCase(await freshAdapter());
     new Book();
     const book = await withoutEncryption(() => Book.create({ name: "Dune" }));
     expect(await withoutEncryption(async () => (await Book.find(book.id)).name)).toBe("Dune");

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -8,7 +8,7 @@ import {
   makeEncryptedPost,
   makeEncryptedBook,
   makeEncryptedBookWithDowncaseName,
-  makeEncryptedBookIgnoreCase,
+  makeEncryptedBookThatIgnoresCase,
   makeEncryptedAuthor,
   makeBookThatWillFailToEncryptName,
   makeEncryptedBookWithBinary,
@@ -270,7 +270,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("when ignore_case: true, it ignores case in queries but keep it when reading the attribute", async () => {
-    const Book = makeEncryptedBookIgnoreCase(await freshAdapter());
+    const Book = makeEncryptedBookThatIgnoresCase(await freshAdapter());
     new Book();
     await Book.create({ name: "Dune" });
     const book = await Book.findBy({ name: "dune" });
@@ -279,7 +279,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("when ignore_case: true, it lets you update attributes normally", async () => {
-    const Book = makeEncryptedBookIgnoreCase(await freshAdapter());
+    const Book = makeEncryptedBookThatIgnoresCase(await freshAdapter());
     const book = await Book.create({ name: "Dune" });
     await book.update({ name: "Dune II" });
     expect(book.name).toBe("Dune II");
@@ -550,7 +550,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     expect(posts.map((p: any) => p.title)).toContain("Post 1");
   });
   it("when ignore_case: true, it keeps both the attribute and the _original counterpart encrypted", async () => {
-    const Book = makeEncryptedBookIgnoreCase(await freshAdapter());
+    const Book = makeEncryptedBookThatIgnoresCase(await freshAdapter());
     new Book();
     const book = await Book.create({ name: "Dune" });
     await assertEncryptedAttribute(book, "name", "Dune");
@@ -565,14 +565,14 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
 
   it("when ignore_case: true, it returns the actual value when not encrypted", async () => {
     Configurable.config.supportUnencryptedData = true;
-    const Book = makeEncryptedBookIgnoreCase(await freshAdapter());
+    const Book = makeEncryptedBookThatIgnoresCase(await freshAdapter());
     new Book();
     const book = await withoutEncryption(async () => Book.create({ name: "Dune" }));
     expect(book.name).toBe("Dune");
   });
 
   it("when ignore_case: true, users can override accessors and call super", async () => {
-    const Book = makeEncryptedBookIgnoreCase(await freshAdapter());
+    const Book = makeEncryptedBookThatIgnoresCase(await freshAdapter());
     const OverridingBook = class extends Book {
       get name() {
         return `${super.name}-overridden`;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -154,12 +154,14 @@ const ENCRYPTION_SCHEMA: Schema = {
     title: { type: "string", limit: 1024 },
     body: { type: "string", limit: 1024 },
   },
-  encrypted_books: { name: { type: "string", limit: 1024, default: "<untitled>" } },
-  encrypted_book_with_downcase_names: { name: { type: "string", limit: 1024 } },
-  encrypted_book_ignore_cases: {
-    name: { type: "string", limit: 1024 },
+  // Rails consolidates EncryptedBook, EncryptedBookThatIgnoresCase, and the
+  // other EncryptedBook* variants onto a single `encrypted_books` table.
+  encrypted_books: {
+    name: { type: "string", limit: 1024, default: "<untitled>" },
     original_name: { type: "string", limit: 1024 },
+    logo: "binary",
   },
+  encrypted_book_with_downcase_names: { name: { type: "string", limit: 1024 } },
   // EncryptedAuthor enforces AUTHOR_NAME_LIMIT at the AR attribute layer
   // (plaintext); the column itself needs room for ciphertext.
   encrypted_authors: { name: { type: "string", limit: 1024 } },
@@ -289,9 +291,10 @@ export function makeEncryptedBookWithDowncaseName(adapter: DatabaseAdapter) {
   } as any;
 }
 
-export function makeEncryptedBookIgnoreCase(adapter: DatabaseAdapter) {
-  return class EncryptedBookIgnoreCase extends Base {
+export function makeEncryptedBookThatIgnoresCase(adapter: DatabaseAdapter) {
+  return class EncryptedBookThatIgnoresCase extends Base {
     static {
+      this._tableName = "encrypted_books";
       this.attribute("id", "integer");
       this.attribute("name", "string");
       this.attribute("original_name", "string");
@@ -459,6 +462,98 @@ export function makeMsgPackTextBook(adapter: DatabaseAdapter) {
       this.attribute("name", "string");
       this.adapter = adapter;
       this.encrypts("name", { messageSerializer: new MessagePackMessageSerializer() });
+    }
+  } as any;
+}
+
+/**
+ * UnencryptedBook: shares the encrypted_books table but declares no encryption.
+ * Mirrors Rails' book_encrypted.rb / UnencryptedBook.
+ */
+export function makeUnencryptedBook(adapter: DatabaseAdapter) {
+  return class UnencryptedBook extends Base {
+    static {
+      this._tableName = "encrypted_books";
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.adapter = adapter;
+    }
+  } as any;
+}
+
+/**
+ * EncryptedBookWithUniquenessValidation: name is encrypted deterministically
+ * and validates uniqueness. Mirrors Rails' EncryptedBookWithUniquenessValidation.
+ */
+export function makeEncryptedBookWithUniquenessValidation(adapter: DatabaseAdapter) {
+  return class EncryptedBookWithUniquenessValidation extends Base {
+    static {
+      this._tableName = "encrypted_books";
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.adapter = adapter;
+      this.validatesUniqueness("name");
+      this.encrypts("name", { deterministic: true });
+    }
+  } as any;
+}
+
+/**
+ * EncryptedBookAttribute: declares `name` as a `:date` attribute, then encrypts it.
+ * Mirrors Rails' EncryptedBookAttribute (attribute :name, :date + encrypts :name).
+ */
+export function makeEncryptedBookAttribute(adapter: DatabaseAdapter) {
+  return class EncryptedBookAttribute extends Base {
+    static {
+      this._tableName = "encrypted_books";
+      this.attribute("id", "integer");
+      this.attribute("name", "date");
+      this.adapter = adapter;
+      this.encrypts("name");
+    }
+  } as any;
+}
+
+/**
+ * EncryptedBookNormalizedFirst: declares normalizes before encrypts on both
+ * `name` and `logo`. Mirrors Rails' EncryptedBookNormalizedFirst — exercises
+ * normalize-then-encrypt order.
+ */
+export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
+  const toLower = (v: unknown) => (v == null ? v : String(v).toLowerCase());
+  return class EncryptedBookNormalizedFirst extends Base {
+    static {
+      this._tableName = "encrypted_books";
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.attribute("logo", "binary");
+      this.adapter = adapter;
+      this.normalizes("name", toLower);
+      this.encrypts("name");
+      this.normalizes("logo", toLower);
+      this.encrypts("logo");
+    }
+  } as any;
+}
+
+/**
+ * EncryptedBookNormalizedSecond: declares encrypts before normalizes on both
+ * `name` and `logo`. Mirrors Rails' EncryptedBookNormalizedSecond — exercises
+ * encrypt-then-normalize order.
+ */
+export function makeEncryptedBookNormalizedSecond(adapter: DatabaseAdapter) {
+  const toLower = (v: unknown) => (v == null ? v : String(v).toLowerCase());
+  return class EncryptedBookNormalizedSecond extends Base {
+    static {
+      this._tableName = "encrypted_books";
+      this.attribute("id", "integer");
+      this.attribute("name", "string");
+      this.attribute("logo", "binary");
+      this.adapter = adapter;
+      this.encrypts("name");
+      this.normalizes("name", toLower);
+      this.encrypts("logo");
+      this.normalizes("logo", toLower);
     }
   } as any;
 }

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -167,11 +167,10 @@ const ENCRYPTION_SCHEMA: Schema = {
   encrypted_book_with_custom_compressors: { name: { type: "string", limit: 1024 } },
   book_that_will_fail_to_encrypt_names: { name: { type: "string", limit: 1024 } },
   encrypted_traffic_light_with_store_states: { state: "text" },
-  // Rails maps EncryptedBookWithBinary onto `encrypted_books` (`t.binary :logo`).
-  // The single shared table now consolidates these too; per-class tables
-  // below stay for variants whose attribute set diverges (serialized JSON,
-  // message-pack) or that we haven't yet rebased onto `encrypted_books`.
-  encrypted_book_with_binaries: { logo: "binary" },
+  // Per-class tables remain for variants whose castType for `logo` diverges
+  // from BLOB on SQLite (the serialized variants store JSON text; the
+  // message-pack variant stores raw binary like Rails but isolates its
+  // serializer assertions from the shared table).
   encrypted_book_with_serialized_first_binaries: { logo: "text" },
   encrypted_book_with_serialized_second_binaries: { logo: "text" },
   encrypted_book_with_binary_message_pack_serializeds: { logo: "binary" },
@@ -387,6 +386,7 @@ export function makeEncryptedTrafficLightWithStoreState(adapter: DatabaseAdapter
 export function makeEncryptedBookWithBinary(adapter: DatabaseAdapter) {
   return class EncryptedBookWithBinary extends Base {
     static {
+      this._tableName = "encrypted_books";
       this.attribute("id", "integer");
       this.attribute("logo", "binary");
       this.adapter = adapter;

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -283,7 +283,7 @@ export function makeEncryptedBookWithDowncaseName(adapter: DatabaseAdapter) {
     static {
       this._tableName = "encrypted_books";
       this.attribute("id", "integer");
-      this.attribute("name", "string");
+      this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
       this.encrypts("name", { deterministic: true, downcase: true });
     }
@@ -295,7 +295,7 @@ export function makeEncryptedBookThatIgnoresCase(adapter: DatabaseAdapter) {
     static {
       this._tableName = "encrypted_books";
       this.attribute("id", "integer");
-      this.attribute("name", "string");
+      this.attribute("name", "string", { default: "<untitled>" });
       this.attribute("original_name", "string");
       this.adapter = adapter;
       this.encrypts("name", { deterministic: true, ignoreCase: true });
@@ -459,7 +459,7 @@ export function makeMsgPackTextBook(adapter: DatabaseAdapter) {
     static {
       this._tableName = "encrypted_books";
       this.attribute("id", "integer");
-      this.attribute("name", "string");
+      this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
       this.encrypts("name", { messageSerializer: new MessagePackMessageSerializer() });
     }
@@ -475,7 +475,7 @@ export function makeUnencryptedBook(adapter: DatabaseAdapter) {
     static {
       this._tableName = "encrypted_books";
       this.attribute("id", "integer");
-      this.attribute("name", "string");
+      this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
     }
   } as any;
@@ -490,7 +490,7 @@ export function makeEncryptedBookWithUniquenessValidation(adapter: DatabaseAdapt
     static {
       this._tableName = "encrypted_books";
       this.attribute("id", "integer");
-      this.attribute("name", "string");
+      this.attribute("name", "string", { default: "<untitled>" });
       this.adapter = adapter;
       this.validatesUniqueness("name");
       this.encrypts("name", { deterministic: true });
@@ -544,7 +544,7 @@ export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
     static {
       this._tableName = "encrypted_books";
       this.attribute("id", "integer");
-      this.attribute("name", "string");
+      this.attribute("name", "string", { default: "<untitled>" });
       this.attribute("logo", "binary");
       this.adapter = adapter;
       this.normalizes("name", _downcaseLikeRails);
@@ -565,7 +565,7 @@ export function makeEncryptedBookNormalizedSecond(adapter: DatabaseAdapter) {
     static {
       this._tableName = "encrypted_books";
       this.attribute("id", "integer");
-      this.attribute("name", "string");
+      this.attribute("name", "string", { default: "<untitled>" });
       this.attribute("logo", "binary");
       this.adapter = adapter;
       this.encrypts("name");

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -514,19 +514,21 @@ export function makeEncryptedBookAttribute(adapter: DatabaseAdapter) {
   } as any;
 }
 
-// Mirrors Rails' `->(value) { value.to_s.downcase }` lambda used by both
-// EncryptedBookNormalizedFirst/Second. Binary inputs are decoded as
-// Latin-1 (byte-preserving 1:1 mapping for bytes 128–255), lowercased,
-// then re-encoded back to Uint8Array so the cast type of a `:binary`
-// attribute is preserved through normalization (normalizes runs after
-// type casting and writes back via writeCastValue).
-const _latin1Decoder = new TextDecoder("latin1");
+// Mirrors Ruby's `value.to_s.downcase` on an ASCII-8BIT string: only ASCII
+// A–Z bytes are lowercased; bytes > 0x7F are preserved bit-for-bit (Ruby's
+// downcase on a binary string does not perform Unicode case folding).
+// For our `logo: binary` attribute the cast type yields a Uint8Array,
+// so we lowercase bytes directly and return a Uint8Array to preserve the
+// binary cast type through normalization (which writes back via
+// writeCastValue after casting).
 function _downcaseLikeRails(v: unknown): unknown {
   if (v == null) return v;
   if (v instanceof Uint8Array) {
-    const lower = _latin1Decoder.decode(v).toLowerCase();
-    const out = new Uint8Array(lower.length);
-    for (let i = 0; i < lower.length; i++) out[i] = lower.charCodeAt(i) & 0xff;
+    const out = new Uint8Array(v.length);
+    for (let i = 0; i < v.length; i++) {
+      const b = v[i]!;
+      out[i] = b >= 0x41 && b <= 0x5a ? b + 0x20 : b;
+    }
     return out;
   }
   return String(v).toLowerCase();

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -521,11 +521,14 @@ export function makeEncryptedBookAttribute(adapter: DatabaseAdapter) {
  */
 export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
   // Mirrors Rails' `->(value) { value.to_s.downcase }`. In Ruby, a binary
-  // string responds to .to_s as itself; for our `logo: binary` attribute the
-  // cast type yields a Uint8Array/Buffer, which we decode as UTF-8 to match.
+  // (ASCII-8BIT) string responds to .to_s as itself. For our `logo: binary`
+  // attribute the cast type yields a Uint8Array/Buffer; decode it as
+  // Latin-1 (byte-preserving 1:1 mapping) so arbitrary bytes 128–255 round
+  // through `.toLowerCase()` intact — matches the codebase's Latin-1
+  // binary round-tripping (EncryptedAttributeType.databaseTypeToText).
   const toLower = (v: unknown) => {
     if (v == null) return v;
-    if (v instanceof Uint8Array) return new TextDecoder().decode(v).toLowerCase();
+    if (v instanceof Uint8Array) return new TextDecoder("latin1").decode(v).toLowerCase();
     return String(v).toLowerCase();
   };
   return class EncryptedBookNormalizedFirst extends Base {
@@ -550,11 +553,14 @@ export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
  */
 export function makeEncryptedBookNormalizedSecond(adapter: DatabaseAdapter) {
   // Mirrors Rails' `->(value) { value.to_s.downcase }`. In Ruby, a binary
-  // string responds to .to_s as itself; for our `logo: binary` attribute the
-  // cast type yields a Uint8Array/Buffer, which we decode as UTF-8 to match.
+  // (ASCII-8BIT) string responds to .to_s as itself. For our `logo: binary`
+  // attribute the cast type yields a Uint8Array/Buffer; decode it as
+  // Latin-1 (byte-preserving 1:1 mapping) so arbitrary bytes 128–255 round
+  // through `.toLowerCase()` intact — matches the codebase's Latin-1
+  // binary round-tripping (EncryptedAttributeType.databaseTypeToText).
   const toLower = (v: unknown) => {
     if (v == null) return v;
-    if (v instanceof Uint8Array) return new TextDecoder().decode(v).toLowerCase();
+    if (v instanceof Uint8Array) return new TextDecoder("latin1").decode(v).toLowerCase();
     return String(v).toLowerCase();
   };
   return class EncryptedBookNormalizedSecond extends Base {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -161,17 +161,16 @@ const ENCRYPTION_SCHEMA: Schema = {
     original_name: { type: "string", limit: 1024 },
     logo: "binary",
   },
-  encrypted_book_with_downcase_names: { name: { type: "string", limit: 1024 } },
   // EncryptedAuthor enforces AUTHOR_NAME_LIMIT at the AR attribute layer
   // (plaintext); the column itself needs room for ciphertext.
   encrypted_authors: { name: { type: "string", limit: 1024 } },
   encrypted_book_with_custom_compressors: { name: { type: "string", limit: 1024 } },
   book_that_will_fail_to_encrypt_names: { name: { type: "string", limit: 1024 } },
   encrypted_traffic_light_with_store_states: { state: "text" },
-  // Mirrors Rails' `t.binary :logo` on `encrypted_books`. Maps to BYTEA on
-  // PG and BLOB on MySQL/SQLite via defineSchema's `binary` mapping. A TEXT
-  // column does not round-trip on PG: BinaryData-wrapped ciphertext binds
-  // as bytea and pg stores the `\x{hex}` literal in the TEXT column.
+  // Rails maps EncryptedBookWithBinary onto `encrypted_books` (`t.binary :logo`).
+  // The single shared table now consolidates these too; per-class tables
+  // below stay for variants whose attribute set diverges (serialized JSON,
+  // message-pack) or that we haven't yet rebased onto `encrypted_books`.
   encrypted_book_with_binaries: { logo: "binary" },
   encrypted_book_with_serialized_first_binaries: { logo: "text" },
   encrypted_book_with_serialized_second_binaries: { logo: "text" },
@@ -283,6 +282,7 @@ export function makeEncryptedBook(adapter: DatabaseAdapter) {
 export function makeEncryptedBookWithDowncaseName(adapter: DatabaseAdapter) {
   return class EncryptedBookWithDowncaseName extends Base {
     static {
+      this._tableName = "encrypted_books";
       this.attribute("id", "integer");
       this.attribute("name", "string");
       this.adapter = adapter;
@@ -520,7 +520,14 @@ export function makeEncryptedBookAttribute(adapter: DatabaseAdapter) {
  * normalize-then-encrypt order.
  */
 export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
-  const toLower = (v: unknown) => (v == null ? v : String(v).toLowerCase());
+  // Mirrors Rails' `->(value) { value.to_s.downcase }`. In Ruby, a binary
+  // string responds to .to_s as itself; for our `logo: binary` attribute the
+  // cast type yields a Uint8Array/Buffer, which we decode as UTF-8 to match.
+  const toLower = (v: unknown) => {
+    if (v == null) return v;
+    if (v instanceof Uint8Array) return new TextDecoder().decode(v).toLowerCase();
+    return String(v).toLowerCase();
+  };
   return class EncryptedBookNormalizedFirst extends Base {
     static {
       this._tableName = "encrypted_books";
@@ -542,7 +549,14 @@ export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
  * encrypt-then-normalize order.
  */
 export function makeEncryptedBookNormalizedSecond(adapter: DatabaseAdapter) {
-  const toLower = (v: unknown) => (v == null ? v : String(v).toLowerCase());
+  // Mirrors Rails' `->(value) { value.to_s.downcase }`. In Ruby, a binary
+  // string responds to .to_s as itself; for our `logo: binary` attribute the
+  // cast type yields a Uint8Array/Buffer, which we decode as UTF-8 to match.
+  const toLower = (v: unknown) => {
+    if (v == null) return v;
+    if (v instanceof Uint8Array) return new TextDecoder().decode(v).toLowerCase();
+    return String(v).toLowerCase();
+  };
   return class EncryptedBookNormalizedSecond extends Base {
     static {
       this._tableName = "encrypted_books";

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -514,23 +514,30 @@ export function makeEncryptedBookAttribute(adapter: DatabaseAdapter) {
   } as any;
 }
 
+// Mirrors Rails' `->(value) { value.to_s.downcase }` lambda used by both
+// EncryptedBookNormalizedFirst/Second. Binary inputs are decoded as
+// Latin-1 (byte-preserving 1:1 mapping for bytes 128–255), lowercased,
+// then re-encoded back to Uint8Array so the cast type of a `:binary`
+// attribute is preserved through normalization (normalizes runs after
+// type casting and writes back via writeCastValue).
+const _latin1Decoder = new TextDecoder("latin1");
+function _downcaseLikeRails(v: unknown): unknown {
+  if (v == null) return v;
+  if (v instanceof Uint8Array) {
+    const lower = _latin1Decoder.decode(v).toLowerCase();
+    const out = new Uint8Array(lower.length);
+    for (let i = 0; i < lower.length; i++) out[i] = lower.charCodeAt(i) & 0xff;
+    return out;
+  }
+  return String(v).toLowerCase();
+}
+
 /**
  * EncryptedBookNormalizedFirst: declares normalizes before encrypts on both
  * `name` and `logo`. Mirrors Rails' EncryptedBookNormalizedFirst — exercises
  * normalize-then-encrypt order.
  */
 export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
-  // Mirrors Rails' `->(value) { value.to_s.downcase }`. In Ruby, a binary
-  // (ASCII-8BIT) string responds to .to_s as itself. For our `logo: binary`
-  // attribute the cast type yields a Uint8Array/Buffer; decode it as
-  // Latin-1 (byte-preserving 1:1 mapping) so arbitrary bytes 128–255 round
-  // through `.toLowerCase()` intact — matches the codebase's Latin-1
-  // binary round-tripping (EncryptedAttributeType.databaseTypeToText).
-  const toLower = (v: unknown) => {
-    if (v == null) return v;
-    if (v instanceof Uint8Array) return new TextDecoder("latin1").decode(v).toLowerCase();
-    return String(v).toLowerCase();
-  };
   return class EncryptedBookNormalizedFirst extends Base {
     static {
       this._tableName = "encrypted_books";
@@ -538,9 +545,9 @@ export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
       this.attribute("name", "string");
       this.attribute("logo", "binary");
       this.adapter = adapter;
-      this.normalizes("name", toLower);
+      this.normalizes("name", _downcaseLikeRails);
       this.encrypts("name");
-      this.normalizes("logo", toLower);
+      this.normalizes("logo", _downcaseLikeRails);
       this.encrypts("logo");
     }
   } as any;
@@ -552,17 +559,6 @@ export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
  * encrypt-then-normalize order.
  */
 export function makeEncryptedBookNormalizedSecond(adapter: DatabaseAdapter) {
-  // Mirrors Rails' `->(value) { value.to_s.downcase }`. In Ruby, a binary
-  // (ASCII-8BIT) string responds to .to_s as itself. For our `logo: binary`
-  // attribute the cast type yields a Uint8Array/Buffer; decode it as
-  // Latin-1 (byte-preserving 1:1 mapping) so arbitrary bytes 128–255 round
-  // through `.toLowerCase()` intact — matches the codebase's Latin-1
-  // binary round-tripping (EncryptedAttributeType.databaseTypeToText).
-  const toLower = (v: unknown) => {
-    if (v == null) return v;
-    if (v instanceof Uint8Array) return new TextDecoder("latin1").decode(v).toLowerCase();
-    return String(v).toLowerCase();
-  };
   return class EncryptedBookNormalizedSecond extends Base {
     static {
       this._tableName = "encrypted_books";
@@ -571,9 +567,9 @@ export function makeEncryptedBookNormalizedSecond(adapter: DatabaseAdapter) {
       this.attribute("logo", "binary");
       this.adapter = adapter;
       this.encrypts("name");
-      this.normalizes("name", toLower);
+      this.normalizes("name", _downcaseLikeRails);
       this.encrypts("logo");
-      this.normalizes("logo", toLower);
+      this.normalizes("logo", _downcaseLikeRails);
     }
   } as any;
 }


### PR DESCRIPTION
## Summary

Rails' `test/models/book_encrypted.rb` defines 13 model classes sharing the `encrypted_books` table; only 6 had TS counterparts. This adds the Rails-shape factories needed to port `encrypted_fixtures_test.rb` (PR 7 of the fixtures plan).

New factories in `packages/activerecord/src/encryption/test-helpers.ts`:

- `makeUnencryptedBook`
- `makeEncryptedBookWithUniquenessValidation`
- `makeEncryptedBookAttribute` (`attribute :name, :date` + `encrypts :name`)
- `makeEncryptedBookNormalizedFirst` (normalizes then encrypts)
- `makeEncryptedBookNormalizedSecond` (encrypts then normalizes)

Rename: `makeEncryptedBookIgnoreCase` → `makeEncryptedBookThatIgnoresCase` (matches Rails class `EncryptedBookThatIgnoresCase`). Schema consolidated: `encrypted_books` now carries `name` / `original_name` / `logo`, mirroring Rails' single fixture table.

## Deferred

- `EncryptedBookWithUnencryptedDataOptedOut` / `…OptedIn`: `encrypts()` doesn't yet accept per-attribute `supportUnencryptedData`; only the global `Configurable.config` flag is wired. Adding these before the option lands would produce aliases of `EncryptedBook` (violates "ship behavior, not signatures").

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/encryption/` — 289 passed, 1 skipped (pre-existing).
- [x] Renamed factory callsites updated in `encryptable-record.test.ts` + `encryptable-record-api.test.ts`.