### PR TITLE
feat(actionpack): port HostAuthorization::DefaultResponseApp + route through Request

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts
@@ -22,13 +22,56 @@ describe("HostAuthorizationTest", () => {
 
   it("blocks request when host does not match", async () => {
     const mw = new HostAuthorization(okApp, { hosts: ["example.com"] });
-    const [status, _, body] = await mw.call({
+    const [status, headers, body] = await mw.call({
       HTTP_HOST: "evil.com",
       REQUEST_METHOD: "GET",
       PATH_INFO: "/",
     });
     expect(status).toBe(403);
-    expect(await bodyToString(body)).toContain("Blocked host: evil.com");
+    expect((headers as Record<string, string>)["content-type"]).toContain("text/html");
+    expect(await bodyToString(body)).toBe("");
+  });
+
+  it("default response renders DebugView body when show_detailed_exceptions is set", async () => {
+    const mw = new HostAuthorization(okApp, { hosts: ["example.com"] });
+    const [status, headers, body] = await mw.call({
+      HTTP_HOST: "evil.com",
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/",
+      "action_dispatch.show_detailed_exceptions": true,
+    });
+    expect(status).toBe(403);
+    expect((headers as Record<string, string>)["content-type"]).toContain("text/html");
+    const rendered = await bodyToString(body);
+    expect(rendered).toContain("Blocked host");
+    expect(rendered).toContain("evil.com");
+  });
+
+  it("default response uses text/plain for XHR requests", async () => {
+    const mw = new HostAuthorization(okApp, { hosts: ["example.com"] });
+    const [status, headers] = await mw.call({
+      HTTP_HOST: "evil.com",
+      HTTP_X_REQUESTED_WITH: "XMLHttpRequest",
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/",
+    });
+    expect(status).toBe(403);
+    expect((headers as Record<string, string>)["content-type"]).toContain("text/plain");
+  });
+
+  it("default response logs blocked hosts via request logger", async () => {
+    const messages: string[] = [];
+    const logger = { error: (msg: string) => messages.push(msg) };
+    const mw = new HostAuthorization(okApp, { hosts: ["example.com"] });
+    await mw.call({
+      HTTP_HOST: "evil.com",
+      REQUEST_METHOD: "GET",
+      PATH_INFO: "/",
+      "action_dispatch.logger": logger,
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("Blocked hosts: evil.com");
+    expect(messages[0]).toContain("DefaultResponseApp");
   });
 
   it("allows wildcard subdomain matching", async () => {

--- a/packages/actionpack/src/action-dispatch/index.ts
+++ b/packages/actionpack/src/action-dispatch/index.ts
@@ -50,6 +50,7 @@ export {
 export { SSL, type SSLOptions, type HSTSOptions } from "./middleware/ssl.js";
 export {
   HostAuthorization,
+  DefaultResponseApp,
   type HostAuthorizationOptions,
 } from "./middleware/host-authorization.js";
 export { MiddlewareStack } from "./middleware/stack.js";

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -307,14 +307,16 @@ export class DefaultResponseApp {
     const request = new Request(env);
     const format = request.xhr ? "text/plain" : "text/html";
     this.logError(request);
-    return this.response(format, this.responseBody(request));
+    return this.response(format, this.responseBody(request, format));
   }
 
   /** @internal */
-  private responseBody(request: Request): string {
+  private responseBody(request: Request, format: string): string {
     if (!request.env["action_dispatch.show_detailed_exceptions"]) return "";
     const blocked = (request.env["action_dispatch.blocked_hosts"] as string[]) ?? [];
-    return renderBlockedHostBody(blocked);
+    return format === "text/plain"
+      ? renderBlockedHostText(blocked)
+      : renderBlockedHostHtml(blocked);
   }
 
   /** @internal */
@@ -351,30 +353,45 @@ export class DefaultResponseApp {
 }
 
 /**
- * Render a minimal HTML body listing the blocked hosts. In Rails this is
- * rendered through `DebugView` + the `rescues/blocked_host` template; the
- * ActionView template stack isn't ported yet, so we emit equivalent
- * structural HTML inline.
+ * Render the blocked-host HTML body. Mirrors Rails'
+ * `templates/rescues/blocked_host.html.erb` line-for-line — the ActionView
+ * template stack isn't ported yet, so the .erb is reproduced inline.
  *
  * @internal
  */
-function renderBlockedHostBody(hosts: string[]): string {
-  const items = hosts.map((h) => `    <li>${escapeHtml(h)}</li>`).join("\n");
+function renderBlockedHostHtml(hosts: string[]): string {
+  const joined = escapeHtml(hosts.join(", "));
+  const lines = hosts.map((host) => `    config.hosts << "${escapeHtml(host)}"`).join("\n");
   return [
-    "<!DOCTYPE html>",
-    '<html lang="en">',
-    "<head>",
-    '  <meta charset="utf-8" />',
-    "  <title>Blocked Host</title>",
-    "</head>",
-    "<body>",
-    "  <h1>Blocked host</h1>",
-    "  <p>To allow requests to these hosts, add them to <code>config.hosts</code>.</p>",
-    "  <ul>",
-    items,
-    "  </ul>",
-    "</body>",
-    "</html>",
+    "<header>",
+    `  <h1>Blocked hosts: ${joined}</h1>`,
+    "</header>",
+    '<main role="main" id="container">',
+    "  <h2>To allow requests to these hosts, make sure they are valid hostnames (containing only numbers, letters, dashes and dots), then add the following to your environment configuration:</h2>",
+    "  <pre>",
+    lines,
+    "  </pre>",
+    '  <p>For more details view: <a href="https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization">the Host Authorization guide</a></p>',
+    "</main>",
+  ].join("\n");
+}
+
+/**
+ * Render the blocked-host plain-text body. Mirrors Rails'
+ * `templates/rescues/blocked_host.text.erb`.
+ *
+ * @internal
+ */
+function renderBlockedHostText(hosts: string[]): string {
+  const lines = hosts.map((host) => `  config.hosts << "${host}"`).join("\n");
+  return [
+    `Blocked hosts: ${hosts.join(", ")}`,
+    "",
+    "To allow requests to these hosts, make sure they are valid hostnames (containing only numbers, letters, dashes and dots), then add the following to your environment configuration:",
+    "",
+    lines,
+    "",
+    "For more details on host authorization view: https://guides.rubyonrails.org/configuring.html#actiondispatch-hostauthorization",
   ].join("\n");
 }
 

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -8,11 +8,7 @@
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { bodyFromString } from "@blazetrails/rack";
 import { Request } from "../http/request.js";
-
-/** @internal Minimal logger surface used by {@link DefaultResponseApp}. */
-export interface HostAuthorizationLogger {
-  error(message: string): void;
-}
+import type { Logger } from "./debug-exceptions.js";
 
 /** @internal */
 export const PORT_REGEX = "(?::\\d+)";
@@ -356,10 +352,10 @@ export class DefaultResponseApp {
   }
 
   /** @internal */
-  private availableLogger(request: Request): HostAuthorizationLogger | null {
-    const explicit = request.logger as HostAuthorizationLogger | undefined;
+  private availableLogger(request: Request): Logger | null {
+    const explicit = request.logger as Logger | undefined;
     if (explicit && typeof explicit.error === "function") return explicit;
-    const rack = request.env["rack.logger"] as HostAuthorizationLogger | undefined;
+    const rack = request.env["rack.logger"] as Logger | undefined;
     if (rack && typeof rack.error === "function") return rack;
     return null;
   }

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -254,7 +254,7 @@ export class HostAuthorization {
     const request = new Request(env);
     const blocked = this.blockedHosts(request);
 
-    if (blocked.length === 0 || this.isExcluded(request)) {
+    if (blocked.length === 0 || this.isExcluded(env)) {
       this.markAsAuthorized(env, request);
       return this.app(env);
     }
@@ -279,17 +279,30 @@ export class HostAuthorization {
     return out;
   }
 
-  /** @internal */
-  private isExcluded(request: Request): boolean {
-    return Boolean(this.exclude?.(request.env));
+  /** @internal Rails passes the Request to `exclude`; we hand back the original env (pre-Request clone) so mutations are visible to downstream middleware. */
+  private isExcluded(env: RackEnv): boolean {
+    return Boolean(this.exclude?.(env));
   }
 
   /** @internal Sets `action_dispatch.authorized_host` from `Request#rawHostWithPort` (port stripped). */
   private markAsAuthorized(env: RackEnv, request: Request): void {
-    const raw = request.rawHostWithPort;
-    const authorized = raw.startsWith("[") ? raw.replace(/\]:\d+$/, "]") : raw.replace(/:\d+$/, "");
-    env["action_dispatch.authorized_host"] = authorized;
+    env["action_dispatch.authorized_host"] = stripPort(request.rawHostWithPort);
   }
+}
+
+/**
+ * Strip a trailing `:port` from `host` without corrupting unbracketed
+ * IPv6 literals. IPv6 addresses with a port arrive bracketed
+ * (`[::1]:3000`); an unbracketed multi-colon string is the IPv6 address
+ * itself with no port suffix.
+ *
+ * @internal
+ */
+function stripPort(host: string): string {
+  if (host.startsWith("[")) return host.replace(/\]:\d+$/, "]");
+  const colons = (host.match(/:/g) ?? []).length;
+  if (colons > 1) return host;
+  return host.replace(/:\d+$/, "");
 }
 
 /**

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -7,6 +7,12 @@
 
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 import { bodyFromString } from "@blazetrails/rack";
+import { Request } from "../http/request.js";
+
+/** @internal Minimal logger surface used by {@link DefaultResponseApp}. */
+export interface HostAuthorizationLogger {
+  error(message: string): void;
+}
 
 /** @internal */
 export const PORT_REGEX = "(?::\\d+)";
@@ -232,64 +238,152 @@ export class HostAuthorization {
   private app: RackApp;
   private permissions: Permissions;
   private exclude?: (env: RackEnv) => boolean;
-  private responseApp?: (env: RackEnv) => Promise<RackResponse>;
+  private responseApp: (env: RackEnv) => Promise<RackResponse>;
 
   constructor(app: RackApp, options: HostAuthorizationOptions) {
     this.app = app;
     this.permissions = new Permissions(options.hosts);
     this.exclude = options.exclude;
-    this.responseApp = options.responseApp;
+    const defaultApp = new DefaultResponseApp();
+    this.responseApp = options.responseApp ?? ((env) => defaultApp.call(env));
   }
 
   async call(env: RackEnv): Promise<RackResponse> {
     if (this.permissions.empty()) return this.app(env);
 
-    const originHost = this.originHost(env);
-    const blocked = this.blockedHosts(env, originHost);
+    const request = new Request(env);
+    const blocked = this.blockedHosts(request);
 
-    if (blocked.length === 0 || this.isExcluded(env)) {
-      this.markAsAuthorized(env, originHost);
+    if (blocked.length === 0 || this.isExcluded(request)) {
+      this.markAsAuthorized(env, request);
       return this.app(env);
     }
 
     env["action_dispatch.blocked_hosts"] = blocked;
-    if (this.responseApp) return this.responseApp(env);
-    return this.blockedResponse(originHost);
-  }
-
-  private originHost(env: RackEnv): string {
-    const httpHost = env["HTTP_HOST"] as string | undefined;
-    if (httpHost) return httpHost;
-    return (env["SERVER_NAME"] as string) || "localhost";
+    return this.responseApp(env);
   }
 
   /** @internal */
-  private blockedHosts(env: RackEnv, originHost: string): string[] {
+  private blockedHosts(request: Request): string[] {
     const out: string[] = [];
+    const env = request.env;
+    const originHost =
+      (env["HTTP_HOST"] as string | undefined) ??
+      (env["SERVER_NAME"] as string | undefined) ??
+      "localhost";
     if (!this.permissions.allows(originHost)) out.push(originHost);
-    const forwarded = (env["HTTP_X_FORWARDED_HOST"] as string | undefined)
-      ?.split(/,\s?/)
-      .pop()
-      ?.trim();
+
+    const forwardedHeader = env["HTTP_X_FORWARDED_HOST"] as string | undefined;
+    const forwarded = forwardedHeader?.split(/,\s?/).pop()?.trim();
     if (forwarded && !this.permissions.allows(forwarded)) out.push(forwarded);
     return out;
   }
 
   /** @internal */
-  private isExcluded(env: RackEnv): boolean {
-    return Boolean(this.exclude?.(env));
+  private isExcluded(request: Request): boolean {
+    return Boolean(this.exclude?.(request.env));
+  }
+
+  /** @internal Sets `action_dispatch.authorized_host` from `Request#rawHostWithPort` (port stripped). */
+  private markAsAuthorized(env: RackEnv, request: Request): void {
+    const raw = request.rawHostWithPort;
+    const authorized = raw.startsWith("[") ? raw.replace(/\]:\d+$/, "]") : raw.replace(/:\d+$/, "");
+    env["action_dispatch.authorized_host"] = authorized;
+  }
+}
+
+/**
+ * Default Rack app invoked when {@link HostAuthorization} blocks a request.
+ *
+ * Mirrors Rails `ActionDispatch::HostAuthorization::DefaultResponseApp`:
+ * picks `text/plain` for XHR requests and `text/html` otherwise, logs the
+ * blocked hosts via the request's logger, and renders a DebugView-style
+ * body when `action_dispatch.show_detailed_exceptions` is set.
+ */
+export class DefaultResponseApp {
+  static readonly RESPONSE_STATUS = 403;
+
+  async call(env: RackEnv): Promise<RackResponse> {
+    const request = new Request(env);
+    const format = request.xhr ? "text/plain" : "text/html";
+    this.logError(request);
+    return this.response(format, this.responseBody(request));
   }
 
   /** @internal */
-  private markAsAuthorized(env: RackEnv, host: string): void {
-    env["action_dispatch.authorized_host"] = host.replace(/:\d+$/, "");
+  private responseBody(request: Request): string {
+    if (!request.env["action_dispatch.show_detailed_exceptions"]) return "";
+    const blocked = (request.env["action_dispatch.blocked_hosts"] as string[]) ?? [];
+    return renderBlockedHostBody(blocked);
   }
 
-  private blockedResponse(host: string): RackResponse {
+  /** @internal */
+  private response(format: string, body: string): RackResponse {
+    const bytes = Buffer.byteLength(body, "utf8");
     return [
-      403,
-      { "content-type": "text/plain; charset=utf-8" },
-      bodyFromString(`Blocked host: ${host}`),
+      DefaultResponseApp.RESPONSE_STATUS,
+      {
+        "content-type": `${format}; charset=utf-8`,
+        "content-length": String(bytes),
+      },
+      bodyFromString(body),
     ];
   }
+
+  /** @internal */
+  private logError(request: Request): void {
+    const logger = this.availableLogger(request);
+    if (!logger) return;
+    const blocked = (request.env["action_dispatch.blocked_hosts"] as string[]) ?? [];
+    logger.error(
+      `[ActionDispatch::HostAuthorization::DefaultResponseApp] Blocked hosts: ${blocked.join(", ")}`,
+    );
+  }
+
+  /** @internal */
+  private availableLogger(request: Request): HostAuthorizationLogger | null {
+    const explicit = request.logger as HostAuthorizationLogger | undefined;
+    if (explicit && typeof explicit.error === "function") return explicit;
+    const rack = request.env["rack.logger"] as HostAuthorizationLogger | undefined;
+    if (rack && typeof rack.error === "function") return rack;
+    return null;
+  }
+}
+
+/**
+ * Render a minimal HTML body listing the blocked hosts. In Rails this is
+ * rendered through `DebugView` + the `rescues/blocked_host` template; the
+ * ActionView template stack isn't ported yet, so we emit equivalent
+ * structural HTML inline.
+ *
+ * @internal
+ */
+function renderBlockedHostBody(hosts: string[]): string {
+  const items = hosts.map((h) => `    <li>${escapeHtml(h)}</li>`).join("\n");
+  return [
+    "<!DOCTYPE html>",
+    '<html lang="en">',
+    "<head>",
+    '  <meta charset="utf-8" />',
+    "  <title>Blocked Host</title>",
+    "</head>",
+    "<body>",
+    "  <h1>Blocked host</h1>",
+    "  <p>To allow requests to these hosts, add them to <code>config.hosts</code>.</p>",
+    "  <ul>",
+    items,
+    "  </ul>",
+    "</body>",
+    "</html>",
+  ].join("\n");
+}
+
+/** @internal */
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
 }

--- a/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/host-authorization.ts
@@ -275,7 +275,7 @@ export class HostAuthorization {
     return out;
   }
 
-  /** @internal Rails passes the Request to `exclude`; we hand back the original env (pre-Request clone) so mutations are visible to downstream middleware. */
+  /** @internal Invokes the `exclude` predicate with the original Rack env so mutations are visible to downstream middleware (the `Request` constructed in `call` clones its env). */
   private isExcluded(env: RackEnv): boolean {
     return Boolean(this.exclude?.(env));
   }


### PR DESCRIPTION
## Summary

- Ports `ActionDispatch::HostAuthorization::DefaultResponseApp` (Rails parity): XHR-aware `text/plain` vs `text/html`, logger.error of blocked hosts via `request.logger` (falls back to `rack.logger`), and an empty body unless `action_dispatch.show_detailed_exceptions` is set — in which case a minimal HTML body lists the blocked hosts.
- Routes `HostAuthorization#call` through a `Request` instance; `action_dispatch.authorized_host` is derived from `Request#rawHostWithPort` (port stripped, IPv6 brackets preserved).
- Replaces the prior `"Blocked host: X"` text/plain stub default response with `DefaultResponseApp`.

Rails renders the detailed body via `DebugView` + the `rescues/blocked_host` template. The ActionView template stack isn't ported yet, so we emit equivalent structural HTML inline. Swapping in `DebugView.render` is a follow-up once ActionView lands.

Plan doc: `docs/actionpack-100-percent.md` Tier 2 HostAuthorization (#2110 followup).

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/host-authorization.test.ts` — 23/23 pass (added 3 new cases: detailed-body, XHR text/plain, logger.error).
- [x] `pnpm typecheck` clean.