### PR TITLE
feat(activerecord): route withTransactionalFixtures through pool.pinConnectionBang (pool epic Phase C)

### DIFF
--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
   adapterType,
+  createPooledTestAdapter,
   createSidecarTestAdapter,
   createTestAdapter,
+  _resetPooledTestAdapterForTests,
+  type SidecarAdapter,
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
 import { snapshotDdlTrackers } from "./ddl-tracker.js";
@@ -328,5 +331,45 @@ describe("withTransactionalFixtures (invalidateSchemaCache: false)", () => {
 
   it("next test still sees the cached columns because the opt-out skipped clear()", () => {
     expect(adapter.schemaCache.isColumnsHashCached(adapter.pool, "opt_out_cache_users")).toBe(true);
+  });
+});
+
+// Phase C: when the adapter was leased from a real ConnectionPool (i.e.
+// produced by `createPooledTestAdapter()`), the helper detects the `.pool`
+// back-reference and routes setup/teardown through `pinConnectionBang(false)`
+// / `unpinConnectionBang()` rather than the wrapper-direct TM begin/rollback.
+// This mirrors Rails test_fixtures.rb:177-184's pin/lease lifecycle exactly.
+describe("withTransactionalFixtures (pooled adapter)", () => {
+  let adapter: SidecarAdapter;
+  const exec = (sql: string) =>
+    (adapter as unknown as { exec(s: string): Promise<void> }).exec(sql);
+  const query = (sql: string) => adapter.execute(sql);
+
+  beforeAll(async () => {
+    const handle = await createPooledTestAdapter();
+    adapter = handle.adapter;
+    await exec(`DROP TABLE IF EXISTS pooled_fixture_users`);
+    await exec(`CREATE TABLE pooled_fixture_users (id INTEGER PRIMARY KEY, name TEXT)`);
+  });
+
+  afterAll(async () => {
+    try {
+      await exec(`DROP TABLE IF EXISTS pooled_fixture_users`);
+    } finally {
+      _resetPooledTestAdapterForTests();
+    }
+  });
+
+  withTransactionalFixtures(() => adapter);
+
+  it("inserts a row inside the pinned transaction (first run)", async () => {
+    await exec(`INSERT INTO pooled_fixture_users (id, name) VALUES (1, 'alice')`);
+    const rows = await query(`SELECT * FROM pooled_fixture_users`);
+    expect(rows).toHaveLength(1);
+  });
+
+  it("sees zero rows because unpinConnectionBang rolled back the previous insert", async () => {
+    const rows = await query(`SELECT * FROM pooled_fixture_users`);
+    expect(rows).toHaveLength(0);
   });
 });

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -1,6 +1,7 @@
 import { beforeAll, beforeEach, afterEach, afterAll } from "vitest";
 import type { DatabaseAdapter } from "../adapter.js";
 import { resetTestAdapterState, type TestDatabaseAdapter } from "../test-adapter.js";
+import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
 import { restoreDdlTrackers, snapshotDdlTrackers } from "./ddl-tracker.js";
 import { popSkipGlobalReset, pushSkipGlobalReset } from "./skip-global-reset.js";
 import { getUseTransactionalTests } from "./use-transactional-tests.js";
@@ -69,6 +70,21 @@ function adapterAndInner(
 ): readonly [DatabaseAdapter, DatabaseAdapter | null] {
   const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter ?? null;
   return [adapter as DatabaseAdapter, wrapped];
+}
+
+/**
+ * Detect a pooled adapter (returned by `createPooledTestAdapter()`). The pool
+ * reference is set by `ConnectionPool#_acquireConnection` when the connection
+ * is leased; non-pooled adapters keep `AbstractAdapter#pool === null`.
+ */
+function pooledAdapterPool(adapter: TransactionalFixturesAdapter): ConnectionPool | null {
+  const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter;
+  const host = (wrapped ?? adapter) as { pool?: unknown };
+  const pool = host.pool;
+  if (pool && typeof (pool as ConnectionPool).pinConnectionBang === "function") {
+    return pool as ConnectionPool;
+  }
+  return null;
 }
 
 /**
@@ -183,15 +199,30 @@ export function withTransactionalFixtures(
     outerSig = _snapshotAppliedSchemaSignaturesForAdapter(outer);
     innerSig = inner ? _snapshotAppliedSchemaSignaturesForAdapter(inner) : null;
     ddlSnapshot = snapshotDdlTrackers();
-    // Mirrors Rails ConnectionPool#pin_connection!:
-    //   @pinned_connection.begin_transaction joinable: false, _lazy: false
-    await tm(getAdapter()).beginTransaction({ joinable: false, _lazy: false });
+    const pool = pooledAdapterPool(getAdapter());
+    if (pool) {
+      // Mirrors Rails test_fixtures.rb:177-184 pin/lease lifecycle.
+      // pinConnectionBang opens `joinable: false, _lazy: false` on the
+      // pinned connection's transactionManager directly.
+      await pool.pinConnectionBang(false);
+    } else {
+      // Non-pooled (wrapper/sidecar) path — preserved verbatim. Mirrors
+      // Rails ConnectionPool#pin_connection! body.
+      await tm(getAdapter()).beginTransaction({ joinable: false, _lazy: false });
+    }
   });
 
   afterEach(async () => {
     if (!active) return;
-    const t = tm(getAdapter());
-    while (t.openTransactions > 0) await t.rollbackTransaction();
+    const pool = pooledAdapterPool(getAdapter());
+    if (pool) {
+      // Mirrors Rails test_fixtures.rb teardown:
+      //   @fixture_connection_pools.map(&:unpin_connection!)
+      await pool.unpinConnectionBang();
+    } else {
+      const t = tm(getAdapter());
+      while (t.openTransactions > 0) await t.rollbackTransaction();
+    }
     if (invalidateSchemaCache) clearSchemaCache(getAdapter());
     const [outer, inner] = adapterAndInner(getAdapter());
     if (outerSig) _restoreAppliedSchemaSignaturesForAdapter(outer, outerSig);

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -73,9 +73,10 @@ function adapterAndInner(
 }
 
 /**
- * Detect a pooled adapter (returned by `createPooledTestAdapter()`). The pool
- * reference is set by `ConnectionPool#_acquireConnection` when the connection
- * is leased; non-pooled adapters keep `AbstractAdapter#pool === null`.
+ * Detect a pooled adapter (returned by `createPooledTestAdapter()`). The
+ * pool back-reference is set by `ConnectionPool#newConnection` (via
+ * `adoptConnection`) when a connection is adopted into the pool;
+ * non-pooled adapters keep `AbstractAdapter#pool === null`.
  */
 function pooledAdapterPool(adapter: TransactionalFixturesAdapter): ConnectionPool | null {
   const wrapped = (adapter as Partial<TestDatabaseAdapter>).innerAdapter;
@@ -201,10 +202,16 @@ export function withTransactionalFixtures(
     ddlSnapshot = snapshotDdlTrackers();
     const pool = pooledAdapterPool(getAdapter());
     if (pool) {
-      // Mirrors Rails test_fixtures.rb:177-184 pin/lease lifecycle.
+      // Mirrors Rails test_fixtures.rb:177-184 pin/lease lifecycle:
+      //   pool.pin_connection!(lock_threads)
+      //   pool.lease_connection
       // pinConnectionBang opens `joinable: false, _lazy: false` on the
-      // pinned connection's transactionManager directly.
+      // pinned connection's transactionManager directly; the follow-up
+      // leaseConnection ensures the pinned connection is also the
+      // execution-context's leased connection so production code that
+      // calls `pool.leaseConnection()` resolves to it.
       await pool.pinConnectionBang(false);
+      pool.leaseConnection();
     } else {
       // Non-pooled (wrapper/sidecar) path — preserved verbatim. Mirrors
       // Rails ConnectionPool#pin_connection! body.


### PR DESCRIPTION
## Summary

Phase C of the connection-pool epic. When `withTransactionalFixtures` receives an adapter leased from a real `ConnectionPool` (i.e. produced by `createPooledTestAdapter()` from PR #2242), route per-test setup/teardown through `pool.pinConnectionBang(false)` / `pool.unpinConnectionBang()` instead of the wrapper-direct `transactionManager.beginTransaction({ joinable: false, _lazy: false })` + manual rollback.

Mirrors Rails `test_fixtures.rb:177-184` exactly:

```ruby
@fixture_connection_pools.each do |pool|
  pool.pin_connection!(lock_threads)
  pool.lease_connection
end
# teardown
@fixture_connection_pools.map(&:unpin_connection!)
```

Detection: `(adapter.innerAdapter ?? adapter).pool != null` with a `pinConnectionBang` method-shape check. `AbstractAdapter#pool` defaults to `null`; the pool back-reference is only set when `ConnectionPool#_acquireConnection` leases a connection, so non-pooled wrapper/sidecar callers stay on the existing path verbatim.

**Additive only.** The wrapper/sidecar code path is preserved with no behavior change. Existing callers are not migrated — consumer sweep is Phase D.

## Test plan

- [x] New describe block in `with-transactional-fixtures.test.ts` exercises the pooled path: pin in `beforeEach`, INSERT in test 1, assert rollback via second test seeing zero rows.
- [x] All 20 existing test cases in the file still pass on SQLite.
- [x] Phase B smoke test (`pooled-test-adapter.test.ts`) unaffected.
- [ ] CI runs PG + MariaDB matrix.

## Notes

- ~78 LOC additions vs `origin/main` (well under the 300 LOC ceiling).
- `_sharedAdapter`, `createTestAdapter`, `createSidecarTestAdapter` untouched (Phase E).
- Uses the existing `pinConnectionBang` / `unpinConnectionBang` API; no reimplementation.