### PR TITLE
feat(actionpack): tier 1 fidelity bundle — MimeType.parse + ActionableError/Exceptions

### DIFF
--- a/packages/actionpack/src/action-dispatch/dispatch/mime-type.test.ts
+++ b/packages/actionpack/src/action-dispatch/dispatch/mime-type.test.ts
@@ -16,24 +16,35 @@ describe("MimeTypeTest", () => {
   });
 
   it("parse text with trailing star at the beginning", () => {
-    const types = MimeType.parse("text/*");
-    expect(types.length).toBe(1);
-    expect(types[0].string).toBe("text/*");
+    const parsed = MimeType.parse("text/*, text/html, application/json, multipart/form-data").map(
+      (m) => m.string,
+    );
+    expect(parsed).toContain("text/html");
+    expect(parsed).toContain("application/json");
+    expect(parsed.length).toBeGreaterThan(2);
+    expect(parsed).not.toContain("text/*");
   });
 
   it("parse text with trailing star in the end", () => {
-    const types = MimeType.parse("text/*");
-    expect(types[0].string).toBe("text/*");
+    const parsed = MimeType.parse("text/html, application/json, multipart/form-data, text/*").map(
+      (m) => m.string,
+    );
+    expect(parsed).toContain("text/html");
+    expect(parsed).not.toContain("text/*");
   });
 
   it("parse text with trailing star", () => {
-    const types = MimeType.parse("text/*");
-    expect(types.length).toBeGreaterThan(0);
+    const parsed = MimeType.parse("text/*").map((m) => m.string);
+    expect(parsed).toContain("text/html");
+    expect(parsed).toContain("text/plain");
+    expect(parsed).not.toContain("text/*");
   });
 
   it("parse application with trailing star", () => {
-    const types = MimeType.parse("application/*");
-    expect(types.length).toBeGreaterThan(0);
+    const parsed = MimeType.parse("application/*").map((m) => m.string);
+    expect(parsed).toContain("application/json");
+    expect(parsed).toContain("application/xml");
+    expect(parsed).not.toContain("application/*");
   });
 
   it("parse without q", () => {

--- a/packages/actionpack/src/action-dispatch/http/mime-type.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-type.ts
@@ -138,7 +138,7 @@ export class AcceptList {
     const seen = new Set<string>();
     const out: MimeType[] = [];
     for (const item of list) {
-      const looked = MimeType.lookup(item.name) ?? new MimeType(item.name, item.name);
+      const looked = lookupForParse(item.name);
       if (!seen.has(looked.toString())) {
         seen.add(looked.toString());
         out.push(looked);

--- a/packages/actionpack/src/action-dispatch/http/mime-type.ts
+++ b/packages/actionpack/src/action-dispatch/http/mime-type.ts
@@ -154,6 +154,22 @@ export class AcceptList {
 }
 
 const TRAILING_STAR_REGEXP = /^(text|application)\/\*/;
+const PARAMETER_SEPARATOR_REGEXP = /;\s*q="?/;
+const ACCEPT_HEADER_REGEXP = /[^,\s"](?:[^,"]|"[^"]*")*/g;
+
+/**
+ * Mirrors Rails' `Mime::Type.lookup` fallback: if the exact string is not
+ * registered, drop any media-type parameters (`;level=2`) and try again,
+ * otherwise return a fresh ad-hoc type whose `string` is the stripped form.
+ * @internal
+ */
+function lookupForParse(s: string): MimeType {
+  const direct = MimeType.lookup(s);
+  if (direct) return direct;
+  const stripped = s.split(";")[0].trimEnd();
+  const fallback = MimeType.lookup(stripped);
+  return fallback ?? new MimeType(stripped, stripped);
+}
 
 export class MimeType {
   /** @internal */
@@ -316,36 +332,40 @@ export class MimeType {
   // --- Parsing ---
 
   static parse(acceptHeader: string): MimeType[] {
-    if (!acceptHeader || acceptHeader.trim() === "") return [];
+    if (!acceptHeader) return [];
 
-    const entries = acceptHeader.split(",").map((part) => {
-      const trimmed = part.trim();
-      const [mediaRange, ...params] = trimmed.split(";").map((s) => s.trim());
-      let q = 1.0;
-      for (const p of params) {
-        const match = p.match(/^q=([\d.]+)/);
-        if (match) q = parseFloat(match[1]);
-      }
-      return {
-        mediaRange: mediaRange || "*/*",
-        q,
-        params: params.filter((p) => !p.startsWith("q=")),
-      };
-    });
+    if (!acceptHeader.includes(",")) {
+      const sepMatch = acceptHeader.match(PARAMETER_SEPARATOR_REGEXP);
+      const header = sepMatch ? acceptHeader.slice(0, sepMatch.index!).trim() : acceptHeader.trim();
+      if (header === "") return [];
+      const trailing = MimeType.parseTrailingStar(header);
+      if (trailing) return trailing;
+      return [lookupForParse(header)];
+    }
 
-    entries.sort((a, b) => b.q - a.q);
-
-    const results: MimeType[] = [];
-    for (const entry of entries) {
-      const found = MimeType.registry.get(entry.mediaRange);
-      if (found) {
-        results.push(found);
+    const list: AcceptItem[] = [];
+    let index = 0;
+    const headers = acceptHeader.match(ACCEPT_HEADER_REGEXP) ?? [];
+    for (const raw of headers) {
+      const sep = raw.match(PARAMETER_SEPARATOR_REGEXP);
+      let params: string;
+      let q: string | null = null;
+      if (sep) {
+        params = raw.slice(0, sep.index!);
+        q = raw.slice(sep.index! + sep[0].length).replace(/"$/, "");
       } else {
-        // Create an ad-hoc type
-        results.push(new MimeType(entry.mediaRange, entry.mediaRange));
+        params = raw;
+      }
+      params = params.trim();
+      if (params === "") continue;
+      const expanded = MimeType.parseTrailingStar(params);
+      const items: string[] = expanded ? expanded.map((m) => m.toString()) : [params];
+      for (const name of items) {
+        list.push(new AcceptItem(index, name, q));
+        index += 1;
       }
     }
-    return results;
+    return AcceptList.sortBang(list);
   }
 
   // --- Built-in types ---

--- a/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.ts
@@ -7,18 +7,35 @@
  */
 
 import { ActionableError } from "@blazetrails/activesupport";
+import { cattrAccessor } from "@blazetrails/activesupport";
 import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
 import { bodyFromString } from "@blazetrails/rack";
 import { LOCATION } from "../constants.js";
 import { Request } from "../http/request.js";
 
 export class ActionableExceptions {
-  static endpoint = "/rails/actions";
+  /**
+   * Endpoint that actionable-exception forms POST back to. Declared via
+   * {@link cattrAccessor} so apps can override it per-class through the
+   * Rails-shaped `cattr_accessor :endpoint` setter without disturbing the
+   * parent (Rails: `ActionDispatch::ActionableExceptions.endpoint = "..."`).
+   */
+  static endpoint: string;
 
   private app: RackApp;
 
   constructor(app: RackApp) {
     this.app = app;
+  }
+
+  static {
+    cattrAccessor(
+      ActionableExceptions as unknown as Record<string, unknown> & { new (): unknown },
+      "endpoint",
+      {
+        default: "/rails/actions",
+      },
+    );
   }
 
   async call(env: RackEnv): Promise<RackResponse> {

--- a/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.ts
@@ -6,8 +6,7 @@
  * `action_dispatch/middleware/actionable_exceptions.rb` 1:1.
  */
 
-import { ActionableError } from "@blazetrails/activesupport";
-import { cattrAccessor } from "@blazetrails/activesupport";
+import { ActionableError, cattrAccessor } from "@blazetrails/activesupport";
 import type { RackApp, RackEnv, RackResponse } from "@blazetrails/rack";
 import { bodyFromString } from "@blazetrails/rack";
 import { LOCATION } from "../constants.js";

--- a/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/actionable-exceptions.ts
@@ -16,9 +16,13 @@ import { Request } from "../http/request.js";
 export class ActionableExceptions {
   /**
    * Endpoint that actionable-exception forms POST back to. Declared via
-   * {@link cattrAccessor} so apps can override it per-class through the
-   * Rails-shaped `cattr_accessor :endpoint` setter without disturbing the
-   * parent (Rails: `ActionDispatch::ActionableExceptions.endpoint = "..."`).
+   * {@link cattrAccessor} to mirror Rails'
+   * `cattr_accessor :endpoint, default: "/rails/actions"`: assignment goes
+   * through a getter/setter pair so apps can swap it via
+   * `ActionableExceptions.endpoint = "..."` (or via Railtie config) instead of
+   * shadowing a plain class field. Rails' `cattr_accessor` stores the value in
+   * a single class variable shared across the hierarchy, so subclass writes
+   * mutate the same slot — `cattrAccessor` matches that semantics.
    */
   static endpoint: string;
 
@@ -29,13 +33,7 @@ export class ActionableExceptions {
   }
 
   static {
-    cattrAccessor(
-      ActionableExceptions as unknown as Record<string, unknown> & { new (): unknown },
-      "endpoint",
-      {
-        default: "/rails/actions",
-      },
-    );
+    cattrAccessor(ActionableExceptions, "endpoint", { default: "/rails/actions" });
   }
 
   async call(env: RackEnv): Promise<RackResponse> {

--- a/packages/activesupport/src/actionable-error.test.ts
+++ b/packages/activesupport/src/actionable-error.test.ts
@@ -54,4 +54,27 @@ describe("ActionableErrorTest", () => {
     TestError.action("Only on test", () => {});
     expect(Object.keys(ActionableError.actions(new SiblingError()))).toHaveLength(0);
   });
+
+  it("warns when two distinct classes register under the same name", () => {
+    class Dup1 extends ActionableError {}
+    Object.defineProperty(Dup1, "name", { value: "DupCollision" });
+    class Dup2 extends ActionableError {}
+    Object.defineProperty(Dup2, "name", { value: "DupCollision" });
+
+    const calls: unknown[][] = [];
+    const original = console.warn;
+    console.warn = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    try {
+      ActionableError.register(Dup1);
+      ActionableError.register(Dup1);
+      ActionableError.register(Dup2);
+    } finally {
+      console.warn = original;
+      ActionableError._registry.delete("DupCollision");
+    }
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0][0])).toContain("DupCollision");
+  });
 });

--- a/packages/activesupport/src/actionable-error.ts
+++ b/packages/activesupport/src/actionable-error.ts
@@ -20,8 +20,19 @@ export class ActionableError extends Error {
     this.name = "ActionableError";
   }
 
-  /** Register an actionable error class so it can be resolved by name. */
+  /**
+   * Register an actionable error class so it can be resolved by name. Mirrors
+   * Rails' implicit registration via `safe_constantize`; emits a console
+   * warning if a different class is already registered under the same name so
+   * silent shadowing doesn't mask a typo or duplicate definition.
+   */
   static register(cls: typeof ActionableError): void {
+    const existing = ActionableError._registry.get(cls.name);
+    if (existing && existing !== cls) {
+      console.warn(
+        `ActionableError._registry collision: a different class is already registered as "${cls.name}"; the previous entry will be replaced.`,
+      );
+    }
     ActionableError._registry.set(cls.name, cls);
   }
 


### PR DESCRIPTION
## Summary

Bundle of small Tier 1 leaf fidelity items from `docs/actionpack-100-percent.md`:

- **http/mime-type** — wire `parseTrailingStar` / `parseDataWithTrailingStar` into `MimeType.parse()` so `Accept: text/*` and `application/*` expand to registered types. Thread Rails' `ACCEPT_HEADER_REGEXP` / `PARAMETER_SEPARATOR_REGEXP` and `AcceptList.sortBang` through the multi-entry branch; add the Rails `lookup` fallback that drops a trailing `;params` for parameterized media types (`text/html;level=2` → `text/html`). `AcceptList.sortBang` now uses the same fallback so the comma and no-comma branches behave identically.
- **middleware/actionable_exceptions** — declare `endpoint` via `cattrAccessor` to mirror Rails' `cattr_accessor :endpoint, default: "/rails/actions"`. Note: `cattrAccessor` and Rails' `cattr_accessor` both store the value in a single hierarchy-wide slot, so subclass writes mutate the same slot (matching Rails). The benefit is going through a real getter/setter pair so apps can swap the endpoint via `ActionableExceptions.endpoint = "..."` (or via railtie config) just like in Rails.
- **activesupport/ActionableError** — warn on `_registry` collision when a different class is registered under the same name, so silent shadowing surfaces. Covered by a new unit test.

## Already shipped by #1953

`http/url` (subdomain clamp), `http/mime_negotiation` (`paramsReadable` rescue list), `http/param_error` (`STATUS_MAP` + request parse rescue), and `middleware/remote-ip` (`customProxies` iterable check) all landed in #1953 — verified in-place, no changes needed.

## Deferred

- **`ActionableError.action` prototype-chain walk** — current `this._actions` copy-on-write already covers single-level inheritance and the test suite is green; the concrete gap behind the plan-doc bullet needs more investigation. Tracked as a tiny follow-up if needed.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/mime-type.test.ts` — 33 passing (trailing-star tests now assert Rails-shape expansion).
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/actionable-exceptions.test.ts` — 6 passing.
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/dispatch/request.test.ts packages/actionpack/src/action-dispatch/http/mime-negotiation.test.ts` — 112 passing (negotiation still routes `*/*` correctly).
- [x] `pnpm vitest run packages/activesupport/src/actionable-error.test.ts` — 7 passing (new collision-warning test).
- [x] `pnpm api:compare --package actiondispatch` — all six touched files at 100%.