### PR TITLE
feat(actionpack): wire Cache::Response + FilterRedirect privates onto Response

### DIFF
--- a/packages/actionpack/src/action-dispatch/http/response.ts
+++ b/packages/actionpack/src/action-dispatch/http/response.ts
@@ -10,6 +10,8 @@ import type { Request } from "./request.js";
 import {
   type CacheControlHash,
   cacheControl as _cacheControl,
+  cacheControlHeaders as _cacheControlHeaders,
+  cacheControlSegments as _cacheControlSegments,
   generateStrongEtag as _generateStrongEtag,
   generateWeakEtag as _generateWeakEtag,
   getDate as _getDate,
@@ -27,7 +29,12 @@ import {
   strongEtag as _strongEtag,
   weakEtag as _weakEtag,
 } from "./cache.js";
-import { filteredLocation as _filteredLocation } from "./filter-redirect.js";
+import {
+  filteredLocation as _filteredLocation,
+  locationFilterMatch as _locationFilterMatch,
+  locationFilters as _locationFilters,
+  parameterFilteredLocation as _parameterFilteredLocation,
+} from "./filter-redirect.js";
 
 // Lowercase to match the rest of this file's header conventions; setHeader
 // is case-insensitive but call sites read `headers["content-type"]` directly.
@@ -371,6 +378,16 @@ export class Response {
    * {@link _cacheControl}.
    */
   declare readonly cacheControl: CacheControlHash;
+  /** @internal Rails: `cache_control_segments` private. */
+  declare cacheControlSegments: () => string[] | undefined;
+  /** @internal Rails: `cache_control_headers` private. */
+  declare cacheControlHeaders: () => CacheControlHash;
+  /** @internal Rails: `FilterRedirect#location_filters` private. */
+  declare locationFilters: () => Array<string | RegExp>;
+  /** @internal Rails: `FilterRedirect#location_filter_match?` private. */
+  declare isLocationFilterMatch: () => boolean;
+  /** @internal Rails: `FilterRedirect#parameter_filtered_location` private. */
+  declare parameterFilteredLocation: () => string;
 
   // --- Rack response ---
 
@@ -701,6 +718,21 @@ Response.prototype.mergeAndNormalizeCacheControlBang = function (
   cacheControl: CacheControlHash,
 ) {
   _mergeAndNormalizeCacheControlBang.call(this, cacheControl);
+};
+Response.prototype.cacheControlSegments = function (this: Response) {
+  return _cacheControlSegments.call(this);
+};
+Response.prototype.cacheControlHeaders = function (this: Response) {
+  return _cacheControlHeaders.call(this);
+};
+Response.prototype.locationFilters = function (this: Response) {
+  return _locationFilters.call(this);
+};
+Response.prototype.isLocationFilterMatch = function (this: Response) {
+  return _locationFilterMatch.call(this);
+};
+Response.prototype.parameterFilteredLocation = function (this: Response) {
+  return _parameterFilteredLocation.call(this);
 };
 export interface CookieOptions {
   value: string;


### PR DESCRIPTION
## Summary

Wires the 5 remaining Rails private methods from `Http::Cache::Response` and `Http::FilterRedirect` onto `ActionDispatch::Response`, taking `http/response.rb` from **94% → 100%** (72/77 → 77/77 methods matched).

Methods now exposed on `Response.prototype` (as `@internal`):

- `cacheControlSegments` / `cacheControlHeaders` (`Cache::Response`)
- `locationFilters` / `isLocationFilterMatch` / `parameterFilteredLocation` (`FilterRedirect`)

The underlying `this`-typed mixin functions already exist in `cache.ts` and `filter-redirect.ts`; this PR just exposes them as prototype methods so the `api-compare` extractor matches them under their Rails names.

### Scope notes (vs. original plan-doc entry)

The original `http/cache wiring` slot listed four items; three were already shipped in prior PRs and are verified intact:

- ✅ `Cache::Request` / `Cache::Response` public wiring on Request/Response prototypes
- ✅ `parseHttpDate` is already strict RFC 1123 (IMF-fixdate)
- ✅ `params` getter already overlays `pathParameters` (parameters.ts:111-124)
- ✅ (this PR) the remaining private methods that `api-compare` was still flagging

No conflicting accessors required removal — the previous wiring already routes `etag`/`lastModified`/`date`/`cacheControl` through the cache module.

## Test plan

- [x] `pnpm api:compare` — `http/response.rb` now 77/77 (100%)
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/http/cache.test.ts` (13/13)
- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/http/filter-redirect.test.ts` (8/8)