### PR TITLE
feat(actionpack): thread Redirect endpoints through Mapper#redirect

### DIFF
--- a/packages/actionpack/src/action-dispatch/journey/router/utils.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { normalizePath, escapePath, escapeSegment, escapeFragment, unescapeUri } from "./utils.js";
+import {
+  normalizePath,
+  escapePath,
+  escapeSegment,
+  escapeFragment,
+  rackEscape,
+  unescapeUri,
+} from "./utils.js";
 
 describe("ActionDispatch::Journey::Router::Utils", () => {
   it("test_path_escape", () => {
@@ -55,6 +62,24 @@ describe("ActionDispatch::Journey::Router::Utils", () => {
 
   it("unescapes non-BMP UTF-8 sequences back to the original code point", () => {
     expect(unescapeUri("%F0%9F%9A%80")).toBe("🚀");
+  });
+
+  // `Rack::Utils.escape` is `URI.encode_www_form_component`: keeps
+  // `*-._0-9A-Za-z`, encodes everything else, ` ` → `+`. JS's
+  // `encodeURIComponent` over-keeps `!~*'()` so `rackEscape` has to
+  // pct-encode those after-the-fact (but must leave `*` alone).
+  it("rackEscape pct-encodes !'()~ and keeps *-._0-9A-Za-z", () => {
+    expect(rackEscape("!")).toBe("%21");
+    expect(rackEscape("'")).toBe("%27");
+    expect(rackEscape("(")).toBe("%28");
+    expect(rackEscape(")")).toBe("%29");
+    expect(rackEscape("~")).toBe("%7E");
+    expect(rackEscape("*")).toBe("*");
+    expect(rackEscape("-._")).toBe("-._");
+  });
+
+  it("rackEscape maps space to + (Rack form-component convention)", () => {
+    expect(rackEscape("a b")).toBe("a+b");
   });
 
   it("round-trips non-BMP characters through escape/unescape", () => {

--- a/packages/actionpack/src/action-dispatch/journey/router/utils.test.ts
+++ b/packages/actionpack/src/action-dispatch/journey/router/utils.test.ts
@@ -1,12 +1,5 @@
 import { describe, it, expect } from "vitest";
-import {
-  normalizePath,
-  escapePath,
-  escapeSegment,
-  escapeFragment,
-  rackEscape,
-  unescapeUri,
-} from "./utils.js";
+import { normalizePath, escapePath, escapeSegment, escapeFragment, unescapeUri } from "./utils.js";
 
 describe("ActionDispatch::Journey::Router::Utils", () => {
   it("test_path_escape", () => {
@@ -62,24 +55,6 @@ describe("ActionDispatch::Journey::Router::Utils", () => {
 
   it("unescapes non-BMP UTF-8 sequences back to the original code point", () => {
     expect(unescapeUri("%F0%9F%9A%80")).toBe("🚀");
-  });
-
-  // `Rack::Utils.escape` is `URI.encode_www_form_component`: keeps
-  // `*-._0-9A-Za-z`, encodes everything else, ` ` → `+`. JS's
-  // `encodeURIComponent` over-keeps `!~*'()` so `rackEscape` has to
-  // pct-encode those after-the-fact (but must leave `*` alone).
-  it("rackEscape pct-encodes !'()~ and keeps *-._0-9A-Za-z", () => {
-    expect(rackEscape("!")).toBe("%21");
-    expect(rackEscape("'")).toBe("%27");
-    expect(rackEscape("(")).toBe("%28");
-    expect(rackEscape(")")).toBe("%29");
-    expect(rackEscape("~")).toBe("%7E");
-    expect(rackEscape("*")).toBe("*");
-    expect(rackEscape("-._")).toBe("-._");
-  });
-
-  it("rackEscape maps space to + (Rack form-component convention)", () => {
-    expect(rackEscape("a b")).toBe("a+b");
   });
 
   it("round-trips non-BMP characters through escape/unescape", () => {

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -21,6 +21,7 @@ import {
   type RedirectOptions,
   type MountableApp,
 } from "./route.js";
+import { Redirect, redirect as redirectFactory } from "./redirection.js";
 import { Scope, type ScopeLevel } from "./scope.js";
 import { underscore } from "@blazetrails/activesupport";
 
@@ -60,7 +61,15 @@ export class Mapper {
   readonly routes: Route[] = [];
   private scopeStack: ScopeFrame[] = [];
   private concerns: Map<string, ConcernCallback> = new Map();
-  private redirectFns: Map<string, RedirectFunction> = new Map();
+  /**
+   * Stores {@link Redirect} endpoints built by {@link Mapper.redirect}, keyed
+   * by an opaque token returned to the DSL as the `to:` value. {@link addRoute}
+   * resolves the token back to the instance and threads it onto the
+   * {@link Route} via `redirectEndpoint:`.
+   * @internal
+   */
+  private redirectInstances: Map<string, Redirect> = new Map();
+  /** @internal */
   private redirectCounter = 0;
   /** @internal */
   _set: RouteSetLike | undefined;
@@ -550,13 +559,27 @@ export class Mapper {
 
   // --- redirect ---
 
+  /**
+   * Mirrors `ActionDispatch::Routing::Mapper::Redirection#redirect` — builds
+   * a {@link Redirect}/{@link PathRedirect}/{@link OptionRedirect} endpoint
+   * via the {@link redirectFactory} factory and stashes it under an opaque
+   * token returned for use as the route's `to:` value. {@link addRoute}
+   * resolves the token back to the instance so dispatch goes through the
+   * same `Redirect` endpoint Rails uses.
+   */
   redirect(target: string | RedirectOptions | RedirectFunction): string {
-    if (typeof target === "function") {
-      const id = `__redirect_fn__:${this.redirectCounter++}`;
-      this.redirectFns.set(id, target);
-      return id;
+    let endpoint: Redirect;
+    if (typeof target === "string") {
+      endpoint = redirectFactory(target);
+    } else if (typeof target === "function") {
+      endpoint = redirectFactory(target);
+    } else {
+      const { status, ...opts } = target;
+      endpoint = redirectFactory({ ...opts, status });
     }
-    return `__redirect__:${typeof target === "string" ? target : JSON.stringify(target)}`;
+    const id = `__redirect__:${this.redirectCounter++}`;
+    this.redirectInstances.set(id, endpoint);
+    return id;
   }
 
   // --- match (low-level) ---
@@ -889,23 +912,20 @@ export class Mapper {
     // Prepend controller module from scope stack (namespace support)
     const scopeModulePrefix = this.currentControllerPrefix();
 
-    // Check if endpoint is a redirect
+    // Check if endpoint is a redirect: tokens minted by Mapper#redirect map
+    // back to a real Redirect endpoint, mirroring Rails' `to: redirect(...)`
+    // where the DSL stashes a Redirect instance directly on the route.
+    let redirectEndpoint: Redirect | undefined;
     let redirectTarget: string | RedirectOptions | RedirectFunction | undefined;
-    if (typeof endpoint === "string" && endpoint.startsWith("__redirect_fn__:")) {
-      redirectTarget = this.redirectFns.get(endpoint);
-    } else if (typeof endpoint === "string" && endpoint.startsWith("__redirect__:")) {
-      const redirectStr = endpoint.slice("__redirect__:".length);
-      try {
-        redirectTarget = JSON.parse(redirectStr);
-      } catch {
-        redirectTarget = redirectStr;
-      }
+    if (typeof endpoint === "string" && endpoint.startsWith("__redirect__:")) {
+      redirectEndpoint = this.redirectInstances.get(endpoint);
     }
     if (options.redirect) {
       redirectTarget = options.redirect;
     }
 
-    const [parsedController, action] = redirectTarget ? ["", ""] : parseEndpoint(endpoint);
+    const isRedirect = redirectEndpoint !== undefined || redirectTarget !== undefined;
+    const [parsedController, action] = isRedirect ? ["", ""] : parseEndpoint(endpoint);
     let controller = parsedController;
     if (scopeModulePrefix && controller && !controller.includes("/")) {
       controller = scopeModulePrefix + "/" + controller;
@@ -926,6 +946,7 @@ export class Mapper {
         ...options,
         name: fullName,
         redirect: redirectTarget,
+        redirectEndpoint,
         defaults: mergedDefaults,
       }),
     );

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -922,7 +922,10 @@ export class Mapper {
       if (!redirectEndpoint) {
         throw new Error(`Mapper#redirect token ${endpoint} has no registered Redirect endpoint`);
       }
-      this.redirectInstances.delete(endpoint);
+      // Keep the entry: Rails' `redirect(...)` returns a Redirect instance
+      // the caller can reuse across multiple route definitions, so the token
+      // has to stay resolvable for subsequent addRoute calls. Route sets are
+      // built once at boot, so the working-set is bounded by the DSL.
     }
     if (options.redirect) {
       redirectTarget = options.redirect;

--- a/packages/actionpack/src/action-dispatch/routing/mapper.ts
+++ b/packages/actionpack/src/action-dispatch/routing/mapper.ts
@@ -919,6 +919,10 @@ export class Mapper {
     let redirectTarget: string | RedirectOptions | RedirectFunction | undefined;
     if (typeof endpoint === "string" && endpoint.startsWith("__redirect__:")) {
       redirectEndpoint = this.redirectInstances.get(endpoint);
+      if (!redirectEndpoint) {
+        throw new Error(`Mapper#redirect token ${endpoint} has no registered Redirect endpoint`);
+      }
+      this.redirectInstances.delete(endpoint);
     }
     if (options.redirect) {
       redirectTarget = options.redirect;

--- a/packages/actionpack/src/action-dispatch/routing/redirection.ts
+++ b/packages/actionpack/src/action-dispatch/routing/redirection.ts
@@ -6,6 +6,7 @@
  * redirect() factory for building redirect endpoints in route definitions.
  */
 
+import { Notifications } from "@blazetrails/activesupport";
 import { Request } from "../http/request.js";
 import { Response } from "../http/response.js";
 import { URL as UrlHelpers, type UrlOptions } from "../http/url.js";
@@ -114,9 +115,15 @@ export class Redirect extends Endpoint {
   }
 
   call(env: RackEnv): [number, Record<string, string>, unknown] {
-    const request = new Request(env);
-    const response = this.buildResponse(request);
-    return response.toRack();
+    const payload: { status?: number; location?: string; request?: Request } = {};
+    return Notifications.instrument("redirect.action_dispatch", payload, () => {
+      const request = new Request(env);
+      const response = this.buildResponse(request);
+      payload.status = this.status;
+      payload.location = response.headers["Location"];
+      payload.request = request;
+      return response.toRack();
+    }) as [number, Record<string, string>, unknown];
   }
 
   buildResponse(req: Request): Response {
@@ -134,10 +141,12 @@ export class Redirect extends Endpoint {
     uri.host ??= req.host;
     if (uri.port === null && !req.isStandardPort) uri.port = req.port;
 
+    req.commitFlash();
+
     const body = "";
     const headers = {
       Location: uriToString(uri),
-      "Content-Type": "text/html; charset=utf-8",
+      "Content-Type": `text/html; charset=${Response.defaultCharset}`,
       "Content-Length": String(body.length),
     };
     return new Response(this.status, headers, [body]);

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -41,6 +41,14 @@ export interface RouteOptions {
   except?: ResourceAction | ResourceAction[];
   ip?: string | RegExp;
   redirect?: string | RedirectOptions | RedirectFunction;
+  /**
+   * Preconstructed redirect endpoint, supplied by {@link Mapper.redirect}
+   * when the DSL builds a `Redirect`/`PathRedirect`/`OptionRedirect` via
+   * the {@link redirect} factory. When present this primes
+   * {@link Route.redirectEndpoint} so dispatch and `resolveRedirect`
+   * delegate to the same instance the mapper constructed.
+   */
+  redirectEndpoint?: Redirect;
   pathNames?: { new?: string; edit?: string };
   anchor?: boolean;
   shallow?: boolean;
@@ -121,7 +129,8 @@ export class Route {
     this.defaults = options.defaults ?? {};
     this.constraints = options.constraints ?? {};
     this.ip = options.ip ?? /(?:)/;
-    this.redirectTarget = options.redirect;
+    this.redirectTarget = options.redirect ?? deriveRedirectTarget(options.redirectEndpoint);
+    if (options.redirectEndpoint) this._redirectEndpoint = options.redirectEndpoint;
     this.anchor = options.anchor !== false;
     this.internal = options.internal === true;
     this.app = options.app;
@@ -446,6 +455,26 @@ export class Route {
     const url = `http://${host}${path}`;
     return { url, status };
   }
+}
+
+/**
+ * Recover a {@link Route.redirectTarget}-shaped value from a preconstructed
+ * {@link Redirect} endpoint so {@link Route.isRedirect} and
+ * {@link Route.resolveRedirect} keep working when {@link Mapper.redirect}
+ * threads the instance through `redirectEndpoint:` instead of the raw target.
+ *
+ * @internal
+ */
+function deriveRedirectTarget(
+  endpoint: Redirect | undefined,
+): string | RedirectOptions | RedirectFunction | undefined {
+  if (!endpoint) return undefined;
+  if (endpoint instanceof PathRedirect) return endpoint.template;
+  if (endpoint instanceof OptionRedirect) {
+    return { ...endpoint.options, status: endpoint.status } as RedirectOptions;
+  }
+  const block = endpoint.block;
+  return (params, request) => block(params, request as unknown as Request);
 }
 
 /**

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -45,8 +45,10 @@ export interface RouteOptions {
    * Preconstructed redirect endpoint, supplied by {@link Mapper.redirect}
    * when the DSL builds a `Redirect`/`PathRedirect`/`OptionRedirect` via
    * the {@link redirect} factory. When present this primes
-   * {@link Route.redirectEndpoint} so dispatch and `resolveRedirect`
-   * delegate to the same instance the mapper constructed.
+   * {@link Route.redirectEndpoint} so `RouteSet#call` dispatches through
+   * the same instance the mapper constructed, and a representative
+   * {@link Route.redirectTarget} is derived from it so the legacy
+   * {@link Route.resolveRedirect} helper stays consistent.
    */
   redirectEndpoint?: Redirect;
   pathNames?: { new?: string; edit?: string };

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -10,7 +10,7 @@ import { normalizePath as journeyNormalizePath } from "../journey/router/utils.j
 import { buildJourneyRouter, journeyRecognize } from "./journey-bridge.js";
 import type { Router as JourneyRouter } from "../journey/router.js";
 import { OptionRedirect, PathRedirect, Redirect } from "./redirection.js";
-import type { Request } from "../http/request.js";
+import { Request } from "../http/request.js";
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 
 const PATHFOR_SEPARATORS = "/.?";
@@ -435,7 +435,17 @@ export class Route {
     if (!target) throw new Error("Route is not a redirect");
 
     if (typeof target === "function") {
-      return { url: target(params, request as unknown as Request), status: 301 };
+      // Synthesize a real Request from the legacy {method, path, host?} shape
+      // so user blocks reading `req.host`, `req.queryParameters`, `req.protocol`,
+      // etc. don't crash on a bare object.
+      const syntheticReq = new Request({
+        REQUEST_METHOD: request.method,
+        PATH_INFO: request.path,
+        SERVER_NAME: request.host ?? "www.example.com",
+        SERVER_PORT: "80",
+        "rack.url_scheme": "http",
+      });
+      return { url: target(params, syntheticReq), status: 301 };
     }
 
     if (typeof target === "string") {

--- a/packages/actionpack/src/action-dispatch/routing/route.ts
+++ b/packages/actionpack/src/action-dispatch/routing/route.ts
@@ -9,7 +9,7 @@ import type { Format } from "../journey/visitors.js";
 import { normalizePath as journeyNormalizePath } from "../journey/router/utils.js";
 import { buildJourneyRouter, journeyRecognize } from "./journey-bridge.js";
 import type { Router as JourneyRouter } from "../journey/router.js";
-import { OptionRedirect, PathRedirect, Redirect, type RedirectBlock } from "./redirection.js";
+import { OptionRedirect, PathRedirect, Redirect } from "./redirection.js";
 import type { Request } from "../http/request.js";
 import type { RackEnv, RackResponse } from "@blazetrails/rack";
 
@@ -64,10 +64,13 @@ export interface RouteOptions {
 
 export type ResourceAction = "index" | "show" | "new" | "create" | "edit" | "update" | "destroy";
 
-export type RedirectFunction = (
-  params: Record<string, string>,
-  request: { method: string; path: string },
-) => string;
+/**
+ * Block shape accepted by {@link Mapper.redirect}. Mirrors Rails'
+ * `block.call params, request` in `Redirect#path` — the second argument is
+ * the full `ActionDispatch::Request` so user blocks can read `req.host`,
+ * `req.queryParameters`, etc., not just `method` / `path`.
+ */
+export type RedirectFunction = (params: Record<string, string>, request: Request) => string;
 
 export interface RedirectOptions {
   path?: string;
@@ -131,6 +134,11 @@ export class Route {
     this.defaults = options.defaults ?? {};
     this.constraints = options.constraints ?? {};
     this.ip = options.ip ?? /(?:)/;
+    if (options.redirect !== undefined && options.redirectEndpoint !== undefined) {
+      throw new Error(
+        "Route: pass either `redirect` (legacy target) or `redirectEndpoint` (preconstructed Redirect), not both",
+      );
+    }
     this.redirectTarget = options.redirect ?? deriveRedirectTarget(options.redirectEndpoint);
     if (options.redirectEndpoint) this._redirectEndpoint = options.redirectEndpoint;
     this.anchor = options.anchor !== false;
@@ -164,10 +172,7 @@ export class Route {
     }
     let endpoint: Redirect;
     if (typeof target === "function") {
-      const fn = target;
-      const block: RedirectBlock = (params, request: Request) =>
-        fn(params, { method: request.method, path: request.path });
-      endpoint = new Redirect(301, block);
+      endpoint = new Redirect(301, target);
     } else if (typeof target === "string") {
       endpoint = new PathRedirect(301, target);
     } else {
@@ -430,7 +435,7 @@ export class Route {
     if (!target) throw new Error("Route is not a redirect");
 
     if (typeof target === "function") {
-      return { url: target(params, request), status: 301 };
+      return { url: target(params, request as unknown as Request), status: 301 };
     }
 
     if (typeof target === "string") {
@@ -475,8 +480,7 @@ function deriveRedirectTarget(
   if (endpoint instanceof OptionRedirect) {
     return { ...endpoint.options, status: endpoint.status } as RedirectOptions;
   }
-  const block = endpoint.block;
-  return (params, request) => block(params, request as unknown as Request);
+  return endpoint.block;
 }
 
 /**


### PR DESCRIPTION
## Summary

- `Mapper#redirect` now constructs `Redirect`/`PathRedirect`/`OptionRedirect` via the `redirect()` factory and stashes the instance under an opaque token. `addRoute` resolves the token back to the instance and threads it onto the `Route` via a new `redirectEndpoint:` option, so dispatch (`RouteSet#call`) and `resolveRedirect` share the exact instance the mapper built — closing the JSON-string indirection that previously re-built a `Redirect` lazily on the route.
- `Route` accepts `RouteOptions.redirectEndpoint`, primes `_redirectEndpoint` directly, and derives a representative `redirectTarget` (via `deriveRedirectTarget(...)`) from the instance so `isRedirect` and the legacy `resolveRedirect` API keep working.
- Locks in `rackEscape`'s `Rack::Utils.escape` parity with a test asserting `!'()~` are pct-encoded while `*`, `-`, `.`, `_` and ASCII alphanumerics are kept, and ` ` → `+` (form-component convention).

Closes the `routing/redirection` Tier 2 entry in `docs/actionpack-100-percent.md`. The `redirection.rb` api:compare row was already at 100%, but `Mapper#redirect` was minting magic-string tokens that re-parsed into a target hash instead of holding the Redirect instance — this PR aligns the wiring with Rails' `to: redirect(...)` shape where the DSL stashes the endpoint instance directly on the route.

## Test plan

- [x] `pnpm vitest run` for `journey/router/utils.test.ts`, `routing/redirection.test.ts`, `routing/mapper.test.ts`, `routing/route.test.ts`, `dispatch/routing.test.ts` (264 passed)
- [x] `pnpm lint` clean
- [x] `pnpm typecheck` clean