### PR TITLE
feat(activerecord): route scoping/ tests through pooled adapter dispatcher (pool epic Phase D batch 1)

### DIFF
--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { Base, Relation } from "../index.js";
 
-import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
+import { createPooledTestAdapterOrFallback, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = createSidecarTestAdapter());
+  ({ adapter: _adapter } = await createPooledTestAdapterOrFallback());
   await defineSchema(_adapter, {
     posts: {
       title: "string",

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -5,14 +5,18 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Relation } from "../index.js";
 
-import { createSidecarTestAdapter, adapterType, type SidecarAdapter } from "../test-adapter.js";
+import {
+  createPooledTestAdapterOrFallback,
+  adapterType,
+  type SidecarAdapter,
+} from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = createSidecarTestAdapter());
+  ({ adapter: _adapter } = await createPooledTestAdapterOrFallback());
   await defineSchema(_adapter, {
     posts: {
       title: "string",

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";
 
-import { createPooledTestAdapterOrFallback, type SidecarAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: SidecarAdapter;
+let _adapter: TestDatabaseAdapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = await createPooledTestAdapterOrFallback());
+  _adapter = createTestAdapter();
   const postCols = {
     title: "string" as const,
     published: "boolean" as const,

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createPooledTestAdapterOrFallback, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = await createPooledTestAdapterOrFallback());
   const postCols = {
     title: "string" as const,
     published: "boolean" as const,

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -269,6 +269,29 @@ export async function createPooledTestAdapter(): Promise<{
   return { adapter, fixtures: new SidecarFixtures(adapter), pool };
 }
 
+/**
+ * Phase D dispatcher: returns the pooled adapter when the active backend can
+ * lease independent connections, otherwise the singleton sidecar. Test files
+ * call this so they don't have to branch on driver/adapter.
+ *
+ * SQLite falls back to the sidecar because AR's test setup registers
+ * better-sqlite3, which compiles with `SQLITE_OMIT_SHARED_CACHE` — pooling
+ * would hand each lease a private in-memory DB. See the
+ * `project_sqlite_shared_cache_spike` memory entry; node:sqlite would
+ * support pooling but isn't registered in the AR test environment today.
+ * PG and MySQL always route through the pool.
+ *
+ * @internal
+ */
+export async function createPooledTestAdapterOrFallback(): Promise<{
+  adapter: SidecarAdapter;
+  fixtures: SidecarFixtures;
+}> {
+  if (adapterType === "sqlite") return createSidecarTestAdapter();
+  const { adapter, fixtures } = await createPooledTestAdapter();
+  return { adapter, fixtures };
+}
+
 /** @internal — for the smoke test only. */
 export function _resetPooledTestAdapterForTests(): void {
   if (_pooledHandler) {


### PR DESCRIPTION
## Summary

- Adds `createPooledTestAdapterOrFallback()` in `test-adapter.ts` — a dispatcher that returns the pooled adapter for PG/MySQL and the singleton sidecar for SQLite (better-sqlite3 compiles with `SQLITE_OMIT_SHARED_CACHE`, so pooling would hand each lease a private in-memory DB; see `project_sqlite_shared_cache_spike` memory).
- Migrates two of three `packages/activerecord/src/scoping/*.test.ts` files (`default-scoping`, `named-scoping`) to call the dispatcher.
- **`relation-scoping.test.ts` migration deferred** — PG CI reproduced Bug 2 (`NestedRelationScopingTest > merge inner scope has priority`: `StatementInvalid: current transaction is aborted, commands ignored until end of transaction block`) under the pooled adapter. Phase C `pinConnectionBang(false)` alone is not sufficient to serialize the 11 concurrent `Post.create` branches under `Promise.all`. Re-migrate in a follow-up after the serialization gap is diagnosed.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/scoping/` — SQLite (better-sqlite3 fallback path), all green
- [x] CI: PG path — `default-scoping` + `named-scoping` green; `relation-scoping` reverted in this PR
- [ ] CI: MariaDB path
- [x] `api:compare`: 4955/4958 (99.9%), 275/275 files — unchanged
- [x] `test:compare`: 13001/21714 (59.9%) — unchanged

## Follow-ups

- Diagnose why `Promise.all` branches still race under the pooled adapter despite `pinConnectionBang(false)`. Hypothesis: pool may hand out separate connections under `Promise.all`, or savepoint-per-branch cascade aborts the outer TX once any branch's assert fails. Once fixed, re-migrate `relation-scoping.test.ts`.
- Phase D batch 2: next test cluster (`relation/` or top-level root tests).
- Phase E: delete `_sharedAdapter`, `createTestAdapter`, `createSidecarTestAdapter`, and the `TestAdapterFixtures` wrapper once all consumers have migrated.