### PR TITLE
feat(actionpack): CookieJar.signedOrEncrypted + serialized signed/encrypted jars

### DIFF
--- a/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
@@ -280,6 +280,24 @@ describe("SignedCookieJar serialized API", () => {
     expect(jar.signed.get("user_id")).toBe(45);
   });
 
+  it("honors a custom serializer from request env for round-trip", () => {
+    const custom: CookieSerializer = {
+      dump: (v) => `!${String(v)}!`,
+      load: (s) => s.slice(1, -1),
+      dumped: (s) => s.startsWith("!") && s.endsWith("!"),
+    };
+    const jar = CookieJar.build(
+      {
+        env: { "action_dispatch.cookies_serializer": custom },
+        cookies: {},
+        cookiesAppOptions: { secret: "x".repeat(32) },
+      },
+      {},
+    );
+    jar.signed.set("k", "abc");
+    expect(jar.signed.get("k")).toBe("abc");
+  });
+
   it("returns undefined when verification fails", () => {
     const seeded = CookieJar.build(
       { env: {}, cookies: {}, cookiesAppOptions: { secret: "x".repeat(32) } },

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.test.ts
@@ -242,6 +242,90 @@ describe("SerializedCookieJars", () => {
   });
 });
 
+describe("CookieJar.signedOrEncrypted", () => {
+  it("prefers encrypted when secret_key_base is present on the request", () => {
+    const jar = CookieJar.build(
+      {
+        env: { "action_dispatch.secret_key_base": "skb" },
+        cookies: {},
+        cookiesAppOptions: { secret: "s" },
+      },
+      {},
+    );
+    expect(jar.signedOrEncrypted).toBeInstanceOf((jar.encrypted as object).constructor);
+  });
+
+  it("falls back to signed when secret_key_base is absent", () => {
+    const jar = CookieJar.build({ env: {}, cookies: {}, cookiesAppOptions: { secret: "s" } }, {});
+    expect(jar.signedOrEncrypted).toBeInstanceOf((jar.signed as object).constructor);
+  });
+});
+
+describe("SignedCookieJar serialized API", () => {
+  it("accepts arbitrary hash values via set and JSON-round-trips them", () => {
+    const jar = CookieJar.build(
+      { env: {}, cookies: {}, cookiesAppOptions: { secret: "x".repeat(32) } },
+      {},
+    );
+    jar.signed.set("user", { id: 45, name: "Aaron" });
+    expect(jar.signed.get("user")).toEqual({ id: 45, name: "Aaron" });
+  });
+
+  it("accepts a hash carrying value alongside cookie options", () => {
+    const jar = CookieJar.build(
+      { env: {}, cookies: {}, cookiesAppOptions: { secret: "x".repeat(32) } },
+      {},
+    );
+    jar.signed.set("user_id", { value: 45, httpOnly: true });
+    expect(jar.signed.get("user_id")).toBe(45);
+  });
+
+  it("returns undefined when verification fails", () => {
+    const seeded = CookieJar.build(
+      { env: {}, cookies: {}, cookiesAppOptions: { secret: "x".repeat(32) } },
+      { user_id: "tampered--badmac" },
+    );
+    expect(seeded.signed.get("user_id")).toBeUndefined();
+  });
+});
+
+describe("EncryptedCookieJar serialized API", () => {
+  it("accepts arbitrary hash values via set and JSON-round-trips them", () => {
+    const jar = CookieJar.build(
+      { env: {}, cookies: {}, cookiesAppOptions: { secret: "x".repeat(32) } },
+      {},
+    );
+    jar.encrypted.set("session", { uid: 7, role: "admin" });
+    expect(jar.encrypted.get("session")).toEqual({ uid: 7, role: "admin" });
+  });
+
+  it("returns undefined when decryption fails", () => {
+    const seeded = CookieJar.build(
+      { env: {}, cookies: {}, cookiesAppOptions: { secret: "x".repeat(32) } },
+      { session: "ffff--ffff" },
+    );
+    expect(seeded.encrypted.get("session")).toBeUndefined();
+  });
+
+  it("honors a custom serializer from request env for round-trip", () => {
+    const custom: CookieSerializer = {
+      dump: (v) => `!${String(v)}!`,
+      load: (s) => s.slice(1, -1),
+      dumped: (s) => s.startsWith("!") && s.endsWith("!"),
+    };
+    const jar = CookieJar.build(
+      {
+        env: { "action_dispatch.cookies_serializer": custom },
+        cookies: {},
+        cookiesAppOptions: { secret: "x".repeat(32) },
+      },
+      {},
+    );
+    jar.encrypted.set("k", "abc");
+    expect(jar.encrypted.get("k")).toBe("abc");
+  });
+});
+
 describe("checkForOverflowBang", () => {
   it("raises CookieOverflow once a value exceeds 4096 bytes", () => {
     const big = "x".repeat(4097);

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -61,6 +61,15 @@ export class CookieJar implements Iterable<[string, string]> {
   private _deletedCookies: Map<string, { path?: string; domain?: string }> = new Map();
   private _options: CookieJarOptions;
   private _committed = false;
+  /**
+   * Backing request reference for the serialized signed/encrypted jars'
+   * `cookies_serializer` lookup and the {@link CookieJar.signedOrEncrypted}
+   * dispatch. Populated by {@link CookieJar.build}; `undefined` when the
+   * jar is constructed standalone (e.g. unit tests of the plain API).
+   *
+   * @internal
+   */
+  _request?: RequestCookieMethodsHost;
 
   constructor(options: CookieJarOptions = {}) {
     this._options = options;
@@ -94,7 +103,11 @@ export class CookieJar implements Iterable<[string, string]> {
    * @internal
    */
   static build(
-    request: { cookiesAppOptions?: CookieJarOptions } | null | undefined,
+    request:
+      | (RequestCookieMethodsHost & { cookiesAppOptions?: CookieJarOptions })
+      | { cookiesAppOptions?: CookieJarOptions }
+      | null
+      | undefined,
     cookies: Record<string, string>,
   ): CookieJar {
     // Rails: `jar = new(req); jar.update(cookies); jar` — the request stores
@@ -102,6 +115,7 @@ export class CookieJar implements Iterable<[string, string]> {
     // `request.cookiesAppOptions` if the host exposes it so signed/encrypted
     // accessors can find their secrets in test setups.
     const jar = new CookieJar(request?.cookiesAppOptions ?? {});
+    if (request && "env" in request) jar._request = request as RequestCookieMethodsHost;
     for (const [k, v] of Object.entries(cookies ?? {})) {
       jar._cookies.set(k, v);
     }
@@ -206,7 +220,7 @@ export class CookieJar implements Iterable<[string, string]> {
   get signed(): SignedCookieJar {
     const secret = this._options.signedSecret ?? this._options.secret;
     if (!secret) throw new Error("No secret configured for signed cookies");
-    return new SignedCookieJar(this, secret);
+    return new SignedCookieJar(this, secret, this._request);
   }
 
   // --- Encrypted ---
@@ -214,7 +228,19 @@ export class CookieJar implements Iterable<[string, string]> {
   get encrypted(): EncryptedCookieJar {
     const secret = this._options.encryptedSecret ?? this._options.secret;
     if (!secret) throw new Error("No secret configured for encrypted cookies");
-    return new EncryptedCookieJar(this, secret);
+    return new EncryptedCookieJar(this, secret, this._request);
+  }
+
+  /**
+   * Returns the `encrypted` jar when `secret_key_base` is configured on the
+   * request, otherwise falls back to `signed`. Mirrors Rails'
+   * `ChainedCookieJars#signed_or_encrypted`, used by
+   * `ActionDispatch::Session::CookieStore` to avoid the need to introduce
+   * new cookie stores.
+   */
+  get signedOrEncrypted(): SignedCookieJar | EncryptedCookieJar {
+    const skb = this._request ? secretKeyBase.call(this._request) : undefined;
+    return skb ? this.encrypted : this.signed;
   }
 
   // --- Response headers ---
@@ -268,31 +294,73 @@ export class PermanentCookieJar {
   }
 }
 
+/**
+ * Options accepted by the signed/encrypted jars' `set` — mirror of
+ * `AbstractCookieJar#[]=` accepting either a bare value or a `Hash` carrying
+ * `:value` alongside cookie metadata.
+ */
+export type SerializedSetOptions = Omit<SetCookieOptions, "value"> & { value: unknown };
+
+/** @internal */
+function makeSerializedHost(
+  request: RequestCookieMethodsHost | undefined,
+): SerializedCookieJarsHost {
+  return { request: request ?? { env: {}, cookies: {} } };
+}
+
+/** @internal */
+function normalizeSerializedInput(input: unknown): SerializedSetOptions {
+  if (
+    input !== null &&
+    typeof input === "object" &&
+    "value" in (input as Record<string, unknown>)
+  ) {
+    return { ...(input as SerializedSetOptions) };
+  }
+  return { value: input };
+}
+
 export class SignedCookieJar {
   private jar: CookieJar;
   private secret: string;
   private digest: string;
+  private host: SerializedCookieJarsHost;
 
-  constructor(jar: CookieJar, secret: string, digest = "sha256") {
+  constructor(
+    jar: CookieJar,
+    secret: string,
+    request?: RequestCookieMethodsHost,
+    digest = "sha256",
+  ) {
     this.jar = jar;
     this.secret = secret;
     this.digest = digest;
+    this.host = makeSerializedHost(request);
   }
 
-  set(key: string, valueOrOptions: string | SetCookieOptions): void {
-    const value = typeof valueOrOptions === "string" ? valueOrOptions : valueOrOptions.value;
-    const signed = this.sign(value);
-    if (typeof valueOrOptions === "string") {
-      this.jar.set(key, signed);
-    } else {
-      this.jar.set(key, { ...valueOrOptions, value: signed });
-    }
+  /**
+   * Mirror of Rails `AbstractCookieJar#[]=` for the signed jar: accept a
+   * bare value or a hash with `:value`, JSON-serialize via the
+   * SerializedCookieJars layer, then sign and write to the parent jar.
+   */
+  set(key: string, valueOrOptions: unknown): void {
+    const options = normalizeSerializedInput(valueOrOptions);
+    commit.call(this.host, key, options);
+    const signed = this.sign(options.value as string);
+    checkForOverflowBang(key, { value: signed });
+    this.jar.set(key, { ...(options as SetCookieOptions), value: signed });
   }
 
-  get(key: string): string | undefined {
+  get(key: string): unknown {
     const raw = this.jar.get(key);
     if (!raw) return undefined;
-    return this.verify(raw);
+    const verified = this.verify(raw);
+    if (verified === undefined) return undefined;
+    try {
+      return serializer.call(this.host).load(verified);
+    } catch {
+      return undefined;
+    }
   }
 
   private sign(value: string): string {
@@ -319,26 +387,37 @@ export class SignedCookieJar {
 export class EncryptedCookieJar {
   private jar: CookieJar;
   private secret: string;
+  private host: SerializedCookieJarsHost;
 
-  constructor(jar: CookieJar, secret: string) {
+  constructor(jar: CookieJar, secret: string, request?: RequestCookieMethodsHost) {
     this.jar = jar;
     this.secret = secret;
+    this.host = makeSerializedHost(request);
   }
 
-  set(key: string, valueOrOptions: string | SetCookieOptions): void {
-    const value = typeof valueOrOptions === "string" ? valueOrOptions : valueOrOptions.value;
-    const encrypted = this.encrypt(value);
-    if (typeof valueOrOptions === "string") {
-      this.jar.set(key, encrypted);
-    } else {
-      this.jar.set(key, { ...valueOrOptions, value: encrypted });
-    }
+  /**
+   * Mirror of Rails `AbstractCookieJar#[]=` for the encrypted jar: accept a
+   * bare value or a hash with `:value`, JSON-serialize via the
+   * SerializedCookieJars layer, then encrypt and write to the parent jar.
+   */
+  set(key: string, valueOrOptions: unknown): void {
+    const options = normalizeSerializedInput(valueOrOptions);
+    commit.call(this.host, key, options);
+    const encrypted = this.encrypt(options.value as string);
+    checkForOverflowBang(key, { value: encrypted });
+    this.jar.set(key, { ...(options as SetCookieOptions), value: encrypted });
   }
 
-  get(key: string): string | undefined {
+  get(key: string): unknown {
     const raw = this.jar.get(key);
     if (!raw) return undefined;
-    return this.decrypt(raw);
+    const decrypted = this.decrypt(raw);
+    if (decrypted === undefined) return undefined;
+    try {
+      return serializer.call(this.host).load(decrypted);
+    } catch {
+      return undefined;
+    }
   }
 
   private encrypt(value: string): string {

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -103,11 +103,7 @@ export class CookieJar implements Iterable<[string, string]> {
    * @internal
    */
   static build(
-    request:
-      | (RequestCookieMethodsHost & { cookiesAppOptions?: CookieJarOptions })
-      | { cookiesAppOptions?: CookieJarOptions }
-      | null
-      | undefined,
+    request: RequestCookieMethodsHost | { cookiesAppOptions?: CookieJarOptions } | null | undefined,
     cookies: Record<string, string>,
   ): CookieJar {
     // Rails: `jar = new(req); jar.update(cookies); jar` — the request stores

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -310,11 +310,7 @@ function makeSerializedHost(
 
 /** @internal */
 function normalizeSerializedInput(input: unknown): SerializedSetOptions {
-  if (
-    input !== null &&
-    typeof input === "object" &&
-    "value" in (input as Record<string, unknown>)
-  ) {
+  if (input !== null && typeof input === "object" && Object.hasOwn(input as object, "value")) {
     return { ...(input as SerializedSetOptions) };
   }
   return { value: input };

--- a/packages/actionpack/src/action-dispatch/middleware/cookies.ts
+++ b/packages/actionpack/src/action-dispatch/middleware/cookies.ts
@@ -353,7 +353,7 @@ export class SignedCookieJar {
 
   get(key: string): unknown {
     const raw = this.jar.get(key);
-    if (!raw) return undefined;
+    if (raw === undefined) return undefined;
     const verified = this.verify(raw);
     if (verified === undefined) return undefined;
     try {
@@ -410,7 +410,7 @@ export class EncryptedCookieJar {
 
   get(key: string): unknown {
     const raw = this.jar.get(key);
-    if (!raw) return undefined;
+    if (raw === undefined) return undefined;
     const decrypted = this.decrypt(raw);
     if (decrypted === undefined) return undefined;
     try {


### PR DESCRIPTION
## Summary

Tier 2 entry from `docs/actionpack-100-percent.md` — `cookies signed/encrypted` (#2109).

- Add `signedOrEncrypted` getter on `CookieJar`. Mirrors Rails' `ChainedCookieJars#signed_or_encrypted`: returns `encrypted` when `action_dispatch.secret_key_base` is set on the request, otherwise `signed`. Used by `ActionDispatch::Session::CookieStore` to avoid the need to introduce new cookie stores.
- Grow the `SerializedCookieJars` layer on `SignedCookieJar` / `EncryptedCookieJar` — `set` now accepts arbitrary values (or `{value, ...options}` hashes), JSON-serializes via the configured serializer, then signs/encrypts; `get` reverses the round-trip. Honors a custom `action_dispatch.cookies_serializer` on the request.
- Wire the request reference through `CookieJar.build` so the serialized jars can read `cookies_serializer` and the `signedOrEncrypted` getter can dispatch.

## Test plan

- [x] `pnpm vitest run packages/actionpack/src/action-dispatch/middleware/cookies.test.ts` (27 tests pass)