### PR TITLE
docs(actionpack): refresh plan — remove shipped items, restructure into ~250 LOC stories

### DIFF
--- a/docs/actionpack-100-percent.md
+++ b/docs/actionpack-100-percent.md
@@ -122,10 +122,13 @@ common.
 - ~20 — `permissionsPolicy` / `permissionsPolicy=` accessors on `Request`
   (env-backed under `action_dispatch.permissions_policy`).
 
-### S3 — Flash + ETag wiring (Tier 2, ~200–250 LOC) — AD + AC
+### S3 — Flash + ETag + LogSubscriber bundle (~100–150 LOC) — AD + AC
 
-Bundles three related files. After this story, `metal/flash.rb` →100%,
-`metal/etag_with_flash.rb` →100%, and `log_subscriber.rb` →100%.
+Bundles three small-surface files into one fidelity-sweep PR. After this
+story, `metal/flash.rb` →100%, `metal/etag_with_flash.rb` →100%, and
+`log_subscriber.rb` →100%. Total LOC budget is intentionally under the
+~250 ceiling — pair with the DoubleRenderError consolidation below to fill
+to ~150 LOC.
 
 - ~10 — wire `Flash::RequestMethods` into `Request` and add a `resetSession`
   wrapper that chains to the original then calls the flash hook.
@@ -141,18 +144,32 @@ Bundles three related files. After this story, `metal/flash.rb` →100%,
   is already ported; this is just plumbing.
 - ~15 — `log_subscriber.rb` last method + wire `LogSubscriber.attachTo("action_controller")`
   via the trailtie (Rails wires this in `action_controller/railtie.rb`).
-  Determine appropriate log levels for `startProcessing`/`processAction`/`halted`.
-
-**Note:** Two `DoubleRenderError` classes exist (abstract-controller vs
-action-controller). `instanceof` against the parent works; identity does not.
-Consolidate as a small cleanup commit inside this PR or leave for S8.
+  Determine appropriate log levels for `startProcessing` / `processAction` /
+  `halted`. **Note on the namespace string:** `"action_controller"` is the
+  AS::Notifications event channel — a cross-package wire identifier shared
+  with `@blazetrails/activesupport` subscribers, not a JS-side identifier.
+  Keep snake_case to match the existing AS::Notifications surface (audit
+  trail in MEMORY [feedback_camelcase_only]; this is the documented
+  cross-package channel exception). Flipping to `"actionController"` would
+  require an activesupport-wide subscriber audit and is out of scope here.
+- ~20 — **Consolidate DoubleRenderError.** Two classes exist:
+  `abstract-controller/rendering.ts:20` and `action-controller/base.ts:949`,
+  both `extends AbstractControllerError`. `instanceof` against the parent
+  works; identity does not. Delete the `action-controller/base.ts` body
+  and switch `action-controller/index.ts:11` to re-export from
+  `../abstract-controller/rendering.js`.
 
 ### S4 — `metal/strong_parameters.rb` reopen (Tier 2, ~250 LOC) — AC
 
 Branch `actioncontroller-leaves-b` (PR #2101, closed for CI capacity, not
-merged) holds +24 methods on strong_parameters. The branch is rebased onto
-main and immediately mergeable per #2098 findings — reopen with a fresh PR,
-verify CI passes, ship.
+merged) holds +24 methods on strong_parameters. As of fetch on 2026-05-22
+the branch has 2 commits ahead of `origin/main`
+(`feat(actionpack): permitted_scalar_filter copies multi-parameter keys`
+and `feat(actionpack): strong-parameters Rails-private surface to 100%`).
+Before reopening, run `git fetch origin actioncontroller-leaves-b &&
+git log --oneline origin/main..origin/actioncontroller-leaves-b` and
+rebase if main has moved beyond the merge-base. Then reopen with a fresh
+PR, verify CI, ship.
 
 - ~250 — `strong_parameters.rb` 65/89 → 89/89.
 
@@ -182,12 +199,18 @@ implementing the followup.
 
 Closes `metal/http_authentication.rb` 13/33 → 33/33 across **two** PRs.
 
-- **S6a (~250)**: `Basic` module — 6 methods + privates.
-- **S6b (~250)**: `Digest` + `Token` modules — 14 methods combined.
+- **S6a (~250)**: `Basic` surface — 6 methods + privates.
+- **S6b (~250)**: `Digest` + `Token` surfaces — 14 methods combined.
 
 Rails source: `actionpack/lib/action_controller/metal/http_authentication.rb`.
-Bundle each module's privates with its public surface; do NOT split a single
-module across PRs (review thrash).
+
+**Porting shape:** Rails' three submodules port to sibling files
+`metal/http-authentication/basic.ts`, `digest.ts`, `token.ts`, each
+exporting `this`-typed functions that mix into the host Controller via
+the `static fooBar = fooBar` pattern (CLAUDE.md). Do NOT inline as
+instance methods on a class literal. Bundle each module's privates with
+its public surface; do NOT split a single module across PRs (review
+thrash).
 
 ### S7 — `test_case.rb` TestRequest/TestResponse split — AC
 
@@ -332,7 +355,8 @@ fidelity-sweep PR.
   `ActionableError.action` (~15). Only port if a real failure surfaces;
   current `_actions` copy-on-write covers single-level inheritance (#2246).
 - `middleware/public_exceptions` — relocate inline `toXml` / `escapeXml`
-  once activemodel ships `to_xml` (~30–50); optional iconv hookup in
+  once activemodel ships `toXml` (Rails `to_xml`; trails port lands
+  camelCase) (~30–50); optional iconv hookup in
   `normalizeCharset()` (~20).
 - `middleware/session/abstract_store` — `privateId` + comparison helpers on
   `SessionId` (~10); add `cookieJar` accessor to `Request` (~20).
@@ -344,11 +368,15 @@ fidelity-sweep PR.
   documenting the gap or porting a real UA library.
 - `processAction args` — optional ESLint rule for rest-param signature on
   overrides (~30, non-urgent).
-- `request/session.ts loadBang` — `id_was_initialized` tracking + `_idWas`
-  update inside `loadBang` (~30); `Session#inspect` (~10); `Session::Options`
-  inner class + delegate `id`/`options` (~40). #2077 followups.
-- `middleware/stack.ts` — port `MiddlewareStack::Middleware` inner class +
-  `InstrumentationProxy`; rewire stack methods (~80). #2077 followup.
+- `request/session.ts loadBang` — `_idWasInitialized` tracking + `_idWas`
+  update inside `loadBang` (~30); `Session#inspect` (~10); port Rails'
+  `Session::Options` as a sibling `SessionOptions` class exported alongside
+  `Session`, with `Session#id` / `Session#options` delegating to it (~40).
+  #2077 followups.
+- `middleware/stack.ts` — port Rails' `MiddlewareStack::Middleware` inner
+  class as a sibling `MiddlewareStackEntry` (or nested static on
+  `MiddlewareStack`) plus `InstrumentationProxy`; rewire stack methods
+  (~80). #2077 followup.
 - `testing/test-request.ts` — Rails-faithful setters (notably
   `requestMethod=` upcase), `create` factory (~30, deps-on Trailtie). #2077.
 - `routing/inspector` — `RouteWrapper.sourceLocation` (~20) — thread a
@@ -376,8 +404,9 @@ Priority order (parallelizable):
 ### S17 — Journey follow-ups (~215 LOC) — AD
 
 - ~80 — GTG symbol char-class widening based on requirement regex
-  (`transition_table.ts` Builder consults `Pattern.requirements`). Unblocks
-  SKIPPED named-character-classes test for `filename: /(.+)/`. **Leaf.**
+  (`transition_table.ts` Builder consults `Pattern.requirements`). **Leaf**
+  (no upstream blocker). Ship the unskip of the SKIPPED named-character-classes
+  test for `filename: /(.+)/` in the same PR.
 - ~80 — Real dispatcher registry; replace throwing-stub `app` in bridge.
   **depends-on ActionController.**
 - ~30 — Swap `RouterRequest` / `RoutableApp` / `FormatterHost` interim
@@ -444,7 +473,7 @@ Future-wired stubs blocked on unported targets (`Response.defaultCharset` /
   no `stale?` conditional integration.
 - **`Renderer.withDefaults`:** merges defaults but does not recompute the
   Rack env.
-- **`permissionsPolicy` DSL:** registers a `before_action` that mutates a
+- **`permissionsPolicy` DSL:** registers a `beforeAction` that mutates a
   fresh directives object; until `Request#permissionsPolicy` + response
   middleware lands, modified directives don't round-trip into the header.
 - **`RateLimiting`:** no global `Rails.cache`; DSL falls back to a

--- a/docs/actionpack-100-percent.md
+++ b/docs/actionpack-100-percent.md
@@ -27,7 +27,7 @@ Current (2026-05-22):
 
 abstractcontroller api-surface is closed. Remaining gaps live in
 ActionDispatch (8 partial files) and ActionController (9 partial files,
-mostly `base.rb` mixin chain + `test_case.rb` + http_authentication).
+mostly `base.rb` mixin chain + `test_case.rb` + `metal/http_authentication.rb`).
 
 ---
 
@@ -284,8 +284,8 @@ Pair with:
 
 - ~20 — wire `ALLOWED_HOSTS_IN_DEVELOPMENT` into a trailties Railtie default
   config (currently exported but consumers must pass manually).
-- ~10 — widen `exclude` to accept Request (`(envOrRequest: RackEnv | Request)
-=> boolean`) or switch fully to Request.
+- ~10 — widen `exclude` to accept Request (signature
+  `(envOrRequest: RackEnv | Request) => boolean`) or switch fully to Request.
 
 ### S13 — DidYouMean reopen sweep (~80 LOC across packages) — cross-package
 
@@ -471,9 +471,9 @@ Future-wired stubs blocked on unported targets (`Response.defaultCharset` /
   whitespace on a non-first forwarded entry is preserved (#2244 c2/c3).
 - **`buildBacktrace`** returns raw stack lines instead of remapping
   template frames through `ActionView::PathRegistry` (#2081).
-- **`isTemplateError`** uses string name-match instead of `instanceof
-ActionView::Template::Error` (avoids actionpack→actionview dependency
-  inversion).
+- **`isTemplateError`** uses string name-match instead of
+  `instanceof ActionView::Template::Error` (avoids actionpack→actionview
+  dependency inversion).
 - **`ShowExceptions`** mutates env directly and restores in `finally`;
   Rails dups env (`env.dup`). Equivalent return value but diverges if
   `exceptionsApp` keeps a reference.
@@ -511,9 +511,16 @@ CLAUDE.md constraints:
 
 - camelCase only — no snake_case identifiers (including Rails payload keys).
 - PR ≤ 300 LOC (excl. lockfiles, snapshots).
-- Mixin methods use the `this`-typed function pattern: `export function
-foo(this: HostInterface, …)` then `static foo = foo`. Do NOT inline the
-  body in `base.ts`.
+- Mixin methods use the `this`-typed function pattern:
+
+  ```ts
+  export function foo(this: HostInterface, ...) { ... }
+  // then on the host class:
+  static foo = foo;
+  ```
+
+  Do NOT inline the body in `base.ts`.
+
 - For class-attached mixin methods, **use declared class fields inside the
   class body** — `declare module "./X" { interface … }` declaration merging
   is NOT picked up by the api:compare extractor (#2137).

--- a/docs/actionpack-100-percent.md
+++ b/docs/actionpack-100-percent.md
@@ -17,155 +17,475 @@ pnpm run test:compare 2>&1 | grep -E "(actiondispatch|actioncontroller|abstractc
 > `pnpm api:compare` is a chained `&&` script and won't forward `--package`;
 > invoke `compare.ts` directly for scoped totals.
 
-Current (2026-05-21):
+Current (2026-05-22):
 
-| Package            | API methods       | Files at 100% | test:compare   |
-| ------------------ | ----------------- | ------------- | -------------- |
-| abstractcontroller | 82/82 (100%)      | 11/11         | 42/52 (81%)    |
-| actiondispatch     | 1268/1351 (93.9%) | 75/83         | 585/1622 (36%) |
-| actioncontroller   | 429/581 (73.8%)   | 34/43         | 527/1860 (28%) |
+| Package            | API methods       | Files at 100% | Inheritance   | test:compare   |
+| ------------------ | ----------------- | ------------- | ------------- | -------------- |
+| abstractcontroller | 82/82 (100%)      | 11/11         | 3/4 (75%)     | 42/52 (81%)    |
+| actiondispatch     | 1268/1351 (93.9%) | 75/83         | 58/66 (87.9%) | 585/1622 (36%) |
+| actioncontroller   | 429/581 (73.8%)   | 42/43         | 16/16 (100%)  | 527/1860 (28%) |
+
+abstractcontroller api-surface is closed. Remaining gaps live in
+ActionDispatch (8 partial files) and ActionController (9 partial files,
+mostly `base.rb` mixin chain + `test_case.rb` + http_authentication).
 
 ---
 
-## ActionDispatch — remaining
+## Indefinite defers (do not port)
 
-### Indefinite defers (do not port)
-
-- **system_testing/** (5 files), **system_test_case.rb**, **testing/test_helpers/page_dump_helper.rb** — trails uses Playwright / Vitest browser mode, not Capybara/Selenium.
+- **system_testing/** (5 files), **system_test_case.rb**,
+  **testing/test_helpers/page_dump_helper.rb** — trails uses Playwright /
+  Vitest browser mode, not Capybara/Selenium.
 - **http/rack_cache.rb** — Rack-specific.
 
-### Partial files
+---
 
-| File                             | %   | Missing                               | Notes                                                                                                                 |
-| -------------------------------- | --- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| `http/permissions_policy.rb`     | 50% | 5 (`applyMappings`/`buildDirective`…) | Spec decision: legacy Feature-Policy vs modern syntax.                                                                |
-| `http/response.rb`               | 94% | 5                                     | Blocked on `Cache::Request`/`Cache::Response` wiring.                                                                 |
-| `middleware/debug_exceptions.rb` | 88% | 2                                     | Blocked on ActionView DebugView + `routesApp` plumbing.                                                               |
-| `middleware/debug_view.rb`       | 88% | 1                                     | Blocked on ActionView Base.                                                                                           |
-| `testing/assertions.rb`          | 95% | 1                                     | `with_routing` class form (~30 LOC, needs Minitest-class-level hook equivalent).                                      |
-| `testing/integration.rb`         | 96% | 3                                     | IntegrationTest::Behavior tail (`app`, `documentRootElement`, `registerEncoder`); needs Rack::MockSession equivalent. |
+## Upstream blockers
 
-### Upstream blockers (chains of follow-ups gated on one port)
+Chains of follow-ups gated on one port. Most stories below cite one of these.
 
-| Blocker                                           | Unblocks                                                                                           |
-| ------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
-| ActionView::Base / TSE pipeline                   | DebugView render+lookupContext, rescue templates, Template::Error exception-wrapper unwrap.        |
-| ActionController (full)                           | server_timing tests, test-process IntegrationTest mixin, dispatcher `to:` form, debug-locks tests. |
-| ActiveSupport::Executor (real port)               | 3 skipped executor_test cases.                                                                     |
-| ActiveSupport::Dependencies.interlock             | `dispatch/debug-locks.test.ts`.                                                                    |
-| ActiveSupport::Notifications                      | `redirect.action_dispatch` notification.                                                           |
-| activesupport Railtie `before:`/`after:` ordering | further railtie ports.                                                                             |
-| activemodel `to_xml`                              | `middleware/public_exceptions` xml helpers relocation.                                             |
-| Rails::Engine                                     | `routing/endpoint.engine()` (~5 LOC).                                                              |
-| `@blazetrails/rack Session::Abstract::Persisted`  | abstract_store reparent, drop local `Persisted` shim.                                              |
-| DOM port (linkedom/jsdom)                         | `RequestEncoder.parsedBody` HTML.                                                                  |
-
-### Leaf follow-ups (unblocked, sized)
-
-Bundle to PR-ceiling (~250 LOC). Group by file.
-
-**Tier 1 (≤30 LOC each):**
-
-- `http/url` — clamp `extractSubdomainsFrom` end at `Math.max(0, parts.length - (tldLength+1))` (~5).
-- `http/mime-type` — wire `parseTrailingStar` / `parseDataWithTrailingStar` into `MimeType.parse()` so `Accept: text/*` expands registered types (~20).
-- `http/mime_negotiation` — tighten `paramsReadable` catch to `[BadRequest, ParseError]` (~5).
-- `routing/endpoint` — `engine()` returns false (~5, blocked on Rails::Engine).
-- `middleware/actionable_exceptions` — prototype-chain walk in `ActionableError.action` (~15); `_registry` collision warn (~10); endpoint to `cattrAccessor` (~5).
-- `middleware/remote-ip` — relax `customProxies` check to `Symbol.iterator in Object(...)` (~10).
-- `middleware/public_exceptions` — relocate inline `toXml`/`escapeXml` once activemodel ships `to_xml` (~30–50); optional iconv hookup in `normalizeCharset()` (~20).
-- `middleware/session/abstract_store` — `privateId` + comparison helpers on `SessionId` (~10); add `cookieJar` accessor to `Request` (~20).
-- `testing/assertions/routing` — `assertRecognizes`/`assertGenerates` test coverage for WHATWG → base-URL fallback (~10).
-- `controller/allow_browser` — `useragent`-gem divergences (regex bot detection, mobile UA folding, semver-tag compare); document or port a real UA library.
-- `testing/test-response` — port `successful`/`notFound`/`redirection`/`serverError`/`clientError` status predicates.
-- `http/param_error` — extend `ExceptionWrapper.STATUS_MAP` for ParseError/ParamError → 400, or prototype-chain walk (~30); wire `ParamError` into request parse rescue (~10).
-- `http/param_builder` — relocate ParamBuilder + QueryParser test files from `http/` to `dispatch/` for layout parity (~20).
-- `processAction args` — optional ESLint rule for rest-param signature on overrides (~30, non-urgent).
-- `middleware/flash + debug-exceptions` (#2090) — decide `etag-with-flash.ts` `toSessionValue` vs `toHash`; wire `Flash::RequestMethods` into `Request` + `resetSession`; extend `DebugExceptionsOptions` with `routesApp?`; public `isLoaded()` on session.
-- `routing/mapper` (#2116) — propagate `formatted`/`anchor` in `decomposedMatch` terminal branch (~3); switch `resolve()` keying from `String(klass)` to `klass.name`/`modelName?.name` (~5); `new(cb)` scope helper for `on: "new"` (~10).
-
-**Tier 2 (50–150 LOC):**
-
-- `http/cache wiring` — wire `Cache::Request`/`Cache::Response` onto Request/Response prototypes; drop conflicting `response.ts:160-199` accessors (~150); strict RFC 1123 `parseHttpDate` (~20); `params` getter must overlay `pathParameters` (~20).
-- `routing/routes_proxy` — wire `PolymorphicRoutes` mixin into `UrlFor`/`RoutesProxy`; lifts `url-for.ts` to 100% (~80); widen `_routes` type on `UrlForHost`.
-- `routing/redirection` — wire `Redirect`/`PathRedirect`/`OptionRedirect` into `Mapper#redirect` + `RouteSet` dispatch (~80); `rackEscape` parity with `Rack::Utils.escape` for `!*'()` (~30).
-- `http/param_builder` — rack-multipart→UploadedFile adapter (~30); `ParamValue` opaque-leaf widening with `OpaqueParamLeaf` branch (~40); narrow rescue from message-prefix match to `instanceof ArgumentError`.
-- `routing/route-set helper/config attrs` (#2112) — ~30 missing public surface (`formatter`, `set`, `router`, `defaultUrlOptions=`, `relativeUrlRoot`, `apiOnly?`, polymorphic helpers, `fromRequirements`, etc.); unify `RouteSet.urlFor` to `urlFor(options, routeName?)`; switch `_routes` to `this`.
-- `routing/mapper.resources` (#2112) — singular `name` emitted for both `index` and `show`; causes `addRoute` duplicate-name collision (file 91%).
-- `cookies signed/encrypted` (#2109) — `signedOrEncrypted` getter on `CookieJar` (~20); grow a `SerializedCookieJars` layer so signed/encrypted jars accept arbitrary hash values via `[]=` and JSON-serialize (~100–150).
-- `HostAuthorization` (#2110) — port `DefaultResponseApp` inner class (XHR detection + logger + DebugView body) (~150); route `#call` through `Request#raw_host_with_port` (~30).
-- `railtie wiring stubs` — future-wired stubs blocked on unported targets (`Response.defaultCharset`/`defaultHeaders`, `CookieJar.alwaysWriteCookie`, etc.); add `action_dispatch/railtie.rb` → `action-dispatch/railtie.ts` to `FILE_OVERRIDES`.
-
-**Tier 3 (200+ LOC):**
-
-- `middleware/remote-ip tests` — port full `RequestIP` test class into `dispatch/request.test.ts` as `<base>b` (~150).
-- `testing/assertions` — `<base>b` (~150–200) Runner mixin (`integrationSession`, `createSession`, `openSession`, `copySessionVariablesBang`, `beforeSetup`); `<base>c` (~100–150) `IntegrationTest::Behavior` + `html_document` + `assigns` + `_mockSession`. Still blocked: RoutingAssertions, UrlFor, PolymorphicRoutes, TestProcess::FixtureFile.
-- `testing/assertions/routing generate` — port `RouteSet#generate` via Journey Formatter (~150); current `generateExtras` linear-scans and can pick wrong route on shared controller/action.
-
-### Journey follow-ups (~215 LOC)
-
-- ~80 — GTG symbol char-class widening based on requirement regex (`transition_table.ts` Builder consults `Pattern.requirements`). Unblocks SKIPPED named-character-classes test for `filename: /(.+)/`. **Leaf.**
-- ~80 — Real dispatcher registry; replace throwing-stub `app` in bridge. **Blocked on ActionController.**
-- ~30 — Swap `RouterRequest`/`RoutableApp`/`FormatterHost` interim interfaces for real `ActionDispatch::Request` types. **Leaf.**
-- ~10 — Drop dead `ESCAPED` regex in `journey/router/utils.ts`; audit four `UNSAFE_*` regexes for `/u` flag (non-BMP surrogate pairs).
-- ~15 — `unescapeUri` non-BMP support (`codePointAt` + variable step).
-
-### test:compare clusters (~2500 missing tests)
-
-Stream order (parallelizable except Controller, which depends on AC):
-
-- **Routing** (~600) — routing (178), resources (78), prefix generation (45), URL generation (37), assertions (29), inspector (28), mapper (21), concerns (11); Journey internals (72).
-- **Controller** (~1295) — needs ActionController.
-- **Request/Response** (~177) — request core (47), param parsing (~57), response core (26), live (10).
-- **Middleware** (~109) — stack (28), static (35), abstract callbacks (26), executor/reloader (19).
-- **Cookies** (~96) — signed/encrypted rotation, domain, JSON fallback, purpose, size, SameSite, max-age.
-- **Sessions** (~87) — CookieStore (27), session-from-request (22), cache store (11), test session (13), abstract (5), memcache (9, defer).
-- **Security middleware** (~81) — SSL (39), Host Authorization (41), Assume SSL (1).
-- **Error handling** (~73) — debug exceptions (42), exception wrapper (15), show exceptions (9), actionable (6), debug locks (1).
-- **Security policies** (~26) — CSP (17), Permissions Policy (9).
-- **Small standalone** (~75).
-
-Out of scope: system_testing, full ERB rendering (~150), fragment/page caching (32), live streaming (37, until ActionCable).
+| Blocker                                           | Unblocks                                                                                                      |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| ActionView::Base / TSE pipeline                   | DebugView render+lookupContext, rescue templates, Template::Error exception-wrapper unwrap.                   |
+| ActionView digestor                               | `metal/etag_with_template_digest.rb` (7).                                                                     |
+| ActionView helper integration                     | `metal/helpers.rb` (6).                                                                                       |
+| ActionController full dispatcher                  | server_timing tests, test-process IntegrationTest mixin, dispatcher `to:` form, debug-locks tests.            |
+| ActiveSupport::Executor (real port)               | 3 skipped executor_test cases.                                                                                |
+| ActiveSupport::Dependencies.interlock             | `dispatch/debug-locks.test.ts`.                                                                               |
+| ActiveSupport::Notifications                      | `redirect.action_dispatch` notification.                                                                      |
+| ActiveSupport::MessageVerifier / MessageEncryptor | `SignedKeyRotatingCookieJar` / `EncryptedKeyRotatingCookieJar`.                                               |
+| ActiveSupport::Messages::SerializerWithFallback   | `:marshal`/`:hybrid`/`:json_allow_marshal` dispatch in cookies serializer.                                    |
+| activesupport Railtie `before:`/`after:` ordering | further railtie ports.                                                                                        |
+| activemodel `to_xml`                              | `middleware/public_exceptions` xml helpers relocation.                                                        |
+| Rails::Engine                                     | `routing/endpoint.engine()` (~5 LOC); `recognizePathWithRequest` engine recursion; `RouteWrapper.isEngine()`. |
+| `@blazetrails/rack` Session::Abstract::Persisted  | abstract_store reparent, drop local `Persisted` shim.                                                         |
+| rails-dom-testing (Nokogiri equivalent)           | `testing/assertions.htmlDocument`, IntegrationTest `documentRootElement`.                                     |
+| Rack::MockSession analogue                        | IntegrationTest `_mockSession`.                                                                               |
 
 ---
 
-## ActionController — remaining
+## Partial files at a glance
 
-### Known divergences from Rails (intentional)
+| File                                 | Pkg | %   | Missing | Story                  |
+| ------------------------------------ | --- | --- | ------- | ---------------------- |
+| `http/permissions_policy.rb`         | AD  | 50% | 5       | S2                     |
+| `http/response.rb`                   | AD  | 94% | 5       | S1                     |
+| `middleware/debug_exceptions.rb`     | AD  | 88% | 2       | upstream (ActionView)  |
+| `middleware/debug_view.rb`           | AD  | 88% | 1       | upstream (ActionView)  |
+| `testing/assertions.rb`              | AD  | 95% | 1       | upstream (rails-dom)   |
+| `testing/integration.rb`             | AD  | 96% | 3       | S5 + upstream          |
+| `base.rb`                            | AC  | 38% | 64      | upstream (mixin chain) |
+| `log_subscriber.rb`                  | AC  | 88% | 1       | S3                     |
+| `metal/etag_with_flash.rb`           | AC  | 56% | 4       | S3                     |
+| `metal/etag_with_template_digest.rb` | AC  | 42% | 7       | upstream (digestor)    |
+| `metal/flash.rb`                     | AC  | 67% | 1       | S3                     |
+| `metal/helpers.rb`                   | AC  | 0%  | 6       | upstream (AV helpers)  |
+| `metal/http_authentication.rb`       | AC  | 39% | 20      | S6                     |
+| `metal/strong_parameters.rb`         | AC  | 73% | 24      | S4                     |
+| `test_case.rb`                       | AC  | 49% | 25      | S7a, S7b               |
 
-- **YAML hook (`Parameters.hookIntoYamlLoading`):** no-op; TS has no built-in YAML.
-- **CSRF token stores (`SessionStore`, `CookieStore`):** take session/cookies hash directly (not `request`); `CookieStore` does plain read/write, no encryption or session ID validation. Refit once a real cookie jar with encryption is wired.
-- **Cache-control (`noStore`):** builds the header string directly instead of mutating a `response.cache_control` hash (we don't have that hash yet).
-- **Etaggers (`etag`):** module-level array shared across controllers; scope per-class once `class_attribute` lands.
-- **Renderers (`renderToBody`, `useRenderers`):** static methods, global `_renderers` Set; should become instance/class methods with per-class state when controller mixin architecture is wired.
-- **Metal.action / Metal.build:** returns the bare endpoint without middleware wrapping; our `MiddlewareStack` doesn't override `build` to accept an action name.
-- **`httpCacheForever`:** sets `Cache-Control` and always calls the block; no `stale?` conditional integration.
-- **`Renderer.withDefaults`:** merges defaults but does not recompute the Rack env.
-- **`permissionsPolicy` DSL:** registers a `before_action` that mutates a fresh directives object; until `Request#permissionsPolicy` + response middleware lands, modified directives don't round-trip into the header.
-- **`RateLimiting`:** no global `Rails.cache`; DSL falls back to a `cacheStore` static on the host controller and throws if neither is set. A `MemoryRateLimitStore` ships for tests; production must supply a `RateLimitStore` where `increment` accepts seconds (not ms) and initializes a missing counter to `amount` (Redis/Memcached behavior).
-- **`BrowserBlocker.versions`:** returns a shallow copy instead of the live array.
+---
 
-### Open slots
+## Dev stories (~250 LOC PRs)
 
-| File                                 | %   | Notes / Blockers                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| ------------------------------------ | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `base.rb`                            | 38% | 64 misses; all in mixin/included-from files (redirecting, etag*with*\*, helpers, request_forgery_protection, implicit_render, instrumentation, params_wrapper privates). Most blocked on rendering/dispatcher pipeline; tracked under each P-slot.                                                                                                                                                                                                                                                                             |
-| `log_subscriber.rb`                  | 88% | 1.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             |
-| `metal/etag_with_flash.rb`           | 56% | 4 — decide `toHash()` vs `toSessionValue()` for ETag inputs.                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-| `metal/etag_with_template_digest.rb` | 42% | 7 — `determineTemplateEtag`/`pickTemplateForEtag`/`lookupAndDigestTemplate` + 4 privates. Blocked on ActionView digestor.                                                                                                                                                                                                                                                                                                                                                                                                      |
-| `metal/flash.rb`                     | 67% | 1 — remaining mixin export.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-| `metal/helpers.rb`                   | 0%  | 6 — `helpersPath`, `helpers`, `helperAttr`, `modulesForHelpers`, `allApplicationHelpers` + 1 private. Blocked on ActionView helper integration.                                                                                                                                                                                                                                                                                                                                                                                |
-| `metal/http_authentication.rb`       | 39% | 20 across Basic/Digest/Token — bundle by module.                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
-| `metal/strong_parameters.rb`         | 73% | 24 — PR draft was ready in `actioncontroller-leaves-b`; reopen when CI capacity permits. Captures +24 methods.                                                                                                                                                                                                                                                                                                                                                                                                                 |
-| `test_case.rb`                       | 49% | 25 — split into two: <br>**b** (~250) TestRequest helpers (`queryString=`, `contentType=`, `assignParameters`, `shouldMultipart`, `paramsParsers`, `newSession`, `create`, `defaultEnv`) + TestResponse status predicates; <br>**c** (~250) `process`, `setupRequest`, `buildResponse`, `wrapExecution`, `processControllerResponse`, `setupControllerRequestAndResponse`, `scrubEnvBang`, `documentRootElement`, `checkRequiredIvars`, `assertTemplate`, `executorAroundEachRequest`, `generatedPath`, `queryParameterNames`. |
+Each story is sized to fit one PR under the 300-LOC ceiling. Pick the
+top-listed one in each thread; cross-story dependencies are marked
+**depends-on**. All sized estimates exclude lockfiles and snapshots.
 
-### Wiring follow-ups (small)
+### S1 — `http/cache` wiring (Tier 2, ~250 LOC) — AD
 
-- **`metal/implicit-render`** — wire real `templateExists`/`anyTemplates` on host once ActionView lookup arrives (~30).
-- **`metal/instrumentation.haltedCallbackHook`** — wire from AS::Callbacks `_runCallbacks` halt path (~50).
-- **`metal.buildMiddleware`** — promote inline `valid` augmentation onto the `Middleware` class (~10).
-- **Two DoubleRenderError classes** — consolidate abstract-controller vs action-controller versions (`instanceof` against parent works, identity does not).
-- **DidYouMean consumer** — `Template::Error#corrections` (actionview) maps to `@blazetrails/did-you-mean`'s exported `Jaro.distance` (~80).
-- **Extractor quirk** — cookies config attrs declared in `middleware/cookies.rb` (`cookie_jar`, `key_generator`, …) are bucketed under `deprecator.rb` by api:compare; one-line fix in `scripts/api-compare/extract-ruby-api.rb`.
+Wire `Cache::Request` / `Cache::Response` onto Request/Response prototypes;
+drop conflicting `response.ts:160-199` accessors. Closes the 5 missing
+methods on `http/response.rb` (gets the file to 100%).
+
+- ~150 — prototype wiring + accessor cleanup.
+- ~20 — strict RFC 1123 `parseHttpDate`.
+- ~20 — `params` getter overlays `pathParameters`.
+- ~30–50 — global `MimeType.lookup` Rails-fallback (strip `;params`, then
+  `Type.new(string)`); drop the `lookupForParse` helper added in #2246 once
+  callers tolerate the new return shape. Audit:
+  `collector.ts:62/90/106`, `mime-negotiation.ts`, `data-streaming.ts`,
+  `respond-to.ts`.
+
+### S2 — `http/permissions_policy` spec decision + 5 helpers (Tier 2, ~150–200 LOC) — AD
+
+The current TS port emits **modern Permissions-Policy** syntax
+(`camera=(self)`); Rails emits **legacy Feature-Policy** (`camera 'self'; …`).
+Picking Rails-shape closes ~7 more methods cheaply but changes header output.
+Picking modern means documenting the divergence and shipping only what's
+common.
+
+- ~30 — design decision in PR body; pick one and add a "Known divergences"
+  entry if modern syntax wins.
+- ~100 — port `applyMappings` / `applyMapping` / `buildDirectives` /
+  `buildDirective` / `resolveSource` (5 methods) for the chosen spec.
+- ~20 — `permissionsPolicy` / `permissionsPolicy=` accessors on `Request`
+  (env-backed under `action_dispatch.permissions_policy`).
+
+### S3 — Flash + ETag wiring (Tier 2, ~200–250 LOC) — AD + AC
+
+Bundles three related files. After this story, `metal/flash.rb` →100%,
+`metal/etag_with_flash.rb` →100%, and `log_subscriber.rb` →100%.
+
+- ~10 — wire `Flash::RequestMethods` into `Request` and add a `resetSession`
+  wrapper that chains to the original then calls the flash hook.
+- ~30 — public `isLoaded()` on `action-dispatch/request/session.ts`;
+  tighten the `FlashRequestHost` contract to require it (drops the
+  unconditional cleanup branch in `commitFlash`).
+- ~5 + decision — `metal/etag-with-flash.ts`: pick `toSessionValue` (current,
+  matches Rails ETagger) or `toHash` (busts ETag on `flash.now` changes).
+  Verify Rails source before flipping. Add inline justification either way.
+- ~25 — extend `DebugExceptionsOptions` with `routesApp?: { routes: { routes: unknown } }`
+  and build an `ActionDispatch::Routing::RoutesInspector` when
+  `wrapper.isRoutingError() || wrapper.isTemplateError()`. Routing inspector
+  is already ported; this is just plumbing.
+- ~15 — `log_subscriber.rb` last method + wire `LogSubscriber.attachTo("action_controller")`
+  via the trailtie (Rails wires this in `action_controller/railtie.rb`).
+  Determine appropriate log levels for `startProcessing`/`processAction`/`halted`.
+
+**Note:** Two `DoubleRenderError` classes exist (abstract-controller vs
+action-controller). `instanceof` against the parent works; identity does not.
+Consolidate as a small cleanup commit inside this PR or leave for S8.
+
+### S4 — `metal/strong_parameters.rb` reopen (Tier 2, ~250 LOC) — AC
+
+Branch `actioncontroller-leaves-b` (PR #2101, closed for CI capacity, not
+merged) holds +24 methods on strong_parameters. The branch is rebased onto
+main and immediately mergeable per #2098 findings — reopen with a fresh PR,
+verify CI passes, ship.
+
+- ~250 — `strong_parameters.rb` 65/89 → 89/89.
+
+**depends-on:** nothing. Pure surface port.
+
+### S5 — Integration::Session followups (Tier 1, ~80 LOC) — AD
+
+Closes the last 3 methods on `testing/integration.rb` (96% → 100%, blocked
+parts excepted).
+
+- ~30 — 404-branch options.env/headers/body merge: factor env-build out of
+  matched-branch into a helper, call from both paths. `followRedirectBang`
+  whose target doesn't match a route currently loses the injected
+  `HTTP_REFERER`.
+- ~10 — drop `host.split(":")` IPv6 mishandling in both `_processPath` and
+  `_buildFullUri` (Rails-parity bug, fix both layers together).
+- ~25 — expose `htmlDocument` + `documentRootElement` once rails-dom-testing
+  lands (**upstream-blocked**, leave a TODO if shipping pre-port).
+- ~15 — expose `_mockSession` once a Rack::MockSession analogue exists
+  (**upstream-blocked**).
+
+`RouteSet.urlFor` Rails-shape rewrite (the throwing `_routes.urlFor`
+adapter) was already addressed in #2129's PR-d slot — re-verify before
+implementing the followup.
+
+### S6 — `metal/http_authentication.rb` Basic/Digest/Token (Tier 2, split into 2 PRs, ~250 LOC each) — AC
+
+Closes `metal/http_authentication.rb` 13/33 → 33/33 across **two** PRs.
+
+- **S6a (~250)**: `Basic` module — 6 methods + privates.
+- **S6b (~250)**: `Digest` + `Token` modules — 14 methods combined.
+
+Rails source: `actionpack/lib/action_controller/metal/http_authentication.rb`.
+Bundle each module's privates with its public surface; do NOT split a single
+module across PRs (review thrash).
+
+### S7 — `test_case.rb` TestRequest/TestResponse split — AC
+
+#2094 followup. Split into two ~250 LOC PRs.
+
+- **S7a (~250)** — TestRequest helpers + TestResponse predicates.
+  `queryString=`, `contentType=`, `assignParameters`, `shouldMultipart`,
+  `paramsParsers`, `newSession`, `create`, `defaultEnv` (TestRequest);
+  `isSuccess`, `isMissing`, `isError`, plus the rest of the
+  `successful`/`notFound`/`redirection`/`serverError`/`clientError`
+  status-predicate set on `TestResponse`. Per #2142, this likely also
+  unblocks several `test-case.ts` misses on the controller side.
+- **S7b (~250)** — `process`, `setupRequest`, `buildResponse`,
+  `wrapExecution`, `processControllerResponse`,
+  `setupControllerRequestAndResponse`, `scrubEnvBang`, `documentRootElement`,
+  `checkRequiredIvars`, `assertTemplate`, `executorAroundEachRequest`,
+  `generatedPath`, `queryParameterNames`.
+
+**S7a depends-on:** nothing. **S7b depends-on:** S7a (shared helpers).
+
+### S8 — Routing leaf bundle (Tier 1, ~200 LOC) — AD
+
+Bundles several tiny mapper/route-set tweaks. Cited from #2116 + #2138
+findings.
+
+- ~3 — propagate `formatted` / `anchor` in `decomposedMatch` terminal branch
+  (`mapper.ts`).
+- ~5 — switch `resolve()` keying from `String(klass)` to
+  `klass.name` / `klass.modelName?.name`.
+- ~10 — add `new(cb)` scope helper so `on: "new"` dispatch works.
+- ~10 — `Route.requirements` getter so `fromRequirements` matches Rails'
+  canonical field (currently matches `route.defaults`).
+- ~30 — align `resources()` / `resource()` `update` emission to **PATCH-then-PUT**
+  to match `setMemberMappingsForResource()` and Rails (#2138). Likely touches
+  `resource-routing.test.ts` expectations.
+- ~40 — shallow **name** prefix preservation in `resources()`. `shallowName()`
+  currently drops all name prefixes when shallow; Rails keeps outer
+  non-resource `as:` / namespace prefixes (`admin_comment_path`, not
+  `comment_path`).
+- ~20 — `namespace` inside a resource scope should delegate through `nested`
+  (Rails `mapper.rb:1626-1632`).
+- ~30 — fix `mapper.resources` singular-vs-plural so `index`/`show` don't
+  both emit the singular `name`; once fixed, re-enable the relaxed
+  `addRoute` duplicate-name check in `route-set.ts` (#2112 followup).
+
+### S9 — Mapper `mount()` end-to-end + direct/resolve consumption (Tier 2, ~250 LOC) — AD
+
+From #2116. Currently `mount` registers the app but the resulting Route has
+no callable endpoint; `direct()` / `resolve()` write to write-only maps.
+
+- ~80 — extend `Route` / `RouteOptions` to carry a callable Rack endpoint;
+  thread through `RouteSet#call` / `buildJourneyRouter` for mount dispatch.
+- ~60 — wire `Mapper._directHelpers` / `_polymorphicMappings` into
+  `RouteSet#draw` so they merge into `RouteSet.polymorphicMappings` and a
+  new direct-helper registry consumed by url-for / polymorphic-routes.
+- ~40 — `mount({ app, at, … })` hash-form overload (Rails' idiomatic shape).
+- ~20 — `define_generate_prefix` should apply `currentNamePrefix` +
+  normalization to the registered helper key (matches Rails for nested-scope
+  mounts).
+
+### S10 — `routing/redirection` (Tier 2, ~150 LOC) — AD
+
+- ~80 — wire `Redirect` / `PathRedirect` / `OptionRedirect` into
+  `Mapper#redirect` + `RouteSet` dispatch.
+- ~30 — `rackEscape` parity with `Rack::Utils.escape` for `!*'()`.
+
+### S11 — Cookies SerializedCookieJars layer (Tier 2, ~250 LOC) — AD
+
+From #2109 findings. `CookieStore`'s round-tripping of session hashes
+through real signed/encrypted jars currently doesn't work.
+
+- ~20 — `signedOrEncrypted` getter on `CookieJar` (delegates to existing
+  standalone helper).
+- ~150 — grow a `SerializedCookieJars` layer so `SignedCookieJar` /
+  `EncryptedCookieJar` accept arbitrary hash values via `[]=` and
+  JSON-serialize internally (Rails defaults JSON; Marshal legacy).
+- ~60 — port `handle_options` domain matching (`:all`, `Array`, `proc`,
+  `tld_length`) on `CookieJar` once `Request#host` wiring solidifies.
+
+**Out of scope here** (depends on `ActiveSupport::MessageVerifier` /
+`MessageEncryptor`): `SignedKeyRotatingCookieJar` /
+`EncryptedKeyRotatingCookieJar`. Track as a separate story when those
+activesupport ports land.
+
+### S12 — DefaultResponseApp ActionView swap (~30 LOC) — AD
+
+**depends-on:** ActionView::Base template rendering.
+
+Swap inline `renderBlockedHostHtml` / `renderBlockedHostText` in
+`host-authorization.ts` for `DebugView.render("rescues/blocked_host",
+layout: "rescues/layout")` once ActionView lands (#2244 followup).
+
+Pair with:
+
+- ~20 — wire `ALLOWED_HOSTS_IN_DEVELOPMENT` into a trailties Railtie default
+  config (currently exported but consumers must pass manually).
+- ~10 — widen `exclude` to accept Request (`(envOrRequest: RackEnv | Request)
+=> boolean`) or switch fully to Request.
+
+### S13 — DidYouMean reopen sweep (~80 LOC across packages) — cross-package
+
+Stacked PRs #2080 / #2082 / #2084 / #2086 were closed (not merged) for CI
+capacity. Each branch already carries the vitest + website alias fix from
+#2079 + its feature commit on top.
+
+- Reopen `didyoumean-pr4-parameter-missing`, `didyoumean-pr5-association-not-found`,
+  `didyoumean-pr6-template-error`, `didyoumean-pr7-url-generation-error`
+  rebased onto main, one at a time.
+- ~30 — `UrlGenerationError#corrections` (actionpack
+  `metal/exceptions.ts:59`) — replace substring-match with `SpellChecker`
+  against `namedRoutes.helperNames`.
+- ~80 — `Template::Error#corrections` (actionview) — export `jaroDistance`
+  from `@blazetrails/did-you-mean` barrel, wire into Template::Error for
+  virtual-path suggestions.
+
+### S14 — `base.rb` mixin closure (multi-PR cluster, ~250 LOC each) — AC
+
+64 misses, all in mixin/included-from files (`redirecting`, `etag_with_*`,
+`helpers`, `request_forgery_protection`, `implicit_render`,
+`instrumentation`, `params_wrapper` privates). **Most are upstream-blocked**
+on rendering/dispatcher pipeline. Track inside individual P-slots in this
+doc rather than as one mega-story.
+
+- `metal/implicit-render` — wire real `templateExists` / `anyTemplates`
+  once ActionView lookup arrives (~30). **depends-on ActionView.**
+- `metal/instrumentation.haltedCallbackHook` — wire from AS::Callbacks
+  `_runCallbacks` halt path (~50). **depends-on activesupport callback halt
+  plumbing.**
+- `metal.buildMiddleware` — promote inline `valid` augmentation onto the
+  `Middleware` class (~10). Standalone.
+- `request_forgery_protection` / `redirecting` / `etag_with_*` —
+  upstream-blocked on rendering pipeline.
+
+### S15 — Smaller leaves (any-time fillers, bundle to 250 LOC) — AD
+
+These are <30-LOC items. Per MEMORY [feedback_no_tiny_prs] /
+[feedback_bundle_to_pr_ceiling], do NOT ship standalone — pile into one
+fidelity-sweep PR.
+
+- `routing/endpoint` — `engine()` returns false (~5). **depends-on Engine.**
+- `middleware/actionable_exceptions` — prototype-chain walk in
+  `ActionableError.action` (~15). Only port if a real failure surfaces;
+  current `_actions` copy-on-write covers single-level inheritance (#2246).
+- `middleware/public_exceptions` — relocate inline `toXml` / `escapeXml`
+  once activemodel ships `to_xml` (~30–50); optional iconv hookup in
+  `normalizeCharset()` (~20).
+- `middleware/session/abstract_store` — `privateId` + comparison helpers on
+  `SessionId` (~10); add `cookieJar` accessor to `Request` (~20).
+- `testing/assertions/routing` — `assertRecognizes` / `assertGenerates` test
+  coverage for WHATWG → base-URL fallback (~10).
+- `testing/test-response` — already covered in S7a.
+- `controller/allow_browser` — `useragent`-gem divergences (regex bot
+  detection, mobile UA folding, semver-tag compare); decide between
+  documenting the gap or porting a real UA library.
+- `processAction args` — optional ESLint rule for rest-param signature on
+  overrides (~30, non-urgent).
+- `request/session.ts loadBang` — `id_was_initialized` tracking + `_idWas`
+  update inside `loadBang` (~30); `Session#inspect` (~10); `Session::Options`
+  inner class + delegate `id`/`options` (~40). #2077 followups.
+- `middleware/stack.ts` — port `MiddlewareStack::Middleware` inner class +
+  `InstrumentationProxy`; rewire stack methods (~80). #2077 followup.
+- `testing/test-request.ts` — Rails-faithful setters (notably
+  `requestMethod=` upcase), `create` factory (~30, deps-on Trailtie). #2077.
+- `routing/inspector` — `RouteWrapper.sourceLocation` (~20) — thread a
+  `sourceLocation` option through `match`/`get`/`post` mapper, propagate
+  into Route. Expanded formatter already wired to print it. #2075.
+
+### S16 — Routing test:compare ports (Tier 3, multi-PR) — AD
+
+`test:compare` for routing is 0/178 on routing.rb, 0/45 on
+prefix_generation, etc. — these are test-name ports, not implementation.
+Each Rails test file should be a ~150–250 LOC PR.
+
+Priority order (parallelizable):
+
+1. `inspector_test.rb` — 22 missing (golden-output assertions). Would
+   surface column-alignment or constraint-formatting divergence (#2075).
+2. `routing.rb` (178), `resources.rb` (78), `prefix_generation.rb` (45),
+   `url_generation.rb` (37), `assertions.rb` (29).
+3. `mapper_test.rb` — 17 remaining (`dispatch/mapper_test.rb` is at 4/21).
+   Mostly scope/anchor/via/format behavior (#2150).
+4. `host_authorization_test.rb` — 0/41 ported (trails currently has 23
+   hand-written cases). New behaviors XHR format / detailed body /
+   logger.error are covered by hand-written tests (#2244).
+
+### S17 — Journey follow-ups (~215 LOC) — AD
+
+- ~80 — GTG symbol char-class widening based on requirement regex
+  (`transition_table.ts` Builder consults `Pattern.requirements`). Unblocks
+  SKIPPED named-character-classes test for `filename: /(.+)/`. **Leaf.**
+- ~80 — Real dispatcher registry; replace throwing-stub `app` in bridge.
+  **depends-on ActionController.**
+- ~30 — Swap `RouterRequest` / `RoutableApp` / `FormatterHost` interim
+  interfaces for real `ActionDispatch::Request` types. **Leaf.**
+- ~10 — Drop dead `ESCAPED` regex in `journey/router/utils.ts`; audit four
+  `UNSAFE_*` regexes for `/u` flag (non-BMP surrogate pairs).
+- ~15 — `unescapeUri` non-BMP support (`codePointAt` + variable step).
+
+### S18 — RouteSet remaining surface (depends-on ActionController dispatcher) — AD
+
+From #2089 / #2112 / #2129 findings.
+
+- **PR-c (~250)** — `#call` / `#serve` path through the route dispatcher.
+  **depends-on ActionController port.**
+- **PR-c2 (~80)** — `routing::Route` → `Journey::Route` bridge. Unblocks
+  real `formatter`, per-route eager-load, AST cache warmup, and `mount`
+  end-to-end (cross-refs S9).
+- **~80** — extend `UrlHelpersModule` to generate per-route `${name}Path` /
+  `${name}Url` once `NamedRouteCollection` is ported.
+- **~5** — flip `draw()` to unconditional `clearBang` / `finalizeBang` once
+  trails callers are Rails-aligned (will break some existing tests).
+
+### S19 — `exception_wrapper` / didyoumean polish (~80 LOC) — AD
+
+From #2081.
+
+- ~50 — promote `MissingTemplate` / `RoutingError` / `ActionNotFound` /
+  `MissingExactTemplate` `.name` assignments to Rails-qualified strings;
+  drop short-key aliases from `RESCUE_TEMPLATES`.
+- ~30 — extend `BacktraceCleaner.clean()` in `@blazetrails/activesupport`
+  to take `kind: "silent" | "noise" | "all"`; drop the local partition in
+  `cleanBacktrace`.
+
+### S20 — railtie wiring stubs (low priority) — AD
+
+Future-wired stubs blocked on unported targets (`Response.defaultCharset` /
+`defaultHeaders`, `CookieJar.alwaysWriteCookie`, etc.). Add
+`action_dispatch/railtie.rb` → `action-dispatch/railtie.ts` to
+`FILE_OVERRIDES` in `scripts/api-compare/compare.ts` and stub forward.
+
+---
+
+## Known divergences from Rails (intentional)
+
+### ActionController
+
+- **YAML hook (`Parameters.hookIntoYamlLoading`):** no-op; TS has no
+  built-in YAML.
+- **CSRF token stores (`SessionStore`, `CookieStore`):** take session/cookies
+  hash directly (not `request`); `CookieStore` does plain read/write, no
+  encryption or session ID validation. Refit once a real cookie jar with
+  encryption is wired.
+- **Cache-control (`noStore`):** builds the header string directly instead
+  of mutating a `response.cache_control` hash (we don't have that hash yet).
+- **Etaggers (`etag`):** module-level array shared across controllers;
+  scope per-class once `class_attribute` lands.
+- **Renderers (`renderToBody`, `useRenderers`):** static methods, global
+  `_renderers` Set; should become instance/class methods with per-class
+  state when controller mixin architecture is wired.
+- **Metal.action / Metal.build:** returns the bare endpoint without
+  middleware wrapping; our `MiddlewareStack` doesn't override `build` to
+  accept an action name.
+- **`httpCacheForever`:** sets `Cache-Control` and always calls the block;
+  no `stale?` conditional integration.
+- **`Renderer.withDefaults`:** merges defaults but does not recompute the
+  Rack env.
+- **`permissionsPolicy` DSL:** registers a `before_action` that mutates a
+  fresh directives object; until `Request#permissionsPolicy` + response
+  middleware lands, modified directives don't round-trip into the header.
+- **`RateLimiting`:** no global `Rails.cache`; DSL falls back to a
+  `cacheStore` static on the host controller and throws if neither is set.
+  A `MemoryRateLimitStore` ships for tests; production must supply a
+  `RateLimitStore` where `increment` accepts seconds (not ms) and
+  initializes a missing counter to `amount` (Redis/Memcached behavior).
+- **`BrowserBlocker.versions`:** returns a shallow copy instead of the live
+  array.
+- **`TestCase.tests` / `determineDefaultControllerClass`:** uses
+  `globalThis` for constant lookup (closest JS analogue to Ruby
+  `constantize`); accepts String|Class only (Symbol dropped).
+- **`render` guard:** `this.performed` instead of `responseBody` —
+  trails' Metal `responseBody` getter returns `""` even when unrendered.
+- **camelCase scriptNamer keys:** `Mapper._mountedScriptNamers` keyed on
+  camelCase `scriptName`/`originalScriptName` (CLAUDE.md "camelCase only,
+  even for Rails payload keys").
+
+### ActionDispatch
+
+- **`Request#checkMethod`** throws a generic `Error`; Rails raises
+  `ActionController::UnknownHttpMethod`. Port that error first.
+- **`Request#rawHostWithPort` whitespace** mirrors Rails' quirk: header
+  whitespace on a non-first forwarded entry is preserved (#2244 c2/c3).
+- **`buildBacktrace`** returns raw stack lines instead of remapping
+  template frames through `ActionView::PathRegistry` (#2081).
+- **`isTemplateError`** uses string name-match instead of `instanceof
+ActionView::Template::Error` (avoids actionpack→actionview dependency
+  inversion).
+- **`ShowExceptions`** mutates env directly and restores in `finally`;
+  Rails dups env (`env.dup`). Equivalent return value but diverges if
+  `exceptionsApp` keeps a reference.
+- **`Static`** rejects `..` escapes upfront; Rails collapses and lets the
+  filesystem miss (#2083).
+- **`Mapper#draw(string)`** throws — Ruby file-load form not supported.
+- **`mount`** only accepts kwarg form `mount(SomeApp, { at: "/path" })`;
+  Rails' hash form `mount(SomeApp => "/path")` deferred to S9.
+- **`asJson` keys `stdparam_states` by `re.source`** for symmetry with
+  `regexp_states`; Rails uses Regexp objects (functionally inert) (#2115).
+- **Permissions-Policy spec divergence** — see S2.
+- **`UploadedFile#open` / `toIo`** return `Buffer` (in-memory by design).
 
 ---
 
@@ -189,12 +509,29 @@ gh pr create --draft --title "..." --body "..."  # quote the Rails source lines 
 
 CLAUDE.md constraints:
 
-- camelCase only — no snake_case identifiers.
+- camelCase only — no snake_case identifiers (including Rails payload keys).
 - PR ≤ 300 LOC (excl. lockfiles, snapshots).
-- Mixin methods use the `this`-typed function pattern: `export function foo(this: HostInterface, ...)` then `static foo = foo`. Do NOT inline the body in `base.ts`.
-- Add a "Known divergences" entry above for any Rails behavior that can't be mirrored exactly.
-- `instance_exec(opts, &block)` → `block.call(this, opts)` with `this: unknown`.
-- Ruby `compact` → `.filter((e) => e !== null && e !== undefined)` (NOT `.filter(Boolean)`).
-- Ruby `Hash#key?` → `Object.hasOwn(obj, "K")` (NOT `obj["K"] != null` or `"K" in obj`).
+- Mixin methods use the `this`-typed function pattern: `export function
+foo(this: HostInterface, …)` then `static foo = foo`. Do NOT inline the
+  body in `base.ts`.
+- For class-attached mixin methods, **use declared class fields inside the
+  class body** — `declare module "./X" { interface … }` declaration merging
+  is NOT picked up by the api:compare extractor (#2137).
+- Add a "Known divergences from Rails" entry above for any behavior that
+  can't be mirrored exactly.
+- `instance_exec(opts, &block)` → `block.call(this, opts)` with
+  `this: unknown`.
+- Ruby `compact` → `.filter((e) => e !== null && e !== undefined)`
+  (NOT `.filter(Boolean)`).
+- Ruby `Hash#key?` → `Object.hasOwn(obj, "K")` (NOT `obj["K"] != null` or
+  `"K" in obj`).
+- Per MEMORY [feedback_no_tiny_prs] / [feedback_bundle_to_pr_ceiling]:
+  don't ship <30-LOC items standalone — pile into S15 fidelity sweeps.
+- Per MEMORY [feedback_copilot_rails_fidelity]: verify Copilot suggestions
+  against `scripts/api-compare/.rails-source/` before accepting.
+- Per #2129 findings: a "Rails-design rationale" preamble in the PR
+  description listing intentional choices upfront cuts Copilot review noise
+  on Rails-faithful PRs (mounted-helpers shared module, `supports_path`
+  scope, etc.).
 
 Sequencing: one agent per source file at a time.


### PR DESCRIPTION
## Summary

- Remove items shipped by #1940, #1953, #2089, #2110, #2111, #2116, #2129, #2244, #2246
- Refresh counts to 2026-05-22 (actioncontroller files 34→42/43, inheritance now 100%)
- Restructure remaining work into 20 numbered dev stories (S1–S20), each sized ~250 LOC with explicit \`depends-on\` markers
- Incorporate post-merge findings from #2075, #2077, #2081, #2090, #2094, #2129, #2137, #2142

## Notable additions

- DoubleRenderError consolidation (#2094)
- LogSubscriber.attachTo wiring (#2142)
- Session::Options / Session#inspect / id_was_initialized tracking (#2077)
- MiddlewareStack::Middleware inner class (#2077)
- RouteWrapper.sourceLocation threading (#2075)
- Cookies handle_options domain matching (#2090)
- BacktraceCleaner.clean(kind:) extension (#2081)
- "Rails-design rationale" preamble process hint (#2129)
- Class-field declaration pattern for api:compare extractor (#2137)
- Expanded "Known divergences" section

## Test plan

- [ ] Doc-only change — no code/tests affected
- [ ] Counts table verified via \`pnpm tsx scripts/api-compare/compare.ts --package <pkg> --privates\`