### PR TITLE
test(activerecord): route scoping/ through pooled adapter (pool epic Phase D batch 1)

### DIFF
--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { Base, Relation } from "../index.js";
 
-import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
+import { createPooledTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = createSidecarTestAdapter());
+  ({ adapter: _adapter } = await createPooledTestAdapter());
   await defineSchema(_adapter, {
     posts: {
       title: "string",

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -13,35 +13,39 @@ import type { DatabaseAdapter } from "../adapter.js";
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
   ({ adapter: _adapter } = await createPooledTestAdapter());
-  await defineSchema(_adapter, {
-    posts: {
-      title: "string",
-      published: "boolean",
-      body: "string",
-      status: "string",
-      category: "string",
-      order_val: "integer",
-      postId: "integer",
-      views: "integer",
-      visible: "boolean",
-      blog_id: "integer",
-      mentor_id: "integer",
-      active: "boolean",
+  await defineSchema(
+    _adapter,
+    {
+      posts: {
+        title: "string",
+        published: "boolean",
+        body: "string",
+        status: "string",
+        category: "string",
+        order_val: "integer",
+        postId: "integer",
+        views: "integer",
+        visible: "boolean",
+        blog_id: "integer",
+        mentor_id: "integer",
+        active: "boolean",
+      },
+      animals: { name: "string", type: "string", active: "boolean" },
+      dogs: { name: "string", type: "string", active: "boolean" },
+      articles: {
+        title: "string",
+        visible: "boolean",
+        order_val: "integer",
+        blog_id: "integer",
+        published: "boolean",
+        category: "string",
+      },
+      comments: { body: "string" },
+      devs: { name: "string", salary: "integer", mentor_id: "integer" },
+      dev2s: { name: "string", salary: "integer", mentor_id: "integer" },
     },
-    animals: { name: "string", type: "string", active: "boolean" },
-    dogs: { name: "string", type: "string", active: "boolean" },
-    articles: {
-      title: "string",
-      visible: "boolean",
-      order_val: "integer",
-      blog_id: "integer",
-      published: "boolean",
-      category: "string",
-    },
-    comments: { body: "string" },
-    devs: { name: "string", salary: "integer", mentor_id: "integer" },
-    dev2s: { name: "string", salary: "integer", mentor_id: "integer" },
-  });
+    { dropExisting: true },
+  );
 });
 withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Relation } from "../index.js";
 
-import { createSidecarTestAdapter, adapterType, type SidecarAdapter } from "../test-adapter.js";
+import { createPooledTestAdapter, adapterType, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = createSidecarTestAdapter());
+  ({ adapter: _adapter } = await createPooledTestAdapter());
   await defineSchema(_adapter, {
     posts: {
       title: "string",

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -13,22 +13,26 @@ import type { DatabaseAdapter } from "../adapter.js";
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
   ({ adapter: _adapter } = await createPooledTestAdapter());
-  await defineSchema(_adapter, {
-    posts: {
-      title: "string",
-      published: "boolean",
-      featured: "boolean",
-      status: "string",
-      views: "integer",
-      author_id: "integer",
-      active: "boolean",
+  await defineSchema(
+    _adapter,
+    {
+      posts: {
+        title: "string",
+        published: "boolean",
+        featured: "boolean",
+        status: "string",
+        views: "integer",
+        author_id: "integer",
+        active: "boolean",
+      },
+      animals: { name: "string", type: "string" },
+      dogs: { name: "string", type: "string" },
+      articles: { title: "string", status: "string" },
+      products: { name: "string", price: "integer", active: "boolean" },
+      users: { name: "string", age: "integer", active: "boolean", role: "string" },
     },
-    animals: { name: "string", type: "string" },
-    dogs: { name: "string", type: "string" },
-    articles: { title: "string", status: "string" },
-    products: { name: "string", price: "integer", active: "boolean" },
-    users: { name: "string", age: "integer", active: "boolean", role: "string" },
-  });
+    { dropExisting: true },
+  );
 });
 withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -19,27 +19,31 @@ beforeAll(async () => {
     salary: "integer" as const,
     author: "string" as const,
   };
-  await defineSchema(_adapter, {
-    developers: { name: "string", salary: "integer" },
-    posts: { title: "string", author: "string", published: "boolean" },
-    ro_posts: postCols,
-    dro_posts: postCols,
-    sf_posts: postCols,
-    sff_posts: postCols,
-    sfl_posts: postCols,
-    sc_posts: postCols,
-    sds_posts: postCols,
-    sfa_posts: postCols,
-    scnt_posts: postCols,
-    sj_posts: postCols,
-    nrs_posts: postCols,
-    ann_posts: postCols,
-    ann_unscoped_posts: postCols,
-    animals: { type: "string", name: "string" },
-    cats: { type: "string", name: "string" },
-    dogs: { type: "string", name: "string" },
-    categories: { name: "string" },
-  });
+  await defineSchema(
+    _adapter,
+    {
+      developers: { name: "string", salary: "integer" },
+      posts: { title: "string", author: "string", published: "boolean" },
+      ro_posts: postCols,
+      dro_posts: postCols,
+      sf_posts: postCols,
+      sff_posts: postCols,
+      sfl_posts: postCols,
+      sc_posts: postCols,
+      sds_posts: postCols,
+      sfa_posts: postCols,
+      scnt_posts: postCols,
+      sj_posts: postCols,
+      nrs_posts: postCols,
+      ann_posts: postCols,
+      ann_unscoped_posts: postCols,
+      animals: { type: "string", name: "string" },
+      cats: { type: "string", name: "string" },
+      dogs: { type: "string", name: "string" },
+      categories: { name: "string" },
+    },
+    { dropExisting: true },
+  );
 });
 withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -5,45 +5,41 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";
 
-import { createPooledTestAdapter, type SidecarAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: SidecarAdapter;
+let _adapter: TestDatabaseAdapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = await createPooledTestAdapter());
+  _adapter = createTestAdapter();
   const postCols = {
     title: "string" as const,
     published: "boolean" as const,
     salary: "integer" as const,
     author: "string" as const,
   };
-  await defineSchema(
-    _adapter,
-    {
-      developers: { name: "string", salary: "integer" },
-      posts: { title: "string", author: "string", published: "boolean" },
-      ro_posts: postCols,
-      dro_posts: postCols,
-      sf_posts: postCols,
-      sff_posts: postCols,
-      sfl_posts: postCols,
-      sc_posts: postCols,
-      sds_posts: postCols,
-      sfa_posts: postCols,
-      scnt_posts: postCols,
-      sj_posts: postCols,
-      nrs_posts: postCols,
-      ann_posts: postCols,
-      ann_unscoped_posts: postCols,
-      animals: { type: "string", name: "string" },
-      cats: { type: "string", name: "string" },
-      dogs: { type: "string", name: "string" },
-      categories: { name: "string" },
-    },
-    { dropExisting: true },
-  );
+  await defineSchema(_adapter, {
+    developers: { name: "string", salary: "integer" },
+    posts: { title: "string", author: "string", published: "boolean" },
+    ro_posts: postCols,
+    dro_posts: postCols,
+    sf_posts: postCols,
+    sff_posts: postCols,
+    sfl_posts: postCols,
+    sc_posts: postCols,
+    sds_posts: postCols,
+    sfa_posts: postCols,
+    scnt_posts: postCols,
+    sj_posts: postCols,
+    nrs_posts: postCols,
+    ann_posts: postCols,
+    ann_unscoped_posts: postCols,
+    animals: { type: "string", name: "string" },
+    cats: { type: "string", name: "string" },
+    dogs: { type: "string", name: "string" },
+    categories: { name: "string" },
+  });
 });
 withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createPooledTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = await createPooledTestAdapter());
   const postCols = {
     title: "string" as const,
     published: "boolean" as const,

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -232,13 +232,15 @@ function _establishPooledTestPool(): Promise<
       adapterName = "sqlite3";
       const database = _pooledSqliteDatabase();
       configuration = { adapter: adapterName, database };
-      // Drivers with SQLITE_OMIT_SHARED_CACHE compiled in (better-sqlite3)
-      // or no URI-mode access (expo-sqlite) can't share an in-memory DB
-      // across connections. Pool size 1 sidesteps the requirement — with
-      // one connection there's nothing to share. The pool's lease queue
-      // still serializes concurrent writes and `adapter.pool` is non-null.
+      // better-sqlite3 is built with SQLITE_OMIT_SHARED_CACHE, so its
+      // connections can't share an in-memory DB. Pool size 1 sidesteps
+      // the requirement — with one connection there's nothing to share.
+      // (expo-sqlite would belong here too, but SQLite3Adapter currently
+      // requires a driver with openSync; expo-sqlite is async-only and
+      // can't construct today — re-add to this branch when the async
+      // adapter path lands.)
       const driverName = await _activeSqliteDriverName();
-      if (driverName === "better-sqlite3" || driverName === "expo-sqlite") {
+      if (driverName === "better-sqlite3") {
         (configuration as Record<string, unknown>).pool = 1;
       }
       const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -167,6 +167,20 @@ let _pooledPoolPromise: Promise<
   import("./connection-adapters/abstract/connection-pool.js").ConnectionPool
 > | null = null;
 
+/**
+ * Resolve the active SQLite driver name (better-sqlite3 / node-sqlite /
+ * expo-sqlite). Returns undefined if no driver is registered or resolution
+ * fails — caller defaults to the standard pool size.
+ */
+async function _activeSqliteDriverName(): Promise<string | undefined> {
+  try {
+    const { getSqlite } = await import("@blazetrails/activesupport/sqlite-adapter");
+    return getSqlite().name;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Per-worker SQLite shared-cache database name (Phase A0 spike: prefer named form). */
 function _pooledSqliteDatabase(): string {
   const workerId = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? "1";
@@ -218,6 +232,15 @@ function _establishPooledTestPool(): Promise<
       adapterName = "sqlite3";
       const database = _pooledSqliteDatabase();
       configuration = { adapter: adapterName, database };
+      // Drivers with SQLITE_OMIT_SHARED_CACHE compiled in (better-sqlite3)
+      // or no URI-mode access (expo-sqlite) can't share an in-memory DB
+      // across connections. Pool size 1 sidesteps the requirement — with
+      // one connection there's nothing to share. The pool's lease queue
+      // still serializes concurrent writes and `adapter.pool` is non-null.
+      const driverName = await _activeSqliteDriverName();
+      if (driverName === "better-sqlite3" || driverName === "expo-sqlite") {
+        (configuration as Record<string, unknown>).pool = 1;
+      }
       const { SQLite3Adapter } = await import("./connection-adapters/sqlite3-adapter.js");
       adapterFactory = () => new SQLite3Adapter(database) as unknown as DatabaseAdapter;
     }

--- a/packages/activerecord/src/test-helpers/pooled-test-adapter.test.ts
+++ b/packages/activerecord/src/test-helpers/pooled-test-adapter.test.ts
@@ -50,6 +50,10 @@ describe("createPooledTestAdapter (Phase B smoke)", () => {
     const tableName = "pooled_smoke_pin_rollback";
     await asExec(setupAdapter).exec(`DROP TABLE IF EXISTS ${tableName}`);
     await asExec(setupAdapter).exec(`CREATE TABLE ${tableName} (id INTEGER PRIMARY KEY)`);
+    // Release the setup lease so a pool-size-1 driver (better-sqlite3 /
+    // expo-sqlite under the corrected Phase D shared-cache strategy) can
+    // acquire the single connection for pinning inside the exec context.
+    pool.releaseConnection();
     try {
       await withExecutionContext(async () => {
         // Pin first, THEN check out so the pinned connection is the one we
@@ -67,10 +71,12 @@ describe("createPooledTestAdapter (Phase B smoke)", () => {
         }
       });
 
-      const after = await setupAdapter.execute(`SELECT count(*) AS c FROM ${tableName}`);
+      const verifyAdapter = pool.leaseConnection();
+      const after = await verifyAdapter.execute(`SELECT count(*) AS c FROM ${tableName}`);
       expect(Number((after[0] as { c: number }).c)).toBe(0);
     } finally {
-      await asExec(setupAdapter).exec(`DROP TABLE IF EXISTS ${tableName}`);
+      const cleanupAdapter = pool.leaseConnection();
+      await asExec(cleanupAdapter).exec(`DROP TABLE IF EXISTS ${tableName}`);
     }
   });
 

--- a/packages/activerecord/src/test-helpers/pooled-test-adapter.test.ts
+++ b/packages/activerecord/src/test-helpers/pooled-test-adapter.test.ts
@@ -72,11 +72,19 @@ describe("createPooledTestAdapter (Phase B smoke)", () => {
       });
 
       const verifyAdapter = pool.leaseConnection();
-      const after = await verifyAdapter.execute(`SELECT count(*) AS c FROM ${tableName}`);
-      expect(Number((after[0] as { c: number }).c)).toBe(0);
+      try {
+        const after = await verifyAdapter.execute(`SELECT count(*) AS c FROM ${tableName}`);
+        expect(Number((after[0] as { c: number }).c)).toBe(0);
+      } finally {
+        pool.releaseConnection();
+      }
     } finally {
       const cleanupAdapter = pool.leaseConnection();
-      await asExec(cleanupAdapter).exec(`DROP TABLE IF EXISTS ${tableName}`);
+      try {
+        await asExec(cleanupAdapter).exec(`DROP TABLE IF EXISTS ${tableName}`);
+      } finally {
+        pool.releaseConnection();
+      }
     }
   });
 


### PR DESCRIPTION
## Summary

Phase D batch 1 of the connection-pool epic. **All drivers** now go through `createPooledTestAdapter()`; `better-sqlite3` gets **pool size 1** (its build sets `SQLITE_OMIT_SHARED_CACHE`, so multiple connections can't share an in-memory DB). All other drivers use the existing `dbConfig.pool` default (5).

`expo-sqlite` would belong on the pool-size-1 branch too, but the current `SQLite3Adapter` requires a driver with `openSync` and expo-sqlite is async-only — it can't construct today. Re-add to the condition when the async adapter path lands.

## Changes

- `test-adapter.ts` — `_activeSqliteDriverName()` helper; `configuration.pool = 1` only for `better-sqlite3`. Other drivers unchanged.
- `scoping/{default,named}-scoping.test.ts` migrated to `createPooledTestAdapter`; `dropExisting: true` on `defineSchema` to avoid cross-file `posts` collisions on the shared-cache in-memory DB.
- `pooled-test-adapter.test.ts` smoke: release/re-lease around `pinConnectionBang` so the pin path works under pool size 1; explicit `releaseConnection()` for verify/cleanup leases.

## Finding — relation-scoping deferred again

`relation-scoping.test.ts` was the Bug 2 victim from #2219. CI verified the pool migration does **not** resolve PG 25P02 on `NestedRelationScopingTest > merge inner scope has priority`. The pool's lease queue only serializes when leases compete for the same connection; with PG pool size 5 and pinning keyed by execution context, the 11 concurrent `Post.create` branches in `Promise.all` can each lease a different connection. The race is unchanged.

Reverted in this PR; kept on `createTestAdapter`. Real fix needs one of:
1. Pin propagation into `Promise.all` sub-branches (so all 11 calls resolve to the same pinned connection).
2. Pool-size-1 for PG test mode (mirrors the better-sqlite3 strategy; would serialize naturally but slows the suite).
3. Different concurrency model in the test itself (sequential awaits — but that changes the test's intent).

## Out of scope (Phase E)

`_sharedAdapter`, `createTestAdapter`, `createSidecarTestAdapter`, `TestAdapterFixtures` unchanged.

## Test plan

- [x] Local: scoping suite passes on better-sqlite3 (pool size 1)
- [x] Local: `test-helpers/{pooled-test-adapter,with-transactional-fixtures}.test.ts` pass
- [x] CI: PG + MariaDB + SQLite all green
- [x] CI: `api:compare` / `test:compare` delta non-negative (source unchanged → expect 0)