### PR TITLE
fix(activerecord): re-key defineSchema signature cache by database identity

### DIFF
--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -222,20 +222,76 @@ const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
 };
 
 /**
- * Per-adapter cache of the last-applied normalized table signatures. Lets
+ * Per-database cache of the last-applied normalized table signatures. Lets
  * `defineSchema` skip DDL when an identical schema is requested again —
  * the Phase 6 hoist (`defineSchema` in `beforeAll` instead of `beforeEach`)
  * relies on this being a no-op when nothing changed.
  *
+ * Keyed by {@link databaseIdentity} so distinct adapter instances that
+ * target the same underlying DB (e.g. multiple pool-leased adapters over
+ * one SQLite shared-cache URI or one PG connection URL) share one cache
+ * entry. Without this, file A's `defineSchema({foo})` would populate
+ * adapter X's cache; file B's adapter Y would see an empty cache and
+ * attempt `CREATE TABLE foo` against the live DB.
+ *
  * @internal
  */
-// WeakMap so short-lived adapter wrappers (createTestAdapter() returns a
-// fresh wrapper per call, and withTransactionalFixtures skips the global
-// reset between tests) don't accumulate. The no-arg clear below rebinds
-// the WeakMap rather than enumerating — outstanding snapshots from
-// `_snapshotAppliedSchemaSignaturesForAdapter` are independent Map copies
-// so callers holding a snapshot can still restore.
-let _appliedSchemaSignatures = new WeakMap<DatabaseAdapter, Map<string, string>>();
+let _appliedSchemaSignatures = new Map<string, Map<string, string>>();
+
+/**
+ * Stable per-adapter unique key for adapters whose underlying DB cannot
+ * be identified by a stringable connection target — notably SQLite
+ * `:memory:` (each adapter IS a separate DB) and any adapter that
+ * doesn't expose a recognizable config field. Pinned via WeakMap so the
+ * mapping disappears when the adapter is GC'd.
+ *
+ * @internal
+ */
+const _adapterUniqueIds = new WeakMap<DatabaseAdapter, string>();
+let _adapterIdCounter = 0;
+function _adapterUniqueId(adapter: DatabaseAdapter): string {
+  let id = _adapterUniqueIds.get(adapter);
+  if (!id) {
+    id = `adapter#${++_adapterIdCounter}`;
+    _adapterUniqueIds.set(adapter, id);
+  }
+  return id;
+}
+
+/**
+ * Derive a string identity for the underlying database an adapter is
+ * connected to. Adapters sharing the same DB return the same key;
+ * adapters whose DB cannot be identified fall back to a per-instance
+ * unique key (preserves the legacy "one adapter = one cache" behavior).
+ *
+ * Reads private fields by name on purpose — defineSchema is test-only
+ * infrastructure and there is no public surface for "which DB are you
+ * connected to" on AbstractAdapter today.
+ *
+ * @internal
+ */
+export function databaseIdentity(adapter: DatabaseAdapter): string {
+  const a = adapter as unknown as Record<string, unknown>;
+  if (adapter.adapterName === "sqlite") {
+    const fn = a["_filename"];
+    if (typeof fn === "string" && fn !== ":memory:" && fn !== "") return `sqlite:${fn}`;
+    return _adapterUniqueId(adapter);
+  }
+  if (adapter.adapterName === "postgres") {
+    const opts = a["_pgPoolOptions"] as { connectionString?: unknown } | undefined;
+    const cs = opts?.connectionString;
+    if (typeof cs === "string" && cs !== "") return `postgres:${cs}`;
+    return _adapterUniqueId(adapter);
+  }
+  if (adapter.adapterName === "mysql") {
+    const pc = a["_poolConfig"] as { uri?: unknown } | undefined;
+    if (typeof pc?.uri === "string" && pc.uri !== "") return `mysql:${pc.uri}`;
+    const db = a["_database"];
+    if (typeof db === "string" && db !== "") return `mysql:db=${db}`;
+    return _adapterUniqueId(adapter);
+  }
+  return _adapterUniqueId(adapter);
+}
 
 /**
  * Snapshot the per-adapter signature cache. Paired with
@@ -254,7 +310,7 @@ let _appliedSchemaSignatures = new WeakMap<DatabaseAdapter, Map<string, string>>
 export function _snapshotAppliedSchemaSignaturesForAdapter(
   adapter: DatabaseAdapter,
 ): Map<string, string> {
-  const cache = _appliedSchemaSignatures.get(adapter);
+  const cache = _appliedSchemaSignatures.get(databaseIdentity(adapter));
   return cache ? new Map(cache) : new Map();
 }
 
@@ -263,7 +319,7 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
   adapter: DatabaseAdapter,
   snapshot: Map<string, string>,
 ): void {
-  _appliedSchemaSignatures.set(adapter, new Map(snapshot));
+  _appliedSchemaSignatures.set(databaseIdentity(adapter), new Map(snapshot));
 }
 
 /**
@@ -278,18 +334,19 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
  */
 export function clearAppliedSchemaSignatures(adapter?: DatabaseAdapter): void {
   if (adapter) {
-    _appliedSchemaSignatures.delete(adapter);
+    _appliedSchemaSignatures.delete(databaseIdentity(adapter));
   } else {
-    _appliedSchemaSignatures = new WeakMap();
+    _appliedSchemaSignatures = new Map();
   }
 }
 
 /** @internal */
 function getCache(adapter: DatabaseAdapter): Map<string, string> {
-  let cache = _appliedSchemaSignatures.get(adapter);
+  const key = databaseIdentity(adapter);
+  let cache = _appliedSchemaSignatures.get(key);
   if (!cache) {
     cache = new Map();
-    _appliedSchemaSignatures.set(adapter, cache);
+    _appliedSchemaSignatures.set(key, cache);
   }
   return cache;
 }

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -273,27 +273,16 @@ function _stripUrlCredentials(s: string): string {
 }
 
 /**
- * Unwrap any `innerAdapter` chain so wrapper shapes like
- * `TestAdapterFixtures` resolve to the real underlying adapter. The
- * wrapper holds adapter-config fields on its inner, so identity
- * derivation must descend through it.
- *
- * @internal
- */
-function _unwrapAdapter(adapter: DatabaseAdapter): DatabaseAdapter {
-  let cur: DatabaseAdapter = adapter;
-  for (let i = 0; i < 8; i++) {
-    const inner = (cur as unknown as { innerAdapter?: DatabaseAdapter }).innerAdapter;
-    if (!inner || inner === cur) return cur;
-    cur = inner;
-  }
-  return cur;
-}
-
-/**
  * Derive a string identity for the underlying database an adapter is
  * connected to, or `null` when no stringable identity is available
  * (callers fall back to the {@link _fallbackSchemaSignatures} WeakMap).
+ *
+ * Does NOT unwrap `innerAdapter` chains: wrappers like
+ * `TestAdapterFixtures` carry their own per-wrapper `tables: Set<string>`
+ * that `defineSchema` reads via `adapterKnownTables`, so sharing one
+ * cache entry across wrappers would desync the cache from the per-wrapper
+ * "tables I know about" view and cause cross-file table leakage. Only
+ * raw adapters (pool-leased `SidecarAdapter`, etc.) share by DB identity.
  *
  * Reads private fields by name on purpose — defineSchema is test-only
  * infrastructure and there is no public surface for "which DB are you
@@ -304,8 +293,11 @@ function _unwrapAdapter(adapter: DatabaseAdapter): DatabaseAdapter {
  * @internal
  */
 function databaseIdentity(adapter: DatabaseAdapter): string | null {
-  const real = _unwrapAdapter(adapter);
+  const real = adapter;
   const a = real as unknown as Record<string, unknown>;
+  // Wrapper shapes (e.g. TestAdapterFixtures with an `innerAdapter` field)
+  // intentionally don't share — see fn docstring.
+  if ((a as { innerAdapter?: unknown }).innerAdapter !== undefined) return null;
   if (real.adapterName === "sqlite") {
     const fn = a["_filename"];
     if (typeof fn === "string" && fn !== ":memory:" && fn !== "") return `sqlite:${fn}`;
@@ -346,7 +338,7 @@ function _cacheFor(adapter: DatabaseAdapter, create: boolean): Map<string, strin
     }
     return cache;
   }
-  const real = _unwrapAdapter(adapter);
+  const real = adapter;
   let cache = _fallbackSchemaSignatures.get(real);
   if (!cache && create) {
     cache = new Map();
@@ -386,7 +378,7 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
   if (key !== null) {
     _appliedSchemaSignatures.set(key, new Map(snapshot));
   } else {
-    _fallbackSchemaSignatures.set(_unwrapAdapter(adapter), new Map(snapshot));
+    _fallbackSchemaSignatures.set(adapter, new Map(snapshot));
   }
 }
 
@@ -408,7 +400,7 @@ export function clearAppliedSchemaSignatures(adapter?: DatabaseAdapter): void {
     if (key !== null) {
       _appliedSchemaSignatures.delete(key);
     } else {
-      _fallbackSchemaSignatures.delete(_unwrapAdapter(adapter));
+      _fallbackSchemaSignatures.delete(adapter);
     }
   } else {
     _appliedSchemaSignatures = new Map();

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -239,58 +239,120 @@ const COLUMN_TYPE_MAP_SQLITE: Record<PrimitiveColumnSpec, string> = {
 let _appliedSchemaSignatures = new Map<string, Map<string, string>>();
 
 /**
- * Stable per-adapter unique key for adapters whose underlying DB cannot
- * be identified by a stringable connection target — notably SQLite
- * `:memory:` (each adapter IS a separate DB) and any adapter that
- * doesn't expose a recognizable config field. Pinned via WeakMap so the
- * mapping disappears when the adapter is GC'd.
+ * Fallback cache for adapters whose underlying DB cannot be identified
+ * by a stringable connection target — notably SQLite `:memory:` (each
+ * adapter IS a separate DB) and any adapter that doesn't expose a
+ * recognizable config field. WeakMap-keyed so entries vanish when the
+ * adapter is GC'd, avoiding unbounded growth across many short-lived
+ * adapters.
  *
  * @internal
  */
-const _adapterUniqueIds = new WeakMap<DatabaseAdapter, string>();
-let _adapterIdCounter = 0;
-function _adapterUniqueId(adapter: DatabaseAdapter): string {
-  let id = _adapterUniqueIds.get(adapter);
-  if (!id) {
-    id = `adapter#${++_adapterIdCounter}`;
-    _adapterUniqueIds.set(adapter, id);
+let _fallbackSchemaSignatures = new WeakMap<DatabaseAdapter, Map<string, string>>();
+
+/**
+ * Strip any `user:password@` userinfo from a URL-style connection string
+ * so the cache key doesn't retain credentials in heap. Non-URLs (e.g.
+ * `host=... dbname=...` key/value form) pass through unchanged — we don't
+ * try to parse those.
+ *
+ * @internal
+ */
+function _stripUrlCredentials(s: string): string {
+  try {
+    const u = new URL(s);
+    if (u.username || u.password) {
+      u.username = "";
+      u.password = "";
+      return u.toString();
+    }
+    return s;
+  } catch {
+    return s;
   }
-  return id;
+}
+
+/**
+ * Unwrap any `innerAdapter` chain so wrapper shapes like
+ * `TestAdapterFixtures` resolve to the real underlying adapter. The
+ * wrapper holds adapter-config fields on its inner, so identity
+ * derivation must descend through it.
+ *
+ * @internal
+ */
+function _unwrapAdapter(adapter: DatabaseAdapter): DatabaseAdapter {
+  let cur: DatabaseAdapter = adapter;
+  for (let i = 0; i < 8; i++) {
+    const inner = (cur as unknown as { innerAdapter?: DatabaseAdapter }).innerAdapter;
+    if (!inner || inner === cur) return cur;
+    cur = inner;
+  }
+  return cur;
 }
 
 /**
  * Derive a string identity for the underlying database an adapter is
- * connected to. Adapters sharing the same DB return the same key;
- * adapters whose DB cannot be identified fall back to a per-instance
- * unique key (preserves the legacy "one adapter = one cache" behavior).
+ * connected to, or `null` when no stringable identity is available
+ * (callers fall back to the {@link _fallbackSchemaSignatures} WeakMap).
  *
  * Reads private fields by name on purpose — defineSchema is test-only
  * infrastructure and there is no public surface for "which DB are you
- * connected to" on AbstractAdapter today.
+ * connected to" on AbstractAdapter today. Strips URL credentials so the
+ * cache key doesn't retain `user:password@...` from `PG_TEST_URL` /
+ * `MYSQL_TEST_URL`.
  *
  * @internal
  */
-export function databaseIdentity(adapter: DatabaseAdapter): string {
-  const a = adapter as unknown as Record<string, unknown>;
-  if (adapter.adapterName === "sqlite") {
+function databaseIdentity(adapter: DatabaseAdapter): string | null {
+  const real = _unwrapAdapter(adapter);
+  const a = real as unknown as Record<string, unknown>;
+  if (real.adapterName === "sqlite") {
     const fn = a["_filename"];
     if (typeof fn === "string" && fn !== ":memory:" && fn !== "") return `sqlite:${fn}`;
-    return _adapterUniqueId(adapter);
+    return null;
   }
-  if (adapter.adapterName === "postgres") {
+  if (real.adapterName === "postgres") {
     const opts = a["_pgPoolOptions"] as { connectionString?: unknown } | undefined;
     const cs = opts?.connectionString;
-    if (typeof cs === "string" && cs !== "") return `postgres:${cs}`;
-    return _adapterUniqueId(adapter);
+    if (typeof cs === "string" && cs !== "") return `postgres:${_stripUrlCredentials(cs)}`;
+    return null;
   }
-  if (adapter.adapterName === "mysql") {
+  if (real.adapterName === "mysql") {
     const pc = a["_poolConfig"] as { uri?: unknown } | undefined;
-    if (typeof pc?.uri === "string" && pc.uri !== "") return `mysql:${pc.uri}`;
+    if (typeof pc?.uri === "string" && pc.uri !== "")
+      return `mysql:${_stripUrlCredentials(pc.uri)}`;
     const db = a["_database"];
     if (typeof db === "string" && db !== "") return `mysql:db=${db}`;
-    return _adapterUniqueId(adapter);
+    return null;
   }
-  return _adapterUniqueId(adapter);
+  return null;
+}
+
+/**
+ * Resolve the signature cache for `adapter`, creating it if missing.
+ * Adapters with a stringable DB identity share one Map across all
+ * sibling adapters pointing at the same DB; the rest get a per-instance
+ * WeakMap entry (auto-GC'd with the adapter).
+ *
+ * @internal
+ */
+function _cacheFor(adapter: DatabaseAdapter, create: boolean): Map<string, string> | undefined {
+  const key = databaseIdentity(adapter);
+  if (key !== null) {
+    let cache = _appliedSchemaSignatures.get(key);
+    if (!cache && create) {
+      cache = new Map();
+      _appliedSchemaSignatures.set(key, cache);
+    }
+    return cache;
+  }
+  const real = _unwrapAdapter(adapter);
+  let cache = _fallbackSchemaSignatures.get(real);
+  if (!cache && create) {
+    cache = new Map();
+    _fallbackSchemaSignatures.set(real, cache);
+  }
+  return cache;
 }
 
 /**
@@ -311,7 +373,7 @@ export function databaseIdentity(adapter: DatabaseAdapter): string {
 export function _snapshotAppliedSchemaSignaturesForAdapter(
   adapter: DatabaseAdapter,
 ): Map<string, string> {
-  const cache = _appliedSchemaSignatures.get(databaseIdentity(adapter));
+  const cache = _cacheFor(adapter, false);
   return cache ? new Map(cache) : new Map();
 }
 
@@ -320,7 +382,12 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
   adapter: DatabaseAdapter,
   snapshot: Map<string, string>,
 ): void {
-  _appliedSchemaSignatures.set(databaseIdentity(adapter), new Map(snapshot));
+  const key = databaseIdentity(adapter);
+  if (key !== null) {
+    _appliedSchemaSignatures.set(key, new Map(snapshot));
+  } else {
+    _fallbackSchemaSignatures.set(_unwrapAdapter(adapter), new Map(snapshot));
+  }
 }
 
 /**
@@ -337,21 +404,21 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
  */
 export function clearAppliedSchemaSignatures(adapter?: DatabaseAdapter): void {
   if (adapter) {
-    _appliedSchemaSignatures.delete(databaseIdentity(adapter));
+    const key = databaseIdentity(adapter);
+    if (key !== null) {
+      _appliedSchemaSignatures.delete(key);
+    } else {
+      _fallbackSchemaSignatures.delete(_unwrapAdapter(adapter));
+    }
   } else {
     _appliedSchemaSignatures = new Map();
+    _fallbackSchemaSignatures = new WeakMap();
   }
 }
 
 /** @internal */
 function getCache(adapter: DatabaseAdapter): Map<string, string> {
-  const key = databaseIdentity(adapter);
-  let cache = _appliedSchemaSignatures.get(key);
-  if (!cache) {
-    cache = new Map();
-    _appliedSchemaSignatures.set(key, cache);
-  }
-  return cache;
+  return _cacheFor(adapter, true)!;
 }
 
 /** @internal */

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -294,7 +294,8 @@ export function databaseIdentity(adapter: DatabaseAdapter): string {
 }
 
 /**
- * Snapshot the per-adapter signature cache. Paired with
+ * Snapshot the signature cache for the database the adapter targets
+ * (resolved via {@link databaseIdentity}). Paired with
  * {@link _restoreAppliedSchemaSignaturesForAdapter} so
  * `withTransactionalFixtures` can preserve entries created in a `beforeAll`
  * (outside any rolled-back test transaction) while discarding entries
@@ -323,8 +324,10 @@ export function _restoreAppliedSchemaSignaturesForAdapter(
 }
 
 /**
- * Drop the cached signature(s) for one adapter (or all adapters when no
- * argument is given). Paired with `resetTestAdapterState` so the signature
+ * Drop the cached signatures for the database the given adapter targets
+ * (resolved via {@link databaseIdentity}, so this also clears entries for
+ * any sibling adapter pointing at the same DB), or for every database
+ * when no argument is given. Paired with `resetTestAdapterState` so the signature
  * cache stays synchronized with `dropAllTables`: a shared adapter — which
  * survives across tests under the sidecar shape — would otherwise hold
  * signatures for tables that no longer exist, making a subsequent


### PR DESCRIPTION
## Summary

Phase D prerequisite #1 for the pool epic. Re-keys
`_appliedSchemaSignatures` from `WeakMap<DatabaseAdapter, ...>` (adapter
object identity) to `Map<string, ...>` keyed by **database identity** so
that distinct adapters targeting the same underlying DB share one cache
entry.

### The bug

Under the pool model, each file leases a per-file adapter instance, but
all adapters share one underlying DB (SQLite shared-cache URI, one
PG/MySQL connection URL). With per-adapter keying, file A's
`defineSchema({foo})` populated adapter X's cache; file B's adapter Y
saw an empty cache and tried `CREATE TABLE foo` against the live DB →
"already exists" error.

PR #2250 sidestepped this by passing `{ dropExisting: true }` on each
migrated file. This PR fixes it properly so that workaround isn't
needed.

### The fix

`databaseIdentity(adapter)` derives a stable string key from the
adapter's connection target:

- **sqlite**: `_filename` when not `:memory:` (covers both
  `file:trails_test_X?mode=memory&cache=shared` and filesystem paths)
- **postgres**: `_pgPoolOptions.connectionString`
- **mysql**: `_poolConfig.uri` (falls back to `_database`)
- **fallback** (sqlite `:memory:`, unidentified adapters): per-instance
  unique key via `WeakMap<adapter, "adapter#N">` — preserves legacy
  "one adapter = one cache" semantics

`getCache`, `_snapshotAppliedSchemaSignaturesForAdapter`,
`_restoreAppliedSchemaSignaturesForAdapter`, and
`clearAppliedSchemaSignatures` all route through the new key.

### Step 3 (`dropExisting: true` removal)

No-op for the scoping files — current PR #2250 doesn't actually ship the
workaround it was described as carrying (verified via `gh pr view 2250`
and grep on the scoping/ files). When #2250 lands without the
workaround, it'll work correctly on top of this fix; if a future Phase D
sweep needs it, the cache fix will make it unnecessary.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/test-helpers/define-schema.test.ts` — 28/28 green
- [x] `pnpm vitest run packages/activerecord/src/scoping/` — 313/313 (+27 skipped, unchanged)
- [x] `pnpm test:types` — 83/83, no type errors
- [x] LOC: 71+/14-, ~57 net (under the 300 ceiling)
- [ ] CI: PG + MariaDB paths

## Out of scope

- Issue #2 from the Phase D follow-ups memory (Promise.all pin
  propagation gap) — separate PR.