### PR TITLE
fix(activerecord): centralize pin lookup across pool lease entry points

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -571,16 +571,16 @@ export class ConnectionPool implements ReapablePool {
   // --- Checkout / Checkin ---
 
   checkout(): DatabaseAdapter {
-    const pin = this._pinnedConnections.get(executionContextId());
-    if (pin) {
-      if (isTransactionAware(pin.connection)) {
-        pin.connection.verifyBang();
+    const pinned = this._resolvePinnedConnection();
+    if (pinned) {
+      if (isTransactionAware(pinned)) {
+        pinned.verifyBang();
       }
-      if (this._connections && !this._connections.includes(pin.connection)) {
-        this._connections.push(pin.connection);
+      if (this._connections && !this._connections.includes(pinned)) {
+        this._connections.push(pinned);
       }
-      this._cacheConfig.checkoutAndVerify(pin.connection as unknown as QueryCacheHost);
-      return pin.connection;
+      this._cacheConfig.checkoutAndVerify(pinned as unknown as QueryCacheHost);
+      return pinned;
     }
     const conn = this._acquireConnection();
     this._cacheConfig.checkoutAndVerify(conn as unknown as QueryCacheHost);
@@ -588,16 +588,16 @@ export class ConnectionPool implements ReapablePool {
   }
 
   async checkoutAsync(timeout?: number): Promise<DatabaseAdapter> {
-    const pin = this._pinnedConnections.get(executionContextId());
-    if (pin) {
-      if (isTransactionAware(pin.connection)) {
-        pin.connection.verifyBang();
+    const pinned = this._resolvePinnedConnection();
+    if (pinned) {
+      if (isTransactionAware(pinned)) {
+        pinned.verifyBang();
       }
-      if (this._connections && !this._connections.includes(pin.connection)) {
-        this._connections.push(pin.connection);
+      if (this._connections && !this._connections.includes(pinned)) {
+        this._connections.push(pinned);
       }
-      this._cacheConfig.checkoutAndVerify(pin.connection as unknown as QueryCacheHost);
-      return pin.connection;
+      this._cacheConfig.checkoutAndVerify(pinned as unknown as QueryCacheHost);
+      return pinned;
     }
     const conn = this._tryAcquire();
     if (conn) {
@@ -628,6 +628,8 @@ export class ConnectionPool implements ReapablePool {
   }
 
   private _acquireConnection(): DatabaseAdapter {
+    const pinned = this._resolvePinnedConnection();
+    if (pinned) return pinned;
     const conn = this._tryAcquire();
     if (conn) return conn;
     throw new ConnectionTimeoutError(
@@ -993,6 +995,21 @@ export class ConnectionPool implements ReapablePool {
       if (pin.connection === conn) return true;
     }
     return false;
+  }
+
+  /**
+   * Resolve the connection that all checkouts in the current execution
+   * context should route to while a pin is active. Centralizes the lookup
+   * used by `checkout`, `checkoutAsync`, and `_acquireConnection` so every
+   * lease entry point honors `pinConnectionBang` consistently — mirrors
+   * Rails' `@pinned_connection` short-circuit in
+   * `ConnectionPool#checkout` (connection_pool.rb:547).
+   *
+   * @internal
+   */
+  private _resolvePinnedConnection(): DatabaseAdapter | undefined {
+    if (this._pinnedConnections.size === 0) return undefined;
+    return this._pinnedConnections.get(executionContextId())?.connection;
   }
 
   private _connectionLease(): Lease {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -822,6 +822,29 @@ it("pin connection isolation across execution contexts", async () => {
   expect(ctx1Conn).not.toBe(ctx2Conn);
 });
 
+it("concurrent checkouts within a pinned context all return the pinned connection", async () => {
+  const pool = makeTransactionAwarePool(5);
+  await pool.pinConnectionBang();
+  const pinned = pool.checkout();
+
+  // Mirrors Promise.all sub-branches inside a `withTransactionalFixtures`
+  // test body: AsyncContext propagates the pin's ctx id to every branch,
+  // so every concurrent lease must resolve to the pinned connection rather
+  // than pulling a free-list connection (which would race the pinned TX).
+  const results = await Promise.all(
+    Array.from({ length: 11 }, async () => {
+      const sync = pool.checkout();
+      const async_ = await pool.checkoutAsync();
+      return { sync, async_ };
+    }),
+  );
+  for (const { sync, async_ } of results) {
+    expect(sync).toBe(pinned);
+    expect(async_).toBe(pinned);
+  }
+  await pool.unpinConnectionBang();
+});
+
 it.skip("pin connection nesting lock", () => {
   // BLOCKED: connection-pool — connection pool / handler gap in connection-pool
   // ROOT-CAUSE: connection-adapters/abstract/connection-pool.ts or abstract/connection-handler.ts missing Rails parity for pool lifecycle

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -5,45 +5,41 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";
 
-import { createPooledTestAdapter, type SidecarAdapter } from "../test-adapter.js";
+import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: SidecarAdapter;
+let _adapter: TestDatabaseAdapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = await createPooledTestAdapter());
+  _adapter = createTestAdapter();
   const postCols = {
     title: "string" as const,
     published: "boolean" as const,
     salary: "integer" as const,
     author: "string" as const,
   };
-  await defineSchema(
-    _adapter,
-    {
-      developers: { name: "string", salary: "integer" },
-      posts: { title: "string", author: "string", published: "boolean" },
-      ro_posts: postCols,
-      dro_posts: postCols,
-      sf_posts: postCols,
-      sff_posts: postCols,
-      sfl_posts: postCols,
-      sc_posts: postCols,
-      sds_posts: postCols,
-      sfa_posts: postCols,
-      scnt_posts: postCols,
-      sj_posts: postCols,
-      nrs_posts: postCols,
-      ann_posts: postCols,
-      ann_unscoped_posts: postCols,
-      animals: { type: "string", name: "string" },
-      cats: { type: "string", name: "string" },
-      dogs: { type: "string", name: "string" },
-      categories: { name: "string" },
-    },
-    { dropExisting: true },
-  );
+  await defineSchema(_adapter, {
+    developers: { name: "string", salary: "integer" },
+    posts: { title: "string", author: "string", published: "boolean" },
+    ro_posts: postCols,
+    dro_posts: postCols,
+    sf_posts: postCols,
+    sff_posts: postCols,
+    sfl_posts: postCols,
+    sc_posts: postCols,
+    sds_posts: postCols,
+    sfa_posts: postCols,
+    scnt_posts: postCols,
+    sj_posts: postCols,
+    nrs_posts: postCols,
+    ann_posts: postCols,
+    ann_unscoped_posts: postCols,
+    animals: { type: "string", name: "string" },
+    cats: { type: "string", name: "string" },
+    dogs: { type: "string", name: "string" },
+    categories: { name: "string" },
+  });
 });
 withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -5,41 +5,45 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createPooledTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = await createPooledTestAdapter());
   const postCols = {
     title: "string" as const,
     published: "boolean" as const,
     salary: "integer" as const,
     author: "string" as const,
   };
-  await defineSchema(_adapter, {
-    developers: { name: "string", salary: "integer" },
-    posts: { title: "string", author: "string", published: "boolean" },
-    ro_posts: postCols,
-    dro_posts: postCols,
-    sf_posts: postCols,
-    sff_posts: postCols,
-    sfl_posts: postCols,
-    sc_posts: postCols,
-    sds_posts: postCols,
-    sfa_posts: postCols,
-    scnt_posts: postCols,
-    sj_posts: postCols,
-    nrs_posts: postCols,
-    ann_posts: postCols,
-    ann_unscoped_posts: postCols,
-    animals: { type: "string", name: "string" },
-    cats: { type: "string", name: "string" },
-    dogs: { type: "string", name: "string" },
-    categories: { name: "string" },
-  });
+  await defineSchema(
+    _adapter,
+    {
+      developers: { name: "string", salary: "integer" },
+      posts: { title: "string", author: "string", published: "boolean" },
+      ro_posts: postCols,
+      dro_posts: postCols,
+      sf_posts: postCols,
+      sff_posts: postCols,
+      sfl_posts: postCols,
+      sc_posts: postCols,
+      sds_posts: postCols,
+      sfa_posts: postCols,
+      scnt_posts: postCols,
+      sj_posts: postCols,
+      nrs_posts: postCols,
+      ann_posts: postCols,
+      ann_unscoped_posts: postCols,
+      animals: { type: "string", name: "string" },
+      cats: { type: "string", name: "string" },
+      dogs: { type: "string", name: "string" },
+      categories: { name: "string" },
+    },
+    { dropExisting: true },
+  );
 });
 withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {


### PR DESCRIPTION
## Summary

- Extract `ConnectionPool#_resolvePinnedConnection()` and route `checkout`, `checkoutAsync`, and `_acquireConnection` through it. All lease entry points now honor `pinConnectionBang` consistently — mirrors Rails' short-circuit in `ConnectionPool#checkout` (connection_pool.rb:548: `return checkout_and_verify(acquire_connection(...)) unless @pinned_connection`).
- Add regression test asserting that concurrent `checkout`/`checkoutAsync` inside a pinned context all return the pinned connection. Locks in the Promise.all-sub-branch contract `withTransactionalFixtures` relies on.

## Scope correction (after CI feedback)

This PR was originally going to re-migrate `scoping/relation-scoping.test.ts` to `createPooledTestAdapter()`. CI reproduced the original PG failure (25P02 + 08P01 `invalid frontend message type 0`) under the pooled migration, so I reverted that hunk and kept only the `ConnectionPool` refactor.

**Why the pool refactor doesn't fix that test:** The failure surface on CI is a PG protocol violation, not a pin-routing miss. AsyncContext propagates through Promise.all sub-branches (verified by the new regression test), so the per-context pin lookup resolves correctly. The actual race is one layer down: `PostgreSQLAdapter#withClient` returns `this._client` when a TX is open, else acquires a fresh client from the inner pg.Pool. Some path under concurrent writes inside a pinned TX must be hitting the fresh-client branch, fanning the single logical TX across multiple pg sockets — one branch aborts the TX server-side, the rest see 25P02. That's a `PostgreSQLAdapter` fix (separate PR), not a `ConnectionPool` change.

## Phase D impact

- Issue 2 in `project_pool_epic_phase_d_followups.md` is **partially addressed**: pin lookup is now consistent across lease entry points (defense in depth) and the Promise.all-within-pinned-context contract has a regression test. The relation-scoping migration remains blocked until the PostgreSQLAdapter pg-pool fan-out is fixed.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/connection-pool.test.ts` (88 tests, +1 new regression — including the pre-existing "pin connection isolation across execution contexts" test that pins per-context)
- [x] `pnpm vitest run packages/activerecord/src/test-helpers/{pooled-test-adapter,with-transactional-fixtures}.test.ts`
- [x] `pnpm api:compare --package activerecord` — Δ 0 (4955/4958)
- [x] `pnpm test:compare --package activerecord` — Δ 0 (6669/7870)
- [ ] CI to confirm PG/MySQL clean with the test migration reverted