### PR TITLE
test(activerecord): migrate scoping/ tests to pooled adapter (pool epic Phase D batch 1)

### DIFF
--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { Base, Relation } from "../index.js";
 
-import { createSidecarTestAdapter, type SidecarAdapter } from "../test-adapter.js";
+import { createPooledTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = createSidecarTestAdapter());
+  ({ adapter: _adapter } = await createPooledTestAdapter());
   await defineSchema(_adapter, {
     posts: {
       title: "string",

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -5,14 +5,14 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Relation } from "../index.js";
 
-import { createSidecarTestAdapter, adapterType, type SidecarAdapter } from "../test-adapter.js";
+import { createPooledTestAdapter, adapterType, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  ({ adapter: _adapter } = createSidecarTestAdapter());
+  ({ adapter: _adapter } = await createPooledTestAdapter());
   await defineSchema(_adapter, {
     posts: {
       title: "string",

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -2,9 +2,14 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  *
- * TODO: migrate to createPooledTestAdapter() after the PG withClient fix lands
- * (Promise.all in NestedRelationScopingTest hits Bug 2 on the wrapper-revert path).
- * Tracked in memory: project_pool_epic_phase_d_followups.md (Issue 2).
+ * TODO: migrate to createPooledTestAdapter() after the PG withClient race
+ * fix lands. NestedRelationScopingTest > "merge inner scope has priority"
+ * issues Promise.all concurrent writes; under a pinned TX the PG adapter's
+ * withClient (postgresql-adapter.ts withClient / _acquireFreshClient) can
+ * fan a single logical TX across multiple pg.PoolClients, producing
+ * 08P01 / 25P02 races. See the closed prior batch-1 attempts #2250 and
+ * #2253 for the exact failure mode. Pool-layer pin lookup is already
+ * centralized (#2258); the remaining work is in the PG adapter.
  */
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";

--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -1,6 +1,10 @@
 /**
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
+ *
+ * TODO: migrate to createPooledTestAdapter() after the PG withClient fix lands
+ * (Promise.all in NestedRelationScopingTest hits Bug 2 on the wrapper-revert path).
+ * Tracked in memory: project_pool_epic_phase_d_followups.md (Issue 2).
  */
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";


### PR DESCRIPTION
## Summary

Phase D batch 1 respawn — migrates `packages/activerecord/src/scoping/` consumer tests to the pooled adapter. Earlier attempts (#2250, #2253) were closed; their workarounds are now obsolete after #2256 (signature-cache re-key by database identity) and #2258 (centralized pin lookup).

- `default-scoping.test.ts` → `createPooledTestAdapter()`
- `named-scoping.test.ts` → `createPooledTestAdapter()`
- `relation-scoping.test.ts` → **stays on `createTestAdapter()` (wrapper)** until the in-flight PG `withClient` race fix lands. Its `NestedRelationScopingTest > merge inner scope has priority` test exercises `Promise.all` concurrent writes that hit the unresolved PG adapter bug (Bug 2 / Issue 2 in `project_pool_epic_phase_d_followups.md`). A `TODO` comment at the top of the file documents the deferral.

No `dropExisting: true` anywhere — the signature-cache fix from #2256 supersedes that workaround.

## Test plan

- [x] `pnpm vitest run packages/activerecord/src/scoping/{default,named}-scoping.test.ts` passes on SQLite (262 tests)
- [x] `pnpm vitest run packages/activerecord/src/scoping/relation-scoping.test.ts` still passes on SQLite (51 passed, 27 pre-existing skips)
- [ ] CI: PG + MariaDB matrix green across all 3 files
- [ ] `pnpm api:compare` + `pnpm test:compare` deltas non-negative

## Follow-ups

- Re-migrate `relation-scoping.test.ts` once the PG `withClient` race fix lands (postgresql-adapter.ts:936-949).
- Phase D batch 2: `relation/` cluster.