### PR TITLE
fix(activerecord): close PostgreSQLAdapter#withClient pinned-TX race

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -934,17 +934,25 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * `pg.PoolClient` reference.
    */
   private async withClient<T>(fn: (client: pg.PoolClient) => Promise<T>): Promise<T> {
+    // Decide ownership SYNCHRONOUSLY from `this._client` — no yield between
+    // the read and the use. Under a pinned TX (Promise.all of concurrent
+    // writes), this guarantees every caller reuses the TX-pinned client.
+    // The prior shape — `txClient = this._client; await this.getClient()` —
+    // raced with begin/commit, letting a concurrent caller's snapshot go
+    // stale across the yield and either (a) checkout a fresh pool client
+    // mid-TX (causing PG `08P01 invalid frontend message type 0` /
+    // `25P02 transaction-aborted` when one logical TX fans across multiple
+    // sockets) or (b) release the TX client from a query's finally.
     const txClient = this._client;
-    // Route through getClient() so tests that stub it (see
-    // postgresql-adapter.exec-query.test.ts) keep working. getClient's
-    // own behavior matches our snapshot: returns `this._client` when
-    // set, otherwise a fresh pool connection.
+    if (txClient) return await fn(txClient);
+    // No TX active at decision time: acquire a fresh client and own its
+    // release. Route through `getClient()` so unit tests can stub the
+    // checkout (see postgresql-adapter.exec-query.test.ts).
     const client = await this.getClient();
-    const ownedByTransaction = client === txClient;
     try {
       return await fn(client);
     } finally {
-      if (!ownedByTransaction) client.release();
+      client.release();
     }
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.with-client.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.with-client.test.ts
@@ -1,0 +1,89 @@
+/**
+ * PostgreSQLAdapter#withClient — pinned-TX concurrency.
+ *
+ * Reproduces the race that fanned a single logical TX across multiple
+ * pg.PoolClient sockets under `Promise.all` writes. The prior shape
+ * snapshotted `txClient = this._client` and then `await this.getClient()`;
+ * a concurrent caller could yield while `_client` was null mid-begin and
+ * checkout a fresh pool client, producing PG `08P01` / `25P02` in live
+ * traffic. The fix: read `_client` synchronously and dispatch without
+ * yielding — under a pinned TX every caller reuses the TX-pinned client.
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PostgreSQLAdapter } from "./postgresql-adapter.js";
+
+interface PrivatePgAdapter {
+  _client: unknown;
+  withClient: <T>(fn: (client: unknown) => Promise<T>) => Promise<T>;
+  getClient: () => Promise<unknown>;
+  close: () => Promise<void>;
+}
+
+describe("PostgreSQLAdapter#withClient under pinned TX", () => {
+  let adapter: PrivatePgAdapter;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (adapter) await adapter.close().catch(() => undefined);
+  });
+
+  it("routes every concurrent caller to the TX-pinned client and never releases it", async () => {
+    adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 }) as unknown as PrivatePgAdapter;
+
+    let txReleaseCount = 0;
+    const txClient = {
+      query: async () => ({ rows: [], fields: [] }),
+      release: () => {
+        txReleaseCount++;
+      },
+    };
+    // Simulate an active pinned transaction.
+    adapter._client = txClient;
+
+    // If withClient ever falls through to getClient, fail the test: under
+    // a pinned TX the synchronous _client read must short-circuit.
+    const getClientSpy = vi.spyOn(adapter, "getClient").mockImplementation(async () => {
+      throw new Error("getClient must not be called when _client is set");
+    });
+
+    const seen: unknown[] = [];
+    const work = Array.from({ length: 11 }, (_, i) =>
+      adapter.withClient(async (client) => {
+        // Yield once to interleave with siblings.
+        await Promise.resolve();
+        seen.push(client);
+        return i;
+      }),
+    );
+    const results = await Promise.all(work);
+
+    expect(results).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(seen).toHaveLength(11);
+    for (const c of seen) expect(c).toBe(txClient);
+    expect(txReleaseCount).toBe(0);
+    expect(getClientSpy).not.toHaveBeenCalled();
+  });
+
+  it("acquires and releases a fresh client when no TX is active", async () => {
+    adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 }) as unknown as PrivatePgAdapter;
+    adapter._client = null;
+
+    let releaseCount = 0;
+    const freshClient = {
+      query: async () => ({ rows: [], fields: [] }),
+      release: () => {
+        releaseCount++;
+      },
+    };
+    vi.spyOn(adapter, "getClient").mockResolvedValue(freshClient);
+
+    const result = await adapter.withClient(async (client) => {
+      expect(client).toBe(freshClient);
+      return "ok";
+    });
+
+    expect(result).toBe("ok");
+    expect(releaseCount).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

`PostgreSQLAdapter#withClient` snapshotted `txClient = this._client` then `await this.getClient()` — the yield between read and use let a concurrent caller's snapshot go stale, either checking out a fresh pool client mid-TX (producing PG `08P01 invalid frontend message type 0` / `25P02 transaction-aborted` when one logical TX fans across multiple pg sockets) or releasing the TX client from a query's `finally`.

This is the adapter-layer half of Bug 2 from the Phase D pool migration. #2258 closed the pool layer (centralized pin lookup via `_resolvePinnedConnection`); this PR closes the adapter layer so `Promise.all` writes under a pinned TX on PG stop failing.

## Fix

Decide ownership **synchronously** from `this._client` — no yield between the read and the dispatch. Under a pinned TX every caller now reuses the TX-pinned client; the `getClient()` path is taken only when no TX is active at decision time.

```ts
const txClient = this._client;
if (txClient) return await fn(txClient);
const client = await this.getClient();
try { return await fn(client); } finally { client.release(); }
```

## Test plan

- [x] New unit test `postgresql-adapter.with-client.test.ts`:
  - 11 concurrent `withClient` callers under a stubbed pinned TX all see the same client; release is never called; `getClient` is never reached (spy throws if it is — regression check for the old shape).
  - No-TX path acquires via `getClient()` and releases exactly once.
- [x] `pnpm vitest run packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts` still green (existing `getClient` stub coverage).
- [ ] Re-migrate `relation-scoping.test.ts` to `createPooledTestAdapter()` and confirm `NestedRelationScopingTest > merge inner scope has priority` passes on PG via CI (follow-up; out of scope for this PR per ceiling).

## Follow-ups

- Re-migrate `relation-scoping.test.ts` and audit other Phase D files reverted to `createTestAdapter()` for `Promise.all`-on-PG patterns.