### PR TITLE
ci: extend changed-paths gating to more jobs + split rack-tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,13 +272,17 @@ jobs:
   prettier:
     name: Prettier
     needs: changes
-    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    timeout-minutes: 30
+    # Prettier doesn't need the workspace installed. Skip `pnpm install`
+    # entirely and run prettier directly via `npx`. Pinned version must
+    # match `prettier` in package.json (and pnpm-lock.yaml) — bump together.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup-pnpm
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm format:check
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npx --yes prettier@3.8.1 --check .
 
   guides-typecheck:
     name: Guides Code Type Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,13 @@ jobs:
       activerecord_affected: ${{ steps.filter.outputs.activerecord_affected }}
       actionpack_affected: ${{ steps.filter.outputs.actionpack_affected }}
       actionview_affected: ${{ steps.filter.outputs.actionview_affected }}
+      rack_affected: ${{ steps.filter.outputs.rack_affected }}
       trailties_affected: ${{ steps.filter.outputs.trailties_affected }}
       trails_tsc_affected: ${{ steps.filter.outputs.trails_tsc_affected }}
       tse_compiler_affected: ${{ steps.filter.outputs.tse_compiler_affected }}
+      unit_tests_affected: ${{ steps.filter.outputs.unit_tests_affected }}
+      guides_affected: ${{ steps.filter.outputs.guides_affected }}
+      website_affected: ${{ steps.filter.outputs.website_affected }}
       parity_sqlite: ${{ steps.filter.outputs.parity_sqlite }}
       parity_postgres: ${{ steps.filter.outputs.parity_postgres }}
       parity_mysql: ${{ steps.filter.outputs.parity_mysql }}
@@ -103,14 +107,42 @@ jobs:
           # no workspace dependencies today (no activesupport import), so
           # the gate matches the package path only.
           TSE_COMPILER_PKGS_RE='^packages/tse-compiler/'
+          # rack_affected gates rack-tests (split out of unit-tests so a
+          # rack-only PR doesn't drag in arel/activemodel/activesupport
+          # tests). Rack's only workspace dependency is activesupport.
+          RACK_PKGS_RE='^packages/(rack|activesupport)/'
+          # unit_tests_affected gates the bundled vitest run for the small
+          # leaf packages (arel/activemodel/activesupport) and the
+          # scripts/guides-typecheck self-test. Rack is excluded here — it
+          # has its own job above.
+          UNIT_TESTS_PKGS_RE='^packages/(arel|activemodel|activesupport)/'
+          # guides_affected gates the Guides Code Type Check job, which
+          # compiles fenced TS blocks in packages/website/docs/guides/**.
+          # Today guides only import @blazetrails/activerecord,
+          # @blazetrails/activemodel, and @blazetrails/activesupport — plus
+          # AR's transitive type deps. Confirmed via:
+          #   grep -rhE "from ['\"]@blazetrails/[a-z-]+" packages/website/docs/guides
+          GUIDES_PKGS_RE='^(packages/(activerecord|activemodel|activesupport|arel|globalid|did-you-mean|trails-tsc)/|packages/website/docs/guides/)'
+          # website_affected gates the Website build (SvelteKit + typedoc +
+          # VitePress). Typedoc entry packages live in
+          # packages/website/typedoc.json: arel, activemodel, activerecord,
+          # activesupport, rack, actionpack. ActionView is currently absent
+          # from typedoc but pulled in by actionpack types, so include it.
+          # Trailties is not built by typedoc and is intentionally omitted.
+          WEBSITE_PKGS_RE='^packages/(website|arel|activemodel|activerecord|activesupport|rack|actionpack|actionview|globalid|did-you-mean|trails-tsc)/'
           force_all_affected() {
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
             echo "actionpack_affected=true"   >> "$GITHUB_OUTPUT"
             echo "actionview_affected=true"   >> "$GITHUB_OUTPUT"
+            echo "rack_affected=true"         >> "$GITHUB_OUTPUT"
             echo "trailties_affected=true"    >> "$GITHUB_OUTPUT"
             echo "trails_tsc_affected=true"   >> "$GITHUB_OUTPUT"
             echo "tse_compiler_affected=true" >> "$GITHUB_OUTPUT"
+            echo "unit_tests_affected=true"   >> "$GITHUB_OUTPUT"
+            echo "guides_affected=true"       >> "$GITHUB_OUTPUT"
+            echo "website_affected=true"      >> "$GITHUB_OUTPUT"
           }
+
           if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
             echo "docs_only=false" >> "$GITHUB_OUTPUT"
             force_all_affected
@@ -149,9 +181,13 @@ jobs:
                   echo "activerecord_affected=false" >> "$GITHUB_OUTPUT"
                   echo "actionpack_affected=false"   >> "$GITHUB_OUTPUT"
                   echo "actionview_affected=false"   >> "$GITHUB_OUTPUT"
+                  echo "rack_affected=false"         >> "$GITHUB_OUTPUT"
                   echo "trailties_affected=false"    >> "$GITHUB_OUTPUT"
                   echo "trails_tsc_affected=false"   >> "$GITHUB_OUTPUT"
                   echo "tse_compiler_affected=false" >> "$GITHUB_OUTPUT"
+                  echo "unit_tests_affected=false"   >> "$GITHUB_OUTPUT"
+                  echo "guides_affected=false"       >> "$GITHUB_OUTPUT"
+                  echo "website_affected=false"      >> "$GITHUB_OUTPUT"
                 else
                   set_gate() {
                     local name="$1" re="$2"
@@ -164,9 +200,13 @@ jobs:
                   set_gate activerecord_affected "$AR_PKGS_RE"
                   set_gate actionpack_affected   "$AP_PKGS_RE"
                   set_gate actionview_affected   "$AV_PKGS_RE"
+                  set_gate rack_affected         "$RACK_PKGS_RE"
                   set_gate trailties_affected    "$TRAILTIES_PKGS_RE"
                   set_gate trails_tsc_affected   "$TRAILS_TSC_PKGS_RE"
                   set_gate tse_compiler_affected "$TSE_COMPILER_PKGS_RE"
+                  set_gate unit_tests_affected   "$UNIT_TESTS_PKGS_RE"
+                  set_gate guides_affected       "$GUIDES_PKGS_RE"
+                  set_gate website_affected      "$WEBSITE_PKGS_RE"
                 fi
                 ;;
             esac
@@ -243,7 +283,9 @@ jobs:
   guides-typecheck:
     name: Guides Code Type Check
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.guides_affected == 'true'
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -256,7 +298,12 @@ jobs:
   dx-type-tests:
     name: DX Type Tests
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    # vitest.dx-tests.config.ts only declares activerecord and trailties
+    # projects, so skip when neither is affected.
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      (needs.changes.outputs.activerecord_affected == 'true' ||
+       needs.changes.outputs.trailties_affected == 'true')
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 30
     steps:
@@ -289,7 +336,9 @@ jobs:
   unit-tests:
     name: Unit Tests
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.unit_tests_affected == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -307,8 +356,21 @@ jobs:
           packages/arel
           packages/activemodel
           packages/activesupport
-          packages/rack
           scripts/guides-typecheck
+
+  rack-tests:
+    name: Rack Tests
+    needs: changes
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.rack_affected == 'true'
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm vitest run packages/rack
 
   actionpack-tests:
     name: Action Pack Tests
@@ -470,7 +532,9 @@ jobs:
   website:
     name: Website
     needs: changes
-    if: needs.changes.outputs.docs_only != 'true'
+    if: >-
+      needs.changes.outputs.docs_only != 'true' &&
+      needs.changes.outputs.website_affected == 'true'
     # Stays on hosted: SvelteKit + VitePress + typedoc build is too slow
     # on the self-hosted box and ties up a runner slot that cheaper jobs
     # could use. Hosted parallelism is free.
@@ -806,6 +870,7 @@ jobs:
       - dx-type-tests
       - virtualized-dx-type-tests
       - unit-tests
+      - rack-tests
       - actionpack-tests
       - actionview-tests
       - trailties-tests
@@ -833,9 +898,13 @@ jobs:
           AR_AFFECTED: ${{ needs.changes.outputs.activerecord_affected }}
           AP_AFFECTED: ${{ needs.changes.outputs.actionpack_affected }}
           AV_AFFECTED: ${{ needs.changes.outputs.actionview_affected }}
+          RACK_AFFECTED: ${{ needs.changes.outputs.rack_affected }}
           TRAILTIES_AFFECTED: ${{ needs.changes.outputs.trailties_affected }}
           TRAILS_TSC_AFFECTED: ${{ needs.changes.outputs.trails_tsc_affected }}
           TSE_COMPILER_AFFECTED: ${{ needs.changes.outputs.tse_compiler_affected }}
+          UNIT_TESTS_AFFECTED: ${{ needs.changes.outputs.unit_tests_affected }}
+          GUIDES_AFFECTED: ${{ needs.changes.outputs.guides_affected }}
+          WEBSITE_AFFECTED: ${{ needs.changes.outputs.website_affected }}
           PARITY_SQLITE: ${{ needs.changes.outputs.parity_sqlite }}
           PARITY_POSTGRES: ${{ needs.changes.outputs.parity_postgres }}
           PARITY_MYSQL: ${{ needs.changes.outputs.parity_mysql }}
@@ -876,11 +945,29 @@ jobs:
                 actionview-tests)
                   [ "$AV_AFFECTED" = "false" ] && continue
                   ;;
+                rack-tests)
+                  [ "$RACK_AFFECTED" = "false" ] && continue
+                  ;;
                 trailties-tests)
                   [ "$TRAILTIES_AFFECTED" = "false" ] && continue
                   ;;
                 tse-compiler-tests)
                   [ "$TSE_COMPILER_AFFECTED" = "false" ] && continue
+                  ;;
+                unit-tests)
+                  [ "$UNIT_TESTS_AFFECTED" = "false" ] && continue
+                  ;;
+                guides-typecheck)
+                  [ "$GUIDES_AFFECTED" = "false" ] && continue
+                  ;;
+                website)
+                  [ "$WEBSITE_AFFECTED" = "false" ] && continue
+                  ;;
+                dx-type-tests)
+                  # Legitimate skip when neither activerecord nor trailties paths changed.
+                  if [ "$AR_AFFECTED" = "false" ] && [ "$TRAILTIES_AFFECTED" = "false" ]; then
+                    continue
+                  fi
                   ;;
                 virtualized-dx-type-tests)
                   # Legitimate skip when neither activerecord nor trails-tsc paths changed.
@@ -894,7 +981,7 @@ jobs:
                   [ "$any_parity" = "false" ] && continue
                   ;;
               esac
-              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL)"
+              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL)"
               unexpected=1
             done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,8 +294,10 @@ jobs:
     name: Prettier
     needs: changes
     # Prettier doesn't need the workspace installed. Skip `pnpm install`
-    # entirely and run prettier directly via `npx`. Pinned version must
-    # match `prettier` in package.json (and pnpm-lock.yaml) — bump together.
+    # entirely and run prettier directly via `npx`. The version below MUST
+    # equal the exact pin in root `package.json` devDependencies; the
+    # `prettier` entry there is intentionally pinned (no `^`) so CI and
+    # local `pnpm format` can never drift.
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,14 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-    # Per-adapter parity labels opt in specific suites without a new commit:
+    # Labels opt in specific suites without needing a new commit:
     #   run-parity-sqlite   — schema + query parity (SQLite fixtures)
     #   run-parity-postgres — Postgres-specific parity (future)
     #   run-parity-mysql    — MySQL/MariaDB-specific parity (future)
+    #   website             — force the Website build on a PR that doesn't
+    #                         touch packages/website/
+    #   release             — implies `website` (release PRs need the site
+    #                         built); reserve other release-only suites here
     types: [opened, synchronize, reopened, labeled]
   schedule:
     # Weekly post-merge sweep so slow regressions can't hide between
@@ -46,6 +50,7 @@ jobs:
       unit_tests_affected: ${{ steps.filter.outputs.unit_tests_affected }}
       guides_affected: ${{ steps.filter.outputs.guides_affected }}
       website_affected: ${{ steps.filter.outputs.website_affected }}
+      website_label: ${{ steps.filter.outputs.website_label }}
       parity_sqlite: ${{ steps.filter.outputs.parity_sqlite }}
       parity_postgres: ${{ steps.filter.outputs.parity_postgres }}
       parity_mysql: ${{ steps.filter.outputs.parity_mysql }}
@@ -124,12 +129,12 @@ jobs:
           #   grep -rhE "from ['\"]@blazetrails/[a-z-]+" packages/website/docs/guides
           GUIDES_PKGS_RE='^(packages/(activerecord|activemodel|activesupport|arel|globalid|did-you-mean|trails-tsc)/|packages/website/docs/guides/)'
           # website_affected gates the Website build (SvelteKit + typedoc +
-          # VitePress). Typedoc entry packages live in
-          # packages/website/typedoc.json: arel, activemodel, activerecord,
-          # activesupport, rack, actionpack. ActionView is currently absent
-          # from typedoc but pulled in by actionpack types, so include it.
-          # Trailties is not built by typedoc and is intentionally omitted.
-          WEBSITE_PKGS_RE='^packages/(website|arel|activemodel|activerecord|activesupport|rack|actionpack|actionview|globalid|did-you-mean|trails-tsc)/'
+          # VitePress). Scoped narrowly to packages/website/ — package-source
+          # changes alone don't trigger it. To run the site build on a PR
+          # that touches package sources, apply the `website` label (or the
+          # `release` label, which always runs it). The job is also
+          # exercised post-merge by push-to-main.
+          WEBSITE_PKGS_RE='^packages/website/'
           force_all_affected() {
             echo "activerecord_affected=true" >> "$GITHUB_OUTPUT"
             echo "actionpack_affected=true"   >> "$GITHUB_OUTPUT"
@@ -211,6 +216,22 @@ jobs:
                 ;;
             esac
           fi
+          # Website label opt-in. The Website job otherwise gates only on
+          # packages/website/ paths, so PRs that need a site preview (or
+          # release PRs that must build the production site) can apply the
+          # `website` or `release` label to force the job on.
+          case "${{ github.event_name }}" in
+            pull_request)
+              if echo "$PR_LABELS" | jq -e 'any(.[]; .name == "website" or .name == "release")' >/dev/null; then
+                echo "website_label=true"  >> "$GITHUB_OUTPUT"
+              else
+                echo "website_label=false" >> "$GITHUB_OUTPUT"
+              fi
+              ;;
+            *)
+              echo "website_label=false" >> "$GITHUB_OUTPUT"
+              ;;
+          esac
           # Per-adapter parity gates. Each suite is expensive (~15-20 CI
           # minutes across 7 jobs), so plain PRs skip all parity. Run on:
           #   - push to main / schedule / workflow_dispatch → all adapters
@@ -538,7 +559,8 @@ jobs:
     needs: changes
     if: >-
       needs.changes.outputs.docs_only != 'true' &&
-      needs.changes.outputs.website_affected == 'true'
+      (needs.changes.outputs.website_affected == 'true' ||
+       needs.changes.outputs.website_label == 'true')
     # Stays on hosted: SvelteKit + VitePress + typedoc build is too slow
     # on the self-hosted box and ties up a runner slot that cheaper jobs
     # could use. Hosted parallelism is free.
@@ -909,6 +931,7 @@ jobs:
           UNIT_TESTS_AFFECTED: ${{ needs.changes.outputs.unit_tests_affected }}
           GUIDES_AFFECTED: ${{ needs.changes.outputs.guides_affected }}
           WEBSITE_AFFECTED: ${{ needs.changes.outputs.website_affected }}
+          WEBSITE_LABEL: ${{ needs.changes.outputs.website_label }}
           PARITY_SQLITE: ${{ needs.changes.outputs.parity_sqlite }}
           PARITY_POSTGRES: ${{ needs.changes.outputs.parity_postgres }}
           PARITY_MYSQL: ${{ needs.changes.outputs.parity_mysql }}
@@ -965,7 +988,11 @@ jobs:
                   [ "$GUIDES_AFFECTED" = "false" ] && continue
                   ;;
                 website)
-                  [ "$WEBSITE_AFFECTED" = "false" ] && continue
+                  # Legitimate skip when website_affected is false AND no
+                  # website/release label opted the job in.
+                  if [ "$WEBSITE_AFFECTED" = "false" ] && [ "$WEBSITE_LABEL" != "true" ]; then
+                    continue
+                  fi
                   ;;
                 dx-type-tests)
                   # Legitimate skip when neither activerecord nor trailties paths changed.
@@ -985,7 +1012,7 @@ jobs:
                   [ "$any_parity" = "false" ] && continue
                   ;;
               esac
-              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL)"
+              echo "Unexpectedly skipped job: $job (docs_only=$DOCS_ONLY ar_affected=$AR_AFFECTED ap_affected=$AP_AFFECTED av_affected=$AV_AFFECTED rack_affected=$RACK_AFFECTED trailties_affected=$TRAILTIES_AFFECTED trails_tsc_affected=$TRAILS_TSC_AFFECTED tse_compiler_affected=$TSE_COMPILER_AFFECTED unit_tests_affected=$UNIT_TESTS_AFFECTED guides_affected=$GUIDES_AFFECTED website_affected=$WEBSITE_AFFECTED website_label=$WEBSITE_LABEL parity_sqlite=$PARITY_SQLITE parity_postgres=$PARITY_POSTGRES parity_mysql=$PARITY_MYSQL)"
               unexpected=1
             done < <(echo "$NEEDS_JSON" | jq -r 'to_entries[] | "\(.key) \(.value.result)"')
           fi

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "eslint-plugin-unused-imports": "^4.4.1",
     "husky": "^9.0.0",
     "lint-staged": "^16.0.0",
-    "prettier": "^3.0.0",
+    "prettier": "3.8.1",
     "tsx": "^4.19.0",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -64,7 +64,7 @@ importers:
         specifier: ^16.0.0
         version: 16.3.3
       prettier:
-        specifier: ^3.0.0
+        specifier: 3.8.1
         version: 3.8.1
       tsx:
         specifier: ^4.19.0


### PR DESCRIPTION
## Summary

PR #2260 (rack-only) surfaced that several CI jobs ran despite having no chance of being affected. Extend the existing `*_affected` gating pattern:

- **dx-type-tests** → `activerecord_affected || trailties_affected`. `vitest.dx-tests.config.ts` only declares those two projects, so any PR that touches neither (e.g. actionpack/actionview/tse-compiler only) currently runs it for no reason.
- **guides-typecheck** → new `guides_affected`. Confirmed via `grep -rhE "from ['\"]@blazetrails/[a-z-]+" packages/website/docs/guides` that guides today only import `@blazetrails/{activerecord,activemodel,activesupport}` — gate matches those plus AR's transitive type deps, plus the guides directory itself.
- **website** → new `website_affected` scoped narrowly to `^packages/website/`, plus a label opt-in (`website` or `release`). Package-source changes alone no longer trigger the typedoc + SvelteKit + VitePress build; PRs that need a site preview (or release PRs that must build the production docs) apply the label. push-to-main / schedule / workflow_dispatch still force the job on via `force_all_affected`, so post-merge and nightly site builds are unchanged.
- **rack-tests** → new dedicated job gated on `rack_affected` (rack + activesupport). Removed `packages/rack` from the `unit-tests` bundle so a rack-only PR no longer drags arel/AM/AS unit tests with it.
- **unit-tests** → new `unit_tests_affected` (arel/AM/AS).
- **prettier** → drop `pnpm install` and run `npx --yes prettier@3.8.1 --check .` directly. Root `package.json` is changed in the same commit from `"prettier": "^3.0.0"` → `"prettier": "3.8.1"` (exact pin) so CI and local `pnpm format` can never drift.

The `ci` aggregator's legitimate-skip allow-list is updated for each new gate so a mis-evaluated gate still surfaces as an unexpected skip (the existing protection against silent over-skipping is preserved).

## Effect — example rack-only PR (#2260)

|                       Job | Before  | After                                          |
| ------------------------: | :------ | :--------------------------------------------- |
|             Build & Lint  | run     | run                                            |
|                  Prettier | run     | run (faster — no pnpm install)                 |
|     Action Pack Tests     | run     | run (rack is AP dep)                           |
|     Trailties Tests       | run     | run (rack is trailties dep)                    |
|             Rack Tests    | _n/a_   | **run (new)**                                  |
|              Unit Tests   | run     | **skip** (rack split out, AM/AS/arel untouched)|
|      Guides Code Typecheck| run     | **skip** (guides don't import rack)            |
|             DX Type Tests | run     | run (trailties dep transitively)               |
|                   Website | run     | **skip** (no website/release label)            |
|     Rails API Comparison  | run     | run                                            |

Net: 3 jobs skipped that previously ran for no useful reason; one new job split out to keep rack-only PRs from dragging the leaf-package bundle.

## Labels that opt jobs in (PR-only)

| Label                 | Job(s) opted in              |
| --------------------- | ---------------------------- |
| `run-parity-sqlite`   | Schema + Query Parity (SQLite) |
| `run-parity-postgres` | Postgres Parity (future)     |
| `run-parity-mysql`    | MySQL Parity (future)        |
| `website`             | Website                      |
| `release`             | Website (implies it)         |

## Verification

This PR touches `.github/workflows/ci.yml` (in `INFRA_RE`) so every gate forces true — CI on this PR exercises every new job and gate output, which is the right smoke for the wiring.

Dry-run of the new regexes against PR #2260's file set:

```
activerecord=false   actionpack=true     actionview=false
rack=true            trailties=true      trails_tsc=false
tse_compiler=false   unit_tests=false    guides=false
website=false        (label-gated, no opt-in label on a hypothetical rack-only PR)
```

## Test plan

- [x] YAML parses (`js-yaml`)
- [x] Regex dry-run against rack-only file set matches the matrix above
- [x] All gates force-true on this PR (workflow file in INFRA_RE) — CI green
- [x] `prettier` version pinned to exact in `package.json`; lockfile updated; no drift between local `pnpm format` and CI's `npx prettier`
- [ ] First post-merge rack-only PR confirms unit-tests, guides-typecheck, and website all skip