### PR TITLE
fix(test-helpers): defineSchema IF NOT EXISTS for shared-adapter cross-file idempotency

### DIFF
--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -410,4 +410,21 @@ describe("defineSchema", () => {
       ).resolves.toBeDefined();
     });
   });
+
+  describe("IF NOT EXISTS idempotency", () => {
+    // Regression: under a shared pooled adapter, File B's defineSchema reaches
+    // createTable with an empty signature cache (different adapter instance) but
+    // the table already exists in the shared DB. Without IF NOT EXISTS the second
+    // call throws "table already exists". Simulate by clearing the cache between
+    // two defineSchema calls without dropping the table.
+    it("does not throw when the table already exists and the cache was cleared", async () => {
+      const { adapter: raw } = createSidecarTestAdapter();
+      const spec = { sprockets: { name: "string" as ColumnSpec } };
+      await defineSchema(raw, spec);
+      // Simulate File B: cache is gone, but the table is still in the DB.
+      clearAppliedSchemaSignatures(raw);
+
+      await expect(defineSchema(raw, spec)).resolves.toBeUndefined();
+    });
+  });
 });

--- a/packages/activerecord/src/test-helpers/define-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.test.ts
@@ -412,11 +412,10 @@ describe("defineSchema", () => {
   });
 
   describe("IF NOT EXISTS idempotency", () => {
-    // Regression: under a shared pooled adapter, File B's defineSchema reaches
-    // createTable with an empty signature cache (different adapter instance) but
-    // the table already exists in the shared DB. Without IF NOT EXISTS the second
-    // call throws "table already exists". Simulate by clearing the cache between
-    // two defineSchema calls without dropping the table.
+    // Regression: when the signature cache is cleared (e.g. between vitest
+    // files sharing one pooled adapter) while the table remains in the DB,
+    // defineSchema must not throw "table already exists". Simulated by
+    // clearing the cache after the first call without dropping the table.
     it("does not throw when the table already exists and the cache was cleared", async () => {
       const { adapter: raw } = createSidecarTestAdapter();
       const spec = { sprockets: { name: "string" as ColumnSpec } };

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -519,8 +519,13 @@ async function _defineSchemaImpl(
     }
     const columns = columnsOf(raw);
     const pk = primaryKeyOf(raw);
+    // ifNotExists only when neither branch above ran: the cache is empty and
+    // the adapter has no `.tables` Set, so we can't confirm the table is absent.
+    // Under a shared pooled adapter, another file may have already created it.
+    // When stillExists was true we just dropped the table; when cachedSig was
+    // set we know the table is gone — both cases need no guard.
     const createOpts: { id?: boolean; primaryKey?: string[]; ifNotExists?: boolean } = {
-      ifNotExists: true,
+      ...(!stillExists && cachedSig === undefined && { ifNotExists: true }),
     };
     if (pk === false) createOpts.id = false;
     else if (Array.isArray(pk)) {

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -519,14 +519,13 @@ async function _defineSchemaImpl(
     }
     const columns = columnsOf(raw);
     const pk = primaryKeyOf(raw);
-    // ifNotExists only when neither branch above ran: the cache is empty and
-    // the adapter has no `.tables` Set, so we can't confirm the table is absent.
-    // Under a shared pooled adapter, another file may have already created it.
-    // When stillExists was true we just dropped the table; when cachedSig was
-    // set we know the table is gone — both cases need no guard.
-    const createOpts: { id?: boolean; primaryKey?: string[]; ifNotExists?: boolean } = {
-      ...(!stillExists && cachedSig === undefined && { ifNotExists: true }),
-    };
+    // Use IF NOT EXISTS when neither branch above ran (no drop, no stale-cache
+    // delete): the cache has no entry and the table may or may not exist in the
+    // DB. Under a shared pooled adapter, another file may have already created
+    // it. When stillExists was true we just dropped it; when cachedSig was set
+    // we cleared it — both cases guarantee the table is absent.
+    const createOpts: { id?: boolean; primaryKey?: string[]; ifNotExists?: boolean } = {};
+    if (!stillExists && cachedSig === undefined) createOpts.ifNotExists = true;
     if (pk === false) createOpts.id = false;
     else if (Array.isArray(pk)) {
       createOpts.primaryKey = pk;

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -519,7 +519,9 @@ async function _defineSchemaImpl(
     }
     const columns = columnsOf(raw);
     const pk = primaryKeyOf(raw);
-    const createOpts: { id?: boolean; primaryKey?: string[] } = {};
+    const createOpts: { id?: boolean; primaryKey?: string[]; ifNotExists?: boolean } = {
+      ifNotExists: true,
+    };
     if (pk === false) createOpts.id = false;
     else if (Array.isArray(pk)) {
       createOpts.primaryKey = pk;


### PR DESCRIPTION
## Summary

- `defineSchema` now passes `ifNotExists: true` to `createTable`. Under a shared pooled adapter, File B's `defineSchema` reaches `createTable` with an empty signature cache (different adapter instance) but the table already exists in the shared in-memory DB — `IF NOT EXISTS` makes the call silently no-op instead of throwing.
- Default `SchemaStatements#createTable` behavior is unchanged; only the test-helper path opts in.
- Adds a regression test that clears the signature cache between two `defineSchema` calls (simulating File B) without dropping the table.

## Context

Part of Pool Epic Phase D. PR #2256 keyed the signature cache by DB identity, but when multiple test files run in the same vitest worker under `createPooledTestAdapter()`, they share one in-memory SQLite DB. File B's adapter starts with an empty cache → hits `createTable` → DB already has the table → was throwing. `IF NOT EXISTS` is the minimal unblock; Phase D-Y (central `test-schema.ts`) will supersede this long-term.

## Follow-ups

- Phase D-Y: central `test-schema.ts` eliminates per-file `defineSchema` entirely (supersedes D-W).
- Issue 2 from `project_pool_epic_phase_d_followups.md` (PG `withClient` 25P02 race) remains open and tracked separately.