### PR TITLE
feat(activerecord): setupHandlerSuite() helper for D-1..N test files

### DIFF
--- a/packages/activerecord/src/test-helpers/handler-resolved-adapter.test.ts
+++ b/packages/activerecord/src/test-helpers/handler-resolved-adapter.test.ts
@@ -15,8 +15,7 @@ import { Base } from "../base.js";
 import { defineSchema } from "./define-schema.js";
 import { dropAllTables } from "./drop-all-tables.js";
 import { clearAppliedSchemaSignatures } from "./define-schema.js";
-import { bootstrapTestHandler } from "./bootstrap-test-handler.js";
-import { pushSkipGlobalReset, popSkipGlobalReset } from "./skip-global-reset.js";
+import { setupHandlerSuite } from "./setup-handler-suite.js";
 
 class HandlerResolvedPost extends Base {
   static {
@@ -29,23 +28,17 @@ class HandlerResolvedPost extends Base {
 }
 
 describe("handler-resolved adapter (Phase D-0)", () => {
+  // Bootstraps Base.connectionHandler and skips the global resetTestAdapterState()
+  // for this suite. D-1..N test files use the same one-liner.
+  setupHandlerSuite();
+
+  // No adapter arg — resolves via Base.connectionHandler. This is the
+  // new Rails-shape call pattern that D-1..N test files will use.
   beforeAll(async () => {
-    // Bootstrap the handler for this test file. Opt-in (not global) so that
-    // tests expecting "no adapter configured" aren't affected.
-    await bootstrapTestHandler();
-    // Skip the global resetTestAdapterState() beforeEach for this suite.
-    // On PG/MySQL the shared adapter and Base.adapter share the same DB,
-    // so the global reset would drop handler_resolved_posts between tests.
-    // withTransactionalFixtures can't be used here because on SQLite the
-    // handler pool uses size=1 and pinConnectionBang would deadlock.
-    pushSkipGlobalReset();
-    // No adapter arg — resolves via Base.connectionHandler. This is the
-    // new Rails-shape call pattern that D-1..N test files will use.
     await defineSchema({ handler_resolved_posts: { title: "string" } });
   });
 
   afterAll(async () => {
-    popSkipGlobalReset();
     const adapter = Base.adapter;
     await dropAllTables(adapter);
     clearAppliedSchemaSignatures(adapter);

--- a/packages/activerecord/src/test-helpers/setup-handler-suite.ts
+++ b/packages/activerecord/src/test-helpers/setup-handler-suite.ts
@@ -1,0 +1,23 @@
+import { beforeAll, afterAll } from "vitest";
+import { bootstrapTestHandler } from "./bootstrap-test-handler.js";
+import { pushSkipGlobalReset, popSkipGlobalReset } from "./skip-global-reset.js";
+
+/**
+ * One-call wiring for D-1..N handler-resolved test files.
+ *
+ * Bootstraps `Base.connectionHandler` once per worker and prevents the global
+ * `resetTestAdapterState()` from wiping shared-DB tables across tests in the
+ * file. Mirrors Rails' `setup_fixtures` / `teardown_fixtures` pattern at the
+ * test-case level.
+ *
+ * @internal
+ */
+export function setupHandlerSuite(): void {
+  beforeAll(async () => {
+    await bootstrapTestHandler();
+    pushSkipGlobalReset();
+  });
+  afterAll(() => {
+    popSkipGlobalReset();
+  });
+}


### PR DESCRIPTION
## Summary

- Adds `setupHandlerSuite()` in `packages/activerecord/src/test-helpers/setup-handler-suite.ts` — bundles `bootstrapTestHandler()` + `push/popSkipGlobalReset()` into one call
- Updates the Phase D-0 proof test (`handler-resolved-adapter.test.ts`) to use the helper instead of the raw 4-import / 6-line pattern

## Motivation

D-1..N batch agents will migrate ~200 test files to the handler pattern. Each file previously needed 4 imports + 6+ lines of lifecycle boilerplate. `setupHandlerSuite()` reduces that to one import + one call.

## Post-merge note (for orchestrator)

Update `project_pool_epic_phase_d_pivot.md`: D-1..N batches should call `setupHandlerSuite()` from `test-helpers/setup-handler-suite.js`, not the raw `bootstrapTestHandler()` + skip-reset pair.

## Testing

- Proof test passes: 3/3 ✓
- `bootstrapTestHandler()` remains exported for callers needing finer control
- No other test files modified (helper is additive)