### PR TITLE
fix(activerecord): unblock loadSchemaFromAdapter on lone-connection pools

### DIFF
--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -11,6 +11,7 @@ import {
 import { isStiSubclass, getStiBase, isBaseClass, baseClass } from "./inheritance.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
+import { FakePool } from "./connection-adapters/schema-cache.js";
 
 /**
  * Schema metadata for ActiveRecord models — table name, primary key,
@@ -842,15 +843,16 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   const table = schemaHost.tableName;
   // Resolve a target for schemaCache lookups. Prefer `.pool` because some
   // wrapper adapters (e.g. TestAdapterFixtures) expose their unwrapped inner
-  // adapter through this getter. But if `.pool` is an actual ConnectionPool
-  // (has `withConnection`), skip it and use the adapter directly: on
-  // lone-connection pools (SQLite :memory: + size 1) the connection is
-  // already permanently checked out to startingAdapter, so asking the pool
-  // for another connection would deadlock.
+  // adapter through this getter. If `.pool` is an actual ConnectionPool
+  // (has `withConnection`), wrap startingAdapter in a FakePool — mirroring
+  // Rails' BoundSchemaReflection.for_lone_connection. On lone-connection
+  // pools (SQLite :memory: + size 1) the connection is already permanently
+  // checked out, so calling pool.withConnection would deadlock; FakePool
+  // yields the connection we already hold.
   const candidate = startingAdapter.pool ?? startingAdapter;
   const pool =
     candidate && typeof (candidate as { withConnection?: unknown }).withConnection === "function"
-      ? startingAdapter
+      ? new FakePool(startingAdapter)
       : candidate;
 
   if (typeof cache.dataSourceExists === "function") {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -840,7 +840,18 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   const cache = startingAdapter.schemaCache;
   if (!cache) return;
   const table = schemaHost.tableName;
-  const pool = startingAdapter.pool ?? startingAdapter;
+  // Resolve a target for schemaCache lookups. Prefer `.pool` because some
+  // wrapper adapters (e.g. TestAdapterFixtures) expose their unwrapped inner
+  // adapter through this getter. But if `.pool` is an actual ConnectionPool
+  // (has `withConnection`), skip it and use the adapter directly: on
+  // lone-connection pools (SQLite :memory: + size 1) the connection is
+  // already permanently checked out to startingAdapter, so asking the pool
+  // for another connection would deadlock.
+  const candidate = startingAdapter.pool ?? startingAdapter;
+  const pool =
+    candidate && typeof (candidate as { withConnection?: unknown }).withConnection === "function"
+      ? startingAdapter
+      : candidate;
 
   if (typeof cache.dataSourceExists === "function") {
     const exists = await cache.dataSourceExists(pool, table);

--- a/packages/activerecord/src/test-helpers/handler-resolved-adapter.test.ts
+++ b/packages/activerecord/src/test-helpers/handler-resolved-adapter.test.ts
@@ -1,14 +1,12 @@
 /**
- * Phase D-0: verify that:
+ * Phase D-0 / D-0a: verify that:
  *   1. Base.connectionHandler is bootstrapped per worker (isConnectedQ)
  *   2. defineSchema(schema) resolves the adapter from Base.adapter internally
  *   3. A model with no direct `static { this.adapter = ... }` assignment
  *      resolves its adapter via the Rails-shape handler chain
- *
- * Attribute types are declared explicitly via `this.attribute(...)` to avoid
- * schema reflection (which would require the pool to checkout a second
- * connection, deadlocking on SQLite :memory: with pool size 1).  DB operations
- * go through Base._adapter — the single connection leased from the handler pool.
+ *   4. (D-0a) A bare `class Post extends Base {}` with no explicit attribute
+ *      declarations loads its schema via lazy reflection without deadlocking
+ *      on SQLite :memory: + pool size 1.
  */
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import { Base } from "../base.js";
@@ -27,6 +25,12 @@ class HandlerResolvedPost extends Base {
   declare title: string;
 }
 
+// D-0a: bare Rails-shape model — no explicit attribute declarations.
+// Schema is loaded via lazy reflection (loadSchemaFromAdapter).
+class HandlerResolvedComment extends Base {
+  declare body: string;
+}
+
 describe("handler-resolved adapter (Phase D-0)", () => {
   // Bootstraps Base.connectionHandler and skips the global resetTestAdapterState()
   // for this suite. D-1..N test files use the same one-liner.
@@ -35,7 +39,13 @@ describe("handler-resolved adapter (Phase D-0)", () => {
   // No adapter arg — resolves via Base.connectionHandler. This is the
   // new Rails-shape call pattern that D-1..N test files will use.
   beforeAll(async () => {
-    await defineSchema({ handler_resolved_posts: { title: "string" } });
+    await defineSchema({
+      handler_resolved_posts: { title: "string" },
+      handler_resolved_comments: { body: "string" },
+    });
+    // D-0a: load schema for the bare model (no explicit attribute declarations).
+    // This deadlocked before the fix; now routes through the checked-out adapter.
+    await HandlerResolvedComment.loadSchema();
   });
 
   afterAll(async () => {
@@ -54,6 +64,14 @@ describe("handler-resolved adapter (Phase D-0)", () => {
     const post = await HandlerResolvedPost.create({ title: "hello" });
     expect(post.title).toBe("hello");
     expect(post.isPersisted()).toBe(true);
+  });
+
+  it("bare class extends Base loads schema via lazy reflection without deadlock", async () => {
+    // D-0a: no explicit this.attribute() — schema comes from loadSchemaFromAdapter.
+    // On SQLite :memory: + pool size 1 this deadlocked before the fix.
+    const comment = await HandlerResolvedComment.create({ body: "world" });
+    expect(comment.body).toBe("world");
+    expect(comment.isPersisted()).toBe(true);
   });
 
   it("model resolves adapter via handler — no static { this.adapter = X } needed", async () => {


### PR DESCRIPTION
## Summary

Phase D-0a follow-up from #2268: fixes the SQLite `loadSchema` deadlock so D-1..N migrated test models can be bare `class Post extends Base {}` (no explicit `this.attribute(...)` workaround).

## Root cause

`loadSchemaFromAdapter` resolved its schema-cache target as `startingAdapter.pool ?? startingAdapter`. When `Base.adapter` returns the permanently checked-out connection of a size-1 pool (SQLite `:memory:` under the new handler bootstrap, expo-sqlite, better-sqlite3), `.pool` points back to the actual `ConnectionPool` — and asking it for another connection through `withConnection` deadlocks because the only connection is already leased to us.

## Fix

Skip `.pool` when it's an actual `ConnectionPool` (detected by `withConnection` method presence) and use `startingAdapter` directly; the adapter is already a valid connection. Wrapper adapters like `TestAdapterFixtures` whose `.pool` getter returns an unwrapped inner adapter (no `withConnection`) still go through `.pool` unchanged — so `defaults.test.ts` and other pool-less paths are unaffected.

The async path needs an explicit `await Model.loadSchema()` before the first DB op (per the existing design at base.ts:1018); the deadlock fix is what makes that call complete on lone-connection pools.

## Test plan

- [x] New `bare class extends Base loads schema via lazy reflection without deadlock` test in `handler-resolved-adapter.test.ts` (extends the Phase D-0 proof file)
- [x] Existing `handler-resolved-adapter.test.ts` tests still pass
- [x] `defaults.test.ts` (37 tests) still passes — wrapper-adapter path unaffected
- [x] `model-schema-load.test.ts` (18 tests) still passes
- [x] `sti-attribute-routing.test.ts`, `attribute-methods/time-zone-conversion.test.ts` still pass
- [ ] CI: full suite on SQLite + PG + MariaDB
- [ ] `pnpm api:compare` delta non-negative
- [ ] `pnpm test:compare` delta non-negative

## Post-merge

D-1..N test models can drop the `static { this.attribute(...) }` workaround and use bare `class Post extends Base {}` with `await Post.loadSchema()` in `beforeAll` (or just let it lazily load on first DB op once that path also routes through this fix). Closes the workaround tracked in `project_pool_epic_d_handler_sqlite_constraint`.