### PR TITLE
fix(activerecord): hotfix scoping test cross-file pooled-adapter collision

### DIFF
--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -13,35 +13,41 @@ import type { DatabaseAdapter } from "../adapter.js";
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
   ({ adapter: _adapter } = await createPooledTestAdapter());
-  await defineSchema(_adapter, {
-    posts: {
-      title: "string",
-      published: "boolean",
-      body: "string",
-      status: "string",
-      category: "string",
-      order_val: "integer",
-      postId: "integer",
-      views: "integer",
-      visible: "boolean",
-      blog_id: "integer",
-      mentor_id: "integer",
-      active: "boolean",
+  // dropExisting: true is a workaround for cross-file pooled-adapter collision.
+  // Once D-W (IF NOT EXISTS in defineSchema) lands, remove this.
+  await defineSchema(
+    _adapter,
+    {
+      posts: {
+        title: "string",
+        published: "boolean",
+        body: "string",
+        status: "string",
+        category: "string",
+        order_val: "integer",
+        postId: "integer",
+        views: "integer",
+        visible: "boolean",
+        blog_id: "integer",
+        mentor_id: "integer",
+        active: "boolean",
+      },
+      animals: { name: "string", type: "string", active: "boolean" },
+      dogs: { name: "string", type: "string", active: "boolean" },
+      articles: {
+        title: "string",
+        visible: "boolean",
+        order_val: "integer",
+        blog_id: "integer",
+        published: "boolean",
+        category: "string",
+      },
+      comments: { body: "string" },
+      devs: { name: "string", salary: "integer", mentor_id: "integer" },
+      dev2s: { name: "string", salary: "integer", mentor_id: "integer" },
     },
-    animals: { name: "string", type: "string", active: "boolean" },
-    dogs: { name: "string", type: "string", active: "boolean" },
-    articles: {
-      title: "string",
-      visible: "boolean",
-      order_val: "integer",
-      blog_id: "integer",
-      published: "boolean",
-      category: "string",
-    },
-    comments: { body: "string" },
-    devs: { name: "string", salary: "integer", mentor_id: "integer" },
-    dev2s: { name: "string", salary: "integer", mentor_id: "integer" },
-  });
+    { dropExisting: true },
+  );
 });
 withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -13,22 +13,28 @@ import type { DatabaseAdapter } from "../adapter.js";
 let _adapter: SidecarAdapter;
 beforeAll(async () => {
   ({ adapter: _adapter } = await createPooledTestAdapter());
-  await defineSchema(_adapter, {
-    posts: {
-      title: "string",
-      published: "boolean",
-      featured: "boolean",
-      status: "string",
-      views: "integer",
-      author_id: "integer",
-      active: "boolean",
+  // dropExisting: true is a workaround for cross-file pooled-adapter collision.
+  // Once D-W (IF NOT EXISTS in defineSchema) lands, remove this.
+  await defineSchema(
+    _adapter,
+    {
+      posts: {
+        title: "string",
+        published: "boolean",
+        featured: "boolean",
+        status: "string",
+        views: "integer",
+        author_id: "integer",
+        active: "boolean",
+      },
+      animals: { name: "string", type: "string" },
+      dogs: { name: "string", type: "string" },
+      articles: { title: "string", status: "string" },
+      products: { name: "string", price: "integer", active: "boolean" },
+      users: { name: "string", age: "integer", active: "boolean", role: "string" },
     },
-    animals: { name: "string", type: "string" },
-    dogs: { name: "string", type: "string" },
-    articles: { title: "string", status: "string" },
-    products: { name: "string", price: "integer", active: "boolean" },
-    users: { name: "string", age: "integer", active: "boolean", role: "string" },
-  });
+    { dropExisting: true },
+  );
 });
 withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {


### PR DESCRIPTION
## Summary

- Adds `dropExisting: true` to `defineSchema` in `default-scoping.test.ts` and `named-scoping.test.ts`
- Both files share the same singleton pooled adapter (same in-memory SQLite DB); whichever runs second in a vitest worker collided on `CREATE TABLE posts` — `StatementInvalid: table "posts" already exists`
- PR #2268 shifted vitest worker scheduling, exposing the latent collision and turning main CI red

## Root cause

PR #2261 migrated these files to `createPooledTestAdapter()`. At merge time the two files happened to land in different workers. PR #2268 added new test files that shifted the scheduling, putting both in the same worker.

## Workaround

`dropExisting: true` drops and recreates tables at `beforeAll` time so whichever file runs second doesn't see a stale table from the first.

## Follow-up

Once **D-W** (`IF NOT EXISTS` in `defineSchema`) lands, remove both `dropExisting: true` markers. They're annotated in-code.