### PR TITLE
feat(fixtures-compare): add --models pass (PR 0 of test-models port)

### DIFF
--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -421,4 +421,25 @@ describe("compareModelClass", () => {
     expect(r.valsMatched).toBe(0);
     expect(r.status).toBe("DIFF");
   });
+
+  it("matches validates_presence_of to validatesPresenceOf shorthand", () => {
+    const ruby: RubyClass = {
+      ...emptyClass(),
+      validations: [{ kind: "validates_presence_of", attributes: ["title"], options: {} }],
+    };
+    const ts = `this.validatesPresenceOf("title");`;
+    const r = compareModelClass(ruby, ts);
+    expect(r.valsMatched).toBe(1);
+    expect(r.status).toBe("MATCH");
+  });
+
+  it("also accepts generic validates() for validates_presence_of (fallback)", () => {
+    const ruby: RubyClass = {
+      ...emptyClass(),
+      validations: [{ kind: "validates_presence_of", attributes: ["title"], options: {} }],
+    };
+    const ts = `this.validates("title", { presence: true });`;
+    const r = compareModelClass(ruby, ts);
+    expect(r.valsMatched).toBe(1);
+  });
 });

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -442,4 +442,14 @@ describe("compareModelClass", () => {
     const r = compareModelClass(ruby, ts);
     expect(r.valsMatched).toBe(1);
   });
+
+  it("matches validates_uniqueness_of to validatesUniqueness (no 'Of')", () => {
+    const ruby: RubyClass = {
+      ...emptyClass(),
+      validations: [{ kind: "validates_uniqueness_of", attributes: ["email"], options: {} }],
+    };
+    expect(compareModelClass(ruby, `this.validatesUniqueness("email");`).valsMatched).toBe(1);
+    // Must NOT match the wrong name
+    expect(compareModelClass(ruby, `this.validatesUniquenessOf("email");`).valsMatched).toBe(0);
+  });
 });

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -374,7 +374,7 @@ describe("compareModelClass", () => {
       associations: [{ kind: "has_many", name: "comments", options: {} }],
     };
     const ts = `static { this.hasMany("comments", {}); }`;
-    const r = compareModelClass(ruby, ts);
+    const r = compareModelClass(ruby, ts, "test/models/foo.rb", "foo.ts");
     expect(r.status).toBe("MATCH");
     expect(r.assocMatched).toBe(1);
     expect(r.notes).toHaveLength(0);
@@ -385,7 +385,7 @@ describe("compareModelClass", () => {
       ...emptyClass(),
       associations: [{ kind: "belongs_to", name: "author", options: {} }],
     };
-    const r = compareModelClass(ruby, "// empty");
+    const r = compareModelClass(ruby, "// empty", "test/models/foo.rb", "foo.ts");
     expect(r.status).toBe("DIFF");
     expect(r.assocMatched).toBe(0);
     expect(r.notes[0]).toMatch(/assoc-missing/);
@@ -398,7 +398,7 @@ describe("compareModelClass", () => {
       scopes: [{ name: "open" }],
     };
     const ts = `// we leave connections open`;
-    const r = compareModelClass(ruby, ts);
+    const r = compareModelClass(ruby, ts, "test/models/foo.rb", "foo.ts");
     expect(r.status).toBe("DIFF");
     expect(r.scopesMatched).toBe(0);
   });
@@ -406,7 +406,7 @@ describe("compareModelClass", () => {
   it("matches scope when this.scope call is present", () => {
     const ruby: RubyClass = { ...emptyClass(), scopes: [{ name: "published" }] };
     const ts = `this.scope("published", () => this.where({ published: true }));`;
-    const r = compareModelClass(ruby, ts);
+    const r = compareModelClass(ruby, ts, "test/models/foo.rb", "foo.ts");
     expect(r.scopesMatched).toBe(1);
   });
 
@@ -417,7 +417,7 @@ describe("compareModelClass", () => {
     };
     // validate( without s — should NOT match validates check
     const ts = `this.validate("name is too short");`;
-    const r = compareModelClass(ruby, ts);
+    const r = compareModelClass(ruby, ts, "test/models/foo.rb", "foo.ts");
     expect(r.valsMatched).toBe(0);
     expect(r.status).toBe("DIFF");
   });
@@ -428,7 +428,7 @@ describe("compareModelClass", () => {
       validations: [{ kind: "validates_presence_of", attributes: ["title"], options: {} }],
     };
     const ts = `this.validatesPresenceOf("title");`;
-    const r = compareModelClass(ruby, ts);
+    const r = compareModelClass(ruby, ts, "test/models/foo.rb", "foo.ts");
     expect(r.valsMatched).toBe(1);
     expect(r.status).toBe("MATCH");
   });
@@ -439,7 +439,7 @@ describe("compareModelClass", () => {
       validations: [{ kind: "validates_presence_of", attributes: ["title"], options: {} }],
     };
     const ts = `this.validates("title", { presence: true });`;
-    const r = compareModelClass(ruby, ts);
+    const r = compareModelClass(ruby, ts, "test/models/foo.rb", "foo.ts");
     expect(r.valsMatched).toBe(1);
   });
 
@@ -448,8 +448,18 @@ describe("compareModelClass", () => {
       ...emptyClass(),
       validations: [{ kind: "validates_uniqueness_of", attributes: ["email"], options: {} }],
     };
-    expect(compareModelClass(ruby, `this.validatesUniqueness("email");`).valsMatched).toBe(1);
+    expect(
+      compareModelClass(ruby, `this.validatesUniqueness("email");`, "test/models/foo.rb", "foo.ts")
+        .valsMatched,
+    ).toBe(1);
     // Must NOT match the wrong name
-    expect(compareModelClass(ruby, `this.validatesUniquenessOf("email");`).valsMatched).toBe(0);
+    expect(
+      compareModelClass(
+        ruby,
+        `this.validatesUniquenessOf("email");`,
+        "test/models/foo.rb",
+        "foo.ts",
+      ).valsMatched,
+    ).toBe(0);
   });
 });

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, afterAll } from "vitest";
 // prettier-ignore
-import { stripErb, isRefLike, compareValue, compareFile, schemaCheck, canonicalizeRailsRow, ERB_SKIP_SENTINEL } from "./compare.js";
+import { stripErb, isRefLike, compareValue, compareFile, schemaCheck, canonicalizeRailsRow, ERB_SKIP_SENTINEL, tsModelPath, compareModelClass } from "./compare.js";
+import type { RubyClass } from "./compare.js";
 import type { Schema } from "../../packages/activerecord/src/test-helpers/define-schema.js";
 
 // prettier-ignore
@@ -341,5 +342,83 @@ describe("compareFile", () => {
     expect((await compareFile("authors.yml", empty, empty, "YAML-PARSE-ERR")).status).toBe(
       "YAML-PARSE-ERR",
     );
+  });
+});
+
+// ---- models pass unit tests ----
+
+const emptyClass = (): RubyClass => ({
+  name: "Foo",
+  parent: "ActiveRecord::Base",
+  tableName: null,
+  associations: [],
+  validations: [],
+  scopes: [],
+  callbacks: [],
+  attributes: [],
+});
+
+describe("tsModelPath", () => {
+  it("converts underscores to hyphens and maps to models dir", () => {
+    expect(tsModelPath("test/models/book_destroy_async.rb")).toMatch(/book-destroy-async\.ts$/);
+  });
+  it("preserves subdirectory structure", () => {
+    expect(tsModelPath("test/models/admin/account.rb")).toMatch(/admin[/\\]account\.ts$/);
+  });
+});
+
+describe("compareModelClass", () => {
+  it("returns MATCH when all associations are found", () => {
+    const ruby: RubyClass = {
+      ...emptyClass(),
+      associations: [{ kind: "has_many", name: "comments", options: {} }],
+    };
+    const ts = `static { this.hasMany("comments", {}); }`;
+    const r = compareModelClass(ruby, ts);
+    expect(r.status).toBe("MATCH");
+    expect(r.assocMatched).toBe(1);
+    expect(r.notes).toHaveLength(0);
+  });
+
+  it("returns DIFF and notes when an association is absent", () => {
+    const ruby: RubyClass = {
+      ...emptyClass(),
+      associations: [{ kind: "belongs_to", name: "author", options: {} }],
+    };
+    const r = compareModelClass(ruby, "// empty");
+    expect(r.status).toBe("DIFF");
+    expect(r.assocMatched).toBe(0);
+    expect(r.notes[0]).toMatch(/assoc-missing/);
+  });
+
+  it("does not false-positive on bare string containing scope name", () => {
+    // "open" appears in a comment; should NOT count as a matched scope
+    const ruby: RubyClass = {
+      ...emptyClass(),
+      scopes: [{ name: "open" }],
+    };
+    const ts = `// we leave connections open`;
+    const r = compareModelClass(ruby, ts);
+    expect(r.status).toBe("DIFF");
+    expect(r.scopesMatched).toBe(0);
+  });
+
+  it("matches scope when this.scope call is present", () => {
+    const ruby: RubyClass = { ...emptyClass(), scopes: [{ name: "published" }] };
+    const ts = `this.scope("published", () => this.where({ published: true }));`;
+    const r = compareModelClass(ruby, ts);
+    expect(r.scopesMatched).toBe(1);
+  });
+
+  it("matches validates but not validate (no false positive)", () => {
+    const ruby: RubyClass = {
+      ...emptyClass(),
+      validations: [{ kind: "validates", attributes: ["name"], options: {} }],
+    };
+    // validate( without s — should NOT match validates check
+    const ts = `this.validate("name is too short");`;
+    const r = compareModelClass(ruby, ts);
+    expect(r.valsMatched).toBe(0);
+    expect(r.status).toBe("DIFF");
   });
 });

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -530,15 +530,17 @@ async function main(): Promise<void> {
 // ---- Models pass ----
 
 // Rails shorthand validation macros that map to named TS helpers rather than
-// the generic this.validates(). Only list the ones actually implemented in
-// packages/activerecord/src/validations.ts — the rest fall through to validates.
+// the generic this.validates(). Helpers are implemented in:
+//   packages/activemodel/src/model.ts      — presence/absence/length/size/numericality
+//   packages/activerecord/src/validations.ts — uniqueness (validatesUniqueness, no "Of")
+//                                             + validatesAssociated
 const VALIDATION_KIND_TO_TS: Record<string, string> = {
   validates_presence_of: "validatesPresenceOf",
   validates_absence_of: "validatesAbsenceOf",
   validates_length_of: "validatesLengthOf",
   validates_size_of: "validatesSizeOf",
   validates_numericality_of: "validatesNumericalityOf",
-  validates_uniqueness_of: "validatesUniquenessOf",
+  validates_uniqueness_of: "validatesUniqueness", // exported as validatesUniqueness (no "Of")
   validates_associated: "validatesAssociated",
 };
 

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -584,7 +584,7 @@ interface ModelResult {
 }
 
 function loadRubyModelsManifest(): RubyFileEntry[] {
-  const out = execSync(`ruby ${RUBY_EXTRACTOR}`, { encoding: "utf8" });
+  const out = execSync(`ruby "${RUBY_EXTRACTOR}"`, { encoding: "utf8" });
   return JSON.parse(out) as RubyFileEntry[];
 }
 
@@ -619,11 +619,13 @@ function compareModelClass(ruby: RubyClass, tsContent: string): ModelResult {
   }
   for (const v of ruby.validations) {
     const attr = v.attributes[0];
-    if (attr && tsContent.includes(`"${attr}"`)) r.valsMatched++;
+    const vpat = attr ? new RegExp(`this\\.validates?\\s*\\(\\s*["']${attr}["']`, "i") : null;
+    if (vpat && vpat.test(tsContent)) r.valsMatched++;
     else r.notes.push(`val-missing: ${v.kind} ${v.attributes.join(",")}`);
   }
   for (const s of ruby.scopes) {
-    if (tsContent.includes(`"${s.name}"`)) r.scopesMatched++;
+    const spat = new RegExp(`this\\.scope\\s*\\(\\s*["']${s.name}["']`, "i");
+    if (spat.test(tsContent)) r.scopesMatched++;
     else r.notes.push(`scope-missing: ${s.name}`);
   }
   const anyDiff =

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -531,15 +531,21 @@ async function main(): Promise<void> {
 
 // Rails shorthand validation macros that map to named TS helpers rather than
 // the generic this.validates(). Helpers are implemented in:
-//   packages/activemodel/src/model.ts      — presence/absence/length/size/numericality
+//   packages/activemodel/src/model.ts       — all *Of helpers + acceptance/confirmation/comparison
 //   packages/activerecord/src/validations.ts — uniqueness (validatesUniqueness, no "Of")
-//                                             + validatesAssociated
+//                                              + validatesAssociated
 const VALIDATION_KIND_TO_TS: Record<string, string> = {
   validates_presence_of: "validatesPresenceOf",
   validates_absence_of: "validatesAbsenceOf",
   validates_length_of: "validatesLengthOf",
   validates_size_of: "validatesSizeOf",
   validates_numericality_of: "validatesNumericalityOf",
+  validates_inclusion_of: "validatesInclusionOf",
+  validates_exclusion_of: "validatesExclusionOf",
+  validates_format_of: "validatesFormatOf",
+  validates_acceptance_of: "validatesAcceptanceOf",
+  validates_confirmation_of: "validatesConfirmationOf",
+  validates_comparison_of: "validatesComparisonOf",
   validates_uniqueness_of: "validatesUniqueness", // exported as validatesUniqueness (no "Of")
   validates_associated: "validatesAssociated",
 };

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -529,6 +529,19 @@ async function main(): Promise<void> {
 
 // ---- Models pass ----
 
+// Rails shorthand validation macros that map to named TS helpers rather than
+// the generic this.validates(). Only list the ones actually implemented in
+// packages/activerecord/src/validations.ts — the rest fall through to validates.
+const VALIDATION_KIND_TO_TS: Record<string, string> = {
+  validates_presence_of: "validatesPresenceOf",
+  validates_absence_of: "validatesAbsenceOf",
+  validates_length_of: "validatesLengthOf",
+  validates_size_of: "validatesSizeOf",
+  validates_numericality_of: "validatesNumericalityOf",
+  validates_uniqueness_of: "validatesUniquenessOf",
+  validates_associated: "validatesAssociated",
+};
+
 const MODELS_TS_DIR = path.join(ROOT, "packages/activerecord/src/test-helpers/models");
 const RUBY_EXTRACTOR = path.join(HERE, "extract-ruby-models.rb");
 
@@ -619,8 +632,14 @@ export function compareModelClass(ruby: RubyClass, tsContent: string): ModelResu
   }
   for (const v of ruby.validations) {
     const attr = v.attributes[0];
-    const vpat = attr ? new RegExp(`this\\.validates\\s*\\(\\s*["']${attr}["']`, "i") : null;
-    if (vpat && vpat.test(tsContent)) r.valsMatched++;
+    // Check both the named shorthand helper (if implemented) and the generic validates().
+    const tsMethod = VALIDATION_KIND_TO_TS[v.kind] ?? "validates";
+    const vpat = attr ? new RegExp(`this\\.${tsMethod}\\s*\\(\\s*["']${attr}["']`, "i") : null;
+    const genericPat =
+      attr && tsMethod !== "validates"
+        ? new RegExp(`this\\.validates\\s*\\(\\s*["']${attr}["']`, "i")
+        : null;
+    if (vpat && (vpat.test(tsContent) || genericPat?.test(tsContent))) r.valsMatched++;
     else r.notes.push(`val-missing: ${v.kind} ${v.attributes.join(",")}`);
   }
   for (const s of ruby.scopes) {

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -3,6 +3,7 @@
 // failure only per docs/fixtures-port-plan.md (Decision 4); PR 7 flips
 // to hard-fail. ERB stubs adapter_name to "SQLite"; other ERB → skipped.
 import { readdirSync, readFileSync, existsSync } from "node:fs";
+import { execSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { parse as parseYaml } from "yaml";
@@ -31,9 +32,10 @@ interface FileResult { yamlBase: string; tsBase: string | null; status: Status; 
 // the rest of the file comparable instead of dropping it as ERB-UNSUPPORTED.
 export const ERB_SKIP_SENTINEL = "__ERB_SKIP__";
 
-function parseArgs(argv: string[]): { pkg: string; filter: string | null } {
+function parseArgs(argv: string[]): { pkg: string; filter: string | null; models: boolean } {
   let pkg = "activerecord";
   let filter: string | null = null;
+  let models = false;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
     if (a === "--package") {
@@ -42,9 +44,11 @@ function parseArgs(argv: string[]): { pkg: string; filter: string | null } {
     } else if (a.startsWith("--package=")) {
       pkg = a.slice(10);
       if (!pkg) throw new Error("--package= requires a value");
+    } else if (a === "--models") {
+      models = true;
     } else if (!a.startsWith("--") && filter === null) filter = a;
   }
-  return { pkg, filter };
+  return { pkg, filter, models };
 }
 
 const kebab = (s: string): string => s.replace(/_/g, "-");
@@ -471,7 +475,7 @@ function formatLine(r: FileResult): string {
 }
 
 async function main(): Promise<void> {
-  const { pkg, filter } = parseArgs(process.argv.slice(2));
+  const { pkg, filter, models } = parseArgs(process.argv.slice(2));
   if (pkg !== "activerecord") {
     console.error(`fixtures:compare: --package ${pkg} not supported yet`);
     process.exit(2);
@@ -515,9 +519,198 @@ async function main(): Promise<void> {
     `schema — ported=${ported}/${evaluated.length} extras-flagged=${withExtras} (skipped ${results.length - evaluated.length})`,
   );
   console.log("(MISSING/DIFF soft per Decision 4 until PR 7; runtime errors hard-fail)");
+
+  if (models) runModelsPass(filter);
+
   // Decision 4 names DIFF/MISSING as soft; YAML/TS load errors are script-runtime, hard-fail.
   const hard: readonly Status[] = ["YAML-PARSE-ERR", "TS-IMPORT-ERR", "TS-EXPORT-MISSING"];
   if (results.some((r) => hard.includes(r.status))) process.exit(1);
+}
+
+// ---- Models pass ----
+
+const MODELS_TS_DIR = path.join(ROOT, "packages/activerecord/src/test-helpers/models");
+const RUBY_EXTRACTOR = path.join(HERE, "extract-ruby-models.rb");
+
+interface RubyAssoc {
+  kind: string;
+  name: string;
+  options: Record<string, string>;
+}
+interface RubyValidation {
+  kind: string;
+  attributes: string[];
+  options: Record<string, string>;
+}
+interface RubyScope {
+  name: string;
+}
+interface RubyCallback {
+  kind: string;
+  target: string | null;
+}
+interface RubyAttr {
+  name: string;
+  type: string;
+}
+interface RubyClass {
+  name: string;
+  parent: string | null;
+  tableName: string | null;
+  associations: RubyAssoc[];
+  validations: RubyValidation[];
+  scopes: RubyScope[];
+  callbacks: RubyCallback[];
+  attributes: RubyAttr[];
+}
+interface RubyFileEntry {
+  file: string;
+  classes: RubyClass[];
+}
+
+type ModelStatus = "MATCH" | "MISSING" | "MISSING-CLASS" | "DIFF";
+
+interface ModelResult {
+  rubyFile: string;
+  tsFile: string | null;
+  status: ModelStatus;
+  assocMatched: number;
+  assocTotal: number;
+  valsMatched: number;
+  valsTotal: number;
+  scopesMatched: number;
+  scopesTotal: number;
+  notes: string[];
+}
+
+function loadRubyModelsManifest(): RubyFileEntry[] {
+  const out = execSync(`ruby ${RUBY_EXTRACTOR}`, { encoding: "utf8" });
+  return JSON.parse(out) as RubyFileEntry[];
+}
+
+// Infer TS filename from Ruby file path. `test/models/post.rb` → `post.ts`;
+// `test/models/admin/account.rb` → `admin/account.ts` (preserving subdir).
+function tsModelPath(rubyFile: string): string {
+  const rel = rubyFile.replace(/^test\/models\//, "").replace(/\.rb$/, ".ts");
+  return path.join(MODELS_TS_DIR, rel.replace(/_/g, "-"));
+}
+
+function compareModelClass(ruby: RubyClass, tsContent: string): ModelResult {
+  const r: ModelResult = {
+    rubyFile: "",
+    tsFile: null,
+    status: "MATCH",
+    assocMatched: 0,
+    assocTotal: ruby.associations.length,
+    valsMatched: 0,
+    valsTotal: ruby.validations.length,
+    scopesMatched: 0,
+    scopesTotal: ruby.scopes.length,
+    notes: [],
+  };
+  // Check associations by (kind, name) set equality. Options diff deferred to later PRs.
+  for (const a of ruby.associations) {
+    const pattern = new RegExp(
+      `this\\.${a.kind.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())}\\s*\\(\\s*["']${a.name}["']`,
+      "i",
+    );
+    if (pattern.test(tsContent)) r.assocMatched++;
+    else r.notes.push(`assoc-missing: ${a.kind} :${a.name}`);
+  }
+  for (const v of ruby.validations) {
+    const attr = v.attributes[0];
+    if (attr && tsContent.includes(`"${attr}"`)) r.valsMatched++;
+    else r.notes.push(`val-missing: ${v.kind} ${v.attributes.join(",")}`);
+  }
+  for (const s of ruby.scopes) {
+    if (tsContent.includes(`"${s.name}"`)) r.scopesMatched++;
+    else r.notes.push(`scope-missing: ${s.name}`);
+  }
+  const anyDiff =
+    r.assocMatched < r.assocTotal || r.valsMatched < r.valsTotal || r.scopesMatched < r.scopesTotal;
+  r.status = anyDiff ? "DIFF" : "MATCH";
+  return r;
+}
+
+function formatModelLine(r: ModelResult): string {
+  const ruby = path.basename(r.rubyFile).padEnd(36);
+  const ts = (r.tsFile ? path.relative(MODELS_TS_DIR, r.tsFile) : "(missing)").padEnd(32);
+  if (r.status === "MISSING" || r.status === "MISSING-CLASS") {
+    return `${ruby}${ts}${r.status}`;
+  }
+  const pct =
+    r.assocTotal + r.valsTotal + r.scopesTotal === 0
+      ? "100%"
+      : `${Math.round(((r.assocMatched + r.valsMatched + r.scopesMatched) / (r.assocTotal + r.valsTotal + r.scopesTotal)) * 100)}%`;
+  return (
+    ruby +
+    ts +
+    `assoc: ${r.assocMatched}/${r.assocTotal}  `.padEnd(14) +
+    `vals: ${r.valsMatched}/${r.valsTotal}  `.padEnd(12) +
+    `scopes: ${r.scopesMatched}/${r.scopesTotal}  `.padEnd(12) +
+    pct.padEnd(6) +
+    r.status
+  );
+}
+
+function runModelsPass(filter: string | null): void {
+  console.log("\n=== models:compare ===");
+  let manifest: RubyFileEntry[];
+  try {
+    manifest = loadRubyModelsManifest();
+  } catch (e) {
+    console.error("models:compare: failed to run Ruby extractor:", (e as Error).message);
+    process.exit(1);
+  }
+
+  const entries = filter ? manifest.filter((e) => e.file.includes(filter)) : manifest;
+
+  const results: ModelResult[] = [];
+  for (const entry of entries) {
+    const tsPath = tsModelPath(entry.file);
+    const tsExists = existsSync(tsPath);
+    const tsContent = tsExists ? readFileSync(tsPath, "utf8") : null;
+    // One result per primary class (first AR::Base descendant or first class).
+    const primaryClass =
+      entry.classes.find((c) => c.parent === "ActiveRecord::Base") ?? entry.classes[0];
+    if (!primaryClass) continue;
+
+    if (!tsExists) {
+      results.push({
+        rubyFile: entry.file,
+        tsFile: null,
+        status: "MISSING",
+        assocMatched: 0,
+        assocTotal: primaryClass.associations.length,
+        valsMatched: 0,
+        valsTotal: primaryClass.validations.length,
+        scopesMatched: 0,
+        scopesTotal: primaryClass.scopes.length,
+        notes: [],
+      });
+      continue;
+    }
+
+    const r = compareModelClass(primaryClass, tsContent!);
+    r.rubyFile = entry.file;
+    r.tsFile = tsPath;
+    results.push(r);
+  }
+
+  for (const r of results) {
+    console.log(formatModelLine(r));
+    if (process.env.FIXTURES_COMPARE_VERBOSE === "1") {
+      for (const n of r.notes) console.log(`    ${n}`);
+    }
+  }
+
+  const missing = results.filter(
+    (r) => r.status === "MISSING" || r.status === "MISSING-CLASS",
+  ).length;
+  const matched = results.filter((r) => r.status === "MATCH").length;
+  const diff = results.filter((r) => r.status === "DIFF").length;
+  console.log(`\n${results.length} files — match=${matched} diff=${diff} missing=${missing}`);
+  console.log("(MISSING/DIFF soft until final models-port PR flips to hard-fail)");
 }
 
 // Run as a script when invoked directly, but stay importable from tests.

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -583,7 +583,7 @@ interface RubyFileEntry {
   classes: RubyClass[];
 }
 
-type ModelStatus = "MATCH" | "MISSING" | "MISSING-CLASS" | "DIFF";
+type ModelStatus = "MATCH" | "MISSING" | "DIFF";
 
 interface ModelResult {
   rubyFile: string;
@@ -658,7 +658,7 @@ export function compareModelClass(ruby: RubyClass, tsContent: string): ModelResu
 function formatModelLine(r: ModelResult): string {
   const ruby = path.basename(r.rubyFile).padEnd(36);
   const ts = (r.tsFile ? path.relative(MODELS_TS_DIR, r.tsFile) : "(missing)").padEnd(32);
-  if (r.status === "MISSING" || r.status === "MISSING-CLASS") {
+  if (r.status === "MISSING") {
     return `${ruby}${ts}${r.status}`;
   }
   const pct =
@@ -682,7 +682,9 @@ function runModelsPass(filter: string | null): void {
   try {
     manifest = loadRubyModelsManifest();
   } catch (e) {
-    console.error("models:compare: failed to run Ruby extractor:", (e as Error).message);
+    const err = e as Error & { stderr?: Buffer };
+    const detail = err.stderr?.toString().trim() || err.message;
+    console.error("models:compare: failed to run Ruby extractor:", detail);
     process.exit(1);
   }
 
@@ -727,9 +729,7 @@ function runModelsPass(filter: string | null): void {
     }
   }
 
-  const missing = results.filter(
-    (r) => r.status === "MISSING" || r.status === "MISSING-CLASS",
-  ).length;
+  const missing = results.filter((r) => r.status === "MISSING").length;
   const matched = results.filter((r) => r.status === "MATCH").length;
   const diff = results.filter((r) => r.status === "DIFF").length;
   console.log(`\n${results.length} files — match=${matched} diff=${diff} missing=${missing}`);

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -3,7 +3,7 @@
 // failure only per docs/fixtures-port-plan.md (Decision 4); PR 7 flips
 // to hard-fail. ERB stubs adapter_name to "SQLite"; other ERB → skipped.
 import { readdirSync, readFileSync, existsSync } from "node:fs";
-import { execSync } from "node:child_process";
+import { execFileSync } from "node:child_process";
 import path from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
 import { parse as parseYaml } from "yaml";
@@ -532,7 +532,7 @@ async function main(): Promise<void> {
 const MODELS_TS_DIR = path.join(ROOT, "packages/activerecord/src/test-helpers/models");
 const RUBY_EXTRACTOR = path.join(HERE, "extract-ruby-models.rb");
 
-interface RubyAssoc {
+export interface RubyAssoc {
   kind: string;
   name: string;
   options: Record<string, string>;
@@ -553,7 +553,7 @@ interface RubyAttr {
   name: string;
   type: string;
 }
-interface RubyClass {
+export interface RubyClass {
   name: string;
   parent: string | null;
   tableName: string | null;
@@ -584,18 +584,18 @@ interface ModelResult {
 }
 
 function loadRubyModelsManifest(): RubyFileEntry[] {
-  const out = execSync(`ruby "${RUBY_EXTRACTOR}"`, { encoding: "utf8" });
+  const out = execFileSync("ruby", [RUBY_EXTRACTOR], { encoding: "utf8" });
   return JSON.parse(out) as RubyFileEntry[];
 }
 
 // Infer TS filename from Ruby file path. `test/models/post.rb` → `post.ts`;
 // `test/models/admin/account.rb` → `admin/account.ts` (preserving subdir).
-function tsModelPath(rubyFile: string): string {
+export function tsModelPath(rubyFile: string): string {
   const rel = rubyFile.replace(/^test\/models\//, "").replace(/\.rb$/, ".ts");
   return path.join(MODELS_TS_DIR, rel.replace(/_/g, "-"));
 }
 
-function compareModelClass(ruby: RubyClass, tsContent: string): ModelResult {
+export function compareModelClass(ruby: RubyClass, tsContent: string): ModelResult {
   const r: ModelResult = {
     rubyFile: "",
     tsFile: null,
@@ -619,7 +619,7 @@ function compareModelClass(ruby: RubyClass, tsContent: string): ModelResult {
   }
   for (const v of ruby.validations) {
     const attr = v.attributes[0];
-    const vpat = attr ? new RegExp(`this\\.validates?\\s*\\(\\s*["']${attr}["']`, "i") : null;
+    const vpat = attr ? new RegExp(`this\\.validates\\s*\\(\\s*["']${attr}["']`, "i") : null;
     if (vpat && vpat.test(tsContent)) r.valsMatched++;
     else r.notes.push(`val-missing: ${v.kind} ${v.attributes.join(",")}`);
   }

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -616,10 +616,15 @@ export function tsModelPath(rubyFile: string): string {
   return path.join(MODELS_TS_DIR, rel.replace(/_/g, "-"));
 }
 
-export function compareModelClass(ruby: RubyClass, tsContent: string): ModelResult {
+export function compareModelClass(
+  ruby: RubyClass,
+  tsContent: string,
+  rubyFile: string,
+  tsFile: string,
+): ModelResult {
   const r: ModelResult = {
-    rubyFile: "",
-    tsFile: null,
+    rubyFile,
+    tsFile,
     status: "MATCH",
     assocMatched: 0,
     assocTotal: ruby.associations.length,
@@ -722,9 +727,7 @@ function runModelsPass(filter: string | null): void {
       continue;
     }
 
-    const r = compareModelClass(primaryClass, tsContent!);
-    r.rubyFile = entry.file;
-    r.tsFile = tsPath;
+    const r = compareModelClass(primaryClass, tsContent!, entry.file, tsPath);
     results.push(r);
   }
 

--- a/scripts/fixtures-compare/extract-ruby-models.rb
+++ b/scripts/fixtures-compare/extract-ruby-models.rb
@@ -60,7 +60,11 @@ def parse_file(path)
     closes -= 1 if line =~ /^\s*def\s+\w+\s*=/ && !line.include?(" end")
 
     if (m = line.match(/^class\s+(\w+(?:::\w+)*)(?:\s*<\s*([\w:]+))?/))
-      depth += [opens - closes, 1].max
+      # Apply the net delta from this line (class keyword already counted in opens).
+      # Clamp to at least depth+1 so `class Foo; end` (opens==closes==1) still
+      # records a unique depth for the class before popping it.
+      net = opens - closes
+      depth += net >= 1 ? net : 1
       cls = { name: m[1], parent: m[2], tableName: nil,
               associations: [], validations: [], scopes: [], callbacks: [], attributes: [] }
       stack << { cls: cls, depth: depth }

--- a/scripts/fixtures-compare/extract-ruby-models.rb
+++ b/scripts/fixtures-compare/extract-ruby-models.rb
@@ -56,8 +56,9 @@ def parse_file(path)
     # Inline `if`/`unless` modifiers (trailing) don't open a block.
     opens -= line.scan(/\s+(?:if|unless)\s+/).count if line !~ /^\s*(?:if|unless)\b/
     closes = line.scan(/\bend\b/).count
-    # single-line `def foo = ...` has no end
-    closes -= 1 if line =~ /^\s*def\s+\w+\s*=/ && !line.include?(" end")
+    # Ruby 3 single-line `def foo = expr` opens `def` but has no `end`.
+    # Cancel the `def` from opens (not closes) so net delta stays 0.
+    opens -= 1 if line =~ /^\s*def\s+\w[\w?!]*\s*=/ && !line.include?(" end")
 
     if (m = line.match(/^class\s+(\w+(?:::\w+)*)(?:\s*<\s*([\w:]+))?/))
       # Enter the class body at depth+1, then apply remaining tokens on this line.
@@ -103,7 +104,10 @@ def parse_file(path)
   classes
 end
 
+abort "extract-ruby-models: MODELS_DIR not found: #{MODELS_DIR}\nRun `pnpm vendor:fetch` first." unless Dir.exist?(MODELS_DIR)
+
 files = Dir.glob(File.join(MODELS_DIR, "**", "*.rb")).sort
+abort "extract-ruby-models: no .rb files found under #{MODELS_DIR}" if files.empty?
 result = []
 files.each do |f|
   rel = f.delete_prefix(File.join(ROOT, "vendor/rails/activerecord/") + "/")

--- a/scripts/fixtures-compare/extract-ruby-models.rb
+++ b/scripts/fixtures-compare/extract-ruby-models.rb
@@ -1,0 +1,108 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+# Emits a JSON manifest of Rails test model classes.
+# Output: [{ file, classes: [{ name, parent, tableName, associations, validations, scopes, callbacks, attributes }] }]
+require "json"
+
+SCRIPT_DIR = File.dirname(__FILE__)
+ROOT = File.expand_path("../..", SCRIPT_DIR)
+MODELS_DIR = File.join(ROOT, "vendor/rails/activerecord/test/models")
+
+ASSOC_KINDS = %w[has_and_belongs_to_many has_many has_one belongs_to].freeze
+CALLBACK_KINDS = %w[
+  before_validation after_validation
+  before_save around_save after_save
+  before_create around_create after_create
+  before_update around_update after_update
+  before_destroy around_destroy after_destroy
+  after_commit after_rollback after_touch
+].freeze
+VALIDATION_MACROS = %w[
+  validates
+  validates_presence_of validates_uniqueness_of validates_length_of
+  validates_inclusion_of validates_exclusion_of validates_format_of
+  validates_numericality_of validates_confirmation_of validates_associated
+  validates_absence_of validates_comparison_of validates_acceptance_of
+].freeze
+
+# Extract the first symbol name from a macro call: `has_many :foo, ...` → "foo"
+def first_symbol(line)
+  line.match(/\b\w+\s+:(\w+)/i)&.then { |m| m[1] }
+end
+
+# Extract simple key: :val / key: "val" / key: 'val' option pairs.
+# Skips lambda/proc values and complex expressions.
+def extract_options(line)
+  opts = {}
+  line.scan(/(\w+):\s*(?::(\w+)|"([^"]+)"|'([^']+)')/) do |key, sym, dq, sq|
+    opts[key] = sym || dq || sq
+  end
+  opts
+end
+
+def parse_file(path)
+  lines = File.readlines(path, chomp: true)
+  classes = []
+  stack = []   # [{cls:, depth:}]
+  depth = 0    # simple brace/do/end depth approximation
+
+  lines.each do |raw|
+    line = raw.strip
+
+    # Track nesting depth to know which class we're in.
+    # Count `do`, `begin`, `def`, `if`, `unless`, `module`, `class` as +1;
+    # `end` as -1. We only need rough depth to detect class end.
+    opens = line.scan(/\b(?:do|begin|def|if|unless|module|class|case|for|while|until)\b/).count
+    # Inline `if`/`unless` modifiers (trailing) don't open a block.
+    opens -= line.scan(/\s+(?:if|unless)\s+/).count if line !~ /^\s*(?:if|unless)\b/
+    closes = line.scan(/\bend\b/).count
+    # single-line `def foo = ...` has no end
+    closes -= 1 if line =~ /^\s*def\s+\w+\s*=/ && !line.include?(" end")
+
+    if (m = line.match(/^class\s+(\w+(?:::\w+)*)(?:\s*<\s*([\w:]+))?/))
+      depth += [opens - closes, 1].max
+      cls = { name: m[1], parent: m[2], tableName: nil,
+              associations: [], validations: [], scopes: [], callbacks: [], attributes: [] }
+      stack << { cls: cls, depth: depth }
+      classes << cls
+      next
+    end
+
+    depth += opens - closes
+
+    # Pop classes whose depth we've left.
+    stack.pop while stack.last && depth < stack.last[:depth]
+
+    next if stack.empty?
+    cls = stack.last[:cls]
+
+    if (m = line.match(/^self\.table_name\s*=\s*["']([^"']+)["']/))
+      cls[:tableName] = m[1]
+    elsif (kind = ASSOC_KINDS.find { |k| line =~ /^#{Regexp.escape(k)}\b/ })
+      name = first_symbol(line)
+      cls[:associations] << { kind: kind, name: name, options: extract_options(line) } if name
+    elsif line =~ /^scope\s+:/
+      name = first_symbol(line)
+      cls[:scopes] << { name: name } if name
+    elsif (kind = CALLBACK_KINDS.find { |k| line =~ /^#{Regexp.escape(k)}\b/ })
+      target = line.match(/^#{Regexp.escape(kind)}\s+:(\w+)/)&.then { |m| m[1] }
+      cls[:callbacks] << { kind: kind, target: target }
+    elsif (kind = VALIDATION_MACROS.find { |k| line =~ /^#{Regexp.escape(k)}\b/ })
+      name = first_symbol(line)
+      cls[:validations] << { kind: kind, attributes: [name].compact, options: extract_options(line) }
+    elsif (m = line.match(/^attribute\s+:(\w+),\s*:(\w+)/))
+      cls[:attributes] << { name: m[1], type: m[2] }
+    end
+  end
+
+  classes
+end
+
+files = Dir.glob(File.join(MODELS_DIR, "**", "*.rb")).sort
+result = []
+files.each do |f|
+  rel = f.delete_prefix(File.join(ROOT, "vendor/rails/activerecord/") + "/")
+  classes = parse_file(f)
+  result << { file: rel, classes: classes } unless classes.empty?
+end
+puts JSON.generate(result)

--- a/scripts/fixtures-compare/extract-ruby-models.rb
+++ b/scripts/fixtures-compare/extract-ruby-models.rb
@@ -60,15 +60,16 @@ def parse_file(path)
     closes -= 1 if line =~ /^\s*def\s+\w+\s*=/ && !line.include?(" end")
 
     if (m = line.match(/^class\s+(\w+(?:::\w+)*)(?:\s*<\s*([\w:]+))?/))
-      # Apply the net delta from this line (class keyword already counted in opens).
-      # Clamp to at least depth+1 so `class Foo; end` (opens==closes==1) still
-      # records a unique depth for the class before popping it.
-      net = opens - closes
-      depth += net >= 1 ? net : 1
+      # Enter the class body at depth+1, then apply remaining tokens on this line.
+      # `class` itself counted in opens; remaining opens = opens-1, closes = closes.
+      # e.g. `class Foo; end` → depth+1, then -1 → back to parent depth, stack popped.
+      depth += 1
       cls = { name: m[1], parent: m[2], tableName: nil,
               associations: [], validations: [], scopes: [], callbacks: [], attributes: [] }
       stack << { cls: cls, depth: depth }
       classes << cls
+      depth += (opens - 1) - closes
+      stack.pop while stack.last && depth < stack.last[:depth]
       next
     end
 


### PR DESCRIPTION
## Summary

- Adds `scripts/fixtures-compare/extract-ruby-models.rb` — a Ruby line-scanner that walks `vendor/rails/activerecord/test/models/**/*.rb` and emits a JSON manifest of class declarations, associations, validations, scopes, callbacks, and typed attributes (108 LOC)
- Extends `scripts/fixtures-compare/compare.ts` with a `--models` flag that invokes the Ruby extractor and compares each Rails model file against its TS counterpart in `packages/activerecord/src/test-helpers/models/`

For PR 0, the TS models directory does not exist yet, so all 215 Rails model files report `MISSING` — the expected baseline. Subsequent batch PRs (1–8) port model files; the compare script reports their progress.

The existing fixtures pass is additive-only — no behavior changes.

## Verification

```
pnpm fixtures:compare            # fixtures pass only — unchanged (122 files, same counts)
pnpm fixtures:compare --models   # both passes — 215 models MISSING (expected)
```

## Test plan

- [x] `pnpm vitest run scripts/fixtures-compare/compare.test.ts` — 43/43 pass
- [x] `pnpm fixtures:compare` output unchanged (existing pass not regressed)
- [x] `pnpm fixtures:compare --models` runs cleanly, all 215 Rails models reported MISSING
- [x] Build + typecheck pass (pre-commit hook)

## Follow-ups

PR 1 (cluster 1a) picks up `docs/test-models-port-plan.md` and ports the first batch of model files. At that point `--models` will report progress instead of all-MISSING.