### PR TITLE
feat(fixtures-compare): comparator hardening for PR 7b strict-flip

### DIFF
--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -23,7 +23,8 @@
 >   (CPK FK + extra `number`), `dead_parrots.yml` / `live_parrots.yml`
 >   (HABTM `treasures`), `developers.yml` (`shared_computers` HABTM),
 >   `sponsors.yml` (extra `club_id`), `peoples_treasures.yml`
->   (`rich_person_id → people` needs a `FK_OVERRIDES` entry).
+>   (TS row's `michael` label doesn't match the row CRC32 the Rails YAML
+>   resolves `rich_person_id` to — fixture-side label or id reconcile).
 > - **PR 7a** — ~1.9k LOC waiver port of `fixtures_test.rb` (1847 LOC),
 >   `test_fixtures_test.rb`, `encryption/encrypted_fixtures_test.rb`.
 > - **PR 7b** — ~30 LOC strict-fail flip + remove 4 exclusions from

--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -1,11 +1,17 @@
 # Fixtures port plan
 
 > **Status (2026-05-22):** ~92% complete. All 122 Rails fixtures
-> translated. `pnpm fixtures:compare` reports match=109 diff=10
-> missing=0 erb-unsupported=0 erb-allowed=3 (soft mode). Compare-script
-> hardening shipped in this PR: enum-symbol comparator, HABTM
-> implicit-id index, FK override scaffold, datetime/YAML/time-of-day
-> tolerance, and the mixins/paragraphs/citations ERB allow-list.
+> translated (PRs 0–6b + 0.5a–h + 0.75 + 4-late, merged 2026-05-20…21).
+> Schema port shipped (#2124/#2128/#2130/#2131/#2133/#2134/#2140).
+> ERB `identify`/`composite_identify` + loop expander shipped (#2247).
+> Fixture-side DIFF reconcile #2228. Loader
+> (`defineFixtures`/`useFixtures`/`ref`/`fixtureId`) live.
+> Compare-script hardening shipped in **this PR**: enum-symbol
+> comparator, HABTM implicit-id index, FK override scaffold,
+> datetime/YAML/time-of-day tolerance, and the
+> mixins/paragraphs/citations ERB allow-list.
+> `pnpm fixtures:compare` reports match=109 diff=10 missing=0
+> erb-unsupported=0 erb-allowed=3 (soft mode).
 >
 > **Remaining (blocks PR 7 strict-fail flip):**
 >

--- a/docs/fixtures-port-plan.md
+++ b/docs/fixtures-port-plan.md
@@ -1,22 +1,23 @@
 # Fixtures port plan
 
-> **Status (2026-05-22):** ~90% complete. All 122 Rails fixtures
-> translated (PRs 0–6b + 0.5a–h + 0.75 + 4-late, merged 2026-05-20…21).
-> `pnpm fixtures:compare` reports match=94 diff=8 missing=0
-> erb-unsupported=20 (soft mode). Schema port shipped (#2124/#2128/
-> #2130/#2131/#2133/#2134/#2140). ERB `identify`/`composite_identify` +
-> loop expander shipped (#2247). Fixture-side DIFF reconcile #2228.
-> Loader (`defineFixtures`/`useFixtures`/`ref`/`fixtureId`) live.
+> **Status (2026-05-22):** ~92% complete. All 122 Rails fixtures
+> translated. `pnpm fixtures:compare` reports match=109 diff=10
+> missing=0 erb-unsupported=0 erb-allowed=3 (soft mode). Compare-script
+> hardening shipped in this PR: enum-symbol comparator, HABTM
+> implicit-id index, FK override scaffold, datetime/YAML/time-of-day
+> tolerance, and the mixins/paragraphs/citations ERB allow-list.
 >
 > **Remaining (blocks PR 7 strict-fail flip):**
 >
-> - Compare-script enhancements (~150 LOC): enum-symbol comparator (~40),
->   HABTM key handling (~30), custom FK override map (~30),
->   datetime/YAML tolerance (~50).
-> - 3 ERB-UNSUPPORTED stragglers post-#2247: `mixins.yml`,
->   `paragraphs.yml`, `citations.yml` — add to allow-list.
-> - 2 newly comparable DIFFs from #2247:
->   `developers.shared_computers` column, `binaries.flowers.data` row.
+> - 10 DIFFs to reconcile fixture-side (follow-up PR): `books.yml`
+>   (populate `ENUM_MAPS["books"]` for status/last_read/language/etc.),
+>   `topics.yml` / `other_topics.yml` (extra `type` column on STI rows
+>   the TS side carries but Rails YAML omits), `binaries.yml`
+>   (`flowers.data` blob), `cpk_order_tags.yml` + `cpk_reviews.yml`
+>   (CPK FK + extra `number`), `dead_parrots.yml` / `live_parrots.yml`
+>   (HABTM `treasures`), `developers.yml` (`shared_computers` HABTM),
+>   `sponsors.yml` (extra `club_id`), `peoples_treasures.yml`
+>   (`rich_person_id → people` needs a `FK_OVERRIDES` entry).
 > - **PR 7a** — ~1.9k LOC waiver port of `fixtures_test.rb` (1847 LOC),
 >   `test_fixtures_test.rb`, `encryption/encrypted_fixtures_test.rb`.
 > - **PR 7b** — ~30 LOC strict-fail flip + remove 4 exclusions from

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -385,6 +385,12 @@ describe("datetime / serialized-YAML tolerance", () => {
     // typically still carries the string form.
     expect(cmp("2003-07-16 14:28:11", new Date("2003-07-16T14:28:11Z"))[0]).toBe(true);
   });
+  it("handles bare date-only scalars (YYYY-MM-DD) as midnight UTC, not as NaN", () => {
+    // Regression: appending `Z` to a date-only string produces invalid ISO
+    // (`2024-01-01Z` → Date.parse NaN). Normalize to midnight UTC first.
+    expect(cmp("2024-01-01", "2024-01-01")[0]).toBe(true);
+    expect(cmp("2024-01-01", new Date("2024-01-01T00:00:00Z"))[0]).toBe(true);
+  });
 });
 
 describe("enum-symbol comparator", () => {
@@ -453,6 +459,16 @@ describe("canonicalizeRailsRow + FK_OVERRIDES", () => {
   it("threads the `table` arg without changing default behavior when no override is registered", () => {
     expect(canonicalizeRailsRow({ pirate: "x" }, { pirate_id: 1 }, null, "some_table")).toEqual({
       pirate_id: "x",
+    });
+  });
+  it("preserves polymorphic `name (Type)` split on the convention path", () => {
+    // Rails fixtures.rb#replace_belongs_to_keys emits both <col> and
+    // <assoc>_type for polymorphic associations. The shared parser keeps
+    // that behavior on the standard `<assoc>_id` path.
+    const cols = new Set(["pirate_id", "pirate_type"]);
+    expect(canonicalizeRailsRow({ pirate: "blackbeard (Pirate)" }, {}, cols)).toEqual({
+      pirate_id: "blackbeard",
+      pirate_type: "Pirate",
     });
   });
 });

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -448,6 +448,13 @@ describe("buildIdIndex (implicit-id fallback)", () => {
     expect(idx.get("t")?.get(1)).toEqual(["a"]);
     expect([...(idx.get("t")?.keys() ?? [])]).toEqual([1]);
   });
+  it("skips rows whose explicit `id:` isn't numeric (string PKs, CPK tables)", () => {
+    // A row with `id: "abc"` lives in a non-numeric PK space — it must NOT
+    // fall through to the CRC32 fallback (would mis-index FK lookups) and
+    // can't go into the numeric Map either. Skip cleanly.
+    const idx = buildIdIndexForTest(new Map([["t", { a: { id: "abc", name: "x" } }]]));
+    expect([...(idx.get("t")?.keys() ?? [])]).toEqual([]);
+  });
 });
 
 describe("canonicalizeRailsRow + FK_OVERRIDES", () => {

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -352,18 +352,15 @@ describe("compareFile", () => {
     const other = await compareFile("not_on_the_list.yml", empty, empty, "ERB-UNSUPPORTED");
     expect(other.status).toBe("ERB-UNSUPPORTED");
   });
-  it("falls back to MISSING when an allow-listed file has no TS counterpart", async () => {
-    // The TS side is the source of truth for allow-listed files; if it's
-    // been deleted we must surface MISSING rather than silently passing.
-    const r = await compareFile("erb_allowed_ghost.yml", empty, empty, "ERB-UNSUPPORTED");
-    // Not in ERB_ALLOW_LIST, so stays ERB-UNSUPPORTED. Use a real entry:
-    const ghost = { ...r }; // ensure assertion below isn't conflated
-    expect(ghost.status).toBe("ERB-UNSUPPORTED");
-    // Allow-listed name without a TS file → MISSING.
-    const r2 = await compareFile("mixins.yml", empty, empty, "ERB-UNSUPPORTED");
-    // mixins.ts exists in the repo, so this asserts the happy path:
-    expect(r2.status).toBe("ERB-ALLOWED");
-    expect(r2.tsBase).toBe("mixins.ts");
+  it("records `tsBase` on the ERB-ALLOWED result so a deleted TS counterpart can be caught", async () => {
+    // ERB-ALLOWED files are the TS-as-source-of-truth bucket; the
+    // promotion in compareFile only succeeds when the TS counterpart
+    // exists (else falls back to MISSING). Asserting on `tsBase` makes
+    // that contract visible: if mixins.ts is removed from the tree, this
+    // resolves to null and the status branch flips to MISSING.
+    const r = await compareFile("mixins.yml", empty, empty, "ERB-UNSUPPORTED");
+    expect(r.status).toBe("ERB-ALLOWED");
+    expect(r.tsBase).toBe("mixins.ts");
   });
 });
 

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -352,6 +352,19 @@ describe("compareFile", () => {
     const other = await compareFile("not_on_the_list.yml", empty, empty, "ERB-UNSUPPORTED");
     expect(other.status).toBe("ERB-UNSUPPORTED");
   });
+  it("falls back to MISSING when an allow-listed file has no TS counterpart", async () => {
+    // The TS side is the source of truth for allow-listed files; if it's
+    // been deleted we must surface MISSING rather than silently passing.
+    const r = await compareFile("erb_allowed_ghost.yml", empty, empty, "ERB-UNSUPPORTED");
+    // Not in ERB_ALLOW_LIST, so stays ERB-UNSUPPORTED. Use a real entry:
+    const ghost = { ...r }; // ensure assertion below isn't conflated
+    expect(ghost.status).toBe("ERB-UNSUPPORTED");
+    // Allow-listed name without a TS file → MISSING.
+    const r2 = await compareFile("mixins.yml", empty, empty, "ERB-UNSUPPORTED");
+    // mixins.ts exists in the repo, so this asserts the happy path:
+    expect(r2.status).toBe("ERB-ALLOWED");
+    expect(r2.tsBase).toBe("mixins.ts");
+  });
 });
 
 describe("datetime / serialized-YAML tolerance", () => {

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, afterAll } from "vitest";
 // prettier-ignore
-import { stripErb, isRefLike, compareValue, compareFile, schemaCheck, canonicalizeRailsRow, ERB_SKIP_SENTINEL, tsModelPath, compareModelClass } from "./compare.js";
+import { stripErb, isRefLike, compareValue, compareFile, schemaCheck, canonicalizeRailsRow, ERB_SKIP_SENTINEL, tsModelPath, compareModelClass, buildIdIndexForTest, loadRailsYamlForTest } from "./compare.js";
 import type { RubyClass } from "./compare.js";
 import type { Schema } from "../../packages/activerecord/src/test-helpers/define-schema.js";
 
@@ -250,7 +250,6 @@ describe("canonicalizeRailsRow", () => {
 import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadRailsYamlForTest } from "./compare.js";
 describe("loadRailsYaml (parsing fidelity)", () => {
   const tmp = mkdtempSync(join(tmpdir(), "fixtures-compare-"));
   const write = (basename: string, contents: string): string => {
@@ -426,7 +425,6 @@ describe("enum-symbol comparator", () => {
   });
 });
 
-import { buildIdIndexForTest } from "./compare.js";
 describe("buildIdIndex (implicit-id fallback)", () => {
   // Mirrors Rails' `ActiveRecord::FixtureSet.identify(label)` so numeric FK
   // references in *other* fixtures resolve to label-only rows. Highest-impact

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -384,6 +384,12 @@ describe("datetime / serialized-YAML tolerance", () => {
     // typically still carries the string form.
     expect(cmp("2003-07-16 14:28:11", new Date("2003-07-16T14:28:11Z"))[0]).toBe(true);
   });
+  it("normalizes yaml-lib's lowercase `t` separator to uppercase (spec ISO 8601)", () => {
+    // V8 tolerates `2003-07-16t14:28:11Z` today, but Date.parse for
+    // non-standard variants is engine-defined and stricter runtimes
+    // (deno/spec'd) can return NaN. Pin the normalization.
+    expect(cmp("2003-07-16 14:28:11", "2003-07-16t14:28:11Z")[0]).toBe(true);
+  });
   it("handles bare date-only scalars (YYYY-MM-DD) as midnight UTC, not as NaN", () => {
     // Regression: appending `Z` to a date-only string produces invalid ISO
     // (`2024-01-01Z` → Date.parse NaN). Normalize to midnight UTC first.

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -384,11 +384,12 @@ describe("datetime / serialized-YAML tolerance", () => {
     // typically still carries the string form.
     expect(cmp("2003-07-16 14:28:11", new Date("2003-07-16T14:28:11Z"))[0]).toBe(true);
   });
-  it("normalizes yaml-lib's lowercase `t` separator to uppercase (spec ISO 8601)", () => {
-    // V8 tolerates `2003-07-16t14:28:11Z` today, but Date.parse for
+  it("normalizes yaml-lib's lowercase `t`/`z` separators to uppercase (spec ISO 8601)", () => {
+    // V8 tolerates `2003-07-16t14:28:11z` today, but Date.parse for
     // non-standard variants is engine-defined and stricter runtimes
     // (deno/spec'd) can return NaN. Pin the normalization.
     expect(cmp("2003-07-16 14:28:11", "2003-07-16t14:28:11Z")[0]).toBe(true);
+    expect(cmp("2003-07-16 14:28:11", "2003-07-16T14:28:11z")[0]).toBe(true);
   });
   it("handles bare date-only scalars (YYYY-MM-DD) as midnight UTC, not as NaN", () => {
     // Regression: appending `Z` to a date-only string produces invalid ISO

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -406,6 +406,42 @@ describe("enum-symbol comparator", () => {
     expect(ok).toBe(false);
     expect(notes[0]).toMatch(/^value-differs:/);
   });
+  it("requires the `:` prefix to soft-skip — bare string ↔ number falls through to value-differs", () => {
+    // Critical contract: without an ENUM_MAPS entry, `name: 5` vs `name: "five"`
+    // is a real mismatch, not an unmapped enum. Only the explicit `:foo`
+    // Ruby-symbol form should trigger the unmapped soft-skip; otherwise we'd
+    // mask data drift on any number/word column pair.
+    const notes: string[] = [];
+    const skip = { n: 0 };
+    const ok = compareValue(5, "five", "row.count", idIndex, notes, "things", skip);
+    expect(ok).toBe(false);
+    expect(skip.n).toBe(0);
+    expect(notes[0]).toMatch(/^value-differs:/);
+  });
+});
+
+import { buildIdIndexForTest } from "./compare.js";
+describe("buildIdIndex (implicit-id fallback)", () => {
+  // Mirrors Rails' `ActiveRecord::FixtureSet.identify(label)` so numeric FK
+  // references in *other* fixtures resolve to label-only rows. Highest-impact
+  // change in this PR — without it 7+ HABTM/join fixtures soft-failed because
+  // their FK targets weren't in the index.
+  it("indexes rows with explicit `id:` by that id", () => {
+    const idx = buildIdIndexForTest(new Map([["t", { a: { id: 100 }, b: { id: 200 } }]]));
+    expect(idx.get("t")?.get(100)).toEqual(["a"]);
+    expect(idx.get("t")?.get(200)).toEqual(["b"]);
+  });
+  it("falls back to CRC32(label) for rows without explicit `id:`", () => {
+    // fixtureIdValue("blackbeard") = 959118195 (stable; pinned in stripErb tests).
+    const idx = buildIdIndexForTest(new Map([["pirates", { blackbeard: { name: "BB" } }]]));
+    expect(idx.get("pirates")?.get(959118195)).toEqual(["blackbeard"]);
+  });
+  it("keeps explicit id taking precedence over the CRC32 fallback", () => {
+    // If a row carries `id: 1`, it must be indexed at 1 — never at CRC32("a").
+    const idx = buildIdIndexForTest(new Map([["t", { a: { id: 1, name: "x" } }]]));
+    expect(idx.get("t")?.get(1)).toEqual(["a"]);
+    expect([...(idx.get("t")?.keys() ?? [])]).toEqual([1]);
+  });
 });
 
 describe("canonicalizeRailsRow + FK_OVERRIDES", () => {

--- a/scripts/fixtures-compare/compare.test.ts
+++ b/scripts/fixtures-compare/compare.test.ts
@@ -343,6 +343,82 @@ describe("compareFile", () => {
       "YAML-PARSE-ERR",
     );
   });
+  it("promotes allow-listed ERB-UNSUPPORTED to ERB-ALLOWED so the strict flip ignores them", async () => {
+    // mixins/paragraphs/citations are documented stragglers — their TS side
+    // is the source of truth, the Rails YAML never reduces. Allow-list lets
+    // PR 7b flip strict without re-classifying these as failures.
+    const r = await compareFile("paragraphs.yml", empty, empty, "ERB-UNSUPPORTED");
+    expect(r.status).toBe("ERB-ALLOWED");
+    // Non-allow-listed files keep the original status.
+    const other = await compareFile("not_on_the_list.yml", empty, empty, "ERB-UNSUPPORTED");
+    expect(other.status).toBe("ERB-UNSUPPORTED");
+  });
+});
+
+describe("datetime / serialized-YAML tolerance", () => {
+  // Rails fixtures store sub-second precision the TS side often trims; both
+  // halves of `compareValue`'s datetime path round to whole-second equality.
+  it("treats identical instants written with `T`/space and fractional seconds as equal", () => {
+    expect(cmp("2003-07-16 14:28:11", "2003-07-16T15:28:11.2233+01:00")[0]).toBe(true);
+  });
+  it("forces UTC when the bare datetime string has no timezone marker", () => {
+    // No tz on either side → both interpreted UTC; otherwise this assertion
+    // would be host-tz dependent (failure mode the regression guards against).
+    expect(cmp("2003-07-16 14:28:11", "2003-07-16T14:28:11")[0]).toBe(true);
+  });
+  it("compares time-of-day against a Rails datetime by UTC hour/min/sec", () => {
+    // TIME columns (`bonus_time`) carry `HH:MM:SS` on the TS side but Rails
+    // YAML often holds a full datetime; compare the UTC time-of-day only.
+    expect(cmp("14:28:00", "2005-01-30T15:28:00.00+01:00")[0]).toBe(true);
+    expect(cmp("14:28:00", "2005-01-30T16:28:00.00+01:00")[0]).toBe(false);
+  });
+  it("flags datetime values that disagree by more than a second", () => {
+    const [ok, notes] = cmp("2003-07-16 14:28:11", "2003-07-16T14:28:30Z");
+    expect(ok).toBe(false);
+    expect(notes[0]).toMatch(/^value-differs:/);
+  });
+  it("peels Rails' `--- … \\n…\\n` YAML wrapper used for serialize columns", () => {
+    expect(cmp("Have a nice day", "--- Have a nice day\n...\n")[0]).toBe(true);
+  });
+  it("matches an `instanceof Date` Rails value against an ISO string TS value", () => {
+    // YAML promotes `!!timestamp`-tagged scalars to Date; the TS side
+    // typically still carries the string form.
+    expect(cmp("2003-07-16 14:28:11", new Date("2003-07-16T14:28:11Z"))[0]).toBe(true);
+  });
+});
+
+describe("enum-symbol comparator", () => {
+  it("counts unmapped `:symbol` ↔ integer pairs as a soft skip, not a DIFF", () => {
+    // The ENUM_MAPS registry is empty by default; an unregistered enum-shaped
+    // pair should bump the per-row attrsSkipped counter and return true so
+    // unported enum metadata doesn't gate the strict flip.
+    const notes: string[] = [];
+    const skip = { n: 0 };
+    const ok = compareValue(2, ":published", "row.status", idIndex, notes, "books", skip);
+    expect(ok).toBe(true);
+    expect(skip.n).toBe(1);
+    expect(notes[0]).toMatch(/^enum-unmapped: row\.status/);
+  });
+  it("ignores enum shape when the rails string isn't a bare identifier", () => {
+    // A multi-word string like `"hello world"` isn't a symbol candidate;
+    // fall through to value-differs so we don't paper over a real mismatch.
+    const [ok, notes] = cmp(1, "hello world");
+    expect(ok).toBe(false);
+    expect(notes[0]).toMatch(/^value-differs:/);
+  });
+});
+
+describe("canonicalizeRailsRow + FK_OVERRIDES", () => {
+  // The override path is a scaffold for fixtures whose Rails shorthand
+  // (`assoc: label`) doesn't follow the `<assoc>_id` column convention.
+  // Today no overrides are populated — the contract is that callers can
+  // pass a `table` name and an entry in FK_OVERRIDES will redirect the
+  // shorthand to the declared column. Tested via a direct call shape.
+  it("threads the `table` arg without changing default behavior when no override is registered", () => {
+    expect(canonicalizeRailsRow({ pirate: "x" }, { pirate_id: 1 }, null, "some_table")).toEqual({
+      pirate_id: "x",
+    });
+  });
 });
 
 // ---- models pass unit tests ----

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -249,10 +249,13 @@ function buildIdIndex(yamls: Map<string, FixtureMap>): Map<string, Map<number, s
       // omits an explicit `id:` — `ActiveRecord::FixtureSet.identify(label)`
       // (CRC32 % MAX_ID). Numeric FK references in *other* fixtures
       // (`<%= identify(:george) %>`) round-trip to that implicit id, so the
-      // reverse lookup must include it. Explicit `id:` always wins over the
-      // CRC32 fallback.
-      const id = typeof row.id === "number" ? row.id : fixtureIdValue(name);
-      inner.set(id, [...(inner.get(id) ?? []), name]);
+      // reverse lookup must include it. CRC32 fallback ONLY when `id` is
+      // absent — an explicit non-numeric id (string PKs, CPK tables) means
+      // the row genuinely doesn't live in the numeric-id space, so leaving
+      // it unindexed is correct.
+      const id =
+        row.id === undefined ? fixtureIdValue(name) : typeof row.id === "number" ? row.id : null;
+      if (id !== null) inner.set(id, [...(inner.get(id) ?? []), name]);
     }
     idx.set(table, inner);
   }
@@ -379,7 +382,7 @@ export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, id
     const mapped = /^\w+$/.test(sym) ? resolveEnumSymbol(table, col, sym) : undefined;
     if (mapped === tsVal) return true;
     if (symMatch && mapped === undefined) {
-      notes.push(`enum-unmapped: ${attr}: ts=${tsVal} rails=${JSON.stringify(railsVal)} (add ENUM_MAPS["${table}"].${col})`); // prettier-ignore
+      notes.push(`enum-unmapped: ${attr}: ts=${tsVal} rails=${JSON.stringify(railsVal)} (add to ENUM_MAPS: ${table}.${col}.${sym} = ${tsVal})`); // prettier-ignore
       if (attrsSkipped) attrsSkipped.n++;
       return true;
     }

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -282,8 +282,14 @@ function normalizeDatetime(v: unknown): number | null {
   // Normalize: T-separator and force UTC when no offset is present. Rails
   // fixtures without a TZ marker mean "UTC" (that's how AR's adapters
   // store timestamps); JS `Date` would otherwise treat them as local time
-  // and the comparison would be host-dependent.
+  // and the comparison would be host-dependent. Date-only scalars
+  // (`YYYY-MM-DD`) get midnight-UTC so `Date.parse` doesn't choke on the
+  // bare `YYYY-MM-DDZ` shape it considers invalid.
   let iso = v.replace(" ", "T");
+  // Date-only check is strict (must be exactly `YYYY-MM-DD`) so lowercase
+  // `t` separators from `yaml` lib's !!timestamp output aren't mistaken
+  // for date-only and double-appended.
+  if (/^\d{4}-\d{2}-\d{2}$/.test(iso)) iso += "T00:00:00";
   if (!/[zZ]|[+\-]\d{2}:?\d{2}$/.test(iso)) iso += "Z";
   const t = Date.parse(iso);
   return Number.isFinite(t) ? t : null;
@@ -475,20 +481,26 @@ export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<str
     columns ? columns.has(`${k}_id`) : Object.hasOwn(tsRow, `${k}_id`);
   for (const [k, v] of Object.entries(railsRow)) {
     if (known(k)) { out[k] = v; continue; } // prettier-ignore
+    // Rails' `replace_belongs_to_keys` also handles polymorphic shorthand —
+    // `assoc: label (Type)` splits into `<col>` + `<assoc>_type`. Shared
+    // between the convention path and FK_OVERRIDES so an override on a
+    // polymorphic belongs_to doesn't drop the `_type` column.
+    const assignAssoc = (assocKey: string, fkCol: string): void => {
+      if (typeof v === "string") {
+        const m = /^(.*?)\s*\(([^)]+)\)\s*$/.exec(v);
+        if (m) { out[fkCol] = m[1]; out[`${assocKey}_type`] = m[2]; }
+        else out[fkCol] = v;
+      } else out[fkCol] = v as Row[string];
+    };
     // FK_OVERRIDES lets a fixture declare `assoc → column` when the shorthand
     // doesn't follow the `<assoc>_id` convention (e.g. `creator → captain_id`).
     const overrideCol = overrides[k];
     if (overrideCol && (columns ? columns.has(overrideCol) : Object.hasOwn(tsRow, overrideCol))) {
-      out[overrideCol] = v as Row[string];
+      assignAssoc(k, overrideCol);
       continue;
     }
     if (hasIdForm(k)) {
-      const idKey = `${k}_id`;
-      if (typeof v === "string") {
-        const m = /^(.*?)\s*\(([^)]+)\)\s*$/.exec(v);
-        if (m) { out[idKey] = m[1]; out[`${k}_type`] = m[2]; }
-        else out[idKey] = v;
-      } else out[idKey] = v as Row[string];
+      assignAssoc(k, `${k}_id`);
       continue;
     }
     // With a schema: drop as HABTM / unknown association (won't be a column on
@@ -567,7 +579,7 @@ export async function compareFile(yamlBase: string, yamlByTable: Map<string, Fix
       if (attr === "id") { if (tsRow.id === railsRow.id) r.attrsMatched++; continue; } // prettier-ignore
       const skipCounter = { n: 0 };
       const ok = compareValue(tsRow[attr], railsRow[attr], `${rowName}.${attr}`, idIndex, r.notes, snake, skipCounter); // prettier-ignore
-      if (skipCounter.n > 0) { r.attrsSkipped += skipCounter.n; r.attrsTotal--; continue; } // prettier-ignore
+      if (skipCounter.n > 0) { r.attrsSkipped += skipCounter.n; r.attrsTotal -= skipCounter.n; continue; } // prettier-ignore
       if (ok) r.attrsMatched++;
       else anyDiff = true;
     }
@@ -601,7 +613,7 @@ function formatLine(r: FileResult): string {
     r.yamlBase.padEnd(32) +
     (r.tsBase ?? "(missing)").padEnd(28) +
     `rows: ${r.rowsMatched}/${r.rowsTotal}`.padEnd(14) +
-    `attrs: ${r.attrsMatched}/${r.attrsTotal}${r.attrsSkipped ? ` (+${r.attrsSkipped} erb-skip)` : ""}`.padEnd(
+    `attrs: ${r.attrsMatched}/${r.attrsTotal}${r.attrsSkipped ? ` (+${r.attrsSkipped} skipped)` : ""}`.padEnd(
       30,
     ) +
     pct.padEnd(6) +

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -531,7 +531,12 @@ export async function compareFile(yamlBase: string, yamlByTable: Map<string, Fix
   const tsBase = existsSync(tsFile) ? `${kebab(snake)}.ts` : null;
   const r: FileResult = { yamlBase, tsBase, status: "MATCH", rowsMatched: 0, rowsTotal: 0, attrsMatched: 0, attrsTotal: 0, attrsSkipped: 0, schemaPorted: false, schemaExtras: 0, notes: [] }; // prettier-ignore
   if (prelimFailure) {
-    r.status = prelimFailure === "ERB-UNSUPPORTED" && ERB_ALLOW_LIST.has(snake) ? "ERB-ALLOWED" : prelimFailure; // prettier-ignore
+    // For ERB-ALLOWED files the TS side is the source of truth, so confirm
+    // the TS counterpart actually exists before silently promoting — if
+    // mixins.ts is deleted we want MISSING to surface, not a clean pass.
+    if (prelimFailure === "ERB-UNSUPPORTED" && ERB_ALLOW_LIST.has(snake)) {
+      r.status = tsBase ? "ERB-ALLOWED" : "MISSING";
+    } else r.status = prelimFailure;
     return r;
   }
   const railsRows = yamlByTable.get(snake)!;

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -30,13 +30,15 @@ type Status = "MATCH" | "MISSING" | "DIFF" | "ERB-UNSUPPORTED" | "ERB-ALLOWED" |
 // statically, with the original ERB intent preserved in a header comment).
 export const ERB_ALLOW_LIST = new Set<string>(["mixins", "paragraphs", "citations"]);
 
-// Per-table FK-column → target-table override map. Convention covers most
-// cases (column `foo_id` resolves to TS `ref("foos", …)`); declare an
-// override here when the column name doesn't match the target table — e.g.
-// `rich_person_id` on `peoples_treasures` points at `people`, not
-// `rich_people`. Consulted by canonicalizeRailsRow when rewriting
-// `assoc: label` shorthand into the `<col>_id` form so the per-attr diff
-// can resolve the FK through the right table's id index.
+// Per-table assoc-shorthand → FK-column override map. Mirrors Rails
+// `fixtures.rb#replace_belongs_to_keys`, which rewrites `pirate: blackbeard`
+// to `pirate_id` via the model's belongs_to reflection. We don't have the
+// reflection, so the convention `<assoc>_id` covers the common case and
+// this table holds explicit overrides for assocs whose FK column doesn't
+// follow it (e.g. a `creator:` shorthand in YAML that targets a `captain_id`
+// column on the TS row). Keys are the YAML association names; values are
+// the materialized FK column on the row. No entries shipped yet —
+// follow-up DIFF-reconcile PRs populate as needed.
 export const FK_OVERRIDES: Readonly<Record<string, Readonly<Record<string, string>>>> = {};
 
 // Per-table enum-symbol → integer map for `enum :status, [:proposed, …]`

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -288,7 +288,10 @@ function normalizeDatetime(v: unknown): number | null {
   // and the comparison would be host-dependent. Date-only scalars
   // (`YYYY-MM-DD`) get midnight-UTC so `Date.parse` doesn't choke on the
   // bare `YYYY-MM-DDZ` shape it considers invalid.
-  let iso = v.replace(" ", "T");
+  // ISO 8601 mandates an uppercase `T`, but yaml-lib's !!timestamp output
+  // uses lowercase `t`. V8 accepts both today; spec'd JS engines and
+  // stricter runtimes can return NaN. Normalize both space and `t` here.
+  let iso = v.replace(" ", "T").replace(/(\d)t(\d)/, "$1T$2");
   // Date-only check is strict (must be exactly `YYYY-MM-DD`) so lowercase
   // `t` separators from `yaml` lib's !!timestamp output aren't mistaken
   // for date-only and double-appended.

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -28,7 +28,11 @@ type Status = "MATCH" | "MISSING" | "DIFF" | "ERB-UNSUPPORTED" | "ERB-ALLOWED" |
 // them as expected gaps rather than failures. Per docs/fixtures-port-plan.md
 // — the TS side is the source of truth for these tables (rows expanded
 // statically, with the original ERB intent preserved in a header comment).
-export const ERB_ALLOW_LIST = new Set<string>(["mixins", "paragraphs", "citations"]);
+export const ERB_ALLOW_LIST: ReadonlySet<string> = new Set<string>([
+  "mixins",
+  "paragraphs",
+  "citations",
+]);
 
 // Per-table assoc-shorthand → FK-column override map. Mirrors Rails
 // `fixtures.rb#replace_belongs_to_keys`, which rewrites `pirate: blackbeard`
@@ -288,10 +292,13 @@ function normalizeDatetime(v: unknown): number | null {
   // and the comparison would be host-dependent. Date-only scalars
   // (`YYYY-MM-DD`) get midnight-UTC so `Date.parse` doesn't choke on the
   // bare `YYYY-MM-DDZ` shape it considers invalid.
-  // ISO 8601 mandates an uppercase `T`, but yaml-lib's !!timestamp output
-  // uses lowercase `t`. V8 accepts both today; spec'd JS engines and
-  // stricter runtimes can return NaN. Normalize both space and `t` here.
-  let iso = v.replace(" ", "T").replace(/(\d)t(\d)/, "$1T$2");
+  // ISO 8601 mandates uppercase `T` and `Z`, but yaml-lib's !!timestamp
+  // output uses lowercase. V8 accepts both today; spec'd JS engines and
+  // stricter runtimes can return NaN. Normalize both separators here.
+  let iso = v
+    .replace(" ", "T")
+    .replace(/(\d)t(\d)/, "$1T$2")
+    .replace(/z$/, "Z");
   // Date-only check is strict (must be exactly `YYYY-MM-DD`) so lowercase
   // `t` separators from `yaml` lib's !!timestamp output aren't mistaken
   // for date-only and double-appended.
@@ -479,7 +486,7 @@ export function schemaCheck(
 // prettier-ignore
 export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<string> | null, table: string = ""): Row {
   const out: Row = {};
-  const overrides = FK_OVERRIDES[table] ?? {};
+  const overrides: Readonly<Record<string, string>> = FK_OVERRIDES[table] ?? {};
   // Use Object.hasOwn for the schemaless tsRow probe so prototype keys
   // (`toString`, `constructor`, …) don't read as columns.
   const known = (k: string): boolean => (columns ? columns.has(k) : Object.hasOwn(tsRow, k));

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -237,6 +237,7 @@ function loadRailsYaml(file: string, basename: string): { ok: true; data: Fixtur
   return { ok: true, data: out };
 }
 
+export { buildIdIndex as buildIdIndexForTest };
 function buildIdIndex(yamls: Map<string, FixtureMap>): Map<string, Map<number, string[]>> {
   const idx = new Map<string, Map<number, string[]>>();
   for (const [table, rows] of yamls) {
@@ -353,20 +354,26 @@ export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, id
   // peel that off before retrying equality.
   const railsUnwrapped = unwrapSerializedYaml(railsVal);
   if (railsUnwrapped !== railsVal && tsVal === railsUnwrapped) return true;
-  // Enum: Rails `enum :status, [:proposed, …]` columns appear as `:foo`
-  // (YAML symbol) or plain string on the Rails side, integer on the TS side.
-  // With a registered mapping we resolve the symbol; without, treat as a
-  // soft skip so unregistered enums don't gate the strict flip.
+  // Enum: Rails `enum :status, [:proposed, …]` columns appear as either
+  // `:foo` (Ruby symbol literal) or a bare string on the Rails side, integer
+  // on the TS side. Resolution order:
+  //   1. Registered ENUM_MAPS entry — exact symbol↔int lookup either way.
+  //   2. Unambiguous `:foo` symbol form with no registry entry — soft-skip
+  //      as `enum-unmapped` so unported enums don't gate the strict flip.
+  //   3. Bare-string ↔ number — fall through to value-differs. Without the
+  //      leading `:` we can't tell an unmapped enum from a real mismatch
+  //      (e.g. `count: 5` vs `count: "five"`), and silent-passing would
+  //      mask data drift.
   if (typeof tsVal === "number" && typeof railsVal === "string") {
-    const sym = SYMBOL_RE.exec(railsVal)?.[1] ?? railsVal;
-    if (/^\w+$/.test(sym)) {
-      const mapped = resolveEnumSymbol(table, attr.split(".").pop() ?? attr, sym);
-      if (mapped === tsVal) return true;
-      if (mapped === undefined) {
-        notes.push(`enum-unmapped: ${attr}: ts=${tsVal} rails=${JSON.stringify(railsVal)} (add ENUM_MAPS["${table}"].${attr.split(".").pop()})`); // prettier-ignore
-        if (attrsSkipped) attrsSkipped.n++;
-        return true; // soft skip: don't fail the file on unmapped enums
-      }
+    const col = attr.split(".").pop() ?? attr;
+    const symMatch = SYMBOL_RE.exec(railsVal);
+    const sym = symMatch ? symMatch[1] : railsVal;
+    const mapped = /^\w+$/.test(sym) ? resolveEnumSymbol(table, col, sym) : undefined;
+    if (mapped === tsVal) return true;
+    if (symMatch && mapped === undefined) {
+      notes.push(`enum-unmapped: ${attr}: ts=${tsVal} rails=${JSON.stringify(railsVal)} (add ENUM_MAPS["${table}"].${col})`); // prettier-ignore
+      if (attrsSkipped) attrsSkipped.n++;
+      return true;
     }
   }
   notes.push(`value-differs: ${attr}: ts=${JSON.stringify(tsVal)} rails=${JSON.stringify(railsVal)}`); // prettier-ignore

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -21,7 +21,36 @@ const TS_DIR = path.join(ROOT, "packages/activerecord/src/test-helpers/fixtures"
 type Row = Record<string, unknown>;
 type FixtureMap = Record<string, Row>;
 // prettier-ignore
-type Status = "MATCH" | "MISSING" | "DIFF" | "ERB-UNSUPPORTED" | "YAML-PARSE-ERR" | "TS-IMPORT-ERR" | "TS-EXPORT-MISSING";
+type Status = "MATCH" | "MISSING" | "DIFF" | "ERB-UNSUPPORTED" | "ERB-ALLOWED" | "YAML-PARSE-ERR" | "TS-IMPORT-ERR" | "TS-EXPORT-MISSING";
+
+// Fixtures whose Rails YAML uses ERB constructs we don't reduce (binary
+// helpers, 1000+ row loops). Listed here so the PR-7b strict flip treats
+// them as expected gaps rather than failures. Per docs/fixtures-port-plan.md
+// — the TS side is the source of truth for these tables (rows expanded
+// statically, with the original ERB intent preserved in a header comment).
+export const ERB_ALLOW_LIST = new Set<string>(["mixins", "paragraphs", "citations"]);
+
+// Per-table FK-column → target-table override map. Convention covers most
+// cases (column `foo_id` resolves to TS `ref("foos", …)`); declare an
+// override here when the column name doesn't match the target table — e.g.
+// `rich_person_id` on `peoples_treasures` points at `people`, not
+// `rich_people`. Consulted by canonicalizeRailsRow when rewriting
+// `assoc: label` shorthand into the `<col>_id` form so the per-attr diff
+// can resolve the FK through the right table's id index.
+export const FK_OVERRIDES: Readonly<Record<string, Readonly<Record<string, string>>>> = {};
+
+// Per-table enum-symbol → integer map for `enum :status, [:proposed, …]`
+// columns. Rails YAML carries `status: :published` (or sometimes
+// `status: "proposed"`); the TS fixture carries the integer assigned by
+// the model's `enum` declaration. Lookups are best-effort: when a column
+// is registered, the comparator resolves symbol↔int; when it isn't, the
+// pair is reported as `enum-unmapped` and counted as a soft attribute skip
+// (not a DIFF). Maps are intentionally small — populating them is the
+// follow-up DIFF-reconcile PR. Keep this an `enums` registry and not a
+// general "I declare this string equals this number" knob.
+export const ENUM_MAPS: Readonly<
+  Record<string, Readonly<Record<string, Readonly<Record<string, number>>>>>
+> = {};
 
 // prettier-ignore
 interface FileResult { yamlBase: string; tsBase: string | null; status: Status; rowsMatched: number; rowsTotal: number; attrsMatched: number; attrsTotal: number; attrsSkipped: number; schemaPorted: boolean; schemaExtras: number; notes: string[]; }
@@ -213,7 +242,14 @@ function buildIdIndex(yamls: Map<string, FixtureMap>): Map<string, Map<number, s
   for (const [table, rows] of yamls) {
     const inner = new Map<number, string[]>();
     for (const [name, row] of Object.entries(rows)) {
-      if (typeof row.id === "number") inner.set(row.id, [...(inner.get(row.id) ?? []), name]);
+      // Rails fixtures.rb assigns each row an effective id even when the YAML
+      // omits an explicit `id:` — `ActiveRecord::FixtureSet.identify(label)`
+      // (CRC32 % MAX_ID). Numeric FK references in *other* fixtures
+      // (`<%= identify(:george) %>`) round-trip to that implicit id, so the
+      // reverse lookup must include it. Explicit `id:` always wins over the
+      // CRC32 fallback.
+      const id = typeof row.id === "number" ? row.id : fixtureIdValue(name);
+      inner.set(id, [...(inner.get(id) ?? []), name]);
     }
     idx.set(table, inner);
   }
@@ -225,8 +261,43 @@ export function isRefLike(v: unknown): v is { tableName: string; fixtureName: st
   return !!o && typeof o === "object" && typeof o.tableName === "string" && typeof o.fixtureName === "string"; // prettier-ignore
 }
 
+// `:foo` (Ruby symbol literal as YAML parses it: a string with a leading colon).
+const SYMBOL_RE = /^:(\w+)$/;
+// "YYYY-MM-DD" optionally followed by [T ]HH:MM:SS[.fff][TZ]. The YAML lib
+// already produces JS `Date` for tagged !!timestamp scalars, but Rails
+// often serializes datetimes as plain strings in fixtures (and AR's own
+// fixture loader re-parses them at insert time) — normalize both sides to
+// epoch ms before comparing so 2003-07-16T15:28:11+01:00 ≡ 2003-07-16 14:28:11.
+const DATETIMEISH_RE = /^\d{4}-\d{2}-\d{2}([T ]\d{2}:\d{2}:\d{2}(\.\d+)?([+\-]\d{2}:?\d{2}|Z)?)?$/i;
+// Rails' YAML coder emits `--- <scalar>\n...\n` for `serialize :col` columns
+// stored as YAML literals. The TS fixture carries the deserialized scalar.
+const SERIALIZED_YAML_RE = /^---\s*([\s\S]*?)\n\.\.\.\n?$/;
+
+function normalizeDatetime(v: unknown): number | null {
+  if (v instanceof Date) return v.getTime();
+  if (typeof v !== "string" || !DATETIMEISH_RE.test(v)) return null;
+  // Normalize: T-separator and force UTC when no offset is present. Rails
+  // fixtures without a TZ marker mean "UTC" (that's how AR's adapters
+  // store timestamps); JS `Date` would otherwise treat them as local time
+  // and the comparison would be host-dependent.
+  let iso = v.replace(" ", "T");
+  if (!/[zZ]|[+\-]\d{2}:?\d{2}$/.test(iso)) iso += "Z";
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? t : null;
+}
+
+function unwrapSerializedYaml(v: unknown): unknown {
+  if (typeof v !== "string") return v;
+  const m = SERIALIZED_YAML_RE.exec(v);
+  return m ? m[1] : v;
+}
+
+function resolveEnumSymbol(table: string, attr: string, symbol: string): number | undefined {
+  return ENUM_MAPS[table]?.[attr]?.[symbol];
+}
+
 // prettier-ignore
-export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, idIndex: Map<string, Map<number, string[]>>, notes: string[]): boolean {
+export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, idIndex: Map<string, Map<number, string[]>>, notes: string[], table: string = "", attrsSkipped?: { n: number }): boolean {
   if (isRefLike(tsVal)) {
     const { tableName, fixtureName } = tsVal;
     if (typeof railsVal === "number") {
@@ -255,6 +326,49 @@ export function compareValue(tsVal: unknown, railsVal: unknown, attr: string, id
   if (Array.isArray(tsVal) && Array.isArray(railsVal)
     && tsVal.length === railsVal.length && tsVal.every((v, i) => v === railsVal[i]))
     return true;
+  // Datetime tolerance: round to second-precision since Rails fixtures often
+  // carry sub-second fractions the TS side trims when materializing values.
+  const tsT = normalizeDatetime(tsVal);
+  const railsT = normalizeDatetime(railsVal);
+  if (tsT !== null && railsT !== null && Math.floor(tsT / 1000) === Math.floor(railsT / 1000))
+    return true;
+  // Mixed datetime ↔ time-of-day: TIME columns (e.g. `bonus_time`) carry just
+  // `HH:MM:SS` in the TS fixture, but the YAML side often has a full datetime
+  // because Rails synthesizes a date prefix. Compare hours/min/sec in UTC.
+  const timeOnly = (v: unknown): [number, number, number] | null =>
+    typeof v === "string" && /^\d{2}:\d{2}:\d{2}$/.test(v)
+      ? (v.split(":").map(Number) as [number, number, number])
+      : null;
+  const tsTime = timeOnly(tsVal);
+  const railsTime = timeOnly(railsVal);
+  const utcHMS = (t: number): [number, number, number] => {
+    const d = new Date(t);
+    return [d.getUTCHours(), d.getUTCMinutes(), d.getUTCSeconds()];
+  };
+  const eqHMS = (a: [number, number, number], b: [number, number, number]): boolean =>
+    a[0] === b[0] && a[1] === b[1] && a[2] === b[2];
+  if (tsTime && railsT !== null && eqHMS(tsTime, utcHMS(railsT))) return true;
+  if (railsTime && tsT !== null && eqHMS(railsTime, utcHMS(tsT))) return true;
+  // `serialize :col` columns: Rails YAML wraps the value in `--- … \n…\n`;
+  // peel that off before retrying equality.
+  const railsUnwrapped = unwrapSerializedYaml(railsVal);
+  if (railsUnwrapped !== railsVal && tsVal === railsUnwrapped) return true;
+  // Enum: Rails `enum :status, [:proposed, …]` columns appear as `:foo`
+  // (YAML symbol) or plain string on the Rails side, integer on the TS side.
+  // With a registered mapping we resolve the symbol; without, treat as a
+  // soft skip so unregistered enums don't gate the strict flip.
+  if (typeof tsVal === "number" && typeof railsVal === "string") {
+    const sym = SYMBOL_RE.exec(railsVal)?.[1] ?? railsVal;
+    if (/^\w+$/.test(sym)) {
+      const mapped = resolveEnumSymbol(table, attr.split(".").pop() ?? attr, sym);
+      if (mapped === tsVal) return true;
+      if (mapped === undefined) {
+        notes.push(`enum-unmapped: ${attr}: ts=${tsVal} rails=${JSON.stringify(railsVal)} (add ENUM_MAPS["${table}"].${attr.split(".").pop()})`); // prettier-ignore
+        if (attrsSkipped) attrsSkipped.n++;
+        return true; // soft skip: don't fail the file on unmapped enums
+      }
+    }
+  }
   notes.push(`value-differs: ${attr}: ts=${JSON.stringify(tsVal)} rails=${JSON.stringify(railsVal)}`); // prettier-ignore
   return false;
 }
@@ -342,8 +456,9 @@ export function schemaCheck(
  * column list AND the `_id` form is missing do we drop the key as HABTM-like.
  */
 // prettier-ignore
-export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<string> | null): Row {
+export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<string> | null, table: string = ""): Row {
   const out: Row = {};
+  const overrides = FK_OVERRIDES[table] ?? {};
   // Use Object.hasOwn for the schemaless tsRow probe so prototype keys
   // (`toString`, `constructor`, …) don't read as columns.
   const known = (k: string): boolean => (columns ? columns.has(k) : Object.hasOwn(tsRow, k));
@@ -351,6 +466,13 @@ export function canonicalizeRailsRow(railsRow: Row, tsRow: Row, columns: Set<str
     columns ? columns.has(`${k}_id`) : Object.hasOwn(tsRow, `${k}_id`);
   for (const [k, v] of Object.entries(railsRow)) {
     if (known(k)) { out[k] = v; continue; } // prettier-ignore
+    // FK_OVERRIDES lets a fixture declare `assoc → column` when the shorthand
+    // doesn't follow the `<assoc>_id` convention (e.g. `creator → captain_id`).
+    const overrideCol = overrides[k];
+    if (overrideCol && (columns ? columns.has(overrideCol) : Object.hasOwn(tsRow, overrideCol))) {
+      out[overrideCol] = v as Row[string];
+      continue;
+    }
     if (hasIdForm(k)) {
       const idKey = `${k}_id`;
       if (typeof v === "string") {
@@ -374,7 +496,10 @@ export async function compareFile(yamlBase: string, yamlByTable: Map<string, Fix
   const tsFile = path.join(TS_DIR, `${kebab(snake)}.ts`);
   const tsBase = existsSync(tsFile) ? `${kebab(snake)}.ts` : null;
   const r: FileResult = { yamlBase, tsBase, status: "MATCH", rowsMatched: 0, rowsTotal: 0, attrsMatched: 0, attrsTotal: 0, attrsSkipped: 0, schemaPorted: false, schemaExtras: 0, notes: [] }; // prettier-ignore
-  if (prelimFailure) { r.status = prelimFailure; return r; } // prettier-ignore
+  if (prelimFailure) {
+    r.status = prelimFailure === "ERB-UNSUPPORTED" && ERB_ALLOW_LIST.has(snake) ? "ERB-ALLOWED" : prelimFailure; // prettier-ignore
+    return r;
+  }
   const railsRows = yamlByTable.get(snake)!;
   r.rowsTotal = Object.keys(railsRows).length;
   if (!tsBase) { r.status = "MISSING"; return r; } // prettier-ignore
@@ -414,7 +539,7 @@ export async function compareFile(yamlBase: string, yamlByTable: Map<string, Fix
       anyDiff = true;
       continue;
     }
-    const railsRow = canonicalizeRailsRow(railsRowRaw, tsRow, cols);
+    const railsRow = canonicalizeRailsRow(railsRowRaw, tsRow, cols, snake);
     r.rowsMatched++;
     if ("id" in railsRow && (!("id" in tsRow) || tsRow.id !== railsRow.id)) {
       r.notes.push(`id-divergence: ${rowName} ts=${String(tsRow.id)} rails=${String(railsRow.id)}`);
@@ -431,8 +556,10 @@ export async function compareFile(yamlBase: string, yamlByTable: Map<string, Fix
       // still flag missing-in-ts when the TS row drops the attribute entirely.
       if (railsRow[attr] === ERB_SKIP_SENTINEL) { r.attrsSkipped++; r.attrsTotal--; continue; } // prettier-ignore
       if (attr === "id") { if (tsRow.id === railsRow.id) r.attrsMatched++; continue; } // prettier-ignore
-      if (compareValue(tsRow[attr], railsRow[attr], `${rowName}.${attr}`, idIndex, r.notes))
-        r.attrsMatched++; // prettier-ignore
+      const skipCounter = { n: 0 };
+      const ok = compareValue(tsRow[attr], railsRow[attr], `${rowName}.${attr}`, idIndex, r.notes, snake, skipCounter); // prettier-ignore
+      if (skipCounter.n > 0) { r.attrsSkipped += skipCounter.n; r.attrsTotal--; continue; } // prettier-ignore
+      if (ok) r.attrsMatched++;
       else anyDiff = true;
     }
   }
@@ -510,11 +637,17 @@ async function main(): Promise<void> {
     }
   }
   const n = (s: Status): number => results.filter((r) => r.status === s).length;
-  const other = results.length - n("MATCH") - n("DIFF") - n("MISSING") - n("ERB-UNSUPPORTED");
+  const other =
+    results.length -
+    n("MATCH") -
+    n("DIFF") -
+    n("MISSING") -
+    n("ERB-UNSUPPORTED") -
+    n("ERB-ALLOWED");
   const evaluated = results.filter(schemaEvaluated);
   const ported = evaluated.filter((r) => r.schemaPorted).length;
   const withExtras = evaluated.filter((r) => r.schemaExtras > 0).length;
-  console.log(`\n${results.length} files — match=${n("MATCH")} diff=${n("DIFF")} missing=${n("MISSING")} erb-unsupported=${n("ERB-UNSUPPORTED")} other=${other}`); // prettier-ignore
+  console.log(`\n${results.length} files — match=${n("MATCH")} diff=${n("DIFF")} missing=${n("MISSING")} erb-unsupported=${n("ERB-UNSUPPORTED")} erb-allowed=${n("ERB-ALLOWED")} other=${other}`); // prettier-ignore
   console.log(
     `schema — ported=${ported}/${evaluated.length} extras-flagged=${withExtras} (skipped ${results.length - evaluated.length})`,
   );


### PR DESCRIPTION
## Summary

Lands the four compare-script enhancements called out in `docs/fixtures-port-plan.md` as blocking the PR 7b strict-fail flip, plus the ERB allow-list for documented stragglers.

- **HABTM implicit-id index**: `buildIdIndex` now also maps the CRC32 id Rails assigns when a fixture omits explicit `id:`, so numeric FK references into label-only fixtures resolve correctly.
- **enum-symbol comparator**: `ENUM_MAPS` registry resolves `:symbol` ↔ int for `enum :status, [...]` columns. Unregistered pairs report `enum-unmapped` and count as soft skips, so unported enum metadata doesn't gate the strict flip.
- **`FK_OVERRIDES` scaffold**: per-table column override for fixtures whose Rails shorthand (`assoc: label`) doesn't follow `<assoc>_id` (e.g. `rich_person_id → people`). No entries populated yet — fixture-side reconcile is the next PR.
- **datetime/YAML tolerance**: second-precision datetime equality with UTC default when no offset is given, time-of-day comparison against full datetimes (TIME columns like `bonus_time`), and unwrapping of Rails' `--- … \n…\n` `serialize :col` YAML envelope.
- **ERB allow-list**: `mixins`/`paragraphs`/`citations` now tagged `ERB-ALLOWED` instead of `ERB-UNSUPPORTED`, letting PR 7b flip strict without re-classifying these documented stragglers as failures.

## Results

`pnpm fixtures:compare` before vs. after:

| metric           | before | after |
|------------------|-------:|------:|
| match            |    101 |   109 |
| diff             |     18 |    10 |
| erb-unsupported  |      3 |     0 |
| erb-allowed      |      — |     3 |

The remaining 10 DIFFs are all fixture-side reconciles (enum maps for `books`, extra columns on `topics`/`other_topics`/`developers`/`sponsors`, etc.) and tracked explicitly in the refreshed status block at the top of `docs/fixtures-port-plan.md`. Those become the follow-up DIFF-reconcile PR; this one is the comparator infrastructure they ride on.

## Test plan

- [x] `pnpm vitest run scripts/fixtures-compare/compare.test.ts` — 53/53 pass (added coverage for datetime/serialize/time-of-day tolerance, enum-unmapped soft-skip behavior, ERB allow-list status promotion, and the `table`-threading on `canonicalizeRailsRow`).
- [x] `pnpm fixtures:compare` — soft-mode counters above; no new runtime failures.
- [x] `pnpm lint` — clean.
- [x] Diff size: 258 LOC (under the 300-LOC ceiling).