### PR TITLE
feat(rack): multipart/parser part A — state machine + parse/result/dequote

### DIFF
--- a/packages/rack/src/multipart.ts
+++ b/packages/rack/src/multipart.ts
@@ -1,34 +1,19 @@
 import { UploadedFile } from "./multipart/uploaded-file.js";
 
 export { UploadedFile } from "./multipart/uploaded-file.js";
+import {
+  MultipartPartLimitError,
+  MultipartTotalPartLimitError,
+  BoundaryTooLongError,
+  EmptyContentError,
+} from "./multipart/parser.js";
 
-export class MultipartPartLimitError extends Error {
-  constructor(message = "exceeded multipart part limit") {
-    super(message);
-    this.name = "MultipartPartLimitError";
-  }
-}
-
-export class MultipartTotalPartLimitError extends Error {
-  constructor(message = "exceeded multipart total part limit") {
-    super(message);
-    this.name = "MultipartTotalPartLimitError";
-  }
-}
-
-export class BoundaryTooLongError extends Error {
-  constructor(message = "multipart boundary is too long") {
-    super(message);
-    this.name = "BoundaryTooLongError";
-  }
-}
-
-export class EmptyContentError extends Error {
-  constructor(message = "bad content body") {
-    super(message);
-    this.name = "EmptyContentError";
-  }
-}
+export {
+  MultipartPartLimitError,
+  MultipartTotalPartLimitError,
+  BoundaryTooLongError,
+  EmptyContentError,
+} from "./multipart/parser.js";
 
 export class MultipartBufferedMimeDataError extends Error {
   constructor(message = "exceeded buffered MIME data size limit") {

--- a/packages/rack/src/multipart/parser.test.ts
+++ b/packages/rack/src/multipart/parser.test.ts
@@ -11,7 +11,7 @@ import {
 import { QueryParser } from "../query-parser.js";
 
 const qp = QueryParser.makeDefault(100);
-const noopIo = { read: () => null as string | null };
+const noopIo = { read: (_size: number) => null as string | null };
 
 describe("Rack::Multipart::Parser", () => {
   it("returns nil if the content type is not multipart", () => {

--- a/packages/rack/src/multipart/parser.test.ts
+++ b/packages/rack/src/multipart/parser.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  Parser,
+  BoundaryTooLongError,
+  EmptyContentError,
+  MultipartPartLimitError,
+  MultipartTotalPartLimitError,
+  EOL,
+  MULTIPART,
+} from "./parser.js";
+import { QueryParser } from "../query-parser.js";
+
+const qp = QueryParser.makeDefault(100);
+const noopIo = { read: () => null as string | null };
+
+describe("Rack::Multipart::Parser", () => {
+  it("returns nil if the content type is not multipart", () => {
+    expect(Parser.parseBoundary("application/x-www-form-urlencoded")).toBeNull();
+  });
+
+  it("parses boundary from multipart/form-data", () => {
+    expect(Parser.parseBoundary("multipart/form-data; boundary=AaB03x")).toBe("AaB03x");
+  });
+
+  it("parses quoted boundary", () => {
+    expect(Parser.parseBoundary('multipart/form-data; boundary="AaB03x"')).toBe("AaB03x");
+  });
+
+  it("returns EMPTY for zero content length", () => {
+    const r = Parser.parse(noopIo, 0, "multipart/form-data; boundary=x", null, 1024, qp);
+    expect(r.params).toBeNull();
+    expect(r.tmpFiles).toEqual([]);
+  });
+
+  it("returns EMPTY when no boundary in content type", () => {
+    expect(Parser.parse(noopIo, null, "multipart/form-data", null, 1024, qp).params).toBeNull();
+  });
+
+  it("raises an exception if boundary is too long", () => {
+    expect(() =>
+      Parser.parse(noopIo, null, `multipart/form-data; boundary=${"A".repeat(71)}`, null, 1024, qp),
+    ).toThrow(BoundaryTooLongError);
+  });
+
+  it("dequote strips surrounding quotes", () => {
+    expect(new Parser("b", null, 1024, qp)._dequote('"hello"')).toBe("hello");
+  });
+
+  it("dequote handles backslash escapes", () => {
+    expect(new Parser("b", null, 1024, qp)._dequote('"hel\\"lo"')).toBe('hel"lo');
+  });
+
+  it("dequote returns unquoted string unchanged", () => {
+    expect(new Parser("b", null, 1024, qp)._dequote("plain")).toBe("plain");
+  });
+
+  it("EOL is CRLF", () => expect(EOL).toBe("\r\n"));
+  it("MULTIPART matches multipart content types", () => {
+    expect(MULTIPART.test("multipart/form-data; boundary=x")).toBe(true);
+    expect(MULTIPART.test("text/plain")).toBe(false);
+  });
+  it("BoundaryTooLongError name", () =>
+    expect(new BoundaryTooLongError().name).toBe("BoundaryTooLongError"));
+  it("EmptyContentError name", () =>
+    expect(new EmptyContentError().name).toBe("EmptyContentError"));
+  it("MultipartPartLimitError name", () =>
+    expect(new MultipartPartLimitError().name).toBe("MultipartPartLimitError"));
+  it("MultipartTotalPartLimitError name", () =>
+    expect(new MultipartTotalPartLimitError().name).toBe("MultipartTotalPartLimitError"));
+});

--- a/packages/rack/src/multipart/parser.ts
+++ b/packages/rack/src/multipart/parser.ts
@@ -1,0 +1,165 @@
+import { QueryParser } from "../query-parser.js";
+
+// ── Error classes ─────────────────────────────────────────────────────────────
+
+export class MultipartPartLimitError extends Error {
+  constructor(message = "Maximum file multiparts in content reached") {
+    super(message);
+    this.name = "MultipartPartLimitError";
+  }
+}
+
+export class MultipartTotalPartLimitError extends Error {
+  constructor(message = "Maximum total multiparts in content reached") {
+    super(message);
+    this.name = "MultipartTotalPartLimitError";
+  }
+}
+
+export class EmptyContentError extends Error {
+  constructor(message = "bad content body") {
+    super(message);
+    this.name = "EmptyContentError";
+  }
+}
+
+export class BoundaryTooLongError extends Error {
+  constructor(message = "multipart boundary is too long") {
+    super(message);
+    this.name = "BoundaryTooLongError";
+  }
+}
+
+// ── Module-level constants ────────────────────────────────────────────────────
+
+export const EOL = "\r\n";
+export const MULTIPART = /^multipart\/.*boundary="?([^";,]+)"?/i;
+export const MULTIPART_CONTENT_TYPE = new RegExp(`Content-Type: (.*)${EOL}`, "i");
+export const MULTIPART_CONTENT_DISPOSITION = new RegExp(
+  `Content-Disposition:(.*)(?=${EOL}(\\S|$))`,
+  "i",
+);
+export const MULTIPART_CONTENT_ID = new RegExp(`Content-ID:\\s*([^${EOL}]*)`, "i");
+
+// ── Result type ───────────────────────────────────────────────────────────────
+
+export interface MultipartInfo {
+  params: Record<string, any> | null;
+  tmpFiles: any[];
+}
+
+const EMPTY: MultipartInfo = { params: null, tmpFiles: [] };
+Object.freeze(EMPTY.tmpFiles);
+Object.freeze(EMPTY);
+
+// ── Parser ────────────────────────────────────────────────────────────────────
+
+type State = "FAST_FORWARD" | "CONSUME_TOKEN" | "MIME_HEAD" | "MIME_BODY" | "DONE";
+
+export class Parser {
+  static readonly BUFSIZE = 1_048_576;
+  static readonly TEXT_PLAIN = "text/plain";
+
+  /** @internal */
+  state: State = "FAST_FORWARD";
+
+  private _queryParser: QueryParser;
+  private _params: ReturnType<QueryParser["makeParams"]>;
+  private _bufsize: number;
+
+  static parseBoundary(contentType: string | null | undefined): string | null {
+    if (!contentType) return null;
+    const m = MULTIPART.exec(contentType);
+    return m ? m[1] : null;
+  }
+
+  static parse(
+    io: { read(size: number): string | null },
+    contentLength: number | null,
+    contentType: string,
+    tmpfile: ((filename: string, ct: string) => any) | null,
+    bufsize: number,
+    qp: QueryParser,
+  ): MultipartInfo {
+    if (contentLength === 0) return EMPTY;
+    const boundary = Parser.parseBoundary(contentType);
+    if (!boundary) return EMPTY;
+    if (boundary.length > 70) {
+      throw new BoundaryTooLongError(
+        `multipart boundary size too large (${boundary.length} characters)`,
+      );
+    }
+    const parser = new Parser(boundary, tmpfile, bufsize, qp);
+    parser.parse(io);
+    return parser.result();
+  }
+
+  constructor(
+    _boundary: string,
+    _tmpfile: ((filename: string, ct: string) => any) | null,
+    bufsize: number,
+    queryParser: QueryParser,
+  ) {
+    this._queryParser = queryParser;
+    this._params = queryParser.makeParams();
+    this._bufsize = bufsize;
+    // Part B: SBuf + regex setup
+  }
+
+  parse(io: { read(size: number): string | null }): void {
+    this._readData(io);
+    while (true) {
+      let status: void | "want_read";
+      switch (this.state) {
+        case "FAST_FORWARD":
+          status = this._handleFastForward();
+          break;
+        case "CONSUME_TOKEN":
+          status = this._handleConsumeToken();
+          break;
+        case "MIME_HEAD":
+          status = this._handleMimeHead();
+          break;
+        case "MIME_BODY":
+          status = this._handleMimeBody();
+          break;
+        default:
+          return;
+      }
+      if (status === "want_read") this._readData(io);
+    }
+  }
+
+  result(): MultipartInfo {
+    // Part B: Collector iteration + tagMultipartEncoding
+    throw new globalThis.Error("not yet implemented (Part B)");
+  }
+
+  /** @internal From WEBrick::HTTPUtils */
+  _dequote(str: string): string {
+    const m = /^"(.*)"$/.exec(str);
+    return (m ? m[1] : str).replace(/\\(.)/g, "$1");
+  }
+
+  // ── Part B stubs ─────────────────────────────────────────────────────────────
+
+  private _readData(_io: { read(size: number): string | null }): void {
+    throw new globalThis.Error("not yet implemented (Part B)");
+  }
+
+  private _handleFastForward(): void | "want_read" {
+    throw new globalThis.Error("not yet implemented (Part B)");
+  }
+
+  private _handleConsumeToken(): void {
+    throw new globalThis.Error("not yet implemented (Part B)");
+  }
+
+  private _handleMimeHead(): void | "want_read" {
+    throw new globalThis.Error("not yet implemented (Part B)");
+  }
+
+  private _handleMimeBody(): void | "want_read" {
+    throw new globalThis.Error("not yet implemented (Part B)");
+  }
+}

--- a/packages/rack/src/multipart/parser.ts
+++ b/packages/rack/src/multipart/parser.ts
@@ -76,7 +76,7 @@ export class Parser {
   static parse(
     io: { read(size: number): string | null },
     contentLength: number | null,
-    contentType: string,
+    contentType: string | null | undefined,
     tmpfile: ((filename: string, ct: string) => any) | null,
     bufsize: number,
     qp: QueryParser,


### PR DESCRIPTION
## Summary

- Ports \`Rack::Multipart::Parser\` Part A from \`vendor/rack/lib/rack/multipart/parser.rb\`
- Implements: error classes (\`MultipartPartLimitError\`, \`MultipartTotalPartLimitError\`, \`EmptyContentError\`, \`BoundaryTooLongError\`), module-level constants (\`EOL\`, \`MULTIPART\`, \`MULTIPART_CONTENT_TYPE\`, \`MULTIPART_CONTENT_DISPOSITION\`, \`MULTIPART_CONTENT_ID\`), \`MultipartInfo\` interface, \`Parser\` class (\`parseBoundary\`, \`parse\` static factory, constructor, \`parse\` instance state machine loop, \`_dequote\`)
- \`result()\` is **present but stubbed** — it depends on \`Collector\` (Part B); throws \`"not yet implemented (Part B)"\`
- State machine handlers (\`_handleFastForward\`, \`_handleConsumeToken\`, \`_handleMimeHead\`, \`_handleMimeBody\`), \`_readData\`, and buffer scanning are all Part B stubs
- \`multipart.ts\` now re-exports the four error classes from \`multipart/parser.ts\` (canonical definition per Rails layout) — fixes prior instanceof fragility
- 15 passing tests covering \`parseBoundary\`, \`parse\` static factory (zero content length, no boundary, boundary-too-long), \`_dequote\`, constants, and error class names

## Follow-ups

- Slot 3 (Part B): \`SBuf\` + \`_handleFastForward\` / \`_handleConsumeToken\` / \`_handleMimeHead\` / \`_handleMimeBody\` + \`_consumeBoundary\` + \`BoundedIO\` + \`Collector\` + MIME header parsing + \`result()\` implementation + encoding helpers + limits