### PR TITLE
feat(rack): request predicates + accessors — isLink/Trace/Unlink, referer, logger, contentCharset, hostname, serverName (slot 7)

### DIFF
--- a/packages/rack/src/request.test.ts
+++ b/packages/rack/src/request.test.ts
@@ -665,6 +665,11 @@ describe("RackRequestTest", () => {
   it("extract referrer correctly", () => {
     const req = makeReq("/", { HTTP_REFERER: "http://example.com/page" });
     expect(req.referrer).toBe("http://example.com/page");
+    expect(req.referer).toBe("http://example.com/page");
+
+    const req2 = makeReq("/");
+    expect(req2.referer).toBeNull();
+    expect(req2.referrer).toBeNull();
   });
 
   it("extract user agent correctly", () => {
@@ -1387,14 +1392,6 @@ describe("RackRequestTest", () => {
     expect(new Request({ REQUEST_METHOD: "TRACE" }).isLink()).toBe(false);
     expect(new Request({ REQUEST_METHOD: "UNLINK" }).isUnlink()).toBe(true);
     expect(new Request({ REQUEST_METHOD: "UNLINK" }).isLink()).toBe(false);
-  });
-
-  it("extract referrer correctly", () => {
-    const req = makeReq("/", { HTTP_REFERER: "/some/path" });
-    expect(req.referer).toBe("/some/path");
-
-    const req2 = makeReq("/");
-    expect(req2.referer).toBeNull();
   });
 
   it("return the logger from the env", () => {

--- a/packages/rack/src/request.test.ts
+++ b/packages/rack/src/request.test.ts
@@ -1379,4 +1379,55 @@ describe("RackRequestTest", () => {
     expect([params["foo"], params["wun"]]).toEqual(["baz", "der"]);
     expect([params["bar"], params["foo"], params["wun"]]).toEqual(["ful", "baz", "der"]);
   });
+
+  it("respond to isLink, isTrace, isUnlink", () => {
+    expect(new Request({ REQUEST_METHOD: "LINK" }).isLink()).toBe(true);
+    expect(new Request({ REQUEST_METHOD: "LINK" }).isTrace()).toBe(false);
+    expect(new Request({ REQUEST_METHOD: "TRACE" }).isTrace()).toBe(true);
+    expect(new Request({ REQUEST_METHOD: "TRACE" }).isLink()).toBe(false);
+    expect(new Request({ REQUEST_METHOD: "UNLINK" }).isUnlink()).toBe(true);
+    expect(new Request({ REQUEST_METHOD: "UNLINK" }).isLink()).toBe(false);
+  });
+
+  it("extract referrer correctly", () => {
+    const req = makeReq("/", { HTTP_REFERER: "/some/path" });
+    expect(req.referer).toBe("/some/path");
+
+    const req2 = makeReq("/");
+    expect(req2.referer).toBeNull();
+  });
+
+  it("return the logger from the env", () => {
+    const fakeLogger = { info: () => {} };
+    const req = new Request({ "rack.logger": fakeLogger });
+    expect(req.logger).toBe(fakeLogger);
+
+    const req2 = new Request({});
+    expect(req2.logger).toBeNull();
+  });
+
+  it("return content_charset from media type params", () => {
+    const req = new Request({
+      REQUEST_METHOD: "POST",
+      CONTENT_TYPE: "text/plain;charset=utf-8",
+    });
+    expect(req.contentCharset).toBe("utf-8");
+
+    const req2 = new Request({ REQUEST_METHOD: "GET" });
+    expect(req2.contentCharset).toBeNull();
+  });
+
+  it("return server_name from the env", () => {
+    const req = new Request({ SERVER_NAME: "example.org", SERVER_PORT: "9292" });
+    expect(req.serverName).toBe("example.org");
+
+    const req2 = new Request({});
+    expect(req2.serverName).toBeNull();
+  });
+
+  it("return hostname from authority", () => {
+    expect(makeReq("/", { HTTP_HOST: "example.org" }).hostname).toBe("example.org");
+    expect(makeReq("/", { HTTP_HOST: "example.org:8080" }).hostname).toBe("example.org");
+    expect(makeReq("/", { SERVER_NAME: "myserver", SERVER_PORT: "80" }).hostname).toBe("myserver");
+  });
 });

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -274,8 +274,12 @@ export class Request {
     return `${this.scriptName}${this.pathInfo}${qs ? "?" + qs : ""}`;
   }
 
+  get referer(): string | null {
+    return this.env["HTTP_REFERER"] ?? null;
+  }
+
   get referrer(): string | null {
-    return this.env["HTTP_REFERER"] || null;
+    return this.referer;
   }
 
   get userAgent(): string | null {
@@ -659,10 +663,6 @@ export class Request {
   }
   isUnlink(): boolean {
     return this.requestMethod === UNLINK;
-  }
-
-  get referer(): string | null {
-    return this.env["HTTP_REFERER"] ?? null;
   }
 
   get logger(): any {

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -10,6 +10,7 @@ import {
   RACK_INPUT,
   RACK_SESSION,
   RACK_SESSION_OPTIONS,
+  RACK_LOGGER,
   HTTP_HOST,
   HTTP_PORT,
   HTTPS,
@@ -23,6 +24,9 @@ import {
   DELETE,
   HEAD,
   OPTIONS,
+  LINK,
+  TRACE,
+  UNLINK,
   RACK_REQUEST_QUERY_HASH,
   RACK_REQUEST_QUERY_STRING,
   RACK_REQUEST_FORM_HASH,
@@ -646,5 +650,34 @@ export class Request {
   }
   isOptions(): boolean {
     return this.requestMethod === OPTIONS;
+  }
+  isLink(): boolean {
+    return this.requestMethod === LINK;
+  }
+  isTrace(): boolean {
+    return this.requestMethod === TRACE;
+  }
+  isUnlink(): boolean {
+    return this.requestMethod === UNLINK;
+  }
+
+  get referer(): string | null {
+    return this.env["HTTP_REFERER"] ?? null;
+  }
+
+  get logger(): any {
+    return this.env[RACK_LOGGER] ?? null;
+  }
+
+  get contentCharset(): string | null {
+    return this.mediaTypeParams["charset"] ?? null;
+  }
+
+  get hostname(): string | null {
+    return splitAuthority(this.authority)[1];
+  }
+
+  get serverName(): string | null {
+    return this.env[SERVER_NAME] ?? null;
   }
 }


### PR DESCRIPTION
## Summary

- Adds `isLink()`, `isTrace()`, `isUnlink()` HTTP method predicates alongside existing `isGet/Post/Put/...`
- Adds `referer` getter (Rails also defines `referrer` alias; our existing `referrer` serves that)
- Adds `logger` getter (`rack.logger` env key)
- Adds `contentCharset` getter (`mediaTypeParams['charset']`)
- Adds `hostname` getter (`splitAuthority(authority)[1]` — strips IPv6 brackets)
- Adds `serverName` getter (`SERVER_NAME` env key)
- 126 tests pass; 84 LOC

## Test plan

- [ ] `pnpm vitest run packages/rack/src/request.test.ts` — all 126 pass