### PR TITLE
feat(activerecord): migrate relation-scoping.test.ts to createPooledTestAdapter (Bug 2 proof)

### DIFF
--- a/packages/activerecord/src/scoping/relation-scoping.test.ts
+++ b/packages/activerecord/src/scoping/relation-scoping.test.ts
@@ -1,54 +1,51 @@
 /**
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
- *
- * TODO: migrate to createPooledTestAdapter() after the PG withClient race
- * fix lands. NestedRelationScopingTest > "merge inner scope has priority"
- * issues Promise.all concurrent writes; under a pinned TX the PG adapter's
- * withClient (postgresql-adapter.ts withClient / _acquireFreshClient) can
- * fan a single logical TX across multiple pg.PoolClients, producing
- * 08P01 / 25P02 races. See the closed prior batch-1 attempts #2250 and
- * #2253 for the exact failure mode. Pool-layer pin lookup is already
- * centralized (#2258); the remaining work is in the PG adapter.
  */
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base, Range, RecordNotFound } from "../index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "../test-adapter.js";
+import { createPooledTestAdapter, type SidecarAdapter } from "../test-adapter.js";
 import { defineSchema } from "../test-helpers/define-schema.js";
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import type { DatabaseAdapter } from "../adapter.js";
 
-let _adapter: TestDatabaseAdapter;
+let _adapter: SidecarAdapter;
 beforeAll(async () => {
-  _adapter = createTestAdapter();
+  ({ adapter: _adapter } = await createPooledTestAdapter());
   const postCols = {
     title: "string" as const,
     published: "boolean" as const,
     salary: "integer" as const,
     author: "string" as const,
   };
-  await defineSchema(_adapter, {
-    developers: { name: "string", salary: "integer" },
-    posts: { title: "string", author: "string", published: "boolean" },
-    ro_posts: postCols,
-    dro_posts: postCols,
-    sf_posts: postCols,
-    sff_posts: postCols,
-    sfl_posts: postCols,
-    sc_posts: postCols,
-    sds_posts: postCols,
-    sfa_posts: postCols,
-    scnt_posts: postCols,
-    sj_posts: postCols,
-    nrs_posts: postCols,
-    ann_posts: postCols,
-    ann_unscoped_posts: postCols,
-    animals: { type: "string", name: "string" },
-    cats: { type: "string", name: "string" },
-    dogs: { type: "string", name: "string" },
-    categories: { name: "string" },
-  });
+  // dropExisting: true is a workaround for cross-file pooled-adapter collision.
+  // Once D-W (IF NOT EXISTS in defineSchema) lands, remove this.
+  await defineSchema(
+    _adapter,
+    {
+      developers: { name: "string", salary: "integer" },
+      posts: { title: "string", author: "string", published: "boolean" },
+      ro_posts: postCols,
+      dro_posts: postCols,
+      sf_posts: postCols,
+      sff_posts: postCols,
+      sfl_posts: postCols,
+      sc_posts: postCols,
+      sds_posts: postCols,
+      sfa_posts: postCols,
+      scnt_posts: postCols,
+      sj_posts: postCols,
+      nrs_posts: postCols,
+      ann_posts: postCols,
+      ann_unscoped_posts: postCols,
+      animals: { type: "string", name: "string" },
+      cats: { type: "string", name: "string" },
+      dogs: { type: "string", name: "string" },
+      categories: { name: "string" },
+    },
+    { dropExisting: true },
+  );
 });
 withTransactionalFixtures(() => _adapter);
 function freshAdapter(): DatabaseAdapter {


### PR DESCRIPTION
## Summary

- Swaps `createTestAdapter()` → `createPooledTestAdapter()` in `relation-scoping.test.ts`, mirroring the sibling `default-scoping` / `named-scoping` files.
- Removes the TODO block that cited the deferred PG `withClient` race fix.
- Adds `{ dropExisting: true }` to the `defineSchema` call (cross-file pooled-adapter collision workaround, consistent with named-scoping pattern; removable after D-W lands).

## Bug 2 arc

- #2253 closed: original migration; reverted after PG 25P02 / 08P01 on `Promise.all` concurrent writes
- #2258 merged: pool-layer pin lookup centralized
- #2262 merged: targeted `withClient` snapshot tightening
- #2265 closed: retry, still failed
- #2279 merged: structural fix — `PostgreSQLAdapter` holds one persistent `pg.Client`; all concurrent queries route to `this._client` deterministically

This PR is the end-to-end proof that Bug 2 is closed.

The critical test is `NestedRelationScopingTest > "merge inner scope has priority"`, which issues 11 concurrent `Promise.all` writes inside a transactional fixture. Under the old dual-pool PG adapter this produced 25P02 / 08P01 races; #2279's single-client fix eliminates the fan-out.

## Test plan

- [ ] CI PG job passes — particularly `NestedRelationScopingTest > "merge inner scope has priority"`
- [ ] SQLite: 51 pass / 27 skipped (verified locally)