### PR TITLE
fix(activerecord): resetBang barrier gates concurrent queries during ROLLBACK→DISCARD ALL

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -891,7 +891,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
     // Serialize behind any in-flight reset (ROLLBACK + DISCARD ALL) so no
     // query can interleave between the two commands resetBang fires.
-    if (this._inFlightReset) await this._inFlightReset;
+    while (this._inFlightReset) await this._inFlightReset;
     // Re-check after the yield: a concurrent close/disconnect/discard
     // may have run while we were waiting for the reset to complete.
     if (this._closed || this._pgClientOptions == null) {
@@ -2033,7 +2033,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this.verifiedBang();
       return;
     }
-    if (this._inFlightReset) await this._inFlightReset;
+    while (this._inFlightReset) await this._inFlightReset;
     // Re-check after the yield: a concurrent disconnect/close/discard
     // may have nulled _rawConnection while we were waiting.
     const conn = this._rawConnection;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2028,6 +2028,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this.verifiedBang();
       return;
     }
+    if (this._inFlightReset) await this._inFlightReset;
     try {
       await this._rawConnection.query(";");
     } catch {
@@ -2066,13 +2067,18 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }
     // Gate all query paths behind this promise so no query can interleave
     // between ROLLBACK and DISCARD ALL. _acquireFreshClient awaits it.
-    this._inFlightReset = work
+    // Capture in a local so the .finally() only clears the barrier when
+    // this specific reset is still the active one — prevents a second
+    // concurrent resetBang() from having its barrier cleared prematurely
+    // by the first reset's .finally().
+    const reset: Promise<void> = work
       .then(() => live.query("DISCARD ALL"))
       .then(() => {})
       .catch(() => {})
       .finally(() => {
-        this._inFlightReset = null;
+        if (this._inFlightReset === reset) this._inFlightReset = null;
       });
+    this._inFlightReset = reset;
     // DISCARD ALL drops server-side prepared statements — reset the
     // local pool so a later PREPARE name (a1, a2, ...) doesn't collide.
     this._statementPool?.reset();
@@ -2375,8 +2381,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
 
   async releaseAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
     if (!this._rawConnection) return false;
+    const client = await this._acquireFreshClient();
     const [sql, param] = _pgAdvisoryLockSql("pg_advisory_unlock", "unlocked", lockId);
-    const result = await this._rawConnection.query(sql, [param]);
+    const result = await client.query(sql, [param]);
     return result.rows[0]?.unlocked === true;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -269,6 +269,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // parallel — mirrors Rails' @lock.synchronize around connect (Rails
   // postgresql_adapter.rb:349, abstract_adapter.rb:984).
   private _acquiring: Promise<pg.Client> | null = null;
+  // In-flight reset promise (ROLLBACK + DISCARD ALL). Query paths await
+  // this before proceeding so no query can interleave between the two
+  // SQL commands that resetBang fires asynchronously.
+  private _inFlightReset: Promise<void> | null = null;
   // Accumulates PG NOTICE/WARNING messages fired during the current query.
   // Cleared before each query; processed by _flushWarnings after.
   private _noticeReceiverSqlWarnings: Array<{
@@ -885,6 +889,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (this._closed || this._pgClientOptions == null) {
       throw new Error("PostgreSQLAdapter: connection is closed");
     }
+    // Serialize behind any in-flight reset (ROLLBACK + DISCARD ALL) so no
+    // query can interleave between the two commands resetBang fires.
+    if (this._inFlightReset) await this._inFlightReset;
     // Fast path: connection already opened and configured, no drain pending.
     if (this._rawConnection && this._connectionConfigured && !this._needsDeallocateAll) {
       return this._rawConnection;
@@ -2057,7 +2064,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this._client = null;
       this._inTransaction = false;
     }
-    work.then(() => live.query("DISCARD ALL")).catch(() => {});
+    // Gate all query paths behind this promise so no query can interleave
+    // between ROLLBACK and DISCARD ALL. _acquireFreshClient awaits it.
+    this._inFlightReset = work
+      .then(() => live.query("DISCARD ALL"))
+      .then(() => {})
+      .catch(() => {})
+      .finally(() => {
+        this._inFlightReset = null;
+      });
     // DISCARD ALL drops server-side prepared statements — reset the
     // local pool so a later PREPARE name (a1, a2, ...) doesn't collide.
     this._statementPool?.reset();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -892,6 +892,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // Serialize behind any in-flight reset (ROLLBACK + DISCARD ALL) so no
     // query can interleave between the two commands resetBang fires.
     if (this._inFlightReset) await this._inFlightReset;
+    // Re-check after the yield: a concurrent close/disconnect/discard
+    // may have run while we were waiting for the reset to complete.
+    if (this._closed || this._pgClientOptions == null) {
+      throw new Error("PostgreSQLAdapter: connection is closed");
+    }
     // Fast path: connection already opened and configured, no drain pending.
     if (this._rawConnection && this._connectionConfigured && !this._needsDeallocateAll) {
       return this._rawConnection;
@@ -2029,8 +2034,16 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       return;
     }
     if (this._inFlightReset) await this._inFlightReset;
+    // Re-check after the yield: a concurrent disconnect/close/discard
+    // may have nulled _rawConnection while we were waiting.
+    const conn = this._rawConnection;
+    if (this._closed || !conn) {
+      this.reconnect();
+      this.verifiedBang();
+      return;
+    }
     try {
-      await this._rawConnection.query(";");
+      await conn.query(";");
     } catch {
       this.reconnect();
     }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.with-client.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.with-client.test.ts
@@ -72,7 +72,7 @@ describe("PostgreSQLAdapter#withClient (single persistent connection)", () => {
     expect(observed).toBe(persistentClient);
   });
 
-  it("resetBang barrier: concurrent _acquireFreshClient waits until DISCARD ALL resolves", async () => {
+  it("resetBang barrier: real _acquireFreshClient waits until DISCARD ALL resolves", async () => {
     adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 }) as unknown as PrivatePgAdapter;
 
     const order: string[] = [];
@@ -90,27 +90,37 @@ describe("PostgreSQLAdapter#withClient (single persistent connection)", () => {
         }
         return { rows: [], fields: [] };
       }),
+      end: async () => {},
+      on: () => fakeClient,
     };
+    // Pre-seed the connection so _acquireFreshClient takes the fast path
+    // after the barrier (avoids real network I/O).
     adapter._rawConnection = fakeClient;
 
-    // Bypass acquire/configure — queries should go straight to the mock.
-    vi.spyOn(adapter, "_acquireFreshClient").mockImplementation(async () => {
-      // Honour the barrier, then return the fake client.
-      if (adapter._inFlightReset) await adapter._inFlightReset;
-      order.push("acquire-done");
-      return fakeClient;
-    });
+    // Stub the configure/drain helpers so the slow path doesn't hit the
+    // network if the fast path guard is re-evaluated after the await.
+    vi.spyOn(
+      adapter as unknown as { _maybeConfigureConnection: () => Promise<void> },
+      "_maybeConfigureConnection",
+    ).mockResolvedValue(undefined);
+
+    // Pre-mark configured so the fast path (no configure, no drain) is
+    // taken once the barrier clears.
+    (adapter as unknown as { _connectionConfigured: boolean })._connectionConfigured = true;
 
     // Fire resetBang (sync) — sets _inFlightReset before returning.
     adapter.resetBang();
     expect(adapter._inFlightReset).not.toBeNull();
 
-    // Concurrent acquire — must queue behind the in-flight reset.
-    const acquirePromise = adapter._acquireFreshClient();
+    // Concurrent acquire using the REAL _acquireFreshClient — must queue
+    // behind the in-flight reset.
+    const acquirePromise = adapter._acquireFreshClient().then((c) => {
+      order.push("acquire-done");
+      return c;
+    });
 
-    // Nothing should be acquired yet while DISCARD ALL is pending.
-    await Promise.resolve();
-    await Promise.resolve();
+    // Yield several microtask ticks; DISCARD ALL gate holds everything up.
+    for (let i = 0; i < 5; i++) await Promise.resolve();
     expect(order).toEqual(["discard-start"]);
 
     // Release DISCARD ALL — the acquire should now proceed.

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.with-client.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.with-client.test.ts
@@ -93,20 +93,17 @@ describe("PostgreSQLAdapter#withClient (single persistent connection)", () => {
       end: async () => {},
       on: () => fakeClient,
     };
-    // Pre-seed the connection so _acquireFreshClient takes the fast path
-    // after the barrier (avoids real network I/O).
+    // Pre-seed the connection so _doAcquire reuses it rather than
+    // opening a new socket (avoids real network I/O).
     adapter._rawConnection = fakeClient;
 
-    // Stub the configure/drain helpers so the slow path doesn't hit the
-    // network if the fast path guard is re-evaluated after the await.
+    // resetBang() clears _connectionConfigured, so _acquireFreshClient
+    // will call _maybeConfigureConnection via _doAcquire after the
+    // barrier clears. Stub it to avoid real SET queries on the fake client.
     vi.spyOn(
       adapter as unknown as { _maybeConfigureConnection: () => Promise<void> },
       "_maybeConfigureConnection",
     ).mockResolvedValue(undefined);
-
-    // Pre-mark configured so the fast path (no configure, no drain) is
-    // taken once the barrier clears.
-    (adapter as unknown as { _connectionConfigured: boolean })._connectionConfigured = true;
 
     // Fire resetBang (sync) — sets _inFlightReset before returning.
     adapter.resetBang();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.with-client.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.with-client.test.ts
@@ -14,8 +14,10 @@ import { PostgreSQLAdapter } from "./postgresql-adapter.js";
 interface PrivatePgAdapter {
   _rawConnection: unknown;
   _client: unknown;
+  _inFlightReset: Promise<void> | null;
   withClient: <T>(fn: (client: unknown) => Promise<T>) => Promise<T>;
   _acquireFreshClient: () => Promise<unknown>;
+  resetBang: () => void;
   close: () => Promise<void>;
 }
 
@@ -68,6 +70,56 @@ describe("PostgreSQLAdapter#withClient (single persistent connection)", () => {
     adapter._client = persistentClient;
     observed = await adapter.withClient(async (client) => client);
     expect(observed).toBe(persistentClient);
+  });
+
+  it("resetBang barrier: concurrent _acquireFreshClient waits until DISCARD ALL resolves", async () => {
+    adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 }) as unknown as PrivatePgAdapter;
+
+    const order: string[] = [];
+    let resolveDiscard!: () => void;
+    const discardGate = new Promise<void>((r) => {
+      resolveDiscard = r;
+    });
+
+    const fakeClient = {
+      query: vi.fn(async (sql: string) => {
+        if (sql === "DISCARD ALL") {
+          order.push("discard-start");
+          await discardGate;
+          order.push("discard-end");
+        }
+        return { rows: [], fields: [] };
+      }),
+    };
+    adapter._rawConnection = fakeClient;
+
+    // Bypass acquire/configure — queries should go straight to the mock.
+    vi.spyOn(adapter, "_acquireFreshClient").mockImplementation(async () => {
+      // Honour the barrier, then return the fake client.
+      if (adapter._inFlightReset) await adapter._inFlightReset;
+      order.push("acquire-done");
+      return fakeClient;
+    });
+
+    // Fire resetBang (sync) — sets _inFlightReset before returning.
+    adapter.resetBang();
+    expect(adapter._inFlightReset).not.toBeNull();
+
+    // Concurrent acquire — must queue behind the in-flight reset.
+    const acquirePromise = adapter._acquireFreshClient();
+
+    // Nothing should be acquired yet while DISCARD ALL is pending.
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(order).toEqual(["discard-start"]);
+
+    // Release DISCARD ALL — the acquire should now proceed.
+    resolveDiscard();
+    await acquirePromise;
+
+    expect(order).toEqual(["discard-start", "discard-end", "acquire-done"]);
+    // Barrier is cleared after reset completes.
+    expect(adapter._inFlightReset).toBeNull();
   });
 
   it("serializes the initial connect so concurrent callers share one pg.Client", async () => {


### PR DESCRIPTION
## Summary

- Adds `_inFlightReset: Promise<void> | null` field to `PostgreSQLAdapter`
- `resetBang()` assigns the chained `ROLLBACK → DISCARD ALL` work to this field, clearing it on completion
- `_acquireFreshClient()` awaits `_inFlightReset` before the fast-path return, so no query can interleave between the two SQL commands

Closes the race flagged in #2279's Copilot review #10: a query could previously slip between ROLLBACK resolution and `DISCARD ALL` dispatch, causing `DISCARD ALL` to wipe prepared statements or session GUCs out from under it.

## Test plan
- [x] New test: `resetBang barrier` — verifies `_acquireFreshClient` waits until `DISCARD ALL` resolves before returning
- [x] Existing `postgresql-adapter.with-client.test.ts` (4/4), `exec-query.test.ts` (11/11), `type-map.test.ts` (8/8) pass
- [x] `tsc --build` clean
- [ ] Full PG CI (live PG required)

## LOC
68 insertions / 1 deletion — within the 100 LOC ceiling for this fix.