### PR TITLE
feat(test-models): port PR 1a — 7 core-association model files

### DIFF
--- a/packages/activerecord/src/test-helpers/models/categorization.ts
+++ b/packages/activerecord/src/test-helpers/models/categorization.ts
@@ -1,0 +1,35 @@
+// vendor/rails/activerecord/test/models/categorization.rb
+import { Base } from "../../base.js";
+
+export class Categorization extends Base {
+  static {
+    this.belongsTo("post");
+    this.belongsTo("category", { counterCache: true });
+    this.belongsTo("namedCategory", {
+      className: "Category",
+      foreignKey: "named_category_name",
+      primaryKey: "name",
+    });
+    this.belongsTo("author");
+    this.hasMany("postTaggings", { through: "author", source: "taggings" });
+    this.belongsTo("authorUsingCustomPk", {
+      className: "Author",
+      foreignKey: "author_id",
+      primaryKey: "author_address_extra_id",
+    });
+    this.hasMany("authorsUsingCustomPk", {
+      className: "Author",
+      foreignKey: "id",
+      primaryKey: "category_id",
+    });
+  }
+}
+
+export class SpecialCategorization extends Base {
+  static {
+    this._tableName = "categorizations";
+    this.defaultScope((q: any) => q.where({ special: true }));
+    this.belongsTo("author");
+    this.belongsTo("category");
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/category.ts
+++ b/packages/activerecord/src/test-helpers/models/category.ts
@@ -1,0 +1,57 @@
+// vendor/rails/activerecord/test/models/category.rb
+import { Base } from "../../base.js";
+
+export class Category extends Base {
+  static {
+    this.hasAndBelongsToMany("posts");
+    this.hasAndBelongsToMany("specialPosts", { className: "Post" });
+    this.hasAndBelongsToMany("otherPosts", { className: "Post" });
+    this.hasAndBelongsToMany("postsWithAuthorsSortedByAuthorId", {
+      scope: (q: any) => q.includes("authors").order("authors.id"),
+      className: "Post",
+    });
+    this.hasAndBelongsToMany("selectTestingPosts", {
+      scope: (q: any) => q.select("posts.*, 1 as correctness_marker"),
+      className: "Post",
+      foreignKey: "category_id",
+      associationForeignKey: "post_id",
+    });
+    this.hasAndBelongsToMany("postWithConditions", {
+      scope: (q: any) => q.where({ title: "Yet Another Testing Title" }),
+      className: "Post",
+    });
+    this.hasAndBelongsToMany("postsGroupedByTitle", {
+      scope: (q: any) => q.group("title").select("title"),
+      className: "Post",
+    });
+    this.hasMany("categorizations");
+    this.hasMany("specialCategorizations");
+    this.hasMany("postComments", { through: "posts", source: "comments" });
+    this.hasMany("orderedPostComments", {
+      scope: (q: any) => q.order({ id: "desc" }),
+      through: "posts",
+      source: "comments",
+    });
+    this.hasMany("authors", { through: "categorizations" });
+    this.hasMany("authorsWithSelect", {
+      scope: (q: any) => q.select("authors.*, categorizations.post_id"),
+      through: "categorizations",
+      source: "author",
+    });
+    this.hasMany("essays", { primaryKey: "name" });
+    this.hasMany("humanWritersOfTypedEssays", {
+      scope: (q: any) => q.where({ essays: { type: "TypedEssay" } }),
+      through: "essays",
+      source: "writer",
+      sourceType: "Human",
+      primaryKey: "name",
+    });
+    this.scope("general", (q: any) => q.where({ name: "General" }));
+  }
+
+  static whatAreYou() {
+    return "a category...";
+  }
+}
+
+export class SpecialCategory extends Category {}

--- a/packages/activerecord/src/test-helpers/models/comment.ts
+++ b/packages/activerecord/src/test-helpers/models/comment.ts
@@ -25,7 +25,7 @@ export class Comment extends Base {
       counterCache: "children_count",
       inverseOf: "children",
     });
-    this.attribute("label", "string");
+    this.enum("label", { default: 0, child: 1 });
   }
 
   static whatAreYou() {
@@ -60,7 +60,8 @@ export class CommentThatAutomaticallyAltersPostBody extends Comment {
       foreignKey: "post_id",
     });
     this.afterSave(async function (this: any) {
-      await this.post.then((p: any) => p.update({ body: "Automatically altered" }));
+      const post = this.post;
+      if (post) await post.update({ body: "Automatically altered" });
     });
   }
 }

--- a/packages/activerecord/src/test-helpers/models/comment.ts
+++ b/packages/activerecord/src/test-helpers/models/comment.ts
@@ -1,0 +1,83 @@
+// vendor/rails/activerecord/test/models/comment.rb
+import { Base } from "../../base.js";
+
+export class Comment extends Base {
+  static {
+    this.scope("limitBy", (q: any, l: number) => q.limit(l));
+    this.scope("containingTheLetterE", (q: any) => q.where("comments.body LIKE '%e%'"));
+    this.scope("notAgain", (q: any) => q.where("comments.body NOT LIKE '%again%'"));
+    this.scope("forFirstPost", (q: any) => q.where({ post_id: 1 }));
+    this.scope("forFirstAuthor", (q: any) => q.joins("post").where({ "posts.author_id": 1 }));
+    this.scope("created", (q: any) => q.all());
+    this.scope("orderedByPostId", (q: any) => q.order("comments.post_id DESC"));
+
+    this.belongsTo("post", { counterCache: true });
+    this.belongsTo("author", { polymorphic: true });
+    this.belongsTo("resource", { polymorphic: true });
+    this.belongsTo("origin", { polymorphic: true });
+    this.belongsTo("company", { foreignKey: "company" });
+    this.hasMany("ratings");
+    this.belongsTo("firstPost", { foreignKey: "post_id" });
+    this.belongsTo("specialPostWithDefaultScope", { foreignKey: "post_id" });
+    this.hasMany("children", { className: "Comment", inverseOf: "parent" });
+    this.belongsTo("parent", {
+      className: "Comment",
+      counterCache: "children_count",
+      inverseOf: "children",
+    });
+    this.attribute("label", "string");
+  }
+
+  static whatAreYou() {
+    return "a comment...";
+  }
+
+  toString() {
+    return this.readAttribute("body") as string;
+  }
+}
+
+export class SpecialComment extends Comment {
+  static {
+    this.belongsTo("ordinaryPost", { foreignKey: "post_id", className: "Post" });
+    this.hasOne("author", { through: "post" });
+    this.defaultScope((q: any) => q.where({ deleted_at: null }));
+  }
+
+  static whatAreYou() {
+    return "a special comment...";
+  }
+}
+
+export class SubSpecialComment extends SpecialComment {}
+
+export class VerySpecialComment extends Comment {}
+
+export class CommentThatAutomaticallyAltersPostBody extends Comment {
+  static {
+    this.belongsTo("post", {
+      className: "PostThatLoadsCommentsInAnAfterSaveHook",
+      foreignKey: "post_id",
+    });
+    this.afterSave(async function (this: any) {
+      await this.post.then((p: any) => p.update({ body: "Automatically altered" }));
+    });
+  }
+}
+
+export class CommentWithDefaultScopeReferencesAssociation extends Comment {
+  static {
+    this.defaultScope((q: any) =>
+      q.includes("developer").order("developers.name").references("developer"),
+    );
+    this.belongsTo("developer");
+  }
+}
+
+export class CommentWithAfterCreateUpdate extends Comment {
+  static {
+    this.afterCreate(async function (this: any) {
+      await this.update({ body: "bar" });
+    });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/comment.ts
+++ b/packages/activerecord/src/test-helpers/models/comment.ts
@@ -10,6 +10,7 @@ export class Comment extends Base {
     this.scope("forFirstAuthor", (q: any) => q.joins("post").where({ "posts.author_id": 1 }));
     this.scope("created", (q: any) => q.all());
     this.scope("orderedByPostId", (q: any) => q.order("comments.post_id DESC"));
+    this.scope("allAsScope", (q: any) => q.all());
 
     this.belongsTo("post", { counterCache: true });
     this.belongsTo("author", { polymorphic: true });

--- a/packages/activerecord/src/test-helpers/models/essay.ts
+++ b/packages/activerecord/src/test-helpers/models/essay.ts
@@ -1,0 +1,15 @@
+// vendor/rails/activerecord/test/models/essay.rb
+import { Base } from "../../base.js";
+
+export class Essay extends Base {
+  static {
+    this.belongsTo("author", { primaryKey: "name" });
+    this.belongsTo("writer", { primaryKey: "name", polymorphic: true });
+    this.belongsTo("category", { primaryKey: "name" });
+    this.hasOne("owner", { primaryKey: "name" });
+  }
+}
+
+export class EssaySpecial extends Essay {}
+
+export class TypedEssay extends Essay {}

--- a/packages/activerecord/src/test-helpers/models/index.ts
+++ b/packages/activerecord/src/test-helpers/models/index.ts
@@ -1,0 +1,8 @@
+// vendor/rails/activerecord/test/models/ — ported model classes for fixture-adoption sweep
+export * from "./category.js";
+export * from "./categorization.js";
+export * from "./comment.js";
+export * from "./essay.js";
+export * from "./reader.js";
+export * from "./tag.js";
+export * from "./tagging.js";

--- a/packages/activerecord/src/test-helpers/models/reader.ts
+++ b/packages/activerecord/src/test-helpers/models/reader.ts
@@ -1,0 +1,37 @@
+// vendor/rails/activerecord/test/models/reader.rb
+import { Base } from "../../base.js";
+
+export class Reader extends Base {
+  static {
+    this.belongsTo("post");
+    this.belongsTo("person", { inverseOf: "readers" });
+    this.belongsTo("singlePerson", {
+      className: "Person",
+      foreignKey: "person_id",
+      inverseOf: "reader",
+    });
+    this.belongsTo("firstPost", { scope: (q: any) => q.where({ id: [2, 3] }) });
+  }
+}
+
+export class SecureReader extends Base {
+  static {
+    this._tableName = "readers";
+    this.belongsTo("securePost", { className: "Post", foreignKey: "post_id" });
+    this.belongsTo("securePerson", {
+      inverseOf: "secureReaders",
+      className: "Person",
+      foreignKey: "person_id",
+    });
+  }
+}
+
+export class LazyReader extends Base {
+  static {
+    this._tableName = "readers";
+    this.defaultScope((q: any) => q.where({ skimmer: true }));
+    this.scope("skimmersOrNot", (q: any) => q.unscope({ where: "skimmer" }));
+    this.belongsTo("post");
+    this.belongsTo("person");
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/tag.ts
+++ b/packages/activerecord/src/test-helpers/models/tag.ts
@@ -1,0 +1,27 @@
+// vendor/rails/activerecord/test/models/tag.rb
+import { Base } from "../../base.js";
+
+export class Tag extends Base {
+  static {
+    this.hasMany("taggings");
+    this.hasMany("taggables", { through: "taggings" });
+    this.hasOne("tagging");
+    this.hasMany("taggedPosts", { through: "taggings", source: "taggable", sourceType: "Post" });
+  }
+}
+
+export class OrderedTag extends Tag {
+  static {
+    this._tableName = "tags";
+    this.hasMany("orderedTaggings", {
+      scope: (q: any) => q.order("taggings.id DESC"),
+      foreignKey: "tag_id",
+      className: "Tagging",
+    });
+    this.hasMany("taggedPosts", {
+      through: "orderedTaggings",
+      source: "taggable",
+      sourceType: "Post",
+    });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/tagging.ts
+++ b/packages/activerecord/src/test-helpers/models/tagging.ts
@@ -1,0 +1,29 @@
+// vendor/rails/activerecord/test/models/tagging.rb
+import { Base } from "../../base.js";
+
+export class Tagging extends Base {
+  static {
+    this.belongsTo("tag", { scope: (q: any) => q.includes("tagging") });
+    this.belongsTo("superTag", { className: "Tag", foreignKey: "super_tag_id" });
+    this.belongsTo("invalidTag", { className: "Tag", foreignKey: "tag_id" });
+    this.belongsTo("orderedTag", { className: "OrderedTag", foreignKey: "tag_id" });
+    this.belongsTo("blueTag", {
+      scope: (q: any) => q.where({ tags: { name: "Blue" } }),
+      className: "Tag",
+      foreignKey: "tag_id",
+    });
+    this.belongsTo("tagWithPrimaryKey", {
+      className: "Tag",
+      foreignKey: "tag_id",
+      primaryKey: "custom_primary_key",
+    });
+    this.belongsTo("taggable", { polymorphic: true, counterCache: "tags_count" });
+    this.hasMany("things", { through: "taggable" });
+  }
+}
+
+export class IndestructibleTagging extends Tagging {
+  static {
+    this.beforeDestroy(() => false as const);
+  }
+}

--- a/scripts/fixtures-compare/compare.ts
+++ b/scripts/fixtures-compare/compare.ts
@@ -807,11 +807,12 @@ export function compareModelClass(
     notes: [],
   };
   // Check associations by (kind, name) set equality. Options diff deferred to later PRs.
+  // Accept both the raw Ruby snake_case name and the camelCase equivalent used in TS.
   for (const a of ruby.associations) {
-    const pattern = new RegExp(
-      `this\\.${a.kind.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase())}\\s*\\(\\s*["']${a.name}["']`,
-      "i",
-    );
+    const tsMacro = a.kind.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+    const camelName = a.name.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+    const nameAlts = a.name === camelName ? a.name : `(?:${a.name}|${camelName})`;
+    const pattern = new RegExp(`this\\.${tsMacro}\\s*\\(\\s*["']${nameAlts}["']`, "i");
     if (pattern.test(tsContent)) r.assocMatched++;
     else r.notes.push(`assoc-missing: ${a.kind} :${a.name}`);
   }
@@ -828,7 +829,9 @@ export function compareModelClass(
     else r.notes.push(`val-missing: ${v.kind} ${v.attributes.join(",")}`);
   }
   for (const s of ruby.scopes) {
-    const spat = new RegExp(`this\\.scope\\s*\\(\\s*["']${s.name}["']`, "i");
+    const sCamel = s.name.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
+    const sAlts = s.name === sCamel ? s.name : `(?:${s.name}|${sCamel})`;
+    const spat = new RegExp(`this\\.scope\\s*\\(\\s*["']${sAlts}["']`, "i");
     if (spat.test(tsContent)) r.scopesMatched++;
     else r.notes.push(`scope-missing: ${s.name}`);
   }

--- a/scripts/fixtures-compare/extract-ruby-models.rb
+++ b/scripts/fixtures-compare/extract-ruby-models.rb
@@ -110,7 +110,7 @@ files = Dir.glob(File.join(MODELS_DIR, "**", "*.rb")).sort
 abort "extract-ruby-models: no .rb files found under #{MODELS_DIR}" if files.empty?
 result = []
 files.each do |f|
-  rel = f.delete_prefix(File.join(ROOT, "vendor/rails/activerecord/") + "/")
+  rel = f.delete_prefix(File.join(ROOT, "vendor/rails/activerecord") + "/")
   classes = parse_file(f)
   result << { file: rel, classes: classes } unless classes.empty?
 end


### PR DESCRIPTION
## Summary

- Ports 7 of 10 planned Cluster 1 model files from `vendor/rails/activerecord/test/models/` to `packages/activerecord/src/test-helpers/models/`: `tag`, `tagging`, `essay`, `reader`, `categorization`, `category`, `comment`
- Fixes two bugs in `fixtures:compare --models` infrastructure (from PR #2275): double-slash in `extract-ruby-models.rb`'s `delete_prefix` broke relative-path output; `compareModelClass` now accepts camelCase equivalents of Ruby snake_case assoc/scope names
- All 7 ported files report **100% MATCH** in `pnpm fixtures:compare --models`

## Follow-up (PR 1b)

`topic.rb`, `author.rb`, `post.rb` deferred — those three files together would bust the 300 LOC ceiling. PR 1b should handle them along with the originally-planned second-half files (`book.rb`, `author_favorite.rb`, `subscriber.rb`, `subscription.rb`, `reference.rb`, `bad_post.rb`).

## Test plan
- [x] `pnpm -w build` passes
- [x] `pnpm fixtures:compare --models` — all 7 ported files show 100% MATCH
- [x] No existing files modified (new files only, plus compare-script bugfixes)