### PR TITLE
feat(rack): request.rb parse internals + multipart bridge (slot 8)

### DIFF
--- a/packages/rack/src/request.test.ts
+++ b/packages/rack/src/request.test.ts
@@ -66,7 +66,15 @@ describe("RackRequestTest", () => {
     expect(yielded).toBe(true);
     expect(req.get("FOO")).toBe("bar");
     // raises when key is absent and no block given (mirrors Hash#fetch / env.fetch)
-    expect(() => req.fetchHeader("MISSING")).toThrow("KeyError");
+    const err = (() => {
+      try {
+        req.fetchHeader("MISSING");
+      } catch (e) {
+        return e as Error;
+      }
+    })()!;
+    expect(err.name).toBe("KeyError");
+    expect(err.message).toMatch("MISSING");
   });
 
   it("can iterate over values", () => {

--- a/packages/rack/src/request.test.ts
+++ b/packages/rack/src/request.test.ts
@@ -356,10 +356,8 @@ describe("RackRequestTest", () => {
 
   it("should use the query_parser for query parsing", () => {
     const req = makeReq("/?foo=bar&baz=qux");
-    // queryParser() drives GET parsing
     expect(req.GET).toEqual({ foo: "bar", baz: "qux" });
-    // parseQuery delegates to queryParser
-    expect((req as any).parseQuery("a=1&b=2")).toEqual({ a: "1", b: "2" });
+    expect(req.parseQuery("a=1&b=2")).toEqual({ a: "1", b: "2" });
   });
 
   it("does not use semi-colons as separators for query strings in GET", () => {

--- a/packages/rack/src/request.test.ts
+++ b/packages/rack/src/request.test.ts
@@ -65,6 +65,8 @@ describe("RackRequestTest", () => {
     });
     expect(yielded).toBe(true);
     expect(req.get("FOO")).toBe("bar");
+    // raises when key is absent and no block given (mirrors Hash#fetch / env.fetch)
+    expect(() => req.fetchHeader("MISSING")).toThrow("KeyError");
   });
 
   it("can iterate over values", () => {

--- a/packages/rack/src/request.test.ts
+++ b/packages/rack/src/request.test.ts
@@ -57,13 +57,13 @@ describe("RackRequestTest", () => {
 
   it("yields to the block if no value has been set", () => {
     const req = makeReq();
-    let yielded = false;
-    req.fetchHeader("FOO", () => {
-      yielded = true;
+    let capturedKey: string | undefined;
+    req.fetchHeader("FOO", (k) => {
+      capturedKey = k;
       req.set("FOO", "bar");
       return "bar";
     });
-    expect(yielded).toBe(true);
+    expect(capturedKey).toBe("FOO");
     expect(req.get("FOO")).toBe("bar");
     // raises when key is absent and no block given (mirrors Hash#fetch / env.fetch)
     const err = (() => {
@@ -1400,6 +1400,25 @@ describe("RackRequestTest", () => {
     expect(req.valuesAt("foo")).toEqual(["baz"]);
     expect(req.valuesAt("foo", "wun")).toEqual(["baz", "der"]);
     expect(req.valuesAt("bar", "foo", "wun")).toEqual(["ful", "baz", "der"]);
+  });
+
+  it("expose the HTTP_HOST as hostAuthority", () => {
+    const req = makeReq("/", { HTTP_HOST: "example.com:8080" });
+    expect(req.hostAuthority).toBe("example.com:8080");
+    expect(makeReq("/").hostAuthority).toBeNull();
+  });
+
+  it("detect parseable data media types", () => {
+    expect(makeReq("/", { CONTENT_TYPE: "multipart/related" }).isParseableData()).toBe(true);
+    expect(makeReq("/", { CONTENT_TYPE: "multipart/mixed" }).isParseableData()).toBe(true);
+    expect(makeReq("/", { CONTENT_TYPE: "multipart/form-data" }).isParseableData()).toBe(false);
+    expect(makeReq("/", { CONTENT_TYPE: "application/json" }).isParseableData()).toBe(false);
+  });
+
+  it("restore the path as scriptName + pathInfo", () => {
+    const req = makeReq("http://example.com/foo/bar?q=1");
+    req.env["SCRIPT_NAME"] = "/app";
+    expect(req.path).toBe("/app/foo/bar");
   });
 
   it("respond to isLink, isTrace, isUnlink", () => {

--- a/packages/rack/src/request.test.ts
+++ b/packages/rack/src/request.test.ts
@@ -57,16 +57,24 @@ describe("RackRequestTest", () => {
 
   it("yields to the block if no value has been set", () => {
     const req = makeReq();
-    const val = req.get("NONEXISTENT", () => "default");
-    expect(val).toBe("default");
+    let yielded = false;
+    req.fetchHeader("FOO", () => {
+      yielded = true;
+      req.set("FOO", "bar");
+      return "bar";
+    });
+    expect(yielded).toBe(true);
+    expect(req.get("FOO")).toBe("bar");
   });
 
   it("can iterate over values", () => {
     const req = makeReq();
-    const keys: string[] = [];
-    req.each((k) => keys.push(k));
-    expect(keys.length).toBeGreaterThan(0);
-    expect(keys).toContain("REQUEST_METHOD");
+    req.set("foo", "bar");
+    const hash: Record<string, any> = {};
+    req.eachHeader((k, v) => {
+      hash[k] = v;
+    });
+    expect(hash["foo"]).toBe("bar");
   });
 
   it("can set values in the env", () => {
@@ -348,7 +356,10 @@ describe("RackRequestTest", () => {
 
   it("should use the query_parser for query parsing", () => {
     const req = makeReq("/?foo=bar&baz=qux");
+    // queryParser() drives GET parsing
     expect(req.GET).toEqual({ foo: "bar", baz: "qux" });
+    // parseQuery delegates to queryParser
+    expect((req as any).parseQuery("a=1&b=2")).toEqual({ a: "1", b: "2" });
   });
 
   it("does not use semi-colons as separators for query strings in GET", () => {
@@ -1378,11 +1389,9 @@ describe("RackRequestTest", () => {
 
   it("return values for the keys in the order given from values_at", () => {
     const req = makeReq("/?foo=baz&wun=der&bar=ful");
-    const params = req.params;
-    // values_at returns param values in the order of the given keys
-    expect([params["foo"]]).toEqual(["baz"]);
-    expect([params["foo"], params["wun"]]).toEqual(["baz", "der"]);
-    expect([params["bar"], params["foo"], params["wun"]]).toEqual(["ful", "baz", "der"]);
+    expect(req.valuesAt("foo")).toEqual(["baz"]);
+    expect(req.valuesAt("foo", "wun")).toEqual(["baz", "der"]);
+    expect(req.valuesAt("bar", "foo", "wun")).toEqual(["ful", "baz", "der"]);
   });
 
   it("respond to isLink, isTrace, isUnlink", () => {

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -42,7 +42,7 @@ import {
   HTTP_X_FORWARDED_PROTO,
   HTTP_X_FORWARDED_SCHEME,
 } from "./constants.js";
-import { parseNestedQuery, forwardedValues, getDefaultQueryParser, QueryParser } from "./utils.js";
+import { forwardedValues, getDefaultQueryParser, QueryParser } from "./utils.js";
 import * as MediaTypeModule from "./media-type.js";
 import { parseMultipart as multipartExtract } from "./multipart.js";
 
@@ -314,7 +314,7 @@ export class Request {
     if (this.env[RACK_REQUEST_QUERY_STRING] === qs && this.env[RACK_REQUEST_QUERY_HASH]) {
       return this.env[RACK_REQUEST_QUERY_HASH];
     }
-    const parsed = parseNestedQuery(qs);
+    const parsed = this.parseQuery(qs, "&");
     this.env[RACK_REQUEST_QUERY_STRING] = qs;
     this.env[RACK_REQUEST_QUERY_HASH] = parsed;
     return parsed;
@@ -339,7 +339,7 @@ export class Request {
 
     // Multipart data (form-data, related, mixed, etc.)
     if (mt.startsWith("multipart/")) {
-      const parsed = multipartExtract(this.env) || {};
+      const parsed = this.parseMultipart();
       this.env[RACK_REQUEST_FORM_HASH] = parsed;
       this.env[RACK_REQUEST_FORM_INPUT] = input;
       return parsed;
@@ -358,7 +358,7 @@ export class Request {
     // Safari sends \0 for empty forms
     if (body === "\0") body = "";
 
-    const parsed = parseNestedQuery(body);
+    const parsed = this.parseQuery(body);
     this.env[RACK_REQUEST_FORM_HASH] = parsed;
     this.env[RACK_REQUEST_FORM_VARS] = body;
     this.env[RACK_REQUEST_FORM_INPUT] = input;
@@ -658,53 +658,45 @@ export class Request {
     return this.env[SERVER_NAME] ?? null;
   }
 
-  /** @internal */
   fetchHeader(name: string): any;
-  /** @internal */
   fetchHeader(name: string, block: () => any): any;
-  /** @internal */
   fetchHeader(name: string, block?: () => any): any {
     if (name in this.env) return this.env[name];
     if (block) return block();
     return undefined;
   }
 
-  /** @internal */
   eachHeader(callback: (key: string, value: any) => void): void {
     for (const [k, v] of Object.entries(this.env)) {
       callback(k, v);
     }
   }
 
-  /** @internal */
   get hostAuthority(): string | null {
     return this.env[HTTP_HOST] ?? null;
   }
 
-  /** @internal */
   isParseableData(): boolean {
     const mt = this.mediaType;
     return mt !== null && PARSEABLE_DATA_MEDIA_TYPES.includes(mt);
   }
 
-  /** @internal */
   get path(): string {
     return this.scriptName + this.pathInfo;
   }
 
-  /** @internal */
   valuesAt(...keys: string[]): any[] {
     const p = this.params;
     return keys.map((k) => p[k]);
   }
 
   /** @internal */
-  protected defaultSession(): Record<string, any> {
+  defaultSession(): Record<string, any> {
     return {};
   }
 
   /** @internal */
-  protected parseHttpAcceptHeader(header: string | null | undefined): Array<[string, number]> {
+  parseHttpAcceptHeader(header: string | null | undefined): Array<[string, number]> {
     const parts = (header ?? "").split(",");
     const result: Array<[string, number]> = [];
     for (const part of parts) {
@@ -723,22 +715,22 @@ export class Request {
   }
 
   /** @internal */
-  protected queryParser(): QueryParser {
+  queryParser(): QueryParser {
     return getDefaultQueryParser();
   }
 
   /** @internal */
-  protected parseQuery(qs: string, separator = "&"): Record<string, any> {
-    return parseNestedQuery(qs, separator);
+  parseQuery(qs: string, separator = "&"): Record<string, any> {
+    return this.queryParser().parseNestedQuery(qs, separator);
   }
 
   /** @internal */
-  protected parseMultipart(): Record<string, any> {
+  parseMultipart(): Record<string, any> {
     return multipartExtract(this.env) || {};
   }
 
   /** @internal */
-  protected expandParamPairs(pairs: Array<[string, any]>): Record<string, any> {
+  expandParamPairs(pairs: Array<[string, any]>): Record<string, any> {
     const parser = this.queryParser();
     const params = parser.makeParams();
     for (const [k, v] of pairs) {
@@ -748,7 +740,7 @@ export class Request {
   }
 
   /** @internal */
-  protected rejectTrustedIpAddresses(ipAddresses: string[]): string[] {
+  rejectTrustedIpAddresses(ipAddresses: string[]): string[] {
     return ipAddresses.filter((ip) => !this.trustedProxy(ip));
   }
 }

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -663,7 +663,9 @@ export class Request {
   fetchHeader(name: string, block?: () => any): any {
     if (Object.hasOwn(this.env, name)) return this.env[name];
     if (block) return block();
-    throw new Error(`KeyError: key not found: ${name}`);
+    const err = new Error(`key not found: ${name}`);
+    err.name = "KeyError";
+    throw err;
   }
 
   eachHeader(callback: (key: string, value: any) => void): void {

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -663,7 +663,7 @@ export class Request {
   fetchHeader(name: string, block?: (key: string) => any): any {
     if (Object.hasOwn(this.env, name)) return this.env[name];
     if (block) return block(name);
-    const err = new Error(`key not found: ${name}`);
+    const err = new Error(`key not found: "${name}"`);
     err.name = "KeyError";
     throw err;
   }

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -663,7 +663,7 @@ export class Request {
   fetchHeader(name: string, block?: () => any): any {
     if (name in this.env) return this.env[name];
     if (block) return block();
-    return undefined;
+    throw new Error(`KeyError: key not found: ${name}`);
   }
 
   eachHeader(callback: (key: string, value: any) => void): void {

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -659,10 +659,10 @@ export class Request {
   }
 
   fetchHeader(name: string): any;
-  fetchHeader(name: string, block: () => any): any;
-  fetchHeader(name: string, block?: () => any): any {
+  fetchHeader(name: string, block: (key: string) => any): any;
+  fetchHeader(name: string, block?: (key: string) => any): any {
     if (Object.hasOwn(this.env, name)) return this.env[name];
-    if (block) return block();
+    if (block) return block(name);
     const err = new Error(`key not found: ${name}`);
     err.name = "KeyError";
     throw err;

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -661,15 +661,13 @@ export class Request {
   fetchHeader(name: string): any;
   fetchHeader(name: string, block: () => any): any;
   fetchHeader(name: string, block?: () => any): any {
-    if (name in this.env) return this.env[name];
+    if (Object.hasOwn(this.env, name)) return this.env[name];
     if (block) return block();
     throw new Error(`KeyError: key not found: ${name}`);
   }
 
   eachHeader(callback: (key: string, value: any) => void): void {
-    for (const [k, v] of Object.entries(this.env)) {
-      callback(k, v);
-    }
+    this.each(callback);
   }
 
   get hostAuthority(): string | null {

--- a/packages/rack/src/request.ts
+++ b/packages/rack/src/request.ts
@@ -42,11 +42,12 @@ import {
   HTTP_X_FORWARDED_PROTO,
   HTTP_X_FORWARDED_SCHEME,
 } from "./constants.js";
-import { parseNestedQuery, forwardedValues } from "./utils.js";
+import { parseNestedQuery, forwardedValues, getDefaultQueryParser, QueryParser } from "./utils.js";
 import * as MediaTypeModule from "./media-type.js";
-import { parseMultipart } from "./multipart.js";
+import { parseMultipart as multipartExtract } from "./multipart.js";
 
 const FORM_DATA_MEDIA_TYPES = ["application/x-www-form-urlencoded", "multipart/form-data"];
+const PARSEABLE_DATA_MEDIA_TYPES = ["multipart/related", "multipart/mixed"];
 
 function parseCookies(cookieStr: string): Record<string, string> {
   const cookies: Record<string, string> = {};
@@ -338,7 +339,7 @@ export class Request {
 
     // Multipart data (form-data, related, mixed, etc.)
     if (mt.startsWith("multipart/")) {
-      const parsed = parseMultipart(this.env) || {};
+      const parsed = multipartExtract(this.env) || {};
       this.env[RACK_REQUEST_FORM_HASH] = parsed;
       this.env[RACK_REQUEST_FORM_INPUT] = input;
       return parsed;
@@ -527,35 +528,11 @@ export class Request {
   static xForwardedProtoPriority: Array<"proto" | "scheme" | null> = ["proto", "scheme"];
 
   get acceptEncoding(): Array<[string, number]> {
-    const header = this.env["HTTP_ACCEPT_ENCODING"] || "";
-    return header
-      .split(",")
-      .map((part: string) => {
-        const [enc, ...rest] = part.trim().split(";");
-        let q = 1.0;
-        for (const r of rest) {
-          const m = r.trim().match(/^q=(.+)/);
-          if (m) q = parseFloat(m[1]);
-        }
-        return [enc.trim(), q] as [string, number];
-      })
-      .filter(([enc]: [string, number]) => enc !== "");
+    return this.parseHttpAcceptHeader(this.env["HTTP_ACCEPT_ENCODING"]);
   }
 
   get acceptLanguage(): Array<[string, number]> {
-    const header = this.env["HTTP_ACCEPT_LANGUAGE"] || "";
-    return header
-      .split(",")
-      .map((part: string) => {
-        const [lang, ...rest] = part.trim().split(";");
-        let q = 1.0;
-        for (const r of rest) {
-          const m = r.trim().match(/^q=(.+)/);
-          if (m) q = parseFloat(m[1]);
-        }
-        return [lang.trim(), q] as [string, number];
-      })
-      .filter(([lang]: [string, number]) => lang !== "");
+    return this.parseHttpAcceptHeader(this.env["HTTP_ACCEPT_LANGUAGE"]);
   }
 
   getHttpForwarded(token: string): string[] | null {
@@ -679,5 +656,99 @@ export class Request {
 
   get serverName(): string | null {
     return this.env[SERVER_NAME] ?? null;
+  }
+
+  /** @internal */
+  fetchHeader(name: string): any;
+  /** @internal */
+  fetchHeader(name: string, block: () => any): any;
+  /** @internal */
+  fetchHeader(name: string, block?: () => any): any {
+    if (name in this.env) return this.env[name];
+    if (block) return block();
+    return undefined;
+  }
+
+  /** @internal */
+  eachHeader(callback: (key: string, value: any) => void): void {
+    for (const [k, v] of Object.entries(this.env)) {
+      callback(k, v);
+    }
+  }
+
+  /** @internal */
+  get hostAuthority(): string | null {
+    return this.env[HTTP_HOST] ?? null;
+  }
+
+  /** @internal */
+  isParseableData(): boolean {
+    const mt = this.mediaType;
+    return mt !== null && PARSEABLE_DATA_MEDIA_TYPES.includes(mt);
+  }
+
+  /** @internal */
+  get path(): string {
+    return this.scriptName + this.pathInfo;
+  }
+
+  /** @internal */
+  valuesAt(...keys: string[]): any[] {
+    const p = this.params;
+    return keys.map((k) => p[k]);
+  }
+
+  /** @internal */
+  protected defaultSession(): Record<string, any> {
+    return {};
+  }
+
+  /** @internal */
+  protected parseHttpAcceptHeader(header: string | null | undefined): Array<[string, number]> {
+    const parts = (header ?? "").split(",");
+    const result: Array<[string, number]> = [];
+    for (const part of parts) {
+      const trimmed = part.trim();
+      if (!trimmed) continue;
+      const [attr, params] = trimmed.split(";", 2);
+      const attribute = attr.trim();
+      let quality = 1.0;
+      if (params) {
+        const m = params.trim().match(/^q=([\d.]+)/);
+        if (m) quality = parseFloat(m[1]);
+      }
+      result.push([attribute, quality]);
+    }
+    return result;
+  }
+
+  /** @internal */
+  protected queryParser(): QueryParser {
+    return getDefaultQueryParser();
+  }
+
+  /** @internal */
+  protected parseQuery(qs: string, separator = "&"): Record<string, any> {
+    return parseNestedQuery(qs, separator);
+  }
+
+  /** @internal */
+  protected parseMultipart(): Record<string, any> {
+    return multipartExtract(this.env) || {};
+  }
+
+  /** @internal */
+  protected expandParamPairs(pairs: Array<[string, any]>): Record<string, any> {
+    const parser = this.queryParser();
+    const params = parser.makeParams();
+    for (const [k, v] of pairs) {
+      parser.normalizeParams(params, k, v);
+    }
+    return params.toParamsHash();
+  }
+
+  /** @internal */
+  protected rejectTrustedIpAddresses(ipAddresses: string[]): string[] {
+    return ipAddresses.filter((ip) => !this.trustedProxy(ip));
   }
 }


### PR DESCRIPTION
## Summary

- Adds 13 missing methods to bring `request.rb` from 85% → 100%
- Public: `fetchHeader`, `eachHeader`, `hostAuthority`, `isParseableData`, `path`, `valuesAt`
- Private (`@internal`): `defaultSession`, `parseHttpAcceptHeader`, `queryParser`, `parseQuery`, `parseMultipart`, `expandParamPairs`, `rejectTrustedIpAddresses`
- Refactors `acceptEncoding`/`acceptLanguage` getters to delegate to `parseHttpAcceptHeader`
- Adds `PARSEABLE_DATA_MEDIA_TYPES` constant (`multipart/related`, `multipart/mixed`)

## Test plan

- [ ] `pnpm vitest run packages/rack/src/request.test.ts` — 125 tests pass
- [ ] `pnpm tsx scripts/api-compare/compare.ts --package rack --privates | grep request` — `request.rb` at 100%