### PR TITLE
feat(activerecord/clone): migrate to Rails-shape (Phase D-1)

### DIFF
--- a/packages/activerecord/src/clone.test.ts
+++ b/packages/activerecord/src/clone.test.ts
@@ -2,23 +2,40 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
-import { describe, it, expect, beforeAll } from "vitest";
+import { afterAll, describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 
-import { createTestAdapter, type TestDatabaseAdapter } from "./test-adapter.js";
-import { defineSchema } from "./test-helpers/define-schema.js";
-import { withTransactionalFixtures } from "./test-helpers/with-transactional-fixtures.js";
+import { clearAppliedSchemaSignatures, defineSchema } from "./test-helpers/define-schema.js";
+import { dropAllTables } from "./test-helpers/drop-all-tables.js";
+import { setupHandlerSuite } from "./test-helpers/setup-handler-suite.js";
+import {
+  withTransactionalFixtures,
+  type TransactionalFixturesAdapter,
+} from "./test-helpers/with-transactional-fixtures.js";
 
-let adapter: TestDatabaseAdapter;
+setupHandlerSuite();
+
+let _txAdapter: TransactionalFixturesAdapter | null = null;
 beforeAll(async () => {
-  adapter = createTestAdapter();
-  await defineSchema(adapter, {
+  await defineSchema({
     topics: { title: "string", author_name: "string" },
     posts: { title: "string" },
     users: { name: "string" },
   });
+  const raw = Base.adapter;
+  _txAdapter = new Proxy(raw, {
+    get(target, prop) {
+      if (prop === "pool") return null;
+      return Reflect.get(target, prop, target);
+    },
+  }) as unknown as TransactionalFixturesAdapter;
 });
-withTransactionalFixtures(() => adapter);
+withTransactionalFixtures(() => _txAdapter!);
+afterAll(async () => {
+  const adapter = Base.adapter;
+  await dropAllTables(adapter);
+  clearAppliedSchemaSignatures(adapter);
+});
 
 describe("CloneTest", () => {
   it("persisted", async () => {
@@ -26,7 +43,6 @@ describe("CloneTest", () => {
       static {
         this.attribute("title", "string");
         this.attribute("author_name", "string");
-        this.adapter = adapter;
       }
     }
     const topic = await Topic.create({ title: "test", author_name: "David" });
@@ -42,7 +58,6 @@ describe("CloneTest", () => {
       static {
         this.attribute("title", "string");
         this.attribute("author_name", "string");
-        this.adapter = adapter;
       }
     }
     const topic = await Topic.create({ title: "test", author_name: "David" });
@@ -55,7 +70,6 @@ describe("CloneTest", () => {
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adapter;
       }
     }
     const p = await Post.create({ title: "test" });
@@ -67,7 +81,6 @@ describe("CloneTest", () => {
     class Post extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adapter;
       }
     }
     const p = await Post.create({ title: "orig" });
@@ -83,7 +96,6 @@ describe("CloneTest", () => {
     class Topic extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adapter;
       }
     }
     const original = await Topic.create({ title: "test" });
@@ -97,7 +109,6 @@ describe("CloneTest", () => {
     class Topic extends Base {
       static {
         this.attribute("title", "string");
-        this.adapter = adapter;
       }
     }
     const original = await Topic.create({ title: "test" });
@@ -116,7 +127,6 @@ describe("Base#clone", () => {
       static {
         this.attribute("id", "integer");
         this.attribute("name", "string");
-        this.adapter = adapter;
       }
     }
     const u = await User.create({ name: "Alice" });
@@ -131,7 +141,6 @@ describe("Base#clone", () => {
       static {
         this.attribute("id", "integer");
         this.attribute("name", "string");
-        this.adapter = adapter;
       }
     }
     const u = await User.create({ name: "Alice" });


### PR DESCRIPTION
Migrates `packages/activerecord/src/clone.test.ts` from the old `createTestAdapter()` / `this.adapter = adapter` pattern to the Rails-shape handler pattern established in #2286.

## Changes

- Replace `createTestAdapter()` + `adapter` variable with `setupHandlerSuite()`
- Replace two-arg `defineSchema(adapter, schema)` with single-arg `defineSchema(schema)`
- Replace `withTransactionalFixtures(() => adapter)` with pool-proxy pattern on `Base.adapter`
- Add `afterAll` teardown (`dropAllTables` + `clearAppliedSchemaSignatures`)
- Remove all `this.adapter = adapter` assignments from model static blocks
- Test names unchanged

All 8 tests pass on SQLite.