### PR TITLE
feat(test-models): port PR 1b — 6 member/club cluster model files

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -195,6 +195,44 @@ describe("BelongsToAssociations", () => {
     expect(loaded).toBeNull();
   });
 
+  it("polymorphic belongs_to with foreignType reads overridden type column", async () => {
+    await defineSchema(adapter, {
+      things: { name: "string" },
+      ft_sponsors: { sponsorable_id: "integer", sponsorable_type: "string" },
+    });
+    class FtThing extends Base {
+      static {
+        this._tableName = "things";
+        this.attribute("name", "string");
+        this.adapter = adapter;
+      }
+    }
+    class FtSponsor extends Base {
+      static {
+        this._tableName = "ft_sponsors";
+        this.attribute("sponsorable_id", "integer");
+        this.attribute("sponsorable_type", "string");
+        this.adapter = adapter;
+      }
+    }
+    registerModel(FtThing);
+    registerModel(FtSponsor);
+
+    const thing = await FtThing.create({ name: "Widget" });
+    const sponsor = await FtSponsor.create({
+      sponsorable_id: thing.id,
+      sponsorable_type: "FtThing",
+    });
+    // foreignType overrides the type column: reads sponsorable_type instead of thing_type
+    const loaded = await loadBelongsTo(sponsor, "thing", {
+      polymorphic: true,
+      foreignType: "sponsorable_type",
+      foreignKey: "sponsorable_id",
+    });
+    expect(loaded).not.toBeNull();
+    expect((loaded as any).name).toBe("Widget");
+  });
+
   // Rails: test_belongs_to_counter_cache (definition only)
   it("test_belongs_to_registers_counter_cache_option", () => {
     class Reply extends Base {

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -233,6 +233,53 @@ describe("BelongsToAssociations", () => {
     expect((loaded as any).name).toBe("Widget");
   });
 
+  it("polymorphic belongs_to with foreignType writes overridden type column on assignment", async () => {
+    await defineSchema(adapter, {
+      ft_targets: { label: "string" },
+      ft_owners: { sponsorable_id: "integer", sponsorable_type: "string" },
+    });
+    class FtTarget extends Base {
+      static {
+        this._tableName = "ft_targets";
+        this.attribute("label", "string");
+        this.adapter = adapter;
+      }
+    }
+    class FtOwner extends Base {
+      static {
+        this._tableName = "ft_owners";
+        this.attribute("sponsorable_id", "integer");
+        this.attribute("sponsorable_type", "string");
+        this.adapter = adapter;
+        this.belongsTo("thing", {
+          polymorphic: true,
+          foreignType: "sponsorable_type",
+          foreignKey: "sponsorable_id",
+        });
+      }
+    }
+    registerModel(FtTarget);
+    registerModel(FtOwner);
+
+    const target = await FtTarget.create({ label: "Acme" });
+    const owner = FtOwner.new();
+    // Writer path: should write sponsorable_type, not thing_type
+    setBelongsTo(owner, "thing", target, {
+      polymorphic: true,
+      foreignType: "sponsorable_type",
+      foreignKey: "sponsorable_id",
+    });
+    expect(owner._readAttribute("sponsorable_type")).toBe("FtTarget");
+    expect(owner._readAttribute("sponsorable_id")).toBe(target.id);
+    // Clearing should null sponsorable_type
+    setBelongsTo(owner, "thing", null, {
+      polymorphic: true,
+      foreignType: "sponsorable_type",
+      foreignKey: "sponsorable_id",
+    });
+    expect(owner._readAttribute("sponsorable_type")).toBeNull();
+  });
+
   // Rails: test_belongs_to_counter_cache (definition only)
   it("test_belongs_to_registers_counter_cache_option", () => {
     class Reply extends Base {

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -817,7 +817,7 @@ export async function loadBelongsTo(
   // Polymorphic: use the _type column to determine the target model
   let className: string;
   if (options.polymorphic) {
-    const typeCol = `${underscore(assocName)}_type`;
+    const typeCol = options.foreignType ?? `${underscore(assocName)}_type`;
     const typeName = record._readAttribute(typeCol) as string | null;
     if (!typeName) return null;
     className = typeName;

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -124,6 +124,10 @@ export interface AssociationOptions {
    * `class_name.foreign_key` default. Mirrors Rails'
    * `has_and_belongs_to_many :tags, association_foreign_key: ...`. */
   associationForeignKey?: string;
+  /** Overrides the column used to store the polymorphic type string.
+   * Mirrors Rails' `belongs_to :thing, polymorphic: true, foreign_type: "sponsorable_type"`.
+   * When absent the default is `${associationName}_type`. */
+  foreignType?: string;
   /** When true, records loaded through this association are marked
    * strict-loading, causing further lazy loads on them to raise.
    *

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -126,7 +126,7 @@ export interface AssociationOptions {
   associationForeignKey?: string;
   /** Overrides the column used to store the polymorphic type string.
    * Mirrors Rails' `belongs_to :thing, polymorphic: true, foreign_type: "sponsorable_type"`.
-   * When absent the default is `${associationName}_type`. */
+   * When absent the default is `${underscore(associationName)}_type`. */
   foreignType?: string;
   /** When true, records loaded through this association are marked
    * strict-loading, causing further lazy loads on them to raise.
@@ -2167,7 +2167,7 @@ export async function updateCounterCaches(
     // For polymorphic, resolve model from _type column
     let className: string;
     if (assoc.options.polymorphic) {
-      const typeCol = `${underscore(assoc.name)}_type`;
+      const typeCol = assoc.options.foreignType ?? `${underscore(assoc.name)}_type`;
       const typeName = record._readAttribute(typeCol) as string | null;
       if (!typeName) continue;
       className = typeName;
@@ -2283,7 +2283,7 @@ export function setBelongsTo(
       record._writeAttribute(foreignKey as string, target._readAttribute(primaryKey as string));
     }
     if (options.polymorphic) {
-      const typeCol = `${underscore(assocName)}_type`;
+      const typeCol = options.foreignType ?? `${underscore(assocName)}_type`;
       record._writeAttribute(typeCol, targetCtor!.name);
     }
   } else {
@@ -2295,7 +2295,7 @@ export function setBelongsTo(
       record._writeAttribute(foreignKey as string, null);
     }
     if (options.polymorphic) {
-      const typeCol = `${underscore(assocName)}_type`;
+      const typeCol = options.foreignType ?? `${underscore(assocName)}_type`;
       record._writeAttribute(typeCol, null);
     }
   }
@@ -2428,7 +2428,7 @@ export async function touchBelongsToParents(record: Base): Promise<void> {
 
     let className: string;
     if (assoc.options.polymorphic) {
-      const typeCol = `${underscore(assoc.name)}_type`;
+      const typeCol = assoc.options.foreignType ?? `${underscore(assoc.name)}_type`;
       const typeName = record._readAttribute(typeCol) as string | null;
       if (!typeName) continue;
       className = typeName;

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -154,7 +154,10 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
    * loadBelongsTo which reads `${underscore(assocName)}_type`.
    */
   private foreignTypeName(): string {
-    return `${underscore(this.reflection.name)}_type`;
+    return (
+      (this.reflection.options.foreignType as string | undefined) ??
+      `${underscore(this.reflection.name)}_type`
+    );
   }
 
   /**

--- a/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-polymorphic-association.ts
@@ -150,8 +150,9 @@ export class BelongsToPolymorphicAssociation extends BelongsToAssociation {
   }
 
   /**
-   * Derive the type column name from the association name, matching
-   * loadBelongsTo which reads `${underscore(assocName)}_type`.
+   * Derive the type column name. Returns `options.foreignType` when provided,
+   * otherwise falls back to `${underscore(assocName)}_type`. Mirrors the same
+   * logic in `loadBelongsTo` so reads and writes use the same column.
    */
   private foreignTypeName(): string {
     return (

--- a/packages/activerecord/src/test-helpers/models/club.ts
+++ b/packages/activerecord/src/test-helpers/models/club.ts
@@ -29,7 +29,7 @@ export class Club extends Base {
 
     this.scope("general", (q: any) =>
       q
-        .leftJoins("category")
+        .leftOuterJoins("category")
         .where({ categories: { name: "General" } })
         .unscope("limit"),
     );

--- a/packages/activerecord/src/test-helpers/models/club.ts
+++ b/packages/activerecord/src/test-helpers/models/club.ts
@@ -29,7 +29,7 @@ export class Club extends Base {
 
     this.scope("general", (q: any) =>
       q
-        .leftOuterJoins("category")
+        .leftJoins("category")
         .where({ categories: { name: "General" } })
         .unscope("limit"),
     );

--- a/packages/activerecord/src/test-helpers/models/club.ts
+++ b/packages/activerecord/src/test-helpers/models/club.ts
@@ -1,0 +1,45 @@
+// vendor/rails/activerecord/test/models/club.rb
+import { Base } from "../../base.js";
+
+export class Club extends Base {
+  static {
+    this.hasOne("membership", { touch: true });
+    this.hasMany("memberships", { inverseOf: false });
+    this.hasMany("members", { through: "memberships" });
+    this.hasOne("sponsor");
+    this.hasOne("sponsoredMember", {
+      through: "sponsor",
+      source: "sponsorable",
+      sourceType: "Member",
+    });
+    this.belongsTo("category");
+
+    this.hasMany("favorites", {
+      scope: (q: any) => q.where({ memberships: { favorite: true } }),
+      through: "memberships",
+      source: "member",
+    });
+
+    this.hasMany("customMemberships", { className: "Membership" });
+    this.hasMany("customFavorites", {
+      scope: (q: any) => q.where({ memberships: { favorite: true } }),
+      through: "customMemberships",
+      source: "member",
+    });
+
+    this.scope("general", (q: any) =>
+      q
+        .leftJoins("category")
+        .where({ categories: { name: "General" } })
+        .unscope("limit"),
+    );
+  }
+}
+
+export class SuperClub extends Base {
+  static {
+    this._tableName = "clubs";
+    this.hasMany("memberships", { className: "SuperMembership", foreignKey: "club_id" });
+    this.hasMany("members", { through: "memberships" });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/index.ts
+++ b/packages/activerecord/src/test-helpers/models/index.ts
@@ -1,8 +1,14 @@
 // vendor/rails/activerecord/test/models/ — ported model classes for fixture-adoption sweep
 export * from "./category.js";
 export * from "./categorization.js";
+export * from "./club.js";
 export * from "./comment.js";
 export * from "./essay.js";
+export * from "./member.js";
+export * from "./member-detail.js";
+export * from "./member-type.js";
+export * from "./membership.js";
 export * from "./reader.js";
+export * from "./sponsor.js";
 export * from "./tag.js";
 export * from "./tagging.js";

--- a/packages/activerecord/src/test-helpers/models/member-detail.ts
+++ b/packages/activerecord/src/test-helpers/models/member-detail.ts
@@ -1,0 +1,16 @@
+// vendor/rails/activerecord/test/models/member_detail.rb
+import { Base } from "../../base.js";
+
+export class MemberDetail extends Base {
+  static {
+    this.belongsTo("member", { inverseOf: false });
+    this.belongsTo("organization");
+    this.hasOne("memberType", { through: "member" });
+    this.hasOne("membership", { through: "member" });
+    this.hasOne("admittable", { through: "member", sourceType: "Member" });
+    this.hasMany("organizationMemberDetails", {
+      through: "organization",
+      source: "memberDetails",
+    });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/member-type.ts
+++ b/packages/activerecord/src/test-helpers/models/member-type.ts
@@ -1,0 +1,8 @@
+// vendor/rails/activerecord/test/models/member_type.rb
+import { Base } from "../../base.js";
+
+export class MemberType extends Base {
+  static {
+    this.hasMany("members");
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/member.ts
+++ b/packages/activerecord/src/test-helpers/models/member.ts
@@ -1,0 +1,88 @@
+// vendor/rails/activerecord/test/models/member.rb
+import { Base } from "../../base.js";
+
+export class Member extends Base {
+  static {
+    this.hasOne("currentMembership");
+    this.hasOne("selectedMembership");
+    this.hasOne("membership");
+    this.hasOne("club", { through: "currentMembership" });
+    this.hasOne("clubWithoutJoins", {
+      through: "currentMembership",
+      source: "club",
+      disableJoins: true,
+    });
+    this.hasOne("selectedClub", { through: "selectedMembership", source: "club" });
+    this.hasOne("favoriteClub", {
+      scope: (q: any) => q.where("memberships.favorite = ?", true),
+      through: "membership",
+      source: "club",
+    });
+    this.hasOne("hairyClub", {
+      scope: (q: any) => q.where({ clubs: { name: "Moustache and Eyebrow Fancier Club" } }),
+      through: "membership",
+      source: "club",
+    });
+    this.hasOne("sponsor", { as: "sponsorable" });
+    this.hasOne("sponsorClub", { through: "sponsor" });
+    this.hasOne("memberDetail", { inverseOf: false });
+    this.hasOne("organization", { through: "memberDetail" });
+    this.hasOne("organizationWithoutJoins", {
+      through: "memberDetail",
+      disableJoins: true,
+      source: "organization",
+    });
+    this.belongsTo("memberType");
+
+    this.hasMany("nestedMemberTypes", { through: "memberDetail", source: "memberType" });
+    this.hasOne("nestedMemberType", { through: "memberDetail", source: "memberType" });
+
+    this.hasMany("nestedSponsors", { through: "sponsorClub", source: "sponsor" });
+    this.hasOne("nestedSponsor", { through: "sponsorClub", source: "sponsor" });
+
+    this.hasMany("organizationMemberDetails", { through: "memberDetail" });
+    this.hasMany("organizationMemberDetails_2", {
+      through: "organization",
+      source: "memberDetails",
+    });
+
+    this.hasOne("clubCategory", { through: "club", source: "category" });
+    this.hasOne("generalClub", {
+      scope: (q: any) => q.general(),
+      through: "currentMembership",
+      source: "club",
+    });
+
+    this.hasMany("superMemberships");
+    this.hasMany("favoriteMemberships", {
+      scope: (q: any) => q.where({ favorite: true }),
+      className: "Membership",
+    });
+    this.hasMany("clubs", { through: "favoriteMemberships" });
+
+    this.hasMany("tenantMemberships");
+    this.hasMany("tenantClubs", {
+      through: "tenantMemberships",
+      className: "Club",
+      source: "club",
+    });
+
+    this.hasOne("clubThroughMany", { through: "favoriteMemberships", source: "club" });
+
+    this.belongsTo("admittable", { polymorphic: true });
+    this.hasOne("premiumClub", { through: "admittable" });
+
+    this.scope("unnamed", (q: any) => q.where({ name: null }));
+    this.scope("withMemberTypeId", (q: any, id: number) => q.where({ member_type_id: id }));
+  }
+}
+
+export class SelfMember extends Base {
+  static {
+    this._tableName = "members";
+    this.hasAndBelongsToMany("friends", {
+      className: "SelfMember",
+      joinTable: "member_friends",
+    });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/membership.ts
+++ b/packages/activerecord/src/test-helpers/models/membership.ts
@@ -1,0 +1,51 @@
+// vendor/rails/activerecord/test/models/membership.rb
+import { Base } from "../../base.js";
+
+export class Membership extends Base {
+  static {
+    this.enum("type", {
+      Membership: 0,
+      CurrentMembership: 1,
+      SuperMembership: 2,
+      SelectedMembership: 3,
+      TenantMembership: 4,
+    });
+    this.belongsTo("member");
+    this.belongsTo("club");
+  }
+}
+
+export class CurrentMembership extends Membership {
+  static {
+    this.belongsTo("member");
+    this.belongsTo("club", { inverseOf: "membership" });
+  }
+}
+
+export class SuperMembership extends Membership {
+  static {
+    this.belongsTo("member", { scope: (q: any) => q.order("members.id DESC") });
+    this.belongsTo("club");
+  }
+}
+
+export class SelectedMembership extends Membership {
+  static {
+    this.defaultScope((q: any) => q.select("'1' as foo"));
+  }
+}
+
+export class TenantMembership extends Membership {
+  static currentMember: any = null;
+
+  static {
+    this.belongsTo("member");
+    this.belongsTo("club");
+    this.defaultScope((q: any) => {
+      if (TenantMembership.currentMember) {
+        return q.where({ member: TenantMembership.currentMember });
+      }
+      return q.all();
+    });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/sponsor.ts
+++ b/packages/activerecord/src/test-helpers/models/sponsor.ts
@@ -1,0 +1,21 @@
+// vendor/rails/activerecord/test/models/sponsor.rb
+import { Base } from "../../base.js";
+
+export class Sponsor extends Base {
+  static {
+    this.belongsTo("sponsorClub", { className: "Club", foreignKey: "club_id" });
+    this.belongsTo("sponsorable", { polymorphic: true });
+    this.belongsTo("sponsor", { polymorphic: true });
+    this.belongsTo("thing", {
+      polymorphic: true,
+      // foreign_type: "sponsorable_type" — not yet in AssociationOptions
+      foreignKey: "sponsorable_id",
+    } as any);
+    this.belongsTo("sponsorableWithConditions", {
+      scope: (q: any) => q.where({ name: "Ernie" }),
+      polymorphic: true,
+      // foreign_type: "sponsorable_type" — not yet in AssociationOptions
+      foreignKey: "sponsorable_id",
+    } as any);
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/sponsor.ts
+++ b/packages/activerecord/src/test-helpers/models/sponsor.ts
@@ -8,14 +8,14 @@ export class Sponsor extends Base {
     this.belongsTo("sponsor", { polymorphic: true });
     this.belongsTo("thing", {
       polymorphic: true,
-      // foreign_type: "sponsorable_type" — not yet in AssociationOptions
+      foreignType: "sponsorable_type",
       foreignKey: "sponsorable_id",
-    } as any);
+    });
     this.belongsTo("sponsorableWithConditions", {
       scope: (q: any) => q.where({ name: "Ernie" }),
       polymorphic: true,
-      // foreign_type: "sponsorable_type" — not yet in AssociationOptions
+      foreignType: "sponsorable_type",
       foreignKey: "sponsorable_id",
-    } as any);
+    });
   }
 }


### PR DESCRIPTION
## Summary

- Ports \`club.rb\`, \`member.rb\`, \`member-detail.rb\`, \`member-type.rb\`, \`membership.rb\`, \`sponsor.rb\` from \`vendor/rails/activerecord/test/models/\` into \`packages/activerecord/src/test-helpers/models/\`
- All 6 primary classes + auxiliary subclasses (SuperClub, SelfMember, CurrentMembership, SuperMembership, SelectedMembership, TenantMembership) included
- All 6 files verified at 100% MATCH via \`pnpm tsx scripts/fixtures-compare/compare.ts --models\`
- Adds \`foreignType\` option to \`AssociationOptions\` and wires it into both \`BelongsToPolymorphicAssociation#foreignTypeName()\` (write/dirty path) and \`loadBelongsTo\` (read path), matching Rails' \`foreign_type:\` option

## Follow-ups (for subsequent PRs)

- Next cluster: PR 1c — \`post.rb\`, \`author.rb\`, \`person.rb\`, \`company.rb\` (the large association-heavy models)