### PR TITLE
feat(test-models): port PR 4 — pets/animals cluster

### DIFF
--- a/packages/activerecord/src/test-helpers/models/bird.ts
+++ b/packages/activerecord/src/test-helpers/models/bird.ts
@@ -1,10 +1,20 @@
 // vendor/rails/activerecord/test/models/bird.rb
 import { Base } from "../../base.js";
+import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
 
 export class Bird extends Base {
+  cancelSaveFromCallback: boolean = false;
+  totalCount: number = 0;
+  enableCount: boolean = false;
+
   static {
     this.belongsTo("pirate");
     this.validates("name", { presence: true });
+
+    this.beforeSave(async function (this: Bird) {
+      const conn = (this.constructor as typeof Base).leaseConnection();
+      await (conn as any).materializeTransactions?.();
+    });
 
     this.beforeSave(
       function (this: any) {
@@ -12,9 +22,19 @@ export class Bird extends Base {
       },
       { if: (r: any) => r.cancelSaveFromCallback },
     );
+
+    this.afterInitialize(function (this: Bird) {
+      if (this.enableCount) {
+        void Bird.count().then((c) => {
+          this.totalCount = c as number;
+        });
+      }
+    });
   }
 
   cancelSaveCallbackMethod() {
     throw "abort";
   }
 }
+
+acceptsNestedAttributesFor(Bird, "pirate");

--- a/packages/activerecord/src/test-helpers/models/cat.ts
+++ b/packages/activerecord/src/test-helpers/models/cat.ts
@@ -1,0 +1,12 @@
+// vendor/rails/activerecord/test/models/cat.rb
+import { Base } from "../../base.js";
+
+export class Cat extends Base {
+  static {
+    this._abstractClass = true;
+    this.enum("gender", { female: 0, male: 1 });
+    this.defaultScope((q: any) => q.where({ is_vegetarian: false }));
+  }
+}
+
+export class Lion extends Cat {}

--- a/packages/activerecord/src/test-helpers/models/dog-lover.ts
+++ b/packages/activerecord/src/test-helpers/models/dog-lover.ts
@@ -1,0 +1,14 @@
+// vendor/rails/activerecord/test/models/dog_lover.rb
+import { Base } from "../../base.js";
+
+export class DogLover extends Base {
+  static {
+    this.hasMany("trainedDogs", {
+      className: "Dog",
+      foreignKey: "trainer_id",
+      dependent: "destroy",
+    });
+    this.hasMany("bredDogs", { className: "Dog", foreignKey: "breeder_id" });
+    this.hasMany("dogs");
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/dog.ts
+++ b/packages/activerecord/src/test-helpers/models/dog.ts
@@ -1,0 +1,14 @@
+// vendor/rails/activerecord/test/models/dog.rb
+import { Base } from "../../base.js";
+
+export class Dog extends Base {
+  static {
+    this.belongsTo("breeder", { className: "DogLover", counterCache: "bred_dogs_count" });
+    this.belongsTo("trainer", { className: "DogLover", counterCache: "trained_dogs_count" });
+    this.belongsTo("doglover", {
+      foreignKey: "dog_lover_id",
+      className: "DogLover",
+      counterCache: true,
+    });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/index.ts
+++ b/packages/activerecord/src/test-helpers/models/index.ts
@@ -20,3 +20,13 @@ export * from "./ship.js";
 export * from "./ship-part.js";
 export * from "./treasure.js";
 export * from "./wheel.js";
+// Cluster 4: pets/animals
+export * from "./cat.js";
+export * from "./dog.js";
+export * from "./dog-lover.js";
+export * from "./mouse.js";
+export * from "./squeak.js";
+export * from "./other-dog.js";
+export * from "./owner.js";
+export * from "./pet.js";
+export * from "./pet-treasure.js";

--- a/packages/activerecord/src/test-helpers/models/mouse.ts
+++ b/packages/activerecord/src/test-helpers/models/mouse.ts
@@ -1,0 +1,9 @@
+// vendor/rails/activerecord/test/models/mouse.rb
+import { Base } from "../../base.js";
+
+export class Mouse extends Base {
+  static {
+    this.hasMany("squeaks", { autosave: true });
+    this.validates("name", { presence: true });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/other-dog.ts
+++ b/packages/activerecord/src/test-helpers/models/other-dog.ts
@@ -1,0 +1,14 @@
+// vendor/rails/activerecord/test/models/other_dog.rb
+import { Base } from "../../base.js";
+
+class ARUnit2Model extends Base {
+  static {
+    this._abstractClass = true;
+  }
+}
+
+export class OtherDog extends ARUnit2Model {
+  static {
+    this._tableName = "dogs";
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/owner.ts
+++ b/packages/activerecord/src/test-helpers/models/owner.ts
@@ -1,0 +1,49 @@
+// vendor/rails/activerecord/test/models/owner.rb
+import { Base } from "../../base.js";
+import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
+
+export class Owner extends Base {
+  private _blocks: Array<(owner: Owner) => void> = [];
+
+  static {
+    this._primaryKey = "owner_id";
+    this.hasMany("pets", { scope: (q: any) => q.order("pets.name desc") });
+    this.hasMany("toys", { through: "pets" });
+    this.hasMany("persons", { through: "pets" });
+    this.belongsTo("lastPet", { className: "Pet" });
+    this.scope("includingLastPet", (q: any) =>
+      q
+        .select(
+          `
+          owners.*, (
+            select p.pet_id from pets p
+            where p.owner_id = owners.owner_id
+            order by p.name desc
+            limit 1
+          ) as last_pet_id
+        `,
+        )
+        .includes("lastPet"),
+    );
+    this.afterCommit(async function (this: Owner) {
+      await this.executeBlocks();
+    });
+  }
+
+  get blocks(): Array<(owner: Owner) => void> {
+    return this._blocks;
+  }
+
+  onAfterCommit(block: (owner: Owner) => void) {
+    this._blocks.push(block);
+  }
+
+  async executeBlocks() {
+    for (const block of this._blocks) {
+      block(this);
+    }
+    this._blocks = [];
+  }
+}
+
+acceptsNestedAttributesFor(Owner, "pets", { allowDestroy: true });

--- a/packages/activerecord/src/test-helpers/models/owner.ts
+++ b/packages/activerecord/src/test-helpers/models/owner.ts
@@ -3,7 +3,7 @@ import { Base } from "../../base.js";
 import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
 
 export class Owner extends Base {
-  private _blocks: Array<(owner: Owner) => void> = [];
+  private _blocks: Array<(owner: Owner) => void | Promise<void>> = [];
 
   static {
     this._primaryKey = "owner_id";
@@ -30,19 +30,20 @@ export class Owner extends Base {
     });
   }
 
-  get blocks(): Array<(owner: Owner) => void> {
+  get blocks(): Array<(owner: Owner) => void | Promise<void>> {
     return this._blocks;
   }
 
-  onAfterCommit(block: (owner: Owner) => void) {
+  onAfterCommit(block: (owner: Owner) => void | Promise<void>) {
     this._blocks.push(block);
   }
 
   async executeBlocks() {
-    for (const block of this._blocks) {
-      block(this);
-    }
+    const blocks = this._blocks;
     this._blocks = [];
+    for (const block of blocks) {
+      await block(this);
+    }
   }
 }
 

--- a/packages/activerecord/src/test-helpers/models/parrot.ts
+++ b/packages/activerecord/src/test-helpers/models/parrot.ts
@@ -16,11 +16,19 @@ export class Parrot extends Base {
       function (this: any) {
         this.cancelSaveCallbackMethod();
       },
-      { if: (r: any) => r.cancelSaveFromCallback },
+      { if: (r: any) => r.readAttribute("cancelSaveFromCallback") },
     );
     this.beforeUpdate(function (this: any) {
       this.incrementUpdatedCount();
     });
+  }
+
+  static async deleteAll() {
+    await this.withConnection(async (c: any) => {
+      await c.delete("DELETE FROM parrots_pirates");
+      await c.delete("DELETE FROM parrots_treasures");
+    });
+    return super.deleteAll();
   }
 
   cancelSaveCallbackMethod() {

--- a/packages/activerecord/src/test-helpers/models/pet-treasure.ts
+++ b/packages/activerecord/src/test-helpers/models/pet-treasure.ts
@@ -1,0 +1,10 @@
+// vendor/rails/activerecord/test/models/pet_treasure.rb
+import { Base } from "../../base.js";
+
+export class PetTreasure extends Base {
+  static {
+    this._tableName = "pets_treasures";
+    this.belongsTo("pet");
+    this.belongsTo("treasure");
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/pet.ts
+++ b/packages/activerecord/src/test-helpers/models/pet.ts
@@ -1,0 +1,21 @@
+// vendor/rails/activerecord/test/models/pet.rb
+import { Base } from "../../base.js";
+
+export class Pet extends Base {
+  static afterDestroyOutput: any;
+
+  currentUser: any = null;
+
+  static {
+    this._primaryKey = "pet_id";
+    this.belongsTo("owner", { touch: true });
+    this.hasMany("toys");
+    this.hasMany("petTreasures");
+    this.hasMany("treasures", { through: "petTreasures" });
+    this.hasMany("persons", { through: "treasures", source: "looter", sourceType: "Person" });
+
+    this.afterDestroy(function (this: Pet) {
+      Pet.afterDestroyOutput = this.currentUser;
+    });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/squeak.ts
+++ b/packages/activerecord/src/test-helpers/models/squeak.ts
@@ -1,0 +1,11 @@
+// vendor/rails/activerecord/test/models/squeak.rb
+import { Base } from "../../base.js";
+import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
+
+export class Squeak extends Base {
+  static {
+    this.belongsTo("mouse");
+  }
+}
+
+acceptsNestedAttributesFor(Squeak, "mouse");


### PR DESCRIPTION
## Summary

- Ports 11 Ruby test models from `activerecord/test/models/` to TypeScript at `packages/activerecord/src/test-helpers/models/`
- Cluster: pets/animals — `bird`, `cat`/`Lion`, `dog`, `dog_lover`, `mouse`, `squeak`, `other_dog` (inline `ARUnit2Model`), `owner`, `parrot`/`LiveParrot`/`DeadParrot`, `pet`, `pet_treasure`
- All 11 models verify at 100% MATCH in `fixtures-compare --models`
- 258 LOC additions, within the 300 LOC ceiling
- No `Model.adapter = X`; models resolve via `Base.connectionHandler`

## Test plan

- [x] `pnpm tsx scripts/fixtures-compare/compare.ts --models` — no regressions, all new models show MATCH
- [x] `tsc --build` passes
- [x] `typecheck` passes