### PR TITLE
feat(test-models): port PR 2 — pirates/ships universe (cluster 2)

### DIFF
--- a/packages/activerecord/src/test-helpers/models/bird.ts
+++ b/packages/activerecord/src/test-helpers/models/bird.ts
@@ -1,0 +1,20 @@
+// vendor/rails/activerecord/test/models/bird.rb
+import { Base } from "../../base.js";
+
+export class Bird extends Base {
+  static {
+    this.belongsTo("pirate");
+    this.validates("name", { presence: true });
+
+    this.beforeSave(
+      function (this: any) {
+        this.cancelSaveCallbackMethod();
+      },
+      { if: (r: any) => r.cancelSaveFromCallback },
+    );
+  }
+
+  cancelSaveCallbackMethod() {
+    throw "abort";
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/index.ts
+++ b/packages/activerecord/src/test-helpers/models/index.ts
@@ -6,3 +6,11 @@ export * from "./essay.js";
 export * from "./reader.js";
 export * from "./tag.js";
 export * from "./tagging.js";
+// Cluster 2: pirates/ships universe
+export * from "./bird.js";
+export * from "./parrot.js";
+export * from "./pirate.js";
+export * from "./ship.js";
+export * from "./ship-part.js";
+export * from "./treasure.js";
+export * from "./wheel.js";

--- a/packages/activerecord/src/test-helpers/models/parrot.ts
+++ b/packages/activerecord/src/test-helpers/models/parrot.ts
@@ -1,0 +1,45 @@
+// vendor/rails/activerecord/test/models/parrot.rb
+import { Base } from "../../base.js";
+
+export class Parrot extends Base {
+  static {
+    this.inheritanceColumn = "parrot_sti_class";
+    this.hasAndBelongsToMany("pirates");
+    this.hasAndBelongsToMany("treasures");
+    this.hasMany("loots", { as: "looter", className: "Treasure" });
+    this.aliasAttribute("title", "name");
+
+    this.validates("name", { presence: true });
+
+    this.attribute("cancelSaveFromCallback", "boolean");
+    this.beforeSave(
+      function (this: any) {
+        this.cancelSaveCallbackMethod();
+      },
+      { if: (r: any) => r.cancelSaveFromCallback },
+    );
+    this.beforeUpdate(function (this: any) {
+      this.incrementUpdatedCount();
+    });
+  }
+
+  cancelSaveCallbackMethod() {
+    throw "abort";
+  }
+
+  incrementUpdatedCount() {
+    (this as any).updatedCount = ((this as any).updatedCount ?? 0) + 1;
+  }
+}
+
+export class LiveParrot extends Parrot {
+  static {
+    this.enum("breed", { african: 0, australian: 1 });
+  }
+}
+
+export class DeadParrot extends Parrot {
+  static {
+    this.belongsTo("killer", { className: "Pirate", foreignKey: "killer_id" });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/pirate.ts
+++ b/packages/activerecord/src/test-helpers/models/pirate.ts
@@ -1,0 +1,130 @@
+// vendor/rails/activerecord/test/models/pirate.rb
+import { Base } from "../../base.js";
+
+export class Pirate extends Base {
+  static {
+    this.belongsTo("parrot", { validate: true });
+    this.belongsTo("nonValidatedParrot", { className: "Parrot" });
+    this.hasAndBelongsToMany("parrots", {
+      scope: (q: any) => q.order("parrots.id ASC"),
+      validate: true,
+    });
+    this.hasAndBelongsToMany("nonValidatedParrots", { className: "Parrot" });
+    this.hasAndBelongsToMany("parrotsWithMethodCallbacks", {
+      className: "Parrot",
+      beforeAdd: (p: any, pa: any) => p.logBeforeAdd(pa),
+      afterAdd: (p: any, pa: any) => p.logAfterAdd(pa),
+      beforeRemove: (p: any, pa: any) => p.logBeforeRemove(pa),
+      afterRemove: (p: any, pa: any) => p.logAfterRemove(pa),
+    });
+    this.hasAndBelongsToMany("parrotsWithProcCallbacks", {
+      className: "Parrot",
+      beforeAdd: (p: any, pa: any) =>
+        p.shipLog.push(`before_adding_proc_parrot_${pa.id ?? "<new>"}`),
+      afterAdd: (p: any, pa: any) => p.shipLog.push(`after_adding_proc_parrot_${pa.id ?? "<new>"}`),
+      beforeRemove: (p: any, pa: any) => p.shipLog.push(`before_removing_proc_parrot_${pa.id}`),
+      afterRemove: (p: any, pa: any) => p.shipLog.push(`after_removing_proc_parrot_${pa.id}`),
+    });
+    this.hasAndBelongsToMany("autosavedParrots", { className: "Parrot", autosave: true });
+
+    this.hasMany("treasures", { as: "looter" });
+    this.hasMany("treasureEstimates", { through: "treasures", source: "priceEstimates" });
+
+    this.hasOne("ship");
+    this.hasOne("updateOnlyShip", { className: "Ship" });
+    this.hasOne("nonValidatedShip", { className: "Ship" });
+    this.hasMany("birds", { scope: (q: any) => q.order("birds.id ASC") });
+    this.hasMany("birdsWithMethodCallbacks", {
+      className: "Bird",
+      beforeAdd: (p: any, b: any) => p.logBeforeAdd(b),
+      afterAdd: (p: any, b: any) => p.logAfterAdd(b),
+      beforeRemove: (p: any, b: any) => p.logBeforeRemove(b),
+      afterRemove: (p: any, b: any) => p.logAfterRemove(b),
+    });
+    this.hasMany("birdsWithProcCallbacks", {
+      className: "Bird",
+      beforeAdd: (p: any, b: any) => p.shipLog.push(`before_adding_proc_bird_${b.id ?? "<new>"}`),
+      afterAdd: (p: any, b: any) => p.shipLog.push(`after_adding_proc_bird_${b.id ?? "<new>"}`),
+      beforeRemove: (p: any, b: any) => p.shipLog.push(`before_removing_proc_bird_${b.id}`),
+      afterRemove: (p: any, b: any) => p.shipLog.push(`after_removing_proc_bird_${b.id}`),
+    });
+    this.hasMany("birdsWithRejectAllBlank", { className: "Bird" });
+
+    this.hasOne("fooBulb", {
+      scope: (q: any) => q.where({ name: "foo" }),
+      foreignKey: "car_id",
+      className: "Bulb",
+    });
+
+    this.hasMany("mateys", { foreignKey: "pirate_id" });
+    this.hasOne("attackerMatey", { foreignKey: "target_id", className: "Matey" });
+
+    this.validates("catchphrase", { presence: true });
+
+    this.beforeSave(
+      function (this: any) {
+        return this.cancelSaveCallbackMethod();
+      },
+      { if: (r: any) => r.cancelSaveFromCallback },
+    );
+  }
+
+  get shipLog(): string[] {
+    if (!this._shipLog) this._shipLog = [];
+    return this._shipLog as string[];
+  }
+  private _shipLog?: string[];
+
+  cancelSaveCallbackMethod() {
+    throw "abort";
+  }
+
+  private log(record: any, callback: string) {
+    this.shipLog.push(
+      `${callback}_${record.constructor.name.toLowerCase()}_${record.id ?? "<new>"}`,
+    );
+  }
+
+  private logBeforeAdd(record: any) {
+    this.log(record, "before_adding_method");
+  }
+  private logAfterAdd(record: any) {
+    this.log(record, "after_adding_method");
+  }
+  private logBeforeRemove(record: any) {
+    this.log(record, "before_removing_method");
+  }
+  private logAfterRemove(record: any) {
+    this.log(record, "after_removing_method");
+  }
+}
+
+export class DestructivePirate extends Pirate {
+  static {
+    this.hasOne("dependentShip", {
+      className: "Ship",
+      foreignKey: "pirate_id",
+      dependent: "destroy",
+    });
+  }
+}
+
+export class FamousPirate extends Base {
+  static {
+    this.tableName = "pirates";
+    this.hasMany("famousShips", { inverseOf: "famousPirate" });
+    this.validates("catchphrase", { presence: true, on: "conference" });
+  }
+}
+
+export class SpacePirate extends Base {
+  static {
+    this.tableName = "pirates";
+    this.belongsTo("parrot");
+    this.hasAndBelongsToMany("parrots", { foreignKey: "pirate_id" });
+    this.hasOne("ship", { foreignKey: "pirate_id" });
+    this.hasMany("birds", { foreignKey: "pirate_id" });
+    this.hasMany("treasures", { as: "looter" });
+    this.hasMany("treasureEstimates", { through: "treasures", source: "priceEstimates" });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/ship-part.ts
+++ b/packages/activerecord/src/test-helpers/models/ship-part.ts
@@ -1,0 +1,11 @@
+// vendor/rails/activerecord/test/models/ship_part.rb
+import { Base } from "../../base.js";
+
+export class ShipPart extends Base {
+  static {
+    this.belongsTo("ship");
+    this.hasMany("trinkets", { className: "Treasure", as: "looter" });
+
+    this.validates("name", { presence: true });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/ship.ts
+++ b/packages/activerecord/src/test-helpers/models/ship.ts
@@ -1,0 +1,55 @@
+// vendor/rails/activerecord/test/models/ship.rb
+import { Base } from "../../base.js";
+
+export class Ship extends Base {
+  static {
+    this.recordTimestamps = false;
+    this.belongsTo("pirate");
+    this.belongsTo("updateOnlyPirate", { className: "Pirate" });
+    this.belongsTo("developer", { dependent: "destroy" });
+    this.hasMany("parts", { className: "ShipPart" });
+    this.hasMany("treasures");
+
+    this.validates("name", { presence: true });
+
+    this.beforeSave(
+      function (this: any) {
+        this.cancelSaveCallbackMethod();
+      },
+      { if: (r: any) => r.cancelSaveFromCallback },
+    );
+  }
+
+  cancelSaveCallbackMethod() {
+    throw "abort";
+  }
+}
+
+export class ShipWithoutNestedAttributes extends Base {
+  static {
+    this.tableName = "ships";
+    this.hasMany("prisoners", { inverseOf: "ship" });
+    this.hasMany("parts", { className: "ShipPart", foreignKey: "ship_id" });
+
+    this.validates("name", { presence: true, if: () => true });
+    this.validates("name", { presence: true, if: () => true });
+  }
+}
+
+export class Prisoner extends Base {
+  static {
+    this.belongsTo("ship", {
+      autosave: true,
+      className: "ShipWithoutNestedAttributes",
+      inverseOf: "prisoners",
+    });
+  }
+}
+
+export class FamousShip extends Base {
+  static {
+    this.tableName = "ships";
+    this.belongsTo("famousPirate", { foreignKey: "pirate_id" });
+    this.validates("name", { presence: true, on: "conference" });
+  }
+}

--- a/packages/activerecord/src/test-helpers/models/treasure.ts
+++ b/packages/activerecord/src/test-helpers/models/treasure.ts
@@ -1,0 +1,14 @@
+// vendor/rails/activerecord/test/models/treasure.rb
+import { Base } from "../../base.js";
+
+export class Treasure extends Base {
+  static {
+    this.hasAndBelongsToMany("parrots");
+    this.belongsTo("looter", { polymorphic: true });
+    this.belongsTo("ship");
+    this.hasMany("priceEstimates", { as: "estimateOf", autosave: true });
+    this.hasAndBelongsToMany("richPeople", { joinTable: "peoples_treasures", validate: false });
+  }
+}
+
+export class HiddenTreasure extends Treasure {}

--- a/packages/activerecord/src/test-helpers/models/wheel.ts
+++ b/packages/activerecord/src/test-helpers/models/wheel.ts
@@ -1,0 +1,12 @@
+// vendor/rails/activerecord/test/models/wheel.rb
+import { Base } from "../../base.js";
+
+export class Wheel extends Base {
+  static {
+    this.belongsTo("wheelable", {
+      polymorphic: true,
+      counterCache: true,
+      touch: "wheels_owned_at",
+    });
+  }
+}


### PR DESCRIPTION
## Summary

- Ports the pirate/ships model universe (cluster 2) from `vendor/rails/activerecord/test/models/` to `packages/activerecord/src/test-helpers/models/`
- 7 new model files: `bird.ts`, `parrot.ts`, `pirate.ts`, `ship-part.ts`, `ship.ts`, `treasure.ts`, `wheel.ts`
- All models verify via `pnpm tsx scripts/fixtures-compare/compare.ts --models` (pirate 100%, ship 100%, parrot 100%, treasure 100%, bird 100%, ship-part 100%, wheel 100%)

## Models ported

**Cluster 2 — pirates/ships:**
- `Pirate` + `DestructivePirate` + `FamousPirate` + `SpacePirate`
- `Ship` + `ShipWithoutNestedAttributes` + `Prisoner` + `FamousShip`
- `Parrot` + `LiveParrot` + `DeadParrot`
- `Treasure` + `HiddenTreasure`
- `Bird`, `ShipPart`, `Wheel`

## Follow-ups (deferred to stay under 300 LOC)

- **Cluster 9 (encryption):** `book_encrypted.rb` — 14 classes around `EncryptedBook`, all using `this.encrypts(...)`. ~115 LOC standalone.
- **Cluster 10 (misc partial):** `electron.rb`, `liquid.rb`, `molecule.rb`, `subscriber.rb`, `subscription.rb`, `aircraft.rb`, `country.rb`, `treaty.rb` — all simple, ~80 LOC total.
- **Cluster 9+10 remainder** can be bundled into a single follow-up PR off main.