### PR TITLE
feat(scripts): add test:deps to inventory Rails AR test fixture deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ dist/
 *.tsbuildinfo
 scripts/test-compare/output/
 scripts/api-compare/output/
+scripts/test-deps/output/
 scripts/guides-typecheck/.tmp/
 scripts/api-compare/.rack-source
 scripts/api-compare/.rails-source

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "api:moves": "pnpm tsx scripts/api-compare/moves.ts",
     "lint:deps": "pnpm vendor:fetch && LIB_PATHS_JSON=$(pnpm -s vendor:fetch --print-lib-paths) LOCKFILE_PATH=$PWD/vendor/sources.lock.json ruby scripts/api-compare/extract-ruby-api.rb && pnpm tsx scripts/api-compare/lint-deps.ts",
     "test:compare": "bash scripts/test-compare/run.sh",
+    "test:deps": "pnpm vendor:fetch >/dev/null && pnpm tsx scripts/test-deps/rails-test-deps.ts",
     "test:stubs": "pnpm test:compare -- --missing --json && pnpm tsx scripts/test-compare/generate-stubs.ts",
     "stats:sync": "pnpm tsx scripts/sync-stats/sync.ts",
     "parity:validate": "ajv compile -s scripts/parity/canonical/schema.schema.json -s scripts/parity/canonical/query.schema.json --spec=draft2020",

--- a/scripts/test-deps/rails-test-deps.test.ts
+++ b/scripts/test-deps/rails-test-deps.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { parseSource } from "./rails-test-deps.js";
+
+describe("parseSource", () => {
+  it("captures model requires", () => {
+    const src = [
+      'require "models/post"',
+      'require "models/author"',
+      'require "models/post"', // duplicate
+      "",
+      "class FooTest < ActiveRecord::TestCase",
+      "end",
+    ].join("\n");
+    expect(parseSource(src).requires).toEqual(["author", "post"]);
+  });
+
+  it("flattens multi-line fixture declarations across classes", () => {
+    const src = [
+      "class A < ActiveRecord::TestCase",
+      "  fixtures :topics, :companies,",
+      '    :developers, "warehouse-things"',
+      "end",
+      "class B < ActiveRecord::TestCase",
+      "  fixtures :posts",
+      "end",
+    ].join("\n");
+    expect(parseSource(src).fixtures).toEqual([
+      "companies",
+      "developers",
+      "posts",
+      "topics",
+      "warehouse-things",
+    ]);
+  });
+
+  it("captures set_fixture_class mappings", () => {
+    const src = [
+      "class X < ActiveRecord::TestCase",
+      "  set_fixture_class items: Book, funny_jokes: Joke",
+      "end",
+    ].join("\n");
+    expect(parseSource(src).setFixtureClass).toEqual({ items: "Book", funny_jokes: "Joke" });
+  });
+
+  it("attributes per-test fixture records for def test_x", () => {
+    const src = [
+      "class T < ActiveRecord::TestCase",
+      "  fixtures :customers, :posts",
+      "  def test_one",
+      "    customers(:david).name",
+      "    posts(:welcome, :thinking)",
+      "  end",
+      "  def test_two",
+      "    customers(:mary)",
+      "  end",
+      "end",
+    ].join("\n");
+    const out = parseSource(src);
+    expect(out.tests).toEqual({
+      test_one: { fixtures: { customers: ["david"], posts: ["thinking", "welcome"] } },
+      test_two: { fixtures: { customers: ["mary"] } },
+    });
+  });
+
+  it('normalizes `test "..." do` labels', () => {
+    const src = [
+      "class T < ActiveRecord::TestCase",
+      "  fixtures :customers",
+      '  test "finds by name" do',
+      "    customers(:david)",
+      "  end",
+      "end",
+    ].join("\n");
+    expect(Object.keys(parseSource(src).tests)).toEqual(["test_finds_by_name"]);
+  });
+
+  it("omits tests with no fixture-accessor calls", () => {
+    const src = [
+      "class T < ActiveRecord::TestCase",
+      "  fixtures :customers",
+      "  def test_other",
+      "    assert true",
+      "  end",
+      "end",
+    ].join("\n");
+    expect(parseSource(src).tests).toEqual({});
+  });
+
+  it("does not treat hash-syntax keys as fixture accessors", () => {
+    const src = [
+      "class T < ActiveRecord::TestCase",
+      "  fixtures :customers",
+      "  def test_hash",
+      "    h = { customers: 1 }",
+      "    h[:customers]",
+      "  end",
+      "end",
+    ].join("\n");
+    expect(parseSource(src).tests).toEqual({});
+  });
+});

--- a/scripts/test-deps/rails-test-deps.ts
+++ b/scripts/test-deps/rails-test-deps.ts
@@ -1,15 +1,19 @@
 /**
  * Extract per-file model/fixture dependencies from Rails activerecord tests.
  *
- * Scans vendor/rails/activerecord/test/cases/**\/*.rb and records, for each
- * test file:
+ * Scans vendor/rails/activerecord/test/cases/**\/*_test.rb and records, for
+ * each test file:
  *   - requires:         `require "models/<path>"` model imports
- *   - fixtures:         `fixtures :a, :b, "warehouse-things"` (flattened
- *                       across all classes in the file, multi-line aware)
+ *   - fixtures:         `fixtures :a, :b, "warehouse-things"` declarations
+ *                       (flattened across all classes in the file,
+ *                       multi-line aware)
  *   - setFixtureClass:  `set_fixture_class items: Book` mappings
+ *   - tests:            per-test (`def test_x` and `test "..." do`) map of
+ *                       `{ fixtureSet: [recordNames] }` based on
+ *                       `fixtureSet(:record)` accessor calls in the body
  *
  * Output: scripts/test-deps/output/activerecord-test-deps.json + a console
- * summary. Consumed by a downstream ESLint rule that lints the trails-side
+ * summary. Consumed by a downstream ESLint rule that lints trails-side
  * ports against the canonical Rails dep set.
  */
 import * as fs from "node:fs";
@@ -20,16 +24,24 @@ const CASES_DIR = path.join(ROOT, "vendor/rails/activerecord/test/cases");
 const OUT_DIR = path.join(__dirname, "output");
 const OUT_FILE = path.join(OUT_DIR, "activerecord-test-deps.json");
 
-interface TestRecord {
+export interface TestRecord {
   fixtures: Record<string, string[]>;
 }
 
-interface FileDeps {
+export interface FileDeps {
   requires: string[];
   fixtures: string[];
   setFixtureClass: Record<string, string>;
   tests: Record<string, TestRecord>;
 }
+
+const REQUIRE_RE = /^\s*require\s+["']models\/([^"']+)["']/;
+const FIXTURES_START_RE = /^\s*fixtures\s+(.+)$/;
+const SET_FIXTURE_CLASS_RE = /^\s*set_fixture_class\s+(.+)$/;
+const SYM_OR_STR = /(?::([a-zA-Z_]\w*)|["']([^"']+)["'])/g;
+const PAIR_RE = /([a-zA-Z_]\w*)\s*:\s*([A-Z][\w:]*)/g;
+const DEF_TEST_RE = /^(\s*)def\s+(test_[a-zA-Z0-9_?!]*)/;
+const TEST_BLOCK_RE = /^(\s*)test\s+["']([^"']+)["']\s+do\b/;
 
 function walk(dir: string, acc: string[] = []): string[] {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -39,14 +51,6 @@ function walk(dir: string, acc: string[] = []): string[] {
   }
   return acc;
 }
-
-const REQUIRE_RE = /^\s*require\s+["']models\/([^"']+)["']/;
-const FIXTURES_START_RE = /^\s*fixtures\s+(.+)$/;
-const SET_FIXTURE_CLASS_RE = /^\s*set_fixture_class\s+(.+)$/;
-const SYM_OR_STR = /(?::([a-zA-Z_][\w]*)|["']([^"']+)["'])/g;
-const PAIR_RE = /([a-zA-Z_][\w]*)\s*:\s*([A-Z][\w:]*)/g;
-const DEF_TEST_RE = /^(\s*)def\s+(test_[a-zA-Z0-9_?!]*)/;
-const TEST_BLOCK_RE = /^(\s*)test\s+["']([^"']+)["']\s+do\b/;
 
 function parseFixtureList(
   initial: string,
@@ -78,8 +82,32 @@ function normalizeTestName(label: string): string {
   return "test_" + label.trim().replace(/\s+/g, "_").replace(/[^\w]/g, "");
 }
 
-function parseFile(file: string): FileDeps {
-  const src = fs.readFileSync(file, "utf8");
+/**
+ * Pull all `:symbol` record names out of the argument list following a
+ * fixture-accessor call (e.g. `customers(:david, :mary)` → ["david","mary"]).
+ * Stops at the matching `)`, handling nested parens conservatively.
+ */
+function collectRecordArgs(src: string, openParenIdx: number): string[] {
+  const out: string[] = [];
+  let depth = 0;
+  for (let i = openParenIdx; i < src.length; i++) {
+    const ch = src[i];
+    if (ch === "(") depth++;
+    else if (ch === ")") {
+      depth--;
+      if (depth === 0) return out;
+    } else if (ch === ":" && depth === 1) {
+      const m = src.slice(i + 1).match(/^([a-zA-Z_]\w*)/);
+      if (m) {
+        out.push(m[1]);
+        i += m[1].length;
+      }
+    }
+  }
+  return out;
+}
+
+export function parseSource(src: string): FileDeps {
   const lines = src.split("\n");
   const deps: FileDeps = { requires: [], fixtures: [], setFixtureClass: {}, tests: {} };
   const fxSet = new Set<string>();
@@ -109,14 +137,16 @@ function parseFile(file: string): FileDeps {
     }
     const dt = line.match(DEF_TEST_RE);
     if (dt) {
-      const end = findBodyEnd(lines, i, dt[1].length);
-      testRanges.push({ name: dt[2], start: i + 1, end });
+      testRanges.push({ name: dt[2], start: i + 1, end: findBodyEnd(lines, i, dt[1].length) });
       continue;
     }
     const tb = line.match(TEST_BLOCK_RE);
     if (tb) {
-      const end = findBodyEnd(lines, i, tb[1].length);
-      testRanges.push({ name: normalizeTestName(tb[2]), start: i + 1, end });
+      testRanges.push({
+        name: normalizeTestName(tb[2]),
+        start: i + 1,
+        end: findBodyEnd(lines, i, tb[1].length),
+      });
     }
   }
 
@@ -125,15 +155,19 @@ function parseFile(file: string): FileDeps {
 
   if (fxSet.size > 0 && testRanges.length > 0) {
     const fxAlt = [...fxSet]
-      .map((n) => n.replace(/[-]/g, "\\-").replace(/[^\w-]/g, ""))
+      .map((n) => n.replace(/[^\w-]/g, ""))
       .filter((n) => n.length > 0)
+      .map((n) => n.replace(/-/g, "\\-"))
       .join("|");
-    const callRe = new RegExp(`\\b(${fxAlt})\\s*\\(\\s*:([a-zA-Z_]\\w*)`, "g");
+    const callRe = new RegExp(`\\b(${fxAlt})\\s*\\(`, "g");
     for (const r of testRanges) {
       const body = lines.slice(r.start, r.end).join("\n");
       const used: Record<string, Set<string>> = {};
       for (const m of body.matchAll(callRe)) {
-        (used[m[1]] ??= new Set()).add(m[2]);
+        const records = collectRecordArgs(body, m.index! + m[0].length - 1);
+        if (records.length === 0) continue;
+        const bucket = (used[m[1]] ??= new Set());
+        for (const rec of records) bucket.add(rec);
       }
       if (Object.keys(used).length === 0) continue;
       const out: Record<string, string[]> = {};
@@ -143,6 +177,10 @@ function parseFile(file: string): FileDeps {
   }
 
   return deps;
+}
+
+export function parseFile(file: string): FileDeps {
+  return parseSource(fs.readFileSync(file, "utf8"));
 }
 
 function main(): void {
@@ -189,4 +227,4 @@ function main(): void {
   console.log(`\nWrote ${path.relative(ROOT, OUT_FILE)}`);
 }
 
-main();
+if (require.main === module) main();

--- a/scripts/test-deps/rails-test-deps.ts
+++ b/scripts/test-deps/rails-test-deps.ts
@@ -1,0 +1,192 @@
+/**
+ * Extract per-file model/fixture dependencies from Rails activerecord tests.
+ *
+ * Scans vendor/rails/activerecord/test/cases/**\/*.rb and records, for each
+ * test file:
+ *   - requires:         `require "models/<path>"` model imports
+ *   - fixtures:         `fixtures :a, :b, "warehouse-things"` (flattened
+ *                       across all classes in the file, multi-line aware)
+ *   - setFixtureClass:  `set_fixture_class items: Book` mappings
+ *
+ * Output: scripts/test-deps/output/activerecord-test-deps.json + a console
+ * summary. Consumed by a downstream ESLint rule that lints the trails-side
+ * ports against the canonical Rails dep set.
+ */
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const ROOT = path.resolve(__dirname, "../..");
+const CASES_DIR = path.join(ROOT, "vendor/rails/activerecord/test/cases");
+const OUT_DIR = path.join(__dirname, "output");
+const OUT_FILE = path.join(OUT_DIR, "activerecord-test-deps.json");
+
+interface TestRecord {
+  fixtures: Record<string, string[]>;
+}
+
+interface FileDeps {
+  requires: string[];
+  fixtures: string[];
+  setFixtureClass: Record<string, string>;
+  tests: Record<string, TestRecord>;
+}
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, acc);
+    else if (entry.isFile() && entry.name.endsWith("_test.rb")) acc.push(full);
+  }
+  return acc;
+}
+
+const REQUIRE_RE = /^\s*require\s+["']models\/([^"']+)["']/;
+const FIXTURES_START_RE = /^\s*fixtures\s+(.+)$/;
+const SET_FIXTURE_CLASS_RE = /^\s*set_fixture_class\s+(.+)$/;
+const SYM_OR_STR = /(?::([a-zA-Z_][\w]*)|["']([^"']+)["'])/g;
+const PAIR_RE = /([a-zA-Z_][\w]*)\s*:\s*([A-Z][\w:]*)/g;
+const DEF_TEST_RE = /^(\s*)def\s+(test_[a-zA-Z0-9_?!]*)/;
+const TEST_BLOCK_RE = /^(\s*)test\s+["']([^"']+)["']\s+do\b/;
+
+function parseFixtureList(
+  initial: string,
+  lines: string[],
+  i: number,
+): { names: string[]; nextIdx: number } {
+  let buf = initial;
+  let j = i;
+  while (buf.trimEnd().endsWith(",") && j + 1 < lines.length) {
+    j++;
+    buf += " " + lines[j].trim();
+  }
+  const names: string[] = [];
+  for (const m of buf.matchAll(SYM_OR_STR)) names.push(m[1] ?? m[2]);
+  return { names, nextIdx: j };
+}
+
+function findBodyEnd(lines: string[], startIdx: number, indent: number): number {
+  for (let j = startIdx + 1; j < lines.length; j++) {
+    const l = lines[j];
+    if (l.trim() === "") continue;
+    const lead = l.match(/^(\s*)/)![1].length;
+    if (lead === indent && /^\s*end\b/.test(l)) return j;
+  }
+  return lines.length;
+}
+
+function normalizeTestName(label: string): string {
+  return "test_" + label.trim().replace(/\s+/g, "_").replace(/[^\w]/g, "");
+}
+
+function parseFile(file: string): FileDeps {
+  const src = fs.readFileSync(file, "utf8");
+  const lines = src.split("\n");
+  const deps: FileDeps = { requires: [], fixtures: [], setFixtureClass: {}, tests: {} };
+  const fxSet = new Set<string>();
+  const rqSet = new Set<string>();
+  const testRanges: Array<{ name: string; start: number; end: number }> = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const rq = line.match(REQUIRE_RE);
+    if (rq) {
+      rqSet.add(rq[1]);
+      continue;
+    }
+    const fx = line.match(FIXTURES_START_RE);
+    if (fx) {
+      const { names, nextIdx } = parseFixtureList(fx[1], lines, i);
+      for (const n of names) fxSet.add(n);
+      i = nextIdx;
+      continue;
+    }
+    const sf = line.match(SET_FIXTURE_CLASS_RE);
+    if (sf) {
+      for (const m of sf[1].matchAll(PAIR_RE)) {
+        deps.setFixtureClass[m[1]] = m[2];
+      }
+      continue;
+    }
+    const dt = line.match(DEF_TEST_RE);
+    if (dt) {
+      const end = findBodyEnd(lines, i, dt[1].length);
+      testRanges.push({ name: dt[2], start: i + 1, end });
+      continue;
+    }
+    const tb = line.match(TEST_BLOCK_RE);
+    if (tb) {
+      const end = findBodyEnd(lines, i, tb[1].length);
+      testRanges.push({ name: normalizeTestName(tb[2]), start: i + 1, end });
+    }
+  }
+
+  deps.requires = [...rqSet].sort();
+  deps.fixtures = [...fxSet].sort();
+
+  if (fxSet.size > 0 && testRanges.length > 0) {
+    const fxAlt = [...fxSet]
+      .map((n) => n.replace(/[-]/g, "\\-").replace(/[^\w-]/g, ""))
+      .filter((n) => n.length > 0)
+      .join("|");
+    const callRe = new RegExp(`\\b(${fxAlt})\\s*\\(\\s*:([a-zA-Z_]\\w*)`, "g");
+    for (const r of testRanges) {
+      const body = lines.slice(r.start, r.end).join("\n");
+      const used: Record<string, Set<string>> = {};
+      for (const m of body.matchAll(callRe)) {
+        (used[m[1]] ??= new Set()).add(m[2]);
+      }
+      if (Object.keys(used).length === 0) continue;
+      const out: Record<string, string[]> = {};
+      for (const k of Object.keys(used).sort()) out[k] = [...used[k]].sort();
+      deps.tests[r.name] = { fixtures: out };
+    }
+  }
+
+  return deps;
+}
+
+function main(): void {
+  if (!fs.existsSync(CASES_DIR)) {
+    console.error(`Rails test dir not found: ${CASES_DIR}\nRun: pnpm vendor:fetch`);
+    process.exit(1);
+  }
+
+  const files = walk(CASES_DIR).sort();
+  const out: Record<string, FileDeps> = {};
+  for (const f of files) {
+    const rel = path.relative(CASES_DIR, f);
+    out[rel] = parseFile(f);
+  }
+
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.writeFileSync(OUT_FILE, JSON.stringify(out, null, 2) + "\n");
+
+  const allModels = new Set<string>();
+  const allFixtures = new Set<string>();
+  let withFixtures = 0;
+  let withSetClass = 0;
+  let testsWithFixtureCalls = 0;
+  for (const d of Object.values(out)) {
+    for (const m of d.requires) allModels.add(m);
+    for (const f of d.fixtures) allFixtures.add(f);
+    if (d.fixtures.length > 0) withFixtures++;
+    if (Object.keys(d.setFixtureClass).length > 0) withSetClass++;
+    testsWithFixtureCalls += Object.keys(d.tests).length;
+  }
+
+  const top = Object.entries(out)
+    .map(([f, d]) => [f, d.requires.length + d.fixtures.length] as const)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10);
+
+  console.log(`Scanned ${files.length} test files`);
+  console.log(`  ${withFixtures} declare fixtures, ${withSetClass} use set_fixture_class`);
+  console.log(`  ${allModels.size} unique model requires`);
+  console.log(`  ${allFixtures.size} unique fixture names`);
+  console.log(`  ${testsWithFixtureCalls} tests reference a declared fixture`);
+  console.log(`Top files by dep count:`);
+  for (const [f, n] of top) console.log(`  ${n.toString().padStart(4)}  ${f}`);
+  console.log(`\nWrote ${path.relative(ROOT, OUT_FILE)}`);
+}
+
+main();

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -196,6 +196,7 @@ export default defineConfig({
             "scripts/api-compare/*.test.ts",
             "scripts/fixtures-compare/*.test.ts",
             "scripts/parity/**/*.test.ts",
+            "scripts/test-deps/*.test.ts",
             "vendor/*.test.ts",
           ],
           exclude: ["packages/activerecord/**", ...SHARED_EXCLUDE],


### PR DESCRIPTION
## Summary
- New script `scripts/test-deps/rails-test-deps.ts` (run via `pnpm test:deps`) scans `vendor/rails/activerecord/test/cases/**/*_test.rb`.
- Emits `scripts/test-deps/output/activerecord-test-deps.json` keyed by test file with:
  - `requires` — `require "models/<name>"` model imports
  - `fixtures` — flattened `fixtures :a, :b, ...` declarations (multi-line aware)
  - `setFixtureClass` — `set_fixture_class foo: Bar` mappings
  - `tests` — per-test (`def test_x` and `test "..." do`) map of `{ fixtureSet: [recordNames] }` based on `fixtureSet(:record)` accessor calls inside the body
- Console summary with totals and top files by dep count.

Current run: 424 test files, 184 unique model requires, 125 unique fixture names, 1,308 tests with fixture references.

## Motivation
Intended to back an ESLint rule that lints the trails-side test ports (test-helpers/models adoption) against the canonical Rails dependency set — both fixture sets declared and individual fixture records referenced per test.

## Test plan
- [ ] `pnpm test:deps` produces the JSON and summary
- [ ] Spot-check `aggregations_test.rb` → `customers(:david)` attribution correct