### PR TITLE
feat(rack/multipart): close out parser.rb to 100%

### DIFF
--- a/packages/rack/src/multipart/parser.ts
+++ b/packages/rack/src/multipart/parser.ts
@@ -203,7 +203,6 @@ export class Collector {
   }
   onMimeFinish(_i: number) {}
 
-  /** @internal */
   private checkPartLimits() {
     const fl = getMultipartFileLimit(),
       pl = getMultipartTotalPartLimit();

--- a/packages/rack/src/multipart/parser.ts
+++ b/packages/rack/src/multipart/parser.ts
@@ -49,6 +49,29 @@ const EMPTY: MultipartInfo = { params: null, tmpFiles: [] };
 Object.freeze(EMPTY.tmpFiles);
 Object.freeze(EMPTY);
 
+// ── BoundedIO ─────────────────────────────────────────────────────────────────
+
+/** @internal */
+export class BoundedIO {
+  private cursor = 0;
+  constructor(
+    private io: { read(n: number): string | null },
+    private contentLength: number,
+  ) {}
+
+  read(size: number, _outbuf?: string): string | null {
+    if (this.cursor >= this.contentLength) return null;
+    const left = this.contentLength - this.cursor;
+    const str = this.io.read(left < size ? left : size);
+    if (str) {
+      this.cursor += str.length;
+    } else {
+      throw new EmptyContentError("bad content body");
+    }
+    return str;
+  }
+}
+
 // ── StringScanner equivalent ──────────────────────────────────────────────────
 
 class SBuf {
@@ -115,7 +138,8 @@ class SBuf {
 
 // ── Collector ─────────────────────────────────────────────────────────────────
 
-class Part {
+/** @internal */
+export class Part {
   isFile = false;
   constructor(
     public body: any,
@@ -144,7 +168,8 @@ class Part {
   }
 }
 
-class Collector {
+/** @internal */
+export class Collector {
   private parts: Part[] = [];
   private openFiles = 0;
   constructor(private tf: ((f: string, ct: string) => any) | null) {}
@@ -169,6 +194,17 @@ class Collector {
       this.openFiles++;
     }
     this.parts[i] = p;
+    this.checkPartLimits();
+  }
+  onMimeBody(i: number, c: string) {
+    const p = this.parts[i];
+    if (typeof p.body === "string") p.body += c;
+    else if (typeof p.body?.write === "function") p.body.write(c);
+  }
+  onMimeFinish(_i: number) {}
+
+  /** @internal */
+  private checkPartLimits() {
     const fl = getMultipartFileLimit(),
       pl = getMultipartTotalPartLimit();
     if (fl > 0 && this.openFiles >= fl) {
@@ -180,12 +216,6 @@ class Collector {
       throw new MultipartTotalPartLimitError();
     }
   }
-  onMimeBody(i: number, c: string) {
-    const p = this.parts[i];
-    if (typeof p.body === "string") p.body += c;
-    else if (typeof p.body?.write === "function") p.body.write(c);
-  }
-  onMimeFinish(_i: number) {}
 }
 
 // ── Parser ────────────────────────────────────────────────────────────────────
@@ -229,8 +259,9 @@ export class Parser {
     if (!b) return EMPTY;
     if (b.length > 70)
       throw new BoundaryTooLongError(`multipart boundary size too large (${b.length} characters)`);
+    const boundedIo = cl != null ? new BoundedIO(io, cl) : io;
     const p = new Parser(b, tmpfile, bufsize, qp);
-    p.parse(io);
+    p.parse(boundedIo);
     return p.result();
   }
 


### PR DESCRIPTION
## Root cause

The api:compare extractor only walks **exported** classes. The inner classes `Part`, `Collector`, and the missing `BoundedIO` were all unexported, making their 9 methods invisible to the extractor despite the code being functionally complete after PRs #2281 and #2289.

Missing methods: `read`, `each`, `onMimeHead`, `onMimeBody`, `onMimeFinish`, `checkPartLimits`, `getData`, `isFile`, `close`

## Changes

- **`BoundedIO`** — new `export class BoundedIO` matching Rails' inner `Parser::BoundedIO` class. Has `read(size, outbuf?)` which limits reads to `content_length` bytes. Wired into `Parser.parse` static method (replaces direct io pass-through when `content_length` is set).
- **`Part`** — `export class Part` with `@internal`. Covers `getData`, `close`, `isFile` (property matching `file?`).
- **`Collector`** — `export class Collector` with `@internal`. Covers `each`, `onMimeHead`, `onMimeBody`, `onMimeFinish`. `checkPartLimits` extracted from inline code in `onMimeHead` into its own private method.

## Result

`multipart/parser.rb` 16/25 (64%) → **25/25 (100%)**

## LOC check

40 additions, 9 deletions = 49 LOC well under 300 ceiling.