### PR TITLE
fix(activerecord): converge inner-join eager alias-tracker seeding and merge join dedup

### DIFF
--- a/packages/activerecord/src/associations/inner-join-association.test.ts
+++ b/packages/activerecord/src/associations/inner-join-association.test.ts
@@ -33,24 +33,25 @@ import { Reference } from "../test-helpers/models/reference.js";
 import { Job } from "../test-helpers/models/job.js";
 
 describe("InnerJoinAssociationTest", () => {
-  const { authors, posts, people, categories, categoriesPosts, shardedBlogPosts } = fixtures(
-    [
-      "authors",
-      "authorAddresses",
-      "essays",
-      "posts",
-      "comments",
-      "categories",
-      "categoriesPosts",
-      "categorizations",
-      "taggings",
-      "tags",
-      "people",
-      "shardedComments",
-      "shardedBlogPosts",
-    ],
-    { schema: canonicalSchema },
-  );
+  const { authors, posts, people, categories, categoriesPosts, shardedBlogPosts, shardedComments } =
+    fixtures(
+      [
+        "authors",
+        "authorAddresses",
+        "essays",
+        "posts",
+        "comments",
+        "categories",
+        "categoriesPosts",
+        "categorizations",
+        "taggings",
+        "tags",
+        "people",
+        "shardedComments",
+        "shardedBlogPosts",
+      ],
+      { schema: canonicalSchema },
+    );
 
   enableSti(Category);
   registerModel(Author);
@@ -151,11 +152,7 @@ describe("InnerJoinAssociationTest", () => {
     expect(result.map((p) => p.id)).toEqual([(expected as any).id]);
   });
 
-  // BLOCKED (tracked-pending-convergence): trails does not deduplicate identical
-  // Arel join nodes when merging a relation into itself, so the `posts` self-join
-  // is emitted twice and `posts.type` becomes ambiguous. Rails dedupes the join.
-  // Deviation: inner-join-association-surfaced-deviations (RFC 0023).
-  it.skip("deduplicate joins", async () => {
+  it("deduplicate joins", async () => {
     const postsTable = new Table("posts");
     const constraint = postsTable.get("author_id").eq(Author.arelTable.get("id"));
 
@@ -170,23 +167,14 @@ describe("InnerJoinAssociationTest", () => {
     expect(result.map((a) => a.id)).toEqual([(authors("david") as any).id]);
   });
 
-  // BLOCKED (tracked-pending-convergence): `eager_load(:agents)` on a
-  // self-referential association aliases the `people` self-join differently than
-  // Rails (which seeds the alias_tracker so the user-supplied string/arel join
-  // resolves `agents_people_2`). trails emits a non-matching alias → "no such
-  // column: agents_people_2.id". Deviation: inner-join-association-surfaced-deviations.
-  it.skip("eager load with string joins", async () => {
+  it("eager load with string joins", async () => {
     const stringJoin =
       "LEFT JOIN people agents_people ON agents_people.primary_contact_id = agents_people_2.id AND agents_people.id > agents_people_2.id";
 
     expect(await Person.eagerLoad("agents").joins(stringJoin).count()).toBe(3);
   });
 
-  // BLOCKED (tracked-pending-convergence): same self-referential eager_load
-  // aliasing gap as test_eager_load_with_string_joins — the user-supplied Arel
-  // join references `agents_people` while the eager_load join collides on
-  // `primary_contact_id`. Deviation: inner-join-association-surfaced-deviations.
-  it.skip("eager load with arel joins", async () => {
+  it("eager load with arel joins", async () => {
     const agents = Person.arelTable.alias("agents_people");
     const agents2 = Person.arelTable.alias("agents_people_2");
     const constraint = agents
@@ -360,21 +348,17 @@ describe("InnerJoinAssociationTest", () => {
     );
   });
 
-  // BLOCKED (tracked-pending-convergence): `joins` on a has_many association with
-  // a composite foreign key (ShardedBlogPost#comments, foreignKey [blog_id,
-  // blog_post_id]) is rejected by the join-dependency builder ("Association named
-  // 'comments' was not found"); the belongs_to composite-FK join works. Deviation:
-  // inner-join-association-surfaced-deviations.
-  it.skip("joins a has_many association with a composite foreign key", async () => {
+  it("joins a has_many association with a composite foreign key", async () => {
     const { ShardedBlogPost } = await import("../test-helpers/models/sharded.js");
     const blogPosts = await ShardedBlogPost.joins("comments").where({
       comments: { body: "Your first blog post is great!" },
     });
 
+    const expectedComment = shardedComments("unique_comment_blog_post_one");
     expect(blogPosts.length).toBeGreaterThan(0);
-    const firstComment = (await (blogPosts[0] as any).comments)[0];
-    const itsBlogPost = await firstComment.blogPost;
-    expect(itsBlogPost.id).toEqual((blogPosts[0] as any).id);
+    // Rails: assert_equal(expected_comment.blog_post, blog_posts.first).
+    const itsBlogPost = await (expectedComment as any).blogPost;
+    expect(Number((blogPosts[0] as any).id)).toEqual(Number(itsBlogPost.id));
   });
 
   it("inner joins includes all nested associations", async () => {

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -8,7 +8,9 @@
  * Mirrors: ActiveRecord::Calculations
  */
 
-import { Nodes, Table, SelectManager } from "@blazetrails/arel";
+import { Nodes, Table, SelectManager, sql as arelSql } from "@blazetrails/arel";
+import { buildMergedJoinAliasTracker } from "./merged-join-alias-tracker.js";
+import type { AliasTracker } from "../associations/alias-tracker.js";
 import { BigIntegerType } from "@blazetrails/activemodel";
 import type { AdapterName } from "../connection-adapters/abstract-adapter.js";
 import type { Base } from "../base.js";
@@ -23,6 +25,31 @@ import {
   buildJoinDependencies,
   QueryMethodBangs,
 } from "./query-methods.js";
+
+/**
+ * Seed the eager-load JoinDependency's AliasTracker with the relation's manual
+ * join nodes (`_joinValues`), mirroring Rails `build_joins`'
+ * `alias_tracker(leading_joins + join_nodes, aliases)` (query_methods.rb:1891).
+ * The live count/aggregate eager path emits the JoinDependency separately from
+ * the user-supplied joins, so without seeding, a self-referential eager join
+ * (e.g. `Person.eager_load(:agents)`) would claim the same `agents_people`
+ * alias a user string/arel join already references as `agents_people_2`. Seeding
+ * counts those tables up front so the eager join is aliased `agents_people_2`,
+ * matching Rails. Returns `undefined` when there are no manual joins, preserving
+ * the JoinDependency's own base-table-only tracker for the common case.
+ *
+ * @internal
+ */
+function eagerJoinAliasTracker(rel: any): AliasTracker | undefined {
+  const joinValues: unknown[] = rel._joinValues ?? [];
+  if (joinValues.length === 0) return undefined;
+  const joinNodes: Nodes.Join[] = joinValues.map((v) =>
+    typeof v === "string"
+      ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join)
+      : (v as Nodes.Join),
+  );
+  return buildMergedJoinAliasTracker(rel, joinNodes);
+}
 
 /**
  * Qualify a GROUP BY column string as an Arel attribute node when it is a
@@ -411,7 +438,11 @@ async function singleAggregate(
   const allEagerSa = [...new Set([...eagerSa, ...includesSa, ...promotedSa])];
   if (allEagerSa.length > 0) {
     const jd = QueryMethodBangs.constructJoinDependency.call(anyRelSa, allEagerSa, Nodes.OuterJoin);
-    for (const node of jd.joinConstraints([], undefined, anyRelSa._aliasableReferences()))
+    for (const node of jd.joinConstraints(
+      [],
+      eagerJoinAliasTracker(anyRelSa),
+      anyRelSa._aliasableReferences(),
+    ))
       manager.appendJoinNode(node);
   }
   rel._applyJoinsToManager(manager);
@@ -688,35 +719,13 @@ export async function performCount(
     if (allEager.length > 0) {
       const pk = this._modelClass.primaryKey;
       if (!Array.isArray(pk)) {
-        // Collect tables already covered by explicit _joinValues. For those,
-        // skip the JD LEFT OUTER JOIN (the explicit join already links the table)
-        // to avoid duplicate table references that cause "ambiguous column name".
-        const explicitJoinTables = new Set<string>();
-        for (const v of (anyRel._joinValues as (string | any)[] | undefined) ?? []) {
-          if (typeof v === "string") {
-            const m = v.match(/JOIN\s+(?:"([^"]+)"|`([^`]+)`|(\w+))/i);
-            if (m) explicitJoinTables.add(m[1] ?? m[2] ?? m[3] ?? "");
-          } else if (v?.left) {
-            const n: string | undefined = typeof v.left.name === "string" ? v.left.name : undefined;
-            if (n) explicitJoinTables.add(n);
-          }
-        }
-        // Only build JD for specs whose target table is NOT already in explicit joins.
-        // Specs already explicitly joined only need DISTINCT (not an extra LEFT JOIN).
-        const specsForJd: string[] = [];
-        for (const spec of allEager) {
-          if (typeof spec !== "string") {
-            specsForJd.push(spec as string);
-            continue;
-          }
-          let tname: string | undefined;
-          try {
-            tname = (this._modelClass as any)._reflectOnAssociation?.(spec)?.tableName;
-          } catch {
-            // reflection.klass may throw when model not yet registered
-          }
-          if (!tname || !explicitJoinTables.has(tname)) specsForJd.push(spec);
-        }
+        // Rails apply_join_dependency always builds the eager LEFT OUTER JOIN for
+        // every eager spec; the shared AliasTracker (seeded with the manual join
+        // nodes via `eagerJoinAliasTracker`) re-aliases a JD join onto a table a
+        // user string/arel join already touches (e.g. a self-referential
+        // `eager_load(:agents)` becomes `agents_people_2`), so there is no
+        // duplicate-table ambiguity to guard against here.
+        const specsForJd: string[] = allEager;
         const table = this._modelClass.arelTable;
         if (this._limitValue !== null || this._offsetValue !== null) {
           // Rails finder_methods.rb apply_join_dependency: with a limit/offset on an
@@ -736,7 +745,11 @@ export async function performCount(
               specsForJd,
               Nodes.OuterJoin,
             );
-            for (const node of jd.joinConstraints([], undefined, anyRel._aliasableReferences()))
+            for (const node of jd.joinConstraints(
+              [],
+              eagerJoinAliasTracker(anyRel),
+              anyRel._aliasableReferences(),
+            ))
               idSubquery.appendJoinNode(node);
           }
           this._applyJoinsToManager(idSubquery);
@@ -768,7 +781,7 @@ export async function performCount(
             );
             for (const node of jdOuter.joinConstraints(
               [],
-              undefined,
+              eagerJoinAliasTracker(anyRel),
               anyRel._aliasableReferences(),
             ))
               countManager.appendJoinNode(node);
@@ -803,7 +816,11 @@ export async function performCount(
             specsForJd,
             Nodes.OuterJoin,
           );
-          for (const node of jd.joinConstraints([], undefined, anyRel._aliasableReferences()))
+          for (const node of jd.joinConstraints(
+            [],
+            eagerJoinAliasTracker(anyRel),
+            anyRel._aliasableReferences(),
+          ))
             manager.appendJoinNode(node);
         }
         this._applyJoinsToManager(manager);

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -104,7 +104,20 @@ export class Merger {
     const clauses: Array<{ type: string; table: string; on: string; quoted?: boolean }> =
       this.other._joinClauses ?? [];
     if (clauses.length > 0) rel._joinClauses.push(...clauses);
-    if (this.other._joinValues?.length > 0) rel._joinValues.push(...this.other._joinValues);
+    // Rails merge_joins unions with `relation.joins_values |= other.joins_values`
+    // (merger.rb:121), so an identical Arel join node already present is not
+    // re-emitted. Merging a relation into itself (a self-merge that shares the
+    // same join node) would otherwise duplicate the join and make its columns
+    // ambiguous. Dedup structurally via the Arel node's `eql` (falling back to
+    // reference/`===` for strings and nodes without it).
+    for (const v of (this.other._joinValues ?? []) as unknown[]) {
+      const dup = (rel._joinValues as unknown[]).some((existing) =>
+        typeof (v as any)?.eql === "function" && v?.constructor === (existing as any)?.constructor
+          ? (v as any).eql(existing)
+          : v === existing,
+      );
+      if (!dup) rel._joinValues.push(v);
+    }
     // Rails merge_joins (merger.rb): when other.klass == relation.klass the
     // association names union directly into joins_values; otherwise Merger builds
     // a single InnerJoin JoinDependency against other.klass and stashes it. We


### PR DESCRIPTION
Un-skips the four tracked-pending-convergence cases in
`inner-join-association.test.ts` (faithful port of Rails'
`inner_join_association_test.rb`) by converging the underlying join behaviours
to Rails.

## Gaps fixed

1. **`deduplicate joins`** — `mergeJoins` now dedups identical Arel join nodes
   (Rails `merge_joins`' `joins_values |= other.joins_values`), so merging a
   relation into itself no longer emits the shared `posts` self-join twice
   (`posts.type` stays unambiguous). Dedup is structural via the Arel node's
   `eql`, falling back to reference equality.

2. **`eager load with string joins` / `eager load with arel joins`** — the live
   count/aggregate eager path seeds the eager `JoinDependency`'s `AliasTracker`
   with the relation's manual join nodes (`_joinValues`), mirroring Rails
   `build_joins`' `alias_tracker(leading_joins + join_nodes, aliases)`. A
   self-referential `eager_load(:agents)` alongside a user string/arel join is
   now aliased `agents_people_2`, so the user join that references that alias
   resolves. The old explicit-join-table skip (which suppressed the eager LEFT
   OUTER JOIN when a manual join touched the same table) is dropped — the seeded
   tracker re-aliases the JD join instead, matching Rails
   `apply_join_dependency`.

3. **`joins a has_many association with a composite foreign key`** — already
   worked on `main`; the test is un-skipped and its assertion aligned to the
   Rails `sharded_comments(:unique_comment_blog_post_one)` fixture accessor.

## Testing

- `inner-join-association.test.ts`: 31 passing (was 27 + 4 skipped).
- Full `packages/activerecord/src/associations/` suite green (1709 passed).
- `calculations` / `merging` / `merged-join-alias-tracker` /
  `build-joins-from-subquery-dedup` suites green.

Closes-story: inner-join-association-surfaced-deviations
