### PR TITLE
ci(activerecord): DDL_PROFILE re-run on current main (measurement, supersedes #4499)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -759,8 +759,29 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
+      # DDL profiler (measurement) — this branch only. The head_ref expression
+      # resolves to "" on every other branch/PR/main, so the profiler is a
+      # dormant no-op there; on this branch it emits per-worker DDL-timing JSON
+      # (see packages/activerecord/src/test-helpers/ddl-profile.ts, PR #3904).
+      # The profiler never fails a test (best-effort dumps), so it can't gate.
       - run: pnpm vitest run packages/activerecord/
+        env:
+          DDL_PROFILE: ${{ github.head_ref == 'ddl-profile-ci-run-085775' && '1' || '' }}
+          DDL_PROFILE_OUT_DIR: ${{ runner.temp }}/ddlprof
       - run: pnpm vitest run packages/activerecord-cli
+      - name: DDL profile aggregate (measurement)
+        if: always() && github.head_ref == 'ddl-profile-ci-run-085775'
+        continue-on-error: true
+        run: |
+          node scripts/ddl-profile-aggregate.mjs "${{ runner.temp }}/ddlprof" \
+            | tee "${{ runner.temp }}/ddlprof/aggregate-sqlite.txt"
+      - name: Upload DDL profile (sqlite)
+        if: always() && github.head_ref == 'ddl-profile-ci-run-085775'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddl-profile-sqlite
+          path: ${{ runner.temp }}/ddlprof
+          if-no-files-found: warn
 
   # Reporting-only AR coverage (story ar-sqlite-lane-coverage-reporting, RFC
   # 0028). Runs the sqlite AR suite (the cheapest backend) with v8 coverage and
@@ -961,14 +982,32 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
+      # DDL profiler (measurement) — this branch only; no-op elsewhere. Postgres
+      # is a DDL-dominated lane (teardown DROP TABLE dominates), so its
+      # DROP-count/ms aggregate is a headline signal. See the sqlite lane.
       - run: pnpm vitest run packages/activerecord/
         env:
           ARCONN: postgresql
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
           AR_DB_FORKS: 8
+          DDL_PROFILE: ${{ github.head_ref == 'ddl-profile-ci-run-085775' && '1' || '' }}
+          DDL_PROFILE_OUT_DIR: ${{ runner.temp }}/ddlprof
       - run: pnpm vitest run packages/activerecord-cli
         env:
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
+      - name: DDL profile aggregate (measurement)
+        if: always() && github.head_ref == 'ddl-profile-ci-run-085775'
+        continue-on-error: true
+        run: |
+          node scripts/ddl-profile-aggregate.mjs "${{ runner.temp }}/ddlprof" \
+            | tee "${{ runner.temp }}/ddlprof/aggregate-postgres.txt"
+      - name: Upload DDL profile (postgres)
+        if: always() && github.head_ref == 'ddl-profile-ci-run-085775'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddl-profile-postgres
+          path: ${{ runner.temp }}/ddlprof
+          if-no-files-found: warn
 
   mysql-tests:
     name: Active Record MySQL Tests
@@ -1075,14 +1114,32 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
+      # DDL profiler (measurement) — this branch only; no-op elsewhere. MariaDB
+      # is the other DDL-dominated lane, so its DROP-count/ms aggregate is a
+      # headline signal. See the sqlite lane.
       - run: pnpm vitest run packages/activerecord/
         env:
           ARCONN: mysql2
           MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
           AR_DB_FORKS: 8
+          DDL_PROFILE: ${{ github.head_ref == 'ddl-profile-ci-run-085775' && '1' || '' }}
+          DDL_PROFILE_OUT_DIR: ${{ runner.temp }}/ddlprof
       # No MYSQL_TEST_URL: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       - run: pnpm vitest run packages/activerecord-cli
+      - name: DDL profile aggregate (measurement)
+        if: always() && github.head_ref == 'ddl-profile-ci-run-085775'
+        continue-on-error: true
+        run: |
+          node scripts/ddl-profile-aggregate.mjs "${{ runner.temp }}/ddlprof" \
+            | tee "${{ runner.temp }}/ddlprof/aggregate-maria.txt"
+      - name: Upload DDL profile (maria)
+        if: always() && github.head_ref == 'ddl-profile-ci-run-085775'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddl-profile-maria
+          path: ${{ runner.temp }}/ddlprof
+          if-no-files-found: warn
 
   website:
     name: Website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -775,6 +775,8 @@ jobs:
         run: |
           node scripts/ddl-profile-aggregate.mjs "${{ runner.temp }}/ddlprof" \
             | tee "${{ runner.temp }}/ddlprof/aggregate-sqlite.txt"
+          node scripts/schema-repair-aggregate.mjs "${{ runner.temp }}/ddlprof" \
+            | tee "${{ runner.temp }}/ddlprof/schema-repair-sqlite.txt"
       - name: Upload DDL profile (sqlite)
         if: always() && github.head_ref == 'ddl-profile-ci-run-085775'
         uses: actions/upload-artifact@v4
@@ -1001,6 +1003,8 @@ jobs:
         run: |
           node scripts/ddl-profile-aggregate.mjs "${{ runner.temp }}/ddlprof" \
             | tee "${{ runner.temp }}/ddlprof/aggregate-postgres.txt"
+          node scripts/schema-repair-aggregate.mjs "${{ runner.temp }}/ddlprof" \
+            | tee "${{ runner.temp }}/ddlprof/schema-repair-postgres.txt"
       - name: Upload DDL profile (postgres)
         if: always() && github.head_ref == 'ddl-profile-ci-run-085775'
         uses: actions/upload-artifact@v4
@@ -1133,6 +1137,8 @@ jobs:
         run: |
           node scripts/ddl-profile-aggregate.mjs "${{ runner.temp }}/ddlprof" \
             | tee "${{ runner.temp }}/ddlprof/aggregate-maria.txt"
+          node scripts/schema-repair-aggregate.mjs "${{ runner.temp }}/ddlprof" \
+            | tee "${{ runner.temp }}/ddlprof/schema-repair-maria.txt"
       - name: Upload DDL profile (maria)
         if: always() && github.head_ref == 'ddl-profile-ci-run-085775'
         uses: actions/upload-artifact@v4

--- a/packages/activerecord/src/test-helpers/schema-repair.test.ts
+++ b/packages/activerecord/src/test-helpers/schema-repair.test.ts
@@ -3,7 +3,12 @@ import { Base } from "../index.js";
 import { columnsOf } from "./define-schema.js";
 import { setupFixtures } from "./fixtures.js";
 import { TEST_SCHEMA } from "./test-schema.js";
-import { driftedTables, repairWorkerSchema } from "./schema-repair.js";
+import {
+  driftedTables,
+  repairWorkerSchema,
+  recordRepairMetrics,
+  repairMetricsSnapshot,
+} from "./schema-repair.js";
 
 /** The physical column set a canonical table has when undrifted (lowercased). */
 function canonicalCols(table: keyof typeof TEST_SCHEMA): Set<string> {
@@ -82,6 +87,25 @@ describe("schema-repair", () => {
     it("is a no-op when nothing drifted", async () => {
       const repaired = await repairWorkerSchema(Base.connection, TEST_SCHEMA);
       expect(repaired).toEqual([]);
+    });
+  });
+
+  describe("recordRepairMetrics (measurement)", () => {
+    // Metrics accumulate at module scope, so assert on deltas from a baseline
+    // rather than absolute values (a sibling file may have recorded already).
+    it("counts files seen, files repaired, and per-table drift frequency", () => {
+      const before = structuredClone(repairMetricsSnapshot());
+
+      recordRepairMetrics([]); // a clean file: seen, not repaired
+      recordRepairMetrics(["topics", "posts"]); // one file drifted two tables
+      recordRepairMetrics(["topics"]); // another file drifted one
+
+      const after = repairMetricsSnapshot();
+      expect(after.filesSeen - before.filesSeen).toBe(3);
+      expect(after.filesRepaired - before.filesRepaired).toBe(2);
+      expect(after.totalTablesRepaired - before.totalTablesRepaired).toBe(3);
+      expect((after.byTable.topics ?? 0) - (before.byTable.topics ?? 0)).toBe(2);
+      expect((after.byTable.posts ?? 0) - (before.byTable.posts ?? 0)).toBe(1);
     });
   });
 });

--- a/packages/activerecord/src/test-helpers/schema-repair.ts
+++ b/packages/activerecord/src/test-helpers/schema-repair.ts
@@ -42,11 +42,75 @@
  * scratch table, so it is deliberately left out.
  */
 
+import { getFs } from "@blazetrails/activesupport";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { columnsOf, type Schema } from "./define-schema.js";
 
 /** Tables the test harness must never touch — migration + environment state. */
 const PROTECTED_TABLES = new Set(["schema_migrations", "ar_internal_metadata"]);
+
+// ---------------------------------------------------------------------------
+// Repair-frequency metrics (measurement).
+//
+// How often does a file open onto a drifted shared DB and have to drop-recreate
+// a canonical table? That rate is the RFC-0019 burndown signal: a table that
+// keeps showing up here is a bespoke `defineSchema` that still needs converging.
+// Counters live at module scope and accumulate across every file a worker runs
+// (the same shared-fork module instance the DDL profiler relies on), then flush
+// to one JSON per worker via {@link flushRepairMetrics}. `record` is cheap and
+// unconditional; the flush only writes when an output dir is configured, so the
+// whole thing is dormant unless a measurement run asks for it.
+const metrics = {
+  filesSeen: 0,
+  filesRepaired: 0,
+  totalTablesRepaired: 0,
+  /** table name → number of files that had to repair it this worker. */
+  byTable: {} as Record<string, number>,
+};
+
+/**
+ * Fold one file's repair outcome into the worker's running metrics. Called once
+ * per file from `test-setup-dy.ts` with the list `repairWorkerSchema` returned
+ * (empty when nothing drifted). Always logs a stable, greppable per-file line
+ * when a repair fired unless silenced.
+ */
+export function recordRepairMetrics(repaired: string[]): void {
+  metrics.filesSeen += 1;
+  if (repaired.length === 0) return;
+  metrics.filesRepaired += 1;
+  metrics.totalTablesRepaired += repaired.length;
+  for (const t of repaired) metrics.byTable[t] = (metrics.byTable[t] ?? 0) + 1;
+}
+
+/** Snapshot of the worker's accumulated repair metrics. Exported for tests. */
+export function repairMetricsSnapshot(): typeof metrics {
+  return metrics;
+}
+
+/**
+ * Write the worker's accumulated repair metrics to one JSON file, mirroring the
+ * DDL profiler's per-worker dump so the same CI artifact upload collects both.
+ * No-op unless an output dir is set. Safe to call multiple times (overwrites
+ * cumulatively — a full-suite worker calls it after every file).
+ */
+export function flushRepairMetrics(): void {
+  const dir = process.env.SCHEMA_REPAIR_OUT_DIR ?? process.env.DDL_PROFILE_OUT_DIR;
+  if (!dir) return;
+  const workerId = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? "1";
+  const adapter = process.env.ARCONN ?? "sqlite";
+  const out = `${dir}/schema-repair-${adapter}-w${workerId}-${process.pid}.json`;
+  const payload = {
+    adapter,
+    ...metrics,
+    repairRate: metrics.filesSeen > 0 ? metrics.filesRepaired / metrics.filesSeen : 0,
+  };
+  try {
+    getFs().mkdirSync(dir, { recursive: true });
+    getFs().writeFileSync(out, JSON.stringify(payload, null, 2));
+  } catch {
+    // Best-effort, exactly like the DDL profiler — never fail a test on a dump.
+  }
+}
 
 /**
  * Read every user table's column-name set in a single catalog query. Returns a

--- a/packages/activerecord/src/test-setup-ddl-profile.ts
+++ b/packages/activerecord/src/test-setup-ddl-profile.ts
@@ -5,6 +5,7 @@
  */
 import { afterAll, beforeEach, expect } from "vitest";
 import { install, flush, setCurrentFile, setTestPathResolver } from "./test-helpers/ddl-profile.js";
+import { flushRepairMetrics } from "./test-helpers/schema-repair.js";
 
 await install();
 
@@ -23,4 +24,5 @@ beforeEach((ctx) => {
 // holds every record this worker saw.
 afterAll(() => {
   flush();
+  flushRepairMetrics();
 });

--- a/packages/activerecord/src/test-setup-dy.ts
+++ b/packages/activerecord/src/test-setup-dy.ts
@@ -54,8 +54,13 @@ if ((adapter === "sqlite" && envConfig.database !== ":memory:") || pgExclusive |
 // This restores the canonical shape of exactly the tables a prior file mutated
 // (a no-op when none were). Gated by AR_DISABLE_SCHEMA_REPAIR as an escape hatch.
 if (process.env.AR_DISABLE_SCHEMA_REPAIR === undefined) {
-  const { repairWorkerSchema } = await import("./test-helpers/schema-repair.js");
+  const { repairWorkerSchema, recordRepairMetrics } =
+    await import("./test-helpers/schema-repair.js");
   const repaired = await repairWorkerSchema(Base.connection, TEST_SCHEMA);
+  // Fold this file's outcome into the worker's cumulative repair-frequency
+  // metrics (dumped per worker by the DDL-profile setup's afterAll flush when a
+  // measurement run configures an output dir; a cheap no-op otherwise).
+  recordRepairMetrics(repaired);
   // When repair actually fires, a prior file in this worker drifted these
   // canonical tables — the exact shared-DB flake source. Surface it with a
   // stable, greppable prefix so CI logs become an RFC-0019 burndown signal:

--- a/scripts/ddl-profile-aggregate.mjs
+++ b/scripts/ddl-profile-aggregate.mjs
@@ -15,7 +15,8 @@ if (dirs.length === 0) {
 const files = [];
 for (const d of dirs) {
   for (const f of fs.readdirSync(d)) {
-    if (f.endsWith(".json")) files.push(path.join(d, f));
+    // Skip the schema-repair dumps that share this dir (own aggregator).
+    if (f.endsWith(".json") && !f.startsWith("schema-repair-")) files.push(path.join(d, f));
   }
 }
 

--- a/scripts/schema-repair-aggregate.mjs
+++ b/scripts/schema-repair-aggregate.mjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Companion to the DDL profiler — aggregate the per-worker schema-repair
+// frequency dumps (written by test-helpers/schema-repair.ts, collected as CI
+// artifacts alongside the DDL profile) into a single summary. Answers: how
+// often does a test file open onto a drifted shared DB and have to
+// drop-recreate a canonical table, and which tables drift most? Usage:
+//   node scripts/schema-repair-aggregate.mjs <dir-of-json> [<dir2> ...]
+import fs from "node:fs";
+import path from "node:path";
+
+const dirs = process.argv.slice(2);
+if (dirs.length === 0) {
+  console.error("usage: schema-repair-aggregate.mjs <dir> [<dir> ...]");
+  process.exit(1);
+}
+
+const files = [];
+for (const d of dirs) {
+  for (const f of fs.readdirSync(d)) {
+    if (f.startsWith("schema-repair-") && f.endsWith(".json")) files.push(path.join(d, f));
+  }
+}
+
+if (files.length === 0) {
+  console.log("(no schema-repair dumps found)");
+  process.exit(0);
+}
+
+// Group worker dumps by adapter.
+const byAdapter = {};
+for (const f of files) {
+  const data = JSON.parse(fs.readFileSync(f, "utf8"));
+  const adapter = data.adapter ?? "unknown";
+  (byAdapter[adapter] ??= []).push(data);
+}
+
+const pct = (n) => `${(n * 100).toFixed(1)}%`;
+
+for (const [adapter, dumps] of Object.entries(byAdapter)) {
+  let filesSeen = 0;
+  let filesRepaired = 0;
+  let totalTablesRepaired = 0;
+  const byTable = {};
+  for (const d of dumps) {
+    filesSeen += d.filesSeen ?? 0;
+    filesRepaired += d.filesRepaired ?? 0;
+    totalTablesRepaired += d.totalTablesRepaired ?? 0;
+    for (const [t, c] of Object.entries(d.byTable ?? {})) byTable[t] = (byTable[t] ?? 0) + c;
+  }
+  const rate = filesSeen > 0 ? filesRepaired / filesSeen : 0;
+
+  console.log(
+    `\n============ schema-repair: ${adapter} (${dumps.length} worker dumps) ============`,
+  );
+  console.log(`Files seen: ${filesSeen}   Files that repaired: ${filesRepaired} (${pct(rate)})`);
+  console.log(`Total table repairs: ${totalTablesRepaired}`);
+  console.log(`\nBy table (files that had to repair it):`);
+  for (const [t, c] of Object.entries(byTable).sort((a, b) => b[1] - a[1]))
+    console.log(`  ${t.padEnd(40)} ${String(c).padStart(6)}`);
+}


### PR DESCRIPTION
> **Benchmarking only — do not merge; kept draft intentionally.** This PR's sole
> purpose is to run the DDL profiler in CI and capture numbers in this
> description. It must stay **draft forever** — never mark ready, never queue for
> merge. It carries no production code change.
>
> **Supersedes #4499** (closed-unmerged; GitHub refused to reopen it). Same
> branch `ddl-profile-ci-run-085775`, rebased onto current `main` for a fresh
> measurement.

## What

Turns on the **dormant** opt-in DDL timing profiler (`DDL_PROFILE=1`, landed in
PR #3904) in the three enabled AR CI lanes (sqlite / postgres / maria) for a
**one-off measurement run**, then aggregates and uploads the per-worker
DDL-timing JSON + summary as a build artifact per lane.

## How it's wired (measurement-only, cannot gate merges)

- `DDL_PROFILE` is set on the existing **required** `pnpm vitest run
  packages/activerecord/` step via a `github.head_ref` expression that resolves
  to `'1'` on this branch and `''` (empty → dormant no-op) on every other
  branch, PR, and `main`. No-op everywhere except here; no second suite run.
- The profiler is best-effort (per-worker JSON dumps in an `afterAll`; dump
  failures are swallowed) and never fails a test, so putting it on the required
  run cannot block a merge.
- A `continue-on-error`, `head_ref`-gated aggregate step runs
  `scripts/ddl-profile-aggregate.mjs` + `tee`s a summary; an `upload-artifact`
  step publishes `ddlprof/` (per-worker JSON + `aggregate-<lane>.txt`) as
  artifacts `ddl-profile-{sqlite,postgres,maria}`.

`mysql-tests` (mysql:8) is left untouched — it is temporarily disabled in CI;
MariaDB stands in for the MySQL-family lane.

### Also on this run: schema-repair frequency metrics

`repairWorkerSchema` (test-helpers/schema-repair.ts) drop-recreates any canonical
table a prior file in the same worker drifted. This run additionally instruments
it with per-worker counters (files seen, files that had to repair, per-table
drift frequency), dumped as `schema-repair-<adapter>-w<id>-<pid>.json` beside the
DDL-profile JSON and summarized by `scripts/schema-repair-aggregate.mjs` into
`schema-repair-<lane>.txt` in the same artifact. Answers **how often the shared-DB
shape-drift repair actually fires and which canonical tables drift most** — the
RFC-0019 burndown signal. Rides the same `DDL_PROFILE` gate/output dir, so it's a
dormant no-op everywhere else.

Verified locally against current `main` post-rebase: `DDL_PROFILE=1` still
installs its adapter patches and emits a valid per-worker aggregate (smoke run
of `aggregations.test.ts` → 3 ops, DROP_TABLE/CREATE_TABLE classified, JSON +
aggregate script both good). No profiler fix needed for RFC 0059.

## Results (re-run 2026-07-03, commit `9ed0382f3` on `main` @ `2ba40adbf`)

Green run [28689759803](https://github.com/blazetrailsdev/trails/actions/runs/28689759803) — all three AR lanes `success`, artifacts uploaded, profiler + repair-metrics added no failures.

### Headline: DDL churn collapsed ~9×. DROP no longer dominates.

| Adapter | Total DDL ops | DROP_TABLE | CREATE_TABLE | **drop:create** | Total DDL ms | Prev DROP → now |
|---|---|---|---|---|---|---|
| sqlite3 | 10,115 | 5,364 | 4,213 | **1.27 : 1** | 2,890 | 90,094 → 5,364 (**−94%**) |
| postgresql | 28,431,381¹ | 5,817 | 4,481 | **1.30 : 1** | 302,032¹ | 96,799 → 5,817 (**−94%**) |
| mysql2 (MariaDB) | 11,377 | 5,874 | 4,448 | **1.32 : 1** | 7,163 | 95,190 → 5,874 (**−94%**) |

¹ PG total is still dominated by **REFERENTIAL_INTEGRITY**: 28,420,280 ops /
289,979 ms = **96.0% of PG DDL time** (was 69% pre-rebase). Its share *rose* only
because the schema DDL around it collapsed — the absolute ref-integrity figure is
essentially unchanged (per-fixture-load `DISABLE/ENABLE TRIGGER ALL` over every
table; unaffected by the schema-boot change). Excluding it, PG **schema** DDL is
~12,052 ms, of which DROP is 6,422 ms (**53%** — no longer the ~95% it was).

**Top DROP-cost is now `ar_internal_metadata`** (per-file reset stamp), not the
cross-file teardown fan-out victims: sqlite 320 drops / 390 ms; MariaDB 349 /
327 ms. The old fan-out victims dropped 250–520× each in the prior run; now
`authors`/`posts`/`topics` drop only ~50–170× total, and remaining schema-DDL
concentrates in the handful of files that still `defineSchema`
(`canonical-schema.test.ts`, `setup-adapter-suite.test.ts`, `migration.test.ts`,
`encryptable-record.test.ts`, `schema-dumper.test.ts`).

### schema-repair frequency (new signal)

`repairWorkerSchema` almost never fires — the shared-DB shape-drift flake is now
rare:

| Adapter | Files seen | Files repaired | Repair rate | Table repairs |
|---|---|---|---|---|
| sqlite | 449 | 6 | **1.3%** | 15 |
| postgresql | 489 | 3 | **0.6%** | 4 |
| mysql2 (MariaDB) | 466 | 4 | **0.9%** | 9 |

`topics` is the most frequent drifter (2 files on every lane); the rest are
one-offs (`posts`, `children`, `group`, `select`, `distinct*`, `values`,
`courses`/`colleges`/`professors`, `fk_test_*`). This is the RFC-0019 burndown
worklist: ~1% of files still carry a bespoke `defineSchema` that drifts a
canonical table, led by `topics`.

### Interpretation — the RFC-0028 premise no longer holds

- **DROP fan-out is gone.** Drops fell ~94% on all three adapters and the
  drop:create ratio inverted from **~20:1 (prev) / ~12:1 (RFC-0028 baseline)** to
  **~1.3:1**. This is the RFC 0059 boot-laid canonical schema + RFC 0060
  truncate-instead-of-drop reset landing: the schema is stamped once per worker
  and reset by TRUNCATE, so per-file teardown no longer drop-recreates ~330
  tables. CREATE fell too (~4.8k → 4.2–4.5k, roughly flat), so the two are now at
  parity.
- **The lever moved.** The RFC-0028 cost model was built on "DROP dominates,
  ~86k drops/run, cut the teardown fan-out." That fan-out is already cut. What's
  left on sqlite/MariaDB is small (~3–7k total DDL ms) and dominated by
  `ar_internal_metadata` reset churn + the residual `defineSchema` files.
- **PG's real lever is now referential-integrity, not DDL.** At 96% of PG DDL ms
  and untouched by the schema-boot work, the per-table `DISABLE/ENABLE TRIGGER
  ALL` on every fixture load is the single remaining large PG target — worth its
  own story (batch it, or skip tables with no FKs).

> ⚠️ Aggregator note: the `ddl-profile-aggregate.mjs` in this run's artifacts
> mis-globbed the sibling `schema-repair-*.json` as a phantom `sqlite` adapter
> group (0 ops / NaN rows). The valid DDL data is the `sqlite3` / `postgresql` /
> `mysql2` groups above. Fixed in a follow-up commit (aggregator now skips
> `schema-repair-*.json`); ignore the phantom group in the artifact text.

---

## Previous run (pre-rebase, PR #4499)

Run [28676162124](https://github.com/blazetrailsdev/trails/actions/runs/28676162124) — all three AR lanes `success`, artifacts uploaded. Full 6-worker suite; the profiler added no failures.

| Adapter | Total DDL ops | DROP_TABLE | CREATE_TABLE | drop:create | DROP share of schema-DDL ms | Total DDL ms |
|---|---|---|---|---|---|---|
| sqlite3 | 95,199 | 90,094 | 4,534 | **19.9 : 1** | 94.6% | 21,077 |
| postgresql | 28,171,207¹ | 96,799 | 4,803 | **20.2 : 1** | 94.9%² | 396,479¹ |
| mysql2 (MariaDB) | 100,967 | 95,190 | 4,770 | **20.0 : 1** | 95.0% | 72,463 |

¹ PG total is dominated by **REFERENTIAL_INTEGRITY**: 28,068,836 ops /
273,656 ms = **69% of PG DDL time**. That's the `disableReferentialIntegrity`
`ALTER TABLE … DISABLE/ENABLE TRIGGER ALL` wrapper fired on every fixture load
over every table (~84k load events × ~330 tables, split per-table by the
profiler's `classifyStatements`). It is a PG-only fixture mechanism, not schema
DDL.
² DROP share computed against PG **schema** DDL (excl. REFERENTIAL_INTEGRITY):
DROP 116,613 ms of ~122,824 ms schema-DDL.

**Top DROP-cost tables** are the same cross-file teardown fan-out victims on
every adapter — `posts`, `authors`, `topics`, `companies`, `books`,
`encrypted_books`, `traffic_lights` — each dropped 250–520× across the suite.
On sqlite the single most expensive is the bespoke `test_with_keyword_column_name`
(263 drops / 1,076 ms).

## Historical baseline (PR #3904 / docs #3995)

**~2,600 distinct tables re-dropped**, **~86k total DROP ops**, DROP dominates,
**~12:1 drop:create**, PG ~63% / MariaDB ~87% of DDL ms.

Measurement only — no production code change.
