### PR TITLE
fix(primary-key): normalize safe bigint id to number for FK=PK equality

### DIFF
--- a/packages/activerecord/src/attribute-methods/primary-key.test.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getId } from "./primary-key.js";
+import { getId, idWas, idInDatabase, idBeforeTypeCast } from "./primary-key.js";
 
 // Unit tests for the `id` accessor's bigint normalization. On PG the driver
 // returns a table's default `bigint` id as a JS `bigint`, while `integer`-typed
@@ -38,6 +38,26 @@ describe("PrimaryKey#id bigint normalization", () => {
   it("passes through a null primary key", () => {
     const record = host("id", null);
     expect(getId.call(record)).toBeNull();
+  });
+
+  it("keeps id, idWas, and idInDatabase in lockstep for a bigint pk", () => {
+    // All three route through readPkWith and must agree on representation, so
+    // `record.id === record.idInDatabase` holds after a fresh PG load.
+    const record = {
+      constructor: { primaryKey: "id" },
+      id: 42n,
+      readAttribute: (_name: string) => 42n,
+      _readAttribute: (_name: string) => 42n,
+      attributeWas: (_name: string) => 42n,
+      attributeInDatabase: (_name: string) => 42n,
+      readAttributeBeforeTypeCast: (_name: string) => 42n,
+      _writeAttribute: () => {},
+    };
+    expect(getId.call(record)).toBe(42);
+    expect(idWas.call(record)).toBe(42);
+    expect(idInDatabase.call(record)).toBe(42);
+    expect(idBeforeTypeCast.call(record)).toBe(42);
+    expect(getId.call(record) === idInDatabase.call(record)).toBe(true);
   });
 
   it("normalizes each component of a composite primary key", () => {

--- a/packages/activerecord/src/attribute-methods/primary-key.test.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { getId } from "./primary-key.js";
+
+// Unit tests for the `id` accessor's bigint normalization. On PG the driver
+// returns a table's default `bigint` id as a JS `bigint`, while `integer`-typed
+// FK columns cast to `number`; the accessor collapses a safe-range `bigint` id
+// to `number` so `child.fk === parent.id` holds cross-adapter. SQLite/MySQL
+// already hand ids back as `number`, so this behavior is only observable when a
+// `bigint` reaches the accessor — simulated here with a stubbed `_readAttribute`.
+describe("PrimaryKey#id bigint normalization", () => {
+  function host(pk: string | string[], value: unknown) {
+    return {
+      constructor: { primaryKey: pk },
+      _readAttribute: (_name: string) => value,
+      _writeAttribute: () => {},
+    };
+  }
+
+  it("collapses a safe-range bigint id to number", () => {
+    const record = host("id", 42n);
+    expect(getId.call(record)).toBe(42);
+    expect(typeof getId.call(record)).toBe("number");
+  });
+
+  it("leaves a number id untouched (sqlite/mysql path)", () => {
+    const record = host("id", 42);
+    expect(getId.call(record)).toBe(42);
+    expect(typeof getId.call(record)).toBe("number");
+  });
+
+  it("preserves a bigint beyond MAX_SAFE_INTEGER to avoid precision loss", () => {
+    const big = BigInt(Number.MAX_SAFE_INTEGER) + 1n;
+    const record = host("id", big);
+    expect(getId.call(record)).toBe(big);
+    expect(typeof getId.call(record)).toBe("bigint");
+  });
+
+  it("passes through a null primary key", () => {
+    const record = host("id", null);
+    expect(getId.call(record)).toBeNull();
+  });
+
+  it("normalizes each component of a composite primary key", () => {
+    const record = {
+      constructor: { primaryKey: ["shop_id", "id"] },
+      _readAttribute: (name: string) => (name === "shop_id" ? 7n : 99n),
+      _writeAttribute: () => {},
+    };
+    expect(getId.call(record)).toEqual([7, 99]);
+  });
+});

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -95,6 +95,27 @@ interface PrimaryKeyInstance {
   _writeAttribute(name: string, value: unknown): void;
 }
 
+const MAX_SAFE_BIGINT = BigInt(Number.MAX_SAFE_INTEGER);
+const MIN_SAFE_BIGINT = BigInt(Number.MIN_SAFE_INTEGER);
+
+/**
+ * Normalize a primary-key value so that a `bigint`-backed id compares `===`
+ * with an `integer`-typed foreign key holding the same logical value.
+ *
+ * On PG the driver returns a table's default `bigint` id as a JS `bigint`,
+ * while `integer`-typed FK columns cast through IntegerType to `number`. Ruby
+ * has a single Integer type, so `child.fk == parent.id` can never straddle two
+ * representations there; here it can. Collapse a safe-range `bigint` to
+ * `number` (values beyond MAX_SAFE_INTEGER stay `bigint` to preserve precision —
+ * they cannot equal a 4-byte integer FK anyway).
+ */
+function normalizeIntegerId(value: unknown): unknown {
+  if (typeof value === "bigint" && value >= MIN_SAFE_BIGINT && value <= MAX_SAFE_BIGINT) {
+    return Number(value);
+  }
+  return value;
+}
+
 /**
  * Mirrors: ActiveRecord::AttributeMethods::PrimaryKey#id
  * @internal
@@ -102,10 +123,10 @@ interface PrimaryKeyInstance {
 export function getId(this: PrimaryKeyInstance): unknown {
   const ctor = this.constructor as any;
   const pk = ctor.primaryKey as string | string[] | null;
-  if (Array.isArray(pk)) return pk.map((col) => this._readAttribute(col));
+  if (Array.isArray(pk)) return pk.map((col) => normalizeIntegerId(this._readAttribute(col)));
   // Rails: `_read_attribute(@primary_key)`. A nil primary key reads through the
   // AttributeSet's Null attribute, returning nil without raising.
-  return this._readAttribute(pk as string);
+  return normalizeIntegerId(this._readAttribute(pk as string));
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -45,12 +45,18 @@ export function isPrimaryKeyValuesPresent(this: PrimaryKeyRecord): boolean {
 function readPkWith(record: PrimaryKeyRecord, method: string): unknown {
   const pk = (record.constructor as any).primaryKey;
   const fn = (record as any)[method];
+  // Normalize each read so `id`, `idWas`, `idInDatabase`, and
+  // `idBeforeTypeCast` agree on representation: without this a PG `bigint` PK
+  // makes `record.id` (number, via getId) diverge from `record.idInDatabase`
+  // (bigint) for the identical logical value. Rails treats all four as the
+  // same Integer (primary_key.rb:18-51); normalizeIntegerId keeps them in
+  // lockstep here. (idForDatabase stays raw — it feeds SQL binding.)
   if (typeof fn === "function") {
-    if (Array.isArray(pk)) return pk.map((k: string) => fn.call(record, k));
-    return fn.call(record, pk);
+    if (Array.isArray(pk)) return pk.map((k: string) => normalizeIntegerId(fn.call(record, k)));
+    return normalizeIntegerId(fn.call(record, pk));
   }
-  if (Array.isArray(pk)) return pk.map((k: string) => record._readAttribute(k));
-  return record._readAttribute(pk);
+  if (Array.isArray(pk)) return pk.map((k: string) => normalizeIntegerId(record._readAttribute(k)));
+  return normalizeIntegerId(record._readAttribute(pk));
 }
 
 export function idBeforeTypeCast(this: PrimaryKeyRecord): unknown {

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -346,9 +346,9 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
 
     // Rails `assert_no_difference "Parrot.count"`: HABTM mark_for_destruction
     // removes the join row, it does NOT destroy the associated record.
-    const before = Number(await Parrot.count());
+    const before = await Parrot.count();
     await pirate.save();
-    expect(Number(await Parrot.count())).toBe(before);
+    expect(await Parrot.count()).toBe(before);
 
     const reloaded = await Pirate.find(pirate.id!);
     expect((await association(reloaded, "parrots").toArray()).length).toBe(0);
@@ -579,7 +579,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     cacheAssoc(company, "clients", [client]);
     const saved = await company.save();
     expect(saved).toBe(true);
-    expect(Number(client.client_of)).toBe(Number(company.id));
+    expect(client.client_of).toBe(company.id);
   });
 
   it("parent should not get saved with duplicate children records", async () => {
@@ -611,7 +611,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     const saved = await company.save();
     expect(saved).toBe(true);
     expect(client.isNewRecord()).toBe(false);
-    expect(Number(client.client_of)).toBe(Number(company.id));
+    expect(client.client_of).toBe(company.id);
   });
 
   it("assign ids", async () => {
@@ -1022,7 +1022,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     cacheAssoc(firm, "account", account);
     await firm.save();
     expect(account.isNewRecord()).toBe(false);
-    expect(Number(account.firm_id)).toBe(Number(firm.id));
+    expect(account.firm_id).toBe(firm.id);
   });
 
   it("build before either saved", async () => {
@@ -1033,7 +1033,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     await firm.save();
     expect(firm.isNewRecord()).toBe(false);
     expect(account.isNewRecord()).toBe(false);
-    expect(Number(account.firm_id)).toBe(Number(firm.id));
+    expect(account.firm_id).toBe(firm.id);
   });
 
   it("assignment before parent saved", async () => {
@@ -1042,7 +1042,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     const account = new Account({ credit_limit: 300 });
     cacheAssoc(firm, "account", account);
     await firm.save();
-    expect(Number(account.firm_id)).toBe(Number(firm.id));
+    expect(account.firm_id).toBe(firm.id);
   });
 
   it("assignment before either saved", async () => {
@@ -1339,7 +1339,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     expect(log).toContain("before_save");
     expect(log).toContain("after_save");
     expect(child.isNewRecord()).toBe(false);
-    expect(Number(child._readAttribute("employable_id"))).toBe(Number(parent.id));
+    expect(child._readAttribute("employable_id")).toBe(parent.id);
     expect(child._readAttribute("employable_type")).toBe("PolyParent");
   });
   it("callbacks on child when child autosaves parent", async () => {
@@ -1440,7 +1440,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     expect(log).toContain("parent_before_save");
     expect(log).toContain("parent_after_save");
     expect(parent.isNewRecord()).toBe(false);
-    expect(Number(child._readAttribute("employable_id"))).toBe(Number(parent.id));
+    expect(child._readAttribute("employable_id")).toBe(parent.id);
     expect(child._readAttribute("employable_type")).toBe("PolyAsParent");
   });
 
@@ -1450,7 +1450,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     const account = await Account.create({ credit_limit: 600, firm_id: firm.id });
     cacheAssoc(firm, "account", account);
     await firm.save();
-    expect(Number(account.firm_id)).toBe(Number(firm.id));
+    expect(account.firm_id).toBe(firm.id);
   });
 });
 
@@ -1495,7 +1495,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     cacheAssoc(pirate, "ship", ship);
     await pirate.save();
     expect(ship.isNewRecord()).toBe(false);
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
   });
 
   it("changed for autosave should handle cycles", async () => {
@@ -1809,7 +1809,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     cacheAssoc(cake, "chef", chef);
     await cake.save();
     expect(chef._readAttribute("employable_type")).toBe("SwapCakeDesigner");
-    expect(Number(chef._readAttribute("employable_id"))).toBe(Number(cake.id));
+    expect(chef._readAttribute("employable_id")).toBe(cake.id);
 
     // Reassign chef to drink — polymorphic type column flips even when
     // employable_id may collide. autosave on drink should re-persist the chef.
@@ -1817,7 +1817,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     cacheAssoc(drink, "chef", chef);
     await drink.save();
     expect(chef._readAttribute("employable_type")).toBe("SwapDrinkDesigner");
-    expect(Number(chef._readAttribute("employable_id"))).toBe(Number(drink.id));
+    expect(chef._readAttribute("employable_id")).toBe(drink.id);
   });
 });
 
@@ -1934,7 +1934,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     cacheAssoc(post, "author", author);
     await post.save();
     expect(author.isNewRecord()).toBe(false);
-    expect(Number(post.author_id)).toBe(Number(author.id));
+    expect(post.author_id).toBe(author.id);
   });
 
   it("assignment before either saved", async () => {
@@ -1955,7 +1955,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     await post.save();
     expect(post.isNewRecord()).toBe(false);
     expect(author.isNewRecord()).toBe(false);
-    expect(Number(post.author_id)).toBe(Number(author.id));
+    expect(post.author_id).toBe(author.id);
   });
 
   it("store association in two relations with one save", async () => {
@@ -1967,19 +1967,11 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     setBilling(order, customer);
     setShipping(order, customer);
     expect(await order.save()).toBe(true);
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     await order.reload();
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     expect(await Order.count()).toBe(numOrders + 1);
     expect(await Customer.count()).toBe(numCustomers + 1);
   });
@@ -1992,19 +1984,11 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     setBilling(order, customer);
     setShipping(order, customer);
     expect(await order.save()).toBe(true);
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     await order.reload();
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     expect(await Order.count()).toBe(numOrders + 1);
     expect(await Customer.count()).toBe(numCustomers + 1);
   });
@@ -2017,24 +2001,16 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     setBilling(order, customer);
     setShipping(order, customer);
     expect(await order.save()).toBe(true);
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     await order.reload();
     customer = new Customer({ name: "C2" });
     setBilling(order, customer);
     setShipping(order, customer);
     expect(await order.save()).toBe(true);
     await order.reload();
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     expect(await Order.count()).toBe(numOrders + 1);
     expect(await Customer.count()).toBe(numCustomers + 2);
   });
@@ -2061,7 +2037,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     setBelongsTo(sponsor, "sponsorable", member, { polymorphic: true });
     await sponsor.save();
     const reloaded = await PolySponsor.find(sponsor.id!);
-    expect(Number(reloaded.sponsorable_id)).toBe(Number(member.id));
+    expect(reloaded.sponsorable_id).toBe(member.id);
     expect(reloaded.sponsorable_type).toBe("PolyMember");
   });
 
@@ -2184,7 +2160,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
     cacheAssoc(ship, "pirate", pirate);
     await ship.save();
     expect(pirate.isNewRecord()).toBe(false);
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
   });
 
   it("should automatically save bang the associated model", async () => {
@@ -2294,7 +2270,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
     const ship = new Ship({ name: "FK", pirate_id: pirate.id });
     cacheAssoc(ship, "pirate", pirate);
     await ship.save();
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
   });
 
   it("should save if previously saved", async () => {
@@ -2602,7 +2578,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await pirate.save();
     expect(pirate.catchphrase).toBe("Ahoy!");
     expect(ship.isNewRecord()).toBe(false);
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
   });
 
   it("autosave does not pass through non custom validation contexts", async () => {
@@ -2722,7 +2698,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await author.save();
     expect(book.isNewRecord()).toBe(false);
     expect(saveCount).toBe(1);
-    expect(Number(book.author_id)).toBe(Number(author.id));
+    expect(book.author_id).toBe(author.id);
   });
 
   it("autosave has one association callbacks get called once", async () => {
@@ -2758,7 +2734,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await user.save();
     expect(profile.isNewRecord()).toBe(false);
     expect(saveCount).toBe(1);
-    expect(Number(profile.author_id)).toBe(Number(user.id));
+    expect(profile.author_id).toBe(user.id);
   });
 
   it("autosave belongs to association callbacks get called once", async () => {
@@ -2794,7 +2770,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await post.save();
     expect(author.isNewRecord()).toBe(false);
     expect(saveCount).toBe(1);
-    expect(Number(post.author_id)).toBe(Number(author.id));
+    expect(post.author_id).toBe(author.id);
   });
 
   it("default belongs_to saves new associated record and propagates the FK", async () => {
@@ -2828,7 +2804,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     cacheAssoc(post, "author", author);
     await post.save();
     expect(author.isNewRecord()).toBe(false);
-    expect(Number(post.author_id)).toBe(Number(author.id));
+    expect(post.author_id).toBe(author.id);
   });
 
   it("belongs_to autosave with mismatched composite FK/PK uses zip semantics", async () => {
@@ -2866,7 +2842,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     cacheAssoc(child, "parent", parent);
     await child.save();
     expect(parent.isNewRecord()).toBe(false);
-    expect(Number(child.parent_id)).toBe(Number(parent.id));
+    expect(child.parent_id).toBe(parent.id);
     // Trailing FK "group" was dropped from the zip; the existing
     // owner value must survive untouched (no overwrite to undefined/null).
     expect(child.group).toBe("us-west");
@@ -2947,7 +2923,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     cacheAssoc(child, "parent", parent);
     await child.save();
     expect(parent.isNewRecord()).toBe(false);
-    expect(Number(child.author_id)).toBe(Number(parent.id));
+    expect(child.author_id).toBe(parent.id);
     // The dropped ("name", nil) pair didn't attempt to write — no throw,
     // no spurious column write.
   });
@@ -3638,7 +3614,7 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
     await pirate.save();
     expect(log).toContain("pirate_created");
     expect(pirate.isNewRecord()).toBe(false);
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
     expect(ship.isNewRecord()).toBe(false);
   });
 
@@ -4162,7 +4138,7 @@ describe("should update children when autosave is true and parent is new but chi
     expect(parent.isNewRecord()).toBe(false);
     const reloaded = await UcChild.find(child.id);
     expect(reloaded.name).toBe("updated");
-    expect(Number(reloaded.readAttribute("author_id"))).toBe(Number(parent.id));
+    expect(reloaded.readAttribute("author_id")).toBe(parent.id);
   });
   it("should automatically save the associated models", async () => {
     class NAutoTag extends Base {


### PR DESCRIPTION
## Problem

During autosave-association canonical conversion (PR #4231), 31 `expect(child.fk).toBe(parent.id)` assertions had to be wrapped with `Number()` on both sides to pass on the PG CI runner.

Root cause: on PG the driver returns a table's default `bigint` primary key as a JS `bigint`, while `integer`-typed FK columns cast through `IntegerType` to `number`. Ruby has a single Integer type, so `child.fk === parent.id` can never straddle two representations there; in trails it could, so `===` (`.toBe`) failed cross-adapter.

## Fix

Normalize a safe-range `bigint` id to `number` in the `Model#id` accessor (`getId`). Values beyond `MAX_SAFE_INTEGER` stay `bigint` to preserve precision — they cannot equal a 4-byte `integer` FK anyway. FK columns already cast BigInt → Number via `IntegerType.castValue`, so both sides are now `number`.

The 31 `Number()` wrappers on FK=PK assertions in `autosave-association.test.ts` are removed. `Parrot.count()` comparisons are left self-consistent (both operands are the same raw count value).

## Testing

- `autosave-association.test.ts` (209 tests), `primary-keys.test.ts`, `bigint-roundtrip.test.ts`, `big-integer.test.ts`, `integer.test.ts` all pass on sqlite locally.

Closes-story: integer-type-bigint-fk-pk-coercion-pg

---

## Review responses

**Finding #1 (self-consistency of id accessors) — fixed.** `normalizeIntegerId` now runs inside `readPkWith`, so `idWas`, `idInDatabase`, and `idBeforeTypeCast` normalize identically to `id`. `record.id === record.idInDatabase` now holds for a PG `bigint` PK. `idForDatabase` intentionally stays raw (native type for SQL binding). New unit test locks the four in lockstep.

**Finding #2 (should normalization live one layer down?) — kept at the accessor layer, deliberately.** Moving it into `BigIntegerType.cast` is not viable: the Rails-mirrored `BigIntegerType` tests assert `cast("42") === 42n` / `typeof === "bigint"` (test names match Rails verbatim, cannot change), and `big_integer` attribute *columns* (e.g. a `score` field, `bigint-roundtrip.test.ts`) must stay `bigint` to preserve precision beyond `MAX_SAFE_INTEGER`. The number/bigint split is fundamental to how trails represents Ruby's unbounded Integer, so the reconciliation belongs where a PK is compared against an `integer` FK — the `id` accessor — not in the type. This is now applied consistently across all four read accessors, so it is not a one-accessor special-case.
