### PR TITLE
test(connection-pool): retire sidecar _pool; build pool-mechanics pools from primary config

### DIFF
--- a/packages/activerecord/src/connection-adapters/pool-config.test.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.test.ts
@@ -1,6 +1,5 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { PoolConfig } from "./pool-config.js";
-import { _reestablishPooledTestPoolForTests } from "../test-adapter.js";
 import { ConnectionDescriptor } from "./abstract/connection-descriptor.js";
 import { HashConfig } from "../database-configurations/hash-config.js";
 import { SchemaReflection } from "./schema-cache.js";
@@ -166,13 +165,6 @@ describe("PoolConfig", () => {
   });
 
   describe("static discardPoolsBang", () => {
-    // discardPoolsBang iterates the global PoolConfig registry, which includes
-    // the shared pooled test adapter; real `discard!` nulls its connections
-    // terminally, so rebuild it before the next test's reset hook runs.
-    afterEach(async () => {
-      await _reestablishPooledTestPoolForTests();
-    });
-
     it("discards pools on all tracked instances", async () => {
       const c1 = new PoolConfig(makeDescriptor("a"), makeDbConfig("a"));
       const c2 = new PoolConfig(makeDescriptor("b"), makeDbConfig("b"));

--- a/packages/activerecord/src/connection-pool.trails.test.ts
+++ b/packages/activerecord/src/connection-pool.trails.test.ts
@@ -24,7 +24,7 @@ import { PoolConfig } from "./connection-adapters/pool-config.js";
 import { SchemaReflection, BoundSchemaReflection } from "./connection-adapters/schema-cache.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { newRawTestAdapter, ambientPoolConfiguration, adapterType } from "./test-adapter.js";
-import type { SidecarAdapter } from "./test-adapter.js";
+import type { LeasedTestAdapter } from "./test-adapter.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import { adapterNameFromConfig } from "./connection-adapters/abstract-adapter.js";
@@ -262,10 +262,10 @@ it("clearReloadableConnections only disconnects reloadable adapters", async () =
 it("pin connection reuses leased connection and checks in on unpin", async () => {
   const pool = makeAmbientPool({ pool: 5 });
   try {
-    const leased = (await pool.leaseConnection()) as SidecarAdapter;
+    const leased = (await pool.leaseConnection()) as LeasedTestAdapter;
 
     await pool.pinConnectionBang();
-    const pinned = (await pool.checkout()) as SidecarAdapter;
+    const pinned = (await pool.checkout()) as LeasedTestAdapter;
     expect(pinned).toBe(leased);
     expect(leased.transactionManager.openTransactions).toBe(1);
     expect(leased.transactionManager.currentTransaction.joinable).toBe(false);
@@ -1016,7 +1016,7 @@ describe("checkout/checkin callbacks", () => {
   it("pinned checkout verifies on every handout (reconnect-on-drop) and skips query-cache wiring", async () => {
     const pool = makeAmbientPool({ pool: 5 });
     await pool.pinConnectionBang();
-    const pinned = (await pool.checkout()) as SidecarAdapter;
+    const pinned = (await pool.checkout()) as LeasedTestAdapter;
     const spy = vi.spyOn(pinned, "verifyBang");
     try {
       // Rails re-runs `verify!` on every pinned checkout (connection_pool.rb:554),

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -29,10 +29,10 @@ import { resetTestTables } from "./test-helpers/drop-all-tables.js";
 import { Base } from "./base.js";
 import { getEnv } from "@blazetrails/activesupport";
 
-// process.env.PG_TEST_URL / MYSQL_TEST_URL are already worker-scoped by
+// PG_TEST_URL / MYSQL_TEST_URL are already worker-scoped by
 // test-setup-worker-db.ts (a setupFile that runs before this module loads).
-const PG_TEST_URL = process.env.PG_TEST_URL;
-const MYSQL_TEST_URL = process.env.MYSQL_TEST_URL;
+const PG_TEST_URL = getEnv("PG_TEST_URL");
+const MYSQL_TEST_URL = getEnv("MYSQL_TEST_URL");
 
 /** Which adapter backend is active. */
 export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -1,26 +1,32 @@
 /**
- * Shared test adapter factory.
+ * Shared test adapter helpers.
  *
- * Returns the appropriate adapter based on environment variables:
+ * Resolves which backend the active lane uses from the environment:
  *   - PG_TEST_URL    → PostgreSQLAdapter
  *   - MYSQL_TEST_URL → Mysql2Adapter
- *   - (default)      → SQLite3Adapter (:memory:)
+ *   - (default)      → SQLite3Adapter (the per-worker template clone, or
+ *     `:memory:` when no clone was built)
  *
- * For real database adapters, a single shared connection pool is reused
- * across all test adapters to avoid exhausting database connections.
+ * RFC 0059 retired the standing sidecar `_pool`: Rails has no sidecar test
+ * pool (`grep -r sidecar vendor/rails/activerecord/test` = 0 hits) — every
+ * test rides `ActiveRecord::Base.connection`, and a test that genuinely needs
+ * its own pool builds one IN-TEST from the primary config
+ * (`vendor/rails/activerecord/test/cases/connection_pool_test.rb:16-30`). So
+ * the standing sidecar pool and its divergent
+ * `file:trails_test_N?mode=memory&cache=shared` handle are gone: the global
+ * reset rides the primary `Base.connection` pool, `newRawTestAdapter` /
+ * `ambientPoolConfiguration` describe the primary lane config, and
+ * `createPooledTestAdapter` builds its duplicate pool from that same config.
  *
- * Schemas are declared explicitly by tests via `defineSchema()`. Phase 7
- * deleted the lazy auto-schema / recovery scaffolding that used to extract
- * tables from registered model classes on the first DB op; tests must now
- * declare their tables up front.
+ * Schemas are declared explicitly by tests via `defineSchema()` / `fixtures()`.
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
+import type { ConnectionPool } from "./connection-adapters/abstract/connection-pool.js";
 import type { TransactionManager } from "./connection-adapters/abstract/transaction.js";
 import { clearAppliedSchemaSignatures } from "./test-helpers/define-schema.js";
-import { dropAllTables, resetTestTables } from "./test-helpers/drop-all-tables.js";
+import { resetTestTables } from "./test-helpers/drop-all-tables.js";
 import { Base } from "./base.js";
-import { ConnectionNotEstablished } from "./errors.js";
 import { getEnv } from "@blazetrails/activesupport";
 
 // process.env.PG_TEST_URL / MYSQL_TEST_URL are already worker-scoped by
@@ -45,184 +51,16 @@ export const adapterType: "sqlite" | "postgres" | "mysql" = PG_TEST_URL
  * which is `AR_TEST_WORKER_DB ?? ":memory:"` — i.e. literally `":memory:"` on the
  * default lane and a real on-disk clone path when a per-worker template exists.
  * So `!AR_TEST_WORKER_DB` is exactly `db_config.database == ":memory:"`.
- *
- * (Note: the pool's *physical* connection URI from `_pooledSqliteDatabase()` —
- * `file:…?mode=memory&cache=shared` — is trails' mechanism for sharing that one
- * `:memory:` database across the pool's connections; it is not the configured
- * `database` value Rails compares, so it is not what this gate keys on.)
  */
 export function inMemoryDb(): boolean {
   return adapterType === "sqlite" && !getEnv("AR_TEST_WORKER_DB");
-}
-
-// --- Connection pool infrastructure -----------------------------------------
-//
-// All test adapters now route through a real ConnectionPool. SQLite uses a
-// shared-cache URI (cache=shared) so all pool connections share the same
-// in-memory database without needing pool size 1.
-
-let _pooledHandler:
-  | import("./connection-adapters/abstract/connection-handler.js").ConnectionHandler
-  | null = null;
-// Memoizes the in-flight initialization so concurrent callers (Promise.all,
-// parallel test bodies in the same worker) all await the same pool instead
-// of racing to establish two ConnectionHandlers and leaking one.
-let _pooledPoolPromise: Promise<
-  import("./connection-adapters/abstract/connection-pool.js").ConnectionPool
-> | null = null;
-
-/** Per-worker SQLite shared-cache database name (Phase A0 spike: prefer named form). */
-function _pooledSqliteDatabase(): string {
-  // Phase 0 template-clone: when a per-worker template clone exists, use that
-  // on-disk file as the worker DB (schema pre-built). Falls back to the
-  // shared-cache :memory: form when no template was built.
-  const cloned = process.env.AR_TEST_WORKER_DB;
-  if (cloned) return cloned;
-  const workerId = process.env.VITEST_POOL_ID ?? process.env.VITEST_WORKER_ID ?? "1";
-  return `file:trails_test_${workerId}?mode=memory&cache=shared`;
-}
-
-/**
- * Synchronous factory that creates a fresh underlying adapter for the active
- * environment. Set once at module boot (after the async pool init resolves).
- * Use this when you need a distinct adapter object per call — e.g. as the
- * `adapterFactory` for a test-local {@link ConnectionPool}.
- *
- * @internal
- */
-export let newRawTestAdapter: () => DatabaseAdapter;
-
-// The raw configuration hash used to establish the ambient pooled test
-// connection (the active CI lane's adapter). Set once at pool boot.
-let _ambientConfiguration: Record<string, unknown> | null = null;
-
-/**
- * A copy of the configuration hash used to establish the ambient pooled test
- * connection for the active CI lane. Mirrors Rails'
- * `ActiveRecord::Base.connection_pool.db_config.configuration_hash`, letting
- * tests clone the ambient adapter's config (with per-test overrides) instead of
- * hardcoding `adapter: "sqlite3"`. This is how pool-under-test fixtures build a
- * duplicate pool that runs against whatever adapter the current lane uses.
- *
- * @internal
- */
-export function ambientPoolConfiguration(): Record<string, unknown> {
-  if (!_ambientConfiguration) {
-    throw new ConnectionNotEstablished("ambient test pool has not been established yet");
-  }
-  return { ..._ambientConfiguration };
-}
-
-function _establishPooledTestPool(): Promise<
-  import("./connection-adapters/abstract/connection-pool.js").ConnectionPool
-> {
-  if (_pooledPoolPromise) return _pooledPoolPromise;
-  _pooledPoolPromise = (async () => {
-    const { ConnectionHandler } =
-      await import("./connection-adapters/abstract/connection-handler.js");
-    const { HashConfig } = await import("./database-configurations/hash-config.js");
-
-    let adapterName: string;
-    let configuration: Record<string, unknown>;
-    let adapterFactory: () => DatabaseAdapter;
-
-    if (PG_TEST_URL) {
-      adapterName = "postgresql";
-      configuration = { adapter: adapterName, url: PG_TEST_URL };
-      const { PostgreSQLAdapter } = await import("./connection-adapters/postgresql-adapter.js");
-      // Rails adapters own a single backend connection; the outer
-      // ConnectionPool does the multiplexing. Constrain the driver pool to
-      // max: 1 so each pooled-adapter slot corresponds to exactly one PG
-      // server connection (otherwise pool-size N × pg.Pool default 10 can
-      // exhaust CI connection limits).
-      adapterFactory = () =>
-        new PostgreSQLAdapter({
-          connectionString: PG_TEST_URL,
-          max: 1,
-        }) as unknown as DatabaseAdapter;
-    } else if (MYSQL_TEST_URL) {
-      adapterName = "mysql2";
-      configuration = { adapter: adapterName, url: MYSQL_TEST_URL };
-      const { Mysql2Adapter } = await import("./connection-adapters/mysql2-adapter.js");
-      // See PG branch: constrain mysql2 driver pool to one physical
-      // connection per adapter so the outer ConnectionPool stays the
-      // single source of multiplexing (matches Rails' one-connection-
-      // per-adapter shape).
-      adapterFactory = () =>
-        new Mysql2Adapter({
-          uri: MYSQL_TEST_URL,
-          connectionLimit: 1,
-          flags: ["FOUND_ROWS"],
-        }) as unknown as DatabaseAdapter;
-    } else {
-      adapterName = "sqlite3";
-      const database = _pooledSqliteDatabase();
-      // cache=shared in the URI is what provides shared-cache semantics across
-      // pool connections; no need to limit pool size to 1.
-      configuration = { adapter: adapterName, database };
-      const { BetterSQLite3Adapter } =
-        await import("./connection-adapters/better-sqlite3-adapter.js");
-      adapterFactory = () => new BetterSQLite3Adapter(database) as unknown as DatabaseAdapter;
-    }
-
-    newRawTestAdapter = adapterFactory;
-    _ambientConfiguration = configuration;
-
-    const handler = new ConnectionHandler();
-    _pooledHandler = handler;
-    // Name = "primary" so HashConfig#isPrimary() reports true and the
-    // pool's SchemaReflection resolves to the conventional
-    // `db/schema_cache.json` path (matches Rails' primary test connection
-    // shape; non-primary configs would hash to `db/<name>_schema_cache.json`).
-    const config = new HashConfig("test", "primary", configuration);
-    return handler.establishConnection(config, {
-      owner: "PooledTestAdapter",
-      adapterFactory,
-    });
-  })().catch((err) => {
-    // Drop the memoized promise on failure so a follow-up call can retry
-    // instead of permanently resolving every caller to the rejection.
-    _pooledPoolPromise = null;
-    throw err;
-  });
-  return _pooledPoolPromise;
-}
-
-// Boot: initialize the pool eagerly so factory calls below are synchronous.
-// newRawTestAdapter is also set during this await.
-let _pool = await _establishPooledTestPool();
-
-/**
- * Re-establish the shared pooled test adapter after it has been torn down
- * terminally (e.g. a test that exercises `PoolConfig.discardPoolsBang()`, whose
- * real `discard!` semantics null the pool's connections so it can never be
- * re-checked-out). Drops the memoized handler/pool and rebuilds a fresh pool so
- * the next `resetTestAdapterState` has a live connection again.
- *
- * @internal — for pool-lifecycle tests only.
- */
-export async function _reestablishPooledTestPoolForTests(): Promise<void> {
-  _resetPooledTestAdapterForTests();
-  _pool = await _establishPooledTestPool();
 }
 
 /** Type alias for pool-leased adapters returned by test factories. */
 export type TestDatabaseAdapter = DatabaseAdapter;
 
 /**
- * Create a fresh pool-leased adapter for testing. Phase 7 removed the lazy
- * auto-schema machinery; F5 removed the TestAdapterFixtures wrapper — the
- * raw pool-leased DatabaseAdapter is returned directly.
- *
- * Async because it awaits the Rails-named {@link ConnectionPool#leaseConnection}
- * (which awaits the per-checkout `verifyBang`); callers must `await`.
- */
-export async function createTestAdapter(): Promise<TestDatabaseAdapter> {
-  return _pool.leaseConnection();
-}
-
-/**
- * Adapter shape returned by {@link createSidecarTestAdapter}. The concrete
+ * Adapter shape returned by {@link createPooledTestAdapter}. The concrete
  * `AbstractAdapter` subclasses (SQLite3 / PostgreSQL / Mysql2) expose these
  * members at runtime; surfacing them here lets callers reach transaction
  * lifecycle methods without unsafe casts.
@@ -239,59 +77,155 @@ export type SidecarAdapter = DatabaseAdapter & {
   openTransactions: number;
 };
 
+// --- Primary lane config + raw adapter factory ------------------------------
+//
+// The configuration hash for the active CI lane's PRIMARY connection — the
+// same database `Base.connection` rides (no separate handle). Mirrors Rails'
+// `ActiveRecord::Base.connection_pool.db_config.configuration_hash`, letting
+// pool-mechanics tests clone the ambient config (with per-test overrides)
+// instead of hardcoding `adapter: "sqlite3"`.
+const _primaryConfiguration: Record<string, unknown> = PG_TEST_URL
+  ? { adapter: "postgresql", url: PG_TEST_URL }
+  : MYSQL_TEST_URL
+    ? { adapter: "mysql2", url: MYSQL_TEST_URL }
+    : { adapter: "sqlite3", database: getEnv("AR_TEST_WORKER_DB") ?? ":memory:" };
+
 /**
- * Returns a pool-leased {@link DatabaseAdapter}. Callers can issue DB ops
- * on `adapter` directly (no delegation overhead).
- *
- * Async because it awaits the Rails-named {@link ConnectionPool#leaseConnection}
- * (which awaits the per-checkout `verifyBang`); callers must `await`.
+ * A copy of the active lane's primary configuration hash. Mirrors Rails'
+ * `ActiveRecord::Base.connection_pool.db_config.configuration_hash` — the shape
+ * a pool-under-test duplicates (see `connection_pool_test.rb:16-30`).
  *
  * @internal
  */
-export async function createSidecarTestAdapter(): Promise<{
-  adapter: SidecarAdapter;
-}> {
-  const adapter = (await _pool.leaseConnection()) as SidecarAdapter;
-  return { adapter };
+export function ambientPoolConfiguration(): Record<string, unknown> {
+  return { ..._primaryConfiguration };
 }
 
 /**
- * Returns a {@link DatabaseAdapter} leased from the pool. Mirrors Rails'
- * transactional-fixtures wiring (`Base.connection_handler.connection_pool_list(:writing)` →
- * `pool.pin_connection!` → `pool.lease_connection`).
+ * Synchronous factory that creates a fresh underlying adapter on the PRIMARY
+ * lane database — the same database `Base.connection` rides (on the file-backed
+ * sqlite lane its connections share the worker DB, exactly like Rails'
+ * file-backed `arunit`). Use this as the `adapterFactory` for a test-local
+ * {@link ConnectionPool}, or when a test needs a distinct adapter object.
  *
- * The pool itself is exposed so callers can call
- * `pool.pinConnectionBang(false)` / `pool.unpinConnectionBang()` per test
- * to mirror Rails' `pin_connection!(lock_threads)` lifecycle.
+ * Wired at module load, importing only the active lane's driver.
+ *
+ * @internal
+ */
+export let newRawTestAdapter: () => DatabaseAdapter;
+
+if (PG_TEST_URL) {
+  const { PostgreSQLAdapter } = await import("./connection-adapters/postgresql-adapter.js");
+  // Constrain the driver pool to max: 1 so each pooled-adapter slot maps to
+  // exactly one PG server connection (the outer ConnectionPool multiplexes).
+  newRawTestAdapter = () =>
+    new PostgreSQLAdapter({ connectionString: PG_TEST_URL, max: 1 }) as unknown as DatabaseAdapter;
+} else if (MYSQL_TEST_URL) {
+  const { Mysql2Adapter } = await import("./connection-adapters/mysql2-adapter.js");
+  newRawTestAdapter = () =>
+    new Mysql2Adapter({
+      uri: MYSQL_TEST_URL,
+      connectionLimit: 1,
+      flags: ["FOUND_ROWS"],
+    }) as unknown as DatabaseAdapter;
+} else {
+  const database = getEnv("AR_TEST_WORKER_DB") ?? ":memory:";
+  const { BetterSQLite3Adapter } = await import("./connection-adapters/better-sqlite3-adapter.js");
+  newRawTestAdapter = () => new BetterSQLite3Adapter(database) as unknown as DatabaseAdapter;
+}
+
+// --- In-test pool for pool-mechanics suites ---------------------------------
+//
+// Mirrors connection_pool_test.rb:16-30: "Keep a duplicate pool so we do not
+// bother others." Derived from `Base.connection_pool.db_config` so it rides the
+// SAME schema-loaded database, and memoized so repeated
+// `createPooledTestAdapter()` calls in a file share one pool.
+
+let _inTestPool: ConnectionPool | null = null;
+let _inTestPoolPromise: Promise<ConnectionPool> | null = null;
+
+async function buildInTestPool(): Promise<ConnectionPool> {
+  const { establishFromTestConfig } = await import("./test-helpers/test-database-config.js");
+  const { HashConfig } = await import("./database-configurations/hash-config.js");
+  const { PoolConfig } = await import("./connection-adapters/pool-config.js");
+  const { ConnectionPool } = await import("./connection-adapters/abstract/connection-pool.js");
+  const { ConnectionDescriptor } =
+    await import("./connection-adapters/abstract/connection-descriptor.js");
+
+  // Ensure the primary pool exists so we can duplicate its db_config
+  // (idempotent — a no-op when a fixtures file already connected Base).
+  await establishFromTestConfig();
+  const src = Base.connectionPool().dbConfig;
+
+  // Duplicate the primary config with a short checkout_timeout so pool-mechanics
+  // tests don't stall on the shared primary — mirrors connection_pool_test.rb's
+  // `configuration_hash.merge(checkout_timeout: 0.2)`.
+  //
+  // We drop the primary's pinned `pool` size: trails' primary test config sets
+  // `pool: 1` (test-database-config.ts) — a trails deviation. Rails' primary
+  // test config leaves `pool` unset (HashConfig#pool defaults to 5,
+  // hash_config.rb:72), so connection_pool_test.rb's duplicate inherits a
+  // multi-connection pool. Dropping the pin lets the duplicate default to 5,
+  // giving the ported mechanics tests Rails' multi-connection shape.
+  const { pool: _primaryPoolSize, ...primaryHash } = src.configurationHash;
+  const dbConfig = new HashConfig(src.envName, src.name, {
+    ...primaryHash,
+    checkoutTimeout: 0.2,
+  });
+
+  const poolConfig = new PoolConfig(
+    new ConnectionDescriptor("primary"),
+    dbConfig,
+    "writing",
+    "default",
+    { adapterFactory: newRawTestAdapter },
+  );
+  return new ConnectionPool(poolConfig);
+}
+
+/**
+ * Returns a {@link DatabaseAdapter} leased from a duplicate pool built in-test
+ * from the primary `db_config`. Mirrors Rails' pool-mechanics setup
+ * (`connection_pool_test.rb:16-30`) and its transactional-fixtures wiring
+ * (`pin_connection!` → `lease_connection`).
+ *
+ * The pool is exposed so callers can drive `pool.pinConnectionBang(false)` /
+ * `pool.unpinConnectionBang()` per test to mirror Rails' `pin_connection!`
+ * lifecycle. Repeated calls in the same file share one memoized pool.
  *
  * @internal
  */
 export async function createPooledTestAdapter(): Promise<{
   adapter: SidecarAdapter;
-  pool: import("./connection-adapters/abstract/connection-pool.js").ConnectionPool;
+  pool: ConnectionPool;
 }> {
-  const pool = await _establishPooledTestPool();
+  if (!_inTestPoolPromise) {
+    _inTestPoolPromise = buildInTestPool().catch((err) => {
+      // Drop the memoized promise on failure so a follow-up call can retry
+      // instead of permanently resolving every caller to the rejection.
+      _inTestPoolPromise = null;
+      throw err;
+    });
+  }
+  const pool = await _inTestPoolPromise;
+  _inTestPool = pool;
   const adapter = (await pool.leaseConnection()) as SidecarAdapter;
   return { adapter, pool };
 }
 
-/** @internal — for the smoke test only. */
-export function _resetPooledTestAdapterForTests(): void {
-  if (_pooledHandler) {
-    // clearAllConnectionsBang is async: its synchronous teardown runs here, but
-    // catch the returned promise so a drain rejection stays best-effort rather
-    // than surfacing as an unhandled rejection during test teardown.
-    _pooledHandler.clearAllConnectionsBang().catch(() => {});
-  }
-  _pooledHandler = null;
-  _pooledPoolPromise = null;
-}
-
 /**
- * Clean up test data by dropping all tables via a pool-leased connection.
+ * Tear down the memoized in-test pool (Rails' `@pool.disconnect!` teardown).
+ * Best-effort — the returned promise is swallowed so a drain rejection during
+ * test teardown never surfaces as an unhandled rejection.
+ *
+ * @internal — for pool-mechanics tests only.
  */
-export async function cleanupTestAdapter(_adapter: DatabaseAdapter): Promise<void> {
-  await _pool.withConnection((a) => dropAllTables(a), { preventPermanentCheckout: true });
+export function _resetPooledTestAdapterForTests(): void {
+  if (_inTestPool) {
+    _inTestPool.disconnectBang().catch(() => {});
+  }
+  _inTestPool = null;
+  _inTestPoolPromise = null;
 }
 
 /**
@@ -299,39 +233,42 @@ export async function cleanupTestAdapter(_adapter: DatabaseAdapter): Promise<voi
  * starts from a clean slate. Called from a global `beforeEach` hook in
  * test-setup-ar.ts.
  *
- * Clears row state by **truncating** the boot-laid canonical tables (RFC 0059
- * lays the canonical schema once at boot and keeps it shape-stable, so dropping
- * the tables between tests is pure redundancy — only the rows need clearing).
- * Every non-canonical table is dropped (bespoke tables a not-yet-converted
- * `defineSchema` caller created, plus the `schema_migrations` /
- * `ar_internal_metadata` bookkeeping tables), matching the previous
- * `dropAllTables` behavior. See {@link resetTestTables}.
+ * Row state is cleared by **truncating** the boot-laid canonical tables (RFC
+ * 0059 lays the canonical schema once at boot and keeps it shape-stable, so
+ * dropping the tables between tests is pure redundancy — only the rows need
+ * clearing); every non-canonical table (bespoke `defineSchema` leftovers plus
+ * the `schema_migrations` / `ar_internal_metadata` bookkeeping tables) is
+ * dropped. See {@link resetTestTables}.
  *
- *   - PG: enumerate every user schema via `current_schemas(false)`, not
- *     just `public`. Tests that create custom schemas (e.g. schema.test.ts
- *     with test_schema/test_schema2) leak tables that survive a public-only
- *     drop and continue to bleed state.
+ * The DDL runs on the primary `Base.connection` pool — the schema-loaded
+ * database every test rides — but only when Base is connected. Worker boot
+ * (`test-setup-dy.ts`) deliberately disconnects Base between files, so a file
+ * that never connected Base did no DB work and has nothing to reset; the
+ * global JS caches below are still cleared unconditionally.
+ *
+ *   - PG: `resetTestTables` enumerates every user schema via
+ *     `current_schemas(false)`, not just `public`.
  *   - MySQL: runs on a single dedicated pool connection with
- *     FOREIGN_KEY_CHECKS=0 for the whole sequence. Per-statement exec()s
- *     can't reliably bracket the drops because each call may pick a
- *     different pool connection.
- *   - SQLite: query `sqlite_master` (excluding internal `sqlite_*` tables).
+ *     FOREIGN_KEY_CHECKS=0 for the whole sequence.
+ *   - SQLite: queries `sqlite_master` (excluding internal `sqlite_*` tables).
  *
  * Idempotent and safe to call when no tables exist.
  *
  * @internal
  */
 export async function resetTestAdapterState(): Promise<void> {
-  await _pool.withConnection(
-    async (adapter) => {
-      await resetTestTables(adapter);
-      // Clear schema cache on all live pool connections (mirrors Rails'
-      // ConnectionPool#clear_cache!). Tests that construct raw adapters directly
-      // also need the global signature cache cleared.
-      _pool.connections.forEach((a) => a.schemaCache?.clear());
-      clearAppliedSchemaSignatures();
-      Base._modelsByName.clear();
-    },
-    { preventPermanentCheckout: true },
-  );
+  if (Base.isConnectedQ()) {
+    const pool = Base.connectionPool();
+    await pool.withConnection(
+      async (adapter) => {
+        await resetTestTables(adapter);
+        // Clear schema cache on all live pool connections (mirrors Rails'
+        // ConnectionPool#clear_cache!).
+        pool.connections.forEach((a) => a.schemaCache?.clear());
+      },
+      { preventPermanentCheckout: true },
+    );
+  }
+  clearAppliedSchemaSignatures();
+  Base._modelsByName.clear();
 }

--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -67,7 +67,7 @@ export type TestDatabaseAdapter = DatabaseAdapter;
  *
  * @internal
  */
-export type SidecarAdapter = DatabaseAdapter & {
+export type LeasedTestAdapter = DatabaseAdapter & {
   transactionManager: TransactionManager;
   withinNewTransaction<T>(
     opts: { isolation?: string | null; joinable?: boolean },
@@ -196,7 +196,7 @@ async function buildInTestPool(): Promise<ConnectionPool> {
  * @internal
  */
 export async function createPooledTestAdapter(): Promise<{
-  adapter: SidecarAdapter;
+  adapter: LeasedTestAdapter;
   pool: ConnectionPool;
 }> {
   if (!_inTestPoolPromise) {
@@ -209,7 +209,7 @@ export async function createPooledTestAdapter(): Promise<{
   }
   const pool = await _inTestPoolPromise;
   _inTestPool = pool;
-  const adapter = (await pool.leaseConnection()) as SidecarAdapter;
+  const adapter = (await pool.leaseConnection()) as LeasedTestAdapter;
   return { adapter, pool };
 }
 

--- a/packages/activerecord/src/test-helpers/use-handler-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-handler-transactional-fixtures.ts
@@ -4,7 +4,7 @@ import { withTransactionalFixtures } from "./with-transactional-fixtures.js";
 /**
  * Handler-resolved variant of {@link withTransactionalFixtures} for Phase D-1
  * test suites that bootstrap their adapter through `setupHandlerSuite()`
- * instead of constructing one directly via `createTestAdapter()`.
+ * instead of constructing one directly.
  *
  * `withTransactionalFixtures(() => Base.adapter)` opens a per-test
  * transaction in `beforeEach` (via the pool's fixture-pin slot, so it's

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -117,9 +117,10 @@ describe("withTransactionalFixtures (schema-cache invalidation)", () => {
 });
 
 // Adapter-cluster files (adapters/postgresql/*.test.ts, etc.) construct a
-// raw DatabaseAdapter directly instead of going through createTestAdapter().
-// The helper must accept that shape — `transactionManager` lives on the
-// adapter itself via AbstractAdapter, not behind an `innerAdapter` wrapper.
+// raw DatabaseAdapter directly instead of leasing one from a pool (Base.connection
+// or createPooledTestAdapter()). The helper must accept that shape —
+// `transactionManager` lives on the adapter itself via AbstractAdapter, not
+// behind an `innerAdapter` wrapper.
 describe("withTransactionalFixtures (raw adapter)", () => {
   let adapter: AbstractSQLite3Adapter;
   const exec = (sql: string) => adapter.exec(sql);

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import {
   createPooledTestAdapter,
   _resetPooledTestAdapterForTests,
-  type SidecarAdapter,
+  type LeasedTestAdapter,
   type TestDatabaseAdapter,
 } from "../test-adapter.js";
 import { Base } from "../base.js";
@@ -218,7 +218,7 @@ describe("withTransactionalFixtures (invalidateSchemaCache: false)", () => {
 // / `unpinConnectionBang()` rather than the wrapper-direct TM begin/rollback.
 // This mirrors Rails test_fixtures.rb:177-184's pin/lease lifecycle exactly.
 describe("withTransactionalFixtures (pooled adapter)", () => {
-  let adapter: SidecarAdapter;
+  let adapter: LeasedTestAdapter;
   const exec = (sql: string) =>
     (adapter as unknown as { exec(s: string): Promise<void> }).exec(sql);
   const query = (sql: string) => adapter.execute(sql);
@@ -264,8 +264,8 @@ describe("withTransactionalFixtures (pooled adapter)", () => {
 describe("concurrency isolation: two concurrent transaction chains stay independent", () => {
   // Skipped at E3: AsyncContext filter removed; pool-backed isolation lands at E5.
   it.skip("chain B sees openTransactions=0 while chain A is mid-transaction", async () => {
-    const chainA = (await primaryAdapter()) as unknown as SidecarAdapter;
-    const chainB = (await primaryAdapter()) as unknown as SidecarAdapter;
+    const chainA = (await primaryAdapter()) as unknown as LeasedTestAdapter;
+    const chainB = (await primaryAdapter()) as unknown as LeasedTestAdapter;
 
     // Coordinate so chain B reads state WHILE chain A holds an open transaction.
     // Without coordination, chain B would read before chain A's async TM open,
@@ -321,7 +321,7 @@ describe("concurrency isolation: two concurrent transaction chains stay independ
 
   // Skipped at E3: AsyncContext filter removed; pool-backed isolation lands at E5.
   it.skip("currentTransaction() returns null for a chain outside any withinNewTransaction", async () => {
-    const adapter = (await primaryAdapter()) as unknown as SidecarAdapter;
+    const adapter = (await primaryAdapter()) as unknown as LeasedTestAdapter;
     // Pool-leased adapters return NullTransaction (not null) when no transaction
     // is open — NullTransaction is the Rails-correct sentinel for "no transaction".
     expect(adapter.openTransactions).toBe(0);

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -17,8 +17,9 @@ interface TxnHost {
 }
 
 /**
- * The helper accepts any `DatabaseAdapter` — pool-leased adapters from
- * `createTestAdapter()` and raw adapters constructed directly by test files
+ * The helper accepts any `DatabaseAdapter` — pool-leased adapters (e.g. from
+ * `Base.connection` or `createPooledTestAdapter()`) and raw adapters
+ * constructed directly by test files
  * (`new PostgreSQLAdapter(...)`, `new SQLite3Adapter(...)`, etc.). The
  * non-pooled path requires `transactionManager` at runtime, but the pooled
  * path (detected via `.pool.pinConnectionBang`) handles transactions through


### PR DESCRIPTION
RFC 0059. **Rails has no sidecar test pool** (`grep -r sidecar vendor/rails/activerecord/test` = 0 hits): every test rides `ActiveRecord::Base.connection`, and a test that genuinely needs its own pool builds one **in-test from the primary config** ([connection_pool_test.rb:16-30](https://github.com/rails/rails/blob/main/activerecord/test/cases/connection_pool_test.rb)):

```ruby
config = ActiveRecord::Base.connection_pool.db_config
@db_config = HashConfig.new(config.env_name, config.name,
  config.configuration_hash.merge(checkout_timeout: 0.2))
@pool_config = PoolConfig.new(ActiveRecord::Base, @db_config, :writing, :default)
@pool = ConnectionPool.new(@pool_config)
```

trails instead kept a standing sidecar `_pool` on a divergent `file:trails_test_N?mode=memory&cache=shared` handle — a Rails-less invention whose schemaless `:memory:` fallback forced sidecar-leased suites to `createTable` in-test.

With every convenience caller now converged onto `Base.connection` (the four prior RFC-0059 batches — #4500, #4501, #4511/#4512/#4515, #4513), this retires the sidecar itself:

- **Delete** the standing `_pool` / `_establishPooledTestPool` / the divergent `_pooledSqliteDatabase()` handle, plus the now-unused `createTestAdapter` / `createSidecarTestAdapter` / `cleanupTestAdapter` and the module-boot pool.
- **`resetTestAdapterState` retargets the primary `Base.connection` pool**, guarded on `Base.isConnectedQ()` — worker boot (`test-setup-dy.ts:85`) deliberately disconnects Base between files, so a file that never connected did no DB work and has nothing to reset; the global JS caches are still cleared unconditionally.
- **`createPooledTestAdapter` builds its duplicate pool from `Base.connection_pool.db_config` + a `PoolConfig`** (mirroring the Rails snippet above), memoized per file, disconnected in teardown. The primary's pinned `pool: 1` (a trails deviation; Rails' `HashConfig#pool` defaults to 5) is dropped so the duplicate gets Rails' multi-connection shape — required by the `pinConnectionBang` mechanics tests.
- **`newRawTestAdapter` / `ambientPoolConfiguration` now describe the PRIMARY lane config** (the same DB `Base.connection` rides), not the divergent handle, so the pool-mechanics suites (`connection-pool.trails`, `pooled-connections`, `migration.trails`, `connection-pool.test`) keep working unchanged.

On the file-backed sqlite lane (the per-worker template clone), the duplicate pool's connections share the worker DB — exactly like Rails' file-backed `arunit` — so the pin/rollback + shared-pool smoke tests pass; pure `:memory:` is the same case Rails special-cases via `in_memory_db?`.

No test renames. `test:compare` delta >= 0.

## Verification (local, sqlite)

All green across the pool-mechanics + reset-sensitive surface (~1100 tests):
- pool: `pooled-test-adapter`, `with-transactional-fixtures(.test)`, `pool-config`, `connection-pool(.trails)`, `pooled-connections`, `migration.trails`
- reset/connection-state: `unconnected`, `establish-connection`, `connection-handling`, `connection-management`, `migrator`, `schema-dumper`, `base`, `persistence`, `reaper`, `dirty`, `finder`, `readonly`, `locking`, `transactions`, `query-cache`, `multiple-db`, `schema-loading`

Closes-story: retire-sidecar-pool-rework-pool-mechanics