### PR TITLE
fix(activemodel): range-check IntegerType in BigInt space at the 2^63 boundary

### DIFF
--- a/packages/activemodel/src/type/integer.test.ts
+++ b/packages/activemodel/src/type/integer.test.ts
@@ -151,6 +151,16 @@ describe("IntegerTest", () => {
     expect(type.cast(bigVal)).toBe(bigVal);
   });
 
+  it("serializable? checks an 8-byte column bound in BigInt space (2^63 exclusive)", () => {
+    // float64 collapses 2^63 and 2^63-1 to the same value, so the range check
+    // must compare in BigInt space to honor Rails' half-open `min...max`.
+    const int8 = new Types.IntegerType({ limit: 8 });
+    expect(int8.isSerializable(2n ** 63n)).toBe(false);
+    expect(int8.isSerializable(2n ** 63n - 1n)).toBe(true);
+    expect(int8.isSerializable(-(2n ** 63n))).toBe(true);
+    expect(int8.isSerializable(-(2n ** 63n) - 1n)).toBe(false);
+  });
+
   it("serialize_cast_value enforces range", () => {
     const values = [1, "123", 0, -5, null];
     for (const v of values) {

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -49,6 +49,11 @@ export class IntegerType extends NumericValueType {
 
   isSerializable(value: unknown): boolean {
     if (value === null || value === undefined) return true;
+    // A BigInt is passed straight to the arbitrary-precision range check.
+    // Routing through `Number(value)` would collapse `2n**63n` and `2n**63n-1n`
+    // to the same float (9223372036854775808), so an exactly-2^63 value on an
+    // 8-byte column would wrongly test in-range — see `isInRange`.
+    if (typeof value === "bigint") return this.isInRange(value);
     let num: number;
     if (typeof value === "number") {
       num = value;
@@ -67,14 +72,14 @@ export class IntegerType extends NumericValueType {
 
   /**
    * Mirrors: ActiveModel::Type::Integer#range (integer.rb:84).
-   * Rails: `attr_reader :range` over the half-open `min_value...max_value`.
-   * Exposed as a getter so subclasses can override; matches Rails'
-   * `private` accessor visibility.
+   * Rails: `attr_reader :range` over the half-open `min_value...max_value`
+   * (exclusive max). Exposed as a getter so subclasses can override; matches
+   * Rails' `private` accessor visibility.
    *
    * @internal Rails-private helper.
    */
   protected get range(): [number, number] {
-    return [this.minValue(), this.maxValue() - 1];
+    return [this.minValue(), this.maxValue()];
   }
 
   /**
@@ -83,12 +88,30 @@ export class IntegerType extends NumericValueType {
    *     !value || range.member?(value)
    *   end
    *
+   * Rails' Integer arithmetic is arbitrary-precision, so its half-open
+   * `min_value...max_value` check is exact. JS `number` is float64, which
+   * cannot distinguish `2**63` from `2**63-1`; comparing there would let an
+   * exactly-2^63 value slip past an 8-byte column's exclusive-max bound. We
+   * therefore compare in BigInt space. `min`/`max` are exact powers of two
+   * (or 0), so they convert losslessly; a `number` value is truncated toward
+   * zero first, matching Ruby's `to_i` before `range.member?`. BigInteger's
+   * unlimited `±Infinity` bounds are honored without a BigInt conversion.
+   *
    * @internal Rails-private helper.
    */
-  protected isInRange(value: number | null): boolean {
+  protected isInRange(value: number | bigint | null): boolean {
     if (value == null) return true;
     const [min, max] = this.range;
-    return value >= min && value <= max;
+    let big: bigint;
+    if (typeof value === "bigint") {
+      big = value;
+    } else {
+      if (!isFinite(value)) return false;
+      big = BigInt(Math.trunc(value));
+    }
+    const lowerOk = min === Number.NEGATIVE_INFINITY || big >= BigInt(min);
+    const upperOk = max === Number.POSITIVE_INFINITY || big < BigInt(max);
+    return lowerOk && upperOk;
   }
 
   /** @internal Rails-private helper. */

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -114,25 +114,11 @@ class MysqlBigInteger extends BigIntegerType {
   // reports the same type as IntegerType({limit:8}) would.
   override readonly name: string = "integer";
 
+  // Re-establish the 8-byte signed bound that BigIntegerType drops
+  // (max_value = Infinity). IntegerType's isInRange/isSerializable already
+  // compare in BigInt space, so an exactly-2^63 value is detected out of range.
   protected override maxValue(): number {
     return 2 ** (this._limit() * 8 - 1);
-  }
-
-  protected override isInRange(value: number | null): boolean {
-    if (value == null) return true;
-    if (typeof value === "bigint") {
-      const bytes = this._limit();
-      const max = (1n << BigInt(bytes * 8 - 1)) - 1n;
-      const min = -(1n << BigInt(bytes * 8 - 1));
-      return value >= min && value <= max;
-    }
-    return super.isInRange(value);
-  }
-
-  override isSerializable(value: unknown): boolean {
-    if (value == null) return true;
-    if (typeof value === "bigint") return this.isInRange(value as unknown as number);
-    return super.isSerializable(value);
   }
 
   override serializeCastValue(value: number | null): number | null {

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -138,28 +138,12 @@ export function registerClassWithPrecision(
  *   mirroring Rails' IntegerType(limit: 8) but with BigInt-precision arithmetic.
  */
 class PgInteger8 extends BigIntegerType {
+  // Re-establish the 8-byte bound that BigIntegerType drops (max_value =
+  // Infinity). IntegerType's isInRange/isSerializable already compare in BigInt
+  // space, so 2^63 is correctly detected out of range (float64 cannot
+  // distinguish 2^63 from 2^63-1).
   protected override maxValue(): number {
     return 2 ** (this._limit() * 8 - 1);
-  }
-
-  // BigInt-precision range check: float64 cannot distinguish 2^63 from 2^63-1.
-  protected override isInRange(value: number | null): boolean {
-    if (value == null) return true;
-    if (typeof value === "bigint") {
-      const bytes = this._limit();
-      const max = (1n << BigInt(bytes * 8 - 1)) - 1n;
-      const min = -(1n << BigInt(bytes * 8 - 1));
-      return value >= min && value <= max;
-    }
-    return super.isInRange(value);
-  }
-
-  // BigInt-aware serializable check (inherited isSerializable converts BigInt via
-  // Number() before calling isInRange, losing precision at the 2^63 boundary).
-  override isSerializable(value: unknown): boolean {
-    if (value == null) return true;
-    if (typeof value === "bigint") return this.isInRange(value as unknown as number);
-    return super.isSerializable(value);
   }
 
   override serializeCastValue(value: number | null): number | null {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -218,6 +218,16 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     return new Visitors.SQLite(this);
   }
 
+  /**
+   * Mirrors: SQLite3Adapter#bind_params_length (sqlite3_adapter.rb:509-512).
+   * SQLite's default SQLITE_LIMIT_VARIABLE_NUMBER is 999; overrides the abstract
+   * DatabaseLimits default (65535), which exceeds the driver's compiled cap.
+   * @internal Rails-private helper.
+   */
+  bindParamsLength(): number {
+    return 999;
+  }
+
   private driver!: SqliteConnection;
   /**
    * True after construction when the bound driver is async-only and the
@@ -2975,12 +2985,6 @@ const REFERENTIAL_ACTION_MAP: Record<string, string> = {
 
 function normalizeReferentialAction(action: string): string {
   return REFERENTIAL_ACTION_MAP[action.toLowerCase()] ?? action.toUpperCase();
-}
-
-/** @internal */
-function bindParamsLength(): number {
-  // https://www.sqlite.org/limits.html — default SQLITE_LIMIT_VARIABLE_NUMBER
-  return 999;
 }
 
 /** @internal */

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -441,6 +441,23 @@ describe("FinderTest", () => {
     expect(await existsWhere(id.lt(bind(negBig)))).toBe(false);
     expect(await existsWhere(id.lteq(bind(negBig)))).toBe(false);
   });
+
+  it("all-out-of-range array collapses to IN (NULL)", async () => {
+    // Every value is past the 8-byte signed bound, so HomogeneousIn#castedValues
+    // (via IntegerType#serializable?) drops them all, leaving `id IN (NULL)` —
+    // matching nothing — and `id NOT IN (NULL)` — a NULL predicate that also
+    // matches nothing. Exercised on SQLite/MySQL/PostgreSQL via the CI matrix.
+    const big = 9223372036854775808n; // 2^63
+    const negBig = -9223372036854775809n; // -(2^63) - 1
+
+    const inRel = Topic.where({ id: [big, negBig] });
+    expect(inRel.toSql()).toMatch(/IN \(NULL\)/);
+    expect(await inRel.exists()).toBe(false);
+
+    const notInRel = Topic.whereNot({ id: [big, negBig] });
+    expect(notInRel.toSql()).toMatch(/NOT IN \(NULL\)/);
+    expect(await notInRel.exists()).toBe(false);
+  });
 });
 
 // ==========================================================================


### PR DESCRIPTION
## Summary

`IntegerType#isInRange` compared in float64 space, where `2**63` and
`2**63 - 1` collapse to the same value. On an 8-byte (`limit: 8`) column an
exactly-`2**63` value therefore tested *in-range*, and `serializable?`
returned `true` — diverging from Rails' arbitrary-precision half-open
`min_value...max_value` (exclusive max, activemodel integer.rb:74-90).

This surfaced while converging `ArrayHandler` onto `HomogeneousIn` (#4440):
neither `HomogeneousIn#castedValues` (via `serializable?`) nor the older
`markUnboundable` sentinel could drop an exactly-`2**63` value, because both
shared the same imprecise range check.

## Fix

- `isInRange` now compares in **BigInt** space. `min`/`max` are exact powers
  of two (or `0`/`±Infinity`), so they convert losslessly; a `number` value is
  truncated toward zero first, mirroring Ruby's `to_i` before `range.member?`.
  BigInteger's unlimited `±Infinity` bounds are honored without conversion.
- `isSerializable` passes a `BigInt` straight through instead of routing it via
  `Number()` (which would collapse the boundary).
- The PG (`PgInteger8`) and MySQL (`MysqlBigInteger`) column types duplicated
  this BigInt range check; with the base type fixed, their redundant
  `isInRange` / `isSerializable` overrides are dropped and they inherit it.

## SQLite bind-params cap (unmasked by the fix)

`AbstractSQLite3Adapter` inherited the abstract `DatabaseLimits` default of
`65535`, which exceeds better-sqlite3's compiled `SQLITE_LIMIT_VARIABLE_NUMBER`
(32766). Rails' `SQLite3Adapter` overrides `bind_params_length` to `999`
(sqlite3_adapter.rb:511); a standalone helper mirroring that already existed but
was never wired into the class. `BindParameterTest#too_many_binds` previously
passed only because the out-of-range `2**63` value padded the `IN` past the
inflated cap and triggered the inline fallback; once `2**63` is correctly
dropped, the remaining `65535` real binds overflowed the driver. The method is
now attached (999) and the orphan removed.

## Tests

- `serializable?` boundary unit test: `2n**63n` out, `2n**63n-1n` in, negative
  boundary likewise (8-byte column).
- End-to-end: an all-out-of-range `where({ id: [big, negBig] })` collapses to
  `id IN (NULL)`, and `whereNot(...)` to `id NOT IN (NULL)` — exercised on
  SQLite/MySQL/PostgreSQL via the CI matrix.
- Existing "exists with large number" finder and "too many binds" bind-parameter
  tests stay green.

Closes-story: integer-type-bigint-precise-range