### PR TITLE
test(join-dependency): build hydration rows by column name via aliasedRow

### DIFF
--- a/packages/activerecord/src/associations/join-dependency-belongs-to-dedup.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-belongs-to-dedup.test.ts
@@ -5,9 +5,9 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { JoinDependency } from "./join-dependency.js";
 
 describe("JoinDependency cross-parent belongsTo dedup", () => {
-  // Ride the canonical schema `fixtures({})` warms: the hand-built `tN_rN`
-  // hydration rows below track the canonical column order (see the model
-  // comments), so no bespoke schema is declared.
+  // Ride the canonical schema `fixtures({})` warms; the hydration rows below are
+  // built by column name via `jd.aliasedRow`, so no bespoke schema is declared
+  // and no `tN_rN` offsets are hardcoded.
   fixtures({});
 
   class Author extends Base {
@@ -17,9 +17,6 @@ describe("JoinDependency cross-parent belongsTo dedup", () => {
     }
   }
 
-  // Canonical `posts` column order (schema.rb): id, author_id, title — the
-  // `tN_rN` hydration offsets below track this so the rows survive the schema
-  // cache `fixtures({})` warms.
   class Post extends Base {
     static {
       this.attribute("id", "integer");
@@ -42,9 +39,18 @@ describe("JoinDependency cross-parent belongsTo dedup", () => {
     jd.addAssociation("author");
 
     const rows = [
-      { t0_r0: 1, t0_r1: 42, t0_r2: "Post A", t1_r0: 42, t1_r1: "Alice" },
-      { t0_r0: 2, t0_r1: 42, t0_r2: "Post B", t1_r0: 42, t1_r1: "Alice" },
-      { t0_r0: 3, t0_r1: 42, t0_r2: "Post C", t1_r0: 42, t1_r1: "Alice" },
+      jd.aliasedRow({
+        "": { id: 1, author_id: 42, title: "Post A" },
+        author: { id: 42, name: "Alice" },
+      }),
+      jd.aliasedRow({
+        "": { id: 2, author_id: 42, title: "Post B" },
+        author: { id: 42, name: "Alice" },
+      }),
+      jd.aliasedRow({
+        "": { id: 3, author_id: 42, title: "Post C" },
+        author: { id: 42, name: "Alice" },
+      }),
     ];
 
     const { parents } = jd.instantiateFromRows(rows);
@@ -66,8 +72,14 @@ describe("JoinDependency cross-parent belongsTo dedup", () => {
     jd.addAssociation("author");
 
     const rows = [
-      { t0_r0: 1, t0_r1: 42, t0_r2: "Post A", t1_r0: 42, t1_r1: "Alice" },
-      { t0_r0: 2, t0_r1: 99, t0_r2: "Post B", t1_r0: 99, t1_r1: "Bob" },
+      jd.aliasedRow({
+        "": { id: 1, author_id: 42, title: "Post A" },
+        author: { id: 42, name: "Alice" },
+      }),
+      jd.aliasedRow({
+        "": { id: 2, author_id: 99, title: "Post B" },
+        author: { id: 99, name: "Bob" },
+      }),
     ];
 
     const { parents } = jd.instantiateFromRows(rows);

--- a/packages/activerecord/src/associations/join-dependency-duplicate-objects.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-duplicate-objects.test.ts
@@ -13,9 +13,9 @@ import { JoinDependency } from "./join-dependency.js";
 // so the raw-aliased key (seeded and looked up through the single `_nodeKey` path)
 // is the only thing under test.
 describe("JoinDependency dedupes duplicate join rows", () => {
-  // Ride the canonical schema `fixtures({})` warms: the hand-built `tN_rN`
-  // hydration rows below track the canonical column order (see the model
-  // comments), so no bespoke schema is declared.
+  // Ride the canonical schema `fixtures({})` warms; the hydration rows below are
+  // built by column name via `jd.aliasedRow`, so no bespoke schema is declared
+  // and no `tN_rN` offsets are hardcoded.
   fixtures({});
 
   class Comment extends Base {
@@ -26,8 +26,6 @@ describe("JoinDependency dedupes duplicate join rows", () => {
     }
   }
 
-  // Canonical `posts` column order (schema.rb): id, author_id, title — so `title`
-  // sits at the third hydration slot, matching the schema `fixtures({})` warms.
   class Post extends Base {
     static {
       this.attribute("id", "integer");
@@ -57,10 +55,11 @@ describe("JoinDependency dedupes duplicate join rows", () => {
     jd.addAssociation("comments");
 
     // Same parent, same child, repeated join rows — must dedupe to one comment.
-    const rows = [
-      { t0_r0: 1, t0_r2: "foo", t1_r0: 10, t1_r1: 1, t1_r2: "hmm" },
-      { t0_r0: 1, t0_r2: "foo", t1_r0: 10, t1_r1: 1, t1_r2: "hmm" },
-    ];
+    const row = jd.aliasedRow({
+      "": { id: 1, title: "foo" },
+      comments: { id: 10, post_id: 1, body: "hmm" },
+    });
+    const rows = [row, { ...row }];
 
     const { parents } = jd.instantiateFromRows(rows);
 
@@ -77,8 +76,16 @@ describe("JoinDependency dedupes duplicate join rows", () => {
     // Two distinct parents share one post which has one comment; the post and the
     // comment must each be a single shared instance, exactly deduped.
     const rows = [
-      { t0_r0: 1, t0_r1: 5, t1_r0: 5, t1_r2: "foo", t2_r0: 10, t2_r1: 5, t2_r2: "lol" },
-      { t0_r0: 2, t0_r1: 5, t1_r0: 5, t1_r2: "foo", t2_r0: 10, t2_r1: 5, t2_r2: "lol" },
+      jd.aliasedRow({
+        "": { id: 1, post_id: 5 },
+        post: { id: 5, title: "foo" },
+        "post.comments": { id: 10, post_id: 5, body: "lol" },
+      }),
+      jd.aliasedRow({
+        "": { id: 2, post_id: 5 },
+        post: { id: 5, title: "foo" },
+        "post.comments": { id: 10, post_id: 5, body: "lol" },
+      }),
     ];
 
     const { parents } = jd.instantiateFromRows(rows);

--- a/packages/activerecord/src/associations/join-dependency-extra-columns.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-extra-columns.test.ts
@@ -5,13 +5,11 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { JoinDependency } from "./join-dependency.js";
 
 describe("JoinDependency extra columns in instantiate", () => {
-  // Ride the canonical schema `fixtures({})` warms: the hand-built `tN_rN`
-  // hydration rows below track the canonical column order (see the model
-  // comments), so no bespoke schema is declared.
+  // Ride the canonical schema `fixtures({})` warms; the hydration rows below are
+  // built by column name via `jd.aliasedRow`, so no bespoke schema is declared
+  // and no `tN_rN` offsets are hardcoded.
   fixtures({});
 
-  // Canonical `posts` column order (schema.rb): id, author_id, title — so `title`
-  // hydrates from `t0_r2`, matching the schema `fixtures({})` warms.
   class Post extends Base {
     static {
       this.attribute("id", "integer");
@@ -42,27 +40,24 @@ describe("JoinDependency extra columns in instantiate", () => {
 
     const rows = [
       {
-        t0_r0: 1,
-        t0_r2: "First Post",
-        t1_r0: 10,
-        t1_r1: 1,
-        t1_r2: "Nice",
+        ...jd.aliasedRow({
+          "": { id: 1, title: "First Post" },
+          comments: { id: 10, post_id: 1, body: "Nice" },
+        }),
         comment_count: 5,
       },
       {
-        t0_r0: 1,
-        t0_r2: "First Post",
-        t1_r0: 11,
-        t1_r1: 1,
-        t1_r2: "Great",
+        ...jd.aliasedRow({
+          "": { id: 1, title: "First Post" },
+          comments: { id: 11, post_id: 1, body: "Great" },
+        }),
         comment_count: 5,
       },
       {
-        t0_r0: 2,
-        t0_r2: "Second Post",
-        t1_r0: 12,
-        t1_r1: 2,
-        t1_r2: "Cool",
+        ...jd.aliasedRow({
+          "": { id: 2, title: "Second Post" },
+          comments: { id: 12, post_id: 2, body: "Cool" },
+        }),
         comment_count: 1,
       },
     ];
@@ -80,11 +75,10 @@ describe("JoinDependency extra columns in instantiate", () => {
 
     const rows = [
       {
-        t0_r0: 1,
-        t0_r2: "Post",
-        t1_r0: 10,
-        t1_r1: 1,
-        t1_r2: "Hello",
+        ...jd.aliasedRow({
+          "": { id: 1, title: "Post" },
+          comments: { id: 10, post_id: 1, body: "Hello" },
+        }),
         extra_col: "extra_value",
       },
     ];
@@ -103,7 +97,9 @@ describe("JoinDependency extra columns in instantiate", () => {
     const jd = new JoinDependency(Post);
     jd.addAssociation("comments");
 
-    const rows = [{ t0_r0: 1, t0_r2: "Post", t1_r0: 10, t1_r1: 1, t1_r2: "Hi" }];
+    const rows = [
+      jd.aliasedRow({ "": { id: 1, title: "Post" }, comments: { id: 10, post_id: 1, body: "Hi" } }),
+    ];
 
     const { parents } = jd.instantiateFromRows(rows);
 

--- a/packages/activerecord/src/associations/join-dependency-nested-hydration.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-nested-hydration.test.ts
@@ -5,15 +5,11 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import { JoinDependency } from "./join-dependency.js";
 
 describe("JoinDependency nested hydration", () => {
-  // Ride the canonical schema `fixtures({})` warms: the hand-built `tN_rN`
-  // hydration rows below track the canonical column order (see the model
-  // comments), so no bespoke schema is declared.
+  // Ride the canonical schema `fixtures({})` warms; the hydration rows below are
+  // built by column name via `jd.aliasedRow`, so no bespoke schema is declared
+  // and no `tN_rN` offsets (or canonical-prefix column padding) are hardcoded.
   fixtures({});
 
-  // Canonical column order (schema.rb) drives the `tN_rN` hydration offsets so
-  // the hand-built rows survive the schema cache `fixtures({})` warms: `authors`
-  // is (id, name); `comments` is (id, post_id, body, …, author_id) with author_id
-  // at slot 8; `posts` is (id, author_id, title).
   // prettier-ignore
   class Author extends Base {
     static { this.attribute("id", "integer"); this.attribute("name", "string"); }
@@ -21,9 +17,8 @@ describe("JoinDependency nested hydration", () => {
   // prettier-ignore
   class Comment extends Base {
     static {
-      this.attribute("id", "integer"); this.attribute("post_id", "integer"); this.attribute("body", "string");
-      this.attribute("type", "string"); this.attribute("label", "integer"); this.attribute("tags_count", "integer");
-      this.attribute("children_count", "integer"); this.attribute("parent_id", "integer"); this.attribute("author_id", "integer");
+      this.attribute("id", "integer"); this.attribute("post_id", "integer");
+      this.attribute("body", "string"); this.attribute("author_id", "integer");
     }
   }
   // prettier-ignore
@@ -44,10 +39,17 @@ describe("JoinDependency nested hydration", () => {
     const jd = new JoinDependency(Post);
     jd.addNestedAssociation("comments.author");
 
-    // prettier-ignore
     const rows = [
-      { t0_r0: 1, t0_r2: "Post A", t1_r0: 10, t1_r1: 1, t1_r2: "Comment 1", t1_r8: 42, t2_r0: 42, t2_r1: "Alice" },
-      { t0_r0: 1, t0_r2: "Post A", t1_r0: 11, t1_r1: 1, t1_r2: "Comment 2", t1_r8: 42, t2_r0: 42, t2_r1: "Alice" },
+      jd.aliasedRow({
+        "": { id: 1, title: "Post A" },
+        comments: { id: 10, post_id: 1, body: "Comment 1", author_id: 42 },
+        "comments.author": { id: 42, name: "Alice" },
+      }),
+      jd.aliasedRow({
+        "": { id: 1, title: "Post A" },
+        comments: { id: 11, post_id: 1, body: "Comment 2", author_id: 42 },
+        "comments.author": { id: 42, name: "Alice" },
+      }),
     ];
 
     const { parents } = jd.instantiateFromRows(rows);
@@ -78,10 +80,17 @@ describe("JoinDependency nested hydration", () => {
     const jd = new JoinDependency(Post);
     jd.addNestedAssociation("comments.author");
 
-    // prettier-ignore
     const rows = [
-      { t0_r0: 1, t0_r2: "Post A", t1_r0: 10, t1_r1: 1, t1_r2: "C1", t1_r8: 42, t2_r0: 42, t2_r1: "Alice" },
-      { t0_r0: 2, t0_r2: "Post B", t1_r0: 20, t1_r1: 2, t1_r2: "C2", t1_r8: 42, t2_r0: 42, t2_r1: "Alice" },
+      jd.aliasedRow({
+        "": { id: 1, title: "Post A" },
+        comments: { id: 10, post_id: 1, body: "C1", author_id: 42 },
+        "comments.author": { id: 42, name: "Alice" },
+      }),
+      jd.aliasedRow({
+        "": { id: 2, title: "Post B" },
+        comments: { id: 20, post_id: 2, body: "C2", author_id: 42 },
+        "comments.author": { id: 42, name: "Alice" },
+      }),
     ];
 
     const { parents } = jd.instantiateFromRows(rows);
@@ -95,7 +104,12 @@ describe("JoinDependency nested hydration", () => {
   it("nested records are not readonly by default when no reflection scope marks readonly", () => {
     const jd = new JoinDependency(Post);
     jd.addNestedAssociation("comments");
-    const rows = [{ t0_r0: 1, t0_r2: "Post A", t1_r0: 10, t1_r1: 1, t1_r2: "C1", t1_r8: null }];
+    const rows = [
+      jd.aliasedRow({
+        "": { id: 1, title: "Post A" },
+        comments: { id: 10, post_id: 1, body: "C1", author_id: null },
+      }),
+    ];
     const { parents } = jd.instantiateFromRows(rows);
     const comment = parents[0].association("comments").target[0];
     expect(comment._readonly).toBeFalsy();

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -214,6 +214,34 @@ export class JoinDependency {
     return result;
   }
 
+  /**
+   * @internal
+   * Build a hydration row from a `{path: {column: value}}` spec, mapping each
+   * column to its `t{n}_r{n}` alias via the live `Aliases` map so tests never
+   * hardcode a column offset (which silently misaligns when the canonical
+   * `schema.rb` column order changes). `path` is the dotted association path
+   * ("" / omitted = join root); columns not in the alias map (extra SELECT
+   * columns) can be spread onto the returned row by the caller.
+   */
+  aliasedRow(spec: Record<string, Record<string, unknown>>): Record<string, unknown> {
+    const aliases = this.aliases();
+    const row: Record<string, unknown> = {};
+    for (const [path, columns] of Object.entries(spec)) {
+      const node = this._findNodeByPath(path || null);
+      if (!node) {
+        throw new Error(`JoinDependency.aliasedRow: no join node at path "${path}"`);
+      }
+      for (const [column, value] of Object.entries(columns)) {
+        const alias = aliases.columnAlias(node, column);
+        if (!alias) {
+          throw new Error(`JoinDependency.aliasedRow: no alias for "${path}".${column}`);
+        }
+        row[alias] = value;
+      }
+    }
+    return row;
+  }
+
   addAssociation(
     assocName: string,
     options?: {


### PR DESCRIPTION
## Summary

The hand-built `tN_rN` hydration rows in the four pure-wiring join-dependency
suites (`belongs-to-dedup`, `duplicate-objects`, `extra-columns`,
`nested-hydration`) hardcoded canonical column offsets — e.g. `comments.author_id`
at `t1_r8`, which forced `nested-hydration` to declare a 9-column canonical
prefix on its inline `Comment`. Those offsets silently misalign if a canonical
`schema.rb` column order changes: tests pass on stale offsets or fail cryptically.

This adds a small `JoinDependency#aliasedRow` helper that builds an aliased row
from a `{path: {column: value}}` spec via the live `Aliases.columnAlias` map, so
tests address columns by name and never hardcode an offset. Extra (non-aliased)
SELECT columns are spread onto the row by the caller.

- `path` is the dotted association path (`""` = join root, `comments`,
  `comments.author`).
- Drops the canonical-prefix column padding on the inline `nested-hydration`
  `Comment` now that offsets are name-derived.
- No test renames; all four suites pass alone and green.

Closes-story: join-dependency-hydration-rows-by-column-name