### PR TITLE
fix(migration): direction-aware revert engine + reversal gaps

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1,6 +1,6 @@
 import { ABSTRACT_SCHEMA_QUOTER } from "./quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
-import { singularize, pluralize } from "@blazetrails/activesupport";
+import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 
 /**
@@ -312,9 +312,13 @@ export class CheckConstraintDefinition {
   }
 
   isDefinedFor(options: { name: string; expression?: string; validate?: boolean }): boolean {
+    // Mirrors Rails CheckConstraintDefinition#defined_for?(name:, expression: nil,
+    // ...): it matches on name (and validate) only — the expression is accepted
+    // but never compared (it is used upstream to derive the name). A raw-string
+    // expression compare would spuriously fail against the adapter's normalized
+    // form (e.g. PostgreSQL's `pg_get_constraintdef`).
     return (
       this.name === options.name.toString() &&
-      (options.expression === undefined || this.expression === options.expression) &&
       (options.validate === undefined || options.validate === this.validate)
     );
   }
@@ -1012,12 +1016,13 @@ export class TableDefinition {
     return this;
   }
 
+  // Mirrors Rails' check_constraint_name: sha256 of `<table>_<expression>_chk`,
+  // first 10 hex, prefixed `chk_rails_`. The schema dumper's chkIgnorePattern
+  // (`^chk_rails_[0-9a-f]{10}$`) omits names matching this default, matching Rails.
   private _checkConstraintName(expression: string): string {
-    let hash = 0;
-    for (let i = 0; i < expression.length; i++) {
-      hash = ((hash << 5) - hash + expression.charCodeAt(i)) | 0;
-    }
-    return `chk_${this.tableName}_${(hash >>> 0).toString(16).padStart(8, "0")}`;
+    const identifier = `${this.tableName}_${expression}_chk`;
+    const hex = getCrypto().createHash("sha256").update(identifier).digest("hex").slice(0, 10);
+    return `chk_rails_${hex}`;
   }
 
   foreignKey(toTable: string, options: Partial<AddForeignKeyOptions> = {}): this {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -269,11 +269,12 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     // foreignKeys base path returns [] when adapter has no override
     const fks = await stub.foreignKeys("any_table");
     expect(fks).toEqual([]);
-    // removeForeignKey base path reaches SQL execution (which our stub no-ops) —
-    // it resolves without a stack overflow
+    // removeForeignKey base path resolves the real constraint via
+    // foreign_key_for! (Rails-faithful); against a stub with no foreign keys it
+    // raises ArgumentError promptly rather than recursing into a stack overflow.
     await expect(
       stub.removeForeignKey("products", { name: "fk_products_user_id" }),
-    ).resolves.toBeUndefined();
+    ).rejects.toThrow(/no foreign key/i);
   });
 
   it("validColumnDefinitionOptions includes ifExists (Rails OPTION_NAMES)", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -7,6 +7,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { AbstractSQLite3Adapter } from "../sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "../better-sqlite3-adapter.js";
 import { AbstractAdapter } from "../abstract-adapter.js";
+import { ForeignKeyDefinition } from "./schema-definitions.js";
 
 let adapter: AbstractSQLite3Adapter | undefined;
 
@@ -274,6 +275,30 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     // raises ArgumentError promptly rather than recursing into a stack overflow.
     await expect(
       stub.removeForeignKey("products", { name: "fk_products_user_id" }),
+    ).rejects.toThrow(/no foreign key/i);
+  });
+
+  it("removeForeignKey ifExists probe matches on to_table only, not name (Rails)", async () => {
+    // Rails' remove_foreign_key checks existence with only the positional
+    // to_table, then resolves the exact constraint (with column/name) via
+    // foreign_key_for!. So an ifExists removal targeting an existing FK to
+    // `other` under the WRONG name must NOT short-circuit to a no-op — it
+    // finds the FK (name ignored for existence) and then raises from the
+    // resolution when the name doesn't match. If the ifExists probe wrongly
+    // sliced in `name`, this would silently no-op instead.
+    class FkStub extends StubAdapter {
+      isUseForeignKeys() {
+        return true;
+      }
+      foreignKeys(_table: string) {
+        return Promise.resolve([
+          new ForeignKeyDefinition("products", "other", "other_id", "id", "real_fk_name"),
+        ]);
+      }
+    }
+    const stub = new FkStub();
+    await expect(
+      stub.removeForeignKey("products", { name: "wrong_name", toTable: "other", ifExists: true }),
     ).rejects.toThrow(/no foreign key/i);
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -780,32 +780,35 @@ export class SchemaStatements {
     toTableOrOptions?:
       | string
       | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
+    options: { column?: string; name?: string; ifExists?: boolean } = {},
   ): Promise<void> {
     const adapter = this.adapter as any;
     if (
       typeof adapter.removeForeignKey === "function" &&
       adapter.removeForeignKey !== SchemaStatements.prototype.removeForeignKey
     ) {
-      return adapter.removeForeignKey(fromTable, toTableOrOptions);
+      return adapter.removeForeignKey(fromTable, toTableOrOptions, options);
     }
-    const ifExists = typeof toTableOrOptions === "object" && toTableOrOptions?.ifExists === true;
-    let name: string;
-    if (typeof toTableOrOptions === "string") {
-      const column = this.foreignKeyColumnFor(toTableOrOptions);
-      name = `fk_${fromTable}_${column}`;
-    } else if (toTableOrOptions?.name) {
-      name = toTableOrOptions.name;
-    } else if (toTableOrOptions?.column) {
-      name = `fk_${fromTable}_${toTableOrOptions.column}`;
-    } else if (toTableOrOptions?.toTable) {
-      const column = this.foreignKeyColumnFor(toTableOrOptions.toTable);
-      name = `fk_${fromTable}_${column}`;
+    // Mirrors Rails remove_foreign_key(from_table, to_table = nil, **options):
+    // resolve the actual constraint via foreign_key_for! (matching column /
+    // name / to_table against the live foreign keys) rather than deriving a
+    // name, so a hashed `fk_rails_<hex>` name drops correctly.
+    let toTable: string | undefined;
+    let opts: { column?: string; name?: string; toTable?: string; ifExists?: boolean };
+    if (typeof toTableOrOptions === "object" && toTableOrOptions !== null) {
+      opts = { ...toTableOrOptions };
+      toTable = opts.toTable;
     } else {
-      throw new Error("removeForeignKey requires a target table or options");
+      toTable = toTableOrOptions;
+      opts = { ...options };
     }
-    const ifExistsSql = ifExists ? " IF EXISTS" : "";
+    const lookup = { toTable, column: opts.column, name: opts.name };
+    if (opts.ifExists === true && !(await this.foreignKeyExists(fromTable, lookup))) {
+      return;
+    }
+    const fk = await this.foreignKeyForBang(fromTable, lookup);
     await this.adapter.executeMutation(
-      `ALTER TABLE ${this._qi(fromTable)} DROP CONSTRAINT${ifExistsSql} ${this._qi(name)}`,
+      `ALTER TABLE ${this._qi(fromTable)} DROP CONSTRAINT ${this._qi(fk.name)}`,
     );
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -318,14 +318,27 @@ export class SchemaStatements {
 
     // Rails: if supports_comments? && !supports_comments_in_create?
     //   change_table_comment(table_name, comment) if options[:comment].present?
-    if (
-      options.comment != null &&
-      options.comment.length > 0 &&
-      this.adapter.supportsComments?.() &&
-      !this.adapter.supportsCommentsInCreate?.() &&
-      typeof this.adapter.changeTableComment === "function"
-    ) {
-      await this.adapter.changeTableComment(name, options.comment);
+    if (this.adapter.supportsComments?.() && !this.adapter.supportsCommentsInCreate?.()) {
+      if (
+        options.comment != null &&
+        options.comment.length > 0 &&
+        typeof this.adapter.changeTableComment === "function"
+      ) {
+        await this.adapter.changeTableComment(name, options.comment);
+      }
+      // Mirrors Rails: adapters that can't inline column comments in CREATE
+      // emit a COMMENT ON COLUMN per column so inline `comment:` options
+      // round-trip through columns().
+      const commentAdapter = this.adapter as {
+        changeColumnComment?(t: string, c: string, comment: string | null): Promise<void>;
+      };
+      if (typeof commentAdapter.changeColumnComment === "function") {
+        for (const column of td.columns as Array<{ name: string; comment?: string | null }>) {
+          if (column.comment != null && String(column.comment).length > 0) {
+            await commentAdapter.changeColumnComment(name, column.name, column.comment);
+          }
+        }
+      }
     }
 
     if (!this.adapter.supportsIndexesInCreate?.()) {
@@ -401,6 +414,16 @@ export class SchemaStatements {
   ): Promise<void> {
     if (options.ifExists && !(await this.columnExists(tableName, columnName))) {
       return;
+    }
+    // SQLite rebuilds the table (alter_table) to drop a column so indexes that
+    // reference it are dropped instead of left dangling; delegate when the
+    // adapter supplies its own removeColumn (mirrors renameColumn's gate).
+    const adapter = this.adapter as any;
+    if (
+      typeof adapter.removeColumn === "function" &&
+      adapter.removeColumn !== SchemaStatements.prototype.removeColumn
+    ) {
+      return adapter.removeColumn(tableName, columnName, _type, options);
     }
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     await this.adapter.executeMutation(
@@ -693,6 +716,19 @@ export class SchemaStatements {
     toTable: string,
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
+    // SQLite can't ALTER TABLE ADD CONSTRAINT, so it rebuilds the table in its
+    // own addForeignKey override. When invoked through a SchemaStatements
+    // wrapper (this !== the adapter), delegate to that override. The
+    // `this !== adapter` guard keeps adapters that call `super` (e.g. PostgreSQL)
+    // from re-entering this gate and recursing.
+    const fkAdapter = this.adapter as any;
+    if (
+      this !== fkAdapter &&
+      typeof fkAdapter.addForeignKey === "function" &&
+      fkAdapter.addForeignKey !== SchemaStatements.prototype.addForeignKey
+    ) {
+      return fkAdapter.addForeignKey(fromTable, toTable, options);
+    }
     // Mirrors Rails' add_foreign_key short-circuit:
     //   return if options[:if_not_exists] == true &&
     //     foreign_key_exists?(from_table, to_table, **options.slice(:column))

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -333,9 +333,15 @@ export class SchemaStatements {
         changeColumnComment?(t: string, c: string, comment: string | null): Promise<void>;
       };
       if (typeof commentAdapter.changeColumnComment === "function") {
-        for (const column of td.columns as Array<{ name: string; comment?: string | null }>) {
-          if (column.comment != null && String(column.comment).length > 0) {
-            await commentAdapter.changeColumnComment(name, column.name, column.comment);
+        // ColumnDefinition keeps the comment under `.options.comment` (Rails'
+        // `column.comment` reads through to the options hash).
+        for (const column of td.columns as Array<{
+          name: string;
+          options?: { comment?: string | null };
+        }>) {
+          const columnComment = column.options?.comment;
+          if (columnComment != null && String(columnComment).length > 0) {
+            await commentAdapter.changeColumnComment(name, column.name, columnComment);
           }
         }
       }
@@ -848,23 +854,32 @@ export class SchemaStatements {
   async removeCheckConstraint(
     tableName: string,
     expressionOrOptions?: string | { name?: string; ifExists?: boolean },
+    options: { name?: string; ifExists?: boolean } = {},
   ): Promise<void> {
     const adapter = this.adapter as any;
     if (
       typeof adapter.removeCheckConstraint === "function" &&
       adapter.removeCheckConstraint !== SchemaStatements.prototype.removeCheckConstraint
     ) {
-      return adapter.removeCheckConstraint(tableName, expressionOrOptions);
+      return adapter.removeCheckConstraint(tableName, expressionOrOptions, options);
     }
-    const ifExists =
-      typeof expressionOrOptions === "object" && expressionOrOptions?.ifExists === true;
-    let name: string;
+    // Mirrors Rails remove_check_constraint(table, expression = nil, **options):
+    // prefer an explicit :name (threaded from invert_add_check_constraint), else
+    // derive from the expression via the same hash add_check_constraint used, so
+    // the reversal drops the constraint under its real name.
+    let name: string | undefined;
+    let ifExists: boolean;
     if (typeof expressionOrOptions === "string") {
-      name = this._checkConstraintName(tableName, expressionOrOptions);
-    } else if (expressionOrOptions?.name) {
-      name = expressionOrOptions.name;
+      ifExists = options.ifExists === true;
+      name = options.name ?? this._checkConstraintName(tableName, expressionOrOptions);
     } else {
-      throw new Error("removeCheckConstraint requires either an expression or { name } option");
+      ifExists = (expressionOrOptions?.ifExists ?? options.ifExists) === true;
+      name = expressionOrOptions?.name ?? options.name;
+    }
+    if (!name) {
+      throw new ArgumentError(
+        "remove_check_constraint requires either an expression or { name } option",
+      );
     }
     const ifExistsSql = ifExists ? " IF EXISTS" : "";
     await this.adapter.executeMutation(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -802,11 +802,17 @@ export class SchemaStatements {
       toTable = toTableOrOptions;
       opts = { ...options };
     }
-    const lookup = { toTable, column: opts.column, name: opts.name };
-    if (opts.ifExists === true && !(await this.foreignKeyExists(fromTable, lookup))) {
+    // Rails checks existence with only the positional to_table
+    // (`foreign_key_exists?(from_table, to_table)`), then resolves the exact
+    // constraint via foreign_key_for! using column/name too.
+    if (opts.ifExists === true && !(await this.foreignKeyExists(fromTable, { toTable }))) {
       return;
     }
-    const fk = await this.foreignKeyForBang(fromTable, lookup);
+    const fk = await this.foreignKeyForBang(fromTable, {
+      toTable,
+      column: opts.column,
+      name: opts.name,
+    });
     await this.adapter.executeMutation(
       `ALTER TABLE ${this._qi(fromTable)} DROP CONSTRAINT ${this._qi(fk.name)}`,
     );

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -843,7 +843,7 @@ export class SchemaStatements {
     ) {
       return adapter.addCheckConstraint(tableName, expression, options);
     }
-    const name = options.name ?? this._checkConstraintName(tableName, expression);
+    const name = this.checkConstraintName(tableName, { name: options.name, expression });
     const validate = options.validate !== false;
     const chkDef = new CheckConstraintDefinition(tableName, expression, name, validate);
     await this.adapter.executeMutation(
@@ -864,36 +864,32 @@ export class SchemaStatements {
       return adapter.removeCheckConstraint(tableName, expressionOrOptions, options);
     }
     // Mirrors Rails remove_check_constraint(table, expression = nil, **options):
-    // prefer an explicit :name (threaded from invert_add_check_constraint), else
-    // derive from the expression via the same hash add_check_constraint used, so
-    // the reversal drops the constraint under its real name.
-    let name: string | undefined;
-    let ifExists: boolean;
+    // resolve the live constraint via check_constraint_for! (by :name, else the
+    // hash of the expression) and drop it by its real name — mirroring how
+    // removeForeignKey resolves via foreignKeyForBang. No name is derived-and-dropped.
+    let expression: string | undefined;
+    let opts: { name?: string; ifExists?: boolean };
     if (typeof expressionOrOptions === "string") {
-      ifExists = options.ifExists === true;
-      name = options.name ?? this._checkConstraintName(tableName, expressionOrOptions);
+      expression = expressionOrOptions;
+      opts = { ...options };
     } else {
-      ifExists = (expressionOrOptions?.ifExists ?? options.ifExists) === true;
-      name = expressionOrOptions?.name ?? options.name;
+      expression = undefined;
+      opts = { ...(expressionOrOptions ?? {}), ...options };
     }
-    if (!name) {
+    // Only pass `name` when present: checkConstraintFor derives one from the
+    // expression, and an explicit `name: undefined` would clobber it.
+    const lookup: { name?: string; expression?: string } = { expression };
+    if (opts.name !== undefined) lookup.name = opts.name;
+    const chk = await this.checkConstraintFor(tableName, lookup);
+    if (!chk) {
+      if (opts.ifExists === true) return;
       throw new ArgumentError(
-        "remove_check_constraint requires either an expression or { name } option",
+        `Table '${tableName}' has no check constraint for ${expression ?? JSON.stringify(opts)}`,
       );
     }
-    const ifExistsSql = ifExists ? " IF EXISTS" : "";
     await this.adapter.executeMutation(
-      `ALTER TABLE ${this._qi(tableName)} DROP CONSTRAINT${ifExistsSql} ${this._qi(name)}`,
+      `ALTER TABLE ${this._qi(tableName)} DROP CONSTRAINT ${this._qi(chk.name)}`,
     );
-  }
-
-  _checkConstraintName(tableName: string, expression: string): string {
-    let hash = 0;
-    for (let i = 0; i < expression.length; i++) {
-      hash = ((hash << 5) - hash + expression.charCodeAt(i)) | 0;
-    }
-    const hex = (hash >>> 0).toString(16).padStart(8, "0");
-    return `chk_${tableName}_${hex}`;
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -307,7 +307,7 @@ describe("InvertibleMigrationTest", () => {
   // trails' changeTable `removeIndex` records no `column` info, so the migrate
   // reverse path throws "Cannot reverse removeIndex without column info".
   // Tracked-pending-convergence under RFC 0023-surfaced-deviations.
-  it.skip("exception on removing index without column option", async () => {
+  it("exception on removing index without column option", async () => {
     const indexDefinition: [string, string[]] = ["horses", ["name", "color"]];
     const migration1 = new RemoveIndexMigration1();
     await migration1.migrate("up");
@@ -338,7 +338,7 @@ describe("InvertibleMigrationTest", () => {
   // migration's own direction, so a migration reverting a `revert` block (and
   // its `dropTable` reverse) is not yet direction-aware. Tracked-pending-
   // convergence under RFC 0023-surfaced-deviations (revert-direction semantics).
-  it.skip("migrate revert", async () => {
+  it("migrate revert", async () => {
     const migration = new InvertibleMigration();
     const revert = new InvertibleRevertMigration();
     await migration.migrate("up");
@@ -359,7 +359,7 @@ describe("InvertibleMigrationTest", () => {
     expect(await migration.connection.columnExists("horses", "remind_at")).toBe(true);
   });
 
-  it.skip("migrate revert by part", async () => {
+  it("migrate revert by part", async () => {
     await new InvertibleMigration().migrate("up");
     const received: symbol[] = [];
     const migration = new InvertibleByPartsMigration();
@@ -381,7 +381,7 @@ describe("InvertibleMigrationTest", () => {
     expect(await migration.connection.tableExists("new_horses")).toBe(false);
   });
 
-  it.skip("migrate revert whole migration", async () => {
+  it("migrate revert whole migration", async () => {
     const migration = new InvertibleMigration();
     for (const klass of [LegacyMigration, InvertibleMigration]) {
       const revert = new RevertWholeMigration(new klass());
@@ -395,7 +395,7 @@ describe("InvertibleMigrationTest", () => {
     }
   });
 
-  it.skip("migrate nested revert whole migration", async () => {
+  it("migrate nested revert whole migration", async () => {
     const revert = new NestedRevertWholeMigration(new InvertibleRevertMigration());
     await revert.migrate("down");
     expect(await revert.connection.tableExists("horses")).toBe(true);
@@ -427,11 +427,7 @@ describe("InvertibleMigrationTest", () => {
     expect(new Horse().readAttribute("name")).toBe("Sekitoba");
   });
 
-  // Column comments don't round-trip on trails yet: the inline `comment:` column
-  // option / changeColumnComment isn't reflected back through columns(), so
-  // columnsHash["name"].comment stays null (table comments, tested below, do
-  // work). Tracked-pending-convergence under RFC 0023-surfaced-deviations.
-  it.skip("migrate revert change column comment", async () => {
+  itIfSupports("comments", "migrate revert change column comment", async () => {
     const migration1 = new ChangeColumnComment1();
     await migration1.migrate("up");
     await resetHorse();
@@ -489,7 +485,7 @@ describe("InvertibleMigrationTest", () => {
   // path can recreate the table on reversal; trails' Migration#dropTable takes
   // no block and _reverseOperation throws IrreversibleMigration for dropTable.
   // Tracked-pending-convergence under RFC 0023-surfaced-deviations.
-  it.skip("migrate revert drop table", async () => {
+  it("migrate revert drop table", async () => {
     const connection = await Base.leaseConnection();
     const migration1 = new InvertibleMigration();
     await migration1.migrate("up");
@@ -507,7 +503,7 @@ describe("InvertibleMigrationTest", () => {
   // ([sym, args, block]); the trails recorder records {cmd, args} without the
   // block, so a verbatim port needs block-tracking in CommandRecorder.
   // Tracked-pending-convergence under RFC 0023-surfaced-deviations.
-  it.skip("revert order", async () => {
+  it("revert order", async () => {
     const block = (t: any) => t.string("name");
     const recorder = new CommandRecorder(await Base.leaseConnection());
     recorder.record("createTable", ["apples", block]);
@@ -574,7 +570,7 @@ describe("InvertibleMigrationTest", () => {
   // CommandRecorder change_table proxy has no `references`, and SQLite's
   // removeColumn rebuild can't drop a column an index still references.
   // Tracked-pending-convergence under RFC 0023-surfaced-deviations.
-  it.skip("migrations can handle foreign keys to specific tables", async () => {
+  it("migrations can handle foreign keys to specific tables", async () => {
     const migration = new RevertCustomForeignKeyTable();
     await new InvertibleMigration().migrate("up");
     await migration.migrate("up");
@@ -646,7 +642,7 @@ describe("InvertibleMigrationTest", () => {
   // reverse names the constraint `fk_horses_parent_id`, which doesn't match the
   // hashed name addForeignKey created. Tracked-pending-convergence under
   // RFC 0023-surfaced-deviations.
-  it.skip("migrate revert add foreign key with invalid option", async () => {
+  it("migrate revert add foreign key with invalid option", async () => {
     await new InvertibleMigration().migrate("up");
     await new RevertForeignKeyWithInvalidOption().migrate("up");
 

--- a/packages/activerecord/src/invertible-migration.test.ts
+++ b/packages/activerecord/src/invertible-migration.test.ts
@@ -482,9 +482,7 @@ describe("InvertibleMigrationTest", () => {
   });
 
   // Rails' drop_table accepts a block (the table definition) so the migrate
-  // path can recreate the table on reversal; trails' Migration#dropTable takes
-  // no block and _reverseOperation throws IrreversibleMigration for dropTable.
-  // Tracked-pending-convergence under RFC 0023-surfaced-deviations.
+  // path can recreate the table on reversal.
   it("migrate revert drop table", async () => {
     const connection = await Base.leaseConnection();
     const migration1 = new InvertibleMigration();
@@ -499,10 +497,9 @@ describe("InvertibleMigrationTest", () => {
     expect(await connection.tableExists("horses")).toBe(true);
   });
 
-  // Rails asserts the exact CommandRecorder#commands triples
-  // ([sym, args, block]); the trails recorder records {cmd, args} without the
-  // block, so a verbatim port needs block-tracking in CommandRecorder.
-  // Tracked-pending-convergence under RFC 0023-surfaced-deviations.
+  // Rails asserts the exact CommandRecorder#commands triples ([sym, args,
+  // block]); the trails recorder folds the block into the trailing arg of
+  // each {cmd, args} entry, so the assertion below matches that shape.
   it("revert order", async () => {
     const block = (t: any) => t.string("name");
     const recorder = new CommandRecorder(await Base.leaseConnection());

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -593,25 +593,19 @@ describe("MigrationTest", () => {
     ]).up(101);
     expect(await personColumnNames(adapter)).not.toContain("last_name");
 
-    // Removing a missing column with if_not_exists unset raises on every
-    // adapter in trails. Rails matches this on PG (`column ... does not exist`)
-    // and MySQL (`check that ... exists`), but on SQLite Rails removes columns
-    // via a table rebuild — copying every column except the dropped one — so a
-    // missing column is a no-op and `assert_nothing_raised` holds. trails'
-    // SchemaStatements emits a native `ALTER TABLE ... DROP COLUMN`, which
-    // SQLite 3.35+ rejects with "no such column" (same class of base-vs-adapter
-    // write-method divergence as the changeColumn rebuild path). Tracked-pending
-    // -convergence under 0023-surfaced-deviations story
-    // sqlite-remove-column-tolerate-missing; assert the current trails raise
-    // until the rebuild path lands.
+    // Removing a missing column with if_not_exists unset: SQLite removes
+    // columns via a table rebuild — copying every column except the dropped one
+    // — so a missing column is a no-op (`assert_nothing_raised`). PG and MySQL
+    // raise.
     const error = await new Migrator(adapter, [
       migrateProxy(102, (m) => m.removeColumn("people", "last_name")),
     ])
       .up(102)
       .catch((e) => e);
-    expect(error).toBeInstanceOf(Error);
-    expect(error.message).toMatch(
-      /no such column.*last_name|column "last_name" of relation "people" does not exist|check that.*exists/i,
+    expect(error?.message ?? "").toMatch(
+      adapterType === "sqlite"
+        ? /^$/
+        : /column "last_name" of relation "people" does not exist|check that.*exists/i,
     );
   });
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1049,11 +1049,10 @@ export abstract class Migration {
       // Nested: reuse the active recorder and just toggle its direction, so a
       // `revert` inside a reverting migration cancels by double-negation
       // (mirrors Rails `connection.revert(&block)` when connection is already a
-      // CommandRecorder — no fresh recorder, no replay).
+      // CommandRecorder — no fresh recorder, no replay, and no suppress_messages:
+      // Rails only suppresses in the outer branch).
       await this._recorder.revert(async () => {
-        await this.suppressMessages(async () => {
-          await fn();
-        });
+        await fn();
       });
       return;
     }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -663,14 +663,20 @@ export abstract class Migration {
     toTableOrOptions?:
       | string
       | { column?: string; name?: string; toTable?: string; ifExists?: boolean },
+    options?: { column?: string; name?: string; ifExists?: boolean },
   ): Promise<void> {
     if (this._recording) {
-      this._recorder.record("removeForeignKey", [fromTable, toTableOrOptions]);
+      // Rails records `remove_foreign_key(from_table, to_table, **options)`;
+      // preserve the trailing options so invert_add_foreign_key's column/name
+      // survive the round-trip and resolve the real constraint on replay.
+      const recordArgs: unknown[] = [fromTable, toTableOrOptions];
+      if (options !== undefined) recordArgs.push(options);
+      this._recorder.record("removeForeignKey", recordArgs);
       return;
     }
     fromTable = this._pt(fromTable);
     if (typeof toTableOrOptions === "string") toTableOrOptions = this._pt(toTableOrOptions);
-    await this.schema.removeForeignKey(fromTable, toTableOrOptions);
+    await this.schema.removeForeignKey(fromTable, toTableOrOptions, options);
   }
 
   async addCheckConstraint(

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -328,8 +328,8 @@ export abstract class Migration {
   async up(): Promise<void> {
     const legacy = this._legacyClassDirection("up");
     if (legacy) return legacy();
-    // Default: run change() in forward direction
-    await this._runChange("up");
+    // Default: run change() in the forward direction.
+    await this.change();
   }
 
   /**
@@ -341,7 +341,8 @@ export abstract class Migration {
   async down(): Promise<void> {
     const legacy = this._legacyClassDirection("down");
     if (legacy) return legacy();
-    await this._runChange("down");
+    // Mirrors Rails exec_migration: `down` == `revert { change }`.
+    await this.revert(() => this.change());
   }
 
   /**
@@ -377,265 +378,6 @@ export abstract class Migration {
     // Subclasses override
   }
 
-  private async _runChange(direction: "up" | "down"): Promise<void> {
-    if (direction === "up") {
-      await this.change();
-    } else {
-      // Record operations from change(), then replay in reverse
-      this._recording = true;
-      // Pass the connection as delegate so the change_table recorder proxy can
-      // surface adapter-specific column-type shorthands (t.hstore, t.jsonb, ...).
-      this._recorder = new CommandRecorder(this.connection);
-      try {
-        await this.change();
-      } finally {
-        this._recording = false;
-      }
-
-      // If no operations were recorded, migration is irreversible
-      if (this._recorder.commands.length === 0) {
-        throw new IrreversibleMigration(
-          `${this.constructor.name}#down is not implemented. This migration is irreversible.`,
-        );
-      }
-
-      // Replay in reverse using CommandRecorder
-      for (const { cmd, args } of this._recorder.commands.slice().reverse()) {
-        await this._reverseOperation(cmd, args);
-      }
-    }
-  }
-
-  private async _reverseOperation(cmd: string, args: unknown[]): Promise<void> {
-    switch (cmd) {
-      case "createTable":
-        await this.dropTable(args[0] as string);
-        break;
-      case "dropTable":
-        throw new IrreversibleMigration("Cannot reverse dropTable without table definition");
-      case "addColumn":
-        await this.removeColumn(args[0] as string, args[1] as string);
-        break;
-      case "removeColumn": {
-        const [rcTable, rcCol, rcType] = args as [string, string, ColumnType?];
-        if (!rcType) {
-          throw new IrreversibleMigration("Cannot reverse removeColumn without type info");
-        }
-        await this.addColumn(rcTable, rcCol, rcType);
-        break;
-      }
-      case "addIndex": {
-        // Rails inverts add_index to remove_index with the original positional
-        // args, so a String expression column (e.g. "remind_at, place_id") routes
-        // through the expression-aware index-name derivation rather than being
-        // wrapped in a `column:` option and matched as a literal identifier list.
-        const column = args[1] as string | string[];
-        const origOpts = args[2] as { name?: string } | undefined;
-        if (origOpts?.name) {
-          await this.removeIndex(args[0] as string, column, { name: origOpts.name });
-        } else {
-          await this.removeIndex(args[0] as string, column);
-        }
-        break;
-      }
-      case "removeIndex": {
-        const riOpts = args[1] as { column?: string | string[]; name?: string } | undefined;
-        if (!riOpts?.column) {
-          throw new IrreversibleMigration("Cannot reverse removeIndex without column info");
-        }
-        if (riOpts.name) {
-          await this.addIndex(args[0] as string, riOpts.column, { name: riOpts.name });
-        } else {
-          await this.addIndex(args[0] as string, riOpts.column);
-        }
-        break;
-      }
-      case "renameColumn":
-        await this.renameColumn(args[0] as string, args[2] as string, args[1] as string);
-        break;
-      case "renameTable":
-        await this.renameTable(args[1] as string, args[0] as string);
-        break;
-      case "renameIndex":
-        await this.renameIndex(args[0] as string, args[2] as string, args[1] as string);
-        break;
-      case "changeColumnDefault": {
-        const [cdTable, cdCol, cdOpts] = args as [string, string, { from?: unknown; to: unknown }];
-        if (cdOpts && typeof cdOpts === "object" && "from" in cdOpts) {
-          await this.changeColumnDefault(cdTable, cdCol, { from: cdOpts.to, to: cdOpts.from });
-        } else {
-          throw new IrreversibleMigration("Cannot reverse changeColumnDefault without from/to");
-        }
-        break;
-      }
-      case "changeColumnNull": {
-        const [cnTable, cnCol, cnAllow, cnDefault] = args as [string, string, boolean, unknown?];
-        await this.changeColumnNull(cnTable, cnCol, !cnAllow, cnDefault);
-        break;
-      }
-      case "changeColumn":
-        throw new IrreversibleMigration("Cannot reverse changeColumn without previous type info");
-      case "addForeignKey": {
-        const fkOpts = args[2] as { column?: string; name?: string } | undefined;
-        await this.removeForeignKey(args[0] as string, fkOpts ?? (args[1] as string));
-        break;
-      }
-      case "addReference":
-        await this.removeReference(
-          args[0] as string,
-          args[1] as string,
-          args[2] as { polymorphic?: boolean } | undefined,
-        );
-        break;
-      case "removeReference":
-        await this.addReference(
-          args[0] as string,
-          args[1] as string,
-          args[2] as { polymorphic?: boolean; foreignKey?: boolean } | undefined,
-        );
-        break;
-      case "createJoinTable":
-        await this.dropJoinTable(
-          args[0] as string,
-          args[1] as string,
-          args[2] as { tableName?: string } | undefined,
-        );
-        break;
-      case "dropJoinTable":
-        throw new IrreversibleMigration("Cannot reverse dropJoinTable without table definition");
-      case "addCheckConstraint": {
-        const [table, expr, opts] = args as [string, string, { name?: string }?];
-        const constraintName = opts?.name ?? this.schema._checkConstraintName(table, expr);
-        await this.removeCheckConstraint(table, { name: constraintName });
-        break;
-      }
-      case "removeCheckConstraint": {
-        const [rmTable, rmArg] = args as [string, string | { name?: string } | undefined];
-        if (typeof rmArg === "string") {
-          await this.addCheckConstraint(rmTable, rmArg);
-        } else {
-          throw new IrreversibleMigration(
-            "Cannot reverse removeCheckConstraint without expression",
-          );
-        }
-        break;
-      }
-      case "changeColumnComment": {
-        const [ccTable, ccCol, ccOpts] = args as [string, string, { from?: unknown; to?: unknown }];
-        if (
-          !ccOpts ||
-          typeof ccOpts !== "object" ||
-          !("from" in ccOpts) ||
-          ccOpts.from === undefined ||
-          !("to" in ccOpts) ||
-          ccOpts.to === undefined
-        ) {
-          throw new IrreversibleMigration(
-            "change_column_comment is only reversible if given a :from and :to option.",
-          );
-        }
-        await this.changeColumnComment(ccTable, ccCol, { from: ccOpts.to, to: ccOpts.from });
-        break;
-      }
-      case "changeTableComment": {
-        const [ctTable, ctOpts] = args as [string, { from?: unknown; to?: unknown }];
-        if (
-          !ctOpts ||
-          typeof ctOpts !== "object" ||
-          !("from" in ctOpts) ||
-          ctOpts.from === undefined ||
-          !("to" in ctOpts) ||
-          ctOpts.to === undefined
-        ) {
-          throw new IrreversibleMigration(
-            "change_table_comment is only reversible if given a :from and :to option.",
-          );
-        }
-        await this.changeTableComment(ctTable, { from: ctOpts.to, to: ctOpts.from });
-        break;
-      }
-      case "enableExtension": {
-        const [extName, extOpts] = args as [string, Record<string, unknown>?];
-        await this.disableExtension(extName, extOpts);
-        break;
-      }
-      case "disableExtension": {
-        const [dextName, dextOpts] = args as [string, Record<string, unknown>?];
-        await this.enableExtension(dextName, dextOpts);
-        break;
-      }
-      case "createEnum": {
-        const [enumName, enumValues, enumOpts] = args as [
-          string,
-          string[],
-          Record<string, unknown>?,
-        ];
-        await this.dropEnum(enumName, enumValues, enumOpts);
-        break;
-      }
-      case "dropEnum": {
-        const [deEnumName, deValues, deOpts] = args as [
-          string,
-          string[] | undefined,
-          Record<string, unknown>?,
-        ];
-        if (!deValues) {
-          throw new IrreversibleMigration("Cannot reverse dropEnum without a list of enum values");
-        }
-        await this.createEnum(deEnumName, deValues, deOpts);
-        break;
-      }
-      case "renameEnumValue": {
-        const [revName, revOpts] = args as [string, { from: string; to: string }];
-        await this.renameEnumValue(revName, { from: revOpts.to, to: revOpts.from });
-        break;
-      }
-      case "addUniqueConstraint": {
-        const [ucTable, ucColumn, ucOpts] = args as [
-          string,
-          string | string[] | undefined,
-          Record<string, unknown>?,
-        ];
-        if (ucOpts?.["usingIndex"]) {
-          throw new IrreversibleMigration(
-            "add_unique_constraint is not reversible if given a using_index.",
-          );
-        }
-        await this.removeUniqueConstraint(ucTable, ucColumn, ucOpts);
-        break;
-      }
-      case "removeUniqueConstraint": {
-        const [rucTable, rucColumn, rucOpts] = args as [
-          string,
-          string | string[] | undefined,
-          Record<string, unknown>?,
-        ];
-        if (!rucColumn) {
-          throw new IrreversibleMigration(
-            "remove_unique_constraint is only reversible if given a column_name.",
-          );
-        }
-        await this.addUniqueConstraint(rucTable, rucColumn, rucOpts);
-        break;
-      }
-      default: {
-        // Delegate unknown commands to CommandRecorder's invert dispatch so
-        // Rails-shape ops like removeColumns/addColumns/changeTable round-
-        // trip. Mirrors Rails: revert { } -> recorder.replay(self) where
-        // replayed cmds are the inverted ones.
-        const { cmd: iCmd, args: iArgs } = this._recorder.inverseOf(cmd, args);
-        const method = (this as unknown as Record<string, (...a: unknown[]) => Promise<void>>)[
-          iCmd
-        ];
-        if (typeof method !== "function") {
-          throw new IrreversibleMigration(`Cannot reverse operation: ${cmd}`);
-        }
-        await method.apply(this, iArgs);
-        break;
-      }
-    }
-  }
-
   // -- Schema operations (delegated to SchemaStatements) --
   // Migration records operations for reversibility, then delegates
   // actual SQL execution to this.schema (a SchemaStatements instance).
@@ -666,7 +408,17 @@ export abstract class Migration {
     fn?: (t: TableDefinition) => void,
   ): Promise<void> {
     if (this._recording) {
-      this._recorder.record("createTable", [name, optionsOrFn, fn]);
+      // Record `[name, options?, block?]` without trailing `undefined`, so the
+      // inversion to drop_table (which keeps every arg, including the block, for
+      // reversibility) doesn't carry a stray arg into the executed statement.
+      const recordArgs: unknown[] = [name];
+      if (typeof optionsOrFn === "function") {
+        recordArgs.push(optionsOrFn);
+      } else {
+        if (optionsOrFn !== undefined) recordArgs.push(optionsOrFn);
+        if (fn !== undefined) recordArgs.push(fn);
+      }
+      this._recorder.record("createTable", recordArgs);
       return;
     }
     const tname = this._pt(name);
@@ -674,20 +426,29 @@ export abstract class Migration {
   }
 
   async dropTable(
-    ...args:
-      | [string, ...string[]]
-      | [string, ...string[], { ifExists?: boolean; force?: "cascade"; temporary?: boolean }]
+    ...args: Array<
+      | string
+      | { ifExists?: boolean; force?: "cascade"; temporary?: boolean }
+      | ((t: TableDefinition) => void)
+    >
   ): Promise<void> {
-    const last = args[args.length - 1];
+    const rest = [...args] as unknown[];
+    // Rails drop_table(*table_names, **options, &block): the trailing block is
+    // the table definition, kept only so the recorder can recreate on reversal.
+    const block = typeof rest[rest.length - 1] === "function" ? rest.pop() : undefined;
+    const last = rest[rest.length - 1];
     const hasOptions = last !== null && typeof last === "object";
     const options = hasOptions
       ? (last as { ifExists?: boolean; force?: "cascade"; temporary?: boolean })
       : undefined;
-    const names = (hasOptions ? args.slice(0, -1) : args) as string[];
+    const names = (hasOptions ? rest.slice(0, -1) : rest) as string[];
     if (this._recording) {
       // Record the raw (un-prefixed) names — invert replays through createTable,
       // which re-applies the table-name prefix. The recorder accepts the splat.
-      this._recorder.record("dropTable", options ? [...names, options] : names);
+      const recordArgs: unknown[] = [...names];
+      if (options) recordArgs.push(options);
+      if (block) recordArgs.push(block);
+      this._recorder.record("dropTable", recordArgs);
       return;
     }
     const tnames = names.map((n) => this._pt(n)) as [string, ...string[]];
@@ -1273,24 +1034,78 @@ export abstract class Migration {
   async revert(migrationOrFn?: Migration | (() => Promise<void>)): Promise<void> {
     if (migrationOrFn === undefined) return;
     if (migrationOrFn instanceof Migration) {
-      (migrationOrFn as any).connection = this.connection;
-      await migrationOrFn.down();
-    } else {
-      // Record operations and reverse them, preserving outer recorder state
-      const outerRecording = this._recording;
-      const outerRecorder = this._recorder;
-      const innerRecorder = new CommandRecorder();
-      this._recording = true;
-      this._recorder = innerRecorder;
+      // Mirrors Rails `revert(*migration_classes)` -> `run(..., revert: true)`.
+      await this._run(migrationOrFn, { revert: true });
+      return;
+    }
+    const fn = migrationOrFn;
+    if (this._recording) {
+      // Nested: reuse the active recorder and just toggle its direction, so a
+      // `revert` inside a reverting migration cancels by double-negation
+      // (mirrors Rails `connection.revert(&block)` when connection is already a
+      // CommandRecorder — no fresh recorder, no replay).
+      await this._recorder.revert(async () => {
+        await this.suppressMessages(async () => {
+          await fn();
+        });
+      });
+      return;
+    }
+    // Outermost: swap in a CommandRecorder as the active delegate, record the
+    // block in reverting mode (commands invert at record time), restore, then
+    // replay the recorded inverses for real.
+    const previousRecorder = this._recorder;
+    const recorder = new CommandRecorder(this.connection);
+    this._recorder = recorder;
+    this._recording = true;
+    try {
+      await recorder.revert(async () => {
+        await this.suppressMessages(async () => {
+          await fn();
+        });
+      });
+    } finally {
+      this._recorder = previousRecorder;
+      this._recording = false;
+    }
+    await recorder.replay(this as unknown as Record<string, (...a: unknown[]) => Promise<void>>);
+  }
+
+  /**
+   * Run another migration in a direction, flipping it under `revert`.
+   *
+   * Mirrors: ActiveRecord::Migration#run — when the current migration is itself
+   * reverting, running a sub-migration `:up` means executing it `:down` without
+   * reverting, so it wraps the call in a nested `revert`.
+   */
+  private async _run(
+    migration: Migration,
+    opts: { direction?: "up" | "down"; revert?: boolean } = {},
+  ): Promise<void> {
+    let dir = opts.direction ?? "up";
+    if (opts.revert) dir = dir === "down" ? "up" : "down";
+    if (this.isReverting()) {
+      await this.revert(async () => {
+        await this._run(migration, { direction: dir, revert: true });
+      });
+    } else if (this._recording) {
+      // Recording (but not reverting): route the sub-migration's ops into the
+      // active recorder by sharing our recorder state with it.
+      const prevRecorder = migration._recorder;
+      const prevRecording = migration._recording;
+      const prevConn = migration._connectionOverride;
+      migration._recorder = this._recorder;
+      migration._recording = true;
+      migration._connectionOverride = this.connection;
       try {
-        await migrationOrFn();
+        await (dir === "up" ? migration.up() : migration.down());
       } finally {
-        this._recording = outerRecording;
-        this._recorder = outerRecorder;
+        migration._recorder = prevRecorder;
+        migration._recording = prevRecording;
+        migration._connectionOverride = prevConn;
       }
-      for (const { cmd, args } of innerRecorder.commands.slice().reverse()) {
-        await this._reverseOperation(cmd, args);
-      }
+    } else {
+      await migration.execMigration(this.connection, dir);
     }
   }
 
@@ -1312,7 +1127,7 @@ export abstract class Migration {
       up: (f) => upFns.push(f),
       down: (f) => downFns.push(f),
     });
-    if (this._recording) {
+    if (this.isReverting()) {
       // During reversal recording, run the down fns
       for (const f of downFns) await f();
     } else {
@@ -1327,7 +1142,7 @@ export abstract class Migration {
    * Mirrors: ActiveRecord::Migration#up_only
    */
   async upOnly(fn?: () => Promise<void>): Promise<void> {
-    if (!this._recording && fn) {
+    if (!this.isReverting() && fn) {
       await fn();
     }
   }
@@ -1353,7 +1168,7 @@ export abstract class Migration {
    * Mirrors: ActiveRecord::Migration#reverting?
    */
   isReverting(): boolean {
-    return this._recording;
+    return this._recording && this._recorder.reverting;
   }
 
   async isViewExists(viewName: string): Promise<boolean> {

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -702,13 +702,19 @@ export abstract class Migration {
   async removeCheckConstraint(
     tableName: string,
     expressionOrOptions?: string | { name?: string; ifExists?: boolean },
+    options?: { name?: string; ifExists?: boolean },
   ): Promise<void> {
     if (this._recording) {
-      this._recorder.record("removeCheckConstraint", [tableName, expressionOrOptions]);
+      // Rails records `remove_check_constraint(table, expression, **options)`;
+      // preserve the trailing options so invert_add_check_constraint's :name
+      // survives the round-trip and resolves the real constraint on replay.
+      const recordArgs: unknown[] = [tableName, expressionOrOptions];
+      if (options !== undefined) recordArgs.push(options);
+      this._recorder.record("removeCheckConstraint", recordArgs);
       return;
     }
     tableName = this._pt(tableName);
-    await this.schema.removeCheckConstraint(tableName, expressionOrOptions);
+    await this.schema.removeCheckConstraint(tableName, expressionOrOptions, options);
   }
   async validateCheckConstraint(
     tableName: string,

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -36,8 +36,19 @@ export class CommandRecorder {
     return [...this._commands];
   }
 
+  /**
+   * Record a command. When the recorder is in reverting mode the command is
+   * inverted at record time (mirrors Rails' `record`, which stores
+   * `inverse_of(...)` when `@reverting`), so nested `revert` blocks cancel out
+   * by double-negation.
+   */
   record(cmd: string, args: unknown[]): void {
-    this._commands.push({ cmd, args });
+    if (this._reverting) {
+      const [iCmd, iArgs] = this._dispatchInvert(cmd, args);
+      this._commands.push({ cmd: iCmd, args: iArgs });
+    } else {
+      this._commands.push({ cmd, args });
+    }
   }
 
   /**
@@ -62,25 +73,17 @@ export class CommandRecorder {
    * Mirrors: ActiveRecord::Migration::CommandRecorder#revert
    */
   async revert(fn: () => Promise<void>): Promise<void> {
-    const was = this._reverting;
-    this._reverting = !was;
-    const savedCommands = this._commands;
+    // Mirrors Rails: toggle reverting, capture the block's commands (already
+    // inverted at record time), then splice them back in reverse order.
+    this._reverting = !this._reverting;
+    const previous = this._commands;
     this._commands = [];
     try {
       await fn();
-      const reversed = this._commands.reverse().map(({ cmd, args }) => {
-        const [invertedCmd, invertedArgs] = this._dispatchInvert(cmd, args);
-        return { cmd: invertedCmd, args: invertedArgs };
-      });
-      this._commands = savedCommands;
-      for (const entry of reversed) {
-        this._commands.push(entry);
-      }
-    } catch (e) {
-      this._commands = savedCommands;
-      throw e;
     } finally {
-      this._reverting = was;
+      const captured = this._commands.reverse();
+      this._commands = previous.concat(captured);
+      this._reverting = !this._reverting;
     }
   }
 
@@ -135,7 +138,7 @@ export class CommandRecorder {
       const sub = new CommandRecorder(this._delegate);
       const proxy = withAdapterColumnMethods(new RecorderTableProxy(tableName, sub), columnTypes);
       await callback(proxy);
-      this._commands.push({ cmd: "changeTable", args: [tableName, sub.commands] });
+      this.record("changeTable", [tableName, sub.commands]);
     } else {
       // Non-bulk: route operations directly through this recorder so the
       // enclosing revert() block can invert them individually.
@@ -201,8 +204,19 @@ export class CommandRecorder {
   /** @internal */
   invertDropTable(args: unknown[]): [string, unknown[]] {
     const a = args.slice();
+    // The reversal block (table definition) rides as a trailing function, the
+    // same convention create_table uses (see the `revert order` test).
+    let block: unknown;
+    if (a.length > 0 && typeof a[a.length - 1] === "function") {
+      block = a.pop();
+    }
     let options: Record<string, unknown> = {};
-    if (a.length > 0 && typeof a[a.length - 1] === "object" && a[a.length - 1] !== null) {
+    if (
+      a.length > 0 &&
+      typeof a[a.length - 1] === "object" &&
+      a[a.length - 1] !== null &&
+      !Array.isArray(a[a.length - 1])
+    ) {
       options = { ...(a.pop() as Record<string, unknown>) };
     }
     delete options["ifExists"];
@@ -212,7 +226,7 @@ export class CommandRecorder {
         "To avoid mistakes, drop_table is only reversible if given a single table name.",
       );
     }
-    if (a.length === 1 && Object.keys(options).length === 0) {
+    if (a.length === 1 && Object.keys(options).length === 0 && block === undefined) {
       throw new IrreversibleMigration(
         "To avoid mistakes, drop_table is only reversible if given options or a block (can be empty).",
       );
@@ -220,6 +234,7 @@ export class CommandRecorder {
 
     const result = [...a];
     if (Object.keys(options).length > 0) result.push(options);
+    if (block !== undefined) result.push(block);
     return ["createTable", result];
   }
 
@@ -764,8 +779,33 @@ export class RecorderTableProxy {
     this._recorder.record("addIndex", [this._tableName, columns, options]);
   }
 
-  removeIndex(options: Record<string, unknown> = {}): void {
-    this._recorder.record("removeIndex", [this._tableName, options]);
+  // Mirrors Rails Table#remove_index(column_name = nil, **options) ->
+  // @base.remove_index(name, column_name, **options). Recording the column is
+  // what lets invert_remove_index reconstruct the add_index.
+  removeIndex(
+    columnOrOptions?: string | string[] | Record<string, unknown>,
+    options: Record<string, unknown> = {},
+  ): void {
+    const isColumn = typeof columnOrOptions === "string" || Array.isArray(columnOrOptions);
+    const column = isColumn ? columnOrOptions : undefined;
+    const opts = isColumn ? options : (columnOrOptions ?? {});
+    const args: unknown[] = [this._tableName, column];
+    if (Object.keys(opts).length > 0) args.push(opts);
+    this._recorder.record("removeIndex", args);
+  }
+
+  // Mirrors Rails Table#references / #belongs_to -> @base.add_reference per name.
+  references(...args: [...string[], Record<string, unknown>] | string[]): void {
+    const last = args[args.length - 1];
+    const hasOpts = typeof last === "object" && last !== null && !Array.isArray(last);
+    const options = hasOpts ? (args.pop() as Record<string, unknown>) : {};
+    for (const refName of args as string[]) {
+      this._recorder.record("addReference", [this._tableName, refName, options]);
+    }
+  }
+
+  belongsTo(...args: [...string[], Record<string, unknown>] | string[]): void {
+    this.references(...args);
   }
 
   timestamps(options: Record<string, unknown> = {}): void {

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -23166,13 +23166,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "create_table",
-    "call": "change_column_comment",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "create_table",
     "call": "columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -23881,20 +23874,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "remove_foreign_key",
     "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_foreign_key",
-    "call": "foreign_key_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_foreign_key",
-    "call": "foreign_key_for!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -32391,13 +32370,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "reversible",
-    "call": "reverting?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "revert",
     "call": "connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -32420,21 +32392,7 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "revert",
-    "call": "replay",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "revert",
     "call": "run",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "revert",
-    "call": "suppress_messages",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -32526,13 +32484,6 @@
     "tsFile": "migration.ts",
     "rubyName": "up_only",
     "call": "execute_block",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "up_only",
-    "call": "reverting?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -32848,13 +32799,6 @@
     "tsFile": "migration/command-recorder.ts",
     "rubyName": "replay",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration/command-recorder.ts",
-    "rubyName": "revert",
-    "call": "concat",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -55480,5 +55424,12 @@
     "rubyName": "build_with_expression_from_value",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
+    "rubyName": "revert",
+    "call": "reverse",
+    "reason": "trails Migration#revert takes a single migration or block, not a splat of migration classes, so Rails' `migration_classes.reverse` has no array to reverse; the single-migration path (_run) covers it."
   }
 ]


### PR DESCRIPTION
Reworks the migration reversal engine to route `down`/`revert` through the
`CommandRecorder` the way Rails does, closing the seven invertible-migration
gaps tracked-pending-convergence from PR #4328.

## What changed

**Engine (migration.ts + command-recorder.ts)**
- `CommandRecorder#record` inverts at record time when `reverting`, and
  `revert` toggles direction + reverses order (Rails semantics). Nested
  `revert` blocks cancel by double-negation → direction-aware revert, and the
  block rides in the args triple (`revert order`).
- `Migration#down` == `revert { change }`. `revert(fn)` reuses the active
  recorder when nested and only swaps-in/replays at the outermost level.
  New private `run()` flips a sub-migration under revert (`revert whole` /
  `nested revert whole`). Deletes the hand-rolled `_reverseOperation` /
  `_runChange` switch (net −109 lines).
- `drop_table` accepts a table-definition block and is reversible via it.
- change_table recorder proxy records `removeIndex` column info and gains
  `references` / `belongsTo`.

**Adapters / schema statements**
- SQLite `removeColumn` and `addForeignKey` delegate to the adapter's
  table-rebuild path (drops indexes on removed columns; avoids the rejected
  `ALTER TABLE ... ADD CONSTRAINT`). The delegation gate guards `this !==
  adapter` so PostgreSQL's `super`-calling override doesn't recurse.
- `removeForeignKey` now resolves the real constraint via `foreign_key_for!`
  (matching column/name/to_table against the live FKs) instead of deriving a
  `fk_<table>_<column>` name — so the reversal drops the hashed
  `fk_rails_<hex>` constraint on PG/MySQL. `Migration#removeForeignKey`
  threads the trailing options through so the inverted column survives.
- `create_table` emits a per-column `COMMENT` for adapters without
  comments-in-create (PostgreSQL), so inline `comment:` round-trips through
  `columns()`.

**Tests**
- Un-skips: `migrate revert`, `migrate revert by part`, `migrate revert whole
  migration`, `migrate nested revert whole migration`, `revert order`,
  `exception on removing index without column option`, `migrate revert drop
  table`, `migrations can handle foreign keys to specific tables`, `migrate
  revert add foreign key with invalid option`, and `migrate revert change
  column comment` (restored under the `comments` gate).
- Converges `remove column with if not exists not set` (migration.test.ts) to
  Rails: SQLite no-ops via rebuild, PG/MySQL raise.
- Updates the removeForeignKey recursion-guard to expect the Rails-faithful
  `ArgumentError` when the FK doesn't exist.

## Verification
`invertible-migration`, `command-recorder`, `migration`, `migrator`,
`schema-dumper`, `schema-statements-on-adapter`, `active-record-schema`,
`multi-db-migrator` suites pass on the SQLite lane (303 passing). The
column-comment/table-comment and PG/MySQL FK-name cases run only on the
PG/MySQL lanes (feature-gated) and rely on CI.

> Note: the diff is ~623 LOC counting the large deletion of the duplicate
> `_reverseOperation` switch (net −109); the seven gaps interlock through the
> single recorder rework and can't be meaningfully split.

Closes-story: invertible-migration-revert-engine-gaps

---

### CI follow-ups (post-open)

- **PG lane:** threaded the `:name` through `Migration#removeCheckConstraint`
  (its reversal previously dropped the options, so an explicit-name constraint
  couldn't be reverted) and read the inline column comment from
  `column.options.comment` (it lives there, not `column.comment`). Both verified
  on a live PostgreSQL.
- **api-compare wide ratchet:** reseeded the baseline — the rework converged 8
  entries (revert→replay/suppress_messages/concat, reversible/up_only→reverting?,
  removeForeignKey→foreign_key_exists?/foreign_key_for!, create_table→
  change_column_comment) and adds one (`revert`'s `migration_classes.reverse`,
  N/A for trails' single-migration revert).

### Check-constraint naming convergence (review follow-up)

Converged trails' two divergent check-constraint name generators onto Rails'
`check_constraint_name` (sha256 `chk_rails_<hex10>`). The bitwise
`_checkConstraintName` (`chk_<table>_<hex8>`) was a deviation, and the dumper's
`chkIgnorePattern` already expected the Rails form — so creation now produces
Rails-shaped names, `removeCheckConstraint` resolves the live constraint via
`checkConstraintFor` and drops it by real name (mirroring
`removeForeignKey`/`foreignKeyForBang`), and `CheckConstraintDefinition#isDefinedFor`
matches on name only (Rails `defined_for?` accepts but ignores the expression,
avoiding a spurious mismatch against PostgreSQL's normalized
`pg_get_constraintdef`). Verified on live PostgreSQL and SQLite.
