### PR TITLE
fix(relation): raise lazily at build for invalid leftOuterJoins arg, matching Rails

### DIFF
--- a/packages/activerecord/src/associations/left-outer-join-association.test.ts
+++ b/packages/activerecord/src/associations/left-outer-join-association.test.ts
@@ -141,10 +141,14 @@ describe("LeftOuterJoinAssociationTest", () => {
     expect(queries.some((sql) => /LEFT OUTER JOIN/i.test(sql))).toBe(false);
   });
 
-  it("left outer joins forbids to use string as argument", () => {
-    expect(() =>
-      Author.leftOuterJoins('LEFT OUTER JOIN "posts" ON "posts"."user_id" = "users"."id"'),
-    ).toThrow();
+  it("left outer joins forbids to use string as argument", async () => {
+    // Rails stores the arg verbatim and only raises lazily at build time (on
+    // `.to_a`), from build_join_buckets — not eagerly at leftOuterJoins(...).
+    await expect(
+      Author.leftOuterJoins(
+        'LEFT OUTER JOIN "posts" ON "posts"."user_id" = "users"."id"',
+      ).toArray(),
+    ).rejects.toThrow("only Hash, Symbol and Array are allowed");
   });
 
   it("left outer joins with string join", async () => {

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -192,6 +192,30 @@ describe("RelationTest", () => {
     expect(rel.toSql()).toMatch(/LEFT OUTER JOIN/i);
   });
 
+  it("leftJoins stores an invalid non-Hash/Symbol/Array arg verbatim and raises lazily at build", () => {
+    class Author extends Base {
+      static {
+        this.tableName = "authors";
+        this.hasMany("posts", { className: "LazyRaisePost", foreignKey: "author_id" });
+      }
+    }
+    class Post extends Base {
+      static {
+        this.tableName = "posts";
+        this.attribute("author_id", "integer");
+      }
+    }
+    registerModel("LazyRaiseAuthor", Author);
+    registerModel("LazyRaisePost", Post);
+
+    // Rails stores args verbatim (`left_outer_joins_values |= args`) and only
+    // raises in build_join_buckets — for ANY non-Hash/Symbol/Array arg, not just
+    // a whitespace string. A bare Integer is neither, so building raises.
+    const rel = Author.leftJoins(5 as any);
+    expect((rel as any)._leftOuterJoinsValues).toContain(5);
+    expect(() => rel.toSql()).toThrow("only Hash, Symbol and Array are allowed");
+  });
+
   it("includes().references() + leftJoins(): no duplicate LEFT OUTER JOIN in SQL", () => {
     // Regression: includes promoted to eager load via references() causes
     // _buildEagerJoinManager to emit the LEFT OUTER JOIN. The pendingLeftOuter

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1968,14 +1968,11 @@ export class Relation<T extends Base> {
     // spawn.left_outer_joins! (query_methods.rb:883-887), so `leftJoins({})` /
     // `leftJoins([])` drop their blank specs instead of polluting join state.
     const specs = _qm.flattenedArgs(args).filter((s) => !_qm.isBlankArgument(s));
+    // Rails stores args verbatim (`left_outer_joins_values |= args`) and only
+    // raises for a non-Hash/Symbol/Array arg lazily at SQL-build time, in
+    // `build_join_buckets` (query_methods.rb:1828-1834) — not eagerly here. See
+    // `buildJoinBuckets` for the raise.
     for (const spec of specs) {
-      // Rails raises ArgumentError when a raw SQL string (containing spaces) is
-      // passed; association names are always single-word identifiers.
-      if (typeof spec === "string" && /\s/.test(spec)) {
-        throw argumentError(
-          "only associations and hashes are supported as arguments to leftOuterJoins",
-        );
-      }
       if (!rel._leftOuterJoinsValues.includes(spec as AssociationSpec)) {
         rel._leftOuterJoinsValues.push(spec as AssociationSpec);
       }
@@ -3587,6 +3584,7 @@ export class Relation<T extends Base> {
     // present the left-outer JD folds into the inner JD's join_constraints (Rails
     // build_join_buckets: stashed_left_joins.unshift), deduping a both-ways
     // association to a single INNER JOIN via `walk`.
+    _qm.assertValidLeftOuterJoinsBang(this._leftOuterJoinsValues);
     const promotedIncludes = this._includesToPromoteFromReferences();
     const eagerCovered = new Set([...this._eagerLoadAssociations, ...promotedIncludes]);
     const pendingLeftOuter = this._leftOuterJoinsValues.filter((v) => !eagerCovered.has(v));

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2694,6 +2694,28 @@ export function selectAssociationList(
   return result;
 }
 
+/**
+ * Rails only accepts Symbol/Hash/Array as a left-outer arg — a bare String is
+ * not a Symbol, so `left_outer_joins("raw sql")` raises "only Hash, Symbol and
+ * Array are allowed" lazily from build_join_buckets' block
+ * (query_methods.rb:1830-1836). trails collapses Ruby Symbol and String to one
+ * JS string type, so an association name and a raw SQL fragment are
+ * indistinguishable by type; a raw fragment is a string containing whitespace,
+ * which no association identifier has. Reject those (and any other non-spec
+ * value) at build time, mirroring Rails' lazy raise point and message.
+ *
+ * @internal
+ */
+export function assertValidLeftOuterJoinsBang(values: unknown[]): void {
+  for (const v of values) {
+    if (typeof v === "string") {
+      if (/\s/.test(v)) throw argumentError("only Hash, Symbol and Array are allowed");
+    } else if (typeof v !== "symbol" && !Array.isArray(v) && !isPlainObject(v)) {
+      throw argumentError("only Hash, Symbol and Array are allowed");
+    }
+  }
+}
+
 /** @internal */
 export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown[]> {
   const buckets: Record<string, unknown[]> = {
@@ -2710,7 +2732,21 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
   // JoinDependency is prepended to stashed_left_joins.
   if (this._leftOuterJoinsValues.length > 0) {
     const stashedLeft: JoinDependency[] = [];
-    const namedLeft = selectNamedJoins.call(this, this._leftOuterJoinsValues, stashedLeft);
+    assertValidLeftOuterJoinsBang(this._leftOuterJoinsValues);
+    // Mirror Rails' block (query_methods.rb:1830-1836): a CTEJoin becomes an
+    // OuterJoin join_node; any other non-association value raises.
+    const namedLeft = selectNamedJoins.call(
+      this,
+      this._leftOuterJoinsValues,
+      stashedLeft,
+      (left) => {
+        if (left instanceof CTEJoin) {
+          buckets.join_node.push(buildWithJoinNode.call(this, left.name, Nodes.OuterJoin));
+        } else {
+          throw argumentError("only Hash, Symbol and Array are allowed");
+        }
+      },
+    );
 
     if (
       this._namedInnerJoins.length === 0 &&

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2698,11 +2698,14 @@ export function selectAssociationList(
  * Rails only accepts Symbol/Hash/Array as a left-outer arg — a bare String is
  * not a Symbol, so `left_outer_joins("raw sql")` raises "only Hash, Symbol and
  * Array are allowed" lazily from build_join_buckets' block
- * (query_methods.rb:1830-1836). trails collapses Ruby Symbol and String to one
- * JS string type, so an association name and a raw SQL fragment are
- * indistinguishable by type; a raw fragment is a string containing whitespace,
- * which no association identifier has. Reject those (and any other non-spec
- * value) at build time, mirroring Rails' lazy raise point and message.
+ * (query_methods.rb:1830-1836) for anything its `select_association_list`
+ * (query_methods.rb:1810-1824) does not recognize as a spec or stash as a
+ * JoinDependency. trails collapses Ruby Symbol and String to one JS string
+ * type, so an association name and a raw SQL fragment are indistinguishable by
+ * type; a raw fragment is a string containing whitespace, which no association
+ * identifier has. Reject those (and any other non-spec value) at build time,
+ * mirroring Rails' lazy raise point and message. A JoinDependency is allowed
+ * through — `select_association_list` stashes it rather than raising.
  *
  * @internal
  */
@@ -2710,7 +2713,12 @@ export function assertValidLeftOuterJoinsBang(values: unknown[]): void {
   for (const v of values) {
     if (typeof v === "string") {
       if (/\s/.test(v)) throw argumentError("only Hash, Symbol and Array are allowed");
-    } else if (typeof v !== "symbol" && !Array.isArray(v) && !isPlainObject(v)) {
+    } else if (
+      typeof v !== "symbol" &&
+      !Array.isArray(v) &&
+      !isPlainObject(v) &&
+      !(v instanceof JoinDependency)
+    ) {
       throw argumentError("only Hash, Symbol and Array are allowed");
     }
   }

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -42969,13 +42969,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_join_buckets",
-    "call": "build_with_join_node",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_join_buckets",
     "call": "concat",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
## Summary

`Relation#leftJoins`/`#leftOuterJoins` decided "raw SQL fragment vs association
name" with an **eager** whitespace heuristic in `_leftOuterJoins`
(`if typeof spec === "string" && /\s/.test(spec)` → throw "only associations and
hashes are supported…"). Rails has no such heuristic: `left_outer_joins(*args)`
stores args verbatim (`left_outer_joins_values |= args`) and only raises
**lazily** at SQL-build time in `build_join_buckets`
(`query_methods.rb:1828-1834`) — `ArgumentError, "only Hash, Symbol and Array
are allowed"` — for any left-outer arg that is not a Hash/Symbol/Array.

## Changes

- Remove the eager `/\s/` check from `_leftOuterJoins`; store args verbatim into
  `_leftOuterJoinsValues` (blank compaction from #4342 preserved).
- Add `assertValidLeftOuterJoinsBang`, run at join-build time from both
  `buildJoinBuckets` (subquery path) and `_applyJoinsToManager` (live path),
  raising Rails' message. Since trails collapses Ruby `Symbol` and `String` to
  one JS string type, a raw SQL fragment (a string containing whitespace) is
  rejected there as Rails' String-is-not-a-Symbol case — matching the raise
  point, trigger, and message. A `JoinDependency` is allowed through, mirroring
  Rails' `select_association_list`, which stashes it rather than raising.
- The left-path `selectNamedJoins` block now routes a `CTEJoin` to an
  `OuterJoin` join_node (it was previously dropped, since no block was passed),
  mirroring Rails' block.

## Tests

- `test_left_outer_joins_forbids_to_use_string_as_argument` now asserts the
  raise happens lazily at `.to_a` (`.toArray()`), matching Rails.
- New trails test: a bare Integer arg is stored verbatim in
  `_leftOuterJoinsValues` and raises `only Hash, Symbol and Array are allowed`
  lazily at build — locking in the broadened trigger (any non-Hash/Symbol/Array,
  not just a whitespace string).

Closes-story: left-outer-joins-lazy-invalid-arg-raise
