### PR TITLE
fix(relation): dedup join value unions structurally, mirroring Ruby Array |=

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -7,7 +7,7 @@ import { polymorphicName } from "../inheritance.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
 import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
-import { constructJoinDependency } from "../relation/query-methods.js";
+import { constructJoinDependency, structuralUnionEq } from "../relation/query-methods.js";
 
 /**
  * Lambda applied to each FK/type bind value before it reaches the
@@ -1032,7 +1032,8 @@ export class AssociationScope {
     if (namedLeft.length > 0) {
       if (sameKlass) {
         for (const v of namedLeft)
-          if (!target._leftOuterJoinsValues.includes(v)) target._leftOuterJoinsValues.push(v);
+          if (!target._leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
+            target._leftOuterJoinsValues.push(v);
       } else {
         target._leftOuterJoinDeps.push(
           constructJoinDependency.call(item as never, namedLeft as never, Nodes.OuterJoin),

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1884,18 +1884,21 @@ export class Relation<T extends Base> {
     const flatArgs = _qm.flattenedArgs(args).filter((a) => !_qm.isBlankArgument(a));
     for (const arg of flatArgs) {
       // Arel join node — stored as-is to preserve type (mirrors Rails joins_values).
-      // Rails joins! uses |= (array union), deduplicating by object identity for
-      // nodes and string equality for strings. JS === matches both behaviours.
+      // Rails joins! uses |= (array union), deduplicating by eql?/hash — object
+      // identity for nodes, structural for strings/hashes. structuralUnionEq
+      // (=== first, then structural) matches both.
       if (arg instanceof Nodes.Join) {
-        if (!rel._joinValues.includes(arg)) rel._joinValues.push(arg);
+        if (!rel._joinValues.some((v) => _qm.structuralUnionEq(v, arg))) rel._joinValues.push(arg);
         continue;
       }
       // Nested association hash: joins({ post: "author" }) mirrors Rails
       // joins(post: :author). Route through JoinDependency (InnerJoin) so the
       // full nested chain is resolved — constructJoinDependency already walks
       // AssociationSpec trees via walkAssociationTree/addTreeToJoinDependency.
+      // joins_values |= dedups structurally-equal Hash specs, so fold here too.
       if (_isPlainObject(arg)) {
-        rel._namedInnerJoins.push(arg as AssociationSpec);
+        if (!rel._namedInnerJoins.some((v) => _qm.structuralUnionEq(v, arg)))
+          rel._namedInnerJoins.push(arg as AssociationSpec);
         continue;
       }
       // Named association joins — both simple `joins(:assoc)` and nested-through
@@ -1905,11 +1908,13 @@ export class Relation<T extends Base> {
       // AliasTracker self-join aliasing and table-klass lookups across simple and
       // through joins; a non-association string falls through to a raw SQL join.
       if (typeof arg === "string" && rel._isAssociationName(arg)) {
-        if (!rel._namedInnerJoins.includes(arg)) rel._namedInnerJoins.push(arg);
+        if (!rel._namedInnerJoins.some((v) => _qm.structuralUnionEq(v, arg)))
+          rel._namedInnerJoins.push(arg);
         continue;
       }
       const joinValue = arg as string | Nodes.Join;
-      if (!rel._joinValues.includes(joinValue)) rel._joinValues.push(joinValue);
+      if (!rel._joinValues.some((v) => _qm.structuralUnionEq(v, joinValue)))
+        rel._joinValues.push(joinValue);
     }
     return rel;
   }
@@ -1973,7 +1978,9 @@ export class Relation<T extends Base> {
     // `build_join_buckets` (query_methods.rb:1828-1834) — not eagerly here. See
     // `buildJoinBuckets` for the raise.
     for (const spec of specs) {
-      if (!rel._leftOuterJoinsValues.includes(spec as AssociationSpec)) {
+      // Rails' left_outer_joins! unions with `|=` (eql?/hash), so a Hash spec
+      // passed twice folds structurally — not by JS reference identity.
+      if (!rel._leftOuterJoinsValues.some((v) => _qm.structuralUnionEq(v, spec))) {
         rel._leftOuterJoinsValues.push(spec as AssociationSpec);
       }
     }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1884,9 +1884,9 @@ export class Relation<T extends Base> {
     const flatArgs = _qm.flattenedArgs(args).filter((a) => !_qm.isBlankArgument(a));
     for (const arg of flatArgs) {
       // Arel join node — stored as-is to preserve type (mirrors Rails joins_values).
-      // Rails joins! uses |= (array union), deduplicating by eql?/hash — object
-      // identity for nodes, structural for strings/hashes. structuralUnionEq
-      // (=== first, then structural) matches both.
+      // Rails joins! uses |= (array union), deduplicating by eql?/hash —
+      // structural for nodes (Arel::Nodes::Binary#eql?), strings, and hashes
+      // alike. structuralUnionEq (=== first, then eql/structural) matches all.
       if (arg instanceof Nodes.Join) {
         if (!rel._joinValues.some((v) => _qm.structuralUnionEq(v, arg))) rel._joinValues.push(arg);
         continue;

--- a/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
+++ b/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
@@ -21,6 +21,10 @@ import { Author } from "../test-helpers/models/author.js";
 import { Comment } from "../test-helpers/models/comment.js";
 
 interface JoinValueHost {
+  // Public Rails-mirrored accessor for `left_outer_joins_values`
+  // (relation.ts get leftOuterJoinsValues, ~:4578). `_namedInnerJoins` has no
+  // public accessor — it is a trails-internal storage split of `joins_values`
+  // for association-name specs, so it is read through the underscore field.
   leftOuterJoinsValues: unknown[];
   _namedInnerJoins: unknown[];
   toSql(): string;

--- a/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
+++ b/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
@@ -1,13 +1,14 @@
 /**
- * Regression coverage for structural dedup of `left_outer_joins_values`
+ * Regression coverage for structural dedup of the join-value unions
  * (RFC 0023 left-outer-joins-values-structural-dedup).
  *
- * Rails' `left_outer_joins!` unions with `left_outer_joins_values |= args`;
- * Array `|=` dedups by Ruby `eql?`/`hash`, which is structural for Hash specs.
- * trails previously deduped via JS `includes` (reference `===`), so a Hash spec
- * passed twice stored two structurally-equal entries and emitted a duplicate
- * LEFT OUTER JOIN. `deepEqual` now mirrors `eql?`: structural for plain objects,
- * identity for Arel nodes.
+ * Rails' `left_outer_joins!` / `joins!` union with `|=`; Array `|=` dedups by
+ * Ruby `eql?`/`hash`, which is structural for Hash specs (and, for Arel nodes,
+ * `Arel::Nodes::Binary#eql?`). trails previously deduped via JS `includes`
+ * (reference `===`) — and the inner-`joins` Hash path deduped not at all — so a
+ * structurally-equal spec passed twice stored two entries and emitted a
+ * duplicate JOIN. `structuralUnionEq` now mirrors `eql?`: `===` first, then a
+ * node's own `eql`, then per-key structural equality for plain objects.
  *
  * Not a Rails-mirrored test name — this covers a trails-specific deviation with
  * no direct Ruby counterpart.
@@ -19,7 +20,15 @@ import { Post } from "../test-helpers/models/post.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Comment } from "../test-helpers/models/comment.js";
 
-describe("left_outer_joins_values structural dedup", () => {
+interface JoinValueHost {
+  leftOuterJoinsValues: unknown[];
+  _namedInnerJoins: unknown[];
+  toSql(): string;
+}
+
+const asHost = (rel: unknown): JoinValueHost => rel as JoinValueHost;
+
+describe("join value union structural dedup", () => {
   fixtures({});
   beforeAll(() => {
     registerModel("Author", Author);
@@ -31,10 +40,31 @@ describe("left_outer_joins_values structural dedup", () => {
     const rel = Author.leftJoins({ posts: "comments" }).leftJoins({ posts: "comments" });
     // left_outer_joins_values |= dedups the structurally-equal Hash spec (eql?),
     // so the value survives once — mirroring Rails, not JS reference identity.
-    expect(
-      (rel as unknown as { leftOuterJoinsValues: unknown[] }).leftOuterJoinsValues,
-    ).toHaveLength(1);
-    const sql = (rel as unknown as { toSql(): string }).toSql();
+    expect(asHost(rel).leftOuterJoinsValues).toHaveLength(1);
+    const sql = asHost(rel).toSql();
     expect((sql.match(/LEFT OUTER JOIN/g) ?? []).length).toBe(2); // posts + comments, no dup
+  });
+
+  it("emits a single INNER JOIN for a structurally-equal Hash spec joined twice", () => {
+    // The inner-joins Hash path previously pushed to _namedInnerJoins with no
+    // dedup at all; joins_values |= folds the structurally-equal spec in Rails.
+    const rel = Author.joins({ posts: "comments" }).joins({ posts: "comments" });
+    expect(asHost(rel)._namedInnerJoins).toHaveLength(1);
+    const sql = asHost(rel).toSql();
+    expect((sql.match(/INNER JOIN/g) ?? []).length).toBe(2); // posts + comments, no dup
+  });
+
+  it("keeps distinct Hash specs as separate joins", () => {
+    // Dedup is by value, not by shape: two hashes with the same key but
+    // different nested target must both survive.
+    const rel = Author.leftJoins({ posts: "comments" }).leftJoins({ posts: "author" });
+    expect(asHost(rel).leftOuterJoinsValues).toHaveLength(2);
+  });
+
+  it("folds a structurally-equal Hash spec across a same-klass merge", () => {
+    // Rails merge_joins unions via joins! (joins_values |=), so a same-klass
+    // merge dedups the equal spec structurally rather than by reference.
+    const rel = Author.joins({ posts: "comments" }).merge(Author.joins({ posts: "comments" }));
+    expect(asHost(rel)._namedInnerJoins).toHaveLength(1);
   });
 });

--- a/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
+++ b/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
@@ -1,0 +1,40 @@
+/**
+ * Regression coverage for structural dedup of `left_outer_joins_values`
+ * (RFC 0023 left-outer-joins-values-structural-dedup).
+ *
+ * Rails' `left_outer_joins!` unions with `left_outer_joins_values |= args`;
+ * Array `|=` dedups by Ruby `eql?`/`hash`, which is structural for Hash specs.
+ * trails previously deduped via JS `includes` (reference `===`), so a Hash spec
+ * passed twice stored two structurally-equal entries and emitted a duplicate
+ * LEFT OUTER JOIN. `deepEqual` now mirrors `eql?`: structural for plain objects,
+ * identity for Arel nodes.
+ *
+ * Not a Rails-mirrored test name — this covers a trails-specific deviation with
+ * no direct Ruby counterpart.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Author } from "../test-helpers/models/author.js";
+import { Comment } from "../test-helpers/models/comment.js";
+
+describe("left_outer_joins_values structural dedup", () => {
+  fixtures({});
+  beforeAll(() => {
+    registerModel("Author", Author);
+    registerModel("Post", Post);
+    registerModel("Comment", Comment);
+  });
+
+  it("emits a single LEFT OUTER JOIN for a structurally-equal Hash spec joined twice", () => {
+    const rel = Author.leftJoins({ posts: "comments" }).leftJoins({ posts: "comments" });
+    // left_outer_joins_values |= dedups the structurally-equal Hash spec (eql?),
+    // so the value survives once — mirroring Rails, not JS reference identity.
+    expect(
+      (rel as unknown as { leftOuterJoinsValues: unknown[] }).leftOuterJoinsValues,
+    ).toHaveLength(1);
+    const sql = (rel as unknown as { toSql(): string }).toSql();
+    expect((sql.match(/LEFT OUTER JOIN/g) ?? []).length).toBe(2); // posts + comments, no dup
+  });
+});

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -129,7 +129,10 @@ export class Merger {
     const otherNamed: unknown[] = this.other._namedInnerJoins ?? [];
     if (sameKlass) {
       for (const v of otherNamed) {
-        if (!rel._namedInnerJoins.includes(v)) rel._namedInnerJoins.push(v);
+        // joins_values |= dedups structurally-equal Hash specs (eql?/hash), so a
+        // same-klass merge folds an equal spec — not by JS reference identity.
+        if (!rel._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v)))
+          rel._namedInnerJoins.push(v);
       }
     } else if (otherNamed.length > 0) {
       rel._namedInnerJoinDeps.push(

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -1,6 +1,6 @@
 import { Nodes } from "@blazetrails/arel";
 
-import { arelColumns, constructJoinDependency } from "./query-methods.js";
+import { arelColumns, constructJoinDependency, structuralUnionEq } from "./query-methods.js";
 
 /**
  * Merges two Relations together, combining their conditions,
@@ -151,7 +151,8 @@ export class Merger {
     const sameKlass = this.other._modelClass === rel._modelClass;
     if (sameKlass) {
       for (const v of otherLeft) {
-        if (!rel._leftOuterJoinsValues.includes(v)) rel._leftOuterJoinsValues.push(v);
+        if (!rel._leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
+          rel._leftOuterJoinsValues.push(v);
       }
     } else if (otherLeft.length > 0) {
       rel._leftOuterJoinDeps.push(

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -908,9 +908,11 @@ function unscopeBang(
 }
 
 function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): any {
-  // Rails joins! uses |= (array union), deduplicating by Ruby eql?/hash — which
-  // is structural for Hash specs and identity for Arel nodes. deepEqual mirrors
-  // that: === first (Arel node identity), then structural for plain objects.
+  // Rails joins! uses |= (array union), deduplicating by Ruby eql?/hash —
+  // structural for Hash specs, strings, and even Arel nodes (Arel::Nodes::Binary
+  // defines eql?/hash by class + members, arel/nodes/binary.rb:20-29).
+  // structuralUnionEq mirrors that: === first, then deepEqual (which delegates
+  // to a node's own eql for Arel nodes).
   for (const arg of args) {
     if (!this._joinValues.some((seen) => structuralUnionEq(seen, arg))) this._joinValues.push(arg);
   }
@@ -1054,10 +1056,12 @@ function uniqArray(arr: unknown[]): unknown[] {
 
 /**
  * Ruby `Array#|=` (and `uniq`) dedup by `eql?`/`hash` — structural for Hash
- * specs, identity for Arel nodes. This mirrors that for the join-value unions
- * (`joins_values`, `left_outer_joins_values`): {@link deepEqual} tests `===`
- * first (Arel node identity) then structural equality for plain-object specs,
- * so `leftJoins({ posts: "x" })` called twice folds to one entry as in Rails.
+ * specs, strings, and Arel nodes alike (Arel::Nodes::Binary, which Join extends,
+ * defines eql?/hash by class + members: arel/nodes/binary.rb:20-29). This mirrors
+ * that for the join-value unions (`joins_values`, `left_outer_joins_values`):
+ * {@link deepEqual} tests `===` first, then delegates to a node's own `eql`, and
+ * falls back to per-key structural equality for plain-object specs — so
+ * `leftJoins({ posts: "x" })` called twice folds to one entry as in Rails.
  * @internal
  */
 export function structuralUnionEq(a: unknown, b: unknown): boolean {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -908,9 +908,11 @@ function unscopeBang(
 }
 
 function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): any {
-  // Rails joins! uses |= (array union), deduplicating by equality/identity.
+  // Rails joins! uses |= (array union), deduplicating by Ruby eql?/hash — which
+  // is structural for Hash specs and identity for Arel nodes. deepEqual mirrors
+  // that: === first (Arel node identity), then structural for plain objects.
   for (const arg of args) {
-    if (!this._joinValues.includes(arg)) this._joinValues.push(arg);
+    if (!this._joinValues.some((seen) => structuralUnionEq(seen, arg))) this._joinValues.push(arg);
   }
   return this;
 }
@@ -918,8 +920,10 @@ function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): an
 function leftOuterJoinsBang(this: QueryMethodsHost, ...args: AssociationSpec[]): any {
   // Mirrors Rails left_outer_joins! which stores into left_outer_joins_values
   // (separate from joins_values / _joinValues which is the inner-join path).
+  // |= dedups by eql?/hash — structural for Hash specs, not JS reference.
   for (const arg of args) {
-    if (!this._leftOuterJoinsValues.includes(arg)) this._leftOuterJoinsValues.push(arg);
+    if (!this._leftOuterJoinsValues.some((seen) => structuralUnionEq(seen, arg)))
+      this._leftOuterJoinsValues.push(arg);
   }
   return this;
 }
@@ -1046,6 +1050,18 @@ function uniqArray(arr: unknown[]): unknown[] {
     if (!out.some((seen) => deepEqual(seen, el))) out.push(el);
   }
   return out;
+}
+
+/**
+ * Ruby `Array#|=` (and `uniq`) dedup by `eql?`/`hash` — structural for Hash
+ * specs, identity for Arel nodes. This mirrors that for the join-value unions
+ * (`joins_values`, `left_outer_joins_values`): {@link deepEqual} tests `===`
+ * first (Arel node identity) then structural equality for plain-object specs,
+ * so `leftJoins({ posts: "x" })` called twice folds to one entry as in Rails.
+ * @internal
+ */
+export function structuralUnionEq(a: unknown, b: unknown): boolean {
+  return deepEqual(a, b);
 }
 
 function deepEqual(a: unknown, b: unknown): boolean {

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -5,7 +5,7 @@
  */
 
 import { Merger, HashMerger } from "./merger.js";
-import { argumentError } from "./query-methods.js";
+import { argumentError, structuralUnionEq } from "./query-methods.js";
 
 interface SpawnRelation<T = unknown> {
   _clone(): T;
@@ -123,10 +123,12 @@ export function mergeBang(this: any, other: any): any {
     this._joinClauses.push(...(other._joinClauses ?? []));
     this._joinValues.push(...(other._joinValues ?? []));
     for (const v of other._leftOuterJoinsValues ?? []) {
-      if (!this._leftOuterJoinsValues.includes(v)) this._leftOuterJoinsValues.push(v);
+      if (!this._leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
+        this._leftOuterJoinsValues.push(v);
     }
     for (const v of other._namedInnerJoins ?? []) {
-      if (!this._namedInnerJoins.includes(v)) this._namedInnerJoins.push(v);
+      if (!this._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v)))
+        this._namedInnerJoins.push(v);
     }
     this._namedInnerJoinDeps.push(...(other._namedInnerJoinDeps ?? []));
     this._leftOuterJoinDeps.push(...(other._leftOuterJoinDeps ?? []));


### PR DESCRIPTION
## Summary

`left_outer_joins`/`joins` stored structurally-equal Hash specs twice because the dedup used JS reference equality (`.includes` / `===`), and the inner-`joins` Hash path deduped *not at all*. Rails' `left_outer_joins!` / `joins!` union with `left_outer_joins_values |= args` / `joins_values |= args`; Array `|=` dedups by Ruby `eql?`/`hash` — **structural** for Hash specs, and for Arel nodes too (`Arel::Nodes::Binary#eql?` compares by class + members). So `leftJoins({ posts: "comments" })` called twice stored two entries in trails but one in Rails.

## Changes

- Add `structuralUnionEq` (exported from `query-methods.ts`): `===` first, then a node's own `eql` (Arel structural equality), then per-key structural `deepEqual` for plain-object specs — mirroring Ruby `|=`.
- Route the join-value union sites through it:
  - `relation.ts` `_leftOuterJoins` (the chained `leftJoins`/`leftOuterJoins` store site) and the parallel inner-`joins` path (`_joinValues` / `_namedInnerJoins`, where Hash specs previously had **no** dedup).
  - Bang methods (`joinsBang`, `leftOuterJoinsBang`) in `query-methods.ts`.
  - Merge paths: `spawn-methods.ts`, `merger.ts` (both inner same-klass and outer unions), `associations/association-scope.ts`.
- Arel-node dedup is now structural (`Arel::Nodes::Binary#eql?`), matching Rails' `|=` — a superset of the identity dedup it replaces; for strings/raw-SQL the behavior is unchanged (`===`).

## Tests

`left-outer-joins-values-structural-dedup.test.ts`:
- `leftJoins({ posts: "comments" })` twice → one `leftOuterJoinsValues` entry, single LEFT OUTER JOIN pair.
- `joins({ posts: "comments" })` twice → one `_namedInnerJoins` entry, single INNER JOIN pair (the previously-undeduped path).
- distinct Hash specs (`{ posts: "comments" }` vs `{ posts: "author" }`) both survive — dedup is by value, not shape.
- same-klass merge folds an equal Hash spec.

## Out of scope

Raw-SQL/Arel-node entries in `_joinValues` are still concatenated (not `|=`-deduped) when two relations are *merged* (`merger.ts:107`, `spawn-methods.ts:124`). That path holds no Hash specs, so it is outside this story's structural-Hash-dedup scope; the string case already matched `===`. Left for a separate follow-up.

Closes-story: left-outer-joins-values-structural-dedup