### PR TITLE
fix(reflection): raise NameError from MacroReflection#computeClass on missing class

### DIFF
--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -13,6 +13,7 @@ import {
   reflectOnAllAutosaveAssociations,
   ThroughReflection,
   AssociationReflection,
+  AggregateReflection,
   registerModel,
   modelRegistry,
   composedOf,
@@ -27,7 +28,7 @@ import {
 } from "./test-helpers/models/company-in-module.js";
 import { Post as CanonicalPost } from "./test-helpers/models/post.js";
 
-import { UnknownPrimaryKey } from "./errors.js";
+import { UnknownPrimaryKey, NameError } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { setupFixtures } from "./test-helpers/fixtures.js";
 import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
@@ -1347,6 +1348,20 @@ describe("ReflectionTest", () => {
     expect(addr).toBeInstanceOf(Address);
     expect(addr.street).toBe("123 Main");
     expect(addr.city).toBe("Springfield");
+  });
+
+  it("aggregate reflection computes class raises NameError for missing class", () => {
+    class Buyer extends Base {
+      static {
+        this.attribute("balance", "integer");
+      }
+    }
+    // AggregateReflection backs composed_of; a string class_name pointing at a
+    // constant that isn't registered must raise NameError (Rails compute_type),
+    // matching AssociationReflection#computeClass so NameError-only rescues apply.
+    const ref = new AggregateReflection("balance", null, { className: "NoSuchMoney" }, Buyer);
+    expect(() => ref.klass).toThrow(NameError);
+    expect(() => ref.klass).toThrow(/not found in registry/);
   });
 
   it("association reflection in modules", async () => {

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -666,7 +666,11 @@ export class MacroReflection extends AbstractReflection {
     const lookupName = name.startsWith("::") ? name.slice(2) : name;
     const resolved = modelRegistry.get(lookupName);
     if (!resolved) {
-      throw new Error(
+      // Rails resolves both association and aggregation reflection classes
+      // through compute_type, which raises NameError for a missing constant
+      // (reflection.rb:495-508). Match AssociationReflection#computeClass so
+      // callers rescuing only NameError treat both paths uniformly.
+      throw new NameError(
         `Model '${lookupName}' not found in registry (for '${this.name}' on ${this.activeRecord.name})`,
       );
     }


### PR DESCRIPTION
## Summary

`MacroReflection#computeClass` threw a bare `Error` when the resolved constant was missing, while the sibling `AssociationReflection#computeClass` raises `NameError` (matching Rails `compute_type`, reflection.rb:495-508). Since `MacroReflection` backs `AggregateReflection` (`composed_of`), a missing `composed_of` class type raised a plain `Error`, so callers rescuing only `NameError` (e.g. `Association#checkKlass`) did not treat the paths uniformly.

This raises `NameError` from `MacroReflection#computeClass`, mirroring the association path.

## Testing

- New test: aggregate reflection computes class raises `NameError` for missing class.
- Existing `/not found in registry/` message assertions still pass.

Closes-story: macro-reflection-compute-class-nameerror-on-missing