### PR TITLE
test(secure-password): harden constant-time authenticate_by timing assertion

### DIFF
--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -8,6 +8,20 @@ import { assertNoQueries } from "./testing/query-assertions.js";
 import { setupFixtures } from "./test-helpers/fixtures.js";
 import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
 
+// Mirrors Rails' `retry_flaky_test` (secure_password_test.rb): retry the timing
+// assertion a few times before failing, so a single unlucky preemption spike
+// doesn't fail CI. Re-throws the last assertion error once retries are spent.
+async function retryFlakyTest(fn: () => Promise<void>, retryCount = 3): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      await fn();
+      return;
+    } catch (error) {
+      if (attempt >= retryCount) throw error;
+    }
+  }
+}
+
 describe("SecurePasswordTest", () => {
   setupFixtures();
   useHandlerTransactionalFixtures();
@@ -43,22 +57,43 @@ describe("SecurePasswordTest", () => {
   });
 
   it("authenticate_by takes the same amount of time regardless of whether record is found", async () => {
-    // Warm-up (mostly to ensure the DB connection is established)
+    // Warm-up both the found (verify) and not-found (decoy hash) paths so the
+    // first timed sample doesn't eat crypto/JIT init cost and the DB connection
+    // is established.
     await (User as any).authenticateBy({ token: user.token, password: PASSWORD });
+    await (User as any).authenticateBy({ token: "wrong", password: PASSWORD });
 
-    // Both the not-found path and the found-but-wrong-password path must run
-    // the password hash so a timing attacker can't distinguish them: the
-    // not-found run should not be substantially shorter than the
-    // wrong-password run.
-    const t0 = performance.now();
-    expect(await (User as any).authenticateBy({ token: user.token, password: "wrong" })).toBeNull();
-    const wrongPasswordMs = performance.now() - t0;
+    // Port of Rails' averaged + retried timing check
+    // (activerecord/test/cases/secure_password_test.rb): Rails sums 1000
+    // iterations to average out jitter and wraps the whole thing in
+    // retry_flaky_test. We can't afford 1000 DB round-trips per path, so we
+    // take the MINIMUM elapsed time over a handful of samples instead — the
+    // min reflects the true CPU cost of the hash and is immune to the
+    // GC/preemption spikes that make a single sample flaky (a preempted
+    // wrong-password run measuring ~30ms was the original flake). Both the
+    // not-found path and the found-but-wrong-password path must run the
+    // password hash so a timing attacker can't distinguish them: the not-found
+    // run must not be substantially shorter than the wrong-password run.
+    await retryFlakyTest(async () => {
+      const SAMPLES = 8;
+      let wrongPasswordMs = Infinity;
+      let notFoundMs = Infinity;
+      for (let i = 0; i < SAMPLES; i++) {
+        const t0 = performance.now();
+        expect(
+          await (User as any).authenticateBy({ token: user.token, password: "wrong" }),
+        ).toBeNull();
+        wrongPasswordMs = Math.min(wrongPasswordMs, performance.now() - t0);
 
-    const t1 = performance.now();
-    expect(await (User as any).authenticateBy({ token: "wrong", password: PASSWORD })).toBeNull();
-    const notFoundMs = performance.now() - t1;
+        const t1 = performance.now();
+        expect(
+          await (User as any).authenticateBy({ token: "wrong", password: PASSWORD }),
+        ).toBeNull();
+        notFoundMs = Math.min(notFoundMs, performance.now() - t1);
+      }
 
-    expect(notFoundMs).toBeGreaterThan(wrongPasswordMs * 0.3);
+      expect(notFoundMs).toBeGreaterThan(wrongPasswordMs * 0.3);
+    });
   });
 
   it("authenticate_by short circuits when password is nil", async () => {

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -10,14 +10,18 @@ import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-tran
 
 // Mirrors Rails' `retry_flaky_test` (secure_password_test.rb): retry the timing
 // assertion a few times before failing, so a single unlucky preemption spike
-// doesn't fail CI. Re-throws the last assertion error once retries are spent.
+// doesn't fail CI. Rails rescues only `Minitest::Assertion`; we likewise retry
+// only assertion failures (vitest throws `AssertionError`) so a genuine
+// exception surfaces immediately instead of being masked and delayed. Re-throws
+// the last assertion error once retries are spent.
 async function retryFlakyTest(fn: () => Promise<void>, retryCount = 3): Promise<void> {
   for (let attempt = 0; ; attempt++) {
     try {
       await fn();
       return;
     } catch (error) {
-      if (attempt >= retryCount) throw error;
+      const isAssertion = error instanceof Error && error.name === "AssertionError";
+      if (!isAssertion || attempt >= retryCount) throw error;
     }
   }
 }

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -74,28 +74,42 @@ describe("SecurePasswordTest", () => {
     // take the MINIMUM elapsed time over a handful of samples instead — the
     // min reflects the true CPU cost of the hash and is immune to the
     // GC/preemption spikes that make a single sample flaky (a preempted
-    // wrong-password run measuring ~30ms was the original flake). Both the
-    // not-found path and the found-but-wrong-password path must run the
-    // password hash so a timing attacker can't distinguish them: the not-found
-    // run must not be substantially shorter than the wrong-password run.
+    // wrong-password run measuring ~30ms was the original flake).
+    //
+    // Every path must run one password hash so a timing attacker can't tell
+    // them apart: the found-and-correct path verifies the stored digest, the
+    // found-but-wrong-password path also verifies it, and the not-found path
+    // runs a decoy hash. We measure all three and assert the not-found run is
+    // not substantially shorter than either found run. Including the
+    // found-and-correct path matches the exact invariant Rails bounds (Rails
+    // compares found-correct vs not-found); the wrong-password comparison is an
+    // additional trails check that the two "auth fails" branches also match.
     await retryFlakyTest(async () => {
       const SAMPLES = 8;
+      let foundCorrectMs = Infinity;
       let wrongPasswordMs = Infinity;
       let notFoundMs = Infinity;
       for (let i = 0; i < SAMPLES; i++) {
         const t0 = performance.now();
         expect(
-          await (User as any).authenticateBy({ token: user.token, password: "wrong" }),
-        ).toBeNull();
-        wrongPasswordMs = Math.min(wrongPasswordMs, performance.now() - t0);
+          (await (User as any).authenticateBy({ token: user.token, password: PASSWORD }))?.id,
+        ).toBe(user.id);
+        foundCorrectMs = Math.min(foundCorrectMs, performance.now() - t0);
 
         const t1 = performance.now();
         expect(
+          await (User as any).authenticateBy({ token: user.token, password: "wrong" }),
+        ).toBeNull();
+        wrongPasswordMs = Math.min(wrongPasswordMs, performance.now() - t1);
+
+        const t2 = performance.now();
+        expect(
           await (User as any).authenticateBy({ token: "wrong", password: PASSWORD }),
         ).toBeNull();
-        notFoundMs = Math.min(notFoundMs, performance.now() - t1);
+        notFoundMs = Math.min(notFoundMs, performance.now() - t2);
       }
 
+      expect(notFoundMs).toBeGreaterThan(foundCorrectMs * 0.3);
       expect(notFoundMs).toBeGreaterThan(wrongPasswordMs * 0.3);
     });
   });


### PR DESCRIPTION
## Problem

CI flaked on `SecurePasswordTest > authenticate_by takes the same amount of time regardless of whether record is found` (PR #4528, SQLite lane):

```
AssertionError: expected 2.92216899999994 to be greater than 9.047780399999965
```

i.e. `notFoundMs=2.92`, `wrongPasswordMs≈30` → the ratio `notFoundMs > wrongPasswordMs*0.3` failed. Surfaced on an unrelated benchmarking branch; pre-existing.

## Diagnosis

The not-found decoy hash **is** present and correct in `secure-password.ts` (`authenticateBy`'s `else` branch runs `pbkdf2Async` over the supplied passwords), so this is **not** a fidelity gap. The failure is pure timing jitter: the test took a **single** sample of each path, and a GC/preemption spike inflated the wrong-password sample to ~30ms.

## Fix

Rails' test (`activerecord/test/cases/secure_password_test.rb`) sums **1000 iterations** to average out jitter and wraps the assertion in `retry_flaky_test`. 1000 DB round-trips + ~5s crypto per path is impractical for our suite, so this mirrors the intent at a fraction of the cost:

- warm up **both** the found and not-found paths before timing;
- take the **minimum** elapsed over 8 samples per path (min reflects true CPU cost and is immune to preemption spikes);
- wrap the assertion in a `retry_flaky_test`-equivalent helper that (like Rails' `rescue Minitest::Assertion`) retries **only** assertion failures, so a genuine exception surfaces immediately.

Same test name, no coverage lost. Ran 6× locally in a loop — passes consistently (~500ms).

## Review follow-ups

- **`retryFlakyTest` name check actually fires the retry** — verified empirically in-repo: vitest `expect()` failures set `error.name === "AssertionError"`, and a forced-failure harness confirmed the loop retries (`isAssertion=true`, succeeded on attempt 3). The retry is also belt-and-suspenders: min-of-8 is the primary flake fix and stands even if retry never fired.
- **Found-and-correct path now included** — Rails bounds found-correct vs not-found; the port previously only compared found-wrong vs not-found. Added the found-correct sample to the loop and assert not-found isn't substantially shorter than it, bounding the exact Rails invariant, while keeping the wrong-password comparison as an extra check that both auth-failure branches match.