### PR TITLE
refactor(test-config): inherit Rails default pool size on file-backed sqlite lane

### DIFF
--- a/packages/activerecord/src/test-adapter.ts
+++ b/packages/activerecord/src/test-adapter.ts
@@ -159,17 +159,11 @@ async function buildInTestPool(): Promise<ConnectionPool> {
 
   // Duplicate the primary config with a short checkout_timeout so pool-mechanics
   // tests don't stall on the shared primary — mirrors connection_pool_test.rb's
-  // `configuration_hash.merge(checkout_timeout: 0.2)`.
-  //
-  // We drop the primary's pinned `pool` size: trails' primary test config sets
-  // `pool: 1` (test-database-config.ts) — a trails deviation. Rails' primary
-  // test config leaves `pool` unset (HashConfig#pool defaults to 5,
-  // hash_config.rb:72), so connection_pool_test.rb's duplicate inherits a
-  // multi-connection pool. Dropping the pin lets the duplicate default to 5,
-  // giving the ported mechanics tests Rails' multi-connection shape.
-  const { pool: _primaryPoolSize, ...primaryHash } = src.configurationHash;
+  // `configuration_hash.merge(checkout_timeout: 0.2)`. The duplicate inherits
+  // the primary's pool size directly (Rails' default 5 on the file-backed lane),
+  // exactly like connection_pool_test.rb derives from `Base.connection_pool.db_config`.
   const dbConfig = new HashConfig(src.envName, src.name, {
-    ...primaryHash,
+    ...src.configurationHash,
     checkoutTimeout: 0.2,
   });
 

--- a/packages/activerecord/src/test-helpers/test-database-config.test.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.test.ts
@@ -26,6 +26,22 @@ describe("buildTestDatabaseConfig", () => {
     expect(DatabaseTasks.resolveTask("sqlite3")).toBeDefined();
   });
 
+  it("inherits Rails' default pool size (5) on the file-backed lane", async () => {
+    vi.stubEnv("PG_TEST_URL", "");
+    vi.stubEnv("MYSQL_TEST_URL", "");
+    vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker.sqlite3");
+    const { envConfig } = await buildTestDatabaseConfig();
+    expect(envConfig.pool).toBe(5);
+  });
+
+  it("pins pool 1 on a bare :memory: primary", async () => {
+    vi.stubEnv("PG_TEST_URL", "");
+    vi.stubEnv("MYSQL_TEST_URL", "");
+    vi.stubEnv("AR_TEST_WORKER_DB", "");
+    const { envConfig } = await buildTestDatabaseConfig();
+    expect(envConfig.pool).toBe(1);
+  });
+
   it("picks postgres when PG_TEST_URL is set", async () => {
     vi.stubEnv("PG_TEST_URL", "postgresql://localhost/trails_test");
     const { adapter } = await buildTestDatabaseConfig();

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -36,11 +36,26 @@ function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfi
   if (mysqlUrl) {
     return { adapter: "mysql", envConfig: new UrlConfig("test", "primary", mysqlUrl) };
   }
-  const database = getEnv("AR_TEST_WORKER_DB") ?? ":memory:";
   return {
     adapter: "sqlite",
-    envConfig: new HashConfig("test", "primary", { adapter: "sqlite3", database, pool: 1 }),
+    envConfig: new HashConfig("test", "primary", sqliteHash()),
   };
+}
+
+/**
+ * Build the sqlite primary config hash. Mirrors Rails' primary test config,
+ * which leaves `pool` unset so `HashConfig#pool` defaults to 5
+ * (`hash_config.rb:72`). We only pin `pool: 1` on a bare `:memory:` primary
+ * (no `AR_TEST_WORKER_DB`): better-sqlite3 gives separate connections separate
+ * empty `:memory:` DBs (Rails' `in_memory_db?`). The file-backed per-worker
+ * clone lane shares the file across connections, so it inherits Rails' 5.
+ */
+function sqliteHash(): { adapter: string; database: string; pool?: number } {
+  const workerDb = getEnv("AR_TEST_WORKER_DB");
+  if (workerDb) {
+    return { adapter: "sqlite3", database: workerDb };
+  }
+  return { adapter: "sqlite3", database: ":memory:", pool: 1 };
 }
 
 /**
@@ -99,6 +114,5 @@ export async function establishFromTestConfig(): Promise<void> {
     await Base.establishConnection(mysqlUrl);
     return;
   }
-  const database = getEnv("AR_TEST_WORKER_DB") ?? ":memory:";
-  await Base.establishConnection({ adapter: "sqlite3", database, pool: 1 });
+  await Base.establishConnection(sqliteHash());
 }


### PR DESCRIPTION
## Summary

trails' primary sqlite test config pinned `pool: 1`, deviating from Rails.
Rails' primary test config leaves `pool` unset, so `HashConfig#pool` defaults
to 5 (`hash_config.rb:72`). This pin forced a workaround in PR #4532's
`buildInTestPool`, which had to strip the pinned size so the in-test duplicate
pool inherited Rails' multi-connection shape.

## Changes

- `test-database-config.ts`: gate `pool: 1` to a bare `:memory:` primary only
  (better-sqlite3's `in_memory_db?` case, where separate connections get
  separate empty DBs). The file-backed per-worker clone lane shares the DB file
  across connections, so it inherits Rails' default 5. Extracted a `sqliteHash()`
  helper shared by `resolve()` and `establishFromTestConfig()`.
- `test-adapter.ts`: remove the pool-stripping workaround in `buildInTestPool`;
  the duplicate now inherits the primary's size directly, exactly like
  `connection_pool_test.rb` derives from `Base.connection_pool.db_config`.

## Verification

`connection-pool.test.ts`, `pooled-test-adapter.test.ts`, and
`test-database-config.test.ts` pass on both the file-backed lane
(`AR_TEST_WORKER_DB` set) and pure `:memory:`.

Closes-story: converge-primary-test-pool-size-to-rails-default