### PR TITLE
perf(pg): scope disableReferentialIntegrity to affected tables

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -284,6 +284,58 @@ describe("DatabaseStatements", () => {
       expect(executed[0]).toMatch(/DELETE FROM/);
       expect(executed[1]).toMatch(/INSERT INTO/);
     });
+
+    it("scopes disableReferentialIntegrity to the fixture tables and delete targets", async () => {
+      const { insertFixturesSet } = await import("./database-statements.js");
+      let scopedTables: string[] | undefined;
+      const host: DatabaseStatementsHost &
+        Pick<Quoting, "quote" | "quoteTableName" | "quoteColumnName"> = {
+        execute: async () => {},
+        transaction: async <T>(fn: (tx?: unknown) => Promise<T> | T) => {
+          await fn();
+          return undefined;
+        },
+        disableReferentialIntegrity: async (fn: () => Promise<void>, tables?: string[]) => {
+          scopedTables = tables;
+          await fn();
+        },
+        quote: (v: unknown) => (typeof v === "string" ? `'${v}'` : String(v)),
+        quoteTableName: (n: string) => `"${n}"`,
+        quoteColumnName: (n: string) => `"${n}"`,
+      };
+
+      await insertFixturesSet.call(host, { users: [{ name: "Alice" }], posts: [{ title: "Hi" }] }, [
+        "old_table",
+        "users",
+      ]);
+
+      // Union of fixture keys and delete targets, de-duplicated.
+      expect(scopedTables && [...scopedTables].sort()).toEqual(["old_table", "posts", "users"]);
+    });
+  });
+
+  describe("truncateTables", () => {
+    it("scopes disableReferentialIntegrity to the tables being truncated", async () => {
+      const { truncateTables } = await import("./database-statements.js");
+      const executed: string[] = [];
+      let scopedTables: string[] | undefined;
+      const host: DatabaseStatementsHost & Pick<Quoting, "quoteTableName"> = {
+        execute: async (sql: string) => {
+          executed.push(sql);
+        },
+        disableReferentialIntegrity: async (fn: () => Promise<void>, tables?: string[]) => {
+          scopedTables = tables;
+          await fn();
+        },
+        quoteTableName: (n: string) => `"${n}"`,
+      };
+
+      // schema_migrations / ar_internal_metadata are filtered out before scoping.
+      await truncateTables.call(host, "users", "posts", "schema_migrations");
+
+      expect(scopedTables).toEqual(["users", "posts"]);
+      expect(executed).toEqual(['TRUNCATE TABLE "users"', 'TRUNCATE TABLE "posts"']);
+    });
   });
 
   describe("truncate / insertFixture quoter dispatch", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -122,7 +122,7 @@ export interface DatabaseStatementsHost {
     userTransaction?: unknown;
   };
   withinNewTransaction?<T>(opts: unknown, fn: (tx?: unknown) => Promise<T> | T): Promise<T>;
-  disableReferentialIntegrity?(fn: () => Promise<void>): Promise<void>;
+  disableReferentialIntegrity?(fn: () => Promise<void>, tables?: string[]): Promise<void>;
   /** @internal */
   executeBatch?(statements: string[], name?: string): Promise<void>;
   /** @internal */
@@ -695,7 +695,7 @@ export async function truncateTables(
     await this.disableReferentialIntegrity(async () => {
       executed = true;
       await doTruncate();
-    });
+    }, filtered);
     if (!executed) await doTruncate();
   } else {
     await doTruncate();
@@ -1125,6 +1125,10 @@ export async function insertFixturesSet(
     }
   };
 
+  // The wrapped block only touches the fixture tables and the delete targets, so
+  // scope the trigger toggle to that set rather than the whole catalog.
+  const affectedTables = [...new Set([...Object.keys(fixtureSet), ...tablesToDelete])];
+
   // Rails wraps fixture loading in a transaction with requires_new: true
   const doLoadInTransaction = async () => {
     if (this.disableReferentialIntegrity) {
@@ -1132,7 +1136,7 @@ export async function insertFixturesSet(
       await this.disableReferentialIntegrity(async () => {
         executed = true;
         await doInserts();
-      });
+      }, affectedTables);
       if (!executed) await doInserts();
     } else {
       await doInserts();

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, it, expect, vi } from "vitest";
 import { disableReferentialIntegrity } from "./referential-integrity.js";
-import { StatementInvalid } from "../../errors.js";
+import { InvalidForeignKey, StatementInvalid } from "../../errors.js";
 
 interface FakeHost {
   quoteTableName(name: string): string;
@@ -92,6 +92,22 @@ describe("disableReferentialIntegrity", () => {
     expect(ran).toBe(true);
     expect(tablesCalls()).toBe(0);
     expect(executed).toHaveLength(0);
+  });
+
+  it("still warns and rethrows when an empty-scope block raises InvalidForeignKey", async () => {
+    const { host } = makeHost(["a", "b"]);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const fkError = new InvalidForeignKey("boom", { sql: "", binds: [] });
+    try {
+      await expect(
+        disableReferentialIntegrity.call(host, async () => {
+          throw fkError;
+        }, []),
+      ).rejects.toBe(fkError);
+      expect(warn).toHaveBeenCalledOnce();
+    } finally {
+      warn.mockRestore();
+    }
   });
 
   it("swallows an enable-pass StatementInvalid when the block dropped a snapshotted table", async () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.test.ts
@@ -70,6 +70,30 @@ describe("disableReferentialIntegrity", () => {
     expect(enableSql).not.toContain(`"c"`);
   });
 
+  it("toggles only the scoped tables and skips the catalog enumeration when a scope is given", async () => {
+    const { host, executed, tablesCalls } = makeHost(["a", "b", "c", "d"]);
+    await disableReferentialIntegrity.call(host, async () => {}, ["b", "c"]);
+    expect(tablesCalls()).toBe(0);
+    const disableSql = executed.find((s) => s.includes("DISABLE TRIGGER ALL"));
+    const enableSql = executed.find((s) => s.includes("ENABLE TRIGGER ALL"));
+    expect(disableSql).toBe(
+      `ALTER TABLE "b" DISABLE TRIGGER ALL;ALTER TABLE "c" DISABLE TRIGGER ALL`,
+    );
+    expect(enableSql).toBe(`ALTER TABLE "b" ENABLE TRIGGER ALL;ALTER TABLE "c" ENABLE TRIGGER ALL`);
+    expect(disableSql).not.toContain(`"a"`);
+  });
+
+  it("runs the block without any ALTER when the scope is empty", async () => {
+    const { host, executed, tablesCalls } = makeHost(["a", "b"]);
+    let ran = false;
+    await disableReferentialIntegrity.call(host, async () => {
+      ran = true;
+    }, []);
+    expect(ran).toBe(true);
+    expect(tablesCalls()).toBe(0);
+    expect(executed).toHaveLength(0);
+  });
+
   it("swallows an enable-pass StatementInvalid when the block dropped a snapshotted table", async () => {
     const host: FakeHost = {
       quoteTableName: (name) => `"${name}"`,

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -7,7 +7,7 @@
 import { ActiveRecordError, InvalidForeignKey } from "../../errors.js";
 
 export interface ReferentialIntegrity {
-  disableReferentialIntegrity(fn: () => Promise<void>): Promise<void>;
+  disableReferentialIntegrity(fn: () => Promise<void>, tables?: string[]): Promise<void>;
   checkAllForeignKeysValidBang(): Promise<void>;
 }
 
@@ -63,22 +63,33 @@ interface ReferentialIntegrityHost extends ReferentialIntegritySqlHost {
   transaction(fn: () => Promise<void>, options: { requiresNew: boolean }): Promise<unknown>;
 }
 
-// Mirrors: ReferentialIntegrity#disable_referential_integrity. Disables every
-// table's triggers (FK checks) inside a requires_new transaction, yields, then
-// re-enables them. Both ALTER passes are wrapped in `requiresNew` so a
-// missing-superuser failure rolls back to the savepoint and leaves any
-// surrounding transaction usable. Only an InvalidForeignKey raised by the block
-// earns the missing-privileges warning; every other error bubbles up unchanged.
+// Mirrors: ReferentialIntegrity#disable_referential_integrity. Disables the
+// triggers (FK checks) on the affected tables inside a requires_new
+// transaction, yields, then re-enables them. Both ALTER passes are wrapped in
+// `requiresNew` so a missing-superuser failure rolls back to the savepoint and
+// leaves any surrounding transaction usable. Only an InvalidForeignKey raised
+// by the block earns the missing-privileges warning; every other error bubbles
+// up unchanged.
+//
+// Rails toggles over the full `tables` set because its fixture load is a single
+// bulk `insert_fixtures_set` per run. trails fires this wrapper per fixture-load
+// and per truncate event (~84k times under RFC 0060's per-test reset), so an
+// ALTER over every canonical table dominates PG DDL cost. Callers that know the
+// exact tables they touch pass `scopedTables`; disabling triggers on just those
+// tables is sufficient because a table's FK-check triggers only fire when that
+// table is itself inserted/deleted/truncated — and those are the only tables the
+// wrapped block touches. Absent a scope, fall back to the whole catalog to
+// preserve the public `disable_referential_integrity` contract.
 export async function disableReferentialIntegrity(
   this: ReferentialIntegrityHost,
   fn: () => Promise<void>,
+  scopedTables?: string[],
 ): Promise<void> {
   let originalException: Error | null = null;
 
-  // Enumerate the catalog once and re-enable exactly the set we disabled.
-  // Re-deriving the list after the block ran would both double the catalog
-  // enumeration (hot under RFC 0060's per-test truncate reset) and risk
-  // re-enabling a different set if the block created/dropped tables.
+  // Snapshot the set once and re-enable exactly what we disabled. Re-deriving
+  // the list after the block ran would risk re-enabling a different set if the
+  // block created/dropped tables.
   //
   // Snapshotting before `fn()` means that if the block drops a table, the
   // ENABLE pass issues `ALTER TABLE <dropped> ENABLE TRIGGER ALL` against a
@@ -86,7 +97,12 @@ export async function disableReferentialIntegrity(
   // translates to StatementInvalid (an ActiveRecordError), so the enable-pass
   // catch below swallows it — same as Rails silently rescues enable-pass
   // errors (referential_integrity.rb:28-34).
-  const tables = await this.tables();
+  const tables = scopedTables ?? (await this.tables());
+
+  if (tables.length === 0) {
+    await fn();
+    return;
+  }
 
   try {
     await this.transaction(

--- a/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/referential-integrity.ts
@@ -80,6 +80,12 @@ interface ReferentialIntegrityHost extends ReferentialIntegritySqlHost {
 // table is itself inserted/deleted/truncated — and those are the only tables the
 // wrapped block touches. Absent a scope, fall back to the whole catalog to
 // preserve the public `disable_referential_integrity` contract.
+//
+// The `scopedTables` parameter has no Rails counterpart (the method is zero-arg
+// in every adapter); it is a tracked deviation pending convergence — see RFC
+// 0060 story `converge-referential-integrity-zero-arg-shape` (hoist the
+// fixture-load flow to one block per set, matching Rails' insert_fixtures_set,
+// then drop the parameter).
 export async function disableReferentialIntegrity(
   this: ReferentialIntegrityHost,
   fn: () => Promise<void>,
@@ -99,21 +105,22 @@ export async function disableReferentialIntegrity(
   // errors (referential_integrity.rb:28-34).
   const tables = scopedTables ?? (await this.tables());
 
-  if (tables.length === 0) {
-    await fn();
-    return;
-  }
-
-  try {
-    await this.transaction(
-      async () => {
-        await this.execute(disableReferentialIntegritySql.call(this, tables).join(";"));
-      },
-      { requiresNew: true },
-    );
-  } catch (e) {
-    if (e instanceof ActiveRecordError) originalException = e as Error;
-    else throw e;
+  // An empty scope has no triggers to toggle, so skip both ALTER passes — but
+  // still route `fn()` through the shared catch below so an InvalidForeignKey it
+  // raises earns the missing-privileges warning Rails always prints
+  // (referential_integrity.rb:20-30), matching the non-empty path.
+  if (tables.length > 0) {
+    try {
+      await this.transaction(
+        async () => {
+          await this.execute(disableReferentialIntegritySql.call(this, tables).join(";"));
+        },
+        { requiresNew: true },
+      );
+    } catch (e) {
+      if (e instanceof ActiveRecordError) originalException = e as Error;
+      else throw e;
+    }
   }
 
   try {
@@ -129,6 +136,8 @@ export async function disableReferentialIntegrity(
     }
     throw e;
   }
+
+  if (tables.length === 0) return;
 
   try {
     await this.transaction(


### PR DESCRIPTION
## Summary

The PostgreSQL `disableReferentialIntegrity` wrapper toggled FK triggers over **every table in the database** (`this.tables()`) on every fixture-load and truncate event. Rails does the same over its full table set because its fixture load is a single bulk `insert_fixtures_set` per run, but trails fires the wrapper per load/truncate (~84k events under RFC 0060's per-test reset), making the `ALTER TABLE … DISABLE/ENABLE TRIGGER ALL` over ~330 canonical tables the dominant PG DDL cost (**69% of PG DDL ms** per PR #4499's profile).

## Change

`disableReferentialIntegrity` now accepts an optional scoped table list. The `truncateTables` and `insertFixturesSet` call sites already know exactly which tables they touch, so they pass that set:
- truncate → the `filtered` truncate targets
- fixtures → the union of the fixture-set keys and `tablesToDelete`

Disabling triggers on just those tables is sufficient because a table's FK-check triggers only fire when the table itself is inserted/deleted/truncated — the only tables the wrapped block touches. Absent a scope, the wrapper still falls back to the whole catalog (`this.tables()`), preserving the public `disable_referential_integrity` contract; the live-PG adapter tests exercise that fallback path unchanged.

An empty scope now short-circuits: run the block with no ALTER at all (previously an empty catalog still issued two empty `requiresNew` transactions).

## Correctness

FK-check triggers are attached to the table being mutated: INSERT/UPDATE checks live on the *referencing* table, DELETE/UPDATE-of-parent checks live on the *referenced* table. The fixtures path writes exactly the fixture-set tables (inserts) and the delete targets (deletes), so every trigger that could fire is on a table in the scope. Circular FK fixtures still load because both sides are fixture-set keys.

For the truncate path I verified empirically against Postgres 17 that `ALTER TABLE child DISABLE TRIGGER ALL` does **not** bypass the `cannot truncate a table referenced in a foreign key constraint` restriction — that check is independent of trigger state. So the trigger-disable scope has no bearing on the truncate restriction either way, and scoping it to the truncated tables is behavior-neutral for FK integrity.

## Tests

- Module-level: scoped set toggles only those tables and skips the catalog enumeration; empty scope runs the block with no ALTER. Existing whole-catalog snapshot / enable-swallow tests unchanged.
- Call-site: `truncateTables` passes the filtered truncate targets; `insertFixturesSet` passes the de-duplicated union of fixture-set keys and delete targets.

Closes-story: pg-scope-referential-integrity-to-loaded-tables