### PR TITLE
test(test-helpers): drop canonical DROP fan-out from two afterAll(dropAllTables) callers

### DIFF
--- a/packages/activerecord/src/test-helpers/handler-resolved-adapter.test.ts
+++ b/packages/activerecord/src/test-helpers/handler-resolved-adapter.test.ts
@@ -8,9 +8,8 @@
  *      declarations loads its schema via lazy reflection without deadlocking
  *      on SQLite :memory: + pool size 1.
  */
-import { describe, it, beforeAll, afterAll, expect } from "vitest";
+import { describe, it, beforeAll, expect } from "vitest";
 import { Base } from "../base.js";
-import { dropAllTables } from "./drop-all-tables.js";
 import { setupFixtures } from "./fixtures.js";
 
 class HandlerResolvedPost extends Base {
@@ -44,9 +43,10 @@ describe("handler-resolved adapter (Phase D-0)", () => {
     await HandlerResolvedComment.loadSchema();
   });
 
-  afterAll(async () => {
-    await dropAllTables(Base.connection);
-  });
+  // No afterAll(dropAllTables): the lone bespoke `handler_resolved_comments`
+  // table is non-canonical, so the next non-skip file's global truncation reset
+  // (`resetTestTables`, which DROPs every non-canonical table) clears it — no
+  // ~330-table canonical DROP fan-out needed here. (RFC 0060)
 
   it("isConnectedQ() is true after setupHandlerSuite()", () => {
     expect(Base.isConnectedQ()).toBe(true);

--- a/packages/activerecord/src/test-helpers/schema-dumping-helper.test.ts
+++ b/packages/activerecord/src/test-helpers/schema-dumping-helper.test.ts
@@ -3,7 +3,6 @@ import { Base } from "../base.js";
 import { SchemaDumper } from "../schema-dumper.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { setupFixtures } from "./fixtures.js";
-import { dropAllTables } from "./drop-all-tables.js";
 import { dumpAllTableSchema, dumpTableSchema } from "./schema-dumping-helper.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
@@ -15,9 +14,20 @@ beforeAll(() => {
   adapter = Base.adapter;
 });
 
+// The bespoke `sdh_*` tables each test creates to exercise the dumper. This
+// suite runs under setupFixtures(), which opts out of the global truncation
+// reset, so nothing clears these between tests in-file — one test reuses
+// `sdh_kept` and would hit "table already exists" if left. Dropping only these
+// named bespoke tables (RFC 0060) replaces the old afterAll/afterEach
+// dropAllTables' ~330-table canonical DROP fan-out; any leak past the file is
+// swept by the next non-skip file's `resetTestTables`.
+const SDH_TABLES = ["sdh_kept", "sdh_other", "sdh_a", "sdh_b", "sdh_c", "sdh_keep", "sdh_skip"];
+
 describe("SchemaDumpingHelper", () => {
   afterEach(async () => {
-    await dropAllTables(adapter);
+    for (const t of SDH_TABLES) {
+      await adapter.executeMutation(`DROP TABLE IF EXISTS ${adapter.quoteTableName(t)}`);
+    }
   });
 
   it("dumps only the named table", async () => {

--- a/packages/activerecord/src/test-helpers/schema-dumping-helper.test.ts
+++ b/packages/activerecord/src/test-helpers/schema-dumping-helper.test.ts
@@ -14,27 +14,32 @@ beforeAll(() => {
   adapter = Base.adapter;
 });
 
-// The bespoke `sdh_*` tables each test creates to exercise the dumper. This
-// suite runs under setupFixtures(), which opts out of the global truncation
-// reset, so nothing clears these between tests in-file — one test reuses
-// `sdh_kept` and would hit "table already exists" if left. Dropping only these
-// named bespoke tables (RFC 0060) replaces the old afterAll/afterEach
+// Track the bespoke `sdh_*` tables each test creates so afterEach can drop
+// exactly those. This suite runs under setupFixtures(), which opts out of the
+// global truncation reset, so nothing clears these between tests in-file — one
+// test reuses `sdh_kept` and would hit "table already exists" if left. Dropping
+// only the created tables (RFC 0060) replaces the old afterAll/afterEach
 // dropAllTables' ~330-table canonical DROP fan-out; any leak past the file is
-// swept by the next non-skip file's `resetTestTables`.
-const SDH_TABLES = ["sdh_kept", "sdh_other", "sdh_a", "sdh_b", "sdh_c", "sdh_keep", "sdh_skip"];
+// swept by the next non-skip file's `resetTestTables`. Deriving the drop set
+// from `createSdhTable` (rather than a hand-maintained list) keeps it correct
+// as tests are added or renamed.
+const createdTables = new Set<string>();
+async function createSdhTable(name: string, columns = "id INTEGER PRIMARY KEY"): Promise<void> {
+  createdTables.add(name);
+  await adapter.executeMutation(`CREATE TABLE ${name} (${columns})`);
+}
 
 describe("SchemaDumpingHelper", () => {
   afterEach(async () => {
-    for (const t of SDH_TABLES) {
+    for (const t of createdTables) {
       await adapter.executeMutation(`DROP TABLE IF EXISTS ${adapter.quoteTableName(t)}`);
     }
+    createdTables.clear();
   });
 
   it("dumps only the named table", async () => {
-    await adapter.executeMutation(
-      `CREATE TABLE sdh_kept (id INTEGER PRIMARY KEY, name varchar(255))`,
-    );
-    await adapter.executeMutation(`CREATE TABLE sdh_other (id INTEGER PRIMARY KEY)`);
+    await createSdhTable("sdh_kept", "id INTEGER PRIMARY KEY, name varchar(255)");
+    await createSdhTable("sdh_other");
 
     const output = await dumpTableSchema(adapter as unknown as SchemaSource, "sdh_kept");
 
@@ -43,9 +48,9 @@ describe("SchemaDumpingHelper", () => {
   });
 
   it("dumps multiple named tables and excludes the rest", async () => {
-    await adapter.executeMutation(`CREATE TABLE sdh_a (id INTEGER PRIMARY KEY)`);
-    await adapter.executeMutation(`CREATE TABLE sdh_b (id INTEGER PRIMARY KEY)`);
-    await adapter.executeMutation(`CREATE TABLE sdh_c (id INTEGER PRIMARY KEY)`);
+    await createSdhTable("sdh_a");
+    await createSdhTable("sdh_b");
+    await createSdhTable("sdh_c");
 
     const output = await dumpTableSchema(adapter as unknown as SchemaSource, "sdh_a", "sdh_c");
 
@@ -55,7 +60,7 @@ describe("SchemaDumpingHelper", () => {
   });
 
   it("restores SchemaDumper.ignoreTables after the dump", async () => {
-    await adapter.executeMutation(`CREATE TABLE sdh_kept (id INTEGER PRIMARY KEY)`);
+    await createSdhTable("sdh_kept");
     const before = SchemaDumper.ignoreTables;
 
     await dumpTableSchema(adapter as unknown as SchemaSource, "sdh_kept");
@@ -79,8 +84,8 @@ describe("SchemaDumpingHelper", () => {
   });
 
   it("dumpAllTableSchema honors the ignore list", async () => {
-    await adapter.executeMutation(`CREATE TABLE sdh_keep (id INTEGER PRIMARY KEY)`);
-    await adapter.executeMutation(`CREATE TABLE sdh_skip (id INTEGER PRIMARY KEY)`);
+    await createSdhTable("sdh_keep");
+    await createSdhTable("sdh_skip");
 
     const output = await dumpAllTableSchema(adapter as unknown as SchemaSource, ["sdh_skip"]);
 


### PR DESCRIPTION
## What

Audit of the four `afterAll(dropAllTables)` callers in
`packages/activerecord/src/test-helpers/*.test.ts` (RFC 0060, follow-on to
`truncate-based-global-reset`).

Two files (`handler-resolved-adapter.test`, `schema-dumping-helper.test`) used
a `dropAllTables` teardown — a ~330-table canonical `DROP TABLE` fan-out — only
to clear a handful of bespoke tables. Both run under `setupFixtures()`, which
opts the file out of the global truncation reset.

- **handler-resolved-adapter.test**: dropped the `afterAll(dropAllTables)`
  entirely. Its lone bespoke `handler_resolved_comments` table is non-canonical,
  so the next non-skip file's global `resetTestTables` (which DROPs every
  non-canonical table) sweeps it. Missing canonical tables are restored by
  `repairWorkerSchema` at file start regardless.
- **schema-dumping-helper.test**: keeps intra-file cleanup — nothing else clears
  the `sdh_*` tables between its tests (global reset is skipped in-file, and one
  test reuses `sdh_kept`) — but now drops only those named bespoke tables
  instead of every canonical table.

## Intentionally retained

`drop-all-tables.test` and `define-schema.test` self-test the drop/`defineSchema`
machinery; their drops are legitimate and stay. (`define-schema.test`'s
`afterAll` was already a targeted `DROP TABLE ds_probe`, not `dropAllTables`.)

## Verification

Both edited files pass on sqlite. `test:compare` unaffected (no test renames).

Closes-story: audit-afterall-dropalltables-callers