### PR TITLE
ci: shard PG/MariaDB AR suites 2-way with vitest --shard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -916,6 +916,18 @@ jobs:
       needs.changes.outputs.activerecord_affected == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # 2-way file-level shard (RFC 0028 shard-ar-adapter-suites). This suite is
+    # the CI critical path; vitest --shard splits the file set across two free
+    # hosted legs that run concurrently, roughly halving wall time. Each matrix
+    # leg gets its own fresh service container automatically. The `needs` graph
+    # keys on the job id (`postgres-tests`), so the `ci` aggregator sees one
+    # merged result for both legs — no allowlist change needed. The
+    # activerecord-cli E2E step is not sharded, so it runs on shard 1 only (see
+    # its per-step `if:`) to avoid a redundant double-run.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     services:
       # tmpfs: the data dir is mounted in RAM so Postgres' per-DDL fsync
       # traffic (WAL flushes + checkpoints) never hits disk. This suite is
@@ -961,12 +973,15 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
-      - run: pnpm vitest run packages/activerecord/
+      - run: pnpm vitest run packages/activerecord/ --shard=${{ matrix.shard }}/2
         env:
           ARCONN: postgresql
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
           AR_DB_FORKS: 8
-      - run: pnpm vitest run packages/activerecord-cli
+      # CLI E2E is not sharded — run it once, on shard 1 only, to avoid a
+      # redundant double-run across the two legs.
+      - if: ${{ matrix.shard == 1 }}
+        run: pnpm vitest run packages/activerecord-cli
         env:
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
 
@@ -1049,6 +1064,14 @@ jobs:
       needs.changes.outputs.activerecord_affected == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # 2-way file-level shard (RFC 0028 shard-ar-adapter-suites) — see the
+    # postgres-tests job above for the rationale. Each matrix leg gets its own
+    # fresh MariaDB service container; the `needs` graph keys on the job id, so
+    # the `ci` aggregator sees one merged result for both legs.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
     services:
       mariadb:
         image: mariadb:11
@@ -1075,14 +1098,16 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
-      - run: pnpm vitest run packages/activerecord/
+      - run: pnpm vitest run packages/activerecord/ --shard=${{ matrix.shard }}/2
         env:
           ARCONN: mysql2
           MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
           AR_DB_FORKS: 8
       # No MYSQL_TEST_URL: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
-      - run: pnpm vitest run packages/activerecord-cli
+      # CLI E2E is not sharded — run it once, on shard 1 only.
+      - if: ${{ matrix.shard == 1 }}
+        run: pnpm vitest run packages/activerecord-cli
 
   website:
     name: Website

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1529,6 +1529,10 @@ jobs:
                   ;;
                 sqlite-tests|postgres-tests|maria-tests)
                   # AR test skip is legitimate when no AR-affecting paths changed.
+                  # postgres-tests and maria-tests are 2-way `--shard` matrices;
+                  # GitHub collapses both legs into a single result under the job
+                  # id here, so this one case covers all four legs — do NOT add
+                  # per-leg names (they don't exist in the `needs` context).
                   [ "$AR_AFFECTED" = "false" ] && continue
                   ;;
                 actionpack-tests)


### PR DESCRIPTION
## What

Turn the `postgres-tests` and `maria-tests` ActiveRecord jobs into 2-way `strategy.matrix.shard: [1, 2]` matrices and pass `--shard=${{ matrix.shard }}/2` to the main `packages/activerecord/` vitest run.

## Why

The PG/MariaDB AR suites are the CI critical path — on green main run 28704587770 the PostgreSQL job took 15m29s and MariaDB 12m44s, while every other job finishes in ≤4 min, so time-to-green ≈ the PG lane. The PR #4528 DDL re-profile shows DDL is no longer the dominant cost outside PG referential integrity, so the residual vitest time is test execution and the remaining wall-time lever is parallelism.

RFC 0028's rejected dimensions were paid larger/self-hosted runners and adapter sampling — sharding across additional _free hosted_ jobs respects both rejections. The PR concurrency guard already cancels superseded runs, bounding pool cost.

## How

- `strategy.matrix.shard: [1, 2]` (with `fail-fast: false`) on both jobs; each matrix leg gets its own fresh service container automatically.
- `--shard=${{ matrix.shard }}/2` on the main suite — vitest file-level sharding, full coverage across the two legs with no file skipped or double-run.
- The activerecord-cli E2E run is not sharded, so it runs on shard 1 only (`if: matrix.shard == 1`) to avoid a redundant double-run.
- The `ci` aggregator's `needs` graph keys on the job id, so both matrix legs collapse to a single `postgres-tests` / `maria-tests` result — the existing skip-allowlist and failure detection work unchanged.
- `sqlite-tests` left unsharded (not on the critical path).

Expected impact: PG lane 929s → ~500s, MariaDB 764s → ~430s; roughly 40–45% off time-to-green. Per RFC 0028's measurement protocol, merge only on measured median improvement across ≥5 runs.

Closes-story: shard-ar-adapter-suites

---

## Review follow-up: branch-protection required-check names

A review flagged that matrix jobs post per-leg check runs (`postgres-tests (1)`/`(2)`) rather than a bare `postgres-tests`, which could strand required checks. Verified this is a non-issue: the repo `main` ruleset lists **only the aggregate `CI` job** as a required status check (confirmed via `gh api repos/.../rulesets`) — no per-job checks are required by name. This matches the convention documented at `ci.yml:30-36`. The `CI` job aggregates the matrix legs through `needs` (fails if any leg fails, succeeds only if all do), so required-check enforcement is unaffected.
