### PR TITLE
test(schema-dumper): scope full-schema dumps off the empty-DB assumption

### DIFF
--- a/packages/activerecord/src/comment.test.ts
+++ b/packages/activerecord/src/comment.test.ts
@@ -9,8 +9,7 @@ import { MigrationContext } from "./migration.js";
 import { adapterType } from "./test-adapter.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { itIfSupports } from "./test-helpers/supports.js";
-import { dumpTableSchema } from "./test-helpers/schema-dumping-helper.js";
-import type { SchemaSource } from "./schema-dumper.js";
+import { SchemaDumper } from "./schema-dumper.js";
 
 describe("CommentTest", () => {
   // Ride the boot-laid `Base.connection` (single-pool test model) rather than a
@@ -142,7 +141,7 @@ describe("CommentTest", () => {
     await ctx.changeColumn("commenteds", "obvious", "string", { comment: null as any });
     // Scope to the table under assertion so the dump stays cheap on a cold
     // schema cache (the truncate-reset leaves the ~330 canonical tables in place).
-    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "commenteds");
+    const output = await SchemaDumper.dumpTableSchema(adapter, "commenteds");
     expect(output).toMatch(/createTable.*"commenteds".*comment:\s*"A table with comment"/);
     expect(output).toMatch(
       /t\.\w+\("name"[^)]*\{[^}]*comment:\s*"Comment should help clarify the column purpose"/,
@@ -157,7 +156,7 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "schema dump omits blank comments", async () => {
-    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "blank_comments");
+    const output = await SchemaDumper.dumpTableSchema(adapter, "blank_comments");
     expect(output).toMatch(/createTable.*"blank_comments"/);
     expect(output).not.toMatch(/createTable.*"blank_comments".*comment:/);
     for (const field of ["space_comment", "empty_comment", "nil_comment", "absent_comment"]) {
@@ -202,7 +201,7 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "schema dump with primary key comment", async () => {
-    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "pk_commenteds");
+    const output = await SchemaDumper.dumpTableSchema(adapter, "pk_commenteds");
     // Tight: the id hash must carry ONLY the comment (no limit/precision/scale/autoIncrement
     // leak), and the table comment must be separate. Catches the columnSpecForPrimaryKey
     // wrapping regression.

--- a/packages/activerecord/src/comment.test.ts
+++ b/packages/activerecord/src/comment.test.ts
@@ -9,6 +9,8 @@ import { MigrationContext } from "./migration.js";
 import { adapterType } from "./test-adapter.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { itIfSupports } from "./test-helpers/supports.js";
+import { dumpTableSchema } from "./test-helpers/schema-dumping-helper.js";
+import type { SchemaSource } from "./schema-dumper.js";
 
 describe("CommentTest", () => {
   // Ride the boot-laid `Base.connection` (single-pool test model) rather than a
@@ -131,7 +133,6 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "schema dump with comments", async () => {
-    const { SchemaDumper } = await import("./schema-dumper.js");
     await ctx.addColumn("commenteds", "rating", "integer", {
       comment: "I am running out of imagination",
     });
@@ -139,7 +140,9 @@ describe("CommentTest", () => {
       comment: "Whoa, content describes itself!",
     });
     await ctx.changeColumn("commenteds", "obvious", "string", { comment: null as any });
-    const output = await SchemaDumper.dump(adapter);
+    // Scope to the table under assertion so the dump stays cheap on a cold
+    // schema cache (the truncate-reset leaves the ~330 canonical tables in place).
+    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "commenteds");
     expect(output).toMatch(/createTable.*"commenteds".*comment:\s*"A table with comment"/);
     expect(output).toMatch(
       /t\.\w+\("name"[^)]*\{[^}]*comment:\s*"Comment should help clarify the column purpose"/,
@@ -154,8 +157,7 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "schema dump omits blank comments", async () => {
-    const { SchemaDumper } = await import("./schema-dumper.js");
-    const output = await SchemaDumper.dump(adapter);
+    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "blank_comments");
     expect(output).toMatch(/createTable.*"blank_comments"/);
     expect(output).not.toMatch(/createTable.*"blank_comments".*comment:/);
     for (const field of ["space_comment", "empty_comment", "nil_comment", "absent_comment"]) {
@@ -200,8 +202,7 @@ describe("CommentTest", () => {
   });
 
   itIfSupports("comments", "schema dump with primary key comment", async () => {
-    const { SchemaDumper } = await import("./schema-dumper.js");
-    const output = await SchemaDumper.dump(adapter);
+    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "pk_commenteds");
     // Tight: the id hash must carry ONLY the comment (no limit/precision/scale/autoIncrement
     // leak), and the table comment must be separate. Catches the columnSpecForPrimaryKey
     // wrapping regression.

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -812,7 +812,7 @@ describe("SchemaDumperTest", () => {
     "schema dump with timestamptz datetime format",
     async () => {
       await withPostgresqlDatetimeType("timestamptz", async () => {
-        await ctx.createTable("timestamps", {}, (t) => {
+        await ctx.createTable("timestamps", { force: true }, (t) => {
           t.datetime("this_should_remain_datetime");
           (t as any).timestamptz("this_is_an_alias_of_datetime");
           t.column("without_time_zone", "timestamp");
@@ -842,7 +842,7 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")(
     "schema dump when changing datetime type for an existing app",
     async () => {
-      await ctx.createTable("timestamps", {}, (t) => {
+      await ctx.createTable("timestamps", { force: true }, (t) => {
         t.datetime("default_format");
         t.column("without_time_zone", "timestamp");
         t.column("with_time_zone", "timestamptz");
@@ -864,7 +864,7 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")(
     "schema dump with correct timestamp types via create table and t timestamptz",
     async () => {
-      await ctx.createTable("timestamps", {}, (t) => {
+      await ctx.createTable("timestamps", { force: true }, (t) => {
         t.datetime("default_format");
         t.datetime("without_time_zone");
         t.timestamp("also_without_time_zone");
@@ -934,7 +934,7 @@ describe("SchemaDumperDefaultsTest", () => {
   });
 
   it("schema dump defaults with universally supported types", async () => {
-    await ctx.createTable("dump_defaults", {}, (t) => {
+    await ctx.createTable("dump_defaults", { force: true }, (t) => {
       t.string("string_with_default", { default: "Hello!" });
       t.date("date_with_default", { default: "2014-06-05" });
       t.datetime("datetime_with_default", { default: "2014-06-05 07:17:04" });
@@ -949,7 +949,7 @@ describe("SchemaDumperDefaultsTest", () => {
 
   // MySQL 8 strict mode forbids TEXT column defaults; MariaDB allowed them.
   itIfSupports("text_column_with_default", "schema dump with text column", async () => {
-    await ctx.createTable("dump_defaults", {}, (t) => {
+    await ctx.createTable("dump_defaults", { force: true }, (t) => {
       t.text("text_with_default", { default: "John" });
     });
     const output = SchemaDumper.dump(ctx);

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -327,9 +327,10 @@ describe("SchemaDumperTest", () => {
   beforeEach(() => {
     // Each case builds its own bespoke tables and dumps only those — `ctx`
     // dumps use MigrationContext's in-memory table set, and adapter dumps go
-    // through the scoped `dumpTableSchema(adapter, ...ownTables)` helper. So
-    // the ~330 canonical tables the truncate-reset preserves never enter the
-    // dump: no empty-DB precondition (and no drop-all crutch) is needed.
+    // through `SchemaDumper.dumpTableSchema(adapter, name)`, which introspects
+    // only the named table (no `tables()` enumeration of the ~330 canonical
+    // tables the truncate-reset preserves). So none of them enter the dump's
+    // output/timing: no empty-DB precondition (and no drop-all crutch) needed.
     ctx = new MigrationContext(Base.connection);
   });
   afterEach(() => {
@@ -413,7 +414,7 @@ describe("SchemaDumperTest", () => {
     await ss.addCheckConstraint("products", "price > discounted_price", {
       name: "products_price_check",
     });
-    const output = await dumpTableSchema(testAdapter as unknown as SchemaSource, "products");
+    const output = await SchemaDumper.dumpTableSchema(testAdapter, "products");
     expect(output).toContain("products_price_check");
     expect(output).toContain("t.checkConstraint");
   });
@@ -429,10 +430,7 @@ describe("SchemaDumperTest", () => {
       "daterange(start_date, end_date) WITH &&",
       { using: "gist", name: "test_schema_exclusion_date_overlap" },
     );
-    const output = await dumpTableSchema(
-      testAdapter as unknown as SchemaSource,
-      "test_schema_exclusion",
-    );
+    const output = await SchemaDumper.dumpTableSchema(testAdapter, "test_schema_exclusion");
     expect(output).toContain("addExclusionConstraint");
     expect(output).toContain("test_schema_exclusion_date_overlap");
     expect(output).toContain("daterange(start_date, end_date) WITH &&");
@@ -451,10 +449,7 @@ describe("SchemaDumperTest", () => {
       nullsNotDistinct: true,
       name: "test_schema_unique_position_2_nnd",
     });
-    const output = await dumpTableSchema(
-      testAdapter as unknown as SchemaSource,
-      "test_schema_unique",
-    );
+    const output = await SchemaDumper.dumpTableSchema(testAdapter, "test_schema_unique");
     expect(output).toContain("addUniqueConstraint");
     expect(output).toContain("test_schema_unique_position_1");
     expect(output).toContain("test_schema_unique_position_2_nnd");
@@ -472,10 +467,7 @@ describe("SchemaDumperTest", () => {
       await (testAdapter as any).addUniqueConstraint("test_uc_no_idx", ["position"], {
         name: "test_uc_no_idx_position",
       });
-      const output = await dumpTableSchema(
-        testAdapter as unknown as SchemaSource,
-        "test_uc_no_idx",
-      );
+      const output = await SchemaDumper.dumpTableSchema(testAdapter, "test_uc_no_idx");
       expect(output).toContain("addUniqueConstraint");
       // The backing index must not also appear as an addIndex call.
       expect(output).not.toMatch(/addIndex.*test_uc_no_idx.*test_uc_no_idx_position/);
@@ -506,7 +498,7 @@ describe("SchemaDumperTest", () => {
         t.binary("var_binary", { limit: 255 });
         t.binary("var_binary_large", { limit: 4095 });
       });
-      const output = await dumpTableSchema(adapter as unknown as SchemaSource, "binary_fields");
+      const output = await SchemaDumper.dumpTableSchema(adapter, "binary_fields");
       expect(output).toMatch(/t\.binary\("var_binary", \{ limit: 255 \}\)/);
       expect(output).toMatch(/t\.binary\("var_binary_large", \{ limit: 4095 \}\)/);
     },
@@ -526,7 +518,7 @@ describe("SchemaDumperTest", () => {
         t.text("medium_text", { size: "medium" });
         t.text("long_text", { size: "long" });
       });
-      const output = await dumpTableSchema(bfAdapter as unknown as SchemaSource, "binary_fields");
+      const output = await SchemaDumper.dumpTableSchema(bfAdapter, "binary_fields");
       expect(output).toMatch(/t\.binary\("tiny_blob", \{ size: "tiny" \}\)/);
       expect(output).toMatch(/t\.binary\("normal_blob"\)/);
       expect(output).toMatch(/t\.binary\("medium_blob", \{ size: "medium" \}\)/);
@@ -545,7 +537,7 @@ describe("SchemaDumperTest", () => {
       await testCtx.createTable("booleans", { force: true }, (t) => {
         t.boolean("has_fun", { default: false });
       });
-      const output = await dumpTableSchema(adapter as unknown as SchemaSource, "booleans");
+      const output = await SchemaDumper.dumpTableSchema(adapter, "booleans");
       expect(output).not.toMatch(/t\.boolean\("has_fun",.+limit: 1/);
     },
   );
@@ -564,7 +556,7 @@ describe("SchemaDumperTest", () => {
       using: "btree",
       name: "index_key_tests_on_pizza",
     });
-    const output = await dumpTableSchema(ktAdapter as unknown as SchemaSource, "key_tests");
+    const output = await SchemaDumper.dumpTableSchema(ktAdapter, "key_tests");
     expect(output).toContain(
       'addIndex("key_tests", "awesome", { name: "index_key_tests_on_awesome", type: "fulltext" })',
     );
@@ -590,7 +582,7 @@ describe("SchemaDumperTest", () => {
     await testCtx.createTable("bigint_array", { force: true }, (t) => {
       (t as any).integer("big_int_data_points", { limit: 8, array: true });
     });
-    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "bigint_array");
+    const output = await SchemaDumper.dumpTableSchema(adapter, "bigint_array");
     expect(output).toMatch(/t\.bigint\("big_int_data_points", \{ array: true \}\)/);
   });
   it.skipIf(adapterType !== "postgres")(
@@ -602,7 +594,7 @@ describe("SchemaDumperTest", () => {
         t.integer("big_int_data_points", { limit: 8, array: true });
         t.decimal("decimal_array_default", { array: true, default: [1.23, 3.45] });
       });
-      const output = await dumpTableSchema(testAdapter as unknown as SchemaSource, "bigint_array");
+      const output = await SchemaDumper.dumpTableSchema(testAdapter, "bigint_array");
       expect(output).toMatch(
         /t\.decimal\("decimal_array_default",\s*\{[^}]*default:\s*\["1\.23", "3\.45"\][^}]*array:\s*true/,
       );
@@ -615,7 +607,7 @@ describe("SchemaDumperTest", () => {
       (t as any).interval("time_interval");
       (t as any).interval("scaled_time_interval", { precision: 6 });
     });
-    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "postgresql_times");
+    const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_times");
     expect(output).toMatch(/t\.interval\("time_interval"\)/);
     expect(output).toMatch(/t\.interval\("scaled_time_interval", \{ precision: 6 \}\)/);
   });
@@ -625,22 +617,27 @@ describe("SchemaDumperTest", () => {
     await testCtx.createTable("postgresql_oids", {}, (t) => {
       (t as any).oid("obj_id");
     });
-    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "postgresql_oids");
+    const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_oids");
     expect(output).toMatch(/t\.oid\("obj_id"\)/);
   });
   it.skipIf(adapterType !== "postgres")("schema dump includes extensions", async () => {
     const adapter = Base.connection;
     const original = (adapter as any).extensions;
+    // This asserts only the extensions header, but the dumper needs a table to
+    // dump. Dump a single throwaway table via `dumpTableSchema` (which does
+    // NOT enumerate the ~330 canonical tables the truncate-reset preserves)
+    // rather than a full dump, so the header stays cheap under CI fork load.
+    await new MigrationContext(adapter).createTable("schema_dump_probe", { force: true }, (t) => {
+      t.integer("x");
+    });
     try {
-      // No bespoke table here — this asserts only the extensions header. Ignore
-      // every canonical table so the dump stays cheap on a cold schema cache.
       (adapter as any).extensions = async () => ["hstore"];
-      let output = await dumpAllTableSchema(adapter as unknown as SchemaSource, [/.*/]);
+      let output = await SchemaDumper.dumpTableSchema(adapter, "schema_dump_probe");
       expect(output).toContain("These are extensions that must be enabled");
       expect(output).toMatch(/enableExtension\("hstore"\)/);
 
       (adapter as any).extensions = async () => [];
-      output = await dumpAllTableSchema(adapter as unknown as SchemaSource, [/.*/]);
+      output = await SchemaDumper.dumpTableSchema(adapter, "schema_dump_probe");
       expect(output).not.toContain("These are extensions that must be enabled");
       expect(output).not.toContain("enableExtension");
     } finally {
@@ -652,9 +649,12 @@ describe("SchemaDumperTest", () => {
     async () => {
       const adapter = Base.connection;
       const original = (adapter as any).extensions;
+      await new MigrationContext(adapter).createTable("schema_dump_probe", { force: true }, (t) => {
+        t.integer("x");
+      });
       try {
         (adapter as any).extensions = async () => ["uuid-ossp", "xml2", "hstore"];
-        const output = await dumpAllTableSchema(adapter as unknown as SchemaSource, [/.*/]);
+        const output = await SchemaDumper.dumpTableSchema(adapter, "schema_dump_probe");
         const enabled = [...output.matchAll(/enableExtension\("(.+?)"\)/g)].map((m) => m[1]);
         expect(enabled).toEqual(["hstore", "uuid-ossp", "xml2"]);
       } finally {
@@ -668,7 +668,7 @@ describe("SchemaDumperTest", () => {
     await testCtx.createTable("numeric_data", { force: true }, (t) => {
       t.float("temperature_with_limit", { limit: 24 });
     });
-    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "numeric_data");
+    const output = await SchemaDumper.dumpTableSchema(adapter, "numeric_data");
     expect(output).toMatch(/t\.float\("temperature_with_limit", \{ limit: 24 \}\)/);
   });
   it.skipIf(adapterType !== "postgres")(
@@ -676,8 +676,13 @@ describe("SchemaDumperTest", () => {
     async () => {
       const adapter = Base.connection;
       await (adapter as any).createEnum("enum_with_comma", ["value1", "value,2", "value3"]);
+      // Dump a throwaway table (not a full dump) so the enum-type header is
+      // emitted without introspecting the ~330 canonical tables.
+      await new MigrationContext(adapter).createTable("schema_dump_probe", { force: true }, (t) => {
+        t.integer("x");
+      });
       try {
-        const output = await dumpAllTableSchema(adapter as unknown as SchemaSource, [/.*/]);
+        const output = await SchemaDumper.dumpTableSchema(adapter, "schema_dump_probe");
         expect(output).toContain('createEnum("enum_with_comma", ["value1","value,2","value3"])');
       } finally {
         // drop-all-tables (per-test reset) does not drop enum types — clean up
@@ -1004,6 +1009,7 @@ afterAll(async () => {
   await ctx.dropTable("postgresql_oids", o);
   await ctx.dropTable("postgresql_times", o);
   await ctx.dropTable("posts", o);
+  await ctx.dropTable("schema_dump_probe", o);
   await ctx.dropTable("products", o);
   await ctx.dropTable("string_key_objects", o);
   await ctx.dropTable("temp_cache", o);

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -502,7 +502,7 @@ describe("SchemaDumperTest", () => {
     async () => {
       const adapter = Base.connection;
       const testCtx = new MigrationContext(adapter);
-      await testCtx.createTable("binary_fields", {}, (t) => {
+      await testCtx.createTable("binary_fields", { force: true }, (t) => {
         t.binary("var_binary", { limit: 255 });
         t.binary("var_binary_large", { limit: 4095 });
       });
@@ -516,7 +516,7 @@ describe("SchemaDumperTest", () => {
     async () => {
       const bfAdapter = Base.connection;
       const bfCtx = new MigrationContext(bfAdapter);
-      await bfCtx.createTable("binary_fields", {}, (t) => {
+      await bfCtx.createTable("binary_fields", { force: true }, (t) => {
         t.binary("tiny_blob", { size: "tiny" });
         t.binary("normal_blob");
         t.binary("medium_blob", { size: "medium" });
@@ -587,7 +587,7 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")("schema dump includes limit on array type", async () => {
     const adapter = Base.connection;
     const testCtx = new MigrationContext(adapter);
-    await testCtx.createTable("bigint_array", {}, (t) => {
+    await testCtx.createTable("bigint_array", { force: true }, (t) => {
       (t as any).integer("big_int_data_points", { limit: 8, array: true });
     });
     const output = await dumpTableSchema(adapter as unknown as SchemaSource, "bigint_array");
@@ -598,7 +598,7 @@ describe("SchemaDumperTest", () => {
     async () => {
       const testAdapter = Base.connection;
       const testCtx = new MigrationContext(testAdapter);
-      await testCtx.createTable("bigint_array", {}, (t) => {
+      await testCtx.createTable("bigint_array", { force: true }, (t) => {
         t.integer("big_int_data_points", { limit: 8, array: true });
         t.decimal("decimal_array_default", { array: true, default: [1.23, 3.45] });
       });

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -8,7 +8,6 @@ import type { TestDatabaseAdapter } from "./test-adapter.js";
 import { itIfSupports, adapterSupports } from "./test-helpers/supports.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { dumpAllTableSchema, dumpTableSchema } from "./test-helpers/schema-dumping-helper.js";
-import { dropAllTables } from "./test-helpers/drop-all-tables.js";
 import { establishFromTestConfig } from "./test-helpers/test-database-config.js";
 
 // The first describe uses `fixtures({})` (canonical schema + reset shield);
@@ -325,18 +324,13 @@ describe("SchemaDumperTest", () => {
 // adapter tables / reflection fixes — tracked as follow-up stories under RFC 0048.
 describe("SchemaDumperTest", () => {
   let ctx: MigrationContext;
-  beforeEach(async () => {
+  beforeEach(() => {
+    // Each case builds its own bespoke tables and dumps only those — `ctx`
+    // dumps use MigrationContext's in-memory table set, and adapter dumps go
+    // through the scoped `dumpTableSchema(adapter, ...ownTables)` helper. So
+    // the ~330 canonical tables the truncate-reset preserves never enter the
+    // dump: no empty-DB precondition (and no drop-all crutch) is needed.
     ctx = new MigrationContext(Base.connection);
-    // These cases build bespoke tables and dump the whole schema; the global
-    // truncate-reset leaves the ~330 canonical tables in place (only clearing
-    // rows), which would make each full-schema dump introspect all of them and
-    // blow the per-test timeout. Drop to an empty DB so the dumps stay cheap and
-    // deterministic (the old drop-all reset contract these cases were written
-    // against). Carpet-bomb is intentional here: the tables to remove are the
-    // boot-laid canonical set this file did NOT create, so dropTable("…") of
-    // owned tables cannot express it.
-    // eslint-disable-next-line blazetrails/require-table-teardown
-    await dropAllTables(Base.connection);
   });
   afterEach(() => {
     SchemaDumper.ignoreTables = [];
@@ -419,13 +413,11 @@ describe("SchemaDumperTest", () => {
     await ss.addCheckConstraint("products", "price > discounted_price", {
       name: "products_price_check",
     });
-    const output = await SchemaDumper.dump(testAdapter);
+    const output = await dumpTableSchema(testAdapter as unknown as SchemaSource, "products");
     expect(output).toContain("products_price_check");
     expect(output).toContain("t.checkConstraint");
   });
   itIfSupports("exclusion_constraints", "schema dumps exclusion constraints", async () => {
-    const { SchemaDumper: PgSchemaDumper } =
-      await import("./connection-adapters/postgresql/schema-dumper.js");
     const testAdapter = Base.connection;
     const testCtx = new MigrationContext(testAdapter);
     await testCtx.createTable("test_schema_exclusion", { id: false }, (t) => {
@@ -437,14 +429,15 @@ describe("SchemaDumperTest", () => {
       "daterange(start_date, end_date) WITH &&",
       { using: "gist", name: "test_schema_exclusion_date_overlap" },
     );
-    const output = await PgSchemaDumper.dump(testAdapter);
+    const output = await dumpTableSchema(
+      testAdapter as unknown as SchemaSource,
+      "test_schema_exclusion",
+    );
     expect(output).toContain("addExclusionConstraint");
     expect(output).toContain("test_schema_exclusion_date_overlap");
     expect(output).toContain("daterange(start_date, end_date) WITH &&");
   });
   itIfSupports("unique_constraints", "schema dumps unique constraints", async () => {
-    const { SchemaDumper: PgSchemaDumper } =
-      await import("./connection-adapters/postgresql/schema-dumper.js");
     const testAdapter = Base.connection;
     const testCtx = new MigrationContext(testAdapter);
     await testCtx.createTable("test_schema_unique", {}, (t) => {
@@ -458,7 +451,10 @@ describe("SchemaDumperTest", () => {
       nullsNotDistinct: true,
       name: "test_schema_unique_position_2_nnd",
     });
-    const output = await PgSchemaDumper.dump(testAdapter);
+    const output = await dumpTableSchema(
+      testAdapter as unknown as SchemaSource,
+      "test_schema_unique",
+    );
     expect(output).toContain("addUniqueConstraint");
     expect(output).toContain("test_schema_unique_position_1");
     expect(output).toContain("test_schema_unique_position_2_nnd");
@@ -468,8 +464,6 @@ describe("SchemaDumperTest", () => {
     "unique_constraints",
     "schema does not dump unique constraints as indexes",
     async () => {
-      const { SchemaDumper: PgSchemaDumper } =
-        await import("./connection-adapters/postgresql/schema-dumper.js");
       const testAdapter = Base.connection;
       const testCtx = new MigrationContext(testAdapter);
       await testCtx.createTable("test_uc_no_idx", {}, (t) => {
@@ -478,7 +472,10 @@ describe("SchemaDumperTest", () => {
       await (testAdapter as any).addUniqueConstraint("test_uc_no_idx", ["position"], {
         name: "test_uc_no_idx_position",
       });
-      const output = await PgSchemaDumper.dump(testAdapter);
+      const output = await dumpTableSchema(
+        testAdapter as unknown as SchemaSource,
+        "test_uc_no_idx",
+      );
       expect(output).toContain("addUniqueConstraint");
       // The backing index must not also appear as an addIndex call.
       expect(output).not.toMatch(/addIndex.*test_uc_no_idx.*test_uc_no_idx_position/);
@@ -509,7 +506,7 @@ describe("SchemaDumperTest", () => {
         t.binary("var_binary", { limit: 255 });
         t.binary("var_binary_large", { limit: 4095 });
       });
-      const output = await SchemaDumper.dump(adapter);
+      const output = await dumpTableSchema(adapter as unknown as SchemaSource, "binary_fields");
       expect(output).toMatch(/t\.binary\("var_binary", \{ limit: 255 \}\)/);
       expect(output).toMatch(/t\.binary\("var_binary_large", \{ limit: 4095 \}\)/);
     },
@@ -529,7 +526,7 @@ describe("SchemaDumperTest", () => {
         t.text("medium_text", { size: "medium" });
         t.text("long_text", { size: "long" });
       });
-      const output = await SchemaDumper.dump(bfAdapter);
+      const output = await dumpTableSchema(bfAdapter as unknown as SchemaSource, "binary_fields");
       expect(output).toMatch(/t\.binary\("tiny_blob", \{ size: "tiny" \}\)/);
       expect(output).toMatch(/t\.binary\("normal_blob"\)/);
       expect(output).toMatch(/t\.binary\("medium_blob", \{ size: "medium" \}\)/);
@@ -548,7 +545,7 @@ describe("SchemaDumperTest", () => {
       await testCtx.createTable("booleans", { force: true }, (t) => {
         t.boolean("has_fun", { default: false });
       });
-      const output = await SchemaDumper.dump(adapter);
+      const output = await dumpTableSchema(adapter as unknown as SchemaSource, "booleans");
       expect(output).not.toMatch(/t\.boolean\("has_fun",.+limit: 1/);
     },
   );
@@ -567,7 +564,7 @@ describe("SchemaDumperTest", () => {
       using: "btree",
       name: "index_key_tests_on_pizza",
     });
-    const output = await SchemaDumper.dump(ktAdapter);
+    const output = await dumpTableSchema(ktAdapter as unknown as SchemaSource, "key_tests");
     expect(output).toContain(
       'addIndex("key_tests", "awesome", { name: "index_key_tests_on_awesome", type: "fulltext" })',
     );
@@ -593,21 +590,19 @@ describe("SchemaDumperTest", () => {
     await testCtx.createTable("bigint_array", {}, (t) => {
       (t as any).integer("big_int_data_points", { limit: 8, array: true });
     });
-    const output = await SchemaDumper.dump(adapter);
+    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "bigint_array");
     expect(output).toMatch(/t\.bigint\("big_int_data_points", \{ array: true \}\)/);
   });
   it.skipIf(adapterType !== "postgres")(
     "schema dump allows array of decimal defaults",
     async () => {
-      const { SchemaDumper: PgSchemaDumper } =
-        await import("./connection-adapters/postgresql/schema-dumper.js");
       const testAdapter = Base.connection;
       const testCtx = new MigrationContext(testAdapter);
       await testCtx.createTable("bigint_array", {}, (t) => {
         t.integer("big_int_data_points", { limit: 8, array: true });
         t.decimal("decimal_array_default", { array: true, default: [1.23, 3.45] });
       });
-      const output = await PgSchemaDumper.dump(testAdapter);
+      const output = await dumpTableSchema(testAdapter as unknown as SchemaSource, "bigint_array");
       expect(output).toMatch(
         /t\.decimal\("decimal_array_default",\s*\{[^}]*default:\s*\["1\.23", "3\.45"\][^}]*array:\s*true/,
       );
@@ -620,7 +615,7 @@ describe("SchemaDumperTest", () => {
       (t as any).interval("time_interval");
       (t as any).interval("scaled_time_interval", { precision: 6 });
     });
-    const output = await SchemaDumper.dump(adapter);
+    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "postgresql_times");
     expect(output).toMatch(/t\.interval\("time_interval"\)/);
     expect(output).toMatch(/t\.interval\("scaled_time_interval", \{ precision: 6 \}\)/);
   });
@@ -630,22 +625,22 @@ describe("SchemaDumperTest", () => {
     await testCtx.createTable("postgresql_oids", {}, (t) => {
       (t as any).oid("obj_id");
     });
-    const output = await SchemaDumper.dump(adapter);
+    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "postgresql_oids");
     expect(output).toMatch(/t\.oid\("obj_id"\)/);
   });
   it.skipIf(adapterType !== "postgres")("schema dump includes extensions", async () => {
-    const { SchemaDumper: PgSchemaDumper } =
-      await import("./connection-adapters/postgresql/schema-dumper.js");
     const adapter = Base.connection;
     const original = (adapter as any).extensions;
     try {
+      // No bespoke table here — this asserts only the extensions header. Ignore
+      // every canonical table so the dump stays cheap on a cold schema cache.
       (adapter as any).extensions = async () => ["hstore"];
-      let output = await PgSchemaDumper.dump(adapter);
+      let output = await dumpAllTableSchema(adapter as unknown as SchemaSource, [/.*/]);
       expect(output).toContain("These are extensions that must be enabled");
       expect(output).toMatch(/enableExtension\("hstore"\)/);
 
       (adapter as any).extensions = async () => [];
-      output = await PgSchemaDumper.dump(adapter);
+      output = await dumpAllTableSchema(adapter as unknown as SchemaSource, [/.*/]);
       expect(output).not.toContain("These are extensions that must be enabled");
       expect(output).not.toContain("enableExtension");
     } finally {
@@ -655,13 +650,11 @@ describe("SchemaDumperTest", () => {
   it.skipIf(adapterType !== "postgres")(
     "schema dump includes extensions in alphabetic order",
     async () => {
-      const { SchemaDumper: PgSchemaDumper } =
-        await import("./connection-adapters/postgresql/schema-dumper.js");
       const adapter = Base.connection;
       const original = (adapter as any).extensions;
       try {
         (adapter as any).extensions = async () => ["uuid-ossp", "xml2", "hstore"];
-        const output = await PgSchemaDumper.dump(adapter);
+        const output = await dumpAllTableSchema(adapter as unknown as SchemaSource, [/.*/]);
         const enabled = [...output.matchAll(/enableExtension\("(.+?)"\)/g)].map((m) => m[1]);
         expect(enabled).toEqual(["hstore", "uuid-ossp", "xml2"]);
       } finally {
@@ -675,7 +668,7 @@ describe("SchemaDumperTest", () => {
     await testCtx.createTable("numeric_data", { force: true }, (t) => {
       t.float("temperature_with_limit", { limit: 24 });
     });
-    const output = await SchemaDumper.dump(adapter);
+    const output = await dumpTableSchema(adapter as unknown as SchemaSource, "numeric_data");
     expect(output).toMatch(/t\.float\("temperature_with_limit", \{ limit: 24 \}\)/);
   });
   it.skipIf(adapterType !== "postgres")(
@@ -684,7 +677,7 @@ describe("SchemaDumperTest", () => {
       const adapter = Base.connection;
       await (adapter as any).createEnum("enum_with_comma", ["value1", "value,2", "value3"]);
       try {
-        const output = await SchemaDumper.dump(adapter);
+        const output = await dumpAllTableSchema(adapter as unknown as SchemaSource, [/.*/]);
         expect(output).toContain('createEnum("enum_with_comma", ["value1","value,2","value3"])');
       } finally {
         // drop-all-tables (per-test reset) does not drop enum types — clean up
@@ -932,13 +925,12 @@ describe("SchemaDumperTest", () => {
 describe("SchemaDumperDefaultsTest", () => {
   let ctx: MigrationContext;
   let adapter: TestDatabaseAdapter;
-  beforeEach(async () => {
+  beforeEach(() => {
     adapter = Base.connection;
     ctx = new MigrationContext(adapter);
-    // See SchemaDumperTest beforeEach: drop to an empty DB so full-schema dumps
-    // don't introspect the ~330 canonical tables the truncate-reset preserves.
-    // eslint-disable-next-line blazetrails/require-table-teardown
-    await dropAllTables(adapter);
+    // See SchemaDumperTest beforeEach: `ctx` dumps are scoped to the in-memory
+    // table set and the adapter case uses `dumpTableSchema`, so no empty-DB
+    // precondition is needed.
   });
 
   it("schema dump defaults with universally supported types", async () => {


### PR DESCRIPTION
## What

Removes the empty-DB precondition (and the `dropAllTables` `beforeEach`
crutch) from the full-schema-dump tests, scoping each dump to only the table
the test builds so the ~330 canonical tables never enter the dump's
output/timing.

The truncate-based global reset (PR #4504) leaves the ~330 canonical tables in
place between tests, so a full `SchemaDumper.dump(adapter)` introspects all of
them and blows the 5s per-test timeout under CI PG fork load. PR #4504 papered
over this by giving the two bespoke `SchemaDumperTest` /
`SchemaDumperDefaultsTest` describes a `dropAllTables(...)` `beforeEach` (with
an `eslint-disable blazetrails/require-table-teardown`). That crutch is a
deviation, and the same latent slowdown lives in sibling files that dump on the
pooled adapter and pass only because the connection's schema cache is warm.

## Changes

- **`schema-dumper.test.ts`**: drop the `dropAllTables` `beforeEach` + its
  `eslint-disable` from both bespoke describes and remove the unused import.
  Route every adapter-level dump through
  `SchemaDumper.dumpTableSchema(adapter, name)` — the non-enumerating scoped
  dump already used for `infinity_defaults`, which introspects only the named
  table and never calls `adapter.tables()`. The extension/enum header cases
  build no table of their own, so they dump a throwaway `schema_dump_probe`
  (dropped in the file `afterAll`) to emit the header cheaply.
- **`comment.test.ts`**: same treatment for its three dumps (`commenteds`,
  `blank_comments`, `pk_commenteds`).
- **`date-time-precision.test.ts` / `time-precision.test.ts`**: no change —
  they dump a `MigrationContext`, whose `tables()` returns the in-memory table
  set, so they are already scoped and robust to a cold cache.
- Reused bespoke table names (`bigint_array`, `binary_fields`, `timestamps`,
  `dump_defaults`) get `{ force: true }` on every create, since without the
  drop-all `beforeEach` those real tables now persist across tests.

## Why the first approach (scoped test helper) was not enough

The initial revision used the Rails-mirroring `dumpTableSchema(source,
...tables)` / `dumpAllTableSchema(source, [/.*/])` test helpers. Those still
call `adapter.tables()` to build their ignore list — one catalog query that
enumerates all ~330 tables. Under CI PG fork load that enumeration alone kept
the extension/enum/float4 cases over the 5s timeout. The static
`SchemaDumper.dumpTableSchema(adapter, name)` skips enumeration entirely.

## Verification

Local PostgreSQL run of the previously-failing cases (extensions ×2, enum,
float4): each dropped from a 5s timeout to **48–110ms**; full file 60 passed /
8 skipped. `comment.test.ts`: 17 passed on PG. sqlite: 41 passed / 27 skipped.
No test-name changes (they match Rails). No new `dropAllTables` callers.

Closes-story: scope-full-schema-dump-tests-off-empty-db
