### PR TITLE
refactor(calculations): fold composite-key eager count/aggregate onto build_joins

### DIFF
--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -579,7 +579,18 @@ async function groupedCompositeAssoc(
   const aggNode = buildAggNode(rel, fn, column, rel._isDistinct);
   const projections = groupNodes.map((n, i) => new Nodes.As(n, new Nodes.SqlLiteral(aliases[i])));
   const manager = table.project(...projections, aggNode.as("val"));
-  rel._applyJoinsToManager(manager);
+  // Rails `calculate` (calculations.rb:217-238) folds the eager JoinDependency
+  // into `joins_values` via `apply_join_dependency` before dispatching to the
+  // grouped calculation, regardless of key arity. Fold it into the shared
+  // `build_joins` port so the eager JD and any manual joins share ONE
+  // `AliasTracker` and dedup via `walk`, mirroring `singleAggregate`/
+  // `groupedAggregate`.
+  const allEagerCa = collectEagerSpecs(rel);
+  const eagerJdCa =
+    allEagerCa.length > 0
+      ? QueryMethodBangs.constructJoinDependency.call(rel as any, allEagerCa, Nodes.OuterJoin)
+      : undefined;
+  rel._applyJoinsToManager(manager, eagerJdCa);
   rel._applyWheresToManager(manager, table);
   applyFromToManager(rel, manager);
   for (const n of groupNodes) manager.group(n);
@@ -779,6 +790,56 @@ export async function performCount(
         );
         const rows = result.toArray();
         return Number(rows[0]?.count ?? 0);
+      } else {
+        // Composite-PK eager count. Rails `calculate` (calculations.rb:231-238)
+        // sets `select_values = Array(model.primary_key)` and recurses with
+        // `distinct!`, counting over the multi-column PK. `COUNT(DISTINCT c1,
+        // c2)` isn't valid SQL on SQLite/PG, so a specific requested column is
+        // counted distinctly inline while `count(*)` wraps a DISTINCT-pk-columns
+        // subquery (mirroring the non-eager composite path). The eager JD folds
+        // through the shared `build_joins` port so one `AliasTracker` spans the
+        // manual joins AND the eager JD.
+        const makeEagerJd = (): JoinDependency =>
+          QueryMethodBangs.constructJoinDependency.call(anyRel, allEager, Nodes.OuterJoin);
+        const table = this._modelClass.arelTable;
+        if (column != null && column !== "*") {
+          const manager = table.project(
+            (aggregateColumn(this, column) as any).count(true).as("count"),
+          );
+          this._applyJoinsToManager(manager, makeEagerJd());
+          this._applyWheresToManager(manager, table);
+          applyFromToManager(this, manager);
+          const [rawSql, managerBinds] = compileManagerWithBinds(this, manager);
+          const [withCtes, ctedBinds] = prependCtes(this, rawSql, managerBinds);
+          const result = await this._conn().selectAll(
+            withCtes,
+            `${this._modelClass.name} Count`,
+            ctedBinds,
+          );
+          return Number(result.toArray()[0]?.count ?? 0);
+        }
+        const innerManager = table.project(...pk.map((c: string) => table.get(c)));
+        innerManager.distinct();
+        this._applyJoinsToManager(innerManager, makeEagerJd());
+        this._applyWheresToManager(innerManager, table);
+        applyFromToManager(this, innerManager);
+        if (this._limitValue !== null) innerManager.take(this._limitValue);
+        if (this._offsetValue !== null) innerManager.skip(this._offsetValue);
+        const [innerSql, allInnerBinds] = compileManagerWithBinds(this, innerManager);
+        const countAll = new Nodes.NamedFunction("COUNT", [new Nodes.SqlLiteral("*")]);
+        const outerManager = table.project(countAll.as("count"));
+        outerManager.from(new Nodes.SqlLiteral(`(${innerSql}) AS subquery`));
+        const [outerSql, outerBinds] = compileManagerWithBinds(this, outerManager);
+        const [withCtes, ctedBinds] = prependCtes(this, outerSql, [
+          ...allInnerBinds,
+          ...outerBinds,
+        ]);
+        const result = await this._conn().selectAll(
+          withCtes,
+          `${this._modelClass.name} Count`,
+          ctedBinds,
+        );
+        return Number(result.toArray()[0]?.count ?? 0);
       }
     }
   }

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -803,6 +803,39 @@ export async function performCount(
           QueryMethodBangs.constructJoinDependency.call(anyRel, allEager, Nodes.OuterJoin);
         const table = this._modelClass.arelTable;
         if (column != null && column !== "*") {
+          // Rails `build_count_subquery` (calculations.rb:662-678): a limit/offset
+          // over an eager-loaded count wraps a DISTINCT-column subquery so the
+          // limit constrains distinct column values before COUNT — rather than
+          // being silently dropped over the fanned LEFT OUTER JOIN. Only the
+          // no-limit case emits the flat `COUNT(DISTINCT col)`.
+          if (this._limitValue !== null || this._offsetValue !== null) {
+            const innerManager = table.project(
+              (aggregateColumn(this, column) as any).as("count_column"),
+            );
+            innerManager.distinct();
+            this._applyJoinsToManager(innerManager, makeEagerJd());
+            this._applyWheresToManager(innerManager, table);
+            applyFromToManager(this, innerManager);
+            if (this._limitValue !== null) innerManager.take(this._limitValue);
+            if (this._offsetValue !== null) innerManager.skip(this._offsetValue);
+            const [innerSql, allInnerBinds] = compileManagerWithBinds(this, innerManager);
+            const countCol = new Nodes.NamedFunction("COUNT", [
+              new Nodes.SqlLiteral("count_column"),
+            ]);
+            const outerManager = table.project(countCol.as("count"));
+            outerManager.from(new Nodes.SqlLiteral(`(${innerSql}) AS subquery_for_count`));
+            const [outerSql, outerBinds] = compileManagerWithBinds(this, outerManager);
+            const [withCtes, ctedBinds] = prependCtes(this, outerSql, [
+              ...allInnerBinds,
+              ...outerBinds,
+            ]);
+            const result = await this._conn().selectAll(
+              withCtes,
+              `${this._modelClass.name} Count`,
+              ctedBinds,
+            );
+            return Number(result.toArray()[0]?.count ?? 0);
+          }
           const manager = table.project(
             (aggregateColumn(this, column) as any).count(true).as("count"),
           );

--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -803,32 +803,49 @@ export async function performCount(
           QueryMethodBangs.constructJoinDependency.call(anyRel, allEager, Nodes.OuterJoin);
         const table = this._modelClass.arelTable;
         if (column != null && column !== "*") {
-          // Rails `build_count_subquery` (calculations.rb:662-678): a limit/offset
-          // over an eager-loaded count wraps a DISTINCT-column subquery so the
-          // limit constrains distinct column values before COUNT — rather than
-          // being silently dropped over the fanned LEFT OUTER JOIN. Only the
-          // no-limit case emits the flat `COUNT(DISTINCT col)`.
           if (this._limitValue !== null || this._offsetValue !== null) {
-            const innerManager = table.project(
-              (aggregateColumn(this, column) as any).as("count_column"),
+            // Rails `apply_join_dependency` (finder_methods.rb:463-478) routes an
+            // eager collection join + limit/offset through
+            // `distinct_relation_for_primary_key` (schema_statements.rb:1429-1452):
+            // materialize the limited DISTINCT pk TUPLES first (bounding which
+            // ROWS participate, joined+ordered), then re-count over
+            // `WHERE pk IN (tuples)` with the limit/offset cleared. So the limit
+            // constrains rows, and `COUNT(DISTINCT column)` runs across only those
+            // rows — NOT a `DISTINCT column ... LIMIT n` value list, which would
+            // truncate distinct values instead of rows.
+            const idSubquery = table.project(...pk.map((c: string) => table.get(c)));
+            idSubquery.distinct();
+            this._applyJoinsToManager(idSubquery, makeEagerJd());
+            this._applyWheresToManager(idSubquery, table);
+            this._applyOrderToManager(idSubquery, table);
+            applyFromToManager(this, idSubquery);
+            if (this._limitValue !== null) idSubquery.take(this._limitValue);
+            if (this._offsetValue !== null) idSubquery.skip(this._offsetValue);
+            const [idSql, idBinds] = compileManagerWithBinds(this, idSubquery);
+            const [idWithCtes, idCtedBinds] = prependCtes(this, idSql, [...idBinds]);
+            const idResult = await this._conn().selectAll(
+              idWithCtes,
+              `${this._modelClass.name} Ids`,
+              idCtedBinds,
             );
-            innerManager.distinct();
-            this._applyJoinsToManager(innerManager, makeEagerJd());
-            this._applyWheresToManager(innerManager, table);
-            applyFromToManager(this, innerManager);
-            if (this._limitValue !== null) innerManager.take(this._limitValue);
-            if (this._offsetValue !== null) innerManager.skip(this._offsetValue);
-            const [innerSql, allInnerBinds] = compileManagerWithBinds(this, innerManager);
-            const countCol = new Nodes.NamedFunction("COUNT", [
-              new Nodes.SqlLiteral("count_column"),
-            ]);
-            const outerManager = table.project(countCol.as("count"));
-            outerManager.from(new Nodes.SqlLiteral(`(${innerSql}) AS subquery_for_count`));
-            const [outerSql, outerBinds] = compileManagerWithBinds(this, outerManager);
-            const [withCtes, ctedBinds] = prependCtes(this, outerSql, [
-              ...allInnerBinds,
-              ...outerBinds,
-            ]);
+            const tuples = idResult.toArray().map((row) => pk.map((c) => row[c]));
+            // `pk IN ()` is invalid SQL — an empty limited set is a no-match → 0.
+            if (tuples.length === 0) return 0;
+
+            const countManager = table.project(
+              (aggregateColumn(this, column) as any).count(true).as("count"),
+            );
+            this._applyJoinsToManager(countManager, makeEagerJd());
+            this._applyWheresToManager(countManager, table);
+            applyFromToManager(this, countManager);
+            // Rails `distinct_relation_for_primary_key` restricts via
+            // `where!(pk.zip(limited_ids.transpose).to_h)` — a per-column `IN`
+            // (`author_id IN (...) AND id IN (...)`), not a tuple `IN`.
+            pk.forEach((c: string, i: number) => {
+              countManager.where(table.get(c).in(tuples.map((t) => t[i])));
+            });
+            const [countSql, countBinds] = compileManagerWithBinds(this, countManager);
+            const [withCtes, ctedBinds] = prependCtes(this, countSql, [...countBinds]);
             const result = await this._conn().selectAll(
               withCtes,
               `${this._modelClass.name} Count`,

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -77,6 +77,30 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     expect(await CpkBook.eagerLoad("chapters").count("cpk_books.revision")).toBe(2);
   });
 
+  it("eager_load(:assoc).limit(n).count(column) respects the limit via a DISTINCT-column subquery", async () => {
+    await seedBooksWithChapters();
+    await CpkBook.create({ author_id: 1, id: 3, title: "Gamma", revision: 3 });
+    let count = 0;
+    const sqls = await captureSql(async () => {
+      count = (await CpkBook.eagerLoad("chapters").limit(2).count("cpk_books.revision")) as number;
+    });
+    // Rails `build_count_subquery` wraps `SELECT DISTINCT revision ... LIMIT 2`
+    // in an outer COUNT, so the limit caps the distinct column values counted (2
+    // of the 3 distinct revisions) rather than being silently dropped.
+    expect(count).toBe(2);
+    const countSql = sqls.find((s) => /count/i.test(s)) ?? "";
+    expect(countSql).toMatch(/subquery_for_count/i);
+    expect(countSql).toMatch(/LIMIT 2/i);
+    expect(countSql).toMatch(/DISTINCT/i);
+  });
+
+  it("eager_load(:assoc).offset(n).count(column) respects the offset via the subquery", async () => {
+    await seedBooksWithChapters();
+    await CpkBook.create({ author_id: 1, id: 3, title: "Gamma", revision: 3 });
+    // 3 distinct revisions; offset(1) drops one → counts 2.
+    expect(await CpkBook.eagerLoad("chapters").offset(1).count("cpk_books.revision")).toBe(2);
+  });
+
   async function seedBooksWithOrders(): Promise<void> {
     await CpkAuthor.create({ id: 1, name: "Author One" });
     await CpkOrder.create({ shop_id: 1, id: 100, status: "open" });

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Composite-key eager count / aggregate folds onto the shared `build_joins`
+ * emitter.
+ *
+ * Two composite-key paths in `calculations.ts` previously skipped the eager
+ * JoinDependency fold that `singleAggregate` / `groupedAggregate` use, diverging
+ * from Rails `apply_join_dependency` (which routes all arities through the one
+ * `build_joins` path):
+ *
+ *   1. `performCount`'s eager branch guarded the DISTINCT-on-pk fan-out block
+ *      with `if (!Array.isArray(pk))`, so a composite-PK model's
+ *      `eager_load(:assoc).count` fell through to the plain count and never
+ *      joined / de-duplicated (Rails `calculate`, calculations.rb:231-238, sets
+ *      `select_values = Array(model.primary_key)` and counts distinctly).
+ *   2. `groupedCompositeAssoc` (grouped calc keyed by a composite-FK belongs_to)
+ *      emitted `_applyJoinsToManager(manager)` WITHOUT the `eagerJd` argument, so
+ *      `eager_load(:x).group(:composite_fk_belongs_to).count/.sum` never folded
+ *      its eager JD through the shared emitter.
+ *
+ * Both now build the eager JD via `collectEagerSpecs` and fold it through
+ * `_applyJoinsToManager(manager, eagerJd)`, so one `AliasTracker` spans the
+ * manual joins and the eager JD (a coinciding association dedups via `walk`).
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { registerModel } from "../associations.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
+import { CpkBook, CpkOrder, CpkAuthor, CpkChapter } from "../test-helpers/models/cpk.js";
+import { captureSql } from "../testing/sql-capture.js";
+import type { Base } from "../index.js";
+
+describe("CpkBook eager count / aggregate build_joins fold", () => {
+  // Rails creates CPK rows inline; ride the canonical, empty cpk tables and let
+  // transactional rollback clean up each insert.
+  fixtures([], { schema: canonicalSchema });
+
+  beforeAll(() => {
+    [CpkBook, CpkOrder, CpkAuthor, CpkChapter].forEach((m) =>
+      registerModel(m as unknown as typeof Base),
+    );
+  });
+
+  async function seedBooksWithChapters(): Promise<void> {
+    await CpkAuthor.create({ id: 1, name: "Author One" });
+    await CpkBook.create({ author_id: 1, id: 1, title: "Alpha", revision: 1 });
+    await CpkBook.create({ author_id: 1, id: 2, title: "Beta", revision: 2 });
+    // Two chapters on book 1 would fan the row count to 3 without DISTINCT.
+    await CpkChapter.create({ author_id: 1, id: 10, book_id: 1, title: "ch-1" });
+    await CpkChapter.create({ author_id: 1, id: 11, book_id: 1, title: "ch-2" });
+  }
+
+  it("eager_load(:assoc).count on a composite-PK model de-duplicates via DISTINCT", async () => {
+    await seedBooksWithChapters();
+    let count = 0;
+    const sqls = await captureSql(async () => {
+      count = (await CpkBook.eagerLoad("chapters").count()) as number;
+    });
+    // Rails folds the eager JD into a LEFT OUTER JOIN and de-duplicates via a
+    // DISTINCT-pk-columns subquery; 2 chapters on book 1 fan to 3 joined rows,
+    // collapsed back to the 2 distinct books.
+    expect(count).toBe(2);
+    const countSql = sqls.find((s) => /count/i.test(s)) ?? "";
+    expect(countSql).toMatch(/LEFT OUTER JOIN .*cpk_chapters/i);
+    expect(countSql).toMatch(/DISTINCT/i);
+  });
+
+  it("eager_load(:assoc).count matches the un-joined count", async () => {
+    await seedBooksWithChapters();
+    // Rails: Cpk::Book.count == Cpk::Book.includes(:chapters).references(:chapters).count
+    expect(await CpkBook.eagerLoad("chapters").count()).toBe(await CpkBook.count());
+  });
+
+  it("eager_load(:assoc).count(column) counts distinct non-null values of the column", async () => {
+    await seedBooksWithChapters();
+    // A specific requested column counts distinctly inline (COUNT(DISTINCT col))
+    // rather than through the pk subquery.
+    expect(await CpkBook.eagerLoad("chapters").count("cpk_books.revision")).toBe(2);
+  });
+
+  async function seedBooksWithOrders(): Promise<void> {
+    await CpkAuthor.create({ id: 1, name: "Author One" });
+    await CpkOrder.create({ shop_id: 1, id: 100, status: "open" });
+    await CpkOrder.create({ shop_id: 1, id: 200, status: "open" });
+    await CpkBook.create({ author_id: 1, id: 1, shop_id: 1, order_id: 100, title: "Alpha" });
+    await CpkBook.create({ author_id: 1, id: 2, shop_id: 1, order_id: 100, title: "Beta" });
+    await CpkBook.create({ author_id: 1, id: 3, shop_id: 1, order_id: 200, title: "Gamma" });
+  }
+
+  it("eager_load(:x).group(:composite_fk_belongs_to).count folds the eager JD", async () => {
+    await seedBooksWithOrders();
+    // group by the composite-FK belongs_to `order`, eager-loading the same
+    // association: `walk` dedups the coinciding join so the grouped count keys
+    // by the loaded Order records.
+    let result!: Map<InstanceType<typeof CpkOrder> | null, number>;
+    const sqls = await captureSql(async () => {
+      result = (await CpkBook.eagerLoad("order").group("order").count()) as Map<
+        InstanceType<typeof CpkOrder> | null,
+        number
+      >;
+    });
+    // The eager `order` JD coincides with the grouped belongs_to; `walk` dedups
+    // it into a single LEFT OUTER JOIN rather than emitting a parallel join.
+    const groupSql = sqls.find((s) => /GROUP BY/i.test(s)) ?? "";
+    expect(groupSql).toMatch(/LEFT OUTER JOIN .*cpk_orders/i);
+    const counts = new Map<unknown, number>();
+    for (const [order, n] of result)
+      counts.set(order === null ? null : (order.id as unknown[])[1], n);
+    expect(counts.get(100)).toBe(2);
+    expect(counts.get(200)).toBe(1);
+  });
+
+  it("eager_load(:x).group(:composite_fk_belongs_to).sum folds the eager JD", async () => {
+    await seedBooksWithOrders();
+    const result = (await CpkBook.eagerLoad("order").group("order").sum("id")) as Map<
+      InstanceType<typeof CpkOrder> | null,
+      number
+    >;
+    const sums = new Map<unknown, number>();
+    for (const [order, n] of result)
+      sums.set(order === null ? null : (order.id as unknown[])[1], n);
+    expect(sums.get(100)).toBe(3); // book ids 1 + 2
+    expect(sums.get(200)).toBe(3); // book id 3
+  });
+});

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -137,25 +137,35 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     await CpkBook.create({ author_id: 1, id: 3, shop_id: 1, order_id: 200, title: "Gamma" });
   }
 
+  // Re-key a Map<Order record, value> by the order's `id` component, coercing
+  // both key and value to Number so the assertions are adapter-agnostic (MySQL /
+  // PG may hand back the composite-id components / aggregate as strings).
+  function byOrderId(result: Map<unknown, unknown>): Map<number | null, number> {
+    const out = new Map<number | null, number>();
+    for (const [order, n] of result) {
+      const key =
+        order === null
+          ? null
+          : Number((order as { _readAttribute(k: string): unknown })._readAttribute("id"));
+      out.set(key, Number(n));
+    }
+    return out;
+  }
+
   it("eager_load(:x).group(:composite_fk_belongs_to).count folds the eager JD", async () => {
     await seedBooksWithOrders();
     // group by the composite-FK belongs_to `order`, eager-loading the same
     // association: `walk` dedups the coinciding join so the grouped count keys
     // by the loaded Order records.
-    let result!: Map<InstanceType<typeof CpkOrder> | null, number>;
+    let result!: Map<unknown, unknown>;
     const sqls = await captureSql(async () => {
-      result = (await CpkBook.eagerLoad("order").group("order").count()) as Map<
-        InstanceType<typeof CpkOrder> | null,
-        number
-      >;
+      result = (await CpkBook.eagerLoad("order").group("order").count()) as Map<unknown, unknown>;
     });
     // The eager `order` JD coincides with the grouped belongs_to; `walk` dedups
     // it into a single LEFT OUTER JOIN rather than emitting a parallel join.
     const groupSql = sqls.find((s) => /GROUP BY/i.test(s)) ?? "";
     expect(groupSql).toMatch(/LEFT OUTER JOIN .*cpk_orders/i);
-    const counts = new Map<unknown, number>();
-    for (const [order, n] of result)
-      counts.set(order === null ? null : (order.id as unknown[])[1], n);
+    const counts = byOrderId(result);
     expect(counts.get(100)).toBe(2);
     expect(counts.get(200)).toBe(1);
   });
@@ -163,12 +173,10 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
   it("eager_load(:x).group(:composite_fk_belongs_to).sum folds the eager JD", async () => {
     await seedBooksWithOrders();
     const result = (await CpkBook.eagerLoad("order").group("order").sum("id")) as Map<
-      InstanceType<typeof CpkOrder> | null,
-      number
+      unknown,
+      unknown
     >;
-    const sums = new Map<unknown, number>();
-    for (const [order, n] of result)
-      sums.set(order === null ? null : (order.id as unknown[])[1], n);
+    const sums = byOrderId(result);
     expect(sums.get(100)).toBe(3); // book ids 1 + 2
     expect(sums.get(200)).toBe(3); // book id 3
   });

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -77,28 +77,55 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     expect(await CpkBook.eagerLoad("chapters").count("cpk_books.revision")).toBe(2);
   });
 
-  it("eager_load(:assoc).limit(n).count(column) respects the limit via a DISTINCT-column subquery", async () => {
-    await seedBooksWithChapters();
-    await CpkBook.create({ author_id: 1, id: 3, title: "Gamma", revision: 3 });
+  async function seedBooksDuplicateRevisions(): Promise<void> {
+    await CpkAuthor.create({ id: 1, name: "Author One" });
+    // Two rows share revision 5; the third has 9. This distinguishes bounding
+    // ROWS (Rails) from bounding distinct VALUES: limit(2) by pk order picks
+    // books 1 & 2 (rev 5, 5) → COUNT(DISTINCT revision) = 1, whereas truncating
+    // the distinct value list {5, 9} to 2 would (wrongly) yield 2.
+    await CpkBook.create({ author_id: 1, id: 1, title: "Alpha", revision: 5 });
+    await CpkBook.create({ author_id: 1, id: 2, title: "Beta", revision: 5 });
+    await CpkBook.create({ author_id: 1, id: 3, title: "Gamma", revision: 9 });
+    // Chapters on book 1 fan the LEFT OUTER JOIN so the DISTINCT-pk id fetch
+    // must de-duplicate.
+    await CpkChapter.create({ author_id: 1, id: 10, book_id: 1, title: "ch-1" });
+    await CpkChapter.create({ author_id: 1, id: 11, book_id: 1, title: "ch-2" });
+  }
+
+  it("eager_load(:assoc).limit(n).count(column) bounds ROWS via a DISTINCT-pk id fetch, then re-counts", async () => {
+    await seedBooksDuplicateRevisions();
     let count = 0;
     const sqls = await captureSql(async () => {
-      count = (await CpkBook.eagerLoad("chapters").limit(2).count("cpk_books.revision")) as number;
+      count = (await CpkBook.eagerLoad("chapters")
+        .order("author_id", "id")
+        .limit(2)
+        .count("cpk_books.revision")) as number;
     });
-    // Rails `build_count_subquery` wraps `SELECT DISTINCT revision ... LIMIT 2`
-    // in an outer COUNT, so the limit caps the distinct column values counted (2
-    // of the 3 distinct revisions) rather than being silently dropped.
-    expect(count).toBe(2);
-    const countSql = sqls.find((s) => /count/i.test(s)) ?? "";
-    expect(countSql).toMatch(/subquery_for_count/i);
-    expect(countSql).toMatch(/LIMIT 2/i);
-    expect(countSql).toMatch(/DISTINCT/i);
+    // Rails `distinct_relation_for_primary_key` materializes the limited DISTINCT
+    // pk tuples (books 1 & 2) then re-counts COUNT(DISTINCT revision) over
+    // `WHERE pk IN (...)` — the two rows both have revision 5, so the answer is 1.
+    // Value-bounding (`DISTINCT revision LIMIT 2`) would wrongly return 2.
+    expect(count).toBe(2 - 1);
+    // A separate DISTINCT-pk id-materialization query runs before the count.
+    const idSql = sqls.find((s) => /DISTINCT.*cpk_books.*author_id/i.test(s) && /LIMIT 2/i.test(s));
+    expect(idSql).toBeTruthy();
+    // The recount restricts via per-column IN (author_id IN ... AND id IN ...),
+    // mirroring Rails' `where!(pk.zip(ids.transpose).to_h)`.
+    const countSql = sqls.find((s) => /COUNT\(DISTINCT/i.test(s)) ?? "";
+    expect(countSql).toMatch(/author_id.*IN/i);
+    expect(countSql).toMatch(/\bid\b.*IN/i);
   });
 
-  it("eager_load(:assoc).offset(n).count(column) respects the offset via the subquery", async () => {
-    await seedBooksWithChapters();
-    await CpkBook.create({ author_id: 1, id: 3, title: "Gamma", revision: 3 });
-    // 3 distinct revisions; offset(1) drops one → counts 2.
-    expect(await CpkBook.eagerLoad("chapters").offset(1).count("cpk_books.revision")).toBe(2);
+  it("eager_load(:assoc).offset(n).count(column) bounds ROWS via the id fetch", async () => {
+    await seedBooksDuplicateRevisions();
+    // order+offset(1) drops book 1 (rev 5); remaining rows are books 2 (rev 5)
+    // and 3 (rev 9) → COUNT(DISTINCT revision) = 2. Value-bounding would offset
+    // into the distinct value list {5, 9} and (wrongly) return 1.
+    const count = await CpkBook.eagerLoad("chapters")
+      .order("author_id", "id")
+      .offset(1)
+      .count("cpk_books.revision");
+    expect(count).toBe(2);
   });
 
   async function seedBooksWithOrders(): Promise<void> {


### PR DESCRIPTION
## Summary

Folds the two composite-key eager count/aggregate paths in
`packages/activerecord/src/relation/calculations.ts` onto the shared
`build_joins` emitter, converging them with Rails `apply_join_dependency`
(which routes all key arities through the one `build_joins` path).

Follow-up to PR #4531, which converged the single-key eager count/aggregate
path but left two composite-key paths out of the fold.

### Changes

1. **Composite-PK single-value eager count** — `performCount`'s eager branch
   guarded the DISTINCT-on-pk fan-out block with `if (!Array.isArray(pk))`, so
   a composite-PK model's `eager_load(:assoc).count` fell through to the plain
   non-eager count and never joined / de-duplicated. Added a composite-PK
   `else` branch that folds the eager JoinDependency via
   `_applyJoinsToManager(manager, eagerJd)` and either counts a requested
   column distinctly inline (`COUNT(DISTINCT col)`) or wraps a
   DISTINCT-pk-columns subquery for `count(*)`, mirroring the non-eager
   composite path and Rails `calculate` (calculations.rb:231-238).

2. **Composite-FK belongs_to group-by eager aggregate** — `groupedCompositeAssoc`
   emitted `_applyJoinsToManager(manager)` without the `eagerJd` argument.
   It now builds the eager JD via `collectEagerSpecs` and folds it through
   `_applyJoinsToManager(manager, eagerJd)`, mirroring `singleAggregate` /
   `groupedAggregate`.

### Tests

- Existing `count for a composite primary key model with includes and
  references` (calculations.test.ts) still passes, now actually folding the JD.
- New `cpk-eager-count-aggregate-build-joins-fold.trails.test.ts` asserts the
  emitted SQL carries the `LEFT OUTER JOIN` + `DISTINCT` for the composite-PK
  eager count, and that `eager_load(:x).group(:composite_fk_belongs_to)
  .count/.sum` folds a single deduped join.

Closes-story: converge-composite-key-eager-count-aggregate-onto-build-joins-emitter