### PR TITLE
refactor(test-helpers): convert remaining defineSchema callers to canonical loader

### DIFF
--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -8,8 +8,7 @@
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import type { TestDatabaseAdapter } from "../test-adapter.js";
 import { establishFromTestConfig } from "../test-helpers/test-database-config.js";
-import { defineSchema, type Schema } from "../test-helpers/define-schema.js";
-import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
+import { ensureCanonicalTables } from "../test-helpers/canonical-schema.js";
 import { Base } from "../index.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
@@ -153,11 +152,11 @@ export const AUTHOR_NAME_LIMIT = 100;
  *   - `EncryptedTrafficLight` / `EncryptedTrafficLightWithStoreState` →
  *     `traffic_lights` (traffic_light_encrypted.rb)
  *
- * All already exist in the canonical `TEST_SCHEMA` with the Rails schema.rb
- * shape, so the fixtures name only canonical tables/columns. Under one-schema
- * mode the tables are already laid into the worker DB and this `defineSchema`
- * call is a canonical no-op; on the default path it lays the full canonical
- * shape once per lease.
+ * All already exist in the canonical schema with the Rails schema.rb shape, so
+ * the fixtures name only canonical tables/columns. Under one-schema mode the
+ * tables are already laid into the worker DB and this ensure-exists call is a
+ * no-op; on the default path it lays each missing canonical table once per
+ * lease. It never drops, so it is safe against the shared `Base.connection`.
  */
 const ENCRYPTION_CANONICAL_TABLES = [
   "posts",
@@ -167,11 +166,7 @@ const ENCRYPTION_CANONICAL_TABLES = [
 ] as const;
 
 export async function installEncryptionSchema(adapter: DatabaseAdapter): Promise<void> {
-  const schema: Schema = {};
-  for (const table of ENCRYPTION_CANONICAL_TABLES) {
-    schema[table] = TEST_SCHEMA[table as keyof typeof TEST_SCHEMA];
-  }
-  await defineSchema(adapter, schema);
+  await ensureCanonicalTables(adapter, ENCRYPTION_CANONICAL_TABLES);
 }
 
 /**

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2130,3 +2130,36 @@ export async function rebuildCanonicalTables(
   }
   (adapter as { clearCacheBang?: () => void }).clearCacheBang?.();
 }
+
+/**
+ * Idempotently lay a named subset of canonical tables, creating each in its full
+ * canonical shape only when it is not already present — the no-drop counterpart
+ * to {@link rebuildCanonicalTables}. Use it against a shared, already-schema-
+ * loaded connection (e.g. `Base.connection`) where dropping an existing table
+ * would clobber data other suites rely on: existing tables are left untouched
+ * and only genuinely-missing ones are created. Throws on an unknown name for the
+ * same reason {@link rebuildCanonicalTables} does.
+ */
+export async function ensureCanonicalTables(
+  adapter: DatabaseAdapter,
+  names: readonly string[],
+): Promise<void> {
+  const registry = await buildCanonicalRegistry();
+  const wanted = new Set(names);
+  const known = new Set(registry.map((d) => d.name));
+  const unknown = [...wanted].filter((n) => !known.has(n));
+  if (unknown.length > 0) {
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(`ensureCanonicalTables: unknown canonical table(s): ${unknown.join(", ")}`);
+  }
+  const defs = registry.filter((d) => wanted.has(d.name));
+  if (defs.length === 0) return;
+  const { ss, typeMap } = await prepareSchema(adapter);
+  let created = false;
+  for (const def of defs) {
+    if (await ss.tableExists(def.name)) continue;
+    await runTable(adapter, ss, typeMap, def);
+    created = true;
+  }
+  if (created) (adapter as { clearCacheBang?: () => void }).clearCacheBang?.();
+}

--- a/packages/activerecord/src/test-helpers/schema-repair.ts
+++ b/packages/activerecord/src/test-helpers/schema-repair.ts
@@ -127,10 +127,10 @@ export function driftedTables(physical: Map<string, Set<string>>, canonical: Sch
  * Restore the canonical shape of every table whose live layout has drifted from
  * `canonical`, returning the repaired table names (empty when nothing drifted).
  *
- * Each drifted table is dropped and recreated from `canonical[table]` via the
- * EXPLICIT-adapter `defineSchema` overload (no eager schema-cache warm; the next
- * read warms on demand). Run at file start, before any test code, so the DB the
- * file sees always matches `TEST_SCHEMA` regardless of what a sibling left.
+ * Each drifted table is dropped and recreated in its full canonical shape via
+ * {@link rebuildCanonicalTables} (no eager schema-cache warm; the next read warms
+ * on demand). Run at file start, before any test code, so the DB the file sees
+ * always matches the canonical schema regardless of what a sibling left.
  */
 export async function repairWorkerSchema(
   adapter: DatabaseAdapter,
@@ -142,9 +142,7 @@ export async function repairWorkerSchema(
   const drifted = driftedTables(physical, canonical);
   if (drifted.length === 0) return [];
 
-  const { defineSchema } = await import("./define-schema.js");
-  for (const table of drifted) {
-    await defineSchema(adapter, { [table]: canonical[table] }, { dropExisting: true });
-  }
+  const { rebuildCanonicalTables } = await import("./canonical-schema.js");
+  await rebuildCanonicalTables(adapter, drifted);
   return drifted;
 }

--- a/packages/activerecord/src/test-helpers/setup-adapter-suite.ts
+++ b/packages/activerecord/src/test-helpers/setup-adapter-suite.ts
@@ -1,16 +1,6 @@
 import { beforeAll, afterAll } from "vitest";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
-import { defineSchema, type Schema } from "./define-schema.js";
-import { TEST_SCHEMA } from "./test-schema.js";
-
-/**
- * Subset of {@link DefineSchemaOpts} exposed through this helper.
- * Files needing per-test schema mutation should call `defineSchema` directly
- * inside their own `beforeEach` rather than this helper.
- */
-export interface AdapterSuiteSchemaOpts {
-  dropExisting?: boolean;
-}
+import { loadCanonicalSchema } from "./canonical-schema.js";
 import {
   withTransactionalFixtures,
   type TransactionalFixturesAdapter,
@@ -20,19 +10,9 @@ export interface AdapterSuiteOptions<A extends TransactionalFixturesAdapter> {
   /** Builds the adapter once per file in `beforeAll`. */
   factory: () => A | Promise<A>;
   /**
-   * Schema to declare via {@link defineSchema}. Defaults to the canonical
-   * {@link TEST_SCHEMA} (mirror of `vendor/rails/activerecord/test/schema/schema.rb`)
-   * so fixture-driven tests resolve named rows without inlining their own
-   * mini-schemas. Pass an explicit object (or `{}`) to override — useful for
-   * adapter-specific suites (e.g. PG-only types created via raw DDL in
-   * {@link setup}).
-   */
-  schema?: Schema;
-  schemaOptions?: AdapterSuiteSchemaOpts;
-  /**
    * Extra DDL or raw setup (CREATE EXTENSION, CREATE FOREIGN TABLE, etc.)
-   * that isn't expressible via {@link defineSchema}. Runs after
-   * `defineSchema` and before `withTransactionalFixtures` opens its first
+   * that isn't expressible via the canonical schema. Runs after the canonical
+   * schema is laid and before `withTransactionalFixtures` opens its first
    * transaction, so DDL committed here is visible to every test and not
    * rolled back at the file boundary.
    *
@@ -61,7 +41,7 @@ export interface AdapterSuiteHandle<A extends TransactionalFixturesAdapter> {
  * Boilerplate-free wrapper around the canonical adapter-cluster test pattern:
  *
  * ```
- * beforeAll(() => adapter = factory(); defineSchema(adapter, schema); setup(adapter));
+ * beforeAll(() => adapter = factory(); loadCanonicalSchema(adapter); setup(adapter));
  * withTransactionalFixtures(() => adapter);
  * afterAll(() => teardown(adapter); adapter.close());
  * ```
@@ -74,7 +54,6 @@ export interface AdapterSuiteHandle<A extends TransactionalFixturesAdapter> {
  * @example
  *   const suite = setupAdapterSuite({
  *     factory: () => new PostgreSQLAdapter(PG_TEST_URL),
- *     schema: { users: { name: "string" } },
  *     setup: async (adapter) => {
  *       await adapter.exec(`CREATE EXTENSION IF NOT EXISTS citext`);
  *     },
@@ -93,11 +72,7 @@ export function setupAdapterSuite<A extends TransactionalFixturesAdapter>(
 
   beforeAll(async () => {
     adapter = await opts.factory();
-    await defineSchema(
-      adapter as unknown as DatabaseAdapter,
-      opts.schema ?? TEST_SCHEMA,
-      opts.schemaOptions,
-    );
+    await loadCanonicalSchema(adapter as unknown as DatabaseAdapter);
     if (opts.setup) await opts.setup(adapter);
   });
 

--- a/packages/activerecord/src/test-helpers/setup-second-pool.ts
+++ b/packages/activerecord/src/test-helpers/setup-second-pool.ts
@@ -1,6 +1,6 @@
 import { Base } from "../base.js";
 import { registerModel } from "../associations.js";
-import { defineSchema, type Schema } from "./define-schema.js";
+import { rebuildCanonicalTables } from "./canonical-schema.js";
 import { ARUnit2Model } from "./models/arunit2-model.js";
 import { Course } from "./models/course.js";
 import { College } from "./models/college.js";
@@ -39,20 +39,6 @@ import { resolveSecondDatabaseConfig } from "./arunit2-config.js";
  *
  * @internal
  */
-const ARUNIT2_SCHEMA: Schema = {
-  colleges: { name: { type: "string", null: false } },
-  courses: { name: { type: "string", null: false }, college_id: "integer" },
-  professors: { name: { type: "string", null: false } },
-  courses_professors: {
-    columns: { course_id: "integer", professor_id: "integer" },
-    primaryKey: false,
-  },
-};
-
-const PRIMARY_SCHEMA: Schema = {
-  entrants: { name: { type: "string", null: false }, course_id: { type: "integer", null: false } },
-};
-
 /** @internal */
 export async function setupSecondPool(): Promise<void> {
   if (!ARUnit2Model.connectionClassQ()) {
@@ -73,6 +59,11 @@ export async function setupSecondPool(): Promise<void> {
   await ss.dropTable("colleges", { ifExists: true });
   await ss.dropTable("professors", { ifExists: true });
 
-  await defineSchema(arunit2, ARUNIT2_SCHEMA, { dropExisting: true });
-  await defineSchema(primary, PRIMARY_SCHEMA, { dropExisting: true });
+  await rebuildCanonicalTables(arunit2, [
+    "colleges",
+    "courses",
+    "professors",
+    "courses_professors",
+  ]);
+  await rebuildCanonicalTables(primary, ["entrants"]);
 }


### PR DESCRIPTION
Converts the four remaining non-fixtures `defineSchema` call-sites onto the
canonical loader (`loadCanonicalSchema` / `rebuildCanonicalTables` in
`test-helpers/canonical-schema.ts`), per RFC 0059. **Rails fidelity above all.**

## Changes

- **setup-second-pool.ts** — replaces the bespoke `ARUNIT2_SCHEMA` /
  `PRIMARY_SCHEMA` subset shapes with `rebuildCanonicalTables(arunit2,
  ["colleges", "courses", "professors", "courses_professors"])` and
  `rebuildCanonicalTables(primary, ["entrants"])`, restoring the full
  schema.rb shapes. `MultipleDbTest` still passes.
- **setup-adapter-suite.ts** — lays the canonical schema via
  `loadCanonicalSchema`; drops the now-unused `schema` / `schemaOptions`
  overrides (no callers passed them) and the `DefineSchemaOpts` import.
- **schema-repair.ts** — rebuilds drifted tables via `rebuildCanonicalTables`.
- **encryption/test-helpers.ts** (`installEncryptionSchema`) — uses a new
  `ensureCanonicalTables`, a no-drop idempotent-ensure that only creates
  genuinely-missing canonical tables, so it is safe against the shared
  `Base.connection` (unlike `rebuildCanonicalTables`, which would drop shared
  tables).
- **canonical-schema.ts** — adds `ensureCanonicalTables`.

## Verification

- None of the four files call `defineSchema`.
- Ran locally (sqlite): `setup-adapter-suite`, `multiple-db`,
  `canonical-schema`, `schema-repair`, `encryption/contexts`,
  `encryption/uniqueness-validations` — all green.
- No `node:*` imports, no `process.*`, async fs only. No test renames.

Closes-story: convert-remaining-defineschema-callers-canonical-loader