### PR TITLE
refactor(fixtures): lay canonical tables via ensureCanonicalTables, not defineSchema

### DIFF
--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -3,7 +3,11 @@ import "../sqlite/better-sqlite3.js";
 import { BetterSQLite3Adapter } from "../connection-adapters/better-sqlite3-adapter.js";
 import type { AbstractAdapter } from "../connection-adapters/abstract-adapter.js";
 import { defineSchema } from "./define-schema.js";
-import { loadCanonicalSchema, rebuildCanonicalTables } from "./canonical-schema.js";
+import {
+  ensureCanonicalTables,
+  loadCanonicalSchema,
+  rebuildCanonicalTables,
+} from "./canonical-schema.js";
 import { TEST_SCHEMA } from "./test-schema.js";
 
 // Phase-1 invariant (RFC 0059): `loadCanonicalSchema` must lay down byte-for-byte
@@ -78,6 +82,75 @@ describe("rebuildCanonicalTables", () => {
       await expect(rebuildCanonicalTables(adapter, ["topics", "not_a_real_table"])).rejects.toThrow(
         /unknown canonical table\(s\): not_a_real_table/,
       );
+    } finally {
+      await (adapter as unknown as BetterSQLite3Adapter).close();
+    }
+  });
+});
+
+// Read the live table-name set from sqlite_master, tolerating both the
+// object-row and `{ columns, rows }` array-row selectAll shapes.
+async function tableNames(adapter: AbstractAdapter): Promise<Set<string>> {
+  const res = (await adapter.selectAll(
+    "SELECT name FROM sqlite_master WHERE type = 'table'",
+  )) as unknown;
+  if (Array.isArray(res)) {
+    return new Set((res as { name: string }[]).map((r) => r.name));
+  }
+  const { columns, rows } = res as { columns: string[]; rows: unknown[][] };
+  const i = columns.indexOf("name");
+  return new Set(rows.map((row) => String(row[i])));
+}
+
+describe("ensureCanonicalTables", () => {
+  test("creates only the missing named tables, restoring canonical shape", async () => {
+    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    try {
+      await loadCanonicalSchema(adapter);
+      const canonical = await dumpSchema(adapter);
+
+      // Drop one table; ensure recreates just it (drop-free for the survivors)
+      // and restores it to its full canonical shape.
+      await adapter.executeMutation("DROP TABLE topics");
+      expect(await tableNames(adapter)).not.toContain("topics");
+
+      await ensureCanonicalTables(adapter, ["topics", "authors"]);
+      expect(await tableNames(adapter)).toContain("topics");
+      expect(await dumpSchema(adapter)).toBe(canonical);
+    } finally {
+      await (adapter as unknown as BetterSQLite3Adapter).close();
+    }
+  });
+
+  test("is a no-op when every named table already exists", async () => {
+    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    try {
+      await loadCanonicalSchema(adapter);
+      // A drifted `topics` must survive: ensure creates nothing (all present)
+      // and — unlike rebuildCanonicalTables — never drops to restore shape.
+      await adapter.executeMutation("DROP TABLE topics");
+      await adapter.executeMutation("CREATE TABLE topics (id integer PRIMARY KEY, title varchar)");
+      const drifted = await dumpSchema(adapter);
+
+      await ensureCanonicalTables(adapter, ["topics", "authors"]);
+      expect(await dumpSchema(adapter)).toBe(drifted);
+    } finally {
+      await (adapter as unknown as BetterSQLite3Adapter).close();
+    }
+  });
+
+  test("silently skips names outside the canonical registry", async () => {
+    const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
+    try {
+      await loadCanonicalSchema(adapter);
+      await adapter.executeMutation("DROP TABLE topics");
+
+      // A non-canonical name is ignored, not thrown on — the canonical `topics`
+      // still gets created alongside it, and no bogus table appears.
+      await ensureCanonicalTables(adapter, ["topics", "not_a_real_table"]);
+      const names = await tableNames(adapter);
+      expect(names).toContain("topics");
+      expect(names).not.toContain("not_a_real_table");
     } finally {
       await (adapter as unknown as BetterSQLite3Adapter).close();
     }

--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -139,18 +139,13 @@ describe("ensureCanonicalTables", () => {
     }
   });
 
-  test("silently skips names outside the canonical registry", async () => {
+  test("throws on an unknown canonical table name", async () => {
     const adapter = new BetterSQLite3Adapter(":memory:") as unknown as AbstractAdapter;
     try {
       await loadCanonicalSchema(adapter);
-      await adapter.executeMutation("DROP TABLE topics");
-
-      // A non-canonical name is ignored, not thrown on — the canonical `topics`
-      // still gets created alongside it, and no bogus table appears.
-      await ensureCanonicalTables(adapter, ["topics", "not_a_real_table"]);
-      const names = await tableNames(adapter);
-      expect(names).toContain("topics");
-      expect(names).not.toContain("not_a_real_table");
+      await expect(ensureCanonicalTables(adapter, ["topics", "not_a_real_table"])).rejects.toThrow(
+        /unknown canonical table\(s\): not_a_real_table/,
+      );
     } finally {
       await (adapter as unknown as BetterSQLite3Adapter).close();
     }

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2096,6 +2096,38 @@ export async function loadCanonicalSchema(adapter: DatabaseAdapter): Promise<voi
 }
 
 /**
+ * Idempotently ensure a named subset of canonical tables exists, creating only
+ * the ones that are missing — the drop-free counterpart of
+ * {@link rebuildCanonicalTables}. This is the ensure-exists primitive the
+ * fixtures engine calls in place of `defineSchema({ …subset })`: under the
+ * template-clone model the canonical tables already exist, so this is a near
+ * no-op (one `tableExists` probe per name, no DDL), which keeps it clean of the
+ * per-load DROP/CREATE churn RFC 0060 targets. Names not in the canonical
+ * registry are silently skipped, mirroring `sliceSchema`'s documented contract
+ * (a non-canonical set's missing table surfaces a precise error at seed time).
+ * Missing tables are created in forward registry order so FK targets exist
+ * before the tables that reference them.
+ */
+export async function ensureCanonicalTables(
+  adapter: DatabaseAdapter,
+  names: readonly string[],
+): Promise<void> {
+  const wanted = new Set(names);
+  const defs = (await buildCanonicalRegistry()).filter((d) => wanted.has(d.name));
+  if (defs.length === 0) return;
+  const { ss, typeMap } = await prepareSchema(adapter);
+  let created = false;
+  for (const def of defs) {
+    if (await ss.tableExists(def.name)) continue;
+    await runTable(adapter, ss, typeMap, def);
+    created = true;
+  }
+  // create_table clears the connection's prepared statements in Rails; only
+  // bother when we actually issued DDL (the common no-op path skips it).
+  if (created) (adapter as { clearCacheBang?: () => void }).clearCacheBang?.();
+}
+
+/**
  * Drop and recreate a named subset of canonical tables, restoring each to its
  * full canonical shape — the `create_table`-based equivalent of
  * `defineSchema({ …subset }, { dropExisting: true })`. Test files use it as an

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2096,38 +2096,6 @@ export async function loadCanonicalSchema(adapter: DatabaseAdapter): Promise<voi
 }
 
 /**
- * Idempotently ensure a named subset of canonical tables exists, creating only
- * the ones that are missing — the drop-free counterpart of
- * {@link rebuildCanonicalTables}. This is the ensure-exists primitive the
- * fixtures engine calls in place of `defineSchema({ …subset })`: under the
- * template-clone model the canonical tables already exist, so this is a near
- * no-op (one `tableExists` probe per name, no DDL), which keeps it clean of the
- * per-load DROP/CREATE churn RFC 0060 targets. Names not in the canonical
- * registry are silently skipped, mirroring `sliceSchema`'s documented contract
- * (a non-canonical set's missing table surfaces a precise error at seed time).
- * Missing tables are created in forward registry order so FK targets exist
- * before the tables that reference them.
- */
-export async function ensureCanonicalTables(
-  adapter: DatabaseAdapter,
-  names: readonly string[],
-): Promise<void> {
-  const wanted = new Set(names);
-  const defs = (await buildCanonicalRegistry()).filter((d) => wanted.has(d.name));
-  if (defs.length === 0) return;
-  const { ss, typeMap } = await prepareSchema(adapter);
-  let created = false;
-  for (const def of defs) {
-    if (await ss.tableExists(def.name)) continue;
-    await runTable(adapter, ss, typeMap, def);
-    created = true;
-  }
-  // create_table clears the connection's prepared statements in Rails; only
-  // bother when we actually issued DDL (the common no-op path skips it).
-  if (created) (adapter as { clearCacheBang?: () => void }).clearCacheBang?.();
-}
-
-/**
  * Drop and recreate a named subset of canonical tables, restoring each to its
  * full canonical shape — the `create_table`-based equivalent of
  * `defineSchema({ …subset }, { dropExisting: true })`. Test files use it as an

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -6,7 +6,8 @@ import {
   throughJoinTableNames,
   type PreparedFixtureSet,
 } from "./define-fixtures.js";
-import { defineSchema, type Schema } from "./define-schema.js";
+import { type Schema } from "./define-schema.js";
+import { ensureCanonicalTables } from "./canonical-schema.js";
 import {
   fixtureRegistry,
   isJoinTableEntry,
@@ -271,11 +272,8 @@ function useTablelessFixtures(
   if (opts?.schema) {
     const fullSchema = opts.schema;
     beforeAll(async () => {
-      const sub: Schema = {};
-      for (const { table } of entries) {
-        if (table in fullSchema) sub[table] = fullSchema[table]!;
-      }
-      await defineSchema(getAdapter(), sub);
+      const names = entries.map((e) => e.table).filter((t) => t in fullSchema);
+      await ensureCanonicalTables(getAdapter(), names);
     });
   }
 
@@ -486,7 +484,7 @@ export function useFixtures(
     const fullSchema = opts.schema;
     beforeAll(async () => {
       if (!fixtures) fixtures = await resolveFixtureNames(keys as readonly FixtureName[]);
-      await defineSchema(getAdapter(), sliceSchema(fixtures, fullSchema));
+      await ensureCanonicalTables(getAdapter(), Object.keys(sliceSchema(fixtures, fullSchema)));
     });
   }
 

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -85,10 +85,16 @@ export type UseFixturesByNameResult<N extends FixtureName> = {
 
 export interface UseFixturesOpts {
   /**
-   * When set, `useFixtures` derives the minimal sub-schema for the requested sets
-   * from this schema (via {@link deriveFixtureSchema}) and creates those tables in a
-   * `beforeAll` — replacing a manual `defineSchema({ ...slice })` call. Pass the full
-   * canonical schema (e.g. `TEST_SCHEMA`); only the tables the fixtures touch are created.
+   * When set, `useFixtures` uses this schema only to pick *which* tables to lay
+   * (the names of the sets the fixtures touch), then creates them via
+   * {@link ensureCanonicalTables} in a `beforeAll` — replacing a manual
+   * `defineSchema({ ...slice })` call. Pass the full canonical schema (e.g.
+   * `TEST_SCHEMA`); only the tables the fixtures touch are created.
+   *
+   * NOTE: only the table *names* are honored, not their column shapes — each
+   * table is created in its full canonical shape from the registry, so a
+   * genuinely bespoke (non-canonical) shape passed here is ignored. The type
+   * still permits an arbitrary `Schema` object for the name-selection role.
    */
   schema?: Schema;
 }


### PR DESCRIPTION
## What

RFC 0059 follow-up (`convert-use-fixtures-schema-off-defineschema`): removes the
last `defineSchema` calls from the fixtures engine.

- The fixtures engine's two `{ schema }` `beforeAll` hooks (the main
  by-name/map path and the tableless path) now call `ensureCanonicalTables`
  instead of `defineSchema`. That primitive (landed on `main` by #4550) creates
  only the *missing* named canonical tables via `create_table` — no drop of
  existing ones (the drop-free counterpart of `rebuildCanonicalTables`) — and
  throws on a name outside the canonical registry.
- Adds test coverage for the primitive (create-missing / no-op-when-present /
  throw-on-unknown).

> Note: this branch originally added its own `ensureCanonicalTables`; #4550
> landed an equivalent one first, so the branch converged on the merged copy
> (which throws on unknown names rather than silently skipping). Every engine
> call site only ever passes canonical names (sliced from `TEST_SCHEMA`, which
> is byte-for-byte the registry), so the throw can never fire there.

## Why

Under the template-clone model the canonical tables already exist, so the hook
becomes a near no-op (one `tableExists` probe per name, no DDL) — clear of the
per-load DROP/CREATE churn RFC 0060 targets, and off `defineSchema` entirely
(the retired trails invention RFC 0059 is removing).

## Testing

- `use-fixtures`, `naked-fixtures`, `canonical-schema` helper suites green.
- Representative fixtures-using suites (annotate, core, enum) green.

Closes-story: convert-use-fixtures-schema-off-defineschema