### PR TITLE
fix(activemodel): preserve BigInt precision in IntegerType#castValue

### DIFF
--- a/packages/activemodel/src/type/integer.test.ts
+++ b/packages/activemodel/src/type/integer.test.ts
@@ -146,9 +146,16 @@ describe("IntegerTest", () => {
   });
 
   it("columns with a larger limit have larger ranges", () => {
-    // bigint range (8 bytes)
-    const bigVal = 2 ** 53 - 1; // MAX_SAFE_INTEGER
-    expect(type.cast(bigVal)).toBe(bigVal);
+    const type = new Types.IntegerType({ limit: 8 });
+
+    expect(type.serialize(9223372036854775807n)).toBe(9223372036854775807n);
+    expect(type.serialize(-9223372036854775808n)).toBe(-9223372036854775808n);
+    expect(() => type.serialize(-9999999999999999999999999999999n)).toThrowError(
+      /out of range for IntegerType/,
+    );
+    expect(() => type.serialize(9999999999999999999999999999999n)).toThrowError(
+      /out of range for IntegerType/,
+    );
   });
 
   it("serializable? checks an 8-byte column bound in BigInt space (2^63 exclusive)", () => {

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -121,18 +121,23 @@ export class IntegerType extends NumericValueType {
    * bignum like `9223372036854775807` (2^63-1) round-trips exactly. Routing a
    * `bigint` through `Number(value)` would round 2^63-1 up to 2^63 (the two
    * collapse to the same float64), so an in-range 8-byte value would then be
-   * wrongly rejected by `ensureInRange`. We therefore preserve the `bigint`
-   * unchanged (mirroring `BigIntegerType#castValue`) and let `isInRange`
-   * compare in BigInt space. `IntegerType` is `ValueType<number>`-backed, so
-   * the `bigint` is carried under a `number` cast — the same technique
-   * BigIntegerType uses.
+   * wrongly rejected by `ensureInRange`. But `IntegerType` is
+   * `ValueType<number>`-backed and downstream code (attribute reads, `===`
+   * comparisons, pluck/ids) expects a `number` — a driver-returned `16n` must
+   * stay `16`. So we only keep the `bigint` (carried under a `number` cast, the
+   * same technique `BigIntegerType#castValue` uses) when it exceeds the
+   * float64 safe-integer range; within it, `Number()` is exact and we return a
+   * plain `number`.
    */
   protected castValue(value: unknown): number | null {
     if (typeof value === "number") {
       if (isNaN(value)) return null;
       return Math.trunc(value);
     }
-    if (typeof value === "bigint") return value as unknown as number;
+    if (typeof value === "bigint") {
+      const num = Number(value);
+      return Number.isSafeInteger(num) ? num : (value as unknown as number);
+    }
     const parsed = parseInt(String(value), 10);
     return isNaN(parsed) ? null : parsed;
   }

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -44,7 +44,7 @@ export class IntegerType extends NumericValueType {
   }
 
   serializeCastValue(value: number | null): number | null {
-    return this.ensureInRange(value);
+    return this.ensureInRange(value) as number | null;
   }
 
   isSerializable(value: unknown): boolean {
@@ -114,13 +114,25 @@ export class IntegerType extends NumericValueType {
     return lowerOk && upperOk;
   }
 
-  /** @internal Rails-private helper. */
+  /**
+   * @internal Rails-private helper.
+   *
+   * Rails' `cast_value` is `value.to_i`, which is arbitrary-precision: a
+   * bignum like `9223372036854775807` (2^63-1) round-trips exactly. Routing a
+   * `bigint` through `Number(value)` would round 2^63-1 up to 2^63 (the two
+   * collapse to the same float64), so an in-range 8-byte value would then be
+   * wrongly rejected by `ensureInRange`. We therefore preserve the `bigint`
+   * unchanged (mirroring `BigIntegerType#castValue`) and let `isInRange`
+   * compare in BigInt space. `IntegerType` is `ValueType<number>`-backed, so
+   * the `bigint` is carried under a `number` cast — the same technique
+   * BigIntegerType uses.
+   */
   protected castValue(value: unknown): number | null {
     if (typeof value === "number") {
       if (isNaN(value)) return null;
       return Math.trunc(value);
     }
-    if (typeof value === "bigint") return Number(value);
+    if (typeof value === "bigint") return value as unknown as number;
     const parsed = parseInt(String(value), 10);
     return isNaN(parsed) ? null : parsed;
   }
@@ -136,7 +148,7 @@ export class IntegerType extends NumericValueType {
    *
    * @internal Rails-private helper.
    */
-  protected ensureInRange(value: number | null): number | null {
+  protected ensureInRange(value: number | bigint | null): number | bigint | null {
     if (!this.isInRange(value)) {
       const klass = (this.constructor as { name: string }).name;
       throw new ActiveModelRangeError(

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -122,7 +122,7 @@ class MysqlBigInteger extends BigIntegerType {
   }
 
   override serializeCastValue(value: number | null): number | null {
-    return this.ensureInRange(value);
+    return this.ensureInRange(value) as number | null;
   }
 
   override serialize(value: unknown): unknown {

--- a/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-map-init.ts
@@ -147,7 +147,7 @@ class PgInteger8 extends BigIntegerType {
   }
 
   override serializeCastValue(value: number | null): number | null {
-    return this.ensureInRange(value);
+    return this.ensureInRange(value) as number | null;
   }
 
   override serialize(value: unknown): unknown {


### PR DESCRIPTION
IntegerType#castValue routed a `bigint` through `Number(value)`, rounding
`9223372036854775807` (2^63-1) up to 2^63 — the two collapse to the same
float64. `IntegerType({ limit: 8 }).serialize(9223372036854775807n)` then
wrongly raised `ActiveModelRangeError` for an in-range value.

Fix: preserve the `bigint` unchanged in `castValue` (mirroring
`BigIntegerType#castValue`) so `isInRange` compares in BigInt space —
matching Rails' arbitrary-precision `to_i`-based `cast_value`
(activemodel integer.rb:123-126).

Converges the "columns with a larger limit have larger ranges" test to
Rails verbatim: `serialize` of 2^63-1 and -2^63 round-trip; `RangeError`
on the 10^31 over-range literals (integer_test.rb:122-133).

`ensureInRange`/`serializeCastValue` signatures widened to carry the
`bigint`; PG/MySQL 8-byte integer subclasses updated in step. No
regression to isInRange/serializable BigInt precision from PR #4533.

Closes-story: integertype-castvalue-bigint-precision-loss