### PR TITLE
test(relation): cover leftOuterJoins(cte) → LEFT OUTER JOIN routing

### DIFF
--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -4,9 +4,8 @@
  * Mirrors: activerecord/test/cases/relation/with_test.rb
  */
 import { describe, it, expect } from "vitest";
-import { sql as arelSql, Nodes } from "@blazetrails/arel";
+import { sql as arelSql } from "@blazetrails/arel";
 import "../index.js";
-import { buildJoinBuckets } from "./query-methods.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post } from "../test-helpers/models/post.js";
@@ -218,42 +217,29 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     ).toEqual(POSTS_WITH_COMMENTS);
   });
 
-  it("with left joins routes a cte symbol to an outer join node", () => {
+  it("with left joins routes a cte symbol to a left outer join", () => {
     // Rails routes a symbol left-outer arg matching a `with(...)` CTE name to a
     // `build_with_join_node(name, Arel::Nodes::OuterJoin)` join_node
-    // (query_methods.rb:1830-1836); a `joins(...)` CTE symbol instead builds an
-    // `Arel::Nodes::InnerJoin` (query_methods.rb:1854). trails mirrors the
-    // former in `buildJoinBuckets`' `selectNamedJoins` block — a `CTEJoin`
-    // becomes `buildWithJoinNode(name, Nodes.OuterJoin)`
-    // (query-methods.ts, buildJoinBuckets). Lock the OuterJoin routing at the
-    // join-plan level: the CTE arg must land in `join_node` as an OuterJoin (not
-    // an InnerJoin) against the CTE table. `buildJoinBuckets` is the subquery
-    // `from(relation)` builder, the only path that carries the CTEJoin block
-    // (the direct `_applyJoinsToManager` live path does not partition CTEs), so
-    // exercise it directly. (trails Symbol is `Symbol("name")`.)
-    const relation = Post.with({
+    // (query_methods.rb:1830-1836), which joins on
+    // `cte[model.foreign_key] = table[model.primary_key]`. trails mirrors this in
+    // `buildJoinBuckets`' `selectNamedJoins` block — a `CTEJoin` becomes
+    // `buildWithJoinNode(name, Nodes.OuterJoin)` — reached end-to-end when the
+    // `with(...).leftOuterJoins(cte)` relation is embedded as a `from(...)`
+    // subquery. Lock the OuterJoin routing: the CTE symbol must emit a
+    // LEFT OUTER JOIN to the CTE (`commented_posts.post_id = posts.id`), not an
+    // INNER JOIN. (trails Symbol is `Symbol("name")`.)
+    const subquery = Post.with({
       commented_posts: Comment.select("post_id").distinct(),
-    }).leftOuterJoins(cteSym("commented_posts"));
+    })
+      .leftOuterJoins(cteSym("commented_posts"))
+      .select("posts.id");
 
-    const buckets = buildJoinBuckets.call(relation as any);
-    const joinNodes = buckets.join_node as Nodes.Node[];
+    const sql = (Post.from(subquery, "posts") as unknown as { toSql(): string }).toSql();
 
-    expect(joinNodes.length).toBe(1);
-    const outer = joinNodes[0] as Nodes.OuterJoin;
-    expect(outer).toBeInstanceOf(Nodes.OuterJoin);
-    expect(outer).not.toBeInstanceOf(Nodes.InnerJoin);
-    // The join targets the CTE table (`commented_posts`), left-joined onto posts.
-    expect((outer.left as { name?: string }).name).toBe("commented_posts");
-
-    // buildWithJoinNode joins on `cte[model.foreign_key] = table[model.primary_key]`
-    // (query_methods.rb build_with_join_node): `commented_posts.post_id = posts.id`.
-    // Assert the full ON so the FK/PK wiring is locked, not just the node type.
-    const on = outer.right as unknown as { expr: Nodes.Equality };
-    const eq = on.expr as unknown as { left: any; right: any };
-    expect(eq.left.relation.name).toBe("commented_posts");
-    expect(eq.left.name).toBe("post_id");
-    expect(eq.right.relation.name).toBe("posts");
-    expect(eq.right.name).toBe("id");
+    expect(sql).toMatch(
+      /LEFT OUTER JOIN "?commented_posts"? ON "?commented_posts"?\."?post_id"? = "?posts"?\."?id"?/,
+    );
+    expect(sql).not.toMatch(/INNER JOIN "?commented_posts"?/);
   });
 
   it("raises when using block", () => {

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -236,10 +236,15 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
 
     const sql = (Post.from(subquery, "posts") as unknown as { toSql(): string }).toSql();
 
+    // Identifier quoting is dialect-specific (`"` on sqlite/pg, backticks on
+    // MariaDB/MySQL), so the quote char is optional in the match.
+    const q = `["\`]?`;
     expect(sql).toMatch(
-      /LEFT OUTER JOIN "?commented_posts"? ON "?commented_posts"?\."?post_id"? = "?posts"?\."?id"?/,
+      new RegExp(
+        `LEFT OUTER JOIN ${q}commented_posts${q} ON ${q}commented_posts${q}\\.${q}post_id${q} = ${q}posts${q}\\.${q}id${q}`,
+      ),
     );
-    expect(sql).not.toMatch(/INNER JOIN "?commented_posts"?/);
+    expect(sql).not.toMatch(new RegExp(`INNER JOIN ${q}commented_posts${q}`));
   });
 
   it("raises when using block", () => {

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -4,8 +4,9 @@
  * Mirrors: activerecord/test/cases/relation/with_test.rb
  */
 import { describe, it, expect } from "vitest";
-import { sql as arelSql } from "@blazetrails/arel";
+import { sql as arelSql, Nodes } from "@blazetrails/arel";
 import "../index.js";
+import { buildJoinBuckets } from "./query-methods.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post } from "../test-helpers/models/post.js";
@@ -31,6 +32,11 @@ const POSTS_WITH_TAGS_AND_MULTIPLE_COMMENTS = POSTS_WITH_MULTIPLE_COMMENTS.filte
 function toIds(ids: any[]): number[] {
   return ids.map((id) => Number(id));
 }
+
+// trails collapses Ruby Symbol and String to one JS string type; a genuine
+// Symbol is how a caller signals "association/CTE name" (vs a raw SQL fragment)
+// to the join partitioner (query_methods.ts `selectNamedJoins`).
+const cteSym = (name: string) => Symbol(name) as unknown as string;
 
 // ==========================================================================
 // WithTest — targets relation/with_test.rb
@@ -210,6 +216,34 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
         .filter((r: any) => r.readAttribute("has_comments") != null)
         .map((r: any) => Number(r.id)),
     ).toEqual(POSTS_WITH_COMMENTS);
+  });
+
+  it("with left joins routes a cte symbol to an outer join node", () => {
+    // Rails routes a symbol left-outer arg matching a `with(...)` CTE name to a
+    // `build_with_join_node(name, Arel::Nodes::OuterJoin)` join_node
+    // (query_methods.rb:1830-1836); a `joins(...)` CTE symbol instead builds an
+    // `Arel::Nodes::InnerJoin` (query_methods.rb:1854). trails mirrors the
+    // former in `buildJoinBuckets`' `selectNamedJoins` block — a `CTEJoin`
+    // becomes `buildWithJoinNode(name, Nodes.OuterJoin)`
+    // (query-methods.ts, buildJoinBuckets). Lock the OuterJoin routing at the
+    // join-plan level: the CTE arg must land in `join_node` as an OuterJoin (not
+    // an InnerJoin) against the CTE table. `buildJoinBuckets` is the subquery
+    // `from(relation)` builder, the only path that carries the CTEJoin block
+    // (the direct `_applyJoinsToManager` live path does not partition CTEs), so
+    // exercise it directly. (trails Symbol is `Symbol("name")`.)
+    const relation = Post.with({
+      commented_posts: Comment.select("post_id").distinct(),
+    }).leftOuterJoins(cteSym("commented_posts"));
+
+    const buckets = buildJoinBuckets.call(relation as any);
+    const joinNodes = buckets.join_node as Nodes.Node[];
+
+    expect(joinNodes.length).toBe(1);
+    const outer = joinNodes[0] as Nodes.OuterJoin;
+    expect(outer).toBeInstanceOf(Nodes.OuterJoin);
+    expect(outer).not.toBeInstanceOf(Nodes.InnerJoin);
+    // The join targets the CTE table (`commented_posts`), left-joined onto posts.
+    expect((outer.left as Nodes.TableAlias | { name?: string }).name).toBe("commented_posts");
   });
 
   it("raises when using block", () => {

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -243,7 +243,17 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     expect(outer).toBeInstanceOf(Nodes.OuterJoin);
     expect(outer).not.toBeInstanceOf(Nodes.InnerJoin);
     // The join targets the CTE table (`commented_posts`), left-joined onto posts.
-    expect((outer.left as Nodes.TableAlias | { name?: string }).name).toBe("commented_posts");
+    expect((outer.left as { name?: string }).name).toBe("commented_posts");
+
+    // buildWithJoinNode joins on `cte[model.foreign_key] = table[model.primary_key]`
+    // (query_methods.rb build_with_join_node): `commented_posts.post_id = posts.id`.
+    // Assert the full ON so the FK/PK wiring is locked, not just the node type.
+    const on = outer.right as unknown as { expr: Nodes.Equality };
+    const eq = on.expr as unknown as { left: any; right: any };
+    expect(eq.left.relation.name).toBe("commented_posts");
+    expect(eq.left.name).toBe("post_id");
+    expect(eq.right.relation.name).toBe("posts");
+    expect(eq.right.name).toBe("id");
   });
 
   it("raises when using block", () => {


### PR DESCRIPTION
## Summary

PR #4536 added a `CTEJoin` branch to `buildJoinBuckets`' `selectNamedJoins`
block: a symbol left-outer arg matching a `with(...)` CTE name routes to
`buildWithJoinNode(name, Nodes.OuterJoin)`, mirroring Rails'
`build_with_join_node(name, Arel::Nodes::OuterJoin)`
(`query_methods.rb:1830-1836`), which joins on
`cte[model.foreign_key] = table[model.primary_key]`. That branch shipped with
**no direct test** — the reviewer noted it is only reachable for a genuine
`CTEJoin`, so a regression there would go unnoticed.

## Changes

- Add a `WithTest` case (`packages/activerecord/src/relation/with.test.ts`)
  asserting that `Post.with(commented_posts: …).leftOuterJoins(cteSymbol)`,
  embedded as a `from(...)` subquery, emits
  `LEFT OUTER JOIN "commented_posts" ON "commented_posts"."post_id" = "posts"."id"`
  — and **not** an `INNER JOIN` — locking in the OuterJoin routing and the
  FK/PK ON clause end-to-end through real generated SQL.

The `from(subquery)` embedding is the public path that carries the `CTEJoin`
block through `buildJoinBuckets`; the test drives it black-box via `toSql()`
rather than poking join-plan internals.

## Verification

- Test passes as written.
- Flipping the branch to `Nodes.InnerJoin` makes the test fail — it genuinely
  guards the routing.

Closes-story: leftouterjoins-cte-outer-join-coverage