### PR TITLE
refactor(schema-dumper): delete cleanDefault/cleanRawPgExpression

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4933,8 +4933,6 @@ export function splitPgDefault(raw: string | null): { literal: unknown; fn: stri
   // Rails' extract_value_from_default (postgresql_adapter.rb:769) only allows
   // an optional ::bigint suffix and would misclassify this as a function default;
   // we go beyond Rails' implementation to match what money_test.rb:98 asserts.
-  // NOTE: both splitPgDefault and cleanRawPgExpression (schema-dumper.ts) must
-  // handle multi-cast chains; cleanRawPgExpression already used (+) for this.
   const parenNum = /^\((-?\d+(?:\.\d+)?)\)(?:::[\w"\s.]+)+$/.exec(raw);
   if (parenNum) return { literal: parenNum[1], fn: null };
   // N::type[::type2...] — bare numeric with one or more casts. PG normalizes

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -1,13 +1,12 @@
 // Trails-only SchemaDumper cases with no 1:1 in Rails'
 // schema_dumper_test.rb. These unit-test trails-invented exported helpers
-// (cleanDefault / cleanRawPgExpression / formatColspecRaw / indexParts), the
-// adapter-introspection dump path (SchemaDumperAdapterTest), async header
-// ordering, and DSL-helper round-trips. Kept out of the Rails-mirrored
-// schema-dumper.test.ts so test:compare maps cleanly.
+// (formatColspecRaw / indexParts), the adapter-introspection dump path
+// (SchemaDumperAdapterTest), async header ordering, and DSL-helper
+// round-trips. Kept out of the Rails-mirrored schema-dumper.test.ts so
+// test:compare maps cleanly.
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { MigrationContext } from "./migration.js";
 import { SchemaDumper } from "./connection-adapters/abstract/schema-dumper.js";
-import { cleanDefault, cleanRawPgExpression } from "./schema-dumper.js";
 import { Base } from "./base.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -379,59 +378,6 @@ describe("SchemaDumper async header ordering", () => {
     const typesIdx = result.indexOf("TYPES");
     expect(schemasIdx).toBeLessThan(extensionsIdx);
     expect(extensionsIdx).toBeLessThan(typesIdx);
-  });
-});
-
-describe("cleanRawPgExpression", () => {
-  it("strips string type casts", () => {
-    expect(cleanRawPgExpression("'happy'::mood")).toBe("happy");
-    expect(cleanRawPgExpression("'192.168.1.1'::inet")).toBe("192.168.1.1");
-    expect(cleanRawPgExpression("'(12.2,13.3)'::point")).toBe("(12.2,13.3)");
-  });
-
-  it("unescapes doubled single-quotes", () => {
-    expect(cleanRawPgExpression("'it''s'::text")).toBe("it's");
-  });
-
-  it("strips numeric type casts", () => {
-    expect(cleanRawPgExpression("150.55::numeric")).toBe(150.55);
-    expect(cleanRawPgExpression("(150.55)::numeric")).toBe(150.55);
-  });
-
-  it("preserves expression defaults like nextval", () => {
-    const val = "nextval('seq_id_seq'::regclass)";
-    expect(cleanRawPgExpression(val)).toBe(val);
-  });
-
-  it("returns unrecognised strings unchanged", () => {
-    expect(cleanRawPgExpression("hello")).toBe("hello");
-  });
-});
-
-describe("cleanDefault", () => {
-  it("delegates raw PG cast expressions to cleanRawPgExpression", () => {
-    expect(cleanDefault("'happy'::mood")).toBe("happy");
-    expect(cleanDefault("'(12.2,13.3)'::point")).toBe("(12.2,13.3)");
-  });
-
-  it("coerces scalar booleans", () => {
-    expect(cleanDefault("true")).toBe(true);
-    expect(cleanDefault("false")).toBe(false);
-  });
-
-  it("coerces plain numeric strings", () => {
-    expect(cleanDefault("42")).toBe(42);
-    expect(cleanDefault("3.14")).toBe(3.14);
-  });
-
-  it("preserves bit-string patterns with leading zeros", () => {
-    expect(cleanDefault("00000011")).toBe("00000011");
-    expect(cleanDefault("0011")).toBe("0011");
-  });
-
-  it("returns null/undefined unchanged", () => {
-    expect(cleanDefault(null)).toBeNull();
-    expect(cleanDefault(undefined)).toBeUndefined();
   });
 });
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -21,7 +21,6 @@ import { assertSchemaAdapter } from "./connection-adapters/abstract/assert-schem
 import type * as SchemaIntrospectionModule from "./schema-introspection.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { Base } from "./base.js";
-import { Duration } from "@blazetrails/activesupport";
 
 // Lazy-load schema-introspection to break the static cycle
 // (schema-dumper -> schema-introspection -> schema-statements ->
@@ -371,68 +370,6 @@ function sqlTypeToDsl(sqlType: string): DslMapping {
   }
 
   return result;
-}
-
-/**
- * Strip a raw PG catalog default expression to a plain value.
- * E.g. `'happy'::mood` → `"happy"`, `'192.168.1.1'::inet` → `"192.168.1.1"`,
- * `nextval(...)` → kept as-is (expression default).
- *
- * Only call this with raw SQL strings from `column_default` /
- * `pg_attrdef.adbin`. For already-deserialized ORM values (e.g. bit-strings
- * like `"00000011"`) use `cleanDefault` instead.
- */
-export function cleanRawPgExpression(raw: string): unknown {
-  const castMatch = raw.match(/^'((?:[^']|'')*)'(::[\w\s."[\](),]+)+$/);
-  if (castMatch) {
-    return castMatch[1].replace(/''/g, "'");
-  }
-
-  const numericCastMatch = raw.match(/^\(?(-?\d+(?:\.\d+)?)\)?(::[\w\s."[\](),]+)+$/);
-  if (numericCastMatch) {
-    return Number(numericCastMatch[1]);
-  }
-
-  // Expression defaults like nextval(...) — keep as-is
-  if (raw.includes("(") && !raw.startsWith("'")) {
-    return raw;
-  }
-
-  return raw;
-}
-
-/**
- * Clean up a default value — either a raw PG catalog expression or an
- * already-deserialized ORM scalar — to the JS literal used in schema dumps.
- *
- * Two distinct inputs flow through here:
- *  1. Raw PG catalog expressions (e.g. `'happy'::mood`, `'(12.2,13.3)'::point`)
- *     — dispatched to `cleanRawPgExpression`.
- *  2. Already-deserialized scalar literals — plain strings like `"00000011"`
- *     (bit-string), `"true"`, or `"42"`. The `/^-?0\d/` guard prevents
- *     bit-string patterns from being coerced to `Number`.
- */
-export function cleanDefault(raw: unknown): unknown {
-  if (raw === null || raw === undefined) return raw;
-  // Interval/Duration round-trips through schema dump as its ISO-8601 form.
-  // Without this branch, Duration.toString() yields seconds — e.g. P3Y →
-  // "94670856" — and the numeric coercion below would emit `default: 94670856`.
-  // Mirrors Rails OID::Interval#type_cast_for_schema → serialize(value).inspect.
-  if (raw instanceof Duration) return raw.iso8601();
-  const str = String(raw);
-
-  // Delegate raw PG expressions (contain a type cast or are expression defaults)
-  if (str.includes("::") || (str.includes("(") && !str.startsWith("'"))) {
-    return cleanRawPgExpression(str);
-  }
-
-  if (str === "true") return true;
-  if (str === "false") return false;
-  // Only coerce to number when there are no leading zeros — leading zeros mean
-  // the string is a bit-string pattern ("00000011") or similar, not a decimal.
-  if (/^-?\d+(\.\d+)?$/.test(str) && !/^-?0\d/.test(str)) return Number(str);
-
-  return raw;
 }
 
 /**
@@ -1023,9 +960,9 @@ export class SchemaDumper {
         return { id: "uuid", default: () => fn };
       }
       // Route the literal default through the same `schemaDefault` cast-type
-      // path `columnSpec` uses (Rails `schema_default`) rather than the
-      // trails-invented `cleanDefault` regex. The result is already-formatted
-      // TS-DSL text, so wrap it so `formatOptions` emits it verbatim.
+      // path `columnSpec` uses (Rails `schema_default`). The result is
+      // already-formatted TS-DSL text, so wrap it so `formatOptions` emits it
+      // verbatim.
       const def = this.schemaDefault(column);
       return { id: "uuid", default: def == null ? null : new RawSchemaLiteral(def) };
     }
@@ -1171,9 +1108,8 @@ export class SchemaDumper {
         colspec.default = () => fn;
       } else {
         // Route through the same `schemaDefault` cast-type path `columnSpec`
-        // uses (Rails `schema_default`) instead of the trails-invented
-        // `cleanDefault` regex. The result is already-formatted TS-DSL text,
-        // so wrap it so `formatColspec` emits it verbatim.
+        // uses (Rails `schema_default`). The result is already-formatted
+        // TS-DSL text, so wrap it so `formatColspec` emits it verbatim.
         const def = this.schemaDefault(col);
         if (def !== undefined) {
           colspec.default = new RawSchemaLiteral(def);


### PR DESCRIPTION
## Summary

The two legacy `emitTable` callsites already route default emission through the
Rails-faithful `schemaDefault` cast-type path (`type.deserialize` +
`typeCastForSchema` via `lookupCastTypeFromColumn`) as of PR #4548, leaving the
trails-invented `cleanDefault` and `cleanRawPgExpression` helpers dead outside
their own unit tests.

- Delete `cleanDefault` and `cleanRawPgExpression` from `schema-dumper.ts`
  (plus the now-unused `Duration` import).
- Drop the now-dead `cleanDefault` / `cleanRawPgExpression` unit cases in
  `schema-dumper.trails.test.ts`; keep the DSL round-trip and
  adapter-introspection cases.
- Remove the stale `splitPgDefault` NOTE in `postgresql-adapter.ts` that
  referenced `cleanRawPgExpression`.

`splitPgDefault` (the `extract_value_from_default` port) is untouched. Dump
output for PG default-bearing columns is unchanged — verified via the existing
Rails-mirrored `schema-dumper.test.ts` cases.

Closes-story: converge-dumper-default-emission-delete-cleandefault