### PR TITLE
fix(type-virtualization): widen integer FK column declares to PrimaryKeyValue

### DIFF
--- a/packages/activerecord/scripts/materialize-model-declares.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.ts
@@ -521,6 +521,17 @@ function collectVisibleClassNames(node: ts.Node, out: Set<string>): void {
   }
 }
 
+/** Names of every class declaration anywhere in the file (any nesting depth). */
+function collectAllClassNames(sf: ts.SourceFile): Set<string> {
+  const out = new Set<string>();
+  const visit = (node: ts.Node): void => {
+    if (ts.isClassDeclaration(node) && node.name) out.add(node.name.text);
+    ts.forEachChild(node, visit);
+  };
+  visit(sf);
+  return out;
+}
+
 function collectTargets(
   info: ClassInfo,
   out: Set<string>,
@@ -757,6 +768,16 @@ async function main(): Promise<void> {
     // omit the schema map: declares then reflect only the class's explicit
     // `attribute()` / association / enum calls — exactly its real surface.
     const underModelsDir = file.startsWith(modelsDirPrefix);
+    // An association-target class name is "known" (resolves to a type in
+    // scope) when it is a registered model, `Base`, or a class declared
+    // anywhere in this file. A `classify`-d target satisfying none of these —
+    // e.g. `hasOne("otherThing")` in a throwaway test class with no
+    // `OtherThing` model — must not be baked verbatim (dangling TS2304); the
+    // synthesizer degrades it to `Base`. Over-approximating with every in-file
+    // class name is safe: it only ever suppresses an unnecessary fallback.
+    const fileClassNames = collectAllClassNames(sf);
+    const isKnownTarget = (name: string): boolean =>
+      name === "Base" || registry.has(name) || fileClassNames.has(name);
     const { text: virtualized } = virtualize(source, file, {
       isModelClass,
       prependImports,
@@ -764,6 +785,7 @@ async function main(): Promise<void> {
       classNameAliases,
       associationTargets,
       composedOfColumns: composedOfColumns.size > 0 ? composedOfColumns : undefined,
+      isKnownTarget,
       // Baked attribute declares allow null assignment (Rails attributes
       // carry no NOT NULL constraint); the live tsc-plugin keeps bare `T`.
       attributesNullable: true,

--- a/packages/activerecord/scripts/materialize-model-declares.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.ts
@@ -521,17 +521,6 @@ function collectVisibleClassNames(node: ts.Node, out: Set<string>): void {
   }
 }
 
-/** Names of every class declaration anywhere in the file (any nesting depth). */
-function collectAllClassNames(sf: ts.SourceFile): Set<string> {
-  const out = new Set<string>();
-  const visit = (node: ts.Node): void => {
-    if (ts.isClassDeclaration(node) && node.name) out.add(node.name.text);
-    ts.forEachChild(node, visit);
-  };
-  visit(sf);
-  return out;
-}
-
 function collectTargets(
   info: ClassInfo,
   out: Set<string>,
@@ -769,15 +758,22 @@ async function main(): Promise<void> {
     // `attribute()` / association / enum calls — exactly its real surface.
     const underModelsDir = file.startsWith(modelsDirPrefix);
     // An association-target class name is "known" (resolves to a type in
-    // scope) when it is a registered model, `Base`, or a class declared
-    // anywhere in this file. A `classify`-d target satisfying none of these —
-    // e.g. `hasOne("otherThing")` in a throwaway test class with no
-    // `OtherThing` model — must not be baked verbatim (dangling TS2304); the
-    // synthesizer degrades it to `Base`. Over-approximating with every in-file
-    // class name is safe: it only ever suppresses an unnecessary fallback.
-    const fileClassNames = collectAllClassNames(sf);
-    const isKnownTarget = (name: string): boolean =>
-      name === "Base" || registry.has(name) || fileClassNames.has(name);
+    // scope at the declare's splice site) when it is a registered model,
+    // `Base`, a module-scope import/declaration, or a class lexically visible
+    // from the host class (same or enclosing block). A `classify`-d target
+    // satisfying none of these — e.g. `hasOne("otherThing")` in a throwaway
+    // test class with no `OtherThing` model — must not be baked verbatim
+    // (dangling TS2304); the synthesizer degrades it to `Base`. Visibility is
+    // scoped to the host (not a flat whole-file scan) so a same-named class in
+    // a SIBLING `describe`/`it` closure does not count as visible — mirrors
+    // `resolveAutoImports`' `moduleScope + collectVisibleClassNames` logic.
+    const moduleScope = collectNamesInScope(sf);
+    const isKnownTarget = (name: string, host: ClassInfo): boolean => {
+      if (name === "Base" || registry.has(name) || moduleScope.has(name)) return true;
+      const visible = new Set<string>();
+      collectVisibleClassNames(host.classDecl, visible);
+      return visible.has(name);
+    };
     const { text: virtualized } = virtualize(source, file, {
       isModelClass,
       prependImports,

--- a/packages/activerecord/scripts/materialize-model-declares.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.ts
@@ -625,6 +625,7 @@ const BUILTIN_IMPORT_FROM_MODELS_DIR: Record<string, string> = {
   AssociationProxy: "../../associations/collection-proxy.js",
   Relation: "../../relation.js",
   IPAddr: "../../connection-adapters/postgresql/oid/cidr.js",
+  PrimaryKeyValue: "../../base.js",
 };
 
 /** Builtin specifier recomputed relative to `fileDir`. */

--- a/packages/activerecord/src/associations/has-one-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-through-associations.test.ts
@@ -752,6 +752,11 @@ describe("HasOneThroughAssociationsTest", () => {
   it("has one through relationship cannot have a counter cache", () => {
     expect(() => {
       class Thing extends Base {
+        declare otherThing: Base | null;
+        declare thing: Base | null;
+        declare loadHasOne: ((name: "otherThing") => Promise<Base | null>) &
+          ((name: "thing") => Promise<Base | null>);
+
         static {
           this.hasOne("otherThing");
           this.hasOne("thing", { through: "otherThing", counterCache: true });

--- a/packages/activerecord/src/type-virtualization/fixtures/20-big-integer/expected.ts
+++ b/packages/activerecord/src/type-virtualization/fixtures/20-big-integer/expected.ts
@@ -1,6 +1,6 @@
 export class Counter extends Base {
   declare hits: bigint;
-  declare user_id: bigint;
+  declare user_id: import("@blazetrails/activerecord").PrimaryKeyValue;
 
   static {
     this.attribute("hits", "big_integer");

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -80,6 +80,18 @@ export interface SynthesizeOptions {
    * scalar type shadowing the aggregation object type.
    */
   composedOfColumns?: ReadonlyMap<string, ReadonlySet<string>>;
+  /**
+   * Whether an association-target class name resolves to a type that is
+   * actually in scope where the declare will be spliced (in the model
+   * registry or lexically visible in-file). A plain (non-`through`)
+   * association whose `classify`-d target has no corresponding model — e.g.
+   * `hasOne("otherThing")` in a throwaway test class with no `OtherThing`
+   * model — would otherwise emit `declare otherThing: OtherThing | null`, a
+   * dangling name (TS2304). When the predicate reports the target unknown the
+   * declare falls back to `Base` (always in scope), mirroring how `through:`
+   * targets already degrade to `Base`. Omitted → every target is trusted.
+   */
+  isKnownTarget?: (name: string) => boolean;
 }
 
 export function synthesizeDeclares(info: ClassInfo, opts: SynthesizeOptions = {}): string[] {
@@ -112,14 +124,27 @@ export function synthesizeDeclares(info: ClassInfo, opts: SynthesizeOptions = {}
     ) {
       continue;
     }
-    for (const line of renderCall(info, call, aliases, targets, opts.attributesNullable ?? false)) {
+    for (const line of renderCall(
+      info,
+      call,
+      aliases,
+      targets,
+      opts.attributesNullable ?? false,
+      opts.isKnownTarget,
+    )) {
       if (!line.skipIfPresent || !memberPresent(info, line)) {
         out.push(line.text);
         if (!line.isStatic) synthesizedInstanceNames.add(line.declaredName);
       }
     }
   }
-  for (const l of renderLoaderOverloads(info, aliases, targets, opts.ancestors)) {
+  for (const l of renderLoaderOverloads(
+    info,
+    aliases,
+    targets,
+    opts.ancestors,
+    opts.isKnownTarget,
+  )) {
     if (!info.existingMembers.has(l.declaredName)) {
       out.push(l.text);
       synthesizedInstanceNames.add(l.declaredName);
@@ -240,6 +265,7 @@ function renderLoaderOverloads(
   aliases: ReadonlyMap<string, string> | undefined,
   targets: ReadonlyMap<string, string> | undefined,
   ancestors: readonly ClassInfo[] | undefined,
+  isKnownTarget: ((name: string) => boolean) | undefined,
 ): RenderedLine[] {
   const belongsToOverloads: string[] = [];
   const hasOneOverloads: string[] = [];
@@ -253,7 +279,7 @@ function renderLoaderOverloads(
       const target =
         call.options["polymorphic"] === "true"
           ? "Base"
-          : resolveTarget(source, call, aliases, targets);
+          : resolveTarget(source, call, aliases, targets, isKnownTarget);
       const overload = `((name: "${call.name}") => Promise<${target} | null>)`;
       const bucket = call.kind === "belongsTo" ? belongsToOverloads : hasOneOverloads;
       if (!bucket.includes(overload)) bucket.push(overload);
@@ -310,7 +336,9 @@ function collectConflictingSingulars(info: ClassInfo, opts: SynthesizeOptions): 
   const superNameOf = opts.superNameOf;
 
   const target = (host: ClassInfo, call: AssociationCall): string =>
-    call.options["polymorphic"] === "true" ? "Base" : resolveTarget(host, call, aliases, targets);
+    call.options["polymorphic"] === "true"
+      ? "Base"
+      : resolveTarget(host, call, aliases, targets, opts.isKnownTarget);
   // Effective inherited target per association, folded base→derived
   // (`ancestors` is nearest-first, so reverse). A suppressed ancestor override
   // (target not assignable to what it inherits) does NOT change the effective
@@ -385,16 +413,17 @@ function renderCall(
   aliases: ReadonlyMap<string, string> | undefined,
   targets: ReadonlyMap<string, string> | undefined,
   attributesNullable: boolean,
+  isKnownTarget: ((name: string) => boolean) | undefined,
 ): RenderedLine[] {
   switch (call.kind) {
     case "attribute":
       return renderAttribute(call, attributesNullable);
     case "hasMany":
     case "hasAndBelongsToMany":
-      return renderCollectionAssoc(info, call, aliases, targets);
+      return renderCollectionAssoc(info, call, aliases, targets, isKnownTarget);
     case "belongsTo":
     case "hasOne":
-      return renderSingularAssoc(info, call, aliases, targets);
+      return renderSingularAssoc(info, call, aliases, targets, isKnownTarget);
     case "scope":
       return renderScope(info, call);
     case "enum":
@@ -424,6 +453,7 @@ function renderCollectionAssoc(
   call: AssociationCall,
   aliases?: ReadonlyMap<string, string>,
   targets?: ReadonlyMap<string, string>,
+  isKnownTarget?: (name: string) => boolean,
 ): RenderedLine[] {
   // Post-Phase-R.2: collection readers return an AssociationProxy,
   // not a plain `Target[]`. The proxy is awaitable — `await blog.posts`
@@ -431,7 +461,7 @@ function renderCollectionAssoc(
   // collections. Singular associations (belongsTo / hasOne) are
   // covered by `loadBelongsTo` / `loadHasOne` overloads rendered by
   // `renderLoaderOverloads` at the end of `synthesizeDeclares`.
-  const target = resolveTarget(info, call, aliases, targets);
+  const target = resolveTarget(info, call, aliases, targets, isKnownTarget);
   const memberName = renderDeclaredMemberName(call.name);
   return [
     line(`declare ${memberName}: ${AR_IMPORT}.AssociationProxy<${target}>;`, call.name, false),
@@ -443,6 +473,7 @@ function renderSingularAssoc(
   call: AssociationCall,
   aliases?: ReadonlyMap<string, string>,
   targets?: ReadonlyMap<string, string>,
+  isKnownTarget?: (name: string) => boolean,
 ): RenderedLine[] {
   // `polymorphic: true` on belongsTo can't be narrowed statically — any
   // Base-rooted class could be on the other end. Fall back to `Base | null`.
@@ -450,7 +481,9 @@ function renderSingularAssoc(
   // `declare loadBelongsTo: ...` / `declare loadHasOne: ...` lines
   // by `renderLoaderOverloads` below.
   const target =
-    call.options["polymorphic"] === "true" ? "Base" : resolveTarget(info, call, aliases, targets);
+    call.options["polymorphic"] === "true"
+      ? "Base"
+      : resolveTarget(info, call, aliases, targets, isKnownTarget);
   const memberName = renderDeclaredMemberName(call.name);
   return [line(`declare ${memberName}: ${target} | null;`, call.name, false)];
 }
@@ -520,11 +553,18 @@ function resolveTarget(
   call: AssociationCall,
   aliases?: ReadonlyMap<string, string>,
   targets?: ReadonlyMap<string, string>,
+  isKnownTarget?: (name: string) => boolean,
 ): string {
   const override = targets?.get(`${info.name}#${call.name}`);
+  // A pre-resolved `through:` override already degrades to `Base` when
+  // unresolvable, so trust it as-is.
   if (override) return override;
   const target = resolveAssociationTarget(call);
-  return aliases?.get(target) ?? target;
+  const resolved = aliases?.get(target) ?? target;
+  // A plain association target that names no in-scope class would emit a
+  // dangling type reference; fall back to the always-visible `Base`.
+  if (isKnownTarget && !isKnownTarget(resolved)) return "Base";
+  return resolved;
 }
 
 function pascal(s: string): string {

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -90,14 +90,22 @@ export interface SynthesizeOptions {
    * dangling name (TS2304). When the predicate reports the target unknown the
    * declare falls back to `Base` (always in scope), mirroring how `through:`
    * targets already degrade to `Base`. Omitted → every target is trusted.
+   *
+   * `host` is the class the declare is spliced into, so the predicate can
+   * scope visibility to that exact splice site (a class in a sibling
+   * `describe`/`it` closure is NOT visible and must not count as known).
    */
-  isKnownTarget?: (name: string) => boolean;
+  isKnownTarget?: (name: string, host: ClassInfo) => boolean;
 }
 
 export function synthesizeDeclares(info: ClassInfo, opts: SynthesizeOptions = {}): string[] {
   const out: string[] = [];
   const aliases = opts.classNameAliases;
   const targets = opts.associationTargets;
+  // Bind the caller's predicate to THIS class — the declare's splice site —
+  // so target visibility is judged from where the declare actually lands,
+  // never from an ancestor's scope. Threaded as a plain `(name) => boolean`.
+  const isKnownTarget = boundKnownTarget(info, opts);
   // Subclass singular associations whose target isn't assignable to the
   // ancestor's (TS2416): suppress the property declare (loader overload kept).
   const conflictingSingulars = collectConflictingSingulars(info, opts);
@@ -130,7 +138,7 @@ export function synthesizeDeclares(info: ClassInfo, opts: SynthesizeOptions = {}
       aliases,
       targets,
       opts.attributesNullable ?? false,
-      opts.isKnownTarget,
+      isKnownTarget,
     )) {
       if (!line.skipIfPresent || !memberPresent(info, line)) {
         out.push(line.text);
@@ -138,13 +146,7 @@ export function synthesizeDeclares(info: ClassInfo, opts: SynthesizeOptions = {}
       }
     }
   }
-  for (const l of renderLoaderOverloads(
-    info,
-    aliases,
-    targets,
-    opts.ancestors,
-    opts.isKnownTarget,
-  )) {
+  for (const l of renderLoaderOverloads(info, aliases, targets, opts.ancestors, isKnownTarget)) {
     if (!info.existingMembers.has(l.declaredName)) {
       out.push(l.text);
       synthesizedInstanceNames.add(l.declaredName);
@@ -156,6 +158,20 @@ export function synthesizeDeclares(info: ClassInfo, opts: SynthesizeOptions = {}
     out.push(line);
   }
   return out;
+}
+
+/**
+ * Bind `opts.isKnownTarget` to `host` (the splice-site class), yielding a
+ * plain `(name) => boolean` threaded down the render helpers. `undefined`
+ * when the caller supplied no predicate (every target trusted verbatim).
+ */
+function boundKnownTarget(
+  host: ClassInfo,
+  opts: SynthesizeOptions,
+): ((name: string) => boolean) | undefined {
+  const predicate = opts.isKnownTarget;
+  if (!predicate) return undefined;
+  return (name: string) => predicate(name, host);
 }
 
 function renderSchemaColumnDeclares(
@@ -335,10 +351,13 @@ function collectConflictingSingulars(info: ClassInfo, opts: SynthesizeOptions): 
   const targets = opts.associationTargets;
   const superNameOf = opts.superNameOf;
 
+  // Conflict detection compares the target as seen from `info`'s splice
+  // site, so bind the predicate to `info` (not each ancestor `host`).
+  const isKnownTarget = boundKnownTarget(info, opts);
   const target = (host: ClassInfo, call: AssociationCall): string =>
     call.options["polymorphic"] === "true"
       ? "Base"
-      : resolveTarget(host, call, aliases, targets, opts.isKnownTarget);
+      : resolveTarget(host, call, aliases, targets, isKnownTarget);
   // Effective inherited target per association, folded base→derived
   // (`ancestors` is nearest-first, so reverse). A suppressed ancestor override
   // (target not assignable to what it inherits) does NOT change the effective
@@ -438,8 +457,15 @@ function renderAttribute(call: AttributeCall, nullable: boolean): RenderedLine[]
   // aware); re-declaring it here as an instance property is a TS2610 error.
   // Skip it, matching how renderSchemaColumnDeclares skips the `id` column.
   if (call.name === "id") return [];
-  const tsType = tsTypeFor(call.railsType);
   const memberName = renderDeclaredMemberName(call.name);
+  // An `*_id` integer attribute is a foreign key; widen it to accept a model
+  // `.id` (`PrimaryKeyValue`) assignment, exactly as the schema-column path
+  // does (see `isForeignKeyColumn`). `PrimaryKeyValue` already admits
+  // null/undefined, so the nullable wrapper is redundant here.
+  if (isForeignKeyColumn(call.name, call.railsType)) {
+    return [line(`declare ${memberName}: ${AR_IMPORT}.PrimaryKeyValue;`, call.name, false)];
+  }
+  const tsType = tsTypeFor(call.railsType);
   const rendered = nullable
     ? tsType.includes("|")
       ? `(${tsType}) | null`

--- a/packages/activerecord/src/type-virtualization/synthesize.ts
+++ b/packages/activerecord/src/type-virtualization/synthesize.ts
@@ -159,13 +159,30 @@ function renderSchemaColumnDeclares(
     if (composedCols?.has(col)) continue;
     // Skip columns listed in `@trails-typegen skip-columns:` JSDoc.
     if (info.skipSchemaColumns.has(col)) continue;
-    const tsType = renderSchemaValueType(value);
+    const tsType = isForeignKeyColumn(col, value)
+      ? `${AR_IMPORT}.PrimaryKeyValue`
+      : renderSchemaValueType(value);
     // Emit a bracket-quoted declare for non-identifier / reserved-word
     // names (e.g. `declare "strange-col": string;`). TypeScript allows
     // string-literal class field names, so this is a valid declare.
     out.push(`${INDENT}declare ${renderDeclaredMemberName(col)}: ${tsType};`);
   }
   return out;
+}
+
+/**
+ * A schema column is treated as a foreign key when its name ends in `_id`
+ * and its type is an integer kind — the shape Rails uses for a `belongs_to`
+ * reference. Such columns are routinely assigned another record's `.id`
+ * accessor (`membership.club_id = club.id`), which is typed `PrimaryKeyValue`
+ * (a union that includes `undefined`). A narrow `number | null` declare would
+ * reject that legitimate assignment (TS2322), so FK columns are widened to
+ * `PrimaryKeyValue` — the exact type an id accessor yields.
+ */
+function isForeignKeyColumn(col: string, value: SchemaColumnValue): boolean {
+  if (col === "id" || !col.endsWith("_id")) return false;
+  const type = typeof value === "string" ? value : value.type;
+  return type === "integer" || type === "big_integer" || type === "bigint";
 }
 
 /**

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -226,6 +226,32 @@ describe("virtualize — deltas", () => {
     expect(text).toMatch(/declare score_nullable: bigint \| null;/);
   });
 
+  test("schemaColumnsByTable widens integer FK columns to PrimaryKeyValue", () => {
+    const src = "export class Membership extends Base {}\n";
+    const { text } = virtualize(src, "membership.ts", {
+      schemaColumnsByTable: {
+        memberships: {
+          club_id: { type: "integer", null: true },
+          member_id: { type: "big_integer", null: false },
+          favorite_things_id: "integer", // legacy string shape is FK too
+          rank: { type: "integer", null: true }, // not an FK: name doesn't end in _id
+        },
+      },
+    });
+    // FK columns accept a model `.id` (PrimaryKeyValue) assignment.
+    expect(text).toMatch(
+      /declare club_id: import\("@blazetrails\/activerecord"\)\.PrimaryKeyValue;/,
+    );
+    expect(text).toMatch(
+      /declare member_id: import\("@blazetrails\/activerecord"\)\.PrimaryKeyValue;/,
+    );
+    expect(text).toMatch(
+      /declare favorite_things_id: import\("@blazetrails\/activerecord"\)\.PrimaryKeyValue;/,
+    );
+    // Non-FK integer column keeps its narrow type.
+    expect(text).toMatch(/declare rank: number \| null;/);
+  });
+
   test("schemaColumnsByTable mixing legacy string and rich shape in same table", () => {
     const src = "export class Post extends Base {}\n";
     const { text } = virtualize(src, "post.ts", {

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -134,6 +134,41 @@ describe("virtualize — deltas", () => {
     expect(text).toMatch(/declare safe: string;/);
   });
 
+  test("isKnownTarget: unknown plain association target falls back to Base", () => {
+    const src =
+      "export class Thing extends Base {\n" +
+      "  static {\n" +
+      '    this.hasOne("otherThing");\n' +
+      '    this.hasMany("gadgets");\n' +
+      '    this.belongsTo("owner");\n' +
+      "  }\n" +
+      "}\n";
+    // Only `Owner` is a known target; `OtherThing` / `Gadget` name no model.
+    const { text } = virtualize(src, "thing.ts", {
+      isKnownTarget: (name) => name === "Base" || name === "Owner",
+    });
+    // Dangling names degrade to Base (in scope); known target is kept.
+    expect(text).toMatch(/declare otherThing: Base \| null;/);
+    expect(text).toMatch(/declare gadgets: .*AssociationProxy<Base>;/);
+    expect(text).toMatch(/declare owner: Owner \| null;/);
+    expect(text).not.toMatch(/OtherThing/);
+    expect(text).not.toMatch(/Gadget/);
+    // Loader overload for the unknown hasOne also degrades to Base.
+    expect(text).toMatch(/declare loadHasOne:.*name: "otherThing".*Promise<Base \| null>/);
+  });
+
+  test("isKnownTarget omitted: every target is trusted verbatim", () => {
+    const src =
+      "export class Thing extends Base {\n" +
+      "  static {\n" +
+      '    this.hasOne("otherThing");\n' +
+      "  }\n" +
+      "}\n";
+    const { text } = virtualize(src, "thing.ts");
+    // No predicate → classify result emitted as-is (back-compat).
+    expect(text).toMatch(/declare otherThing: OtherThing \| null;/);
+  });
+
   test("schemaColumnsByTable doesn't collide with hasMany / belongsTo names", () => {
     const src =
       "export class Post extends Base {\n" +

--- a/packages/activerecord/src/type-virtualization/virtualize.test.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.test.ts
@@ -157,6 +157,47 @@ describe("virtualize — deltas", () => {
     expect(text).toMatch(/declare loadHasOne:.*name: "otherThing".*Promise<Base \| null>/);
   });
 
+  test("isKnownTarget is scoped to the splice-site host, not a flat file scan", () => {
+    // Two independent model classes each associate `widget`. The predicate
+    // only reports `Widget` known when the host is `A` — modeling `Widget`
+    // being visible in A's closure but NOT B's sibling closure. B's declare
+    // must degrade to Base even though the name is "known" for A.
+    const src =
+      "export class A extends Base {\n" +
+      "  static {\n" +
+      '    this.hasOne("widget");\n' +
+      "  }\n" +
+      "}\n" +
+      "export class B extends Base {\n" +
+      "  static {\n" +
+      '    this.hasOne("widget");\n' +
+      "  }\n" +
+      "}\n";
+    const { text } = virtualize(src, "ab.ts", {
+      isKnownTarget: (name, host) => name === "Base" || (name === "Widget" && host.name === "A"),
+    });
+    // A sees Widget; B does not — B falls back to Base.
+    expect(text).toMatch(/class A extends Base \{\s*declare widget: Widget \| null;/);
+    expect(text).toMatch(/class B extends Base \{\s*declare widget: Base \| null;/);
+  });
+
+  test("integer FK attribute() declare widens to PrimaryKeyValue", () => {
+    const src =
+      "export class Membership extends Base {\n" +
+      "  static {\n" +
+      '    this.attribute("club_id", "integer");\n' +
+      '    this.attribute("rank", "integer");\n' +
+      "  }\n" +
+      "}\n";
+    const { text } = virtualize(src, "membership.ts", { attributesNullable: true });
+    // FK attribute accepts a model `.id` (PrimaryKeyValue) assignment.
+    expect(text).toMatch(
+      /declare club_id: import\("@blazetrails\/activerecord"\)\.PrimaryKeyValue;/,
+    );
+    // Non-FK integer attribute keeps its (nullable) narrow type.
+    expect(text).toMatch(/declare rank: number \| null;/);
+  });
+
   test("isKnownTarget omitted: every target is trusted verbatim", () => {
     const src =
       "export class Thing extends Base {\n" +

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -109,6 +109,14 @@ export interface VirtualizeOptions extends WalkOptions {
    * for a column whose value is exposed as an aggregate object.
    */
   composedOfColumns?: ReadonlyMap<string, ReadonlySet<string>>;
+  /**
+   * Predicate: does an association-target class name resolve to a type in
+   * scope where the declare is spliced? Forwarded to `synthesizeDeclares` so a
+   * plain association naming no in-scope model falls back to `Base` instead of
+   * emitting a dangling type reference. See
+   * {@link import("./synthesize.js").SynthesizeOptions.isKnownTarget}.
+   */
+  isKnownTarget?: (name: string) => boolean;
 }
 
 export function virtualize(
@@ -147,6 +155,7 @@ export function virtualize(
       attributesNullable: options.attributesNullable,
       associationTargets: options.associationTargets,
       composedOfColumns: options.composedOfColumns,
+      isKnownTarget: options.isKnownTarget,
       ancestors: ancestorsOf.get(info),
       superNameOf,
     });

--- a/packages/activerecord/src/type-virtualization/virtualize.ts
+++ b/packages/activerecord/src/type-virtualization/virtualize.ts
@@ -113,10 +113,11 @@ export interface VirtualizeOptions extends WalkOptions {
    * Predicate: does an association-target class name resolve to a type in
    * scope where the declare is spliced? Forwarded to `synthesizeDeclares` so a
    * plain association naming no in-scope model falls back to `Base` instead of
-   * emitting a dangling type reference. See
+   * emitting a dangling type reference. `host` is the class the declare is
+   * spliced into, so visibility is judged at the splice site. See
    * {@link import("./synthesize.js").SynthesizeOptions.isKnownTarget}.
    */
-  isKnownTarget?: (name: string) => boolean;
+  isKnownTarget?: (name: string, host: import("./walker.js").ClassInfo) => boolean;
 }
 
 export function virtualize(


### PR DESCRIPTION
## What

Two generator gaps that blocked baking `has-one-through-associations.test.ts`
typecheck-green, both discovered via the story's named file.

### 1. FK column declares widened to `PrimaryKeyValue`

Generator-emitted schema `declare`s for foreign-key columns were typed
`number | null`. Test code routinely assigns another record's `.id` accessor
to such a column (`membership.club_id = club.id`), and `.id` returns the
`PrimaryKeyValue` union (which includes `undefined`), so the narrow declare
failed `pnpm typecheck` with TS2322. `renderSchemaColumnDeclares` now detects
FK columns — a name ending in `_id` (excluding `id`) whose type is an integer
kind — and emits `PrimaryKeyValue`, the exact type an id accessor yields.
Non-FK integer columns keep their narrow `number`. `PrimaryKeyValue` is added
to the materializer's builtin import map so the hoisted `import type` resolves
to `base.js`.

### 2. Unresolvable plain association target degrades to `Base`

Baking the file surfaced a second gap: a plain (non-`through`) association
whose `classify`-d target names no in-scope model — `hasOne("otherThing")` in
the throwaway `Thing` class of the "cannot have a counter cache" test — emitted
`declare otherThing: OtherThing | null`, a dangling reference (TS2304). A new
`isKnownTarget` predicate (model registry + in-file class names + `Base`),
threaded through `synthesizeDeclares`, degrades such a target to `Base` —
mirroring how `through:` targets already fall back. Omitting the predicate
preserves verbatim output (back-compat).

## Result

`has-one-through-associations.test.ts` bakes typecheck-green (the +4 declares
now resolve to `Base`); full package `tsc --noEmit` clean; its suite passes
(51 passed, 2 pre-existing skips).

## Tests

`virtualize.test.ts` gains three cases: FK columns → `PrimaryKeyValue`
(rich + legacy shapes, non-FK integer stays `number`); unknown plain target →
`Base` (property + collection + loader overload); predicate omitted → verbatim.
Full suite green (79 tests). Existing fixture-pair tests unchanged, confirming
no default-path regression (canonical models' targets are all registry-known).

Closes-story: materialize-declares-generator-fk-primarykeyvalue-gap
Closes-story: materialize-declares-generator-unresolvable-assoc-target-fallback