### PR TITLE
fix(materialize-declares): don't misparse dynamic-import .then as named import

### DIFF
--- a/packages/activerecord/scripts/materialize-model-declares.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.ts
@@ -615,12 +615,15 @@ function collectNamesInScope(sf: ts.SourceFile): Set<string> {
 // AR built-ins are pointed at the same relative paths the hand-written
 // model declares use, to match convention; anything else keeps its
 // original module specifier.
-// The negative lookahead `(?!\s*\()` excludes runtime dynamic imports —
+// The trailing `(?![\w$]|\s*\()` lookahead excludes runtime dynamic imports —
 // `import("mod").then((m) => m.Foo)` — where the member access is immediately
 // CALLED. The virtualizer only ever emits `import("mod").Sym` in TYPE position
 // (used as `Sym`, `Sym<…>`, `Sym | null`, …), which is never followed by `(`,
-// so distinguishing a call site keeps a `.then(...)` Promise chain from being
-// misparsed as a named import of a symbol called `then`.
+// so rejecting a call site keeps a `.then(...)` Promise chain from being
+// misparsed as a named import of a symbol called `then`. The `[\w$]` half of
+// the lookahead pins the identifier to its full extent: without it the greedy
+// `[\w$]*` would backtrack and match the prefix `the` of `then(`, whose next
+// char is `n` (not `(`), re-introducing the bug.
 const INLINE_IMPORT_RE = /import\("([^"]+)"\)\.([A-Za-z_$][\w$]*)(?![\w$]|\s*\()/g;
 // AR built-ins, keyed by symbol → the source module relative to MODELS_DIR
 // (the same paths the hand-written model declares under that dir use). The

--- a/packages/activerecord/scripts/materialize-model-declares.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.ts
@@ -615,7 +615,13 @@ function collectNamesInScope(sf: ts.SourceFile): Set<string> {
 // AR built-ins are pointed at the same relative paths the hand-written
 // model declares use, to match convention; anything else keeps its
 // original module specifier.
-const INLINE_IMPORT_RE = /import\("([^"]+)"\)\.([A-Za-z_$][\w$]*)/g;
+// The negative lookahead `(?!\s*\()` excludes runtime dynamic imports —
+// `import("mod").then((m) => m.Foo)` — where the member access is immediately
+// CALLED. The virtualizer only ever emits `import("mod").Sym` in TYPE position
+// (used as `Sym`, `Sym<…>`, `Sym | null`, …), which is never followed by `(`,
+// so distinguishing a call site keeps a `.then(...)` Promise chain from being
+// misparsed as a named import of a symbol called `then`.
+const INLINE_IMPORT_RE = /import\("([^"]+)"\)\.([A-Za-z_$][\w$]*)(?![\w$]|\s*\()/g;
 // AR built-ins, keyed by symbol → the source module relative to MODELS_DIR
 // (the same paths the hand-written model declares under that dir use). The
 // specifier is recomputed relative to each materialized file's directory in

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -1,6 +1,7 @@
 /**
  * Mirrors Rails activerecord/test/cases/associations/has_many_through_associations_test.rb
  */
+import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { Base, registerModel, RecordInvalid } from "../index.js";
 import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
@@ -342,6 +343,9 @@ describe("HasManyThroughAssociationsTest", () => {
   it("ordered has many through", async () => {
     // Rails creates an anonymous person class with ordered posts
     class PersonPrime extends Base {
+      declare readers: AssociationProxy<Reader>;
+      declare posts: AssociationProxy<Post>;
+
       static {
         this._tableName = "people";
         this.hasMany("readers", { foreignKey: "person_id" });
@@ -382,6 +386,10 @@ describe("HasManyThroughAssociationsTest", () => {
   it("no pk join table append", async () => {
     // Rails: make_no_pk_hm_t creates anonymous models using lessons/lessons_students/students
     class NoPkLesson extends Base {
+      declare name: string | null;
+      declare lessonStudents: AssociationProxy<NoPkLessonStudent>;
+      declare students: AssociationProxy<Base>;
+
       static {
         this._tableName = "lessons";
         this.attribute("name", "string");
@@ -390,6 +398,11 @@ describe("HasManyThroughAssociationsTest", () => {
       }
     }
     class NoPkLessonStudent extends Base {
+      declare lesson_id: bigint | null;
+      declare student_id: bigint | null;
+      declare student: NoPkStudent | null;
+      declare loadBelongsTo: (name: "student") => Promise<NoPkStudent | null>;
+
       static {
         this._tableName = "lessons_students";
         this.attribute("lesson_id", "big_integer");
@@ -398,6 +411,8 @@ describe("HasManyThroughAssociationsTest", () => {
       }
     }
     class NoPkStudent extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "students";
         this.attribute("name", "string");
@@ -416,6 +431,10 @@ describe("HasManyThroughAssociationsTest", () => {
 
   it("no pk join table delete", async () => {
     class NoPkDelLesson extends Base {
+      declare name: string | null;
+      declare lessonStudents: AssociationProxy<NoPkDelLessonStudent>;
+      declare students: AssociationProxy<Base>;
+
       static {
         this._tableName = "lessons";
         this.attribute("name", "string");
@@ -427,6 +446,11 @@ describe("HasManyThroughAssociationsTest", () => {
       }
     }
     class NoPkDelLessonStudent extends Base {
+      declare lesson_id: bigint | null;
+      declare student_id: bigint | null;
+      declare student: NoPkDelStudent | null;
+      declare loadBelongsTo: (name: "student") => Promise<NoPkDelStudent | null>;
+
       static {
         this._tableName = "lessons_students";
         this.attribute("lesson_id", "big_integer");
@@ -435,6 +459,8 @@ describe("HasManyThroughAssociationsTest", () => {
       }
     }
     class NoPkDelStudent extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "students";
         this.attribute("name", "string");
@@ -462,6 +488,10 @@ describe("HasManyThroughAssociationsTest", () => {
 
   it("no pk join model callbacks", async () => {
     class NoPkCbLesson extends Base {
+      declare name: string | null;
+      declare lessonStudents: AssociationProxy<NoPkCbLessonStudent>;
+      declare students: AssociationProxy<Base>;
+
       static {
         this._tableName = "lessons";
         this.attribute("name", "string");
@@ -474,6 +504,11 @@ describe("HasManyThroughAssociationsTest", () => {
     }
     let afterDestroyCalled = false;
     class NoPkCbLessonStudent extends Base {
+      declare lesson_id: bigint | null;
+      declare student_id: bigint | null;
+      declare student: NoPkCbStudent | null;
+      declare loadBelongsTo: (name: "student") => Promise<NoPkCbStudent | null>;
+
       static {
         this._tableName = "lessons_students";
         this.attribute("lesson_id", "big_integer");
@@ -485,6 +520,8 @@ describe("HasManyThroughAssociationsTest", () => {
       }
     }
     class NoPkCbStudent extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "students";
         this.attribute("name", "string");
@@ -2373,6 +2410,12 @@ describe("HasManyThroughAssociationsTest", () => {
   // TS-only: insertRecord with validate false skips join record validation
   it("insertRecord with validate false skips join record validation", async () => {
     class IrpvTagging extends Base {
+      declare taggable_id: number | null;
+      declare taggable_type: string | null;
+      declare tag_id: number | null;
+      declare tag: Tag | null;
+      declare loadBelongsTo: (name: "tag") => Promise<Tag | null>;
+
       static {
         this._tableName = "taggings";
         this.attribute("taggable_id", "integer");
@@ -2390,6 +2433,11 @@ describe("HasManyThroughAssociationsTest", () => {
     const tag = await Tag.create({ name: "testjoin" });
 
     class IrpvPost extends Base {
+      declare title: string | null;
+      declare body: string | null;
+      declare irpvTaggings: AssociationProxy<IrpvTagging>;
+      declare irpvTags: AssociationProxy<Base>;
+
       static {
         this._tableName = "posts";
         this.attribute("title", "string");


### PR DESCRIPTION
## Problem

The `materialize-model-declares.ts` generator misparsed dynamic imports of
the form `import("...").then((m) => m.Foo)` as a named import of a symbol
called `then`. Running it on `has-many-through-associations.test.ts` injected
a phantom `import type { then } from "../test-helpers/models/cpk.js";` and
rewrote existing dynamic-import call sites to `await then((m) => m.Foo)`,
yielding `ReferenceError: then is not defined` at runtime.

## Root cause

`INLINE_IMPORT_RE` (used to hoist the virtualizer's inline
`import("mod").Sym` type expressions into top-level `import type` lines) also
matched runtime dynamic imports `import("mod").then(...)`. The virtualizer
only ever emits `import("mod").Sym` in **type** position, which is never
immediately called.

## Fix

Add a `(?![\w$]|\s*\()` boundary to the regex so a `.then(` Promise chain is
left untouched (the identifier-boundary half of the lookahead also prevents
backtracking from matching a prefix like `the`). Then re-bake the now-clean
declares into `has-many-through-associations.test.ts`.

- Generator no longer treats `import("...").then(...)` as a named import.
- Re-running on `has-many-through-associations.test.ts` produces only valid
  `declare` accessors — no phantom `then` import, dynamic-import sites intact.
- Suite passes (168 passed, 1 skipped) and typechecks green.

Closes-story: materialize-declares-generator-then-dynamic-import-misparse