### PR TITLE
fix(activerecord): fall back unresolvable plain assoc targets to Base in declare generator

### DIFF
--- a/packages/activerecord/scripts/materialize-model-declares.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.ts
@@ -24,6 +24,7 @@ import { walk, type ClassInfo, type AssociationCall } from "../src/type-virtuali
 import {
   resolveAssociationTarget,
   resolveThroughTarget,
+  isEmittableTargetName,
   stripQuotes,
   type ModelAssociationLookup,
 } from "../src/type-virtualization/resolve-target.js";
@@ -362,24 +363,56 @@ function buildModelAssociationLookup(
  * Resolve every `through:` association on the file's models to its source
  * class, keyed `"<ClassName>#<assocName>"`. Unresolvable chains fall back to
  * `Base` (always in scope) — keeps output green.
+ *
+ * Plain (non-`through`) `belongsTo`/`hasOne`/`hasMany` targets are also
+ * pinned to `Base` when they classify to a name that is neither a registered
+ * model nor lexically visible from the declaring class — otherwise the
+ * synthesizer would emit a dangling class reference (TS2304), e.g.
+ * `hasOne("otherThing")` with no `OtherThing` model → `declare otherThing:
+ * OtherThing | null`. Resolvable targets are left untouched so their real
+ * type (and auto-import) is preserved.
  */
 function buildAssociationTargets(
+  sf: ts.SourceFile,
   modelClasses: readonly ClassInfo[],
   lookup: ModelAssociationLookup,
   aliases: ReadonlyMap<string, string>,
+  registry: ReadonlyMap<string, string>,
 ): Map<string, string> {
   const targets = new Map<string, string>();
+  const moduleScope = collectNamesInScope(sf);
   for (const info of modelClasses) {
     const own = associationCalls(info);
+    // Names a bare target reference spliced into this class can resolve to:
+    // module-scope imports/decls plus lexically-visible in-file classes.
+    // Mirrors the visibility set `resolveAutoImports` uses.
+    const visible = new Set(moduleScope);
+    collectVisibleClassNames(info.classDecl, visible);
     // Resolve `through:` against the class's inheritance-merged association
     // set so a subclass whose `through` target is an INHERITED association
     // (e.g. `SpecialComment.has_one :author, through: :post`, where `post` is
     // `Comment`'s `belongs_to`) finds it instead of degrading to `Base`.
     const defining = lookup(info.name) ?? own;
     for (const call of own) {
-      if (!call.options["through"]) continue;
-      const resolved = resolveThroughTarget(defining, call, lookup, aliases) ?? "Base";
-      targets.set(`${info.name}#${call.name}`, resolved);
+      if (call.options["through"]) {
+        const resolved = resolveThroughTarget(defining, call, lookup, aliases) ?? "Base";
+        targets.set(`${info.name}#${call.name}`, resolved);
+        continue;
+      }
+      // Polymorphic belongsTo is rendered as `Base` by the synthesizer
+      // directly (no single target class), so leave it out of the map.
+      if (call.options["polymorphic"] === "true") continue;
+      const resolved = resolveAssociationTarget(call);
+      const mapped = aliases.get(resolved) ?? resolved;
+      if (
+        isEmittableTargetName(
+          mapped,
+          (n) => registry.has(n),
+          (n) => visible.has(n),
+        )
+      )
+        continue;
+      targets.set(`${info.name}#${call.name}`, "Base");
     }
   }
   return targets;
@@ -733,9 +766,11 @@ async function main(): Promise<void> {
     // Pre-resolve `through:` targets so declares + auto-imports name the real
     // source class, not `classify`-of-the-association-name.
     const associationTargets = buildAssociationTargets(
+      sf,
       walk(sf, { isModelClass }),
       associationLookup,
       classNameAliases,
+      registry,
     );
     const prependImports = resolveAutoImports(
       sf,

--- a/packages/activerecord/src/type-virtualization/resolve-target.test.ts
+++ b/packages/activerecord/src/type-virtualization/resolve-target.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { resolveThroughTarget, type ModelAssociationLookup } from "./resolve-target.js";
+import {
+  resolveThroughTarget,
+  isEmittableTargetName,
+  type ModelAssociationLookup,
+} from "./resolve-target.js";
 import type { AssociationCall, AssociationKind, RecordLiteral } from "./walker.js";
 
 function assoc(kind: AssociationKind, name: string, options: RecordLiteral = {}): AssociationCall {
@@ -72,5 +76,28 @@ describe("resolveThroughTarget", () => {
     expect(resolveThroughTarget([plain], plain, () => undefined)).toBeUndefined();
     const orphan = assoc("hasMany", "comments", { through: '"posts"' });
     expect(resolveThroughTarget([orphan], orphan, () => undefined)).toBeUndefined();
+  });
+});
+
+describe("isEmittableTargetName", () => {
+  const none = () => false;
+
+  test("Base is always emittable (in scope everywhere)", () => {
+    expect(isEmittableTargetName("Base", none, none)).toBe(true);
+  });
+
+  test("a registered model is emittable (auto-import will resolve it)", () => {
+    const registered = (n: string) => n === "Comment";
+    expect(isEmittableTargetName("Comment", registered, none)).toBe(true);
+  });
+
+  test("a lexically-visible in-file class is emittable", () => {
+    const visible = (n: string) => n === "Thing";
+    expect(isEmittableTargetName("Thing", none, visible)).toBe(true);
+  });
+
+  test("an unregistered, invisible name is NOT emittable — caller pins it to Base", () => {
+    // classify("otherThing") → "OtherThing" with no backing model: dangling.
+    expect(isEmittableTargetName("OtherThing", none, none)).toBe(false);
   });
 });

--- a/packages/activerecord/src/type-virtualization/resolve-target.ts
+++ b/packages/activerecord/src/type-virtualization/resolve-target.ts
@@ -17,6 +17,24 @@ export function resolveAssociationTarget(call: AssociationCall): string {
 export type ModelAssociationLookup = (className: string) => readonly AssociationCall[] | undefined;
 
 /**
+ * Whether a resolved plain (non-`through`) association target class NAME can be
+ * emitted as a bare reference in a synthesized `declare` — i.e. it is `Base`, a
+ * registered model (an `import type` will be added for it), or lexically visible
+ * from the declaring class. A name that is none of these — e.g.
+ * `classify("otherThing")` → `OtherThing` with no backing `OtherThing` model —
+ * is unresolvable; the caller pins it to `Base` so the synthesizer never emits
+ * a dangling reference (TS2304). Mirrors the `?? "Base"` fallback that
+ * `resolveThroughTarget` already gets for `through:` targets.
+ */
+export function isEmittableTargetName(
+  name: string,
+  isRegistered: (name: string) => boolean,
+  isVisible: (name: string) => boolean,
+): boolean {
+  return name === "Base" || isRegistered(name) || isVisible(name);
+}
+
+/**
  * Resolve a `has_many`/`has_one :x, through: :y` target by following Rails'
  * through→source reflection chain — the element type is the SOURCE class on the
  * through model (`Comment`), not `classify(name)` (`CommentsWithOrder`). `lookup`


### PR DESCRIPTION
## What

An unresolvable **plain** (non-`through:`) `belongsTo`/`hasOne`/`hasMany`
association target — one whose classified name has no backing model and
is not lexically visible from the declaring class — made the
materialize-declares generator emit a dangling class reference. For
`has-one-through-associations.test.ts`'s throwaway model:

```ts
class Thing extends Base {
  static {
    this.hasOne("otherThing");                                   // no OtherThing model
    this.hasOne("thing", { through: "otherThing", counterCache: true });
  }
}
```

`classify("otherThing")` → `OtherThing`, which is neither registered nor
in scope, so the generator emitted `declare otherThing: OtherThing | null;`
with no import — TS2304 `Cannot find name 'OtherThing'`, blocking the bake.

`through:` targets already fall back to `Base` when unresolvable
(`resolveThroughTarget ?? "Base"`); plain targets did not.

## Fix

`buildAssociationTargets` now pins a plain target to `Base` when its
resolved name is neither `Base`, a registered model, nor lexically
visible from the declaring class — mirroring the existing `through:`
fallback. Resolvable targets (a registered model or an in-scope in-file
class) are left untouched, so their real type and auto-import are
preserved.

The emittability decision is extracted into `isEmittableTargetName` in
the shared `resolve-target` module and unit-tested.

## Verification

- Baking `has-one-through-associations.test.ts` now emits
  `declare otherThing: Base | null;` (no dangling name) — typecheck-green.
- Regression guard: baking the `topic.ts`/`developer.ts` pilot leaves
  resolvable targets (`Mentor`, `Firm`, `Ship`, `SpecialContract`, …)
  unchanged — no spurious `Base` fallback.
- `resolve-target.test.ts` + `virtualize.test.ts` pass (86 tests).

This is a generator-fix-only change (does not bake the test file into
source), following the precedent of #4170.

Closes-story: materialize-declares-generator-unresolvable-assoc-target-fallback
