### PR TITLE
test(associations): materialize declare accessors for large association bakes

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -2,6 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
+import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, expect, beforeAll } from "vitest";
 import { Notifications, throwAbort } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
@@ -337,6 +338,8 @@ describe("HasManyAssociationsTestForReorderWithJoinDependency", () => {
 
   it("should generate valid sql", () => {
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -737,6 +740,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("destroy all", async () => {
     class DestroyAllAuthor extends Base {
+      declare name: string | null;
+      declare destroy_all_posts: AssociationProxy<DestroyAllPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -748,6 +754,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DestroyAllPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -769,6 +778,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("delete all with not yet loaded association collection", async () => {
     class DeleteAllUnloadedAuthor extends Base {
+      declare name: string | null;
+      declare delete_all_unloaded_posts: AssociationProxy<DeleteAllUnloadedPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -780,6 +792,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DeleteAllUnloadedPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -801,6 +816,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("depends and nullify", async () => {
     class NullifyAuthor extends Base {
+      declare name: string | null;
+      declare nullify_posts: AssociationProxy<NullifyPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -812,6 +830,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class NullifyPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -831,6 +852,9 @@ describe("HasManyAssociationsTest", () => {
     // Regression guard: the pre-ForeignAssociation.nullifiedOwnerAttributes
     // path only nulled the first FK column when `foreignKey` was an array.
     class CpkAuthor extends Base {
+      declare name: string | null;
+      declare cpk_posts: AssociationProxy<CpkPost>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("cpk_posts", {
@@ -842,6 +866,10 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class CpkPost extends Base {
+      declare tenant_id: number | null;
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this.attribute("tenant_id", "integer");
         this.attribute("author_id", "integer");
@@ -869,6 +897,9 @@ describe("HasManyAssociationsTest", () => {
     // not targets. Our equivalents are _associationInstances (singular)
     // and _collectionProxies (collection).
     class CacheAuthor extends Base {
+      declare name: string | null;
+      declare cache_posts: AssociationProxy<CachePost>;
+
       declare cachePosts: CollectionProxy<Base>;
       static {
         this._tableName = "authors";
@@ -880,6 +911,8 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class CachePost extends Base {
+      declare cache_author_id: number | null;
+
       static {
         this.attribute("cache_author_id", "integer");
       }
@@ -960,6 +993,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("clearing an association collection", async () => {
     class ClearAuthor extends Base {
+      declare name: string | null;
+      declare clear_posts: AssociationProxy<ClearPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -971,6 +1007,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ClearPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -992,6 +1031,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("clearing a dependent association collection", async () => {
     class ClearDepAuthor extends Base {
+      declare name: string | null;
+      declare clear_dep_posts: AssociationProxy<ClearDepPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1003,6 +1045,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ClearDepPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1273,6 +1318,8 @@ describe("HasManyAssociationsTest", () => {
 
   it("association with extend option", () => {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
@@ -1345,6 +1392,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("anonymous has many", async () => {
     class AnonAuthor extends Base {
+      declare name: string | null;
+      declare anon_posts: AssociationProxy<AnonPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1355,6 +1405,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class AnonPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1411,12 +1464,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("create from association should respect default scope", async () => {
     class DefScopeAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class DefScopePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1432,12 +1490,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("build and create from association should respect passed attributes over default scope", async () => {
     class AttrAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class AttrPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1452,12 +1515,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("build and create from association should respect unscope over default scope", async () => {
     class UnscopeAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class UnscopePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1477,12 +1545,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("build from association should respect scope", async () => {
     class ScopeAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ScopePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1498,12 +1571,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("build from association sets inverse instance", async () => {
     class InvAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class InvPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1520,6 +1598,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("delete all on association is the same as not loaded", async () => {
     class DelAllAuthor extends Base {
+      declare name: string | null;
+      declare del_all_posts: AssociationProxy<DelAllPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1531,6 +1612,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DelAllPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1552,6 +1636,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("delete all on association with nil dependency is the same as not loaded", async () => {
     class NilDepAuthor extends Base {
+      declare name: string | null;
+      declare nil_dep_posts: AssociationProxy<NilDepPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1563,6 +1650,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class NilDepPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1581,6 +1671,10 @@ describe("HasManyAssociationsTest", () => {
   it("building the associated object with implicit sti base class", () => {
     // DependentFirm has_many :companies; Company has STI with type column
     class StiCompany extends Base {
+      declare name: string | null;
+      declare "type": string | null;
+      declare firm_id: number | null;
+
       static {
         this.attribute("name", "string");
         this.attribute("type", "string");
@@ -1593,6 +1687,8 @@ describe("HasManyAssociationsTest", () => {
     class StiClient extends StiCompany {}
     registerSubclass(StiClient);
     class StiAccount extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
@@ -1603,6 +1699,9 @@ describe("HasManyAssociationsTest", () => {
     registerModel(StiAccount);
 
     class DepFirm extends Base {
+      declare name: string | null;
+      declare stiCompanies: AssociationProxy<StiCompany>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("stiCompanies", {
@@ -1621,6 +1720,10 @@ describe("HasManyAssociationsTest", () => {
 
   it("building the associated object with explicit sti base class", () => {
     class StiCompany2 extends Base {
+      declare name: string | null;
+      declare "type": string | null;
+      declare firm_id: number | null;
+
       static {
         this.attribute("name", "string");
         this.attribute("type", "string");
@@ -1634,6 +1737,9 @@ describe("HasManyAssociationsTest", () => {
     registerModel(StiClient2);
 
     class DepFirm2 extends Base {
+      declare name: string | null;
+      declare stiCompany2s: AssociationProxy<StiCompany2>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("stiCompany2s", {
@@ -1652,6 +1758,10 @@ describe("HasManyAssociationsTest", () => {
 
   it("building the associated object with sti subclass", () => {
     class StiCompany3 extends Base {
+      declare name: string | null;
+      declare "type": string | null;
+      declare firm_id: number | null;
+
       static {
         this.attribute("name", "string");
         this.attribute("type", "string");
@@ -1665,6 +1775,9 @@ describe("HasManyAssociationsTest", () => {
     registerModel(StiClient3);
 
     class DepFirm3 extends Base {
+      declare name: string | null;
+      declare stiCompany3s: AssociationProxy<StiCompany3>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("stiCompany3s", {
@@ -1683,6 +1796,10 @@ describe("HasManyAssociationsTest", () => {
 
   it("building the associated object with an invalid type", () => {
     class StiCompany4 extends Base {
+      declare name: string | null;
+      declare "type": string | null;
+      declare firm_id: number | null;
+
       static {
         this.attribute("name", "string");
         this.attribute("type", "string");
@@ -1693,6 +1810,9 @@ describe("HasManyAssociationsTest", () => {
     registerModel(StiCompany4);
 
     class DepFirm4 extends Base {
+      declare name: string | null;
+      declare stiCompany4s: AssociationProxy<StiCompany4>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("stiCompany4s", {
@@ -1710,6 +1830,10 @@ describe("HasManyAssociationsTest", () => {
 
   it("building the associated object with an unrelated type", () => {
     class StiCompany5 extends Base {
+      declare name: string | null;
+      declare "type": string | null;
+      declare firm_id: number | null;
+
       static {
         this.attribute("name", "string");
         this.attribute("type", "string");
@@ -1718,6 +1842,8 @@ describe("HasManyAssociationsTest", () => {
     }
     enableSti(StiCompany5);
     class UnrelatedModel extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
@@ -1726,6 +1852,9 @@ describe("HasManyAssociationsTest", () => {
     registerModel(UnrelatedModel);
 
     class DepFirm5 extends Base {
+      declare name: string | null;
+      declare stiCompany5s: AssociationProxy<StiCompany5>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("stiCompany5s", {
@@ -1781,12 +1910,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("association protect foreign key", async () => {
     class ProtAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ProtPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1803,11 +1937,17 @@ describe("HasManyAssociationsTest", () => {
   // TODO: canonical posts has no status column
   it.skip("association enum works properly", async () => {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Post extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+      declare status: string | null;
+
       static {
         this.attribute("author_id", "integer");
         this.attribute("title", "string");
@@ -1834,12 +1974,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("finder method with dirty target", async () => {
     class FinderDirtyAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FinderDirtyPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1861,6 +2006,9 @@ describe("HasManyAssociationsTest", () => {
   // TODO: counter cache: canonical authors has no posts_count (use HmTopic/HmReply)
   it.skip("create resets cached counters", async () => {
     class CcResetAuthor extends Base {
+      declare name: string | null;
+      declare posts_count: number | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1868,6 +2016,11 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class CcResetPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+      declare author: CcResetAuthor | null;
+      declare loadBelongsTo: (name: "author") => Promise<CcResetAuthor | null>;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1891,12 +2044,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("counting with counter sql", async () => {
     class CcSqlAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class CcSqlPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1940,12 +2098,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("find many with merged options", async () => {
     class MergedAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class MergedPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1968,12 +2131,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("find should append to association order", async () => {
     class AppOrdAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class AppOrdPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -1993,12 +2161,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("dynamic find should respect association order", async () => {
     class DynOrdAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class DynOrdPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2025,6 +2198,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("taking not found", async () => {
     class TakeNotFoundPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2057,12 +2233,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("cant save has many readonly association", async () => {
     class RoAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class RoPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2088,12 +2269,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("finding default orders", async () => {
     class DefOrdAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class DefOrdPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2113,6 +2299,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("finding with different class name and order", async () => {
     class DiffNameAuthor extends Base {
+      declare name: string | null;
+      declare articles: AssociationProxy<DiffNameArticle>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2123,6 +2312,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DiffNameArticle extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2165,12 +2357,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("finding using primary key", async () => {
     class PkAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class PkPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2187,12 +2384,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("update all on association accessed before save", async () => {
     class UpdAllAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class UpdAllPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2210,12 +2412,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("update all on association accessed before save with explicit foreign key", async () => {
     class UpdAllFkAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class UpdAllFkPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2276,12 +2483,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("find in batches", async () => {
     class FibAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FibPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2318,12 +2530,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("find first after reset scope", async () => {
     class ResetAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ResetPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2343,12 +2560,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("find first after reload", async () => {
     class ReloadAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ReloadPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2375,6 +2597,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("reload with query cache", async () => {
     class ReloadQcAuthor extends Base {
+      declare name: string | null;
+      declare reloadQcPosts: AssociationProxy<ReloadQcPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2385,6 +2610,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ReloadQcPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2408,6 +2636,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("reloading unloaded associations with query cache", async () => {
     class ReloadUlAuthor extends Base {
+      declare name: string | null;
+      declare reloadUlPosts: AssociationProxy<ReloadUlPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2418,6 +2649,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ReloadUlPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2483,12 +2717,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("find scoped grouped having", async () => {
     class GrpAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class GrpPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2562,6 +2801,8 @@ describe("HasManyAssociationsTest", () => {
   });
   it("create with bang on habtm when parent is new raises", async () => {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
@@ -2579,6 +2820,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("inverse on before validate", async () => {
     class InvValAuthor extends Base {
+      declare name: string | null;
+      declare inv_val_posts: AssociationProxy<InvValPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2589,6 +2833,11 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class InvValPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+      declare author: InvValAuthor | null;
+      declare loadBelongsTo: (name: "author") => Promise<InvValAuthor | null>;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2614,12 +2863,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("collection size with dirty target", async () => {
     class SizeDirtyAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class SizeDirtyPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2639,12 +2893,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("collection empty with dirty target", async () => {
     class EmptyDirtyAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class EmptyDirtyPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2663,12 +2922,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("collection size twice for regressions", async () => {
     class SizeTwiceAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class SizeTwicePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2694,12 +2958,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("build followed by save does not load target", async () => {
     class BuildSaveAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class BuildSavePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2721,12 +2990,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("build without loading association", async () => {
     class BuildNoLoadAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class BuildNoLoadPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2743,12 +3017,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("build many via block", async () => {
     class BuildManyBlockAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class BuildManyBlockPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2770,12 +3049,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("create without loading association", async () => {
     class CreateNoLoadAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class CreateNoLoadPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2800,12 +3084,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("create followed by save does not load target", async () => {
     class CreateSaveAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class CreateSavePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2831,6 +3120,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("clearing an exclusively dependent association collection", async () => {
     class ExclDepAuthor extends Base {
+      declare name: string | null;
+      declare excl_dep_posts: AssociationProxy<ExclDepPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2842,6 +3134,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ExclDepPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2861,6 +3156,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("dependent association respects optional conditions on delete", async () => {
     class DcFirm extends Base {
+      declare name: string | null;
+      declare conditionalClients: AssociationProxy<DcClient>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -2873,6 +3171,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DcClient extends Base {
+      declare firm_id: number | null;
+      declare name: string | null;
+
       static {
         this._tableName = "companies";
         this.attribute("firm_id", "integer");
@@ -2897,6 +3198,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("dependent association respects optional sanitized conditions on delete", async () => {
     class DsFirm extends Base {
+      declare name: string | null;
+      declare conditionalClients: AssociationProxy<DsClient>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -2909,6 +3213,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DsClient extends Base {
+      declare firm_id: number | null;
+      declare name: string | null;
+
       static {
         this._tableName = "companies";
         this.attribute("firm_id", "integer");
@@ -2925,6 +3232,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("dependent association respects optional hash conditions on delete", async () => {
     class DhFirm extends Base {
+      declare name: string | null;
+      declare conditionalClients: AssociationProxy<DhClient>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -2937,6 +3247,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DhClient extends Base {
+      declare firm_id: number | null;
+      declare name: string | null;
+
       static {
         this._tableName = "companies";
         this.attribute("firm_id", "integer");
@@ -2953,6 +3266,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("delete all association with primary key deletes correct records", async () => {
     class DelPkAuthor extends Base {
+      declare name: string | null;
+      declare del_pk_posts: AssociationProxy<DelPkPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2964,6 +3280,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DelPkPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -2990,6 +3309,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("clearing without initial access", async () => {
     class ClearNoAccessAuthor extends Base {
+      declare name: string | null;
+      declare clear_no_access_posts: AssociationProxy<ClearNoAccessPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3001,6 +3323,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ClearNoAccessPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3054,6 +3379,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("destroy all on association clears scope", async () => {
     class DestroyAllScopeAuthor extends Base {
+      declare name: string | null;
+      declare destroy_all_scope_posts: AssociationProxy<DestroyAllScopePost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3065,6 +3393,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DestroyAllScopePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3086,12 +3417,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("destroy on association clears scope", async () => {
     class DestroyScopeAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class DestroyScopePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3112,12 +3448,17 @@ describe("HasManyAssociationsTest", () => {
 
   it("delete on association clears scope", async () => {
     class DeleteScopeAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class DeleteScopePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3137,6 +3478,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("dependence for associations with hash condition", async () => {
     class HashCondAuthor extends Base {
+      declare name: string | null;
+      declare hash_cond_posts: AssociationProxy<HashCondPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3148,6 +3492,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class HashCondPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3164,6 +3511,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("three levels of dependence", async () => {
     class ThreeLvlTopic extends Base {
+      declare title: string | null;
+      declare replies: AssociationProxy<ThreeLvlReply>;
+
       static {
         this._tableName = "topics";
         this.attribute("title", "string");
@@ -3175,6 +3525,11 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ThreeLvlReply extends Base {
+      declare title: string | null;
+      declare content: string | null;
+      declare parent_id: number | null;
+      declare replies: AssociationProxy<ThreeLvlReply>;
+
       static {
         this._tableName = "topics";
         this.attribute("title", "string");
@@ -3200,6 +3555,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("dependence with transaction support on failure", async () => {
     class DepTxAuthor extends Base {
+      declare name: string | null;
+      declare dep_tx_posts: AssociationProxy<DepTxPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3211,6 +3569,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DepTxPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3232,6 +3593,9 @@ describe("HasManyAssociationsTest", () => {
 
   it("restrict with error with locale", async () => {
     class ReLocaleAuthor extends Base {
+      declare name: string | null;
+      declare re_locale_posts: AssociationProxy<ReLocalePost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3243,6 +3607,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ReLocalePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3267,12 +3634,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("included in collection for composite keys", async () => {
     class InclAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class InclPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3291,12 +3663,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("adding array and collection", async () => {
     class ArrAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ArrPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3317,12 +3694,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("replace failure", async () => {
     class ReplFailAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ReplFailPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3344,12 +3726,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("transactions when replacing on persisted", async () => {
     class TxReplAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class TxReplPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3361,7 +3748,7 @@ describe("HasManyAssociationsTest", () => {
     const author1 = await TxReplAuthor.create({ name: "Alice" });
     const author2 = await TxReplAuthor.create({ name: "Bob" });
     const post = await TxReplPost.create({ author_id: author1.id, title: "A", body: "body" });
-    post.author_id = author2.id;
+    post.author_id = author2.id as number;
     await post.save();
     const posts1 = await loadHasMany(author1, "tx_repl_posts", {
       className: "TxReplPost",
@@ -3376,12 +3763,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("transactions when replacing on new record", async () => {
     class TxReplNewAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class TxReplNewPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3397,12 +3789,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("get ids for unloaded associations does not load them", async () => {
     class UnloadedAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class UnloadedPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3426,12 +3823,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("ids reader cache not used for size when association is dirty", async () => {
     class DirtyIdAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class DirtyIdPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3457,12 +3859,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("ids reader cache should be cleared when collection is deleted", async () => {
     class ClrIdAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ClrIdPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3487,12 +3894,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("get ids ignores include option", async () => {
     class GiiAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class GiiPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3512,12 +3924,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("get ids for ordered association", async () => {
     class OrdIdAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class OrdIdPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3539,12 +3956,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("set ids for association on new record applies association correctly", async () => {
     class SetIdAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class SetIdPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3565,12 +3987,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("assign ids ignoring blanks", async () => {
     class BlankIdAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class BlankIdPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3592,6 +4019,10 @@ describe("HasManyAssociationsTest", () => {
   });
   it("get ids for through", async () => {
     class ThrIdAuthor extends Base {
+      declare name: string | null;
+      declare thr_id_posts: AssociationProxy<ThrIdPost>;
+      declare thr_id_comments: AssociationProxy<Base>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3607,6 +4038,10 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ThrIdPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+      declare thr_id_comments: AssociationProxy<ThrIdComment>;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3618,6 +4053,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ThrIdComment extends Base {
+      declare post_id: number | null;
+      declare body: string | null;
+
       static {
         this._tableName = "comments";
         this.attribute("post_id", "integer");
@@ -3641,12 +4079,17 @@ describe("HasManyAssociationsTest", () => {
   it("modifying a through a has many should raise", async () => {
     // Through associations are read-only; modifying them directly should not be allowed
     class ThrModAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ThrModPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3665,12 +4108,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("associations order should be priority over throughs order", async () => {
     class OrdThrAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class OrdThrPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3690,12 +4138,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("dynamic find should respect association order for through", async () => {
     class DynThrAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class DynThrPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3715,6 +4168,10 @@ describe("HasManyAssociationsTest", () => {
   });
   it("has many through respects hash conditions", async () => {
     class HcAuthor extends Base {
+      declare name: string | null;
+      declare hcPosts: AssociationProxy<HcPost>;
+      declare helloPostComments: AssociationProxy<Base>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3731,6 +4188,10 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class HcPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+      declare hcComments: AssociationProxy<HcComment>;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3742,6 +4203,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class HcComment extends Base {
+      declare post_id: number | null;
+      declare body: string | null;
+
       static {
         this._tableName = "comments";
         this.attribute("post_id", "integer");
@@ -3773,12 +4237,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("include checks if record exists if target not loaded", async () => {
     class InclAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class InclPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3802,6 +4271,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("include returns false for non matching record to verify scoping", async () => {
     class InclScopeAuthor extends Base {
+      declare name: string | null;
+      declare inclScopePosts: AssociationProxy<InclScopePost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3812,6 +4284,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class InclScopePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3829,12 +4304,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling first nth or last on association should not load association", async () => {
     class FnlAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FnlPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3855,12 +4335,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling first or last on loaded association should not fetch with query", async () => {
     class FlLoadAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FlLoadPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3882,12 +4367,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling first nth or last on existing record with build should load association", async () => {
     class FnlBuildAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FnlBuildPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3910,12 +4400,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling first nth or last on existing record with create should not load association", async () => {
     class FnlCreateAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FnlCreatePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3935,12 +4430,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling first nth or last on new record should not run queries", async () => {
     class FnlNewAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FnlNewPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3959,12 +4459,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling first or last with integer on association should not load association", async () => {
     class FlIntAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FlIntPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -3987,6 +4492,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling many should count instead of loading association", async () => {
     class ManyCountAuthor extends Base {
+      declare name: string | null;
+      declare manyCountPosts: AssociationProxy<ManyCountPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3997,6 +4505,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ManyCountPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4016,6 +4527,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling many on loaded association should not use query", async () => {
     class ManyLoadAuthor extends Base {
+      declare name: string | null;
+      declare manyLoadPosts: AssociationProxy<ManyLoadPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4026,6 +4540,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ManyLoadPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4055,6 +4572,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("subsequent calls to many should use query", async () => {
     class ManySubAuthor extends Base {
+      declare name: string | null;
+      declare manySubPosts: AssociationProxy<ManySubPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4065,6 +4585,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ManySubPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4085,6 +4608,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling many should defer to collection if using a block", async () => {
     class ManyBlkAuthor extends Base {
+      declare name: string | null;
+      declare manyBlkPosts: AssociationProxy<ManyBlkPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4095,6 +4621,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ManyBlkPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4116,6 +4645,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling none should count instead of loading association", async () => {
     class NoneCountAuthor extends Base {
+      declare name: string | null;
+      declare noneCountPosts: AssociationProxy<NoneCountPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4126,6 +4658,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class NoneCountPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4143,6 +4678,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling none on loaded association should not use query", async () => {
     class NoneLoadAuthor extends Base {
+      declare name: string | null;
+      declare noneLoadPosts: AssociationProxy<NoneLoadPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4153,6 +4691,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class NoneLoadPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4180,6 +4721,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling none should defer to collection if using a block", async () => {
     class NoneBlkAuthor extends Base {
+      declare name: string | null;
+      declare noneBlkPosts: AssociationProxy<NoneBlkPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4190,6 +4734,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class NoneBlkPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4209,12 +4756,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling one should count instead of loading association", async () => {
     class OneCountAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class OneCountPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4233,12 +4785,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling one on loaded association should not use query", async () => {
     class OneLoadAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class OneLoadPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4257,12 +4814,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("subsequent calls to one should use query", async () => {
     class OneSubAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class OneSubPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4287,12 +4849,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling one should defer to collection if using a block", async () => {
     class OneBlkAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class OneBlkPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4313,12 +4880,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling one should return false if zero", async () => {
     class OneZeroAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class OneZeroPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4338,12 +4910,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("calling one should return false if more than one", async () => {
     class OneMultiAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class OneMultiPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4365,12 +4942,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("joins with namespaced model should use correct type", async () => {
     class NsAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class NsPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4389,6 +4971,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("association proxy transaction method starts transaction in association class", async () => {
     class TxProxyAuthor extends Base {
+      declare name: string | null;
+      declare tx_proxy_posts: AssociationProxy<TxProxyPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4399,6 +4984,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class TxProxyPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4413,12 +5001,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("creating using primary key", async () => {
     class PkAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class PkPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4439,6 +5032,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("defining has many association with delete all dependency lazily evaluates target class", async () => {
     class LazyDelAuthor extends Base {
+      declare name: string | null;
+      declare lazy_del_posts: AssociationProxy<LazyDelPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4450,6 +5046,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class LazyDelPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4470,6 +5069,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("defining has many association with nullify dependency lazily evaluates target class", async () => {
     class LazyNullAuthor extends Base {
+      declare name: string | null;
+      declare lazy_null_posts: AssociationProxy<LazyNullPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4481,6 +5083,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class LazyNullPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4497,12 +5102,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("attributes are being set when initialized from has many association with where clause", async () => {
     class WhereInitAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class WhereInitPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4530,12 +5140,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("load target respects protected attributes", async () => {
     class ProtAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ProtPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4555,12 +5170,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("merging with custom attribute writer", async () => {
     class MergeAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class MergePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4577,12 +5197,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("dont call save callbacks twice on has many", async () => {
     class NoDblAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class NoDblPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4600,12 +5225,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("association attributes are available to after initialize", async () => {
     class InitAttrAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class InitAttrPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4622,12 +5252,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("attributes are set when initialized from has many null relationship", async () => {
     class NullRelAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class NullRelPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4650,12 +5285,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("collection association with private kernel method", async () => {
     class KernelAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class KernelPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4674,12 +5314,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("association with or doesnt set inverse instance key", async () => {
     class OrAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class OrPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4698,12 +5343,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("association with rewhere doesnt set inverse instance key", async () => {
     class RewhereAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class RewherePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4722,12 +5372,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("first_or_initialize adds the record to the association", async () => {
     class FoiAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FoiPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4749,12 +5404,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("first_or_create adds the record to the association", async () => {
     class FocAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FocPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4780,12 +5440,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("first_or_create! adds the record to the association", async () => {
     class FocBangAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class FocBangPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4814,6 +5479,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("delete_all, when not loaded, doesn't load the records", async () => {
     class NoLoadDelAuthor extends Base {
+      declare name: string | null;
+      declare no_load_del_posts: AssociationProxy<NoLoadDelPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4825,6 +5493,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class NoLoadDelPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4846,6 +5517,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("association with extend option with multiple extensions", async () => {
     class ExtAuthor extends Base {
+      declare name: string | null;
+      declare ext_posts: AssociationProxy<ExtPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4856,6 +5530,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ExtPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4874,6 +5551,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("extend option affects per association", async () => {
     class ExtPerAuthor extends Base {
+      declare name: string | null;
+      declare ext_per_posts: AssociationProxy<ExtPerPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4884,6 +5564,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class ExtPerPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4902,12 +5585,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("delete record with complex joins", async () => {
     class CjAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class CjPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4927,12 +5615,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("unscopes the default scope of associated model when used with include", async () => {
     class UsInclAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class UsInclPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4951,12 +5644,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("raises RecordNotDestroyed when replaced child can't be destroyed", async () => {
     class RndAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class RndPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4974,12 +5672,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("passes custom context validation to validate children", async () => {
     class CtxValAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class CtxValPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -4994,12 +5697,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("association with instance dependent scope", async () => {
     class InstScopeAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class InstScopePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5018,12 +5726,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("associations replace in memory when records have the same id", async () => {
     class ReplMemAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ReplMemPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5058,12 +5771,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("in memory replacement executes no queries", async () => {
     class InMemAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class InMemPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5080,12 +5798,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("in memory replacements do not execute callbacks", async () => {
     class InMemCbAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class InMemCbPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5097,17 +5820,22 @@ describe("HasManyAssociationsTest", () => {
     const author1 = await InMemCbAuthor.create({ name: "Alice" });
     const author2 = await InMemCbAuthor.create({ name: "Bob" });
     const post = InMemCbPost.new({ author_id: author1.id, title: "A" });
-    post.author_id = author2.id;
+    post.author_id = author2.id as number;
     expect((post as any).author_id).toBe(Number(author2.id));
   });
   it("in memory replacements sets inverse instance", async () => {
     class InMemInvAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class InMemInvPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5122,12 +5850,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("reattach to new objects replaces inverse association and foreign key", async () => {
     class ReattachAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class ReattachPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5139,7 +5872,7 @@ describe("HasManyAssociationsTest", () => {
     const author1 = await ReattachAuthor.create({ name: "Alice" });
     const author2 = await ReattachAuthor.create({ name: "Bob" });
     const post = await ReattachPost.create({ author_id: author1.id, title: "A", body: "body" });
-    post.author_id = author2.id;
+    post.author_id = author2.id as number;
     await post.save();
     const reloaded = await ReattachPost.find(post.id!);
     expect((reloaded as any).author_id).toBe(Number(author2.id));
@@ -5156,12 +5889,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("association size calculation works with default scoped selects when not previously fetched", async () => {
     class SizeCalcAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class SizeCalcPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5178,12 +5916,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("prevent double firing the before save callback of new object when the parent association saved in the callback", async () => {
     class DblFireAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class DblFirePost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5207,12 +5950,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("destroy with bang bubbles errors from associations", async () => {
     class DestroyBangAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class DestroyBangPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5228,12 +5976,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("ids reader memoization", async () => {
     class MemoAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class MemoPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5259,12 +6012,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("loading association in validate callback doesnt affect persistence", async () => {
     class LoadValAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class LoadValPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5285,12 +6043,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("create children could be rolled back by after save", async () => {
     class RollbackAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class RollbackPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5321,6 +6084,10 @@ describe("HasManyAssociationsTest", () => {
   it("has many association with same foreign key name", async () => {
     // Two hasMany associations with the same FK should both work
     class SameFkAuthor extends Base {
+      declare name: string | null;
+      declare posts: AssociationProxy<SameFkPost>;
+      declare published_posts: AssociationProxy<SameFkPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -5329,6 +6096,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class SameFkPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5352,6 +6122,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("key ensuring owner was is not valid without dependent option", async () => {
     class KeyValAuthor extends Base {
+      declare name: string | null;
+      declare key_val_posts: AssociationProxy<KeyValPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -5362,6 +6135,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class KeyValPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5381,6 +6157,8 @@ describe("HasManyAssociationsTest", () => {
   });
   it("invalid key raises with message including all default options", async () => {
     class InvKeyAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -5397,6 +6175,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("key ensuring owner was is valid when dependent option is destroy async", async () => {
     class AsyncDepAuthor extends Base {
+      declare name: string | null;
+      declare async_dep_posts: AssociationProxy<AsyncDepPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -5408,6 +6189,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class AsyncDepPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5455,12 +6239,17 @@ describe("HasManyAssociationsTest", () => {
   });
   it("ids reader on preloaded association with composite primary key", async () => {
     class PreCpkAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class PreCpkPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -5482,6 +6271,9 @@ describe("HasManyAssociationsTest", () => {
   });
   it("delete all with option delete all", async () => {
     class DelAllOptAuthor extends Base {
+      declare name: string | null;
+      declare del_all_opt_posts: AssociationProxy<DelAllOptPost>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -5493,6 +6285,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class DelAllOptPost extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "posts";
         this.attribute("author_id", "integer");
@@ -6008,6 +6803,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class AuthorWithErrorDestroyingAssociation extends Base {
+      declare name: string | null;
+      declare postsWithErrorDestroying: AssociationProxy<PostWithErrorDestroying>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -6038,6 +6836,9 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class AuthorWithErrorDestroyingAssociation2 extends Base {
+      declare name: string | null;
+      declare postsWithErrorDestroying2: AssociationProxy<PostWithErrorDestroying2>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -6076,6 +6877,8 @@ describe("HasManyAssociationsTest", () => {
     // RecordNotDestroyed and rolls back the whole batch — an earlier, already
     // destroyed sibling is restored.
     class HaltingComment extends Base {
+      declare body: string | null;
+
       static {
         this._tableName = "comments";
         this.attribute("body", "string");
@@ -6085,6 +6888,10 @@ describe("HasManyAssociationsTest", () => {
       }
     }
     class PostWithHaltingComments extends Base {
+      declare title: string | null;
+      declare body: string | null;
+      declare haltingComments: AssociationProxy<HaltingComment>;
+
       static {
         this._tableName = "posts";
         this.attribute("title", "string");

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -2,6 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
+import type { AssociationProxy } from "./associations/collection-proxy.js";
 import { describe, it, expect, beforeAll } from "vitest";
 import { throwAbort } from "@blazetrails/activesupport";
 import { I18n, Error as ModelError } from "@blazetrails/activemodel";
@@ -486,6 +487,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
 
   function makeModels() {
     class Company extends Base {
+      declare name: string | null;
+      declare clients: AssociationProxy<Client>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -493,6 +497,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
       }
     }
     class Client extends Base {
+      declare name: string | null;
+      declare client_of: number | null;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -535,6 +542,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   it("invalid adding with validate false", async () => {
     const { Company } = makeModels();
     class UnvalidatedClient extends Base {
+      declare name: string | null;
+      declare client_of: number | null;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -633,6 +643,10 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     // FK has_many keyed on the "id" component (primaryKey: :id). Assigning the
     // child ids must populate order_id with the owner's "id" component.
     class AiCpkOrder extends Base {
+      declare shop_id: number | null;
+      declare status: string | null;
+      declare orderAgreements: AssociationProxy<AiCpkOrderAgreement>;
+
       static {
         this._tableName = "cpk_orders";
         this.attribute("shop_id", "integer");
@@ -647,6 +661,11 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
       }
     }
     class AiCpkOrderAgreement extends Base {
+      declare order_id: number | null;
+      declare signature: string | null;
+      declare order: AiCpkOrder | null;
+      declare loadBelongsTo: (name: "order") => Promise<AiCpkOrder | null>;
+
       static {
         this._tableName = "cpk_order_agreements";
         this.attribute("order_id", "integer");
@@ -682,6 +701,10 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     // keyed on [shop_id, order_id] auto-derived from the owner's CPK. The child
     // (book) is itself CPK [author_id, id], so its ids arrive as tuples.
     class AiCpkTwoOrder extends Base {
+      declare shop_id: number | null;
+      declare status: string | null;
+      declare books: AssociationProxy<AiCpkTwoBook>;
+
       static {
         this._tableName = "cpk_orders";
         this.attribute("shop_id", "integer");
@@ -695,6 +718,13 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
       }
     }
     class AiCpkTwoBook extends Base {
+      declare author_id: number | null;
+      declare title: string | null;
+      declare order_id: number | null;
+      declare shop_id: number | null;
+      declare order: AiCpkTwoOrder | null;
+      declare loadBelongsTo: (name: "order") => Promise<AiCpkTwoOrder | null>;
+
       static {
         this._tableName = "cpk_books";
         this.attribute("author_id", "integer");
@@ -749,6 +779,11 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     // and the has_one uses a non-composite single-column FK, autosave should propagate
     // the "id" component of the composite PK into the child's FK column.
     class CpkOrderPk extends Base {
+      declare shop_id: number | null;
+      declare status: string | null;
+      declare cpkBookFk: CpkBookFk | null;
+      declare loadHasOne: (name: "cpkBookFk") => Promise<CpkBookFk | null>;
+
       static {
         this._tableName = "cpk_orders";
         this.attribute("shop_id", "integer");
@@ -763,6 +798,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
       }
     }
     class CpkBookFk extends Base {
+      declare order_id: number | null;
+      declare signature: string | null;
+
       static {
         this._tableName = "cpk_order_agreements";
         this.attribute("order_id", "integer");
@@ -784,6 +822,10 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   });
   it("assign ids for through a belongs to", async () => {
     class AidFirm extends Base {
+      declare name: string | null;
+      declare aidContracts: AssociationProxy<AidContract>;
+      declare aidDevelopers: AssociationProxy<Base>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -799,6 +841,11 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
       }
     }
     class AidContract extends Base {
+      declare company_id: number | null;
+      declare developer_id: number | null;
+      declare aidDeveloper: AidDeveloper | null;
+      declare loadBelongsTo: (name: "aidDeveloper") => Promise<AidDeveloper | null>;
+
       static {
         this._tableName = "contracts";
         this.attribute("company_id", "integer");
@@ -810,6 +857,8 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
       }
     }
     class AidDeveloper extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "developers";
         this.attribute("name", "string");
@@ -933,6 +982,10 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
 
   function makeModels() {
     class Firm extends Base {
+      declare name: string | null;
+      declare account: Account | null;
+      declare loadHasOne: (name: "account") => Promise<Account | null>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -944,6 +997,9 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class Account extends Base {
+      declare credit_limit: number | null;
+      declare firm_id: number | null;
+
       static {
         this._tableName = "accounts";
         this.attribute("credit_limit", "integer");
@@ -959,6 +1015,10 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   it("should save parent but not invalid child", async () => {
     // Without autosave: invalid has_one child does not block parent save
     class PFirm extends Base {
+      declare name: string | null;
+      declare pAccount: PAccount | null;
+      declare loadHasOne: (name: "pAccount") => Promise<PAccount | null>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -966,6 +1026,9 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class PAccount extends Base {
+      declare credit_limit: number | null;
+      declare firm_id: number | null;
+
       static {
         this._tableName = "accounts";
         this.attribute("credit_limit", "integer");
@@ -1000,6 +1063,9 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   it("save succeeds for invalid has one with validate false", async () => {
     const { Firm } = makeModels();
     class LooseAccount extends Base {
+      declare credit_limit: number | null;
+      declare firm_id: number | null;
+
       static {
         this._tableName = "accounts";
         this.attribute("credit_limit", "integer");
@@ -1075,6 +1141,10 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   it("callbacks firing order on create", async () => {
     const log: string[] = [];
     class CbFirm extends Base {
+      declare name: string | null;
+      declare cbAccount: CbAccount | null;
+      declare loadHasOne: (name: "cbAccount") => Promise<CbAccount | null>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -1095,6 +1165,9 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class CbAccount extends Base {
+      declare credit_limit: number | null;
+      declare firm_id: number | null;
+
       static {
         this._tableName = "accounts";
         this.attribute("credit_limit", "integer");
@@ -1120,6 +1193,10 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   it("callbacks firing order on update", async () => {
     const log: string[] = [];
     class CuFirm extends Base {
+      declare name: string | null;
+      declare cuAccount: CuAccount | null;
+      declare loadHasOne: (name: "cuAccount") => Promise<CuAccount | null>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -1140,6 +1217,9 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class CuAccount extends Base {
+      declare credit_limit: number | null;
+      declare firm_id: number | null;
+
       static {
         this._tableName = "accounts";
         this.attribute("credit_limit", "integer");
@@ -1164,6 +1244,10 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   it("callbacks firing order on save", async () => {
     const log: string[] = [];
     class CsFirm extends Base {
+      declare name: string | null;
+      declare csAccount: CsAccount | null;
+      declare loadHasOne: (name: "csAccount") => Promise<CsAccount | null>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -1181,6 +1265,9 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class CsAccount extends Base {
+      declare credit_limit: number | null;
+      declare firm_id: number | null;
+
       static {
         this._tableName = "accounts";
         this.attribute("credit_limit", "integer");
@@ -1203,6 +1290,10 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   it("callbacks on child when parent autosaves child", async () => {
     const log: string[] = [];
     class CbParent extends Base {
+      declare name: string | null;
+      declare cbChild: CbChild | null;
+      declare loadHasOne: (name: "cbChild") => Promise<CbChild | null>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1214,6 +1305,9 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class CbChild extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -1240,6 +1334,10 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       static _tableName = "companies";
     }
     class Iris extends Base {
+      declare firm_id: number | null;
+      declare eye: Eye | null;
+      declare loadBelongsTo: (name: "eye") => Promise<Eye | null>;
+
       static _tableName = "accounts";
       static {
         this.attribute("firm_id", "integer");
@@ -1291,6 +1389,10 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   it("callbacks on child when parent autosaves polymorphic child with inverse of", async () => {
     const log: string[] = [];
     class PolyParent extends Base {
+      declare name: string | null;
+      declare polyChild: PolyChild | null;
+      declare loadHasOne: (name: "polyChild") => Promise<PolyChild | null>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1303,6 +1405,11 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class PolyChild extends Base {
+      declare employable_id: number | null;
+      declare employable_type: string | null;
+      declare employable: Base | null;
+      declare loadBelongsTo: (name: "employable") => Promise<Base | null>;
+
       static {
         this._tableName = "chefs";
         this.attribute("employable_id", "integer");
@@ -1345,6 +1452,8 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   it("callbacks on child when child autosaves parent", async () => {
     const log: string[] = [];
     class CbOwner extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1354,6 +1463,11 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class CbPet extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+      declare cbOwner: CbOwner | null;
+      declare loadBelongsTo: (name: "cbOwner") => Promise<CbOwner | null>;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -1392,6 +1506,10 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   it("callbacks on child when polymorphic child with inverse of autosaves parent", async () => {
     const log: string[] = [];
     class PolyAsParent extends Base {
+      declare name: string | null;
+      declare polyAsChild: PolyAsChild | null;
+      declare loadHasOne: (name: "polyAsChild") => Promise<PolyAsChild | null>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1415,6 +1533,11 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class PolyAsChild extends Base {
+      declare employable_id: number | null;
+      declare employable_type: string | null;
+      declare employable: Base | null;
+      declare loadBelongsTo: (name: "employable") => Promise<Base | null>;
+
       static {
         this._tableName = "chefs";
         this.attribute("employable_id", "integer");
@@ -1462,12 +1585,17 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
 
   function makeModels() {
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
       }
     }
     class Ship extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -1519,12 +1647,17 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
 
   it("should automatically save bang the associated model if it sets the inverse record", async () => {
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
       }
     }
     class Ship extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -1583,6 +1716,9 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     // When multiple validators fire on the same child attribute, all messages
     // should be merged onto the parent under the dotted attribute key.
     class DualValidShip extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -1592,6 +1728,10 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class DualPirate extends Base {
+      declare catchphrase: string | null;
+      declare dualValidShip: DualValidShip | null;
+      declare loadHasOne: (name: "dualValidShip") => Promise<DualValidShip | null>;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
@@ -1615,6 +1755,9 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
   it("should still allow to bypass validations on the associated model", async () => {
     const { Pirate } = makeModels();
     class FlexShip extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -1634,6 +1777,9 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     // Rails: test "should allow to bypass validations on associated models at any depth"
     // save(validate: false) should skip validation on the parent and all nested records.
     class DeepPart extends Base {
+      declare name: string | null;
+      declare ship_id: number | null;
+
       static {
         this._tableName = "ship_parts";
         this.attribute("name", "string");
@@ -1642,6 +1788,10 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class DeepShip extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+      declare deepParts: AssociationProxy<DeepPart>;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -1651,6 +1801,10 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class DeepPirate extends Base {
+      declare catchphrase: string | null;
+      declare deepShip: DeepShip | null;
+      declare loadHasOne: (name: "deepShip") => Promise<DeepShip | null>;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
@@ -1697,6 +1851,8 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
   });
   it("should not save and return false if a callback cancelled saving", async () => {
     class CcPirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
@@ -1738,12 +1894,17 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     // registration time and never re-registers (define_non_cyclic_method's
     // `method_defined?` guard), so a re-declaration would not take effect.
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
       }
     }
     class Ship extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -1764,6 +1925,11 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
 
   it("recognises inverse polymorphic association changes with same foreign key", async () => {
     class SwapChef extends Base {
+      declare employable_id: number | null;
+      declare employable_type: string | null;
+      declare employable: Base | null;
+      declare loadBelongsTo: (name: "employable") => Promise<Base | null>;
+
       static {
         this._tableName = "chefs";
         this.attribute("employable_id", "integer");
@@ -1775,6 +1941,10 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class SwapCakeDesigner extends Base {
+      declare name: string | null;
+      declare chef: SwapChef | null;
+      declare loadHasOne: (name: "chef") => Promise<SwapChef | null>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1787,6 +1957,10 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
       }
     }
     class SwapDrinkDesigner extends Base {
+      declare name: string | null;
+      declare chef: SwapChef | null;
+      declare loadHasOne: (name: "chef") => Promise<SwapChef | null>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1829,6 +2003,8 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
 
   function makeModels() {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1836,6 +2012,9 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
       }
     }
     class Post extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -1850,12 +2029,22 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
 
   function makeOrderModels() {
     class Customer extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "customers";
         this.attribute("name", "string");
       }
     }
     class Order extends Base {
+      declare name: string | null;
+      declare tree_id: number | null;
+      declare parent_id: number | null;
+      declare billing: Customer | null;
+      declare shipping: Customer | null;
+      declare loadBelongsTo: ((name: "billing") => Promise<Customer | null>) &
+        ((name: "shipping") => Promise<Customer | null>);
+
       static {
         this._tableName = "nodes";
         this.attribute("name", "string");
@@ -1905,6 +2094,8 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
 
   it("save succeeds for invalid belongs to with validate false", async () => {
     class FlexAuthor extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -1912,6 +2103,11 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     }
     registerModel("FlexAuthor", FlexAuthor);
     class FlexPost extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+      declare flexAuthor: FlexAuthor | null;
+      declare loadBelongsTo: (name: "flexAuthor") => Promise<FlexAuthor | null>;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -2041,12 +2237,19 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
 
   it("store association with a polymorphic relationship", async () => {
     class PolyMember extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "members";
         this.attribute("name", "string");
       }
     }
     class PolySponsor extends Base {
+      declare sponsorable_id: number | null;
+      declare sponsorable_type: string | null;
+      declare sponsorable: Base | null;
+      declare loadBelongsTo: (name: "sponsorable") => Promise<Base | null>;
+
       static {
         this._tableName = "sponsors";
         this.attribute("sponsorable_id", "integer");
@@ -2096,6 +2299,11 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     // Rails: test "composite primary key autosave" — creating a has_one child
     // via autosave propagates composite FK columns from parent to child.
     class CpkOrder2 extends Base {
+      declare shop_id: number | null;
+      declare status: string | null;
+      declare cpkBook2: CpkBook2 | null;
+      declare loadHasOne: (name: "cpkBook2") => Promise<CpkBook2 | null>;
+
       static {
         this._tableName = "cpk_orders";
         this.attribute("shop_id", "integer");
@@ -2110,6 +2318,11 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
       }
     }
     class CpkBook2 extends Base {
+      declare author_id: number | null;
+      declare shop_id: number | null;
+      declare order_id: number | null;
+      declare title: string | null;
+
       static {
         this._tableName = "cpk_books";
         this.attribute("author_id", "integer");
@@ -2151,6 +2364,8 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
 
   function makeModels() {
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
@@ -2158,6 +2373,9 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
       }
     }
     class Ship extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -2218,6 +2436,8 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
 
   it("should still allow to bypass validations on the associated model", async () => {
     class FlexPirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
@@ -2225,6 +2445,9 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
     }
     registerModel("FlexPirate", FlexPirate);
     class FlexShip extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -2253,6 +2476,9 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
   });
   it("should not save and return false if a callback cancelled saving", async () => {
     class CcShip extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -2318,12 +2544,17 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
 
   function makeModels() {
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
       }
     }
     class Bird extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "birds";
         this.attribute("name", "string");
@@ -2378,11 +2609,16 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
   function makeIndexedHasMany(opts: { indexErrors?: boolean } = {}) {
     const seed = `Idx${Math.random().toString(36).slice(2, 8)}`;
     class Parent extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Child extends Base {
+      declare name: string | null;
+      declare parent_id: number | null;
+
       static {
         this.attribute("name", "string");
         this.attribute("parent_id", "integer");
@@ -2422,6 +2658,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
   });
   it("errors details with error on base should be indexed when passed as array", () => {
     class P extends Base {
+      declare name: string | null;
+      declare kids: AssociationProxy<C>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("kids", {
@@ -2432,6 +2671,9 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
       }
     }
     class C extends Base {
+      declare favorite: boolean | null;
+      declare p_id: number | null;
+
       static {
         this.attribute("favorite", "boolean");
         this.attribute("p_id", "integer");
@@ -2463,6 +2705,10 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
     });
     try {
       class Reference extends Base {
+        declare favorite: boolean | null;
+        declare job_id: number | null;
+        declare person_id: number | null;
+
         static {
           this.attribute("favorite", "boolean");
           this.attribute("job_id", "integer");
@@ -2474,6 +2720,8 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
         }
       }
       class Person extends Base {
+        declare name: string | null;
+
         static {
           this.attribute("name", "string");
         }
@@ -2512,6 +2760,10 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
     });
     try {
       class Reference extends Base {
+        declare favorite: boolean | null;
+        declare job_id: number | null;
+        declare person_id: number | null;
+
         static {
           this.attribute("favorite", "boolean");
           this.attribute("job_id", "integer");
@@ -2523,6 +2775,8 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
         }
       }
       class Person extends Base {
+        declare name: string | null;
+
         static {
           this.attribute("name", "string");
           this.validates("reference", { presence: true });
@@ -2572,6 +2826,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
   useHandlerTransactionalFixtures();
   it("autosave works even when other callbacks update the parent model", async () => {
     class Ship extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -2579,6 +2836,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
@@ -2610,6 +2869,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // When autosave validates an associated record, it should NOT pass the owner's
     // standard (:create/:update) validation context — only custom contexts propagate.
     class Person extends Base {
+      declare first_name: string | null;
+
       static {
         this._tableName = "people";
         this.attribute("first_name", "string");
@@ -2625,6 +2886,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class Reference extends Base {
+      declare person_id: number | null;
+
       static {
         this._tableName = "references";
         this.attribute("person_id", "integer");
@@ -2657,6 +2920,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // propagation (autosave_association.rb:384) means custom contexts fire even
     // on unchanged persisted children, unlike the default :create/:update skip.
     class Widget extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -2665,6 +2931,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class Owner extends Base {
+      declare name: string | null;
+      declare widgets: AssociationProxy<Widget>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2692,6 +2961,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
   it("autosave collection association callbacks get called once", async () => {
     let saveCount = 0;
     class Book extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -2702,6 +2974,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2728,6 +3002,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
   it("autosave has one association callbacks get called once", async () => {
     let saveCount = 0;
     class Profile extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -2738,6 +3015,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class User extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2764,6 +3043,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
   it("autosave belongs to association callbacks get called once", async () => {
     let saveCount = 0;
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2773,6 +3054,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class Post extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -2803,12 +3087,17 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // saves a new target during owner save and writes the parent PK back
     // onto the owner's foreign key.
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class Post extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -2837,12 +3126,18 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // drops the extra FK entries; the loop only writes the positions
     // where both sides exist. No CompositePrimaryKeyMismatchError.
     class Parent extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class Child extends Base {
+      declare parent_id: number | null;
+      declare group: string | null;
+      declare title: string | null;
+
       static {
         this._tableName = "topics";
         this.attribute("parent_id", "integer");
@@ -2880,6 +3175,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // default branch, so the lambda doesn't `throw(:abort)` and the owner
     // save still succeeds — the child simply remains unpersisted.
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2887,6 +3184,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class Post extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -2919,12 +3219,17 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // Ruby's `self[nil] = id` would raise — our impl skips the nil-FK
     // partner so a misconfigured pair doesn't blow up the owner save.
     class Parent extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class Child extends Base {
+      declare author_id: number | null;
+      declare name: string | null;
+
       static {
         this._tableName = "books";
         this.attribute("author_id", "integer");
@@ -2955,6 +3260,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
   it("should not add the same callbacks multiple times for has one", async () => {
     let saveCount = 0;
     class Profile extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -2965,6 +3273,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class User extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -2993,6 +3303,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
   it("should not add the same callbacks multiple times for belongs to", async () => {
     let saveCount = 0;
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3002,6 +3314,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class Post extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3029,6 +3344,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
   it("should not add the same callbacks multiple times for has many", async () => {
     let saveCount = 0;
     class Book extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3039,6 +3357,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3065,6 +3385,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
   it("should not add the same callbacks multiple times for has and belongs to many", async () => {
     let saveCount = 0;
     class Parrot extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "parrots";
         this.attribute("name", "string");
@@ -3074,6 +3396,8 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
@@ -3108,6 +3432,9 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     // Prisoner: belongs_to :ship (autosave: true). Cyclic: prisoner.valid? calls ship.valid? again.
     // _ensureNoDuplicateErrors (after_validation) deduplicates to exactly 1 error for :name.
     class ShipCyclic extends Base {
+      declare name: string | null;
+      declare prisoners: AssociationProxy<PrisonerCyclic>;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -3117,6 +3444,10 @@ describe("TestAutosaveAssociationsInGeneral", () => {
       }
     }
     class PrisonerCyclic extends Base {
+      declare ship_id: number | null;
+      declare ship: ShipCyclic | null;
+      declare loadBelongsTo: (name: "ship") => Promise<ShipCyclic | null>;
+
       static {
         this._tableName = "prisoners";
         this.attribute("ship_id", "integer");
@@ -3153,12 +3484,17 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
 
   function makeModels() {
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
       }
     }
     class Ship extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -3166,6 +3502,9 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
       }
     }
     class Part extends Base {
+      declare name: string | null;
+      declare ship_id: number | null;
+
       static {
         this._tableName = "ship_parts";
         this.attribute("name", "string");
@@ -3263,6 +3602,9 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
 
   it("should generate validation methods for has_many associations", async () => {
     class VmParent extends Base {
+      declare name: string | null;
+      declare vmChildren: AssociationProxy<VmChild>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3274,6 +3616,9 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
       }
     }
     class VmChild extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3291,6 +3636,10 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
 
   it("should generate validation methods for has_one associations with :validate => true", async () => {
     class VoParent extends Base {
+      declare name: string | null;
+      declare voChild: VoChild | null;
+      declare loadHasOne: (name: "voChild") => Promise<VoChild | null>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -3302,6 +3651,9 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
       }
     }
     class VoChild extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3319,6 +3671,10 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
 
   it("should not generate validation methods for has_one associations without :validate => true", async () => {
     class NvParent extends Base {
+      declare name: string | null;
+      declare nvChild: NvChild | null;
+      declare loadHasOne: (name: "nvChild") => Promise<NvChild | null>;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -3330,6 +3686,9 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
       }
     }
     class NvChild extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3347,6 +3706,8 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
 
   it("should generate validation methods for belongs_to associations with :validate => true", async () => {
     class BvOwner extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3354,6 +3715,11 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
       }
     }
     class BvChild extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+      declare bvOwner: BvOwner | null;
+      declare loadBelongsTo: (name: "bvOwner") => Promise<BvOwner | null>;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3375,6 +3741,8 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
 
   it("should not generate validation methods for belongs_to associations without :validate => true", async () => {
     class NbOwner extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3382,6 +3750,11 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
       }
     }
     class NbChild extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+      declare nbOwner: NbOwner | null;
+      declare loadBelongsTo: (name: "nbOwner") => Promise<NbOwner | null>;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3403,6 +3776,9 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
 
   it("should generate validation methods for HABTM associations with :validate => true", async () => {
     class HvParent extends Base {
+      declare catchphrase: string | null;
+      declare hvTags: AssociationProxy<HvTag>;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
@@ -3416,6 +3792,8 @@ describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
       }
     }
     class HvTag extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "parrots";
         this.attribute("name", "string");
@@ -3439,12 +3817,17 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
 
   function makeModels() {
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
       }
     }
     class Ship extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -3452,6 +3835,9 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
       }
     }
     class Part extends Base {
+      declare name: string | null;
+      declare ship_id: number | null;
+
       static {
         this._tableName = "ship_parts";
         this.attribute("name", "string");
@@ -3515,12 +3901,17 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
   useHandlerTransactionalFixtures();
   it("autosave new record on belongs to can be disabled per relationship", async () => {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class Post extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3546,6 +3937,9 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
 
   it("autosave new record on has one can be disabled per relationship", async () => {
     class Profile extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3553,6 +3947,8 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
       }
     }
     class User extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3577,6 +3973,9 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
 
   it("autosave new record on has many can be disabled per relationship", async () => {
     class Book extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -3584,6 +3983,8 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
       }
     }
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3609,6 +4010,9 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
   it("autosave new record with after create callback", async () => {
     const log: string[] = [];
     class Ship extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "ships";
         this.attribute("name", "string");
@@ -3616,6 +4020,8 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
       }
     }
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
@@ -3644,6 +4050,9 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
 
   it("autosave new record with after create callback and habtm association", async () => {
     class Comment extends Base {
+      declare post_id: number | null;
+      declare body: string | null;
+
       static {
         this._tableName = "comments";
         this.attribute("post_id", "integer");
@@ -3651,12 +4060,20 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
       }
     }
     class Category extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "categories";
         this.attribute("name", "string");
       }
     }
     class PostWithAfterCreateCallback extends Base {
+      declare title: string | null;
+      declare body: string | null;
+      declare author_id: number | null;
+      declare comments: AssociationProxy<Comment>;
+      declare categories: AssociationProxy<Category>;
+
       static {
         this._tableName = "posts";
         this.attribute("title", "string");
@@ -3703,6 +4120,8 @@ describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
   useHandlerTransactionalFixtures();
   it("should automatically validate associations", async () => {
     class Item extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
         this.validates("name", { presence: true });
@@ -3714,6 +4133,8 @@ describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
   });
   it("validations still fire on unchanged association with custom validation context", async () => {
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
         this.validates("title", { presence: true, on: "create" });
@@ -3782,6 +4203,8 @@ describe("TestAutosaveAssociationValidationsOnABelongsToAssociation", () => {
   useHandlerTransactionalFixtures();
   it("should automatically validate associations with :validate => true", async () => {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
         this.validates("name", { presence: true });
@@ -3794,6 +4217,8 @@ describe("TestAutosaveAssociationValidationsOnABelongsToAssociation", () => {
 
   it("should not automatically validate associations without :validate => true", async () => {
     class Item extends Base {
+      declare label: string | null;
+
       static {
         this.attribute("label", "string");
       }
@@ -3805,6 +4230,8 @@ describe("TestAutosaveAssociationValidationsOnABelongsToAssociation", () => {
 
   it("validations still fire on unchanged association with custom validation context", async () => {
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
         this.validates("title", { presence: true, on: "create" });
@@ -3820,6 +4247,8 @@ describe("TestAutosaveAssociationValidationsOnAHasOneAssociation", () => {
   useHandlerTransactionalFixtures();
   it("should automatically validate associations with :validate => true", async () => {
     class Profile extends Base {
+      declare bio: string | null;
+
       static {
         this.attribute("bio", "string");
         this.validates("bio", { presence: true });
@@ -3832,6 +4261,8 @@ describe("TestAutosaveAssociationValidationsOnAHasOneAssociation", () => {
 
   it("should not automatically add validate associations without :validate => true", async () => {
     class Address extends Base {
+      declare street: string | null;
+
       static {
         this.attribute("street", "string");
       }
@@ -3846,12 +4277,20 @@ describe("TestAutosaveAssociationOnAHasOneThroughAssociation", () => {
   useHandlerTransactionalFixtures();
   it("should not has one through model", async () => {
     class HotOrg extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
       }
     }
     class HotMember extends Base {
+      declare name: string | null;
+      declare hotDetail: HotDetail | null;
+      declare hotOrg: Base | null;
+      declare loadHasOne: ((name: "hotDetail") => Promise<HotDetail | null>) &
+        ((name: "hotOrg") => Promise<Base | null>);
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -3867,6 +4306,13 @@ describe("TestAutosaveAssociationOnAHasOneThroughAssociation", () => {
       }
     }
     class HotDetail extends Base {
+      declare company_id: number | null;
+      declare developer_id: number | null;
+      declare hotOrg: HotOrg | null;
+      declare hotMember: HotMember | null;
+      declare loadBelongsTo: ((name: "hotOrg") => Promise<HotOrg | null>) &
+        ((name: "hotMember") => Promise<HotMember | null>);
+
       static {
         this._tableName = "contracts";
         this.attribute("company_id", "integer");
@@ -3898,6 +4344,12 @@ describe("TestAutosaveAssociationOnAHasOneThroughAssociation", () => {
   });
   it("should not reversed has one through model", async () => {
     class RevOrg extends Base {
+      declare name: string | null;
+      declare revDetail: RevDetail | null;
+      declare revMember: Base | null;
+      declare loadHasOne: ((name: "revDetail") => Promise<RevDetail | null>) &
+        ((name: "revMember") => Promise<Base | null>);
+
       static {
         this._tableName = "companies";
         this.attribute("name", "string");
@@ -3913,12 +4365,21 @@ describe("TestAutosaveAssociationOnAHasOneThroughAssociation", () => {
       }
     }
     class RevMember extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class RevDetail extends Base {
+      declare company_id: number | null;
+      declare developer_id: number | null;
+      declare revOrg: RevOrg | null;
+      declare revMember: RevMember | null;
+      declare loadBelongsTo: ((name: "revOrg") => Promise<RevOrg | null>) &
+        ((name: "revMember") => Promise<RevMember | null>);
+
       static {
         this._tableName = "contracts";
         this.attribute("company_id", "integer");
@@ -3953,6 +4414,8 @@ describe("TestAutosaveAssociationValidationsOnAHABTMAssociation", () => {
   useHandlerTransactionalFixtures();
   it("should automatically validate associations with :validate => true", async () => {
     class Tag extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
         this.validates("name", { presence: true });
@@ -3964,6 +4427,8 @@ describe("TestAutosaveAssociationValidationsOnAHABTMAssociation", () => {
   });
   it("should not automatically validate associations without :validate => true", async () => {
     class Label extends Base {
+      declare text: string | null;
+
       static {
         this.attribute("text", "string");
       }
@@ -3981,6 +4446,10 @@ describe("TestAutosaveAssociationOnAHasManyAssociationWithInverse", () => {
   // Comment after_save callback that reads back the inverse `post.comments`.
   function makeModels() {
     class Post extends Base {
+      declare title: string | null;
+      declare body: string | null;
+      declare comments: AssociationProxy<Comment>;
+
       static {
         this._tableName = "posts";
         this.attribute("title", "string");
@@ -3989,6 +4458,11 @@ describe("TestAutosaveAssociationOnAHasManyAssociationWithInverse", () => {
       }
     }
     class Comment extends Base {
+      declare body: string | null;
+      declare post_id: number | null;
+      declare post: Post | null;
+      declare loadBelongsTo: (name: "post") => Promise<Post | null>;
+
       postCommentsCount?: number;
       static {
         this._tableName = "comments";
@@ -4020,12 +4494,19 @@ describe("TestAutosaveAssociationOnABelongsToAssociationDefinedAsRecord", () => 
   useHandlerTransactionalFixtures();
   it("should not raise error", async () => {
     class BtOwner extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
       }
     }
     class BtRecord extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+      declare btOwner: BtOwner | null;
+      declare loadBelongsTo: (name: "btOwner") => Promise<BtOwner | null>;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4091,12 +4572,17 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
 
   function makeModels() {
     class Pirate extends Base {
+      declare catchphrase: string | null;
+
       static {
         this._tableName = "pirates";
         this.attribute("catchphrase", "string");
       }
     }
     class Bird extends Base {
+      declare name: string | null;
+      declare pirate_id: number | null;
+
       static {
         this._tableName = "birds";
         this.attribute("name", "string");
@@ -4134,6 +4620,9 @@ describe("should update children when autosave is true and parent is new but chi
   useHandlerTransactionalFixtures();
   it("should update children when autosave is true and parent is new but child is not", async () => {
     class UcParent extends Base {
+      declare name: string | null;
+      declare ucChildren: AssociationProxy<UcChild>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4145,6 +4634,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class UcChild extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4166,6 +4658,9 @@ describe("should update children when autosave is true and parent is new but chi
   });
   it("should automatically save the associated models", async () => {
     class NAutoTag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4173,6 +4668,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class NAutoArticle extends Base {
+      declare name: string | null;
+      declare nautoTags: AssociationProxy<NAutoTag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4196,6 +4694,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should automatically save bang the associated models", async () => {
     class ASB1Tag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4203,6 +4704,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class ASB1Article extends Base {
+      declare name: string | null;
+      declare asb1Tags: AssociationProxy<ASB1Tag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4225,6 +4729,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should not update children when parent creation with no reason", async () => {
     class NUCTag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4232,6 +4739,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class NUCArticle extends Base {
+      declare name: string | null;
+      declare nucTags: AssociationProxy<NUCTag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4253,6 +4763,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should automatically validate the associated models", async () => {
     class AVTag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4261,6 +4774,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class AVArticle extends Base {
+      declare name: string | null;
+      declare avTags: AssociationProxy<AVTag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4280,6 +4796,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should not use default invalid error on associated models", async () => {
     class NDITag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4288,6 +4807,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class NDIArticle extends Base {
+      declare name: string | null;
+      declare ndiTags: AssociationProxy<NDITag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4309,6 +4831,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should default invalid error from i18n", async () => {
     class DITag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4317,6 +4842,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class DIArticle extends Base {
+      declare name: string | null;
+      declare diTags: AssociationProxy<DITag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4337,6 +4865,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should allow to bypass validations on the associated models on update", async () => {
     class BVUTag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4345,6 +4876,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class BVUArticle extends Base {
+      declare name: string | null;
+      declare bvuTags: AssociationProxy<BVUTag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4367,6 +4901,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should validation the associated models on create", async () => {
     class VCTag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4375,6 +4912,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class VCArticle extends Base {
+      declare name: string | null;
+      declare vcTags: AssociationProxy<VCTag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4394,6 +4934,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should allow to bypass validations on the associated models on create", async () => {
     class BVTag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4402,6 +4945,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class BVArticle extends Base {
+      declare name: string | null;
+      declare bvTags: AssociationProxy<BVTag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4423,6 +4969,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should not save and return false if a callback cancelled saving in either create or update", async () => {
     class CBTag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4433,6 +4982,8 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class CBArticle extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4447,6 +4998,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should not load the associated models if they were not loaded yet", async () => {
     class NLTag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4454,6 +5008,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class NLArticle extends Base {
+      declare name: string | null;
+      declare nlTags: AssociationProxy<NLTag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4472,6 +5029,9 @@ describe("should update children when autosave is true and parent is new but chi
   });
   it("should merge errors on the associated models onto the parent even if it is not valid", async () => {
     class METag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4480,6 +5040,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class MEArticle extends Base {
+      declare name: string | null;
+      declare meTags: AssociationProxy<METag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4500,6 +5063,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should rollback any changes if an exception occurred while saving", async () => {
     class RBTag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4507,6 +5073,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class RBArticle extends Base {
+      declare name: string | null;
+      declare rbTags: AssociationProxy<RBTag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4532,6 +5101,9 @@ describe("should update children when autosave is true and parent is new but chi
 
   it("should still raise an ActiveRecordRecord Invalid exception if we want that", async () => {
     class RITag extends Base {
+      declare name: string | null;
+      declare author_id: number | null;
+
       static {
         this._tableName = "books";
         this.attribute("name", "string");
@@ -4540,6 +5112,9 @@ describe("should update children when autosave is true and parent is new but chi
       }
     }
     class RIArticle extends Base {
+      declare name: string | null;
+      declare riTags: AssociationProxy<RITag>;
+
       static {
         this._tableName = "authors";
         this.attribute("name", "string");
@@ -4565,6 +5140,8 @@ describe("ChangedForAutosaveTest", () => {
 
   it("parent is changed_for_autosave when nested autosave child is changed", () => {
     class Child extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("id", "integer");
         this.attribute("name", "string");
@@ -4673,6 +5250,11 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
   // hits branch 2 and returns queryConstraintsList — pairing with the composite FK.
   it("pairs queryConstraintsList PK with explicit composite FK on QC owner", async () => {
     class QcOwner extends Base {
+      declare tree_id: number | null;
+      declare name: string | null;
+      declare qcChild: QcChild | null;
+      declare loadHasOne: (name: "qcChild") => Promise<QcChild | null>;
+
       static {
         this._tableName = "nodes";
         this.attribute("tree_id", "integer");
@@ -4688,6 +5270,10 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
       }
     }
     class QcChild extends Base {
+      declare tree_id: number | null;
+      declare parent_id: number | null;
+      declare name: string | null;
+
       static {
         this._tableName = "nodes";
         this.attribute("tree_id", "integer");
@@ -4722,6 +5308,11 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
     // association both FK and PK would be composite, so no-mismatch is the happy path.
     // This test confirms the collapse does NOT fire for QC-derived PK arrays.
     class QcNoCollapse extends Base {
+      declare tree_id: number | null;
+      declare name: string | null;
+      declare qcNoCollapseChild: QcNoCollapseChild | null;
+      declare loadHasOne: (name: "qcNoCollapseChild") => Promise<QcNoCollapseChild | null>;
+
       static {
         this._tableName = "nodes";
         this.attribute("tree_id", "integer");
@@ -4738,6 +5329,10 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
       }
     }
     class QcNoCollapseChild extends Base {
+      declare tree_id: number | null;
+      declare parent_id: number | null;
+      declare name: string | null;
+
       static {
         this._tableName = "nodes";
         this.attribute("tree_id", "integer");
@@ -4766,6 +5361,11 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
   // computePrimaryKey collapses the QC list to a scalar PK via the "id" rule.
   it("uses queryConstraintsList as PK when class has_query_constraints? and scalar FK", async () => {
     class QcTenant extends Base {
+      declare tree_id: number | null;
+      declare name: string | null;
+      declare qcTenantRecord: QcTenantRecord | null;
+      declare loadHasOne: (name: "qcTenantRecord") => Promise<QcTenantRecord | null>;
+
       static {
         this._tableName = "nodes";
         this.attribute("tree_id", "integer");
@@ -4782,6 +5382,10 @@ describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
       }
     }
     class QcTenantRecord extends Base {
+      declare tree_id: number | null;
+      declare parent_id: number | null;
+      declare name: string | null;
+
       static {
         this._tableName = "nodes";
         this.attribute("tree_id", "integer");

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -2,6 +2,7 @@
  * Tests to increase Rails test coverage matching.
  * Test names are chosen to match Ruby test names from the Rails test suite.
  */
+import type { AssociationProxy } from "./associations/collection-proxy.js";
 import { describe, it, expect } from "vitest";
 import {
   Base,
@@ -39,17 +40,25 @@ useHandlerTransactionalFixtures();
 describe("ReflectionTest", () => {
   function makeModels() {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Book extends Base {
+      declare title: string | null;
+      declare author_id: number | null;
+
       static {
         this.attribute("title", "string");
         this.attribute("author_id", "integer");
       }
     }
     class Chapter extends Base {
+      declare title: string | null;
+      declare book_id: number | null;
+
       static {
         this.attribute("title", "string");
         this.attribute("book_id", "integer");
@@ -67,6 +76,12 @@ describe("ReflectionTest", () => {
 
   it("scope chain does not interfere with hmt with polymorphic case", async () => {
     class ScHotel extends Base {
+      declare name: string | null;
+      declare departments: AssociationProxy<ScDept>;
+      declare chefs: AssociationProxy<Base>;
+      declare cakeDesigners: AssociationProxy<ScCake>;
+      declare drinkDesigners: AssociationProxy<ScDrink>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("departments", {
@@ -89,6 +104,9 @@ describe("ReflectionTest", () => {
       }
     }
     class ScDept extends Base {
+      declare hotel_id: number | null;
+      declare chefs: AssociationProxy<ScChef>;
+
       static {
         this.attribute("hotel_id", "integer");
         this.hasMany("chefs", {
@@ -98,6 +116,12 @@ describe("ReflectionTest", () => {
       }
     }
     class ScChef extends Base {
+      declare department_id: number | null;
+      declare employable_id: number | null;
+      declare employable_type: string | null;
+      declare employable: Base | null;
+      declare loadBelongsTo: (name: "employable") => Promise<Base | null>;
+
       static {
         this.attribute("department_id", "integer");
         this.attribute("employable_id", "integer");
@@ -138,6 +162,10 @@ describe("ReflectionTest", () => {
   });
   it("scope chain does not interfere with hmt with polymorphic case and subclass source", async () => {
     class SC2Hotel extends Base {
+      declare name: string | null;
+      declare chefLists: AssociationProxy<SC2ChefList>;
+      declare mocktailDesigners: AssociationProxy<SC2Mocktail>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("chefLists", {
@@ -153,6 +181,13 @@ describe("ReflectionTest", () => {
       }
     }
     class SC2ChefList extends Base {
+      declare employable_list_id: number | null;
+      declare employable_list_type: string | null;
+      declare employable_id: number | null;
+      declare employable_type: string | null;
+      declare employable: Base | null;
+      declare loadBelongsTo: (name: "employable") => Promise<Base | null>;
+
       static {
         this.attribute("employable_list_id", "integer");
         this.attribute("employable_list_type", "string");
@@ -190,6 +225,10 @@ describe("ReflectionTest", () => {
   });
   it("scope chain does not interfere with hmt with polymorphic and subclass source 2", async () => {
     class SC3Author extends Base {
+      declare name: string | null;
+      declare books: AssociationProxy<SC3Book>;
+      declare bestHardbacks: AssociationProxy<SC3BestHardback>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("books", {
@@ -205,6 +244,12 @@ describe("ReflectionTest", () => {
       }
     }
     class SC3Book extends Base {
+      declare author_id: number | null;
+      declare format_record_id: number | null;
+      declare format_record_type: string | null;
+      declare formatRecord: Base | null;
+      declare loadBelongsTo: (name: "formatRecord") => Promise<Base | null>;
+
       static {
         this.attribute("author_id", "integer");
         this.attribute("format_record_id", "integer");
@@ -243,6 +288,12 @@ describe("ReflectionTest", () => {
   });
   it("scope chain of polymorphic association does not leak into other hmt associations", async () => {
     class SC4Hotel extends Base {
+      declare name: string | null;
+      declare departments: AssociationProxy<SC4Dept>;
+      declare chefs: AssociationProxy<Base>;
+      declare drinkDesigners: AssociationProxy<SC4Drink>;
+      declare recipes: AssociationProxy<Base>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("departments", {
@@ -260,6 +311,9 @@ describe("ReflectionTest", () => {
       }
     }
     class SC4Dept extends Base {
+      declare hotel_id: number | null;
+      declare chefs: AssociationProxy<SC4Chef>;
+
       static {
         this.attribute("hotel_id", "integer");
         this.hasMany("chefs", {
@@ -269,6 +323,13 @@ describe("ReflectionTest", () => {
       }
     }
     class SC4Chef extends Base {
+      declare department_id: number | null;
+      declare employable_id: number | null;
+      declare employable_type: string | null;
+      declare employable: Base | null;
+      declare recipes: AssociationProxy<SC4Recipe>;
+      declare loadBelongsTo: (name: "employable") => Promise<Base | null>;
+
       static {
         this.attribute("department_id", "integer");
         this.attribute("employable_id", "integer");
@@ -282,6 +343,9 @@ describe("ReflectionTest", () => {
     }
     class SC4Drink extends Base {}
     class SC4Recipe extends Base {
+      declare chef_id: number | null;
+      declare hotel_id: number | null;
+
       static {
         this.attribute("chef_id", "integer");
         this.attribute("hotel_id", "integer");
@@ -329,6 +393,10 @@ describe("ReflectionTest", () => {
   });
   it("has many through reflection", () => {
     class Subscriber extends Base {
+      declare name: string | null;
+      declare subscriptions: AssociationProxy<Subscription>;
+      declare subBooks: AssociationProxy<Base>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("subscriptions", {});
@@ -340,6 +408,11 @@ describe("ReflectionTest", () => {
       }
     }
     class Subscription extends Base {
+      declare subscriber_id: number | null;
+      declare book_id: number | null;
+      declare subBook: SubBook | null;
+      declare loadBelongsTo: (name: "subBook") => Promise<SubBook | null>;
+
       static {
         this.attribute("subscriber_id", "integer");
         this.attribute("book_id", "integer");
@@ -350,6 +423,8 @@ describe("ReflectionTest", () => {
       }
     }
     class SubBook extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -366,6 +441,9 @@ describe("ReflectionTest", () => {
 
   it("has and belongs to many reflection", () => {
     class Category extends Base {
+      declare name: string | null;
+      declare habtmPosts: AssociationProxy<HabtmPost>;
+
       static {
         this.attribute("name", "string");
         this.hasAndBelongsToMany("habtmPosts", {
@@ -374,6 +452,8 @@ describe("ReflectionTest", () => {
       }
     }
     class HabtmPost extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -387,6 +467,10 @@ describe("ReflectionTest", () => {
   });
   it("columns are returned in the order they were declared", () => {
     class Topic extends Base {
+      declare title: string | null;
+      declare author_name: string | null;
+      declare body: string | null;
+
       static {
         this.attribute("title", "string");
         this.attribute("author_name", "string");
@@ -411,6 +495,8 @@ describe("ReflectionTest", () => {
   });
   it("non existent types are identity types", () => {
     class Topic2 extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -423,11 +509,15 @@ describe("ReflectionTest", () => {
   });
   it("reflection klass for nested class name", async () => {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Book extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -441,11 +531,15 @@ describe("ReflectionTest", () => {
   });
   it("irregular reflection class name", async () => {
     class Person extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Address extends Base {
+      declare street: string | null;
+
       static {
         this.attribute("street", "string");
       }
@@ -458,11 +552,17 @@ describe("ReflectionTest", () => {
   });
   it("reflection klass with same demodularized different modularized name", async () => {
     class NestedUser extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class AdminUser extends Base {
+      declare name: string | null;
+      declare user: NestedUser | null;
+      declare loadHasOne: (name: "user") => Promise<NestedUser | null>;
+
       static {
         this.attribute("name", "string");
         this.hasOne("user", { className: "Nested::User" });
@@ -475,6 +575,9 @@ describe("ReflectionTest", () => {
   });
   it("reflection klass with same modularized name", async () => {
     class NestedNestedUser extends Base {
+      declare name: string | null;
+      declare nestedUsers: AssociationProxy<NestedNestedUser>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("nestedUsers", {});
@@ -486,6 +589,10 @@ describe("ReflectionTest", () => {
   });
   it("reflect on all autosave associations", () => {
     class Ship extends Base {
+      declare name: string | null;
+      declare parts: AssociationProxy<Part>;
+      declare crews: AssociationProxy<Crew>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("parts", { autosave: true });
@@ -493,11 +600,15 @@ describe("ReflectionTest", () => {
       }
     }
     class Part extends Base {
+      declare ship_id: number | null;
+
       static {
         this.attribute("ship_id", "integer");
       }
     }
     class Crew extends Base {
+      declare ship_id: number | null;
+
       static {
         this.attribute("ship_id", "integer");
       }
@@ -515,6 +626,9 @@ describe("ReflectionTest", () => {
     expect(ref.associationPrimaryKey).toBe("id");
     // Custom primary key
     class SpecialBook extends Base {
+      declare isbn: string | null;
+      declare author_id: number | null;
+
       static {
         this.attribute("isbn", "string");
         this.attribute("author_id", "integer");
@@ -533,6 +647,8 @@ describe("ReflectionTest", () => {
       }
     }
     class Owner extends Base {
+      declare no_pk_model_id: number | null;
+
       static {
         this.attribute("no_pk_model_id", "integer");
       }
@@ -545,6 +661,8 @@ describe("ReflectionTest", () => {
   });
   it("active record primary key raises when missing primary key", () => {
     class NoPkOwner extends Base {
+      declare targets: AssociationProxy<Target>;
+
       static {
         this._primaryKey = "";
         this.hasMany("targets", {});
@@ -558,6 +676,16 @@ describe("ReflectionTest", () => {
   });
   it("foreign type", () => {
     class Sponsor extends Base {
+      declare sponsorable_id: number | null;
+      declare sponsorable_type: string | null;
+      declare sponsor_club_id: number | null;
+      declare sponsorable: Base | null;
+      declare thing: Base | null;
+      declare sponsorClub: Base | null;
+      declare loadBelongsTo: ((name: "sponsorable") => Promise<Base | null>) &
+        ((name: "thing") => Promise<Base | null>) &
+        ((name: "sponsorClub") => Promise<Base | null>);
+
       static {
         this.attribute("sponsorable_id", "integer");
         this.attribute("sponsorable_type", "string");
@@ -583,11 +711,15 @@ describe("ReflectionTest", () => {
   });
   it("default association validation", () => {
     class Owner extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Pet extends Base {
+      declare owner_id: number | null;
+
       static {
         this.attribute("owner_id", "integer");
       }
@@ -600,11 +732,15 @@ describe("ReflectionTest", () => {
   });
   it("always validate association if explicit", () => {
     class Owner extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Pet extends Base {
+      declare owner_id: number | null;
+
       static {
         this.attribute("owner_id", "integer");
       }
@@ -617,11 +753,15 @@ describe("ReflectionTest", () => {
   });
   it("validate association if autosave", () => {
     class Owner extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Pet extends Base {
+      declare owner_id: number | null;
+
       static {
         this.attribute("owner_id", "integer");
       }
@@ -634,11 +774,15 @@ describe("ReflectionTest", () => {
   });
   it("never validate association if explicit", () => {
     class Owner extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Pet extends Base {
+      declare owner_id: number | null;
+
       static {
         this.attribute("owner_id", "integer");
       }
@@ -654,11 +798,15 @@ describe("ReflectionTest", () => {
   });
   it("class for class name", () => {
     class Firm extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Client extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
@@ -674,11 +822,15 @@ describe("ReflectionTest", () => {
   });
   it("class for source type", () => {
     class NsTag extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class NsPost extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
@@ -696,11 +848,16 @@ describe("ReflectionTest", () => {
   });
   it("join table with common prefix", () => {
     class CatalogCategory extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class CatalogProduct extends Base {
+      declare name: string | null;
+      declare catalogCategories: AssociationProxy<CatalogCategory>;
+
       static {
         this.attribute("name", "string");
         this.hasAndBelongsToMany("catalogCategories", {
@@ -718,11 +875,16 @@ describe("ReflectionTest", () => {
 
   it("join table with different prefix", () => {
     class CatCategory extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class ContentPage extends Base {
+      declare name: string | null;
+      declare catCategories: AssociationProxy<CatCategory>;
+
       static {
         this.attribute("name", "string");
         this.hasAndBelongsToMany("catCategories", {
@@ -739,11 +901,16 @@ describe("ReflectionTest", () => {
 
   it("join table can be overridden", () => {
     class JtCategory extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class JtProduct extends Base {
+      declare name: string | null;
+      declare jtCategories: AssociationProxy<JtCategory>;
+
       static {
         this.attribute("name", "string");
         this.hasAndBelongsToMany("jtCategories", {
@@ -759,17 +926,25 @@ describe("ReflectionTest", () => {
   });
   it("includes accepts strings", async () => {
     class Hotel extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Department extends Base {
+      declare hotel_id: number | null;
+      declare name: string | null;
+
       static {
         this.attribute("hotel_id", "integer");
         this.attribute("name", "string");
       }
     }
     class Chef extends Base {
+      declare department_id: number | null;
+      declare name: string | null;
+
       static {
         this.attribute("department_id", "integer");
         this.attribute("name", "string");
@@ -803,6 +978,10 @@ describe("ReflectionTest", () => {
     // Mirrors Rails test/cases/reflection_test.rb: Hotel has_many :lost_items,
     // through: :departments; Department has no :lost_items assoc.
     class MsHotel extends Base {
+      declare name: string | null;
+      declare departments: AssociationProxy<MsDepartment>;
+      declare lostItems: AssociationProxy<Base>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("departments", {
@@ -816,6 +995,8 @@ describe("ReflectionTest", () => {
       }
     }
     class MsDepartment extends Base {
+      declare hotel_id: number | null;
+
       static {
         this.attribute("hotel_id", "integer");
       }
@@ -840,12 +1021,19 @@ describe("ReflectionTest", () => {
 
   it("has one and belongs to should find inverse automatically", () => {
     class Car extends Base {
+      declare bulb: Bulb | null;
+      declare loadHasOne: (name: "bulb") => Promise<Bulb | null>;
+
       static {
         this.attribute("id", "integer");
         this.hasOne("bulb", {});
       }
     }
     class Bulb extends Base {
+      declare car_id: number | null;
+      declare car: Car | null;
+      declare loadBelongsTo: (name: "car") => Promise<Car | null>;
+
       static {
         this.attribute("id", "integer");
         this.attribute("car_id", "integer");
@@ -872,6 +1060,10 @@ describe("ReflectionTest", () => {
       }
     }
     class Rating extends Base {
+      declare comment_id: number | null;
+      declare comment: Comment | null;
+      declare loadBelongsTo: (name: "comment") => Promise<Comment | null>;
+
       static {
         this.attribute("id", "integer");
         this.attribute("comment_id", "integer");
@@ -894,6 +1086,10 @@ describe("ReflectionTest", () => {
       }
     }
     class Room extends Base {
+      declare owner_id: number | null;
+      declare owner: User | null;
+      declare loadBelongsTo: (name: "owner") => Promise<User | null>;
+
       static {
         this.attribute("id", "integer");
         this.attribute("owner_id", "integer");
@@ -910,6 +1106,9 @@ describe("ReflectionTest", () => {
 
   it("through association should not find inverse automatically", () => {
     class Doctor extends Base {
+      declare appointments: AssociationProxy<Appointment>;
+      declare patients: AssociationProxy<Base>;
+
       static {
         this.attribute("id", "integer");
         this.hasMany("appointments", {});
@@ -917,6 +1116,13 @@ describe("ReflectionTest", () => {
       }
     }
     class Appointment extends Base {
+      declare doctor_id: number | null;
+      declare patient_id: number | null;
+      declare doctor: Doctor | null;
+      declare patient: Patient | null;
+      declare loadBelongsTo: ((name: "doctor") => Promise<Doctor | null>) &
+        ((name: "patient") => Promise<Patient | null>);
+
       static {
         this.attribute("id", "integer");
         this.attribute("doctor_id", "integer");
@@ -940,6 +1146,9 @@ describe("ReflectionTest", () => {
 
   it("polymorphic belongs to should not find inverse automatically", () => {
     class Tag extends Base {
+      declare taggable_id: number | null;
+      declare taggable_type: string | null;
+
       static {
         this.attribute("id", "integer");
         this.attribute("taggable_id", "integer");
@@ -967,6 +1176,8 @@ describe("ReflectionTest", () => {
       }
     }
     class Child extends Base {
+      declare parent_id: number | null;
+
       static {
         this.attribute("id", "integer");
         this.attribute("parent_id", "integer");
@@ -990,6 +1201,10 @@ describe("ReflectionTest", () => {
         }
       }
       class Contract extends Base {
+        declare company_id: number | null;
+        declare company: Company | null;
+        declare loadBelongsTo: (name: "company") => Promise<Company | null>;
+
         static {
           this.attribute("id", "integer");
           this.attribute("company_id", "integer");
@@ -1013,6 +1228,10 @@ describe("ReflectionTest", () => {
         }
       }
       class Contract2 extends Base {
+        declare company2_id: number | null;
+        declare company2: Company2 | null;
+        declare loadBelongsTo: (name: "company2") => Promise<Company2 | null>;
+
         static automaticScopeInversing = true;
         static {
           this.attribute("id", "integer");
@@ -1035,6 +1254,8 @@ describe("ReflectionTest", () => {
     // Scopes on the inverse (belongs_to) side always block automatic detection,
     // even when automatic_scope_inversing is enabled
     class Publisher extends Base {
+      declare magazines: AssociationProxy<Magazine>;
+
       static automaticScopeInversing = true;
       static {
         this.attribute("id", "integer");
@@ -1042,6 +1263,8 @@ describe("ReflectionTest", () => {
       }
     }
     class Magazine extends Base {
+      declare publisher_id: number | null;
+
       static automaticScopeInversing = true;
       static {
         this.attribute("id", "integer");
@@ -1059,6 +1282,8 @@ describe("ReflectionTest", () => {
 
   it("human name", () => {
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -1069,6 +1294,8 @@ describe("ReflectionTest", () => {
 
   it("column string type and limit", () => {
     class Article extends Base {
+      declare title: string | null;
+
       static {
         // Use a table absent from the canonical schema so columnsHash() falls
         // back to _attributeDefinitions instead of the DB schema cache.
@@ -1083,6 +1310,8 @@ describe("ReflectionTest", () => {
 
   it("column null not null", () => {
     class Article extends Base {
+      declare title: string | null;
+
       static {
         this._tableName = "refl_articles";
         this.attribute("title", "string");
@@ -1094,6 +1323,8 @@ describe("ReflectionTest", () => {
 
   it("human name for column", () => {
     class Article extends Base {
+      declare body_text: string | null;
+
       static {
         this._tableName = "refl_articles";
         this.attribute("body_text", "string");
@@ -1106,6 +1337,8 @@ describe("ReflectionTest", () => {
 
   it("integer columns", () => {
     class Article extends Base {
+      declare views: number | null;
+
       static {
         this._tableName = "refl_articles";
         this.attribute("views", "integer");
@@ -1118,6 +1351,8 @@ describe("ReflectionTest", () => {
 
   it("non existent columns return null object", () => {
     class Article extends Base {
+      declare title: string | null;
+
       static {
         this._tableName = "refl_articles";
         this.attribute("title", "string");
@@ -1130,11 +1365,15 @@ describe("ReflectionTest", () => {
 
   it("belongs to inferred foreign key from assoc name", () => {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Post extends Base {
+      declare author_id: number | null;
+
       static {
         this.attribute("author_id", "integer");
         Associations.belongsTo.call(this, "author", { className: "Author" });
@@ -1148,11 +1387,15 @@ describe("ReflectionTest", () => {
 
   it("reflections should return keys as strings", () => {
     class Comment extends Base {
+      declare post_id: number | null;
+
       static {
         this.attribute("post_id", "integer");
       }
     }
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
         Associations.hasMany.call(this, "comments", { className: "Comment" });
@@ -1173,11 +1416,15 @@ describe("ReflectionTest", () => {
 
   it("collection association", () => {
     class Comment extends Base {
+      declare post_id: number | null;
+
       static {
         this.attribute("post_id", "integer");
       }
     }
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
         Associations.hasMany.call(this, "comments", { className: "Comment" });
@@ -1189,11 +1436,15 @@ describe("ReflectionTest", () => {
 
   it("foreign key", () => {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Post extends Base {
+      declare author_id: number | null;
+
       static {
         this.attribute("author_id", "integer");
         Associations.belongsTo.call(this, "author", { className: "Author" });
@@ -1205,11 +1456,15 @@ describe("ReflectionTest", () => {
 
   it("foreign key is inferred from model name", () => {
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
     }
     class Comment extends Base {
+      declare post_id: number | null;
+
       static {
         this.attribute("post_id", "integer");
         Associations.belongsTo.call(this, "post", { className: "Post" });
@@ -1221,6 +1476,8 @@ describe("ReflectionTest", () => {
 
   it("reflection should not raise error when compared to other object", () => {
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -1232,6 +1489,8 @@ describe("ReflectionTest", () => {
 
   it("reflect on missing source assocation", () => {
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -1242,6 +1501,8 @@ describe("ReflectionTest", () => {
 
   it("active record primary key", () => {
     class Post extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -1251,6 +1512,9 @@ describe("ReflectionTest", () => {
 
   it("reflection klass not found with no class name option", () => {
     class Orphan extends Base {
+      declare name: string | null;
+      declare ghosts: AssociationProxy<Base>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("ghosts", {});
@@ -1264,6 +1528,9 @@ describe("ReflectionTest", () => {
 
   it("reflection klass not found with pointer to non existent class name", () => {
     class Orphan2 extends Base {
+      declare name: string | null;
+      declare items: AssociationProxy<Base>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("items", { className: "NonExistentModel" });
@@ -1276,11 +1543,15 @@ describe("ReflectionTest", () => {
 
   it("reflection klass requires ar subclass", () => {
     class Parent extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Child extends Base {
+      declare parent_id: number | null;
+
       static {
         this.attribute("parent_id", "integer");
       }
@@ -1307,12 +1578,17 @@ describe("ReflectionTest", () => {
 
   it("reflection klass with same demodularized name", async () => {
     class Project extends Base {
+      declare name: string | null;
+      declare tasks: AssociationProxy<Task>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("tasks", {});
       }
     }
     class Task extends Base {
+      declare title: string | null;
+
       static {
         this.attribute("title", "string");
       }
@@ -1325,6 +1601,9 @@ describe("ReflectionTest", () => {
 
   it("aggregation reflection", () => {
     class Customer extends Base {
+      declare address_street: string | null;
+      declare address_city: string | null;
+
       static {
         this.attribute("address_street", "string");
         this.attribute("address_city", "string");
@@ -1352,6 +1631,8 @@ describe("ReflectionTest", () => {
 
   it("aggregate reflection computes class raises NameError for missing class", () => {
     class Buyer extends Base {
+      declare balance: number | null;
+
       static {
         this.attribute("balance", "integer");
       }
@@ -1415,11 +1696,22 @@ describe("ReflectionTest", () => {
 
   it("chain", () => {
     class ReflCategory extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class ReflEssay extends Base {
+      declare name: string | null;
+      declare writer_id: number | null;
+      declare writer_type: string | null;
+      declare category_id: number | null;
+      declare category: ReflCategory | null;
+      declare writer: Base | null;
+      declare loadBelongsTo: ((name: "category") => Promise<ReflCategory | null>) &
+        ((name: "writer") => Promise<Base | null>);
+
       static {
         this.attribute("name", "string");
         this.attribute("writer_id", "integer");
@@ -1433,6 +1725,10 @@ describe("ReflectionTest", () => {
       }
     }
     class ReflAuthor extends Base {
+      declare name: string | null;
+      declare essays: AssociationProxy<ReflEssay>;
+      declare essayCategories: AssociationProxy<Base>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("essays", {
@@ -1447,6 +1743,10 @@ describe("ReflectionTest", () => {
       }
     }
     class ReflOrganization extends Base {
+      declare name: string | null;
+      declare authors: AssociationProxy<ReflAuthor>;
+      declare authorEssayCategories: AssociationProxy<Base>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("authors", {
@@ -1476,6 +1776,11 @@ describe("ReflectionTest", () => {
 
   it("nested?", () => {
     class NPost extends Base {
+      declare author_id: number | null;
+      declare comments: AssociationProxy<NComment>;
+      declare taggings: AssociationProxy<NTagging>;
+      declare tags: AssociationProxy<Base>;
+
       static {
         this.attribute("author_id", "integer");
         this.hasMany("comments", { className: "NComment" });
@@ -1484,12 +1789,23 @@ describe("ReflectionTest", () => {
       }
     }
     class NComment extends Base {
+      declare post_id: number | null;
+      declare post: NPost | null;
+      declare loadBelongsTo: (name: "post") => Promise<NPost | null>;
+
       static {
         this.attribute("post_id", "integer");
         this.belongsTo("post", { className: "NPost" });
       }
     }
     class NTagging extends Base {
+      declare post_id: number | null;
+      declare tag_id: number | null;
+      declare post: NPost | null;
+      declare tag: NTag | null;
+      declare loadBelongsTo: ((name: "post") => Promise<NPost | null>) &
+        ((name: "tag") => Promise<NTag | null>);
+
       static {
         this.attribute("post_id", "integer");
         this.attribute("tag_id", "integer");
@@ -1498,11 +1814,18 @@ describe("ReflectionTest", () => {
       }
     }
     class NTag extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class NAuthor extends Base {
+      declare name: string | null;
+      declare posts: AssociationProxy<NPost>;
+      declare comments: AssociationProxy<Base>;
+      declare tags: AssociationProxy<Base>;
+
       static {
         this.attribute("name", "string");
         this.hasMany("posts", { className: "NPost" });
@@ -1511,6 +1834,10 @@ describe("ReflectionTest", () => {
       }
     }
     class NCategory extends Base {
+      declare name: string | null;
+      declare posts: AssociationProxy<NPost>;
+      declare postComments: AssociationProxy<Base>;
+
       static {
         this.attribute("name", "string");
         this.hasAndBelongsToMany("posts", { className: "NPost" });
@@ -1542,6 +1869,9 @@ describe("ReflectionTest", () => {
     // Rails stubs klass on a has_many reflection; join_table derives from both
     // table names regardless of which side declares the association.
     class DjtCategory extends Base {
+      declare name: string | null;
+      declare products: AssociationProxy<DjtProduct>;
+
       static _tableName = "categories";
       static {
         this.attribute("name", "string");
@@ -1549,6 +1879,9 @@ describe("ReflectionTest", () => {
       }
     }
     class DjtProduct extends Base {
+      declare name: string | null;
+      declare categories: AssociationProxy<DjtCategory>;
+
       static _tableName = "products";
       static {
         this.attribute("name", "string");
@@ -1566,17 +1899,25 @@ describe("ReflectionTest", () => {
 
   it("includes accepts symbols", async () => {
     class Hotel extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
     }
     class Department extends Base {
+      declare hotel_id: number | null;
+      declare name: string | null;
+
       static {
         this.attribute("hotel_id", "integer");
         this.attribute("name", "string");
       }
     }
     class Chef extends Base {
+      declare department_id: number | null;
+      declare name: string | null;
+
       static {
         this.attribute("department_id", "integer");
         this.attribute("name", "string");
@@ -1602,6 +1943,8 @@ describe("ReflectionTest", () => {
 
   it("association primary key uses explicit primary key option as first priority", () => {
     class Author extends Base {
+      declare name: string | null;
+
       static {
         this.attribute("name", "string");
       }
@@ -1614,6 +1957,8 @@ describe("ReflectionTest", () => {
 
   it("belongs to reflection with query constraints infers correct foreign key", () => {
     class BlogPost extends Base {
+      declare blog_id: number | null;
+
       static _primaryKey: string | string[] = ["blog_id", "id"];
       static {
         this.attribute("blog_id", "integer");
@@ -1621,6 +1966,8 @@ describe("ReflectionTest", () => {
       }
     }
     class Comment extends Base {
+      declare blog_post_id: number | null;
+
       static {
         this.attribute("id", "integer");
         this.attribute("blog_post_id", "integer");
@@ -1641,6 +1988,10 @@ describe("ReflectionTest", () => {
   // Rails: test "columns"
   it("columns", () => {
     class Person extends Base {
+      declare name: string | null;
+      declare age: number | null;
+      declare active: boolean | null;
+
       static {
         this._tableName = "people";
         this.attribute("id", "integer");
@@ -1658,6 +2009,8 @@ describe("ReflectionTest", () => {
   // Rails: test "column_names"
   it("read attribute names", () => {
     class Person extends Base {
+      declare name: string | null;
+
       static {
         this._tableName = "people";
         this.attribute("id", "integer");


### PR DESCRIPTION
## What

Bakes materialized `declare` accessors into three association test files via
`scripts/materialize-model-declares.ts`, then `prettier --write` + `pnpm eslint`:

- `reflection.test.ts` (+348 generated)
- `autosave-association.test.ts` (+599 generated)
- `has-many-associations.test.ts` (+807 generated)

Continuation of the "large bakes" set — the files too big to combine with the
small clean files baked in the prior follow-up story.

## Size / scoping

**Mechanical/generated bake — the entire diff is generator output** (types-only
`declare` accessors + the `import type { AssociationProxy }` lines the generator
adds) plus three one-line type-only casts (below). Combined it exceeds the
500-LOC ceiling; the ceiling is waived here as a purely mechanical generated
test-only bake. It is kept as **one PR to match the one-story/one-PR tracking
model** (a single `Closes-story` trailer / `tasks done --pr`); the three files
are disjoint, so this is not a stacked PR.

## Hand-corrections on top of the generator (both type-only, no runtime change)

- Retyped three `declare` accessors whose association `className` points at an
  unregistered/non-existent model (`SponsorClub`, `Ghost`, `NonExistentModel`)
  to `Base` — the generator emitted phantom class-type references for those,
  matching how it already falls back to `Base` for other unresolved classNames.
- Cast three direct FK-from-`.id` assignments (`PrimaryKeyValue` → `number`) to
  satisfy the newly-declared `number | null` FK columns.

## Verification

- `tsc --noEmit` green for all three files; package `tsc --build` + typecheck
  green via pre-commit.
- Affected suites green on sqlite: reflection (76), autosave-association (209),
  has-many-associations (316) — 594 passed / 7 skipped.
- Audited the diff: no test-logic/assertion lines changed — declares, imports,
  and the three casts only.

Closes-story: materialize-declares-large-bakes-reflection-autosave-hasmany
