### PR TITLE
fix(activesupport): coerce MemoryStore increment amount via Integer() semantics

### DIFF
--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -1,7 +1,7 @@
 import type { CacheOptions, CacheStore } from "./index.js";
 import { coder } from "./coder.js";
 import { Entry } from "./entry.js";
-import { Store } from "./store.js";
+import { Store, ArgumentError } from "./store.js";
 
 // In-memory record backing a single key. We store the coder-serialized value
 // (so Date/undefined/bigint/non-finite numbers and deep-clone isolation survive
@@ -25,6 +25,18 @@ function toI(value: unknown): number {
     return m ? parseInt(m[0], 10) : 0;
   }
   return 0;
+}
+
+// Mirrors Ruby `Integer(amount)` (memory_store.rb:248) over the numeric domain:
+// a finite number truncates toward zero (`Integer(1.5) # => 1`,
+// `Integer(-1.9) # => -1`), while NaN/Infinity raise the way Ruby's
+// `Integer(Float::NAN)`/`Integer(Float::INFINITY)` raise FloatDomainError —
+// rather than silently coercing to a non-integer.
+function integer(amount: number): number {
+  if (!Number.isFinite(amount)) {
+    throw new ArgumentError(`invalid value for Integer(): ${amount}`);
+  }
+  return Math.trunc(amount);
 }
 
 export class MemoryStore extends Store implements CacheStore {
@@ -121,15 +133,19 @@ export class MemoryStore extends Store implements CacheStore {
   // `increment("foo") # => 1`); on a hit it adds to entry.value.to_i, preserving
   // the entry's expiresAt/version.
   private modifyValue(name: string, amount: number, options?: CacheOptions): number {
+    // Rails coerces `amount = Integer(amount)` once (memory_store.rb:248) and
+    // threads that integer through the seed write, the return value, and the
+    // hit-path addition alike — so coerce up front rather than per-branch.
+    const coerced = integer(amount);
     const merged = this.mergedOptions(options);
     const key = this.normalizeKey(name, merged);
     const version = this.normalizeVersion(name, merged) ?? null;
     const entry = this.readEntry(key, merged);
     if (!entry || entry.isExpired() || entry.isMismatched(version)) {
-      this.write(name, Math.trunc(amount), options);
-      return amount;
+      this.write(name, coerced, options);
+      return coerced;
     }
-    const num = toI(entry.value) + amount;
+    const num = toI(entry.value) + coerced;
     // Rails calls `write_entry(key, entry)` with no options (memory_store.rb:255),
     // so `unless_exist` never suppresses the hit-path rewrite; pass `{}` to match.
     this.writeEntry(

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -27,11 +27,10 @@ function toI(value: unknown): number {
   return 0;
 }
 
-// Mirrors Ruby `Integer(amount)` (memory_store.rb:248) over the numeric domain:
-// a finite number truncates toward zero (`Integer(1.5) # => 1`,
-// `Integer(-1.9) # => -1`), while NaN/Infinity raise the way Ruby's
-// `Integer(Float::NAN)`/`Integer(Float::INFINITY)` raise FloatDomainError —
-// rather than silently coercing to a non-integer.
+// Mirrors Ruby `Integer(amount)` over the numeric domain: a finite number
+// truncates toward zero (`Integer(1.5) # => 1`, `Integer(-1.9) # => -1`), while
+// NaN/Infinity raise the way Ruby's `Integer(Float::NAN)`/`Integer(Float::INFINITY)`
+// raise FloatDomainError — rather than silently coercing to a non-integer.
 function integer(amount: number): number {
   if (!Number.isFinite(amount)) {
     throw new ArgumentError(`invalid value for Integer(): ${amount}`);
@@ -133,19 +132,20 @@ export class MemoryStore extends Store implements CacheStore {
   // `increment("foo") # => 1`); on a hit it adds to entry.value.to_i, preserving
   // the entry's expiresAt/version.
   private modifyValue(name: string, amount: number, options?: CacheOptions): number {
-    // Rails coerces `amount = Integer(amount)` once (memory_store.rb:248) and
-    // threads that integer through the seed write, the return value, and the
-    // hit-path addition alike — so coerce up front rather than per-branch.
-    const coerced = integer(amount);
     const merged = this.mergedOptions(options);
     const key = this.normalizeKey(name, merged);
     const version = this.normalizeVersion(name, merged) ?? null;
     const entry = this.readEntry(key, merged);
     if (!entry || entry.isExpired() || entry.isMismatched(version)) {
-      this.write(name, coerced, options);
-      return coerced;
+      // Rails seeds with `Integer(amount)` (raises on NaN/Infinity) but returns
+      // the raw `amount` (memory_store.rb:248-249), so `increment("foo", 1.5)`
+      // writes 1 yet returns 1.5.
+      this.write(name, integer(amount), options);
+      return amount;
     }
-    const num = toI(entry.value) + coerced;
+    // Hit path adds the raw `amount` — Rails never calls `Integer()` here
+    // (memory_store.rb:251), so no truncation and no NaN/Infinity raise.
+    const num = toI(entry.value) + amount;
     // Rails calls `write_entry(key, entry)` with no options (memory_store.rb:255),
     // so `unless_exist` never suppresses the hit-path rewrite; pass `{}` to match.
     this.writeEntry(

--- a/packages/activesupport/src/cache/stores/memory-store.test.ts
+++ b/packages/activesupport/src/cache/stores/memory-store.test.ts
@@ -84,31 +84,33 @@ describe("CacheIncrementDecrementBehavior", () => {
     expect(cache.decrement("quux", 100)).toBe(-100);
   });
 
-  // Rails coerces `amount` through `Integer()` (memory_store.rb:248), which
-  // raises FloatDomainError on NaN/Infinity rather than seeding a non-integer.
-  it("increment raises on a non-integer amount", () => {
+  // The seed path writes `Integer(amount)` (memory_store.rb:248), which raises
+  // FloatDomainError on NaN/Infinity rather than seeding a non-integer entry.
+  it("increment raises on a non-integer amount when seeding a missing key", () => {
     expect(() => cache.increment("foo", NaN)).toThrow();
     expect(() => cache.increment("foo", Infinity)).toThrow();
     // The raise fires before any write, so the key is never seeded.
     expect(cache.read("foo")).toBeNull();
   });
 
-  it("decrement raises on a non-integer amount", () => {
+  it("decrement raises on a non-integer amount when seeding a missing key", () => {
     expect(() => cache.decrement("foo", NaN)).toThrow();
     expect(() => cache.decrement("foo", Infinity)).toThrow();
     expect(cache.read("foo")).toBeNull();
   });
 
-  // `Integer(1.5) # => 1`: a finite fractional amount truncates toward zero, and
-  // the coerced integer — not the raw amount — is what both the seed write and
-  // the hit-path addition use.
-  it("increment coerces the amount once for seed and hit paths", () => {
-    // Seed path: return value equals the coerced integer, not the raw 1.5.
-    expect(cache.increment("frac", 1.5)).toBe(1);
+  // Rails seeds a missing key with `Integer(amount)` (so `1.5` writes `1`) but
+  // returns the raw `amount` (memory_store.rb:248-249).
+  it("increment seeds with the integer amount but returns the raw amount", () => {
+    expect(cache.increment("frac", 1.5)).toBe(1.5);
     expect(Number(cache.read("frac"))).toBe(1);
-    // Hit path: adds the coerced integer, keeping the value integral.
-    expect(cache.increment("frac", 2.9)).toBe(3);
-    expect(Number(cache.read("frac"))).toBe(3);
+  });
+
+  // The hit path never calls `Integer()` (memory_store.rb:251): it adds the raw
+  // `amount` to `entry.value.to_i` without truncation.
+  it("increment adds the raw amount on the hit path", () => {
+    cache.write("frac", 1, { raw: true });
+    expect(cache.increment("frac", 2.5)).toBe(3.5);
   });
 
   it("test_ttl_isnt_updated", async () => {

--- a/packages/activesupport/src/cache/stores/memory-store.test.ts
+++ b/packages/activesupport/src/cache/stores/memory-store.test.ts
@@ -84,6 +84,33 @@ describe("CacheIncrementDecrementBehavior", () => {
     expect(cache.decrement("quux", 100)).toBe(-100);
   });
 
+  // Rails coerces `amount` through `Integer()` (memory_store.rb:248), which
+  // raises FloatDomainError on NaN/Infinity rather than seeding a non-integer.
+  it("increment raises on a non-integer amount", () => {
+    expect(() => cache.increment("foo", NaN)).toThrow();
+    expect(() => cache.increment("foo", Infinity)).toThrow();
+    // The raise fires before any write, so the key is never seeded.
+    expect(cache.read("foo")).toBeNull();
+  });
+
+  it("decrement raises on a non-integer amount", () => {
+    expect(() => cache.decrement("foo", NaN)).toThrow();
+    expect(() => cache.decrement("foo", Infinity)).toThrow();
+    expect(cache.read("foo")).toBeNull();
+  });
+
+  // `Integer(1.5) # => 1`: a finite fractional amount truncates toward zero, and
+  // the coerced integer — not the raw amount — is what both the seed write and
+  // the hit-path addition use.
+  it("increment coerces the amount once for seed and hit paths", () => {
+    // Seed path: return value equals the coerced integer, not the raw 1.5.
+    expect(cache.increment("frac", 1.5)).toBe(1);
+    expect(Number(cache.read("frac"))).toBe(1);
+    // Hit path: adds the coerced integer, keeping the value integral.
+    expect(cache.increment("frac", 2.9)).toBe(3);
+    expect(Number(cache.read("frac"))).toBe(3);
+  });
+
   it("test_ttl_isnt_updated", async () => {
     expect(cache.increment("foo", 1, { expiresIn: 0.1 })).toBe(1);
     // A second increment with a longer TTL must not reset the original expiry.


### PR DESCRIPTION
## What

`MemoryStore#modifyValue` now seeds a missing/expired/mismatched key with
`Integer(amount)` semantics on the **write only**, matching Ruby's `Integer()`
which raises on NaN/Infinity instead of silently truncating to a non-integer.

Rails (`memory_store.rb:245-256`) calls `Integer(amount)` **only** for the seed
`write`; the method then returns the **raw** `amount`, and the hit path
(`entry.value.to_i + amount`) uses the raw `amount` with no coercion. This PR
mirrors that exactly:

- **Seed path**: `write(name, integer(amount), options)` — raises on NaN/Infinity
  — then `return amount` (raw). `increment("foo", 1.5)` writes `1`, returns `1.5`.
- **Hit path**: unchanged `toI(entry.value) + amount` — raw amount, no truncation,
  no raise (Rails never calls `Integer()` here).

The only behavioral change from `main` is that the seed write now raises on a
non-integer (NaN/Infinity) `amount` instead of silently truncating; return and
hit-path semantics are unchanged.

## Tests

- seed path raises on NaN/Infinity for increment and decrement (no key seeded);
- seed path writes the integer amount but returns the raw amount;
- hit path adds the raw amount (no truncation).

Closes-story: memory-store-increment-integer-amount-raise
