### PR TITLE
fix(relation): validate merge(Hash) keys against VALUE_METHODS

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -349,14 +349,10 @@ describe("RelationTest", () => {
     expect(merged.toSql()).toContain("SELECT");
   });
 
-  // it.fails (active, not skipped): Rails `Relation::HashMerger#initialize`
-  // validates keys with `assert_valid_keys(*Relation::VALUE_METHODS)`, so
-  // `merge(omg: "lol")` raises ArgumentError (merger.rb:7-12,
-  // relation_test.rb:164-166). trails' `merge(Hash)` instead treats the hash as
-  // `where` conditions (merger.ts HashMerger#merge → `relation.where(hash)`) and
-  // validates nothing, so it does not raise. Marked `it.fails` so CI tracks the
-  // mismatch and flips red once HashMerger gains key validation.
-  it.fails("merging a hash with unknown keys raises", () => {
+  // Rails `Relation::HashMerger#initialize` validates keys with
+  // `assert_valid_keys(*Relation::VALUE_METHODS)`, so `merge(omg: "lol")` raises
+  // ArgumentError (merger.rb:7-12, relation_test.rb:164-166).
+  it("merging a hash with unknown keys raises", () => {
     expect(() => CanonPost.all().merge({ omg: "lol" } as any)).toThrow();
   });
 

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -59,6 +59,22 @@ describe("RelationTest", () => {
   setupFixtures();
   useHandlerTransactionalFixtures();
 
+  // No like-named Rails test: relation_test.rb only covers the invalid-key path
+  // ("merging a hash with unknown keys raises"). This guards the positive
+  // HashMerger path — a valid VALUE_METHODS-keyed hash builds a fresh base
+  // Relation (via `_newRelation`) and dispatches each key to its value-method
+  // bang setter, then merges through Merger — so a regression to the old
+  // where-conditions behavior (or a missing base-class `_newRelation`) is caught.
+  it("merging a valid-key hash dispatches to value-methods", () => {
+    const rel = CanonPost.all().merge({ where: { title: "a" }, limit: 5, order: "id" } as any);
+    const sql = rel.toSql();
+    expect(sql).toContain("WHERE");
+    expect(sql).toContain("title");
+    expect(sql).toContain("LIMIT");
+    expect(sql.toLowerCase()).toContain("order by");
+    expect(CanonPost.all().merge({ readonly: true } as any).isReadonly).toBe(true);
+  });
+
   it("dotted string order passes through as raw SQL (Rails treats all string orders as SqlLiteral)", () => {
     class Post extends Base {
       static _tableName = "posts";

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -329,11 +329,18 @@ export class HashMerger {
   // Rails `HashMerger#other`: build a fresh relation and apply each hash value
   // to it via `public_send("#{k}!", *v)` so where-value interpolation etc.
   // happens on the built relation rather than by directly merging raw values.
-  // `select` dispatches to `_select!` (Rails renames `:select` → `:_select` to
-  // avoid Enumerable#select!); trails mirrors this with `_selectBang`.
   private buildOther(): any {
     const other = this.relation._newRelation();
     for (const [key, value] of Object.entries(this.hash)) {
+      // `select` dispatches to `_select!` (Rails renames `:select` → `:_select`
+      // to avoid Enumerable#select!); trails mirrors this with `_selectBang`.
+      // `reordering` is a VALUE_METHOD Rails writes with `reordering!` (a bare
+      // `@values[:reordering] = value`); trails exposes no such bang, so set the
+      // backing field directly (Merger doesn't propagate it, matching Rails).
+      if (key === "reordering") {
+        other._reordering = value;
+        continue;
+      }
       const method = key === "select" ? "_selectBang" : `${key}Bang`;
       if (Array.isArray(value)) {
         other[method](...value);

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -334,13 +334,11 @@ export class HashMerger {
     for (const [key, value] of Object.entries(this.hash)) {
       // `select` dispatches to `_select!` (Rails renames `:select` → `:_select`
       // to avoid Enumerable#select!); trails mirrors this with `_selectBang`.
-      // `reordering` is a VALUE_METHOD Rails writes with `reordering!` (a bare
-      // `@values[:reordering] = value`); trails exposes no such bang, so set the
-      // backing field directly (Merger doesn't propagate it, matching Rails).
-      if (key === "reordering") {
-        other._reordering = value;
-        continue;
-      }
+      // Every other key routes to its `#{key}!` value-method, exactly as Rails'
+      // `other.public_send("#{k}!", *v)`. Note `:reordering` is in VALUE_METHODS
+      // but Rails defines no `reordering!` (only `reorder!`, query_methods.rb:760),
+      // so `merge(reordering: ...)` raises there too — we let it fall through and
+      // fail the same way rather than inventing a working path.
       const method = key === "select" ? "_selectBang" : `${key}Bang`;
       if (Array.isArray(value)) {
         other[method](...value);

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -1,4 +1,5 @@
 import { Nodes } from "@blazetrails/arel";
+import { assertValidKeys } from "@blazetrails/activesupport";
 
 import { arelColumns, constructJoinDependency, structuralUnionEq } from "./query-methods.js";
 
@@ -264,21 +265,82 @@ export class Merger {
 }
 
 /**
- * Merges a hash of conditions into a Relation by converting
- * the hash into where/having/etc. clauses first.
+ * Rails `Relation::VALUE_METHODS` (relation.rb:54-65) — the union of
+ * MULTI_VALUE_METHODS, SINGLE_VALUE_METHODS, and CLAUSE_METHODS — expressed as
+ * trails' camelCase keys. These are the only keys a hash `merge` accepts; each
+ * dispatches to the matching value-method bang setter on the built relation.
+ */
+const VALUE_METHODS = [
+  // MULTI_VALUE_METHODS
+  "includes",
+  "eagerLoad",
+  "preload",
+  "select",
+  "group",
+  "order",
+  "joins",
+  "leftOuterJoins",
+  "references",
+  "extending",
+  "unscope",
+  "optimizerHints",
+  "annotate",
+  "with",
+  // SINGLE_VALUE_METHODS
+  "limit",
+  "offset",
+  "lock",
+  "readonly",
+  "reordering",
+  "strictLoading",
+  "reverseOrder",
+  "distinct",
+  "createWith",
+  "skipQueryCache",
+  // CLAUSE_METHODS
+  "where",
+  "having",
+  "from",
+];
+
+/**
+ * Merges a hash of value-method directives into a Relation.
  *
- * Mirrors: ActiveRecord::Relation::HashMerger
+ * Mirrors: ActiveRecord::Relation::HashMerger. Rails validates the hash keys
+ * against `Relation::VALUE_METHODS` (raising ArgumentError on any unknown key),
+ * then builds a relation from the hash by dispatching each key to its
+ * value-method bang setter and merges that via `Merger`.
  */
 export class HashMerger {
   readonly relation: any;
   readonly hash: Record<string, unknown>;
 
   constructor(relation: any, hash: Record<string, unknown>) {
+    // Rails `HashMerger#initialize`: `hash.assert_valid_keys(*VALUE_METHODS)`.
+    assertValidKeys(hash, VALUE_METHODS);
     this.relation = relation;
     this.hash = hash;
   }
 
   merge(): any {
-    return this.relation.where(this.hash);
+    return new Merger(this.relation, this.buildOther()).merge();
+  }
+
+  // Rails `HashMerger#other`: build a fresh relation and apply each hash value
+  // to it via `public_send("#{k}!", *v)` so where-value interpolation etc.
+  // happens on the built relation rather than by directly merging raw values.
+  // `select` dispatches to `_select!` (Rails renames `:select` → `:_select` to
+  // avoid Enumerable#select!); trails mirrors this with `_selectBang`.
+  private buildOther(): any {
+    const other = this.relation._newRelation();
+    for (const [key, value] of Object.entries(this.hash)) {
+      const method = key === "select" ? "_selectBang" : `${key}Bang`;
+      if (Array.isArray(value)) {
+        other[method](...value);
+      } else {
+        other[method](value);
+      }
+    }
+    return other;
   }
 }

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -41855,20 +41855,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
-    "rubyName": "initialize",
-    "call": "assert_valid_keys",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
     "rubyName": "merge",
     "call": "relation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Mirror Rails `Relation::HashMerger` for `Relation#merge(Hash)`.

Previously trails `HashMerger#merge` treated the hash as bare `where`
conditions (`relation.where(hash)`) and validated nothing, so
`merge(omg: "lol")` did not raise. Rails
(`vendor/rails/activerecord/lib/active_record/relation/merger.rb:7-12`)
instead validates the hash keys via `assert_valid_keys(*Relation::VALUE_METHODS)`
in the constructor, then builds a relation by dispatching each key to its
matching value-method setter and merges it through `Merger`.

This change:
- Validates hash keys against `VALUE_METHODS` (raising `ArgumentError` on
  unknown keys) in `HashMerger`.
- Builds the `other` relation by dispatching each key to its `*Bang` setter
  (`select` → `_selectBang`, mirroring Rails renaming `:select` → `:_select`),
  then merges via `Merger`.
- Removes the `it.fails` marker on `merging a hash with unknown keys raises`
  in `relation.test.ts`.

Closes-story: merge-hash-value-methods-key-validation

---

## Review responses

**Blocking — `_newRelation` "doesn't exist on base `Relation`":** Not accurate.
`relation.ts` defines a single class (`export class Relation`, line 482); its
`_newRelation()` lives at `relation.ts:7239` and is used by `_clone()` at 7306.
It's `protected` (which JS ignores at runtime), not subclass-only — the
`AssociationRelation` copy is an override, not the sole definition. `CanonPost.all().merge({ where, limit, order })` builds and runs correctly. Added a
committed regression test (`relation.trails.test.ts`, "merging a valid-key hash
dispatches to value-methods") exercising this positive path so it can't regress.

**Question — `reordering` special-case:** You're right. Rails defines no
`reordering!` (only `reorder!`, `query_methods.rb:760`), so `merge(reordering: ...)`
would `NoMethodError` there. Dropped the invented `other._reordering = value`
branch; the key now falls through to generic `${key}Bang` dispatch and is
unsupported/raises the same way Rails is.
