### PR TITLE
test(type-virtualization): make materialize-model-declares unit-testable

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -603,6 +603,7 @@ export default defineConfig(
           allowDefaultProject: [
             "packages/actionview/types/tse-modules.d.ts",
             "packages/activerecord/scripts/materialize-model-declares.ts",
+            "packages/activerecord/scripts/materialize-model-declares.test.ts",
             "packages/website/docs/.vitepress/config.ts",
             "vitest.config.ts",
             "vitest.dx-tests.config.ts",

--- a/packages/activerecord/scripts/materialize-model-declares.test.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from "vitest";
+import { INLINE_IMPORT_RE, hoistInlineImports } from "./materialize-model-declares.js";
+
+describe("INLINE_IMPORT_RE", () => {
+  it("does not misparse a dynamic-import .then() call site as a named import", () => {
+    // Runtime dynamic import chained through `.then((m) => m.Foo)`. The member
+    // access is immediately CALLED, so the trailing `(?![\w$]|\s*\()` lookahead
+    // must reject it — otherwise a phantom `then` import gets hoisted and the
+    // call site is rewritten to a bare `then`. Regression for PR #4557.
+    const src = `const p = import("mod").then((m) => m.Foo);`;
+    INLINE_IMPORT_RE.lastIndex = 0;
+    expect(INLINE_IMPORT_RE.test(src)).toBe(false);
+    const { text, importLines } = hoistInlineImports(src, new Set(), "/x");
+    expect(text).toBe(src);
+    expect(importLines).toEqual([]);
+  });
+
+  it("hoists an inline type-position import expression", () => {
+    // The virtualizer only emits `import("mod").Sym` in TYPE position, never
+    // followed by `(`, so the lookahead admits it: the call site rewrites to a
+    // bare `Relation` and a top-level `import type` line is hoisted.
+    const src = `declare posts: import("mod").Relation<Post>;`;
+    const { text, importLines } = hoistInlineImports(src, new Set(), "/x");
+    expect(text).toBe(`declare posts: Relation<Post>;`);
+    expect(importLines).toHaveLength(1);
+    expect(importLines[0]).toContain("import type { Relation }");
+  });
+});

--- a/packages/activerecord/scripts/materialize-model-declares.ts
+++ b/packages/activerecord/scripts/materialize-model-declares.ts
@@ -17,7 +17,7 @@
 import ts from "typescript";
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { classify, camelize } from "@blazetrails/activesupport";
 import { virtualize } from "../src/type-virtualization/virtualize.js";
 import { walk, type ClassInfo, type AssociationCall } from "../src/type-virtualization/walker.js";
@@ -657,7 +657,7 @@ function collectNamesInScope(sf: ts.SourceFile): Set<string> {
 // the lookahead pins the identifier to its full extent: without it the greedy
 // `[\w$]*` would backtrack and match the prefix `the` of `then(`, whose next
 // char is `n` (not `(`), re-introducing the bug.
-const INLINE_IMPORT_RE = /import\("([^"]+)"\)\.([A-Za-z_$][\w$]*)(?![\w$]|\s*\()/g;
+export const INLINE_IMPORT_RE = /import\("([^"]+)"\)\.([A-Za-z_$][\w$]*)(?![\w$]|\s*\()/g;
 // AR built-ins, keyed by symbol → the source module relative to MODELS_DIR
 // (the same paths the hand-written model declares under that dir use). The
 // specifier is recomputed relative to each materialized file's directory in
@@ -680,7 +680,7 @@ function builtinSpecifierFor(sym: string, fileDir: string): string | undefined {
   return rel;
 }
 
-function hoistInlineImports(
+export function hoistInlineImports(
   text: string,
   inScope: ReadonlySet<string>,
   fileDir: string,
@@ -849,4 +849,11 @@ async function main(): Promise<void> {
   }
 }
 
-await main();
+// Only run the generator when invoked as the CLI entry point — importing the
+// module (e.g. from a unit test) must not rewrite the pilot model files.
+// Compare module URL to argv[1] via `pathToFileURL` so Windows paths and
+// URL-encoded chars don't trip a naive `file://` string compare.
+const entry = process.argv[1];
+if (entry !== undefined && import.meta.url === pathToFileURL(entry).href) {
+  await main();
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -315,7 +315,10 @@ export default defineConfig({
         resolve: { alias },
         test: {
           name: "activerecord",
-          include: ["packages/activerecord/src/**/*.test.ts"],
+          include: [
+            "packages/activerecord/src/**/*.test.ts",
+            "packages/activerecord/scripts/**/*.test.ts",
+          ],
           exclude: [...SHARED_EXCLUDE, ...ADAPTER_SPECIFIC_EXCLUDE, ...SQLITE_DRIVER_TESTS],
           // Phase 0 sqlite template-clone (perf): build the canonical schema
           // into a template file once for the whole run; workers clone it


### PR DESCRIPTION
## What

`packages/activerecord/scripts/materialize-model-declares.ts` ended with a
top-level `await main()`, so importing it for a unit test executed `main()`
with no args and rewrote the PILOT model files on disk. This blocked adding a
focused regression test for the `import("...").then(...)` misparse fixed in
PR #4557.

- Guard `main()` behind a CLI-entry check (`import.meta.url` vs `argv[1]` via
  `pathToFileURL`) so the module is importable with no side effects.
- Export the pure helpers `hoistInlineImports` and `INLINE_IMPORT_RE`.
- Add `materialize-model-declares.test.ts` asserting `import("mod").then((m) =>
  m.Foo)` is left untouched (no phantom `then` import, no rewritten call site)
  while `import("mod").Relation` in type position still hoists.
- Wire `packages/activerecord/scripts/**/*.test.ts` into the activerecord
  vitest project and the eslint default project so the new test is collected
  and linted.

No behavior change to the generator output.

Closes-story: materialize-declares-generator-unit-testable