### PR TITLE
feat(migration): widen createTable id option to accept IdHashOptions

### DIFF
--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
@@ -27,7 +27,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { Base, registerModel } from "../index.js";
+import { Base, registerModel, TableDefinition } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { setupFixtures } from "../test-helpers/fixtures.js";
 import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
@@ -68,11 +68,11 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
   }
 
   beforeAll(async () => {
-    const conn = Base.connection as any;
-    await conn.createTable("dp_authors", { force: true }, (t: any) => {
+    const conn = Base.connection;
+    await conn.createTable("dp_authors", { force: true }, (t: TableDefinition) => {
       t.string("name");
     });
-    await conn.createTable("dp_galleries", { force: true }, (t: any) => {
+    await conn.createTable("dp_galleries", { force: true }, (t: TableDefinition) => {
       t.integer("dp_author_id");
       t.string("imageable_uuid");
       t.string("imageable_type");
@@ -80,14 +80,14 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
     await conn.createTable(
       "dp_non_id_photos",
       { primaryKey: "uuid", id: { type: "string" }, force: true },
-      (t: any) => {
+      (t: TableDefinition) => {
         t.string("title");
       },
     );
     await conn.createTable(
       "dp_non_id_articles",
       { primaryKey: "slug", id: { type: "string" }, force: true },
-      (t: any) => {
+      (t: TableDefinition) => {
         t.string("headline");
       },
     );

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
@@ -129,7 +129,7 @@ describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
   });
 
   afterAll(async () => {
-    await (Base.connection as any).dropTable(
+    await Base.connection.dropTable(
       "dp_non_id_articles",
       "dp_non_id_photos",
       "dp_galleries",

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -19,6 +19,7 @@ import {
   type ColumnOptions,
   type AddForeignKeyOptions,
   type AddIndexOptions,
+  type IdHashOptions,
 } from "./connection-adapters/abstract/schema-definitions.js";
 import {
   SchemaStatements,
@@ -393,7 +394,7 @@ export abstract class Migration {
     name: string,
     optionsOrFn?:
       | {
-          id?: boolean | "uuid";
+          id?: boolean | "uuid" | IdHashOptions;
           primaryKey?: string | string[] | false;
           force?: boolean | "cascade";
           ifNotExists?: boolean;
@@ -1831,7 +1832,7 @@ export class MigrationContext {
       primaryKey?: string | string[] | false;
       force?: boolean | "cascade";
       ifNotExists?: boolean;
-      id?: boolean | "uuid";
+      id?: boolean | "uuid" | IdHashOptions;
       default?: unknown;
       options?: string;
       comment?: string;


### PR DESCRIPTION
## What

`MigrationContext.createTable` and `Migration#createTable` only exposed `id?: boolean | "uuid"` on their public overloads, even though the `IdHashOptions` hash form (`id: { type: "string" }`) is handled correctly at runtime by `TableDefinition` and is already typed on the inner adapter overloads (`AbstractAdapter#createTable`, `SchemaStatements#createTable`).

This gap forced a `Base.connection as any` bypass in `disable-joins-polymorphic-nonid-pk.test.ts`, which creates string-typed PK tables (`uuid`, `slug`).

## Changes

- Widen `id` to `boolean | "uuid" | IdHashOptions` on both public `createTable` overloads in `migration.ts`.
- Replace the `Base.connection as any` bypass in `disable-joins-polymorphic-nonid-pk.test.ts` with a typed call (`t: TableDefinition`).

Rails equivalent: `create_table "dp_non_id_photos", primary_key: "uuid", id: :string`.

## Test

`pnpm vitest run --project activerecord packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts` — 2 passed.

Closes-story: migration-context-createtable-id-hash-options