### PR TITLE
ci: make reporting-only coverage artifact uploads non-fatal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,7 +728,10 @@ jobs:
         if: always()
         run: node scripts/ci/coverage-summary.mjs
       - name: Upload coverage report (lcov + json)
+        # Reporting-only: a transient artifact-service upload timeout must not
+        # turn this non-gating job red (see RFC 0061-ci-failures).
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: coverage-report
@@ -798,7 +801,10 @@ jobs:
         if: always()
         run: node scripts/ci/coverage-summary.mjs
       - name: Upload AR coverage report (lcov + json)
+        # Reporting-only: a transient artifact-service upload timeout must not
+        # turn this non-gating job red (see RFC 0061-ci-failures).
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: ar-coverage-report
@@ -849,7 +855,10 @@ jobs:
         if: always()
         run: node scripts/ci/coverage-summary.mjs
       - name: Upload AR CLI coverage report (lcov + json)
+        # Reporting-only: a transient artifact-service upload timeout must not
+        # turn this non-gating job red (see RFC 0061-ci-failures).
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: ar-cli-coverage-report
@@ -897,7 +906,10 @@ jobs:
         if: always()
         run: node scripts/ci/coverage-summary.mjs
       - name: Upload trails-tsc coverage report (lcov + json)
+        # Reporting-only: a transient artifact-service upload timeout must not
+        # turn this non-gating job red (see RFC 0061-ci-failures).
         if: always()
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: trails-tsc-coverage-report


### PR DESCRIPTION
## Problem

The **Active Record SQLite Coverage (reporting-only)** job failed on main @37b37e5c. Root cause was **not** a test or coverage regression — coverage computed fine (74.67% lines). The `Upload AR coverage report` step hit a transient GitHub artifact-service outage:

```
Attempt 1..5 of 5 failed with error: Request timeout: /twirp/.../CreateArtifact
##[error]Failed to CreateArtifact: Failed to make request after 5 attempts
```

A flaky artifact upload turned an intentionally non-gating reporting-only job red.

## Fix

Mark the upload step `continue-on-error: true` across all four reporting-only coverage jobs (light `Coverage`, `ar-sqlite-coverage`, `ar-cli-coverage`, `trails-tsc-coverage`). These jobs exist only to publish numbers; a transient artifact upload should never fail them. The coverage summary is still written to the run UI regardless.

Closes-story: red-37b37e5c