### PR TITLE
fix(test): read dumpSchema through array-row selectAll shape

### DIFF
--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -21,16 +21,25 @@ import { TEST_SCHEMA } from "./test-schema.js";
 // dumped DDL. The per-adapter transforms (serialIdType, DATETIME(6)) are shared
 // code imported from define-schema.ts, so PG/MySQL cannot diverge independently.
 
+// Reads sqlite_master through both the object-row and `{ columns, rows }`
+// array-row selectAll shapes — the BetterSQLite3Adapter returns the latter, so
+// naive `r.type`/`r.name`/`r.sql` access on the array rows yields undefined and
+// silently collapses every dump line to "undefined undefined: undefined".
 async function dumpSchema(adapter: AbstractAdapter): Promise<string> {
   const res = (await adapter.selectAll(
     "SELECT type, name, sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY name, type, sql",
   )) as unknown;
-  const rows = (Array.isArray(res) ? res : ((res as { rows?: unknown[] }).rows ?? [])) as {
-    type: string;
-    name: string;
-    sql: string;
-  }[];
-  return rows.map((r) => `${r.type} ${r.name}: ${r.sql}`).join("\n");
+  let objectRows: { type: unknown; name: unknown; sql: unknown }[];
+  if (Array.isArray(res)) {
+    objectRows = res as { type: unknown; name: unknown; sql: unknown }[];
+  } else {
+    const { columns, rows } = res as { columns: string[]; rows: unknown[][] };
+    const t = columns.indexOf("type");
+    const n = columns.indexOf("name");
+    const s = columns.indexOf("sql");
+    objectRows = rows.map((row) => ({ type: row[t], name: row[n], sql: row[s] }));
+  }
+  return objectRows.map((r) => `${r.type} ${r.name}: ${r.sql}`).join("\n");
 }
 
 describe("loadCanonicalSchema", () => {
@@ -48,6 +57,10 @@ describe("loadCanonicalSchema", () => {
       // Sanity floor: the canonical schema is hundreds of tables + indexes, so a
       // silently-empty dump (both empty ⇒ trivially equal) can't pass this test.
       expect(expected.split("\n").length).toBeGreaterThan(300);
+      // Content floor: the dump must carry real DDL, not placeholder rows — a
+      // shape mismatch collapses every line to "undefined undefined: undefined".
+      expect(expected).not.toContain("undefined undefined: undefined");
+      expect(expected).toMatch(/table topics: CREATE TABLE "?topics"?/);
     } finally {
       await viaDefineSchema.close();
       await viaLoader.close();

--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -21,25 +21,19 @@ import { TEST_SCHEMA } from "./test-schema.js";
 // dumped DDL. The per-adapter transforms (serialIdType, DATETIME(6)) are shared
 // code imported from define-schema.ts, so PG/MySQL cannot diverge independently.
 
-// Reads sqlite_master through both the object-row and `{ columns, rows }`
-// array-row selectAll shapes — the BetterSQLite3Adapter returns the latter, so
-// naive `r.type`/`r.name`/`r.sql` access on the array rows yields undefined and
-// silently collapses every dump line to "undefined undefined: undefined".
+// `selectAll` returns a `Result` whose rows are positional arrays; `toArray()`
+// maps them to hash rows via the column index, so `r.type`/`r.name`/`r.sql`
+// resolve to real values. Reading the raw `{ columns, rows }` array rows
+// directly instead silently collapses every dump line to
+// "undefined undefined: undefined".
 async function dumpSchema(adapter: AbstractAdapter): Promise<string> {
-  const res = (await adapter.selectAll(
+  const res = await adapter.selectAll(
     "SELECT type, name, sql FROM sqlite_master WHERE sql IS NOT NULL ORDER BY name, type, sql",
-  )) as unknown;
-  let objectRows: { type: unknown; name: unknown; sql: unknown }[];
-  if (Array.isArray(res)) {
-    objectRows = res as { type: unknown; name: unknown; sql: unknown }[];
-  } else {
-    const { columns, rows } = res as { columns: string[]; rows: unknown[][] };
-    const t = columns.indexOf("type");
-    const n = columns.indexOf("name");
-    const s = columns.indexOf("sql");
-    objectRows = rows.map((row) => ({ type: row[t], name: row[n], sql: row[s] }));
-  }
-  return objectRows.map((r) => `${r.type} ${r.name}: ${r.sql}`).join("\n");
+  );
+  return res
+    .toArray()
+    .map((r) => `${r.type} ${r.name}: ${r.sql}`)
+    .join("\n");
 }
 
 describe("loadCanonicalSchema", () => {


### PR DESCRIPTION
## Problem

`dumpSchema` in `canonical-schema.test.ts` mapped `sqlite_master` rows as
`r.type`/`r.name`/`r.sql`, but the `BetterSQLite3Adapter` `selectAll` returns a
`Result` with a `{ columns, rows }` array-row shape. So every mapped field was
`undefined` and each dump line collapsed to `"undefined undefined: undefined"`.
The `loadCanonicalSchema` / `rebuildCanonicalTables` parity tests only compared
dump-to-dump, so they passed trivially on equal-shaped placeholder rows —
validating row count/order, not actual schema content.

## Fix

- `dumpSchema` now maps `columns` → indices to build real object rows through
  both the array-row and object-row shapes.
- The `loadCanonicalSchema` parity test gains a content floor: it asserts the
  dump carries real DDL (no `"undefined undefined: undefined"`, and a real
  `table topics: CREATE TABLE topics` line), keeping the `> 300`-line sanity
  floor.

No test renames. Local run: all 6 tests pass.

Closes-story: fix-canonical-schema-test-dumpschema-array-rows