### PR TITLE
fix(activesupport): assertValidKeys raises ArgumentError, not generic Error

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -354,6 +354,13 @@ describe("RelationTest", () => {
   // ArgumentError (merger.rb:7-12, relation_test.rb:164-166).
   it("merging a hash with unknown keys raises", () => {
     expect(() => CanonPost.all().merge({ omg: "lol" } as any)).toThrow();
+    let error: unknown;
+    try {
+      CanonPost.all().merge({ omg: "lol" } as any);
+    } catch (err) {
+      error = err;
+    }
+    expect((error as Error).name).toBe("ArgumentError");
   });
 
   it("merging nil or false raises", () => {

--- a/packages/activesupport/src/hash-ext.test.ts
+++ b/packages/activesupport/src/hash-ext.test.ts
@@ -9,6 +9,7 @@ import {
   deepStringifyKeys,
   reverseMerge,
   assertValidKeys,
+  ArgumentError,
   slice,
   except,
   extractKeys,
@@ -111,6 +112,17 @@ describe("HashExtTest", () => {
     expect(() =>
       assertValidKeys({ failore: "stuff", funny: "business" }, ["failure", "funny"]),
     ).toThrow(/Unknown key: failore/);
+  });
+
+  it("assert_valid_keys — raises ArgumentError on unknown key", () => {
+    let error: unknown;
+    try {
+      assertValidKeys({ failore: "stuff", funny: "business" }, ["failure", "funny"]);
+    } catch (err) {
+      error = err;
+    }
+    expect(error).toBeInstanceOf(ArgumentError);
+    expect((error as Error).name).toBe("ArgumentError");
   });
 
   it("assert_valid_keys — includes valid keys in error message", () => {

--- a/packages/activesupport/src/hash-ext.test.ts
+++ b/packages/activesupport/src/hash-ext.test.ts
@@ -109,12 +109,11 @@ describe("HashExtTest", () => {
   });
 
   it("assert_valid_keys — throws on unknown key", () => {
+    // Rails' assert_valid_keys raises Ruby's ArgumentError (keys.rb:52), so
+    // callers can narrow on the type — assert both the message and the type.
     expect(() =>
       assertValidKeys({ failore: "stuff", funny: "business" }, ["failure", "funny"]),
     ).toThrow(/Unknown key: failore/);
-  });
-
-  it("assert_valid_keys — raises ArgumentError on unknown key", () => {
     let error: unknown;
     try {
       assertValidKeys({ failore: "stuff", funny: "business" }, ["failure", "funny"]);

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -5,6 +5,16 @@
 type AnyObject = Record<string, unknown>;
 
 /**
+ * Mirrors Ruby's `ArgumentError`. Raised by {@link assertValidKeys} so callers
+ * can `catch`/narrow on the Rails-faithful error type (`err.name ===
+ * "ArgumentError"`) the way they would in Ruby.
+ * @internal
+ */
+export class ArgumentError extends Error {
+  override name = "ArgumentError";
+}
+
+/**
  * Deep merge two objects recursively. When both values are objects, they are
  * merged recursively. Otherwise the source value wins.
  */
@@ -182,7 +192,7 @@ export function assertValidKeys(obj: AnyObject, validKeys: string[]): void {
   const validSet = new Set(validKeys);
   for (const key of Object.keys(obj)) {
     if (!validSet.has(key)) {
-      throw new Error(`Unknown key: ${key}. Valid keys are: ${validKeys.join(", ")}`);
+      throw new ArgumentError(`Unknown key: ${key}. Valid keys are: ${validKeys.join(", ")}`);
     }
   }
 }


### PR DESCRIPTION
## Summary

Rails' `Hash#assert_valid_keys` raises `ArgumentError` on an unknown key. trails' shared `assertValidKeys` helper (`packages/activesupport/src/hash-utils.ts`) threw a bare `new Error(...)`, so callers wiring through it — notably `Relation::HashMerger#initialize`'s `assert_valid_keys(*Relation::VALUE_METHODS)` (`merger.rb:11`) — could not `catch`/narrow on the Rails-faithful `ArgumentError` type the way they can in Ruby. `merge({ omg: "lol" })` raised, but not with the right type.

Mirrors sibling stories `derive-fk-query-constraints-argumenterror-type` and `relation-handler-composite-pk-argumenterror-parity`. Surfaced by PR #4561.

## Changes

- Add a local `ArgumentError` class in `hash-utils.ts` (mirrors Ruby, `name === "ArgumentError"`) and throw it from `assertValidKeys`.
- Assert the `ArgumentError` type in `hash-ext.test.ts` and in `relation.test.ts`'s merge-unknown-keys case.
- Audited all `assertValidKeys` callers: only `merger.ts` (no type/message dependency) and existing `.toThrow(/regex/)` tests, which still pass — no regression.

Closes-story: assert-valid-keys-argumenterror-type