### PR TITLE
test(relation): merge empty hash into relation, assert empty where clause

### DIFF
--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -6,6 +6,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { ValueType } from "@blazetrails/activemodel";
 import { Relation } from "./index.js";
+import { WhereClause } from "./relation/where-clause.js";
 import { Base } from "./base.js";
 import { registerModel } from "./associations.js";
 
@@ -344,8 +345,10 @@ describe("RelationTest", () => {
   });
 
   it("merging an empty hash into a relation", () => {
+    // merge()'s type only accepts a Relation; Rails accepts a hash, so cast the
+    // empty hash to exercise the HashMerger empty-hash path (relation_test.rb:160).
     const merged = CanonPost.all().merge({} as any);
-    expect((merged as any)._whereClause.isEmpty()).toBe(true);
+    expect(merged._whereClause).toEqual(WhereClause.empty());
   });
 
   // Rails `Relation::HashMerger#initialize` validates keys with

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -344,9 +344,8 @@ describe("RelationTest", () => {
   });
 
   it("merging an empty hash into a relation", () => {
-    const base = CanonPost.where({ title: "a" });
-    const merged = base.merge(CanonPost.all());
-    expect(merged.toSql()).toContain("SELECT");
+    const merged = CanonPost.all().merge({} as any);
+    expect((merged as any)._whereClause.isEmpty()).toBe(true);
   });
 
   // Rails `Relation::HashMerger#initialize` validates keys with


### PR DESCRIPTION
Converges the "merging an empty hash into a relation" test to mirror Rails `relation_test.rb:160-162`: it now merges an empty hash (`{}`) through the `HashMerger`/`buildOther` path and asserts the where clause stays empty, instead of merging a Relation and only checking for `SELECT`.

Now that `HashMerger` routes an empty hash through `buildOther()` (PR #4561), the trails test can exercise the same path Rails targets.

Test name unchanged; surrounding merge suite passes.

Closes-story: converge-merge-empty-hash-test