### PR TITLE
fix(migration): gate isUseAdvisoryLock on advisory-lock support only

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2836,11 +2836,18 @@ export class Migrator {
     return this._useTransaction(migration);
   }
 
-  /** @internal Mirrors: ActiveRecord::Migrator#use_advisory_lock? */
+  /**
+   * @internal Mirrors: ActiveRecord::Migrator#use_advisory_lock?
+   *
+   * Rails gates solely on the adapter's advisory-lock support
+   * (`connection.advisory_locks_enabled?`). The `currentDatabase` requirement is
+   * enforced at the point it's actually needed — `_withAdvisoryLock` /
+   * `generateMigratorAdvisoryLockId`, which throw if an advisory-lock-capable
+   * adapter can't supply the DB name — rather than silently skipping the lock
+   * here (which Rails never does).
+   */
   isUseAdvisoryLock(): boolean {
-    return !!(
-      this._adapter.supportsAdvisoryLocks?.() && typeof this._adapter.currentDatabase === "function"
-    );
+    return !!this._adapter.supportsAdvisoryLocks?.();
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#with_advisory_lock */

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2839,15 +2839,16 @@ export class Migrator {
   /**
    * @internal Mirrors: ActiveRecord::Migrator#use_advisory_lock?
    *
-   * Rails gates solely on the adapter's advisory-lock support
-   * (`connection.advisory_locks_enabled?`). The `currentDatabase` requirement is
-   * enforced at the point it's actually needed — `_withAdvisoryLock` /
+   * Rails gates solely on `connection.advisory_locks_enabled?`
+   * (`supports_advisory_locks? && @advisory_locks_enabled`), mirrored here by
+   * `isAdvisoryLocksEnabled()`. The `currentDatabase` requirement is enforced at
+   * the point it's actually needed — `_withAdvisoryLock` /
    * `generateMigratorAdvisoryLockId`, which throw if an advisory-lock-capable
    * adapter can't supply the DB name — rather than silently skipping the lock
    * here (which Rails never does).
    */
   isUseAdvisoryLock(): boolean {
-    return !!this._adapter.supportsAdvisoryLocks?.();
+    return !!this._adapter.isAdvisoryLocksEnabled?.();
   }
 
   /** @internal Mirrors: ActiveRecord::Migrator#with_advisory_lock */

--- a/packages/activerecord/src/migrator.trails.test.ts
+++ b/packages/activerecord/src/migrator.trails.test.ts
@@ -401,4 +401,25 @@ describe("Migrator advisory lock wrapping", () => {
     const migrator = new Migrator(rawAdapter, []);
     await expect(migrator.migrate()).rejects.toThrow("must implement currentDatabase()");
   });
+
+  it("isUseAdvisoryLock does not depend on currentDatabase", async () => {
+    // Regression: the gate must mirror Rails' advisory_locks_enabled? only, and
+    // NOT return false (silently skipping the lock) merely because the adapter
+    // lacks a currentDatabase() function.
+    const adapter = {
+      isAdvisoryLocksEnabled: () => true,
+      // currentDatabase intentionally absent
+    } as unknown as DatabaseAdapter;
+    const migrator = new Migrator(adapter, []);
+    expect(migrator.isUseAdvisoryLock()).toBe(true);
+  });
+
+  it("isUseAdvisoryLock is false when advisory locks are disabled", async () => {
+    const adapter = {
+      isAdvisoryLocksEnabled: () => false,
+      currentDatabase: async () => "test_db",
+    } as unknown as DatabaseAdapter;
+    const migrator = new Migrator(adapter, []);
+    expect(migrator.isUseAdvisoryLock()).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary

`Migrator#isUseAdvisoryLock` carried a trails-only guard —
`typeof this._adapter.currentDatabase === "function"` — on top of the
advisory-lock check. Rails' `Migrator#use_advisory_lock?` gates **only** on
`connection.advisory_locks_enabled?` (`activerecord/lib/active_record/migration.rb:1596`).
The extra guard meant trails could return `false` and silently skip migration
advisory locking on an adapter that supports advisory locks but doesn't expose
`currentDatabase` — behavior Rails never exhibits.

This converges the gate to the exact Rails predicate: `advisory_locks_enabled?`
(= `supports_advisory_locks? && @advisory_locks_enabled`), mirrored in trails by
`AbstractAdapter#isAdvisoryLocksEnabled()`. This also fixes a secondary
under-mirror — the gate now honors the `:advisory_locks` config flag like Rails,
instead of keying off raw `supportsAdvisoryLocks`.

The `currentDatabase` requirement is genuinely load-bearing only for lock-id
generation, and that need is already enforced at the point of use:
`_withAdvisoryLock` / `generateMigratorAdvisoryLockId` throw if an
advisory-lock-capable adapter can't supply the DB name.

## Testing

- `pnpm vitest run packages/activerecord/src/migrator.trails.test.ts packages/activerecord/src/migration.test.ts` — pass.
- Added direct regression coverage: `isUseAdvisoryLock` must not return `false`
  merely because the adapter lacks `currentDatabase()`, and must be `false` when
  advisory locks are disabled.

Closes-story: migrator-use-advisory-lock-currentdatabase-guard