### PR TITLE
fix(migration): validate names before versions to tolerate nil version

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -3126,10 +3126,21 @@ export class Migrator {
 
   /** @internal */
   private validate(migrations: MigrationProxy[]): void {
-    const versions = new Set<string>();
-    const names = new Set<string>();
     const validateTs = this.isValidateTimestamp();
 
+    // Rails' Migrator#validate checks duplicate names before touching
+    // versions, and tolerates a nil version. Mirror that ordering so a list of
+    // same-name, version-less migrations raises DuplicateMigrationNameError
+    // rather than being rejected for a missing version.
+    const names = new Set<string>();
+    for (const m of migrations) {
+      if (names.has(m.name)) {
+        throw new DuplicateMigrationNameError(m.name);
+      }
+      names.add(m.name);
+    }
+
+    const versions = new Set<string>();
     for (const m of migrations) {
       if (!m.version || !/^\d+$/.test(m.version)) {
         throw new MigrationError(
@@ -3143,11 +3154,7 @@ export class Migrator {
       if (versions.has(normalized)) {
         throw new DuplicateMigrationVersionError(m.version);
       }
-      if (names.has(m.name)) {
-        throw new DuplicateMigrationNameError(m.name);
-      }
       versions.add(normalized);
-      names.add(m.name);
     }
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -3132,15 +3132,21 @@ export class Migrator {
     // versions, and tolerates a nil version. Mirror that ordering so a list of
     // same-name, version-less migrations raises DuplicateMigrationNameError
     // rather than being rejected for a missing version.
-    const names = new Set<string>();
+    //
+    // Rails uses `group_by(&:name).find { |_, v| v.length > 1 }`, which reports
+    // the first *name* in first-occurrence order that has any duplicate — not
+    // the name whose repeat appears earliest. Count first, then walk the list
+    // in order to find the first duplicated name/version, to match that.
+    const nameCounts = new Map<string, number>();
     for (const m of migrations) {
-      if (names.has(m.name)) {
+      nameCounts.set(m.name, (nameCounts.get(m.name) ?? 0) + 1);
+    }
+    for (const m of migrations) {
+      if (nameCounts.get(m.name)! > 1) {
         throw new DuplicateMigrationNameError(m.name);
       }
-      names.add(m.name);
     }
 
-    const versions = new Set<string>();
     for (const m of migrations) {
       if (!m.version || !/^\d+$/.test(m.version)) {
         throw new MigrationError(
@@ -3150,11 +3156,17 @@ export class Migrator {
       if (validateTs && !this.isValidMigrationTimestamp(m.version)) {
         throw new InvalidMigrationTimestampError(m.version, m.name);
       }
+    }
+
+    const versionCounts = new Map<string, number>();
+    for (const m of migrations) {
       const normalized = String(BigInt(m.version));
-      if (versions.has(normalized)) {
+      versionCounts.set(normalized, (versionCounts.get(normalized) ?? 0) + 1);
+    }
+    for (const m of migrations) {
+      if (versionCounts.get(String(BigInt(m.version)))! > 1) {
         throw new DuplicateMigrationVersionError(m.version);
       }
-      versions.add(normalized);
     }
   }
 

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -20,7 +20,10 @@ const MIGRATIONS_ROOT = new URL("./test-helpers/migrations", import.meta.url).pa
 // Rails: ActiveRecord::Migration.new(name, version) — a bare migration with
 // no-op up/down. Rails tolerates a nil version (e.g. `Migration.new("Chunky")`);
 // `Migrator#validate` checks duplicate names before ever reading versions, so a
-// version-less input is valid. Omit `version` to reproduce that nil case.
+// version-less input is valid. Omit `version` to reproduce that nil case. In
+// Rails the nil-version inputs are `Migration` instances (a disk-loaded
+// `MigrationProxy` always has a version), so the null cast faithfully models
+// passing a bare Migration where the proxy type is annotated.
 function migration(name: string, version?: number): MigrationProxy {
   return {
     version: version === undefined ? (null as unknown as string) : String(version),

--- a/packages/activerecord/src/migrator.test.ts
+++ b/packages/activerecord/src/migrator.test.ts
@@ -17,11 +17,13 @@ import { fixtures } from "./test-helpers/fixtures.js";
 // trails equivalents live under test-helpers/migrations.
 const MIGRATIONS_ROOT = new URL("./test-helpers/migrations", import.meta.url).pathname;
 
-// Rails: ActiveRecord::Migration.new(name, version) — a bare migration proxy
-// with no-op up/down. trails requires a numeric version, so callers supply one.
-function migration(name: string, version: number): MigrationProxy {
+// Rails: ActiveRecord::Migration.new(name, version) — a bare migration with
+// no-op up/down. Rails tolerates a nil version (e.g. `Migration.new("Chunky")`);
+// `Migrator#validate` checks duplicate names before ever reading versions, so a
+// version-less input is valid. Omit `version` to reproduce that nil case.
+function migration(name: string, version?: number): MigrationProxy {
   return {
-    version: String(version),
+    version: version === undefined ? (null as unknown as string) : String(version),
     name,
     migration: () => ({ up: async () => {}, down: async () => {} }),
   };
@@ -85,7 +87,7 @@ describe("MigratorTest", () => {
 
   it("migrator with duplicate names", () => {
     expect(() => {
-      const list = [migration("Chunky", 1), migration("Chunky", 2)];
+      const list = [migration("Chunky"), migration("Chunky")];
       new Migrator(adapter, list);
     }).toThrow(/Multiple migrations have the name Chunky/);
   });


### PR DESCRIPTION
## What

Rails' `Migrator#validate` checks duplicate **names** before touching versions and tolerates a nil version — so two bare `Migration.new("Chunky")` instances (both nil-version) raise `DuplicateMigrationNameError`. trails validated the missing/non-numeric version *first*, throwing `Invalid migration version` instead.

This splits `validate` into a name-dup pass followed by the version-format/dup pass, matching Rails' version-then-name independent ordering, and restores `migrator.test.ts` "migrator with duplicate names" to the faithful nil-version inputs (`migration("Chunky")` without a version).

## Testing

`pnpm vitest run packages/activerecord/src/migrator.test.ts` — 35 passed.

Closes-story: migrator-validate-nil-version-name-dup