### PR TITLE
fix(activesupport): render assertValidKeys message with symbol-style keys

### DIFF
--- a/packages/activesupport/src/collections.test.ts
+++ b/packages/activesupport/src/collections.test.ts
@@ -228,12 +228,12 @@ describe("assertValidKeys", () => {
   it("throws on unknown key", () => {
     expect(() =>
       assertValidKeys({ failore: "stuff", funny: "business" }, ["failure", "funny"]),
-    ).toThrow(/Unknown key: failore/);
+    ).toThrow("Unknown key: :failore. Valid keys are: :failure, :funny");
   });
 
   it("includes valid keys in error message", () => {
     expect(() => assertValidKeys({ failore: "stuff" }, ["failure"])).toThrow(
-      /Valid keys are: failure/,
+      "Unknown key: :failore. Valid keys are: :failure",
     );
   });
 });

--- a/packages/activesupport/src/hash-ext.test.ts
+++ b/packages/activesupport/src/hash-ext.test.ts
@@ -113,7 +113,7 @@ describe("HashExtTest", () => {
     // callers can narrow on the type — assert both the message and the type.
     expect(() =>
       assertValidKeys({ failore: "stuff", funny: "business" }, ["failure", "funny"]),
-    ).toThrow(/Unknown key: failore/);
+    ).toThrow("Unknown key: :failore. Valid keys are: :failure, :funny");
     let error: unknown;
     try {
       assertValidKeys({ failore: "stuff", funny: "business" }, ["failure", "funny"]);
@@ -126,7 +126,7 @@ describe("HashExtTest", () => {
 
   it("assert_valid_keys — includes valid keys in error message", () => {
     expect(() => assertValidKeys({ failore: "stuff" }, ["failure"])).toThrow(
-      /Valid keys are: failure/,
+      "Unknown key: :failore. Valid keys are: :failure",
     );
   });
 

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -192,8 +192,11 @@ export function assertValidKeys(obj: AnyObject, validKeys: string[]): void {
   const validSet = new Set(validKeys);
   // Rails builds the message with Symbol#inspect on each key, so keys carry a
   // leading `:` (keys.rb:52). Our keys are strings, but we mirror the symbol
-  // rendering to match hash_ext_test.rb:254's exact expectation.
-  const inspect = (key: string): string => `:${key}`;
+  // rendering to match hash_ext_test.rb:254's exact expectation. Symbol#inspect
+  // bare-renders identifier-shaped symbols (`:name`) and quotes the rest
+  // (`:"foo bar"`), so we branch on the same identifier shape.
+  const inspect = (key: string): string =>
+    /^[a-zA-Z_][a-zA-Z0-9_]*[?!=]?$/.test(key) ? `:${key}` : `:${JSON.stringify(key)}`;
   for (const key of Object.keys(obj)) {
     if (!validSet.has(key)) {
       throw new ArgumentError(

--- a/packages/activesupport/src/hash-utils.ts
+++ b/packages/activesupport/src/hash-utils.ts
@@ -190,9 +190,15 @@ export function reverseMerge<T extends AnyObject>(obj: T, defaults: AnyObject): 
  */
 export function assertValidKeys(obj: AnyObject, validKeys: string[]): void {
   const validSet = new Set(validKeys);
+  // Rails builds the message with Symbol#inspect on each key, so keys carry a
+  // leading `:` (keys.rb:52). Our keys are strings, but we mirror the symbol
+  // rendering to match hash_ext_test.rb:254's exact expectation.
+  const inspect = (key: string): string => `:${key}`;
   for (const key of Object.keys(obj)) {
     if (!validSet.has(key)) {
-      throw new ArgumentError(`Unknown key: ${key}. Valid keys are: ${validKeys.join(", ")}`);
+      throw new ArgumentError(
+        `Unknown key: ${inspect(key)}. Valid keys are: ${validKeys.map(inspect).join(", ")}`,
+      );
     }
   }
 }


### PR DESCRIPTION
Rails' `Hash#assert_valid_keys` builds the `ArgumentError` message with `Symbol#inspect` on each key (`keys.rb:52`), producing colon-prefixed keys: `Unknown key: :failore. Valid keys are: :failure, :funny` (asserted verbatim at `hash_ext_test.rb:254`). trails emitted plain string keys with no colon.

This mirrors the symbol rendering in `assertValidKeys` (`packages/activesupport/src/hash-utils.ts`) and tightens the `hash-ext.test.ts` and `collections.test.ts` cases to assert the exact message string instead of a regex fragment.

Closes-story: assert-valid-keys-message-format-fidelity