### PR TITLE
fix(nested-attributes): raise UnknownAttributeError on build path

### DIFF
--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -130,13 +130,10 @@ describe("TestNestedAttributesInGeneral", () => {
     expect(() => Pirate.acceptsNestedAttributesFor("honesty")).toThrow(/No association found/);
   });
 
-  // tracked-pending-convergence (0023-surfaced-deviations): building a nested
-  // record from a hash with an unknown key does not raise UnknownAttributeError
-  // because trails' `Model.new`/build silently drops unknown attributes (a
-  // base-level deviation, not nested-attributes-specific). trails does raise it
-  // on the UPDATE-existing flush path, but Rails raises here on the build path.
-  // See model-new-unknown-attribute convergence story.
-  it.skip("should raise an UnknownAttributeError for non existing nested attributes", async () => {
+  it("should raise an UnknownAttributeError for non existing nested attributes", async () => {
+    // Rails' setup keeps `accepts_nested_attributes_for :ship` configured; the
+    // trails tests configure per-case and restore via resetShipConfig.
+    resetShipConfig();
     await expect(
       (async () => {
         const pirate = new Pirate({ catchphrase: "Arr" });
@@ -182,7 +179,11 @@ describe("TestNestedAttributesInGeneral", () => {
     // `attributes.delete("_reject_me_if_new").present? && !persisted?`
     Pirate.acceptsNestedAttributesFor("ship", {
       rejectIf: (attrs, rec) => {
+        // Rails `attributes.delete("_reject_me_if_new")` removes the control key
+        // from the hash so the subsequent build never assigns it (which would
+        // now raise UnknownAttributeError).
         const v = attrs["_reject_me_if_new"];
+        delete attrs["_reject_me_if_new"];
         return v != null && v !== "" && v !== false && !rec.isPersisted();
       },
     });
@@ -854,10 +855,7 @@ function collectionAssociationTests(
     }).not.toThrow();
   });
 
-  // tracked-pending-convergence (0023-surfaced-deviations): see the singular
-  // counterpart — building a new nested record from an unknown key does not
-  // raise (trails' build drops unknown attributes). model-new-unknown-attribute.
-  it.skip("should raise an UnknownAttributeError for non existing nested attributes for has many", async () => {
+  it("should raise an UnknownAttributeError for non existing nested attributes for has many", async () => {
     const { pirate } = await buildSetup();
     await expect(
       (async () => {

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -594,6 +594,49 @@ function assignableNestedAttributes(attributes: Record<string, unknown>): Record
 }
 
 /**
+ * Rails builds a nested record via `association.build(attributes)` →
+ * `assign_attributes`, which raises `UnknownAttributeError` for any key with no
+ * writer. trails' `Model.new`/build silently drops unknown keys (the base-level
+ * constructor leniency tracked by RFC 0046), so the nested build path guards
+ * explicitly — mirroring the same check the collection flush path already runs.
+ * Control keys (`_destroy`, the addressing `id`) are stripped by
+ * `assignableNestedAttributes` before this sees them; the primary key is always
+ * assignable. When the target schema isn't loaded (`_attributeDefinitions`
+ * empty) there is nothing to validate against, so the check is skipped.
+ */
+function assertNestedAttributesAreKnown(
+  targetModel: typeof Base,
+  assignable: Record<string, unknown>,
+): void {
+  const keys = Object.keys(assignable);
+  if (keys.length === 0) return;
+  let attrDefs: Map<string, unknown> | undefined = (targetModel as any)._attributeDefinitions;
+  // trails loads a model's schema lazily on first `new`, so `_attributeDefinitions`
+  // may still be empty before the first nested build. Warm it once (and reuse the
+  // instance as an alias-aware probe below); when the model is genuinely
+  // schemaless there is nothing to validate against, so skip.
+  let probe: Base | undefined;
+  if (!attrDefs || attrDefs.size === 0) {
+    probe = new (targetModel as any)() as Base;
+    attrDefs = (targetModel as any)._attributeDefinitions;
+  }
+  if (!attrDefs || attrDefs.size === 0) return;
+  const pk = (targetModel as any).primaryKey;
+  const pkColumns = new Set<string>((Array.isArray(pk) ? pk : [pk]).map(String));
+  // `assignable` comes from `assignableNestedAttributes`, which already strips
+  // the `id` addressing key (UNASSIGNABLE_KEYS), so only a non-`id` primary key
+  // needs an explicit exemption here.
+  for (const key of keys) {
+    if (attrDefs.has(key) || pkColumns.has(key)) continue;
+    // Resolve aliases before raising: `hasAttribute` maps an aliased name onto
+    // its real column (matching the flush path's lazy dummy construction).
+    probe ??= new (targetModel as any)() as Base;
+    if ((probe as any).hasAttribute(key)) continue;
+    throw new UnknownAttributeError(probe as object, key);
+  }
+}
+
+/**
  * The slice of the singular (`belongsTo`/`hasOne`) runtime association used by
  * the one-to-one nested-attributes writer. `target` is the in-memory record (or
  * null); `build` / `initializeAttributes` mirror Rails' `build_#{name}` and
@@ -695,6 +738,8 @@ export function assignNestedAttributesForOneToOneAssociation(
   // Rails nested_attributes.rb:443 — build a new record (no matching id).
   if (!isRejectNewRecord(record, associationName, attributes)) {
     const assignable = assignableNestedAttributes(attributes);
+    const targetModel = resolveCollectionTargetModel(record, associationName);
+    if (targetModel) assertNestedAttributesAreKnown(targetModel, assignable);
     if (existing && existing.isNewRecord()) {
       // Rails reuses an already-built unsaved target (e.g. after `buildShip`)
       // rather than replacing it: assign into it, then re-anchor FK/scope/
@@ -815,14 +860,16 @@ export function assignNestedAttributesForCollectionAssociation(
   // `isAutosave` is always true here. The branch remains only as a guard for a
   // hypothetical direct caller on a non-autosave collection (which never sets a
   // nestedAttributesTarget and defers everything to the post-save flush).
+  const collectionTargetModel = resolveCollectionTargetModel(record, associationName);
   const nestedTarget: (Base | null)[] = [];
   const deferred: Record<string, unknown>[] = [];
   for (const a of attrs) {
     if (!hasNestedId(a)) {
       if (!isRejectNewRecord(record, associationName, a)) {
-        nestedTarget.push(
-          collectionProxyFor(record, associationName).build(assignableNestedAttributes(a)),
-        );
+        const assignable = assignableNestedAttributes(a);
+        if (collectionTargetModel)
+          assertNestedAttributesAreKnown(collectionTargetModel, assignable);
+        nestedTarget.push(collectionProxyFor(record, associationName).build(assignable));
       } else {
         nestedTarget.push(null);
       }


### PR DESCRIPTION
## Summary

Rails builds a nested record via `association.build(attributes)` → `assign_attributes`, which raises `UnknownAttributeError` for any key with no writer. trails' `Model.new`/build silently drops unknown keys (base-level constructor leniency, tracked by RFC 0046), so the nested build path never raised for the has_one/has_many "new record from an unknown key" cases — even though the collection *flush* path already validated.

This adds a shared `assertNestedAttributesAreKnown` guard that probes the target model (warming its lazily-loaded schema) and rejects any assignable key that is not a real attribute (aliases resolved; primary key / `id` always allowed). It is called at both the singular and collection build sites.

- Un-skip both tracked-pending-convergence tests ("should raise an UnknownAttributeError for non existing nested attributes" and its has_many counterpart).
- Align the `reject if method with arguments` proc with Rails' `attributes.delete("_reject_me_if_new")` — the control key must be removed before build, otherwise it now (correctly) raises.

Scope is deliberately limited to the nested-attributes build path; full constructor strictness (`Model.new(unknownKey)`) remains RFC 0046's `converge-construction-unknown-attribute-strict`.

## Test plan

- `pnpm vitest run packages/activerecord/src/nested-attributes.test.ts` — 159 passed.
- `pnpm vitest run packages/activerecord/src/autosave-association.test.ts packages/activerecord/src/associations` — 2076 passed.

Closes-story: model-new-unknown-attribute