### PR TITLE
fix(activemodel): derive toXml type= from cast type, not JS runtime type

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -141,6 +141,25 @@ function _validationOnToIf<TRecord extends object>(
 }
 
 /**
+ * Maps a cast type's symbolic `type()` name to the Rails `XmlMini` `type=`
+ * attribute name emitted by `to_xml`. Types absent here (strings, unknown
+ * attributes) carry no `type=` attribute, matching Rails.
+ *
+ * Mirrors: ActiveSupport::XmlMini::TYPE_NAMES (by cast-type, not value class).
+ */
+const XML_MINI_TYPE_NAMES: Record<string, string> = {
+  integer: "integer",
+  big_integer: "integer",
+  float: "float",
+  decimal: "decimal",
+  boolean: "boolean",
+  date: "date",
+  datetime: "dateTime",
+  time: "time",
+  binary: "binary",
+};
+
+/**
  * Model — the base class that bundles Attributes, Validations, Callbacks,
  * Dirty tracking, Serialization, and Naming.
  *
@@ -2156,10 +2175,36 @@ export class Model {
   toXml(options?: SerializeOptions & { root?: string; skipTypes?: boolean }): string {
     const hash = this.serializableHash(options);
     const root = options?.root ?? (this.constructor as typeof Model).modelName.singular;
-    return `<${root}>\n${this._hashToXml(hash, "  ", options?.skipTypes ?? false)}</${root}>`;
+    return `<${root}>\n${this._hashToXml(hash, "  ", options?.skipTypes ?? false, this._xmlTypeMap(hash))}</${root}>`;
   }
 
-  private _hashToXml(hash: Record<string, unknown>, indent: string, skipTypes = false): string {
+  /**
+   * Map each top-level serialized key to its Rails `XmlMini` `type=` name,
+   * derived from the attribute's cast/column type rather than the JS runtime
+   * type of the materialized value. This keeps `type="integer"` on a bigint
+   * `id` even when PG/MariaDB hand it back as a JS `BigInt`/string instead of a
+   * `number`. Keys whose cast type has no XmlMini name (strings, unknown
+   * attributes) are omitted so the serializer falls back to runtime inference.
+   *
+   * Mirrors: ActiveSupport::XmlMini::TYPE_NAMES applied to the attribute's type.
+   */
+  private _xmlTypeMap(hash: Record<string, unknown>): Record<string, string> {
+    const ctor = this.constructor as typeof Model;
+    if (typeof ctor.typeForAttribute !== "function") return {};
+    const map: Record<string, string> = {};
+    for (const key of Object.keys(hash)) {
+      const xmlName = XML_MINI_TYPE_NAMES[ctor.typeForAttribute(key).type()];
+      if (xmlName) map[key] = xmlName;
+    }
+    return map;
+  }
+
+  private _hashToXml(
+    hash: Record<string, unknown>,
+    indent: string,
+    skipTypes = false,
+    typeMap: Record<string, string> = {},
+  ): string {
     // `skip_types: true` (XmlMini) suppresses the inferred `type="..."`
     // attribute on every tag; the `nil="true"` marker is a separate attribute
     // and stays. (active_support/core_ext/array/conversions.rb / xml_mini.rb)
@@ -2167,6 +2212,10 @@ export class Model {
     let xml = "";
     for (const [key, value] of Object.entries(hash)) {
       const tag = dasherize(key);
+      // The cast/column type name (when known) overrides JS-runtime inference so
+      // the `type=` attribute is adapter-agnostic (e.g. a bigint `id` stays
+      // `type="integer"` whether it arrives as a JS number, BigInt, or string).
+      const castTypeName = typeMap[key];
       if (value === null || value === undefined) {
         xml += `${indent}<${tag} nil="true"/>\n`;
       } else if (
@@ -2196,9 +2245,9 @@ export class Model {
         }
         xml += `${indent}</${tag}>\n`;
       } else if (typeof value === "number") {
-        xml += `${indent}<${tag}${typeAttr("integer")}>${value}</${tag}>\n`;
+        xml += `${indent}<${tag}${typeAttr(castTypeName ?? "integer")}>${value}</${tag}>\n`;
       } else if (typeof value === "boolean") {
-        xml += `${indent}<${tag}${typeAttr("boolean")}>${value}</${tag}>\n`;
+        xml += `${indent}<${tag}${typeAttr(castTypeName ?? "boolean")}>${value}</${tag}>\n`;
       } else if (value instanceof Temporal.Instant || value instanceof Temporal.PlainDateTime) {
         xml += `${indent}<${tag}${typeAttr("dateTime")}>${value.toJSON()}</${tag}>\n`;
       } else if (value instanceof Temporal.ZonedDateTime) {
@@ -2210,6 +2259,10 @@ export class Model {
         xml += `${indent}<${tag}${typeAttr("date")}>${value.toString()}</${tag}>\n`;
       } else if (value instanceof Temporal.PlainTime) {
         xml += `${indent}<${tag}${typeAttr("time")}>${value.toString()}</${tag}>\n`;
+      } else if (castTypeName) {
+        // BigInt/string-materialized numeric columns (bigint ids on PG/MariaDB,
+        // decimals as strings) land here; the cast type restores their `type=`.
+        xml += `${indent}<${tag}${typeAttr(castTypeName)}>${this._escapeXml(String(value))}</${tag}>\n`;
       } else {
         xml += `${indent}<${tag}>${this._escapeXml(String(value))}</${tag}>\n`;
       }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -148,8 +148,9 @@ function _validationOnToIf<TRecord extends object>(
  * Mirrors: ActiveSupport::XmlMini::TYPE_NAMES (by cast-type, not value class).
  */
 const XML_MINI_TYPE_NAMES: Record<string, string> = {
+  // BigIntegerType.type() returns "integer" (a bigint column's Rails
+  // `column.type` is :integer), so there is no separate "big_integer" key.
   integer: "integer",
-  big_integer: "integer",
   float: "float",
   decimal: "decimal",
   boolean: "boolean",

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -752,6 +752,22 @@ describe("toXml()", () => {
     expect(xml).toContain('nil="true"');
   });
 
+  it("derives the type attribute from the cast type, not the JS runtime type", () => {
+    // PG/MariaDB materialize a bigint `id` as a JS BigInt/string rather than a
+    // number; the `type="integer"` attribute must still be emitted because it
+    // comes from the attribute's cast type (mirroring Rails XmlMini TYPE_NAMES),
+    // not from `typeof value`.
+    class Widget extends Model {
+      static {
+        this.attribute("id", "big_integer");
+      }
+    }
+    const w = new Widget({});
+    w.writeAttribute("id", "42");
+    const xml = w.toXml();
+    expect(xml).toContain('<id type="integer">42</id>');
+  });
+
   it("supports custom root element", () => {
     class User extends Model {
       static {

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -768,6 +768,19 @@ describe("toXml()", () => {
     expect(xml).toContain('<id type="integer">42</id>');
   });
 
+  it("uses the cast type name for a float column that materializes as a JS number", () => {
+    // A float value is a JS `number`, same runtime type as an integer; keying
+    // off the cast type keeps it `type="float"` rather than `type="integer"`.
+    class Widget extends Model {
+      static {
+        this.attribute("rating", "float");
+      }
+    }
+    const w = new Widget({ rating: 4.5 });
+    const xml = w.toXml();
+    expect(xml).toContain('<rating type="float">4.5</rating>');
+  });
+
   it("supports custom root element", () => {
     class User extends Model {
       static {

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -498,9 +498,10 @@ describe("DelegationTest", () => {
       expect(xml).toContain("</comments>");
       expect(xml).toContain("<comment>");
       const records = await Comment.where({ type: "Comment" });
-      // The `type="integer"` attribute is adapter-dependent (PG/MariaDB return
-      // ids as BigInt/string, not JS number), so match the id tag agnostically.
-      expect(xml).toMatch(new RegExp(`<id[^>]*>${records[0].id}</id>`));
+      // The `type="integer"` attribute derives from the id's cast type, so it is
+      // present on every adapter (even where PG/MariaDB return ids as
+      // BigInt/string rather than a JS number).
+      expect(xml).toContain(`<id type="integer">${records[0].id}</id>`);
     });
 
     it("to_xml(skip_types: true) drops the type attributes and skip_instruct omits the prolog", async () => {


### PR DESCRIPTION
## Summary

`ActiveModel::Model#toXml` / `_hashToXml` inferred the XML `type=` attribute
from the **JS runtime type** of each serialized value (`typeof value ===
"number"` → `type="integer"`, etc.), not from the attribute's declared
cast/column type. On PostgreSQL and MariaDB a bigint `id` comes back as a JS
`BigInt`/string rather than a `number`, so the integer branch was skipped and a
bare `<id>1</id>` was emitted instead of `<id type="integer">1</id>` — the same
value serialized _with_ the type attribute on SQLite (JS `number`).

The historical AR `XmlSerializer` / `ActiveModel::Serializers::Xml` gem
(pre-extraction) keyed `type=` off the attribute's **column type**, mapped
through the same `ActiveSupport::XmlMini` type-name vocabulary. (Vanilla
`Hash#to_xml` derives `type=` from `value.class.name` directly; that stays
adapter-stable in Ruby only because a pg bigint always deserializes to an
arbitrary-precision `Integer`. JS has no such guarantee, which is why keying off
the cast type is required here.) This PR replicates the AR-serializer behavior.

## Changes

- `_hashToXml` now builds a per-key map from each top-level attribute's cast
  `type()` symbol to its `XmlMini` type name (`XML_MINI_TYPE_NAMES`) and
  prefers it over runtime inference. BigInt/string-materialized numeric columns
  now emit the correct `type=` on every adapter.
- The collection-serializer test in `delegation.test.ts` now asserts the full
  `<id type="integer">…</id>` tag instead of the adapter-agnostic regex
  workaround. (`relations.test.ts` keeps its matcher: that tag is a `methods:`
  value, not a column attribute, so it has no cast type to derive from.)
- Added an activemodel regression test locking `type="integer"` for a
  `big_integer` attribute materialized as a string.

## Scope

Top-level attributes only. Nested `toXml({ include: ... })` hashes are flattened
by `serializableHash` and no longer carry the associated model's class, so
nested numeric columns still fall back to runtime inference. Deriving their cast
types requires threading the nested model's type info through serialization —
tracked as follow-up story `model-toxml-nested-include-type-attr` (RFC 0055).

Closes-story: model-toxml-type-attr-adapter-dependent
