### PR TITLE
fix(mysql): gate inline-index sort-order DDL on supportsIndexSortOrder

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -314,6 +314,11 @@ export class SchemaStatements {
     });
     if (definer) definer(td);
 
+    // Prime the cached database version before the visitor emits DDL: inline
+    // `t.index order:` runs through SchemaCreation's synchronous
+    // supportsIndexSortOrder gate, which yields false on a cold connection
+    // (mirrors addIndex's warm-up). Memoized → no-op when already warm.
+    await this.adapter.getDatabaseVersion?.();
     await this.adapter.executeMutation(this.schemaCreation.accept(td));
 
     // Rails: if supports_comments? && !supports_comments_in_create?

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -78,6 +78,24 @@ describe("MySQL::SchemaCreation", () => {
     expect((sc as any).visitCreateIndexDefinition(def)).toContain("INPLACE");
   });
 
+  it("emits inline index sort order when the adapter supports it", () => {
+    const host = { supportsIndexSortOrder: () => true };
+    const withHost = new SchemaCreation(host as any);
+    const idx = new IndexDefinition("users", "idx", false, ["email"], {
+      orders: { email: "desc" },
+    });
+    expect((withHost as any).visitIndexDefinition(idx, false)).toBe("INDEX `idx` (`email` DESC)");
+  });
+
+  it("drops inline index sort order when the adapter version gate is unsupported", () => {
+    const host = { supportsIndexSortOrder: () => false };
+    const withHost = new SchemaCreation(host as any);
+    const idx = new IndexDefinition("users", "idx", false, ["email"], {
+      orders: { email: "desc" },
+    });
+    expect((withHost as any).visitIndexDefinition(idx, false)).toBe("INDEX `idx` (`email`)");
+  });
+
   it("addTableOptionsBang appends charset and collation", () => {
     const td = new TableDefinition("users", { adapterName: "mysql" });
     (td as any).charset = "utf8mb4";

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -53,6 +53,9 @@ export interface VisitorHostAdapter {
   supportsCheckConstraints?(): boolean;
   supportsForeignKeys?(): boolean;
   supportsIndexesInCreate?(): boolean;
+  /** Version-gated: MariaDB ≥ 10.8.1 / MySQL ≥ 8.0.1. Reads the cached version
+   * synchronously and yields false when cold — warm via `getDatabaseVersion`. */
+  supportsIndexSortOrder?(): boolean;
   isMariadb?(): boolean;
   /** Mirrors `SchemaStatements#isForeignKeysEnabled` (`adapter.config?.foreignKeys !== false`). */
   config?: { foreignKeys?: boolean };
@@ -301,10 +304,19 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const quotedMap = new Map<string, string>(
       o.columns.map((c) => [c, this.adapter.quoteIdentifier(c)]),
     );
-    addOptionsForIndexColumns(quotedMap, {
-      length: idx.lengths as Record<string, number> | number | undefined,
-      order: idx.orders as Record<string, string> | string | undefined,
-    });
+    // Host-less unit-test path (no adapter) has no sort-order flag; default to
+    // supported so pure DDL fixtures still emit DESC/ASC. When the adapter is
+    // threaded, honor its version gate — the createTable path warms
+    // getDatabaseVersion() upstream so this synchronous read isn't cold.
+    const sortOrderSupported = this._hostAdapter?.supportsIndexSortOrder?.() ?? true;
+    addOptionsForIndexColumns(
+      quotedMap,
+      {
+        length: idx.lengths as Record<string, number> | number | undefined,
+        order: idx.orders as Record<string, string> | string | undefined,
+      },
+      sortOrderSupported,
+    );
     return [...quotedMap.values()].join(", ");
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -89,6 +89,15 @@ export class SchemaCreation extends AbstractSchemaCreation {
     return this._hostAdapter?.isMariadb?.() ?? this._mariadb;
   }
 
+  /** @internal Rails gates the index DESC/ASC suffix on `supports_index_sort_order?`
+   * (MariaDB >= 10.8.1 / MySQL >= 8.0.1). Consult the threaded adapter's version-gated
+   * flag; on the host-less unit-test path default to supported so pure DDL fixtures
+   * still emit the suffix. The base returns `adapterName !== "mysql"` (always false),
+   * so this override is what makes MySQL honor the version gate. */
+  protected override supportsIndexSortOrder(): boolean {
+    return this._hostAdapter?.supportsIndexSortOrder?.() ?? true;
+  }
+
   /** @internal */
   override typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
     if (options.array && type !== "primary_key") {
@@ -304,18 +313,15 @@ export class SchemaCreation extends AbstractSchemaCreation {
     const quotedMap = new Map<string, string>(
       o.columns.map((c) => [c, this.adapter.quoteIdentifier(c)]),
     );
-    // Host-less unit-test path (no adapter) has no sort-order flag; default to
-    // supported so pure DDL fixtures still emit DESC/ASC. When the adapter is
-    // threaded, honor its version gate — the createTable path warms
-    // getDatabaseVersion() upstream so this synchronous read isn't cold.
-    const sortOrderSupported = this._hostAdapter?.supportsIndexSortOrder?.() ?? true;
+    // The createTable path warms getDatabaseVersion() upstream so the version-gated
+    // supportsIndexSortOrder read isn't cold.
     addOptionsForIndexColumns(
       quotedMap,
       {
         length: idx.lengths as Record<string, number> | number | undefined,
         order: idx.orders as Record<string, string> | string | undefined,
       },
-      sortOrderSupported,
+      this.supportsIndexSortOrder(),
     );
     return [...quotedMap.values()].join(", ");
   }

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -292,6 +292,16 @@ describe("MySQL::SchemaStatements", () => {
     expect(result.get("b")).toBe("`b` ASC");
   });
 
+  it("addOptionsForIndexColumns: drops order when sort order is unsupported", () => {
+    const cols = new Map([["name", "`name`"]]);
+    const result = addOptionsForIndexColumns(
+      cols,
+      { length: { name: 5 }, order: { name: "desc" } },
+      false,
+    );
+    expect(result.get("name")).toBe("`name`(5)");
+  });
+
   it("extractSchemaQualifiedName splits schema.table", () => {
     expect(extractSchemaQualifiedName("mydb.users")).toEqual(["mydb", "users"]);
     expect(extractSchemaQualifiedName("`mydb`.`users`")).toEqual(["mydb", "users"]);

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -343,9 +343,14 @@ export function addOptionsForIndexColumns(
     length?: Record<string, number> | number;
     order?: Record<string, string> | string;
   } = {},
+  sortOrderSupported = true,
 ): Map<string, string> {
   quotedColumns = addIndexLength(quotedColumns, options);
-  if (options.order) {
+  // Rails gates the DESC/ASC suffix on `supports_index_sort_order?`
+  // (abstract/schema_statements.rb add_options_for_index_columns via super);
+  // MariaDB < 10.8.1 / MySQL < 8.0.1 silently drop it. The visitor threads the
+  // gate in — the pure helper defaults to supported for host-less unit tests.
+  if (options.order && sortOrderSupported) {
     const orders = typeof options.order === "object" ? options.order : {};
     for (const [name, col] of quotedColumns) {
       const dir = typeof options.order === "string" ? options.order : orders[name];


### PR DESCRIPTION
## Summary

The MySQL `SchemaCreation` visitor path (`createTable` inline `t.index order:` /
`SchemaCreation.accept(CreateIndexDefinition)`) applied the `DESC`/`ASC` sort-order
suffix **unconditionally**, unlike Rails which gates it on
`supports_index_sort_order?` (MariaDB ≥ 10.8.1 / MySQL ≥ 8.0.1). MariaDB < 10.8.1 /
MySQL < 8.0.1 silently drop the suffix. This is the same deviation PR #4397 fixed on
the sibling `MigrationContext.addIndex` path.

## Changes

- Thread a `sortOrderSupported` flag from the visitor's `quotedColumns` into the pure
  `addOptionsForIndexColumns` helper (defaults to `true` for host-less unit tests);
  the flag comes from the threaded adapter's `supportsIndexSortOrder()`.
- Warm `getDatabaseVersion()` in `createTable` before `schemaCreation.accept`, so the
  synchronous version read isn't cold (memoized → no-op when warm). Mirrors `addIndex`.
- Coverage for both gate branches on the inline-index visitor path and the pure helper.

No regression on the CI MariaDB 11 lane (still emits order; version ≥ threshold).

Closes-story: mysql-inline-index-sort-order-version-gate