### PR TITLE
fix(test): isolate schema_migrations in test-databases createAndMigrate

### DIFF
--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -286,12 +286,13 @@ describe("TestDatabasesTest", () => {
     // recorded in schema_migrations — in which case migrator.up() correctly
     // no-ops and the log stays empty. Clear this version first so the migration
     // actually runs, mirroring how Rails' migrator tests isolate
-    // schema_migrations state.
-    try {
-      await new SchemaMigration(adapter).deleteVersion("1");
-    } catch {
-      /* schema_migrations may not exist yet */
-    }
+    // schema_migrations state. createTable is CREATE TABLE IF NOT EXISTS, so
+    // ensuring the table exists before the delete keeps both statements from
+    // erroring inside the fixtures transaction (a failed DELETE would poison
+    // the PG transaction with 25P02).
+    const schemaMigration = new SchemaMigration(adapter);
+    await schemaMigration.createTable();
+    await schemaMigration.deleteVersion("1");
 
     await createAndMigrate([adapter], migrations);
     expect(log).toEqual(["up"]);

--- a/packages/activerecord/src/test-databases.test.ts
+++ b/packages/activerecord/src/test-databases.test.ts
@@ -5,6 +5,7 @@ import { Base } from "./index.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { DatabaseTasks } from "./tasks/database-tasks.js";
 import { fixtures } from "./test-helpers/fixtures.js";
+import { SchemaMigration } from "./schema-migration.js";
 
 // Build a (minimal) DatabaseConfigurations whose `configsFor` returns the
 // supplied stubbed configs. Mirrors the production shape — production code
@@ -279,6 +280,18 @@ describe("TestDatabasesTest", () => {
         }),
       },
     ];
+
+    // This runs against the shared worker DB (Base.connection). Many other
+    // test files apply a version-"1" migration too, so version 1 may already be
+    // recorded in schema_migrations — in which case migrator.up() correctly
+    // no-ops and the log stays empty. Clear this version first so the migration
+    // actually runs, mirroring how Rails' migrator tests isolate
+    // schema_migrations state.
+    try {
+      await new SchemaMigration(adapter).deleteVersion("1");
+    } catch {
+      /* schema_migrations may not exist yet */
+    }
 
     await createAndMigrate([adapter], migrations);
     expect(log).toEqual(["up"]);


### PR DESCRIPTION
## Problem

`TestDatabasesTest > createAndMigrate runs migrations on all adapters` intermittently failed with `[] !== ['up']`. The test runs against the shared worker DB (`Base.connection`) and asserts a version-"1" migration's `up` callback fires. Co-scheduled files that also record version 1 (migration.test.ts's `First`, migration.trails.test.ts's `AsyncFirst`, etc.) leave version 1 already recorded in `schema_migrations`, so `migrator.up()` correctly no-ops and the log stays empty. Passed in isolation; classic cross-file shared-DB ordering flake.

## Fix

Clear version "1" from `schema_migrations` before running the migrator, using the same `SchemaMigration` idiom the migrator tests use to isolate schema_migrations state. No test rename, no weakened assertion, keeps the canonical version-1 migration.

## Verification

- `test-databases.test.ts` in isolation: 10 passed
- co-scheduled with migration.test.ts + migration.trails.test.ts: 81 passed / 24 skipped (sqlite)