### PR TITLE
fix(mysql2): NullPool default + bigint add_reference converge FK/pool deviations

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -7,20 +7,16 @@
  * probes, the empty-result-set guard, extended timezone re-sync) live in the
  * sibling mysql2-adapter.trails.test.ts.
  *
- * Tracked deviations (RFC 0023 surfaced-deviations,
- * converge-mysql2-adapter-rails-port follow-ups):
- *   - test_connection_error / test_reconnection_error assert
- *     `error.connection_pool` is a NullPool. A standalone trails adapter
- *     carries a ConnectionPool (pool-config.ts `get pool`), never NullPool, so
- *     those two cases are deferred rather than bent.
- *   - The FK type-mismatch tests build their fixture tables via raw DDL with
- *     Rails' own table names (old_cars: int PK, cars: bigint PK,
- *     subscribers: varchar nick PK) instead of `add_reference` /
- *     `add_foreign_key`: trails' `addReference` defaults the ref column to
- *     :integer (Rails defaults to :bigint), and the canonical `old_cars`
- *     widens its PK to bigint, so neither path reproduces the
- *     integer-vs-bigint mismatch the test exercises. The error message,
- *     cause, and MismatchedForeignKey class are asserted faithfully.
+ * connection_error / reconnection_error drive `reconnectBang()` — the method
+ * Rails' `connect!` reaches (verify! → reconnect!) when a fresh adapter has no
+ * live connection — since trails connects lazily and has no eager `connect!`.
+ * A standalone adapter now carries a NullPool by default (matching Rails
+ * `@pool = NullPool.new`), so `error.connection_pool` is asserted faithfully.
+ *
+ * The FK type-mismatch tests ride the canonical `engines` / `old_cars` (int PK)
+ * / `cars` (bigint PK) / `subscribers` (varchar `nick`) tables, adding the
+ * reference column via `add_reference` (which now defaults to `:bigint`, as
+ * Rails does) and the constraint via `add_foreign_key`.
  */
 import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
@@ -33,11 +29,14 @@ import {
 import { withTimezoneConfig } from "../../test-helper.js";
 import {
   AdapterTimeout,
+  ConnectionNotEstablished,
   MismatchedForeignKey,
   QueryAborted,
   StatementTimeout,
 } from "../../errors.js";
 import { AbstractMysqlAdapter } from "../../connection-adapters/abstract-mysql-adapter.js";
+import { NullPool } from "../../connection-adapters/abstract/connection-pool.js";
+import { rebuildCanonicalTables } from "../../test-helpers/canonical-schema.js";
 import { Result } from "../../result.js";
 import * as Arel from "@blazetrails/arel";
 
@@ -52,6 +51,45 @@ describeIfMysql("Mysql2AdapterTest", () => {
     // into subsequent suites.
     vi.restoreAllMocks();
     await adapter.close();
+  });
+
+  it("connection error", async () => {
+    // Rails: `Mysql2Adapter.new(socket: File::NULL, ...).connect!` raises
+    // ConnectionNotEstablished whose `connection_pool` is a NullPool. trails
+    // connects lazily (there is no eager `connect!`), so the failure to connect
+    // to a dead socket surfaces on the first query — the same rescued
+    // `connect` → `set_pool(@pool)` path, carrying the standalone adapter's
+    // NullPool.
+    const badAdapter = new Mysql2Adapter({ socketPath: "/dev/null", preparedStatements: false });
+    try {
+      const error = await badAdapter
+        .execute("SELECT 1")
+        .then(() => null)
+        .catch((e) => e);
+      expect(error).toBeInstanceOf(ConnectionNotEstablished);
+      expect(error.connectionPool).toBeInstanceOf(NullPool);
+    } finally {
+      await badAdapter.close();
+    }
+  });
+
+  it("reconnection error", async () => {
+    // Rails reconnects a standalone adapter whose config points at a dead
+    // socket and asserts the raised ConnectionNotEstablished's `connection_pool`
+    // equals the adapter's own pool (a NullPool). trails connects lazily, so
+    // force the connect via a query after a reconnect and assert the same.
+    const badAdapter = new Mysql2Adapter({ socketPath: "/dev/null", preparedStatements: false });
+    try {
+      await badAdapter.reconnectBang().catch(() => {});
+      const error = await badAdapter
+        .execute("SELECT 1")
+        .then(() => null)
+        .catch((e) => e);
+      expect(error).toBeInstanceOf(ConnectionNotEstablished);
+      expect(error.connectionPool).toBe(badAdapter.pool);
+    } finally {
+      await badAdapter.close();
+    }
   });
 
   it("mysql2 default prepared statements", () => {
@@ -138,45 +176,30 @@ describeIfMysql("Mysql2AdapterTest", () => {
     }
   });
 
-  // FK type-mismatch fixture tables — created/dropped around each test so the
-  // FK tests are self-contained, with Rails' own table names and PK types:
-  //   old_cars    — integer PK  (Rails: `create_table :old_cars, id: :integer`)
-  //   cars        — bigint PK   (Rails: `create_table :cars`)
-  //   subscribers — varchar PK  (Rails: `create_table :subscribers, id: false` w/ nick)
-  //   engines     — bigint PK, used as the referencing table
+  // The FK type-mismatch tests ride the canonical tables (engines, old_cars —
+  // integer PK, cars — bigint PK, subscribers — varchar `nick`, people —
+  // bigint PK). rebuildCanonicalTables restores each to its canonical shape;
+  // FK checks are disabled for the pre-drop so a leftover engines→people FK
+  // (from the multiple-fks test) can't block dropping its parent table.
   beforeEach(async () => {
-    await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
-    await adapter.executeMutation("DROP TABLE IF EXISTS `old_cars`");
-    await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
-    await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
-    await adapter.executeMutation(
-      "CREATE TABLE `old_cars` (`id` INT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB",
-    );
-    await adapter.executeMutation(
-      "CREATE TABLE `cars` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB",
-    );
-    await adapter.executeMutation(
-      "CREATE TABLE `subscribers` (`nick` VARCHAR(255) NOT NULL PRIMARY KEY) ENGINE=InnoDB",
-    );
-    await adapter.executeMutation(
-      "CREATE TABLE `engines` (`id` BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY, `old_car_id` BIGINT) ENGINE=InnoDB",
-    );
+    await adapter.executeMutation("SET FOREIGN_KEY_CHECKS=0");
+    for (const t of ["foos", "engines", "old_cars", "cars", "subscribers", "people"]) {
+      await adapter.executeMutation(`DROP TABLE IF EXISTS \`${t}\``);
+    }
+    await adapter.executeMutation("SET FOREIGN_KEY_CHECKS=1");
+    await rebuildCanonicalTables(adapter, ["people", "cars", "old_cars", "subscribers", "engines"]);
   });
 
   afterEach(async () => {
-    await adapter.executeMutation("DROP TABLE IF EXISTS `engines`");
     await adapter.executeMutation("DROP TABLE IF EXISTS `foos`");
-    await adapter.executeMutation("DROP TABLE IF EXISTS `old_cars`");
-    await adapter.executeMutation("DROP TABLE IF EXISTS `cars`");
-    await adapter.executeMutation("DROP TABLE IF EXISTS `subscribers`");
   });
 
   it("errors for bigint fks on integer pk table in alter table", async () => {
-    // engines.old_car_id is BIGINT but old_cars.id is INT — type mismatch
+    // add_reference defaults old_car_id to :bigint; old_cars.id is INT — the
+    // add_foreign_key then trips the type mismatch.
     const error = await adapter
-      .executeMutation(
-        "ALTER TABLE `engines` ADD CONSTRAINT `fk_test` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
-      )
+      .addReference("engines", "old_car")
+      .then(() => adapter.addForeignKey("engines", "old_cars"))
       .then(() => null)
       .catch((e) => e);
 
@@ -196,16 +219,11 @@ describeIfMysql("Mysql2AdapterTest", () => {
   it.skipIf(isMariaDb)(
     "errors for multiple fks on mismatched types for pk table in alter table",
     async () => {
-      // Add matching FK first (cars.id is BIGINT, engines.id is BIGINT — OK)
-      await adapter.executeMutation(
-        "ALTER TABLE `engines` ADD COLUMN `car_id` BIGINT, ADD CONSTRAINT `fk_car` FOREIGN KEY (`car_id`) REFERENCES `cars` (`id`)",
-      );
-
-      // Then add mismatched FK (old_cars.id is INT but old_car_id is BIGINT)
       const error = await adapter
-        .executeMutation(
-          "ALTER TABLE `engines` ADD CONSTRAINT `fk_old_car` FOREIGN KEY (`old_car_id`) REFERENCES `old_cars` (`id`)",
-        )
+        // Add a matching FK first (person_id is :bigint, people.id is bigint).
+        .addReference("engines", "person", { foreignKey: true })
+        // Then the mismatched one: old_car_id is :bigint but old_cars.id is INT.
+        .then(() => adapter.addReference("engines", "old_car", { foreignKey: true }))
         .then(() => null)
         .catch((e) => e);
 

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -25,6 +25,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import { disablePreparedStatements } from "../ar-config.js";
 import { Result, type ColumnTypes } from "../result.js";
 import { SchemaCache, SchemaReflection, BoundSchemaReflection } from "./schema-cache.js";
+import { NullPool, poolAbsent } from "./abstract/connection-pool.js";
 import { stripSqlComments } from "./sql-classification.js";
 import {
   TransactionManager,
@@ -605,6 +606,11 @@ export class AbstractAdapter implements Quoting {
     ensureAbstractAdapterMixinsApplied();
     // Mirrors Rails abstract_adapter.rb:155 — @visitor = arel_visitor
     this._visitor = this.arelVisitor();
+    // Mirrors Rails abstract_adapter.rb:153 — @pool = NullPool.new. A standalone
+    // adapter carries a NullPool until a real ConnectionPool claims it (the pool
+    // overwrites `pool` when it owns the connection), so `connection_pool` on a
+    // connect-time error is a NullPool rather than null.
+    this.pool = new NullPool();
   }
 
   protected _visitor!: Visitors.ToSql;
@@ -1548,7 +1554,7 @@ export class AbstractAdapter implements Quoting {
     // so the no-pool branch expires a leased connection and otherwise no-ops
     // (matching NullPool#checkin).
     const pool = this.pool as { checkin?: (conn: unknown) => void } | null;
-    if (pool && typeof pool.checkin === "function") {
+    if (!poolAbsent(pool) && pool && typeof pool.checkin === "function") {
       pool.checkin(this);
     } else if (this._inUse) {
       this.expire();
@@ -2331,7 +2337,7 @@ export class AbstractAdapter implements Quoting {
     // derived table); unwrap to the bare identifier for the schema-cache lookup.
     const tableName = relationName(attribute.relation.name);
     let hash = await (this.schemaCache as any).columnsHash(this.pool, tableName);
-    if (!hash && this.pool == null && typeof (this as any).columns === "function") {
+    if (!hash && poolAbsent(this.pool) && typeof (this as any).columns === "function") {
       // Bare-adapter path (no pool): the null-pool guard in columnsHash blocks the
       // DB fallback. Fetch directly so callers like caseSensitiveComparison can
       // resolve collations even when the schema cache was cleared by model

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -127,6 +127,28 @@ export class NullPool implements AbstractPool {
 }
 
 /**
+ * True when `pool` is not a real, connection-owning pool — i.e. it is either
+ * `null` or a {@link NullPool}. A standalone adapter (constructed outside a
+ * pool) carries a NullPool by default, matching Rails' `@pool = NullPool.new`;
+ * the schema-cache / bare-adapter fallbacks that historically keyed off
+ * `pool == null` use this so a NullPool is treated the same as "no pool".
+ */
+export function poolAbsent(pool: unknown): boolean {
+  return pool == null || pool instanceof NullPool;
+}
+
+/**
+ * Returns `pool` when it is a real, connection-owning pool, else `null` — the
+ * NullPool-aware form of the historical `adapter.pool ?? fallback` idiom. Use
+ * `realPool(adapter.pool) ?? adapter` where code previously wrote
+ * `adapter.pool ?? adapter` to yield a schema-cache target that can actually
+ * check out a connection.
+ */
+export function realPool(pool: unknown): unknown | null {
+  return poolAbsent(pool) ? null : pool;
+}
+
+/**
  * Mirrors: ActiveRecord::ConnectionAdapters::ConnectionPool::Lease
  */
 export class Lease {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -602,7 +602,11 @@ export class ReferenceDefinition {
     this.polymorphic = options.polymorphic ?? false;
     this.index = options.index !== false ? (options.index ?? true) : false;
     this.foreignKey = options.foreignKey ?? false;
-    this.type = options.type ?? "integer";
+    // Rails' ReferenceDefinition defaults `type: :bigint`
+    // (schema_definitions.rb:204) — the same class backs both `t.references`
+    // and `add_reference`, so the reference column lines up with the default
+    // `bigint` primary key of the table it points at.
+    this.type = options.type ?? "bigint";
     const { polymorphic: _, foreignKey: _fk, index: _idx, type: _t, ...rest } = options;
     this.options = rest;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -721,8 +721,27 @@ export class SchemaStatements {
   async removeReference(
     tableName: string,
     refName: string,
-    options: { polymorphic?: boolean } = {},
+    options: {
+      polymorphic?: boolean;
+      foreignKey?: boolean | { toTable?: string; column?: string };
+    } = {},
   ): Promise<void> {
+    // Mirrors Rails remove_reference (schema_statements.rb): when `foreign_key`
+    // is given, drop the constraint BEFORE the column, otherwise MySQL/MariaDB
+    // refuses to drop the column's index while the FK still needs it. This is
+    // the inverse `add_reference ... foreign_key:` records (CommandRecorder
+    // passes the same args through), so it has to undo the FK the forward call
+    // created.
+    if (options.foreignKey) {
+      const fkOptions =
+        typeof options.foreignKey === "object"
+          ? { ...options.foreignKey }
+          : { toTable: pluralize(refName) };
+      if ((fkOptions as { column?: string }).column == null) {
+        (fkOptions as { column?: string }).column = `${refName}_id`;
+      }
+      await this.removeForeignKey(tableName, fkOptions);
+    }
     if (options.polymorphic) {
       await this.removeColumn(tableName, `${refName}_type`);
     }
@@ -733,7 +752,10 @@ export class SchemaStatements {
   async removeBelongsTo(
     tableName: string,
     refName: string,
-    options: { polymorphic?: boolean } = {},
+    options: {
+      polymorphic?: boolean;
+      foreignKey?: boolean | { toTable?: string; column?: string };
+    } = {},
   ): Promise<void> {
     return this.removeReference(tableName, refName, options);
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -672,6 +672,11 @@ export class SchemaStatements {
       index?: boolean;
     } = {},
   ): Promise<void> {
+    // Mirrors ReferenceDefinition#initialize (schema_definitions.rb:214-216):
+    // a foreign key can't target a polymorphic (type-tagged) reference.
+    if (options.polymorphic && options.foreignKey) {
+      throw new ArgumentError("Cannot add a foreign key to a polymorphic relation");
+    }
     // Rails' ReferenceDefinition defaults `type: :bigint`
     // (schema_definitions.rb:204), matching the default `bigint` primary key a
     // referenced table gets — so a reference column lines up with the PK it

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -38,7 +38,7 @@ import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
 import { deduplicate } from "../deduplicable.js";
-import { singularize, getCrypto } from "@blazetrails/activesupport";
+import { singularize, pluralize, getCrypto } from "@blazetrails/activesupport";
 import { SchemaDumper } from "./schema-dumper.js";
 import { Utils as PgUtils } from "../postgresql/utils.js";
 import { indexes as sqliteIndexes } from "../sqlite3/schema-statements.js";
@@ -667,12 +667,16 @@ export class SchemaStatements {
     refName: string,
     options: ColumnOptions & {
       polymorphic?: boolean;
-      foreignKey?: boolean;
+      foreignKey?: boolean | { toTable?: string; column?: string };
       type?: ColumnType;
       index?: boolean;
     } = {},
   ): Promise<void> {
-    const colType = options.type ?? "integer";
+    // Rails' ReferenceDefinition defaults `type: :bigint`
+    // (schema_definitions.rb:204), matching the default `bigint` primary key a
+    // referenced table gets — so a reference column lines up with the PK it
+    // points at.
+    const colType = options.type ?? "bigint";
     await this.addColumn(tableName, `${refName}_id`, colType, options);
     if (options.polymorphic) {
       await this.addColumn(tableName, `${refName}_type`, "string", options);
@@ -680,6 +684,18 @@ export class SchemaStatements {
     if (options.index !== false) {
       const cols = options.polymorphic ? [`${refName}_id`, `${refName}_type`] : [`${refName}_id`];
       await this.addIndex(tableName, cols);
+    }
+    if (options.foreignKey) {
+      // Mirrors ReferenceDefinition#add: `connection.add_foreign_key(table_name,
+      // foreign_table_name, **foreign_key_options)`. foreign_table_name defaults
+      // to the pluralized reference name; foreign_key_options carries the
+      // `<ref>_id` column and, when `foreign_key:` is a hash, its `to_table`.
+      const fkOptions = typeof options.foreignKey === "object" ? options.foreignKey : {};
+      const toTable = (fkOptions as { toTable?: string }).toTable ?? pluralize(refName);
+      await this.addForeignKey(tableName, toTable, {
+        ...(fkOptions as Record<string, unknown>),
+        column: `${refName}_id`,
+      });
     }
   }
 
@@ -689,7 +705,7 @@ export class SchemaStatements {
     refName: string,
     options: ColumnOptions & {
       polymorphic?: boolean;
-      foreignKey?: boolean;
+      foreignKey?: boolean | { toTable?: string; column?: string };
       type?: ColumnType;
       index?: boolean;
     } = {},

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -633,7 +633,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       (err) => {
         if (this._connectingPromiseGen === gen) this._connectingPromise = null;
         this._activeState = false;
-        throw translateConnectError(err, this._database, this._poolConfig);
+        // Mirrors Rails' Mysql2Adapter#connect: `rescue ConnectionNotEstablished
+        // => ex; raise ex.set_pool(@pool)`. Attach the originating pool (a
+        // NullPool for a standalone adapter) so `error.connection_pool` is set
+        // on a connect-time failure.
+        const translated = translateConnectError(err, this._database, this._poolConfig);
+        if (translated instanceof AdapterError) translated.setConnectionPool(this.pool);
+        throw translated;
       },
     );
     return this._connectingPromise;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -636,9 +636,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // Mirrors Rails' Mysql2Adapter#connect: `rescue ConnectionNotEstablished
         // => ex; raise ex.set_pool(@pool)`. Attach the originating pool (a
         // NullPool for a standalone adapter) so `error.connection_pool` is set
-        // on a connect-time failure.
+        // on a connect-time failure. translateConnectError returns a
+        // ConnectionNotEstablished in every branch but NoDatabaseError; use its
+        // dedicated setPool (which flips the `_poolSet` guard) so a later
+        // setPool on the same object can't silently overwrite it.
         const translated = translateConnectError(err, this._database, this._poolConfig);
-        if (translated instanceof AdapterError) translated.setConnectionPool(this.pool);
+        if (translated instanceof ConnectionNotEstablished) {
+          translated.setPool(this.pool);
+        } else if (translated instanceof AdapterError) {
+          translated.setConnectionPool(this.pool);
+        }
         throw translated;
       },
     );

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -12,6 +12,7 @@ import type { ColumnJSON } from "./column.js";
 import { Column as MysqlColumn } from "./mysql/column.js";
 import { isSchemaCacheIgnoredTable } from "../ar-config.js";
 import { StatementInvalid } from "../errors.js";
+import { poolAbsent } from "./abstract/connection-pool.js";
 
 // ---------------------------------------------------------------------------
 // Helper: run callback inside pool.withConnection if available
@@ -252,7 +253,7 @@ export class SchemaCache {
     // attached) may pass `pool: null` to consult only the warm cache. Don't
     // attempt to acquire a connection in that case — return undefined and
     // let the caller fall back to the schema-less NullColumn shape.
-    if (pool == null) return undefined;
+    if (poolAbsent(pool)) return undefined;
 
     return withConnection(pool, async (connection) => {
       if (typeof connection.columns === "function") {

--- a/packages/activerecord/src/insert-all.ts
+++ b/packages/activerecord/src/insert-all.ts
@@ -2,6 +2,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Nodes, Visitors } from "@blazetrails/arel";
 import { ArgumentError, SerializeCastValue } from "@blazetrails/activemodel";
 import { IndexDefinition } from "./connection-adapters/abstract/schema-definitions.js";
+import { realPool } from "./connection-adapters/abstract/connection-pool.js";
 import { UnknownAttributeError } from "./errors.js";
 import type { Base } from "./base.js";
 import { quoteSqlValue } from "./base.js";
@@ -494,7 +495,7 @@ export class InsertAll {
     } else {
       const cache = conn.schemaCache;
       if (!cache || typeof cache.indexes !== "function") return [];
-      indexes = await cache.indexes(conn.pool ?? conn, tableName);
+      indexes = await cache.indexes(realPool(conn.pool) ?? conn, tableName);
     }
     return indexes.filter((i: any) => i.unique);
   }
@@ -516,7 +517,7 @@ export class InsertAll {
     } else {
       const cache = conn.schemaCache;
       if (!cache || typeof cache.primaryKeys !== "function") return [];
-      pk = await cache.primaryKeys(conn.pool ?? conn, tableName);
+      pk = await cache.primaryKeys(realPool(conn.pool) ?? conn, tableName);
     }
     if (pk == null) return [];
     return Array.isArray(pk) ? pk : [pk];

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -21,6 +21,7 @@ import {
 } from "./inheritance.js";
 import { singularize } from "@blazetrails/activesupport";
 import { modelRegistry } from "./associations.js";
+import { realPool } from "./connection-adapters/abstract/connection-pool.js";
 import { TableNotSpecified } from "./errors.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
@@ -1128,7 +1129,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   // pools (SQLite :memory: + size 1) the connection is already permanently
   // checked out, so calling pool.withConnection would deadlock; FakePool
   // yields the connection we already hold.
-  const candidate = startingAdapter.pool ?? startingAdapter;
+  const candidate = realPool(startingAdapter.pool) ?? startingAdapter;
   const pool =
     candidate && typeof (candidate as { withConnection?: unknown }).withConnection === "function"
       ? new FakePool(startingAdapter)
@@ -1208,7 +1209,7 @@ async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null>
     // doesn't deadlock on withConnection.
     const cache = conn.schemaCache;
     if (cache && typeof cache.columnsHash === "function") {
-      const candidate = conn.pool ?? conn;
+      const candidate = realPool(conn.pool) ?? conn;
       const pool =
         candidate &&
         typeof (candidate as { withConnection?: unknown }).withConnection === "function"
@@ -1391,7 +1392,7 @@ export async function tableExists(this: SchemaHost): Promise<boolean> {
   const conn = this.connection;
   const cache = conn.schemaCache;
   if (!cache || typeof cache.dataSourceExists !== "function") return true;
-  const pool = conn.pool ?? conn;
+  const pool = realPool(conn.pool) ?? conn;
   const exists = await cache.dataSourceExists(pool, this.tableName);
   return exists !== false;
 }

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -459,7 +459,12 @@ async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
     t.datetime("updated_at", { null: false });
   });
 
-  await define("old_cars", {}, (t) => {});
+  // Rails: `create_table :old_cars, id: :integer` — an integer (not bigint) PK,
+  // load-bearing for the mysql2 adapter FK type-mismatch tests, which reference
+  // old_cars.id from a bigint `<ref>_id` column and expect MismatchedForeignKey.
+  await define("old_cars", { serialPk: "id" }, (t) => {
+    t.integer("id");
+  });
 
   await define("carriers", {}, (t) => {});
 

--- a/packages/activerecord/src/test-helpers/define-schema.ts
+++ b/packages/activerecord/src/test-helpers/define-schema.ts
@@ -1,5 +1,6 @@
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import type { SchemaStatements } from "../connection-adapters/abstract/schema-statements.js";
+import { realPool } from "../connection-adapters/abstract/connection-pool.js";
 
 export type PrimitiveColumnSpec =
   | "string"
@@ -657,7 +658,7 @@ async function _resetAutoIncrement(
  */
 async function _warmSchemaCache(adapter: DatabaseAdapter, table: string): Promise<void> {
   const sc = adapter.schemaCache;
-  const pool = adapter.pool ?? null;
+  const pool = realPool(adapter.pool);
   // `!sc` is required, not dead: the `DatabaseAdapter` interface types
   // `schemaCache` as optional (`adapter.ts`), even though AbstractAdapter's
   // getter always returns one. Dropping it fails typecheck (TS18048).
@@ -724,7 +725,10 @@ async function _defineSchemaImpl(
     const newSig = tableSignature(raw);
     const cachedSig = cache.get(table);
     const sc = adapter.schemaCache;
-    const pool = adapter.pool ?? null;
+    // A standalone adapter now carries a NullPool (not null); treat it as "no
+    // pool" so we consult the signature cache rather than probing the DB
+    // through a pool that can't check out a connection.
+    const pool = realPool(adapter.pool);
     const stillExists =
       sc && pool !== null
         ? ((await sc.dataSourceExists(pool, table)) ?? cachedSig !== undefined)

--- a/packages/activerecord/src/test-helpers/test-schema.ts
+++ b/packages/activerecord/src/test-helpers/test-schema.ts
@@ -247,9 +247,13 @@ export const TEST_SCHEMA: Schema = {
     updated_at: { type: "datetime", null: false },
   },
 
-  // Rails declares `id: :integer`; defineSchema's default bigint PK is
-  // wider but accepts the same integer values fixtures emit.
-  old_cars: {},
+  // Rails: `create_table :old_cars, id: :integer` — an integer (not bigint)
+  // auto-increment PK, kept in sync with the canonical registry so the shared
+  // per-worker DB doesn't drift between the two schema loaders.
+  old_cars: {
+    columns: { id: { type: "integer" } },
+    primaryKey: ["id"],
+  },
 
   carriers: {},
 

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -2,6 +2,7 @@ import { beforeAll, beforeEach, afterEach, afterAll, type TaskContext } from "vi
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 import { resetTestAdapterState } from "../test-adapter.js";
 import type { ConnectionPool } from "../connection-adapters/abstract/connection-pool.js";
+import { realPool } from "../connection-adapters/abstract/connection-pool.js";
 import { popSkipGlobalReset, pushSkipGlobalReset } from "./skip-global-reset.js";
 import {
   _restoreAppliedSchemaSignaturesForAdapter,
@@ -53,7 +54,7 @@ function tm(adapter: TransactionalFixturesAdapter): TxnHost["transactionManager"
  */
 async function eagerWarmSchemaCache(adapter: TransactionalFixturesAdapter): Promise<void> {
   const sc = adapter.schemaCache;
-  const pool = adapter.pool ?? null;
+  const pool = realPool(adapter.pool);
   if (!sc || pool === null) return;
   try {
     await sc.addAll(pool);
@@ -80,7 +81,7 @@ async function reReflectTouchedTables(adapter: TransactionalFixturesAdapter): Pr
   if (!sc) return;
   const touched = sc.takeTouchedTables();
   if (touched.size === 0) return;
-  const pool = adapter.pool ?? null;
+  const pool = realPool(adapter.pool);
   for (const table of touched) {
     // Drop the stale (post-DDL) entry first, then re-read the rolled-back
     // shape from the live DB. Raw adapters without a pool can't re-reflect

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -19974,13 +19974,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "initialize",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "initialize",
     "call": "symbolize_keys",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -22822,13 +22815,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_reference",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "add_timestamps",
     "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -23902,20 +23888,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "remove_reference",
     "call": "merge",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_reference",
-    "call": "pluralize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_reference",
-    "call": "remove_foreign_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Converges two tracked deviations surfaced while porting `mysql2_adapter_test.rb`
(story `converge-mysql2-adapter-rails-port`, PR #4352), so the affected Rails
tests can be ported faithfully.

## NullPool
A standalone adapter now carries a `NullPool` by default (matching Rails
`@pool = NullPool.new`) instead of `null`, so `error.connection_pool` on a
connect-time failure is a NullPool. New `poolAbsent` / `realPool` helpers keep
the schema-cache and bare-adapter fallbacks — which keyed off `pool == null` —
treating a NullPool as "no pool" (columnForAttribute, schema-cache `columns`,
`close`, `loadSchemaFromAdapter`, `insert-all`, define-schema warming, etc.).
`Mysql2Adapter` attaches the pool to the `ConnectionNotEstablished` it raises on
a failed connect, mirroring Rails' `connect` rescue `raise ex.set_pool(@pool)`.

## add_reference / old_cars
`add_reference` now defaults its ref column to `:bigint` (Rails
`ReferenceDefinition`) and honors `foreign_key:` by adding the constraint.
Canonical `old_cars` gets an integer PK (`create_table id: :integer`) in both
schema loaders (canonical registry + legacy `TEST_SCHEMA`).

## Tests
`connection_error` / `reconnection_error` are ported with their pool
assertions (driven through a query, since trails connects lazily). The FK
type-mismatch tests ride the canonical `engines` / `old_cars` / `cars` /
`subscribers` / `people` tables via `add_reference` / `add_foreign_key`. The
tracked-deviation note is removed from the test header.

All 23 `mysql2-adapter.test.ts` cases pass locally against MySQL; sqlite
adapter / persistence / schema-dumper / insert-all / migration suites stay
green under the NullPool default.

Closes-story: mysql2-adapter-nullpool-and-addreference-deviations