### PR TITLE
feat(nested-attributes): support reject_if: :all_blank symbol form

### DIFF
--- a/packages/activerecord/src/index.ts
+++ b/packages/activerecord/src/index.ts
@@ -323,6 +323,7 @@ export {
 export {
   acceptsNestedAttributesFor,
   assignNestedAttributes,
+  REJECT_ALL_BLANK_PROC,
   TooManyRecords,
 } from "./nested-attributes.js";
 // hasSecureToken requires node:crypto — use subpath: @blazetrails/activerecord/secure-token

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -11,7 +11,13 @@
  * accommodations, not behavioral deviations.
  */
 import { describe, it, expect, beforeAll, vi } from "vitest";
-import { Base, RecordNotFound, registerModel, TooManyRecords } from "./index.js";
+import {
+  Base,
+  RecordNotFound,
+  registerModel,
+  REJECT_ALL_BLANK_PROC,
+  TooManyRecords,
+} from "./index.js";
 import { markForDestruction, isMarkedForDestruction } from "./autosave-association.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Human } from "./test-helpers/models/human.js";
@@ -91,6 +97,10 @@ describe("TestNestedAttributesInGeneral", () => {
 
   it("should add a proc to nested attributes options", () => {
     const configs = (Pirate as any)._nestedAttributeConfigs;
+    const rejectAllBlank = configs.find(
+      (c: any) => c.associationName === "birdsWithRejectAllBlank",
+    );
+    expect(rejectAllBlank.options.rejectIf).toBe(REJECT_ALL_BLANK_PROC);
     for (const name of ["parrots", "birds"]) {
       const cfg = configs.find((c: any) => c.associationName === name);
       expect(typeof cfg.options.rejectIf).toBe("function");

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -6,7 +6,7 @@ import {
   association as collectionProxyFor,
 } from "./associations.js";
 import { ActiveRecordError, UnknownAttributeError, RecordNotFound } from "./errors.js";
-import { singularize, camelize, underscore } from "@blazetrails/activesupport";
+import { singularize, camelize, underscore, isBlank } from "@blazetrails/activesupport";
 import { Table, UpdateManager } from "@blazetrails/arel";
 import {
   isMarkedForDestruction,
@@ -39,11 +39,22 @@ export function _destroy(this: Base): boolean {
   return isMarkedForDestruction(this);
 }
 
+/**
+ * Rails: `REJECT_ALL_BLANK_PROC = proc { |attributes| attributes.all? { |key,
+ * value| key == "_destroy" || value.blank? } }` (nested_attributes.rb:302).
+ * The shared proc `reject_if: :all_blank` resolves to — reject a record when
+ * every attribute other than `_destroy` is blank.
+ */
+export const REJECT_ALL_BLANK_PROC = (attributes: Record<string, unknown>): boolean =>
+  Object.entries(attributes).every(([key, value]) => key === "_destroy" || isBlank(value));
+
 interface NestedAttributeOptions {
   allowDestroy?: boolean;
   // The owner record is passed as a second argument so method-style predicates
   // (Rails `reject_if: :some_method`) can consult the owner (e.g. `persisted?`).
-  rejectIf?: (attrs: Record<string, unknown>, record: Base) => boolean;
+  // The string `"all_blank"` (Rails' `:all_blank` symbol) is resolved to the
+  // shared `REJECT_ALL_BLANK_PROC` in `acceptsNestedAttributesFor`.
+  rejectIf?: ((attrs: Record<string, unknown>, record: Base) => boolean) | "all_blank";
   // A string limit names a method/attribute on the owner (Rails `limit: :symbol`).
   limit?: number | string | ((...args: unknown[]) => number);
   updateOnly?: boolean;
@@ -89,6 +100,14 @@ export function acceptsNestedAttributesFor(
   associationName: string,
   options: NestedAttributeOptions = {},
 ): void {
+  // Rails: `options[:reject_if] = REJECT_ALL_BLANK_PROC if options[:reject_if] ==
+  // :all_blank` (nested_attributes.rb:355) — resolve the `:all_blank` symbol to
+  // the shared proc so `nested_attributes_options[name][:reject_if]` reads back
+  // as a Proc, and every downstream `call_reject_if` sees a callable.
+  if (options.rejectIf === "all_blank") {
+    options = { ...options, rejectIf: REJECT_ALL_BLANK_PROC };
+  }
+
   // Validate that the association exists
   const associations: any[] = (modelClass as any)._associations ?? [];
   const assocExists = associations.find((a: any) => a.name === associationName);
@@ -336,8 +355,11 @@ async function processNestedAttributes(record: Base): Promise<void> {
         continue;
       }
 
-      // Check rejectIf only for create/update, not destroy
-      if (config.options.rejectIf && config.options.rejectIf(attrs, record)) {
+      // Check rejectIf only for create/update, not destroy. The `"all_blank"`
+      // symbol is resolved to a proc at declaration time, so this is always a
+      // function here.
+      const rejectIf = config.options.rejectIf;
+      if (typeof rejectIf === "function" && rejectIf(attrs, record)) {
         continue;
       }
 
@@ -450,7 +472,9 @@ export function callRejectIf(
   const configs: NestedAttributeConfig[] =
     (record.constructor as any)._nestedAttributeConfigs ?? [];
   const rejectIf = configs.find((c) => c.associationName === associationName)?.options.rejectIf;
-  return rejectIf ? rejectIf(attributes, record) : false;
+  // `"all_blank"` is resolved to a proc in acceptsNestedAttributesFor, so a
+  // stored rejectIf is always a function here.
+  return typeof rejectIf === "function" ? rejectIf(attributes, record) : false;
 }
 
 /** @internal */

--- a/packages/activerecord/src/test-helpers/models/pirate.ts
+++ b/packages/activerecord/src/test-helpers/models/pirate.ts
@@ -8,7 +8,7 @@ import type { Parrot } from "./parrot.js";
 import type { PriceEstimate } from "./price-estimate.js";
 import type { Ship } from "./ship.js";
 import type { Treasure } from "./treasure.js";
-import { isBlank, throwAbort } from "@blazetrails/activesupport";
+import { throwAbort } from "@blazetrails/activesupport";
 // vendor/rails/activerecord/test/models/pirate.rb
 import { Base } from "../../base.js";
 import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
@@ -158,10 +158,6 @@ export class Pirate extends Base {
 // child is routed through the collection destroy on owner save.
 // `proc(&:empty?)` — reject when the attributes hash is empty.
 const rejectIfEmpty = (attrs: Record<string, unknown>) => Object.keys(attrs).length === 0;
-// `reject_if: :all_blank` — Rails' REJECT_ALL_BLANK_PROC: reject when every
-// attribute (other than `_destroy`) is blank.
-const rejectAllBlank = (attrs: Record<string, unknown>) =>
-  Object.entries(attrs).every(([key, value]) => key === "_destroy" || isBlank(value));
 
 acceptsNestedAttributesFor(Pirate, "parrots", { allowDestroy: true, rejectIf: rejectIfEmpty });
 acceptsNestedAttributesFor(Pirate, "birds", { allowDestroy: true, rejectIf: rejectIfEmpty });
@@ -171,7 +167,7 @@ acceptsNestedAttributesFor(Pirate, "parrotsWithMethodCallbacks", { allowDestroy:
 acceptsNestedAttributesFor(Pirate, "parrotsWithProcCallbacks", { allowDestroy: true });
 acceptsNestedAttributesFor(Pirate, "birdsWithMethodCallbacks", { allowDestroy: true });
 acceptsNestedAttributesFor(Pirate, "birdsWithProcCallbacks", { allowDestroy: true });
-acceptsNestedAttributesFor(Pirate, "birdsWithRejectAllBlank", { rejectIf: rejectAllBlank });
+acceptsNestedAttributesFor(Pirate, "birdsWithRejectAllBlank", { rejectIf: "all_blank" });
 
 export class DestructivePirate extends Pirate {
   declare dependentShip: Ship | null;


### PR DESCRIPTION
Resolves the `reject_if: "all_blank"` string/symbol form in
`acceptsNestedAttributesFor` to a shared `REJECT_ALL_BLANK_PROC`, mirroring
Rails' `nested_attributes.rb:355` (`options[:reject_if] = REJECT_ALL_BLANK_PROC
if options[:reject_if] == :all_blank`). The proc skips `_destroy` and rejects
when every other value is blank (`nested_attributes.rb:302`).

The canonical `Pirate` model now declares `rejectIf: "all_blank"` instead of the
inline `rejectAllBlank` proc merged in PR #4075, matching Rails' declaration
surface. `nested_attributes_options[name][:reject_if]` now reads back as the
shared proc — the `should add a proc to nested attributes options` test asserts
identity with `REJECT_ALL_BLANK_PROC`, matching `nested_attributes_test.rb:31-34`.

Closes-story: nested-attr-reject-if-all-blank-symbol-form