### PR TITLE
test(nested-attributes): un-skip extend-affects-nested-attributes

### DIFF
--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -14,6 +14,7 @@ import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Base, RecordNotFound, registerModel, TooManyRecords } from "./index.js";
 import { markForDestruction, isMarkedForDestruction } from "./autosave-association.js";
 import { fixtures } from "./test-helpers/fixtures.js";
+import type { AssociationProxy } from "./associations/collection-proxy.js";
 import { Human } from "./test-helpers/models/human.js";
 import { Interest } from "./test-helpers/models/interest.js";
 import { Owner } from "./test-helpers/models/owner.js";
@@ -1532,13 +1533,31 @@ describe("TestIndexErrorsWithNestedAttributesOnlyMode", () => {
 // TestNestedAttributesWithExtend
 // ==========================================================================
 describe("TestNestedAttributesWithExtend", () => {
-  // tracked-pending-convergence (0023-surfaced-deviations): the `extend:` option
-  // on an association (Rails `has_many :treasures, extend: PostTreasuresExtension`)
-  // is not wired into nested-attributes builds — the extension module's overrides
-  // (e.g. `build` naming the record "from extension") do not run.
-  // See nested-attributes-association-extend convergence story.
-  it.skip("extend affects nested attributes", async () => {
-    /* requires association `extend:` support */
+  fixtures({ pirates: [Pirate, {}], treasures: [Treasure, {}] });
+
+  it("extend affects nested attributes", async () => {
+    // Rails: `has_many :treasures, as: :looter, extend: Pirate::PostTreasuresExtension`
+    // with `PostTreasuresExtension#build` prepending `name: "from extension"`.
+    class SuperPirate extends Base {
+      static tableName = "pirates";
+      declare treasures: AssociationProxy<Treasure>;
+      static {
+        this.hasMany("treasures", {
+          as: "looter",
+          className: "Treasure",
+          extend: Pirate.postTreasuresExtension,
+        });
+        this.acceptsNestedAttributesFor("treasures");
+      }
+    }
+    registerModel(SuperPirate);
+
+    const pirate = await SuperPirate.createBang({
+      catchphrase: "Don' botharrr talkin' like one, savvy?",
+    });
+    (pirate as any).treasuresAttributes = [{ id: null }];
+    const treasures = (await pirate.association("treasures").loadTarget()) as Treasure[];
+    expect(treasures[0].name).toEqual("from extension");
   });
 });
 

--- a/packages/activerecord/src/test-helpers/models/pirate.ts
+++ b/packages/activerecord/src/test-helpers/models/pirate.ts
@@ -1,4 +1,5 @@
 import type { AssociationProxy } from "../../associations/collection-proxy.js";
+import { CollectionProxy } from "../../associations/collection-proxy.js";
 import type { Temporal } from "@blazetrails/activesupport/temporal";
 import type { Bird } from "./bird.js";
 import type { Bulb } from "./bulb.js";
@@ -51,6 +52,23 @@ export class Pirate extends Base {
   declare parrot_id: number;
   declare updated_on: Temporal.Instant | Temporal.PlainDateTime;
 
+  /**
+   * Rails: `module PostTreasuresExtension; def build(attributes = {})`
+   * `super({ name: "from extension" }.merge(attributes)); end; end`.
+   * Ruby's `super` reaches the CollectionProxy's own `build`; trails installs
+   * extension methods on the proxy instance (not a prototype layer), so the
+   * "super" call is expressed as `CollectionProxy.prototype.build.call`.
+   */
+  static postTreasuresExtension = {
+    build(this: CollectionProxy<Base>, ...args: unknown[]): Base {
+      const attributes = (args[0] as Record<string, unknown>) ?? {};
+      return CollectionProxy.prototype.build.call(this, {
+        name: "from extension",
+        ...attributes,
+      }) as Base;
+    },
+  };
+
   static {
     // Rails: `attr_accessor :cancel_save_from_callback, :parrots_limit`
     this.attribute("parrotsLimit", "integer", { virtual: true });
@@ -79,7 +97,7 @@ export class Pirate extends Base {
     });
     this.hasAndBelongsToMany("autosavedParrots", { className: "Parrot", autosave: true });
 
-    this.hasMany("treasures", { as: "looter" });
+    this.hasMany("treasures", { as: "looter", extend: Pirate.postTreasuresExtension });
     this.hasMany("treasureEstimates", { through: "treasures", source: "priceEstimates" });
 
     this.hasOne("ship");


### PR DESCRIPTION
## What

Un-skips `TestNestedAttributesWithExtend > extend affects nested attributes`, ported verbatim from Rails' `nested_attributes_test.rb`, and mirrors `pirate.rb` by adding the `PostTreasuresExtension` module + `extend:` wiring to the trails `Pirate` model.

## Why it already works (no production change)

The association `extend:` option is already wired into the nested-attributes build path:

- Rails builds a nested collection record via `association.reader.build(attributes)` (`nested_attributes.rb:525`).
- trails maps this to `collectionProxyFor(record, associationName).build(assignable)` (`nested-attributes.ts:872`).
- The `CollectionProxy` constructor applies `reflection.extensions` via `extendingBang` (`collection-proxy.ts:555-567`), so an extension module's `build` override runs on that path.

## Fidelity notes

- The trails `Pirate` model now carries `postTreasuresExtension` (Rails `Pirate::PostTreasuresExtension`) and wires `has_many :treasures, ..., extend:`, matching `pirate.rb`. No existing test builds `pirate.treasures` expecting a default name, so this is behavior-safe.
- Ruby's `super` (which reaches the `CollectionProxy`'s own `build`) is expressed as `CollectionProxy.prototype.build.call`, since trails installs extension methods on the proxy instance rather than in a prototype layer.

Closes-story: nested-attributes-association-extend