### PR TITLE
feat(nested-attributes): build concrete delegated type on nested path

### DIFF
--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -1561,12 +1561,7 @@ describe("TestNestedAttributesForDelegatedType", () => {
     Entry.acceptsNestedAttributesFor("entryable");
   });
 
-  // tracked-pending-convergence (0023-surfaced-deviations): nested attributes
-  // for a delegated_type association are not yet supported — trails treats the
-  // delegated `entryable` as a plain polymorphic belongs_to and refuses to build
-  // it, rather than instantiating the concrete type from `entryable_type`.
-  // See nested-attributes-delegated-type convergence story.
-  it.skip("should build a new record based on the delegated type", () => {
+  it("should build a new record based on the delegated type", () => {
     const entry = new Entry({
       entryable_type: "Message",
       entryableAttributes: { subject: "Hello world!" },

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -771,17 +771,26 @@ export function assignNestedAttributesForOneToOneAssociation(
       existing.assignAttributes(assignable);
       assoc.initializeAttributes(existing);
     } else {
-      // Rails defers the polymorphic-target check to build time: a polymorphic
-      // belongs_to has no `build_#{association_name}` method, so the writer
-      // raises. Immediate in-memory build otherwise (`part.ship.name` is
-      // readable right after assignment); autosave persists it on save.
+      // Rails nested_attributes.rb:451 — `method = :"build_#{association_name}";
+      // respond_to?(method) ? public_send(method, ...) : raise`. A plain
+      // polymorphic belongs_to has no `build_#{name}` method, so the writer
+      // raises. A `delegated_type` role, however, defines `build_#{role}`
+      // (delegated-type.ts) which instantiates the concrete type named by the
+      // `*_type` column, so it builds through that method instead of raising.
       if (isPolymorphicBelongsTo(record, associationName)) {
-        throw new Error(
-          `Cannot build association \`${associationName}'. ` +
-            `Are you trying to build a polymorphic one-to-one association?`,
-        );
+        const buildMethod = `build${camelize(associationName, true)}`;
+        const builder = (record as unknown as Record<string, unknown>)[buildMethod];
+        if (typeof builder === "function") {
+          (builder as (attrs: Record<string, unknown>) => unknown).call(record, assignable);
+        } else {
+          throw new Error(
+            `Cannot build association \`${associationName}'. ` +
+              `Are you trying to build a polymorphic one-to-one association?`,
+          );
+        }
+      } else {
+        assoc.build(assignable);
       }
-      assoc.build(assignable);
     }
   }
 }


### PR DESCRIPTION
## What

Nested attributes for a `delegated_type` association previously threw
``Cannot build association `entryable'`` — trails treated the delegated role as
a plain polymorphic belongs_to and refused to build it.

Mirror Rails `nested_attributes.rb:451`: dispatch the build through
`build_#{association_name}` when the record responds to it. A `delegated_type`
role defines that method (`delegated-type.ts`), which instantiates the concrete
type named by the `*_type` column (e.g. `Message`); a genuine polymorphic
belongs_to with no such method still raises.

## Test

Un-skips `TestNestedAttributesForDelegatedType > should build a new record
based on the delegated type` (canonical `Entry`/`Message`). The existing
polymorphic-raise test still passes.

Closes-story: nested-attributes-delegated-type-build