### PR TITLE
fix(activesupport): FileStore increment coerces amount via Integer() raise semantics

### DIFF
--- a/packages/activesupport/src/cache/file-store.ts
+++ b/packages/activesupport/src/cache/file-store.ts
@@ -4,6 +4,7 @@ import { coder } from "./coder.js";
 import { DeserializationError } from "./deserialization-error.js";
 import { Entry } from "./entry.js";
 import { Store, type StoreOptions } from "./store.js";
+import { integer } from "./integer.js";
 import { type CacheEntry, isExpired } from "./entry-record.js";
 
 const FILENAME_MAX_SIZE = 228;
@@ -238,8 +239,9 @@ export class FileStore extends Store implements CacheStore {
     const key = this.normalizeKey(name, options);
     const version = this.normalizeVersion(name, options) ?? null;
     // Rails coerces `amount = Integer(amount)` once (file_store.rb:226) and uses
-    // it uniformly for the seed write, the return, and the hit-path addition.
-    const amt = Math.trunc(amount);
+    // it uniformly for the seed write, the return, and the hit-path addition;
+    // `Integer()` raises on NaN/Infinity rather than silently truncating.
+    const amt = integer(amount);
     const entry = this.readEntry(key, options);
     if (!entry || entry.isExpired() || entry.isMismatched(version)) {
       this.write(name, amt, options);

--- a/packages/activesupport/src/cache/integer.ts
+++ b/packages/activesupport/src/cache/integer.ts
@@ -1,0 +1,12 @@
+import { ArgumentError } from "./store.js";
+
+// Mirrors Ruby `Integer(amount)` over the numeric domain: a finite number
+// truncates toward zero (`Integer(1.5) # => 1`, `Integer(-1.9) # => -1`), while
+// NaN/Infinity raise the way Ruby's `Integer(Float::NAN)`/`Integer(Float::INFINITY)`
+// raise FloatDomainError — rather than silently coercing to a non-integer.
+export function integer(amount: number): number {
+  if (!Number.isFinite(amount)) {
+    throw new ArgumentError(`invalid value for Integer(): ${amount}`);
+  }
+  return Math.trunc(amount);
+}

--- a/packages/activesupport/src/cache/memory-store.ts
+++ b/packages/activesupport/src/cache/memory-store.ts
@@ -1,7 +1,8 @@
 import type { CacheOptions, CacheStore } from "./index.js";
 import { coder } from "./coder.js";
 import { Entry } from "./entry.js";
-import { Store, ArgumentError } from "./store.js";
+import { Store } from "./store.js";
+import { integer } from "./integer.js";
 
 // In-memory record backing a single key. We store the coder-serialized value
 // (so Date/undefined/bigint/non-finite numbers and deep-clone isolation survive
@@ -25,17 +26,6 @@ function toI(value: unknown): number {
     return m ? parseInt(m[0], 10) : 0;
   }
   return 0;
-}
-
-// Mirrors Ruby `Integer(amount)` over the numeric domain: a finite number
-// truncates toward zero (`Integer(1.5) # => 1`, `Integer(-1.9) # => -1`), while
-// NaN/Infinity raise the way Ruby's `Integer(Float::NAN)`/`Integer(Float::INFINITY)`
-// raise FloatDomainError — rather than silently coercing to a non-integer.
-function integer(amount: number): number {
-  if (!Number.isFinite(amount)) {
-    throw new ArgumentError(`invalid value for Integer(): ${amount}`);
-  }
-  return Math.trunc(amount);
 }
 
 export class MemoryStore extends Store implements CacheStore {

--- a/packages/activesupport/src/cache/stores/file-store.test.ts
+++ b/packages/activesupport/src/cache/stores/file-store.test.ts
@@ -240,6 +240,30 @@ describe("CacheIncrementDecrementBehavior", () => {
     expect(cache.decrement("quux", 100)).toBe(-100);
   });
 
+  // Rails coerces `amount = Integer(amount)` (file_store.rb:226), which raises
+  // FloatDomainError on NaN/Infinity rather than seeding a non-integer entry.
+  it("increment raises on a non-integer amount when seeding a missing key", () => {
+    expect(() => cache.increment("foo", NaN)).toThrow();
+    expect(() => cache.increment("foo", Infinity)).toThrow();
+    expect(() => cache.increment("foo", -Infinity)).toThrow();
+    expect(cache.read("foo")).toBeNull();
+  });
+
+  it("decrement raises on a non-integer amount when seeding a missing key", () => {
+    expect(() => cache.decrement("foo", NaN)).toThrow();
+    expect(() => cache.decrement("foo", Infinity)).toThrow();
+    expect(cache.read("foo")).toBeNull();
+  });
+
+  // Rails coerces once, so the seed write, the return value, and the hit-path
+  // addition all use `Integer(amount)` — a finite float truncates toward zero.
+  it("increment truncates a finite float amount toward zero", () => {
+    expect(cache.increment("frac", 1.9)).toBe(1);
+    expect(Number(cache.read("frac"))).toBe(1);
+    expect(cache.increment("frac", 2.9)).toBe(3);
+    expect(Number(cache.read("frac"))).toBe(3);
+  });
+
   it("test_ttl_isnt_updated", async () => {
     expect(cache.increment("foo", 1, { expiresIn: 0.1 })).toBe(1);
     // A second increment with a longer TTL must not reset the original expiry.


### PR DESCRIPTION
`FileStore#modifyValue` coerced `amount` via `Math.trunc(amount)`, silently
truncating `NaN`/`Infinity` instead of raising. Rails `file_store.rb:226` calls
`amount = Integer(amount)`, which raises `FloatDomainError` on
`Integer(Float::NAN)` / `Integer(Float::INFINITY)`.

FileStore genuinely coerces once and threads `amount` through the seed write,
the return value, and the hit-path addition, so the structure was already
correct — only the `Math.trunc` → `Integer()` raise semantics diverged.

- Extract the `integer()` helper (Ruby `Integer()` numeric semantics: finite →
  truncate toward zero, NaN/Infinity → throw ArgumentError) from `memory-store.ts`
  (PR #4560) into shared `cache/integer.ts`; reuse in both stores.
- `FileStore#modifyValue` now coerces via `integer(amount)`.
- Tests assert the raise on NaN/±Infinity and that finite floats truncate.

Closes-story: file-store-increment-integer-amount-raise