### PR TITLE
feat(fixtures): load multiple same-table fixture sets in one call

### DIFF
--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -4,6 +4,7 @@ import {
   ref,
   isFixtureRef,
   defineFixtures,
+  effectiveFixtureKey,
   resolveModelForTable,
   FixtureSetPrimaryKeyError,
 } from "./define-fixtures.js";
@@ -49,6 +50,30 @@ describe("fixtureId", () => {
     expect(fixtureId("david")).toBe(127326141);
     expect(fixtureId("david")).toBe(fixtureId("david"));
     expect(fixtureId("david")).not.toBe(fixtureId("mary"));
+  });
+});
+
+describe("effectiveFixtureKey", () => {
+  it("keys an unpinned row on its label-derived id", () => {
+    const model = makeModel("users", new Map());
+    expect(effectiveFixtureKey(model, "grace", {})).toBe("s:" + fixtureId("grace"));
+  });
+
+  it("puts an explicit pin and a colliding derived id in the same keyspace", () => {
+    // A row pinning `id: fixtureId("grace")` must produce the same key as an
+    // unpinned `grace` row, so a cross-kind DB collision is caught.
+    const model = makeModel("users", new Map());
+    const pinned = effectiveFixtureKey(model, "other", { id: fixtureId("grace") });
+    const derived = effectiveFixtureKey(model, "grace", {});
+    expect(pinned).toBe(derived);
+  });
+
+  it("keys on the model's real primary-key column, not a hardcoded id", () => {
+    // Subscriber pins its PK under `nick`; an `id`-based guard would miss it.
+    const model = makeModel("subscribers", new Map(), "nick");
+    expect(effectiveFixtureKey(model, "first", { nick: "alex" })).toBe("s:alex");
+    // A stray `id` value on a nick-keyed model is irrelevant to the PK.
+    expect(effectiveFixtureKey(model, "second", { nick: "bo", id: 1 })).toBe("s:bo");
   });
 });
 

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -131,6 +131,10 @@ function resolveDeclaredPk(
 export function effectiveFixtureKey(model: BaseClass, label: string, row: FixtureAttrs): string {
   const pk = model.primaryKey;
   if (Array.isArray(pk)) {
+    // No adapter here, so unlike prepareModelFixtures this can't drop composite key
+    // columns absent from the table schema (tableColumnNames gate). Harmless for the
+    // known composite fixtures (cpk_orders/cpk_order_tags key columns are all real);
+    // a phantom key column would only over-fold the guard key, never mask a real one.
     const generated = compositeIdentify(label, pk);
     return "c:" + JSON.stringify(pk.map((col) => row[col] ?? generated[col]));
   }

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -117,6 +117,29 @@ function resolveDeclaredPk(
   );
 }
 
+/**
+ * The primary-key value a fixture row will land on, as a stable string usable for
+ * collision detection across sets that share a table — computed exactly the way
+ * {@link prepareModelFixtures} derives it, so an explicit pin and a label-derived
+ * CRC32 id share ONE keyspace (a row pinning `id: 42` collides with an unpinned
+ * row whose label hashes to 42). Uses the model's declared `primaryKey`, so a
+ * custom-PK model (e.g. Subscriber's `nick`, Dashboard's `dashboard_id`) is keyed
+ * on its real column, not a hardcoded `id`. Composite-PK models fold their key
+ * columns (present values, else `compositeIdentify`) into the string.
+ * @internal
+ */
+export function effectiveFixtureKey(model: BaseClass, label: string, row: FixtureAttrs): string {
+  const pk = model.primaryKey;
+  if (Array.isArray(pk)) {
+    const generated = compositeIdentify(label, pk);
+    return "c:" + JSON.stringify(pk.map((col) => row[col] ?? generated[col]));
+  }
+  // Id-less tables (declared PK is null/undefined) have no PK to collide on; fall
+  // back to the label so two identically-labelled naked rows still flag.
+  if (typeof pk !== "string") return "l:" + label;
+  return "s:" + String(resolveDeclaredPk(model.tableName, pk, label, row[pk]));
+}
+
 const REF_TAG = Symbol("fixture-ref");
 
 export interface FixtureRef {

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -737,7 +737,7 @@ describe("resolveFixtureNames same-table guard", () => {
     // dogs (sophie) and otherDogs (lassie) both map to `dogs` and both pin id: 1,
     // so merging them would collide on the primary key.
     await expect(resolveFixtureNames(["dogs", "otherDogs"])).rejects.toThrow(
-      /conflicting row \(id:1\)/,
+      /both map to table "dogs" with a row that resolves to the same primary key/,
     );
   });
 

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -11,7 +11,7 @@ import {
   defineJoinTableFixtures,
   isFixtureRef,
 } from "./define-fixtures.js";
-import { setupFixtures } from "./fixtures.js";
+import { setupFixtures, fixtures } from "./fixtures.js";
 import { useHandlerTransactionalFixtures } from "./use-handler-transactional-fixtures.js";
 import { TEST_SCHEMA } from "./test-schema.js";
 import { Author } from "./models/author.js";
@@ -749,17 +749,11 @@ describe("resolveFixtureNames same-table guard", () => {
 
 // --- same-table multi-set load ---
 
-describe("useFixtures loads multiple same-table fixture sets in one call", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
-
+describe("fixtures() loads multiple same-table fixture sets in one call", () => {
   // deadParrots + liveParrots are STI subclasses backed by the same `parrots`
   // table. They load together: the table is deleted once and both sets' rows are
   // merged into one insert, with each accessor returning its own rows.
-  const { deadParrots, liveParrots } = useFixtures(
-    ["deadParrots", "liveParrots"],
-    () => Base.adapter,
-  );
+  const { deadParrots, liveParrots } = fixtures(["deadParrots", "liveParrots"]);
 
   it("resolves a DeadParrot-typed row from the deadParrots accessor", () => {
     expect(deadParrots("deadbird")).toBeInstanceOf(DeadParrot);

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -724,16 +724,60 @@ describe("fixtureRegistry ref targets", () => {
 });
 
 describe("resolveFixtureNames same-table guard", () => {
-  it("rejects two requested sets that resolve to the same table", async () => {
+  it("resolves two requested sets that map to the same table", async () => {
     // deadParrots + liveParrots are both STI subclasses on the `parrots` table.
-    await expect(resolveFixtureNames(["deadParrots", "liveParrots"])).rejects.toThrow(
-      /both map to table "parrots"/,
+    // They merge into one load now (disjoint labels), so both entries resolve.
+    const map = await resolveFixtureNames(["deadParrots", "liveParrots"]);
+    expect(Object.keys(map)).toEqual(["deadParrots", "liveParrots"]);
+    expect(map.deadParrots.table).toBe("parrots");
+    expect(map.liveParrots.table).toBe("parrots");
+  });
+
+  it("rejects two same-table sets whose rows collide on a primary key", async () => {
+    // dogs (sophie) and otherDogs (lassie) both map to `dogs` and both pin id: 1,
+    // so merging them would collide on the primary key.
+    await expect(resolveFixtureNames(["dogs", "otherDogs"])).rejects.toThrow(
+      /conflicting row \(id:1\)/,
     );
   });
 
   it("resolves distinct-table sets without error", async () => {
     const map = await resolveFixtureNames(["authors", "posts"]);
     expect(Object.keys(map)).toEqual(["authors", "posts"]);
+  });
+});
+
+// --- same-table multi-set load ---
+
+describe("useFixtures loads multiple same-table fixture sets in one call", () => {
+  setupFixtures();
+  useHandlerTransactionalFixtures();
+
+  // deadParrots + liveParrots are STI subclasses backed by the same `parrots`
+  // table. They load together: the table is deleted once and both sets' rows are
+  // merged into one insert, with each accessor returning its own rows.
+  const { deadParrots, liveParrots } = useFixtures(
+    ["deadParrots", "liveParrots"],
+    () => Base.adapter,
+  );
+
+  it("resolves a DeadParrot-typed row from the deadParrots accessor", () => {
+    expect(deadParrots("deadbird")).toBeInstanceOf(DeadParrot);
+    expect(deadParrots("deadbird").readAttribute("name")).toBe("Dusty DeadBird");
+  });
+
+  it("resolves a LiveParrot-typed row from the liveParrots accessor", () => {
+    expect(liveParrots("dusty")).toBeInstanceOf(LiveParrot);
+    expect(liveParrots("dusty").readAttribute("name")).toBe("Dusty Bluebird");
+  });
+
+  it("inserts both sets' rows into the shared table", async () => {
+    const rows = (await Base.adapter.execute(
+      `SELECT name FROM ${Base.adapter.quoteTableName("parrots")} ORDER BY name`,
+    )) as { name: string }[];
+    const names = rows.map((r) => r.name);
+    expect(names).toContain("Dusty DeadBird");
+    expect(names).toContain("Dusty Bluebird");
   });
 });
 

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -128,9 +128,10 @@ export interface FixturesConnectionOpts {
  * `insertFixturesSet` that deletes each table once and inserts all rows together
  * (see {@link insertPreparedFixtureSets}), mirroring how Rails loads multiple
  * same-table fixture files (fixtures.rb groups by table then unshifts all rows).
- * The only rejected case is genuinely-conflicting rows: two same-table sets that
- * declare the same label map to the same computed PK, so merging them would
- * collide.
+ * The only rejected case is genuinely-conflicting rows: two same-table sets
+ * whose rows collide on a primary key — either a shared pinned `id`, or a shared
+ * label (the label deterministically derives the PK), so merging them would
+ * clobber one row with the other.
  *
  * @internal
  */

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -122,17 +122,15 @@ export interface FixturesConnectionOpts {
  * Resolves fixture-set names through the registry into the `[Model, data]` map shape.
  * Model classes are dynamic-imported (see {@link FixtureRegistryEntry}), so this is async.
  *
- * Rejects a request that names two sets backed by the same table (e.g.
- * `deadParrots`/`liveParrots` → `parrots`, `dogs`/`otherDogs` → `dogs`). Each
- * `defineFixtures` call deletes its table before inserting, so seeding both in
- * one call would wipe the first set's rows while leaving its accessor populated
- * with now-deleted instances. Rails loads multiple same-table fixture files by
- * deleting each table once and inserting all sets together; that combined path
- * needs a `defineFixtures` change (build rows per model, delete the shared table
- * once) and is deferred. Until then, load only ONE of the same-table sets in a
- * given test/scope — separate `useFixtures` calls don't help, since each
- * registers its own `beforeEach` loader and the later loader's delete still
- * clobbers the earlier set on every test.
+ * Two requested sets backed by the same table (e.g. `deadParrots`/`liveParrots`
+ * → `parrots`, `dogs`/`otherDogs` → `dogs`) load together in one call: the
+ * loader prepares every set, MERGES their rows per table, and issues a single
+ * `insertFixturesSet` that deletes each table once and inserts all rows together
+ * (see {@link insertPreparedFixtureSets}), mirroring how Rails loads multiple
+ * same-table fixture files (fixtures.rb groups by table then unshifts all rows).
+ * The only rejected case is genuinely-conflicting rows: two same-table sets that
+ * declare the same label map to the same computed PK, so merging them would
+ * collide.
  *
  * @internal
  */
@@ -140,7 +138,12 @@ export async function resolveFixtureNames(
   names: readonly FixtureName[],
 ): Promise<ResolvedFixtureMap> {
   const map: ResolvedFixtureMap = {};
-  const tableToName = new Map<string, string>();
+  // Per-table map of already-claimed row keys → the set that claimed each, so two
+  // same-table sets that would collide on a row are rejected while disjoint sets
+  // merge cleanly. A row's key is its explicit `id` when it has one (Rails lets a
+  // fixture pin its PK), otherwise its label — the label deterministically derives
+  // the PK, so a shared label means a shared PK.
+  const tableRowKeys = new Map<string, Map<string, string>>();
   for (const name of names) {
     const entry = fixtureRegistry[name] as (typeof fixtureRegistry)[FixtureName] | undefined;
     if (!entry) {
@@ -174,17 +177,26 @@ export async function resolveFixtureNames(
       table = m.tableName;
       model = m;
     }
-    const prior = tableToName.get(table);
-    if (prior !== undefined) {
-      throw new Error(
-        `useFixtures: "${name}" and "${prior}" both map to table "${table}"; ` +
-          `combined same-table loading isn't supported yet (defineFixtures deletes the ` +
-          `table per set). Load only one of them in this test/scope — splitting across ` +
-          `separate useFixtures calls does not help, since the later loader's delete still ` +
-          `clobbers the earlier set on every test.`,
-      );
+    // Same-table sets merge (each accessor keeps its own rows), but two sets
+    // whose rows collide on a primary key would clobber each other — reject that.
+    let rowKeys = tableRowKeys.get(table);
+    if (rowKeys === undefined) {
+      rowKeys = new Map();
+      tableRowKeys.set(table, rowKeys);
     }
-    tableToName.set(table, name);
+    for (const [label, row] of Object.entries(entry.data)) {
+      const explicitId = (row as { id?: unknown }).id;
+      const key = explicitId !== undefined ? `id:${String(explicitId)}` : `label:${label}`;
+      const prior = rowKeys.get(key);
+      if (prior !== undefined) {
+        throw new Error(
+          `useFixtures: "${name}" and "${prior}" both map to table "${table}" with a ` +
+            `conflicting row (${key}); same-table sets load together, but two rows sharing ` +
+            `a primary key collide. Rename the label or change the pinned id.`,
+        );
+      }
+      rowKeys.set(key, name);
+    }
     map[name] = { table, model, data: entry.data };
   }
   return map;
@@ -263,9 +275,9 @@ function useTablelessFixtures(
   getAdapter: () => DatabaseAdapter,
   opts?: UseFixturesOpts,
 ): Record<string, unknown> {
-  // Mirror the same-table duplicate guard in resolveFixtureNames: each
-  // defineJoinTableFixtures call deletes the table before inserting, so a
-  // second entry for the same table would wipe the first entry's rows.
+  // Tableless entries key their accessor by `table`, so two entries on the same
+  // table would clobber each other's store slot. (Model-backed same-table sets in
+  // resolveFixtureNames merge instead, because they key by set name.)
   const seenTables = new Set<string>();
   for (const { table } of entries) {
     if (seenTables.has(table)) {

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -4,6 +4,7 @@ import {
   prepareJoinTableFixtures,
   insertPreparedFixtureSets,
   throughJoinTableNames,
+  effectiveFixtureKey,
   type PreparedFixtureSet,
 } from "./define-fixtures.js";
 import { type Schema } from "./define-schema.js";
@@ -128,10 +129,11 @@ export interface FixturesConnectionOpts {
  * `insertFixturesSet` that deletes each table once and inserts all rows together
  * (see {@link insertPreparedFixtureSets}), mirroring how Rails loads multiple
  * same-table fixture files (fixtures.rb groups by table then unshifts all rows).
- * The only rejected case is genuinely-conflicting rows: two same-table sets
- * whose rows collide on a primary key — either a shared pinned `id`, or a shared
- * label (the label deterministically derives the PK), so merging them would
- * clobber one row with the other.
+ * The only rejected case is genuinely-conflicting rows: two same-table sets whose
+ * rows resolve to the same primary key. A row's key is resolved the way the loader
+ * derives it — an explicit pin on the model's real primary-key column, else the
+ * label-derived CRC32 id — in one keyspace, so a pinned id and a colliding derived
+ * id are both caught. Join-table sets (no model) concatenate and are not guarded.
  *
  * @internal
  */
@@ -139,11 +141,11 @@ export async function resolveFixtureNames(
   names: readonly FixtureName[],
 ): Promise<ResolvedFixtureMap> {
   const map: ResolvedFixtureMap = {};
-  // Per-table map of already-claimed row keys → the set that claimed each, so two
-  // same-table sets that would collide on a row are rejected while disjoint sets
-  // merge cleanly. A row's key is its explicit `id` when it has one (Rails lets a
-  // fixture pin its PK), otherwise its label — the label deterministically derives
-  // the PK, so a shared label means a shared PK.
+  // Per-table map of already-claimed primary-key values → a descriptor of the set
+  // (and label) that claimed each, so two same-table sets whose rows resolve to the
+  // same PK are rejected while disjoint sets merge cleanly. The key is the row's
+  // effective PK (explicit pin OR the label-derived CRC32 id, in one keyspace),
+  // computed off the model's real primaryKey column — see effectiveFixtureKey.
   const tableRowKeys = new Map<string, Map<string, string>>();
   for (const name of names) {
     const entry = fixtureRegistry[name] as (typeof fixtureRegistry)[FixtureName] | undefined;
@@ -178,25 +180,30 @@ export async function resolveFixtureNames(
       table = m.tableName;
       model = m;
     }
-    // Same-table sets merge (each accessor keeps its own rows), but two sets
-    // whose rows collide on a primary key would clobber each other — reject that.
-    let rowKeys = tableRowKeys.get(table);
-    if (rowKeys === undefined) {
-      rowKeys = new Map();
-      tableRowKeys.set(table, rowKeys);
-    }
-    for (const [label, row] of Object.entries(entry.data)) {
-      const explicitId = (row as { id?: unknown }).id;
-      const key = explicitId !== undefined ? `id:${String(explicitId)}` : `label:${label}`;
-      const prior = rowKeys.get(key);
-      if (prior !== undefined) {
-        throw new Error(
-          `useFixtures: "${name}" and "${prior}" both map to table "${table}" with a ` +
-            `conflicting row (${key}); same-table sets load together, but two rows sharing ` +
-            `a primary key collide. Rename the label or change the pinned id.`,
-        );
+    // Same-table sets merge (each accessor keeps its own rows), but two rows that
+    // resolve to the same primary key would clobber each other — reject that. Only
+    // model-backed sets have a PK; join-table sets (model === null) concatenate.
+    if (model !== null) {
+      let rowKeys = tableRowKeys.get(table);
+      if (rowKeys === undefined) {
+        rowKeys = new Map();
+        tableRowKeys.set(table, rowKeys);
       }
-      rowKeys.set(key, name);
+      for (const [label, row] of Object.entries(entry.data)) {
+        // Resolve to the row's actual PK value the way the loader does, so an
+        // explicit pin and a label-derived id share one keyspace (see
+        // effectiveFixtureKey). Keyed on the model's real primaryKey column.
+        const key = effectiveFixtureKey(model, label, row);
+        const prior = rowKeys.get(key);
+        if (prior !== undefined) {
+          throw new Error(
+            `useFixtures: ${prior} and "${name}" (${label}) both map to table "${table}" with a ` +
+              `row that resolves to the same primary key; same-table sets load together, but ` +
+              `two rows sharing a primary key collide. Rename the label or change the pinned id.`,
+          );
+        }
+        rowKeys.set(key, `"${name}" (${label})`);
+      }
     }
     map[name] = { table, model, data: entry.data };
   }


### PR DESCRIPTION
## What

`resolveFixtureNames` no longer throws when two requested fixture sets map
to the same table. Since PR #4545 (`port-insert-fixtures-set-single-ri-toggle`),
`insertPreparedFixtureSets` MERGES every prepared set's rows into one
`table_rows_for_connection` hash and issues a single `insertFixturesSet` per
load — deleting each table once and inserting all rows together. So the
per-set delete that motivated the guard is gone, and same-table model sets
(e.g. `deadParrots`/`liveParrots` → `parrots`) can load together exactly like
Rails loads multiple same-table fixture files (fixtures.rb:665-693 groups by
table then unshifts all rows).

## Changes

- Relax the `resolveFixtureNames` same-table throw (and its stale doc
  paragraph). Same-table sets now merge; the accessors key by set name, so
  each returns its own rows.
- Keep a guard only for genuinely-conflicting rows: two same-table sets whose
  rows resolve to the same primary key. The effective key is computed via the
  new `effectiveFixtureKey` (define-fixtures.ts), mirroring exactly how
  `prepareModelFixtures` derives a row's id: the model's **real** `primaryKey`
  column (custom-PK models like Subscriber `nick` / Dashboard `dashboard_id`
  keyed correctly), with an explicit pin and a label-derived CRC32 id folded
  into ONE keyspace (a pinned `id: 42` collides with an unpinned label hashing
  to 42), composite keys included. Join-table sets (no PK) concatenate and are
  not guarded.
- Refresh the stale `resolveFixtureNames` cross-reference in the tableless path.

## Tests

- STI same-table load (`deadParrots` + `liveParrots` → `parrots`): both accessors
  resolve real rows and both land in the shared table.
- PK-conflict rejection (`dogs` + `otherDogs`, both pin `id: 1`).
- `effectiveFixtureKey` unit tests: label-derived key, unified explicit-vs-derived
  keyspace, and keying on a custom `nick` PK column (not hardcoded `id`).

`pnpm vitest run .../use-fixtures.test.ts .../define-fixtures.test.ts` — 85 pass.

## Review follow-up (#4583)

Addressed both correctness findings from the Claude review: the guard no longer
hardcodes `row.id` (now uses `model.primaryKey`), and explicit vs. CRC32-derived
ids now share one keyspace, so cross-kind collisions are caught. Same-set
collision messages name the label on both sides.

Closes-story: support-same-table-multi-set-fixture-load