### PR TITLE
ci(activerecord): re-measure DDL DROP-churn on AR lanes (RFC 0060 verification)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -762,8 +762,30 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
+      # DDL profiler (measurement) — this branch only. The head_ref expression
+      # resolves to "" on every other branch/PR/main, so the profiler is a
+      # dormant no-op there; on this branch it emits per-worker DDL-timing JSON
+      # (see packages/activerecord/src/test-helpers/ddl-profile.ts, PR #3904).
+      # The profiler never fails a test (best-effort dumps), so it can't gate.
+      # Re-measurement for RFC 0060 remeasure-drop-churn-verification.
       - run: pnpm vitest run packages/activerecord/
+        env:
+          DDL_PROFILE: ${{ github.head_ref == 'remeasure-drop-churn-verification-3d98' && '1' || '' }}
+          DDL_PROFILE_OUT_DIR: ${{ runner.temp }}/ddlprof
       - run: pnpm vitest run packages/activerecord-cli
+      - name: DDL profile aggregate (measurement)
+        if: always() && github.head_ref == 'remeasure-drop-churn-verification-3d98'
+        continue-on-error: true
+        run: |
+          node scripts/ddl-profile-aggregate.mjs "${{ runner.temp }}/ddlprof" \
+            | tee "${{ runner.temp }}/ddlprof/aggregate-sqlite.txt"
+      - name: Upload DDL profile (sqlite)
+        if: always() && github.head_ref == 'remeasure-drop-churn-verification-3d98'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddl-profile-sqlite
+          path: ${{ runner.temp }}/ddlprof
+          if-no-files-found: warn
 
   # Reporting-only AR coverage (story ar-sqlite-lane-coverage-reporting, RFC
   # 0028). Runs the sqlite AR suite (the cheapest backend) with v8 coverage and
@@ -985,17 +1007,37 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
+      # DDL profiler (measurement) — this branch only; no-op elsewhere. Postgres
+      # is a DDL-dominated lane (teardown DROP TABLE dominates), so its
+      # DROP-count/ms aggregate is a headline signal. Sharded 2 ways: each leg
+      # writes its own runner.temp dir; artifacts are named per shard and merged
+      # at analysis time. See the sqlite lane.
       - run: pnpm vitest run packages/activerecord/ --shard=${{ matrix.shard }}/2
         env:
           ARCONN: postgresql
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
           AR_DB_FORKS: 8
+          DDL_PROFILE: ${{ github.head_ref == 'remeasure-drop-churn-verification-3d98' && '1' || '' }}
+          DDL_PROFILE_OUT_DIR: ${{ runner.temp }}/ddlprof
       # CLI E2E is not sharded — run it once, on shard 1 only, to avoid a
       # redundant double-run across the two legs.
       - if: ${{ matrix.shard == 1 }}
         run: pnpm vitest run packages/activerecord-cli
         env:
           PG_TEST_URL: postgres://postgres:postgres@localhost:5432/rails_js_test
+      - name: DDL profile aggregate (measurement)
+        if: always() && github.head_ref == 'remeasure-drop-churn-verification-3d98'
+        continue-on-error: true
+        run: |
+          node scripts/ddl-profile-aggregate.mjs "${{ runner.temp }}/ddlprof" \
+            | tee "${{ runner.temp }}/ddlprof/aggregate-postgres-${{ matrix.shard }}.txt"
+      - name: Upload DDL profile (postgres)
+        if: always() && github.head_ref == 'remeasure-drop-churn-verification-3d98'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddl-profile-postgres-${{ matrix.shard }}
+          path: ${{ runner.temp }}/ddlprof
+          if-no-files-found: warn
 
   mysql-tests:
     name: Active Record MySQL Tests
@@ -1110,16 +1152,35 @@ jobs:
       # redundant double-run and keeps the CLI's subprocess tests out of this
       # large suite's worker scheduler (they otherwise starve its reporter RPC
       # / perturb fork scheduling — see trails-models-dump tests).
+      # DDL profiler (measurement) — this branch only; no-op elsewhere. MariaDB
+      # is the other DDL-dominated lane, so its DROP-count/ms aggregate is a
+      # headline signal. Sharded 2 ways; artifacts named per shard, merged at
+      # analysis time. See the sqlite lane.
       - run: pnpm vitest run packages/activerecord/ --shard=${{ matrix.shard }}/2
         env:
           ARCONN: mysql2
           MYSQL_TEST_URL: mysql://root@localhost:3306/rails_js_test
           AR_DB_FORKS: 8
+          DDL_PROFILE: ${{ github.head_ref == 'remeasure-drop-churn-verification-3d98' && '1' || '' }}
+          DDL_PROFILE_OUT_DIR: ${{ runner.temp }}/ddlprof
       # No MYSQL_TEST_URL: no mysql-happy-path E2E exists yet. This run
       # covers the SQLite E2E until a mysql suite lands and can be wired up.
       # CLI E2E is not sharded — run it once, on shard 1 only.
       - if: ${{ matrix.shard == 1 }}
         run: pnpm vitest run packages/activerecord-cli
+      - name: DDL profile aggregate (measurement)
+        if: always() && github.head_ref == 'remeasure-drop-churn-verification-3d98'
+        continue-on-error: true
+        run: |
+          node scripts/ddl-profile-aggregate.mjs "${{ runner.temp }}/ddlprof" \
+            | tee "${{ runner.temp }}/ddlprof/aggregate-maria-${{ matrix.shard }}.txt"
+      - name: Upload DDL profile (maria)
+        if: always() && github.head_ref == 'remeasure-drop-churn-verification-3d98'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ddl-profile-maria-${{ matrix.shard }}
+          path: ${{ runner.temp }}/ddlprof
+          if-no-files-found: warn
 
   website:
     name: Website

--- a/docs/infrastructure/ar-test-reset-raw-sql-burndown-churn-payoff-verification.md
+++ b/docs/infrastructure/ar-test-reset-raw-sql-burndown-churn-payoff-verification.md
@@ -128,3 +128,95 @@ shrunk from the burndown, and the controlled A/B shows it nudged **up**.
   - `batch-drop-all-tables-single-statement` — collapse the wide per-table
     `dropAllTables` fan-out into one statement.
   - per-file reset shape-stability (`repairWorkerSchema` as the drift backstop).
+
+---
+
+# RFC 0060 verification: did the DROP-churn reduction land?
+
+Measurement for story `remeasure-drop-churn-verification`
+(RFC 0060-reduce-test-drop-churn). Re-runs the PR #4499 `DDL_PROFILE=1`
+full-suite protocol on the post-reduction tree and records the deltas as the
+RFC's acceptance gate. Measurement only — no production code change (the CI
+wiring is a `head_ref`-gated no-op on every other branch).
+
+## TL;DR
+
+**All three RFC 0060 targets are met with wide margin.** After the five
+reduction stories landed (`truncate-based-global-reset` #4504,
+`remove-redundant-dropexisting-shields` #4475,
+`audit-afterall-dropalltables-callers` #4544,
+`gate-repairworkerschema-drops-behind-drift` #3351,
+`pg-scope-referential-integrity-to-loaded-tables` #4543), full-suite
+`DROP_TABLE` ops fell **~97%** on every adapter, schema-DDL ms fell **~94%**,
+and the PG `disableReferentialIntegrity` fixture wrapper — the single largest PG
+DDL cost in the #4499 baseline — fell **~96%** in ms and collapsed from ~28.1M
+ops to ~86k.
+
+## Methodology
+
+Identical to PR #4499: turn on the dormant `DDL_PROFILE=1` profiler
+(`packages/activerecord/src/test-helpers/ddl-profile.ts`, PR #3904) on the three
+enabled AR CI lanes (sqlite / postgres / maria) for a one-off measurement run,
+gated on the measurement branch's `head_ref` so it is a no-op everywhere else,
+and upload the per-worker JSON + `scripts/ddl-profile-aggregate.mjs` summary as a
+per-lane artifact. The postgres and maria lanes are now 2-way file-sharded
+(drift since #4499), so each shard writes its own `runner.temp/ddlprof` and
+uploads a per-shard artifact (`ddl-profile-{postgres,maria}-{1,2}`); the two
+shards are merged at analysis time (`ddl-profile-aggregate.mjs <shard1> <shard2>`)
+to recover the per-lane totals. `mysql-tests` (mysql:8) stays disabled in CI;
+MariaDB stands in for the MySQL-family lane, as in #4499.
+
+Measured on PR #4585, run
+[28725969426](https://github.com/blazetrailsdev/trails/actions/runs/28725969426).
+The PG shard-2 leg tripped the pre-existing `schema-dumper.trails.test.ts`
+`schema_migrations_pkey` dup-key flake (unrelated to this diff; the profiler is
+best-effort and never fails a test), but its aggregate artifact still uploaded
+(`if: always()`), so the per-lane totals are complete.
+
+`schema-DDL ms` excludes the PG-only `REFERENTIAL_INTEGRITY` wrapper (a
+fixture-load mechanism, not schema DDL) and the new `TRUNCATE` global-reset ops
+(a data op, not schema DDL) — matching the #4499 footnote definition.
+
+## Results vs the PR #4499 baseline
+
+| Adapter          | Metric                     | #4499 baseline | #4585 (post-reduction) | delta      | target     | pass |
+| ---------------- | -------------------------- | -------------: | ---------------------: | ---------- | ---------- | :--: |
+| sqlite3          | `DROP_TABLE` ops           |         90,094 |                  2,018 | **−97.8%** | ≥ 90% down |  ✅  |
+| sqlite3          | schema-DDL ms              |         21,077 |                1,300.8 | **−93.8%** | ≥ 85% down |  ✅  |
+| postgresql       | `DROP_TABLE` ops           |         96,799 |                  2,537 | **−97.4%** | ≥ 90% down |  ✅  |
+| postgresql       | schema-DDL ms              |        122,824 |                6,862.2 | **−94.4%** | ≥ 85% down |  ✅  |
+| postgresql       | `REFERENTIAL_INTEGRITY` ms |        273,656 |               10,186.1 | **−96.3%** | ≥ 60% down |  ✅  |
+| mysql2 (MariaDB) | `DROP_TABLE` ops           |         95,190 |                  2,604 | **−97.3%** | ≥ 90% down |  ✅  |
+| mysql2 (MariaDB) | schema-DDL ms              |         72,463 |                3,753.7 | **−94.8%** | ≥ 85% down |  ✅  |
+
+Supporting per-op totals from this run:
+
+| Adapter          | Total DDL ops | Total DDL ms | `DROP_TABLE` ms | `CREATE_TABLE` ops | `REFERENTIAL_INTEGRITY` ops |
+| ---------------- | ------------: | -----------: | --------------: | -----------------: | --------------------------: |
+| sqlite3          |         6,422 |      1,300.8 |           379.4 |              4,076 |                         n/a |
+| postgresql       |        93,599 |     17,160.4 |         3,831.2 |              4,362 |                      86,194 |
+| mysql2 (MariaDB) |         7,413 |      3,854.3 |         1,939.3 |              4,338 |                         n/a |
+
+## What changed the numbers
+
+- **`truncate-based-global-reset` (#4504)** flipped the per-file global reset
+  from DROP-and-recreate to TRUNCATE, which is what collapsed the ~90–97k
+  per-lane `DROP_TABLE` fan-out to ~2–2.6k. This is the dominant lever; the
+  residual drops are the genuine schema-shape teardowns (bespoke tables,
+  `ar_internal_metadata`/`schema_migrations` churn, migration/dumper suites)
+  that still need a real DROP.
+- **`pg-scope-referential-integrity-to-loaded-tables` (#4543)** scoped the
+  `disableReferentialIntegrity` `ALTER TABLE … DISABLE/ENABLE TRIGGER ALL`
+  wrapper from every table on every fixture load to only the tables actually
+  loaded, cutting `REFERENTIAL_INTEGRITY` from ~28.1M ops / 273,656 ms to
+  ~86k ops / 10,186 ms.
+- `CREATE_TABLE` ops (~4.1–4.4k) are essentially unchanged from #4499 — RFC 0059
+  already lays the canonical schema once at boot, so CREATE was never the lever;
+  the reduction is entirely on the teardown DROP + PG referential-integrity side,
+  exactly as the #4499 analysis predicted.
+
+## Verdict
+
+All three acceptance targets pass (DROP_TABLE ops ≥ 90% down on each adapter;
+schema-DDL ms ≥ 85% down; PG `REFERENTIAL_INTEGRITY` ms ≥ 60% down). No residual
+DROP source misses a target, so no follow-up story is filed under RFC 0060.


### PR DESCRIPTION
## What

Re-runs the PR #4499 `DDL_PROFILE=1` measurement protocol on the post-reduction
tree to verify the RFC 0060 acceptance gate. Turns on the dormant DDL timing
profiler (`test-helpers/ddl-profile.ts`, PR #3904) in the three AR CI lanes
(sqlite / postgres / maria) for a **one-off measurement run**, gated on this
branch's `head_ref` so it is a no-op on every other branch/PR/main. The
postgres/maria lanes are now 2-way sharded (drift since #4499), so each shard
uploads a per-shard artifact and the two are merged at analysis time.

Measurement-only — no production code change. The doc update
(`docs/infrastructure/ar-test-reset-raw-sql-burndown-churn-payoff-verification.md`)
records the deltas; it is docs-only and exempt from the AR docs freeze.

## Results vs #4499 baseline — all targets pass

Run [28725969426](https://github.com/blazetrailsdev/trails/actions/runs/28725969426).

| Adapter | Metric | #4499 | this run | delta | target | ✓ |
|---|---|--:|--:|--|--|:-:|
| sqlite3 | DROP_TABLE ops | 90,094 | 2,018 | −97.8% | ≥90% | ✅ |
| sqlite3 | schema-DDL ms | 21,077 | 1,300.8 | −93.8% | ≥85% | ✅ |
| postgresql | DROP_TABLE ops | 96,799 | 2,537 | −97.4% | ≥90% | ✅ |
| postgresql | schema-DDL ms | 122,824 | 6,862.2 | −94.4% | ≥85% | ✅ |
| postgresql | REFERENTIAL_INTEGRITY ms | 273,656 | 10,186.1 | −96.3% | ≥60% | ✅ |
| mysql2 (MariaDB) | DROP_TABLE ops | 95,190 | 2,604 | −97.3% | ≥90% | ✅ |
| mysql2 (MariaDB) | schema-DDL ms | 72,463 | 3,753.7 | −94.8% | ≥85% | ✅ |

No target missed → no residual-DROP follow-up story filed under RFC 0060.

The PG shard-2 leg tripped the pre-existing `schema-dumper.trails.test.ts`
`schema_migrations_pkey` dup-key flake (unrelated to this diff — the profiler is
best-effort and never fails a test); its aggregate artifact still uploaded, so
the per-lane totals are complete. Re-running that leg for a green board.

Closes-story: remeasure-drop-churn-verification