### PR TITLE
feat(fixtures): autoload fallback for canonical models (Zeitwerk analog)

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -300,14 +300,50 @@ export function registerModel(
 }
 
 /**
+ * Zeitwerk analog: a fallback name→class index populated by the canonical
+ * test-models barrel. When {@link resolveModel} or reflection's `computeClass`
+ * miss {@link modelRegistry}, they consult this index to autoload a canonical
+ * model by name — the trails equivalent of Rails autoloading a constant on
+ * first reference from an already-indexed `test/models/` tree. It stays
+ * undefined in production (no index installed), so a genuine miss still throws.
+ * @internal
+ */
+let canonicalModelAutoloadIndex: ReadonlyMap<string, typeof Base> | undefined;
+
+/**
+ * Install the eager canonical-model autoload index. Called once, as a side
+ * effect, by the canonical test-models index module.
+ * @internal
+ */
+export function _setCanonicalModelAutoloadIndex(index: ReadonlyMap<string, typeof Base>): void {
+  canonicalModelAutoloadIndex = index;
+}
+
+/**
+ * Look up a model by name, falling back to the canonical autoload index on a
+ * {@link modelRegistry} miss. A hit in the index is registered so subsequent
+ * lookups resolve directly from the registry. Returns undefined on a genuine
+ * miss (name in neither the registry nor the index).
+ * @internal
+ */
+export function lookupModelWithAutoload(name: string): typeof Base | undefined {
+  const model = modelRegistry.get(name);
+  if (model) return model;
+  const autoloaded = canonicalModelAutoloadIndex?.get(name);
+  if (autoloaded) {
+    registerModel(autoloaded);
+    return autoloaded;
+  }
+  return undefined;
+}
+
+/**
  * Resolve a model class by name.
  */
 export function resolveModel(name: string): typeof Base {
-  const model = modelRegistry.get(name);
+  const model = lookupModelWithAutoload(name);
   if (!model) {
-    throw new NameError(
-      `Model "${name}" not found in registry. Did you call registerModel(${name})?`,
-    );
+    throw new NameError(`uninitialized constant ${name}`);
   }
   return model;
 }

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -9,6 +9,12 @@ import { describe, it, expect } from "vitest";
 import { throwAbort } from "@blazetrails/activesupport";
 import { Base, association, registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
+// Opt this file into the canonical-model autoload index (Zeitwerk analog):
+// `Comment`, `Tagging`, `Tag`, and `Owner` — association targets with no
+// fixture set of their own — resolve by name on first reference instead of
+// needing a manual `registerModel`. Installed per-file rather than globally so
+// only converted (fully-canonical) files pick up the fallback.
+import "../test-helpers/canonical-model-index.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Tagging } from "../test-helpers/models/tagging.js";

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -11,24 +11,19 @@ import { Base, association, registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
-import { Comment } from "../test-helpers/models/comment.js";
 import { Tagging } from "../test-helpers/models/tagging.js";
 import { Tag } from "../test-helpers/models/tag.js";
 import { CpkAuthor, CpkBook } from "../test-helpers/models/cpk.js";
 import { Pet } from "../test-helpers/models/pet.js";
 import { Toy } from "../test-helpers/models/toy.js";
-import { Owner } from "../test-helpers/models/owner.js";
 
 // `authors`, `posts`, `cpkAuthors`, `cpkBooks`, `pets`, and `toys` are declared
 // fixture sets below, so their models (`Author`, `Post`, `CpkAuthor`, `CpkBook`,
 // `Pet`, `Toy`) register automatically when the set resolves — no `registerModel`
 // needed, mirroring Rails' `fixtures :authors`. `Comment`, `Tagging`, `Tag`, and
-// `Owner` are association targets with no fixture set of their own, so they still
-// register explicitly until the autoload fallback (part b) lands.
-registerModel(Comment);
-registerModel(Tagging);
-registerModel(Tag);
-registerModel(Owner);
+// `Owner` are association targets with no fixture set of their own; the canonical
+// autoload fallback resolves them by name on first association reference, the
+// trails equivalent of Rails autoloading the constant from `test/models/`.
 
 describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   fixtures(["authors", "posts"]);

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1253,7 +1253,7 @@ export class AssociationReflection extends MacroReflection {
         const segments = nestingSource.split("::");
         for (let i = segments.length; i > 0; i--) {
           const candidate = [...segments.slice(0, i), simpleName].join("::");
-          const resolved = modelRegistry.get(candidate);
+          const resolved = lookupModelWithAutoload(candidate);
           if (resolved) {
             if (!(resolved as any)._isActiveRecordBase) {
               throw new ArgumentError(

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -15,7 +15,7 @@ import { _correctNames } from "./associations.js";
 import { joinTableName } from "./migration/join-table.js";
 import { rubyInspectArray } from "./relation/ruby-inspect.js";
 
-import { modelRegistry } from "./associations.js";
+import { modelRegistry, lookupModelWithAutoload } from "./associations.js";
 import {
   hasQueryConstraints,
   queryConstraintsList,
@@ -664,7 +664,7 @@ export class MacroReflection extends AbstractReflection {
 
   computeClass(name: string): typeof Base {
     const lookupName = name.startsWith("::") ? name.slice(2) : name;
-    const resolved = modelRegistry.get(lookupName);
+    const resolved = lookupModelWithAutoload(lookupName);
     if (!resolved) {
       // Rails resolves both association and aggregation reflection classes
       // through compute_type, which raises NameError for a missing constant
@@ -1266,7 +1266,7 @@ export class AssociationReflection extends MacroReflection {
       }
     }
 
-    const resolved = modelRegistry.get(simpleName);
+    const resolved = lookupModelWithAutoload(simpleName);
     if (!resolved) {
       // Rails' compute_class raises NameError for a missing constant (the only
       // error check_validity! callers rescue); the subclass guard below raises

--- a/packages/activerecord/src/test-helpers/canonical-model-index-encryption-setup.ts
+++ b/packages/activerecord/src/test-helpers/canonical-model-index-encryption-setup.ts
@@ -1,0 +1,10 @@
+// Side-effect module: register the encryption namespace and install the
+// standard test key config. Imported for its side effect *before* the canonical
+// models barrel so encrypted models (which derive key material at module-eval
+// time) are loadable. Kept separate because ESM hoists all `import`s ahead of
+// top-level statements — the config must run in a module evaluated before the
+// barrel, not as a statement wedged between imports in the same file.
+import "../encryption.js";
+import { configureEncryption } from "../encryption/test-helpers.js";
+
+configureEncryption();

--- a/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { canonicalModelIndex } from "./canonical-model-index.js";
+import { resolveModel } from "../associations.js";
+import { Comment } from "./models/comment.js";
+import { Owner } from "./models/owner.js";
+
+describe("canonical model autoload index (Zeitwerk analog)", () => {
+  it("indexes canonical models by their class name", () => {
+    // Association-target-only models (no fixture set of their own) are present
+    // so they resolve on first reference without a manual `registerModel`.
+    expect(canonicalModelIndex.get("Comment")).toBe(Comment);
+    expect(canonicalModelIndex.get("Owner")).toBe(Owner);
+  });
+
+  it("resolveModel autoloads an indexed model on a registry miss", () => {
+    // Whether or not another test already registered it, resolveModel returns
+    // the canonical class — the fallback covers the un-registered case.
+    expect(resolveModel("Comment")).toBe(Comment);
+    expect(resolveModel("Owner")).toBe(Owner);
+  });
+
+  it("throws a constant-not-found error for a genuine miss", () => {
+    // A name in neither the registry nor the index must still throw, so the
+    // fallback can never silently mask a missing or misnamed model.
+    expect(() => resolveModel("NoSuchCanonicalModel")).toThrow(
+      /uninitialized constant NoSuchCanonicalModel/,
+    );
+  });
+});

--- a/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
@@ -4,6 +4,7 @@ import { resolveModel } from "../associations.js";
 import { Comment } from "./models/comment.js";
 import { Owner } from "./models/owner.js";
 import { Pet } from "./models/pet.js";
+import { MyAppBusinessCompany } from "./models/company-in-module.js";
 
 describe("canonical model autoload index (Zeitwerk analog)", () => {
   it("indexes canonical models by their class name", () => {
@@ -11,6 +12,14 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
     // so they resolve on first reference without a manual `registerModel`.
     expect(canonicalModelIndex.get("Comment")).toBe(Comment);
     expect(canonicalModelIndex.get("Owner")).toBe(Owner);
+  });
+
+  it("indexes namespaced models under their `::`-qualified Ruby name", () => {
+    // Rails resolves a namespaced association target through the namespace walk
+    // (`MyApplication::Business::Company`), not the flat JS constructor name, so
+    // the index must carry the qualified key for the walk to hit it.
+    expect(canonicalModelIndex.get("MyApplication::Business::Company")).toBe(MyAppBusinessCompany);
+    expect(resolveModel("MyApplication::Business::Company")).toBe(MyAppBusinessCompany);
   });
 
   it("resolveModel autoloads an indexed model on a registry miss", () => {

--- a/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
@@ -3,6 +3,7 @@ import { canonicalModelIndex } from "./canonical-model-index.js";
 import { resolveModel } from "../associations.js";
 import { Comment } from "./models/comment.js";
 import { Owner } from "./models/owner.js";
+import { Pet } from "./models/pet.js";
 
 describe("canonical model autoload index (Zeitwerk analog)", () => {
   it("indexes canonical models by their class name", () => {
@@ -17,6 +18,17 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
     // the canonical class — the fallback covers the un-registered case.
     expect(resolveModel("Comment")).toBe(Comment);
     expect(resolveModel("Owner")).toBe(Owner);
+  });
+
+  it("autoloads an association-target model through reflection's computeClass", () => {
+    // `Pet belongsTo owner` names `Owner` only as a target — no fixture set, no
+    // manual `registerModel`. Resolving the reflection's `.klass` must autoload
+    // it via the fallback (reflection.ts computeClass), the empirical anchor for
+    // this part (HasManyReflection/BelongsToReflection._klass).
+    const refl = (
+      Pet as unknown as { _reflectOnAssociation(name: string): { klass: unknown } }
+    )._reflectOnAssociation("owner");
+    expect(refl.klass).toBe(Owner);
   });
 
   it("throws a constant-not-found error for a genuine miss", () => {

--- a/packages/activerecord/src/test-helpers/canonical-model-index.ts
+++ b/packages/activerecord/src/test-helpers/canonical-model-index.ts
@@ -1,5 +1,6 @@
 import { Base } from "../base.js";
 import { _setCanonicalModelAutoloadIndex } from "../associations.js";
+import { qualifiedName } from "../inheritance.js";
 // The canonical models barrel eagerly evaluates encrypted models
 // (`EncryptedTrafficLight.encrypts(...)`, `EncryptedPost`'s eager key provider,
 // etc.) at module load, which requires the encryption namespace to be
@@ -30,9 +31,15 @@ function buildCanonicalModelIndex(): ReadonlyMap<string, typeof Base> {
   for (const exported of Object.values(canonicalModels)) {
     if (typeof exported === "function" && exported !== Base && exported.prototype instanceof Base) {
       const cls = exported as typeof Base;
-      // First export wins on a name clash; the barrel never re-exports two
-      // distinct classes under one name, so this only guards STI re-exports.
-      if (cls.name && !index.has(cls.name)) index.set(cls.name, cls);
+      // Index by both the flat JS constructor name AND the `::`-qualified Ruby
+      // name (`Publisher::Magazine`), so a namespaced association target resolves
+      // whether the reflection's namespace-walk asks for the qualified candidate
+      // or a caller asks for the bare name. First export wins on a name clash;
+      // the barrel never re-exports two distinct classes under one name, so this
+      // only guards STI re-exports.
+      for (const key of new Set([cls.name, qualifiedName(cls)])) {
+        if (key && !index.has(key)) index.set(key, cls);
+      }
     }
   }
   return index;

--- a/packages/activerecord/src/test-helpers/canonical-model-index.ts
+++ b/packages/activerecord/src/test-helpers/canonical-model-index.ts
@@ -1,0 +1,43 @@
+import { Base } from "../base.js";
+import { _setCanonicalModelAutoloadIndex } from "../associations.js";
+// The canonical models barrel eagerly evaluates encrypted models
+// (`EncryptedTrafficLight.encrypts(...)`, `EncryptedPost`'s eager key provider,
+// etc.) at module load, which requires the encryption namespace to be
+// registered AND a key config present. This side-effect import registers +
+// configures the standard test keys, and MUST precede the barrel import — it
+// lives in its own module because ESM hoists sibling `import`s ahead of any
+// top-level statement, so an inline config call would run too late.
+import "./canonical-model-index-encryption-setup.js";
+import * as canonicalModels from "./models/index.js";
+
+/**
+ * Zeitwerk analog for the canonical test models.
+ *
+ * Rails autoloads a model constant on first reference from the already-indexed
+ * `test/models/` tree; a test that names a model only as an association
+ * _target_ (a `hasMany` target with no fixture set of its own) never needs a
+ * manual `registerModel`. ESM has no synchronous `autoload`, so we build an
+ * eager name→class index from the canonical models barrel and hand it to the
+ * `associations` autoload fallback. Importing this module for its side effect
+ * is the trails equivalent of "Zeitwerk has indexed `test/models/`."
+ *
+ * A genuine miss (a name in neither the model registry nor this index) still
+ * throws a constant-not-found error, so the fallback can never silently mask a
+ * missing or misnamed model.
+ */
+function buildCanonicalModelIndex(): ReadonlyMap<string, typeof Base> {
+  const index = new Map<string, typeof Base>();
+  for (const exported of Object.values(canonicalModels)) {
+    if (typeof exported === "function" && exported !== Base && exported.prototype instanceof Base) {
+      const cls = exported as typeof Base;
+      // First export wins on a name clash; the barrel never re-exports two
+      // distinct classes under one name, so this only guards STI re-exports.
+      if (cls.name && !index.has(cls.name)) index.set(cls.name, cls);
+    }
+  }
+  return index;
+}
+
+export const canonicalModelIndex = buildCanonicalModelIndex();
+
+_setCanonicalModelAutoloadIndex(canonicalModelIndex);

--- a/packages/activerecord/src/test-helpers/fixtures.ts
+++ b/packages/activerecord/src/test-helpers/fixtures.ts
@@ -1,3 +1,7 @@
+// Eagerly build & install the canonical-model autoload index (Zeitwerk
+// analog): any test declaring fixtures can then reference an association-target
+// model by name without a manual `registerModel`.
+import "./canonical-model-index.js";
 import { setupHandlerSuite } from "./setup-handler-suite.js";
 import { TEST_SCHEMA } from "./test-schema.js";
 import { type WithTransactionalFixturesOptions } from "./with-transactional-fixtures.js";

--- a/packages/activerecord/src/test-helpers/fixtures.ts
+++ b/packages/activerecord/src/test-helpers/fixtures.ts
@@ -1,7 +1,3 @@
-// Eagerly build & install the canonical-model autoload index (Zeitwerk
-// analog): any test declaring fixtures can then reference an association-target
-// model by name without a manual `registerModel`.
-import "./canonical-model-index.js";
 import { setupHandlerSuite } from "./setup-handler-suite.js";
 import { TEST_SCHEMA } from "./test-schema.js";
 import { type WithTransactionalFixturesOptions } from "./with-transactional-fixtures.js";


### PR DESCRIPTION
Part 2 of 4 converging the AR fixtures helper to Rails' `fixtures :authors`
surface (RFC 0048 capstone) — the Zeitwerk analog over the canonical models
index.

## What

Build an eager `name→class` index from the `test-helpers/models` barrel and
consult it when `resolveModel` (associations.ts) and reflection's
`computeClass` (both the base and the namespace-walking subclass override) miss
`modelRegistry`. On a hit the class is registered and returned, so a test can
reference a model only as an association _target_ (a `hasMany`/`belongsTo`
target with no fixture set of its own) without a manual `registerModel` —
exactly as Rails autoloads the constant on first reference.

The index is keyed by both the flat JS constructor name and the `::`-qualified
Ruby name (`MyApplication::Business::Company`), so the reflection namespace walk
(`inheritance.rb:253-264` / `reflection.rb:495-508`) resolves namespaced
targets too. Building it eagerly requires the encrypted canonical models to be
loadable, so a dedicated side-effect module registers + configures encryption
with the standard test keys before the barrel import (ESM hoists sibling
imports ahead of inline statements, so it can't be a wedged config call).

A genuine miss (a name in neither the registry nor the index) still throws a
constant-not-found error, so the fallback can never silently mask a
missing/misnamed model. `resolveModel`'s old
`Model "…" not found in registry. Did you call registerModel(…)?` NameError
becomes a Rails-style `uninitialized constant …`.

## Opt-in per file (not global)

The index is installed by a test file importing `canonical-model-index.js`
directly, **not** globally via the `fixtures()` surface. A first pass wired it
into `fixtures.ts`; CI showed why that's wrong — installing it globally makes
`deriveFixtureSchema`/`sliceSchema` resolve association targets that previously
threw, ballooning the derived fixture schema from the requested sets to every
transitively-reachable table (`use-fixtures.test.ts` — 14 tables vs 3), and the
eager barrel adds ~150 modules to every fixtures test. Suppressing autoload
during slicing isn't viable either: the through-source reflection caches its
result on the shared reflection object, so a suppressed resolution poisons the
cache and breaks later runtime navigation. Per-file opt-in also matches the
collision-hazard guidance — only converted, fully-canonical files pick up the
fallback.

## Demonstration

`collection-proxy.test.ts` opts in and drops its last four
association-target-only registrations (`Comment`, `Tagging`, `Tag`, `Owner`)
plus two now-unused imports; they resolve via the fallback on first association
reference.

## Tests

- `canonical-model-index.test.ts`: index maps canonical classes by flat and
  qualified name; `resolveModel` and reflection `computeClass` both autoload on
  a registry miss; a genuine miss throws `/uninitialized constant …/`.
- Green locally: collection-proxy, reflection, use-fixtures, counter-cache,
  habtm, has-many-through, nested-through, modules, extension, encryptable-record.
- test:compare unaffected; no test names changed.

Closes-story: fixtures-autoload-canonical-model-index
