### PR TITLE
test(fixtures): drop redundant setupFixtures() beside fixtures() calls

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -4,12 +4,17 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { describeIfMysql, isMariaDb, Mysql2Adapter } from "./test-helper.js";
 import { Version } from "../../connection-adapters/abstract-adapter.js";
-import { fixtures } from "../../test-helpers/fixtures.js";
+import { fixtures, setupFixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 import { Author } from "../../test-helpers/models/author.js";
 import { Post } from "../../test-helpers/models/post.js";
 import { registerModel } from "../../index.js";
+
+// The outer `describeIfMysql` beforeAll reads `Base.connection` before the
+// nested MySQLExplainTest `fixtures()` establishes it, so the handler wiring has
+// to be laid at file scope here — it is NOT redundant with the nested call.
+setupFixtures();
 
 describeIfMysql("Mysql2Adapter", () => {
   registerModel(Author);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -4,14 +4,12 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { describeIfMysql, isMariaDb, Mysql2Adapter } from "./test-helper.js";
 import { Version } from "../../connection-adapters/abstract-adapter.js";
-import { fixtures, setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 import { Author } from "../../test-helpers/models/author.js";
 import { Post } from "../../test-helpers/models/post.js";
 import { registerModel } from "../../index.js";
-
-setupFixtures();
 
 describeIfMysql("Mysql2Adapter", () => {
   registerModel(Author);

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -19,13 +19,12 @@ import { registerModel } from "../index.js";
 import { loadHasMany, loadBelongsTo } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
 import { StatementCache } from "../statement-cache.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
 
 describe("Association scope cache", () => {
-  setupFixtures();
   const { authors, posts } = fixtures(["authors", "posts", "comments"]);
 
   beforeAll(async () => {

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -15,7 +15,7 @@ import {
   modelRegistry,
 } from "../index.js";
 import { assertNoQueries } from "../testing/query-assertions.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Author, AuthorAddress } from "../test-helpers/models/author.js";
@@ -198,7 +198,6 @@ async function withHasManyInversing(fn: () => Promise<void>): Promise<void> {
 }
 
 describe("BelongsToWithForeignKeyTest", () => {
-  setupFixtures();
   const { authors, authorAddresses } = fixtures(["authors", "authorAddresses"], {
     schema: canonicalSchema,
   });
@@ -215,7 +214,6 @@ describe("BelongsToWithForeignKeyTest", () => {
 });
 
 describe("BelongsToAssociationsTest", () => {
-  setupFixtures();
   const {
     accounts,
     companies,
@@ -2024,7 +2022,6 @@ describe("BelongsToAssociationsTest", () => {
 });
 
 describe("AsyncBelongsToAssociationsTest", () => {
-  setupFixtures();
   useHandlerTransactionalFixtures();
   const { companies } = fixtures(["companies"], { schema: canonicalSchema });
 

--- a/packages/activerecord/src/associations/getmodelcolumns-virtual-projection.test.ts
+++ b/packages/activerecord/src/associations/getmodelcolumns-virtual-projection.test.ts
@@ -12,12 +12,11 @@
  */
 import { describe, it, expect } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Firm, Company, Client } from "../test-helpers/models/company.js";
 import { registerModel } from "../index.js";
 
 describe("getModelColumns virtual-attribute eager projection", () => {
-  setupFixtures();
   const { companies } = fixtures(["companies"]);
   registerModel(Company);
   registerModel(Firm);

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -1081,7 +1081,6 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  setupFixtures();
   useHandlerTransactionalFixtures();
   const { companies } = fixtures(["companies"]);
   beforeAll(async () => {

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -4,7 +4,7 @@
 import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
 import { Base, registerModel, RecordInvalid } from "../index.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { association } from "../associations.js";
 import { quoteTableName } from "../test-helpers/quote-regex.js";
 import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
@@ -79,7 +79,6 @@ import {
 import { PersonalLegacyThing } from "../test-helpers/models/personal-legacy-thing.js";
 
 describe("HasManyThroughAssociationsTest", () => {
-  setupFixtures();
   const {
     posts,
     readers,

--- a/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { association } from "../associations.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
@@ -35,7 +35,6 @@ function djasScope(owner: Base, assocName: string): any {
 }
 
 describe("HasManyThroughDisableJoinsAssociationsTest", () => {
-  setupFixtures();
   const { authors } = fixtures(["posts", "authors", "comments", "authorAddresses"], {
     schema: canonicalSchema,
   });

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -19,7 +19,7 @@ import {
   EagerLoadPolymorphicError,
 } from "./errors.js";
 import { assertNoQueries, assertQueriesCount } from "../testing/query-assertions.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
 import { Author, AuthorAddress, AuthorFavorite } from "../test-helpers/models/author.js";
 import {
@@ -111,7 +111,6 @@ class ScopedSourceTag extends Base {
 }
 
 describe("AssociationsJoinModelTest", () => {
-  setupFixtures();
   useHandlerTransactionalFixtures();
   const { authors, posts, categories, tags, taggings, comments, items, books, vertices } = fixtures(
     [

--- a/packages/activerecord/src/associations/preloader-bigint-number-key-match.test.ts
+++ b/packages/activerecord/src/associations/preloader-bigint-number-key-match.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Preloader } from "./preloader.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
@@ -24,7 +24,6 @@ type RecordInternals = {
 const internals = (record: Base): RecordInternals => record as unknown as RecordInternals;
 
 describe("Preloader BigInt PK / number FK key match", () => {
-  setupFixtures();
   const { authors } = fixtures(["authors", "posts"], { schema: TEST_SCHEMA });
 
   beforeAll(() => {

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -16,7 +16,7 @@ import { Base } from "../index.js";
 import { registerModel } from "../associations.js";
 import { registerSubclass } from "../inheritance.js";
 import { adapterType } from "../test-adapter.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Topic } from "../test-helpers/models/topic.js";
 import { Reply, UniqueReply, SillyUniqueReply } from "../test-helpers/models/reply.js";
 import { WarehouseThing } from "../test-helpers/models/warehouse-thing.js";
@@ -117,7 +117,6 @@ for (const klass of [IneptWizard, Conjurer, Thaumaturgist]) {
 }
 
 describe("UniquenessValidationTest", () => {
-  setupFixtures();
   // Rails `fixtures :topics, "warehouse-things"`.
   fixtures(["topics", "warehouseThings"]);
 
@@ -701,7 +700,6 @@ describe("UniquenessValidationTest", () => {
 });
 
 describe("UniquenessValidationWithIndexTest", () => {
-  setupFixtures();
   fixtures(["topics"]);
 
   afterEach(() => {
@@ -833,7 +831,6 @@ describe("UniquenessValidationWithIndexTest", () => {
 });
 
 describe("UniquenessWithCompositeKey", () => {
-  setupFixtures();
   fixtures(["cpkAuthors"]);
 
   beforeAll(() => {

--- a/packages/activerecord/src/validations/validations.test.ts
+++ b/packages/activerecord/src/validations/validations.test.ts
@@ -13,7 +13,7 @@ import { afterEach, describe, expect, it, beforeAll } from "vitest";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { DecimalType } from "@blazetrails/activemodel";
 import { Base, RecordInvalid, registerModel } from "../index.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { assertNoQueries } from "../testing/query-assertions.js";
 import { Topic } from "../test-helpers/models/topic.js";
 import { Reply, WrongReply } from "../test-helpers/models/reply.js";
@@ -21,8 +21,6 @@ import { Developer } from "../test-helpers/models/developer.js";
 import { Parrot } from "../test-helpers/models/parrot.js";
 import { Company } from "../test-helpers/models/company.js";
 import { PriceEstimate } from "../test-helpers/models/price-estimate.js";
-
-setupFixtures();
 
 // `isAttributeCameFromUser` is mixed into Base instances but not surfaced on the
 // model's declared instance type, so narrow it through a typed shim.


### PR DESCRIPTION
## Summary

RFC 0062 (transactional-fixtures burndown) — the zero-risk quick win. `fixtures()`
(`test-helpers/fixtures.ts`) already calls `setupHandlerSuite()` internally via
`useHandlerFixtures`, so a standalone `setupFixtures()` (= `setupHandlerSuite()`)
sitting in the **same describe scope** as a `fixtures()` call is dead
double-wiring. This drops those redundant calls (and narrows the now-unused
`setupFixtures` import where nothing else uses it).

Scope-aware, not a blind delete. Only removed `setupFixtures()` calls that share
a scope with a `fixtures()` call registered as the first hook. Left in place
every `setupFixtures()` that is the sole handler wiring for a describe block with
no `fixtures()` (`callbacks.test.ts`, `eager-load-nested-include.test.ts`,
`eager.test.ts`, `inverse-associations.test.ts`, and the several
`has-many-associations.test.ts` blocks without fixtures).

Note on `mysql-explain.test.ts`: its file-scope `setupFixtures()` is **kept** —
`fixtures()` there lives in a nested `describe`, but the outer `describeIfMysql`
`beforeAll` reads `Base.connection` before that nested call runs, so the wiring
must stay at file scope. (This surfaced as a MariaDB CI failure and is now
documented inline.)

No behavior change: `fixtures()` still wires the handler suite. Touched test
names unchanged.

## Files

- `associations/association-scope-cache.test.ts`
- `associations/belongs-to-associations.test.ts` (3)
- `associations/getmodelcolumns-virtual-projection.test.ts`
- `associations/has-many-associations.test.ts` (1 of 7)
- `associations/has-many-through-associations.test.ts`
- `associations/has-many-through-disable-joins-associations.test.ts`
- `associations/join-model.test.ts`
- `associations/preloader-bigint-number-key-match.test.ts`
- `validations/uniqueness-validation.test.ts` (3)
- `validations/validations.test.ts`

Closes-story: converge-setupfixtures-redundant-next-to-fixtures
