### PR TITLE
refactor(fixtures): make useHandlerFixtures internal so fixtures() is the sole surface

### DIFF
--- a/packages/activerecord/src/test-helpers/fixtures.ts
+++ b/packages/activerecord/src/test-helpers/fixtures.ts
@@ -1,83 +1,10 @@
 import { setupHandlerSuite } from "./setup-handler-suite.js";
-import { TEST_SCHEMA } from "./test-schema.js";
-import { type WithTransactionalFixturesOptions } from "./with-transactional-fixtures.js";
-import {
-  useHandlerFixtures,
-  type FixtureMap,
-  type FixtureName,
-  type TablelessFixtureEntry,
-  type UseFixturesResult,
-  type UseFixturesByNameResult,
-  type UseTablelessFixturesResult,
-  type UseFixturesOpts,
-  type FixturesConnectionOpts,
-} from "./use-fixtures.js";
 
-type FixturesOptions = WithTransactionalFixturesOptions & UseFixturesOpts & FixturesConnectionOpts;
-
-/**
- * Rails-faithful public surface for declaring fixtures in a test file.
- *
- * Thin alias for {@link useHandlerFixtures} — same overloads (map / names /
- * tableless), same runtime path. Mirrors Rails' `fixtures :authors, :posts`
- * declaration, which carries no "handler" qualifier. New and newly-ported
- * tests should prefer this name; existing `useHandlerFixtures` call sites stay
- * as-is and migrate mechanically later.
- *
- * Calling `fixtures()` IS the opt-in to the canonical schema: it defaults
- * `schema` to `TEST_SCHEMA`, so converted tests never pass `schema` and the
- * minimal sub-schema for the requested sets is derived automatically. An
- * explicit `schema` still overrides for sets the canonical schema lacks.
- *
- * @example  // primary documented form
- *   const { authors, posts } = fixtures({
- *     authors: [Author, { david: { name: "David" } }],
- *     posts: [Post, { welcome: { title: "Welcome" } }],
- *   });
- *
- * @example  // by registry name
- *   const { authors, posts } = fixtures(["authors", "posts"]);
- *
- * @example  // non-transactional (Rails `use_transactional_tests = false`)
- *   const { books } = fixtures(["books", "authors"], { useTransactionalTests: false });
- *
- * @example  // seed through a caller-supplied connection/adapter
- *   const { colleges } = fixtures(["colleges"], {
- *     connection: () => College.connection,
- *     useTransactionalTests: false,
- *   });
- *
- * @internal
- */
-export function fixtures<M extends FixtureMap>(
-  fixtures: M,
-  options?: FixturesOptions,
-): UseFixturesResult<M>;
-export function fixtures<const N extends FixtureName>(
-  names: readonly N[],
-  options?: FixturesOptions,
-): UseFixturesByNameResult<N>;
-export function fixtures<const T extends readonly TablelessFixtureEntry[]>(
-  tablelessEntries: T,
-  options?: FixturesOptions,
-): UseTablelessFixturesResult<T>;
-export function fixtures(
-  fixturesOrNames: FixtureMap | readonly FixtureName[] | readonly TablelessFixtureEntry[],
-  options: FixturesOptions | undefined = undefined,
-): Record<string, unknown> {
-  // Opting into `fixtures()` IS the opt-in to the canonical schema: converted
-  // tests get `TEST_SCHEMA` slice-derivation by default and never pass `schema`
-  // themselves. An explicit `schema` still wins for the few sets the canonical
-  // schema doesn't yet cover.
-  const withSchema: FixturesOptions = {
-    schema: TEST_SCHEMA,
-    ...options,
-  };
-  return (useHandlerFixtures as (...args: unknown[]) => Record<string, unknown>)(
-    fixturesOrNames,
-    withSchema,
-  );
-}
+// `fixtures()` is the sole public fixture surface. Its implementation lives in
+// `use-fixtures.js` alongside the module-private `useFixtures` engine it
+// composes (the engine and its former `useHandlerFixtures` wrapper are no longer
+// exported); this module re-exports it as the Rails-faithful entry point.
+export { fixtures } from "./use-fixtures.js";
 
 /**
  * Rails-faithful alias for {@link setupHandlerSuite}.

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, expectTypeOf, vi, beforeAll, afterAll } from "vitest";
-import { useHandlerFixtures, resolveFixtureNames, deriveFixtureSchema } from "./use-fixtures.js";
+import { resolveFixtureNames, deriveFixtureSchema } from "./use-fixtures.js";
 import { fixtureRegistry, isJoinTableEntry } from "./fixtures-registry.js";
 import { registerModel } from "../associations.js";
 import { FixtureSet } from "./fixture-set.js";
@@ -99,9 +99,11 @@ describe("useFixtures", () => {
   const rows = new Map([[topicId, { id: topicId, title: "Rails" }]]);
   const Topic = makeModel("topics", rows);
 
-  const { topics } = useHandlerFixtures(
+  const { topics } = fixtures(
     { topics: [Topic, { rails: { title: "Rails" } }] },
-    { connection: () => adapter, useTransactionalTests: false },
+    // Mock adapter over a non-canonical / stubbed table: opt out of the
+    // `fixtures()` TEST_SCHEMA slice-derivation (there is nothing to create).
+    { connection: () => adapter, useTransactionalTests: false, schema: undefined },
   );
 
   it("accessor returns the instance by label after beforeEach runs", () => {
@@ -125,12 +127,14 @@ describe("useFixtures multi-set", () => {
   const Topic = makeModel("topics", topicRows);
   const Post = makeModel("posts", postRows);
 
-  const { topics, posts } = useHandlerFixtures(
+  const { topics, posts } = fixtures(
     {
       topics: [Topic, { rails: { title: "Rails" } }],
       posts: [Post, { hello: { title: "Hello" } }],
     },
-    { connection: () => adapter, useTransactionalTests: false },
+    // Mock adapter over a non-canonical / stubbed table: opt out of the
+    // `fixtures()` TEST_SCHEMA slice-derivation (there is nothing to create).
+    { connection: () => adapter, useTransactionalTests: false, schema: undefined },
   );
 
   it("both sets are accessible", () => {
@@ -149,9 +153,11 @@ describe("useFixtures slash-keyed fixture sets", () => {
 
   // Slash-keyed entries in the object-map overload. The result property is
   // accessible via bracket notation only; dot-access would be a syntax error.
-  const result = useHandlerFixtures(
+  const result = fixtures(
     { "admin/accounts": [AccountModel, { david: { name: "David" } }] },
-    { connection: () => adapter, useTransactionalTests: false },
+    // Mock adapter over a non-canonical / stubbed table: opt out of the
+    // `fixtures()` TEST_SCHEMA slice-derivation (there is nothing to create).
+    { connection: () => adapter, useTransactionalTests: false, schema: undefined },
   );
 
   it("result property is accessible via bracket notation", () => {
@@ -180,14 +186,16 @@ describe("all/ fixture sets — explicit enumeration", () => {
   const PersonModel = makeModel("people", new Map());
   const TaskModel = makeModel("tasks", new Map());
 
-  const result = useHandlerFixtures(
+  const result = fixtures(
     {
       "all/developers": [DevModel, {}],
       "all/people": [PersonModel, {}],
       "all/tasks": [TaskModel, {}],
       "all/namespaced/accounts": [AccountModel, { signals37: { name: "37signals" } }],
     },
-    { connection: () => adapter, useTransactionalTests: false },
+    // Mock adapter over a non-canonical / stubbed table: opt out of the
+    // `fixtures()` TEST_SCHEMA slice-derivation (there is nothing to create).
+    { connection: () => adapter, useTransactionalTests: false, schema: undefined },
   );
 
   it("all four fixture sets are accessible via bracket notation", () => {
@@ -223,12 +231,14 @@ describe("useFixtures type contract", () => {
     }
   }
 
-  const { topics, posts } = useHandlerFixtures(
+  const { topics, posts } = fixtures(
     {
       topics: [Topic, { first: { title: "First" }, second: { title: "Second" } }],
       posts: [Post, { welcome: { body: "Hi" } }],
     },
-    { connection: () => makeAdapter() as any, useTransactionalTests: false },
+    // Mock adapter over stubbed models: opt out of the `fixtures()` TEST_SCHEMA
+    // slice-derivation (there is nothing to create).
+    { connection: () => makeAdapter() as any, useTransactionalTests: false, schema: undefined },
   );
 
   it("accessor return type is narrowed to the model instance type", () => {
@@ -255,7 +265,7 @@ describe("useFixtures by registry name", () => {
 
   // author_addresses listed first: authors.author_address_id ref() resolves to its
   // declared ids, so the target set must load before its dependent.
-  const { authors, posts } = useHandlerFixtures(["authorAddresses", "authors", "posts"], {
+  const { authors, posts } = fixtures(["authorAddresses", "authors", "posts"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
   });
@@ -313,7 +323,7 @@ describe("useFixtures seeds HABTM join tables (no model class)", () => {
 
   // categories + posts declare explicit ids, so they load BEFORE the join set —
   // categoriesPosts' category_id/post_id ref()s then resolve to those declared ids.
-  const { categories, posts, categoriesPosts } = useHandlerFixtures(
+  const { categories, posts, categoriesPosts } = fixtures(
     ["categories", "posts", "categoriesPosts"],
     { connection: () => Base.adapter, useTransactionalTests: false },
   );
@@ -351,7 +361,7 @@ describe("useFixtures seeds a single-row HABTM join table", () => {
   setupFixtures();
   useHandlerTransactionalFixtures();
 
-  const { people, treasures, peoplesTreasures } = useHandlerFixtures(
+  const { people, treasures, peoplesTreasures } = fixtures(
     ["people", "treasures", "peoplesTreasures"],
     { connection: () => Base.adapter, useTransactionalTests: false },
   );
@@ -370,7 +380,7 @@ describe("useFixtures vertices and edges", () => {
   useHandlerTransactionalFixtures();
 
   // vertices must load before edges so edge ref()s resolve to declared vertex ids.
-  const { vertices, edges } = useHandlerFixtures(["vertices", "edges"], {
+  const { vertices, edges } = fixtures(["vertices", "edges"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
   });
@@ -397,7 +407,7 @@ describe("useFixtures { schema } auto-derivation", () => {
 
   // No manual schema-priming beforeAll: passing the full TEST_SCHEMA lets
   // useFixtures create just the tables these sets touch (authorAddresses → posts).
-  const { authors } = useHandlerFixtures(["authorAddresses", "authors", "posts"], {
+  const { authors } = fixtures(["authorAddresses", "authors", "posts"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
     schema: TEST_SCHEMA,
@@ -443,7 +453,7 @@ describe("useFixtures auto-stamps NOT NULL timestamps", () => {
   // people.michael declares neither created_at nor updated_at, but both columns
   // are NOT NULL — defineFixtures must fill them with the current time, mirroring
   // Rails' FixtureSet::TableRow#fill_timestamps. Without it the INSERT fails.
-  const { people } = useHandlerFixtures(["people"], {
+  const { people } = fixtures(["people"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
   });
@@ -470,7 +480,7 @@ describe("useFixtures with a string primary key", () => {
   // row declares `nick: "alterself"`; resolveDeclaredPk must use that string
   // verbatim instead of coercing/rejecting it. Without string-PK support the
   // seeder threw on the non-integer declared id.
-  const { subscribers } = useHandlerFixtures(["subscribers"], {
+  const { subscribers } = fixtures(["subscribers"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
   });
@@ -500,17 +510,17 @@ describe("useFixtures reconciles the PK column against the schema", () => {
   // seeder must seed `ID`, not a phantom `id`. Bulb also has a default_scope
   // (`where(name: "defaulty")`) that would hide the `special` row on reload —
   // the unscoped reload covers that.
-  const { bulbs } = useHandlerFixtures(["bulbs"], {
+  const { bulbs } = fixtures(["bulbs"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
   });
   // mixed_case_monkeys: `t.primary_key :monkeyID` under a non-`id` camelCased name.
-  const { mixedCaseMonkeys } = useHandlerFixtures(["mixedCaseMonkeys"], {
+  const { mixedCaseMonkeys } = fixtures(["mixedCaseMonkeys"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
   });
   // mateys is id-less (`id: false`, no PK) — no PK column may be seeded at all.
-  const { mateys } = useHandlerFixtures(["mateys"], {
+  const { mateys } = fixtures(["mateys"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
   });
@@ -553,7 +563,7 @@ describe("useFixtures seeds composite-primary-key tables", () => {
   // "tag_id"]`); both key columns are supplied by ref()s in the fixture row.
   // cpkOrders loads first so its declared key map backs the cpkOrderTags
   // order_id ref() (which resolves to the order's `id` column).
-  const { cpkOrders, cpkOrderTags, cpkBooks } = useHandlerFixtures(
+  const { cpkOrders, cpkOrderTags, cpkBooks } = fixtures(
     ["cpkOrders", "cpkOrderTags", "cpkBooks"],
     { connection: () => Base.adapter, useTransactionalTests: false },
   );
@@ -600,12 +610,12 @@ describe("useFixtures resolves STI subclasses on standalone load", () => {
   // pointing at LiveParrot/DeadParrot. Loading the base `parrots` set must
   // hydrate each row as its declared subclass — the subclasses live in the same
   // module as Parrot, so the registry's `model` thunk eagerly loads them.
-  const { parrots } = useHandlerFixtures(["parrots"], {
+  const { parrots } = fixtures(["parrots"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
   });
   // vegetables.yml uses `custom_type` → Cucumber/Cabbage/RedCabbage.
-  const { vegetables } = useHandlerFixtures(["vegetables"], {
+  const { vegetables } = fixtures(["vegetables"], {
     connection: () => Base.adapter,
     useTransactionalTests: false,
   });
@@ -851,7 +861,7 @@ describe("useFixtures bootstraps the encryption add-on for encrypted fixtures", 
   // hazard `resolveFixtureNames` rejects within a single call), so each is scoped
   // to its own nested describe — only one seeder runs per test.
   describe("encryptedBooks set", () => {
-    const { encryptedBooks } = useHandlerFixtures(["encryptedBooks"], {
+    const { encryptedBooks } = fixtures(["encryptedBooks"], {
       connection: () => Base.adapter,
       useTransactionalTests: false,
     });
@@ -874,10 +884,10 @@ describe("useFixtures bootstraps the encryption add-on for encrypted fixtures", 
   });
 
   describe("encryptedBookThatIgnoresCases set", () => {
-    const { encryptedBookThatIgnoresCases } = useHandlerFixtures(
-      ["encryptedBookThatIgnoresCases"],
-      { connection: () => Base.adapter, useTransactionalTests: false },
-    );
+    const { encryptedBookThatIgnoresCases } = fixtures(["encryptedBookThatIgnoresCases"], {
+      connection: () => Base.adapter,
+      useTransactionalTests: false,
+    });
 
     it("reads an ignore-case encrypted fixture back as plaintext", () => {
       // For ignoreCase attributes, the `name` column stores the lowercased ciphertext;

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -8,6 +8,7 @@ import {
   type PreparedFixtureSet,
 } from "./define-fixtures.js";
 import { type Schema } from "./define-schema.js";
+import { TEST_SCHEMA } from "./test-schema.js";
 import { ensureCanonicalTables } from "./canonical-schema.js";
 import {
   fixtureRegistry,
@@ -107,8 +108,8 @@ export interface UseFixturesOpts {
 
 export interface FixturesConnectionOpts {
   /**
-   * Caller-supplied connection/adapter thunk. When set, {@link fixtures} /
-   * {@link useHandlerFixtures} seed, clean, and (when transactional) pin fixtures
+   * Caller-supplied connection/adapter thunk. When set, {@link fixtures}
+   * seeds, cleans, and (when transactional) pins fixtures
    * through this connection instead of the default `() => Base.connection`.
    *
    * Mirrors Rails loading a fixture set through a model-specific `connection`
@@ -360,8 +361,8 @@ function useTablelessFixtures(
 /**
  * Vitest helper that inserts fixture rows in a `beforeEach` and cleans them up in `afterEach`.
  *
- * **Internal implementation — test files must call `fixtures()` (or its
- * wrapper {@link useHandlerFixtures}) instead.** This lower-level entry point
+ * **Internal implementation — test files must call {@link fixtures}
+ * instead.** This lower-level entry point
  * takes an explicit `getAdapter` thunk and runs a per-test delete/reseed. It
  * was once a documented escape hatch for suites that could not use the
  * handler-resolved path (non-transactional suites committing across
@@ -369,8 +370,8 @@ function useTablelessFixtures(
  * connections, adapter-owning suites). Every one of those call sites has since
  * converged: non-transactional and caller-supplied-connection needs are now
  * expressed through the `useTransactionalTests` / `connection` options on
- * `fixtures()` / {@link useHandlerFixtures}, which forward the resolved thunk
- * here. It is no longer exported: the only caller is {@link useHandlerFixtures}
+ * {@link fixtures}, which forwards the resolved thunk
+ * here. It is no longer exported: the only caller is {@link fixtures}
  * (below, same module), so no test file can reach the raw engine directly.
  *
  * Returns an object of typed accessor functions — one per fixture set. Each accessor is callable
@@ -596,57 +597,61 @@ function useFixtures(
   return result;
 }
 
+type FixturesOptions = WithTransactionalFixturesOptions & UseFixturesOpts & FixturesConnectionOpts;
+
 /**
- * One-call wiring for handler-path test files that use fixtures.
+ * Rails-faithful public surface for declaring fixtures in a test file — the sole
+ * fixture entry point.
  *
- * Combines {@link setupHandlerSuite} + {@link withTransactionalFixtures} +
- * the module-private `useFixtures` engine into a single call, eliminating the
- * three-line boilerplate that every fixture-backed describe block previously
- * required. The engine lives here (unexported) so no test file can reach it
- * directly — `fixtures()` / `useHandlerFixtures` are the only fixture surfaces.
+ * One-call wiring that combines {@link setupHandlerSuite} +
+ * {@link withTransactionalFixtures} + the module-private `useFixtures` engine,
+ * eliminating the three-line boilerplate every fixture-backed describe block
+ * previously required. The engine lives here (unexported) so no test file can
+ * reach it directly — `fixtures()` is the only fixture surface. Mirrors Rails'
+ * `fixtures :authors, :posts` declaration and the `ActiveRecord::TestCase`
+ * contract where including `TestFixtures`, declaring `fixtures :name`, and
+ * enabling `use_transactional_tests` are a single class-level opt-in.
  *
- * Mirrors the Rails `ActiveRecord::TestCase` contract where including
- * `TestFixtures`, declaring `fixtures :name`, and enabling
- * `use_transactional_tests` are a single opt-in at the class level.
+ * Calling `fixtures()` IS the opt-in to the canonical schema: it defaults
+ * `schema` to `TEST_SCHEMA`, so converted tests never pass `schema` and the
+ * minimal sub-schema for the requested sets is derived automatically. An
+ * explicit `schema` still overrides for sets the canonical schema lacks.
  *
- * @example
- *   const { topics } = useHandlerFixtures({
- *     topics: [Topic, { rails: { title: "Rails" } }],
+ * @example  // primary documented form
+ *   const { authors, posts } = fixtures({
+ *     authors: [Author, { david: { name: "David" } }],
+ *     posts: [Post, { welcome: { title: "Welcome" } }],
  *   });
  *
  * @example  // by registry name
- *   const { customers } = useHandlerFixtures(["customers"]);
+ *   const { authors, posts } = fixtures(["authors", "posts"]);
  *
- * @example  // with usesTransaction opt-out
- *   const { posts } = useHandlerFixtures(["posts"], {
- *     usesTransaction: ["fires after_commit callback"],
- *   });
+ * @example  // non-transactional (Rails `use_transactional_tests = false`)
+ *   const { books } = fixtures(["books", "authors"], { useTransactionalTests: false });
  *
- * @example  // seed through a model-specific / caller-owned connection
- *   const { colleges } = useHandlerFixtures(["colleges"], {
+ * @example  // seed through a caller-supplied connection/adapter
+ *   const { colleges } = fixtures(["colleges"], {
  *     connection: () => College.connection,
  *     useTransactionalTests: false,
  *   });
  *
  * @internal
  */
-export function useHandlerFixtures<M extends FixtureMap>(
+export function fixtures<M extends FixtureMap>(
   fixtures: M,
-  options?: WithTransactionalFixturesOptions & UseFixturesOpts & FixturesConnectionOpts,
+  options?: FixturesOptions,
 ): UseFixturesResult<M>;
-export function useHandlerFixtures<const N extends FixtureName>(
+export function fixtures<const N extends FixtureName>(
   names: readonly N[],
-  options?: WithTransactionalFixturesOptions & UseFixturesOpts & FixturesConnectionOpts,
+  options?: FixturesOptions,
 ): UseFixturesByNameResult<N>;
-export function useHandlerFixtures<const T extends readonly TablelessFixtureEntry[]>(
+export function fixtures<const T extends readonly TablelessFixtureEntry[]>(
   tablelessEntries: T,
-  options?: WithTransactionalFixturesOptions & UseFixturesOpts & FixturesConnectionOpts,
+  options?: FixturesOptions,
 ): UseTablelessFixturesResult<T>;
-export function useHandlerFixtures(
+export function fixtures(
   fixturesOrNames: FixtureMap | readonly FixtureName[] | readonly TablelessFixtureEntry[],
-  options:
-    | (WithTransactionalFixturesOptions & UseFixturesOpts & FixturesConnectionOpts)
-    | undefined = undefined,
+  options: FixturesOptions | undefined = undefined,
 ): Record<string, unknown> {
   const {
     usesTransaction,
@@ -655,6 +660,12 @@ export function useHandlerFixtures(
     connection,
     ...fixtureOpts
   } = options ?? {};
+
+  // Opting into `fixtures()` IS the opt-in to the canonical schema: converted
+  // tests get `TEST_SCHEMA` slice-derivation by default and never pass `schema`
+  // themselves. An explicit `schema` (including `undefined`) still wins for the
+  // few sets the canonical schema doesn't yet cover.
+  const fixtureOptsWithSchema = { schema: TEST_SCHEMA, ...fixtureOpts };
 
   // Caller-supplied connection/adapter thunk wins over the default handler
   // connection: multi-database suites seed through a model-specific
@@ -673,9 +684,5 @@ export function useHandlerFixtures(
     });
   }
 
-  return useFixtures(
-    fixturesOrNames as FixtureMap,
-    getConnection,
-    Object.keys(fixtureOpts).length > 0 ? fixtureOpts : undefined,
-  );
+  return useFixtures(fixturesOrNames as FixtureMap, getConnection, fixtureOptsWithSchema);
 }

--- a/packages/activerecord/src/test-helpers/use-transactional-tests.ts
+++ b/packages/activerecord/src/test-helpers/use-transactional-tests.ts
@@ -55,7 +55,7 @@ import {
  *
  * NOTE: distinct from the same-named *option field*
  * `WithTransactionalFixturesOptions.useTransactionalTests` (a boolean consumed
- * by `fixtures()` / `useHandlerFixtures` to select the non-transactional mode).
+ * by `fixtures()` to select the non-transactional mode).
  * This is a no-arg opt-in *function*; that is `{ useTransactionalTests: false }`.
  */
 export function useTransactionalTests(options?: WithTransactionalFixturesOptions): void {

--- a/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/with-transactional-fixtures.ts
@@ -197,7 +197,7 @@ export interface WithTransactionalFixturesOptions {
 
   /**
    * Mirrors Rails' `self.use_transactional_tests`. Defaults to `true`. When set
-   * to `false`, {@link useHandlerFixtures} / {@link fixtures} skip the
+   * to `false`, {@link fixtures} skips the
    * transactional wrapper entirely: fixtures are seeded and deleted per test via
    * `useFixtures`' own `beforeEach`/`afterEach` (real committed DML, no savepoint
    * pin), so inserts/updates are visible across pooled connections. Required by


### PR DESCRIPTION
## What

`remove-usefixtures-public-surface` (#4584) made `useFixtures` a non-exported
engine internal but left `useHandlerFixtures` exported as the composition
wrapper. This folds that composition into the exported `fixtures()` so
`fixtures()` is the **sole** public fixture surface.

- `useHandlerFixtures` (the setupHandlerSuite + withTransactionalFixtures +
  module-private `useFixtures` composition) is merged into `fixtures()` in
  `use-fixtures.ts`, which also applies the `TEST_SCHEMA` default. It is no
  longer a separate export.
- `fixtures.ts` now re-exports `fixtures` from `use-fixtures.js` (keeps
  `setupFixtures`).
- The engine self-test (`use-fixtures.test.ts`) is repointed through
  `fixtures()`. Mock-adapter describes pass `schema: undefined` to opt out of
  the `TEST_SCHEMA` slice-derivation (their stubbed adapters/non-canonical
  tables have nothing to create), preserving prior behavior. Canonical
  by-name describes ride the boot-laid schema — `ensureCanonicalTables` is a
  no-op when the tables already exist.

## Verification

- `git grep -l "useHandlerFixtures" -- '**/*.test.ts'` → none.
- No `useHandlerFixtures` export remains (only a doc comment references it).
- `use-fixtures.test.ts` (57 tests) and `boolean.test.ts` pass locally.
- No test renames.

Closes-story: de-export-usehandlerfixtures-single-surface