### PR TITLE
refactor(test-helpers): read tableNames via Result#pluck in canonical-schema.test

### DIFF
--- a/packages/activerecord/src/test-helpers/canonical-schema.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.test.ts
@@ -95,18 +95,10 @@ describe("rebuildCanonicalTables", () => {
   });
 });
 
-// Read the live table-name set from sqlite_master, tolerating both the
-// object-row and `{ columns, rows }` array-row selectAll shapes.
+// Read the live table-name set from sqlite_master.
 async function tableNames(adapter: AbstractAdapter): Promise<Set<string>> {
-  const res = (await adapter.selectAll(
-    "SELECT name FROM sqlite_master WHERE type = 'table'",
-  )) as unknown;
-  if (Array.isArray(res)) {
-    return new Set((res as { name: string }[]).map((r) => r.name));
-  }
-  const { columns, rows } = res as { columns: string[]; rows: unknown[][] };
-  const i = columns.indexOf("name");
-  return new Set(rows.map((row) => String(row[i])));
+  const res = await adapter.selectAll("SELECT name FROM sqlite_master WHERE type = 'table'");
+  return new Set(res.pluck("name").map((name) => String(name)));
 }
 
 describe("ensureCanonicalTables", () => {


### PR DESCRIPTION
Replaces the hand-rolled shape-tolerant `tableNames` reader in
`canonical-schema.test.ts` with `Result#pluck("name")`, dropping the
never-taken `Array.isArray` branch and manual `columns.indexOf`.

`selectAll` is declared `Promise<Result>` (abstract-adapter.ts:374), and
`Result` exposes `pluck()`/`toArray()` — so the array-row branch was dead.
Same treatment PR #4565 applied to `dumpSchema`.

The three `ensureCanonicalTables` tests that use it pass unchanged.

Closes-story: simplify-canonical-schema-test-tablenames-result-toarray