### PR TITLE
refactor(fixtures): drop the fixtures schema arg and delete the escape hatch

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -21,7 +21,6 @@ import {
 } from "./index.js";
 import { Result } from "./result.js";
 import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { adapterType, inMemoryDb } from "./test-adapter.js";
 import { itIfSupports } from "./test-helpers/supports.js";
 import { establishFromTestConfig } from "./test-helpers/test-database-config.js";
@@ -219,7 +218,6 @@ async function activePredicate(conn: DatabaseAdapter): Promise<boolean> {
 // `Base.connection` stands in for Rails' `@connection = ...lease_connection`.
 describe("AdapterTest", () => {
   fixtures(["accounts", "authors", "tasks", "topics", "subscribers", "posts", "books"], {
-    schema: canonicalSchema,
     usesTransaction: [
       // Raise a DB error mid-statement (aborts an open PG transaction, poisoning
       // transactional teardown) — run un-wrapped; they persist nothing. The
@@ -643,7 +641,6 @@ describe("AdapterTestWithoutTransaction", () => {
     "reset table with non integer pk",
   ];
   const { posts } = fixtures(["posts", "authors", "authorAddresses", "movies", "subscribers"], {
-    schema: canonicalSchema,
     usesTransaction: withoutTransaction,
   });
 
@@ -788,7 +785,6 @@ describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
     "disconnect and recover on #configure_connection failure",
   ];
   fixtures(["posts", "authors", "authorAddresses"], {
-    schema: canonicalSchema,
     usesTransaction: nonTransactional,
   });
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/active-schema.test.ts
@@ -6,7 +6,6 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
 import { captureSql } from "../../testing/sql-capture.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -27,7 +26,6 @@ describeIfMysql("Mysql2Adapter", () => {
     // must not happen while Base.connection holds a fixture transaction on
     // `people` (MySQL DDL implicitly commits and would strand that state).
     fixtures(["people"], {
-      schema: canonicalSchema,
       usesTransaction: ["add index"],
     });
 

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -6,7 +6,6 @@ import { describeIfMysql, isMariaDb, Mysql2Adapter } from "./test-helper.js";
 import { Version } from "../../connection-adapters/abstract-adapter.js";
 import { fixtures, setupFixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 import { Author } from "../../test-helpers/models/author.js";
 import { Post } from "../../test-helpers/models/post.js";
 import { registerModel } from "../../index.js";
@@ -28,9 +27,7 @@ describeIfMysql("Mysql2Adapter", () => {
 
   describe("MySQLExplainTest", () => {
     // mirrors Rails: fixtures :authors, :author_addresses
-    const { authors } = fixtures(["authors", "authorAddresses", "posts"], {
-      schema: canonicalSchema,
-    });
+    const { authors } = fixtures(["authors", "authorAddresses", "posts"]);
 
     // Mirror Rails' explain_option / expected_analyze_clause split exactly:
     //   supports_analyze?         = mariadb && version >= 10.1.0       → "ANALYZE"

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/optimizer-hints.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/optimizer-hints.test.ts
@@ -6,7 +6,6 @@ import { describeIfMysql, Mysql2Adapter } from "./test-helper.js";
 import { describeIfSupports } from "../../test-helpers/supports.js";
 import { captureSql } from "../../testing/sql-capture.js";
 import { Base } from "../../index.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { Post } from "../../test-helpers/models/post.js";
 
@@ -16,7 +15,7 @@ import { Post } from "../../test-helpers/models/post.js";
 describeIfMysql("Mysql2Adapter", () => {
   describeIfSupports("optimizer_hints", "OptimizerHintsTest", () => {
     // mirrors Rails: fixtures :posts
-    fixtures(["posts"], { schema: canonicalSchema });
+    fixtures(["posts"]);
 
     let adapter: Mysql2Adapter;
     beforeAll(async () => {

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/sp.test.ts
@@ -6,12 +6,11 @@ import { describeIfMysql, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { Topic } from "../../test-helpers/models/topic.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 
 describeIfMysql("Mysql2Adapter", () => {
   describe("StoredProcedureTest", () => {
     // Rails `fixtures :topics` — load canonical topics via the handler connection.
-    const { topics } = fixtures(["topics"], { schema: canonicalSchema });
+    const { topics } = fixtures(["topics"]);
 
     beforeAll(async () => {
       await Base.connection.executeMutation("DROP PROCEDURE IF EXISTS ten");

--- a/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/active-schema.test.ts
@@ -14,7 +14,6 @@ import { ArgumentError } from "@blazetrails/activemodel";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL, pgServerVersion } from "./test-helper.js";
 import { captureSql } from "../../testing/sql-capture.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 
 // Rails PostgreSQLAdapter#supports_nulls_not_distinct? — PG 15+ (150000).
 const supportsNullsNotDistinct = pgServerVersion >= 150000;
@@ -31,7 +30,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   describe("PostgreSQLActiveSchemaTest", () => {
     // `add_index_options` introspects the canonical `people` table when a bare
     // column name is passed as `:where`; seed it through the fixtures framework.
-    fixtures(["people"], { schema: canonicalSchema });
+    fixtures(["people"]);
 
     it("create database with encoding", async () => {
       let sqls = await captureSql(() => adapter.createDatabase("matt"), { stub: adapter });

--- a/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bind-parameter.test.ts
@@ -3,7 +3,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { describeIfPg } from "./test-helper.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { Post } from "../../test-helpers/models/post.js";
 
@@ -11,7 +10,7 @@ describeIfPg("PostgreSQLAdapter", () => {
   describe("BindParameterTest", () => {
     // Mirrors Rails' `fixtures :posts`. Authors are declared first so the posts
     // fixture's author label-ref resolves to David's id (matching Rails posts.yml).
-    fixtures(["authors", "posts"], { schema: canonicalSchema });
+    fixtures(["authors", "posts"]);
 
     // Mirrors Rails' private `assert_quoted_as(expected, value, match: 0)`:
     // Post.where("title = ?", value) inlines `value` into the displayed SQL with

--- a/packages/activerecord/src/adapters/postgresql/optimizer-hints.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/optimizer-hints.test.ts
@@ -7,7 +7,6 @@ import { describeIfSupports } from "../../test-helpers/supports.js";
 import { assertQueriesMatch } from "../../testing/query-assertions.js";
 import { captureSql } from "../../testing/sql-capture.js";
 import { Base } from "../../index.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
 import { Post } from "../../test-helpers/models/post.js";
 
@@ -21,7 +20,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     // `author_id: 1` (David); our ported posts fixture references the author by
     // label, so authors must be declared first for that ref to resolve to
     // David's id (1) rather than the label-hash fallback.
-    fixtures(["authors", "posts"], { schema: canonicalSchema });
+    fixtures(["authors", "posts"]);
 
     beforeAll(async () => {
       // Mirrors Rails setup: enable_extension!("pg_hint_plan")

--- a/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
@@ -7,7 +7,6 @@ import { describeIfPg } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { registerModel } from "../../associations.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 import { Developer } from "../../test-helpers/models/developer.js";
 import { Computer } from "../../test-helpers/models/computer.js";
 import { developerFixtureData } from "../../test-helpers/fixtures/developers.js";
@@ -26,10 +25,7 @@ describeIfPg("PostgreSQLAdapter", () => {
     // `computers_developers` join table the `sharedComputers` label materializes)
     // so the shared Developer model resolves regardless of any bespoke schema a
     // sibling file left in the worker DB.
-    const { developers } = fixtures(
-      { developers: [Developer, developerFixtureData] },
-      { schema: canonicalSchema },
-    );
+    const { developers } = fixtures({ developers: [Developer, developerFixtureData] });
 
     // `preparedStatements` lives on AbstractAdapter but isn't on the
     // `DatabaseAdapter` interface that `connection` is typed as.

--- a/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/prepared-statements-disabled.test.ts
@@ -14,17 +14,15 @@ import { developerFixtureData } from "../../test-helpers/fixtures/developers.js"
 // `developerFixtureData.david` carries the `sharedComputers: ["laptop"]` HABTM
 // association label, which the fixture loader materializes into a
 // `computers_developers` join row. Register Computer at module load so the
-// `sharedComputers` reflection resolves when `fixtures()` slices the schema —
-// without it the join table is dropped from the slice and the seed insert fails.
+// `sharedComputers` reflection resolves when the loader writes that join row —
+// without it the join target is unresolved and the seed insert fails.
 registerModel(Computer);
 
 describeIfPg("PostgreSQLAdapter", () => {
   describe("PreparedStatementsDisabledTest", () => {
     // Rails `fixtures :developers`. Seeded through the inline `[Model, data]` map.
-    // `schema` recreates the canonical `developers` table (and the
-    // `computers_developers` join table the `sharedComputers` label materializes)
-    // so the shared Developer model resolves regardless of any bespoke schema a
-    // sibling file left in the worker DB.
+    // The canonical `developers` table (and the `computers_developers` join table
+    // the `sharedComputers` label materializes) come from the template clone.
     const { developers } = fixtures({ developers: [Developer, developerFixtureData] });
 
     // `preparedStatements` lives on AbstractAdapter but isn't on the

--- a/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
@@ -6,7 +6,6 @@ import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { Base } from "../../base.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 
 // Rails calls the private `copy_table` with `{ temporary: true }.merge(options)`.
 function copyTable(conn: any, from: string, to: string, options: Record<string, unknown> = {}) {
@@ -79,7 +78,7 @@ describeIfSqlite("CopyTableTest", () => {
   // Rails `fixtures :customers`. `schema` recreates the canonical tables so the
   // copy_table source tables (comments, owners, …) resolve regardless of any
   // bespoke schema a sibling file left in the shared worker DB.
-  fixtures(["customers"], { schema: canonicalSchema });
+  fixtures(["customers"]);
 
   it("copy table", async () => {
     await testCopyTable((await Base.leaseConnection()) as any);

--- a/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
@@ -75,9 +75,9 @@ async function testCopyTable(
 // and the assertions probe SQLite identifier quoting / PRAGMA structure, so this
 // must skip when the handler connection is PG/MySQL in the CI matrix.
 describeIfSqlite("CopyTableTest", () => {
-  // Rails `fixtures :customers`. `schema` recreates the canonical tables so the
-  // copy_table source tables (comments, owners, …) resolve regardless of any
-  // bespoke schema a sibling file left in the shared worker DB.
+  // Rails `fixtures :customers`. The canonical tables — including the
+  // copy_table source tables (comments, owners, …) — come from the template
+  // clone.
   fixtures(["customers"]);
 
   it("copy table", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/explain.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/explain.test.ts
@@ -13,9 +13,8 @@ import "../../test-helpers/models/post.js";
 // and the `SEARCH … authors USING … PRIMARY KEY` plan shape are SQLite-specific,
 // so this must skip when the handler connection is PG/MySQL in the CI matrix.
 describeIfSqlite("SQLite3ExplainTest", () => {
-  // Rails `fixtures :authors, :author_addresses`. `schema` recreates the
-  // canonical tables so the shared Author/Post models resolve regardless of
-  // any bespoke schema a sibling file left in the shared worker DB.
+  // Rails `fixtures :authors, :author_addresses`. The canonical tables come
+  // from the template clone.
   const { authors } = fixtures(["authors", "authorAddresses"]);
 
   it("explain for one query", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/explain.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/explain.test.ts
@@ -5,7 +5,6 @@ import { it, expect } from "vitest";
 import "../../index.js";
 import { describeIfSqlite } from "./test-helper.js";
 import { fixtures } from "../../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../../test-helpers/test-schema.js";
 import { Author } from "../../test-helpers/models/author.js";
 import "../../test-helpers/models/post.js";
 
@@ -17,9 +16,7 @@ describeIfSqlite("SQLite3ExplainTest", () => {
   // Rails `fixtures :authors, :author_addresses`. `schema` recreates the
   // canonical tables so the shared Author/Post models resolve regardless of
   // any bespoke schema a sibling file left in the shared worker DB.
-  const { authors } = fixtures(["authors", "authorAddresses"], {
-    schema: canonicalSchema,
-  });
+  const { authors } = fixtures(["authors", "authorAddresses"]);
 
   it("explain for one query", async () => {
     const explain = await Author.where({ id: authors("david").id }).explain();

--- a/packages/activerecord/src/aggregations.test.ts
+++ b/packages/activerecord/src/aggregations.test.ts
@@ -7,7 +7,6 @@ import { Base, composedOf, reflectOnAggregation } from "./index.js";
 import { reload as persistenceReload } from "./persistence.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import {
   Customer as CustomerModel,
   Money as MoneyClass,
@@ -33,7 +32,7 @@ afterAll(() => {
 describe("AggregationsTest", () => {
   // Mirrors Rails `fixtures :customers` via the shared Customer model; `{ schema }`
   // recreates the canonical `customers` table to survive sibling-file contamination.
-  const { customers } = fixtures(["customers"], { schema: canonicalSchema });
+  const { customers } = fixtures(["customers"]);
 
   // Rails: test_find_single_value_object
   it("find single value object", () => {

--- a/packages/activerecord/src/aggregations.test.ts
+++ b/packages/activerecord/src/aggregations.test.ts
@@ -30,8 +30,8 @@ afterAll(() => {
 // against the canonical Customer model + composed_of mappings, rather than the
 // ad-hoc inline Customer classes used elsewhere in this file.
 describe("AggregationsTest", () => {
-  // Mirrors Rails `fixtures :customers` via the shared Customer model; `{ schema }`
-  // recreates the canonical `customers` table to survive sibling-file contamination.
+  // Mirrors Rails `fixtures :customers` via the shared Customer model; the
+  // canonical `customers` table comes from the template clone.
   const { customers } = fixtures(["customers"]);
 
   // Rails: test_find_single_value_object

--- a/packages/activerecord/src/annotate.test.ts
+++ b/packages/activerecord/src/annotate.test.ts
@@ -12,9 +12,8 @@ describe("AnnotateTest", () => {
   // `fixtures` wires `setupFixtures` internally, so no separate call.
   // Mirrors Rails `fixtures :posts` — seed the canonical posts rows so each
   // annotated `select(:id)` relation has data to read back with `.first()`
-  // (Rails' `assert posts.first`). `schema` recreates the canonical `posts`
-  // table so the shared Post model resolves regardless of any bespoke `posts`
-  // a sibling file left in the shared worker DB.
+  // (Rails' `assert posts.first`). The canonical `posts` table comes from the
+  // template clone.
   const { posts } = fixtures(["posts"]);
 
   it("annotate wraps content in an inline comment", async () => {

--- a/packages/activerecord/src/annotate.test.ts
+++ b/packages/activerecord/src/annotate.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect } from "vitest";
 import "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Post } from "./test-helpers/models/post.js";
 
 describe("AnnotateTest", () => {
@@ -16,7 +15,7 @@ describe("AnnotateTest", () => {
   // (Rails' `assert posts.first`). `schema` recreates the canonical `posts`
   // table so the shared Post model resolves regardless of any bespoke `posts`
   // a sibling file left in the shared worker DB.
-  const { posts } = fixtures(["posts"], { schema: canonicalSchema });
+  const { posts } = fixtures(["posts"]);
 
   it("annotate wraps content in an inline comment", async () => {
     const relation = Post.select("id").annotate("foo");

--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -10,7 +10,6 @@ import { Base, association, reflectOnAssociation, registerModel, NameError, pp }
 import { ArgumentError } from "@blazetrails/activemodel";
 import { captureSql } from "./testing/sql-capture.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Author, type Author as AuthorT } from "./test-helpers/models/author.js";
 import { CpkOrder, CpkBook } from "./test-helpers/models/cpk.js";
 import type { Firm as FirmT } from "./test-helpers/models/company.js";
@@ -105,21 +104,18 @@ describe("AssociationProxyTest", () => {
     Human,
     Interest,
   ]);
-  const { authors, developers, members, posts, categories } = fixtures(
-    [
-      "authorAddresses",
-      "authors",
-      "posts",
-      "categories",
-      "categorizations",
-      "developers",
-      "projects",
-      "developersProjects",
-      "memberTypes",
-      "members",
-    ],
-    { schema: canonicalSchema },
-  );
+  const { authors, developers, members, posts, categories } = fixtures([
+    "authorAddresses",
+    "authors",
+    "posts",
+    "categories",
+    "categorizations",
+    "developers",
+    "projects",
+    "developersProjects",
+    "memberTypes",
+    "members",
+  ]);
 
   it("push does not lose additions to new record", async () => {
     const josh = new Author({ name: "Josh" }) as any;
@@ -1680,10 +1676,12 @@ describe("OverridingAssociationsTest", () => {
 });
 
 describe("GeneratedMethodsTest", () => {
-  const { computers, developers, posts, comments } = fixtures(
-    ["computers", "developers", "posts", "comments"],
-    { schema: canonicalSchema },
-  );
+  const { computers, developers, posts, comments } = fixtures([
+    "computers",
+    "developers",
+    "posts",
+    "comments",
+  ]);
   it("association methods override attribute methods of same name", async () => {
     const computer = await Computer.find(computers("workstation").id);
     const developer = await Developer.find(developers("david").id);
@@ -1759,10 +1757,14 @@ describe("WithAnnotationsTest", () => {
     }
   }
 
-  const { pirates } = fixtures(
-    ["pirates", "parrots", "parrotsPirates", "ships", "treasures", "priceEstimates"],
-    { schema: canonicalSchema },
-  );
+  const { pirates } = fixtures([
+    "pirates",
+    "parrots",
+    "parrotsPirates",
+    "ships",
+    "treasures",
+    "priceEstimates",
+  ]);
 
   it("belongs to with annotation includes a query comment", async () => {
     const pirate = await SpacePirateAnnotated.find(pirates("blackbeard").id);
@@ -1848,23 +1850,18 @@ describe("AssociationsTest", () => {
   // `authorFavorites` is declared so its rows are loaded (Rails: `fixtures
   // :author_favorites`); the subselect test reads them through the association.
   const { companies, authors, shardedBlogs, shardedBlogPosts, shardedComments, cpkOrders } =
-    fixtures(
-      [
-        "companies",
-        "authors",
-        "authorFavorites",
-        "shardedBlogs",
-        "shardedBlogPosts",
-        "shardedComments",
-        "shardedTags",
-        "shardedBlogPostsTags",
-        "cpkOrders",
-        "cpkBooks",
-      ],
-      {
-        schema: canonicalSchema,
-      },
-    );
+    fixtures([
+      "companies",
+      "authors",
+      "authorFavorites",
+      "shardedBlogs",
+      "shardedBlogPosts",
+      "shardedComments",
+      "shardedTags",
+      "shardedBlogPostsTags",
+      "cpkOrders",
+      "cpkBooks",
+    ]);
 
   let Author: typeof AuthorT;
   let AuthorFavorite: typeof Base;

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -16,7 +16,6 @@ import {
 } from "../index.js";
 import { assertNoQueries } from "../testing/query-assertions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Author, AuthorAddress } from "../test-helpers/models/author.js";
 import { Essay } from "../test-helpers/models/essay.js";
 import { Account } from "../test-helpers/models/account.js";
@@ -197,9 +196,7 @@ async function withHasManyInversing(fn: () => Promise<void>): Promise<void> {
 }
 
 describe("BelongsToWithForeignKeyTest", () => {
-  const { authors, authorAddresses } = fixtures(["authors", "authorAddresses"], {
-    schema: canonicalSchema,
-  });
+  const { authors, authorAddresses } = fixtures(["authors", "authorAddresses"]);
 
   it("destroy linked models", async () => {
     const address = await AuthorAddress.create({});
@@ -229,32 +226,29 @@ describe("BelongsToAssociationsTest", () => {
     members,
     nodes,
     cpkBooks,
-  } = fixtures(
-    [
-      "accounts",
-      "companies",
-      "developers",
-      "projects",
-      "developersProjects",
-      "topics",
-      "authors",
-      "authorAddresses",
-      "essays",
-      "posts",
-      "tags",
-      "taggings",
-      "comments",
-      "sponsors",
-      "members",
-      "computers",
-      "nodes",
-      "trees",
-      "cpkAuthors",
-      "cpkBooks",
-      "cpkOrders",
-    ],
-    { schema: canonicalSchema },
-  );
+  } = fixtures([
+    "accounts",
+    "companies",
+    "developers",
+    "projects",
+    "developersProjects",
+    "topics",
+    "authors",
+    "authorAddresses",
+    "essays",
+    "posts",
+    "tags",
+    "taggings",
+    "comments",
+    "sponsors",
+    "members",
+    "computers",
+    "nodes",
+    "trees",
+    "cpkAuthors",
+    "cpkBooks",
+    "cpkOrders",
+  ]);
 
   it("belongs to", async () => {
     const client = await Client.find(3);
@@ -2021,7 +2015,7 @@ describe("BelongsToAssociationsTest", () => {
 });
 
 describe("AsyncBelongsToAssociationsTest", () => {
-  const { companies } = fixtures(["companies"], { schema: canonicalSchema });
+  const { companies } = fixtures(["companies"]);
 
   it("async load belongs to", async () => {
     const client = await Client.find(3);

--- a/packages/activerecord/src/associations/bidirectional-destroy-dependencies.test.ts
+++ b/packages/activerecord/src/associations/bidirectional-destroy-dependencies.test.ts
@@ -10,7 +10,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import {
   Content,
   ContentPosition,
@@ -18,7 +17,7 @@ import {
 } from "../test-helpers/models/content.js";
 
 describe("BidirectionalDestroyDependenciesTest", () => {
-  fixtures(["content", "contentPositions"], { schema: canonicalSchema });
+  fixtures(["content", "contentPositions"]);
 
   registerModel(Content);
   registerModel(ContentPosition);

--- a/packages/activerecord/src/associations/callbacks.test.ts
+++ b/packages/activerecord/src/associations/callbacks.test.ts
@@ -8,7 +8,6 @@ import { throwAbort } from "@blazetrails/activesupport";
 
 import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
 import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Project } from "../test-helpers/models/project.js";
 import { Developer, AuditLog } from "../test-helpers/models/developer.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -563,9 +562,7 @@ describe("AssociationCallbacksTest", () => {
 // developers_projects fixtures.
 // ==========================================================================
 describe("AssociationCallbacksTest", () => {
-  const { projects, developers } = fixtures(["projects", "developers", "developersProjects"], {
-    schema: canonicalSchema,
-  });
+  const { projects, developers } = fixtures(["projects", "developers", "developersProjects"]);
 
   it("has and belongs to many add callback", async () => {
     const david = developers("david");

--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -10,7 +10,6 @@
 import { describe, it, expect } from "vitest";
 import { registerModel, enableSti, registerSubclass, resetCallbacks } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Base } from "../base.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Person } from "../test-helpers/models/person.js";
@@ -32,23 +31,20 @@ import { Account } from "../test-helpers/models/account.js";
 import { assertQueriesCount } from "../testing/query-assertions.js";
 
 describe("CascadedEagerLoadingTest", () => {
-  const { authors, topics, vertices, companies, people } = fixtures(
-    [
-      "authors",
-      "posts",
-      "topics",
-      "companies",
-      "accounts",
-      "comments",
-      "categorizations",
-      "categories",
-      "categoriesPosts",
-      "edges",
-      "vertices",
-      "people",
-    ],
-    { schema: canonicalSchema },
-  );
+  const { authors, topics, vertices, companies, people } = fixtures([
+    "authors",
+    "posts",
+    "topics",
+    "companies",
+    "accounts",
+    "comments",
+    "categorizations",
+    "categories",
+    "categoriesPosts",
+    "edges",
+    "vertices",
+    "people",
+  ]);
 
   enableSti(Topic);
   registerModel(Person);

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -14,7 +14,6 @@ import { Notifications } from "@blazetrails/activesupport";
 import { HasManyThroughAssociation } from "./has-many-through-association.js";
 import { assertNotCalledOnInstanceOf } from "../testing/method-call-assertions.js";
 import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { assertNoQueries, assertQueriesCount } from "../testing/query-assertions.js";
 import {
   Post,
@@ -2531,10 +2530,13 @@ describe("EagerAssociationTest", () => {
 // composite-key preloading cases.
 // ==========================================================================
 describe("EagerAssociationTest", () => {
-  const { shardedBlogs, shardedBlogPosts, shardedComments } = fixtures(
-    ["shardedBlogs", "shardedBlogPosts", "shardedComments", "shardedTags", "shardedBlogPostsTags"],
-    { schema: canonicalSchema },
-  );
+  const { shardedBlogs, shardedBlogPosts, shardedComments } = fixtures([
+    "shardedBlogs",
+    "shardedBlogPosts",
+    "shardedComments",
+    "shardedTags",
+    "shardedBlogPostsTags",
+  ]);
 
   // fixtures loads the rows but does not register the models under the
   // class names the associations resolve by; register them here (dynamic import

--- a/packages/activerecord/src/associations/extension.test.ts
+++ b/packages/activerecord/src/associations/extension.test.ts
@@ -7,7 +7,6 @@ import { Base, CollectionProxy, association, registerModel } from "../index.js";
 import { HasMany } from "./builder/has-many.js";
 
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment, OopsError } from "../test-helpers/models/comment.js";
 import { Developer } from "../test-helpers/models/developer.js";
@@ -23,10 +22,13 @@ registerModel(Project);
 // `with_content` extension block) + real posts/comments fixture lookups,
 // mirroring `AssociationsExtensionsTest` against `posts(:welcome).comments`.
 describe("AssociationsExtensionsTest", () => {
-  const { posts, comments, developers, projects } = fixtures(
-    ["posts", "comments", "developers", "projects", "developersProjects"],
-    { schema: canonicalSchema },
-  );
+  const { posts, comments, developers, projects } = fixtures([
+    "posts",
+    "comments",
+    "developers",
+    "projects",
+    "developersProjects",
+  ]);
   it("extension on has many", async () => {
     const proxy = association(posts("welcome"), "comments") as unknown as {
       findMostRecent: () => Promise<Base | null>;

--- a/packages/activerecord/src/associations/habtm.test.ts
+++ b/packages/activerecord/src/associations/habtm.test.ts
@@ -10,7 +10,6 @@ import { describe, it, expect } from "vitest";
 import "../index.js";
 import { association } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 // Opt into the canonical-model autoload index so the `Developer`/`Project`
 // association targets resolve by name on first reference — no manual
 // `registerModel`.
@@ -19,9 +18,7 @@ import { Developer as CanonicalDeveloper } from "../test-helpers/models/develope
 import { Project as CanonicalProject } from "../test-helpers/models/project.js";
 
 describe("has_and_belongs_to_many", () => {
-  const { developers, projects } = fixtures(["developers", "projects", "developersProjects"], {
-    schema: canonicalSchema,
-  });
+  const { developers, projects } = fixtures(["developers", "projects", "developersProjects"]);
 
   it("loads associated records through a join table", async () => {
     // `david` joins both projects via the `developers_projects` join table.

--- a/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-and-belongs-to-many-associations.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Base, registerModel, AssociationTypeMismatch, ReadOnlyRecord } from "../index.js";
 import { assertNoQueries, assertQueriesCount } from "../testing/query-assertions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Project, SpecialProject } from "../test-helpers/models/project.js";
 import {
   Developer,
@@ -171,28 +170,25 @@ class Source extends Base {
 // Developer/Project models + developers_projects fixtures.
 // ==========================================================================
 describe("HasAndBelongsToManyAssociationsTest", () => {
-  const { developers, projects, computers } = fixtures(
-    [
-      "developers",
-      "projects",
-      "developersProjects",
-      "computers",
-      "categories",
-      "posts",
-      "categoriesPosts",
-      "authors",
-      "categorizations",
-      "tags",
-      "taggings",
-      "parrots",
-      "pirates",
-      "parrotsPirates",
-      "treasures",
-      "parrotsTreasures",
-      "priceEstimates",
-    ],
-    { schema: canonicalSchema },
-  );
+  const { developers, projects, computers } = fixtures([
+    "developers",
+    "projects",
+    "developersProjects",
+    "computers",
+    "categories",
+    "posts",
+    "categoriesPosts",
+    "authors",
+    "categorizations",
+    "tags",
+    "taggings",
+    "parrots",
+    "pirates",
+    "parrotsPirates",
+    "treasures",
+    "parrotsTreasures",
+    "priceEstimates",
+  ]);
 
   beforeAll(async () => {
     for (const m of [

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -100,7 +100,6 @@ import { captureSql } from "../testing/sql-capture.js";
 import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import { TypedEssay } from "../test-helpers/models/essay.js";
 import { PersonWithPolymorphicDependentNullifyComments } from "../test-helpers/models/person.js";
-import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 
 describe("HasManyAssociationsTestPrimaryKeys", () => {
   const { people } = fixtures([
@@ -348,10 +347,16 @@ describe("HasManyAssociationsTestForReorderWithJoinDependency", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  const { posts, humans, categories } = fixtures(
-    ["posts", "comments", "humans", "categories", "essays", "tags", "taggings", "people"],
-    { schema: TEST_SCHEMA },
-  );
+  const { posts, humans, categories } = fixtures([
+    "posts",
+    "comments",
+    "humans",
+    "categories",
+    "essays",
+    "tags",
+    "taggings",
+    "people",
+  ]);
 
   beforeAll(async () => {
     registerModel(HmPost);
@@ -6303,7 +6308,7 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  const { posts } = fixtures(["posts", "tags", "taggings"], { schema: TEST_SCHEMA });
+  const { posts } = fixtures(["posts", "tags", "taggings"]);
 
   beforeAll(async () => {
     registerModel(HmPost);
@@ -6610,7 +6615,7 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  const { authors } = fixtures(["authors", "posts"], { schema: TEST_SCHEMA });
+  const { authors } = fixtures(["authors", "posts"]);
 
   beforeAll(async () => {
     registerModel(HmAuthor);
@@ -6679,10 +6684,16 @@ describe("HasManyAssociationsTestPrimaryKeys", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  const { companies, topics } = fixtures(
-    ["companies", "accounts", "topics", "posts", "comments", "taggings", "cars", "bulbs"],
-    { schema: TEST_SCHEMA },
-  );
+  const { companies, topics } = fixtures([
+    "companies",
+    "accounts",
+    "topics",
+    "posts",
+    "comments",
+    "taggings",
+    "cars",
+    "bulbs",
+  ]);
 
   beforeAll(() => {
     registerModel(Company);
@@ -6951,9 +6962,7 @@ describe("AsyncHasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  const { topics } = fixtures(["companies", "accounts", "topics"], {
-    schema: TEST_SCHEMA,
-  });
+  const { topics } = fixtures(["companies", "accounts", "topics"]);
 
   beforeAll(() => {
     registerModel(Company);
@@ -7053,9 +7062,7 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  const { cars } = fixtures(["cars", "topics", "ships", "treasures"], {
-    schema: TEST_SCHEMA,
-  });
+  const { cars } = fixtures(["cars", "topics", "ships", "treasures"]);
 
   beforeAll(() => {
     registerModel(HmCar);
@@ -7201,10 +7208,13 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  const { cpkAuthors, shardedBlogPosts } = fixtures(
-    ["cpkAuthors", "cpkBooks", "shardedBlogs", "shardedBlogPosts", "shardedComments"],
-    { schema: TEST_SCHEMA },
-  );
+  const { cpkAuthors, shardedBlogPosts } = fixtures([
+    "cpkAuthors",
+    "cpkBooks",
+    "shardedBlogs",
+    "shardedBlogPosts",
+    "shardedComments",
+  ]);
 
   // fixtures loads the fixture rows but does not register the models
   // under the class names the associations resolve by (`CpkBook`,
@@ -7272,9 +7282,7 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  const { categories } = fixtures(["categories", "categorizations"], {
-    schema: TEST_SCHEMA,
-  });
+  const { categories } = fixtures(["categories", "categorizations"]);
 
   beforeAll(() => {
     registerModel(Category);
@@ -7304,14 +7312,11 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  fixtures(
-    {
-      user_comments_counts: [UserCommentsCount, {}],
-      post_comments_counts: [PostCommentsCount, {}],
-      comment_overlapping_counter_caches: [CommentOverlappingCounterCache, {}],
-    },
-    { schema: TEST_SCHEMA },
-  );
+  fixtures({
+    user_comments_counts: [UserCommentsCount, {}],
+    post_comments_counts: [PostCommentsCount, {}],
+    comment_overlapping_counter_caches: [CommentOverlappingCounterCache, {}],
+  });
 
   beforeAll(() => {
     registerModel(CommentOverlappingCounterCache);

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -7,7 +7,6 @@ import { Base, registerModel, RecordInvalid } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { association } from "../associations.js";
 import { quoteTableName } from "../test-helpers/quote-regex.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 
 import {
   Author,
@@ -150,7 +149,6 @@ describe("HasManyThroughAssociationsTest", () => {
       "organizations",
     ],
     {
-      schema: canonicalSchema,
       // "update counter caches on destroy with indestructible through record"
       // intentionally raises on destroy, which aborts the PG transaction and
       // poisons transactional-fixture teardown for all subsequent tests.
@@ -2138,9 +2136,7 @@ describe("HasManyThroughAssociationsTest", () => {
   });
 
   describe("through scope (canonical)", () => {
-    const { authors: canonicalAuthors } = fixtures(["authors", "posts", "comments"], {
-      schema: canonicalSchema,
-    });
+    const { authors: canonicalAuthors } = fixtures(["authors", "posts", "comments"]);
 
     beforeAll(async () => {
       registerModel([Author, Post, FirstPost, Comment]);

--- a/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-disable-joins-associations.test.ts
@@ -4,7 +4,6 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { association } from "../associations.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
 
@@ -35,9 +34,7 @@ function djasScope(owner: Base, assocName: string): any {
 }
 
 describe("HasManyThroughDisableJoinsAssociationsTest", () => {
-  const { authors } = fixtures(["posts", "authors", "comments", "authorAddresses"], {
-    schema: canonicalSchema,
-  });
+  const { authors } = fixtures(["posts", "authors", "comments", "authorAddresses"]);
 
   registerModel([Author, AuthorAddress, Post, Comment, Rating, Member, MemberType]);
 

--- a/packages/activerecord/src/associations/inner-join-association.test.ts
+++ b/packages/activerecord/src/associations/inner-join-association.test.ts
@@ -11,7 +11,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel, registerSubclass, enableSti } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Table, Nodes } from "@blazetrails/arel";
 import { captureSql } from "../testing/sql-capture.js";
 import { Author, AuthorAddress } from "../test-helpers/models/author.js";
@@ -34,24 +33,21 @@ import { Job } from "../test-helpers/models/job.js";
 
 describe("InnerJoinAssociationTest", () => {
   const { authors, posts, people, categories, categoriesPosts, shardedBlogPosts, shardedComments } =
-    fixtures(
-      [
-        "authors",
-        "authorAddresses",
-        "essays",
-        "posts",
-        "comments",
-        "categories",
-        "categoriesPosts",
-        "categorizations",
-        "taggings",
-        "tags",
-        "people",
-        "shardedComments",
-        "shardedBlogPosts",
-      ],
-      { schema: canonicalSchema },
-    );
+    fixtures([
+      "authors",
+      "authorAddresses",
+      "essays",
+      "posts",
+      "comments",
+      "categories",
+      "categoriesPosts",
+      "categorizations",
+      "taggings",
+      "tags",
+      "people",
+      "shardedComments",
+      "shardedBlogPosts",
+    ]);
 
   enableSti(Category);
   registerModel(Author);

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -13,7 +13,6 @@ import {
 } from "../index.js";
 import { loadBelongsTo, loadHasOne, loadHasMany, setBelongsTo } from "../associations.js";
 import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Branch, BrokenBranch } from "../test-helpers/models/branch.js";
 import { Human } from "../test-helpers/models/human.js";
 import { Face } from "../test-helpers/models/face.js";
@@ -91,12 +90,15 @@ async function withAutomaticScopeInversing(
 }
 
 describe("AutomaticInverseFindingTests", () => {
-  const { books } = fixtures(
-    ["ratings", "comments", "cars", "bulbs", "books", "subscriptions", "subscribers"],
-    {
-      schema: canonicalSchema,
-    },
-  );
+  const { books } = fixtures([
+    "ratings",
+    "comments",
+    "cars",
+    "bulbs",
+    "books",
+    "subscriptions",
+    "subscribers",
+  ]);
   beforeAll(() => {
     [
       MixedCaseMonkey,
@@ -396,7 +398,7 @@ describe("InverseAssociationTests", () => {
 });
 
 describe("InverseHasOneTests", () => {
-  const { humans } = fixtures(["humans", "faces"], { schema: canonicalSchema });
+  const { humans } = fixtures(["humans", "faces"]);
   beforeAll(() => {
     registerModel(Human);
     registerModel(Face);
@@ -512,7 +514,6 @@ describe("InverseHasManyTests", () => {
     // to a CRC32 fallback id unless the authors set is already loaded, which
     // would orphan every post's `author_id`.
     ["humans", "interests", "authors", "posts", "comments", "cpkAuthors", "cpkOrders", "cpkBooks"],
-    { schema: canonicalSchema },
   );
   beforeAll(async () => {
     [Human, Interest, Post, SpecialPost, Author, Comment, CpkAuthor, CpkBook, CpkOrder].forEach(
@@ -840,9 +841,7 @@ describe("InverseHasManyTests", () => {
 });
 
 describe("InverseBelongsToTests", () => {
-  const { faces, interests } = fixtures(["humans", "faces", "interests"], {
-    schema: canonicalSchema,
-  });
+  const { faces, interests } = fixtures(["humans", "faces", "interests"]);
   beforeAll(() => {
     [Human, Face, Interest].forEach((m) => registerModel(m));
   });
@@ -1046,9 +1045,7 @@ describe("InverseBelongsToTests", () => {
 });
 
 describe("InversePolymorphicBelongsToTests", () => {
-  const { faces, interests } = fixtures(["humans", "faces", "interests"], {
-    schema: canonicalSchema,
-  });
+  const { faces, interests } = fixtures(["humans", "faces", "interests"]);
   beforeAll(() => {
     [Human, Face, Interest].forEach((m) => registerModel(m));
   });
@@ -1236,7 +1233,7 @@ describe("InversePolymorphicBelongsToTests", () => {
 // NOTE - these tests might not be meaningful, ripped as they were from the parental_control plugin
 // which would guess the inverse rather than look for an explicit configuration option.
 describe("InverseMultipleHasManyInversesForSameModel", () => {
-  fixtures(["humans", "interests", "zines"], { schema: canonicalSchema });
+  fixtures(["humans", "interests", "zines"]);
   beforeAll(() => {
     [Human, Interest, Zine].forEach((m) => registerModel(m));
   });

--- a/packages/activerecord/src/associations/left-outer-join-association.test.ts
+++ b/packages/activerecord/src/associations/left-outer-join-association.test.ts
@@ -11,7 +11,6 @@
 import { describe, it, expect } from "vitest";
 import { registerModel, registerSubclass } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Table } from "@blazetrails/arel";
 import { captureSql } from "../testing/sql-capture.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -32,19 +31,16 @@ import { Reference } from "../test-helpers/models/reference.js";
 import { Job } from "../test-helpers/models/job.js";
 
 describe("LeftOuterJoinAssociationTest", () => {
-  const { authors, posts } = fixtures(
-    [
-      "authors",
-      "authorAddresses",
-      "essays",
-      "posts",
-      "comments",
-      "ratings",
-      "categorizations",
-      "people",
-    ],
-    { schema: canonicalSchema },
-  );
+  const { authors, posts } = fixtures([
+    "authors",
+    "authorAddresses",
+    "essays",
+    "posts",
+    "comments",
+    "ratings",
+    "categorizations",
+    "people",
+  ]);
 
   registerModel(Author);
   registerModel(Post);

--- a/packages/activerecord/src/associations/nested-through-advanced.test.ts
+++ b/packages/activerecord/src/associations/nested-through-advanced.test.ts
@@ -8,7 +8,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { registerModel } from "../index.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Tag } from "../test-helpers/models/tag.js";
@@ -31,10 +30,13 @@ registerModel(CakeDesigner);
 registerModel(DrinkDesigner);
 
 describe("HMT Slot E — nested-through advanced", () => {
-  const { authors, tags, taggings } = fixtures(
-    ["authors", "authorAddresses", "posts", "taggings", "tags"],
-    { schema: canonicalSchema },
-  );
+  const { authors, tags, taggings } = fixtures([
+    "authors",
+    "authorAddresses",
+    "posts",
+    "taggings",
+    "tags",
+  ]);
 
   it("distinct on the source-reflection scope returns one row when a tag is reachable via multiple posts", async () => {
     // david has two posts (welcome + thinking) each tagged "general".

--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -3,7 +3,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { registerModel } from "../index.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
@@ -86,36 +85,33 @@ describe("NestedThroughAssociationsTest", () => {
     people,
     references,
     jobs,
-  } = fixtures(
-    [
-      "authors",
-      "authorAddresses",
-      "books",
-      "posts",
-      "subscriptions",
-      "subscribers",
-      "tags",
-      "taggings",
-      "people",
-      "readers",
-      "references",
-      "jobs",
-      "ratings",
-      "comments",
-      "members",
-      "memberDetails",
-      "memberTypes",
-      "sponsors",
-      "clubs",
-      "organizations",
-      "categories",
-      "categoriesPosts",
-      "categorizations",
-      "memberships",
-      "essays",
-    ],
-    { schema: canonicalSchema },
-  );
+  } = fixtures([
+    "authors",
+    "authorAddresses",
+    "books",
+    "posts",
+    "subscriptions",
+    "subscribers",
+    "tags",
+    "taggings",
+    "people",
+    "readers",
+    "references",
+    "jobs",
+    "ratings",
+    "comments",
+    "members",
+    "memberDetails",
+    "memberTypes",
+    "sponsors",
+    "clubs",
+    "organizations",
+    "categories",
+    "categoriesPosts",
+    "categorizations",
+    "memberships",
+    "essays",
+  ]);
 
   // has_many through
   // Source: has_many through

--- a/packages/activerecord/src/associations/nested-through-preloader.test.ts
+++ b/packages/activerecord/src/associations/nested-through-preloader.test.ts
@@ -28,7 +28,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { registerModel } from "../index.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Comment, SpecialComment, SubSpecialComment } from "../test-helpers/models/comment.js";
@@ -47,9 +46,7 @@ describe("HMT Slot D — nested-through preloader / STI / joins+includes", () =>
     authors,
     ratings,
     comments: fixtureComments,
-  } = fixtures(["authors", "authorAddresses", "posts", "comments", "ratings"], {
-    schema: canonicalSchema,
-  });
+  } = fixtures(["authors", "authorAddresses", "posts", "comments", "ratings"]);
 
   it("proxy.toArray() walks a 3-level nested-through chain and filters by owner", async () => {
     // Author → comments (through posts) → ratings (3-level chain).

--- a/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
+++ b/packages/activerecord/src/associations/polymorphic-sti-through.test.ts
@@ -29,7 +29,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { registerModel } from "../index.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Hotel } from "../test-helpers/models/hotel.js";
 import { Department } from "../test-helpers/models/department.js";
@@ -44,7 +43,7 @@ registerModel(CakeDesigner);
 registerModel(DrinkDesigner);
 
 describe("HABTM Slot E — polymorphic + STI through", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   async function seed() {
     const hotel = await Hotel.create({});

--- a/packages/activerecord/src/associations/preloader-bigint-number-key-match.test.ts
+++ b/packages/activerecord/src/associations/preloader-bigint-number-key-match.test.ts
@@ -11,7 +11,6 @@ import { describe, it, expect } from "vitest";
 import { Base } from "../index.js";
 import { Preloader } from "./preloader.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 // Opt into the canonical-model autoload index so the `posts` association target
 // (`Post`) resolves by name during preload — no manual `registerModel`.
 import "../test-helpers/canonical-model-index.js";
@@ -26,7 +25,7 @@ type RecordInternals = {
 const internals = (record: Base): RecordInternals => record as unknown as RecordInternals;
 
 describe("Preloader BigInt PK / number FK key match", () => {
-  const { authors } = fixtures(["authors", "posts"], { schema: TEST_SCHEMA });
+  const { authors } = fixtures(["authors", "posts"]);
 
   it("matches children when the owner PK is a BigInt and the child FK is a number", async () => {
     const david = await Author.find(authors("david").id);

--- a/packages/activerecord/src/associations/source-type-validation.test.ts
+++ b/packages/activerecord/src/associations/source-type-validation.test.ts
@@ -32,7 +32,6 @@
 import { describe, it, expect } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations, association, loadHasMany } from "../associations.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
 // Local model classes for testing invalid through-association configurations.
@@ -81,7 +80,7 @@ function author() {
 }
 
 describe("ThroughReflection — checkValidityBang at first use", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   it("raises PolymorphicSourceError when source is polymorphic but sourceType is missing", () => {
     freshAssociations();

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -16,7 +16,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { registerModel } from "../index.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Preloader } from "./preloader.js";
 import { ThroughAssociation } from "./preloader/through-association.js";
@@ -38,9 +37,7 @@ registerModel(Comment);
 });
 
 describe("Preloader::ThroughAssociation#through_scope", () => {
-  const { authors, posts } = fixtures(["authors", "authorAddresses", "posts", "comments"], {
-    schema: canonicalSchema,
-  });
+  const { authors, posts } = fixtures(["authors", "authorAddresses", "posts", "comments"]);
 
   function throughLoader(owners: Author[], name: string, scope?: any): ThroughAssociation {
     const loaders = new Preloader({

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect } from "vitest";
 import { Relation } from "./index.js";
 import { errorOnIgnoredOrder, setErrorOnIgnoredOrder } from "./ar-config.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { assertQueriesCount, assertQueriesMatch } from "./testing/query-assertions.js";
 import { quoteTableName, escapeRegExp } from "./test-helpers/quote-regex.js";
 import {
@@ -31,18 +30,15 @@ import { registerModel } from "./associations.js";
 registerModel([Tagging, Tag]);
 
 describe("EachTest", () => {
-  const { posts } = fixtures(
-    [
-      "posts",
-      "taggings",
-      "developers",
-      "subscribers",
-      "cpkOrders",
-      "cpkBooks",
-      "cpkAuthors",
-    ] as const,
-    { schema: canonicalSchema },
-  );
+  const { posts } = fixtures([
+    "posts",
+    "taggings",
+    "developers",
+    "subscribers",
+    "cpkOrders",
+    "cpkBooks",
+    "cpkAuthors",
+  ] as const);
 
   it("each should execute one query per batch", async () => {
     const total = Number(await Post.count());

--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -14,7 +14,6 @@ import { Base, RecordNotFound } from "./index.js";
 import { registerModel } from "./associations.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { Author } from "./test-helpers/models/author.js";
 import { Post } from "./test-helpers/models/post.js";
@@ -78,9 +77,7 @@ async function logBinds(
 // unprepared, logging no binds (matching Rails).
 describe("BindParameterTest", () => {
   // Rails: `fixtures :topics, :authors, :author_addresses, :posts`.
-  fixtures(["topics", "authors", "authorAddresses", "posts"], {
-    schema: canonicalSchema,
-  });
+  fixtures(["topics", "authors", "authorAddresses", "posts"]);
 
   beforeAll(async () => {
     // A sibling file (e.g. coders/json.test.ts's SerializedTopic) physically

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect } from "vitest";
 import { sql as arelSql, star as arelStar } from "@blazetrails/arel";
 import { adapterType } from "./test-adapter.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 // Opt into the canonical-model autoload index so association targets resolve by
 // name on first reference — no manual `registerModel`.
 import "./test-helpers/canonical-model-index.js";
@@ -49,7 +48,6 @@ describe("CalculationsTest", () => {
       "oneNeedQuoting",
     ] as const,
     {
-      schema: canonicalSchema,
       usesTransaction: [
         // These tests intentionally trigger DB errors (invalid column/syntax) which
         // abort PG transactions; they must run outside the transactional fixtures wrapper.

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -6,7 +6,6 @@ import { fixtures } from "./test-helpers/fixtures.js";
 // Opt into the canonical-model autoload index so the `topics` association target
 // (`Topic`) resolves by name on first reference — no manual `registerModel`.
 import "./test-helpers/canonical-model-index.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 
 // ==========================================================================
 // lookupCastTypeFromJoinDependencies unit tests
@@ -114,7 +113,7 @@ describe("lookupCastTypeFromJoinDependencies integration", () => {
     }
   }
 
-  fixtures(["topics", "authors"], { schema: canonicalSchema });
+  fixtures(["topics", "authors"]);
 
   // A plain `joins(:assoc)` now feeds buildJoinDependencies (via _namedInnerJoins),
   // so lookupCastTypeFromJoinDependencies recovers the joined column's cast type

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -11,7 +11,6 @@ import { describe, it, expect } from "vitest";
 import { makeRange, throwAbort } from "@blazetrails/activesupport";
 import { Base, RecordNotSaved, RecordNotDestroyed, RecordInvalid } from "./index.js";
 import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { ContextualCallbacksDeveloper } from "./test-helpers/models/contextual-callbacks-developer.js";
 
 type HistoryEntry = [string, string];
@@ -220,7 +219,7 @@ class CallbackHaltedDeveloper extends Base {
 }
 
 setupFixtures();
-const { developers } = fixtures(["developers"], { schema: canonicalSchema });
+const { developers } = fixtures(["developers"]);
 
 function assertSaveCallbacksNotCalled(someone: CallbackHaltedDeveloper): void {
   expect(someone.afterSaveCalled).toBe(false);

--- a/packages/activerecord/src/clone.test.ts
+++ b/packages/activerecord/src/clone.test.ts
@@ -4,13 +4,12 @@
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Topic } from "./test-helpers/models/topic.js";
 
 describe("CloneTest", () => {
   // `fixtures` wires `setupFixtures` internally and is
   // transactional, mirroring Rails' `fixtures :topics`.
-  fixtures(["topics"], { schema: canonicalSchema });
+  fixtures(["topics"]);
 
   it("persisted", async () => {
     const topic = await Topic.first();

--- a/packages/activerecord/src/collection-cache-key.test.ts
+++ b/packages/activerecord/src/collection-cache-key.test.ts
@@ -4,7 +4,6 @@ import { Base, StatementInvalid, Relation } from "./index.js";
 import { hexdigest } from "@blazetrails/activesupport";
 import { assertQueriesCount, assertNoQueries } from "./testing/query-assertions.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { registerModel } from "./associations.js";
 import { Developer } from "./test-helpers/models/developer.js";
 import { Comment } from "./test-helpers/models/comment.js";
@@ -46,7 +45,6 @@ describe("CollectionCacheKeyTest", () => {
   const { topics, projects } = fixtures(
     ["developers", "developersProjects", "projects", "topics", "comments", "posts"],
     {
-      schema: canonicalSchema,
       // This test deliberately runs `cache_key(:published_at)` against a column
       // that doesn't exist. On Postgres the resulting StatementInvalid aborts
       // the surrounding transaction, which would poison the shared

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -7,7 +7,6 @@ import { HashConfig } from "./database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
 import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
 import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Post } from "./test-helpers/models/post.js";
 import {
   connectedToStack,
@@ -786,7 +785,6 @@ describe("ConnectionHandlingTest common APIs with_connection", () => {
   const testName =
     "common APIs don't permanently hold a connection when permanent checkout is deprecated or disallowed";
   fixtures(["posts"], {
-    schema: canonicalSchema,
     usesTransaction: [testName],
   });
 

--- a/packages/activerecord/src/core.test.ts
+++ b/packages/activerecord/src/core.test.ts
@@ -7,14 +7,13 @@ import { Base } from "./index.js";
 import { formatForInspect } from "./attribute-inspection.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Topic, TitlePrimaryKeyTopic } from "./test-helpers/models/topic.js";
 import { CpkBook } from "./test-helpers/models/cpk.js";
 
 describe("CoreTest", () => {
   // Rails `CoreTest` declares `fixtures :topics`; every inspect/pretty-print
   // case reads `topics(:first)` (id 1, "The First Topic", author "David").
-  const { topics } = fixtures(["topics"], { schema: canonicalSchema });
+  const { topics } = fixtures(["topics"]);
 
   /** Stub `Topic.attributes_for_inspect`, restoring the prior own-property. */
   async function withAttributesForInspect<T>(value: unknown, fn: () => T | Promise<T>): Promise<T> {

--- a/packages/activerecord/src/core.trails.test.ts
+++ b/packages/activerecord/src/core.trails.test.ts
@@ -6,11 +6,10 @@
 import { describe, it, expect } from "vitest";
 
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Topic } from "./test-helpers/models/topic.js";
 
 describe("frozen / isFrozen", () => {
-  fixtures(["topics"], { schema: canonicalSchema });
+  fixtures(["topics"]);
 
   it("deleting an unpersisted record still marks it destroyed and frozen", async () => {
     // Matches Rails' `delete` which only issues the DELETE when persisted?

--- a/packages/activerecord/src/counter-cache.test.ts
+++ b/packages/activerecord/src/counter-cache.test.ts
@@ -27,7 +27,6 @@ import { Category } from "./test-helpers/models/category.js";
 import { Categorization } from "./test-helpers/models/categorization.js";
 import { CpkOrder, CpkBook } from "./test-helpers/models/cpk.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { assertQueriesCount } from "./testing/query-assertions.js";
 
 // Register the canonical models used directly and via through/dependent
@@ -130,24 +129,21 @@ async function assertTouching(
   }
 }
 
-const { topics, categories, cars, dogLovers, people, subscribers } = fixtures(
-  [
-    "topics",
-    "categories",
-    "categorizations",
-    "cars",
-    "dogs",
-    "dogLovers",
-    "people",
-    "friendships",
-    "subscribers",
-    "subscriptions",
-    "books",
-    "cpkOrders",
-    "cpkBooks",
-  ],
-  { schema: canonicalSchema },
-);
+const { topics, categories, cars, dogLovers, people, subscribers } = fixtures([
+  "topics",
+  "categories",
+  "categorizations",
+  "cars",
+  "dogs",
+  "dogLovers",
+  "people",
+  "friendships",
+  "subscribers",
+  "subscriptions",
+  "books",
+  "cpkOrders",
+  "cpkBooks",
+]);
 
 describe("CounterCacheTest", () => {
   let topic: Topic;

--- a/packages/activerecord/src/counter-cache.trails.test.ts
+++ b/packages/activerecord/src/counter-cache.trails.test.ts
@@ -10,12 +10,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base, registerModel } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Post as CanonicalPost } from "./test-helpers/models/post.js";
 import { Comment as CanonicalComment } from "./test-helpers/models/comment.js";
 
 describe("CounterCacheTest (trails)", () => {
-  fixtures(["posts", "comments"], { schema: canonicalSchema });
+  fixtures(["posts", "comments"]);
   beforeAll(() => {
     registerModel(CanonicalPost);
     registerModel(CanonicalComment);

--- a/packages/activerecord/src/custom-locking.test.ts
+++ b/packages/activerecord/src/custom-locking.test.ts
@@ -7,12 +7,11 @@ import { adapterType } from "./test-adapter.js";
 import { Base } from "./base.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Person } from "./test-helpers/models/person.js";
 import { assertQueriesMatch } from "./testing/query-assertions.js";
 
 describe("CustomLockingTest", () => {
-  const { people } = fixtures(["people"], { schema: canonicalSchema });
+  const { people } = fixtures(["people"]);
   beforeAll(async () => {
     await rebuildCanonicalTables(Base.connection, ["people"]);
   });

--- a/packages/activerecord/src/date.test.ts
+++ b/packages/activerecord/src/date.test.ts
@@ -11,17 +11,15 @@ import { Topic } from "./test-helpers/models/topic.js";
 describe("DateTest", () => {
   // `fixtures` wires `setupFixtures` internally, so no separate call.
   // Rails date_test.rb declares no `fixtures`; wiring the canonical `topics`
-  // table (and recreating its shape via `{ schema }`) lets the file ride the
-  // shared Topic model with a real `last_read` date column instead of an inline
-  // scratch table that collided under parallel forks.
+  // table lets the file ride the shared Topic model with a real `last_read`
+  // date column instead of an inline scratch table that collided under
+  // parallel forks.
   fixtures(["topics"]);
 
-  // Force-recreate the canonical `topics` table to its full shape. Under
-  // vitest's per-file module isolation the signature/schema caches reset to
-  // canonical each file, so `fixtures`' own `{ schema }` `defineSchema`
-  // sees a cache-hit and skips the repair — leaving a reduced `topics` shape
-  // (e.g. `attribute-methods.test.ts` / `finder.test.ts` both declare a bespoke
-  // `topics` with NO `last_read` column) that a sibling handler-suite file
+  // Force-recreate the canonical `topics` table to its full shape. The table
+  // comes from the template clone and nothing else recreates it, so a reduced
+  // `topics` shape (e.g. `attribute-methods.test.ts` / `finder.test.ts` both
+  // declare a bespoke `topics` with NO `last_read` column) that a sibling handler-suite file
   // co-scheduled earlier in the same fork wrote to the shared worker DB. The
   // date cases below `Topic.create({ last_read })` then fail with a missing
   // `last_read` column — the documented PG flake. `rebuildCanonicalTables`

--- a/packages/activerecord/src/date.test.ts
+++ b/packages/activerecord/src/date.test.ts
@@ -6,7 +6,6 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Base } from "./base.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Topic } from "./test-helpers/models/topic.js";
 
 describe("DateTest", () => {
@@ -15,7 +14,7 @@ describe("DateTest", () => {
   // table (and recreating its shape via `{ schema }`) lets the file ride the
   // shared Topic model with a real `last_read` date column instead of an inline
   // scratch table that collided under parallel forks.
-  fixtures(["topics"], { schema: canonicalSchema });
+  fixtures(["topics"]);
 
   // Force-recreate the canonical `topics` table to its full shape. Under
   // vitest's per-file module isolation the signature/schema caches reset to

--- a/packages/activerecord/src/defaults.test.ts
+++ b/packages/activerecord/src/defaults.test.ts
@@ -22,7 +22,6 @@ import { describeIfPg } from "./adapters/postgresql/test-helper.js";
 import { describeIfSqlite } from "./adapters/sqlite3/test-helper.js";
 import { describeIfSupports, itIfSupports } from "./test-helpers/supports.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Entrant } from "./test-helpers/models/entrant.js";
 
 // Ride the boot-laid `Base.connection` (single-pool test model) rather than a
@@ -58,7 +57,7 @@ describe("DefaultTest", () => {
   // Rails: `require "models/entrant"` + `fixtures` not needed — the test only
   // reads `Entrant.columns_hash`. Wire the canonical `entrants` table so the
   // shared model resolves regardless of any bespoke `entrants` a sibling left.
-  fixtures(["entrants"], { schema: canonicalSchema });
+  fixtures(["entrants"]);
 
   it("nil defaults for not null columns", async () => {
     await Entrant.loadSchema();

--- a/packages/activerecord/src/delegate.test.ts
+++ b/packages/activerecord/src/delegate.test.ts
@@ -2,10 +2,9 @@ import { describe, it, expect } from "vitest";
 import { Base, registerModel, delegate } from "./index.js";
 import { Associations } from "./associations.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 
 describe("Delegate (Rails-guided)", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   // D-Y-INCOMPATIBLE: canonical posts table has `body NOT NULL`; tests create Post
   // without body. defineSchema fast-path reuses the canonical table (title+author_id

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -8,7 +8,6 @@ import { adapterType } from "./test-adapter.js";
 import { StringInquirer, travel, travelBack } from "@blazetrails/activesupport";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Base } from "./base.js";
 import { delegatedType } from "./index.js";
 // Canonical models — mirror Rails' `require "models/{account,entry,message,recipient,comment}"`.
@@ -32,9 +31,7 @@ afterAll(() => {
 describe("DelegatedTypeTest", () => {
   // Rails: `fixtures :comments, :accounts, :posts`. `{ schema }` recreates the
   // canonical fixture tables so the suite survives sibling-file contamination.
-  const { comments, accounts, posts } = fixtures(["comments", "accounts", "posts"], {
-    schema: canonicalSchema,
-  });
+  const { comments, accounts, posts } = fixtures(["comments", "accounts", "posts"]);
 
   // Entry/Message/Recipient aren't fixture-loaded (Rails builds them in setup),
   // so register them by name for polymorphic type resolution and create their

--- a/packages/activerecord/src/delegated-type.test.ts
+++ b/packages/activerecord/src/delegated-type.test.ts
@@ -29,8 +29,9 @@ afterAll(() => {
 });
 
 describe("DelegatedTypeTest", () => {
-  // Rails: `fixtures :comments, :accounts, :posts`. `{ schema }` recreates the
-  // canonical fixture tables so the suite survives sibling-file contamination.
+  // Rails: `fixtures :comments, :accounts, :posts`. The canonical tables come
+  // from the template clone; the beforeAll below force-recreates them so the
+  // suite survives sibling-file contamination.
   const { comments, accounts, posts } = fixtures(["comments", "accounts", "posts"]);
 
   // Entry/Message/Recipient aren't fixture-loaded (Rails builds them in setup),
@@ -44,10 +45,9 @@ describe("DelegatedTypeTest", () => {
   registerModel("Recipient", Recipient);
 
   beforeAll(async () => {
-    // Force-recreate every canonical table this suite touches. The worker's
-    // canonical schema preload keeps signatures cache-warm, so a plain
-    // schema load (including the fixtures' own `{ schema }` derivation) is a
-    // no-op — meaning a sibling file that physically replaced `posts` with a
+    // Force-recreate every canonical table this suite touches. The tables
+    // already exist from the template clone, so nothing else drops them —
+    // meaning a sibling file that physically replaced `posts` with a
     // reduced shape (e.g. `posts: { title }`, no `body`) would survive into this
     // suite and break fixture seeding. Drop + recreate them verbatim. Covers the
     // fixture tables (`comments`/`accounts`/`posts`) plus the setup-built

--- a/packages/activerecord/src/dup.test.ts
+++ b/packages/activerecord/src/dup.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { repairValidations } from "./test-helpers/repair-validations.js";
 import { clearTimestampAttributes } from "./timestamp.js";
 import { DefaultScope } from "./scoping/default.js";
@@ -25,7 +24,7 @@ for (const klass of [Topic, Reply, SillyReply, UniqueReply, SillyUniqueReply]) {
 
 describe("DupTest", () => {
   // Mirrors Rails `fixtures :topics, :cars`.
-  fixtures(["topics", "cars"], { schema: canonicalSchema });
+  fixtures(["topics", "cars"]);
 
   beforeAll(async () => {
     // Car declares `attribute :wheels_owned_at`, so its cold-cache `load_schema`

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -32,7 +32,6 @@ import {
 import { Configurable } from "./configurable.js";
 import { itIfSupports } from "../test-helpers/supports.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { EncryptableRecord } from "./encryptable-record.js";
 import { isEncryptedAttribute } from "../encryption.js";
 import { RecordInvalid } from "../index.js";
@@ -896,7 +895,7 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     restoreEncryption?.();
   });
 
-  const { encryptedBooks } = fixtures(["encryptedBooks"], { schema: canonicalSchema });
+  const { encryptedBooks } = fixtures(["encryptedBooks"]);
 
   it("can only save unencrypted attributes when frozen encryption is true", async () => {
     const book = encryptedBooks("awdr");

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -23,10 +23,9 @@ import { Base, registerModel } from "./index.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Book } from "./test-helpers/models/book.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA } from "./test-helpers/test-schema.js";
 
 describe("EnumTest", () => {
-  const { books } = fixtures(["books"], { schema: TEST_SCHEMA });
+  const { books } = fixtures(["books"]);
 
   beforeAll(() => {
     registerModel(Book);

--- a/packages/activerecord/src/excluding.test.ts
+++ b/packages/activerecord/src/excluding.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect } from "vitest";
 import "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { registerModel } from "./associations.js";
 import type { Relation } from "./relation.js";
 import { Post } from "./test-helpers/models/post.js";
@@ -20,9 +19,7 @@ describe("ExcludingTest", () => {
   // tables are pre-built per worker; seed them so each `excluding` relation has
   // rows to read back, and so the shared models resolve regardless of any
   // bespoke table a sibling file left in the worker DB.
-  const { posts, comments } = fixtures(["posts", "comments"], {
-    schema: canonicalSchema,
-  });
+  const { posts, comments } = fixtures(["posts", "comments"]);
 
   const ids = (records: { id: unknown }[]) => records.map((r) => r.id);
 

--- a/packages/activerecord/src/explain.test.ts
+++ b/packages/activerecord/src/explain.test.ts
@@ -13,7 +13,6 @@ import { buildExplainClause } from "./explain.js";
 import { itIfSupports } from "./test-helpers/supports.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Car } from "./test-helpers/models/car.js";
 import { Bulb } from "./test-helpers/models/bulb.js";
 
@@ -21,7 +20,7 @@ registerModel(Car);
 registerModel(Bulb);
 
 describe("ExplainTest", () => {
-  fixtures(["cars", "bulbs"], { schema: canonicalSchema });
+  fixtures(["cars", "bulbs"]);
 
   itIfSupports("explain", "relation explain", async () => {
     const message = await Car.where({ name: "honda" }).explain();

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -16,7 +16,6 @@ import { sql as arelSql } from "@blazetrails/arel";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { CpkBook } from "./test-helpers/models/cpk.js";
 import { adapterType } from "./test-adapter.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
 import {
   assertQueriesCount,
@@ -57,7 +56,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 // those onto the real finder_test.rb models/fixtures is tracked under RFC 0048.
 // ==========================================================================
 describe("FinderTest", () => {
-  const { topics } = fixtures(["topics"], { schema: canonicalSchema });
+  const { topics } = fixtures(["topics"]);
   const rid = (r: unknown) => (r as { id: number }).id;
   const Topic = CanonicalTopic;
   // Register by Rails name so STI Reply rows resolve their belongs_to :topic
@@ -469,9 +468,7 @@ describe("FinderTest", () => {
 // builder; tracked under RFC 0023.
 // ==========================================================================
 describe("FinderTest", () => {
-  const { topics, cpkBooks } = fixtures(["topics", "cpkAuthors", "cpkBooks"], {
-    schema: canonicalSchema,
-  });
+  const { topics, cpkBooks } = fixtures(["topics", "cpkAuthors", "cpkBooks"]);
   const Topic = CanonicalTopic;
   registerModel("Topic", Topic);
   registerModel("Reply", CanonicalReply);
@@ -563,7 +560,7 @@ describe("FinderTest", () => {
 // FinderTest — targets finder_test.rb
 // ==========================================================================
 describe("FinderTest", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   it("count by sql", async () => {
     class Topic extends Base {
@@ -1484,7 +1481,7 @@ describe("FinderTest", () => {
 // FinderTest2 — additional coverage for finder_test.rb
 // ==========================================================================
 describe("FinderTest", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   class Post extends Base {
     static {
@@ -1606,7 +1603,7 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   // Rails: test_find_with_array_of_ids
   // Rails: test_find_raises_record_not_found
@@ -1630,7 +1627,7 @@ describe("FinderTest", () => {
 });
 
 describe("FinderTest", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   it("find_by with non-hash conditions returns the first matching record", async () => {
     class Item extends Base {
@@ -1652,7 +1649,7 @@ describe("FinderTest", () => {
 // faithful-port-finder-test-synthetic-clusters.
 // ==========================================================================
 describe("FinderTest", () => {
-  const { posts } = fixtures(["posts", "comments"], { schema: canonicalSchema });
+  const { posts } = fixtures(["posts", "comments"]);
   registerModel(CanonicalPost);
   registerModel(CanonicalComment);
 
@@ -1738,7 +1735,6 @@ describe("FinderTest", () => {
 // ==========================================================================
 describe("FinderTest", () => {
   fixtures(["topics", "comments", "posts", "companies", "accounts"], {
-    schema: canonicalSchema,
     // Rails' malformed-condition test intentionally raises StatementInvalid
     // (unknown `dhh` column), which aborts the surrounding PG transaction and
     // poisons transactional-fixtures teardown; run it outside the wrapper.
@@ -2016,10 +2012,14 @@ describe("FinderTest", () => {
 // Customer/Cpk::Book pair asserts identical behavior.
 // ==========================================================================
 describe("FinderTest", () => {
-  const { customers, cpkBooks, authors, topics } = fixtures(
-    ["customers", "cpkBooks", "cpkAuthors", "topics", "authors", "posts"],
-    { schema: canonicalSchema },
-  );
+  const { customers, cpkBooks, authors, topics } = fixtures([
+    "customers",
+    "cpkBooks",
+    "cpkAuthors",
+    "topics",
+    "authors",
+    "posts",
+  ]);
   const Customer = CanonicalCustomer;
   const Author = CanonicalAuthor;
   registerModel("Customer", Customer);
@@ -2235,7 +2235,7 @@ describe("FinderTest", () => {
 // Kept in its own describe so declaring fixtures() does not activate
 // test-fixture-parity across the stub-heavy exists/find-by block above.
 describe("FinderTest", () => {
-  const { customers } = fixtures(["customers"], { schema: canonicalSchema });
+  const { customers } = fixtures(["customers"]);
   const Customer = CanonicalCustomer;
 
   it("exists with aggregate having three mappings", async () => {
@@ -2286,20 +2286,17 @@ describe("FinderTest", () => {
 // coverage (RFC 0023). Test names match Rails verbatim.
 // ==========================================================================
 describe("FinderTest", () => {
-  const { topics, authors, developers } = fixtures(
-    [
-      "topics",
-      "authors",
-      "posts",
-      "comments",
-      "categorizations",
-      "taggings",
-      "subscribers",
-      "developers",
-      "ratings",
-    ],
-    { schema: canonicalSchema },
-  );
+  const { topics, authors, developers } = fixtures([
+    "topics",
+    "authors",
+    "posts",
+    "comments",
+    "categorizations",
+    "taggings",
+    "subscribers",
+    "developers",
+    "ratings",
+  ]);
 
   const Topic = CanonicalTopic;
   const Author = CanonicalAuthor;

--- a/packages/activerecord/src/forbidden-attributes-protection.test.ts
+++ b/packages/activerecord/src/forbidden-attributes-protection.test.ts
@@ -24,7 +24,6 @@ import { Ship } from "./test-helpers/models/ship.js";
 import { Treasure } from "./test-helpers/models/treasure.js";
 import { registerModel } from "./associations.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { ProtectedParams } from "./test-helpers/protected-params.js";
 
 // ShipPart's nested associations resolve `Ship` / `Treasure` from the model
@@ -34,7 +33,7 @@ registerModel(Ship);
 registerModel(Treasure);
 
 describe("ForbiddenAttributesProtectionTest", () => {
-  fixtures(["people", "companies"], { schema: canonicalSchema });
+  fixtures(["people", "companies"]);
 
   it("forbidden attributes cannot be used for mass assignment", () => {
     const params = new ProtectedParams({ first_name: "Guille", gender: "m" });

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -20,7 +20,6 @@ import { UnknownAttributeError, RecordNotUnique } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { adapterType } from "./test-adapter.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
 // Opt into the canonical-model autoload index so association targets resolve by
 // name on first reference — no manual `registerModel`.
@@ -108,7 +107,6 @@ async function withRecordTimestamps(
 describe("InsertAllTest", () => {
   setupFixtures();
   fixtures(["authors", "books"], {
-    schema: canonicalSchema,
     // These two raise a DB-level RecordNotUnique; a PG unique violation aborts
     // the surrounding transaction and poisons transactional-fixtures teardown,
     // so run them unwrapped (the per-test fixture reseed cleans up). The other

--- a/packages/activerecord/src/instrumentation.test.ts
+++ b/packages/activerecord/src/instrumentation.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 // Opt into the canonical-model autoload index so association targets resolve by
 // name on first reference — no manual `registerModel`.
 import "./test-helpers/canonical-model-index.js";
@@ -16,7 +15,7 @@ import { Author } from "./test-helpers/models/author.js";
 import { ClothingItem } from "./test-helpers/models/clothing-item.js";
 
 describe("InstrumentationTest", () => {
-  fixtures(["books", "authors"], { schema: canonicalSchema });
+  fixtures(["books", "authors"]);
 
   afterEach(() => {
     Notifications.unsubscribeAll();
@@ -231,7 +230,7 @@ function transactionInSqlActiveRecordPayloadTests(): void {
 }
 
 describe("TransactionInSqlActiveRecordPayloadTest", () => {
-  fixtures(["books"], { schema: canonicalSchema });
+  fixtures(["books"]);
 
   afterEach(() => {
     Notifications.unsubscribeAll();
@@ -244,7 +243,6 @@ describe("TransactionInSqlActiveRecordPayloadNonTransactionalTest", () => {
   // Rails: `self.use_transactional_tests = false` — neither case may run inside
   // the rollback-on-teardown outer transaction.
   fixtures(["books"], {
-    schema: canonicalSchema,
     usesTransaction: ["payload without an open transaction", "payload with an open transaction"],
   });
 

--- a/packages/activerecord/src/locking.test.ts
+++ b/packages/activerecord/src/locking.test.ts
@@ -809,10 +809,9 @@ describe("OptimisticLockingWithSchemaChangeTest", () => {
 describe("PessimisticLockingTest", () => {
   // Mirrors Rails `fixtures :people` — seed the canonical people rows and read
   // them with `Person.find(people("michael").id)` (Rails' `Person.find(1)`)
-  // instead of constructing records inline. `schema` recreates the canonical
-  // `people` table so the full fixture columns (gender, *_id, counts) and the
-  // shared Person model resolve, regardless of any bespoke `people` a sibling
-  // file left in the shared worker DB.
+  // instead of constructing records inline. The canonical `people` table —
+  // with its full fixture columns (gender, *_id, counts) — comes from the
+  // template clone.
   // `with lock sets isolation` must run outside the transactional-fixtures
   // wrapper — setting an isolation level inside a nested transaction raises
   // (mirrors Rails, where isolation requires a top-level transaction).

--- a/packages/activerecord/src/locking.test.ts
+++ b/packages/activerecord/src/locking.test.ts
@@ -16,7 +16,6 @@ import { Associations, association } from "./associations.js";
 
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Person, RichPerson } from "./test-helpers/models/person.js";
 import { Frog } from "./test-helpers/models/frog.js";
 import { Treasure } from "./test-helpers/models/treasure.js";
@@ -47,10 +46,14 @@ describe("OptimisticLockingTest", () => {
   // bespoke `LockWithoutDefault*` (Rails declares these top-level, no fixtures)
   // and `ReadonlyNameShip < Ship` tables are canonical too. Treasures are listed
   // before peoples_treasures so their IDs are resolved first (ref ordering).
-  const { people, stringKeyObjects, legacyThings, references } = fixtures(
-    ["people", "stringKeyObjects", "legacyThings", "references", "treasures", "peoplesTreasures"],
-    { schema: canonicalSchema },
-  );
+  const { people, stringKeyObjects, legacyThings, references } = fixtures([
+    "people",
+    "stringKeyObjects",
+    "legacyThings",
+    "references",
+    "treasures",
+    "peoplesTreasures",
+  ]);
   beforeAll(async () => {
     // Force-recreate every canonical table this suite touches. The worker's
     // canonical schema preload keeps their signatures cache-warm, so a plain
@@ -668,7 +671,6 @@ describe("OptimisticLockingWithSchemaChangeTest", () => {
     "destroy stale object",
   ];
   const { people, legacyThings } = fixtures(["people", "legacyThings", "references"], {
-    schema: canonicalSchema,
     usesTransaction: schemaChangeTests,
   });
   beforeAll(async () => {
@@ -815,7 +817,6 @@ describe("PessimisticLockingTest", () => {
   // wrapper — setting an isolation level inside a nested transaction raises
   // (mirrors Rails, where isolation requires a top-level transaction).
   const { people } = fixtures(["people"], {
-    schema: canonicalSchema,
     usesTransaction: ["with lock sets isolation"],
   });
 

--- a/packages/activerecord/src/model-schema-columnshash-recovery.test.ts
+++ b/packages/activerecord/src/model-schema-columnshash-recovery.test.ts
@@ -14,11 +14,10 @@
 import { describe, it, expect } from "vitest";
 import "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Developer, SpecialDeveloper } from "./test-helpers/models/developer.js";
 
 describe("columnsHash warm-cache same-table read", () => {
-  fixtures(["developers"], { schema: canonicalSchema });
+  fixtures(["developers"]);
 
   it("reads real columns for a fresh sibling of an ignoredColumns model", () => {
     // Warm the cache via the sibling that DECLARES `ignoredColumns`

--- a/packages/activerecord/src/multiparameter-attributes.test.ts
+++ b/packages/activerecord/src/multiparameter-attributes.test.ts
@@ -7,7 +7,6 @@ import { TimeWithZone } from "@blazetrails/activesupport";
 import { Base, composedOf, MultiparameterAssignmentErrors } from "./index.js";
 import { withTimezoneConfig } from "./test-helper.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA } from "./test-helpers/test-schema.js";
 import { Topic } from "./test-helpers/models/topic.js";
 
 const utc = (v: Temporal.Instant) => v.toZonedDateTimeISO("UTC");
@@ -17,7 +16,7 @@ describe("MultiParameterAttributeTest", () => {
   // schema cache for topics so the synchronous loadSchema path (triggered by
   // new Topic() inside tests) finds the date/time column types correctly on all
   // adapters including MariaDB. Mirrors date.test.ts.
-  fixtures(["topics"], { schema: TEST_SCHEMA });
+  fixtures(["topics"]);
 
   beforeAll(async () => {
     // Eagerly populate Topic._attributeDefinitions from the warm pool schema cache.

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -29,10 +29,9 @@ describe.skipIf(!isSqliteRun())("MultipleDbTest", () => {
   // ref("courses", …) which can't cross adapter registries (arunit2 ↔ primary).
   // Seed each set through its model-specific connection via `fixtures()`'
   // caller-supplied `connection` knob. `use_transactional_tests = false`
-  // (Rails), and `schema: undefined` because the tables are created by
-  // `setupSecondPool` (colleges/courses in arunit2, entrants in primary), not
-  // sliced from the canonical `TEST_SCHEMA` default.
-  const seedOpts = { useTransactionalTests: false, schema: undefined } as const;
+  // (Rails). The tables are created by `setupSecondPool` (colleges/courses in
+  // arunit2, entrants in primary), not from the canonical template clone.
+  const seedOpts = { useTransactionalTests: false } as const;
   const { colleges } = fixtures(["colleges"], {
     connection: () => College.connection,
     ...seedOpts,

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -41,8 +41,8 @@ import { repairValidations } from "./test-helpers/repair-validations.js";
 import { assertNoQueries, assertQueriesCount } from "./testing/query-assertions.js";
 
 // The canonical models these tests exercise, declared as (data-less) fixture
-// sets. Declaring a set derives its slice of TEST_SCHEMA (plus HABTM join
-// tables) and auto-registers the model on resolution — replacing the manual
+// sets. Their tables come from the template clone; declaring a set
+// auto-registers the model on resolution — replacing the manual
 // `defineSchema` + `registerModel` bootstrap. Empty data means no seeded rows;
 // each test builds the records it needs (matching Rails, which doesn't declare
 // fixtures for these classes).

--- a/packages/activerecord/src/null-relation.test.ts
+++ b/packages/activerecord/src/null-relation.test.ts
@@ -6,7 +6,6 @@
 import { describe, it, expect } from "vitest";
 import "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { assertNoQueries, assertQueriesCount } from "./testing/query-assertions.js";
 import { association, registerModel } from "./associations.js";
 import { Developer } from "./test-helpers/models/developer.js";
@@ -25,7 +24,7 @@ registerModel(Topic);
 describe("NullRelationTest", () => {
   // Mirrors Rails `fixtures :posts, :comments`; `{ schema }` recreates the
   // canonical tables so the suite survives sibling-file contamination.
-  fixtures(["posts", "comments"], { schema: canonicalSchema });
+  fixtures(["posts", "comments"]);
 
   it("none", async () => {
     await assertNoQueries(false, async () => {

--- a/packages/activerecord/src/null-relation.test.ts
+++ b/packages/activerecord/src/null-relation.test.ts
@@ -22,8 +22,8 @@ registerModel(Topic);
 // NullRelationTest — targets null_relation_test.rb
 // ==========================================================================
 describe("NullRelationTest", () => {
-  // Mirrors Rails `fixtures :posts, :comments`; `{ schema }` recreates the
-  // canonical tables so the suite survives sibling-file contamination.
+  // Mirrors Rails `fixtures :posts, :comments`; the canonical tables come from
+  // the template clone.
   fixtures(["posts", "comments"]);
 
   it("none", async () => {

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -28,7 +28,6 @@ import type { PostgreSQLAdapter } from "./connection-adapters/postgresql-adapter
 import type { TableDefinition as PgTableDefinition } from "./connection-adapters/postgresql/schema-definitions.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { adapterType } from "./test-adapter.js";
 import { ChatMessage, ChatMessageCustomPk } from "./test-helpers/models/chat-message.js";
 import { captureSql } from "./testing/sql-capture.js";
@@ -114,10 +113,12 @@ for (const klass of [
 // ==========================================================================
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
-  const { topics, accounts, clothingItems } = fixtures(
-    ["topics", "minimalistics", "accounts", "clothingItems"],
-    { schema: canonicalSchema },
-  );
+  const { topics, accounts, clothingItems } = fixtures([
+    "topics",
+    "minimalistics",
+    "accounts",
+    "clothingItems",
+  ]);
 
   // The `auto_id_tests` table is prebuilt on the per-worker DB from the
   // canonical schema (`template-global-setup.ts`); `loadSchema` warms the cache
@@ -500,9 +501,7 @@ describe("PersistenceTest", () => {
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
   const Post = CanonicalPost;
-  const { topics } = fixtures(["topics", "developers", "parrots", "posts"], {
-    schema: canonicalSchema,
-  });
+  const { topics } = fixtures(["topics", "developers", "parrots", "posts"]);
 
   // Rails: `Developer.update!(salary: 1_000_000)` — the class-level bang
   // update touches every Developer, and the salary inclusion validation
@@ -571,9 +570,7 @@ describe("PersistenceTest", () => {
 // ==========================================================================
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
-  const { topics } = fixtures(["topics", "companies"], {
-    schema: canonicalSchema,
-  });
+  const { topics } = fixtures(["topics", "companies"]);
 
   it("build", () => {
     const topic = Topic.build({ title: "New Topic" });
@@ -807,7 +804,7 @@ describe("PersistenceTest", () => {
 // bespoke Post to canonical Client + companies fixtures.
 // ==========================================================================
 describe("PersistenceTest", () => {
-  fixtures(["companies"], { schema: canonicalSchema });
+  fixtures(["companies"]);
 
   // Rails: test_delete_new_record
   it("delete new record", async () => {
@@ -861,7 +858,7 @@ describe("PersistenceTest", () => {
 // SpecialPost STI (persistence_test.rb#test_instantiate_creates_a_new_instance)
 // ==========================================================================
 describe("PersistenceTest", () => {
-  fixtures(["posts", "authors"], { schema: canonicalSchema });
+  fixtures(["posts", "authors"]);
 
   // Rails: test_instantiate_creates_a_new_instance
   it("instantiate creates a new instance", () => {
@@ -879,7 +876,7 @@ describe("PersistenceTest", () => {
 // PersistenceTest — create with custom timestamps (canonical LiveParrot).
 // ==========================================================================
 describe("PersistenceTest", () => {
-  fixtures(["parrots"], { schema: canonicalSchema });
+  fixtures(["parrots"]);
 
   // Rails: test_create_with_custom_timestamps
   it("create with custom timestamps", async () => {
@@ -897,7 +894,7 @@ describe("PersistenceTest", () => {
 // PersistenceTest — becomes errors base (canonical AdminUser subclass).
 // ==========================================================================
 describe("PersistenceTest", () => {
-  fixtures(["admin/users"], { schema: canonicalSchema });
+  fixtures(["admin/users"]);
 
   // Rails: test_becomes_errors_base
   it("becomes errors base", () => {
@@ -927,9 +924,7 @@ describe("PersistenceTest", () => {
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
   const Developer = CanonicalDeveloper;
-  const { topics } = fixtures(["topics", "minivans", "developers"], {
-    schema: canonicalSchema,
-  });
+  const { topics } = fixtures(["topics", "minivans", "developers"]);
 
   // Rails: test_update_column_should_not_modify_updated_at
   // Developer aliases updated_at → legacy_updated_at (developer.rb), so the
@@ -994,7 +989,7 @@ describe("PersistenceTest", () => {
 // ==========================================================================
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
-  const { topics } = fixtures(["topics"], { schema: canonicalSchema });
+  const { topics } = fixtures(["topics"]);
 
   // Rails: test_delete
   it("delete", async () => {
@@ -1071,9 +1066,7 @@ describe("PersistenceTest", () => {
 // ==========================================================================
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
-  const { topics, people } = fixtures(["topics", "people", "cars"], {
-    schema: canonicalSchema,
-  });
+  const { topics, people } = fixtures(["topics", "people", "cars"]);
 
   it("decrement with touch an attribute updates timestamps", async () => {
     const topic = topics("first");
@@ -1129,7 +1122,7 @@ describe("PersistenceTest", () => {
 });
 
 describe("PersistenceTest", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   const Topic = CanonicalTopic;
 
@@ -1351,7 +1344,7 @@ describe("PersistenceTest", () => {
   }); // QueryConstraintsTest
 });
 describe("PersistenceTest", () => {
-  fixtures(["topics", "posts", "authors"], { schema: canonicalSchema });
+  fixtures(["topics", "posts", "authors"]);
   const Topic = CanonicalTopic;
   const Post = CanonicalPost;
 
@@ -1390,7 +1383,7 @@ describe("PersistenceTest", () => {
 });
 
 describe("PersistenceTest", () => {
-  fixtures(["topics", "developers"], { schema: canonicalSchema });
+  fixtures(["topics", "developers"]);
   const Topic = CanonicalTopic;
 
   it("update column", async () => {
@@ -1472,9 +1465,7 @@ describe("PersistenceTest", () => {
 // PersistenceTest — composite primary key destroy (persistence_test.rb)
 // ==========================================================================
 describe("PersistenceTest", () => {
-  const { cpkBooks } = fixtures(["cpkAuthors", "cpkBooks"], {
-    schema: canonicalSchema,
-  });
+  const { cpkBooks } = fixtures(["cpkAuthors", "cpkBooks"]);
 
   it("destroy with single composite primary key", async () => {
     const book = cpkBooks("cpk_great_author_first_book");
@@ -1517,7 +1508,7 @@ describe("PersistenceTest", () => {
 // ==========================================================================
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
-  const { topics } = fixtures(["topics", "companies"], { schema: canonicalSchema });
+  const { topics } = fixtures(["topics", "companies"]);
 
   it("becomes after reload schema from cache", () => {
     (Reply as any).defineAttributeMethods();
@@ -1576,9 +1567,7 @@ describe("PersistenceTest", () => {
 // PersistenceTest — readonly attributes + non-id primary keys (persistence_test.rb)
 // ==========================================================================
 describe("PersistenceTest", () => {
-  const { developers } = fixtures(["developers", "minivans", "speedometers"], {
-    schema: canonicalSchema,
-  });
+  const { developers } = fixtures(["developers", "minivans", "speedometers"]);
 
   it("update attribute for readonly attribute", async () => {
     const minivan = await Minivan.find("m1");
@@ -1707,7 +1696,7 @@ describe("PersistenceTest", () => {
 describe("PersistenceTest", () => {
   registerModel(ChatMessage);
   registerModel(ChatMessageCustomPk);
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
   beforeAll(async () => {
     // uuid is a PG-only defineSchema type, so the schema is only applied on
     // postgres; the tests below are individually gated to the same adapter.
@@ -1767,7 +1756,7 @@ describe("PersistenceTest", () => {
 // becomes + restricted-name dirty tracking (persistence_test.rb:473)
 // ==========================================================================
 describe("PersistenceTest", () => {
-  fixtures(["companies"], { schema: canonicalSchema });
+  fixtures(["companies"]);
   // Warm the schema cache so Company's column accessors (incl. the restricted
   // `name` reader) are generated before `new Company(...)`, matching Rails where
   // the connection reflects columns lazily on first use.
@@ -1788,7 +1777,7 @@ describe("PersistenceTest", () => {
 // ==========================================================================
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
-  fixtures(["topics", "developers", "parrots"], { schema: canonicalSchema });
+  fixtures(["topics", "developers", "parrots"]);
 
   it("save valid record", async () => {
     const topic = new Topic({ title: "New Topic" });
@@ -1832,9 +1821,7 @@ describe("PersistenceTest", () => {
 // QueryConstraintsTest — targets persistence_test.rb QueryConstraintsTest
 // ==========================================================================
 describe("QueryConstraintsTest", () => {
-  const { clothingItems } = fixtures(["clothingItems", "dashboards", "topics", "posts"], {
-    schema: canonicalSchema,
-  });
+  const { clothingItems } = fixtures(["clothingItems", "dashboards", "topics", "posts"]);
 
   beforeAll(async () => {
     // `developers_projects` is a join table with no single primary key; warm its

--- a/packages/activerecord/src/persistence.trails.test.ts
+++ b/packages/activerecord/src/persistence.trails.test.ts
@@ -11,7 +11,6 @@
 import { describe, it, expect } from "vitest";
 import { RecordInvalid } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { repairValidations } from "./test-helpers/repair-validations.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
 import { Developer as CanonicalDeveloper } from "./test-helpers/models/developer.js";
@@ -21,7 +20,7 @@ import { captureSql } from "./testing/sql-capture.js";
 
 describe("PersistenceTest (trails)", () => {
   const Topic = CanonicalTopic;
-  fixtures(["topics", "developers"], { schema: canonicalSchema });
+  fixtures(["topics", "developers"]);
 
   // Rails: Model.update([ids], [attrs]) — parallel arrays, index-aligned.
   it("update with parallel ids + attrs arrays updates each record", async () => {
@@ -136,7 +135,7 @@ describe("PersistenceTest (trails)", () => {
 });
 
 describe("PersistenceTest (trails)", () => {
-  fixtures(["items"], { schema: canonicalSchema });
+  fixtures(["items"]);
 
   const Item = CanonicalItem;
 
@@ -163,7 +162,7 @@ describe("PersistenceTest (trails)", () => {
 });
 
 describe("PersistenceTest (trails)", () => {
-  const { clothingItems } = fixtures(["clothingItems"], { schema: canonicalSchema });
+  const { clothingItems } = fixtures(["clothingItems"]);
 
   // Regression guard: like save/delete, `updateColumns` must locate the row via
   // `_query_constraints_hash` (Rails persistence.rb:615-624/852-858), so a model

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -6,7 +6,6 @@ import { Base, registerModel } from "./index.js";
 import { SchemaDumper } from "./schema-dumper.js";
 import { MissingAttributeError } from "@blazetrails/activemodel";
 import { adapterType } from "./test-adapter.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { Topic } from "./test-helpers/models/topic.js";
@@ -20,10 +19,12 @@ import { CpkBook, CpkOrder } from "./test-helpers/models/cpk.js";
 import { Country } from "./test-helpers/models/country.js";
 
 describe("PrimaryKeysTest", () => {
-  const { topics, subscribers, mixedCaseMonkeys } = fixtures(
-    ["topics", "subscribers", "movies", "mixedCaseMonkeys"],
-    { schema: canonicalSchema },
-  );
+  const { topics, subscribers, mixedCaseMonkeys } = fixtures([
+    "topics",
+    "subscribers",
+    "movies",
+    "mixedCaseMonkeys",
+  ]);
 
   beforeAll(async () => {
     registerModel(Reply);
@@ -544,9 +545,7 @@ async function primaryKeysOf(tableName: string): Promise<string[]> {
 }
 
 describe("CompositePrimaryKeyTest", () => {
-  const { cpkBooks } = fixtures(["cpkAuthors", "cpkOrders", "cpkBooks"], {
-    schema: canonicalSchema,
-  });
+  const { cpkBooks } = fixtures(["cpkAuthors", "cpkOrders", "cpkBooks"]);
 
   beforeAll(async () => {
     await rebuildCanonicalTables(Base.connection, ["cpk_books", "cpk_orders", "cpk_authors"]);

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -11,7 +11,6 @@ import { Topic } from "./test-helpers/models/topic.js";
 import { Category } from "./test-helpers/models/category.js";
 import { Post } from "./test-helpers/models/post.js";
 import { association } from "./associations.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { assertQueriesCount, assertNoQueries } from "./testing/query-assertions.js";
 import { QueryCache } from "./query-cache.js";
 import { LogSubscriber } from "./log-subscriber.js";
@@ -61,9 +60,7 @@ function assertCache(
 }
 
 describe("QueryCacheTest", () => {
-  fixtures(["tasks", "topics", "categories", "posts", "categoriesPosts"], {
-    schema: canonicalSchema,
-  });
+  fixtures(["tasks", "topics", "categories", "posts", "categoriesPosts"]);
 
   afterEach(async () => {
     Task.connectionPool().clearQueryCache();
@@ -632,9 +629,7 @@ describe("QuerySerializedParamTest", () => {
 });
 
 describe("QueryCacheExpiryTest", () => {
-  fixtures(["tasks", "posts", "categories", "categoriesPosts"], {
-    schema: canonicalSchema,
-  });
+  fixtures(["tasks", "posts", "categories", "categoriesPosts"]);
 
   afterEach(async () => {
     (await Task.leaseConnection()).clearQueryCache();
@@ -724,7 +719,6 @@ describe("QueryCacheExpiryTest", () => {
 
 describe("TransactionInCachedSqlActiveRecordPayloadTest", () => {
   fixtures(["tasks"], {
-    schema: canonicalSchema,
     usesTransaction: ["payload with open transaction"],
   });
 

--- a/packages/activerecord/src/query-logs.test.ts
+++ b/packages/activerecord/src/query-logs.test.ts
@@ -8,7 +8,6 @@ import { queryLogs } from "./query-logs-instance.js";
 import { queryTransformers, type QueryTransformer } from "./query-transformers.js";
 import { assertQueriesMatch } from "./testing/query-assertions.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Dashboard } from "./test-helpers/models/dashboard.js";
 import { adapterType } from "./test-adapter.js";
 
@@ -28,9 +27,8 @@ function leaseConnection(): RawAdapter {
 // counterpart does (`Dashboard.first`, `connection.execute "SELECT 1"`).
 describe("QueryLogsTest", () => {
   // Rails: `fixtures :dashboards`. `fixtures` wires the handler suite
-  // internally. `schema: canonicalSchema` defends against sibling-file schema
-  // contamination in the shared worker DB.
-  fixtures(["dashboards"], { schema: canonicalSchema });
+  // internally; canonical tables come from the template clone.
+  fixtures(["dashboards"]);
 
   let originalTransformers: QueryTransformer[];
 

--- a/packages/activerecord/src/querying-methods-delegation.test.ts
+++ b/packages/activerecord/src/querying-methods-delegation.test.ts
@@ -5,11 +5,10 @@
 import { describe, it, expect } from "vitest";
 import { Topic } from "./test-helpers/models/topic.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 
 // Rails `fixtures :topics`. Recreate the canonical topics table empty; each test
 // seeds its own rows and the transactional wrapper rolls them back.
-fixtures({ topics: [Topic, {}] }, { schema: canonicalSchema });
+fixtures({ topics: [Topic, {}] });
 
 describe("Base static query delegations", () => {
   it("Base.first() returns the first record", async () => {

--- a/packages/activerecord/src/querying.test.ts
+++ b/packages/activerecord/src/querying.test.ts
@@ -5,12 +5,11 @@ import { Result } from "./result.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { Reply } from "./test-helpers/models/reply.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 
 // Rails `fixtures :topics`. Recreate the canonical topics table empty so the
 // forwarder/aggregate assertions run against a clean shape on the shared worker
 // DB; the static forwarders only assert relation/promise types, not row data.
-fixtures({ topics: [Topic, {}] }, { schema: canonicalSchema });
+fixtures({ topics: [Topic, {}] });
 
 describe("QueryingTest — static forwarders on Base", () => {
   it("includes() returns a Relation without throwing", () => {

--- a/packages/activerecord/src/relation-exec-main-query.test.ts
+++ b/packages/activerecord/src/relation-exec-main-query.test.ts
@@ -9,7 +9,6 @@
 import { describe, it, expect } from "vitest";
 import "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
 import { registerModel } from "./associations.js";
 import { Author } from "./test-helpers/models/author.js";
@@ -17,7 +16,7 @@ import { Author } from "./test-helpers/models/author.js";
 registerModel(Author);
 
 describe("RelationTest", () => {
-  fixtures(["authors", "authorAddresses"], { schema: canonicalSchema });
+  fixtures(["authors", "authorAddresses"]);
 
   it("find in empty array", async () => {
     const authors = Author.all().where({ id: [] });

--- a/packages/activerecord/src/relation.test.ts
+++ b/packages/activerecord/src/relation.test.ts
@@ -11,7 +11,6 @@ import { Base } from "./base.js";
 import { registerModel } from "./associations.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { quoteTableName as canonicalQuoteTableName } from "./test-helpers/quote-regex.js";
 // Aliased so the canonical models read clearly alongside the merge-block usage
 // below and so the `test:compare` `RelationTest` matcher stays unambiguous.
@@ -72,9 +71,7 @@ class UpdateAllTestModel extends Base {
 // scope to records they create under the rolled-back transactional fixture.
 // ==========================================================================
 describe("RelationTest", () => {
-  fixtures(["posts", "comments", "authors", "authorAddresses", "ratings", "categorizations"], {
-    schema: canonicalSchema,
-  });
+  fixtures(["posts", "comments", "authors", "authorAddresses", "ratings", "categorizations"]);
 
   beforeAll(() => {
     registerModel(CanonAuthor);
@@ -523,12 +520,14 @@ describe("RelationTest", () => {
 // describe name so `test:compare` matches it to Ruby's `RelationTest` in
 // relation_test.rb.
 describe("RelationTest", () => {
-  const { authors } = fixtures(
-    ["authors", "posts", "comments", "ratings", "categorizations", "categories"],
-    {
-      schema: canonicalSchema,
-    },
-  );
+  const { authors } = fixtures([
+    "authors",
+    "posts",
+    "comments",
+    "ratings",
+    "categorizations",
+    "categories",
+  ]);
 
   beforeAll(() => {
     registerModel(CanonAuthor);

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -13,7 +13,6 @@ import { Base } from "./index.js";
 import { registerModel, modelRegistry } from "./associations.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Post as CanonPost } from "./test-helpers/models/post.js";
 import {
   Comment as CanonComment,
@@ -29,7 +28,7 @@ describe("isBlank / isPresent", () => {
   // boot-laid empty on the primary worker DB, so ride `Base.connection` (the
   // handler suite) rather than a sidecar-pool lease with an in-test
   // `createTable`. Transactional fixtures roll back the inserted row per test.
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   it("isBlank returns true when no records exist", async () => {
     // Inline model on the canonical `developers` table (not the canonical
@@ -54,7 +53,7 @@ describe("isBlank / isPresent", () => {
 });
 
 describe("RelationTest", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   // No like-named Rails test: relation_test.rb only covers the invalid-key path
   // ("merging a hash with unknown keys raises"). This guards the positive
@@ -489,7 +488,7 @@ describe("RelationTest", () => {
 // to exactly the same SQL as `relation.toSql()` — i.e. the legacy string-assembly
 // path and the Arel-manager path can no longer drift.
 describe("Relation#arel build_arel convergence", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
   beforeAll(() => {
     registerModel("Widget", Widget);
     registerModel("Gadget", Gadget);
@@ -608,12 +607,14 @@ describe("Relation#arel build_arel convergence", () => {
 });
 
 describe("RelationTest", () => {
-  const { authors } = fixtures(
-    ["authors", "posts", "comments", "ratings", "categorizations", "categories"],
-    {
-      schema: canonicalSchema,
-    },
-  );
+  const { authors } = fixtures([
+    "authors",
+    "posts",
+    "comments",
+    "ratings",
+    "categorizations",
+    "categories",
+  ]);
 
   beforeAll(() => {
     registerModel(CanonAuthor);

--- a/packages/activerecord/src/relation/and.test.ts
+++ b/packages/activerecord/src/relation/and.test.ts
@@ -6,13 +6,10 @@
 import { describe, it, expect } from "vitest";
 import "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Author } from "../test-helpers/models/author.js";
 
 describe("AndTest", () => {
-  const { authors } = fixtures(["authors", "authorAddresses"], {
-    schema: canonicalSchema,
-  });
+  const { authors } = fixtures(["authors", "authorAddresses"]);
 
   it("and", async () => {
     const david = authors("david");

--- a/packages/activerecord/src/relation/arel-ast-convergence.test.ts
+++ b/packages/activerecord/src/relation/arel-ast-convergence.test.ts
@@ -30,7 +30,6 @@ import { describe, it, expect } from "vitest";
 import { Base } from "../index.js";
 import { adapterType } from "../test-adapter.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post as CanonicalPost } from "../test-helpers/models/post.js";
 
 // Establish the primary (boot-laid canonical-schema) pool so the bespoke
@@ -128,7 +127,7 @@ describe("RFC 0022 arel-AST convergence (relation layer)", () => {
     describe("executing through Relation#pluck", () => {
       // `posts` rides the boot-laid canonical schema (RFC 0059 Phase 1);
       // per-file `repairWorkerSchema` restores any sibling drift beforehand.
-      fixtures(["posts"], { schema: canonicalSchema });
+      fixtures(["posts"]);
 
       it("scopes plucked rows to the from(subquery)", async () => {
         const sub = CanonicalPost.where("id <= 2");

--- a/packages/activerecord/src/relation/bound-sql-literal-relation.test.ts
+++ b/packages/activerecord/src/relation/bound-sql-literal-relation.test.ts
@@ -11,7 +11,6 @@ import { Nodes } from "@blazetrails/arel";
 import "../index.js";
 import { registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Topic } from "../test-helpers/models/topic.js";
 
 registerModel(Topic);
@@ -30,7 +29,7 @@ type BoundSqlLiteralBuilders = {
 };
 
 describe("bound SQL literal with Relation bind value", () => {
-  fixtures(["topics"], { schema: canonicalSchema });
+  fixtures(["topics"]);
 
   it("inlines a Relation positional bind as an IN subquery", async () => {
     const approved = Topic.where({ approved: true });

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -14,14 +14,13 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { CpkBook, CpkOrder, CpkAuthor, CpkChapter } from "../test-helpers/models/cpk.js";
 
 describe("Relation#where — composite-key form", () => {
   // Rails creates the CPK rows inline with `Cpk::Book.create!` — no cpk
   // fixtures are loaded — so we ride the canonical, empty `cpk_books`
   // table and let transactional rollback clean up each test's inserts.
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   beforeAll(() => {
     [CpkBook, CpkOrder, CpkAuthor, CpkChapter].forEach((m) => registerModel(m));

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -24,7 +24,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { CpkBook, CpkOrder, CpkAuthor, CpkChapter } from "../test-helpers/models/cpk.js";
 import { captureSql } from "../testing/sql-capture.js";
 import type { Base } from "../index.js";
@@ -32,7 +31,7 @@ import type { Base } from "../index.js";
 describe("CpkBook eager count / aggregate build_joins fold", () => {
   // Rails creates CPK rows inline; ride the canonical, empty cpk tables and let
   // transactional rollback clean up each insert.
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   beforeAll(() => {
     [CpkBook, CpkOrder, CpkAuthor, CpkChapter].forEach((m) =>

--- a/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
@@ -26,7 +26,6 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "../index.js";
 import { registerModel } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { CpkBook, CpkOrder, CpkAuthor, CpkChapter } from "../test-helpers/models/cpk.js";
 import { JoinDependency } from "../associations/join-dependency.js";
 import { Nodes } from "@blazetrails/arel";
@@ -44,7 +43,7 @@ function withCollectionCacheVersioning(fn: () => Promise<void>): Promise<void> {
 describe("CpkBook eager pluck / cache_version over a composite-FK collection", () => {
   // Rails creates CPK rows inline; no cpk fixtures exist. Ride the canonical,
   // empty cpk tables and let transactional rollback clean up each insert.
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   beforeAll(() => {
     [CpkBook, CpkOrder, CpkAuthor, CpkChapter].forEach((m) => registerModel(m));

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -14,7 +14,6 @@ import {
 import { NotImplementedError } from "../errors.js";
 import { CollectionProxy } from "../associations/collection-proxy.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { Project } from "../test-helpers/models/project.js";
@@ -24,7 +23,7 @@ describe("DelegationTest", () => {
   // Mirrors Rails `fixtures :posts` (DelegationCachingTest declares fixtures).
   // `comments` is added for the Enumerable delegation sweep below
   // (DelegationRelationTest declares `fixtures :comments`).
-  fixtures(["posts", "comments"], { schema: canonicalSchema });
+  fixtures(["posts", "comments"]);
 
   registerModel(Post);
   registerModel(Comment);
@@ -560,9 +559,7 @@ describe("DelegationTest", () => {
 });
 
 describe("DelegationCachingTest", () => {
-  const { projects } = fixtures(["projects", "developers", "developersProjects"], {
-    schema: canonicalSchema,
-  });
+  const { projects } = fixtures(["projects", "developers", "developersProjects"]);
 
   registerModel(Project);
   registerModel(Developer);

--- a/packages/activerecord/src/relation/delete-all.test.ts
+++ b/packages/activerecord/src/relation/delete-all.test.ts
@@ -5,7 +5,6 @@
  */
 import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Author, AuthorAddress } from "../test-helpers/models/author.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { Post } from "../test-helpers/models/post.js";
@@ -23,19 +22,16 @@ for (const klass of [Author, AuthorAddress, Comment, Post, Pet, Toy, CpkOrder, C
 // DeleteAllTest — targets relation/delete_all_test.rb
 // ==========================================================================
 describe("DeleteAllTest", () => {
-  const { authors, posts, cpkOrderAgreements } = fixtures(
-    [
-      "authors",
-      "authorAddresses",
-      "comments",
-      "posts",
-      "pets",
-      "toys",
-      "cpkOrders",
-      "cpkOrderAgreements",
-    ],
-    { schema: canonicalSchema },
-  );
+  const { authors, posts, cpkOrderAgreements } = fixtures([
+    "authors",
+    "authorAddresses",
+    "comments",
+    "posts",
+    "pets",
+    "toys",
+    "cpkOrders",
+    "cpkOrderAgreements",
+  ]);
 
   it("destroy all", async () => {
     const davids = Author.where({ name: "David" });

--- a/packages/activerecord/src/relation/field-ordered-values.test.ts
+++ b/packages/activerecord/src/relation/field-ordered-values.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect } from "vitest";
 import { sql as arelSql } from "@blazetrails/arel";
 import { registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Book } from "../test-helpers/models/book.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -15,7 +14,7 @@ import { Author } from "../test-helpers/models/author.js";
 describe("FieldOrderedValuesTest", () => {
   // Mirrors Rails `fixtures :posts`. The enum/string/nil book tests destroy_all
   // and create their own rows, so `books`/`authors` are defined (no fixtures).
-  fixtures(["posts"], { schema: canonicalSchema });
+  fixtures(["posts"]);
   registerModel(Author);
   registerModel(Book);
 

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -9,7 +9,6 @@ import { sql as arelSql } from "@blazetrails/arel";
 
 import { registerModel, Range } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { assertQueriesCount, assertQueriesMatch } from "../testing/query-assertions.js";
 import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -35,10 +34,14 @@ registerModel([
 const ids = async (rel: any): Promise<unknown[]> => (await rel.toArray()).map((r: any) => r.id);
 
 describe("RelationMergingTest", () => {
-  const { authors, developers } = fixtures(
-    ["developers", "comments", "authors", "authorAddresses", "posts", "ratings"],
-    { schema: canonicalSchema },
-  );
+  const { authors, developers } = fixtures([
+    "developers",
+    "comments",
+    "authors",
+    "authorAddresses",
+    "posts",
+    "ratings",
+  ]);
 
   const mergeClauseAssertions = async (
     davidAndMary: any,
@@ -389,7 +392,6 @@ describe("RelationMergingTest", () => {
 
 describe("MergingDifferentRelationsTest", () => {
   const { posts } = fixtures(["posts", "authors", "authorAddresses", "developers", "comments"], {
-    schema: canonicalSchema,
     // The same-alias CTE case deliberately triggers a StatementInvalid, which
     // aborts the PG transaction and would poison shared transactional
     // fixtures; run it outside the shared transaction.

--- a/packages/activerecord/src/relation/or.test.ts
+++ b/packages/activerecord/src/relation/or.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect } from "vitest";
 import { registerModel } from "../index.js";
 import { adapterType } from "../test-adapter.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post, SpecialPost } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
@@ -22,9 +21,7 @@ const byId = (records: any[]) =>
   [...records].sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
 
 describe("OrTest", () => {
-  fixtures(["posts", "authors", "authorAddresses"], {
-    schema: canonicalSchema,
-  });
+  fixtures(["posts", "authors", "authorAddresses"]);
 
   it("or with relation", async () => {
     const expected = await Post.where("id = 1 or id = 2");
@@ -252,7 +249,7 @@ describe("OrTest", () => {
 // The maximum expression tree depth is 1000 by default for SQLite3.
 // https://www.sqlite.org/limits.html#max_expr_depth
 describe("TooManyOrTest", () => {
-  fixtures(["paragraphs"], { schema: canonicalSchema });
+  fixtures(["paragraphs"]);
 
   it.skipIf(adapterType === "sqlite")("too many or", async () => {
     const paragraphs = Array.from({ length: 1001 }, (_, i) =>

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -6,7 +6,6 @@ import { Range } from "../connection-adapters/postgresql/oid/range.js";
 import { TableMetadata } from "../table-metadata.js";
 import { Base, registerModel, modelRegistry } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Topic } from "../test-helpers/models/topic.js";
 import { Reply } from "../test-helpers/models/reply.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -27,9 +26,7 @@ describe("PredicateBuilderTest", () => {
 
   // Rails declares no fixtures here; we still ride the canonical tables so the
   // models' schema is warmed for the synchronous `toSql()` assertions below.
-  fixtures(["topics", "posts", "authors", "products"], {
-    schema: canonicalSchema,
-  });
+  fixtures(["topics", "posts", "authors", "products"]);
 
   beforeAll(() => {
     // Reply.belongs_to(:topic) and the nested {topics: …} key both resolve

--- a/packages/activerecord/src/relation/select-star-join-collision.test.ts
+++ b/packages/activerecord/src/relation/select-star-join-collision.test.ts
@@ -19,7 +19,6 @@
 import { describe, it, expect } from "vitest";
 import { registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 import { Person } from "../test-helpers/models/person.js";
 import { Friendship } from "../test-helpers/models/friendship.js";
 import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
@@ -32,7 +31,7 @@ describe("SELECT * column collision in joined relations", () => {
   // `fixtures` wires setupFixtures + transactional fixtures +
   // fixture seeding in one call; `schema` recreates the canonical `people` /
   // `friendships` tables so a sibling file's reduced shape can't survive in.
-  const { people } = fixtures(["people", "friendships"], { schema: TEST_SCHEMA });
+  const { people } = fixtures(["people", "friendships"]);
 
   it("hydrates the target's columns, not the join table's, when ids collide", async () => {
     // friendships("Connection 1"): id=1, friend_id=michael(1), follower_id=david(2).

--- a/packages/activerecord/src/relation/select-star-join-collision.test.ts
+++ b/packages/activerecord/src/relation/select-star-join-collision.test.ts
@@ -29,8 +29,8 @@ registerModel(Friendship);
 
 describe("SELECT * column collision in joined relations", () => {
   // `fixtures` wires setupFixtures + transactional fixtures +
-  // fixture seeding in one call; `schema` recreates the canonical `people` /
-  // `friendships` tables so a sibling file's reduced shape can't survive in.
+  // fixture seeding in one call; the canonical `people` / `friendships` tables
+  // come from the template clone.
   const { people } = fixtures(["people", "friendships"]);
 
   it("hydrates the target's columns, not the join table's, when ids collide", async () => {

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -9,7 +9,6 @@ import { StatementInvalid } from "../index.js";
 import { MissingAttributeError } from "@blazetrails/activemodel";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post, PostWithDefaultSelect } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { registerModel } from "../associations.js";
@@ -37,7 +36,6 @@ describe("SelectTest", () => {
   // of the wrapping transaction via `usesTransaction` and run in autocommit —
   // the failed statement then errors cleanly without leaving an aborted txn.
   fixtures(["posts", "comments"], {
-    schema: canonicalSchema,
     usesTransaction: [
       "select with not exists field",
       "select with hash with not exists field",

--- a/packages/activerecord/src/relation/structural-compatibility.test.ts
+++ b/packages/activerecord/src/relation/structural-compatibility.test.ts
@@ -6,12 +6,11 @@
 import { describe, it, expect } from "vitest";
 import "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post } from "../test-helpers/models/post.js";
 
 describe("StructuralCompatibilityTest", () => {
   // Mirrors Rails `fixtures :posts`.
-  fixtures(["posts"], { schema: canonicalSchema });
+  fixtures(["posts"]);
 
   it("compatible values", () => {
     const left = Post.where({ id: 1 });

--- a/packages/activerecord/src/relation/thenable.test.ts
+++ b/packages/activerecord/src/relation/thenable.test.ts
@@ -7,7 +7,6 @@
 import { describe, it, expect } from "vitest";
 import { Relation, association, registerModel } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
@@ -17,9 +16,7 @@ registerModel(Post);
 registerModel(Comment);
 
 describe("Thenable", () => {
-  const { posts } = fixtures(["authorAddresses", "authors", "posts", "comments"], {
-    schema: canonicalSchema,
-  });
+  const { posts } = fixtures(["authorAddresses", "authors", "posts", "comments"]);
 
   it("Relation is directly awaitable", async () => {
     const authors = await Author.where({ id: [1, 2] });

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -8,7 +8,6 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { Developer } from "../test-helpers/models/developer.js";
@@ -91,7 +90,6 @@ describe("UpdateAllTest", () => {
       "cpkOrderAgreements",
     ],
     {
-      schema: canonicalSchema,
       // "update all doesnt ignore order" deliberately raises a DB error to test
       // ORDER BY semantics; on PG this aborts the transaction, poisoning teardown.
       usesTransaction: ["update all doesnt ignore order"],

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -8,7 +8,6 @@ import "../index.js";
 import { Range } from "../index.js";
 import { registerModel } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -31,10 +30,15 @@ const includesRecord = (records: unknown[], record: unknown): boolean =>
   records.some((r) => (r as any).id === (record as any).id);
 
 describe("WhereChainTest", () => {
-  const { posts, comments, authors, humans } = fixtures(
-    ["posts", "comments", "authors", "humans", "essays", "authorAddresses", "books"],
-    { schema: canonicalSchema },
-  );
+  const { posts, comments, authors, humans } = fixtures([
+    "posts",
+    "comments",
+    "authors",
+    "humans",
+    "essays",
+    "authorAddresses",
+    "books",
+  ]);
 
   // david is author 1, mary is author 2.
   const davidPostsCount = async (): Promise<number> =>

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -12,7 +12,6 @@ import { ProtectedParams } from "../test-helpers/protected-params.js";
 import { adapterType } from "../test-adapter.js";
 import { seconds } from "@blazetrails/activesupport";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { Author, AuthorAddress } from "../test-helpers/models/author.js";
@@ -63,25 +62,22 @@ describe("WhereTest", () => {
     priceEstimates,
     essays,
     topics,
-  } = fixtures(
-    [
-      "authors",
-      "authorAddresses",
-      "categories",
-      "categorizations",
-      "cars",
-      "treasures",
-      "priceEstimates",
-      "binaries",
-      "edges",
-      "vertices",
-      "essays",
-      "posts",
-      "comments",
-      "topics",
-    ],
-    { schema: canonicalSchema },
-  );
+  } = fixtures([
+    "authors",
+    "authorAddresses",
+    "categories",
+    "categorizations",
+    "cars",
+    "treasures",
+    "priceEstimates",
+    "binaries",
+    "edges",
+    "vertices",
+    "essays",
+    "posts",
+    "comments",
+    "topics",
+  ]);
 
   it("type casting nested joins", async () => {
     const comment = comments("eager_other_comment1");

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -7,7 +7,6 @@ import { describe, it, expect } from "vitest";
 import { sql as arelSql } from "@blazetrails/arel";
 import "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
 import { Company } from "../test-helpers/models/company.js";
@@ -41,7 +40,7 @@ const cteSym = (name: string) => Symbol(name) as unknown as string;
 // WithTest — targets relation/with_test.rb
 // ==========================================================================
 describeIfSupports("common_table_expressions", "WithTest", () => {
-  fixtures(["comments", "posts", "companies"], { schema: canonicalSchema });
+  fixtures(["comments", "posts", "companies"]);
   // `comments`/`posts`/`companies` ride the boot-laid canonical schema (RFC 0059
   // Phase 1); per-file `repairWorkerSchema` (test-setup-dy.ts) restores the
   // canonical shape of any table a sibling file drifted on the shared worker DB

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -10,7 +10,6 @@ import {
 } from "./index.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { adapterType } from "./test-adapter.js";
 import { sql as arelSql } from "@blazetrails/arel";
 
@@ -83,7 +82,6 @@ describe("RelationTest", () => {
       "subscribers",
     ],
     {
-      schema: canonicalSchema,
       usesTransaction: ["finding with subquery without select does not change the select"],
     },
   );

--- a/packages/activerecord/src/scoping/all-queries-option.test.ts
+++ b/packages/activerecord/src/scoping/all-queries-option.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect } from "vitest";
 import "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { DeveloperwithDefaultMentorScopeNot } from "../test-helpers/models/developer.js";
 
 // `Base.all(all_queries:)` threads the flag into build_default_scope (mirrors
@@ -9,7 +8,7 @@ import { DeveloperwithDefaultMentorScopeNot } from "../test-helpers/models/devel
 // applies to ordinary reads but is suppressed when `all_queries: true` is
 // requested — the path `_find_record` uses on reload.
 describe("Base.all all_queries option", () => {
-  fixtures([], { schema: canonicalSchema });
+  fixtures([]);
 
   it("applies a non-all_queries default scope to all() but not to all({ allQueries: true })", () => {
     const normal = DeveloperwithDefaultMentorScopeNot.all().toSql();

--- a/packages/activerecord/src/scoping/default-scoping.test.ts
+++ b/packages/activerecord/src/scoping/default-scoping.test.ts
@@ -16,7 +16,6 @@ import "../index.js";
 import { registerModel, RecordNotFound } from "../index.js";
 import { captureSql } from "../testing/sql-capture.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import {
   Developer,
   DeveloperOrderedBySalary,
@@ -92,9 +91,7 @@ describe("DefaultScopingTest", () => {
   // the join + STI-association ports (default scope through joins, `unscoped`
   // joins, STI association with `unscoped`), which read the canonical posts and
   // comments fixtures exactly as Rails does.
-  const { developers, posts, comments } = fixtures(["developers", "posts", "comments"], {
-    schema: canonicalSchema,
-  });
+  const { developers, posts, comments } = fixtures(["developers", "posts", "comments"]);
 
   it("default scope", async () => {
     const expected = salaries(await Developer.order("salary DESC"));

--- a/packages/activerecord/src/scoping/named-scoping.test.ts
+++ b/packages/activerecord/src/scoping/named-scoping.test.ts
@@ -17,7 +17,6 @@ import "../index.js";
 import { registerModel } from "../index.js";
 import { captureSql } from "../testing/sql-capture.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { adapterType } from "../test-adapter.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { Topic } from "../test-helpers/models/topic.js";
@@ -44,10 +43,13 @@ const capSql = (fn: () => unknown) =>
   captureSql(fn as () => Promise<void>, { includeSchema: false });
 
 describe("NamedScopingTest", () => {
-  const { topics, posts, authors } = fixtures(
-    ["topics", "posts", "authors", "comments", "authorAddresses"],
-    { schema: canonicalSchema },
-  );
+  const { topics, posts, authors } = fixtures([
+    "topics",
+    "posts",
+    "authors",
+    "comments",
+    "authorAddresses",
+  ]);
 
   it("implements enumerable", async () => {
     expect((await Topic.all()).length).toBeGreaterThan(0);

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -9,7 +9,6 @@ import { Base, serialize, SerializationTypeMismatch } from "./index.js";
 import { HashObject } from "./serialize.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { SerializedPerson } from "./test-helpers/models/person.js";
 import { TrafficLight } from "./test-helpers/models/traffic-light.js";
@@ -37,9 +36,7 @@ class MyObject {
 }
 
 describe("SerializedAttributeTest", () => {
-  const { topics, posts } = fixtures(["topics", "posts"], {
-    schema: canonicalSchema,
-  });
+  const { topics, posts } = fixtures(["topics", "posts"]);
 
   it("serialize does not eagerly load columns", () => {
     // Rails: assert_no_queries { Topic.serialize(:content) }
@@ -611,7 +608,7 @@ describe("SerializedAttributeTest", () => {
 // Reruns a subset of tests with use_yaml_unsafe_load=false. In trails we use
 // JSON serialization regardless; we mirror the safe-load overrides using JSON coders.
 describe("SerializedAttributeTestWithYamlSafeLoad", () => {
-  fixtures(["topics"], { schema: canonicalSchema });
+  fixtures(["topics"]);
 
   it("serialized attribute", async () => {
     // Rails SafeLoad override: type: String (safe under Psych safe_load; base class uses MyObject which isn't).

--- a/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { canonicalModelIndex } from "./canonical-model-index.js";
 import { resolveModel } from "../associations.js";
-import { deriveFixtureSchema } from "./use-fixtures.js";
-import { TEST_SCHEMA } from "./test-schema.js";
 import { Comment } from "./models/comment.js";
 import { Owner } from "./models/owner.js";
 import { Pet } from "./models/pet.js";
@@ -40,17 +38,6 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
       Pet as unknown as { _reflectOnAssociation(name: string): { klass: unknown } }
     )._reflectOnAssociation("owner");
     expect(refl.klass).toBe(Owner);
-  });
-
-  it("keeps deriveFixtureSchema bounded with the autoload index installed", async () => {
-    // Importing this module installed the autoload index globally, so every
-    // through/HABTM target now resolves instead of throwing. `deriveFixtureSchema`
-    // must still slice ONLY the requested sets' tables plus their HABTM join
-    // tables — never the whole transitively-reachable graph. `posts` owns the
-    // HABTM `categories_posts`; `has_many :through` join tables (taggings,
-    // categorizations, readers, …) belong to real models and are NOT pulled in.
-    const sub = await deriveFixtureSchema(["authors", "posts"], TEST_SCHEMA);
-    expect(Object.keys(sub).sort()).toEqual(["authors", "categories_posts", "posts"]);
   });
 
   it("throws a constant-not-found error for a genuine miss", () => {

--- a/packages/activerecord/src/test-helpers/fixtures-registry.ts
+++ b/packages/activerecord/src/test-helpers/fixtures-registry.ts
@@ -288,10 +288,10 @@ export const fixtureRegistry = {
   },
   developers: {
     // Register Computer (the `sharedComputers` HABTM target) so its join-table
-    // reflection resolves when `useFixtures` slices the schema — the loader
-    // materializes `computers_developers` rows from the owner's `sharedComputers`
-    // association label, so that table must be created even when the join set
-    // isn't requested by name.
+    // reflection resolves when the loader materializes `computers_developers`
+    // rows from the owner's `sharedComputers` association label — the join
+    // target must be registered even when the join set isn't requested by name.
+    // The `computers_developers` table itself comes from the template clone.
     model: (): Promise<
       [
         typeof import("./models/developer.js").Developer,

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -100,9 +100,9 @@ describe("useFixtures", () => {
 
   const { topics } = fixtures(
     { topics: [Topic, { rails: { title: "Rails" } }] },
-    // Mock adapter over a non-canonical / stubbed table: opt out of the
-    // `fixtures()` TEST_SCHEMA slice-derivation (there is nothing to create).
-    { connection: () => adapter, useTransactionalTests: false, schema: undefined },
+    // Mock adapter over a non-canonical / stubbed table: seeding goes through
+    // the mock adapter, so no real table is involved.
+    { connection: () => adapter, useTransactionalTests: false },
   );
 
   it("accessor returns the instance by label after beforeEach runs", () => {
@@ -131,9 +131,9 @@ describe("useFixtures multi-set", () => {
       topics: [Topic, { rails: { title: "Rails" } }],
       posts: [Post, { hello: { title: "Hello" } }],
     },
-    // Mock adapter over a non-canonical / stubbed table: opt out of the
-    // `fixtures()` TEST_SCHEMA slice-derivation (there is nothing to create).
-    { connection: () => adapter, useTransactionalTests: false, schema: undefined },
+    // Mock adapter over a non-canonical / stubbed table: seeding goes through
+    // the mock adapter, so no real table is involved.
+    { connection: () => adapter, useTransactionalTests: false },
   );
 
   it("both sets are accessible", () => {
@@ -154,9 +154,9 @@ describe("useFixtures slash-keyed fixture sets", () => {
   // accessible via bracket notation only; dot-access would be a syntax error.
   const result = fixtures(
     { "admin/accounts": [AccountModel, { david: { name: "David" } }] },
-    // Mock adapter over a non-canonical / stubbed table: opt out of the
-    // `fixtures()` TEST_SCHEMA slice-derivation (there is nothing to create).
-    { connection: () => adapter, useTransactionalTests: false, schema: undefined },
+    // Mock adapter over a non-canonical / stubbed table: seeding goes through
+    // the mock adapter, so no real table is involved.
+    { connection: () => adapter, useTransactionalTests: false },
   );
 
   it("result property is accessible via bracket notation", () => {
@@ -192,9 +192,9 @@ describe("all/ fixture sets — explicit enumeration", () => {
       "all/tasks": [TaskModel, {}],
       "all/namespaced/accounts": [AccountModel, { signals37: { name: "37signals" } }],
     },
-    // Mock adapter over a non-canonical / stubbed table: opt out of the
-    // `fixtures()` TEST_SCHEMA slice-derivation (there is nothing to create).
-    { connection: () => adapter, useTransactionalTests: false, schema: undefined },
+    // Mock adapter over a non-canonical / stubbed table: seeding goes through
+    // the mock adapter, so no real table is involved.
+    { connection: () => adapter, useTransactionalTests: false },
   );
 
   it("all four fixture sets are accessible via bracket notation", () => {
@@ -235,9 +235,9 @@ describe("useFixtures type contract", () => {
       topics: [Topic, { first: { title: "First" }, second: { title: "Second" } }],
       posts: [Post, { welcome: { body: "Hi" } }],
     },
-    // Mock adapter over stubbed models: opt out of the `fixtures()` TEST_SCHEMA
-    // slice-derivation (there is nothing to create).
-    { connection: () => makeAdapter() as any, useTransactionalTests: false, schema: undefined },
+    // Mock adapter over stubbed models: seeding goes through the mock
+    // adapter, so no real table is involved.
+    { connection: () => makeAdapter() as any, useTransactionalTests: false },
   );
 
   it("accessor return type is narrowed to the model instance type", () => {

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, expectTypeOf, vi, beforeAll, afterAll } from "vitest";
-import { resolveFixtureNames, deriveFixtureSchema } from "./use-fixtures.js";
+import { resolveFixtureNames } from "./use-fixtures.js";
 import { fixtureRegistry, isJoinTableEntry } from "./fixtures-registry.js";
 import { registerModel } from "../associations.js";
 import { FixtureSet } from "./fixture-set.js";
@@ -13,7 +13,6 @@ import {
 } from "./define-fixtures.js";
 import { setupFixtures, fixtures } from "./fixtures.js";
 import { useHandlerTransactionalFixtures } from "./use-handler-transactional-fixtures.js";
-import { TEST_SCHEMA } from "./test-schema.js";
 import { Author } from "./models/author.js";
 import { Post } from "./models/post.js";
 import { LiveParrot, DeadParrot } from "./models/parrot.js";
@@ -396,54 +395,6 @@ describe("useFixtures vertices and edges", () => {
       expect(vertexIds).toContain(Number(edge.readAttribute("source_id")));
       expect(vertexIds).toContain(Number(edge.readAttribute("sink_id")));
     }
-  });
-});
-
-// --- useFixtures schema auto-derivation ({ schema } option) ---
-
-describe("useFixtures { schema } auto-derivation", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
-
-  // No manual schema-priming beforeAll: passing the full TEST_SCHEMA lets
-  // useFixtures create just the tables these sets touch (authorAddresses → posts).
-  const { authors } = fixtures(["authorAddresses", "authors", "posts"], {
-    connection: () => Base.adapter,
-    useTransactionalTests: false,
-    schema: TEST_SCHEMA,
-  });
-
-  it("creates the needed tables and seeds without a manual defineSchema call", async () => {
-    const david = authors("david");
-    expect(Number(david.id)).toBe(1);
-    const [row] = await Base.adapter.execute(
-      `SELECT name FROM ${Base.adapter.quoteTableName(Author.tableName)} WHERE id = 1`,
-    );
-    expect((row as { name: string }).name).toBe("David");
-  });
-});
-
-describe("deriveFixtureSchema", () => {
-  it("slices only the requested sets' tables out of the full schema", async () => {
-    const sub = await deriveFixtureSchema(["authors", "posts"], TEST_SCHEMA);
-    // `posts` pulls in `categories_posts` too: `sliceSchema` includes the join
-    // table of any HABTM association on a model-backed set (the loader may write
-    // join rows from an owner association label). `Post habtm categories` owns
-    // the anonymous `categories_posts` join model, so its table is read straight
-    // off the through reflection — no target resolution, so it is detected the
-    // same whether or not the autoload index is installed. `has_many :through`
-    // join tables (taggings, categorizations, …) are deliberately NOT pulled in:
-    // they belong to real models whose fixture sets are requested by name.
-    expect(Object.keys(sub).sort()).toEqual(
-      [Author.tableName, Post.tableName, "categories_posts"].sort(),
-    );
-    // The slice carries the real column spec, not a placeholder.
-    expect(sub[Author.tableName]).toBe(TEST_SCHEMA[Author.tableName]);
-  });
-
-  it("omits a requested set whose table is absent from the schema", async () => {
-    const sub = await deriveFixtureSchema(["authors"], { other_table: { name: "string" } });
-    expect(sub).toEqual({});
   });
 });
 

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -1,15 +1,11 @@
-import { afterEach, beforeAll, beforeEach } from "vitest";
+import { afterEach, beforeEach } from "vitest";
 import {
   prepareModelFixtures,
   prepareJoinTableFixtures,
   insertPreparedFixtureSets,
-  throughJoinTableNames,
   effectiveFixtureKey,
   type PreparedFixtureSet,
 } from "./define-fixtures.js";
-import { type Schema } from "./define-schema.js";
-import { TEST_SCHEMA } from "./test-schema.js";
-import { ensureCanonicalTables } from "./canonical-schema.js";
 import {
   fixtureRegistry,
   isJoinTableEntry,
@@ -51,7 +47,7 @@ export type FixtureMap = Record<string, [BaseClass, Record<string, FixtureAttrs>
 /**
  * Internally-resolved fixture set. `model === null` marks a HABTM join-table set
  * (seeded via {@link defineJoinTableFixtures}); otherwise it's a model-backed set.
- * `table` is the DB table to seed/clean and to slice the schema by.
+ * `table` is the DB table to seed and clean.
  */
 type ResolvedFixtureSet = {
   table: string;
@@ -89,22 +85,6 @@ export type UseFixturesByNameResult<N extends FixtureName> = {
     ? JoinTableAccessor<Extract<keyof RegistryData<K>, string>>
     : FixtureAccessor<RegistryModel<K>, Extract<keyof RegistryData<K>, string>>;
 };
-
-export interface UseFixturesOpts {
-  /**
-   * When set, `useFixtures` uses this schema only to pick *which* tables to lay
-   * (the names of the sets the fixtures touch), then creates them via
-   * {@link ensureCanonicalTables} in a `beforeAll` — replacing a manual
-   * `defineSchema({ ...slice })` call. Pass the full canonical schema (e.g.
-   * `TEST_SCHEMA`); only the tables the fixtures touch are created.
-   *
-   * NOTE: only the table *names* are honored, not their column shapes — each
-   * table is created in its full canonical shape from the registry, so a
-   * genuinely bespoke (non-canonical) shape passed here is ignored. The type
-   * still permits an arbitrary `Schema` object for the name-selection role.
-   */
-  schema?: Schema;
-}
 
 export interface FixturesConnectionOpts {
   /**
@@ -211,50 +191,6 @@ export async function resolveFixtureNames(
   return map;
 }
 
-/**
- * Slices the minimal sub-schema needed to seed the requested fixture sets out of a
- * full schema: each set's table (resolved through the registry), keyed by the model's
- * own `tableName`. Lets a caller hand `useFixtures` the whole canonical `TEST_SCHEMA`
- * and have it pick out only the tables it touches — no hand-maintained
- * `defineSchema({ customers: TEST_SCHEMA.customers })` slice that drifts when the
- * fixture set's columns change.
- *
- * A requested set whose table is absent from `fullSchema` is silently skipped here —
- * the seed-time `defineFixtures` call then surfaces a precise "no such table" error,
- * which is a better signal than an opaque schema-derivation failure. Column-level
- * `references:` targets are intentionally NOT pulled in: `defineSchema` treats them
- * as creation-ordering hints only (never emitted as FK constraints) and skips any
- * target missing from the schema, so a per-table slice creates valid DDL on its own.
- */
-export async function deriveFixtureSchema(
-  names: readonly FixtureName[],
-  fullSchema: Schema,
-): Promise<Schema> {
-  return sliceSchema(await resolveFixtureNames(names), fullSchema);
-}
-
-/**
- * Picks each resolved set's table out of `fullSchema`, plus the join table of any
- * HABTM association on a model-backed set (see {@link throughJoinTableNames} for
- * why the pull is HABTM-only, not every `has_many :through`). The join-table pull
- * lets a model fixture materialize join rows from an owner association label (e.g.
- * `developers` seeding `computers_developers` from `sharedComputers: ["laptop"]`)
- * without the caller also requesting the join set by name — the HABTM join table,
- * having no fixture set of its own, must exist in the slice regardless.
- */
-function sliceSchema(fixtures: ResolvedFixtureMap, fullSchema: Schema): Schema {
-  const sub: Schema = {};
-  for (const { table, model } of Object.values(fixtures)) {
-    if (table in fullSchema) sub[table] = fullSchema[table]!;
-    if (model) {
-      for (const joinTable of throughJoinTableNames(model)) {
-        if (joinTable in fullSchema) sub[joinTable] = fullSchema[joinTable]!;
-      }
-    }
-  }
-  return sub;
-}
-
 /** Returns true for "table/relation does not exist" errors from any adapter. */
 function isTableMissingError(e: unknown): boolean {
   const msg = e instanceof Error ? e.message : String(e);
@@ -283,7 +219,6 @@ export type UseTablelessFixturesResult<T extends readonly TablelessFixtureEntry[
 function useTablelessFixtures(
   entries: readonly TablelessFixtureEntry[],
   getAdapter: () => DatabaseAdapter,
-  opts?: UseFixturesOpts,
 ): Record<string, unknown> {
   // Tableless entries key their accessor by `table`, so two entries on the same
   // table would clobber each other's store slot. (Model-backed same-table sets in
@@ -301,14 +236,6 @@ function useTablelessFixtures(
 
   const keys = entries.map((e) => e.table);
   const store: Record<string, Record<string, unknown>> = {};
-
-  if (opts?.schema) {
-    const fullSchema = opts.schema;
-    beforeAll(async () => {
-      const names = entries.map((e) => e.table).filter((t) => t in fullSchema);
-      await ensureCanonicalTables(getAdapter(), names);
-    });
-  }
 
   beforeEach(async () => {
     const adapter = getAdapter();
@@ -404,38 +331,27 @@ function useTablelessFixtures(
  * fixtures["admin/accounts"]("signals37"); // → Admin::Account instance
  * ```
  *
- * Pass `{ schema }` to skip the manual `defineSchema` step: `useFixtures` derives the
- * minimal sub-schema for the requested sets (see {@link deriveFixtureSchema}) and
- * creates those tables in a `beforeAll`. Hand it the whole `TEST_SCHEMA` and it picks
- * out only what it needs:
- *
- * ```ts
- * setupHandlerSuite();
- * useHandlerTransactionalFixtures();
- * const { customers } = useFixtures(["customers"], () => Base.connection, { schema: TEST_SCHEMA });
- * ```
+ * No `schema` is needed: globalSetup lays the full `TEST_SCHEMA` into every
+ * worker DB and clones it to each per-worker slot, so the canonical tables
+ * already exist before any test runs — `useFixtures` only seeds and cleans rows.
  *
  * @internal
  */
 function useFixtures<M extends FixtureMap>(
   fixtures: M,
   getAdapter: () => DatabaseAdapter,
-  opts?: UseFixturesOpts,
 ): UseFixturesResult<M>;
 function useFixtures<const N extends FixtureName>(
   names: readonly N[],
   getAdapter: () => DatabaseAdapter,
-  opts?: UseFixturesOpts,
 ): UseFixturesByNameResult<N>;
 function useFixtures<const T extends readonly TablelessFixtureEntry[]>(
   tablelessEntries: T,
   getAdapter: () => DatabaseAdapter,
-  opts?: UseFixturesOpts,
 ): UseTablelessFixturesResult<T>;
 function useFixtures(
   fixturesOrNames: FixtureMap | readonly FixtureName[] | readonly TablelessFixtureEntry[],
   getAdapter: () => DatabaseAdapter,
-  opts?: UseFixturesOpts,
 ): Record<string, unknown> {
   // Tableless array: every element is an object with { table, data }.
   // The `length > 0` guard is intentional: an empty array is vacuously correct for
@@ -462,11 +378,7 @@ function useFixtures(
         );
       }
     }
-    return useTablelessFixtures(
-      fixturesOrNames as readonly TablelessFixtureEntry[],
-      getAdapter,
-      opts,
-    );
+    return useTablelessFixtures(fixturesOrNames as readonly TablelessFixtureEntry[], getAdapter);
   }
   // Symmetric guard: if the first element is a by-name string, scan remaining elements
   // for any tableless { table, data } object. A mixed array here would reach
@@ -508,18 +420,6 @@ function useFixtures(
 
   // Per-test mutable state: populated in beforeEach, cleared in afterEach.
   const store: Record<string, Record<string, unknown>> = {};
-
-  // Schema auto-derivation (opt-in via opts.schema): create just the tables these
-  // fixture sets touch, sliced from the supplied schema. Registered as a beforeAll so
-  // it runs once before the per-test seeding beforeEach below — and after any handler
-  // suite's setup (registered earlier in the describe body), so getAdapter() is live.
-  if (opts?.schema) {
-    const fullSchema = opts.schema;
-    beforeAll(async () => {
-      if (!fixtures) fixtures = await resolveFixtureNames(keys as readonly FixtureName[]);
-      await ensureCanonicalTables(getAdapter(), Object.keys(sliceSchema(fixtures, fullSchema)));
-    });
-  }
 
   // TODO(fixtures-adoption Spike S1): seed once per worker in a global beforeAll
   // (before the pinned transaction opens) when useHandlerTransactionalFixtures is
@@ -598,7 +498,7 @@ function useFixtures(
   return result;
 }
 
-type FixturesOptions = WithTransactionalFixturesOptions & UseFixturesOpts & FixturesConnectionOpts;
+type FixturesOptions = WithTransactionalFixturesOptions & FixturesConnectionOpts;
 
 /**
  * Rails-faithful public surface for declaring fixtures in a test file — the sole
@@ -613,10 +513,11 @@ type FixturesOptions = WithTransactionalFixturesOptions & UseFixturesOpts & Fixt
  * contract where including `TestFixtures`, declaring `fixtures :name`, and
  * enabling `use_transactional_tests` are a single class-level opt-in.
  *
- * Calling `fixtures()` IS the opt-in to the canonical schema: it defaults
- * `schema` to `TEST_SCHEMA`, so converted tests never pass `schema` and the
- * minimal sub-schema for the requested sets is derived automatically. An
- * explicit `schema` still overrides for sets the canonical schema lacks.
+ * Calling `fixtures()` IS the opt-in to the canonical schema: the full
+ * `TEST_SCHEMA` is laid into every worker DB once by globalSetup (trails'
+ * `db:test:prepare`) and cloned to each per-worker slot, so the canonical
+ * tables already exist before any test runs — `fixtures()` only seeds and
+ * cleans rows, never issues DDL.
  *
  * @example  // primary documented form
  *   const { authors, posts } = fixtures({
@@ -654,19 +555,8 @@ export function fixtures(
   fixturesOrNames: FixtureMap | readonly FixtureName[] | readonly TablelessFixtureEntry[],
   options: FixturesOptions | undefined = undefined,
 ): Record<string, unknown> {
-  const {
-    usesTransaction,
-    invalidateSchemaCache,
-    useTransactionalTests,
-    connection,
-    ...fixtureOpts
-  } = options ?? {};
-
-  // Opting into `fixtures()` IS the opt-in to the canonical schema: converted
-  // tests get `TEST_SCHEMA` slice-derivation by default and never pass `schema`
-  // themselves. An explicit `schema` (including `undefined`) still wins for the
-  // few sets the canonical schema doesn't yet cover.
-  const fixtureOptsWithSchema = { schema: TEST_SCHEMA, ...fixtureOpts };
+  const { usesTransaction, invalidateSchemaCache, useTransactionalTests, connection } =
+    options ?? {};
 
   // Caller-supplied connection/adapter thunk wins over the default handler
   // connection: multi-database suites seed through a model-specific
@@ -685,5 +575,5 @@ export function fixtures(
     });
   }
 
-  return useFixtures(fixturesOrNames as FixtureMap, getConnection, fixtureOptsWithSchema);
+  return useFixtures(fixturesOrNames as FixtureMap, getConnection);
 }

--- a/packages/activerecord/src/transaction-callbacks.test.ts
+++ b/packages/activerecord/src/transaction-callbacks.test.ts
@@ -23,7 +23,6 @@ import {
 import { Owner } from "./test-helpers/models/owner.js";
 import { Pet } from "./test-helpers/models/pet.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 
 function defineBehaviourTopic() {
   return class extends Base {
@@ -47,9 +46,7 @@ function defineBehaviourTopic() {
 
 // Rails `fixtures :topics, :owners, :pets`. `{ schema }` recreates the canonical
 // tables so sibling-file contamination on the shared worker DB can't leak rows.
-fixtures(["topics", "owners", "pets"], {
-  schema: canonicalSchema,
-});
+fixtures(["topics", "owners", "pets"]);
 
 describe("TransactionCallbacksTest", () => {
   it("before commit exception should pop transaction stack", async () => {

--- a/packages/activerecord/src/transaction-callbacks.test.ts
+++ b/packages/activerecord/src/transaction-callbacks.test.ts
@@ -44,8 +44,8 @@ function defineBehaviourTopic() {
   };
 }
 
-// Rails `fixtures :topics, :owners, :pets`. `{ schema }` recreates the canonical
-// tables so sibling-file contamination on the shared worker DB can't leak rows.
+// Rails `fixtures :topics, :owners, :pets`. The canonical tables come from the
+// template clone.
 fixtures(["topics", "owners", "pets"]);
 
 describe("TransactionCallbacksTest", () => {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -25,7 +25,6 @@ import {
 import { adapterType } from "./test-adapter.js";
 import { itIfSupports } from "./test-helpers/supports.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
 import { Reply, SillyReply, UniqueReply, SillyUniqueReply } from "./test-helpers/models/reply.js";
 import { Movie } from "./test-helpers/models/movie.js";
@@ -62,7 +61,6 @@ for (const klass of [
 // ==========================================================================
 describe("TransactionTest", () => {
   const { topics } = fixtures(["topics", "developers", "authors", "authorAddresses", "posts"], {
-    schema: canonicalSchema,
     usesTransaction: [
       "successful with return outside inner transaction",
       "number of transactions in commit",
@@ -1299,7 +1297,6 @@ describe("TransactionTest", () => {
 // ==========================================================================
 describe("TransactionTest", () => {
   const { topics } = fixtures(["topics"], {
-    schema: canonicalSchema,
     usesTransaction: [
       "rollback dirty changes even with raise during rollback removes from pool",
       "rollback dirty changes even with raise during rollback doesnt commit transaction",
@@ -1404,7 +1401,6 @@ describe("TransactionTest", () => {
 // ==========================================================================
 describe("TransactionTest", () => {
   fixtures(["topics"], {
-    schema: canonicalSchema,
     usesTransaction: [
       "savepoints name",
       "releasing named savepoints",
@@ -1698,7 +1694,7 @@ describe("TransactionTest", () => {
 // TransactionsWithTransactionalFixturesTest — from transactions_test.rb
 // ==========================================================================
 describe("TransactionsWithTransactionalFixturesTest", () => {
-  fixtures(["topics"], { schema: canonicalSchema });
+  fixtures(["topics"]);
 
   itIfSupports("savepoints", "automatic savepoint in outer transaction", async () => {
     const first = (await Topic.find(1)) as any;
@@ -1740,7 +1736,7 @@ describe("TransactionsWithTransactionalFixturesTest", () => {
 // TransactionUUIDTest — from transactions_test.rb
 // ==========================================================================
 describe("TransactionUUIDTest", () => {
-  fixtures(["topics"], { schema: canonicalSchema });
+  fixtures(["topics"]);
 
   it("the uuid is lazily computed", async () => {
     await Topic.transaction(async () => {
@@ -1784,7 +1780,7 @@ describe("ConcurrentTransactionTest", () => {
 // guards the standalone `transaction(Model, (tx) => ...)` callback wiring).
 // ==========================================================================
 describe("TransactionTest", () => {
-  fixtures(["topics"], { schema: canonicalSchema });
+  fixtures(["topics"]);
 
   it("call after commit after transaction commits", async () => {
     const log: string[] = [];

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1396,8 +1396,8 @@ describe("TransactionTest", () => {
 // TransactionTest (materialization + savepoint-name determinism) — Rails runs
 // these against a fresh, empty connection. They count exact query sequences and
 // assert savepoint names, so they opt out of the fixture transaction
-// (`usesTransaction`) to begin from a clean connection state, and the canonical
-// `topics` table is recreated for this describe via `{ schema }`.
+// (`usesTransaction`) to begin from a clean connection state; the canonical
+// `topics` table comes from the template clone.
 // ==========================================================================
 describe("TransactionTest", () => {
   fixtures(["topics"], {

--- a/packages/activerecord/src/type-caster/connection.test.ts
+++ b/packages/activerecord/src/type-caster/connection.test.ts
@@ -3,10 +3,9 @@ import { StringType } from "@blazetrails/activemodel";
 import { Connection } from "./connection.js";
 import { AttributedDeveloper, DeveloperName } from "../test-helpers/models/developer.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
 
 describe("ConnectionTest", () => {
-  fixtures(["developers"], { schema: TEST_SCHEMA });
+  fixtures(["developers"]);
 
   beforeAll(async () => {
     await AttributedDeveloper.loadSchema();

--- a/packages/activerecord/src/unsafe-raw-sql.test.ts
+++ b/packages/activerecord/src/unsafe-raw-sql.test.ts
@@ -7,7 +7,6 @@ import { sql as arelSql } from "@blazetrails/arel";
 import { adapterType } from "./test-adapter.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Post } from "./test-helpers/models/post.js";
 import { Comment } from "./test-helpers/models/comment.js";
 
@@ -18,7 +17,7 @@ describe("UnsafeRawSqlTest", () => {
   // Rails `fixtures :posts, :comments` — seed the canonical rows so the
   // ordering/pluck comparisons (Arel.sql vs string column name) read back the
   // same set of records.
-  fixtures(["posts", "comments"], { schema: canonicalSchema });
+  fixtures(["posts", "comments"]);
 
   // Shield against the shared-worker `posts` collision: sibling files that
   // physically replace `posts` with a title-only shape survive into this suite

--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -36,9 +36,8 @@ async function dropView(name: string): Promise<void> {
 }
 
 // Force-recreate `books`/`authors` to the canonical shape before each suite's
-// view is created. Vitest resets the schema-signature cache to canonical per
-// file, so `fixtures()`' own schema-priming sees a cache-hit and skips the
-// repair — leaving whatever reduced `books` shape (no `cover`/`status`) a sibling
+// view is created. The tables come from the template clone and nothing else
+// recreates them, so whatever reduced `books` shape (no `cover`/`status`) a sibling
 // handler-suite file co-scheduled earlier in the same fork left in the shared
 // worker DB. The `CREATE VIEW … SELECT cover, status FROM books` below then fails
 // with "Unknown column" on MySQL. This drops + recreates unconditionally.

--- a/packages/activerecord/src/view.test.ts
+++ b/packages/activerecord/src/view.test.ts
@@ -11,7 +11,6 @@ import { Base } from "./index.js";
 import type { AbstractAdapter } from "./connection-adapters/abstract-adapter.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
-import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { adapterType } from "./test-adapter.js";
 import { describeIfSupports, itIfSupports } from "./test-helpers/supports.js";
 import { dumpTableSchema } from "./test-helpers/schema-dumping-helper.js";
@@ -58,7 +57,7 @@ async function rebuildBooksTables(): Promise<void> {
 // so gate this suite the same way (all adapters support views, so it gates
 // nothing at runtime — it keeps the gate-fidelity match with Rails).
 describeIfSupports("views", "ViewWithPrimaryKeyTest", () => {
-  const { books } = fixtures(["books", "authors"], { schema: canonicalSchema });
+  const { books } = fixtures(["books", "authors"]);
 
   class Ebook extends Base {
     static override _tableName = "ebooks'";
@@ -144,7 +143,6 @@ describeIfSupports("views", "ViewWithPrimaryKeyTest", () => {
 // (vendor/rails/activerecord/test/cases/view_test.rb:100).
 describeIfSupports("views", "ViewWithoutPrimaryKeyTest", () => {
   const { books } = fixtures(["books", "authors"], {
-    schema: canonicalSchema,
     useTransactionalTests: false,
   });
 
@@ -222,7 +220,6 @@ describeIfSupports("views", "ViewWithoutPrimaryKeyTest", () => {
 // delete/reseed via beforeEach/afterEach, committed DML, no savepoint).
 describe("UpdateableViewTest", () => {
   const { books } = fixtures(["books", "authors"], {
-    schema: canonicalSchema,
     useTransactionalTests: false,
   });
 


### PR DESCRIPTION
Part 4 of 4 converging the AR `fixtures()` helper to the Rails surface (RFC
0048 capstone). Gated on RFC 0019 → 0 (canonical-schema burndown), which is
now complete — the schema arg's last legitimate users were bespoke-table
tests, all since converged.

## What & why

globalSetup lays the full `TEST_SCHEMA` into every worker DB once and clones
it to each per-worker slot (`db:test:prepare`), so the canonical tables
already exist before any test runs. The `{ schema }` arg only drove a
`beforeAll` that re-created those tables via `ensureCanonicalTables` — pure
ceremony under one-schema, and DROP+CREATE churn on top of the
already-dominant DROP-TABLE cost. Rails' `fixtures :authors` never takes a
schema.

- `fixtures()` no longer defaults `schema` to `TEST_SCHEMA`; the option is
  removed from `UseFixturesOpts` (interface deleted), `useFixtures`, the
  tableless path, and `useHandlerFixtures`.
- Deleted the now-unreachable `deriveFixtureSchema` / `sliceSchema` helpers
  and their unit tests.
- Stripped `{ schema: TEST_SCHEMA }` (and the now-unused `canonicalSchema` /
  `TEST_SCHEMA` imports) from every caller. A converged file now reads
  `setupFixtures(); fixtures({ authors, posts, comments });` — no schema.

## Verification

- `node scripts/typecheck.mjs` — 0 errors.
- `eslint` on all changed files — clean.
- Smoke-ran a sample of converged suites (annotate, enum, delegated-type,
  use-fixtures) — all green; seeding works with tables from the template clone.
- No test names changed (only trails-internal schema-derivation unit tests,
  which tested the deleted feature, were removed).

## Size note

Over the 500-LOC default: the change is a single mechanical codemod (drop one
option + its now-unused imports) that is **atomic by construction** — removing
the option from the type forces every caller to change in the same commit or
TypeScript fails to compile. It cannot be split without leaving the tree
red. Test-only.

Closes-story: fixtures-drop-schema-arg-default-off
