### PR TITLE
fix(mysql): drop promoted-unique bogus Column.primaryKey flag via authoritative reconcile

### DIFF
--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -208,6 +208,17 @@ describe("SchemaCacheTest", () => {
     expect(id.primaryKey).toBe(true);
   });
 
+  it("setPrimaryKeys reconciles already-warm columns regardless of warm order", () => {
+    // Reverse order: columns warmed first (bogus promoted-unique flag), then the
+    // authoritative key. setPrimaryKeys reconciles the already-warm columns.
+    const cache = new SchemaCache();
+    const nick = makeColumn("nick", "varchar(100)", { primaryKey: true, null: false });
+    cache.setColumns("subscribers", [nick, makeColumn("name", "varchar(100)")]);
+    expect(nick.primaryKey).toBe(true);
+    cache.setPrimaryKeys("subscribers", null);
+    expect(nick.primaryKey).toBe(false);
+  });
+
   it("columns for existent table", async () => {
     const cache = new SchemaCache();
     cache.setColumns("users", [makeColumn("id", "integer"), makeColumn("name", "text")]);

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -179,6 +179,35 @@ describe("SchemaCacheTest", () => {
     expect(cache.getCachedPrimaryKeys("users")).toBeNull();
   });
 
+  it("setColumns clears a promoted-unique primaryKey flag the authoritative key excludes", () => {
+    // MySQL/MariaDB report column_key = 'PRI' for a UNIQUE-NOT-NULL column when
+    // the table has no PRIMARY KEY, so the adapter reflects a bogus primary
+    // flag. add() warms _primaryKeys (authoritative, null here) before columns,
+    // so setColumns reconciles the flag away — matching Rails' MySQL::Column,
+    // which carries no per-column primary flag.
+    const cache = new SchemaCache();
+    cache.setPrimaryKeys("subscribers", null);
+    const nick = makeColumn("nick", "varchar(100)", { primaryKey: true, null: false });
+    cache.setColumns("subscribers", [nick, makeColumn("name", "varchar(100)")]);
+    expect(nick.primaryKey).toBe(false);
+    expect(cache.getCachedColumnsHash("subscribers")!["nick"].primaryKey).toBe(false);
+  });
+
+  it("setColumns keeps a genuine primaryKey flag the authoritative key includes", () => {
+    const cache = new SchemaCache();
+    cache.setPrimaryKeys("users", "id");
+    const id = makeColumn("id", "integer", { primaryKey: true, null: false });
+    cache.setColumns("users", [id, makeColumn("name", "text")]);
+    expect(id.primaryKey).toBe(true);
+  });
+
+  it("setColumns leaves flags untouched when the authoritative key is not warm", () => {
+    const cache = new SchemaCache();
+    const id = makeColumn("id", "integer", { primaryKey: true, null: false });
+    cache.setColumns("countries", [id]);
+    expect(id.primaryKey).toBe(true);
+  });
+
   it("columns for existent table", async () => {
     const cache = new SchemaCache();
     cache.setColumns("users", [makeColumn("id", "integer"), makeColumn("name", "text")]);

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -208,6 +208,29 @@ describe("SchemaCacheTest", () => {
     expect(id.primaryKey).toBe(true);
   });
 
+  it("initWith reconciles a stale dump's promoted-unique primaryKey flag", () => {
+    // A schema cache dumped before this convergence can carry MySQL's bogus
+    // promoted-unique `primaryKey: true` alongside `primary_keys: { table: null }`.
+    // Deriving the columns hash on load must not resurface the flag.
+    const cache = new SchemaCache();
+    cache.initWith({
+      columns: {
+        subscribers: [
+          new Column(
+            "nick",
+            null,
+            new SqlTypeMetadata({ sqlType: "varchar(100)", type: "varchar" }),
+            false,
+            { primaryKey: true },
+          ),
+        ],
+      },
+      primary_keys: { subscribers: null },
+    });
+    expect(cache.getCachedColumnsHash("subscribers")!["nick"].primaryKey).toBe(false);
+    expect(cache.getCachedPrimaryKeys("subscribers")).toBeNull();
+  });
+
   it("setPrimaryKeys reconciles already-warm columns regardless of warm order", () => {
     // Reverse order: columns warmed first (bogus promoted-unique flag), then the
     // authoritative key. setPrimaryKeys reconciles the already-warm columns.

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -167,15 +167,7 @@ export class SchemaCache {
 
     this._version = (coder["version"] as string | number) ?? null;
 
-    // Derive columnsHash from columns (Rails: derive_columns_hash_and_deduplicate_values)
-    this._columnsHash.clear();
-    for (const [table, cols] of this._columns) {
-      const hash: Record<string, Column> = {};
-      for (const col of cols) {
-        hash[col.name] = col;
-      }
-      this._columnsHash.set(table, hash);
-    }
+    this.deriveColumnsHash();
   }
 
   isCached(tableName: string): boolean {
@@ -511,9 +503,23 @@ export class SchemaCache {
     );
     this._indexes = new Map(Object.entries((indexes as Record<string, unknown[]>) ?? {}));
 
-    // Derive columnsHash (Rails: derive_columns_hash_and_deduplicate_values)
+    this.deriveColumnsHash();
+  }
+
+  /**
+   * Rebuild `_columnsHash` from `_columns` (Rails:
+   * derive_columns_hash_and_deduplicate_values). Both `_columns` and the
+   * authoritative `_primaryKeys` are already loaded, so reconcile the per-column
+   * `primaryKey` flags against the key cache before exposing the hash — a schema
+   * cache dumped before this convergence can carry MySQL's promoted-unique
+   * `primaryKey: true` alongside `primary_keys: { table: null }`, and the derive
+   * step must not resurface the bogus flag. Mirrors Rails treating `@primary_keys`
+   * as authoritative while deriving `columns_hash` (schema_cache.rb).
+   */
+  private deriveColumnsHash(): void {
     this._columnsHash.clear();
     for (const [table, cols] of this._columns) {
+      this.reconcilePrimaryKeyFlags(table, cols);
       const hash: Record<string, Column> = {};
       for (const col of cols) {
         hash[col.name] = col;

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -404,6 +404,7 @@ export class SchemaCache {
   }
 
   setColumns(tableName: string, cols: Column[]): void {
+    this.reconcilePrimaryKeyFlags(tableName, cols);
     this._columns.set(tableName, cols);
     const hash: Record<string, Column> = {};
     for (const col of cols) {
@@ -415,6 +416,34 @@ export class SchemaCache {
 
   setPrimaryKeys(tableName: string, pk: string | string[] | null): void {
     this._primaryKeys.set(tableName, pk);
+  }
+
+  /**
+   * Clear per-column `primaryKey` flags that the authoritative `_primaryKeys`
+   * cache contradicts. MySQL/MariaDB report `column_key = 'PRI'` for a
+   * UNIQUE-NOT-NULL index when a table has no PRIMARY KEY (the "promoted unique"
+   * case), so `mysql/schema-statements.ts` reflects a bogus primary flag on that
+   * column — Rails' `MySQL::Column` carries no per-column primary flag and
+   * resolves the key solely from the `PRIMARY` constraint. `add()` warms
+   * `_primaryKeys` (via the authoritative `SHOW KEYS ... 'PRIMARY'` /
+   * key_column_usage query) before `columns()`, so by the time `setColumns` runs
+   * the correct answer is already in hand — reconcile against it query-free.
+   *
+   * Clear-only: a flag is dropped when the authoritative key set excludes the
+   * column, never added. Real primary keys (whose flag the adapter already set
+   * and whose name the query returns) are untouched, and adapters that reflect
+   * the flag correctly (sqlite/postgres) agree with the query so nothing changes.
+   * When `_primaryKeys` is not yet warm the flags are left as reflected.
+   */
+  private reconcilePrimaryKeyFlags(tableName: string, cols: Column[]): void {
+    if (!this._primaryKeys.has(tableName)) return;
+    const pk = this._primaryKeys.get(tableName);
+    const pkNames = new Set(pk == null ? [] : Array.isArray(pk) ? pk : [pk]);
+    for (const col of cols) {
+      if (col.primaryKey && !pkNames.has(col.name)) {
+        (col as { primaryKey: boolean }).primaryKey = false;
+      }
+    }
   }
 
   setDataSourceExists(tableName: string, exists: boolean): void {

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -416,6 +416,8 @@ export class SchemaCache {
 
   setPrimaryKeys(tableName: string, pk: string | string[] | null): void {
     this._primaryKeys.set(tableName, pk);
+    const cols = this._columns.get(tableName);
+    if (cols) this.reconcilePrimaryKeyFlags(tableName, cols);
   }
 
   /**
@@ -426,8 +428,9 @@ export class SchemaCache {
    * column — Rails' `MySQL::Column` carries no per-column primary flag and
    * resolves the key solely from the `PRIMARY` constraint. `add()` warms
    * `_primaryKeys` (via the authoritative `SHOW KEYS ... 'PRIMARY'` /
-   * key_column_usage query) before `columns()`, so by the time `setColumns` runs
-   * the correct answer is already in hand — reconcile against it query-free.
+   * key_column_usage query) before `columns()`, so the correct answer is already
+   * in hand — reconcile against it query-free. Called from both `setColumns` and
+   * `setPrimaryKeys` so the correction is independent of which warms first.
    *
    * Clear-only: a flag is dropped when the authoritative key set excludes the
    * column, never added. Real primary keys (whose flag the adapter already set


### PR DESCRIPTION
## What

MySQL/MariaDB report `column_key = 'PRI'` for a UNIQUE-NOT-NULL column when a table has **no** PRIMARY KEY (the "promoted unique" case). trails' information_schema `columns()` reflection (`mysql/schema-statements.ts:677`) therefore sets a bogus `Column.primaryKey` flag on that column. Rails' `MySQL::Column` carries **no** per-column primary flag at all — it resolves the key solely from the `PRIMARY` constraint (`@connection.primary_key`).

Follow-up to #4379, which fixed the observable dumper bug at the dumper layer but left this reflection deviation live. The flag feeds `SchemaCache#getCachedPrimaryKeys`' column-flag fallback and `introspectPrimaryKey`'s fallback.

## How

`SchemaCache#add` warms the authoritative `_primaryKeys` cache (via `SHOW KEYS … 'PRIMARY'` / key_column_usage) **before** `columns()`, so the correct answer is already in hand by the time `setColumns` runs. A new `reconcilePrimaryKeyFlags` clears any per-column `primaryKey` flag the authoritative key set contradicts — **query-free** and **clear-only**:

- No new per-table query on the dump path → no `QueryCacheTest` regression, no `SchemaDumperTest` timeout (the two failure modes documented as blocking a source-level fix in `columns()`).
- Real primary keys (flag set + name returned by the query) are untouched.
- sqlite/postgres reflect the flag correctly, so their columns already agree with the query — nothing changes there.
- When `_primaryKeys` is not yet warm, flags are left as reflected.

## Test

Added `SchemaCacheTest` cases: promoted-unique flag cleared, genuine PK flag kept, and flags untouched when the authoritative key is not warm. `schema-cache` / `primary-keys` / `schema-introspection.trails` suites green.

Closes-story: converge-mysql-column-primarykey-flag-promoted-unique