### PR TITLE
test(fixtures): convert Bucket D mixed per-describe associations to fixtures()

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -9,8 +9,7 @@ import { describe, it, expect, afterEach, beforeAll, beforeEach, vi } from "vite
 import { Base, association, reflectOnAssociation, registerModel, NameError, pp } from "./index.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { captureSql } from "./testing/sql-capture.js";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Author, type Author as AuthorT } from "./test-helpers/models/author.js";
 import { CpkOrder, CpkBook } from "./test-helpers/models/cpk.js";
@@ -69,8 +68,7 @@ function expectQuotedColumnInSql(
 }
 
 describe("AssociationsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(() => {
     registerModel("CpkOrder", CpkOrder);
     registerModel("CpkBook", CpkBook);
@@ -394,8 +392,7 @@ describe("AssociationProxyTest", () => {
 });
 
 describe("PreloaderTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   afterEach(() => vi.restoreAllMocks());
 
@@ -1582,13 +1579,12 @@ describe("PreloaderTest", () => {
 });
 
 describe("OverridingAssociationsTest", () => {
-  // Tests are synchronous reflection checks — no DB queries. setupFixtures +
-  // useHandlerTransactionalFixtures keep _skipGlobalResetDepth > 0 so the global
-  // beforeEach does not call resetTestAdapterState() (dropAllTables) between tests,
-  // which would silently drop canonical tables (cpk_order_agreements, cpk_cars, etc.)
-  // needed by the later AssociationsTest describe block.
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  // Tests are synchronous reflection checks — no DB queries. fixtures([]) keeps
+  // _skipGlobalResetDepth > 0 so the global beforeEach does not call
+  // resetTestAdapterState() (dropAllTables) between tests, which would silently
+  // drop canonical tables (cpk_order_agreements, cpk_cars, etc.) needed by the
+  // later AssociationsTest describe block.
+  fixtures([]);
 
   // Mirrors Rails' nested DifferentPerson / PeopleList / DifferentPeopleList classes.
   // vendor/rails/activerecord/test/cases/associations_test.rb:710
@@ -1763,7 +1759,6 @@ describe("WithAnnotationsTest", () => {
     }
   }
 
-  setupFixtures();
   const { pirates } = fixtures(
     ["pirates", "parrots", "parrotsPirates", "ships", "treasures", "priceEstimates"],
     { schema: canonicalSchema },

--- a/packages/activerecord/src/associations/belongs-to-associations.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-associations.test.ts
@@ -16,7 +16,6 @@ import {
 } from "../index.js";
 import { assertNoQueries } from "../testing/query-assertions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
 import { Author, AuthorAddress } from "../test-helpers/models/author.js";
 import { Essay } from "../test-helpers/models/essay.js";
@@ -2022,7 +2021,6 @@ describe("BelongsToAssociationsTest", () => {
 });
 
 describe("AsyncBelongsToAssociationsTest", () => {
-  useHandlerTransactionalFixtures();
   const { companies } = fixtures(["companies"], { schema: canonicalSchema });
 
   it("async load belongs to", async () => {

--- a/packages/activerecord/src/associations/eager-load-nested-include.test.ts
+++ b/packages/activerecord/src/associations/eager-load-nested-include.test.ts
@@ -3,8 +3,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { Base, registerModel } from "../index.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { assertNoQueries } from "../testing/query-assertions.js";
 import { Author, AuthorFavorite } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
@@ -108,8 +107,7 @@ function sample<T>(arr: T[]): T {
 }
 
 describe("EagerLoadPolyAssocsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   it("include query", async () => {
     const circles: Circle[] = [];

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -43,8 +43,7 @@ import {
 import { DeleteRestrictionError } from "./errors.js";
 import { assertQueriesCount, assertNoQueries } from "../testing/query-assertions.js";
 
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 // Imported under HM-prefixed local aliases so the top-level bindings don't
 // collide with the bespoke `class Author` / `class Post` declarations in the
 // still-unconverted describes below. Without the alias, esbuild renames those
@@ -333,8 +332,7 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTestForReorderWithJoinDependency", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   it("should generate valid sql", () => {
     class Post extends Base {
@@ -729,8 +727,7 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   // -- Destroying --
   // `test_destroying`, `test_destroying_by_integer_id`,
   // `test_destroying_by_string_id`, and `test_destroying_a_collection` live in
@@ -1081,7 +1078,6 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  useHandlerTransactionalFixtures();
   const { companies } = fixtures(["companies"]);
   beforeAll(async () => {
     // A sibling test file may have warmed the shared schema cache for `bulbs`
@@ -1274,8 +1270,7 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   // -- Scoped queries --
 
@@ -6344,8 +6339,7 @@ describe("HasManyAssociationsTest", () => {
 // means each test runs inside BEGIN/ROLLBACK against the ambient canonical
 // tables rather than rebuilding them.
 describe("HasManyAssociationsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   beforeAll(() => {
     registerModel(HmAuthor);
@@ -6555,8 +6549,7 @@ describe("HasManyAssociationsTest", () => {
 // scope applies), `:all_bulbs` (unscope where:name), `:other_bulbs`
 // (unscope + rewrite), `:old_bulbs` (rewhere).
 describe("HasManyAssociationsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(async () => {
     registerModel(HmCar);
     registerModel(HmBulb);
@@ -7164,8 +7157,7 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   // Regression for HasManyAssociation#deleteRecords (the association-layer
   // `delete`, reached only via `record.association(name)` for a non-through

--- a/packages/activerecord/src/associations/join-model.test.ts
+++ b/packages/activerecord/src/associations/join-model.test.ts
@@ -20,7 +20,6 @@ import {
 } from "./errors.js";
 import { assertNoQueries, assertQueriesCount } from "../testing/query-assertions.js";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
 import { Author, AuthorAddress, AuthorFavorite } from "../test-helpers/models/author.js";
 import {
   Post,
@@ -111,7 +110,6 @@ class ScopedSourceTag extends Base {
 }
 
 describe("AssociationsJoinModelTest", () => {
-  useHandlerTransactionalFixtures();
   const { authors, posts, categories, tags, taggings, comments, items, books, vertices } = fixtures(
     [
       "authors",

--- a/packages/activerecord/src/counter-cache.trails.test.ts
+++ b/packages/activerecord/src/counter-cache.trails.test.ts
@@ -9,14 +9,12 @@
  */
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base, registerModel } from "./index.js";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Post as CanonicalPost } from "./test-helpers/models/post.js";
 import { Comment as CanonicalComment } from "./test-helpers/models/comment.js";
 
 describe("CounterCacheTest (trails)", () => {
-  setupFixtures();
   fixtures(["posts", "comments"], { schema: canonicalSchema });
   beforeAll(() => {
     registerModel(CanonicalPost);
@@ -37,8 +35,7 @@ describe("CounterCacheTest (trails)", () => {
 });
 
 describe("CounterCacheTest deferred resolution (trails)", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   afterAll(async () => {
     const { modelRegistry } = await import("./associations.js");
     modelRegistry.delete("Reply");

--- a/packages/activerecord/src/custom-locking.test.ts
+++ b/packages/activerecord/src/custom-locking.test.ts
@@ -6,15 +6,12 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { adapterType } from "./test-adapter.js";
 import { Base } from "./base.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { Person } from "./test-helpers/models/person.js";
 import { assertQueriesMatch } from "./testing/query-assertions.js";
 
 describe("CustomLockingTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
   const { people } = fixtures(["people"], { schema: canonicalSchema });
   beforeAll(async () => {
     await rebuildCanonicalTables(Base.connection, ["people"]);


### PR DESCRIPTION
## Summary

Bucket D of the RFC 0062 transactional-fixtures burndown: mixed per-describe
association test files that carried both the legacy `setupFixtures()` /
`useHandlerTransactionalFixtures()` pair AND a `fixtures(...)` call. Converted
per describe block:

- **Data blocks** — dropped the redundant `setupFixtures()` /
  `useHandlerTransactionalFixtures()` lines; the `fixtures([...])` call already
  wires the handler suite + per-test transaction.
- **No-data blocks** — replaced the pair with `fixtures([], …)`, the
  accessor-less equivalent (empty array = vacuous zero-fixture case that still
  wires suite + per-test txn).
- Dropped the now-unused `setupFixtures` / `useHandlerTransactionalFixtures`
  imports from each file.

### Files (7)

- `associations/belongs-to-associations.test.ts`
- `associations/eager-load-nested-include.test.ts`
- `associations/has-many-associations.test.ts`
- `associations/join-model.test.ts`
- `associations.test.ts`
- `counter-cache.trails.test.ts`
- `custom-locking.test.ts`

### Lint rule

`fixtures([])` is the accessor-less transactional surface, so taught the
`test-fixture-parity` ESLint rule to treat an empty-array `fixtures([])` call as
a transactional scope marker (same exemption as `useHandlerTransactionalFixtures()`),
with a matching RuleTester case. Without this the no-data conversions would
regress the parity gate.

No test renames. Ran each touched file locally — all green.

Closes-story: convert-mixed-perdescribe-associations-d
