### PR TITLE
test(fixtures): convert Bucket A pair→fixtures([]) for adapters + associations (1/4)

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/adapter-prevent-writes.test.ts
@@ -5,13 +5,10 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { describeIfMysql, Mysql2Adapter } from "./test-helper.js";
 import { Base } from "../../index.js";
 import { ReadOnlyError, QueryCanceled } from "../../errors.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../../test-helpers/use-handler-transactional-fixtures.js";
-
-setupFixtures();
+import { fixtures } from "../../test-helpers/fixtures.js";
 
 describeIfMysql("Mysql2Adapter", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   // Rails: @conn = ActiveRecord::Base.lease_connection
   let conn: Mysql2Adapter;

--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -4,8 +4,7 @@
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base, serialize, ColumnNotSerializableError, StatementInvalid } from "../../index.js";
 import { TimeWithZone, TimeZone, setZone, resetZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -23,8 +22,7 @@ afterAll(() => {
 // builder; it is created via raw DDL below (mirroring Rails'
 // `@connection.create_table "pg_arrays"`). The outer per-test transaction
 // rolls back inserts and any addColumn DDL done inside it() bodies.
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/explain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/explain.test.ts
@@ -3,8 +3,7 @@
  */
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 
 beforeAll(() => {
@@ -18,8 +17,7 @@ afterAll(() => {
 // EXPLAIN tests build their own ad-hoc `ex_*` tables via raw DDL. The outer
 // transaction wrapping each test rolls back those tables (PG DDL is
 // transactional).
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -5,8 +5,7 @@ import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
 import { FixtureSet } from "../../test-helpers/fixture-set.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 
@@ -21,8 +20,7 @@ afterAll(() => {
 // The `virtual_columns` table uses PG generated/virtual columns; it is
 // built inline below via `createTable` (mirroring Rails'
 // `@connection.create_table "virtual_columns"`).
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
+++ b/packages/activerecord/src/associations/association-scope-alias-tracker.test.ts
@@ -27,12 +27,10 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { AssociationScope } from "./association-scope.js";
 import { AliasTracker } from "./alias-tracker.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 describe("AssociationScope — AliasTracker aliases repeated tables", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   // Rides the canonical `comments` table, which carries `parent_id` for
   // Rails' self-referential `Comment belongs_to :parent` / `has_many

--- a/packages/activerecord/src/associations/association-scope.test.ts
+++ b/packages/activerecord/src/associations/association-scope.test.ts
@@ -3,8 +3,7 @@ import { describe, it, expect } from "vitest";
 import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
 import { Associations, loadHasMany, loadHasOne } from "../associations.js";
 import { AssociationScope, ReflectionProxy } from "./association-scope.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
@@ -18,8 +17,7 @@ import { Club } from "../test-helpers/models/club.js";
 import { MemberDetail } from "../test-helpers/models/member-detail.js";
 
 describe("AssociationScope", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   // The DB-roundtrip cases ride the canonical Author/Post/Comment,
   // Categorization/Category, Tag/Tagging and Member/Membership/Club models —
   // every STI / polymorphic-source-type / has-many-through / has-one-through

--- a/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
+++ b/packages/activerecord/src/associations/cp-count-disable-joins-through.test.ts
@@ -22,16 +22,14 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, association, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 function migrationCtx() {
   return new MigrationContext(Base.connection);
 }
 
 describe("CollectionProxy#count — disable_joins through", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   class CdAuthor extends Base {
     static {

--- a/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.test.ts
@@ -4,16 +4,14 @@ import { Base, MigrationContext, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { DisableJoinsAssociationScope } from "./disable-joins-association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 function migrationCtx() {
   return new MigrationContext(Base.connection);
 }
 
 describe("DisableJoinsAssociationScope", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   class DjsAuthor extends Base {
     static {

--- a/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-key.test.ts
@@ -19,16 +19,14 @@ import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 function migrationCtx() {
   return new MigrationContext(Base.connection);
 }
 
 describe("DJAS — composite key support", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   class CkShop extends Base {
     static {

--- a/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-composite-nested.test.ts
@@ -32,16 +32,14 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 function migrationCtx() {
   return new MigrationContext(Base.connection);
 }
 
 describe("DJAS composite-key + nested-through", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   class CknShop extends Base {
     static {

--- a/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-nested-through.test.ts
@@ -23,16 +23,14 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 function migrationCtx() {
   return new MigrationContext(Base.connection);
 }
 
 describe("DJAS routing widening — nested-through", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   class NtAuthor extends Base {
     static {

--- a/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-polymorphic-nonid-pk.test.ts
@@ -29,12 +29,10 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, registerModel, TableDefinition } from "../index.js";
 import { Associations, loadHasMany } from "../associations.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 describe("DJAS — polymorphic belongsTo-through with non-id target PK", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   class DpAuthor extends Base {
     static {

--- a/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
+++ b/packages/activerecord/src/associations/disable-joins-routing-widening.test.ts
@@ -22,16 +22,14 @@ import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { Notifications } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "../index.js";
 import { Associations, association, loadHasMany } from "../associations.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 function migrationCtx() {
   return new MigrationContext(Base.connection);
 }
 
 describe("DJAS routing widening — sourceType + polymorphic source", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   class RwAuthor extends Base {
     static {

--- a/packages/activerecord/src/associations/eager-load-includes-full-sti-class.test.ts
+++ b/packages/activerecord/src/associations/eager-load-includes-full-sti-class.test.ts
@@ -14,8 +14,7 @@ import { Base } from "../base.js";
 import { registerModel } from "../index.js";
 import { Tagging } from "../test-helpers/models/tagging.js";
 import { Post } from "../test-helpers/models/post.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 // Rails defines `Namespaced::Post` inline (table "posts") with a polymorphic
 // has_one :tagging, as: :taggable. trails flattens the `::` into a collision-free
@@ -77,8 +76,7 @@ describe("PolymorphicNonFullClassNamesTest", () => {
 // stays at its default of true), flipping store_full_sti_class never changes how
 // the taggable association resolves — both branches must find the tagging.
 function runStiSharedTests(storeFullStiClass: boolean): void {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   beforeAll(async () => {
     await NamespacedPost.loadSchema();
@@ -150,8 +148,7 @@ function runStiSharedTests(storeFullStiClass: boolean): void {
 // disagrees with how the row was written, the type-column value mismatches and
 // the association resolves to nil.
 function runPolymorphicSharedTests(storeFullClassName: boolean): void {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   beforeAll(async () => {
     await NamespacedPost.loadSchema();

--- a/packages/activerecord/src/associations/eager-singularization.test.ts
+++ b/packages/activerecord/src/associations/eager-singularization.test.ts
@@ -13,12 +13,10 @@ import type { AssociationProxy } from "./collection-proxy.js";
 import { describe, it, beforeAll, afterAll, expect } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { MigrationContext } from "../migration.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 describe("EagerSingularizationTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   let ctx: MigrationContext;
 

--- a/packages/activerecord/src/associations/required.test.ts
+++ b/packages/activerecord/src/associations/required.test.ts
@@ -6,12 +6,10 @@ import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Associations } from "../associations.js";
 import { MigrationContext } from "../migration.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 describe("RequiredAssociationsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   let ctx: MigrationContext;
   beforeAll(async () => {
     ctx = new MigrationContext(Base.connection);


### PR DESCRIPTION
## Summary

RFC 0062 (transactional-fixtures burndown), Bucket A conversion cluster 1/4. Converts the `setupFixtures()` + `useHandlerTransactionalFixtures()` pair to a single `fixtures([])` call across 16 adapter + association test files. Empty array is the vacuous zero-fixture surface (`use-fixtures.ts`) that still wires the handler suite + per-test transaction — identical wiring, one call.

Schema setup is left untouched: files that ride the canonical schema keep riding it (`fixtures([])` derives an empty slice → no DDL), and files with their own `createTable`/bespoke tables keep their `beforeAll` unchanged.

No test renames. `eager-load-includes-full-sti-class` had two per-`describe` pairs → two calls.

## Testing

Ran all touched files locally on sqlite (PG/MySQL-gated adapter files skip on sqlite as expected):
- 91 tests passed across the association files.

Closes-story: convert-pair-adapters-associations-a