### PR TITLE
test(fixtures): convert Bucket A pair→fixtures([]) for associations + encryption

### DIFF
--- a/eslint/test-fixture-parity.mjs
+++ b/eslint/test-fixture-parity.mjs
@@ -164,6 +164,17 @@ function destructuredNames(callNode) {
   return [];
 }
 
+/**
+ * True for a zero-fixture surface call — the first argument is an empty array
+ * literal, e.g. `fixtures([])`. This is the RFC 0062 replacement for
+ * `useHandlerTransactionalFixtures()`: it wires the suite + per-test txn in
+ * scope but seeds no rows and exposes no named accessor.
+ */
+function isEmptyFixtureCall(callNode) {
+  const first = callNode.arguments[0];
+  return first?.type === "ArrayExpression" && first.elements.length === 0;
+}
+
 /** Collect all Identifier call names inside a subtree (for it() body scanning). */
 function collectCallNamesIn(node, out = new Set()) {
   if (!node || typeof node !== "object") return out;
@@ -237,12 +248,13 @@ const rule = {
               accessorsByScope.set(scope, s);
             }
             for (const n of names) s.add(n);
-          } else {
-            // A fixture surface invoked without destructuring a named accessor
-            // (e.g. `fixtures([])`, the RFC 0062 replacement for
-            // `useHandlerTransactionalFixtures()`) still wires the suite in
-            // scope, so — like the transactional helper — it satisfies the
-            // parity check via scope presence without a per-test accessor call.
+          } else if (isEmptyFixtureCall(node)) {
+            // A zero-fixture surface call (`fixtures([])`, the RFC 0062
+            // replacement for `useHandlerTransactionalFixtures()`) still wires
+            // the suite in scope, so — like the transactional helper — it
+            // satisfies the parity check via scope presence without a per-test
+            // accessor call. A non-empty call with no destructuring seeds rows
+            // but exposes no accessor, so it is left to fall through and warn.
             transactionalScopes.add(scope);
           }
           return;

--- a/eslint/test-fixture-parity.mjs
+++ b/eslint/test-fixture-parity.mjs
@@ -7,9 +7,11 @@
  * `const { x } = useFixtures(...)` / `useHandlerFixtures(...)` destructuring
  * anywhere in scope.
  *
- * For `useHandlerTransactionalFixtures()` (no return value) the check falls
- * back to the describe-scope presence check — those tests load fixtures
- * transactionally without a named accessor.
+ * For `useHandlerTransactionalFixtures()` (no return value) — and for a
+ * fixture surface called without destructuring a named accessor, e.g. the
+ * RFC 0062 `fixtures([])` replacement — the check falls back to the
+ * describe-scope presence check: those tests load fixtures transactionally
+ * without a named accessor.
  *
  * Skipped tests (it.skip / it.skipIf / it.todo / test.skip, and anything nested
  * in describe.skip / describe.todo) are exempt — they are the migration backlog
@@ -235,6 +237,13 @@ const rule = {
               accessorsByScope.set(scope, s);
             }
             for (const n of names) s.add(n);
+          } else {
+            // A fixture surface invoked without destructuring a named accessor
+            // (e.g. `fixtures([])`, the RFC 0062 replacement for
+            // `useHandlerTransactionalFixtures()`) still wires the suite in
+            // scope, so — like the transactional helper — it satisfies the
+            // parity check via scope presence without a per-test accessor call.
+            transactionalScopes.add(scope);
           }
           return;
         }

--- a/eslint/test-fixture-parity.test.mjs
+++ b/eslint/test-fixture-parity.test.mjs
@@ -68,6 +68,11 @@ describe("test-fixture-parity rule", () => {
           code: `describe("T", () => { useHandlerTransactionalFixtures(); it("find single value object", () => { expect(1).toBe(1); }); });`,
         },
         {
+          name: "fixtures([]) without destructuring (RFC 0062) → scope-level pass",
+          filename: AR("aggregations.test.ts"),
+          code: `describe("T", () => { fixtures([]); it("find single value object", () => { expect(1).toBe(1); }); });`,
+        },
+        {
           name: "accessor from outer describe used in nested it() → no warning",
           filename: AR("aggregations.test.ts"),
           code: `describe("Outer", () => { const { customers } = useFixtures(["c"], () => conn); describe("Inner", () => { it("find single value object", () => { customers("david"); }); }); });`,

--- a/eslint/test-fixture-parity.test.mjs
+++ b/eslint/test-fixture-parity.test.mjs
@@ -152,6 +152,12 @@ describe("test-fixture-parity rule", () => {
           errors: [{ messageId: "missing" }],
         },
         {
+          name: "non-empty fixtures() without destructuring → still warns (only fixtures([]) is scope-level)",
+          filename: AR("aggregations.test.ts"),
+          code: `describe("T", () => { fixtures(["customers"]); it("find single value object", () => { expect(1).toBe(1); }); });`,
+          errors: [{ messageId: "missing" }],
+        },
+        {
           name: "sibling describe accessor not visible → warns",
           filename: AR("aggregations.test.ts"),
           code: `describe("A", () => { const { customers } = useFixtures(["c"], () => conn); }); describe("B", () => { it("find single value object", () => { customers("david"); }); });`,

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -9,16 +9,14 @@ import { TimeWithZone, TimeZone } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 
 import { inTimeZone } from "./test-helpers/in-time-zone.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { adapterType } from "./test-adapter.js";
 
 // ==========================================================================
 // AttributeMethodsTest — targets attribute_methods_test.rb
 // ==========================================================================
 describe("AttributeMethodsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   it("attribute keys on a new instance", async () => {
     class Post extends Base {
@@ -860,8 +858,7 @@ describe("AttributeMethodsTest", () => {
 // AttributeMethodsTestExtra — additional targets for attribute_methods_test.rb
 // ==========================================================================
 describe("AttributeMethodsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   it("read_attribute with nil should not asplode", async () => {
     class Topic extends Base {
@@ -1226,8 +1223,7 @@ describe("AttributeMethodsTest", () => {
 // ==========================================================================
 
 describe("attribute_alias arelTable integration", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("test_attribute_alias_in_where_references_association_name", () => {
     // Unit cover for the `arelTable.get(alias)` mechanism, NOT the Rails port:
     // the Rails `test_attribute_alias_in_where_references_association_name` lives

--- a/packages/activerecord/src/attribute-methods.trails.test.ts
+++ b/packages/activerecord/src/attribute-methods.trails.test.ts
@@ -11,8 +11,7 @@ import { describe, it, expect } from "vitest";
 import { Base, ReadonlyAttributeError, registerModel } from "./index.js";
 import { formatForInspect } from "./attribute-inspection.js";
 
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { Minivan } from "./test-helpers/models/minivan.js";
 
 registerModel(Minivan);
@@ -25,8 +24,7 @@ interface Generatable {
 const generatable = (cls: unknown): Generatable => cls as Generatable;
 
 describe("AttributeMethodsTest (trails)", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   it("defineAttributeMethods cascades to the superclass", async () => {
     class Animal extends Base {

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -14,8 +14,7 @@ import { BigDecimal } from "@blazetrails/activesupport";
 
 import { registerModel } from "./associations.js";
 import { loadSchemaFromAdapter } from "./model-schema.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { inTimeZone } from "./test-helpers/in-time-zone.js";
 import { adapterType } from "./test-adapter.js";
 
@@ -50,8 +49,7 @@ class UnoverloadedType extends Base {
 }
 
 describe("CustomPropertiesTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(async () => {
     // Reflect the canonical `overloaded_types` columns onto each class that
     // rides the table (Rails does this implicitly on first access). AR_NO_AUTO_SCHEMA

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -37,22 +37,21 @@ import {
   computePrimaryKey,
   addAutosaveAssociationCallbacks,
 } from "./autosave-association.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
 
 function cacheAssoc(record: Base, name: string, value: unknown) {
   record.association(name).setTarget(value as any);
 }
 
-setupFixtures();
+fixtures([], { useTransactionalTests: false });
 
 describe("TestDestroyAsPartOfAutosaveAssociation", () => {
   // Transactional fixtures roll back every persisted pirate/ship/parrot per test
   // so this block does not pollute the shared worker DB for sibling blocks
   // (e.g. TestAutosaveAssociationOnACollectionRemoveCallbacks) — Rails'
   // `use_transactional_tests`.
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(() => {
     registerModel(CanonicalPirate);
     registerModel(CanonicalShip);
@@ -483,7 +482,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
     record.association(name).setTarget(value as any);
   }
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   function makeModels() {
     class Company extends Base {
@@ -978,7 +977,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
     record.association(name).setTarget(value as any);
   }
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   function makeModels() {
     class Firm extends Base {
@@ -1578,7 +1577,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
 });
 
 describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   function cacheAssoc(record: Base, name: string, value: unknown) {
     record.association(name).setTarget(value as any);
   }
@@ -1999,7 +1998,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
     record.association(name).setTarget(value as any);
   }
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   function makeModels() {
     class Author extends Base {
@@ -2360,7 +2359,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
   function cacheAssoc(record: Base, name: string, value: unknown) {
     record.association(name).setTarget(value as any);
   }
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   function makeModels() {
     class Pirate extends Base {
@@ -2540,7 +2539,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
   function cacheAssoc(record: Base, name: string, value: unknown) {
     record.association(name).setTarget(value as any);
   }
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   function makeModels() {
     class Pirate extends Base {
@@ -2823,7 +2822,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
 });
 
 describe("TestAutosaveAssociationsInGeneral", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("autosave works even when other callbacks update the parent model", async () => {
     class Ship extends Base {
       declare name: string | null;
@@ -3480,7 +3479,7 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
   function cacheAssoc(record: Base, name: string, value: unknown) {
     record.association(name).setTarget(value as any);
   }
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   function makeModels() {
     class Pirate extends Base {
@@ -3598,7 +3597,7 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
 });
 
 describe("TestAutosaveAssociationValidationMethodsGeneration", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   it("should generate validation methods for has_many associations", async () => {
     class VmParent extends Base {
@@ -3813,7 +3812,7 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
   function cacheAssoc(record: Base, name: string, value: unknown) {
     record.association(name).setTarget(value as any);
   }
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   function makeModels() {
     class Pirate extends Base {
@@ -3898,7 +3897,7 @@ describe("TestHasOneAutosaveAssociationWhichItselfHasAutosaveAssociations", () =
 });
 
 describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("autosave new record on belongs to can be disabled per relationship", async () => {
     class Author extends Base {
       declare name: string | null;
@@ -4117,7 +4116,7 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
 });
 
 describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("should automatically validate associations", async () => {
     class Item extends Base {
       declare name: string | null;
@@ -4147,7 +4146,7 @@ describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
 });
 
 describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   // Dynamic import so esbuild doesn't rename the bespoke same-named classes
   // declared inside the describe.skip blocks above (Author/Book) — see the
@@ -4200,7 +4199,7 @@ describe("TestAutosaveAssociationValidationsOnAHasManyAssociation", () => {
 });
 
 describe("TestAutosaveAssociationValidationsOnABelongsToAssociation", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("should automatically validate associations with :validate => true", async () => {
     class Author extends Base {
       declare name: string | null;
@@ -4244,7 +4243,7 @@ describe("TestAutosaveAssociationValidationsOnABelongsToAssociation", () => {
 });
 
 describe("TestAutosaveAssociationValidationsOnAHasOneAssociation", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("should automatically validate associations with :validate => true", async () => {
     class Profile extends Base {
       declare bio: string | null;
@@ -4274,7 +4273,7 @@ describe("TestAutosaveAssociationValidationsOnAHasOneAssociation", () => {
 });
 
 describe("TestAutosaveAssociationOnAHasOneThroughAssociation", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("should not has one through model", async () => {
     class HotOrg extends Base {
       declare name: string | null;
@@ -4411,7 +4410,7 @@ describe("TestAutosaveAssociationOnAHasOneThroughAssociation", () => {
 });
 
 describe("TestAutosaveAssociationValidationsOnAHABTMAssociation", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("should automatically validate associations with :validate => true", async () => {
     class Tag extends Base {
       declare name: string | null;
@@ -4440,7 +4439,7 @@ describe("TestAutosaveAssociationValidationsOnAHABTMAssociation", () => {
 });
 
 describe("TestAutosaveAssociationOnAHasManyAssociationWithInverse", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   // Mirrors Rails' nested Post/Comment classes (posts/comments tables) with a
   // Comment after_save callback that reads back the inverse `post.comments`.
@@ -4491,7 +4490,7 @@ describe("TestAutosaveAssociationOnAHasManyAssociationWithInverse", () => {
 });
 
 describe("TestAutosaveAssociationOnABelongsToAssociationDefinedAsRecord", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("should not raise error", async () => {
     class BtOwner extends Base {
       declare name: string | null;
@@ -4529,7 +4528,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociationDefinedAsRecord", () => 
 });
 
 describe("TestAutosaveAssociationWithTouch", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(() => {
     registerModel(Invoice);
     registerModel(LineItem);
@@ -4541,7 +4540,7 @@ describe("TestAutosaveAssociationWithTouch", () => {
 });
 
 describe("TestAutosaveAssociationOnAHasManyAssociationDefinedInSubclassWithAcceptsNestedAttributes", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   beforeAll(() => {
     registerModel("Company", CanonicalCompany);
@@ -4568,7 +4567,7 @@ describe("TestAutosaveAssociationOnAHasManyAssociationDefinedInSubclassWithAccep
 });
 
 describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAttributes", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   function makeModels() {
     class Pirate extends Base {
@@ -4617,7 +4616,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociationWithAcceptsNestedAt
 });
 
 describe("should update children when autosave is true and parent is new but child is not", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("should update children when autosave is true and parent is new but child is not", async () => {
     class UcParent extends Base {
       declare name: string | null;
@@ -5136,7 +5135,7 @@ describe("should update children when autosave is true and parent is new but chi
 });
 
 describe("ChangedForAutosaveTest", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   it("parent is changed_for_autosave when nested autosave child is changed", () => {
     class Child extends Base {
@@ -5243,7 +5242,7 @@ describe("ChangedForAutosaveTest", () => {
 });
 
 describe("autosaveHasOne queryConstraints PK/FK pairing", () => {
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   // When a class has queryConstraints and the has_one uses an explicit composite FK,
   // assoc.options.foreignKey is the composite array. The reflection normalizes it
   // into options.queryConstraints internally. computePrimaryKey(reflection) therefore
@@ -5495,7 +5494,7 @@ describe("computePrimaryKey", () => {
 // (save_collection_association -> association.destroy(record)) which fires the
 // before_remove/after_remove callbacks, not record-level child.destroy().
 describe("TestAutosaveAssociationOnACollectionRemoveCallbacks", () => {
-  setupFixtures();
+  fixtures([], { useTransactionalTests: false });
   beforeAll(() => {
     registerModel(CanonicalPirate);
     registerModel(CanonicalBird);

--- a/packages/activerecord/src/base-prevent-writes.test.ts
+++ b/packages/activerecord/src/base-prevent-writes.test.ts
@@ -2,12 +2,10 @@ import { describe, it, expect } from "vitest";
 
 import { Base } from "./index.js";
 import { ReadOnlyError } from "./errors.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 describe("BasePreventWritesTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   class Bird extends Base {
     static {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -19,8 +19,7 @@ import { connectedToStack } from "./core.js";
 import { Range as ArRange } from "./connection-adapters/postgresql/oid/range.js";
 import { Notifications, Logger, TimeWithZone } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { withTimezoneConfig } from "./test-helper.js";
 import { IntegerType } from "@blazetrails/activemodel";
 
@@ -30,8 +29,7 @@ vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 // BasicsTest — targets base_test.rb
 // ==========================================================================
 describe("BasicsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -2033,8 +2031,7 @@ describe("BasicsTest", () => {
 // BasicsTest2 — additional coverage for base_test.rb
 // ==========================================================================
 describe("BasicsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   class PostInner extends Base {
     static {
@@ -2153,8 +2150,7 @@ describe("BasicsTest", () => {
 });
 
 describe("BasicsTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   // -- Table name inference --
   it("table name guesses", () => {

--- a/packages/activerecord/src/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/bigint-roundtrip.test.ts
@@ -8,12 +8,10 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import { Base } from "./index.js";
 import { MigrationContext } from "./migration.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 const BIG = 2n ** 62n; // 4611686018427387904 — above Number.MAX_SAFE_INTEGER
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 // `metrics` is a trails-only scratch table (no Rails counterpart). Build it via
 // the migration API and drop it afterward rather than seeding it into the

--- a/packages/activerecord/src/column-names-sync-virtual-exclusion.test.ts
+++ b/packages/activerecord/src/column-names-sync-virtual-exclusion.test.ts
@@ -10,19 +10,19 @@
  * connected model with a real table is DB-faithful without a prior reflection —
  * matching Rails' `columns.map(&:name)`.
  *
- * No `useHandlerTransactionalFixtures()` here on purpose: its per-test
- * `clearSchemaCache` teardown would wipe the boot-warmed cache, which is
- * exactly the cold-cache state this test must avoid.
+ * `fixtures([], { useTransactionalTests: false })` here on purpose: the
+ * transactional variant's per-test `clearSchemaCache` teardown would wipe the
+ * boot-warmed cache, which is exactly the cold-cache state this test must avoid.
  */
 import { describe, it, expect, beforeAll, vi } from "vitest";
 import { Base } from "./index.js";
 
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
 describe("column_names sync virtual exclusion", () => {
-  setupFixtures();
+  fixtures([], { useTransactionalTests: false });
   beforeAll(async () => {
     // Warm the shared schema cache for `posts` (the boot-time analogue of Rails
     // loading `db/schema_cache.yml`) so a synchronous `columnNames()` on a cold

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -27,8 +27,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 
 import { describeIfSupports } from "./test-helpers/supports.js";
 import { withTimezoneConfig } from "./test-helper.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 
 import { Pirate } from "./test-helpers/models/pirate.js";
@@ -94,8 +93,7 @@ function checkPirateAfterSaveFailure(pirate: Rec): void {
 }
 
 describe("DirtyTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   // Canonical-schema shield. This suite rides the preloaded canonical tables
   // (people / topics / pirates / parrots / aircraft / numeric_data) rather than
@@ -1185,7 +1183,7 @@ describe("DirtyTest", () => {
 // set is unchanged (PG only).
 // ==========================================================================
 describeIfSupports("identity_columns", "DirtyTest", () => {
-  setupFixtures();
+  fixtures([], { useTransactionalTests: false });
 
   beforeEach(async () => {
     const conn = Base.connection as unknown as {

--- a/packages/activerecord/src/encryption/contexts.test.ts
+++ b/packages/activerecord/src/encryption/contexts.test.ts
@@ -2,8 +2,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Base } from "../index.js";
 import "../relation.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import {
   configureEncryption,
   snapshotEncryptionConfig,
@@ -17,8 +16,7 @@ import { NullEncryptor } from "./null-encryptor.js";
 import { Configuration as ConfigurationError } from "./errors.js";
 import { RecordInvalid } from "../validations.js";
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 describe("ActiveRecord::Encryption::ContextsTest", () => {
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;
@@ -41,8 +39,8 @@ describe("ActiveRecord::Encryption::ContextsTest", () => {
     // Models are defined inline (rather than via the makeEncryptedPost /
     // makeEncryptedBook factories) because those factories pin `this.adapter`
     // to a passed adapter, which bypasses the connection handler and would put
-    // writes outside the per-test BEGIN/ROLLBACK savepoint that
-    // useHandlerTransactionalFixtures relies on. The sibling handler-suite
+    // writes outside the per-test BEGIN/ROLLBACK savepoint that the
+    // transactional `fixtures([])` wiring relies on. The sibling handler-suite
     // encryption test (uniqueness-validations.test.ts) hand-rolls models for
     // the same reason. They are also defined after configureEncryption so
     // encrypts() builds the scheme against the configured key material

--- a/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
+++ b/packages/activerecord/src/encryption/extended-deterministic-queries.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import {
   AdditionalValue,
   EncryptedQuery,
@@ -20,7 +19,7 @@ import "../encryption.js";
 import { Base } from "../base.js";
 import { Relation } from "../relation.js";
 
-setupFixtures();
+fixtures([], { useTransactionalTests: false });
 
 // 32 bytes (base64-encoded) for AES-256-GCM. Cipher decodes the key from
 // base64, so we pad a known repeating byte to 32 bytes and encode. Shared
@@ -130,7 +129,7 @@ describe("ActiveRecord::Encryption::ExtendedDeterministicQueriesTest", () => {
     await books.EncryptedBook.where("1=1");
   });
 
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   afterAll(() => {
     Relation.prototype.where = savedMethods.where as typeof Relation.prototype.where;

--- a/packages/activerecord/src/encryption/unencrypted-attributes.test.ts
+++ b/packages/activerecord/src/encryption/unencrypted-attributes.test.ts
@@ -7,8 +7,7 @@ import {
   assertNotEncryptedAttribute,
   withoutEncryption,
 } from "./test-helpers.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import type { EncryptedPost as EncryptedPostType } from "../test-helpers/models/post-encrypted.js";
 import { Configurable } from "./configurable.js";
 import { Decryption as DecryptionError } from "./errors.js";
@@ -18,8 +17,7 @@ import { Decryption as DecryptionError } from "./errors.js";
 // before the model is imported — load it lazily after configureEncryption().
 let EncryptedPost: typeof EncryptedPostType;
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 beforeAll(async () => {
   configureEncryption();
   ({ EncryptedPost } = await import("../test-helpers/models/post-encrypted.js"));

--- a/packages/activerecord/src/encryption/uniqueness-validations.test.ts
+++ b/packages/activerecord/src/encryption/uniqueness-validations.test.ts
@@ -5,8 +5,7 @@ import {
   restoreEncryptionConfig,
   makeKeyProvider,
 } from "./test-helpers.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Configurable } from "./configurable.js";
 import { installExtendedQueriesIfConfigured } from "./install.js";
 import { ExtendedDeterministicUniquenessValidator } from "./extended-deterministic-uniqueness-validator.js";
@@ -16,8 +15,7 @@ import { EncryptedAttributeType } from "./encrypted-attribute-type.js";
 import { Relation } from "../relation.js";
 import { Base } from "../index.js";
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 describe("ActiveRecord::Encryption::UniquenessValidationsTest", () => {
   let configSnapshot: ReturnType<typeof snapshotEncryptionConfig>;

--- a/packages/activerecord/src/finder-respond-to.test.ts
+++ b/packages/activerecord/src/finder-respond-to.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, RecordNotFound } from "./index.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 let Topic: typeof Base;
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 // Recreate the model per test so a test that mutates the class (adds an
 // attribute, primes a finder cache, etc.) can't leak into later tests.


### PR DESCRIPTION
## Summary

RFC 0062 transactional-fixtures burndown, **Bucket A** (2/4): convert the
`setupFixtures()` + `useHandlerTransactionalFixtures()` pairs to a single
`fixtures([], { … })` call across 14 associations/encryption/core test files.

## What changed

- **Adjacent per-describe pairs** collapse to `fixtures([])`
  (attribute-methods, attributes, base, base-prevent-writes, bigint-roundtrip,
  finder-respond-to, dirty, and the four encryption files).
- **File-scope `setupFixtures()` + per-describe `useHandlerTransactionalFixtures()`**
  (autosave-association, extended-deterministic-queries): keep the suite via a
  file-scope `fixtures([], { useTransactionalTests: false })` and convert each
  transactional call to `fixtures([])`.
- **`setupFixtures()`-only callers that deliberately opt out of the per-test
  savepoint** (column-names-sync, dirty `identity_columns`, the
  collection-remove-callbacks describe) convert to
  `fixtures([], { useTransactionalTests: false })`.
- Teach the `test-fixture-parity` ESLint rule that a fixture surface invoked
  without destructuring a named accessor (the `fixtures([])` replacement for
  `useHandlerTransactionalFixtures`) satisfies the parity check via scope
  presence — same as the transactional helper it replaces. Added a RuleTester
  case.

Schema setup is left untouched (Rails fixture wiring is per-test transactional,
independent of table creation).

## Testing

- All 14 touched test files pass locally (sqlite).
- `eslint/test-fixture-parity.test.mjs` passes.
- `tsc --build` clean via pre-commit.

Closes-story: convert-pair-associations-encryption-a