### PR TITLE
test(fixtures): convert Bucket A core+relation pairs to fixtures([])

### DIFF
--- a/packages/activerecord/src/habtm-destroy-order.test.ts
+++ b/packages/activerecord/src/habtm-destroy-order.test.ts
@@ -1,14 +1,12 @@
 import type { AssociationProxy } from "./associations/collection-proxy.js";
 import { describe, it, expect } from "vitest";
 import { Base, association, registerModel, Rollback } from "./index.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 // Mirrors vendor/rails/activerecord/test/models/lesson.rb — `class LessonError`.
 class LessonError extends Error {}
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 describe("HabtmDestroyOrderTest", () => {
   function makeModels() {

--- a/packages/activerecord/src/i18n.test.ts
+++ b/packages/activerecord/src/i18n.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base } from "./index.js";
 import { I18n } from "@blazetrails/activemodel";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 beforeEach(() => {
   I18n.reset();
 });

--- a/packages/activerecord/src/inheritance-namespaced.test.ts
+++ b/packages/activerecord/src/inheritance-namespaced.test.ts
@@ -10,8 +10,7 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { stiName, polymorphicName, qualifiedName, namespaceSegments } from "./inheritance.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import {
   ClothingItem,
   ClothingItemUsed,
@@ -21,8 +20,7 @@ import { AdminUser } from "./test-helpers/models/admin/user.js";
 import { AdminAccount } from "./test-helpers/models/admin/account.js";
 
 describe("InheritanceTest (module-namespaced sti_name)", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(async () => {
     await ClothingItem.loadSchema();
   });

--- a/packages/activerecord/src/lazy-schema-reflection.test.ts
+++ b/packages/activerecord/src/lazy-schema-reflection.test.ts
@@ -7,12 +7,10 @@
 import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 describe("lazy async schema reflection", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   it("find_by without an explicit load_schema", async () => {
     // No `this.attribute(...)` and no explicit `Topic.loadSchema()` —

--- a/packages/activerecord/src/log-subscriber.test.ts
+++ b/packages/activerecord/src/log-subscriber.test.ts
@@ -8,8 +8,7 @@ import {
   Logger,
 } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { Developer } from "./test-helpers/models/developer.js";
 
 const REGEXP_CLEAR_STR = `\\x1b\\[${BaseLogSubscriber.MODES.clear}m`;
@@ -102,8 +101,7 @@ describe("LogSubscriberTest", () => {
   // The DB-backed tests (basic/exists query logging) drive a real query
   // through the auto-attached production LogSubscriber, which logs via
   // ActiveRecord::Base.logger. A `developers` table is all those SELECTs need.
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeEach(() => {
     mockLogger = new MockLogger();
     LogSubscriber.logger = mockLogger;

--- a/packages/activerecord/src/mixin.test.ts
+++ b/packages/activerecord/src/mixin.test.ts
@@ -1,11 +1,9 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { Base } from "./index.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 describe("TouchTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   afterEach(() => {
     vi.useRealTimers();
   });

--- a/packages/activerecord/src/model-schema.test.ts
+++ b/packages/activerecord/src/model-schema.test.ts
@@ -5,8 +5,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { Base } from "./index.js";
 
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { assertNoQueriesMatch } from "./testing/query-assertions.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -19,8 +18,7 @@ vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 // query-free. There is no upstream Rails counterpart — this guards a trails-only
 // cold-cache write-path optimization.
 describe("virtual attribute reconciliation warms the schema cache", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   it("populates the shared schema cache when reconciling on a cold cache", async () => {
     class Post extends Base {
       static {

--- a/packages/activerecord/src/nested-attributes-with-callbacks.test.ts
+++ b/packages/activerecord/src/nested-attributes-with-callbacks.test.ts
@@ -6,8 +6,7 @@
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Base, registerModel, acceptsNestedAttributesFor } from "./index.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 // Shared callback sink — Rails uses a class variable `@@add_callback_called`
 // captured by the `before_add` procs declared on the associations below.
@@ -74,8 +73,7 @@ registerModel("NwcBird", NwcBird);
 registerModel("NwcPirate", NwcPirate);
 
 describe("NestedAttributesWithCallbacksTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   let pirate: any;
   let birds: NwcBird[];

--- a/packages/activerecord/src/normalized-attribute.test.ts
+++ b/packages/activerecord/src/normalized-attribute.test.ts
@@ -4,15 +4,14 @@
  * Rails drives the canonical `Aircraft` (`aircraft` table) plus a
  * `NormalizedAircraft < Aircraft` subclass carrying `normalizes` declarations.
  * Both shapes are canonical, so this file rides the worker-built `aircraft`
- * table via `setupFixtures` — no `defineSchema`, no bespoke adapter.
+ * table via `fixtures([])` — no `defineSchema`, no bespoke adapter.
  */
 import { describe, it, expect, beforeEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { presence, titleize } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 import { Aircraft } from "./test-helpers/models/aircraft.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 // Rails `Time#noon` — the same instant moved to 12:00:00 (midday) UTC.
 function noon(time: Temporal.Instant): Temporal.Instant {
@@ -41,8 +40,7 @@ class NormalizedAircraft extends Aircraft {
 }
 
 describe("NormalizedAttributeTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   let time: Temporal.Instant;
   let aircraft: NormalizedAircraft;
@@ -184,8 +182,7 @@ function succ(value: string): string {
 }
 
 describe("normalizes on Base", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   it("normalizes attributes before persistence", async () => {
     class NormalizedUser extends Base {

--- a/packages/activerecord/src/numeric-data.test.ts
+++ b/packages/activerecord/src/numeric-data.test.ts
@@ -4,16 +4,14 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { adapterType } from "./test-adapter.js";
 
 // Rails guards test_numeric_fields_with_nan with current_adapter?(:PostgreSQLAdapter):
 // only PostgreSQL's numeric type stores NaN (SQLite/MySQL reject 'NaN'::numeric).
 const itPg = adapterType === "postgres" ? it : it.skip;
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 beforeAll(async () => {
   await NumericData.loadSchema();

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -31,11 +31,9 @@ import { Post as CanonicalPost } from "./test-helpers/models/post.js";
 
 import { UnknownPrimaryKey, NameError } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 describe("ReflectionTest", () => {
   function makeModels() {

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -16,14 +16,12 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel } from "../index.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Author } from "../test-helpers/models/author.js";
 
 describe("build_joins from(subquery) dedup", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(async () => {
     // Register the belongsTo("author") target so `joins("author")` resolves
     // during JoinDependency construction.

--- a/packages/activerecord/src/relation/eager-shared-alias-tracker.test.ts
+++ b/packages/activerecord/src/relation/eager-shared-alias-tracker.test.ts
@@ -18,14 +18,12 @@
  */
 import { describe, it, expect, beforeAll } from "vitest";
 import { registerModel } from "../index.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Author } from "../test-helpers/models/author.js";
 
 describe("eager build_joins shared AliasTracker", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(async () => {
     registerModel("Post", Post);
     registerModel("Author", Author);

--- a/packages/activerecord/src/relation/mutation.test.ts
+++ b/packages/activerecord/src/relation/mutation.test.ts
@@ -12,12 +12,10 @@
  */
 import { describe, it, expect } from "vitest";
 import "../index.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Post } from "../test-helpers/models/post.js";
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 /** Fresh relation per test — the trails analogue of Rails' `Relation.new(FakeKlass)`. */
 function relation(): any {
   return Post.all();


### PR DESCRIPTION
Converts the Bucket A setupFixtures + useHandlerTransactionalFixtures pairs (no fixture data) to a single `fixtures([])` call across 14 core + relation test files, per RFC 0062 (transactional-fixtures burndown).

All files ride the canonical schema with no table creation, so `fixtures([])` (default `TEST_SCHEMA`) is a faithful replacement for the handler-suite + per-test-transaction pair. No test renames; schema setup left untouched.

Ran the 14 touched files locally: 173 passed, 9 skipped.

Closes-story: convert-pair-core-relation-a