### PR TITLE
test(fixtures): convert Bucket A pairs to fixtures([]) — secure/type/validations

### DIFF
--- a/packages/activerecord/src/relation/value-accessor-semantics.test.ts
+++ b/packages/activerecord/src/relation/value-accessor-semantics.test.ts
@@ -9,13 +9,11 @@
  */
 import { describe, it, expect } from "vitest";
 import "../index.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Post } from "../test-helpers/models/post.js";
 import type { Relation } from "../relation.js";
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 /** The split join-storage and group fields the reader semantics build on. */
 type JoinInternals = {
   _namedInnerJoins: unknown[];

--- a/packages/activerecord/src/secure-password.test.ts
+++ b/packages/activerecord/src/secure-password.test.ts
@@ -5,8 +5,7 @@
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { User } from "./test-helpers/models/user.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 // Mirrors Rails' `retry_flaky_test` (secure_password_test.rb): retry the timing
 // assertion a few times before failing, so a single unlucky preemption spike
@@ -27,8 +26,7 @@ async function retryFlakyTest(fn: () => Promise<void>, retryCount = 3): Promise<
 }
 
 describe("SecurePasswordTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(async () => {
     await User.loadSchema();
   });

--- a/packages/activerecord/src/secure-token.test.ts
+++ b/packages/activerecord/src/secure-token.test.ts
@@ -6,12 +6,10 @@ import { describe, it, expect, beforeAll, beforeEach } from "vitest";
 import { Base } from "./index.js";
 import { User } from "./test-helpers/models/user.js";
 import { hasSecureToken, MinimumLengthError } from "./secure-token.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 describe("SecureTokenTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
   beforeAll(async () => {
     await User.loadSchema();
   });

--- a/packages/activerecord/src/statement-cache.test.ts
+++ b/packages/activerecord/src/statement-cache.test.ts
@@ -9,8 +9,7 @@ import { Electron } from "./test-helpers/models/electron.js";
 import { NumericData } from "./test-helpers/models/numeric-data.js";
 import { ClothingItem } from "./test-helpers/models/clothing-item.js";
 import { RecordNotFound } from "./errors.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 registerModel("Book", Book);
 registerModel("Liquid", Liquid);
@@ -18,8 +17,7 @@ registerModel("Molecule", Molecule);
 registerModel("Electron", Electron);
 registerModel("NumericData", NumericData);
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 beforeAll(async () => {
   await Promise.all([

--- a/packages/activerecord/src/suppressor.test.ts
+++ b/packages/activerecord/src/suppressor.test.ts
@@ -4,13 +4,11 @@
  */
 import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "./test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { Notification } from "./test-helpers/models/notification.js";
 import { User, UserWithNotification } from "./test-helpers/models/user.js";
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 
 describe("SuppressorTest", () => {
   it("suppresses create", async () => {

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -31,7 +31,7 @@ class TokenUser extends User {
 const DAY = 24 * 60 * 60 * 1000;
 
 describe("TokenForTest", () => {
-  // NOT useHandlerTransactionalFixtures(): these tests `destroy` the user, and a
+  // `useTransactionalTests: false`: these tests `destroy` the user, and a
   // model destroy opens its own transaction. On PostgreSQL, nesting that destroy
   // transaction inside the per-test fixtures transaction double-starts the
   // transaction instrumenter (InstrumentationAlreadyStartedError). Cleaning up

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -11,7 +11,7 @@ import { CpkBook } from "./test-helpers/models/cpk.js";
 import { InvalidSignature } from "@blazetrails/activesupport/message-verifier";
 import { travel, travelBack } from "@blazetrails/activesupport";
 import { generatesTokenFor, setTokenForSecret } from "./token-for.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 // Rails: class User < ::User { generates_token_for :lookup; … }
 class TokenUser extends User {
@@ -37,7 +37,7 @@ describe("TokenForTest", () => {
   // transaction instrumenter (InstrumentationAlreadyStartedError). Cleaning up
   // with deleteAll in afterEach (the signed-id.test.ts pattern) keeps the shared
   // `users` table isolated without an enclosing transaction.
-  setupFixtures();
+  fixtures([], { useTransactionalTests: false });
   beforeAll(async () => {
     registerModel(Room);
     await TokenUser.loadSchema();

--- a/packages/activerecord/src/type/date-time.test.ts
+++ b/packages/activerecord/src/type/date-time.test.ts
@@ -2,12 +2,10 @@ import { describe, it, expect, afterAll, vi } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { DateTime } from "./date-time.js";
 import { Base } from "../index.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 describe("DateTimeTest", () => {
   afterAll(() => {
     vi.unstubAllEnvs();

--- a/packages/activerecord/src/validations/i18n-validation.test.ts
+++ b/packages/activerecord/src/validations/i18n-validation.test.ts
@@ -1,12 +1,10 @@
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { Error as ActiveModelError, I18n } from "@blazetrails/activemodel";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { seedAssociationCache } from "../test-helpers/seed-association-cache.js";
 
-setupFixtures();
-useHandlerTransactionalFixtures();
+fixtures([]);
 // The canonical `topics` table is laid at boot by loadCanonicalSchema.
 
 /** An associated child whose validation always fails — stands in for Rails'

--- a/packages/activerecord/src/validations/length-validation.test.ts
+++ b/packages/activerecord/src/validations/length-validation.test.ts
@@ -6,18 +6,16 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import "../index.js";
 import { registerModel, association } from "../associations.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Owner } from "../test-helpers/models/owner.js";
 import { Pet } from "../test-helpers/models/pet.js";
 
 describe("LengthValidationTest", () => {
-  setupFixtures();
   // Mirrors Rails `fixtures :owners` — transactional fixtures (per-test
   // BEGIN/ROLLBACK). The owner rows themselves are never read by these tests;
   // every case builds fresh records, exactly like the Rails counterpart's
   // `@owner = Class.new(Owner)` + `@owner.new`.
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   beforeAll(async () => {
     registerModel("Owner", Owner);

--- a/packages/activerecord/src/validations/presence-validation.test.ts
+++ b/packages/activerecord/src/validations/presence-validation.test.ts
@@ -6,8 +6,7 @@
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { Base, registerModel } from "../index.js";
 import { association } from "../associations.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
-import { useHandlerTransactionalFixtures } from "../test-helpers/use-handler-transactional-fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { repairValidations } from "../test-helpers/repair-validations.js";
 import { Human } from "../test-helpers/models/human.js";
 import { Face } from "../test-helpers/models/face.js";
@@ -37,8 +36,7 @@ function setAssoc(record: Base, name: string, value: unknown) {
 }
 
 describe("PresenceValidationTest", () => {
-  setupFixtures();
-  useHandlerTransactionalFixtures();
+  fixtures([]);
 
   beforeAll(async () => {
     // The canonical humans/faces/interests/speedometers/dashboards tables are


### PR DESCRIPTION
Converts the RFC 0062 Bucket A setupFixtures + useHandlerTransactionalFixtures pairs to a single `fixtures([], { … })` call across the secure/type/validations cluster. Empty-array `fixtures([])` is the vacuous zero-fixture surface that still wires the handler suite + per-test transaction (use-fixtures.ts:439-443).

- 9 files: pair → `fixtures([])` (default transactional).
- `token-for.test.ts`: lone `setupFixtures()` (deliberately non-transactional — destroy opens its own txn, PG double-start) → `fixtures([], { useTransactionalTests: false })`, preserving semantics.

Schema setup left untouched; no test renames. All 10 files pass locally (90 tests).

Closes-story: convert-pair-secure-validations-a