### PR TITLE
fix(mysql): drop bogus per-column primaryKey flag at columns() source

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -19,6 +19,7 @@ import {
   foreignKeys,
   indexes,
   parseMysqlName,
+  columns,
   MysqlSchemaStatements,
 } from "./schema-statements.js";
 import { quote } from "./quoting.js";
@@ -491,6 +492,50 @@ describe("MySQL::SchemaStatements", () => {
     );
     expect(idx[0].columns).toEqual(["(lower(`title`))"]);
     expect(idx[0].orders).toEqual({ "(lower(`title`))": "desc" });
+  });
+});
+
+describe("MySQL::SchemaStatements#columns primary flag", () => {
+  // Minimal IntrospectionHost for columns(): stub schemaQuery to return the
+  // information_schema.columns rows MySQL yields, plus the type/version helpers
+  // columns() consults. No float-like column is present, so columnDefinitions
+  // (the MariaDB SHOW FULL FIELDS fallback) is never invoked.
+  const columnsHost = (rows: Record<string, unknown>[]) => ({
+    schemaQuery: async () => rows,
+    parseMysqlName,
+    lookupCastType: (sqlType: string) => ({
+      name: sqlType.startsWith("bigint") ? "integer" : "value",
+    }),
+    getFullVersion: async () => "8.0.32",
+    isMariadb: () => false,
+    columnDefinitions: async () => [],
+  });
+
+  // MySQL/MariaDB report column_key = 'PRI' for a promoted UNIQUE-NOT-NULL index
+  // when a table has no PRIMARY KEY, so keying Column.primaryKey off column_key
+  // over-reports. Rails' MySQL::Column carries no per-column primary flag, so
+  // columns() must not set one — the key is resolved via adapter.primaryKey().
+  it("does not flag a column primary even when column_key is PRI", async () => {
+    const host = columnsHost([
+      {
+        name: "code",
+        default_value: null,
+        nullable: "NO",
+        type: "bigint",
+        full_type: "bigint(20)",
+        char_len: null,
+        num_precision: 20,
+        num_scale: 0,
+        col_key: "PRI",
+        collation: null,
+        comment: null,
+        extra: "",
+      },
+    ]) as unknown as ThisParameterType<typeof columns>;
+    const cols = await columns.call(host, "widgets");
+    expect(cols).toHaveLength(1);
+    expect(cols[0].name).toBe("code");
+    expect(cols[0].primaryKey).toBeFalsy();
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -473,7 +473,8 @@ interface IntrospectionHost {
  * Return Column metadata for the named table. Reads from
  * `information_schema.columns` — matches Rails' column introspection
  * shape. Populates the fields SchemaCache serializes (name, default,
- * null, sqlTypeMetadata, primaryKey).
+ * null, sqlTypeMetadata). Carries no per-column primary flag — like
+ * Rails' MySQL::Column, the primary key is resolved via adapter.primaryKey().
  */
 export async function columns(this: IntrospectionHost, tableName: string): Promise<Column[]> {
   const { schema, table } = this.parseMysqlName(tableName);
@@ -486,7 +487,6 @@ export async function columns(this: IntrospectionHost, tableName: string): Promi
             character_maximum_length AS char_len,
             numeric_precision AS num_precision,
             numeric_scale AS num_scale,
-            column_key AS col_key,
             collation_name AS collation,
             column_comment AS comment,
             extra AS extra
@@ -588,7 +588,6 @@ export async function columns(this: IntrospectionHost, tableName: string): Promi
     });
     const nullable =
       String((r.nullable ?? r.NULLABLE ?? r.IS_NULLABLE ?? "YES") as string).toUpperCase() !== "NO";
-    const colKey = String((r.col_key ?? r.COL_KEY ?? r.COLUMN_KEY ?? "") as string);
     const extraRaw = String((r.extra ?? r.EXTRA ?? "") as string);
     const extra = extraRaw.toLowerCase();
     // Mirror newColumnFromField's function-default detection (mysql/schema-statements.ts):
@@ -674,7 +673,17 @@ export async function columns(this: IntrospectionHost, tableName: string): Promi
         collation: (r.collation ?? r.COLLATION ?? null) as string | null,
         comment: presence((r.comment ?? r.COMMENT) as string | null | undefined) ?? null,
         defaultFunction: defFn,
-        primaryKey: colKey === "PRI",
+        // No per-column primary flag — mirrors Rails' MySQL::Column
+        // (abstract_mysql_adapter.rb / mysql/schema_statements.rb#new_column_from_field,
+        // which passes no primary argument), and the SHOW FULL FIELDS sibling path
+        // newColumnFromField above, which likewise omits it. MySQL/MariaDB report
+        // column_key = 'PRI' not only for a real PRIMARY KEY but also for a promoted
+        // UNIQUE-NOT-NULL index when a table has no PRIMARY KEY, so keying the flag off
+        // column_key over-reports that promoted-unique column as primary. information_schema
+        // alone can't distinguish the two, and the authoritative resolution is via
+        // adapter.primaryKey() (SHOW KEYS ... 'PRIMARY') — so carry no flag here rather
+        // than a bogus one. A separate PK query would trip QueryCacheTest and a JOIN would
+        // time out SchemaDumperTest's full-DB dump (see PR #4379 / #4594).
         autoIncrement: extra === "auto_increment",
         // Literal port of Rails MySQL::Column#unsigned? (`/\bunsigned(?: zerofill)?\z/`).
         // End-anchored (JS `$` without /m ≡ Ruby `\z`): the modifier only ever trails the

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -298,6 +298,21 @@ export class SchemaCache {
    * cache resolves `primary_key` from the reflected table rather than the
    * convention.
    *
+   * This column-flag derivation is adapter-scoped: it fires only for adapters
+   * whose `columns()` flag the PK (sqlite/postgres). MySQL/MariaDB's `columns()`
+   * carries no per-column primary flag — matching Rails' `MySQL::Column`
+   * (`abstract_mysql_adapter.rb`), which resolves the key solely via
+   * `@connection.primary_key` — so this branch never resolves a MySQL key and
+   * falls through to `undefined`. That is not a gap: MySQL PK resolution is
+   * authoritative-only, and `loadSchema` → `loadSchemaFromAdapter`
+   * (`model-schema.ts`) always warms `_primaryKeys` (via `adapter.primaryKey()`)
+   * alongside the columns hash, so the `_primaryKeys` hit above answers first.
+   * A MySQL custom-PK table therefore still resolves through the model path
+   * (regression-tested in `primary-keys.test.ts`); only a low-level caller that
+   * warms `_columns` without `_primaryKeys` — which the model path never does —
+   * would see the fall-through, exactly as Rails would require a `primary_keys`
+   * query there.
+   *
    * Deliberately returns `undefined` (not `null`) when the warm columns flag no
    * primary key: the authoritative keyless→`null` answer comes from the async
    * `primaryKeys` query, and resolving it here would change a warm-but-unqueried

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -429,15 +429,21 @@ export class SchemaCache {
 
   /**
    * Clear per-column `primaryKey` flags that the authoritative `_primaryKeys`
-   * cache contradicts. MySQL/MariaDB report `column_key = 'PRI'` for a
-   * UNIQUE-NOT-NULL index when a table has no PRIMARY KEY (the "promoted unique"
-   * case), so `mysql/schema-statements.ts` reflects a bogus primary flag on that
-   * column — Rails' `MySQL::Column` carries no per-column primary flag and
-   * resolves the key solely from the `PRIMARY` constraint. `add()` warms
-   * `_primaryKeys` (via the authoritative `SHOW KEYS ... 'PRIMARY'` /
-   * key_column_usage query) before `columns()`, so the correct answer is already
-   * in hand — reconcile against it query-free. Called from both `setColumns` and
-   * `setPrimaryKeys` so the correction is independent of which warms first.
+   * cache contradicts. This is a general safety net for any adapter whose
+   * `columns()` could over-report a primary flag, reconciled query-free against
+   * `_primaryKeys` (which `add()` warms via the authoritative
+   * `SHOW KEYS ... 'PRIMARY'` / key_column_usage query before `columns()`).
+   * Called from both `setColumns` and `setPrimaryKeys` so the correction is
+   * independent of which warms first.
+   *
+   * Historically this cleared MySQL/MariaDB's "promoted unique" false positive:
+   * they report `column_key = 'PRI'` for a UNIQUE-NOT-NULL index when a table has
+   * no PRIMARY KEY, so `columns()` used to reflect a bogus flag on that column.
+   * `columns()` now carries no per-column primary flag at all for MySQL/MariaDB —
+   * matching Rails' `MySQL::Column`, which has none and resolves the key solely
+   * from the `PRIMARY` constraint — so this reconcile is a no-op for MySQL
+   * (nothing is ever set `true`, so there is nothing to clear). It stays as a
+   * harmless guard for any adapter that could theoretically over-report.
    *
    * Clear-only: a flag is dropped when the authoritative key set excludes the
    * column, never added. Real primary keys (whose flag the adapter already set

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -17,6 +17,7 @@ import { MixedCaseMonkey } from "./test-helpers/models/mixed-case-monkey.js";
 import { Dashboard } from "./test-helpers/models/dashboard.js";
 import { NonPrimaryKey } from "./test-helpers/models/non-primary-key.js";
 import { CpkBook, CpkOrder } from "./test-helpers/models/cpk.js";
+import { Country } from "./test-helpers/models/country.js";
 
 describe("PrimaryKeysTest", () => {
   const { topics, subscribers, mixedCaseMonkeys } = fixtures(
@@ -36,6 +37,7 @@ describe("PrimaryKeysTest", () => {
       "developers",
       "developers_projects",
       "cpk_books",
+      "countries",
     ]);
   });
 
@@ -44,6 +46,19 @@ describe("PrimaryKeysTest", () => {
     expect(topic.toKey()).toBeNull();
     const found = await Topic.find(topics("first").id);
     expect(found.toKey()).toEqual([topics("first").id]);
+  });
+
+  it("resolves a custom string primary key with no explicit primary_key= via the schema cache", async () => {
+    // Country declares no `static _primaryKey`; its `country_id` PK is resolved
+    // from the reflected schema. This guards the schema-cache PK resolution
+    // across adapters — notably MySQL/MariaDB, whose `columns()` carries no
+    // per-column primary flag (matching Rails' `MySQL::Column`), so resolution
+    // must come through the authoritative `_primaryKeys` warming rather than a
+    // column flag. A regression there would silently misresolve to the "id"
+    // convention.
+    (Country as unknown as { resetColumnInformation?: () => void }).resetColumnInformation?.();
+    await (Country as unknown as { loadSchema?: () => Promise<void> }).loadSchema?.();
+    expect(Country.primaryKey).toBe("country_id");
   });
 
   it("to key with customized primary key", async () => {

--- a/packages/activerecord/src/schema-introspection.trails.test.ts
+++ b/packages/activerecord/src/schema-introspection.trails.test.ts
@@ -259,7 +259,14 @@ describe("introspectPrimaryKey", () => {
 
     const pk = await introspectPrimaryKey(stripped, "widgets");
 
-    expect(pk).toEqual(["id"]);
+    // The fallback derives the key from columns whose reflected `primaryKey`
+    // flag is set. MySQL/MariaDB's columns() carries no per-column primary flag
+    // — matching Rails' MySQL::Column (abstract_mysql_adapter.rb /
+    // mysql/schema_statements.rb#new_column_from_field), which passes no primary
+    // argument and resolves the key solely via @connection.primary_key. So with
+    // primaryKey() stripped there is nothing to fall back to and the result is
+    // empty; sqlite/postgres, whose columns() flag the PK, yield ["id"].
+    expect(pk).toEqual(adapterType === "mysql" ? [] : ["id"]);
   });
 });
 


### PR DESCRIPTION
## What

`mysql/schema-statements.ts` `columns()` (the `information_schema` path) keyed
`Column.primaryKey` off `column_key === "PRI"`. MySQL/MariaDB report
`column_key = 'PRI'` not only for a real PRIMARY KEY but also for a **promoted
UNIQUE-NOT-NULL** index when a table has no PRIMARY KEY, so a direct
`adapter.columns()` caller (bypassing the schema cache's `reconcilePrimaryKeyFlags`)
received a bogus primary flag on that promoted-unique column.

Rails' `MySQL::Column` carries **no** per-column primary flag
(`mysql/schema_statements.rb#new_column_from_field` passes no primary argument)
and resolves the key solely via `@connection.primary_key`. Our SHOW FULL FIELDS
sibling path (`newColumnFromField`) already omits it; this converges the
`information_schema` path to match — carrying no flag rather than a
`column_key`-derived one.

Query-free: no separate PK query (would trip `QueryCacheTest`) and no JOIN
(would time out `SchemaDumperTest`'s full-DB dump). See PR #4379 / #4594.

## Follow-up to

PR #4594, which converged the *observable* deviation at the schema-cache layer
(clear-only reconcile). This removes the underlying *source* deviation so direct
`columns()` consumers get the correct flag too.

## Reviewer response — `getCachedPrimaryKeys` / `introspectPrimaryKey` flag fallbacks

The review flagged that removing the source flag could break the two trails
query-free fallbacks that derive PK from `Column.primaryKey`. Investigated on a
**real MariaDB/MySQL** instance:

- **Production model resolution is safe.** `Country.primaryKey` (custom
  `country_id` PK, no explicit `_primaryKey`) resolves correctly end-to-end on
  MySQL. `loadSchema` → `loadSchemaFromAdapter` warms `_primaryKeys`
  authoritatively (`model-schema.ts:1156-1158`) alongside columns, so
  `getCachedPrimaryKeys` returns from `_primaryKeys`, never the column-flag
  fallback. Verified `getCachedPrimaryKeys("countries") === "country_id"` after
  the real `add()` path. The cold-`_primaryKeys`/warm-columns window the review
  describes is not reachable through model loading — `loadSchemaFromCacheSync`
  only *reads* an already-warm cache, and every warming path (`add`,
  `loadSchemaFromAdapter`, dump/load) populates `_primaryKeys` too.
- **`introspectPrimaryKey`** already prefers `adapter.primaryKey()`; the
  column-flag fallback only fires for an adapter that *lacks* `primaryKey()` —
  which no real MySQL adapter does. The one test exercising it
  (`schema-introspection.trails.test.ts`) synthetically strips `primaryKey()`;
  its expectation encoded the old divergent flag. It is now adapter-aware:
  MySQL/MariaDB yield `[]` (no flag, matching Rails' `MySQL::Column`),
  sqlite/postgres still yield `["id"]`.

HABTM + `primary-keys` suites pass against live MySQL.

## Tests
- New `columns()` unit test: a `col_key: "PRI"` row is not flagged primary.
- `introspectPrimaryKey` fallback test made adapter-aware with a Rails citation.

Closes-story: converge-mysql-column-primarykey-flag-at-source


## Reviewer follow-up — is the MySQL derive-from-columns fallback an intended dead path?

**Intended, and now documented + regression-tested.** Rails' `MySQL::Column`
(`abstract_mysql_adapter.rb`) carries no per-column primary flag and resolves the
key solely via `@connection.primary_key`, so a column-flag-based PK derivation is
inherently inapplicable to MySQL — it worked before only via the bogus
`column_key === 'PRI'` flag this PR removes. MySQL PK resolution is
authoritative-only.

- `getCachedPrimaryKeys`'s docstring now states the column-flag derivation is
  adapter-scoped (fires for sqlite/postgres; MySQL/MariaDB rely on `_primaryKeys`
  warming).
- **Verified not to silently misresolve:** new cross-adapter test in
  `primary-keys.test.ts` — `Country` (custom `country_id` PK, *no* explicit
  `static _primaryKey`, resolved purely from the reflected schema) resolves to
  `"country_id"` on live MySQL, not the `"id"` convention. `loadSchema` →
  `loadSchemaFromAdapter` (`model-schema.ts:1156-1158`) warms `_primaryKeys`
  alongside columns, so the model path (the only caller of `getCachedPrimaryKeys`,
  via `getPrimaryKeyAttr`) always answers from `_primaryKeys`. The cold-columns/
  warm-`_primaryKeys` window is unreachable through model loading; a schema-cache
  dump/load serializes `primary_keys` too.
