### PR TITLE
test(fixtures): roll out canonical-model autoload, drop target-only registerModel blocks

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -17,7 +17,6 @@ import {
   InvalidForeignKey,
   RangeError,
   ValueTooLong,
-  registerModel,
   Rollback,
 } from "./index.js";
 import { Result } from "./result.js";
@@ -27,6 +26,9 @@ import { adapterType, inMemoryDb } from "./test-adapter.js";
 import { itIfSupports } from "./test-helpers/supports.js";
 import { establishFromTestConfig } from "./test-helpers/test-database-config.js";
 import { runWithoutConnection } from "./test-helpers/connection-helper.js";
+// Opt into the canonical-model autoload index so association targets resolve by
+// name on first reference — no manual `registerModel`.
+import "./test-helpers/canonical-model-index.js";
 import { Book } from "./test-helpers/models/book.js";
 import { Post } from "./test-helpers/models/post.js";
 import { Author, AuthorAddress } from "./test-helpers/models/author.js";
@@ -216,10 +218,6 @@ async function activePredicate(conn: DatabaseAdapter): Promise<boolean> {
 // schema + official Book/Post/Author/Event models and real fixtures; the leased
 // `Base.connection` stands in for Rails' `@connection = ...lease_connection`.
 describe("AdapterTest", () => {
-  registerModel("Author", Author);
-  registerModel("Post", Post);
-  registerModel("Book", Book);
-  registerModel("Event", Event);
   fixtures(["accounts", "authors", "tasks", "topics", "subscribers", "posts", "books"], {
     schema: canonicalSchema,
     usesTransaction: [
@@ -632,12 +630,6 @@ describe("AdapterForeignKeyTest", () => {
 });
 
 describe("AdapterTestWithoutTransaction", () => {
-  registerModel("Author", Author);
-  registerModel("Post", Post);
-  registerModel("AuthorAddress", AuthorAddress);
-  registerModel("Movie", Movie);
-  registerModel("Subscriber", Subscriber);
-
   // Rails: `self.use_transactional_tests = false`. truncate commits (and on
   // MySQL implicitly commits as DDL), so these run un-wrapped; fixtures()
   // re-seeds each table in its beforeEach, standing in for `reset_fixtures`.
@@ -764,10 +756,6 @@ describe("AdapterTestWithoutTransaction", () => {
 // MySQL/PostgreSQL (Rails `skip`s on SQLite), so the cases that depend on them
 // stay gated on a non-SQLite adapter.
 describe.skipIf(inMemoryDb())("AdapterConnectionTest", () => {
-  registerModel("Post", Post);
-  registerModel("Author", Author);
-  registerModel("AuthorAddress", AuthorAddress);
-
   // Rails: `self.use_transactional_tests = false`; the disconnect/reconnect
   // lifecycle would be meaningless wrapped in a per-test transaction, so every
   // case runs un-wrapped and fixtures re-seed each table in their beforeEach.

--- a/packages/activerecord/src/associations/habtm.test.ts
+++ b/packages/activerecord/src/associations/habtm.test.ts
@@ -6,22 +6,21 @@
  * `developers` / `projects` / `developers_projects` tables and the canonical
  * `Developer` / `Project` models that drive `has_and_belongs_to_many` in Rails.
  */
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect } from "vitest";
 import "../index.js";
-import { registerModel, association } from "../associations.js";
+import { association } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "../test-helpers/test-schema.js";
+// Opt into the canonical-model autoload index so the `Developer`/`Project`
+// association targets resolve by name on first reference — no manual
+// `registerModel`.
+import "../test-helpers/canonical-model-index.js";
 import { Developer as CanonicalDeveloper } from "../test-helpers/models/developer.js";
 import { Project as CanonicalProject } from "../test-helpers/models/project.js";
 
 describe("has_and_belongs_to_many", () => {
   const { developers, projects } = fixtures(["developers", "projects", "developersProjects"], {
     schema: canonicalSchema,
-  });
-
-  beforeEach(() => {
-    registerModel("Developer", CanonicalDeveloper);
-    registerModel("Project", CanonicalProject);
   });
 
   it("loads associated records through a join table", async () => {

--- a/packages/activerecord/src/associations/preloader-bigint-number-key-match.test.ts
+++ b/packages/activerecord/src/associations/preloader-bigint-number-key-match.test.ts
@@ -7,13 +7,15 @@
  * association comes back empty even though Ruby's width-agnostic `Integer ==`
  * would match. Guards against that regression on the PG bigserial-PK lane.
  */
-import { describe, it, expect, beforeAll } from "vitest";
-import { Base, registerModel } from "../index.js";
+import { describe, it, expect } from "vitest";
+import { Base } from "../index.js";
 import { Preloader } from "./preloader.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { TEST_SCHEMA } from "../test-helpers/test-schema.js";
+// Opt into the canonical-model autoload index so the `posts` association target
+// (`Post`) resolves by name during preload — no manual `registerModel`.
+import "../test-helpers/canonical-model-index.js";
 import { Author } from "../test-helpers/models/author.js";
-import { Post } from "../test-helpers/models/post.js";
 
 type RecordInternals = {
   _attributes: { writeCastValue(name: string, value: unknown): void };
@@ -25,11 +27,6 @@ const internals = (record: Base): RecordInternals => record as unknown as Record
 
 describe("Preloader BigInt PK / number FK key match", () => {
   const { authors } = fixtures(["authors", "posts"], { schema: TEST_SCHEMA });
-
-  beforeAll(() => {
-    registerModel("Author", Author);
-    registerModel("Post", Post);
-  });
 
   it("matches children when the owner PK is a BigInt and the child FK is a number", async () => {
     const david = await Author.find(authors("david").id);

--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -2,20 +2,21 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 // Side-effect: registers encryptionHooks so Base.encrypts() is wired up.
 import "./encryption.js";
 import { describe, it, expect } from "vitest";
-import { registerModel } from "./index.js";
 import { sql as arelSql, star as arelStar } from "@blazetrails/arel";
 import { adapterType } from "./test-adapter.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
+// Opt into the canonical-model autoload index so association targets resolve by
+// name on first reference — no manual `registerModel`.
+import "./test-helpers/canonical-model-index.js";
 import { Account } from "./test-helpers/models/account.js";
-import { Company, Firm, DependentFirm, Client } from "./test-helpers/models/company.js";
+import { Company, DependentFirm, Client } from "./test-helpers/models/company.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { Reply } from "./test-helpers/models/reply.js";
 import { Post } from "./test-helpers/models/post.js";
-import { Comment } from "./test-helpers/models/comment.js";
 import { Book } from "./test-helpers/models/book.js";
 import { NumericData } from "./test-helpers/models/numeric-data.js";
-import { CpkBook, CpkChapter } from "./test-helpers/models/cpk.js";
+import { CpkBook } from "./test-helpers/models/cpk.js";
 import { Speedometer } from "./test-helpers/models/speedometer.js";
 import { Minivan } from "./test-helpers/models/minivan.js";
 import { Contract } from "./test-helpers/models/contract.js";
@@ -59,28 +60,6 @@ describe("CalculationsTest", () => {
       ],
     },
   );
-
-  registerModel("Company", Company);
-  registerModel("Firm", Firm);
-  registerModel("DependentFirm", DependentFirm);
-  registerModel("Client", Client);
-  registerModel("Account", Account);
-  registerModel("Topic", Topic);
-  registerModel("Reply", Reply);
-  registerModel("Post", Post);
-  registerModel("Comment", Comment);
-  registerModel("Book", Book);
-  registerModel("Author", Author);
-  registerModel("Contract", Contract);
-  registerModel("Speedometer", Speedometer);
-  registerModel("Minivan", Minivan);
-  registerModel("ShipPart", ShipPart);
-  registerModel("Treasure", Treasure);
-  registerModel("NeedQuoting", NeedQuoting);
-  registerModel("Edge", Edge);
-  registerModel("CpkBook", CpkBook);
-  registerModel("CpkChapter", CpkChapter);
-  registerModel("NumericData", NumericData);
 
   it("should sum field", async () => {
     expect(await Account.sum("credit_limit")).toBe(318);

--- a/packages/activerecord/src/calculations.trails.test.ts
+++ b/packages/activerecord/src/calculations.trails.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { Base, registerModel } from "./index.js";
+import { Base } from "./index.js";
 import type { JoinDependency } from "./associations/join-dependency.js";
 import { lookupCastTypeFromJoinDependencies } from "./relation/calculations.js";
-import { Topic } from "./test-helpers/models/topic.js";
 import { fixtures } from "./test-helpers/fixtures.js";
+// Opt into the canonical-model autoload index so the `topics` association target
+// (`Topic`) resolves by name on first reference — no manual `registerModel`.
+import "./test-helpers/canonical-model-index.js";
 import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 
 // ==========================================================================
@@ -96,8 +98,6 @@ describe("lookupCastTypeFromJoinDependencies", () => {
 // ==========================================================================
 
 describe("lookupCastTypeFromJoinDependencies integration", () => {
-  registerModel("Topic", Topic);
-
   // Rails' Author `has_many :topics, primary_key: "name", foreign_key:
   // "author_name"`. Defined locally under a distinct class name (not the
   // canonical Author model) so importing it does not perturb the shared model

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -16,13 +16,15 @@
  *     partitioned indexes, Speedometer no-DB-key — d2-insert-all-canonical-models
  */
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel } from "./index.js";
 import { UnknownAttributeError, RecordNotUnique } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { adapterType } from "./test-adapter.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
 import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+// Opt into the canonical-model autoload index so association targets resolve by
+// name on first reference — no manual `registerModel`.
+import "./test-helpers/canonical-model-index.js";
 import { withDbWarningsAction } from "./test-helpers/with-db-warnings-action.js";
 import { assertQueriesMatch, assertNoQueriesMatch } from "./testing/query-assertions.js";
 import { captureLogOutput } from "./testing/sql-capture.js";
@@ -36,8 +38,6 @@ import { Category, SpecialCategory } from "./test-helpers/models/category.js";
 import { Developer } from "./test-helpers/models/developer.js";
 import { Ship } from "./test-helpers/models/ship.js";
 import { Speedometer } from "./test-helpers/models/speedometer.js";
-import { Subscriber } from "./test-helpers/models/subscriber.js";
-import { Subscription } from "./test-helpers/models/subscription.js";
 
 // Adapter capability gates (mirror Rails' supports_* predicates / current_adapter?).
 // Feature-gated tests use itIfSupports(...) / adapterSupports(...) so the
@@ -107,16 +107,6 @@ async function withRecordTimestamps(
 
 describe("InsertAllTest", () => {
   setupFixtures();
-  registerModel("Author", Author);
-  registerModel("Book", Book);
-  registerModel("Cart", Cart);
-  registerModel("Category", Category);
-  registerModel("SpecialCategory", SpecialCategory);
-  registerModel("Developer", Developer);
-  registerModel("Ship", Ship);
-  registerModel("Speedometer", Speedometer);
-  registerModel("Subscriber", Subscriber);
-  registerModel("Subscription", Subscription);
   fixtures(["authors", "books"], {
     schema: canonicalSchema,
     // These two raise a DB-level RecordNotUnique; a PG unique violation aborts

--- a/packages/activerecord/src/instrumentation.test.ts
+++ b/packages/activerecord/src/instrumentation.test.ts
@@ -5,17 +5,17 @@
 import { describe, it, expect, afterEach } from "vitest";
 
 import { Notifications } from "@blazetrails/activesupport";
-import { Base, registerModel } from "./index.js";
+import { Base } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { TEST_SCHEMA as canonicalSchema } from "./test-helpers/test-schema.js";
+// Opt into the canonical-model autoload index so association targets resolve by
+// name on first reference — no manual `registerModel`.
+import "./test-helpers/canonical-model-index.js";
 import { Book } from "./test-helpers/models/book.js";
 import { Author } from "./test-helpers/models/author.js";
 import { ClothingItem } from "./test-helpers/models/clothing-item.js";
 
 describe("InstrumentationTest", () => {
-  registerModel("Author", Author);
-  registerModel("Book", Book);
-  registerModel("ClothingItem", ClothingItem);
   fixtures(["books", "authors"], { schema: canonicalSchema });
 
   afterEach(() => {
@@ -231,7 +231,6 @@ function transactionInSqlActiveRecordPayloadTests(): void {
 }
 
 describe("TransactionInSqlActiveRecordPayloadTest", () => {
-  registerModel("Book", Book);
   fixtures(["books"], { schema: canonicalSchema });
 
   afterEach(() => {
@@ -242,7 +241,6 @@ describe("TransactionInSqlActiveRecordPayloadTest", () => {
 });
 
 describe("TransactionInSqlActiveRecordPayloadNonTransactionalTest", () => {
-  registerModel("Book", Book);
   // Rails: `self.use_transactional_tests = false` — neither case may run inside
   // the rollback-on-teardown outer transaction.
   fixtures(["books"], {

--- a/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
+++ b/packages/activerecord/src/relation/build-joins-from-subquery-dedup.test.ts
@@ -14,20 +14,16 @@
  * Not a Rails-mirrored test name — this is a TS-internal refactor invariant
  * with no Ruby counterpart.
  */
-import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel } from "../index.js";
+import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
+// Opt into the canonical-model autoload index so the belongsTo("author") target
+// (`Author`) resolves by name during JoinDependency construction — no manual
+// `registerModel`.
+import "../test-helpers/canonical-model-index.js";
 import { Post } from "../test-helpers/models/post.js";
-import { Author } from "../test-helpers/models/author.js";
 
 describe("build_joins from(subquery) dedup", () => {
   fixtures([]);
-  beforeAll(async () => {
-    // Register the belongsTo("author") target so `joins("author")` resolves
-    // during JoinDependency construction.
-    registerModel("Post", Post);
-    registerModel("Author", Author);
-  });
 
   it("emits a single INNER JOIN (no LEFT OUTER JOIN) through the from-subquery", () => {
     const sub = Post.joins("author").leftOuterJoins("author");

--- a/packages/activerecord/src/relation/eager-shared-alias-tracker.test.ts
+++ b/packages/activerecord/src/relation/eager-shared-alias-tracker.test.ts
@@ -16,18 +16,16 @@
  * Not a Rails-mirrored test name — this is a TS-internal threading invariant
  * with no single Ruby counterpart.
  */
-import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel } from "../index.js";
+import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
+// Opt into the canonical-model autoload index so the `author` association target
+// (`Author`) resolves by name during eager build_joins — no manual
+// `registerModel`.
+import "../test-helpers/canonical-model-index.js";
 import { Post } from "../test-helpers/models/post.js";
-import { Author } from "../test-helpers/models/author.js";
 
 describe("eager build_joins shared AliasTracker", () => {
   fixtures([]);
-  beforeAll(async () => {
-    registerModel("Post", Post);
-    registerModel("Author", Author);
-  });
 
   it("aliases the eager OUTER JOIN when an explicit joins already claims the table", () => {
     const rel = Post.includes("author")

--- a/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
+++ b/packages/activerecord/src/relation/left-outer-joins-values-structural-dedup.test.ts
@@ -13,12 +13,13 @@
  * Not a Rails-mirrored test name — this covers a trails-specific deviation with
  * no direct Ruby counterpart.
  */
-import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel } from "../index.js";
+import { describe, it, expect } from "vitest";
 import { fixtures } from "../test-helpers/fixtures.js";
-import { Post } from "../test-helpers/models/post.js";
+// Opt into the canonical-model autoload index so the `posts`/`comments`
+// association targets (`Post`, `Comment`) resolve by name during build_joins —
+// no manual `registerModel`.
+import "../test-helpers/canonical-model-index.js";
 import { Author } from "../test-helpers/models/author.js";
-import { Comment } from "../test-helpers/models/comment.js";
 
 interface JoinValueHost {
   // Public Rails-mirrored accessor for `left_outer_joins_values`
@@ -34,11 +35,6 @@ const asHost = (rel: unknown): JoinValueHost => rel as JoinValueHost;
 
 describe("join value union structural dedup", () => {
   fixtures({});
-  beforeAll(() => {
-    registerModel("Author", Author);
-    registerModel("Post", Post);
-    registerModel("Comment", Comment);
-  });
 
   it("emits a single LEFT OUTER JOIN for a structurally-equal Hash spec joined twice", () => {
     const rel = Author.leftJoins({ posts: "comments" }).leftJoins({ posts: "comments" });

--- a/packages/activerecord/src/statement-cache.test.ts
+++ b/packages/activerecord/src/statement-cache.test.ts
@@ -1,6 +1,5 @@
 // Faithful port of vendor/rails/activerecord/test/cases/statement_cache_test.rb
 import { describe, it, expect, beforeAll } from "vitest";
-import { registerModel } from "./index.js";
 import { StatementCache } from "./statement-cache.js";
 import { Book } from "./test-helpers/models/book.js";
 import { Liquid } from "./test-helpers/models/liquid.js";
@@ -10,12 +9,10 @@ import { NumericData } from "./test-helpers/models/numeric-data.js";
 import { ClothingItem } from "./test-helpers/models/clothing-item.js";
 import { RecordNotFound } from "./errors.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-
-registerModel("Book", Book);
-registerModel("Liquid", Liquid);
-registerModel("Molecule", Molecule);
-registerModel("Electron", Electron);
-registerModel("NumericData", NumericData);
+// Opt into the canonical-model autoload index so association targets
+// (`Molecule`/`Electron` via `Liquid`) resolve by name — no manual
+// `registerModel`.
+import "./test-helpers/canonical-model-index.js";
 
 fixtures([]);
 

--- a/packages/activerecord/src/touch-later.test.ts
+++ b/packages/activerecord/src/touch-later.test.ts
@@ -7,30 +7,21 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { travel, travelBack } from "@blazetrails/activesupport";
-import { registerModel } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
+// Opt into the canonical-model autoload index so association targets resolve by
+// name on first reference — no manual `registerModel`.
+import "./test-helpers/canonical-model-index.js";
 import { setBeforeCommittedOnAllRecords } from "./ar-config.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
 import { Invoice } from "./test-helpers/models/invoice.js";
 import { LineItem } from "./test-helpers/models/line-item.js";
 import { Node } from "./test-helpers/models/node.js";
-import { Tree } from "./test-helpers/models/tree.js";
-import { Owner } from "./test-helpers/models/owner.js";
-import { Pet } from "./test-helpers/models/pet.js";
 import { Topic } from "./test-helpers/models/topic.js";
 
 // Mirrors Rails `fixtures :nodes, :trees, :owners, :pets`. The fixture loader
 // seeds explicit PKs and resets serial sequences, which a plain `create` does
 // not do for the custom-named `owner_id`/`pet_id` PKs on Postgres.
 const { nodes, trees, owners, pets } = fixtures(["nodes", "trees", "owners", "pets"]);
-
-registerModel("Invoice", Invoice);
-registerModel("LineItem", LineItem);
-registerModel("Node", Node);
-registerModel("Tree", Tree);
-registerModel("Owner", Owner);
-registerModel("Pet", Pet);
-registerModel("Topic", Topic);
 
 // Mirrors Ruby's `time.to_i` — whole epoch seconds, the granularity Rails'
 // touch_later assertions compare at (DB datetime columns drop sub-second

--- a/packages/activerecord/src/validations/association-validation.test.ts
+++ b/packages/activerecord/src/validations/association-validation.test.ts
@@ -14,9 +14,12 @@
  * association cache — the behavior under test is the cascading `valid?`, not
  * collection persistence.
  */
-import { afterEach, describe, expect, it, beforeAll } from "vitest";
-import { registerModel } from "../index.js";
+import { afterEach, describe, expect, it } from "vitest";
 import { association } from "../associations.js";
+// Opt into the canonical-model autoload index so association targets
+// (`Human`/`Interest`) resolve by name on first reference — no manual
+// `registerModel`.
+import "../test-helpers/canonical-model-index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { repairValidations } from "../test-helpers/repair-validations.js";
 import { seedAssociationCache } from "../test-helpers/seed-association-cache.js";
@@ -29,13 +32,6 @@ describe("AssociationValidationTest", () => {
   // Rails `fixtures :topics` — needed by test_validates_associated_missing's
   // `Topic.first`. Loading the set also registers Topic/Reply (STI).
   fixtures(["topics"]);
-
-  beforeAll(() => {
-    registerModel("Topic", Topic);
-    registerModel("Reply", Reply);
-    registerModel("Human", Human);
-    registerModel("Interest", Interest);
-  });
 
   // Rails `repair_validations(Topic, Reply)` — clear validators added to the
   // canonical models so per-test `validates_*` calls do not leak.

--- a/packages/activerecord/src/validations/validations.test.ts
+++ b/packages/activerecord/src/validations/validations.test.ts
@@ -9,14 +9,17 @@
  * mutated. We still clear Topic's validators in `afterEach` to mirror the
  * repair behavior exactly.
  */
-import { afterEach, describe, expect, it, beforeAll } from "vitest";
+import { afterEach, describe, expect, it } from "vitest";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { DecimalType } from "@blazetrails/activemodel";
-import { Base, RecordInvalid, registerModel } from "../index.js";
+import { Base, RecordInvalid } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
+// Opt into the canonical-model autoload index so association targets resolve by
+// name on first reference — no manual `registerModel`.
+import "../test-helpers/canonical-model-index.js";
 import { assertNoQueries } from "../testing/query-assertions.js";
 import { Topic } from "../test-helpers/models/topic.js";
-import { Reply, WrongReply } from "../test-helpers/models/reply.js";
+import { WrongReply } from "../test-helpers/models/reply.js";
 import { Developer } from "../test-helpers/models/developer.js";
 import { Parrot } from "../test-helpers/models/parrot.js";
 import { Company } from "../test-helpers/models/company.js";
@@ -32,16 +35,6 @@ describe("ValidationsTest", () => {
   // Rails `fixtures :topics, :developers`. Loading the topics set registers the
   // Topic/Reply STI subtree; loading developers builds the developers table.
   fixtures(["topics", "developers"]);
-
-  beforeAll(() => {
-    registerModel("Topic", Topic);
-    registerModel("Reply", Reply);
-    registerModel("WrongReply", WrongReply);
-    registerModel("Developer", Developer);
-    registerModel("Parrot", Parrot);
-    registerModel("Company", Company);
-    registerModel("PriceEstimate", PriceEstimate);
-  });
 
   // Rails: `repair_validations(Topic)` — Topic is never mutated by these tests,
   // but mirror the cleanup anyway.


### PR DESCRIPTION
## What

Rolls out the canonical-model autoload fallback (PR #4588) across 14 fully-canonical
test files: each opts into the eager index via
`import ".../test-helpers/canonical-model-index.js"` and drops its
association-target-only `registerModel(...)` calls. Dropped targets resolve by
name on first reference through the index (the Zeitwerk analog), mirroring Rails
autoloading a constant from `test/models/`.

Only files whose `registerModel` args are all canonical models (imported from
`test-helpers/models/`) were converted, per the collision-hazard guidance — no
bespoke same-named classes are affected. The autoload import is per-file, so it
only changes that file's name resolution.

## Files converted (14)

adapter, associations/habtm, associations/preloader-bigint-number-key-match,
calculations, calculations.trails, insert-all, instrumentation,
relation/build-joins-from-subquery-dedup, relation/eager-shared-alias-tracker,
relation/left-outer-joins-values-structural-dedup, statement-cache, touch-later,
validations/association-validation, validations/validations.

## Left alone (documented)

- `dup.test.ts` — the `registerModel("Car", Car)` is coupled to cold-cache schema
  warming (`resetColumnInformation` / `loadSchema`) for optimistic locking, not a
  pure target registration.
- `register-model-batch.test.ts` — exercises `registerModel` itself.

## Verification

All converted files pass locally on the sqlite lane (388 tests across the batch).
No test names changed. Test:compare unaffected (no renames, no behavioral change).

Closes-story: fixtures-autoload-rollout-delete-target-registrations
