### PR TITLE
fix(fixtures): bound sliceSchema join-table walk to HABTM tables

### DIFF
--- a/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { canonicalModelIndex } from "./canonical-model-index.js";
 import { resolveModel } from "../associations.js";
+import { deriveFixtureSchema } from "./use-fixtures.js";
+import { TEST_SCHEMA } from "./test-schema.js";
+import { Author } from "./models/author.js";
+import { Post } from "./models/post.js";
 import { Comment } from "./models/comment.js";
 import { Owner } from "./models/owner.js";
 import { Pet } from "./models/pet.js";
@@ -38,6 +42,19 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
       Pet as unknown as { _reflectOnAssociation(name: string): { klass: unknown } }
     )._reflectOnAssociation("owner");
     expect(refl.klass).toBe(Owner);
+  });
+
+  it("keeps deriveFixtureSchema bounded with the autoload index installed", async () => {
+    // Importing this module installed the autoload index globally, so every
+    // through/HABTM target now resolves instead of throwing. `deriveFixtureSchema`
+    // must still slice ONLY the requested sets' tables plus their HABTM join
+    // tables — never the whole transitively-reachable graph. `posts` owns the
+    // HABTM `categories_posts`; `has_many :through` join tables (taggings,
+    // categorizations, readers, …) belong to real models and are NOT pulled in.
+    void Author; // resolves the requested sets through the same globally-installed index
+    void Post;
+    const sub = await deriveFixtureSchema(["authors", "posts"], TEST_SCHEMA);
+    expect(Object.keys(sub).sort()).toEqual(["authors", "categories_posts", "posts"]);
   });
 
   it("throws a constant-not-found error for a genuine miss", () => {

--- a/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
+++ b/packages/activerecord/src/test-helpers/canonical-model-index.test.ts
@@ -3,8 +3,6 @@ import { canonicalModelIndex } from "./canonical-model-index.js";
 import { resolveModel } from "../associations.js";
 import { deriveFixtureSchema } from "./use-fixtures.js";
 import { TEST_SCHEMA } from "./test-schema.js";
-import { Author } from "./models/author.js";
-import { Post } from "./models/post.js";
 import { Comment } from "./models/comment.js";
 import { Owner } from "./models/owner.js";
 import { Pet } from "./models/pet.js";
@@ -51,8 +49,6 @@ describe("canonical model autoload index (Zeitwerk analog)", () => {
     // tables — never the whole transitively-reachable graph. `posts` owns the
     // HABTM `categories_posts`; `has_many :through` join tables (taggings,
     // categorizations, readers, …) belong to real models and are NOT pulled in.
-    void Author; // resolves the requested sets through the same globally-installed index
-    void Post;
     const sub = await deriveFixtureSchema(["authors", "posts"], TEST_SCHEMA);
     expect(Object.keys(sub).sort()).toEqual(["authors", "categories_posts", "posts"]);
   });

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -412,9 +412,40 @@ export function throughLabelAssociations(ModelClass: BaseClass): Map<string, Thr
   return out;
 }
 
-/** The join-table names for every resolvable through/HABTM association on the model. */
+/**
+ * The join-table names {@link sliceSchema} must add so a model fixture can
+ * materialize join rows from an owner association label.
+ *
+ * ONLY HABTM join tables qualify (`macro === "hasAndBelongsToMany"`): a HABTM
+ * join model is an anonymous class the declaring model owns (its table, e.g.
+ * `categories_posts`, has no fixture set of its own), so it must be pulled into
+ * the slice implicitly. A plain `has_many :through` join table, by contrast,
+ * belongs to a real model whose fixture set — if a test seeds it — is requested
+ * by name and slices its own table in; we deliberately do NOT pull it in from the
+ * owner's reflections.
+ *
+ * Restricting to the HABTM macro is also what lets the canonical-model autoload
+ * index install globally without ballooning the derived schema. The join table
+ * is read off the HABTM through reflection (whose `.klass` is the owned join
+ * model, resolving no further); the association's TARGET class is never touched,
+ * so this walk triggers NO autoload. Consulting `.klass`/`modelRegistry` for a
+ * plain `:through` reflection here would, with autoload active, resolve (and
+ * register) every transitively reachable model instead of throwing, leaking the
+ * slice far past the requested sets.
+ */
 export function throughJoinTableNames(ModelClass: BaseClass): string[] {
-  return Array.from(throughLabelAssociations(ModelClass).values(), (a) => a.joinTable);
+  const reflections: Record<string, unknown> = (ModelClass as any)._reflections ?? {};
+  const names: string[] = [];
+  for (const refl of Object.values(reflections)) {
+    const r = refl as {
+      macro?: string;
+      throughReflection?: { tableName?: string };
+    };
+    if (r.macro !== "hasAndBelongsToMany") continue;
+    const joinTable = r.throughReflection?.tableName;
+    if (typeof joinTable === "string") names.push(joinTable);
+  }
+  return names;
 }
 
 /**

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -442,8 +442,16 @@ export function throughJoinTableNames(ModelClass: BaseClass): string[] {
       throughReflection?: { tableName?: string };
     };
     if (r.macro !== "hasAndBelongsToMany") continue;
-    const joinTable = r.throughReflection?.tableName;
-    if (typeof joinTable === "string") names.push(joinTable);
+    try {
+      // `throughReflection.tableName` resolves the anonymous join model (owned by
+      // the declaring model, so no target resolution and no autoload). Guarded so
+      // an unresolvable HABTM skips rather than failing the whole slice, matching
+      // throughLabelAssociations.
+      const joinTable = r.throughReflection?.tableName;
+      if (typeof joinTable === "string") names.push(joinTable);
+    } catch {
+      continue;
+    }
   }
   return names;
 }

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -432,6 +432,15 @@ export function throughLabelAssociations(ModelClass: BaseClass): Map<string, Thr
  * plain `:through` reflection here would, with autoload active, resolve (and
  * register) every transitively reachable model instead of throwing, leaking the
  * slice far past the requested sets.
+ *
+ * NOTE for the future wiring of {@link throughLabelAssociations} into actual
+ * fixture loading: that materializer expands plain `has_many :through` labels
+ * too, but this slice no longer creates those join tables implicitly. A test
+ * whose fixture row expands a plain-through label must therefore also request the
+ * through model's fixture set by name (so its table slices in) — otherwise the
+ * load hits "no such table". HABTM labels are unaffected (their table is pulled
+ * in here). Today `throughLabelAssociations` has no production caller, so there
+ * is no live gap; this is a guard-rail for whoever wires it up.
  */
 export function throughJoinTableNames(ModelClass: BaseClass): string[] {
   const reflections: Record<string, unknown> = (ModelClass as any)._reflections ?? {};

--- a/packages/activerecord/src/test-helpers/use-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.test.ts
@@ -428,9 +428,12 @@ describe("deriveFixtureSchema", () => {
     const sub = await deriveFixtureSchema(["authors", "posts"], TEST_SCHEMA);
     // `posts` pulls in `categories_posts` too: `sliceSchema` includes the join
     // table of any HABTM association on a model-backed set (the loader may write
-    // join rows from an owner association label). Post HABTM categories now
-    // resolves because resolving the set registers Post, so its through
-    // reflection's join table is detectable.
+    // join rows from an owner association label). `Post habtm categories` owns
+    // the anonymous `categories_posts` join model, so its table is read straight
+    // off the through reflection — no target resolution, so it is detected the
+    // same whether or not the autoload index is installed. `has_many :through`
+    // join tables (taggings, categorizations, …) are deliberately NOT pulled in:
+    // they belong to real models whose fixture sets are requested by name.
     expect(Object.keys(sub).sort()).toEqual(
       [Author.tableName, Post.tableName, "categories_posts"].sort(),
     );

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -235,11 +235,12 @@ export async function deriveFixtureSchema(
 
 /**
  * Picks each resolved set's table out of `fullSchema`, plus the join table of any
- * `has_many :through` / HABTM association on a model-backed set. The join-table pull
+ * HABTM association on a model-backed set (see {@link throughJoinTableNames} for
+ * why the pull is HABTM-only, not every `has_many :through`). The join-table pull
  * lets a model fixture materialize join rows from an owner association label (e.g.
  * `developers` seeding `computers_developers` from `sharedComputers: ["laptop"]`)
- * without the caller also requesting the join set by name — the table it writes to
- * must exist in the slice.
+ * without the caller also requesting the join set by name — the HABTM join table,
+ * having no fixture set of its own, must exist in the slice regardless.
  */
 function sliceSchema(fixtures: ResolvedFixtureMap, fullSchema: Schema): Schema {
   const sub: Schema = {};


### PR DESCRIPTION
## What

`sliceSchema` / `throughJoinTableNames` pulled in the join table of every
through/HABTM reflection on a requested model, relying on **unregistered
targets throwing** to bound the set. With the canonical-model autoload index
active those `.klass` accesses resolve instead of throwing, so the derived
schema ballooned from the requested sets to every transitively reachable table
(14 tables vs 3) — the reason PR #4588 had to ship the index opt-in per file
rather than globally via `fixtures.ts`.

## How

Restrict the join-table walk to HABTM associations
(`macro === "hasAndBelongsToMany"`), whose join model is anonymous and owns a
table (e.g. `categories_posts`) with **no fixture set of its own**, so it must
be sliced in implicitly. A plain `has_many :through` join table belongs to a
real model whose fixture set — if a test seeds it — is requested by name and
slices its own table in.

The join table is read off the HABTM through reflection (its `.klass` is the
owned join model, resolving no further); the association's TARGET class is
never touched, so the walk triggers **no autoload and registers nothing**. This
bounds the slice without relying on a throw and without a suppression flag that
would poison reflection caches (`_sourceReflectionNameCache`).

`throughLabelAssociations` (the fixture-load path) is unchanged — it still
resolves targets through the ordinary getters (autoload allowed) because a
referenced label needs the target's table for id resolution.

## Result

`deriveFixtureSchema(["authors","posts"], TEST_SCHEMA)` yields exactly
`[authors, posts, categories_posts]` whether or not the autoload index is
installed globally. A regression test in `canonical-model-index.test.ts` (which
installs the index globally) asserts the bound holds under global autoload.

Closes-story: fixtures-slice-schema-autoload-safe-for-global-install
