### PR TITLE
feat(mysql2): eager connectBang + failing reconnectBang for connect! parity

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts
@@ -7,10 +7,10 @@
  * probes, the empty-result-set guard, extended timezone re-sync) live in the
  * sibling mysql2-adapter.trails.test.ts.
  *
- * connection_error / reconnection_error drive `reconnectBang()` — the method
- * Rails' `connect!` reaches (verify! → reconnect!) when a fresh adapter has no
- * live connection — since trails connects lazily and has no eager `connect!`.
- * A standalone adapter now carries a NullPool by default (matching Rails
+ * connection_error drives `connectBang()` — trails' eager connect, the
+ * `PostgreSQLAdapter#connectBang`-style analog of Rails' public `connect!` —
+ * and reconnection_error drives `reconnectBang()` directly (Rails' `reconnect!`).
+ * A standalone adapter carries a NullPool by default (matching Rails
  * `@pool = NullPool.new`), so `error.connection_pool` is asserted faithfully.
  *
  * The FK type-mismatch tests ride the canonical `engines` / `old_cars` (int PK)
@@ -55,15 +55,15 @@ describeIfMysql("Mysql2AdapterTest", () => {
 
   it("connection error", async () => {
     // Rails: `Mysql2Adapter.new(socket: File::NULL, ...).connect!` raises
-    // ConnectionNotEstablished whose `connection_pool` is a NullPool. trails
-    // connects lazily (there is no eager `connect!`), so the failure to connect
-    // to a dead socket surfaces on the first query — the same rescued
-    // `connect` → `set_pool(@pool)` path, carrying the standalone adapter's
-    // NullPool.
+    // ConnectionNotEstablished whose `connection_pool` is a NullPool. trails'
+    // `connectBang()` is the eager connect (Rails' `connect!` establishing
+    // `@raw_connection`), so the dead-socket failure surfaces here via the same
+    // rescued `connect` → `set_pool(@pool)` path, carrying the standalone
+    // adapter's NullPool.
     const badAdapter = new Mysql2Adapter({ socketPath: "/dev/null", preparedStatements: false });
     try {
       const error = await badAdapter
-        .execute("SELECT 1")
+        .connectBang()
         .then(() => null)
         .catch((e) => e);
       expect(error).toBeInstanceOf(ConnectionNotEstablished);
@@ -76,13 +76,13 @@ describeIfMysql("Mysql2AdapterTest", () => {
   it("reconnection error", async () => {
     // Rails reconnects a standalone adapter whose config points at a dead
     // socket and asserts the raised ConnectionNotEstablished's `connection_pool`
-    // equals the adapter's own pool (a NullPool). trails connects lazily, so
-    // force the connect via a query after a reconnect and assert the same.
+    // equals the adapter's own pool (a NullPool). trails' `reconnectBang()`
+    // (Rails' `reconnect!`) now re-establishes the connection eagerly and
+    // re-raises the translated ConnectionNotEstablished, so assert it directly.
     const badAdapter = new Mysql2Adapter({ socketPath: "/dev/null", preparedStatements: false });
     try {
-      await badAdapter.reconnectBang().catch(() => {});
       const error = await badAdapter
-        .execute("SELECT 1")
+        .reconnectBang()
         .then(() => null)
         .catch((e) => e);
       expect(error).toBeInstanceOf(ConnectionNotEstablished);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1357,17 +1357,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /**
-   * Disconnect and mark reconnectable. Mirrors Rails'
-   * `Mysql2Adapter#reconnect!` (disconnect! + connect). Connection is
-   * re-established lazily on the next query.
-   */
-  /**
    * Eagerly establish the single persistent connection. Mirrors Rails' private
    * `Mysql2Adapter#connect` (`@raw_connection = new_client(@connection_parameters)`,
    * mysql2_adapter.rb:144), which raises `ConnectionNotEstablished` (carrying the
-   * pool via `set_pool`) when the socket is dead. Driven eagerly by `connectBang()`
-   * (Rails' public `connect!`) and by `reconnect()` — `_ensureClient()` is the
-   * `new_client` analog and already attaches the pool to a connect failure.
+   * pool via `set_pool`) when the socket is dead. Driven by `connectBang()`
+   * (Rails' public `connect!`); `reconnect()` establishes the same way via
+   * `_ensureClient()` — the `new_client` analog, which already attaches the pool
+   * to a connect failure.
    * @internal
    */
   async connect(): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1362,12 +1362,29 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * re-established lazily on the next query.
    */
   /**
-   * No-op: connection is established lazily in `_ensureClient` on the first
-   * query. Exists for lifecycle API parity with Rails' `connect` method.
+   * Eagerly establish the single persistent connection. Mirrors Rails' private
+   * `Mysql2Adapter#connect` (`@raw_connection = new_client(@connection_parameters)`,
+   * mysql2_adapter.rb:144), which raises `ConnectionNotEstablished` (carrying the
+   * pool via `set_pool`) when the socket is dead. Driven eagerly by `connectBang()`
+   * (Rails' public `connect!`) and by `reconnect()` — `_ensureClient()` is the
+   * `new_client` analog and already attaches the pool to a connect failure.
    * @internal
    */
-  connect(): void {
-    // intentionally empty — single connection is established lazily
+  async connect(): Promise<void> {
+    await this._ensureClient();
+  }
+
+  /**
+   * Eager connect — mirrors Rails' `AbstractAdapter#connect!` (`verify!; self`),
+   * which `with_raw_connection` calls when `@raw_connection` is nil. Rather than
+   * route through `verify!` (whose `active?` short-circuit assumes an
+   * already-established `@raw_connection`), trails opens the raw connection
+   * directly — the same posture as `PostgreSQLAdapter#connectBang`. A dead socket
+   * surfaces as `ConnectionNotEstablished` here instead of on the first query.
+   * @internal
+   */
+  override async connectBang(): Promise<void> {
+    await this.connect();
   }
 
   /**
@@ -1380,7 +1397,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    *
    * @internal
    */
-  override reconnect(): void {
+  override async reconnect(): Promise<void> {
     if (this._permanentlyClosed) throw new Error("Mysql2Adapter: client is permanently closed");
     this._activeState = false;
     this._connectGeneration++;
@@ -1395,10 +1412,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._connection = null;
     this._closeRawHandle();
     this._activeState = true;
-    // Kick off connection eagerly so verify/ping paths find a live connection
-    // promptly. Mirrors Rails' reconnect! which calls connect (not lazy) after
-    // disconnect!. Errors are surfaced on the next awaited call via _ensureClient.
-    this._ensureClient().catch(() => {});
+    // Re-establish the connection eagerly and PROPAGATE any connect failure —
+    // Rails' private `reconnect` calls `connect` synchronously, so a dead socket
+    // raises out of `reconnect!` (mysql2_adapter.rb:150 → :144). Awaiting here
+    // lets the inherited `reconnectBang` translate + re-raise the
+    // `ConnectionNotEstablished` (carrying the pool) instead of swallowing it.
+    await this._ensureClient();
   }
 
   /**

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -24929,6 +24929,20 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2-adapter.ts",
+    "rubyName": "connect",
+    "call": "new_client",
+    "reason": "Rails' private connect (mysql2_adapter.rb:144) is `@raw_connection = new_client(...)`; trails' connect() delegates to _ensureClient(), which calls Mysql2Adapter.newClient() (the new_client analog) — so the call is satisfied one frame down, not inlined here."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2-adapter.ts",
+    "rubyName": "connect",
+    "call": "set_pool",
+    "reason": "Rails' connect rescues ConnectionNotEstablished and re-raises `ex.set_pool(@pool)` (mysql2_adapter.rb:146-147); trails' connect() delegates to _ensureClient(), whose catch attaches the pool via translated.setPool(this.pool) — same set_pool behavior, one frame down."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "disconnect!",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

Ports `mysql2_adapter_test.rb`'s `test_connection_error` / `test_reconnection_error` so they drive `connect!` / `reconnect!` directly, closing the deviation surfaced in PR #4578 (which had to proxy through `execute("SELECT 1")`).

## Changes

- **`Mysql2Adapter#connect`** now eagerly establishes the raw connection via `_ensureClient()` — mirroring Rails' private `connect` (`@raw_connection = new_client(@connection_parameters)`, mysql2_adapter.rb:144) — instead of being a lazy no-op.
- **`Mysql2Adapter#connectBang`** overrides the base to call `connect()`, mirroring `PostgreSQLAdapter#connectBang` as trails' analog of Rails' public `connect!` (which `with_raw_connection` invokes when `@raw_connection` is nil). A dead socket now surfaces `ConnectionNotEstablished` (carrying the pool) here instead of on the first query.
- **`Mysql2Adapter#reconnect`** now awaits `_ensureClient()` and propagates a connect failure (Rails' private `reconnect` calls `connect` synchronously), so the inherited `reconnectBang` translates + re-raises `ConnectionNotEstablished` rather than swallowing it fire-and-forget.
- **Tests** re-ported to drive `connectBang()` / `reconnectBang()` directly, keeping the `NullPool` / `pool` assertions verbatim.

## Notes

- Test names unchanged (`connection error` / `reconnection error`).
- MySQL tests are CI-gated (no local DB); typecheck + prettier clean.

Closes-story: mysql2-active-reflects-connection-state-for-connect-bang