### PR TITLE
fix(migration): mirror default_index_type? for addIndex using bookkeeping

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1682,6 +1682,17 @@ export class AbstractAdapter implements Quoting {
     return false;
   }
 
+  // Mirrors Rails' `abstract_adapter.rb#default_index_type?` (`index.using.nil?`),
+  // the predicate the schema dumper uses to decide whether to print `using:`
+  // (schema_dumper.rb#indexes: `... if !default_index_type?(index)`). PostgreSQL
+  // and MySQL override to also treat `:btree` as the default; SQLite inherits
+  // this nil-only check (so a non-nil `using` on sqlite still dumps). Surfaced
+  // here so `MigrationContext#addIndex` gates the stored `using` on the same
+  // per-adapter predicate the dumper reads, rather than an adapter-name check.
+  defaultIndexType(using?: string): boolean {
+    return using == null;
+  }
+
   supportsConcurrentConnections(): boolean {
     return true;
   }

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -423,6 +423,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return true;
   }
 
+  // Rails: `index.using == :btree || super` (abstract_mysql_adapter.rb#default_index_type?).
+  override defaultIndexType(using?: string): boolean {
+    return using === "btree" || super.defaultIndexType(using);
+  }
+
   supportsIndexSortOrder(): boolean {
     // Rails: `mariadb? ? database_version >= "10.8.1" : database_version >= "8.0.1"`
     // (abstract_mysql_adapter.rb#supports_index_sort_order?).

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2926,6 +2926,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   supportsIndexSortOrder(): boolean {
     return true;
   }
+  // Rails: `index.using == :btree || super` (postgresql_adapter.rb#default_index_type?).
+  override defaultIndexType(using?: string): boolean {
+    return using === "btree" || super.defaultIndexType(using);
+  }
   supportsPartitionedIndexes(): boolean {
     return this.databaseVersion >= 110000;
   }

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -202,6 +202,52 @@ describe("MigrationTest", () => {
     expect(idx?.name).toBe("index_users_on_lower_email");
   });
 
+  it("addIndex bookkeeping stores using per default_index_type?", async () => {
+    // Regression: MigrationContext#addIndex records `using` into `_indexes` for
+    // the schema dump. Rails stores `using` unconditionally (add_index_options);
+    // the dumper prints it only when `!default_index_type?(index)` — nil-only on
+    // the abstract adapter (so sqlite, which does not override, keeps a non-nil
+    // `using`), and nil-or-`:btree` on postgres/mysql. Mirror that per-adapter
+    // predicate here, not a postgres-only adapter-name check.
+    const ss = new SchemaStatements({} as unknown as DatabaseAdapter);
+    const makeStub = (an: "sqlite" | "mysql", defaultIndexType: (u?: string) => boolean) => ({
+      adapterName: an,
+      addIndex: async () => {},
+      indexName: (t: string, o: { column?: string | string[]; name?: string }) =>
+        ss.indexName(t, o),
+      indexNameOptions: (c: string | string[]) => ss.indexNameOptions(c),
+      addIndexOptions: (t: string, c: string | string[], o: Record<string, unknown>) =>
+        ss.addIndexOptions(t, c, o),
+      defaultIndexType,
+    });
+    // postgres/mysql: `using == :btree || using.nil?`; abstract/sqlite: `using.nil?`.
+    const mysqlDefault = (u?: string) => u === "btree" || u == null;
+    const sqliteDefault = (u?: string) => u == null;
+
+    const mysqlCtx = new MigrationContext(
+      makeStub("mysql", mysqlDefault) as unknown as DatabaseAdapter,
+    );
+    await mysqlCtx.addIndex("users", "email", { using: "hash" });
+    expect(mysqlCtx.indexes("users").find((i) => i.columns.includes("email"))?.using).toBe("hash");
+
+    const btreeCtx = new MigrationContext(
+      makeStub("mysql", mysqlDefault) as unknown as DatabaseAdapter,
+    );
+    await btreeCtx.addIndex("users", "email", { using: "btree" });
+    expect(
+      btreeCtx.indexes("users").find((i) => i.columns.includes("email"))?.using,
+    ).toBeUndefined();
+
+    // sqlite does NOT override default_index_type?, so a non-nil `using`
+    // round-trips (matches Rails: dumper prints `using:` whenever `using` is
+    // non-nil there).
+    const sqliteCtx = new MigrationContext(
+      makeStub("sqlite", sqliteDefault) as unknown as DatabaseAdapter,
+    );
+    await sqliteCtx.addIndex("users", "email", { using: "hash" });
+    expect(sqliteCtx.indexes("users").find((i) => i.columns.includes("email"))?.using).toBe("hash");
+  });
+
   it("_introspectColumns handles PG ARRAY + USER-DEFINED + datetime_precision rows", async () => {
     // Stub the adapter to feed PG-shaped catalog rows through the live
     // _introspectColumns code path (sqlite test adapter can't return them).

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2306,10 +2306,12 @@ export class MigrationContext {
     // (version-gated on MySQL/MariaDB — the #4397 reconstruct parity, warmed
     // above via `getDatabaseVersion`), and `NULLS NOT DISTINCT` / covering
     // `INCLUDE` (Postgres). The `typeof` guards keep this resilient to the
-    // minimal stub adapters some tests pass. `using` has no adapter-level
-    // capability predicate (`supportsIndexUsing?` lives on the SchemaCreation),
-    // so it stays keyed on Postgres, where a non-default access method
-    // round-trips (the dumper drops the `btree` default).
+    // minimal stub adapters some tests pass. `using` follows the dumper's own
+    // gate — `!default_index_type?(index)` (schema_dumper.rb#indexes) — which is
+    // nil-only on the abstract adapter (so a non-default `using` on sqlite still
+    // round-trips) and nil-or-`btree` on Postgres/MySQL. Rails stores `using`
+    // unconditionally (`add_index_options`); only the dump is gated, so mirror
+    // that predicate here rather than an adapter-name check.
     const supportsPartialIndex =
       typeof this.connection.supportsPartialIndex === "function"
         ? this.connection.supportsPartialIndex()
@@ -2326,6 +2328,13 @@ export class MigrationContext {
       typeof this.connection.supportsIndexInclude === "function"
         ? this.connection.supportsIndexInclude()
         : false;
+    const usingStored =
+      idx.using != null &&
+      !(typeof this.connection.defaultIndexType === "function"
+        ? this.connection.defaultIndexType(idx.using)
+        : idx.using == null)
+        ? idx.using
+        : undefined;
     const comment = idx.comment?.trim() ? idx.comment : undefined;
     if (!this._indexes.has(table)) this._indexes.set(table, []);
     this._indexes.get(table)!.push({
@@ -2334,7 +2343,7 @@ export class MigrationContext {
       name: idx.name,
       where: supportsPartialIndex ? idx.where : undefined,
       orders: supportsSortOrder ? _emptyOptionToUndefined(idx.orders) : undefined,
-      using: an === "postgres" && idx.using && idx.using !== "btree" ? idx.using : undefined,
+      using: usingStored,
       type: idx.type,
       lengths: _emptyOptionToUndefined(idx.lengths),
       nullsNotDistinct: supportsNullsNotDistinct ? idx.nullsNotDistinct : undefined,


### PR DESCRIPTION
## Summary

`MigrationContext#addIndex` gated the stored `using` on `an === "postgres"`, so
a MySQL index built with a non-default access method (`USING BTREE|HASH`)
DDL-persisted it but never landed in `_indexes` — the schema dump omitted it.

The fix mirrors the exact Rails predicate. In Rails, `add_index_options`
(`abstract/schema_statements.rb`) stores `using` into the `IndexDefinition`
**unconditionally**; whether it appears in the dump is governed solely by the
dumper's `!default_index_type?(index)` gate (`schema_dumper.rb#indexes`):

- `abstract_adapter.rb#default_index_type?` → `index.using.nil?`
- `postgresql_adapter.rb` / `abstract_mysql_adapter.rb` override → `index.using == :btree || super`
- sqlite3 does **not** override → inherits the nil-only check, so a non-nil
  `using` (e.g. `hash`) on sqlite still round-trips.

## Changes

- `abstract-adapter.ts`: add `defaultIndexType(using)` → `using == null`.
- `postgresql-adapter.ts` / `abstract-mysql-adapter.ts`: override →
  `using === "btree" || super.defaultIndexType(using)`.
- `migration.ts`: gate `usingStored` on `!defaultIndexType(options.using)`
  instead of `an === "postgres"`.
- `migration.trails.test.ts`: mysql `using: "hash"` round-trips; `btree` default
  dropped; sqlite `using: "hash"` round-trips (matches Rails).

Closes-story: migrationcontext-index-using-bookkeeping-from-capability