### PR TITLE
fix(activemodel): reject nil in numericality by default

### DIFF
--- a/packages/activemodel/src/validations.test.ts
+++ b/packages/activemodel/src/validations.test.ts
@@ -138,7 +138,13 @@ describe("ValidationsTest", () => {
     });
 
     it("validates numericality of with nil allowed", () => {
-      expect(new Numeric({}).isValid()).toBe(true);
+      class NilOk extends Model {
+        static {
+          this.attribute("value", "string");
+          this.validates("value", { numericality: { allowNil: true } });
+        }
+      }
+      expect(new NilOk({}).isValid()).toBe(true);
     });
 
     it("validates numericality of only integers", () => {
@@ -1669,7 +1675,13 @@ describe("Validations", () => {
     });
 
     it("validates numericality of with nil allowed", () => {
-      expect(new Numeric({}).isValid()).toBe(true);
+      class NilOk extends Model {
+        static {
+          this.attribute("count", "string");
+          this.validates("count", { numericality: { allowNil: true } });
+        }
+      }
+      expect(new NilOk({}).isValid()).toBe(true);
     });
 
     it("validates numericality of with integer only", () => {

--- a/packages/activemodel/src/validations/numericality-validation.test.ts
+++ b/packages/activemodel/src/validations/numericality-validation.test.ts
@@ -164,7 +164,7 @@ describe("NumericalityValidationTest", () => {
     class Person extends Model {
       static {
         this.attribute("value", "string");
-        this.validates("value", { numericality: true });
+        this.validates("value", { numericality: { allowNil: true } });
       }
     }
     expect(new Person({}).isValid()).toBe(true);

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -55,8 +55,11 @@ export class NumericalityValidator extends EachValidator {
     precision = 15,
     scale?: number,
   ): void {
+    // Mirrors Rails `is_number?(nil) => false`: a nil/undefined value that
+    // reaches validate_each (i.e. `allow_nil: true` did NOT short-circuit it in
+    // EachValidator#validate) is always :not_a_number. The default is to reject
+    // nil — matching `test_default_validates_numericality_of`.
     if (value === null || value === undefined) {
-      if (this.options.allowNil !== false) return;
       record.errors.add(attribute, "not_a_number", this.filteredOptions(value));
       return;
     }

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -1510,32 +1510,43 @@ describe("TestHasManyAutosaveAssociationWhichItselfHasAutosaveAssociations", () 
 // ==========================================================================
 describe("TestIndexErrorsWithNestedAttributesOnlyMode", () => {
   fixtures({ guitars: [Guitar, {}], tuning_pegs: [TuningPeg, {}] });
-  beforeAll(() => {
-    Guitar.acceptsNestedAttributesFor("tuningPegs", {
-      rejectIf: (a) => Number(a["pitch"]) % 2 === 1,
-    });
-  });
 
-  // tracked-pending-convergence (0023-surfaced-deviations): nested has_many
-  // index_errors validation does not propagate to the parent's `valid?` when
-  // the children are assigned in-memory via nested attributes — trails does not
-  // run the indexed nested-record validators for the unloaded/assigned target.
-  // See nested-attributes-index-errors convergence story.
-  it.skip("index in nested_attributes_order order", async () => {
-    const guitar = await Guitar.createBang({});
+  // Mirrors Rails' anonymous `@guitar_class` (nested_attributes_test.rb:1171):
+  // `has_many :tuning_pegs, index_errors: :nested_attributes_order` keys nested
+  // errors by write order rather than the association/DB order used by the
+  // canonical `Guitar` model (`index_errors: true`). Rides the canonical
+  // `guitars`/`tuning_pegs` tables and the canonical `TuningPeg`
+  // (`validates_numericality_of :pitch`).
+  class IndexedGuitar extends Base {
+    static tableName = "guitars";
+    declare tuningPegs: AssociationProxy<TuningPeg>;
+    static {
+      this.hasMany("tuningPegs", {
+        className: "TuningPeg",
+        foreignKey: "guitar_id",
+        indexErrors: "nestedAttributesOrder",
+      });
+      this.acceptsNestedAttributesFor("tuningPegs", {
+        rejectIf: (a) => Number(a["pitch"]) % 2 === 1,
+      });
+    }
+  }
+
+  it("index in nested_attributes_order order", async () => {
+    const guitar = await IndexedGuitar.createBang({});
     await (guitar as any).tuningPegs.createBang({ pitch: 1 });
     const peg2 = await (guitar as any).tuningPegs.createBang({ pitch: 2 });
     expect(await guitar.isValid()).toBe(true);
     await guitar.update({ tuningPegsAttributes: [{ id: peg2.id, pitch: null }] });
     expect(await guitar.isValid()).toBe(false);
-    expect(Object.keys((guitar as any).errors.messages)).toEqual(["tuningPegs[0].pitch"]);
+    expect([...(guitar as any).errors.messages.keys()]).toEqual(["tuningPegs[0].pitch"]);
   });
 
-  it.skip("index unaffected by reject_if", async () => {
-    const guitar = await Guitar.createBang({});
+  it("index unaffected by reject_if", async () => {
+    const guitar = await IndexedGuitar.createBang({});
     await guitar.update({ tuningPegsAttributes: [{ pitch: 1 }, { pitch: null }] });
     expect(await guitar.isValid()).toBe(false);
-    expect(Object.keys((guitar as any).errors.messages)).toEqual(["tuningPegs[1].pitch"]);
+    expect([...(guitar as any).errors.messages.keys()]).toEqual(["tuningPegs[1].pitch"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Un-skips both `TestIndexErrorsWithNestedAttributesOnlyMode` cases (faithful port
of `nested_attributes_test.rb`) and makes them pass, surfacing indexed nested
`has_many` validation errors (`tuningPegs[i].pitch`) on the parent's `valid?`.

## Root cause

The blocker was not the nested-error propagation but `NumericalityValidator`.
trails short-circuited a nil/undefined value to **valid** whenever `allowNil`
was unset, so `validates_numericality_of :pitch` accepted `pitch: null`. A
nested `TuningPeg` assigned `pitch: null` therefore validated fine, `update`
persisted it, dirty state cleared, and the parent guitar's `valid?` had nothing
to flag.

Rails' `is_number?(nil)` is `false`: a nil reaching `validate_each` (i.e.
`allow_nil: true` did **not** short-circuit it in `EachValidator#validate`) is
always `:not_a_number`, matching `test_default_validates_numericality_of`. The
fix drops the extra `allowNil !== false` early-return.

With that, the nested peg fails validation, `update` fails, the peg stays dirty,
and the parent's indexed nested validators run and key errors by index.

## Changes

- `activemodel/.../numericality.ts`: nil/undefined at `validateEach` → always
  `:not_a_number` (base `EachValidator` still honors `allow_nil: true`).
- Un-skip the two cases; port Rails' anonymous
  `index_errors: :nested_attributes_order` guitar class (`IndexedGuitar`) over
  the canonical `guitars`/`tuning_pegs` tables + canonical `TuningPeg`.
- Fix three mis-ported "nil allowed" numericality tests to pass `allowNil: true`
  (matching Rails `test_validates_numericality_of_with_nil_allowed`).

## Verification

- `nested-attributes.test.ts` (163) ✅
- activemodel `numericality-validation` + `validations` ✅
- activerecord `validations/numericality-validation`, `validations`,
  `associations` ✅

Closes-story: nested-attributes-index-errors-validation
