### PR TITLE
fix(nested-attributes): resolve aliases on flush-path unknown-key validation

### DIFF
--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -13,6 +13,8 @@ import { fixtures } from "./test-helpers/fixtures.js";
 import { CpkBook, CpkOrder, CpkCar, CpkCarReview } from "./test-helpers/models/cpk.js";
 import { Category } from "./test-helpers/models/category.js";
 import { Categorization } from "./test-helpers/models/categorization.js";
+import { Pirate } from "./test-helpers/models/pirate.js";
+import { Parrot } from "./test-helpers/models/parrot.js";
 
 // Dynamic column reads/writes (FK/counter-cache columns and the generated
 // `*Attributes=` setters vary per model and are not statically declared), kept
@@ -103,5 +105,33 @@ describe("nested attributes (trails-only)", () => {
     expect(cols(reviews[0]).comment).toBe("zippy");
     expect(cols(reviews[0]).car_make).toBe("Honda");
     expect(cols(reviews[0]).car_model).toBe("Civic");
+  });
+});
+
+describe("nested attributes flush path alias resolution (trails-only)", () => {
+  fixtures({
+    pirates: [Pirate, {}],
+    parrots: [Parrot, {}],
+  });
+
+  // The post-save flush (`processNestedAttributes`) routes an existing-record
+  // update through `existing.update(childAttrs)`. The alias-backed key `title`
+  // (aliasAttribute("title", "name")) has a real writer, so it must update the
+  // record rather than raise UnknownAttributeError — matching the build path,
+  // which Rails' `assign_attributes` → `_assign_attribute` also resolves.
+  it("updates an existing record via an alias-backed nested key on the flush path", async () => {
+    Pirate.acceptsNestedAttributesFor("parrot");
+
+    const parrot = await Parrot.createBang({ name: "Original" });
+    const pirate = await Pirate.createBang({
+      catchphrase: "Arr",
+      parrot_id: readAttr(parrot, "id"),
+    });
+
+    cols(pirate).parrotAttributes = { id: readAttr(parrot, "id"), title: "Renamed" };
+    await pirate.save();
+
+    const reloaded = await Parrot.find(readAttr(parrot, "id"));
+    expect(readAttr(reloaded, "name")).toBe("Renamed");
   });
 });

--- a/packages/activerecord/src/nested-attributes.ts
+++ b/packages/activerecord/src/nested-attributes.ts
@@ -287,7 +287,6 @@ async function processNestedAttributes(record: Base): Promise<void> {
         : assocDef.type === "belongsTo"
           ? `${underscore(assocName)}_id`
           : `${underscore(ctor.name)}_id`);
-    const fkColumns = compositeFkColumns ?? [foreignKey];
 
     // Foreign-key attributes anchoring a built has_many/has_one child back to
     // this owner. A composite FK reads each owner PK column named by the
@@ -312,22 +311,6 @@ async function processNestedAttributes(record: Base): Promise<void> {
 
     const childPk = (targetModel as any).primaryKey || "id";
 
-    // Get known attribute names from the target model
-    const knownAttrs = new Set<string>();
-    const attrDefs: Map<string, any> | undefined = (targetModel as any)._attributeDefinitions;
-    if (attrDefs) {
-      for (const name of attrDefs.keys()) {
-        knownAttrs.add(name);
-      }
-    }
-    // Also allow the primary key and foreign key. Nested attributes
-    // conventionally address the existing record by the literal `id` key (Rails
-    // matches `record.id.to_s == attributes["id"].to_s`), which maps to the
-    // model's primary key even when it is named something other than `id`.
-    knownAttrs.add(childPk);
-    for (const col of fkColumns) knownAttrs.add(col);
-    knownAttrs.add("id");
-
     for (const attrs of attrsList) {
       const { _destroy, ...restAttrs } = attrs as any;
       const pkValue = restAttrs[childPk] ?? restAttrs["id"];
@@ -335,15 +318,12 @@ async function processNestedAttributes(record: Base): Promise<void> {
       // as regular attributes during update.
       const { [childPk]: _pkIgnored, id: _idIgnored, ...childAttrs } = restAttrs;
 
-      // Validate attributes against the target model's known columns
-      if (knownAttrs.size > 0) {
-        for (const key of Object.keys(childAttrs)) {
-          if (!knownAttrs.has(key)) {
-            const dummy = new (targetModel as any)();
-            throw new UnknownAttributeError(dummy, key);
-          }
-        }
-      }
+      // Validate attributes against the target model's known columns, resolving
+      // `alias_attribute` keys the same way the build path does. `childAttrs`
+      // already has the PK/`id` addressing keys stripped; the foreign-key
+      // columns are real target columns (present in `_attributeDefinitions`), so
+      // `assertNestedAttributesAreKnown` accepts them without a bespoke set.
+      assertNestedAttributesAreKnown(targetModel, childAttrs);
 
       // Check _destroy before rejectIf — destroy should work regardless of rejectIf
       if (_destroy && config.options.allowDestroy) {


### PR DESCRIPTION
## Summary

The nested-attributes **build** path validates unknown keys via
`assertNestedAttributesAreKnown`, which resolves `alias_attribute` keys by
probing `record.hasAttribute(key)` before raising `UnknownAttributeError`. The
pre-existing **flush** path in `processNestedAttributes` instead validated
against a raw `knownAttrs` set built directly from
`targetModel._attributeDefinitions.keys()` + pk/fk/`id`, with **no** alias
resolution.

So an `alias_attribute`-backed key with a real writer passed on the build path
but incorrectly raised `UnknownAttributeError` on the flush (update) path — an
internal inconsistency and a Rails deviation (Rails routes both through
`assign_attributes` → `_assign_attribute`, which resolves via the writer).

## Change

- Flush path now reuses `assertNestedAttributesAreKnown` (the same alias-aware
  guard the build path uses), dropping the bespoke `knownAttrs` set. Foreign-key
  columns are real target columns already present in `_attributeDefinitions`, so
  the helper accepts them without special-casing.
- Adds a trails-only test: an `alias_attribute`-backed nested key (`title` →
  `name` on `Parrot`) updates an existing record via the flush path without
  raising. Verified red without the fix (`UnknownAttributeError: unknown
  attribute 'title'`), green with it.

No regression to the build-path tests un-skipped in #4573.

Closes-story: nested-flush-unknown-attribute-alias-resolution