### PR TITLE
test(preloader): un-skip nested preload through has_one :through

### DIFF
--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -493,13 +493,40 @@ describe("CascadedEagerLoadingTest", () => {
     expect(retrievedComments[0].id).toBe(lastComment.id);
   });
 
-  it.skip("preloading across has one through constrains loaded records", () => {
-    // BLOCKED: nested preload through a has_one :through does not instantiate the
-    //   nested association (separate from the now-available resetCallbacks API).
-    // ROOT-CAUSE: `preload(recent_response: :author)` loads recent_response (the
-    //   has_one :through), but the nested `:author` on that record is never
-    //   instantiated, so the after_initialize recorder sees 1 record instead of
-    //   2. The recentResponse target loads; its `author` child does not preload.
-    //   Tracked: RFC 0030 story nested-preload-through-has-one-source.
+  it("preloading across has one through constrains loaded records", async () => {
+    const author = (await Author.findBy({ id: (authors("david") as any).id }))!;
+
+    const oldPost = await (author as any).posts.createBang({ title: "first post", body: "test" });
+    await oldPost.comments.createBang({
+      author: authors("mary"),
+      body: "a response",
+    });
+
+    const recentPost = await (author as any).posts.createBang({
+      title: "first post",
+      body: "test",
+    });
+    await recentPost.comments.createBang({
+      author: authors("bob"),
+      body: "a response",
+    });
+
+    const authorsRel = Author.where({ id: author.id });
+    const retrievedAuthors: Base[] = [];
+
+    await resetCallbacks(Author, "initialize", async () => {
+      Author.afterInitialize((record: Author) => {
+        retrievedAuthors.push(record);
+      });
+      await authorsRel.preload({ recentResponse: "author" }).load();
+    });
+
+    // Rails: assert_equal [author, authors(:bob)], retrieved_authors — AR#== is
+    // same class + same id, so match the recorded records' class and ids.
+    expect(retrievedAuthors).toHaveLength(2);
+    expect(retrievedAuthors.map((r) => (r as any).id)).toEqual([
+      author.id,
+      (authors("bob") as any).id,
+    ]);
   });
 });

--- a/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
+++ b/packages/activerecord/src/associations/cascaded-eager-loading.test.ts
@@ -463,7 +463,7 @@ describe("CascadedEagerLoadingTest", () => {
 
     const oldPost = await (author as any).posts.createBang({ title: "first post", body: "test" });
     await oldPost.comments.createBang({
-      author_id: (authors("mary") as any).id,
+      author: authors("mary"),
       body: "a response",
     });
 
@@ -472,7 +472,7 @@ describe("CascadedEagerLoadingTest", () => {
       body: "test",
     });
     const lastComment = await recentPost.comments.createBang({
-      author_id: (authors("bob") as any).id,
+      author: authors("bob"),
       body: "a response",
     });
 


### PR DESCRIPTION
## Summary

Un-skips `preloading across has one through constrains loaded records` in
`cascaded-eager-loading.test.ts`.

The test was skipped citing a supposed implementation gap ("nested preload
through a `has_one :through` does not instantiate the nested association").
Investigation showed the gap was in the **test data**, not the preloader:
`Comment#author` is a **polymorphic** `belongs_to`, and the test seeded the
comment with only `author_id` (leaving `author_type` nil), so the nested
`:author` preload had no type to resolve and returned nothing — the recorder
saw 1 Author instead of 2.

Rails' own test creates the comment with `create!(author: authors(:bob))`,
which sets both `author_id` and `author_type`. Mirroring that (passing the
Author record instead of the bare id) makes the nested-through preload
resolve correctly with **no production code change** — the preloader already
instantiates the nested association on the through target.

The sibling `has one constrains` test is aligned to the same Rails
`author: authors(...)` setup for fidelity and file consistency (it passed
either way, since it records Comments rather than Authors).

## Test plan

- `pnpm vitest run packages/activerecord/src/associations/cascaded-eager-loading.test.ts` — 30 passed, 2 skipped.

Closes-story: nested-preload-through-has-one-source