### PR TITLE
test(associations): cover nested-through direct-load multiset fidelity

### DIFF
--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -147,8 +147,15 @@ describe("NestedThroughAssociationsTest", () => {
   // has_many through
   // Source: has_many
   // Through: has_many through
-  // trails deduplicates nested-through results by PK; Rails returns all rows including duplicates.
-  it.todo("has many through has many through with has many source reflection");
+  it("has many through has many through with has many source reflection", async () => {
+    const luke = subscribers("first");
+    const davidSub = subscribers("second");
+    const david = authors("david");
+    const result = await david.subscribers.order("subscribers.nick");
+    expect(result.map((s: any) => s.nick)).toEqual(
+      [luke, davidSub, davidSub].map((s: any) => s.nick),
+    );
+  });
 
   it("has many through has many through with has many source reflection preload", async () => {
     const luke = subscribers("first");
@@ -399,8 +406,12 @@ describe("NestedThroughAssociationsTest", () => {
   // has_many through
   // Source: belongs_to
   // Through: has_many through
-  // Rails returns [general, general] (duplicate because two posts have the same tag); trails deduplicates by PK.
-  it.todo("has many through has many through with belongs to source reflection");
+  it("has many through has many through with belongs to source reflection", async () => {
+    const general = tags("general");
+    const david = authors("david");
+    const result = await david.taggingTags.toArray();
+    expect(result.map((t: any) => t.id)).toEqual([general.id, general.id]);
+  });
 
   it("has many through has many through with belongs to source reflection preload", async () => {
     const general = tags("general");


### PR DESCRIPTION
## What

Un-skip the two `it.todo` nested-through direct-load tests in
`nested-through-associations.test.ts` that assert Rails' full-multiset
semantics — a target reachable via multiple intermediate paths appears
once **per path**, not deduplicated by PK:

- `has many through has many through with has many source reflection`
  — `david.subscribers` = `[alterself, webster132, webster132]`
- `has many through has many through with belongs to source reflection`
  — `david.taggingTags` = `[general, general]`

## Why

Rails' `nested_through_associations_test.rb` (lines 98-101, 312-313)
returns the full multiset from the direct-load path. trails historically
deduplicated nested-through results by PK, but #4505 ("route all
nested-through loads onto the JOIN AssociationScope") already fixed the
direct-load path to return the full multiset. These tests were left as
`it.todo` and are now converted to real assertions locking in that
behavior. The distinct variants (`distinctSubscribers`, `distinctTags`)
remain covered separately and still return the unique set.

Test names match Rails verbatim. No production code change — behavior is
already correct across adapters; CI exercises sqlite/postgres/mysql.

Closes-story: nested-through-pk-dedup-in-direct-load