### PR TITLE
fix(mysql2): active sync getter reflects real connection state

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -97,7 +97,11 @@ describeIfMysql("Mysql2Adapter", () => {
       expect(adapter.quote("string")).toBe("'string'");
     });
 
-    it("active after disconnect", () => {
+    it("active after disconnect", async () => {
+      // Rails' @connection is a live pooled connection (raw_connection set), so
+      // establish one here before disconnecting — the sync `active` getter now
+      // tracks real connection state (`_client !== null`) like Rails' active?.
+      await adapter.execute("SELECT 1");
       expect(adapter.active).toBe(true);
       adapter.disconnectBang();
       expect(adapter.active).toBe(false);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/connection.test.ts
@@ -60,7 +60,11 @@ describeIfMysql("Mysql2Adapter", () => {
         expect(await singleConn.activeAsync()).toBe(true);
         await singleConn.execute("SET SESSION wait_timeout=1");
         await new Promise((r) => setTimeout(r, 2000));
-        singleConn.reconnectBang();
+        // Rails' reconnect! is synchronous; trails' reconnectBang is async, so
+        // await it before reading the sync `active` getter — which now tracks
+        // real connection state (`_client !== null`), only re-established once
+        // reconnectBang's _ensureClient resolves.
+        await singleConn.reconnectBang();
         expect(singleConn.active).toBe(true);
         await expect(singleConn.execute("SELECT 1")).resolves.toBeDefined();
       } finally {
@@ -79,7 +83,10 @@ describeIfMysql("Mysql2Adapter", () => {
         // connection, so getConnection() returns the dead socket and ping() fails.
         // activeAsync() sets _activeState = false, making active return false.
         await singleConn.activeAsync();
-        singleConn.verifyBang(); // active is false → calls reconnectBang()
+        // active is false → verifyBang calls reconnectBang(). Await it (async in
+        // trails, unlike Rails' synchronous verify!) before reading the sync
+        // `active` getter, which now reflects `_client !== null`.
+        await singleConn.verifyBang();
         expect(singleConn.active).toBe(true);
         await expect(singleConn.execute("SELECT 1")).resolves.toBeDefined();
       } finally {

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -46,6 +46,14 @@ describe("Mysql2Adapter#translateException (fabricated errors)", () => {
     await adapter.close().catch(() => {});
   });
 
+  it("active is false for a never-connected / fake adapter", () => {
+    // Rails' Mysql2Adapter#active? is gated on connected? (raw_connection
+    // non-nil). A fake or never-connected adapter has no _client, so the sync
+    // getter reports inactive without touching a real DB.
+    expect(adapter.active).toBe(false);
+    expect(new Mysql2Adapter(MYSQL_TEST_URL).active).toBe(false);
+  });
+
   it("translates connection-loss errnos to ConnectionFailed", () => {
     // Mirrors AbstractMysqlAdapter#translate_exception cases for
     // ER_CONNECTION_KILLED / ER_SERVER_SHUTDOWN / CR_SERVER_GONE_ERROR /
@@ -135,6 +143,27 @@ describeIfMysql("Mysql2Adapter (trails extensions)", () => {
   afterEach(async () => {
     vi.restoreAllMocks();
     await adapter.close();
+  });
+
+  // trails-only: the sync `active` getter converges to Rails' Mysql2Adapter#active?
+  // `connected?` guard (`!(@raw_connection.nil? || ...)`) — a never-connected
+  // adapter (`_client === null`) reports inactive until a query establishes the
+  // connection, then false again after disconnectBang(). Rails eager-connects so
+  // it has no never-connected window to cover; this guards trails' lazy-connect.
+  describe("#active sync getter reflects connection state", () => {
+    it("is false before any connection and true after the first query", async () => {
+      const fresh = new Mysql2Adapter(MYSQL_TEST_URL);
+      try {
+        expect(fresh.active).toBe(false);
+        // First query still connects lazily (verifyBang's _ensureClient net).
+        await fresh.execQuery("SELECT 1");
+        expect(fresh.active).toBe(true);
+        fresh.disconnectBang();
+        expect(fresh.active).toBe(false);
+      } finally {
+        await fresh.close();
+      }
+    });
   });
 
   // Rails: activerecord/test/cases/adapters/abstract_mysql_adapter/mysql_adapter_test.rb

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -49,9 +49,13 @@ describe("Mysql2Adapter#translateException (fabricated errors)", () => {
   it("active is false for a never-connected / fake adapter", () => {
     // Rails' Mysql2Adapter#active? is gated on connected? (raw_connection
     // non-nil). A fake or never-connected adapter has no _client, so the sync
-    // getter reports inactive without touching a real DB.
+    // getter — and isConnected() (Rails' connected?) — report inactive without
+    // touching a real DB, preserving the `active ⟹ isConnected` invariant.
     expect(adapter.active).toBe(false);
-    expect(new Mysql2Adapter(MYSQL_TEST_URL).active).toBe(false);
+    expect(adapter.isConnected()).toBe(false);
+    const fresh = new Mysql2Adapter(MYSQL_TEST_URL);
+    expect(fresh.active).toBe(false);
+    expect(fresh.isConnected()).toBe(false);
   });
 
   it("translates connection-loss errnos to ConnectionFailed", () => {
@@ -155,11 +159,14 @@ describeIfMysql("Mysql2Adapter (trails extensions)", () => {
       const fresh = new Mysql2Adapter(MYSQL_TEST_URL);
       try {
         expect(fresh.active).toBe(false);
+        expect(fresh.isConnected()).toBe(false);
         // First query still connects lazily (verifyBang's _ensureClient net).
         await fresh.execQuery("SELECT 1");
         expect(fresh.active).toBe(true);
+        expect(fresh.isConnected()).toBe(true);
         fresh.disconnectBang();
         expect(fresh.active).toBe(false);
+        expect(fresh.isConnected()).toBe(false);
       } finally {
         await fresh.close();
       }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -153,25 +153,40 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     }
   }
 
-  // Mirrors Rails' Mysql2Adapter#connected? — false only after a known
-  // disconnect/close or for fake adapters. A freshly-constructed adapter
-  // with no _client yet is still "connected" in the sense that it will
-  // connect on the next query (matching Rails, which always has @raw_connection
-  // non-nil before the adapter reaches callers).
+  // Mirrors Rails' Mysql2Adapter#connected? — `!(@raw_connection.nil? ||
+  // @raw_connection.closed?)` (mysql2_adapter.rb:104). `_client` is trails'
+  // `@raw_connection`, so a never-connected / disconnected adapter (`_client
+  // === null`) reports NOT connected. This also matches the base adapter's
+  // `isConnected()` (`_connection !== null`) and keeps `active ⟹ isConnected`,
+  // the invariant Rails guarantees by checking `connected?` first inside
+  // `active?`.
   override isConnected(): boolean {
-    return !this._permanentlyClosed && !this._isFakeConnection && this._activeState;
+    return (
+      this._client !== null &&
+      !this._permanentlyClosed &&
+      !this._isFakeConnection &&
+      this._activeState
+    );
   }
 
-  // Now that the sync `active` getter requires `_client !== null`, a
-  // never-connected adapter reports inactive, so the base `verifyBang` would
-  // take the full reconnectBang (reset caches, restore transactions, retry
-  // loop) on the very first query of every fresh adapter. That reset cycle is
-  // spurious when there is simply no connection yet — establish it lazily via
-  // `_ensureClient` (Rails' `connect` on a nil `@raw_connection`) and mark the
-  // adapter verified. A `_client` that already exists but is stale still falls
-  // through to the base path, whose `active` check drives the real reconnect.
+  // A never-connected adapter with no failure observed (`_client === null` but
+  // `_activeState` still true) reported `active === true` before the sync getter
+  // was tightened, so the base `verifyBang` no-op'd and the first query connected
+  // lazily via `_ensureClient` — WITHOUT a reconnectBang/configure cycle. Tightening
+  // `active` now makes that state report inactive, which would route it through the
+  // full reconnectBang (checkVersion + configure + cache/transaction reset) on the
+  // first query of every fresh adapter — behavior that never ran on main. Preserve
+  // the prior path exactly: connect lazily and mark verified. Only the fresh,
+  // no-failure state is intercepted; a disconnected/failed adapter
+  // (`_activeState === false`, e.g. after disconnectBang) falls through to the base
+  // reconnect path so its clearCache/reset/configure still run as before.
   override async verifyBang(): Promise<void> {
-    if (this._client === null && !this._permanentlyClosed && !this._isFakeConnection) {
+    if (
+      this._client === null &&
+      this._activeState &&
+      !this._permanentlyClosed &&
+      !this._isFakeConnection
+    ) {
       await this._ensureClient();
       this.verifiedBang();
       return;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -169,33 +169,18 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     );
   }
 
-  // A never-connected adapter with no failure observed (`_client === null` but
-  // `_activeState` still true) reports `active === false` once the sync getter is
-  // tightened, so the base `verifyBang` would route it through the full
-  // `reconnectBang` (reconnect() close/reopen + retry loop + enableLazyTransactions
-  // + resetTransaction + clearCache + configure) on the first query of every fresh
-  // adapter. reconnect()'s close-and-reopen and the reset/clearCache steps are pure
-  // no-ops on an adapter that has nothing to close and no cache/transaction yet, so
-  // establish the connection lazily via `_ensureClient` and run `configure` directly
-  // — the one step with observable effect. This mirrors Rails' `reconnect!` →
-  // `attempt_configure_connection` guarantee (abstract_adapter.rb:662) without the
-  // spurious teardown/retry churn. A disconnected/failed adapter
-  // (`_activeState === false`, e.g. after disconnectBang) still falls through to the
-  // base reconnect path so its transaction restore + clearCache run as before.
-  override async verifyBang(): Promise<void> {
-    if (
-      this._client === null &&
-      this._activeState &&
-      !this._permanentlyClosed &&
-      !this._isFakeConnection
-    ) {
-      await this._ensureClient();
-      await this.attemptConfigureConnection();
-      this.verifiedBang();
-      return;
-    }
-    await super.verifyBang();
-  }
+  // No verifyBang override: now that the sync `active` getter reflects real
+  // connection state, a never-connected adapter reports inactive and flows
+  // through the inherited base `verifyBang` (abstract-adapter.ts) exactly like
+  // any other inactive adapter — `_unconfiguredConnection` promotion when the
+  // deprecated raw-connection was stashed (mysql2's `_isFakeConnection` path),
+  // otherwise `reconnectBang({ restoreTransactions: true })` with its retry
+  // loop. This mirrors Rails' `verify!` (abstract_adapter.rb:759), which gates
+  // the `attempt_configure_connection`-only shortcut on `@unconfigured_connection`
+  // and routes a genuinely fresh (`@raw_connection == nil`) adapter through the
+  // full retry-capable `reconnect!` — there is no separate "never connected"
+  // shortcut. `Mysql2Adapter#reconnect` closes a nil `_client` as a no-op, so the
+  // full path costs nothing extra on a fresh adapter and gains connect retries.
 
   // Single persistent connection — mirrors Rails' @raw_connection.
   private _client: mysql.Connection | null = null;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -170,16 +170,18 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   // A never-connected adapter with no failure observed (`_client === null` but
-  // `_activeState` still true) reported `active === true` before the sync getter
-  // was tightened, so the base `verifyBang` no-op'd and the first query connected
-  // lazily via `_ensureClient` — WITHOUT a reconnectBang/configure cycle. Tightening
-  // `active` now makes that state report inactive, which would route it through the
-  // full reconnectBang (checkVersion + configure + cache/transaction reset) on the
-  // first query of every fresh adapter — behavior that never ran on main. Preserve
-  // the prior path exactly: connect lazily and mark verified. Only the fresh,
-  // no-failure state is intercepted; a disconnected/failed adapter
-  // (`_activeState === false`, e.g. after disconnectBang) falls through to the base
-  // reconnect path so its clearCache/reset/configure still run as before.
+  // `_activeState` still true) reports `active === false` once the sync getter is
+  // tightened, so the base `verifyBang` would route it through the full
+  // `reconnectBang` (reconnect() close/reopen + retry loop + enableLazyTransactions
+  // + resetTransaction + clearCache + configure) on the first query of every fresh
+  // adapter. reconnect()'s close-and-reopen and the reset/clearCache steps are pure
+  // no-ops on an adapter that has nothing to close and no cache/transaction yet, so
+  // establish the connection lazily via `_ensureClient` and run `configure` directly
+  // — the one step with observable effect. This mirrors Rails' `reconnect!` →
+  // `attempt_configure_connection` guarantee (abstract_adapter.rb:662) without the
+  // spurious teardown/retry churn. A disconnected/failed adapter
+  // (`_activeState === false`, e.g. after disconnectBang) still falls through to the
+  // base reconnect path so its transaction restore + clearCache run as before.
   override async verifyBang(): Promise<void> {
     if (
       this._client === null &&
@@ -188,6 +190,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       !this._isFakeConnection
     ) {
       await this._ensureClient();
+      await this.attemptConfigureConnection();
       this.verifiedBang();
       return;
     }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -112,15 +112,23 @@ class Mysql2StatementPool extends MysqlStatementPool {
  */
 export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapter {
   // Cached liveness state — true until a failure is observed (ping fail,
-  // disconnect, permanent close). Does not require _client to be non-null:
-  // a freshly-constructed adapter has no connection yet but is considered
-  // active (matching Rails, where @raw_connection is set before the adapter
-  // is handed to callers). Set false by disconnectBang(); restored to true
-  // by reconnectBang() and by successful activeAsync().
+  // disconnect, permanent close). Set false by disconnectBang(); restored to
+  // true by reconnectBang() and by successful activeAsync().
   private _activeState = true;
 
+  // Mirrors Rails' Mysql2Adapter#active? (mysql2_adapter.rb:108) whose first
+  // guard is `connected?` — `!(@raw_connection.nil? || @raw_connection.closed?)`.
+  // A never-connected adapter (`_client === null`) therefore reports inactive:
+  // trails connects lazily, so `_client` stands in for `@raw_connection`. The
+  // sync getter can't do the live `ping` half of Rails' active? (that's
+  // activeAsync); `_activeState` is the cached liveness that ping updates.
   override get active(): boolean {
-    return !this._permanentlyClosed && !this._isFakeConnection && this._activeState;
+    return (
+      this._client !== null &&
+      !this._permanentlyClosed &&
+      !this._isFakeConnection &&
+      this._activeState
+    );
   }
 
   /**
@@ -152,6 +160,23 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // non-nil before the adapter reaches callers).
   override isConnected(): boolean {
     return !this._permanentlyClosed && !this._isFakeConnection && this._activeState;
+  }
+
+  // Now that the sync `active` getter requires `_client !== null`, a
+  // never-connected adapter reports inactive, so the base `verifyBang` would
+  // take the full reconnectBang (reset caches, restore transactions, retry
+  // loop) on the very first query of every fresh adapter. That reset cycle is
+  // spurious when there is simply no connection yet — establish it lazily via
+  // `_ensureClient` (Rails' `connect` on a nil `@raw_connection`) and mark the
+  // adapter verified. A `_client` that already exists but is stale still falls
+  // through to the base path, whose `active` check drives the real reconnect.
+  override async verifyBang(): Promise<void> {
+    if (this._client === null && !this._permanentlyClosed && !this._isFakeConnection) {
+      await this._ensureClient();
+      this.verifiedBang();
+      return;
+    }
+    await super.verifyBang();
   }
 
   // Single persistent connection — mirrors Rails' @raw_connection.


### PR DESCRIPTION
## What

Converge `Mysql2Adapter#active` (the sync getter) to Rails' `active?`
`connected?` guard (`mysql2_adapter.rb:108-117`, whose first check is
`connected?` = `!(@raw_connection.nil? || @raw_connection.closed?)`).

Previously the sync getter was `!_permanentlyClosed && !_isFakeConnection && _activeState`, with `_activeState` defaulting to `true` — so a
freshly-constructed, never-connected adapter reported `active === true`
before any connection existed. PR #4605 closed the sibling `connect!`
story via eager `connectBang()` but left this sync-getter deviation
standing.

## Changes

- **`Mysql2Adapter#active`** now also requires `_client !== null`
  (trails' lazy-connect stand-in for Rails' `@raw_connection`), so a
  never-connected / disconnected adapter reports inactive.
- **`Mysql2Adapter#isConnected`** likewise now requires `_client !== null`,
  matching Rails' `connected?` (raw_connection non-nil), the base adapter's
  `_connection !== null`, and preserving the `active ⟹ isConnected` invariant
  Rails guarantees by checking `connected?` first inside `active?`.
- **No `verifyBang` override.** Now that `active` reflects real state, a
  never-connected adapter flows through the inherited base `verifyBang`
  exactly like any other inactive adapter: `_unconfiguredConnection`
  promotion (mysql2's deprecated raw-connection / `_isFakeConnection` path)
  or `reconnectBang({ restoreTransactions: true })` with its connect-retry
  loop. This mirrors Rails' `verify!` (`abstract_adapter.rb:759`), which gates
  the `attempt_configure_connection`-only shortcut on `@unconfigured_connection`
  and routes a genuinely fresh (`@raw_connection == nil`) adapter through the
  full retry-capable `reconnect!` — there is no separate "never connected"
  shortcut, and `Mysql2Adapter#reconnect` closes a nil `_client` as a no-op so
  the full path costs nothing extra on a fresh adapter.
- **Tests**: a non-gated assertion that a fake / never-connected adapter
  reports `active === false` and `isConnected() === false`; a MySQL-gated
  lifecycle test (both false before connect → both true after first query →
  both false after `disconnectBang()`); and `connection_test.rb`'s
  `active after disconnect` now establishes a live connection first (mirroring
  Rails' live pooled `@connection`) instead of leaning on the old default-true
  deviation.

## Hot-path readers unaffected

`disableReferentialIntegrity` restore and the transaction `rollback`
materialization guard only read `active` after a connection exists, so
they behave identically. First-query connect is preserved by the base
reconnect / lazy `_ensureClient` path.

MySQL/MariaDB is adapter-gated (no local DB); typecheck + prettier clean.

Closes-story: mysql2-active-sync-getter-reflects-connection-state