### PR TITLE
fix(predicate-builder): lift force_equality? to uniform build dispatch

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -534,11 +534,21 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("where by attribute with array", async () => {
+      class PgArrays extends Base {
+        static tableName = "pg_arrays";
+      }
+      await PgArrays.loadSchema();
       const tags = ["black", "blue"];
-      await adapter.execute(`INSERT INTO pg_arrays (tags) VALUES ($1)`, [tags]);
-      const rows = await adapter.execute(`SELECT * FROM pg_arrays WHERE tags = $1`, [tags]);
-      expect(rows).toHaveLength(1);
-      expect(rows[0].tags).toEqual(tags);
+      // Rails: record = PgArray.create!(tags: tags);
+      //        assert_equal record, PgArray.where(tags: tags).take
+      // force_equality? on the array type routes `where(tags: [..])` to a single
+      // `tags = $1` bind ('{black,blue}'), NOT `tags IN ('black', 'blue')`.
+      const record = await (PgArrays as any).create({ tags });
+      const relation = (PgArrays as any).where({ tags });
+      expect(relation.toSql()).toContain('"tags" = ');
+      const found = await relation.take();
+      expect(found).not.toBeNull();
+      expect(found.id).toBe(record.id);
     });
 
     it("uniqueness validation", async () => {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1157,9 +1157,7 @@ export class Relation<T extends Base> {
     }
     const castConditions: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(conditions)) {
-      castConditions[key] = Array.isArray(value)
-        ? value.map((v) => this._castWhereValue(key, v))
-        : this._castWhereValue(key, value);
+      castConditions[key] = this._castWhereValue(key, value);
     }
     // Mirrors Rails' WhereClause#invert — branches on the actual predicate count,
     // not the key count, since one key can expand to multiple predicates:
@@ -1209,12 +1207,7 @@ export class Relation<T extends Base> {
     const buildClause = (cond: Record<string, unknown>): WhereClause => {
       const cast: Record<string, unknown> = {};
       for (const [key, value] of Object.entries(cond)) {
-        cast[key] =
-          value instanceof Relation
-            ? value
-            : Array.isArray(value)
-              ? value.map((v) => this._castWhereValue(key, v))
-              : this._castWhereValue(key, value);
+        cast[key] = value instanceof Relation ? value : this._castWhereValue(key, value);
       }
       return new WhereClause(this.predicateBuilder.buildFromHash(cast));
     };
@@ -6168,6 +6161,24 @@ export class Relation<T extends Base> {
       if (tablePrefix === this._modelClass.arelTable.name) {
         attrKey = key.slice(firstDot + 1);
       }
+    }
+    if (Array.isArray(value)) {
+      // A `where(col: [...])` array is one of two things: an `IN (...)` list of
+      // scalars (element-cast each through the column type) or — on a
+      // force-equality column (PG array / range / serialized) — a single
+      // force-equality value the predicate builder binds whole. `force_equality?`
+      // on the column type distinguishes them. Element-casting a whole array
+      // through an OID::Array column would run the string-only
+      // `_castAttributeValue` per element and parse each scalar as its own array
+      // literal (`'black'` → `[]`), corrupting `['black','blue']` → `[[],[]]`;
+      // leave the array intact and let the predicate builder's force-equality
+      // bind serialize it via the column type. Non-force-equality columns keep
+      // the element-wise IN-list cast.
+      const type = this._modelClass.typeForAttribute?.(attrKey) as
+        | { isForceEquality?(v: unknown): boolean }
+        | undefined;
+      if (type?.isForceEquality?.(value)) return value;
+      return value.map((v) => this._modelClass._castAttributeValue(attrKey, v));
     }
     return this._modelClass._castAttributeValue(attrKey, value);
   }

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -223,6 +223,30 @@ describe("PredicateBuilderTest", () => {
       expect(sql).toMatch(/>= 18/);
       expect(sql).toMatch(/< 65/);
     });
+
+    // No verbatim Rails test for this in isolation: it pins the trails
+    // convergence for Rails' uniform `force_equality?` dispatch at the top of
+    // `PredicateBuilder#build` (predicate_builder.rb:57-69). When the column
+    // type reports `force_equality?(value)` — as OID::Array does for an Array —
+    // the value is bound as a single equality (`col = ?`) BEFORE any handler
+    // dispatch, so an array never reaches ArrayHandler → `IN (...)`. This is the
+    // PG-array case (`where(arrayCol: [1, 2])` → `arr = '{1,2}'`) at unit level.
+    it("forces equality for a force-equality type instead of dispatching to a handler", () => {
+      const builder = new PredicateBuilder(table);
+      const forceEqType = {
+        isForceEquality: (v: unknown) => Array.isArray(v),
+        cast: (v: unknown) => v,
+        serialize: (v: unknown) => v,
+      };
+      (builder as any)._tableContext = { typeForAttribute: () => forceEqType };
+      const node = builder.build(table.get("tags"), [1, 2]);
+      const [sql, binds] = new Visitors.ToSql().compileWithBinds(node);
+      // Single equality bind, NOT `IN (?, ?)`.
+      expect(sql).toContain('"posts"."tags" = ?');
+      expect(sql).not.toMatch(/IN \(/);
+      expect(binds).toHaveLength(1);
+      expect((binds[0] as { value: unknown }).value).toEqual([1, 2]);
+    });
   });
 
   describe("buildNegatedFromHash", () => {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -439,13 +439,18 @@ export class PredicateBuilder {
     if (value instanceof Set) {
       value = Array.from(value);
     }
+    // Rails checks `table.type(attribute.name).force_equality?(value)` at the top
+    // of `build` — BEFORE any handler dispatch (predicate_builder.rb:57-69). So a
+    // force-equality value (PG array, PG range, serialized coder object) never
+    // reaches a registered handler. Mirror that precedence: run the check above
+    // the custom-handler / range / array branches.
+    const forceEqNode = this._buildForceEqualityOrNull(attribute, value);
+    if (forceEqNode !== null) return forceEqNode;
     const customHandler = this.handlers.length > 0 ? this.handlerFor(value) : null;
     if (customHandler && customHandler !== this.basicObjectHandler) {
       return customHandler.call(attribute, value);
     }
     if (value instanceof Range) {
-      const rangeNode = this._buildRangeEqualityOrNull(attribute, value);
-      if (rangeNode !== null) return rangeNode;
       return this.rangeHandler.call(attribute, value);
     }
     if (Array.isArray(value)) {
@@ -458,7 +463,7 @@ export class PredicateBuilder {
   }
 
   buildRangePredicate(attribute: Nodes.Attribute, range: Range): Nodes.Node {
-    const rangeNode = this._buildRangeEqualityOrNull(attribute, range);
+    const rangeNode = this._buildForceEqualityOrNull(attribute, range);
     if (rangeNode !== null) return rangeNode;
     return this.rangeHandler.call(attribute, range);
   }
@@ -604,8 +609,18 @@ export class PredicateBuilder {
     this._tableContext = context;
   }
 
-  /** @internal */
-  private _buildRangeEqualityOrNull(attribute: Nodes.Attribute, value: Range): Nodes.Node | null {
+  /**
+   * Mirrors Rails `PredicateBuilder#build` force-equality dispatch
+   * (`operator ||= table.type(attribute.name).force_equality?(value) && :eq`):
+   * runs the multi-source type lookup and, when the resolved type reports
+   * `force_equality?(value)`, returns `attribute.eq(bind)` built with the SAME
+   * type object that matched — otherwise `null` so the caller falls through to
+   * handler dispatch. Type-agnostic: applies to `OID::Range`, `OID::Array`, and
+   * `Type::Serialized` alike.
+   *
+   * @internal
+   */
+  private _buildForceEqualityOrNull(attribute: Nodes.Attribute, value: unknown): Nodes.Node | null {
     type CastLike = { cast(v: unknown): unknown; serialize(v: unknown): unknown };
     type TypeLike =
       | ({ isForceEquality?(v: unknown): boolean } & Partial<CastLike>)

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -433,19 +433,23 @@ export class PredicateBuilder {
     if (value === null || value === undefined) {
       return attribute.isNull();
     }
+    // Rails checks `table.type(attribute.name).force_equality?(value)` at the top
+    // of `build` — right after the `id` deref and BEFORE any handler dispatch
+    // (predicate_builder.rb:57-69). So a force-equality value (PG array, PG range,
+    // serialized coder object) never reaches a registered handler. Mirror that
+    // precedence, and run it on the value BEFORE the Set→Array normalization
+    // below: Rails routes a Set through handler_for (ArrayHandler), and
+    // `OID::Array#force_equality?` is `value.is_a?(::Array)` — a Ruby Set is not
+    // an Array, so a Set on an array column force-equalizes in neither Rails nor
+    // here. Normalizing Set→Array first would spuriously trip force-equality.
+    const forceEqNode = this._buildForceEqualityOrNull(attribute, value);
+    if (forceEqNode !== null) return forceEqNode;
     // Normalize Set → Array before dispatch so every code path (custom handlers,
     // explicit Array branch, handlerFor fallback) receives an array. Rails registers
     // Set with ArrayHandler by default (predicate_builder.rb:20).
     if (value instanceof Set) {
       value = Array.from(value);
     }
-    // Rails checks `table.type(attribute.name).force_equality?(value)` at the top
-    // of `build` — BEFORE any handler dispatch (predicate_builder.rb:57-69). So a
-    // force-equality value (PG array, PG range, serialized coder object) never
-    // reaches a registered handler. Mirror that precedence: run the check above
-    // the custom-handler / range / array branches.
-    const forceEqNode = this._buildForceEqualityOrNull(attribute, value);
-    if (forceEqNode !== null) return forceEqNode;
     const customHandler = this.handlers.length > 0 ? this.handlerFor(value) : null;
     if (customHandler && customHandler !== this.basicObjectHandler) {
       return customHandler.call(attribute, value);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -979,11 +979,7 @@ export function buildWhereClause(
     const normalized: Record<string, unknown> = {};
     for (const [key, value] of Object.entries(opts)) {
       const resolved = aliases[key] ?? key;
-      normalized[resolved] = isRelationLike(value)
-        ? value
-        : Array.isArray(value)
-          ? value.map((v) => this._castWhereValue(resolved, v))
-          : this._castWhereValue(resolved, value);
+      normalized[resolved] = isRelationLike(value) ? value : this._castWhereValue(resolved, value);
     }
     const block = (tableName: string) => lookupTableKlassFromJoinDependencies.call(this, tableName);
     const parts = this.predicateBuilder.buildFromHash(normalized, block);
@@ -1294,13 +1290,7 @@ function havingBang(
 
   const cast: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(opts)) {
-    if (isRelationLike(value)) {
-      cast[key] = value;
-    } else {
-      cast[key] = Array.isArray(value)
-        ? value.map((v) => this._castWhereValue(key, v))
-        : this._castWhereValue(key, value);
-    }
+    cast[key] = isRelationLike(value) ? value : this._castWhereValue(key, value);
   }
   this._havingClause.predicates.push(...this.predicateBuilder.buildFromHash(cast));
   return this;

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -43144,6 +43144,13 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
+    "call": "map",
+    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` — no `map` over keys applies."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_where_clause",
     "call": "attribute_aliases",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
## Summary

Rails applies `force_equality?` uniformly for every value at the top of
`PredicateBuilder#build`, **before** any handler dispatch
(`predicate_builder.rb:57-69`). trails only consulted `isForceEquality` inside
the `value instanceof Range` branch (`force-equality-bind-convergence`, #4062),
so two cases diverged:

- **PG array column**, `where(arrayCol: [1, 2])`: routed to `arrayHandler` →
  `arr IN (1, 2)`. Rails forces `=` → `arr = '{1,2}'` (one force-equality bind
  through `OID::Array#serialize` → `encode_array`).
- **Serialized force-equality** (`OID::Range`/`OID::Array`/`Type::Serialized`):
  the bind path never fired outside the Range branch.

## Change

1. **Uniform force-equality dispatch.** Generalize `_buildRangeEqualityOrNull` →
   type-agnostic `_buildForceEqualityOrNull(attribute, value)`: runs the
   three-source type lookup (`attribute.relation` / `_tableContext` /
   `this.table`) and, on `isForceEquality(value)`, returns
   `attribute.eq(new QueryAttribute(name, value, type))` built with the **same**
   type object that matched. Call it at the top of `build` — after the `id`
   deref, above the custom-handler / range / array branches — mirroring Rails'
   `operator ||= force_equality? && :eq` precedence. Run it **before** the
   `Set→Array` normalization: Rails routes a `Set` via `handler_for`
   (ArrayHandler) and `OID::Array#force_equality?` is `value.is_a?(::Array)` — a
   Ruby `Set` fails it, so normalizing first would spuriously force-equalize.

2. **Don't element-cast a force-equality array through the column type.**
   `Relation#where(col: [...])` element-mapped the array through
   `_castWhereValue` → `_castAttributeValue`, which casts strings via the column
   type's `cast` per element. On a PG array column that parses each scalar as
   its own array literal (`'black'` → `[]`), corrupting `['black','blue']` →
   `[[],[]]` → `malformed array literal "{{},{}}"`. Latent before (the old path
   fed garbage to `IN`), surfaced as a hard error once the force-equality lift
   routes the whole array to one `= $1` bind. `_castWhereValue` now checks
   `force_equality?(value)` for the whole array and passes it through intact when
   true, else keeps the element-wise IN-list cast — folding the four
   `Array.isArray(v) ? v.map(...) : ...` call sites into one call.

## Tests

- `predicate-builder.test.ts`: new unit test pins the precedence — a
  force-equality type routes an array value to a single equality bind
  (`"posts"."tags" = ?`, one bind) instead of `ArrayHandler` → `IN (?, ?)`.
- `adapters/postgresql/array.test.ts` "where by attribute with array" converged
  to the Rails model-`where` form and asserts `"tags" = ` (not `IN`), and now
  round-trips (`.take()` finds the record).
- Verified locally against a live PostgreSQL 16: full `array.test.ts` (42) and
  `range.test.ts` (86) green; sqlite `predicate-builder` / `where` / `finder` /
  `relation` suites green.

Closes-story: predicate-builder-force-equality-uniform-build