### PR TITLE
fix(uniqueness): detect integer case-insensitive collisions on sqlite

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -5,7 +5,7 @@ import type {
   SqliteOpenConfig,
   SqliteStatement,
 } from "../sqlite-adapter.js";
-import { Visitors } from "@blazetrails/arel";
+import { Nodes, Visitors } from "@blazetrails/arel";
 import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
 import type { InsertBuilder } from "../insert-all.js";
 import type { AdapterName } from "./abstract-adapter.js";
@@ -166,6 +166,44 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   get schemaCreation(): SQLite3SchemaCreation {
     return (this._sqlite3SchemaCreation ??= new SQLite3SchemaCreation("sqlite", this));
+  }
+
+  /**
+   * Mirrors: AbstractAdapter#case_insensitive_comparison
+   * (abstract_adapter.rb:814) — look up the column and only wrap both sides in
+   * `LOWER()` when `can_perform_case_insensitive_comparison_for?` is true,
+   * otherwise fall back to plain equality.
+   *
+   * Rails' SQLite3Adapter inherits the abstract `can_perform...? => true`, so on
+   * MRI a `LOWER(int_col) = LOWER(?)` comparison still matches: the sqlite3 gem
+   * binds a Ruby Integer as SQLITE_INTEGER, and `LOWER(1)` yields the text `'1'`
+   * on both sides. Our better-sqlite3 driver binds a JS number as SQLITE_FLOAT,
+   * so `LOWER(?)` yields `'1.0'` and never matches `LOWER(int_col)` = `'1'` —
+   * silently missing integer scope/attribute collisions
+   * (uniqueness_validation_test.rb `test_validate_case_insensitive_uniqueness`,
+   * `:parent_id`). Restricting the `LOWER()` form to text columns converges the
+   * behavior with Rails without touching the driver's numeric binding.
+   * @internal
+   */
+  override async caseInsensitiveComparison(
+    attribute: Nodes.Attribute,
+    value: unknown,
+  ): Promise<Nodes.Node> {
+    const column = await this.columnForAttribute(attribute);
+    if (column && this.canPerformCaseInsensitiveComparisonFor(column)) {
+      return attribute.lower().eq((attribute.relation as any).lower(value));
+    }
+    return attribute.eq(value);
+  }
+
+  /**
+   * Only text columns can be meaningfully lowercased; non-text columns (integer,
+   * float, date, …) fall back to plain equality. See caseInsensitiveComparison
+   * for why this diverges structurally from Rails' unconditional `true`.
+   * @internal
+   */
+  override canPerformCaseInsensitiveComparisonFor(column: { type?: string | null }): boolean {
+    return column.type === "string" || column.type === "text";
   }
 
   /** @internal */

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -392,7 +392,8 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate case insensitive uniqueness", async () => {
-    Topic.validatesUniqueness("title", { caseSensitive: false });
+    Topic.validatesUniqueness("title", { caseSensitive: false, allowNil: true });
+    Topic.validatesUniqueness("parent_id", { caseSensitive: false, allowNil: true });
 
     const t = new Topic({ title: "I'm unique!", parent_id: 2 });
     expect(await t.save()).toBe(true);
@@ -400,21 +401,33 @@ describe("UniquenessValidationTest", () => {
     t.writeAttribute("content", "Remaining unique");
     expect(await t.save()).toBe(true);
 
+    // fixture topics(:second) has parent_id 1, so parent_id collides too.
     const t2 = new Topic({ title: "I'm UNIQUE!", parent_id: 1 });
     expect(await t2.save()).toBe(false);
+    expect(t2.errors.get("title").length).toBeGreaterThan(0);
+    expect(t2.errors.get("parent_id").length).toBeGreaterThan(0);
     expect(t2.errors.get("title")).toEqual(["has already been taken"]);
 
     t2.writeAttribute("title", "I'm truly UNIQUE!");
+    expect(await t2.save()).toBe(false);
+    expect(t2.errors.get("title")).toEqual([]);
+    expect(t2.errors.get("parent_id").length).toBeGreaterThan(0);
+
+    t2.writeAttribute("parent_id", 4);
+    expect(await t2.save()).toBe(true);
+
+    t2.writeAttribute("parent_id", null);
+    t2.writeAttribute("title", null);
     expect(await t2.save()).toBe(true);
   });
 
   it("validate uniqueness of with multiple attributes and array forms", async () => {
     // Rails' `validates_uniqueness_of(*attr_names)` arity: `_merge_attributes`
     // flattens nested arrays and registers a deferred check per attribute, so a
-    // single call can guard several columns. (Mirrors the multi-attr form used by
-    // Rails' test_validate_case_insensitive_uniqueness without the integer
-    // case-insensitive scope column, which hits a separate SQLite LOWER(bind)
-    // quirk tracked by story uniqueness-case-insensitive-integer-column-sqlite.)
+    // single call can guard several columns. (A string-column variant of the
+    // multi-attr form used by Rails' test_validate_case_insensitive_uniqueness;
+    // the integer `:parent_id` case-insensitive column that test also covers is
+    // asserted directly in "validate case insensitive uniqueness".)
     Topic.validatesUniquenessOf(["title"], "author_name");
 
     // Fixture topics(:first): title "The First Topic", author_name "David".

--- a/packages/activerecord/src/validations/uniqueness-validation.test.ts
+++ b/packages/activerecord/src/validations/uniqueness-validation.test.ts
@@ -392,8 +392,8 @@ describe("UniquenessValidationTest", () => {
   });
 
   it("validate case insensitive uniqueness", async () => {
-    Topic.validatesUniqueness("title", { caseSensitive: false, allowNil: true });
-    Topic.validatesUniqueness("parent_id", { caseSensitive: false, allowNil: true });
+    // Rails: `validates_uniqueness_of(:title, :parent_id, case_sensitive: false, allow_nil: true)`.
+    Topic.validatesUniquenessOf("title", "parent_id", { caseSensitive: false, allowNil: true });
 
     const t = new Topic({ title: "I'm unique!", parent_id: 2 });
     expect(await t.save()).toBe(true);

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -46,6 +46,8 @@ export function validatesUniqueness(
     message?: string;
     conditions?: (this: any) => any;
     caseSensitive?: boolean;
+    allowNil?: boolean;
+    allowBlank?: boolean;
     // Context-guard keys honored by Base#_runAsyncValidations (it re-applies
     // the on:/if:/unless: intersection that the sync callback chain installs).
     on?: string | string[];

--- a/packages/activerecord/src/validations/uniqueness.ts
+++ b/packages/activerecord/src/validations/uniqueness.ts
@@ -47,7 +47,6 @@ export function validatesUniqueness(
     conditions?: (this: any) => any;
     caseSensitive?: boolean;
     allowNil?: boolean;
-    allowBlank?: boolean;
     // Context-guard keys honored by Base#_runAsyncValidations (it re-applies
     // the on:/if:/unless: intersection that the sync callback chain installs).
     on?: string | string[];


### PR DESCRIPTION
## What

`UniquenessValidator#build_relation` routes a `case_sensitive: false` comparison through the adapter's `caseInsensitiveComparison`, which on SQLite emitted `LOWER(col) = LOWER(?)` unconditionally. For an **integer** column (`validates_uniqueness_of :title, :parent_id, case_sensitive: false`), the collision was silently missed:

- Rails' sqlite3 gem binds a Ruby Integer as `SQLITE_INTEGER`, so `LOWER(1)` yields text `'1'` on both sides and the row matches.
- Our better-sqlite3 driver binds a JS number as `SQLITE_FLOAT`, so `LOWER(?)` yields `'1.0'` and never matches an integer column's `LOWER(col)` = `'1'`.

## Fix

Mirror Rails' `AbstractAdapter#case_insensitive_comparison` (abstract_adapter.rb:814) in the SQLite adapter: look up the column and only wrap both sides in `LOWER()` when the column is text (`canPerformCaseInsensitiveComparisonFor`), otherwise fall back to plain equality (`attribute.eq(value)`). This converges the behavior with Rails without touching the driver's numeric binding.

## Test

Port the full Rails `test_validate_case_insensitive_uniqueness` (multi-attr `:title, :parent_id`) including the integer `parent_id` collision and the nil-allowed assertions.

Closes-story: uniqueness-case-insensitive-integer-column-sqlite