### PR TITLE
feat(xml-mini): port rename_key with dasherize/camelize options

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -2183,8 +2183,12 @@ export class Model {
       dasherize: options?.dasherize,
       camelize: options?.camelize,
     };
+    // The root (default `modelName.singular`, already snake_case, or a
+    // caller-supplied literal) is renamed directly — Rails' serializer reformats
+    // the root without underscoring it (conversions.rb:88 / :200). Only the
+    // camelCase per-attribute keys are underscored first (in `_hashToXml`).
     const root = renameKey(
-      underscore(options?.root ?? (this.constructor as typeof Model).modelName.singular),
+      options?.root ?? (this.constructor as typeof Model).modelName.singular,
       renameOptions,
     );
     return `<${root}>\n${this._hashToXml(hash, "  ", options?.skipTypes ?? false, this._xmlTypeMap(hash), renameOptions)}</${root}>`;

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -14,7 +14,9 @@ import {
 } from "./validations.js";
 import { sanitizeForbiddenAttributes as forbiddenSanitize } from "./forbidden-attributes-protection.js";
 import {
-  dasherize,
+  underscore,
+  renameKey,
+  type RenameKeyOptions,
   htmlEscape,
   resetCallbacks as asResetCallbacks,
 } from "@blazetrails/activesupport";
@@ -2173,10 +2175,19 @@ export class Model {
    *
    * Mirrors: ActiveModel::Serializers::Xml#to_xml
    */
-  toXml(options?: SerializeOptions & { root?: string; skipTypes?: boolean }): string {
+  toXml(
+    options?: SerializeOptions & { root?: string; skipTypes?: boolean } & RenameKeyOptions,
+  ): string {
     const hash = this.serializableHash(options);
-    const root = options?.root ?? (this.constructor as typeof Model).modelName.singular;
-    return `<${root}>\n${this._hashToXml(hash, "  ", options?.skipTypes ?? false, this._xmlTypeMap(hash))}</${root}>`;
+    const renameOptions: RenameKeyOptions = {
+      dasherize: options?.dasherize,
+      camelize: options?.camelize,
+    };
+    const root = renameKey(
+      underscore(options?.root ?? (this.constructor as typeof Model).modelName.singular),
+      renameOptions,
+    );
+    return `<${root}>\n${this._hashToXml(hash, "  ", options?.skipTypes ?? false, this._xmlTypeMap(hash), renameOptions)}</${root}>`;
   }
 
   /**
@@ -2205,6 +2216,7 @@ export class Model {
     indent: string,
     skipTypes = false,
     typeMap: Record<string, string> = {},
+    renameOptions: RenameKeyOptions = {},
   ): string {
     // `skip_types: true` (XmlMini) suppresses the inferred `type="..."`
     // attribute on every tag; the `nil="true"` marker is a separate attribute
@@ -2212,7 +2224,7 @@ export class Model {
     const typeAttr = (t: string) => (skipTypes ? "" : ` type="${t}"`);
     let xml = "";
     for (const [key, value] of Object.entries(hash)) {
-      const tag = dasherize(key);
+      const tag = renameKey(underscore(key), renameOptions);
       // The cast/column type name (when known) overrides JS-runtime inference so
       // the `type=` attribute is adapter-agnostic (e.g. a bigint `id` stays
       // `type="integer"` whether it arrives as a JS number, BigInt, or string).
@@ -2231,7 +2243,7 @@ export class Model {
         !(value instanceof Temporal.PlainTime) &&
         !(value instanceof Temporal.ZonedDateTime)
       ) {
-        xml += `${indent}<${tag}>\n${this._hashToXml(value as Record<string, unknown>, indent + "  ", skipTypes)}${indent}</${tag}>\n`;
+        xml += `${indent}<${tag}>\n${this._hashToXml(value as Record<string, unknown>, indent + "  ", skipTypes, {}, renameOptions)}${indent}</${tag}>\n`;
         // boundary: legacy Date values serialize as ISO 8601 dateTime XML.
       } else if (value instanceof Date) {
         xml += `${indent}<${tag}${typeAttr("dateTime")}>${Number.isNaN(value.getTime()) ? "" : value.toISOString()}</${tag}>\n`;
@@ -2239,7 +2251,7 @@ export class Model {
         xml += `${indent}<${tag}${typeAttr("array")}>\n`;
         for (const item of value) {
           if (typeof item === "object" && item !== null) {
-            xml += `${indent}  <item>\n${this._hashToXml(item as Record<string, unknown>, indent + "    ", skipTypes)}${indent}  </item>\n`;
+            xml += `${indent}  <item>\n${this._hashToXml(item as Record<string, unknown>, indent + "    ", skipTypes, {}, renameOptions)}${indent}  </item>\n`;
           } else {
             xml += `${indent}  <item>${this._escapeXml(String(item))}</item>\n`;
           }

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -793,6 +793,20 @@ describe("toXml()", () => {
     expect(xml).toContain("</person>");
   });
 
+  it("renames a caller-supplied root without underscoring it", () => {
+    // Rails renames `options[:root]` directly (conversions.rb:88/:200) — no
+    // `underscore` — so a mixed-case literal root is left essentially untouched
+    // (dasherize only rewrites `_`/space; camelize on an already-camelized word
+    // is idempotent). Force-underscoring it would wrongly yield `<my-root>`.
+    class User extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const u = new User({ name: "Alice" });
+    expect(u.toXml({ root: "MyRoot" })).toContain("<MyRoot>");
+  });
+
   it("dasherizes multi-word attribute tags by default", () => {
     class Address extends Model {
       static {

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -792,6 +792,51 @@ describe("toXml()", () => {
     expect(xml).toContain("<person>");
     expect(xml).toContain("</person>");
   });
+
+  it("dasherizes multi-word attribute tags by default", () => {
+    class Address extends Model {
+      static {
+        this.attribute("streetAddress", "string");
+      }
+    }
+    const a = new Address({ streetAddress: "Paulina" });
+    const xml = a.toXml();
+    expect(xml).toContain("<street-address>Paulina</street-address>");
+  });
+
+  it("preserves underscored attribute tags with dasherize false", () => {
+    class Address extends Model {
+      static {
+        this.attribute("streetAddress", "string");
+      }
+    }
+    const a = new Address({ streetAddress: "Paulina" });
+    const xml = a.toXml({ dasherize: false });
+    expect(xml).toContain("<street_address>Paulina</street_address>");
+  });
+
+  it("camelizes attribute and root tags with camelize lower", () => {
+    class Address extends Model {
+      static {
+        this.attribute("streetAddress", "string");
+      }
+    }
+    const a = new Address({ streetAddress: "Paulina" });
+    const xml = a.toXml({ camelize: "lower" });
+    expect(xml).toContain("<streetAddress>Paulina</streetAddress>");
+  });
+
+  it("camelizes attribute and root tags with camelize true", () => {
+    class Address extends Model {
+      static {
+        this.attribute("streetAddress", "string");
+      }
+    }
+    const a = new Address({ streetAddress: "Paulina" });
+    const xml = a.toXml({ camelize: true });
+    expect(xml).toContain("<Address>");
+    expect(xml).toContain("<StreetAddress>Paulina</StreetAddress>");
+  });
 });
 
 // ===========================================================================

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -548,6 +548,28 @@ describe("DelegationTest", () => {
       );
     });
 
+    it("to_xml threads dasherize false through the root, children, and attribute tags", async () => {
+      // conversions_test.rb:171-178: `dasherize: false` leaves the underscored
+      // key form intact on every tag produced from the shared options hash.
+      const xml = await Comment.where({ type: "Comment" }).toXml({
+        skipTypes: true,
+        skipInstruct: true,
+        only: ["post_id"],
+        dasherize: false,
+      });
+      expect(xml).toContain("<post_id>");
+    });
+
+    it("to_xml threads camelize through the root, children, and attribute tags", async () => {
+      const xml = await Comment.where({ type: "Comment" }).toXml({
+        skipTypes: true,
+        skipInstruct: true,
+        only: ["post_id"],
+        camelize: "lower",
+      });
+      expect(xml).toContain("<postId>");
+    });
+
     it("delegates connection, primary_key, table_name and transaction to the model", async () => {
       const relation = Comment.all();
       expect(relation.tableName).toBe(Comment.tableName);

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -548,6 +548,19 @@ describe("DelegationTest", () => {
       );
     });
 
+    it("to_xml threads dasherize/camelize through the empty-collection default root", async () => {
+      // conversions.rb:189-195: the empty default is the pre-rename value
+      // "nil_classes", so `dasherize: false` keeps the underscore and `camelize`
+      // capitalizes it — the pre-dashed literal would defeat both.
+      const empty = Comment.where({ id: -1 });
+      expect(await empty.toXml({ skipInstruct: true, dasherize: false })).toBe(
+        '<nil_classes type="array"/>',
+      );
+      expect(await Comment.where({ id: -1 }).toXml({ skipInstruct: true, camelize: true })).toBe(
+        '<NilClasses type="array"/>',
+      );
+    });
+
     it("to_xml threads dasherize false through the root, children, and attribute tags", async () => {
       // conversions_test.rb:171-178: `dasherize: false` leaves the underscored
       // key form intact on every tag produced from the shared options hash.

--- a/packages/activerecord/src/relation/delegation.test.ts
+++ b/packages/activerecord/src/relation/delegation.test.ts
@@ -583,6 +583,20 @@ describe("DelegationTest", () => {
       expect(xml).toContain("<postId>");
     });
 
+    it("to_xml threads camelize true through the root, children, and attribute tags together", async () => {
+      // The same options hash camelizes the collection root, each child element,
+      // AND every attribute tag uniformly (conversions.rb:200-201 + to_tag).
+      const xml = await Comment.where({ type: "Comment" }).toXml({
+        skipTypes: true,
+        skipInstruct: true,
+        only: ["post_id"],
+        camelize: true,
+      });
+      expect(xml).toContain("<Comments>");
+      expect(xml).toContain("<Comment>");
+      expect(xml).toContain("<PostId>");
+    });
+
     it("delegates connection, primary_key, table_name and transaction to the model", async () => {
       const relation = Comment.all();
       expect(relation.tableName).toBe(Comment.tableName);

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -14,7 +14,6 @@ import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/
 import type { SerializeOptions } from "@blazetrails/activemodel";
 import {
   Delegation as ASDelegation,
-  underscore,
   renameKey,
   type RenameKeyOptions,
   inGroups,
@@ -898,17 +897,22 @@ export class DelegationMethods {
         : records.every((r) => r.constructor === records[0].constructor)
           ? (records[0].constructor as { modelName: { plural: string } }).modelName.plural
           : "objects");
-    const children = options.children ?? singularize(root);
     const renameOptions: RenameKeyOptions = {
       dasherize: options.dasherize,
       camelize: options.camelize,
     };
-    const rootTag = renameKey(underscore(root), renameOptions);
+    // conversions.rb:200-201: Rails renames the root FIRST, then singularizes
+    // the already-renamed root for the child name — never underscoring the
+    // (already snake_case, or caller-supplied) root string. `to_tag` then
+    // re-applies `rename_key` to each child, which is idempotent since the name
+    // is already in target form.
+    const rootTag = renameKey(root, renameOptions);
+    const children = options.children ?? singularize(rootTag);
     const arrayAttr = skipTypes ? "" : ' type="array"';
 
     const instruct = skipInstruct ? "" : '<?xml version="1.0" encoding="UTF-8"?>\n';
-    // Pass the raw (un-transformed) child name as each record's `:root`; the
-    // record's own `toXml` applies the same `renameKey` transform, so root,
+    // Each record's own `toXml` re-applies the same `renameKey` transform to its
+    // `:root`; passing the already-renamed `children` is idempotent, so root,
     // children, and attribute tags all honor `dasherize:`/`camelize:` uniformly.
     const childOpts = { ...recordOptions, root: children };
 

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -893,7 +893,11 @@ export class DelegationMethods {
     const root =
       options.root ??
       (records.length === 0
-        ? "nil-classes"
+        ? // conversions.rb:189-195: the empty default is the *pre-rename* value
+          // `underscore(NilClass.name).pluralize` = "nil_classes"; `renameKey`
+          // below dashes it to "nil-classes" under default options and composes
+          // correctly with `dasherize: false` / `camelize:`.
+          "nil_classes"
         : records.every((r) => r.constructor === records[0].constructor)
           ? (records[0].constructor as { modelName: { plural: string } }).modelName.plural
           : "objects");

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -14,7 +14,9 @@ import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/
 import type { SerializeOptions } from "@blazetrails/activemodel";
 import {
   Delegation as ASDelegation,
-  dasherize,
+  underscore,
+  renameKey,
+  type RenameKeyOptions,
   inGroups,
   inGroupsOf,
   singularize,
@@ -649,17 +651,20 @@ export type ToSentenceOptions = {
 };
 
 /** Options for the collection {@link DelegationMethods.toXml} serializer. */
-export type ToXmlOptions = SerializeOptions & {
-  root?: string;
-  children?: string;
-  skipTypes?: boolean;
-  skipInstruct?: boolean;
-};
+export type ToXmlOptions = SerializeOptions &
+  RenameKeyOptions & {
+    root?: string;
+    children?: string;
+    skipTypes?: boolean;
+    skipInstruct?: boolean;
+  };
 
 /** A record that knows how to serialize itself to XML (ActiveModel#to_xml). */
 interface XmlSerializable {
   constructor: unknown;
-  toXml(options?: SerializeOptions & { root?: string; skipTypes?: boolean }): string;
+  toXml(
+    options?: SerializeOptions & RenameKeyOptions & { root?: string; skipTypes?: boolean },
+  ): string;
 }
 
 /**
@@ -894,12 +899,18 @@ export class DelegationMethods {
           ? (records[0].constructor as { modelName: { plural: string } }).modelName.plural
           : "objects");
     const children = options.children ?? singularize(root);
-    const rootTag = dasherize(root);
-    const childTag = dasherize(children);
+    const renameOptions: RenameKeyOptions = {
+      dasherize: options.dasherize,
+      camelize: options.camelize,
+    };
+    const rootTag = renameKey(underscore(root), renameOptions);
     const arrayAttr = skipTypes ? "" : ' type="array"';
 
     const instruct = skipInstruct ? "" : '<?xml version="1.0" encoding="UTF-8"?>\n';
-    const childOpts = { ...recordOptions, root: childTag };
+    // Pass the raw (un-transformed) child name as each record's `:root`; the
+    // record's own `toXml` applies the same `renameKey` transform, so root,
+    // children, and attribute tags all honor `dasherize:`/`camelize:` uniformly.
+    const childOpts = { ...recordOptions, root: children };
 
     if (records.length === 0) {
       return `${instruct}<${rootTag}${arrayAttr}/>`;

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -193,11 +193,12 @@ describe("RelationTest", () => {
     const xml = await baseTopics.toXml({ only: ["id"], methods: ["topicId"] });
     const topics = await Topic.where({ type: null });
     expect(xml).toContain('<topics type="array">');
-    // trails method names are camelCase, so the serialized tag is `topicId`
-    // (Rails' snake_case `topic_id` would dasherize to `topic-id`). The
-    // `type="integer"` attribute is adapter-dependent (PG/MariaDB return the id
-    // as BigInt/string, not JS number), so match the tag agnostically.
-    expect(xml).toMatch(new RegExp(`<topicId[^>]*>${topics[0].id}</topicId>`));
+    // The camelCase method name `topicId` is underscored then dasherized by
+    // `renameKey`, yielding Rails' `<topic-id>` tag (matching Ruby's snake_case
+    // `topic_id` method). The `type="integer"` attribute is adapter-dependent
+    // (PG/MariaDB return the id as BigInt/string, not JS number), so match the
+    // tag agnostically.
+    expect(xml).toMatch(new RegExp(`<topic-id[^>]*>${topics[0].id}</topic-id>`));
   });
 
   it("scoped all", async () => {

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -165,6 +165,8 @@ export {
 
 export { Inflections, loadDefaults } from "./inflector/inflections.js";
 
+export { renameKey, type RenameKeyOptions } from "./xml-mini.js";
+
 export {
   isBlank,
   isPresent,

--- a/packages/activesupport/src/xml-mini.test.ts
+++ b/packages/activesupport/src/xml-mini.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { dasherize, camelize } from "./inflector.js";
+import { renameKey } from "./xml-mini.js";
 
 describe("ParsingTest", () => {
   it.skip("symbol");
@@ -17,28 +17,6 @@ describe("ParsingTest", () => {
 });
 
 describe("RenameKeyTest", () => {
-  // renameKey: transform an underscore_key with dasherize/camelize options
-  function renameKey(
-    key: string,
-    options: { dasherize?: boolean; camelize?: boolean | "lower" | "upper" } = {},
-  ): string {
-    let result = key;
-    if (options.camelize === true || options.camelize === "upper") {
-      result = camelize(result, true);
-    } else if (options.camelize === "lower") {
-      result = camelize(result, false);
-    } else if (options.dasherize !== false) {
-      // Extract leading/trailing underscores
-      const leadingMatch = result.match(/^(_+)/);
-      const trailingMatch = result.match(/(_+)$/);
-      const leading = leadingMatch ? leadingMatch[1] : "";
-      const trailing = trailingMatch ? trailingMatch[1] : "";
-      const inner = result.slice(leading.length, result.length - trailing.length);
-      result = leading + dasherize(inner) + trailing;
-    }
-    return result;
-  }
-
   it("rename key dasherizes by default", () => {
     expect(renameKey("hello_world")).toBe("hello-world");
   });

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -1,0 +1,43 @@
+import { camelize } from "./inflector.js";
+
+export interface RenameKeyOptions {
+  /** Convert `snake_case` keys to `dashed-keys`. Defaults to `true`. */
+  dasherize?: boolean;
+  /** Camelize the key first: `true`/`"upper"` for UpperCamel, `"lower"` for lowerCamel. */
+  camelize?: boolean | "lower" | "upper";
+}
+
+/**
+ * Dasherize an `underscore_key`, preserving any leading/trailing underscores.
+ *
+ * Mirrors: ActiveSupport::XmlMini._dasherize — the `$2` (interior) capture is
+ * non-greedy so surrounding runs of underscores are left untouched and only the
+ * interior `_`/space characters become `-`.
+ */
+function underscoreToDash(key: string): string {
+  const match = /^(_*)([\s\S]*?)(_*)$/.exec(key.trim());
+  if (!match) return key;
+  const [, left, middle, right] = match;
+  return `${left}${middle.replace(/[_ ]/g, "-")}${right}`;
+}
+
+/**
+ * Apply the `camelize`/`dasherize` key transforms to a single XML tag name.
+ *
+ * Mirrors: ActiveSupport::XmlMini.rename_key — camelize (when requested) runs
+ * first, then dasherize (default `true`) runs on the result. Both transforms
+ * compose exactly as in Rails, so `camelize: true` still passes through
+ * `_dasherize` (a no-op on an already-camelized, underscore-free key).
+ */
+export function renameKey(key: string, options: RenameKeyOptions = {}): string {
+  const { camelize: camelizeOpt } = options;
+  const dasherize = options.dasherize === undefined || options.dasherize;
+  let result = key;
+  if (camelizeOpt) {
+    result = camelizeOpt === true ? camelize(result) : camelize(result, camelizeOpt);
+  }
+  if (dasherize) {
+    result = underscoreToDash(result);
+  }
+  return result;
+}


### PR DESCRIPTION
## Summary

Ports `ActiveSupport::XmlMini.rename_key` (`xml_mini.rb:152-159`) as a shared
`renameKey(key, { dasherize, camelize })` helper and threads the
`dasherize:`/`camelize:` options from the same options hash through **both**
XML serializers so the collection root, child element, and every attribute tag
transform uniformly:

- `Model#toXml` / `_hashToXml` — root, nested-hash, and per-attribute tags.
- `Relation#toXml` — collection root, children, and per-record tags.

`renameKey` is a faithful port: `camelize` (true / `"lower"` / `"upper"`) runs
first, then `dasherize` (default `true`), preserving leading/trailing
underscores via the non-greedy `_dasherize` regex.

## camelCase → snake_case mapping

trails serializes camelCase attribute keys, whereas Rails' `rename_key` operates
on `snake_case` keys. Each serializer therefore `underscore`s the key before
calling `renameKey`, mapping camelCase through the Rails underscore-then-transform
path so tag names match Rails verbatim (`conversions_test.rb:171-189` dasherize
cases and the single-record `xml_serialization` cases): `streetAddress` →
`street_address` → `street-address` (default), `street_address` (`dasherize:false`),
`streetAddress` (`camelize:"lower"`).

## Tests

- `RenameKeyTest` now exercises the real exported helper.
- Added dasherize/camelize coverage to `Model#toXml` and `Relation#toXml`.

Closes-story: xml-mini-rename-key-dasherize-camelize