### PR TITLE
fix(associations): run OO concatRecords insert inside add_to_target block

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -235,7 +235,7 @@ export class CollectionAssociation extends Association {
       // before_add abort (`added == null`) skips the yield, so `inserted`
       // stays true and the fold leaves `result` unchanged.
       let inserted = true;
-      await this.addToTargetAsync(record, {}, async () => {
+      await this.addToTarget(record, {}, async () => {
         // `resultStillTrue === false` → a prior record failed, so Rails'
         // `result &&= insert_record` short-circuits the save.
         if (this.owner.isNewRecord() || !resultStillTrue) return;
@@ -517,34 +517,31 @@ export class CollectionAssociation extends Association {
   }
 
   /**
-   * Add a record to the in-memory target array, firing callbacks
-   * and setting inverse associations.
+   * Add a record to the in-memory target array, firing callbacks and setting
+   * inverse associations. Mirrors Rails' single `add_to_target(record, &block)`
+   * (collection_association.rb:281-283): when a `save` callback is supplied it
+   * runs at Rails' `yield(record)` point — after `set_inverse_instance`, before
+   * the target mutation and after_add — and the method returns a promise.
+   * `concatRecords` passes the per-record insert as `save` so it runs inside the
+   * add funnel; the target push happens regardless of the save result (Rails
+   * relies on the surrounding `raise Rollback` to undo a failed insert), keeping
+   * the OO path's membership behavior unchanged. Sync callers (build/replace,
+   * no `save`) get the synchronous return.
    */
+  addToTarget(record: Base, options?: { skipCallbacks?: boolean; replace?: boolean }): Base | null;
+  addToTarget(
+    record: Base,
+    options: { skipCallbacks?: boolean; replace?: boolean },
+    save: () => Promise<void>,
+  ): Promise<Base | null>;
   addToTarget(
     record: Base,
     options: { skipCallbacks?: boolean; replace?: boolean } = {},
-  ): Base | null {
-    const { skipCallbacks = false, replace: shouldReplace = false } = options;
-    return replaceOnTarget(this, record, skipCallbacks, shouldReplace);
-  }
-
-  /**
-   * Async sibling of `addToTarget` that runs `save` between
-   * `set_inverse_instance` and the target mutation, mirroring Rails'
-   * `replace_on_target`'s `yield(record)` step (collection_association.rb:457-483).
-   * `concatRecords` uses it to `insert_record` inside the add funnel; the target
-   * push happens regardless of the save result (Rails relies on the surrounding
-   * `raise Rollback` to undo a failed insert), keeping the OO path's membership
-   * behavior unchanged.
-   * @internal
-   */
-  addToTargetAsync(
-    record: Base,
-    options: { skipCallbacks?: boolean; replace?: boolean } = {},
     save?: () => Promise<void>,
-  ): Promise<Base | null> {
+  ): Base | null | Promise<Base | null> {
     const { skipCallbacks = false, replace: shouldReplace = false } = options;
-    return replaceOnTargetAsync(this, record, skipCallbacks, shouldReplace, save);
+    if (save) return replaceOnTargetAsync(this, record, skipCallbacks, shouldReplace, save);
+    return replaceOnTarget(this, record, skipCallbacks, shouldReplace);
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -1107,6 +1107,48 @@ function replaceCommonRecordsInMemory(
   }
 }
 
+/**
+ * Rails `replace_on_target`'s pre-`yield` half: the index lookup, `before_add`
+ * abort check, `set_inverse_instance`, and `@association_ids` reset. Returns the
+ * replace index (`-1` when appending) or `null` when `before_add` aborted the
+ * add (Rails' `catch(:abort) { ... } || return`). Shared by the sync
+ * `replaceOnTarget` and the async `replaceOnTargetAsync` so both stay in parity.
+ * @internal
+ */
+function beginReplaceOnTarget(
+  assoc: CollectionAssociation,
+  record: Base,
+  skipCallbacks: boolean,
+  replace: boolean,
+): number | null {
+  const index = replace ? assoc.target.indexOf(record) : -1;
+  if (!skipCallbacks && !callback(assoc, "beforeAdd", record)) return null;
+  assoc.setInverseInstance(record);
+  (assoc as any)._associationIds = null;
+  return index;
+}
+
+/**
+ * Rails `replace_on_target`'s post-`yield` half: the target mutation and
+ * `after_add` callback.
+ * @internal
+ */
+function finishReplaceOnTarget(
+  assoc: CollectionAssociation,
+  record: Base,
+  skipCallbacks: boolean,
+  index: number,
+): Base {
+  const target = assoc.target;
+  if (index !== -1) {
+    target[index] = record;
+  } else {
+    target.push(record);
+  }
+  if (!skipCallbacks) callback(assoc, "afterAdd", record);
+  return record;
+}
+
 /** @internal */
 function replaceOnTarget(
   assoc: CollectionAssociation,
@@ -1114,28 +1156,9 @@ function replaceOnTarget(
   skipCallbacks: boolean,
   replace: boolean,
 ): Base | null {
-  const replaced = assoc as any;
-  let index = -1;
-  if (replace) {
-    index = assoc.target.indexOf(record);
-  }
-
-  // Rails: catch(:abort) { callback(:before_add, record) } || return unless skip_callbacks
-  if (!skipCallbacks && !callback(assoc, "beforeAdd", record)) return null;
-
-  assoc.setInverseInstance(record);
-  replaced._associationIds = null;
-
-  const target = assoc.target;
-  if (index !== -1) {
-    target[index] = record;
-  } else {
-    target.push(record);
-  }
-
-  if (!skipCallbacks) callback(assoc, "afterAdd", record);
-
-  return record;
+  const index = beginReplaceOnTarget(assoc, record, skipCallbacks, replace);
+  if (index === null) return null;
+  return finishReplaceOnTarget(assoc, record, skipCallbacks, index);
 }
 
 /**
@@ -1152,29 +1175,10 @@ async function replaceOnTargetAsync(
   replace: boolean,
   save?: () => Promise<void>,
 ): Promise<Base | null> {
-  const replaced = assoc as any;
-  let index = -1;
-  if (replace) {
-    index = assoc.target.indexOf(record);
-  }
-
-  if (!skipCallbacks && !callback(assoc, "beforeAdd", record)) return null;
-
-  assoc.setInverseInstance(record);
-  replaced._associationIds = null;
-
+  const index = beginReplaceOnTarget(assoc, record, skipCallbacks, replace);
+  if (index === null) return null;
   if (save) await save();
-
-  const target = assoc.target;
-  if (index !== -1) {
-    target[index] = record;
-  } else {
-    target.push(record);
-  }
-
-  if (!skipCallbacks) callback(assoc, "afterAdd", record);
-
-  return record;
+  return finishReplaceOnTarget(assoc, record, skipCallbacks, index);
 }
 
 /**

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -228,12 +228,20 @@ export class CollectionAssociation extends Association {
   protected async concatRecords(records: Base[], shouldRaise = false): Promise<Base[]> {
     await concatRecordsLoop(records, async (record, resultStillTrue) => {
       (this as any).raiseOnTypeMismatchBang(record);
-      const added = this.addToTarget(record);
-      // `!added` → before_add aborted; `resultStillTrue === false` → a prior
-      // record failed, so Rails' `result &&= insert_record` short-circuits the
-      // save while still buffering this record above.
-      if (!added || this.owner.isNewRecord() || !resultStillTrue) return true;
-      return await this.insertRecord(record, true, shouldRaise);
+      // Mirror Rails' `add_to_target(record) { insert_record }`
+      // (collection_association.rb:440-446): the insert runs *inside* the
+      // funnel — after before_add + set_inverse_instance, before the target
+      // mutation and after_add — rather than after the whole add. A
+      // before_add abort (`added == null`) skips the yield, so `inserted`
+      // stays true and the fold leaves `result` unchanged.
+      let inserted = true;
+      await this.addToTargetAsync(record, {}, async () => {
+        // `resultStillTrue === false` → a prior record failed, so Rails'
+        // `result &&= insert_record` short-circuits the save.
+        if (this.owner.isNewRecord() || !resultStillTrue) return;
+        inserted = await this.insertRecord(record, true, shouldRaise);
+      });
+      return inserted;
     });
     return records;
   }
@@ -518,6 +526,25 @@ export class CollectionAssociation extends Association {
   ): Base | null {
     const { skipCallbacks = false, replace: shouldReplace = false } = options;
     return replaceOnTarget(this, record, skipCallbacks, shouldReplace);
+  }
+
+  /**
+   * Async sibling of `addToTarget` that runs `save` between
+   * `set_inverse_instance` and the target mutation, mirroring Rails'
+   * `replace_on_target`'s `yield(record)` step (collection_association.rb:457-483).
+   * `concatRecords` uses it to `insert_record` inside the add funnel; the target
+   * push happens regardless of the save result (Rails relies on the surrounding
+   * `raise Rollback` to undo a failed insert), keeping the OO path's membership
+   * behavior unchanged.
+   * @internal
+   */
+  addToTargetAsync(
+    record: Base,
+    options: { skipCallbacks?: boolean; replace?: boolean } = {},
+    save?: () => Promise<void>,
+  ): Promise<Base | null> {
+    const { skipCallbacks = false, replace: shouldReplace = false } = options;
+    return replaceOnTargetAsync(this, record, skipCallbacks, shouldReplace, save);
   }
 
   /**
@@ -1098,6 +1125,45 @@ function replaceOnTarget(
 
   assoc.setInverseInstance(record);
   replaced._associationIds = null;
+
+  const target = assoc.target;
+  if (index !== -1) {
+    target[index] = record;
+  } else {
+    target.push(record);
+  }
+
+  if (!skipCallbacks) callback(assoc, "afterAdd", record);
+
+  return record;
+}
+
+/**
+ * Async twin of `replaceOnTarget`: runs `save` at Rails' `yield(record)` point
+ * — after `set_inverse_instance`, before the target mutation and after_add.
+ * Kept as a separate async function so the sync `replaceOnTarget` callers
+ * (build/replace paths) stay synchronous.
+ * @internal
+ */
+async function replaceOnTargetAsync(
+  assoc: CollectionAssociation,
+  record: Base,
+  skipCallbacks: boolean,
+  replace: boolean,
+  save?: () => Promise<void>,
+): Promise<Base | null> {
+  const replaced = assoc as any;
+  let index = -1;
+  if (replace) {
+    index = assoc.target.indexOf(record);
+  }
+
+  if (!skipCallbacks && !callback(assoc, "beforeAdd", record)) return null;
+
+  assoc.setInverseInstance(record);
+  replaced._associationIds = null;
+
+  if (save) await save();
 
   const target = assoc.target;
   if (index !== -1) {


### PR DESCRIPTION
## What

Rails' `CollectionAssociation#concat_records` yields `insert_record` **inside** the `add_to_target(record) { ... }` funnel (collection_association.rb:440-446), so the per-record ordering is:

before_add → set_inverse_instance → **insert** → target mutation → after_add.

trails' OO `concatRecords` ran `addToTarget` first and inserted afterward, firing after_add and committing the record to the target *before* the DB insert — inverting Rails' sequence.

## How

- Add `addToTargetAsync` and its `replaceOnTargetAsync` twin, which run a `save` callback at Rails' `yield(record)` point (after `set_inverse_instance`, before the target mutation and after_add). Kept separate from the sync `replaceOnTarget` so the build/replace paths stay synchronous.
- Route `concatRecords` through it so the insert runs inside the add funnel, gated on the same `result &&= insert_record` short-circuit as before.
- The target push still happens regardless of the insert result (Rails relies on `raise Rollback` to undo a failed insert), so OO membership behavior is unchanged.

The runtime `CollectionProxy#push` path — already faithful via `_addToTarget` — is untouched.

## Tests

Existing has-many / through / habtm / join-model / collection-proxy concat + replace/writer suites stay green (locally on sqlite).

## Review responses

**Save-returns-false semantics vs `_addToTarget`.** The OO path is the faithful one. Rails' `replace_on_target` runs `yield(record)` but never inspects its return value — only a raised exception unwinds before the post-yield target push (collection_association.rb:457-483), and `raise ActiveRecord::Rollback` rolls back the DB without reverting the in-memory `@target` array. So a non-raising failed save (`insertRecord(..., shouldRaise=false)` → `false`) still leaves the record in `target`, exactly as `replaceOnTargetAsync` now does. The proxy `_addToTarget`'s `if (save && !(await save())) return record;` early-exit is a pre-existing, self-documented workaround for the `create`/`_createThrough` path lacking a transaction wrap — a deviation, not the reference. Reconciling it is out of scope here and tracked as story `reconcile-addtotarget-save-falsy-early-return` (RFC 0033).

**`distinct_value` OR-in for `replace`.** Confirmed pre-existing gap, not introduced by this diff: the old `addToTarget(record)` this PR replaced also passed no `replace`, and `addToTarget`/`addToTargetAsync` still don't OR in `association_scope.distinct_value` (collection_association.rb:281-283) the way the proxy callers thread `{ replace: this.distinctValue }`. Kept out of this ordering-only convergence and tracked as story `oo-addtotarget-or-in-distinct-value` (RFC 0033).

Closes-story: oo-concatrecords-insert-inside-add-to-target
