### PR TITLE
fix(associations): normalize BigInt in belongs_to composite-FK staleState

### DIFF
--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -215,7 +215,14 @@ export class BelongsToAssociation extends SingularAssociation {
         ? (this.owner as any)._readAttribute(fk)
         : (this.owner as any)[fk],
     );
-    return values.length === 1 ? values[0] : JSON.stringify(values);
+    if (values.length === 1) return values[0];
+    // BigInt FK components (int8 under PG bigserial) can't go through
+    // JSON.stringify ("Do not know how to serialize a BigInt"); fold to their
+    // decimal string, mirroring CollectionAssociation#recordIdentity. The
+    // single-FK branch returns the raw value, so only the composite path needs
+    // this. The key stays deterministic — same source on every read.
+    const ids = values.map((v) => (typeof v === "bigint" ? v.toString() : v));
+    return JSON.stringify(ids);
   }
 
   protected override findTargetNeeded(): boolean {

--- a/packages/activerecord/src/associations/belongs-to-stale-state-bigint-composite-fk.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-stale-state-bigint-composite-fk.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Regression guard: `BelongsToAssociation#staleState` composite-FK path folds
+ * BigInt FK components before `JSON.stringify`. node-postgres deserializes int8
+ * columns (default under PG bigserial) to JS `BigInt`, which `JSON.stringify`
+ * rejects ("Do not know how to serialize a BigInt"). The composite-FK branch
+ * used a raw `JSON.stringify(values)`, so a `belongs_to` with a composite FK
+ * carrying a BigInt component threw on the stale-state check. Mirrors the
+ * `CollectionAssociation#recordIdentity` fix (fold `bigint` → `.toString()`).
+ */
+import { describe, it, expect } from "vitest";
+
+import { Base } from "../base.js";
+import { registerModel } from "../associations.js";
+
+class CpkStaleParent extends Base {
+  static _tableName = "cpk_stale_parents";
+  static {
+    this._primaryKey = ["blog_id", "id"];
+    this.attribute("blog_id", "integer");
+    this.attribute("id", "integer");
+  }
+}
+
+class CpkStaleChild extends Base {
+  static _tableName = "cpk_stale_children";
+  static {
+    this.attribute("blog_id", "integer");
+    this.attribute("blog_post_id", "integer");
+    this.belongsTo("blogPost", {
+      className: "CpkStaleParent",
+      foreignKey: ["blog_id", "blog_post_id"],
+    });
+  }
+}
+
+describe("belongs_to composite-FK staleState with a BigInt component", () => {
+  registerModel(CpkStaleParent);
+  registerModel(CpkStaleChild);
+
+  it("serializes a BigInt FK component without throwing", () => {
+    const child = new CpkStaleChild({ blog_id: 1, blog_post_id: 9007199254740993n });
+    const holder = child.association("blogPost") as unknown as { staleState(): unknown };
+
+    let state: unknown;
+    expect(() => {
+      state = holder.staleState();
+    }).not.toThrow();
+    expect(state).toBe(JSON.stringify([1, "9007199254740993"]));
+  });
+
+  it("preserves a deterministic key across reads", () => {
+    const child = new CpkStaleChild({ blog_id: 2, blog_post_id: 9007199254740993n });
+    const holder = child.association("blogPost") as unknown as { staleState(): unknown };
+
+    expect(holder.staleState()).toBe(holder.staleState());
+  });
+});

--- a/packages/activerecord/src/associations/belongs-to-stale-state-bigint-composite-fk.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-stale-state-bigint-composite-fk.test.ts
@@ -4,16 +4,25 @@
  * columns (default under PG bigserial) to JS `BigInt`, which `JSON.stringify`
  * rejects ("Do not know how to serialize a BigInt"). The composite-FK branch
  * used a raw `JSON.stringify(values)`, so a `belongs_to` with a composite FK
- * carrying a BigInt component threw on the stale-state check. Mirrors the
- * `CollectionAssociation#recordIdentity` fix (fold `bigint` → `.toString()`).
+ * carrying a BigInt component threw on the stale-state check. The single-FK
+ * branch returns the raw value, so only the composite path was affected.
+ * Mirrors the `CollectionAssociation#recordIdentity` fix (fold `bigint` →
+ * `.toString()`).
+ *
+ * `staleState` reads the owner's in-memory FK attributes, so this exercises the
+ * path with no database round-trip. The models mirror the canonical
+ * `Sharded::Comment` → `blog_post_with_inverse` shape (composite FK
+ * `[blog_id, blog_post_id]`); the columns are declared here so the in-memory
+ * owner carries the BigInt component without a schema load, following the
+ * sibling `belongs-to-inverse-seed-composite-pk.test.ts` pattern.
  */
 import { describe, it, expect } from "vitest";
 
 import { Base } from "../base.js";
 import { registerModel } from "../associations.js";
 
-class CpkStaleParent extends Base {
-  static _tableName = "cpk_stale_parents";
+class BigIntCpkBlogPost extends Base {
+  static _tableName = "bigint_cpk_blog_posts";
   static {
     this._primaryKey = ["blog_id", "id"];
     this.attribute("blog_id", "integer");
@@ -21,25 +30,28 @@ class CpkStaleParent extends Base {
   }
 }
 
-class CpkStaleChild extends Base {
-  static _tableName = "cpk_stale_children";
+class BigIntCpkComment extends Base {
+  static _tableName = "bigint_cpk_comments";
   static {
     this.attribute("blog_id", "integer");
     this.attribute("blog_post_id", "integer");
-    this.belongsTo("blogPost", {
-      className: "CpkStaleParent",
+    this.belongsTo("blogPostWithInverse", {
+      className: "BigIntCpkBlogPost",
       foreignKey: ["blog_id", "blog_post_id"],
+      primaryKey: ["blog_id", "id"],
     });
   }
 }
 
 describe("belongs_to composite-FK staleState with a BigInt component", () => {
-  registerModel(CpkStaleParent);
-  registerModel(CpkStaleChild);
+  registerModel(BigIntCpkBlogPost);
+  registerModel(BigIntCpkComment);
 
   it("serializes a BigInt FK component without throwing", () => {
-    const child = new CpkStaleChild({ blog_id: 1, blog_post_id: 9007199254740993n });
-    const holder = child.association("blogPost") as unknown as { staleState(): unknown };
+    const comment = new BigIntCpkComment({ blog_id: 1, blog_post_id: 9007199254740993n });
+    const holder = comment.association("blogPostWithInverse") as unknown as {
+      staleState(): unknown;
+    };
 
     let state: unknown;
     expect(() => {
@@ -49,8 +61,10 @@ describe("belongs_to composite-FK staleState with a BigInt component", () => {
   });
 
   it("preserves a deterministic key across reads", () => {
-    const child = new CpkStaleChild({ blog_id: 2, blog_post_id: 9007199254740993n });
-    const holder = child.association("blogPost") as unknown as { staleState(): unknown };
+    const comment = new BigIntCpkComment({ blog_id: 2, blog_post_id: 9007199254740993n });
+    const holder = comment.association("blogPostWithInverse") as unknown as {
+      staleState(): unknown;
+    };
 
     expect(holder.staleState()).toBe(holder.staleState());
   });


### PR DESCRIPTION
## Summary

`BelongsToAssociation#staleState` composite-FK branch did a raw
`JSON.stringify(values)`. node-postgres deserializes `int8` columns (default
under PG bigserial) to JS `BigInt`, which `JSON.stringify` rejects ("Do not
know how to serialize a BigInt") — so a `belongs_to` with a composite FK
carrying a BigInt component threw on the stale-state check. The single-FK
branch returns the raw value, so only the composite path was affected.

Fold `bigint` → `.toString()` before `JSON.stringify`, mirroring the
`CollectionAssociation#recordIdentity` fix. Deterministic key preserved.

Audited sibling `JSON.stringify` PK/FK sites: `has-one-association.ts`
stringifies `foreignKeyColumns()` (column *names* — safe); preloader
`_convertKey` is already BigInt-hardened.

## Test

New unit test exercises a composite-FK `belongs_to` with a BigInt FK
component; fails before the fix, passes after.

Closes-story: pg-bigint-belongs-to-stalestate-composite-key-serialize

## Review disposition

Review flagged (out of scope, correctly) that trails' *entire* composite-FK
`stale_state` branch — the `JSON.stringify(values)` shape, not just this PR's
BigInt fix — is a pre-existing deviation from Rails. Rails' `stale_state`
(`belongs_to_association.rb:164`) is `owner._read_attribute(reflection.foreign_key)`
with no array branch; an Array `foreign_key` flows through
`AttributeSet#fetch_value` (`attribute_set.rb:50`) and matches no stored
attribute, so Rails' composite `stale_state` never yields a real composite
value. Confirmed against vendored Rails.

This PR keeps its scope (BigInt normalization within the existing trails shape,
verified correct by review). The broader convergence is tracked as its own
story: `belongs-to-composite-fk-stale-state-rails-convergence`
(RFC 0030), rather than expanding this PR or reverting the fix.
