### PR TITLE
feat(normalization): normalize query values and changed-in-place attributes

### DIFF
--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -85,6 +85,7 @@ export type { SerializeOptions, SerializableHash } from "./serialization.js";
 // can import as `JSONSerializer` or alias on import.
 export { JSON as JSONSerializer } from "./serializers/json.js";
 export { Type } from "./type/value.js";
+export { normalizedValueType } from "./type/normalized-value.js";
 export { typeRegistry } from "./type/registry.js";
 
 export { StringType } from "./type/string.js";

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -270,6 +270,9 @@ export class Model {
     { fns: Array<(value: unknown) => unknown>; applyToNil: boolean }
   > = new Map();
 
+  /** Guards one-time `before_validation` registration per class (see `normalizes`). */
+  static _normalizeChangedInPlaceRegistered?: boolean;
+
   /**
    * Register a normalization function for one or more attributes.
    * The function is called before validation on every write.
@@ -315,6 +318,36 @@ export class Model {
       } else {
         this._normalizations.set(attr, { fns: [fn], applyToNil });
       }
+    }
+
+    // Rails' ActiveRecord::Normalization registers
+    // `before_validation :normalize_changed_in_place_attributes` at include
+    // time. We register it lazily on the first class in a hierarchy to call
+    // `normalizes` (subclasses inherit the callback via the copy-on-write
+    // chain, so the inherited-truthy guard keeps exactly one registration).
+    if (!this._normalizeChangedInPlaceRegistered) {
+      Object.defineProperty(this, "_normalizeChangedInPlaceRegistered", {
+        value: true,
+        writable: true,
+        configurable: true,
+      });
+      this.beforeValidation((record) => {
+        record.normalizeChangedInPlaceAttributes();
+      });
+    }
+  }
+
+  /**
+   * Re-normalize every normalized attribute that has changed in place, so a
+   * mutated value is normalized before validation and persistence.
+   *
+   * Mirrors: ActiveRecord::Normalization#normalize_changed_in_place_attributes
+   */
+  normalizeChangedInPlaceAttributes(): void {
+    const ctor = this.constructor as typeof Model;
+    if (!ctor._normalizations) return;
+    for (const name of ctor._normalizations.keys()) {
+      if (this.attributeChangedInPlace(name)) this.normalizeAttribute(name);
     }
   }
 
@@ -2412,9 +2445,17 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#attribute_changed_in_place?
    */
   attributeChangedInPlace(name: string): boolean {
-    const original = this._dirty.attributeWas(name);
+    // trails can't observe true in-place mutation of an immutable JS value, so
+    // we infer it: an attribute was changed *outside* the tracked write path
+    // (e.g. a direct `_attributes` write) when its live value no longer matches
+    // what dirty tracking recorded. A normal assignment records the new value
+    // as the change's right-hand side, so `current === recorded` and this
+    // returns false — the assignment path already normalized the value, and
+    // re-normalizing would double-apply a non-idempotent normalizer.
     const current = this.readAttribute(name);
-    // In-place change = same type but different identity
+    const recorded = this._dirty.mutationsFromDatabase[name];
+    if (recorded) return current !== recorded[1];
+    const original = this._dirty.attributeWas(name);
     if (original === undefined) return false;
     return original !== current;
   }

--- a/packages/activemodel/src/type/normalized-value.ts
+++ b/packages/activemodel/src/type/normalized-value.ts
@@ -1,0 +1,64 @@
+import { Type } from "./value.js";
+
+/**
+ * Decorates an underlying cast type with a normalizer. When `cast` is called,
+ * the value is first cast by the underlying type, then the normalizer is
+ * applied — this is the single point where normalization happens. Because
+ * trails always feeds an already-cast value into `serialize`
+ * (`Attribute#serialize(value)` where `value = type.cast(raw)`), `serialize`
+ * and `serializeCastValue` delegate straight to the underlying type WITHOUT
+ * re-normalizing; re-normalizing there would double-apply a non-idempotent
+ * normalizer on every save/query round-trip. Every other method (deserialize,
+ * isChanged, type metadata, …) delegates to the underlying type unchanged —
+ * notably `deserialize` does NOT normalize, so values read from the database
+ * are left as-is (Rails: normalization is applied on assignment and query, not
+ * on load).
+ *
+ * Mirrors: ActiveRecord::Normalization::NormalizedValueType, which is a
+ * `DelegateClass(ActiveModel::Type::Value)` overriding `cast`, `serialize`, and
+ * `serialize_cast_value`. We model the DelegateClass with a Proxy so the full
+ * surface of the wrapped type is forwarded, and normalize only in `cast`
+ * (relying on cast-value memoization to bound applications to one per write).
+ */
+export function normalizedValueType(
+  castType: Type,
+  normalizer: (value: unknown) => unknown,
+  normalizeNil: boolean,
+): Type {
+  const normalize = (value: unknown): unknown => {
+    if ((value === null || value === undefined) && !normalizeNil) return value;
+    return normalizer(value);
+  };
+
+  const cast = (value: unknown): unknown => normalize(castType.cast(value));
+
+  const overrides: Record<string | symbol, unknown> = {
+    cast,
+    serialize(value: unknown): unknown {
+      // Rails: serialize_cast_value(cast(value)). Normalize on serialize too so
+      // any query path that serializes a raw value (prepared-statement binds,
+      // `type_cast_for_database`) still normalizes it. Safe against double-apply
+      // because this wrapper is used only by the query-side type caster, never
+      // on the write path — and the query-time normalizers are idempotent.
+      return castType.serialize(cast(value));
+    },
+    serializeCastValue(value: unknown): unknown {
+      return castType.serializeCastValue(value as never);
+    },
+    // Rails exposes cast_type / normalizer / normalize_nil as attr_readers.
+    castType,
+    normalizer,
+    normalizeNil,
+  };
+
+  return new Proxy(castType, {
+    get(target, prop, receiver) {
+      if (prop in overrides) return overrides[prop];
+      const value = Reflect.get(target, prop, target);
+      // Bind delegated methods to the underlying type so that, e.g.,
+      // `deserialize` (which internally calls `this.cast`) uses the underlying
+      // type's un-normalized cast rather than the proxy's normalizing one.
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  }) as unknown as Type;
+}

--- a/packages/activemodel/src/validations/numericality.ts
+++ b/packages/activemodel/src/validations/numericality.ts
@@ -526,13 +526,11 @@ export function prepareValueForValidation(
   // Rails has an early `return value if record_attribute_changed_in_place?`
   // short-circuit (numericality.rb:121) — in-place mutation means the
   // cast value IS what the user just changed; raw before_type_cast is
-  // stale. Trails skips this optimization today because
-  // `Model.attributeChangedInPlace` returns true for ANY change (not
-  // just in-place mutation), so honoring the short-circuit would let
-  // normal `10 → "abc"` updates bypass numericality. The
-  // `isRecordAttributeChangedInPlace` helper is still exported (Rails
-  // parity surface), it just isn't a gate here yet. Revisit once
-  // trails grows true in-place-mutation tracking.
+  // stale. Trails does not yet gate on this: `isRecordAttributeChangedInPlace`
+  // is exported (Rails parity surface) but unused here. `attributeChangedInPlace`
+  // now infers genuine in-place mutation (value diverged from tracked change),
+  // so wiring the short-circuit is plausible — but left for a focused change
+  // with its own coverage rather than as a side effect of this path.
   //
   // Trails exposes raw values through the generic
   // `readAttributeBeforeTypeCast(name)` API on Model rather than the

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -195,10 +195,7 @@ import {
   idBeforeTypeCast as _idBeforeTypeCast,
   isSavedChanges as _isSavedChanges,
 } from "./attribute-methods.js";
-import {
-  normalizeChangedInPlaceAttributes as _normalizeChangedInPlaceAttributesFn,
-  normalizedAttributes as _normalizedAttributes,
-} from "./normalization.js";
+import { normalizedAttributes as _normalizedAttributes } from "./normalization.js";
 import {
   toKey as _toKey,
   getId as _getId,
@@ -4852,10 +4849,11 @@ include(Base, {
   hasDeferTouchAttrs(this: Base) {
     return TouchLater.hasDeferTouchAttrs(this);
   },
-  // normalizeChangedInPlaceAttributes is not on Model; safe to wire.
-  normalizeChangedInPlaceAttributes(this: Base) {
-    return _normalizeChangedInPlaceAttributesFn(this);
-  },
+  // normalizeChangedInPlaceAttributes now lives on Model.prototype (this PR wires
+  // the before_validation there). Reference it directly so api:compare credits
+  // base.ts without a wrapper that would shadow — and diverge from — the single
+  // Model implementation.
+  normalizeChangedInPlaceAttributes: Model.prototype.normalizeChangedInPlaceAttributes,
   // normalizeAttribute lives on Model.prototype (inherited). Wire via direct
   // prototype reference so api:compare credits it to base.ts without shadowing
   // Model's implementation via a wrapper that would create a circular call.

--- a/packages/activerecord/src/normalization.ts
+++ b/packages/activerecord/src/normalization.ts
@@ -104,24 +104,6 @@ export function normalize(normalizedType: NormalizedValueType, value: unknown): 
   return normalizedType.normalizer(value);
 }
 
-/**
- * For each normalized attribute that changed in place, re-normalize its value.
- *
- * Mirrors: ActiveRecord::Normalization#normalize_changed_in_place_attributes (private)
- *
- * @internal
- */
-export function normalizeChangedInPlaceAttributes(record: any): void {
-  // Rails: self.class.normalized_attributes (Set from class_attribute).
-  // TS activemodel stores normalizations in Model._normalizations (Map<string, ...>).
-  const normalizations: Map<string, unknown> | undefined = record.constructor?._normalizations;
-  if (!normalizations) return;
-  for (const name of normalizations.keys()) {
-    if (
-      typeof record.attributeChangedInPlace === "function" &&
-      record.attributeChangedInPlace(name)
-    ) {
-      record.normalizeAttribute(name);
-    }
-  }
-}
+// `normalize_changed_in_place_attributes` lives on ActiveModel::Model
+// (`Model.prototype.normalizeChangedInPlaceAttributes`) and is wired onto Base
+// there; base.ts references that single implementation directly.

--- a/packages/activerecord/src/normalized-attribute.test.ts
+++ b/packages/activerecord/src/normalized-attribute.test.ts
@@ -70,7 +70,7 @@ describe("NormalizedAttributeTest", () => {
   // Skipped pending RFC 0030 story `normalizes-query-and-in-place-type-decoration`:
   // `valid?` does not re-normalize changed-in-place attributes before
   // validation, so `validated_name` keeps the un-normalized in-place value.
-  it.skip("normalizes changed-in-place value before validation", async () => {
+  it("normalizes changed-in-place value before validation", async () => {
     aircraft._attributes.set("name", "fly high");
     expect(aircraft.name).toBe("fly high");
 
@@ -123,7 +123,7 @@ describe("NormalizedAttributeTest", () => {
   // Skipped pending RFC 0030 story `normalizes-query-and-in-place-type-decoration`:
   // trails normalizes on write but does not wire NormalizedValueType into the
   // query path, so `find_by` does not normalize the query value (noon) here.
-  it.skip("finds record by normalized value", async () => {
+  it("finds record by normalized value", async () => {
     expect((aircraft.manufactured_at as Temporal.Instant).equals(noon(time))).toBe(true);
     const found = await NormalizedAircraft.findBy({ manufactured_at: time.toString() });
     expect(found).not.toBeNull();
@@ -133,7 +133,7 @@ describe("NormalizedAttributeTest", () => {
   // Skipped pending RFC 0030 story `normalizes-query-and-in-place-type-decoration`:
   // `where` does not normalize query values, so `where(name: "")` renders `= ''`
   // instead of normalizing `""` -> nil -> `IS NULL`.
-  it.skip("uses the same query when finding record by nil and normalized nil values", () => {
+  it("uses the same query when finding record by nil and normalized nil values", () => {
     expect(NormalizedAircraft.where({ name: null }).toSql()).toBe(
       NormalizedAircraft.where({ name: "" }).toSql(),
     );
@@ -154,7 +154,7 @@ describe("NormalizedAttributeTest", () => {
   // Skipped pending RFC 0030 story `normalizes-query-and-in-place-type-decoration`:
   // the changed-in-place portion (`name.replace("0")` then `save`) requires
   // re-normalizing mutated values before save, which trails does not yet wire.
-  it.skip("minimizes number of times normalization is applied", async () => {
+  it("minimizes number of times normalization is applied", async () => {
     const CountApplied = class extends Aircraft {};
     CountApplied.normalizes("name", (name: unknown) => succ(name as string));
 

--- a/packages/activerecord/src/normalized-attribute.test.ts
+++ b/packages/activerecord/src/normalized-attribute.test.ts
@@ -67,9 +67,6 @@ describe("NormalizedAttributeTest", () => {
     expect(aircraft.name).toBe("Fly Higher");
   });
 
-  // Skipped pending RFC 0030 story `normalizes-query-and-in-place-type-decoration`:
-  // `valid?` does not re-normalize changed-in-place attributes before
-  // validation, so `validated_name` keeps the un-normalized in-place value.
   it("normalizes changed-in-place value before validation", async () => {
     aircraft._attributes.set("name", "fly high");
     expect(aircraft.name).toBe("fly high");
@@ -120,9 +117,6 @@ describe("NormalizedAttributeTest", () => {
     expect(fromDatabase.name).toBe("NOT titlecase");
   });
 
-  // Skipped pending RFC 0030 story `normalizes-query-and-in-place-type-decoration`:
-  // trails normalizes on write but does not wire NormalizedValueType into the
-  // query path, so `find_by` does not normalize the query value (noon) here.
   it("finds record by normalized value", async () => {
     expect((aircraft.manufactured_at as Temporal.Instant).equals(noon(time))).toBe(true);
     const found = await NormalizedAircraft.findBy({ manufactured_at: time.toString() });
@@ -130,9 +124,6 @@ describe("NormalizedAttributeTest", () => {
     expect(found!.id).toBe(aircraft.id);
   });
 
-  // Skipped pending RFC 0030 story `normalizes-query-and-in-place-type-decoration`:
-  // `where` does not normalize query values, so `where(name: "")` renders `= ''`
-  // instead of normalizing `""` -> nil -> `IS NULL`.
   it("uses the same query when finding record by nil and normalized nil values", () => {
     expect(NormalizedAircraft.where({ name: null }).toSql()).toBe(
       NormalizedAircraft.where({ name: "" }).toSql(),
@@ -151,9 +142,6 @@ describe("NormalizedAttributeTest", () => {
     expect(NormalizedAircraft.normalizeValueFor("name", "ONLY titlecase")).toBe("Only Titlecase");
   });
 
-  // Skipped pending RFC 0030 story `normalizes-query-and-in-place-type-decoration`:
-  // the changed-in-place portion (`name.replace("0")` then `save`) requires
-  // re-normalizing mutated values before save, which trails does not yet wire.
   it("minimizes number of times normalization is applied", async () => {
     const CountApplied = class extends Aircraft {};
     CountApplied.normalizes("name", (name: unknown) => succ(name as string));

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -432,10 +432,14 @@ export class PredicateBuilder {
       value = (value as { id: unknown }).id;
     }
     // Rails applies the attribute's cast type — including any NormalizedValueType
-    // decoration — to `where`/`find_by` keyword arguments. Normalize the query
-    // value here so a normalizer that maps to nil (e.g. `presence`) routes through
-    // the same `IS NULL` path as an explicit nil, matching `where(col: nil)`.
-    value = this.normalizeQueryValue(attribute.name, value);
+    // decoration — to `where`/`find_by` keyword arguments. Normalize the scalar
+    // query value here so a normalizer that maps to nil (e.g. `presence`) routes
+    // through the same `IS NULL` path as an explicit nil, matching
+    // `where(col: nil)`. Multi-value forms (Array/Set/Range/Relation) are left
+    // for their handlers, which normalize each element via the wrapped bind type.
+    if (this.isScalarQueryValue(value)) {
+      value = this.normalizeQueryValue(attribute.name, value);
+    }
     if (value === null || value === undefined) {
       return attribute.isNull();
     }
@@ -470,11 +474,26 @@ export class PredicateBuilder {
    * decorated type's `cast` casts then normalizes, mirroring Rails'
    * `type_for_attribute(name).cast(value)`.
    */
+  /**
+   * A scalar reaches the equality/`basicObjectHandler` path where a single
+   * normalized value applies. Multi-value forms (Array/Set/Range/Relation) and
+   * StatementCache Substitute placeholders are excluded: their elements are
+   * normalized later by the wrapped bind type, and a Substitute must stay
+   * un-cast so the cached statement binds the real value at execution time.
+   */
+  private isScalarQueryValue(value: unknown): boolean {
+    return !(
+      value === null ||
+      value === undefined ||
+      Array.isArray(value) ||
+      value instanceof Set ||
+      value instanceof Range ||
+      value instanceof Substitute ||
+      this.isRelation(value)
+    );
+  }
+
   private normalizeQueryValue(columnName: string, value: unknown): unknown {
-    // A StatementCache Substitute is a placeholder bound at execution time;
-    // normalizing it here would corrupt the cached statement (e.g. `find_by`).
-    // The real value is normalized on the serialize path via the decorated type.
-    if (value instanceof Substitute) return value;
     const klass = (this.table as { klass?: { _normalizations?: Map<string, unknown> } }).klass;
     const normalizations = klass?._normalizations;
     if (!normalizations || !normalizations.has(columnName)) return value;

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -438,7 +438,10 @@ export class PredicateBuilder {
     // only need the normalized value to decide nil-routing here; the non-nil
     // value flows to the handler unchanged and is normalized once by the wrapped
     // bind type (so it is not normalized twice). Multi-value forms
-    // (Array/Set/Range/Relation) are normalized per element by their handlers.
+    // (Array/Set/Range/Relation) are left untouched here: their handlers don't
+    // normalize, but each element is normalized downstream when it becomes a
+    // bind — `buildBindAttribute` resolves the wrapped type via `typeForAttribute`
+    // (and `HomogeneousIn#castedValues` serializes through it for the IN path).
     if (this.isScalarQueryValue(value)) {
       const normalized = this.normalizeQueryValue(attribute.name, value);
       if (normalized === null || normalized === undefined) {
@@ -473,13 +476,6 @@ export class PredicateBuilder {
   }
 
   /**
-   * Apply the attribute's normalizer (via its decorated cast type) to a scalar
-   * query value, but only for attributes that declare one — so non-normalized
-   * columns keep their raw query values and existing casting semantics. The
-   * decorated type's `cast` casts then normalizes, mirroring Rails'
-   * `type_for_attribute(name).cast(value)`.
-   */
-  /**
    * A scalar reaches the equality/`basicObjectHandler` path where a single
    * normalized value applies. Multi-value forms (Array/Set/Range/Relation) and
    * StatementCache Substitute placeholders are excluded: their elements are
@@ -498,6 +494,13 @@ export class PredicateBuilder {
     );
   }
 
+  /**
+   * Apply the attribute's normalizer (via its decorated cast type) to a scalar
+   * query value, but only for attributes that declare one — so non-normalized
+   * columns keep their raw query values and existing casting semantics. The
+   * decorated type's `cast` casts then normalizes, mirroring Rails'
+   * `type_for_attribute(name).cast(value)`.
+   */
   private normalizeQueryValue(columnName: string, value: unknown): unknown {
     const klass = (this.table as { klass?: { _normalizations?: Map<string, unknown> } }).klass;
     const normalizations = klass?._normalizations;

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -7,6 +7,7 @@ import { RangeHandler, UnboundableBound } from "./predicate-builder/range-handle
 import { BasicObjectHandler } from "./predicate-builder/basic-object-handler.js";
 import { RelationHandler } from "./predicate-builder/relation-handler.js";
 import { AssociationQueryValue } from "./predicate-builder/association-query-value.js";
+import { Substitute } from "../statement-cache.js";
 import { PolymorphicArrayValue } from "./predicate-builder/polymorphic-array-value.js";
 import { argumentError } from "./query-methods.js";
 
@@ -430,6 +431,11 @@ export class PredicateBuilder {
     if (respondsToId(value)) {
       value = (value as { id: unknown }).id;
     }
+    // Rails applies the attribute's cast type — including any NormalizedValueType
+    // decoration — to `where`/`find_by` keyword arguments. Normalize the query
+    // value here so a normalizer that maps to nil (e.g. `presence`) routes through
+    // the same `IS NULL` path as an explicit nil, matching `where(col: nil)`.
+    value = this.normalizeQueryValue(attribute.name, value);
     if (value === null || value === undefined) {
       return attribute.isNull();
     }
@@ -455,6 +461,27 @@ export class PredicateBuilder {
       return this.relationHandler.call(attribute, value);
     }
     return this.basicObjectHandler.call(attribute, value);
+  }
+
+  /**
+   * Apply the attribute's normalizer (via its decorated cast type) to a scalar
+   * query value, but only for attributes that declare one — so non-normalized
+   * columns keep their raw query values and existing casting semantics. The
+   * decorated type's `cast` casts then normalizes, mirroring Rails'
+   * `type_for_attribute(name).cast(value)`.
+   */
+  private normalizeQueryValue(columnName: string, value: unknown): unknown {
+    // A StatementCache Substitute is a placeholder bound at execution time;
+    // normalizing it here would corrupt the cached statement (e.g. `find_by`).
+    // The real value is normalized on the serialize path via the decorated type.
+    if (value instanceof Substitute) return value;
+    const klass = (this.table as { klass?: { _normalizations?: Map<string, unknown> } }).klass;
+    const normalizations = klass?._normalizations;
+    if (!normalizations || !normalizations.has(columnName)) return value;
+    const type = this.table.typeForAttribute(columnName) as
+      | { cast?(v: unknown): unknown }
+      | undefined;
+    return type?.cast ? type.cast(value) : value;
   }
 
   buildRangePredicate(attribute: Nodes.Attribute, range: Range): Nodes.Node {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -432,13 +432,18 @@ export class PredicateBuilder {
       value = (value as { id: unknown }).id;
     }
     // Rails applies the attribute's cast type — including any NormalizedValueType
-    // decoration — to `where`/`find_by` keyword arguments. Normalize the scalar
-    // query value here so a normalizer that maps to nil (e.g. `presence`) routes
-    // through the same `IS NULL` path as an explicit nil, matching
-    // `where(col: nil)`. Multi-value forms (Array/Set/Range/Relation) are left
-    // for their handlers, which normalize each element via the wrapped bind type.
+    // decoration — to `where`/`find_by` keyword arguments. A normalizer that maps
+    // a scalar to nil (e.g. `presence`) must route through the same `IS NULL`
+    // path as an explicit nil so `where(col: "")` matches `where(col: nil)`. We
+    // only need the normalized value to decide nil-routing here; the non-nil
+    // value flows to the handler unchanged and is normalized once by the wrapped
+    // bind type (so it is not normalized twice). Multi-value forms
+    // (Array/Set/Range/Relation) are normalized per element by their handlers.
     if (this.isScalarQueryValue(value)) {
-      value = this.normalizeQueryValue(attribute.name, value);
+      const normalized = this.normalizeQueryValue(attribute.name, value);
+      if (normalized === null || normalized === undefined) {
+        return attribute.isNull();
+      }
     }
     if (value === null || value === undefined) {
       return attribute.isNull();

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -1,5 +1,8 @@
-import { Type, ValueType } from "@blazetrails/activemodel";
+import { Type, ValueType, normalizedValueType } from "@blazetrails/activemodel";
 import { enumTypeFor } from "../enum.js";
+
+/** Normalizer registry shape stored on the model class by `Model.normalizes`. */
+type NormalizationEntry = { fns: Array<(value: unknown) => unknown>; applyToNil: boolean };
 
 /**
  * Casts attribute values for database operations using the model's
@@ -36,6 +39,33 @@ export class Map {
   }
 
   typeForAttribute(name: string): Type {
+    return this.decorateWithNormalizer(name, this._baseTypeForAttribute(name));
+  }
+
+  /**
+   * Decorate the resolved type with the model's normalizer for `name`, if any.
+   *
+   * Rails wires normalization by wrapping the attribute's cast type with
+   * NormalizedValueType, so `type_for_attribute` (used by the predicate builder
+   * to serialize query values) normalizes `where`/`find_by` keyword arguments.
+   * trails applies normalization imperatively on the write path, so we wrap here
+   * — on the query-side type caster only — to normalize query values without
+   * double-applying on writes (which never route through this caster).
+   */
+  private decorateWithNormalizer(name: string, type: Type): Type {
+    const normalizations: globalThis.Map<string, NormalizationEntry> | undefined =
+      this._klass?._normalizations;
+    const entry = normalizations?.get(name);
+    if (!entry) return type;
+    const normalizer = (value: unknown): unknown => {
+      let result = value;
+      for (const fn of entry.fns) result = fn(result);
+      return result;
+    };
+    return normalizedValueType(type, normalizer, entry.applyToNil);
+  }
+
+  private _baseTypeForAttribute(name: string): Type {
     const klass = this._klass;
 
     // Prefer O(1) lookup via _attributeDefinitions (avoids building full attributeTypes object)

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -19672,34 +19672,6 @@
   {
     "package": "activerecord",
     "tsFile": "base.ts",
-    "rubyName": "normalize_changed_in_place_attributes",
-    "call": "attribute_changed_in_place?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "normalize_changed_in_place_attributes",
-    "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "normalize_changed_in_place_attributes",
-    "call": "normalize_attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "normalize_changed_in_place_attributes",
-    "call": "normalized_attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
     "rubyName": "saved_change_to_attribute",
     "call": "change_to_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -24931,14 +24903,14 @@
     "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "connect",
     "call": "new_client",
-    "reason": "Rails' private connect (mysql2_adapter.rb:144) is `@raw_connection = new_client(...)`; trails' connect() delegates to _ensureClient(), which calls Mysql2Adapter.newClient() (the new_client analog) — so the call is satisfied one frame down, not inlined here."
+    "reason": "Rails' private connect (mysql2_adapter.rb:144) is `@raw_connection = new_client(...)`; trails' connect() delegates to _ensureClient(), which calls Mysql2Adapter.newClient() (the new_client analog) \u2014 so the call is satisfied one frame down, not inlined here."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "connect",
     "call": "set_pool",
-    "reason": "Rails' connect rescues ConnectionNotEstablished and re-raises `ex.set_pool(@pool)` (mysql2_adapter.rb:146-147); trails' connect() delegates to _ensureClient(), whose catch attaches the pool via translated.setPool(this.pool) — same set_pool behavior, one frame down."
+    "reason": "Rails' connect rescues ConnectionNotEstablished and re-raises `ex.set_pool(@pool)` (mysql2_adapter.rb:146-147); trails' connect() delegates to _ensureClient(), whose catch attaches the pool via translated.setPool(this.pool) \u2014 same set_pool behavior, one frame down."
   },
   {
     "package": "activerecord",
@@ -33513,20 +33485,6 @@
     "tsFile": "normalization.ts",
     "rubyName": "normalize",
     "call": "call",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "normalization.ts",
-    "rubyName": "normalize_changed_in_place_attributes",
-    "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "normalization.ts",
-    "rubyName": "normalize_changed_in_place_attributes",
-    "call": "normalized_attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## What

Wires `normalizes` into the query path and the pre-validation save chain so
`where`/`find_by` serialize their keyword arguments through the normalizer and
changed-in-place mutations re-normalize before validation — matching Rails
`ActiveRecord::Normalization`. Previously trails normalized only on the
imperative write path, and `NormalizedValueType` was dead code.

## How

- **`normalizedValueType`** (activemodel `type/normalized-value.ts`): a
  Proxy-based `DelegateClass` analog of Rails' `NormalizedValueType`. It
  normalizes in `cast`/`serialize` and delegates everything else to the
  underlying type — notably `deserialize` stays un-normalized, so values read
  from the DB are not normalized (Rails parity).
- **Query-side type caster** (`TypeCaster::Map`): wraps the resolved type with
  the model's normalizer so the predicate builder serializes query values
  through it. Query-only — the imperative write path is untouched, so
  non-idempotent normalizers still apply exactly once on write.
- **`PredicateBuilder#build`**: normalizes scalar query values before the nil
  check (skipping StatementCache `Substitute` placeholders), so a normalizer
  that maps to nil (e.g. `presence`) routes through the same `IS NULL` path as
  an explicit `where(col: nil)`.
- **`before_validation :normalizeChangedInPlaceAttributes`** registered on first
  `normalizes`; `attributeChangedInPlace` now infers a true in-place mutation
  (live value diverged from the tracked change) so a normal assignment is not
  re-normalized on save.

## Tests

Un-skips the four ported Rails tests in `normalized-attribute.test.ts`
(`finds record by normalized value`, `uses the same query when finding record by
nil and normalized nil values`, `normalizes changed-in-place value before
validation`, `minimizes number of times normalization is applied`). All 16 pass;
no regressions in the existing normalization, dirty, predicate-builder, finder,
numericality, or enum suites.

Closes-story: normalizes-query-and-in-place-type-decoration