### PR TITLE
fix(associations): match BigInt PK to number find(id) in collection findByScan

### DIFF
--- a/packages/activerecord/src/associations/collection-association-bigint-number-key-match.test.ts
+++ b/packages/activerecord/src/associations/collection-association-bigint-number-key-match.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Collection-association in-memory `find` key-type normalization: when a loaded
+ * `inverse_of` collection is scanned by `find(id)` (CollectionAssociation
+ * `findByScan`), the target PKs are matched against the `find` argument in
+ * memory. On the PG bigserial-PK lane node-postgres parses an int8 PK to a JS
+ * `BigInt` while the `find(id)` argument is a `number`; `1n` and `1` are
+ * distinct JS values and a raw `JSON.stringify` of a `BigInt` throws outright.
+ * Without normalization the scan mismatches (or crashes) even though Ruby's
+ * width-agnostic `Integer ==` would match. Guards that regression.
+ */
+import { describe, it, expect } from "vitest";
+import { Base } from "../index.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import "../test-helpers/canonical-model-index.js";
+import { Firm } from "../test-helpers/models/company.js";
+
+type RecordInternals = {
+  _attributes: { writeCastValue(name: string, value: unknown): void };
+  _readAttribute(name: string): unknown;
+  _associationInstances: Map<string, { find(...args: unknown[]): Promise<Base | Base[] | null> }>;
+};
+
+const internals = (record: Base): RecordInternals => record as unknown as RecordInternals;
+
+describe("CollectionAssociation BigInt PK / number find(id) key match", () => {
+  const { companies } = fixtures(["companies"]);
+
+  it("finds a loaded record when its in-memory PK is a BigInt and the id is a number", async () => {
+    const firm = (await Firm.find(companies("first_firm").id)) as Base;
+    // `clientsOfFirm` declares `inverse_of`, so a loaded CollectionAssociation
+    // scans its in-memory target (`findByScan`) instead of re-querying.
+    const clients = await (
+      firm as unknown as { clientsOfFirm: { load(): Promise<Base[]> } }
+    ).clientsOfFirm.load();
+    expect(clients.length).toBeGreaterThan(0);
+
+    // Simulate node-postgres parsing an int8 (bigserial) PK to BigInt on the
+    // in-memory target; the `find` argument below stays a number.
+    const target = clients[0];
+    const numberId = Number(internals(target)._readAttribute("id"));
+    internals(target)._attributes.writeCastValue("id", BigInt(numberId));
+
+    const assoc = internals(firm)._associationInstances.get("clientsOfFirm")!;
+    const found = (await assoc.find(numberId)) as Base;
+    expect(Number(internals(found)._readAttribute("id"))).toBe(numberId);
+  });
+});

--- a/packages/activerecord/src/associations/collection-association-bigint-number-key-match.test.ts
+++ b/packages/activerecord/src/associations/collection-association-bigint-number-key-match.test.ts
@@ -1,12 +1,17 @@
 /**
- * Collection-association in-memory `find` key-type normalization: when a loaded
- * `inverse_of` collection is scanned by `find(id)` (CollectionAssociation
- * `findByScan`), the target PKs are matched against the `find` argument in
- * memory. On the PG bigserial-PK lane node-postgres parses an int8 PK to a JS
- * `BigInt` while the `find(id)` argument is a `number`; `1n` and `1` are
- * distinct JS values and a raw `JSON.stringify` of a `BigInt` throws outright.
- * Without normalization the scan mismatches (or crashes) even though Ruby's
- * width-agnostic `Integer ==` would match. Guards that regression.
+ * Collection-association in-memory `find` key-type normalization. When a loaded
+ * `inverse_of` collection is scanned by `find(id)`, the target PKs are matched
+ * against the `find` argument in memory. On the PG bigserial-PK lane
+ * node-postgres parses an int8 PK to a JS `BigInt` while the `find(id)` argument
+ * is a `number`; `1n` and `1` are distinct JS values even though Ruby's
+ * width-agnostic `Integer ==` matches them.
+ *
+ * Two scan implementations exist: `CollectionProxy#find` (the public path) keys
+ * both sides through `String(...)`, so it was already width-agnostic — the
+ * second test pins that. The association-level `CollectionAssociation#findByScan`
+ * keyed target PKs through a raw `JSON.stringify`, which *throws* on a BigInt
+ * (`Do not know how to serialize a BigInt`) and mismatches a BigInt PK against a
+ * number id — the first test guards that fix.
  */
 import { describe, it, expect } from "vitest";
 import { Base } from "../index.js";
@@ -14,10 +19,16 @@ import { fixtures } from "../test-helpers/fixtures.js";
 import "../test-helpers/canonical-model-index.js";
 import { Firm } from "../test-helpers/models/company.js";
 
+type CollectionProxyLike = {
+  load(): Promise<Base[]>;
+  find(...args: unknown[]): Promise<Base | Base[]>;
+};
+
 type RecordInternals = {
   _attributes: { writeCastValue(name: string, value: unknown): void };
   _readAttribute(name: string): unknown;
   _associationInstances: Map<string, { find(...args: unknown[]): Promise<Base | Base[] | null> }>;
+  clientsOfFirm: CollectionProxyLike;
 };
 
 const internals = (record: Base): RecordInternals => record as unknown as RecordInternals;
@@ -25,23 +36,37 @@ const internals = (record: Base): RecordInternals => record as unknown as Record
 describe("CollectionAssociation BigInt PK / number find(id) key match", () => {
   const { companies } = fixtures(["companies"]);
 
-  it("finds a loaded record when its in-memory PK is a BigInt and the id is a number", async () => {
+  // Force the first loaded `clientsOfFirm` target PK to BigInt (as if int8
+  // bigserial via node-postgres) and return its equal-valued number id.
+  async function loadFirmWithBigIntTargetPk(): Promise<{
+    firm: Base;
+    target: Base;
+    numberId: number;
+  }> {
     const firm = (await Firm.find(companies("first_firm").id)) as Base;
-    // `clientsOfFirm` declares `inverse_of`, so a loaded CollectionAssociation
-    // scans its in-memory target (`findByScan`) instead of re-querying.
-    const clients = await (
-      firm as unknown as { clientsOfFirm: { load(): Promise<Base[]> } }
-    ).clientsOfFirm.load();
+    // `clientsOfFirm` declares `inverse_of`, so a loaded collection is scanned
+    // in memory (never re-queried) by `find(id)`.
+    const clients = await internals(firm).clientsOfFirm.load();
     expect(clients.length).toBeGreaterThan(0);
 
-    // Simulate node-postgres parsing an int8 (bigserial) PK to BigInt on the
-    // in-memory target; the `find` argument below stays a number.
     const target = clients[0];
     const numberId = Number(internals(target)._readAttribute("id"));
     internals(target)._attributes.writeCastValue("id", BigInt(numberId));
+    return { firm, target, numberId };
+  }
+
+  it("finds a loaded record via CollectionAssociation#findByScan when its in-memory PK is a BigInt and the id is a number", async () => {
+    const { firm, numberId } = await loadFirmWithBigIntTargetPk();
 
     const assoc = internals(firm)._associationInstances.get("clientsOfFirm")!;
     const found = (await assoc.find(numberId)) as Base;
+    expect(Number(internals(found)._readAttribute("id"))).toBe(numberId);
+  });
+
+  it("finds a loaded record via the collection proxy find(id) when its in-memory PK is a BigInt and the id is a number", async () => {
+    const { firm, numberId } = await loadFirmWithBigIntTargetPk();
+
+    const found = (await internals(firm).clientsOfFirm.find(numberId)) as Base;
     expect(Number(internals(found)._readAttribute("id"))).toBe(numberId);
   });
 });

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -968,7 +968,11 @@ export class CollectionAssociation extends Association {
     // `find(id)` argument is a number, and a raw `JSON.stringify` of a BigInt
     // throws outright ("Do not know how to serialize a BigInt"). Normalizing
     // both sides folds `1n` and `1` to the same key so the scan matches the way
-    // Ruby's width-agnostic `Integer ==` does.
+    // Ruby's width-agnostic `Integer ==` does. `normalize` runs over both the
+    // incoming `ids` and each target's `primaryKeyValue(r)`, which returns an
+    // *array* for a composite-PK klass (see `primaryKeyValue`) — hence the
+    // per-element map, so a composite key holding a BigInt doesn't re-introduce
+    // the `JSON.stringify` throw on the target side.
     const normalize = (v: unknown) =>
       JSON.stringify(
         Array.isArray(v) ? v.map(normalizeAssociationKey) : normalizeAssociationKey(v),

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -8,6 +8,7 @@ import { throughForeignKeyPresent } from "./through-association.js";
 import type { AssociationReflection } from "../reflection.js";
 import { RecordNotSaved, Rollback } from "../errors.js";
 import { raiseNotFoundAll } from "../relation/finder-methods.js";
+import { normalizeAssociationKey } from "./key-normalization.js";
 import { polymorphicName } from "../inheritance.js";
 
 /**
@@ -962,7 +963,16 @@ export class CollectionAssociation extends Association {
   }
 
   private findByScan(ids: unknown[]): Base | Base[] {
-    const normalize = (v: unknown) => JSON.stringify(v);
+    // Fold each key through `normalizeAssociationKey` before stringifying: an
+    // in-memory target PK is a BigInt (int8 default under PG bigserial) while a
+    // `find(id)` argument is a number, and a raw `JSON.stringify` of a BigInt
+    // throws outright ("Do not know how to serialize a BigInt"). Normalizing
+    // both sides folds `1n` and `1` to the same key so the scan matches the way
+    // Ruby's width-agnostic `Integer ==` does.
+    const normalize = (v: unknown) =>
+      JSON.stringify(
+        Array.isArray(v) ? v.map(normalizeAssociationKey) : normalizeAssociationKey(v),
+      );
     const normalizedIds = ids.map(normalize);
 
     if (ids.length === 1) {


### PR DESCRIPTION
## Summary

Follow-up audit to PR #4010 (preloader) and #4033 (through/inverse/disable-joins) for the PG bigserial-PK / number-FK key-type split: node-postgres parses an int8 default PK to a JS `BigInt` and an int4 `integer`/`references` FK to a `number`, so `1n !== 1` as JS Map/Set keys even though Ruby's width-agnostic `Integer ==` matches them.

### Audit result

Swept `packages/activerecord/src/associations/**` for owner-PK / child-FK Map/Set keying and `===` matching. The reachable cross-type paths are already normalized:

- **preloader** `_convertKey` — #4010
- **inverse wiring** `Association#matchesForeignKey` / `keyValuesEqual` — #4033
- **has_many_through in-memory join matching** `associationKeysEqual` — #4033
- **collection-proxy `find`** (the public in-memory scan) — already keys both sides through `String(...)`, so bigint-safe
- **`recordIdentity`** (mergeTargetLists dedup) — already folds bigint→string

One un-normalized site remained: **`CollectionAssociation#findByScan`** — the association-level in-memory scan for `find(id)` on a loaded `inverse_of` collection. It keyed target PKs through a raw `JSON.stringify`, which *throws* on a BigInt PK (`Do not know how to serialize a BigInt`) and would mismatch a BigInt PK against a number `find` argument. This is the association-level implementation shadowed by `CollectionProxy#find` today, so the fix is defensive — but it removes a latent crash and brings the method in line with every other key path via the shared `normalizeAssociationKey`.

## Test

`collection-association-bigint-number-key-match.test.ts` forces a loaded `Firm#clientsOfFirm` target PK to `BigInt` via `writeCastValue`, then finds by the equal-valued number id through **both** scan implementations:

- via `CollectionAssociation#findByScan` — fails without the fix (`Do not know how to serialize a BigInt`), passes with it.
- via the public `CollectionProxy#find` — green either way, pinning that the reachable path stays width-agnostic.

Green on all three lanes.

Closes-story: pg-bigint-number-key-match-inmemory-association-audit

## Review notes

**Re: the `Array.isArray(v)` branch in `findByScan`'s `normalize` closure.** It is not dead code. `normalize` runs over *both* the incoming `ids` and each scan target's `primaryKeyValue(r)`, and `primaryKeyValue` returns an **array** for a composite-PK klass (`collection-association.ts:912-917`). So the target side can be an array whose elements include a BigInt; without the per-element map, `JSON.stringify` would re-throw exactly as it did for scalars. The review traced only the flattened `ids` argument (correctly scalar there) and missed the target side. Kept, with a clarifying comment added.
