### PR TITLE
refactor(test-models): materialize Pirate.catchphrase declare, drop skip-columns

### DIFF
--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -901,11 +901,11 @@ describe("DirtyTest", () => {
     Object.defineProperty(Foo.prototype, "catchphrase", {
       configurable: true,
       get(this: Pirate): string | null {
-        const v = (this as any).readAttribute("catchphrase") as string | null;
+        const v = this.readAttribute("catchphrase") as string | null;
         return v == null ? v : v.toUpperCase();
       },
       set(this: Pirate, v: string | null) {
-        (this as any).writeAttribute("catchphrase", v);
+        this.writeAttribute("catchphrase", v);
       },
     });
 

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -890,15 +890,14 @@ describe("DirtyTest", () => {
 
   it("changes is correct for subclass", async () => {
     // Rails overrides only the reader (`def catchphrase; super.upcase; end`),
-    // keeping the generated writer. A JS getter override shadows the inherited
-    // accessor pair and drops the setter, so re-add a setter; both delegate to
-    // `readAttribute`/`writeAttribute` — the trails analog of the `super`
-    // accessor — for a functionally reader-only override. Dirty tracking reads
-    // the raw stored value (not the public reader), so `changes` is unaffected.
+    // keeping the generated writer. `declare catchphrase: string` on Pirate
+    // forbids overriding it as an accessor pair via TS syntax (TS2611), so
+    // shadow it on the subclass prototype with `Object.defineProperty` — the
+    // runtime effect Ruby's `def catchphrase` has. Both accessors delegate to
+    // `readAttribute`/`writeAttribute` (the trails analog of `super`) for a
+    // functionally reader-only override. Dirty tracking reads the raw stored
+    // value (not the public reader), so `changes` is unaffected.
     const Foo = class extends Pirate {};
-    // `declare catchphrase: string` on Pirate forbids overriding it as an
-    // accessor pair via TS syntax (TS2611), so shadow it on the subclass
-    // prototype directly — the runtime effect Ruby's `def catchphrase` has.
     Object.defineProperty(Foo.prototype, "catchphrase", {
       configurable: true,
       get(this: Pirate): string | null {

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -895,15 +895,20 @@ describe("DirtyTest", () => {
     // `readAttribute`/`writeAttribute` — the trails analog of the `super`
     // accessor — for a functionally reader-only override. Dirty tracking reads
     // the raw stored value (not the public reader), so `changes` is unaffected.
-    const Foo = class extends Pirate {
-      get catchphrase(): string | null {
+    const Foo = class extends Pirate {};
+    // `declare catchphrase: string` on Pirate forbids overriding it as an
+    // accessor pair via TS syntax (TS2611), so shadow it on the subclass
+    // prototype directly — the runtime effect Ruby's `def catchphrase` has.
+    Object.defineProperty(Foo.prototype, "catchphrase", {
+      configurable: true,
+      get(this: Pirate): string | null {
         const v = (this as any).readAttribute("catchphrase") as string | null;
         return v == null ? v : v.toUpperCase();
-      }
-      set catchphrase(v: string | null) {
+      },
+      set(this: Pirate, v: string | null) {
         (this as any).writeAttribute("catchphrase", v);
-      }
-    };
+      },
+    });
 
     const pirate = (await Foo.createBang({ catchphrase: "arrrr" })) as Rec;
 

--- a/packages/activerecord/src/test-helpers/models/pirate.ts
+++ b/packages/activerecord/src/test-helpers/models/pirate.ts
@@ -15,7 +15,7 @@ import { Base } from "../../base.js";
 import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
 
 export class Pirate extends Base {
-  declare parrotsLimit: number | null;
+  declare parrotsLimit: number;
   declare catchphrase: string;
 
   declare parrot: Parrot | null;

--- a/packages/activerecord/src/test-helpers/models/pirate.ts
+++ b/packages/activerecord/src/test-helpers/models/pirate.ts
@@ -14,13 +14,10 @@ import { throwAbort } from "@blazetrails/activesupport";
 import { Base } from "../../base.js";
 import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
 
-/**
- * @trails-typegen skip-columns: catchphrase
- * dirty.test.ts overrides `catchphrase` as a get/set accessor pair (TS2611 —
- * a declared property cannot be overridden as an accessor). Suppress this
- * column's schema declare; all association declares still materialize.
- */
 export class Pirate extends Base {
+  declare parrotsLimit: number | null;
+  declare catchphrase: string;
+
   declare parrot: Parrot | null;
   declare nonValidatedParrot: Parrot | null;
   declare parrots: AssociationProxy<Parrot>;


### PR DESCRIPTION
Removes the `@trails-typegen skip-columns: catchphrase` annotation from `Pirate` (added in #4222) and materializes `declare catchphrase: string`.

The annotation existed because dirty.test.ts's `changes is correct for subclass` test overrode `catchphrase` as a get/set accessor pair on an anonymous Pirate subclass — TS2611 forbids overriding a declared field as an accessor. Restructure the test to shadow the property via `Object.defineProperty` on the subclass prototype instead (the runtime effect of Ruby's `def catchphrase` reader override in `vendor/rails/activerecord/test/cases/dirty_test.rb`), so the typed declare stands with no `as any` casts and no TS2611.

Re-running the materializer also emits `declare parrotsLimit: number;` for the existing `this.attribute("parrotsLimit", "integer", { virtual: true })` virtual attribute (previously undeclared because the whole file was suppressed via skip-columns). Typed non-null to match the sibling virtual-attribute convention (`Developer.lastName`, `Parrot.cancelSaveFromCallback`, etc.).

- `skip-columns: catchphrase` annotation removed; `declare catchphrase: string` materialized.
- `dirty.test.ts` subclass test compiles and passes.
- `node scripts/typecheck.mjs` clean.
- Materializer output is idempotent (re-run reports `unchanged`).

Closes-story: pirate-catchphrase-skip-columns-converge