### PR TITLE
refactor(activerecord): widen except skip type to accept arbitrary strings

### DIFF
--- a/packages/activerecord/src/querying.ts
+++ b/packages/activerecord/src/querying.ts
@@ -968,7 +968,7 @@ export function extractAssociated<T extends typeof Base>(this: T, name: string):
  */
 export function except<T extends typeof Base>(
   this: T,
-  ...skips: Array<import("./relation/query-methods.js").ExceptKey>
+  ...skips: Array<import("./relation/query-methods.js").ExceptSkip>
 ): Relation<InstanceType<T>> {
   return this.all().except(...skips);
 }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -63,7 +63,7 @@ import {
   arelColumnsFromHash as _arelColumnsFromHash,
   referencesFromConditions,
   type UnscopeType,
-  type ExceptKey,
+  type ExceptSkip,
   type AssociationSpec,
   type JoinSpec,
   type OrderArg,
@@ -1801,7 +1801,7 @@ export class Relation<T extends Base> {
    * directive, so merging the result does not erase the same parts on the
    * other relation.
    */
-  except(...skips: Array<ExceptKey>): Relation<T> {
+  except(...skips: Array<ExceptSkip>): Relation<T> {
     const rel = this._clone();
     for (const skip of skips) {
       switch (skip) {
@@ -1837,7 +1837,9 @@ export class Relation<T extends Base> {
           rel._skipQueryCache = undefined;
           break;
         default:
-          _qm.resetValueForScope(rel as any, skip);
+          // Rails' `values.except(*skips)` silently ignores unknown keys;
+          // resetValueForScope's switch no-ops on any non-UnscopeType string.
+          _qm.resetValueForScope(rel as any, skip as UnscopeType);
           break;
       }
     }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -792,6 +792,14 @@ export type ExceptKey =
   | "skipQueryCache";
 
 /**
+ * Argument type for `SpawnMethods#except`. Rails' `values.except(*skips)`
+ * (spawn_methods.rb:59-60) accepts ANY key — unrecognized ones are a silent
+ * no-op. The `(string & {})` arm preserves `ExceptKey` autocomplete while
+ * still admitting arbitrary strings without a cast (e.g. `Post.except("bogus")`).
+ */
+export type ExceptSkip = ExceptKey | (string & {});
+
+/**
  * Reset a single value-key to its default, with no merge-replay side effect.
  *
  * Shared by `unscope!` (which additionally records the key in

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -1711,6 +1711,16 @@ describe("RelationTest", () => {
     expect(authorPostsArr.map((p) => p.id)).toEqual(directPosts.map((p) => p.id));
   });
 
+  it("except with unrecognized key is a no-op", async () => {
+    const relation = Post.where({ author_id: 1 }).order("id ASC").limit(1);
+    const baseline = (await relation.toArray()).map((p) => p.id);
+
+    // Rails' `values.except(*skips)` silently ignores unknown keys; the widened
+    // skip type lets `except("bogus")` typecheck without a cast.
+    const unchanged = relation.except("bogus");
+    expect((await unchanged.toArray()).map((p) => p.id)).toEqual(baseline);
+  });
+
   it("only", async () => {
     const relation = Post.where({ author_id: 1 }).order("id ASC").limit(1);
     expect((await relation.toArray()).map((p) => p.id)).toEqual([posts("welcome").id]);


### PR DESCRIPTION
## Summary

Rails' `SpawnMethods#except(*skips)` (spawn_methods.rb:59-60) does a bare
`values.except(*skips)` that accepts ANY key — unrecognized ones are a silent
no-op. trails typed the skip parameter as the finite `ExceptKey` union on both
`Relation#except` and the `Querying#except` delegator, so `Post.except("bogus")`
required a cast.

This introduces `ExceptSkip = ExceptKey | (string & {})` and uses it on both
signatures — keeping `ExceptKey` autocomplete while admitting arbitrary strings
without a cast. Unrecognized keys stay a runtime no-op (`resetValueForScope`'s
switch no-ops on any non-`UnscopeType` string).

## Changes

- `relation/query-methods.ts`: add exported `ExceptSkip` type.
- `relation.ts`: `Relation#except` accepts `ExceptSkip`; default case casts to
  `UnscopeType` (no-op for unknown keys).
- `querying.ts`: `Querying#except` delegator widened to `ExceptSkip`.
- `relations.test.ts`: test asserting `except("bogus")` typechecks and is a no-op.

api:compare querying.ts is unaffected (arity/method presence unchanged; type-only widening).

Closes-story: ar-except-skip-key-widen-string