### PR TITLE
fix(associations): buffer record into target regardless of insert_record result

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -37,6 +37,7 @@ import {
   ConfigurationError,
   AssociationTypeMismatch,
   RecordNotFound,
+  Rollback,
 } from "../errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { strictLoadingViolationBang } from "../core.js";
@@ -1280,9 +1281,21 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     }
     const record = this._buildRaw(attrs) as T;
     if (block) block(record);
+    // Rails' `_create_record` wraps the insert in a transaction and re-raises
+    // `Rollback unless result` (collection_association.rb:363-371) so a
+    // non-raising `save` failure undoes any partial write. `add_to_target`
+    // buffers the record into the target and fires after_add regardless of the
+    // save result — the `yield(record)` return is ignored — so we accumulate it
+    // in `result` here rather than gating the in-memory push.
     // Rails' add_to_target computes `replace: replace || association_scope.distinct_value`,
     // so a `distinct` association scope dedups in place rather than appending twice.
-    await this._addToTarget(record, { replace: this.distinctValue }, () => record.save());
+    await this.transaction(async () => {
+      let result: boolean | undefined = undefined;
+      await this._addToTarget(record, { replace: this.distinctValue }, async () => {
+        result = await record.save();
+      });
+      if (!result) throw new Rollback();
+    });
     return record;
   }
 
@@ -1293,11 +1306,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    *
    * `save`, when supplied, runs between `set_inverse_instance` and the target
    * mutation (Rails' `yield(record)` inside `replace_on_target`, used by
-   * `create` to `insert_record`). If it resolves false the record is left out
-   * of the target — matching the prior `if (saved)` gate. (Rails pushes
-   * regardless and relies on the surrounding `transaction { ... } / raise
-   * Rollback` to undo the DB write; trails' `create` has no transaction yet —
-   * see `_createThrough` — so we gate the in-memory push on save success.)
+   * `create`/`concat` to `insert_record`). Its return value is ignored: the
+   * record is committed to the target and `after_add` fires regardless of the
+   * save result, matching Rails' `replace_on_target` (the `yield(record)` at
+   * collection_association.rb:470 is unused). A non-raising save failure that
+   * needs to be undone is rolled back by the surrounding `transaction { ... } /
+   * raise Rollback` — the `create` and persisted-`concat` paths both wrap the
+   * insert in a transaction (see `create` and the `concat` funnel below).
    *
    * Rails' append branch is gated on `@_was_loaded || !loaded?`. On the create
    * path `@_was_loaded` is set true before the save and reset to `loaded?`
@@ -1308,7 +1323,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private async _addToTarget(
     record: T,
     options: { skipCallbacks?: boolean; replace?: boolean } = {},
-    save?: () => Promise<boolean | undefined>,
+    save?: () => Promise<unknown>,
   ): Promise<T | null> {
     const { skipCallbacks = false, replace = false } = options;
     const index = this._targetReplaceIndex(record, replace);
@@ -1319,7 +1334,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       return null;
     }
     _setCollectionInverseInstance(this._record, this._assocName, this._assocDef.options, record);
-    if (save && !(await save())) return record;
+    if (save) await save();
     this._commitToTarget(record, index);
     if (!skipCallbacks) fireAssocCallbacks(this._assocDef.options.afterAdd, this._record, record);
     return record;

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -267,6 +267,24 @@ describe("HasManyAssociationsTest", () => {
     expect(reloaded).not.toContain(bad);
   });
 
+  it("creating a record whose save fails buffers it into the target", async () => {
+    // `_create_record` wraps the insert in a transaction and buffers the record
+    // into the target regardless of the save result (collection_association.rb:363-371).
+    // A `before_save` throw :abort makes `save` return false without raising, so
+    // the record stays in the in-memory target while the insert is rolled back.
+    const firstFirm = companies("first_firm") as any;
+    await firstFirm.clientsOfFirm.load();
+
+    const bad = await firstFirm.clientsOfFirm.create({ name: "Bad" }, (r: any) => {
+      r.throwOnSave = true;
+    });
+
+    expect(bad.isNewRecord()).toBe(true);
+    expect(await firstFirm.clientsOfFirm.toArray()).toContain(bad);
+    const reloaded = (await firstFirm.clientsOfFirm.reload()) as any[];
+    expect(reloaded).not.toContain(bad);
+  });
+
   it("destroying", async () => {
     const firstFirm = companies("first_firm") as any;
     await firstFirm.clientsOfFirm.load();

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -248,6 +248,25 @@ describe("HasManyAssociationsTest", () => {
     });
   });
 
+  it("adding buffers a record whose save fails into the target", async () => {
+    // Rails' `replace_on_target` adds the record to the in-memory target and
+    // fires after_add regardless of the insert result — only a `before_add`
+    // throw :abort skips it (collection_association.rb:457-483). A `before_save`
+    // throw :abort makes `save` return false without raising, so the record is
+    // still buffered; the failed insert is undone by the surrounding
+    // transaction's `raise Rollback unless result`.
+    const bad = Client.new({ name: "Bad" }) as any;
+    bad.throwOnSave = true;
+
+    const firstFirm = companies("first_firm") as any;
+    await firstFirm.clientsOfFirm.load();
+    await firstFirm.clientsOfFirm.concat(bad);
+
+    expect(await firstFirm.clientsOfFirm.toArray()).toContain(bad);
+    const reloaded = (await firstFirm.clientsOfFirm.reload()) as any[];
+    expect(reloaded).not.toContain(bad);
+  });
+
   it("destroying", async () => {
     const firstFirm = companies("first_firm") as any;
     await firstFirm.clientsOfFirm.load();


### PR DESCRIPTION
## What

Converge `CollectionProxy#_addToTarget` to Rails' `replace_on_target`
semantics: a record whose `insert_record` returns false (non-raising) is now
still added to the in-memory target and `after_add` still fires. Rails ignores
the `yield(record)` return at `collection_association.rb:470`; only a
`before_add` `throw :abort` skips the add.

## Changes

- **Drop the save-success gate** in `_addToTarget`
  (`if (save && !(await save())) return record;` → `if (save) await save();`).
  The record is committed to the target and after_add fires regardless of the
  save result.
- **Wrap the non-through `create` path in a transaction** with
  `raise Rollback unless result`, mirroring `_create_record`
  (`collection_association.rb:363-371`), so a non-raising `save` failure is
  undone by the transaction rather than by withholding the record from the
  target. The persisted `concat`/`push` path already wraps its inserts in a
  transaction (PR #4288 + #4308), and the OO `replaceOnTargetAsync` already
  added regardless.

## Tests

- Added `adding buffers a record whose save fails into the target` — a
  `before_save` `throw :abort` makes `save` return false without raising; the
  record is buffered into the in-memory target and the failed insert is rolled
  back on reload.
- Existing has-many / through / habtm push/concat/create + callbacks suites
  stay green.

Closes-story: replace-on-target-add-regardless-of-save-result
