### PR TITLE
test(fixtures): convert remaining setupFixtures callers to fixtures()

### DIFF
--- a/packages/activerecord/src/adapter.test.ts
+++ b/packages/activerecord/src/adapter.test.ts
@@ -20,7 +20,7 @@ import {
   Rollback,
 } from "./index.js";
 import { Result } from "./result.js";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { adapterType, inMemoryDb } from "./test-adapter.js";
 import { itIfSupports } from "./test-helpers/supports.js";
 import { establishFromTestConfig } from "./test-helpers/test-database-config.js";
@@ -520,7 +520,7 @@ describe("AdapterTest", () => {
 // header), so we add it via raw DDL once per worker and tear it down after,
 // then drive the tables directly (Rails sets `use_transactional_tests = false`).
 describe("AdapterForeignKeyTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   const addFkSql = (): string =>
     "ALTER TABLE fk_test_has_fk ADD CONSTRAINT fk_name " +
@@ -1232,7 +1232,7 @@ describe("AdapterThreadSafetyTest", () => {
 // the abstract/sqlite/pg default is false, matching Rails
 // savepoint_errors_invalidate_transactions?.
 describe("InvalidateTransactionTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   // Rails wraps this in `if connection.savepoint_errors_invalidate_transactions?`
   // — a capability guard (true only on MySQL), not an adapter-fidelity gate

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/mysql-explain.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { describeIfMysql, isMariaDb, Mysql2Adapter } from "./test-helper.js";
 import { Version } from "../../connection-adapters/abstract-adapter.js";
-import { fixtures, setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { Author } from "../../test-helpers/models/author.js";
 import { Post } from "../../test-helpers/models/post.js";
@@ -13,7 +13,7 @@ import { registerModel } from "../../index.js";
 // The outer `describeIfMysql` beforeAll reads `Base.connection` before the
 // nested MySQLExplainTest `fixtures()` establishes it, so the handler wiring has
 // to be laid at file scope here — it is NOT redundant with the nested call.
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 describeIfMysql("Mysql2Adapter", () => {
   registerModel(Author);

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/schema-migrations.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { SchemaMigration } from "../../schema-migration.js";
 import { InternalMetadata } from "../../internal-metadata.js";
 import { describeIfMysql, Mysql2Adapter, MYSQL_TEST_URL } from "./test-helper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 
 describeIfMysql("Mysql2Adapter", () => {
   let adapter: Mysql2Adapter;
@@ -19,10 +19,10 @@ describeIfMysql("Mysql2Adapter", () => {
   describe("SchemaMigrationsTest", () => {
     // Ride the canonical `engines`/`cars` tables built into the worker DB by
     // the global TEST_SCHEMA setup (Rails has no engines fixture — the schema
-    // alone provides the table). setupFixtures skips the global adapter
+    // alone provides the table). The handler suite skips the global adapter
     // reset so the canonical tables stay put for the DDL test below, which
     // restores their original state in its `finally`.
-    setupFixtures();
+    fixtures({}, { useTransactionalTests: false });
 
     it("renaming index on foreign key", async () => {
       try {
@@ -33,7 +33,7 @@ describeIfMysql("Mysql2Adapter", () => {
         const idxNames = (await adapter.indexes("engines")).map((i: { name: string }) => i.name);
         expect(idxNames).toEqual(["idx_renamed"]);
       } finally {
-        // This file skips the global adapter reset (setupFixtures), so the
+        // This file skips the global adapter reset (handler suite), so the
         // canonical `engines` table must be restored to its original (no-index)
         // shape even if a step above failed partway. The FK must be dropped
         // before the index it depends on. Cover both the pre- and post-rename

--- a/packages/activerecord/src/adapters/postgresql/bytea.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bytea.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import pg from "pg";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 
@@ -18,7 +18,7 @@ class ByteaDataType extends Base {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let connection: PostgreSQLAdapter;
   let column: PgColumn;

--- a/packages/activerecord/src/adapters/postgresql/citext.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/citext.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { Base, Rollback } from "../../index.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
 import type { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 
@@ -17,7 +17,7 @@ class Citext extends Base {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let connection: PostgreSQLAdapter;
 

--- a/packages/activerecord/src/adapters/postgresql/composite.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/composite.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { ValueType } from "@blazetrails/activemodel";
 
@@ -47,7 +47,7 @@ class FullAddressType extends ValueType<FullAddress> {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
   let connection: PostgreSQLAdapter;
 
   async function setupCompositeType(): Promise<void> {

--- a/packages/activerecord/src/adapters/postgresql/create-unlogged-tables.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/create-unlogged-tables.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 
 const TABLE_NAME = "things";
@@ -14,7 +14,7 @@ const UNLOGGED = "u";
 const TEMPORARY = "t";
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let connection: PostgreSQLAdapter;
   let previousCreateUnlogged: boolean;

--- a/packages/activerecord/src/adapters/postgresql/domain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/domain.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 
@@ -17,7 +17,7 @@ class PostgresqlDomain extends Base {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let connection: PostgreSQLAdapter;
 

--- a/packages/activerecord/src/adapters/postgresql/enum.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/enum.test.ts
@@ -6,7 +6,7 @@ import { describeIfPg, PostgreSQLAdapter, pgServerVersion } from "./test-helper.
 import { SchemaDumper } from "../../connection-adapters/abstract/schema-dumper.js";
 import { Base, Schema } from "../../index.js";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 
 // Rails: class PostgresqlEnum < ActiveRecord::Base
 //   enum :current_mood, { sad: "sad", okay: "ok", happy: "happy", aliased_field: "happy" }, prefix: true
@@ -47,7 +47,7 @@ async function withTestSchema(
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let adapter: PostgreSQLAdapter;
   // The scoped tests qualify enum sql_types relative to the live search_path, so

--- a/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/foreign-table.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { Professor } from "../../test-helpers/models/professor.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
@@ -33,7 +33,7 @@ function quoteLit(s: string): string {
   return `'${s.replace(/'/g, "''")}'`;
 }
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base, serialize, Migration } from "../../index.js";
 import { stringify as yamlStringify, parse as yamlParse } from "@blazetrails/activesupport/yaml";
 
@@ -38,7 +38,7 @@ class HstoreWithSerialize extends Hstore {}
 serialize(HstoreWithSerialize, "tags", { coder: TagCollection });
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let connection: PostgreSQLAdapter;
   let column: any;

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Duration } from "@blazetrails/activesupport";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { Column as PostgreSQLColumn } from "../../connection-adapters/postgresql/column.js";
 
@@ -19,7 +19,7 @@ class IntervalDataType extends Base {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let adapter: PostgreSQLAdapter;
   let columnMax: PostgreSQLColumn;

--- a/packages/activerecord/src/adapters/postgresql/ltree.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/ltree.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { Base } from "../../index.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import type { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
 
@@ -19,7 +19,7 @@ class Ltree extends Base {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let connection: PostgreSQLAdapter;
 

--- a/packages/activerecord/src/adapters/postgresql/money.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/money.test.ts
@@ -5,7 +5,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import { sql as arelSql } from "@blazetrails/arel";
 import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
@@ -21,7 +21,7 @@ class PostgresqlMoney extends Base {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   // Rails: @connection = ActiveRecord::Base.lease_connection
   let connection: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/network.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/network.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 import type { Column as PgColumn } from "../../connection-adapters/postgresql/column.js";
 import type { TableDefinition as PgTableDefinition } from "../../connection-adapters/postgresql/schema-definitions.js";
@@ -17,7 +17,7 @@ class PostgresqlNetworkAddress extends Base {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let connection: PostgreSQLAdapter;
 

--- a/packages/activerecord/src/adapters/postgresql/numbers.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/numbers.test.ts
@@ -3,7 +3,7 @@
  */
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 
 // Rails: class PostgresqlNumber < ActiveRecord::Base
@@ -14,7 +14,7 @@ class PostgresqlNumber extends Base {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let connection: PostgreSQLAdapter;
 

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -9,7 +9,7 @@ import { Base } from "../../index.js";
 import { SchemaDumper } from "../../schema-dumper.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { TimeWithZone, TimeZone, setZone, resetZone, BigDecimal } from "@blazetrails/activesupport";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 
 beforeAll(() => {
   vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -29,7 +29,7 @@ const toInt = (s: string) => parseInt(s, 10);
 const toFloat = (s: string) => parseFloat(s);
 const toBigInt = (s: string) => BigInt(s);
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/schema-authorization.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema-authorization.test.ts
@@ -5,14 +5,14 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { StatementInvalid } from "../../errors.js";
 import { makeSchemaThingModel } from "./schema-ar-models.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 
 const TABLE_NAME = "schema_things";
 const COLUMNS = "id serial primary key, name character varying(50)";
 const USERS = ["rails_pg_schema_user1", "rails_pg_schema_user2"];
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -6,7 +6,7 @@ import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
 import { StatementInvalid } from "../../errors.js";
 import { makeThingModels, makeThing5Model, makeSongAlbumModels } from "./schema-ar-models.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { dumpAllTableSchema } from "../../test-helpers/schema-dumping-helper.js";
 import type { SchemaSource } from "../../schema-dumper.js";
 import { Base } from "../../index.js";
@@ -119,7 +119,7 @@ async function teardownSchemas(adapter: PostgreSQLAdapter) {
   await adapter.dropSchema("music", { ifExists: true });
 }
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -13,11 +13,11 @@ import {
 } from "./test-helper.js";
 import { SchemaDumper } from "../../connection-adapters/abstract/schema-dumper.js";
 import { DateTime as OidDateTime } from "../../connection-adapters/postgresql/oid/date-time.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { withTimezoneConfig } from "../../test-helper.js";
 import { Base } from "../../index.js";
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -8,7 +8,7 @@ import { SchemaDumper } from "../../schema-dumper.js";
 import { SchemaStatements } from "../../connection-adapters/abstract/schema-statements.js";
 import { RecordNotFound } from "../../errors.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base, registerModel } from "../../index.js";
 
 beforeAll(() => {
@@ -24,7 +24,7 @@ afterAll(() => {
 // in beforeAll) — a function-call default that createTable's typed builder
 // can't express. It is created via raw DDL below (mirroring Rails'
 // `@connection.create_table "uuid_data_type"`).
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/xml.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/xml.test.ts
@@ -4,7 +4,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { describeIfPg, PostgreSQLAdapter } from "./test-helper.js";
 import { SchemaDumper } from "../../schema-dumper.js";
-import { setupFixtures } from "../../test-helpers/fixtures.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import { Base } from "../../index.js";
 
 // Rails: class XmlDataType < ActiveRecord::Base
@@ -16,7 +16,7 @@ class XmlDataType extends Base {
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   let connection: PostgreSQLAdapter;
 

--- a/packages/activerecord/src/annotate.test.ts
+++ b/packages/activerecord/src/annotate.test.ts
@@ -9,7 +9,7 @@ import { fixtures } from "./test-helpers/fixtures.js";
 import { Post } from "./test-helpers/models/post.js";
 
 describe("AnnotateTest", () => {
-  // `fixtures` wires `setupFixtures` internally, so no separate call.
+  // `fixtures` wires the handler suite internally, so no separate call.
   // Mirrors Rails `fixtures :posts` — seed the canonical posts rows so each
   // annotated `select(:id)` relation has data to read back with `.first()`
   // (Rails' `assert posts.first`). The canonical `posts` table comes from the

--- a/packages/activerecord/src/associations/callbacks.test.ts
+++ b/packages/activerecord/src/associations/callbacks.test.ts
@@ -6,8 +6,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { Base, association, registerModel, enableSti, registerSubclass } from "../index.js";
 import { throwAbort } from "@blazetrails/activesupport";
 
-import { withTransactionalFixtures } from "../test-helpers/with-transactional-fixtures.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Project } from "../test-helpers/models/project.js";
 import { Developer, AuditLog } from "../test-helpers/models/developer.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -53,8 +52,7 @@ function makeAuthorWithCallbacks(callbacks: any) {
 // The canonical `authors`/`posts` tables ride the boot-laid schema.
 // Used by the has_many callback describes below.
 function setupAuthorPostSuite(): void {
-  setupFixtures();
-  withTransactionalFixtures(() => Base.connection);
+  fixtures({});
 }
 
 // ==========================================================================
@@ -532,8 +530,7 @@ describe("AssociationCallbacksTest", () => {
 // (associations/callbacks_test.rb:105-111).
 // ==========================================================================
 describe("AssociationCallbacksTest", () => {
-  setupFixtures();
-  withTransactionalFixtures(() => Base.connection);
+  fixtures({});
   beforeAll(async () => {
     registerModel(Company);
     registerModel(Firm);

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -1143,6 +1143,9 @@ describe("EagerAssociationTest", () => {
 });
 
 describe("EagerLoadingTooManyIdsTest", () => {
+  // Opt out of transactional fixtures: the 65536-row seed below is committed
+  // once in `beforeAll` (via chunked insertAll) and torn down manually in
+  // `afterAll`, rather than reseeded/rolled back per test.
   fixtures({}, { useTransactionalTests: false });
   // Mirrors the citations.yml fixture: 65536 rows (id 0..65535, book2_id i*i).
   // The point of these tests is that preload/eager_load split an IN clause whose

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -13,7 +13,7 @@ import {
 import { Notifications } from "@blazetrails/activesupport";
 import { HasManyThroughAssociation } from "./has-many-through-association.js";
 import { assertNotCalledOnInstanceOf } from "../testing/method-call-assertions.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { assertNoQueries, assertQueriesCount } from "../testing/query-assertions.js";
 import {
   Post,
@@ -1143,7 +1143,7 @@ describe("EagerAssociationTest", () => {
 });
 
 describe("EagerLoadingTooManyIdsTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
   // Mirrors the citations.yml fixture: 65536 rows (id 0..65535, book2_id i*i).
   // The point of these tests is that preload/eager_load split an IN clause whose
   // id list exceeds the adapter's bind-parameter limit, so the row count must be

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -12,7 +12,7 @@ import {
   InverseOfAssociationRecursiveError,
 } from "../index.js";
 import { loadBelongsTo, loadHasOne, loadHasMany, setBelongsTo } from "../associations.js";
-import { fixtures, setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { Branch, BrokenBranch } from "../test-helpers/models/branch.js";
 import { Human } from "../test-helpers/models/human.js";
 import { Face } from "../test-helpers/models/face.js";
@@ -1257,7 +1257,7 @@ describe("InverseMultipleHasManyInversesForSameModel", () => {
 // dedicated `branches` table setup BrokenBranch needs without disturbing the
 // fixture-backed block above.
 describe("InverseBelongsToTests", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
   beforeAll(() => {
     [Branch, BrokenBranch].forEach((m) => registerModel(m));
   });

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -1257,7 +1257,7 @@ describe("InverseMultipleHasManyInversesForSameModel", () => {
 // dedicated `branches` table setup BrokenBranch needs without disturbing the
 // fixture-backed block above.
 describe("InverseBelongsToTests", () => {
-  fixtures({}, { useTransactionalTests: false });
+  fixtures({});
   beforeAll(() => {
     [Branch, BrokenBranch].forEach((m) => registerModel(m));
   });

--- a/packages/activerecord/src/callbacks.test.ts
+++ b/packages/activerecord/src/callbacks.test.ts
@@ -10,7 +10,7 @@
 import { describe, it, expect } from "vitest";
 import { makeRange, throwAbort } from "@blazetrails/activesupport";
 import { Base, RecordNotSaved, RecordNotDestroyed, RecordInvalid } from "./index.js";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { ContextualCallbacksDeveloper } from "./test-helpers/models/contextual-callbacks-developer.js";
 
 type HistoryEntry = [string, string];
@@ -218,7 +218,7 @@ class CallbackHaltedDeveloper extends Base {
   }
 }
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 const { developers } = fixtures(["developers"]);
 
 function assertSaveCallbacksNotCalled(someone: CallbackHaltedDeveloper): void {

--- a/packages/activerecord/src/clone.test.ts
+++ b/packages/activerecord/src/clone.test.ts
@@ -7,7 +7,7 @@ import { fixtures } from "./test-helpers/fixtures.js";
 import { Topic } from "./test-helpers/models/topic.js";
 
 describe("CloneTest", () => {
-  // `fixtures` wires `setupFixtures` internally and is
+  // `fixtures` wires the handler suite internally and is
   // transactional, mirroring Rails' `fixtures :topics`.
   fixtures(["topics"]);
 

--- a/packages/activerecord/src/column-alias.test.ts
+++ b/packages/activerecord/src/column-alias.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 describe("TestColumnAlias", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
   beforeAll(async () => {
     await (Base.connection as any).executeMutation("INSERT INTO topics (title) VALUES ('a')");
   });

--- a/packages/activerecord/src/connection-handling.test.ts
+++ b/packages/activerecord/src/connection-handling.test.ts
@@ -5,7 +5,7 @@ import { setPermanentConnectionCheckout } from "./ar-config.js";
 import { ActiveRecordError } from "./errors.js";
 import { HashConfig } from "./database-configurations/hash-config.js";
 import { DatabaseConfigurations } from "./database-configurations.js";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { BetterSQLite3Adapter } from "./connection-adapters/better-sqlite3-adapter.js";
 import { Post } from "./test-helpers/models/post.js";
 import {
@@ -536,7 +536,7 @@ describe("ConnectionHandlingTest", () => {
 });
 
 describe("withRoleAndShard loads Relation return values within scope (Story K gap 5)", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   it("calls .load() on a Relation returned from the block", async () => {
     const { withRoleAndShard } = await import("./connection-handling.js");

--- a/packages/activerecord/src/date.test.ts
+++ b/packages/activerecord/src/date.test.ts
@@ -9,7 +9,7 @@ import { fixtures } from "./test-helpers/fixtures.js";
 import { Topic } from "./test-helpers/models/topic.js";
 
 describe("DateTest", () => {
-  // `fixtures` wires `setupFixtures` internally, so no separate call.
+  // `fixtures` wires the handler suite internally, so no separate call.
   // Rails date_test.rb declares no `fixtures`; wiring the canonical `topics`
   // table lets the file ride the shared Topic model with a real `last_read`
   // date column instead of an inline scratch table that collided under

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -105,7 +105,6 @@ async function withRecordTimestamps(
 }
 
 describe("InsertAllTest", () => {
-  fixtures({}, { useTransactionalTests: false });
   fixtures(["authors", "books"], {
     // These two raise a DB-level RecordNotUnique; a PG unique violation aborts
     // the surrounding transaction and poisons transactional-fixtures teardown,

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -20,7 +20,7 @@ import { UnknownAttributeError, RecordNotUnique } from "./errors.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { adapterType } from "./test-adapter.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 // Opt into the canonical-model autoload index so association targets resolve by
 // name on first reference — no manual `registerModel`.
 import "./test-helpers/canonical-model-index.js";
@@ -105,7 +105,7 @@ async function withRecordTimestamps(
 }
 
 describe("InsertAllTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
   fixtures(["authors", "books"], {
     // These two raise a DB-level RecordNotUnique; a PG unique violation aborts
     // the surrounding transaction and poisons transactional-fixtures teardown,

--- a/packages/activerecord/src/json-serialization.test.ts
+++ b/packages/activerecord/src/json-serialization.test.ts
@@ -25,14 +25,14 @@ import { Comment } from "./test-helpers/models/comment.js";
 import { Tag } from "./test-helpers/models/tag.js";
 import { Tagging } from "./test-helpers/models/tagging.js";
 
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import "./associations/collection-proxy.js";
 import "./association-relation.js";
 
 // Establish the worker's canonical template DB for the whole file so the
 // in-memory `Contact` suite below doesn't lazily initialize a bare connection
 // that would shadow the handler clone for the fixture-backed suite.
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 registerModel(Author);
 registerModel(Post);

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -14,7 +14,7 @@ import { adapterType } from "./test-adapter.js";
 import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { Migration } from "./migration.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { repairWorkerSchema } from "./test-helpers/schema-repair.js";
 import { TEST_SCHEMA } from "./test-helpers/test-schema.js";
 import { TableDefinition } from "./connection-adapters/abstract/schema-definitions.js";
@@ -52,7 +52,7 @@ async function freshContext(): Promise<{ adapter: DatabaseAdapter; ctx: Migratio
 
 // The migration-on-`people` tests (Rails runs `add_column/remove_column
 // "people", "last_name"` through a `Migrator`) need the canonical `people`
-// table materialized before the migrator runs. `setupFixtures()` establishes
+// table materialized before the migrator runs. `fixtures()` establishes
 // the schema-loaded primary pool, so `Base.connection` already carries the
 // canonical `people` table — no hand-built shape required. The afterEach strips
 // the scratch `last_name` column so sibling files see the pristine shape.
@@ -95,12 +95,12 @@ async function personColumnNames(adp: DatabaseAdapter): Promise<string[]> {
 }
 
 // Rails runs every migration test on `ActiveRecord::Base.connection`; ride the
-// schema-loaded primary pool established by `setupFixtures()` rather than a
-// sidecar `_pool` lease (RFC 0059). `setupFixtures()` shields the shared worker
+// schema-loaded primary pool established by `fixtures()` rather than a
+// sidecar `_pool` lease (RFC 0059). `fixtures()` shields the shared worker
 // DB from the global `resetTestAdapterState()`, so this file owns the per-test
 // cleanup of the bespoke tables its `MigrationContext` sub-describes create —
 // see the afterEach/afterAll below and each test's own `finally`.
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 // Mirrors migration_test.rb's teardown, which strips the scratch columns the
 // people-migration tests add back off the shared canonical `people` table and
@@ -230,7 +230,7 @@ describe("MigrationTest", () => {
     ctx.tableNamePrefix = "pre_";
     ctx.tableNameSuffix = "_suf";
     // Own the scratch tables for the whole test: with the global reset shielded
-    // by setupFixtures(), a leaked `pre_old_suf`/`pre_new_suf` would break the
+    // by fixtures(), a leaked `pre_old_suf`/`pre_new_suf` would break the
     // create/rename below, so clear any leak up front and drop in the finally.
     await ctx.dropTable("pre_old_suf", "pre_new_suf", { ifExists: true });
     try {
@@ -308,7 +308,7 @@ async function freshAdapter(): Promise<DatabaseAdapter> {
 // ==========================================================================
 // D-1 partial conversion: columnsHash()-only tests drop their adapter assignment
 // (adapter-independent). The 3 DB-operation tests and the DDL sub-describes retain
-// freshAdapterWithPeople()/await freshContext() isolation — adding setupFixtures() here
+// freshAdapterWithPeople()/await freshContext() isolation — adding fixtures() here
 // would call pushSkipGlobalReset() and prevent the per-test DDL cleanup that the
 // MigrationContext-based tests (ReservedWordsMigrationTest, BulkAlterTable, etc.)
 // depend on. Same structural reason as transaction-instrumentation.test.ts.
@@ -750,7 +750,7 @@ describe("MigrationTest", () => {
 
   it("create table with if not exists true", async () => {
     const { ctx } = await freshContext();
-    // With the global reset shielded by setupFixtures(), a leaked `things` from
+    // With the global reset shielded by fixtures(), a leaked `things` from
     // a sibling file would make the first, non-ifNotExists create raise; clear
     // any leak up front and drop in the finally so DDL stays confined here.
     await ctx.dropTable("things", { ifExists: true });
@@ -1495,7 +1495,7 @@ describe("MigrationTest", () => {
       bulkAdapter = await freshAdapter();
     });
     // Each test creates its own uniquely-named `bk*` table; with the global
-    // reset shielded by setupFixtures() they would persist across tests and into
+    // reset shielded by fixtures() they would persist across tests and into
     // sibling files, so drop them here (Rails' teardown drops the ad-hoc table).
     afterEach(async () => {
       const o = { ifExists: true } as const;
@@ -2203,9 +2203,9 @@ function mockMigration(): { migration: Migration; sql: string[] } {
 
 // Connection-fallback tests need a live Base connection pool (Rails leases the
 // migration connection from ActiveRecord::Base), so they run under
-// setupFixtures rather than the await freshAdapter()-per-test MigrationTest block.
+// fixtures() rather than the await freshAdapter()-per-test MigrationTest block.
 describe("MigrationTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   it("migration instance has connection", async () => {
     const migration = new (class extends Migration {})();

--- a/packages/activerecord/src/multiparameter-attributes.test.ts
+++ b/packages/activerecord/src/multiparameter-attributes.test.ts
@@ -12,7 +12,7 @@ import { Topic } from "./test-helpers/models/topic.js";
 const utc = (v: Temporal.Instant) => v.toZonedDateTimeISO("UTC");
 
 describe("MultiParameterAttributeTest", () => {
-  // fixtures wires setupFixtures + withTransactionalFixtures and warms the pool's
+  // fixtures wires the handler suite + transactional fixtures and warms the pool's
   // schema cache for topics so the synchronous loadSchema path (triggered by
   // new Topic() inside tests) finds the date/time column types correctly on all
   // adapters including MariaDB. Mirrors date.test.ts.

--- a/packages/activerecord/src/multiple-db.test.ts
+++ b/packages/activerecord/src/multiple-db.test.ts
@@ -2,7 +2,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import "./index.js";
 import { Base } from "./base.js";
 import { StatementInvalid } from "./errors.js";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { setupSecondPool } from "./test-helpers/setup-second-pool.js";
 import { isSqliteRun } from "./test-helpers/sqlite-template.js";
 import { ARUnit2Model } from "./test-helpers/models/arunit2-model.js";
@@ -15,9 +15,9 @@ import { Bird } from "./test-helpers/models/bird.js";
 // reproduce the split with a second in-memory SQLite pool on ARUnit2Model. The
 // PG/MySQL suites don't provision a second named database, so gate to SQLite.
 describe.skipIf(!isSqliteRun())("MultipleDbTest", () => {
-  // Rails sets `self.use_transactional_tests = false`; setupFixtures pins
+  // Rails sets `self.use_transactional_tests = false`; fixtures() pins
   // the schema/fixtures across the file (skips the global per-test reset).
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
   beforeAll(async () => {
     await setupSecondPool();
   });

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -6,7 +6,7 @@ import { Base, registerModel } from "./index.js";
 import { SchemaDumper } from "./schema-dumper.js";
 import { MissingAttributeError } from "@blazetrails/activemodel";
 import { adapterType } from "./test-adapter.js";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 import { Topic } from "./test-helpers/models/topic.js";
 import { Reply, SillyReply } from "./test-helpers/models/reply.js";
@@ -422,7 +422,7 @@ describe("PrimaryKeysTest", () => {
 });
 
 describe("PrimaryKeyWithAutoIncrementTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   class AutoIncrement extends Base {
     static _tableName = "auto_increments";
@@ -480,7 +480,7 @@ describe("PrimaryKeyWithAutoIncrementTest", () => {
 });
 
 describe("PrimaryKeyAnyTypeTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   class Barcode extends Base {
     static _tableName = "barcodes";
@@ -684,7 +684,7 @@ describe("CompositePrimaryKeyTest", () => {
 });
 
 describe("PrimaryKeyIntegerNilDefaultTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   beforeEach(async () => {
     await (Base.connection as any).dropTable("int_defaults", { ifExists: true });
@@ -721,7 +721,7 @@ describe("PrimaryKeyIntegerNilDefaultTest", () => {
 });
 
 describe("PrimaryKeyIntegerTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   class Widget extends Base {
     static _tableName = "widgets";

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -4,7 +4,7 @@
 // Rails test names and assertions as closely as TypeScript allows.
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { registerModel } from "./index.js"; // also eager-loads CollectionProxy for association()
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { Base } from "./base.js";
 import { Task } from "./test-helpers/models/task.js";
 import { Topic } from "./test-helpers/models/topic.js";
@@ -575,7 +575,7 @@ describe("QueryCacheTest", () => {
 });
 
 describe("QueryCacheMutableParamTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   // Mirrors Rails' `class JsonObj; self.table_name = "json_objs"; attribute
   // :payload, :json; end` — a scratch table Rails creates in `setup` (not a

--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -14,9 +14,9 @@ import {
   counterCacheColumnOption,
   resolveAliasedColumn,
 } from "./reflection.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 describe("ReflectionTest", () => {
   it("plain function for source type does not raise (only ES classes are rejected)", () => {

--- a/packages/activerecord/src/relation/select-star-join-collision.test.ts
+++ b/packages/activerecord/src/relation/select-star-join-collision.test.ts
@@ -28,7 +28,7 @@ import { quoteTableName, escapeRegExp } from "../test-helpers/quote-regex.js";
 registerModel(Friendship);
 
 describe("SELECT * column collision in joined relations", () => {
-  // `fixtures` wires setupFixtures + transactional fixtures +
+  // `fixtures` wires the handler suite + transactional fixtures +
   // fixture seeding in one call; the canonical `people` / `friendships` tables
   // come from the template clone.
   const { people } = fixtures(["people", "friendships"]);

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -23,7 +23,7 @@ const sym = (name: string) => Symbol(name) as unknown as string;
 // SelectTest — targets relation/select_test.rb
 // ==========================================================================
 describe("SelectTest", () => {
-  // `fixtures` wires `setupFixtures` internally. Mirrors Rails
+  // `fixtures` wires the handler suite internally. Mirrors Rails
   // `fixtures :posts, :comments`; the canonical `welcome` post
   // ("Welcome to the weblog") drives the `UPPER(title)` assertions and its
   // `greetings` comment ("Thank you for the welcome") drives the merge tests.

--- a/packages/activerecord/src/reserved-word.test.ts
+++ b/packages/activerecord/src/reserved-word.test.ts
@@ -14,7 +14,7 @@ import { describe, it, expect, beforeEach, afterAll } from "vitest";
 import { Base, RecordNotFound, registerModel } from "./index.js";
 import "./relation.js";
 import { Associations } from "./associations.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
 import { assertNoQueries } from "./testing/query-assertions.js";
 import { defineFixtures, defineJoinTableFixtures } from "./test-helpers/define-fixtures.js";
@@ -54,7 +54,7 @@ Associations.hasAndBelongsToMany.call(Distinct, "selects");
 // declare time), so we mirror it verbatim for class-body parity.
 Associations.hasMany.call(Distinct, "values", { through: "groups" });
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 // `adapter.schemaStatements()` is optional on the adapter interface; fall back
 // to constructing one directly, mirroring schema-types.ts.

--- a/packages/activerecord/src/sanitize.test.ts
+++ b/packages/activerecord/src/sanitize.test.ts
@@ -5,9 +5,9 @@
 import { describe, it, expect } from "vitest";
 import { sql as arelSql } from "@blazetrails/arel";
 import { Base, Range, UnknownAttributeReference } from "./index.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 // ==========================================================================
 // SanitizeTest — targets sanitize_test.rb

--- a/packages/activerecord/src/statement-invalid.test.ts
+++ b/packages/activerecord/src/statement-invalid.test.ts
@@ -2,7 +2,7 @@ import pg from "pg";
 import { describe, it, expect, beforeAll } from "vitest";
 import { Base } from "./index.js";
 import { StatementInvalid } from "./errors.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { adapterType } from "./test-adapter.js";
 
 class MockDatabaseError extends Error {}
@@ -28,7 +28,7 @@ class Book extends Base {
 }
 
 describe("StatementInvalidTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
   beforeAll(async () => {
     await Book.loadSchema();
   });

--- a/packages/activerecord/src/strict-loading.trails.test.ts
+++ b/packages/activerecord/src/strict-loading.trails.test.ts
@@ -30,7 +30,7 @@ interface ReflectionHost {
 // same models Rails' strict_loading_test.rb drives (`has_many :audit_logs`,
 // `has_one :ship`, `belongs_to :firm`, `has_and_belongs_to_many :projects`).
 describe("StrictLoadingNewRecordFindTargetTest", () => {
-  // `fixtures` wires `setupFixtures` internally; the `developers`
+  // `fixtures` wires the handler suite internally; the `developers`
   // fixture gives a persisted owner for the unchanged-behavior assertion.
   const { developers } = fixtures(["developers"]);
   // The loaders resolve target classes by name from the registry; register the

--- a/packages/activerecord/src/table-metadata.test.ts
+++ b/packages/activerecord/src/table-metadata.test.ts
@@ -3,7 +3,7 @@ import { StringType } from "@blazetrails/activemodel";
 import { Table } from "@blazetrails/arel";
 import { Base } from "./index.js";
 import { TableMetadata } from "./table-metadata.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 class AuditLog extends Base {
   static override _tableName = "audit_logs";
@@ -21,7 +21,7 @@ class AuditRequiredDeveloper extends Base {
 }
 
 describe("TableMetadataTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
   beforeAll(async () => {
     await AuditLog.loadSchema();
     await AuditRequiredDeveloper.loadSchema();

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { travel, travelBack, travelTo } from "@blazetrails/activesupport";
 import { Base, MigrationContext, registerModel } from "./index.js";
-import { fixtures, setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import {
   Developer,
   DeveloperCalledJamis,
@@ -531,7 +531,7 @@ describe("TimestampTest", () => {
 });
 
 describe("TimestampsWithoutTransactionTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   afterEach(async () => {
     const ctx = new MigrationContext(Base.connection);

--- a/packages/activerecord/src/transaction-isolation.test.ts
+++ b/packages/activerecord/src/transaction-isolation.test.ts
@@ -2,13 +2,13 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
 import { Base, TransactionIsolationError } from "./index.js";
 import { adapterType } from "./test-adapter.js";
 import { adapterSupports } from "./test-helpers/supports.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { describeIfPg, PG_TEST_URL } from "./adapters/postgresql/test-helper.js";
 
 // Runs when the adapter does NOT support transaction isolation (or is SQLite3).
 // Rails: TransactionIsolationUnsupportedTest
 describe("TransactionIsolationUnsupportedTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   it.skipIf(adapterType !== "sqlite")("setting the isolation level raises an error", async () => {
     class Tag extends Base {
@@ -44,7 +44,7 @@ describe("TransactionIsolationUnsupportedTest", () => {
 // body that also runs on MySQL is required before their gate can match Rails'
 // mysql,postgresql adapter set).
 describe("TransactionIsolationTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   it.skipIf(adapterType === "sqlite" || !adapterSupports("transaction_isolation"))(
     "setting isolation when joining a transaction raises an error",
@@ -85,7 +85,7 @@ describe("TransactionIsolationTest", () => {
 // their transactions run on independent physical connections — matching Rails'
 // `Tag.establish_connection :arunit` / `Tag2.establish_connection :arunit` pattern.
 describeIfPg("TransactionIsolationTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   class Tag extends Base {
     static {

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from "vitest";
 import { Base, transaction } from "./index.js";
 import { NullTransaction } from "./connection-adapters/abstract/transaction.js";
-import { setupFixtures, fixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import { AbstractSQLite3Adapter } from "./connection-adapters/sqlite3-adapter.js";
@@ -72,7 +72,7 @@ afterEach(async () => {
 });
 
 describe("TransactionTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
 
   beforeAll(async () => {
     // Re-lay the canonical `topics` on the handler connection (drop-and-recreate,

--- a/packages/activerecord/src/type/integer.test.ts
+++ b/packages/activerecord/src/type/integer.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from "vitest";
 import { IntegerType } from "@blazetrails/activemodel";
 import { Base } from "../index.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 describe("IntegerTest", () => {
   it("casting ActiveRecord models", () => {

--- a/packages/activerecord/src/type/integer.test.ts
+++ b/packages/activerecord/src/type/integer.test.ts
@@ -3,7 +3,7 @@ import { IntegerType } from "@blazetrails/activemodel";
 import { Base } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 
-fixtures({}, { useTransactionalTests: false });
+fixtures({});
 
 describe("IntegerTest", () => {
   it("casting ActiveRecord models", () => {

--- a/packages/activerecord/src/types.test.ts
+++ b/packages/activerecord/src/types.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest";
 import { ValueType } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
-import { setupFixtures } from "./test-helpers/fixtures.js";
+import { fixtures } from "./test-helpers/fixtures.js";
 
 describe("TypesTest", () => {
-  setupFixtures();
+  fixtures({}, { useTransactionalTests: false });
   it("attributes which are invalid for database can still be reassigned", async () => {
     const TypeWhichCannotGoToTheDatabase = class extends ValueType {
       override serialize(): unknown {

--- a/packages/activerecord/src/validations/numericality-validation.test.ts
+++ b/packages/activerecord/src/validations/numericality-validation.test.ts
@@ -10,7 +10,7 @@ import { Base } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { NumericData } from "../test-helpers/models/numeric-data.js";
 
-fixtures({}, { useTransactionalTests: false });
+fixtures({});
 
 beforeAll(async () => {
   await NumericData.loadSchema();

--- a/packages/activerecord/src/validations/numericality-validation.test.ts
+++ b/packages/activerecord/src/validations/numericality-validation.test.ts
@@ -7,10 +7,10 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { BigDecimal } from "@blazetrails/activesupport";
 import { DecimalType } from "@blazetrails/activemodel";
 import { Base } from "../index.js";
-import { setupFixtures } from "../test-helpers/fixtures.js";
+import { fixtures } from "../test-helpers/fixtures.js";
 import { NumericData } from "../test-helpers/models/numeric-data.js";
 
-setupFixtures();
+fixtures({}, { useTransactionalTests: false });
 
 beforeAll(async () => {
   await NumericData.loadSchema();


### PR DESCRIPTION
Drives the deprecated `setupFixtures` / `useHandlerTransactionalFixtures`
surface to **zero test-file callers** across `packages/activerecord/src`,
genuinely unblocking the RFC 0062 terminal removal story
(`delete-setupfixtures-surface`).

### Gate note

The story/gate glob `packages/activerecord/src/**/*.test.ts` is **buggy under
git pathspec** — `**/` fails to match top-level `src/*.test.ts` files, so it
returned 0 while 24 real callers remained. The correct gate is:

```
git grep -l "setupFixtures\|useHandlerTransactionalFixtures" -- 'packages/activerecord/src' | grep '\.test\.ts' | grep -v test-helpers
```

which now returns **0**. (The only repo-wide remaining references are in
`scripts/d1-migrate*.ts` — the codemod tooling that *emits* the surface into
generated files; updating/removing that tooling belongs to the terminal-removal
story, not here.)

## Changes (52 files)

**Conversion rule — exact behavioral equivalence, no behavior change:**
- bare `setupFixtures()` → `fixtures({}, { useTransactionalTests: false })`.
  `setupFixtures()` is a bare alias for `setupHandlerSuite()`
  (`test-helpers/fixtures.ts:17-19`) with no transactional wrapping; the
  `useTransactionalTests: false` form skips `withTransactionalFixtures`
  entirely (`use-fixtures.ts:571-596`) — a like-for-like wiring swap.
- `setupFixtures()` + `withTransactionalFixtures(() => Base.connection)` →
  `fixtures({})` (`use-fixtures.ts:554-598` — identical composition, no options
  dropped).

**Canonical suites upgraded to the endgame transactional surface** where they
do no persistent writes (or benefit from per-test rollback): `type/integer`,
`validations/numericality-validation`, `associations/inverse-associations`
(`InverseBelongsToTests` gains proper rollback of created `Branch` records),
`associations/callbacks` → plain `fixtures({})`.

**`EagerLoadingTooManyIdsTest`** keeps `useTransactionalTests: false` (its
65536-row set is committed once in `beforeAll` and torn down in `afterAll`,
not reseeded/rolled back per test) — now annotated.

**Bespoke PG/MySQL DDL suites** (19 `adapters/postgresql/*`, 2
`adapters/abstract-mysql-adapter/*`) and the **top-level `src/*.test.ts`
callers** (adapter, callbacks, column-alias, connection-handling, insert-all,
json-serialization, migration, multiple-db, primary-keys, query-cache,
reflection.trails, reserved-word, sanitize, statement-invalid, table-metadata,
timestamp, transaction-isolation, transactions.trails, types): the
exact-equivalent `fixtures({}, { useTransactionalTests: false })`.

**Comment-only mentions** reworded so the gate reads clean (relation/select*,
schema-migrations, mysql-explain, annotate, clone, date,
multiparameter-attributes, strict-loading.trails).

## Verification

- Correct gate → 0 (command above).
- All converted top-level + canonical suites pass locally on sqlite
  (adapter/callbacks/…/types: 443 + 88 skipped; migration: 66 + 24 skipped;
  integer/numericality/inverse: 110; eager: 194 + 8 skipped). PG/MySQL adapter
  suites are `describeIf*`-gated / excluded from the local sqlite project and
  are exercised by their CI lanes.
- No test renames. 238 LOC (119/119), single mechanical rename. Pre-commit
  (eslint + prettier + tsc build) passes.

Closes-story: convert-remaining-setupfixtures-callers-to-fixtures

> **Follow-up in this PR:** removed the pre-existing redundant double handler-suite wiring in `insert-all.test.ts` (`InsertAllTest`) flagged in review — the leading empty `fixtures({})` was already superseded by the `fixtures(["authors","books"])` call on the next line.
