### PR TITLE
test(schema-dumper): bump adapter-introspection dump timeouts to 60s on PG

### DIFF
--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -275,6 +275,11 @@ describe("SchemaDumperAdapterTest", () => {
     const { SchemaMigration } = await import("./schema-migration.js");
     const sm = new SchemaMigration(adapter);
     await sm.createTable();
+    // schema_migrations survives per-file truncation (truncate skips it by
+    // design), so a prior run's version row can survive in the shared PG
+    // worker DB and collide on schema_migrations_pkey. Clear first to keep
+    // this test hermetic — same guard the sibling "defaults to 0" test uses.
+    await sm.deleteAllVersions();
     await sm.recordVersion("20240101000000");
     await sm.recordVersion("20240201000000");
     const result = await TopLevelDumper.dumpWithVersion(adapter);

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -208,9 +208,9 @@ describe("SchemaDumperAdapterTest", () => {
     expect(result).toContain('"body"');
     // Adapter-introspection dumps walk the entire canonical schema (~200
     // tables) on the shared PG worker DB; under 6-fork parallel load this
-    // legitimately exceeds vitest's 5s default. Bump to 30s (I/O contention,
+    // legitimately exceeds vitest's 5s default. Bump to 60s (I/O contention,
     // not a logic bug). See project_schema_dumper_trails_pg_schema_migrations_flake.
-  }, 30000);
+  }, 60000);
 
   it("dumps schema with indexes from adapter", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -221,7 +221,7 @@ describe("SchemaDumperAdapterTest", () => {
     const result = await TopLevelDumper.dump(adapter);
     expect(result).toContain("addIndex");
     expect(result).toContain("index_testings_on_post_id");
-  }, 30000);
+  }, 60000);
 
   it("adapter-backed dump emits precision: null for datetime column without precision", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -230,7 +230,7 @@ describe("SchemaDumperAdapterTest", () => {
     });
     const result = await TopLevelDumper.dump(adapter);
     expect(result).toMatch(/t\.datetime\("happened_at"[^}]*precision\s*:\s*null/);
-  }, 30000);
+  }, 60000);
 
   it("adapter-backed dump preserves explicit string limit through AdapterSchemaSource", async () => {
     // Guards the U2 type/sqlType split: emitTable resolves the limit from the
@@ -243,7 +243,7 @@ describe("SchemaDumperAdapterTest", () => {
     });
     const result = await TopLevelDumper.dump(adapter);
     expect(result).toMatch(/t\.string\("code"[^}]*limit\s*:\s*10/);
-  }, 30000);
+  }, 60000);
 
   it("skips internal tables when dumping from adapter", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -258,7 +258,7 @@ describe("SchemaDumperAdapterTest", () => {
     expect(result).toContain("reminders");
     expect(result).not.toContain("schema_migrations");
     expect(result).not.toContain("ar_internal_metadata");
-  }, 30000);
+  }, 60000);
 
   it("dumpWithVersion defaults to 0 when no versions recorded", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -268,7 +268,7 @@ describe("SchemaDumperAdapterTest", () => {
     await sm.deleteAllVersions();
     const result = await TopLevelDumper.dumpWithVersion(adapter);
     expect(result).toContain("Schema version: 0");
-  }, 30000);
+  }, 60000);
 
   it("dumpWithVersion includes latest migration version", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -284,7 +284,7 @@ describe("SchemaDumperAdapterTest", () => {
     await sm.recordVersion("20240201000000");
     const result = await TopLevelDumper.dumpWithVersion(adapter);
     expect(result).toContain("Schema version: 20240201000000");
-  }, 30000);
+  }, 60000);
 
   it("emitTable forwards comment from fetchTableOptions into createTable options", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -206,7 +206,11 @@ describe("SchemaDumperAdapterTest", () => {
     expect(result).toContain("horses");
     expect(result).toContain('"title"');
     expect(result).toContain('"body"');
-  });
+    // Adapter-introspection dumps walk the entire canonical schema (~200
+    // tables) on the shared PG worker DB; under 6-fork parallel load this
+    // legitimately exceeds vitest's 5s default. Bump to 30s (I/O contention,
+    // not a logic bug). See project_schema_dumper_trails_pg_schema_migrations_flake.
+  }, 30000);
 
   it("dumps schema with indexes from adapter", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -217,7 +221,7 @@ describe("SchemaDumperAdapterTest", () => {
     const result = await TopLevelDumper.dump(adapter);
     expect(result).toContain("addIndex");
     expect(result).toContain("index_testings_on_post_id");
-  });
+  }, 30000);
 
   it("adapter-backed dump emits precision: null for datetime column without precision", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -226,7 +230,7 @@ describe("SchemaDumperAdapterTest", () => {
     });
     const result = await TopLevelDumper.dump(adapter);
     expect(result).toMatch(/t\.datetime\("happened_at"[^}]*precision\s*:\s*null/);
-  });
+  }, 30000);
 
   it("adapter-backed dump preserves explicit string limit through AdapterSchemaSource", async () => {
     // Guards the U2 type/sqlType split: emitTable resolves the limit from the
@@ -239,7 +243,7 @@ describe("SchemaDumperAdapterTest", () => {
     });
     const result = await TopLevelDumper.dump(adapter);
     expect(result).toMatch(/t\.string\("code"[^}]*limit\s*:\s*10/);
-  });
+  }, 30000);
 
   it("skips internal tables when dumping from adapter", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -254,7 +258,7 @@ describe("SchemaDumperAdapterTest", () => {
     expect(result).toContain("reminders");
     expect(result).not.toContain("schema_migrations");
     expect(result).not.toContain("ar_internal_metadata");
-  });
+  }, 30000);
 
   it("dumpWithVersion defaults to 0 when no versions recorded", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -264,7 +268,7 @@ describe("SchemaDumperAdapterTest", () => {
     await sm.deleteAllVersions();
     const result = await TopLevelDumper.dumpWithVersion(adapter);
     expect(result).toContain("Schema version: 0");
-  });
+  }, 30000);
 
   it("dumpWithVersion includes latest migration version", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -275,7 +279,7 @@ describe("SchemaDumperAdapterTest", () => {
     await sm.recordVersion("20240201000000");
     const result = await TopLevelDumper.dumpWithVersion(adapter);
     expect(result).toContain("Schema version: 20240201000000");
-  });
+  }, 30000);
 
   it("emitTable forwards comment from fetchTableOptions into createTable options", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");


### PR DESCRIPTION
## Problem

`SchemaDumperAdapterTest` in `packages/activerecord/src/schema-dumper.trails.test.ts` is a long-standing PG flake — it failed the "Active Record PostgreSQL Tests (2)" shard two runs in a row on #4623. It fails **only** on PostgreSQL under parallel fork load (green on sqlite and locally), with two documented symptoms.

## Root cause

The suite uses `fixtures({}, { useTransactionalTests: false })`, so it rides the full canonical schema (~200 tables) on `Base.connection`.

1. **`Test timed out in 5000ms`** (6 tests) — each calls `TopLevelDumper.dump/dumpWithVersion`, which introspects and dumps the **entire** database. Under 6-worker fork contention on the PG lane, a full-DB dump routinely exceeds vitest's 5s default. I/O contention, not a logic bug (same class as comment.test / enum.test #4250).
2. **`duplicate key value violates unique constraint "schema_migrations_pkey"`** — the `dumpWithVersion includes latest migration version` test recorded `20240101000000` without first clearing versions. Per-file truncation skips `schema_migrations` by design, so a prior run's row survives in the shared PG worker DB and collides.

## Fix

1. Raise the per-test timeout to `60000ms` (matching the #4250 scoped-dump precedent) for the full-DB-dump cases — the 6 flaky ones plus the sibling `dumps schema from adapter introspection` test, which does the identical full-DB walk and is a latent flake. A higher timeout ceiling has no cost on green runs and absorbs CI load spikes.
2. Clear `schema_migrations` before recording versions in the version test, matching the sibling `defaults to 0` test — makes it hermetic against surviving rows.

No assertions weakened, no tests renamed.

Verified locally: `pnpm vitest run packages/activerecord/src/schema-dumper.trails.test.ts` → 22 passed.