### PR TITLE
fix(relation): fold eager load into from() subquery source

### DIFF
--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2425,15 +2425,20 @@ export function buildFrom(this: QueryMethodsHost): unknown {
     // `SelectManager#as`, so the alias is caller-trusted (same trust model as
     // the set-op branch above). A regex guard here was stricter than Rails and
     // left the two `from(Relation)` paths asymmetric.
-    // When the from-value is a Relation that needs eager loading, derive the
-    // from clause via applyJoinDependency on a clone first (mirrors Rails
-    // build_from). Clone avoids mutating the caller's relation in-place since
-    // applyJoinDependency modifies _joinClauses.
+    // When the from-value is a Relation that needs eager loading (Rails
+    // `opts.eager_loading?`), derive the from clause via
+    // `apply_join_dependency` first (Rails build_from). This folds the eager
+    // `includes`/`eager_load` into LEFT OUTER JOINs so a WHERE that references
+    // the joined table (e.g. `posts.type`) resolves inside the subquery.
+    // `applyJoinDependencyForArel` clones internally, so the caller's relation
+    // is not mutated.
     let resolved: any = opts;
-    if (typeof opts._eagerLoadingForSql === "function" && opts._eagerLoadingForSql()) {
-      resolved = opts._clone
-        ? opts._clone().applyJoinDependency(true)
-        : opts.applyJoinDependency(true);
+    if (
+      typeof opts._eagerLoadingForSql === "function" &&
+      opts._eagerLoadingForSql() &&
+      typeof opts.applyJoinDependencyForArel === "function"
+    ) {
+      resolved = opts.applyJoinDependencyForArel(opts._groupColumns?.length === 0);
     }
     // Rails build_from wraps `opts.arel.as(name)`, where `arel` is the full
     // `build_arel` — joins, HAVING, nested FROM, LOCK, CTEs, etc. Use the

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -384,15 +384,20 @@ describe("RelationTest", () => {
     // BLOCKED: relations — canonical comments table lacks STI `type` column
   });
 
-  it.skip("finding with subquery with eager loading in from", () => {
-    // BLOCKED: relations — Comment.includes("post").where({ "posts.type": "Post" }) subquery
-    // needs eager_load JOIN folded into FROM subquery; eagerLoad is implemented but
-    // composing it with from() as a subquery source is not yet supported
+  it("finding with subquery with eager loading in from", async () => {
+    const relation = Comment.includes("post").where({ "posts.type": "Post" }).order("id");
+    const expected = (await relation.toArray()).map((c) => c.id);
+    expect((await Comment.select("*").from(relation)).map((c) => c.id)).toEqual(expected);
+    expect((await Comment.select("subquery.*").from(relation)).map((c) => c.id)).toEqual(expected);
+    expect((await Comment.select("a.*").from(relation, "a")).map((c) => c.id)).toEqual(expected);
   });
 
-  it.skip("finding with subquery with eager loading in where", () => {
-    // BLOCKED: relations — same as above; Comment.includes("post").where({ "posts.type": "Post" })
-    // used as an id-in subquery requires eager_load→JOIN in the subquery context
+  it("finding with subquery with eager loading in where", async () => {
+    const relation = Comment.includes("post").where({ "posts.type": "Post" });
+    const expected = (await relation.toArray()).map((c) => Number(c.id)).sort((a, b) => a - b);
+    expect(
+      (await Comment.where({ id: relation })).map((c) => Number(c.id)).sort((a, b) => a - b),
+    ).toEqual(expected);
   });
 
   it("finding with conditions", async () => {


### PR DESCRIPTION
## What

Rails `build_from` calls `apply_join_dependency` when the `from()` value is an eager-loading relation, so a WHERE that references the joined table (e.g. `posts.type`) resolves inside the subquery. trails' `buildFrom` routed the eager branch through a legacy stub `applyJoinDependency` that only flipped join types and never actually added the join — so the subquery dropped the LEFT OUTER JOIN and failed with `no such column: posts.type`.

This routes the eager branch through `applyJoinDependencyForArel` — the same method the where-subquery path (`relation-handler`) and the calculation paths use — which clones the relation and folds the eager `includes`/`eager_load` specs into LEFT OUTER JOINs.

## Tests

Unskips both Rails-ported tests in `relations.test.ts`:
- `finding with subquery with eager loading in from`
- `finding with subquery with eager loading in where`

Rails source: `vendor/rails/activerecord/test/cases/relations_test.rb:252,259`; `build_from` at `query_methods.rb:1783`.

Closes-story: relations-eager-load-from-subquery