### PR TITLE
feat(relation): route joins(:cte) symbol to INNER JOIN via buildWithJoinNode

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -1907,6 +1907,17 @@ export class Relation<T extends Base> {
           rel._namedInnerJoins.push(arg);
         continue;
       }
+      // A genuine Symbol is trails' signal for "association/CTE name" (vs a raw
+      // SQL string), mirroring Ruby's `joins(:name)`. Route it into
+      // `_namedInnerJoins` so `emitJoinPlan`'s `selectNamedJoins` can partition a
+      // `with(...)` CTE name out to `buildWithJoinNode(name, InnerJoin)`; a raw
+      // Symbol left in `_joinValues` would reach the arel visitor and raise
+      // "Unknown node type: Symbol".
+      if (typeof arg === "symbol") {
+        if (!rel._namedInnerJoins.some((v) => _qm.structuralUnionEq(v, arg)))
+          rel._namedInnerJoins.push(arg as unknown as AssociationSpec);
+        continue;
+      }
       const joinValue = arg as string | Nodes.Join;
       if (!rel._joinValues.some((v) => _qm.structuralUnionEq(v, joinValue)))
         rel._joinValues.push(joinValue);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2920,9 +2920,31 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   // mirrors `unless named_joins.empty? && stashed_joins.empty?`; when named_joins
   // is empty but the stash is not, Rails still builds an empty
   // `construct_join_dependency([], InnerJoin)` and folds the stash into it.
-  const [namedJoins, joinType] =
+  //
+  // Rails build_join_buckets (query_methods.rb:1865-1873) runs the inner
+  // joins_values through select_named_joins, whose block routes a CTEJoin — a
+  // joins() symbol matching a with(...) CTE name — to build_with_join_node(name)
+  // (an InnerJoin node), while ordinary association names fold into the named
+  // JoinDependency. Mirror it here so BOTH the live path (_applyJoinsToManager)
+  // and the subquery path (buildJoins) route the CTE symbol; without the
+  // partition the bare Symbol reaches the arel visitor and raises
+  // "Unknown node type: Symbol".
+  const cteInnerJoinNodes: Nodes.Join[] = [];
+  const innerNamed =
     this._namedInnerJoins.length > 0
-      ? ([this._namedInnerJoins, Nodes.InnerJoin] as const)
+      ? (selectNamedJoins.call(this, this._namedInnerJoins, plan.stashedJoins, (join) => {
+          if (join instanceof CTEJoin) {
+            cteInnerJoinNodes.push(
+              buildWithJoinNode.call(this, join.name, Nodes.InnerJoin) as Nodes.Join,
+            );
+          } else {
+            throw argumentError("only Hash, Symbol and Array are allowed");
+          }
+        }) as AssociationSpec[])
+      : ([] as AssociationSpec[]);
+  const [namedJoins, joinType] =
+    innerNamed.length > 0
+      ? ([innerNamed, Nodes.InnerJoin] as const)
       : plan.namedJoins.length > 0
         ? ([plan.namedJoins, Nodes.OuterJoin] as const)
         : ([[] as AssociationSpec[], Nodes.InnerJoin] as const);
@@ -2944,6 +2966,10 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
   for (const jd of this._leftOuterJoinDeps) {
     for (const node of jd.joinConstraints([], sharedTracker)) manager.appendJoinNode(node);
   }
+
+  // CTE inner-join nodes (from a joins(cteSym) partitioned above) emit as
+  // Rails' buckets[:join_node], after the named JoinDependency constraints.
+  for (const node of cteInnerJoinNodes) manager.appendJoinNode(node);
 
   for (const node of plan.joinNodes) manager.appendJoinNode(node);
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2938,7 +2938,14 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
               buildWithJoinNode.call(this, join.name, Nodes.InnerJoin) as Nodes.Join,
             );
           } else {
-            throw argumentError("only Hash, Symbol and Array are allowed");
+            // Rails' inner joins_values fallback raises a plain RuntimeError
+            // `"unknown class: <ClassName>"` (query_methods.rb:1870-1872) — NOT
+            // the left-outer bucket's `ArgumentError` "only Hash, Symbol and
+            // Array are allowed" (query_methods.rb:1834). The two buckets diverge
+            // here, so mirror that divergence.
+            throw new Error(
+              `unknown class: ${(join as { constructor?: { name?: string } })?.constructor?.name}`,
+            );
           }
         }) as AssociationSpec[])
       : ([] as AssociationSpec[]);
@@ -2967,11 +2974,15 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
     for (const node of jd.joinConstraints([], sharedTracker)) manager.appendJoinNode(node);
   }
 
-  // CTE inner-join nodes (from a joins(cteSym) partitioned above) emit as
-  // Rails' buckets[:join_node], after the named JoinDependency constraints.
-  for (const node of cteInnerJoinNodes) manager.appendJoinNode(node);
-
+  // Rails' single `buckets[:join_node]` array is populated raw joins_values Join
+  // nodes FIRST (the `while joins.first.is_a?(Arel::Nodes::Join)` loop,
+  // query_methods.rb:1856-1863), THEN CTE nodes appended by the select_named_joins
+  // block (query_methods.rb:1865-1873); `build_joins` concats the whole array once
+  // (query_methods.rb:1899). Preserve that order: raw `plan.joinNodes` before the
+  // partitioned `cteInnerJoinNodes`.
   for (const node of plan.joinNodes) manager.appendJoinNode(node);
+
+  for (const node of cteInnerJoinNodes) manager.appendJoinNode(node);
 
   // When a tracker was threaded in (Rails passes the alias HASH itself to
   // `join_scope.arel(alias_tracker.aliases)`, so claims made while building this

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -189,12 +189,11 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
   });
 
   it("with joins", async () => {
-    // Rails: `.joins(:commented_posts)`. trails' inner-join API does not accept a
-    // bare CTE name as a symbol (the CTEJoin partition only runs on the
-    // left_outer/eager paths), so we join the CTE by its SQL name instead — the
-    // assertion (POSTS_WITH_COMMENTS) is unchanged.
+    // Rails: `.joins(:commented_posts)`. trails routes a CTE-name symbol in
+    // joins() to build_with_join_node(name, InnerJoin) — an
+    // `INNER JOIN commented_posts ON commented_posts.post_id = posts.id`.
     const relation = Post.with({ commented_posts: Comment.select("post_id").distinct() }).joins(
-      "JOIN commented_posts ON commented_posts.post_id = posts.id",
+      cteSym("commented_posts"),
     );
 
     expect(toIds(await relation.order("id").pluck("id"))).toEqual(POSTS_WITH_COMMENTS);

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -199,6 +199,32 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     expect(toIds(await relation.order("id").pluck("id"))).toEqual(POSTS_WITH_COMMENTS);
   });
 
+  it("with joins routes a cte symbol to an inner join", () => {
+    // Rails routes a symbol joins() arg matching a `with(...)` CTE name to a
+    // `build_with_join_node(name, Arel::Nodes::InnerJoin)` join_node
+    // (query_methods.rb:1865-1873), which joins on
+    // `cte[model.foreign_key] = table[model.primary_key]`. trails mirrors this in
+    // `emitJoinPlan`' `selectNamedJoins` block — a `CTEJoin` becomes
+    // `buildWithJoinNode(name, Nodes.InnerJoin)`. Lock the InnerJoin routing: the
+    // CTE symbol must emit an INNER JOIN to the CTE
+    // (`commented_posts.post_id = posts.id`), not a LEFT OUTER JOIN.
+    const sql = (
+      Post.with({
+        commented_posts: Comment.select("post_id").distinct(),
+      }).joins(cteSym("commented_posts")) as unknown as { toSql(): string }
+    ).toSql();
+
+    // Identifier quoting is dialect-specific (`"` on sqlite/pg, backticks on
+    // MariaDB/MySQL), so the quote char is optional in the match.
+    const q = `["\`]?`;
+    expect(sql).toMatch(
+      new RegExp(
+        `INNER JOIN ${q}commented_posts${q} ON ${q}commented_posts${q}\\.${q}post_id${q} = ${q}posts${q}\\.${q}id${q}`,
+      ),
+    );
+    expect(sql).not.toMatch(new RegExp(`LEFT OUTER JOIN ${q}commented_posts${q}`));
+  });
+
   it("with left joins", async () => {
     const relation = Post.with({ commented_posts: Comment.select("post_id").distinct() })
       .joins("LEFT OUTER JOIN commented_posts ON commented_posts.post_id = posts.id")


### PR DESCRIPTION
## What

Routes a CTE-name Symbol in `joins(...)` position to an **INNER JOIN**, matching Rails `build_join_buckets` (`query_methods.rb:1865-1873`, `build_with_join_node(name, Arel::Nodes::InnerJoin)`).

Previously `Post.with(cte: sub).joins(cteSym)` raised `Unknown node type: Symbol`: a JS Symbol failed the `typeof arg === "string"` association check in `joins` and fell through to `_joinValues` (raw SQL joins), so the bare Symbol reached the arel visitor.

## Changes

- `relation.ts` (`joins`): a genuine Symbol now routes into `_namedInnerJoins` (trails' `joins_values` inner path), mirroring Ruby's `joins(:name)`.
- `query-methods.ts` (`emitJoinPlan`): the inner named joins run through `selectNamedJoins`, whose block partitions a `CTEJoin` out to `buildWithJoinNode(name, Nodes.InnerJoin)` (emitted as a `join_node` after the named JoinDependency), while ordinary association names fold into the JD. Centralized here so BOTH the live path (`_applyJoinsToManager`) and the subquery path (`buildJoins`) route it.
- `with.test.ts`: converts the WithTest "with joins" case from the raw-SQL-string workaround to the canonical `joins(cteSym)` form, mirroring Rails' `test_with_joins`.

## Out of scope

- Left-outer live-path routing (separate story).

Closes-story: route-cte-symbol-joins-inner-join