### PR TITLE
feat(relation): route leftOuterJoins CTE symbol on live path

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3595,12 +3595,14 @@ export class Relation<T extends Base> {
     // a CTEJoin routes to `buildWithJoinNode(name, OuterJoin)` (like the
     // subquery `from(relation)` path) so `Post.with(cte).leftOuterJoins(cteSym)`
     // emits a LEFT OUTER JOIN directly on this live path instead of raising
-    // "Invalid association spec".
-    const stashedJoins: JoinDependency[] = [];
+    // "Invalid association spec". A JoinDependency already in the values is
+    // stashed into `leftStashed`; the constructed left-outer JD is `unshift`ed
+    // ahead of it (query_methods.rb:1843: `stashed_left_joins.unshift`).
+    const leftStashed: JoinDependency[] = [];
     const leftAssociations = _qm.selectNamedJoins.call(
       this as any,
       pendingLeftOuter,
-      stashedJoins,
+      leftStashed,
       (left: unknown) => {
         if (left instanceof _qm.CTEJoin) {
           joinNodes.push(
@@ -3619,7 +3621,8 @@ export class Relation<T extends Base> {
             Nodes.OuterJoin,
           )
         : null;
-    if (leftOuterJd) stashedJoins.push(leftOuterJd);
+    if (leftOuterJd) leftStashed.unshift(leftOuterJd);
+    const stashedJoins: JoinDependency[] = [...leftStashed];
     // Fold the eager JoinDependency in last, mirroring Rails' `joins_values`
     // ordering (left-outer stash unshifted ahead of the eager stash in
     // `build_join_buckets`). `walk` dedups any eager node coinciding with a

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3589,15 +3589,36 @@ export class Relation<T extends Base> {
     const promotedIncludes = this._includesToPromoteFromReferences();
     const eagerCovered = new Set([...this._eagerLoadAssociations, ...promotedIncludes]);
     const pendingLeftOuter = this._leftOuterJoinsValues.filter((v) => !eagerCovered.has(v));
+    // Partition CTE-name symbols out of the left-outer values into LEFT OUTER
+    // JOIN nodes, mirroring buildJoinBuckets' `select_named_joins` block
+    // (query_methods.rb:1830-1836). Only true associations remain for the JD;
+    // a CTEJoin routes to `buildWithJoinNode(name, OuterJoin)` (like the
+    // subquery `from(relation)` path) so `Post.with(cte).leftOuterJoins(cteSym)`
+    // emits a LEFT OUTER JOIN directly on this live path instead of raising
+    // "Invalid association spec".
+    const stashedJoins: JoinDependency[] = [];
+    const leftAssociations = _qm.selectNamedJoins.call(
+      this as any,
+      pendingLeftOuter,
+      stashedJoins,
+      (left: unknown) => {
+        if (left instanceof _qm.CTEJoin) {
+          joinNodes.push(
+            _qm.buildWithJoinNode.call(this as any, left.name, Nodes.OuterJoin) as Nodes.Join,
+          );
+        } else {
+          throw _qm.argumentError("only Hash, Symbol and Array are allowed");
+        }
+      },
+    );
     const leftOuterJd =
-      pendingLeftOuter.length > 0
+      leftAssociations.length > 0
         ? QueryMethodBangs.constructJoinDependency.call(
             this as any,
-            pendingLeftOuter,
+            leftAssociations as any,
             Nodes.OuterJoin,
           )
         : null;
-    const stashedJoins: JoinDependency[] = [];
     if (leftOuterJd) stashedJoins.push(leftOuterJd);
     // Fold the eager JoinDependency in last, mirroring Rails' `joins_values`
     // ordering (left-outer stash unshifted ahead of the eager stash in

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3598,6 +3598,14 @@ export class Relation<T extends Base> {
     // "Invalid association spec". A JoinDependency already in the values is
     // stashed into `leftStashed`; the constructed left-outer JD is `unshift`ed
     // ahead of it (query_methods.rb:1843: `stashed_left_joins.unshift`).
+    //
+    // Rails pushes the CTE join_node in the left-outer section (query_methods.rb:1832)
+    // BEFORE the `joins_values` loop appends its nodes to the same bucket
+    // (query_methods.rb:1852-1863), so `buckets[:join_node]` is
+    // `[...cteNodes, ...joinsValuesNodes]`. Here the `_joinValues` loop already
+    // ran and populated `joinNodes`, so collect the CTE nodes separately and
+    // `unshift` them to the front to preserve that Rails order.
+    const cteOuterJoinNodes: Nodes.Join[] = [];
     const leftStashed: JoinDependency[] = [];
     const leftAssociations = _qm.selectNamedJoins.call(
       this as any,
@@ -3605,7 +3613,7 @@ export class Relation<T extends Base> {
       leftStashed,
       (left: unknown) => {
         if (left instanceof _qm.CTEJoin) {
-          joinNodes.push(
+          cteOuterJoinNodes.push(
             _qm.buildWithJoinNode.call(this as any, left.name, Nodes.OuterJoin) as Nodes.Join,
           );
         } else {
@@ -3613,6 +3621,7 @@ export class Relation<T extends Base> {
         }
       },
     );
+    if (cteOuterJoinNodes.length > 0) joinNodes.unshift(...cteOuterJoinNodes);
     const leftOuterJd =
       leftAssociations.length > 0
         ? QueryMethodBangs.constructJoinDependency.call(

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -222,18 +222,19 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     // (query_methods.rb:1830-1836), which joins on
     // `cte[model.foreign_key] = table[model.primary_key]`. trails mirrors this in
     // `buildJoinBuckets`' `selectNamedJoins` block — a `CTEJoin` becomes
-    // `buildWithJoinNode(name, Nodes.OuterJoin)` — reached end-to-end when the
-    // `with(...).leftOuterJoins(cte)` relation is embedded as a `from(...)`
-    // subquery. Lock the OuterJoin routing: the CTE symbol must emit a
-    // LEFT OUTER JOIN to the CTE (`commented_posts.post_id = posts.id`), not an
-    // INNER JOIN. (trails Symbol is `Symbol("name")`.)
-    const subquery = Post.with({
+    // `buildWithJoinNode(name, Nodes.OuterJoin)`. The same partition runs on the
+    // live `_applyJoinsToManager` path, so `with(...).leftOuterJoins(cte)` emits
+    // the LEFT OUTER JOIN directly (no `from(...)` subquery wrapper). Lock the
+    // OuterJoin routing: the CTE symbol must emit a LEFT OUTER JOIN to the CTE
+    // (`commented_posts.post_id = posts.id`), not an INNER JOIN. (trails Symbol
+    // is `Symbol("name")`.)
+    const relation = Post.with({
       commented_posts: Comment.select("post_id").distinct(),
     })
       .leftOuterJoins(cteSym("commented_posts"))
       .select("posts.id");
 
-    const sql = (Post.from(subquery, "posts") as unknown as { toSql(): string }).toSql();
+    const sql = (relation as unknown as { toSql(): string }).toSql();
 
     // Identifier quoting is dialect-specific (`"` on sqlite/pg, backticks on
     // MariaDB/MySQL), so the quote char is optional in the match.

--- a/packages/activerecord/src/relation/with.test.ts
+++ b/packages/activerecord/src/relation/with.test.ts
@@ -247,6 +247,29 @@ describeIfSupports("common_table_expressions", "WithTest", () => {
     expect(sql).not.toMatch(new RegExp(`INNER JOIN ${q}commented_posts${q}`));
   });
 
+  it("with left joins routes a cte symbol before a raw joins node", () => {
+    // Rails' build_join_buckets pushes the CTE join_node in the left-outer
+    // section (query_methods.rb:1832) BEFORE the joins_values loop appends its
+    // nodes to the same bucket (query_methods.rb:1852-1863), so the CTE LEFT
+    // OUTER JOIN precedes a raw `.joins("...")` node in the emitted SQL. Lock
+    // that order on the live path when both are present.
+    const relation = Post.with({
+      commented_posts: Comment.select("post_id").distinct(),
+    })
+      .joins("INNER JOIN authors ON authors.id = posts.author_id")
+      .leftOuterJoins(cteSym("commented_posts"))
+      .select("posts.id");
+
+    const sql = (relation as unknown as { toSql(): string }).toSql();
+
+    const q = `["\`]?`;
+    const cteJoin = sql.search(new RegExp(`LEFT OUTER JOIN ${q}commented_posts${q}`));
+    const rawJoin = sql.search(/INNER JOIN authors/);
+    expect(cteJoin).toBeGreaterThanOrEqual(0);
+    expect(rawJoin).toBeGreaterThanOrEqual(0);
+    expect(cteJoin).toBeLessThan(rawJoin);
+  });
+
   it("raises when using block", () => {
     // Rails passes a literal block (`Post.with(attributes_for_inspect: :id) { }`);
     // the TS equivalent of a Ruby block is a trailing function argument.


### PR DESCRIPTION
## What

`leftOuterJoins(:cte)` now routes a CTE-name symbol to a `LEFT OUTER JOIN`
on the **live** `_applyJoinsToManager` path, not only from the
`from(subquery)` embedding.

`buildJoinBuckets` already partitioned a CTE symbol out of `leftOuterJoins`
into a `CTEJoin` and routed it to `buildWithJoinNode(name, Nodes.OuterJoin)`,
but that was only reachable on the subquery `from(relation)` path. The live
`toSql`/load path fed `_leftOuterJoinsValues` straight into
`constructJoinDependency`, so a CTE symbol raised `Invalid association spec`.

This change runs the same `selectNamedJoins` partition inside
`_applyJoinsToManager`: a `CTEJoin` becomes a
`buildWithJoinNode(name, Nodes.OuterJoin)` join node, leaving only real
associations for the left-outer JoinDependency. So
`Post.with(cte).leftOuterJoins(cteSym).toSql()` emits
`LEFT OUTER JOIN <cte> ON <cte>.<fk> = <table>.<pk>` directly, matching
Rails' live `left_outer_joins(:cte_name)`.

## Test

Updated the WithTest case "with left joins routes a cte symbol to a left
outer join" to assert the direct-path SQL and drop the `from(subquery)`
scaffolding.

Closes-story: route-cte-symbol-leftouterjoins-live-path
