### PR TITLE
fix(sqlite3): re-emit GENERATED clause in copy_table for virtual columns

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
@@ -162,16 +162,27 @@ describeIfSqlite("CopyTableTest", () => {
     await testCopyTable((await Base.leaseConnection()) as any, "binaries", "binaries2");
   });
 
-  it.skip("copy table with virtual column", () => {
-    // BLOCKED: adapter-sqlite — columns() never threads generatedType, so
-    // Sqlite3Column#isVirtual() is always false. copy_table then treats the
-    // generated `upper_name` as a content column and emits an INSERT into it,
-    // which SQLite rejects, and column.virtualStored?/default_function never
-    // report the generated expression.
-    // ROOT-CAUSE: connection-adapters/sqlite3-adapter.ts columns() omits the
-    // GENERATED-column detection that table_structure_with_collation already
-    // computes; the value is dropped before reaching Sqlite3Column.
-    // SCOPE: thread generatedType + default_function through columns(); file
-    // sqlite3-columns-thread-generated-type.
+  it("copy table with virtual column", async () => {
+    const conn = (await Base.leaseConnection()) as any;
+    await conn.createTable("virtual_columns", { force: true }, (t: any) => {
+      t.string("name");
+      t.virtual("upper_name", { type: "string", as: "UPPER(name)", stored: true });
+    });
+
+    try {
+      await testCopyTable(conn, "virtual_columns", "virtual_columns2", {}, async () => {
+        const columns = await conn.columns("virtual_columns2");
+        const column = columns.find((col: any) => col.name === "upper_name");
+        expect(column.isVirtualStored()).toBe(true);
+        expect(column.type).toBe("string");
+        expect(column.defaultFunction).toBe("UPPER(name)");
+      });
+    } finally {
+      try {
+        await conn.dropTable("virtual_columns");
+      } catch {
+        // rescue nil
+      }
+    }
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2612,9 +2612,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         if (!sqlite3Col.autoIncrement && col.default !== null && col.default !== undefined) {
           def += ` DEFAULT ${this.quoteDefault(col.default)}`;
         }
+        // Generated columns are computed, never copied as content (Rails rejects
+        // columns whose options carry `:as`).
+        contentCols.push(destName);
       }
       colDefs.push(def);
-      if (!sqlite3Col.isVirtual()) contentCols.push(destName);
     }
     if (compositePk) {
       const renamedPks = pkCols.map((c) => rename[c] ?? c);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -2601,10 +2601,17 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       const sqlType = col.sqlTypeMetadata?.sqlType ?? "TEXT";
       let def = `${quoteColumnName(destName)} ${sqlType}`;
       if (col.collation) def += ` COLLATE ${quoteColumnName(col.collation)}`;
-      if (!compositePk && pkCols.includes(col.name)) def += " PRIMARY KEY";
-      if (!col.null) def += " NOT NULL";
-      if (!sqlite3Col.autoIncrement && col.default !== null && col.default !== undefined) {
-        def += ` DEFAULT ${this.quoteDefault(col.default)}`;
+      if (sqlite3Col.isVirtual()) {
+        // Re-emit the GENERATED clause so the copy stays a generated column
+        // (Rails copy_table passes as:/stored:/type: through to create_table).
+        def += ` GENERATED ALWAYS AS (${col.defaultFunction})`;
+        def += sqlite3Col.isVirtualStored() ? " STORED" : " VIRTUAL";
+      } else {
+        if (!compositePk && pkCols.includes(col.name)) def += " PRIMARY KEY";
+        if (!col.null) def += " NOT NULL";
+        if (!sqlite3Col.autoIncrement && col.default !== null && col.default !== undefined) {
+          def += ` DEFAULT ${this.quoteDefault(col.default)}`;
+        }
       }
       colDefs.push(def);
       if (!sqlite3Col.isVirtual()) contentCols.push(destName);


### PR DESCRIPTION
## Summary

`copy_table` built plain column definitions for generated columns, dropping the `GENERATED ALWAYS AS (...) STORED/VIRTUAL` clause. Even though `columns()` correctly threads `generatedType`/`defaultFunction` (via `newColumnFromField` reading the `table_xinfo` `hidden` flag), the *copied* table's column was emitted as a normal column, so `isVirtualStored()`/`defaultFunction` no longer reported the generated state.

This mirrors Rails' `copy_table`, which re-passes `as:`/`stored:`/`type:` through to `create_table`.

## Changes

- `sqlite3-adapter.ts` `copyTable`: for virtual columns, re-emit the generation clause instead of NOT NULL/DEFAULT.
- Un-skip `copy table with virtual column` in `copy-table.test.ts` (ported from Rails' `test_copy_table_with_virtual_column`).

## Test

`pnpm vitest run packages/activerecord/src/adapters/sqlite3/copy-table.test.ts` — green.

Closes-story: sqlite3-columns-thread-generated-type