### PR TITLE
fix(sqlite3): serialize structured column defaults through the column type

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
@@ -84,14 +84,16 @@ describeIfSqlite("CopyTableTest", () => {
     await testCopyTable((await Base.leaseConnection()) as any);
   });
 
-  it.skip("copy table with column with default", () => {
-    // BLOCKED: adapter-sqlite — a `json` column added with `default: {}` quotes
-    // its default via String({}) → "[object Object]" instead of serializing the
-    // value to JSON "{}", so the copied column's default mismatches Rails.
-    // ROOT-CAUSE: the json type's default serialization is not applied on the
-    // addColumn DEFAULT path for SQLite.
-    // SCOPE: serialize structured defaults through the column type before
-    // quoting; file sqlite3-json-default-serialization.
+  it("copy table with column with default", async () => {
+    const conn = (await Base.leaseConnection()) as any;
+    await testCopyTable(conn, "comments", "comments_with_default", {}, async () => {
+      await conn.addColumn("comments_with_default", "options", "json", { default: {} });
+      await testCopyTable(conn, "comments_with_default", "comments_with_default2", {}, async () => {
+        const columns = await conn.columns("comments_with_default2");
+        const column = columns.find((col: { name: string }) => col.name === "options");
+        expect(column.default).toEqual("{}");
+      });
+    });
   });
 
   it("copy table renaming column", async () => {

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -27,7 +27,7 @@ afterEach(async () => {
   // multi-table DROP, so one IF EXISTS statement per name; this balances
   // require-table-teardown and is behavior-neutral on the fresh per-test adapter.
   await adapter.exec(
-    `DROP TABLE IF EXISTS items; DROP TABLE IF EXISTS typed; DROP TABLE IF EXISTS no_pk; DROP TABLE IF EXISTS bin_esc; DROP TABLE IF EXISTS enc_test; DROP TABLE IF EXISTS def_vals; DROP TABLE IF EXISTS strict_items; DROP TABLE IF EXISTS custom_pk_src; DROP TABLE IF EXISTS custom_pk_dest; DROP TABLE IF EXISTS cpk_src; DROP TABLE IF EXISTS cpk_dest; DROP TABLE IF EXISTS custom_pk; DROP TABLE IF EXISTS change_pk; DROP TABLE IF EXISTS add_col_pk; DROP TABLE IF EXISTS barcodes; DROP TABLE IF EXISTS test; DROP TABLE IF EXISTS testings; DROP TABLE IF EXISTS rowid_test; DROP TABLE IF EXISTS rowid_lower; DROP TABLE IF EXISTS text_pk; DROP TABLE IF EXISTS mixed_case; DROP TABLE IF EXISTS auto_inc; DROP TABLE IF EXISTS cpk; DROP TABLE IF EXISTS ex`,
+    `DROP TABLE IF EXISTS items; DROP TABLE IF EXISTS typed; DROP TABLE IF EXISTS no_pk; DROP TABLE IF EXISTS bin_esc; DROP TABLE IF EXISTS enc_test; DROP TABLE IF EXISTS def_vals; DROP TABLE IF EXISTS strict_items; DROP TABLE IF EXISTS custom_pk_src; DROP TABLE IF EXISTS custom_pk_dest; DROP TABLE IF EXISTS cpk_src; DROP TABLE IF EXISTS cpk_dest; DROP TABLE IF EXISTS custom_pk; DROP TABLE IF EXISTS change_pk; DROP TABLE IF EXISTS add_col_pk; DROP TABLE IF EXISTS barcodes; DROP TABLE IF EXISTS test; DROP TABLE IF EXISTS testings; DROP TABLE IF EXISTS rowid_test; DROP TABLE IF EXISTS rowid_lower; DROP TABLE IF EXISTS text_pk; DROP TABLE IF EXISTS mixed_case; DROP TABLE IF EXISTS auto_inc; DROP TABLE IF EXISTS cpk; DROP TABLE IF EXISTS ex; DROP TABLE IF EXISTS json_defs`,
   );
   await adapter.close();
   Notifications.unsubscribeAll();
@@ -89,6 +89,23 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     expect(types).toContain("INTEGER");
     expect(types).toContain("REAL");
     expect(types).toContain("BLOB");
+  });
+
+  // Structured (`default: {}`) json defaults must serialize to the JSON text
+  // `{}` on every DEFAULT-emitting path, not just addColumn. Mirrors Rails'
+  // quote_default_expression serializing through the column's cast type.
+  it("change column default serializes a structured json default", async () => {
+    adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" json)`);
+    await adapter.changeColumnDefault("json_defs", "options", {});
+    const col = (await adapter.columns("json_defs")).find((c) => c.name === "options");
+    expect(col?.default).toEqual("{}");
+  });
+
+  it("change column serializes a structured json default", async () => {
+    adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" TEXT)`);
+    await adapter.changeColumn("json_defs", "options", "json", { default: {} });
+    const col = (await adapter.columns("json_defs")).find((c) => c.name === "options");
+    expect(col?.default).toEqual("{}");
   });
 
   it("exec insert", async () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -150,6 +150,17 @@ function _driverBind(this: QuotingDispatchHost, value: unknown): unknown {
   return sqliteTypeCast.call(this, value);
 }
 
+// A structured column default: an array or a plain object literal (`default: {}`
+// / `default: []`). Excludes null, SqlLiteral, Date, and other class instances,
+// which have their own quoting paths and must not be routed through the column
+// type's `serialize`.
+function isStructuredDefault(value: unknown): boolean {
+  if (Array.isArray(value)) return true;
+  if (value === null || typeof value !== "object" || isSqlLiteral(value)) return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 function _isSqliteMissingDbError(error: unknown): boolean {
   if (!error || typeof error !== "object") return false;
   const e = error as { code?: unknown; message?: unknown };
@@ -985,12 +996,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   // column's cast type before quoting (abstract/quoting.rb:157). A structured
   // default for a `json` column (`default: {}`) must serialize to the JSON text
   // `{}` rather than being coerced with `String({})` → "[object Object]". Route
-  // object/array defaults through the column type; SqlLiteral and scalars keep
-  // their existing quoting.
+  // only plain-object/array defaults through the column type; scalars, dates,
+  // SqlLiteral, and other class instances keep their existing quoting paths.
   private serializeDefaultForColumn(value: unknown, sqlType: string | null | undefined): unknown {
-    if (value === null || typeof value !== "object" || isSqlLiteral(value) || !sqlType) {
-      return value;
-    }
+    if (!sqlType || !isStructuredDefault(value)) return value;
     const castType = this.lookupCastType(sqlType) as { serialize?(v: unknown): unknown };
     return typeof castType.serialize === "function" ? castType.serialize(value) : value;
   }

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1662,14 +1662,25 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     columnName: string,
     defaultOrChanges: unknown,
   ): Promise<void> {
-    const newDefault =
-      typeof defaultOrChanges === "object" && defaultOrChanges !== null
-        ? (defaultOrChanges as any).to
-        : defaultOrChanges;
+    // Rails' extract_new_default_value only unwraps a Hash when it carries BOTH
+    // :from and :to (schema_statements.rb:1820); a bare structured default like
+    // `{}` is the literal default, not a changes hash.
+    const isChanges =
+      typeof defaultOrChanges === "object" &&
+      defaultOrChanges !== null &&
+      "from" in defaultOrChanges &&
+      "to" in defaultOrChanges;
+    const newDefault = isChanges ? (defaultOrChanges as { to: unknown }).to : defaultOrChanges;
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     await this.alterTable(tableName, (columns) => {
       if (columns[columnName]) {
-        columns[columnName].dflt_value = newDefault === null ? null : this.quoteDefault(newDefault);
+        // Rails recreates the table and re-emits DEFAULT through
+        // quote_default_expression, which serializes structured values through
+        // the column's cast type (sqlite3_adapter.rb:366). Mirror that so a
+        // `default: {}` on a json column quotes to `{}` and not `[object Object]`.
+        const columnType = columns[columnName].type as string | null | undefined;
+        const serialized = this.serializeDefaultForColumn(newDefault, columnType);
+        columns[columnName].dflt_value = serialized === null ? null : this.quoteDefault(serialized);
       }
     });
   }
@@ -1681,7 +1692,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     defaultValue?: unknown,
   ): Promise<void> {
     if (!allowNull && defaultValue !== undefined) {
-      const quotedDefault = this.quoteDefault(defaultValue);
+      // Rails backfills NULLs via quote_default_expression, which serializes the
+      // value through the column's cast type (abstract/schema_statements.rb).
+      const existing = (await this.columns(tableName)).find((c) => c.name === columnName);
+      const serialized = this.serializeDefaultForColumn(defaultValue, existing?.sqlType ?? null);
+      const quotedDefault = this.quoteDefault(serialized);
       await this.executeMutation(
         `UPDATE ${quoteTableName(tableName)} SET ${quoteColumnName(columnName)} = ${quotedDefault} WHERE ${quoteColumnName(columnName)} IS NULL`,
       );
@@ -1704,9 +1719,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       if (columns[columnName]) {
         columns[columnName].type = sqlType;
         if (options?.null !== undefined) columns[columnName].notnull = options.null ? 0 : 1;
-        if (options?.default !== undefined)
+        if (options?.default !== undefined) {
+          const serialized = this.serializeDefaultForColumn(options.default, sqlType);
           columns[columnName].dflt_value =
-            options.default === null ? null : this.quoteDefault(options.default);
+            serialized === null ? null : this.quoteDefault(serialized);
+        }
         if (options?.collation !== undefined) columns[columnName].collation = options.collation;
       }
     });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -977,7 +977,22 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       }
       return /^\w+\(.*\)$/.test(str) ? ` DEFAULT (${str})` : ` DEFAULT ${str}`;
     }
-    return super.quoteDefaultExpression(value, column);
+    const sqlType = (column as { sqlType?: string | null } | undefined)?.sqlType;
+    return super.quoteDefaultExpression(this.serializeDefaultForColumn(value, sqlType), column);
+  }
+
+  // Rails' abstract quote_default_expression serializes the value through the
+  // column's cast type before quoting (abstract/quoting.rb:157). A structured
+  // default for a `json` column (`default: {}`) must serialize to the JSON text
+  // `{}` rather than being coerced with `String({})` → "[object Object]". Route
+  // object/array defaults through the column type; SqlLiteral and scalars keep
+  // their existing quoting.
+  private serializeDefaultForColumn(value: unknown, sqlType: string | null | undefined): unknown {
+    if (value === null || typeof value !== "object" || isSqlLiteral(value) || !sqlType) {
+      return value;
+    }
+    const castType = this.lookupCastType(sqlType) as { serialize?(v: unknown): unknown };
+    return typeof castType.serialize === "function" ? castType.serialize(value) : value;
   }
 
   override quotedTrue(): string {
@@ -1609,7 +1624,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     if (options?.collation) sql += ` COLLATE ${quoteColumnName(String(options.collation))}`;
     if (options?.null === false) sql += " NOT NULL";
     if (options?.default !== undefined) {
-      sql += ` DEFAULT ${this.quoteDefault(options.default)}`;
+      sql += ` DEFAULT ${this.quoteDefault(this.serializeDefaultForColumn(options.default, sqlType))}`;
     }
     // Invalidate the cached reflection for this table, matching the abstract
     // SchemaStatements#addColumn (which clears before mutating). Without this


### PR DESCRIPTION
## What

Adding a `json` column with `default: {}` quoted its default via `String({})` → `"[object Object]"` instead of serializing the value to the JSON text `{}`. After `copy_table`, the copied column's introspected `default` came back as `"[object Object]"` where Rails reports `"{}"`.

Rails' abstract `quote_default_expression` (`abstract/quoting.rb:157`) serializes the value through the column's cast type before quoting. The SQLite adapter emits DEFAULT on several paths, so this routes structured defaults through a shared `serializeDefaultForColumn` helper (`lookupCastType(sqlType).serialize(value)`) on all of them:

- `addColumn` and `quoteDefaultExpression` (create-table / add-column-for-alter)
- `changeColumn`, `changeColumnDefault`, `changeColumnNull` (table-rebuild paths — Rails re-emits DEFAULT via `quote_default_expression` during `copy_table`)

`isStructuredDefault` narrows serialization to plain objects/arrays only, so scalars, dates, `SqlLiteral`, and other class instances keep their existing quoting paths (matching PG's per-adapter, non-blanket approach).

Also tightens `changeColumnDefault`'s changes-hash extraction to require **both** `:from` and `:to` (Rails `extract_new_default_value`, `schema_statements.rb:1820`); previously any object was treated as a `{from,to}` hash, collapsing a bare `default: {}` to its (absent) `.to`.

## Test

- Un-skips `copy table with column with default` in `copy-table.test.ts` (mirrors `test_copy_table_with_column_with_default`).
- Adds `change column default`/`change column` structured-json-default coverage in `sqlite3-adapter.test.ts`.

Closes-story: sqlite3-json-default-serialization