### PR TITLE
test(activerecord): upgrade exact-equivalent canonical suites to transactional fixtures({})

### DIFF
--- a/packages/activerecord/src/reflection.trails.test.ts
+++ b/packages/activerecord/src/reflection.trails.test.ts
@@ -16,7 +16,7 @@ import {
 } from "./reflection.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 
-fixtures({}, { useTransactionalTests: false });
+fixtures({});
 
 describe("ReflectionTest", () => {
   it("plain function for source type does not raise (only ES classes are rejected)", () => {

--- a/packages/activerecord/src/sanitize.test.ts
+++ b/packages/activerecord/src/sanitize.test.ts
@@ -7,7 +7,7 @@ import { sql as arelSql } from "@blazetrails/arel";
 import { Base, Range, UnknownAttributeReference } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 
-fixtures({}, { useTransactionalTests: false });
+fixtures({});
 
 // ==========================================================================
 // SanitizeTest — targets sanitize_test.rb

--- a/packages/activerecord/src/table-metadata.test.ts
+++ b/packages/activerecord/src/table-metadata.test.ts
@@ -21,7 +21,7 @@ class AuditRequiredDeveloper extends Base {
 }
 
 describe("TableMetadataTest", () => {
-  fixtures({}, { useTransactionalTests: false });
+  fixtures({});
   beforeAll(async () => {
     await AuditLog.loadSchema();
     await AuditRequiredDeveloper.loadSchema();

--- a/packages/activerecord/src/types.test.ts
+++ b/packages/activerecord/src/types.test.ts
@@ -4,7 +4,7 @@ import { Base } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 
 describe("TypesTest", () => {
-  fixtures({}, { useTransactionalTests: false });
+  fixtures({});
   it("attributes which are invalid for database can still be reassigned", async () => {
     const TypeWhichCannotGoToTheDatabase = class extends ValueType {
       override serialize(): unknown {


### PR DESCRIPTION
## Summary

RFC 0062's endgame is for canonical-riding suites to use the **transactional**
`fixtures({})` surface (per-test savepoint rollback) rather than the
`{ useTransactionalTests: false }` escape hatch that PR #4627 conservatively
converted every bare `setupFixtures()` call to.

This upgrades the four candidate suites that are safe to flip — describe-scoped,
sole-seeding, ride canonical tables, do **no** in-test DDL or deliberate DB
errors, and run transactionally in Rails (no `use_transactional_tests`
override):

- `types.test.ts` — TypesTest
- `table-metadata.test.ts` — TableMetadataTest
- `sanitize.test.ts` — SanitizeTest
- `reflection.trails.test.ts` — ReflectionTest

## Candidates deliberately kept on `{ useTransactionalTests: false }`

Verified per-file against Rails source and behavior:

- **Rails overrides `use_transactional_tests = false`:** `reserved-word` (also
  in-test DDL), `query-cache` (QueryCacheMutableParamTest scratch `json_objs`
  table), `timestamp` (TimestampsWithoutTransactionTest, DDL in afterEach),
  `transaction-isolation`, `multiple-db`, and the DDL-only blocks of
  `primary-keys` (PrimaryKeyWithAutoIncrementTest / CompositePrimaryKeyTest /
  PrimaryKeyIntegerTest — the non-DDL PrimaryKeysTest block is already
  transactional).
- **Transaction-semantics / DDL suites:** `transactions.trails`, `adapter`
  (DDL, already annotated), `connection-handling` (pool-swap + WithoutTransaction
  block).
- **Raw non-fixture write:** `column-alias` (beforeAll `INSERT INTO topics`).
- **File-scope handler primers** (the established idiom, coexist with
  describe-scope list fixtures): `callbacks`, `json-serialization`.

## Testing

`pnpm vitest run` on the four flipped files: 59 passed, 2 skipped. No test
renames; test names match Rails verbatim.

Closes-story: upgrade-exact-equiv-suites-to-transactional-fixtures
