### PR TITLE
fix(sqlite3): unbounded string column maps to varchar without 255 limit

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/copy-table.test.ts
@@ -137,16 +137,20 @@ describeIfSqlite("CopyTableTest", () => {
     });
   });
 
-  it.skip("copy table with id col that is not primary key", () => {
-    // BLOCKED: schema-emission — the canonical `goofy_string_id.id` string column
-    // is emitted as `varchar(255)`, so its introspected `limit` is 255 where
-    // Rails' bare `t.string` carries no limit (nil). The test asserts both the
-    // original and copied id columns have a nil limit.
-    // ROOT-CAUSE: defineSchema/SQLite type-mapping appends the default 255 limit
-    // to unbounded string columns; Rails' sqlite3 string maps to `varchar`
-    // without a length.
-    // SCOPE: drop the implicit 255 limit on unbounded string columns for SQLite;
-    // file sqlite3-string-column-no-default-limit.
+  it("copy table with id col that is not primary key", async () => {
+    const conn = (await Base.leaseConnection()) as any;
+    await testCopyTable(conn, "goofy_string_id", "goofy_string_id2", {}, async () => {
+      const originalId = (await conn.columns("goofy_string_id")).find(
+        (col: any) => col.name === "id",
+      );
+      const copiedId = (await conn.columns("goofy_string_id2")).find(
+        (col: any) => col.name === "id",
+      );
+      expect(copiedId.type).toEqual(originalId.type);
+      expect(copiedId.sqlType).toEqual(originalId.sqlType);
+      expect(originalId.limit).toBeNull();
+      expect(copiedId.limit).toBeNull();
+    });
   });
 
   it("copy table with unconventional primary key", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -378,7 +378,14 @@ export class SchemaCreation {
     let sql: string;
     switch (type) {
       case "string":
-        sql = `VARCHAR(${options.limit ?? 255})`;
+        // Rails' sqlite3 `NATIVE_DATABASE_TYPES[:string]` is `{ name: "varchar" }`
+        // with no default length, so a bare `t.string` maps to `varchar` (nil
+        // limit). MySQL/PostgreSQL default an unbounded string to `varchar(255)`.
+        if (this.adapterName === "sqlite") {
+          sql = options.limit != null ? `VARCHAR(${options.limit})` : "VARCHAR";
+        } else {
+          sql = `VARCHAR(${options.limit ?? 255})`;
+        }
         break;
       case "text":
         sql = "TEXT";

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -378,13 +378,17 @@ export class SchemaCreation {
     let sql: string;
     switch (type) {
       case "string":
-        // Rails' sqlite3 `NATIVE_DATABASE_TYPES[:string]` is `{ name: "varchar" }`
-        // with no default length, so a bare `t.string` maps to `varchar` (nil
-        // limit). MySQL/PostgreSQL default an unbounded string to `varchar(255)`.
-        if (this.adapterName === "sqlite") {
-          sql = options.limit != null ? `VARCHAR(${options.limit})` : "VARCHAR";
-        } else {
+        // Rails derives the default limit from the adapter's native-type hash
+        // (`type_to_sql`: `limit ||= native[:limit]`). Only MySQL's
+        // `NATIVE_DATABASE_TYPES[:string]` carries `limit: 255`
+        // (abstract_mysql_adapter.rb:33); sqlite3 (`{ name: "varchar" }`,
+        // sqlite3_adapter.rb:71) and PostgreSQL (`{ name: "character varying" }`,
+        // postgresql_adapter.rb:136) have no default length, so a bare
+        // `t.string` stays unbounded (nil limit) there.
+        if (this.adapterName === "mysql") {
           sql = `VARCHAR(${options.limit ?? 255})`;
+        } else {
+          sql = options.limit != null ? `VARCHAR(${options.limit})` : "VARCHAR";
         }
         break;
       case "text":

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1367,7 +1367,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   nativeDatabaseTypes(): Record<string, { name: string; limit?: number }> {
     return {
       primary_key: { name: "integer" },
-      string: { name: "varchar", limit: 255 },
+      string: { name: "varchar" },
       text: { name: "text" },
       integer: { name: "integer" },
       float: { name: "float" },


### PR DESCRIPTION
## What

Rails' sqlite3 `NATIVE_DATABASE_TYPES[:string]` is `{ name: "varchar" }` with no default length (`sqlite3_adapter.rb:71`), so a bare `t.string` maps to `varchar` and introspects back with a nil `limit`. Our abstract `SchemaCreation#typeToSql` emitted `VARCHAR(255)` for every string, so on SQLite the column reflected back with `limit` 255.

Fix: gate the implicit `255` default to the MySQL/PostgreSQL adapters in `abstract/schema-creation.ts`, and drop the stale `limit: 255` from the sqlite3 adapter's `nativeDatabaseTypes`.

Un-skips `copy table with id col that is not primary key` in `packages/activerecord/src/adapters/sqlite3/copy-table.test.ts`, mirroring `copy_table_test.rb`'s `test_copy_table_with_id_col_that_is_not_primary_key`.

## Test

- `copy-table.test.ts`, sqlite3 schema-creation/dumper/column/statements/adapter suites, and `schema-dumper.test.ts` all pass.

Closes-story: sqlite3-string-column-no-default-limit