### PR TITLE
refactor(connection): thread connection through schema-reflection reads

### DIFF
--- a/packages/activerecord/src/connection-handling.ts
+++ b/packages/activerecord/src/connection-handling.ts
@@ -450,15 +450,6 @@ const CONNECTION_DEPRECATION_MSG =
 export function connection(this: typeof Base): DatabaseAdapter {
   // Fast path: directly assigned via `Model.adapter = x` (tests + simple setups)
   if ((this as any)._adapter) return (this as any)._adapter;
-  // Inside an internal `withQueryConnection` wrap, resolve to the connection it
-  // threaded for *this* pool — without flipping the lease permanent. This keeps
-  // schema-reflection reads on the wrapped query/transaction path (columnsHash,
-  // timestamp columns, …) off the deprecated-getter lease, matching Rails, which
-  // threads the `with_connection` block parameter through that code. An explicit
-  // `lease_connection()` still goes straight to the pool and makes the lease
-  // permanent.
-  const threaded = threadedConnectionFor(this);
-  if (threaded) return threaded;
   const pool = connectionPool.call(this);
   if (pool.isPermanentLease()) {
     const setting = permanentConnectionCheckout;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -26,6 +26,21 @@ import { TableNotSpecified } from "./errors.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
 import { FakePool } from "./connection-adapters/schema-cache.js";
+import { threadedConnectionFor } from "./connection-handling.js";
+
+/**
+ * Adapter for a schema-reflection read: prefer the connection threaded by the
+ * enclosing internal `with_connection` wrap ({@link threadedConnectionFor}) —
+ * matching Rails, which threads the block's `connection` through schema
+ * reflection — and only fall back to the deprecated `Model.connection` getter
+ * when no wrap is active (or the wrap belongs to a different pool). Reading the
+ * threaded connection keeps these reads off the getter so they never flip the
+ * lease permanent. `threadedConnectionFor` never throws (returns `null`), so the
+ * `.connection` fallback still throws where callers rely on a `try`/`catch`.
+ */
+function reflectionAdapter(klass: any): any {
+  return threadedConnectionFor(klass) ?? klass.connection;
+}
 
 /**
  * Schema metadata for ActiveRecord models — table name, primary key,
@@ -105,7 +120,7 @@ function containedTableNamePrefix(this: typeof Base): string {
  */
 export function buildPkWhere(this: typeof Base, idValue: unknown): string {
   const pk = this.primaryKey;
-  const a = this.connection;
+  const a = reflectionAdapter(this);
   if (Array.isArray(pk)) {
     if (!Array.isArray(idValue) || idValue.length !== pk.length) return "1=0";
     const conditions: string[] = [];
@@ -249,7 +264,7 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
   let adapter: DatabaseAdapterLike | null = null;
   for (const cand of candidates) {
     try {
-      adapter = cand.connection as DatabaseAdapterLike;
+      adapter = reflectionAdapter(cand) as DatabaseAdapterLike;
     } catch {
       adapter = null;
     }
@@ -494,7 +509,7 @@ export function deriveJoinTableName(this: SchemaHost, otherTableName: string): s
 }
 
 export function quotedTableName(this: SchemaHost): string {
-  return this.connection.quoteTableName(this.tableName);
+  return reflectionAdapter(this).quoteTableName(this.tableName);
 }
 
 /**
@@ -1110,7 +1125,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   const candidates: SchemaHost[] = schemaHost === this ? [schemaHost] : [schemaHost, this];
   for (const cand of candidates) {
     try {
-      startingAdapter = cand.connection;
+      startingAdapter = reflectionAdapter(cand);
     } catch {
       startingAdapter = undefined;
     }
@@ -1163,7 +1178,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
   // adapter moved.
   let currentAdapter: SchemaHost["connection"] | undefined;
   try {
-    currentAdapter = adapterOwner.connection;
+    currentAdapter = reflectionAdapter(adapterOwner);
   } catch {
     currentAdapter = undefined;
   }
@@ -1178,7 +1193,7 @@ export async function loadSchemaFromAdapter(this: SchemaHost): Promise<void> {
  */
 function cachedColumnNames(host: SchemaHost): Set<string> | null {
   try {
-    const cached = host.connection?.schemaCache?.getCachedColumnsHash?.(host.tableName) as
+    const cached = reflectionAdapter(host)?.schemaCache?.getCachedColumnsHash?.(host.tableName) as
       | Record<string, unknown>
       | undefined;
     if (cached) return new Set(Object.keys(cached));
@@ -1199,7 +1214,7 @@ async function reflectColumnNames(host: SchemaHost): Promise<Set<string> | null>
   const cached = cachedColumnNames(host);
   if (cached) return cached;
   try {
-    const conn = host.connection;
+    const conn = reflectionAdapter(host);
     const table = host.tableName;
     if (!conn || !table) return null;
     // Resolve columns through the shared schema cache so the reflection is
@@ -1305,7 +1320,7 @@ function loadSchemaFromCacheSync(host: SchemaHost): boolean {
   const candidates = schemaHost === host ? [schemaHost] : [schemaHost, host];
   for (const cand of candidates) {
     try {
-      adapter = cand.connection;
+      adapter = reflectionAdapter(cand);
     } catch {
       adapter = undefined;
     }
@@ -1389,7 +1404,7 @@ export function columnDefaults(this: SchemaHost): Record<string, unknown> {
 }
 
 export async function tableExists(this: SchemaHost): Promise<boolean> {
-  const conn = this.connection;
+  const conn = reflectionAdapter(this);
   const cache = conn.schemaCache;
   if (!cache || typeof cache.dataSourceExists !== "function") return true;
   const pool = realPool(conn.pool) ?? conn;

--- a/packages/activerecord/src/relation/merged-join-alias-tracker.ts
+++ b/packages/activerecord/src/relation/merged-join-alias-tracker.ts
@@ -16,6 +16,7 @@
 import { Nodes } from "@blazetrails/arel";
 import { underscore, pluralize } from "@blazetrails/activesupport";
 import { AliasTracker } from "../associations/alias-tracker.js";
+import { threadedConnectionFor } from "../connection-handling.js";
 import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
 
 interface MergedJoinAliasHost {
@@ -43,7 +44,13 @@ export function buildMergedJoinAliasTracker(
   joinNodes: Nodes.Join[],
   existingAliases?: Map<string, number>,
 ): AliasTracker {
-  const connection = host._modelClass.connection;
+  // Prefer the connection threaded by the enclosing `withQueryConnection` wrap
+  // (Rails threads the `with_connection` connection through join building)
+  // rather than the deprecated `.connection` getter, which would flip the lease
+  // permanent under `permanent_connection_checkout = :deprecated|:disallowed`.
+  const connection = (threadedConnectionFor(
+    host._modelClass as unknown as Parameters<typeof threadedConnectionFor>[0],
+  ) ?? host._modelClass.connection) as Quoting & { tableAliasLength(): number };
   const aliasLength = connection.tableAliasLength();
   const seededAliases = existingAliases ? new Map(existingAliases) : new Map<string, number>();
   const tracker = new AliasTracker(aliasLength, seededAliases, joinNodes, connection);

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -34,6 +34,7 @@ import { columnNameWithOrderMatcher as abstractOrderMatcher } from "../connectio
 import { JoinDependency } from "../associations/join-dependency.js";
 import type { AliasTracker } from "../associations/alias-tracker.js";
 import { buildMergedJoinAliasTracker } from "./merged-join-alias-tracker.js";
+import { threadedConnectionFor } from "../connection-handling.js";
 import { wrapWithScopeProxy } from "./delegation.js";
 import { foreignKey } from "@blazetrails/activesupport";
 
@@ -581,7 +582,7 @@ function orderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
       if (first instanceof Nodes.Node) {
         // Bind array: [Arel.sql("col = ?"), bind1, ...] — Arel bypasses check.
         // Store as a SqlLiteral so _applyOrderToManager emits it verbatim.
-        const rawSql = (first as any).value ?? this._modelClass.connection.toSql(first);
+        const rawSql = (first as any).value ?? connectionFor(this._modelClass).toSql(first);
         const interpolated =
           rest.length > 0 ? this._modelClass.sanitizeSqlArray(rawSql, ...rest) : rawSql;
         if (interpolated.trim() !== "")
@@ -654,7 +655,7 @@ function reorderBang(this: QueryMethodsHost, ...args: OrderArg[]): any {
     if (Array.isArray(arg)) {
       const [first, ...rest] = arg as unknown[];
       if (first instanceof Nodes.Node) {
-        const rawSql = (first as any).value ?? this._modelClass.connection.toSql(first);
+        const rawSql = (first as any).value ?? connectionFor(this._modelClass).toSql(first);
         const interpolated =
           rest.length > 0 ? this._modelClass.sanitizeSqlArray(rawSql, ...rest) : rawSql;
         if (interpolated.trim() !== "")
@@ -1817,7 +1818,7 @@ export function buildCastValue(name: string, value: unknown): Attribute {
  */
 export function normalizeBoundValue(this: QueryMethodsHost, value: unknown): unknown {
   if (value instanceof Nodes.Node) {
-    return arelSql(this._modelClass.connection.toSql(value));
+    return arelSql(connectionFor(this._modelClass).toSql(value));
   }
   if (isRelationLike(value)) {
     return arelSql((value as { toSql(): string }).toSql());
@@ -2219,13 +2220,19 @@ function escapeRegex(s: string): string {
 }
 
 /**
- * Resolve the active connection for a model. Lets `Base.connection` propagate
- * its `ConnectionNotDefined` (or other connection errors) so callers
- * see the real cause rather than a `TypeError` on the next `.quote*`
- * access.
+ * Resolve the active connection for a model on a relation-build read. Prefers
+ * the connection threaded by the enclosing `withQueryConnection` wrap (Rails
+ * threads the `with_connection` connection through query building) so the read
+ * stays off the deprecated `.connection` getter — which would flip the lease
+ * permanent under `permanent_connection_checkout = :deprecated|:disallowed` when
+ * a scope is built inside a wrap (eager-load/preload scope construction during
+ * `first`/`last`/`find_each`). Falls back to the getter outside a wrap, which
+ * lets `Base.connection` propagate its `ConnectionNotDefined` (or other
+ * connection errors) so callers see the real cause rather than a `TypeError` on
+ * the next `.quote*`/`.toSql` access.
  */
 function connectionFor(modelClass: any): any {
-  return modelClass?.connection;
+  return threadedConnectionFor(modelClass) ?? modelClass?.connection;
 }
 
 function safeQuoteTableName(modelClass: any, name: string): string {


### PR DESCRIPTION
## Summary

Follow-up to `thread-yielded-connection-internal-query-path` (PR #3876). That PR
threaded the `withQueryConnection`-yielded connection through the relation /
calculations / persistence / transactions / `base.ts` record paths. This PR
extends the same treatment to the **schema-reflection** reads (and the
relation-build reads) that still went through the deprecated `Model.connection`
getter, then removes the getter→threaded-connection bridge.

## Changes

- `model-schema.ts`: `buildPkWhere`, `columnsHash`, `quotedTableName`,
  `loadSchemaFromAdapter`, `cachedColumnNames`, `reflectColumnNames`,
  `loadSchemaFromCacheSync`, `tableExists` now resolve their adapter via a
  `reflectionAdapter` helper that prefers `threadedConnectionFor(klass)` and only
  falls back to `.connection` outside a wrap (or for a foreign pool).
- `relation/merged-join-alias-tracker.ts`: `buildMergedJoinAliasTracker` reads
  the threaded connection for `tableAliasLength()` rather than the getter — this
  runs on the wrapped `first`/`last`/etc. build path.
- `relation/query-methods.ts`: the `connectionFor` helper now threads via
  `threadedConnectionFor`, and the three direct `_modelClass.connection` build
  reads — `orderBang`/`reorderBang` (bind-array Arel-node order) and
  `normalizeBoundValue` (Arel-node bound `where`/`having` value) — route through
  it. This also covers `safeQuoteTableName`/`safeQuoteColumnName`, which are the
  same relation-build read category and would otherwise still hit the un-bridged
  getter inside a wrap.
- `connection-handling.ts`: removed the `threadedConnectionFor(this)` early
  return bridge from the deprecated `connection()` getter.

Mirrors Rails, which threads the `with_connection` block's connection through
schema reflection and query building instead of re-resolving the deprecated
getter.

## Verification

- `ConnectionHandlingTest` "common APIs don't permanently hold a connection when
  permanent checkout is deprecated or disallowed" still passes.
- model-schema, timestamp, connection-handling, finder-methods, persistence,
  order, where, where-chain, transactions, and join-collision suites pass
  locally; typecheck clean.

Closes-story: thread-connection-through-schema-reflection-reads