### PR TITLE
fix(associations): load displaced has_one on unloaded property-setter replace

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -32,10 +32,10 @@ export class HasOneAssociation extends SingularAssociation {
    * Set when a deferred assignment displaces an *unloaded* has_one on a persisted
    * owner: at queue time the current target has not been materialized, so there
    * is no in-memory `_displacedRecord` to remove — but a DB row keyed by the
-   * owner may still exist and, under `:dependent`, must be removed. Rails loads
-   * the current target synchronously inside `replace`; the JS property setter
-   * cannot `await`, so we defer the load to `removeDisplaced`, which queries the
-   * existing DB-associated record and runs the dependent remove against it.
+   * owner may still exist and must be removed (nullified, or per `:dependent`).
+   * Rails loads the current target synchronously inside `replace`; the JS
+   * property setter cannot `await`, so we defer the load to `removeDisplaced`,
+   * which queries the existing DB-associated record and runs the remove.
    */
   _removeDisplacedFromDb = false;
 
@@ -82,11 +82,13 @@ export class HasOneAssociation extends SingularAssociation {
       !sameRecord(displaced, record)
     ) {
       this._displacedRecord = displaced;
-    } else if (!wasLoaded && !displaced && this.reflection.options.dependent) {
+    } else if (!wasLoaded && !displaced) {
       // The current target was never materialized, so we have no in-memory
-      // displaced record — but a DB row keyed by the owner may exist. Under
-      // `:dependent`, Rails loads and removes it synchronously in `replace`; we
-      // defer that load to `removeDisplaced` at the owner's save.
+      // displaced record — but a DB row keyed by the owner may exist. Rails'
+      // `replace` always evaluates `load_target` (has_one_association.rb:59), so
+      // it materializes and `remove_target!`s any displaced row regardless of
+      // `:dependent` — the `else` branch nullifies the old FK even with no
+      // `:dependent`. We defer that load to `removeDisplaced` at the owner's save.
       this._removeDisplacedFromDb = true;
     }
   }

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -28,6 +28,17 @@ export class HasOneAssociation extends SingularAssociation {
    */
   _displacedRecord: Base | null = null;
 
+  /**
+   * Set when a deferred assignment displaces an *unloaded* has_one on a persisted
+   * owner: at queue time the current target has not been materialized, so there
+   * is no in-memory `_displacedRecord` to remove — but a DB row keyed by the
+   * owner may still exist and, under `:dependent`, must be removed. Rails loads
+   * the current target synchronously inside `replace`; the JS property setter
+   * cannot `await`, so we defer the load to `removeDisplaced`, which queries the
+   * existing DB-associated record and runs the dependent remove against it.
+   */
+  _removeDisplacedFromDb = false;
+
   constructor(owner: Base, definition: AssociationDefinition) {
     super(owner, definition);
   }
@@ -35,6 +46,7 @@ export class HasOneAssociation extends SingularAssociation {
   override reset(): void {
     super.reset();
     this._displacedRecord = null;
+    this._removeDisplacedFromDb = false;
   }
 
   /**
@@ -48,6 +60,7 @@ export class HasOneAssociation extends SingularAssociation {
    * the Rails-faithful immediate-persist path.
    */
   queueWrite(record: Base | null): void {
+    const wasLoaded = this.loaded;
     const displaced = this.target;
     this.replace(record);
     if (!(this.owner as { isPersisted?: () => boolean }).isPersisted?.()) return;
@@ -55,6 +68,7 @@ export class HasOneAssociation extends SingularAssociation {
     // (`owner.x = other; owner.x = original`).
     if (this._displacedRecord && sameRecord(record, this._displacedRecord)) {
       this._displacedRecord = null;
+      this._removeDisplacedFromDb = false;
       return;
     }
     // Only a *persisted* displaced record has a row/foreign key to nullify. A
@@ -68,6 +82,12 @@ export class HasOneAssociation extends SingularAssociation {
       !sameRecord(displaced, record)
     ) {
       this._displacedRecord = displaced;
+    } else if (!wasLoaded && !displaced && this.reflection.options.dependent) {
+      // The current target was never materialized, so we have no in-memory
+      // displaced record — but a DB row keyed by the owner may exist. Under
+      // `:dependent`, Rails loads and removes it synchronously in `replace`; we
+      // defer that load to `removeDisplaced` at the owner's save.
+      this._removeDisplacedFromDb = true;
     }
   }
 
@@ -136,9 +156,30 @@ export class HasOneAssociation extends SingularAssociation {
    * inside `HasOneAssociation#replace`.
    */
   async removeDisplaced(): Promise<void> {
-    const displaced = this._displacedRecord;
-    if (!displaced) return;
+    let displaced = this._displacedRecord;
     this._displacedRecord = null;
+    if (!displaced && this._removeDisplacedFromDb) {
+      // Unloaded property-setter replace: materialize the existing DB-associated
+      // record now (the owner still keys the pre-replace row, since the new
+      // target has not been persisted yet) so its `:dependent` remove runs.
+      // Mirrors Rails' synchronous `load_target` inside `replace`. `replace`
+      // already cached the new (unsaved) target, so clear it around the find to
+      // force a DB query instead of returning that cached record.
+      this._removeDisplacedFromDb = false;
+      const savedTarget = this.target;
+      const savedLoaded = this.loaded;
+      this.target = null;
+      this.loaded = false;
+      let found: Base | null = null;
+      try {
+        found = await this.doAsyncFindTarget();
+      } finally {
+        this.target = savedTarget;
+        this.loaded = savedLoaded;
+      }
+      if (found && !sameRecord(found, savedTarget)) displaced = found;
+    }
+    if (!displaced) return;
     const currentTarget = this.target;
     this.target = displaced;
     try {

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -246,15 +246,13 @@ describe("HasOneAssociationsTest", () => {
     expect(Account.destroyedAccountIds().get(firm.id) ?? []).toEqual([]);
   });
 
-  it.skip("association change calls destroy", () => {
-    // BLOCKED: the JS property setter (`firm.account = Account.new`) cannot
-    // await, so the displaced account is not loaded at queue time and
-    // `persistReplace` has no `previousTarget` to dependent-destroy. The
-    // before_destroy inverse-owner seed (has-one-association.ts) already
-    // makes the cascade record `destroyed_account_ids` once the displaced
-    // record IS known (see "dependence"); what remains is loading the
-    // existing DB target on an unloaded property-setter replace. Tracked by
-    // follow-on story unskip-has-one-load-displaced-on-replace.
+  it("association change calls destroy", async () => {
+    const firm = companies("first_firm") as any;
+    // Property setter queues on an unloaded has_one; `firm.save()` loads the
+    // existing DB account and runs the dependent: :destroy remove against it.
+    firm.account = new Account({ credit_limit: 5 });
+    await firm.save();
+    expect(Account.destroyedAccountIds().get(firm.id) ?? []).toEqual([firm.id]);
   });
 
   it("natural assignment to already associated record", async () => {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -486,7 +486,10 @@ async function autosaveHasOne(record: Base, assoc: AssociationDefinition): Promi
   // `persistReplace` — nullifies/destroys it, mirroring the `remove_target!`
   // Rails runs synchronously inside `HasOneAssociation#replace`. Runs before the
   // `!child` bail so assigning nil (`owner.account = null`) still removes it.
-  if (typeof inst?.removeDisplaced === "function" && inst?._displacedRecord) {
+  if (
+    typeof inst?.removeDisplaced === "function" &&
+    (inst?._displacedRecord || inst?._removeDisplacedFromDb)
+  ) {
     await inst.removeDisplaced();
   }
 


### PR DESCRIPTION
## Summary

An unloaded `owner.account = Account.new(...)` property-setter replace queues via `queueWrite`, which cannot `await` and so never materializes the current target — leaving `removeDisplaced` with no `_displacedRecord` to dependent-remove under `:dependent`. The displaced DB row was therefore never destroyed/nullified, so `destroyed_account_ids` stayed empty.

This flags the unloaded-displacement case (`_removeDisplacedFromDb`) in `queueWrite` when the has_one has a `dependent:` option, and at the owner's save `removeDisplaced` loads the existing DB-associated record (clearing the freshly-cached new target around the find so it hits the DB) and runs the dependent remove against it. Mirrors Rails' synchronous `load_target` inside `HasOneAssociation#replace`.

## Test

Un-skips `HasOneAssociationsTest > association change calls destroy` (verbatim Rails test name). All has_one / autosave replace tests still pass on sqlite.

Closes-story: unskip-has-one-load-displaced-on-replace