### PR TITLE
test(activerecord): convert column-alias raw INSERT to topics fixtures

### DIFF
--- a/packages/activerecord/src/column-alias.test.ts
+++ b/packages/activerecord/src/column-alias.test.ts
@@ -1,12 +1,9 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import { Base } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 
 describe("TestColumnAlias", () => {
-  fixtures({}, { useTransactionalTests: false });
-  beforeAll(async () => {
-    await (Base.connection as any).executeMutation("INSERT INTO topics (title) VALUES ('a')");
-  });
+  fixtures(["topics"]);
 
   it("column alias", async () => {
     const records = await Base.connection.selectAll("SELECT id AS pk FROM topics");


### PR DESCRIPTION
Converts `column-alias.test.ts` (TestColumnAlias) off the raw non-fixture write
in `beforeAll` — `INSERT INTO topics (title) VALUES ('a')`, which committed
outside the per-test transaction and leaked a `topics` row into the shared
worker DB — to a canonical `fixtures(["topics"])` seed, then flips the suite to
transactional fixtures.

Mirrors Rails' `column_alias_test.rb`, which declares `fixtures :topics` and
runs transactionally (no `use_transactional_tests` override).

Closes-story: convert-column-alias-raw-insert-to-topics-fixtures