### PR TITLE
fix(relation): alias standalone self-joins in where.associated/missing

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -2117,7 +2117,16 @@ export class Relation<T extends Base> {
     // / belongsTo / polymorphic `as`) rather than re-deriving inline, so a
     // polymorphic or explicitly-keyed inverse resolves correctly too.
     if (reflection.options.inverseOf != null && inferFromInverseOf) {
-      const targetClassName = reflection.options.className ?? _camelize(_singularize(name));
+      // Mirror Rails' `derive_class_name` (reflection.rb:812-816): only a
+      // collection association singularizes before camelizing; belongsTo/hasOne
+      // camelize the name as-is. Matches the `isPlural` branching at the fallback
+      // resolver above rather than singularizing unconditionally.
+      const isPlural =
+        reflection.type === "hasMany" ||
+        reflection.type === "hasAndBelongsToMany" ||
+        (reflection.type as string) === "hasManyThrough";
+      const targetClassName =
+        reflection.options.className ?? _camelize(isPlural ? _singularize(name) : name);
       const targetModel: any = modelRegistry.get(targetClassName);
       const inverse = (targetModel?._associations ?? []).find(
         (a: any) => a.name === reflection.options.inverseOf,

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -916,8 +916,9 @@ export class Relation<T extends Base> {
     // standalone self-join (target == owner, e.g. `Comment has_many :children`)
     // that whereAssociated/whereMissing must ADD to alias itself (`aliased_table_for`
     // sees the owner already taken) instead of colliding on the bare owner table.
-    // Identity-based ON rebind (`_rebindTableInNode` with the target Table node)
-    // then aliases only the target side, leaving the owner reference intact.
+    // The ON rebind (`_rebindTableInNode`) then swaps the target references to the
+    // alias while excluding the owner `Table` instance by identity, leaving the
+    // owner side intact.
     if ((tracker.aliases.get(ownerTable) ?? 0) === 0) tracker.aliases.set(ownerTable, 1);
     const jdJoins: Array<{ table: string; assoc: string; as: string }> = [];
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -324,20 +324,13 @@ function _addAssocJoin(
   // reused. The IS NULL / IS NOT NULL predicate must land on that join's
   // effective table: a self-join is aliased (e.g. `children_comments`), so
   // return the alias; a plain join keeps its real table, so return undefined.
+  // `jd.as` already carries the effective alias the manager-build path emits —
+  // computed once, in bucket order, by `_unifiedJoinAliasTracker` (including the
+  // self-join case whose seed-time JD left `effectiveSqlName` un-aliased). Reuse
+  // it so a self-join predicate lands on the joined child rows (`children_comments`)
+  // rather than the always-present owner PK; a plain join keeps its real table.
   const jd = jdJoins.find((j) => j.assoc === assocName && j.table === join.table);
-  if (jd) {
-    if (jd.as !== join.table) return jd.as;
-    // A self-join JD (target == owner, e.g. `leftJoins(:children)` on Comment)
-    // is aliased at emit time, but the seed-time JoinDependency here has not run
-    // its alias assignment, so `jd.as` is still the bare owner table. The
-    // emitting path aliases it to the tracker candidate (`{plural}_{owner}`);
-    // reuse that same alias so the IS NULL / IS NOT NULL predicate lands on the
-    // joined child rows rather than the always-present owner PK.
-    if (join.table === ownerTable) {
-      return _trackerAliasFor(tracker, join.table, assocName, ownerTable);
-    }
-    return undefined;
-  }
+  if (jd) return jd.as !== join.table ? jd.as : undefined;
   const sameAssoc = clauses.find((j) => j.assoc === assocName && j.table === join.table);
   if (sameAssoc) return sameAssoc.as;
   // Flat-to-flat repeat with a compatible ON collapses into the existing join.
@@ -949,8 +942,19 @@ export class Relation<T extends Base> {
         // count never rises above 1 (first use keeps the real name); repeat
         // joins are counted under their alias name so the next `_N` is correct.
         if ((tracker.aliases.get(table) ?? 0) === 0) tracker.aliases.set(table, 1);
-        const eff = node.effectiveSqlName;
-        if (eff && eff !== table) tracker.aliases.set(eff, (tracker.aliases.get(eff) ?? 0) + 1);
+        let eff = node.effectiveSqlName;
+        if (eff && eff !== table) {
+          tracker.aliases.set(eff, (tracker.aliases.get(eff) ?? 0) + 1);
+        } else if (table === ownerTable) {
+          // Self-join whose seed-time JoinDependency did NOT run its alias
+          // assignment (`effectiveSqlName` is still the bare owner table). The
+          // manager-build path aliases it to the tracker candidate; mint that
+          // alias HERE, in bucket order, so the tracker's `_N` bookkeeping is the
+          // single source of truth and the stored `as` is the exact string the
+          // emitted `JOIN ... <alias>` will use — even when several self-joins on
+          // the same owner table are in play.
+          eff = _trackerAliasFor(tracker, table, node.immediateAssocName, ownerTable) ?? table;
+        }
         jdJoins.push({
           table,
           assoc: node.immediateAssocName,
@@ -2081,33 +2085,44 @@ export class Relation<T extends Base> {
    * - polymorphic `as` → `#{as}_id`
    * - otherwise → `#{owner.model_name}_id` (the owning model)
    *
+   * - `inverse_of` (when `inferFromInverseOf`) → the inverse reflection's own
+   *   foreign key, recursively (reflection.rb:558-566:
+   *   `inverse_of.foreign_key(infer_from_inverse_of: false)`)
+   *
    * An explicit `foreignKey` option always wins (and may be a composite
    * `string[]`). `ownerName` is the owning model's class name — for a `:through`
    * source association the owner is the through model, not the base model, so
-   * callers pass the appropriate name. The `infer_from_inverse_of` /
-   * `inverse_of` branch is not yet ported.
+   * callers pass the appropriate name.
+   *
+   * `inferFromInverseOf` mirrors Rails' `infer_from_inverse_of:` guard: the
+   * recursive call into the inverse passes `false` so the inverse's OWN
+   * `inverse_of` is not chased (prevents two mutually-inverse associations from
+   * bouncing forever).
    *
    * @internal
    */
-  private _deriveForeignKey(reflection: any, name: string, ownerName: string): string | string[] {
+  private _deriveForeignKey(
+    reflection: any,
+    name: string,
+    ownerName: string,
+    inferFromInverseOf = true,
+  ): string | string[] {
     if (reflection.options.foreignKey != null) return reflection.options.foreignKey;
     if (reflection.type === "belongsTo") return `${_toUnderscore(name)}_id`;
     if (reflection.options.as) return `${_toUnderscore(reflection.options.as)}_id`;
-    // Rails' `derive_foreign_key` defers to the inverse belongs_to's foreign key
-    // when `inverse_of:` is set (reflection.rb:558-566), so a self-referential
-    // `has_many :children, inverse_of: :parent` uses the parent's `parent_id`
-    // instead of the owner-name default `comment_id`. Resolve the inverse on the
-    // target model and read its (option or `<name>_id`) foreign key.
-    if (reflection.options.inverseOf != null) {
+    // When `inverse_of:` is set, defer to the inverse reflection's foreign key so
+    // a self-referential `has_many :children, inverse_of: :parent` uses the
+    // parent belongs_to's `parent_id` rather than the owner-name default
+    // `comment_id`. Recurse through the full derivation (option / composite array
+    // / belongsTo / polymorphic `as`) rather than re-deriving inline, so a
+    // polymorphic or explicitly-keyed inverse resolves correctly too.
+    if (reflection.options.inverseOf != null && inferFromInverseOf) {
       const targetClassName = reflection.options.className ?? _camelize(_singularize(name));
       const targetModel: any = modelRegistry.get(targetClassName);
       const inverse = (targetModel?._associations ?? []).find(
         (a: any) => a.name === reflection.options.inverseOf,
       );
-      if (inverse) {
-        if (inverse.options.foreignKey != null) return inverse.options.foreignKey;
-        return `${_toUnderscore(inverse.name)}_id`;
-      }
+      if (inverse) return this._deriveForeignKey(inverse, inverse.name, targetClassName, false);
     }
     return `${_toUnderscore(ownerName)}_id`;
   }

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -225,32 +225,47 @@ function _onEquals(a: string | Nodes.Node, b: string | Nodes.Node): boolean {
  * substitution. Other operands (the owner-side attribute, a `Casted` STI-type
  * literal, raw values) are left untouched.
  *
- * Two faithful limitations carried over verbatim from the string path this
- * replaces (so executed SQL is unchanged — both are matched on the target
- * table NAME, exactly as the old `quoteTable(join.table)` substitution was):
+ * A **true self-association** (e.g. `Comment has_many :children` or `Employee
+ * has_many :subordinates`) shares one table NAME across owner and target, so an
+ * ON like `comments.parent_id = comments.id` would rebind BOTH sides if matched
+ * purely by name. Rails' AliasTracker aliases only the target `Table` object;
+ * the caller threads that owner (source) `Table` instance in as `excludeNode` so
+ * the owner-side attribute is skipped by identity while every other `fromName`
+ * reference — the target column and any scope predicate on it — is rebound.
  *
- * - **True self-association** (e.g. `Employee has_many :subordinates,
- *   foreign_key: :manager_id`): owner and target are the SAME table, so an ON
- *   like `employees.manager_id = employees.id` rebinds BOTH sides to the alias.
- *   Rails' AliasTracker aliases only the target table object, leaving the owner
- *   unaliased; matching by name can't distinguish them. This is a pre-existing
- *   latent deviation (identical under the old string substitution), not changed
- *   here — converging it needs identity-based (target `Table` instance)
- *   rebinding at the builder, out of scope for this string→AST conversion.
+ * One faithful limitation remains:
+ *
  * - **`SqlLiteral` operand** (e.g. a raw `where("table.col = ?")` scope folded
  *   into the ON): opaque text with no walkable attribute, so it falls through
  *   unrebound. The builder call sites here emit purely Arel-node predicates, so
  *   this never fires today; a top-level raw-SQL `on` string still takes the
  *   `typeof join.on === "string"` substitution path in `_addAssocJoin`.
  */
-function _rebindOperand(value: unknown, fromName: string, alias: string): unknown {
-  return value instanceof Nodes.Node ? _rebindTableInNode(value, fromName, alias) : value;
+function _rebindOperand(
+  value: unknown,
+  fromName: string,
+  alias: string,
+  excludeNode?: Table,
+): unknown {
+  return value instanceof Nodes.Node
+    ? _rebindTableInNode(value, fromName, alias, excludeNode)
+    : value;
 }
 
-function _rebindTableInNode(node: Nodes.Node, fromName: string, alias: string): Nodes.Node {
+function _rebindTableInNode(
+  node: Nodes.Node,
+  fromName: string,
+  alias: string,
+  // The owner-side Table instance of a self-join. Attributes whose relation IS
+  // this exact instance are left unaliased (the owner keeps the real table),
+  // while every OTHER `fromName`-named reference — the target column plus any
+  // scope predicate the association appended on the target — is rebound. Omitted
+  // for non-self-joins, where owner and target names differ and nothing collides.
+  excludeNode?: Table,
+): Nodes.Node {
   if (node instanceof Nodes.Attribute) {
     const rel = node.relation;
-    if (rel instanceof Table && !rel.tableAlias && rel.name === fromName) {
+    if (rel instanceof Table && !rel.tableAlias && rel.name === fromName && rel !== excludeNode) {
       return new Nodes.Attribute(new Table(alias), node.name, node.caster);
     }
     return node;
@@ -258,18 +273,18 @@ function _rebindTableInNode(node: Nodes.Node, fromName: string, alias: string): 
   const clone: any = Object.create(Object.getPrototypeOf(node));
   if (node instanceof Nodes.Nary) {
     return Object.assign(clone, node, {
-      children: node.children.map((c) => _rebindTableInNode(c, fromName, alias)),
+      children: node.children.map((c) => _rebindTableInNode(c, fromName, alias, excludeNode)),
     });
   }
   if (node instanceof Nodes.Binary) {
     return Object.assign(clone, node, {
-      left: _rebindOperand(node.left, fromName, alias),
-      right: _rebindOperand(node.right, fromName, alias),
+      left: _rebindOperand(node.left, fromName, alias, excludeNode),
+      right: _rebindOperand(node.right, fromName, alias, excludeNode),
     });
   }
   if (node instanceof Nodes.Grouping || node instanceof Nodes.Unary) {
     return Object.assign(clone, node, {
-      expr: _rebindOperand((node as { expr: unknown }).expr, fromName, alias),
+      expr: _rebindOperand((node as { expr: unknown }).expr, fromName, alias, excludeNode),
     });
   }
   return node;
@@ -286,10 +301,9 @@ function _addAssocJoin(
     assoc?: string;
   }>,
   type: "inner" | "left",
-  join: { table: string; on: string | Nodes.Node },
+  join: { table: string; on: string | Nodes.Node; ownerNode?: Table },
   assocName: string,
   modelClass: any,
-  leftOuterJoinsValues: ReadonlyArray<unknown> | undefined,
   ownerTable: string,
   quoteTable: (name: string) => string,
   // One AliasTracker shared across every JoinDependency bucket (inner joins,
@@ -302,18 +316,28 @@ function _addAssocJoin(
   // eager). Used only for association-level dedup (a repeat of the same
   // association reuses the existing join); their SQL is owned by JoinDependency
   // and never re-emitted here.
-  jdJoins: ReadonlyArray<{ table: string; assoc: string }> = [],
+  jdJoins: ReadonlyArray<{ table: string; assoc: string; as: string }> = [],
 ): string | undefined {
-  // If the association is already covered by the deferred LEFT OUTER JOIN path,
-  // skip — that join is emitted when the manager is built, so adding a second
-  // join here would cause ambiguous column names.
-  if (leftOuterJoinsValues?.some((v) => typeof v === "string" && v === assocName)) return undefined;
   // Association-level dedup (Rails `left_outer_joins_values |= args`,
   // query_methods.rb:124-128): a sibling join for the SAME association already
-  // emitted via JoinDependency or a prior flat where-join is reused. A
-  // JoinDependency join carries no flat alias, so the predicate keeps the real
-  // table; a prior flat join reuses whatever alias it minted.
-  if (jdJoins.some((j) => j.assoc === assocName && j.table === join.table)) return undefined;
+  // emitted via JoinDependency (inner `joins`, `leftOuterJoins`, or eager) is
+  // reused. The IS NULL / IS NOT NULL predicate must land on that join's
+  // effective table: a self-join is aliased (e.g. `children_comments`), so
+  // return the alias; a plain join keeps its real table, so return undefined.
+  const jd = jdJoins.find((j) => j.assoc === assocName && j.table === join.table);
+  if (jd) {
+    if (jd.as !== join.table) return jd.as;
+    // A self-join JD (target == owner, e.g. `leftJoins(:children)` on Comment)
+    // is aliased at emit time, but the seed-time JoinDependency here has not run
+    // its alias assignment, so `jd.as` is still the bare owner table. The
+    // emitting path aliases it to the tracker candidate (`{plural}_{owner}`);
+    // reuse that same alias so the IS NULL / IS NOT NULL predicate lands on the
+    // joined child rows rather than the always-present owner PK.
+    if (join.table === ownerTable) {
+      return _trackerAliasFor(tracker, join.table, assocName, ownerTable);
+    }
+    return undefined;
+  }
   const sameAssoc = clauses.find((j) => j.assoc === assocName && j.table === join.table);
   if (sameAssoc) return sameAssoc.as;
   // Flat-to-flat repeat with a compatible ON collapses into the existing join.
@@ -336,7 +360,7 @@ function _addAssocJoin(
     const reboundOn =
       typeof join.on === "string"
         ? join.on.split(`${quoteTable(join.table)}.`).join(`${quoteTable(alias)}.`)
-        : _rebindTableInNode(join.on, join.table, alias);
+        : _rebindTableInNode(join.on, join.table, alias, join.ownerNode);
     clauses.push({
       type,
       table: join.table,
@@ -469,7 +493,16 @@ const StrictLoadingScope = {
  * is no longer copied onto `_joinClauses`, since a plain `.joins(:assoc)` now
  * resolves its klass through the join-dependency walk.
  */
-type JoinClauseSpec = { table: string; on: string | Nodes.Node; klass?: unknown };
+type JoinClauseSpec = {
+  table: string;
+  on: string | Nodes.Node;
+  klass?: unknown;
+  // The owner-side (source) `Table` instance inside `on`. For a self-join the
+  // owner and target share a table NAME but are distinct Table objects, so an
+  // alias rebind must swap every target reference by name yet leave THIS owner
+  // instance untouched (`_rebindTableInNode` excludes it by identity).
+  ownerNode?: Table;
+};
 
 /**
  * Shared frozen empty array returned by value readers whose backing field is
@@ -759,7 +792,6 @@ export class Relation<T extends Base> {
           join,
           assocName,
           rel._modelClass as any,
-          cloned._leftOuterJoinsValues,
           ownerTable,
           quoteTable,
           tracker,
@@ -807,7 +839,6 @@ export class Relation<T extends Base> {
           join,
           assocName,
           rel._modelClass as any,
-          cloned._leftOuterJoinsValues,
           ownerTable,
           quoteTable,
           tracker,
@@ -856,20 +887,20 @@ export class Relation<T extends Base> {
    * identically to the JoinDependency/adapter path. It is seeded from the actual
    * join *nodes*: a table joined in any bucket — including the owner table via a
    * self-join — is claimed, so a later flat where-join on it aliases
-   * (`aliased_table_for`, alias_tracker.rb:58-77). A *standalone* true
-   * self-association (target == owner with no prior join) is intentionally left
-   * unaliased: the flat path rebinds the ON predicate by table NAME
-   * (`_rebindTableInNode`), which cannot distinguish the owner side from the
-   * target side, so aliasing it here would rewrite both. That is the pre-existing
-   * deviation documented on `_rebindOperand`; converging it needs identity-based
-   * rebinding and is out of scope for this story. `jdJoins` carries each
-   * JoinDependency join's (table, association) for association-level dedup.
+   * (`aliased_table_for`, alias_tracker.rb:58-77). The owner (FROM) table is
+   * pre-claimed below, so even a *standalone* true self-association (target ==
+   * owner with no prior join) aliases: the flat path rebinds the ON predicate by
+   * table NAME while excluding the owner `Table` instance by identity
+   * (`_rebindTableInNode`), so the target side takes the alias and the owner side
+   * stays put. `jdJoins` carries each JoinDependency join's (table, association,
+   * effective alias) for association-level dedup — a self-join predicate reuses
+   * the emitted alias rather than the always-present owner PK.
    *
    * @internal
    */
   private _unifiedJoinAliasTracker(aliasLength: number): {
     tracker: AliasTracker;
-    jdJoins: Array<{ table: string; assoc: string }>;
+    jdJoins: Array<{ table: string; assoc: string; as: string }>;
   } {
     // Seed the tracker with the manual `_joinValues` (raw string / Arel join
     // nodes) so a where-chain alias decision counts collisions against them via
@@ -880,7 +911,15 @@ export class Relation<T extends Base> {
     );
     const tracker = new AliasTracker(aliasLength, undefined, manualJoins, this._conn() as any);
     const ownerTable = (this._modelClass as any).tableName;
-    const jdJoins: Array<{ table: string; assoc: string }> = [];
+    // Claim the owner (FROM) table, mirroring Rails' JoinDependency, whose base
+    // node occupies the tracker before any association join. This forces a
+    // standalone self-join (target == owner, e.g. `Comment has_many :children`)
+    // that whereAssociated/whereMissing must ADD to alias itself (`aliased_table_for`
+    // sees the owner already taken) instead of colliding on the bare owner table.
+    // Identity-based ON rebind (`_rebindTableInNode` with the target Table node)
+    // then aliases only the target side, leaving the owner reference intact.
+    if ((tracker.aliases.get(ownerTable) ?? 0) === 0) tracker.aliases.set(ownerTable, 1);
+    const jdJoins: Array<{ table: string; assoc: string; as: string }> = [];
 
     // Mirror the join buckets `_applyJoinsToManager` actually emits: named inner
     // joins, eager load, includes promoted to eager load, and left-outer joins
@@ -911,7 +950,11 @@ export class Relation<T extends Base> {
         if ((tracker.aliases.get(table) ?? 0) === 0) tracker.aliases.set(table, 1);
         const eff = node.effectiveSqlName;
         if (eff && eff !== table) tracker.aliases.set(eff, (tracker.aliases.get(eff) ?? 0) + 1);
-        jdJoins.push({ table, assoc: node.immediateAssocName });
+        jdJoins.push({
+          table,
+          assoc: node.immediateAssocName,
+          as: eff && eff !== table ? eff : table,
+        });
       }
     }
     // Replay flat where-joins already on this relation so a repeat self-join in
@@ -945,7 +988,7 @@ export class Relation<T extends Base> {
    * - through/HABTM: returns null (caller throws).
    */
   private _resolveAssociationTarget(assocName: string): {
-    joins: Array<{ table: string; on: string | Nodes.Node }>;
+    joins: Array<{ table: string; on: string | Nodes.Node; ownerNode?: Table }>;
     table: string;
     pks: string[];
   } | null {
@@ -2049,6 +2092,22 @@ export class Relation<T extends Base> {
     if (reflection.options.foreignKey != null) return reflection.options.foreignKey;
     if (reflection.type === "belongsTo") return `${_toUnderscore(name)}_id`;
     if (reflection.options.as) return `${_toUnderscore(reflection.options.as)}_id`;
+    // Rails' `derive_foreign_key` defers to the inverse belongs_to's foreign key
+    // when `inverse_of:` is set (reflection.rb:558-566), so a self-referential
+    // `has_many :children, inverse_of: :parent` uses the parent's `parent_id`
+    // instead of the owner-name default `comment_id`. Resolve the inverse on the
+    // target model and read its (option or `<name>_id`) foreign key.
+    if (reflection.options.inverseOf != null) {
+      const targetClassName = reflection.options.className ?? _camelize(_singularize(name));
+      const targetModel: any = modelRegistry.get(targetClassName);
+      const inverse = (targetModel?._associations ?? []).find(
+        (a: any) => a.name === reflection.options.inverseOf,
+      );
+      if (inverse) {
+        if (inverse.options.foreignKey != null) return inverse.options.foreignKey;
+        return `${_toUnderscore(inverse.name)}_id`;
+      }
+    }
     return `${_toUnderscore(ownerName)}_id`;
   }
 
@@ -2110,6 +2169,7 @@ export class Relation<T extends Base> {
         table: targetTable,
         on: predicates.length === 1 ? predicates[0] : new Nodes.And(predicates),
         klass: targetModel,
+        ownerNode: src,
       };
     }
 
@@ -2155,6 +2215,7 @@ export class Relation<T extends Base> {
         table: targetTable,
         on: predicates.length === 1 ? predicates[0] : new Nodes.And(predicates),
         klass: targetModel,
+        ownerNode: src,
       };
     }
 

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -51,27 +51,14 @@ describe("WhereChainTest", () => {
     expect(includesRecord(relation, posts("authorless"))).toBe(false);
   });
 
-  // Skip boundary: only the standalone self-join cases where
-  // where.associated / where.missing must ADD the `Comment.children` self-join
-  // itself (no prior join). trails' flat string ON-rebind path can't alias a
-  // self-join it adds with no sibling join to disambiguate — the predicate
-  // collapses to the unaliased owner table (`ambiguous column name: comments.id`).
-  // This is the documented `_rebindOperand` deviation; converging it requires
-  // routing whereAssociated/whereMissing through JoinDependency/AliasTracker.
-  // Tracked by RFC 0027 `converge-where-associated-missing-onto-join-dependency`.
-  //
-  // The `add joins before` case (further down) is NOT skipped: a prior inner
-  // `joins("children")` is built by JoinDependency, which aliases the child side
-  // (`children_comments`) correctly. whereAssociated dedups onto that join, so the
-  // emitted SQL is `FROM comments INNER JOIN comments children_comments ON
-  // children_comments.parent_id = comments.id WHERE comments.id IS NOT NULL`. The
-  // base-table `IS NOT NULL` is degenerate but harmless — the INNER JOIN already
-  // restricts to comments that have a child, a Rails-equivalent result set that
-  // is deterministic across adapters. The `add left joins before` /
-  // `add left outer joins before` cases ARE skipped: a LEFT join keeps childless
-  // rows, so the predicate must land on the aliased child column to filter them,
-  // which the flat path can't do.
-  it.skip("associated with child association", async () => {
+  // Self-join `children` (RFC 0027 convergence): where.associated / where.missing
+  // that must ADD the `Comment.children` self-join now alias it via the unified
+  // AliasTracker — the owner (FROM) table is pre-claimed, so the added join takes
+  // the `children_comments` alias and an identity-based ON rebind swaps only the
+  // target side, leaving `comments.id` intact. When a prior `leftJoins(:children)`
+  // already emits the aliased join, the predicate dedups onto that alias instead
+  // of the always-present owner PK, so childless rows filter correctly.
+  it("associated with child association", async () => {
     const relation = await Comment.all().where().associated("children");
     expect(includesRecord(relation, comments("greetings"))).toBe(true);
     expect(includesRecord(relation, comments("more_greetings"))).toBe(false);
@@ -209,24 +196,24 @@ describe("WhereChainTest", () => {
     expect((first as any).id).toBe(((await Author.find(2)) as any).id);
   });
 
-  // NOT skipped: the prior inner `joins("children")` provides a JoinDependency
-  // self-join (aliased `children_comments`) that does the filtering. See the
-  // skip-boundary note above.
+  // Prior inner `joins("children")` supplies the JoinDependency self-join
+  // (aliased `children_comments`); the predicate dedups onto it. See the
+  // self-join note above.
   it("associated with add joins before", async () => {
     const relation = await Comment.joins("children").where().associated("children");
     expect(includesRecord(relation, comments("greetings"))).toBe(true);
     expect(includesRecord(relation, comments("more_greetings"))).toBe(false);
   });
 
-  // Self-join `children` — see skip note above (RFC 0027 convergence story).
-  it.skip("associated with add left joins before", async () => {
+  // Self-join `children` — see the self-join note above.
+  it("associated with add left joins before", async () => {
     const relation = await Comment.leftJoins("children").where().associated("children");
     expect(includesRecord(relation, comments("greetings"))).toBe(true);
     expect(includesRecord(relation, comments("more_greetings"))).toBe(false);
   });
 
-  // Self-join `children` — see skip note above (RFC 0027 convergence story).
-  it.skip("associated with add left outer joins before", async () => {
+  // Self-join `children` — see the self-join note above.
+  it("associated with add left outer joins before", async () => {
     const relation = await Comment.leftOuterJoins("children").where().associated("children");
     expect(includesRecord(relation, comments("greetings"))).toBe(true);
     expect(includesRecord(relation, comments("more_greetings"))).toBe(false);
@@ -243,8 +230,8 @@ describe("WhereChainTest", () => {
     expect(ids(relation)).toEqual([posts("authorless").id]);
   });
 
-  // Self-join `children` — see skip note above (RFC 0027 convergence story).
-  it.skip("missing with child association", async () => {
+  // Self-join `children` — see the self-join note above.
+  it("missing with child association", async () => {
     const relation = await Comment.all().where().missing("children");
     expect(includesRecord(relation, comments("more_greetings"))).toBe(true);
     expect(includesRecord(relation, comments("greetings"))).toBe(false);


### PR DESCRIPTION
Un-skips the four self-join `where.associated` / `where.missing` cases in
`where-chain.test.ts` by converging the flat association where-join path onto
the unified `AliasTracker` (RFC 0027).

## What changed

- **Pre-claim the owner (FROM) table** in `_unifiedJoinAliasTracker`, mirroring
  Rails' `JoinDependency`, whose base node occupies the tracker before any
  association join. A standalone self-join that `where.associated`/`where.missing`
  must ADD (e.g. `Comment.where.associated("children")`) now takes the
  `children_comments` alias instead of colliding on the bare `comments` table
  (`ambiguous column name: comments.id`).
- **Identity-based ON rebind exclusion**: `_rebindTableInNode` rebinds every
  `fromName`-named reference to the alias EXCEPT the owner-side `Table` instance
  (threaded through as `ownerNode`/`excludeNode`). This aliases only the target
  side while leaving `comments.id` intact, and still catches scope-predicate
  columns that use a fresh target `Table` instance.
- **Self-join JD dedup**: when a prior `leftJoins("children")` already emits the
  aliased join, the predicate now dedups onto that alias so childless rows filter
  correctly (the LEFT-join variants previously kept them).
- **`inverse_of` FK derivation**: `_deriveForeignKey` now defers to the inverse
  belongs_to's foreign key when `inverse_of:` is set (mirroring Rails'
  `derive_foreign_key`), so `has_many :children, inverse_of: :parent` resolves
  `parent_id` rather than the owner-name default `comment_id`.

## Tests

All 54 `where-chain.test.ts` cases pass (the four formerly-skipped self-join
cases included). Also verified no regressions in `inverse-associations`,
`join-dependency-quoting`, `join-dependency-through-aliasing`,
`left-outer-joins-values-structural-dedup`, `select-star-join-collision`,
`build-joins-from-subquery-dedup`, and `relation.test.ts`.

Closes-story: unskip-where-chain-self-join-cases

---

## Review responses (round 1)

1. **Stale `_deriveForeignKey` docstring** — fixed. Removed the "not yet ported"
   sentence and documented the `inverse_of` branch + the `inferFromInverseOf`
   guard.

2. **`inverse_of` FK derivation was a partial re-implementation** — fixed. The
   branch now recurses via `_deriveForeignKey(inverse, inverse.name,
   targetClassName, /* inferFromInverseOf */ false)`, mirroring Rails'
   `inverse_of.foreign_key(infer_from_inverse_of: false)`. The recursion runs the
   full chain (`options[:foreign_key]` string-or-array → `belongsTo` → polymorphic
   `as` → owner-name default), so a polymorphic or explicitly-keyed inverse now
   resolves correctly rather than being hardcoded to `<name>_id`. The `false`
   guard prevents two mutually-inverse associations from bouncing.

3. **Self-join JD dedup could drift from the emitted alias** — resolved
   structurally. The predicate-time second `_trackerAliasFor` call is gone. The
   self-join alias is now computed exactly once, **in bucket order**, inside
   `_unifiedJoinAliasTracker`'s seed loop and stored in `jdJoins.as`;
   `_addAssocJoin` just returns it. There is now a single `_N`-bookkeeping path
   through the tracker, so the predicate alias is guaranteed to be the same string
   the manager-build path emits — including when multiple self-joins on the same
   owner are seeded (each mints its candidate against the shared tracker state, in
   the same order the emitter processes the buckets). Note: a *two-distinct-self-
   association* regression fixture isn't expressible against the canonical `Comment`
   model (its only self-association is `children`/`parent`), so the guarantee is
   established by construction rather than a bespoke non-canonical model.


## Review responses (round 2)

1. **`_camelize(_singularize(name))` singularized unconditionally** — fixed. Now
   branches on `isPlural` (`hasMany`/`hasAndBelongsToMany`/`hasManyThrough`) before
   singularizing, matching Rails' `derive_class_name` (reflection.rb:812-816,
   `collection? ? name.singularize.camelize : name.camelize`) and the file's own
   fallback resolver a few hundred lines up. A belongsTo/hasOne inverse target
   class name now camelizes as-is.

2. **No coverage for the fallback / polymorphic-inverse / composite-FK branches**
   — acknowledged; left as-is by design. Those branches are a line-for-line port
   of Rails' `foreign_key` → `derive_foreign_key` recursion, and exercising them
   would require a self-referential association whose target resolves without an
   explicit `className:` (or a polymorphic/composite self-inverse) — no such shape
   exists in the canonical schema, and per project convention I won't add a bespoke
   non-canonical model to reach an untriggered branch. The self-referential
   `belongsTo` inverse that this PR actually needs (`Comment#children`/`#parent`)
   is covered by the four un-skipped tests. If a canonical model later grows such
   an association, the coverage should ride that.
