### PR TITLE
refactor(relation): unify joins_values into one insertion-ordered store

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -1003,6 +1003,7 @@ export class AssociationScope {
     const refs = item._referencesValues ?? [];
     if (refs.length === 0) return;
     const target = scope as {
+      _joinsValues: unknown[];
       _joinValues: unknown[];
       _joinClauses: unknown[];
       _namedInnerJoins: unknown[];
@@ -1016,12 +1017,12 @@ export class AssociationScope {
     // straight across, then union named association joins (same-klass) or build
     // cross-klass JoinDependencies (Merger#merge_joins / #merge_outer_joins).
     for (const jc of item._joinClauses ?? []) target._joinClauses.push(jc);
-    for (const jv of item._joinValues ?? []) target._joinValues.push(jv);
+    for (const jv of item._joinValues ?? []) target._joinsValues.push(jv);
     const namedInner = item._namedInnerJoins ?? [];
     if (namedInner.length > 0) {
       if (sameKlass) {
         for (const v of namedInner)
-          if (!target._namedInnerJoins.includes(v)) target._namedInnerJoins.push(v);
+          if (!target._namedInnerJoins.includes(v)) target._joinsValues.push(v);
       } else {
         target._namedInnerJoinDeps.push(
           constructJoinDependency.call(item as never, namedInner as never, Nodes.InnerJoin),

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -539,13 +539,43 @@ export class Relation<T extends Base> {
     // _selfJoinAlias) — used to attribute repeat counts to the right candidate.
     aliasBase?: string;
   }> = [];
-  private _joinValues: (string | Nodes.Join)[] = [];
+  // Single insertion-ordered backing store for `joins_values` (mirrors Rails'
+  // one `@values[:joins]` array). Every `.joins` argument lands here in call
+  // order — Arel join nodes and raw SQL strings alongside association names and
+  // nested-association hashes — so `joins_values=`/`joins_values` round-trip
+  // faithfully with no named-before-raw reorder. The named-vs-raw split the
+  // builders need is derived on read (`_namedInnerJoins` / `_joinValues`), not
+  // stored separately.
+  private _joinsValues: (AssociationSpec | string | Nodes.Join)[] = [];
   private _leftOuterJoinsValues: AssociationSpec[] = [];
+  // A `joins_values` entry is a "named" inner association join (resolved through
+  // JoinDependency) when it is a nested-association hash, a genuine Symbol
+  // (trails' signal for an association/CTE name, e.g. `joins(:name)`), or a
+  // string naming an association; everything else (Arel join nodes, raw SQL
+  // strings) is a raw join value. The two derived getters below partition
+  // `_joinsValues` by this rule — the same rule `joins` uses at insert time. A
+  // raw Symbol misrouted to `_joinValues` would reach the arel visitor and raise
+  // "Unknown node type: Symbol", so Symbols must land in `_namedInnerJoins`.
+  private _isNamedJoinValue(v: unknown): boolean {
+    return (
+      _isPlainObject(v) ||
+      typeof v === "symbol" ||
+      (typeof v === "string" && this._isAssociationName(v))
+    );
+  }
   // INNER `joins(:assoc)` association names (and nested hash/through specs),
   // resolved through JoinDependency — mirroring Rails' joins_values, which feed
   // build_join_dependencies so every node in the chain carries its base_klass
-  // and shares Rails' AliasTracker self-join aliasing.
-  private _namedInnerJoins: AssociationSpec[] = [];
+  // and shares Rails' AliasTracker self-join aliasing. Derived from the unified
+  // store so insertion order is preserved.
+  get _namedInnerJoins(): AssociationSpec[] {
+    return this._joinsValues.filter((v) => this._isNamedJoinValue(v)) as AssociationSpec[];
+  }
+  // Raw join values (Arel `Nodes.Join` and non-association SQL strings). Derived
+  // from the unified store; the complement of `_namedInnerJoins`.
+  get _joinValues(): (string | Nodes.Join)[] {
+    return this._joinsValues.filter((v) => !this._isNamedJoinValue(v)) as (string | Nodes.Join)[];
+  }
   // Pre-built InnerJoin JoinDependencies from a cross-klass `merge` (Rails
   // merge_joins builds these against `other.klass` since the association names
   // can't resolve on the receiver's model).
@@ -1876,50 +1906,15 @@ export class Relation<T extends Base> {
     // longer a `(table, on)` heuristic to disambiguate against, so the flatten
     // is uniform.
     const flatArgs = _qm.flattenedArgs(args).filter((a) => !_qm.isBlankArgument(a));
+    // Rails joins! uses `joins_values |= args` — one array union over the whole
+    // set, deduplicating by eql?/hash (structural for Arel `Nodes.Binary`, plain
+    // strings, and Hash specs alike). structuralUnionEq mirrors that (=== first,
+    // then eql/structural), and a single unified store preserves insertion order
+    // across named and raw joins. The named-vs-raw partition the builders need is
+    // derived on read (see `_namedInnerJoins` / `_joinValues`).
     for (const arg of flatArgs) {
-      // Arel join node — stored as-is to preserve type (mirrors Rails joins_values).
-      // Rails joins! uses |= (array union), deduplicating by eql?/hash —
-      // structural for nodes (Arel::Nodes::Binary#eql?), strings, and hashes
-      // alike. structuralUnionEq (=== first, then eql/structural) matches all.
-      if (arg instanceof Nodes.Join) {
-        if (!rel._joinValues.some((v) => _qm.structuralUnionEq(v, arg))) rel._joinValues.push(arg);
-        continue;
-      }
-      // Nested association hash: joins({ post: "author" }) mirrors Rails
-      // joins(post: :author). Route through JoinDependency (InnerJoin) so the
-      // full nested chain is resolved — constructJoinDependency already walks
-      // AssociationSpec trees via walkAssociationTree/addTreeToJoinDependency.
-      // joins_values |= dedups structurally-equal Hash specs, so fold here too.
-      if (_isPlainObject(arg)) {
-        if (!rel._namedInnerJoins.some((v) => _qm.structuralUnionEq(v, arg)))
-          rel._namedInnerJoins.push(arg as AssociationSpec);
-        continue;
-      }
-      // Named association joins — both simple `joins(:assoc)` and nested-through
-      // chains route through JoinDependency (InnerJoin), matching Rails:
-      // joins_values feeds build_join_dependencies, so every node in the chain
-      // (base, through, target) is represented with its base_klass. This unifies
-      // AliasTracker self-join aliasing and table-klass lookups across simple and
-      // through joins; a non-association string falls through to a raw SQL join.
-      if (typeof arg === "string" && rel._isAssociationName(arg)) {
-        if (!rel._namedInnerJoins.some((v) => _qm.structuralUnionEq(v, arg)))
-          rel._namedInnerJoins.push(arg);
-        continue;
-      }
-      // A genuine Symbol is trails' signal for "association/CTE name" (vs a raw
-      // SQL string), mirroring Ruby's `joins(:name)`. Route it into
-      // `_namedInnerJoins` so `emitJoinPlan`'s `selectNamedJoins` can partition a
-      // `with(...)` CTE name out to `buildWithJoinNode(name, InnerJoin)`; a raw
-      // Symbol left in `_joinValues` would reach the arel visitor and raise
-      // "Unknown node type: Symbol".
-      if (typeof arg === "symbol") {
-        if (!rel._namedInnerJoins.some((v) => _qm.structuralUnionEq(v, arg)))
-          rel._namedInnerJoins.push(arg as unknown as AssociationSpec);
-        continue;
-      }
-      const joinValue = arg as string | Nodes.Join;
-      if (!rel._joinValues.some((v) => _qm.structuralUnionEq(v, joinValue)))
-        rel._joinValues.push(joinValue);
+      if (!rel._joinsValues.some((v) => _qm.structuralUnionEq(v, arg)))
+        rel._joinsValues.push(arg as AssociationSpec | string | Nodes.Join);
     }
     return rel;
   }
@@ -4568,41 +4563,26 @@ export class Relation<T extends Base> {
 
   /**
    * Mirrors: ActiveRecord::Relation#joins_values — Rails stores every `.joins`
-   * argument (association names and raw SQL/Arel joins) in one array; trails
-   * splits them into `_namedInnerJoins` (resolved through JoinDependency) and
-   * `_joinValues` (raw string/Arel), so the accessor recombines them.
+   * argument (association names and raw SQL/Arel joins) in one insertion-ordered
+   * array. trails backs that directly with `_joinsValues`, so the reader returns
+   * the stored array (a copy) and preserves the exact order in which joins were
+   * added. The named-vs-raw split the builders need is derived from this store
+   * on read (`_namedInnerJoins` / `_joinValues`).
    */
   get joinsValues(): (AssociationSpec | string | Nodes.Join)[] {
-    return [...this._namedInnerJoins, ...this._joinValues];
+    return [...this._joinsValues];
   }
   /**
-   * Split-routing writer for `joins_values=`. trails has no single field to
-   * round-trip (the reader concatenates `_namedInnerJoins` + `_joinValues`), so
-   * the setter re-routes each entry using the same rule as `joins` itself
-   * (relation.ts `joins`): Arel `Join` nodes and non-association strings go to
-   * `_joinValues`; association-name strings and nested-association hashes go to
-   * `_namedInnerJoins`. A value assigned then read back is preserved by
-   * category, but — matching the reader's concat order — named joins always
-   * precede raw joins regardless of their original interleaving. The
-   * SQL-emitted `_joinClauses` (the explicit-ON `leftJoins(table, on)` form and
+   * Writer for `joins_values=` (query_methods.rb:162-181, `@values[:joins] =
+   * value`). Assigns the unified backing store directly, so a value assigned
+   * then read back round-trips faithfully in insertion order. The SQL-emitted
+   * `_joinClauses` (the explicit-ON `leftJoins(table, on)` form and
    * where-association joins) are not part of `joins_values` and are left
    * untouched.
    */
   set joinsValues(value: (AssociationSpec | string | Nodes.Join)[]) {
     this.assertModifiableBang();
-    this._namedInnerJoins = [];
-    this._joinValues = [];
-    for (const arg of value) {
-      if (arg instanceof Nodes.Join) {
-        this._joinValues.push(arg);
-      } else if (_isPlainObject(arg)) {
-        this._namedInnerJoins.push(arg as AssociationSpec);
-      } else if (typeof arg === "string" && this._isAssociationName(arg)) {
-        this._namedInnerJoins.push(arg);
-      } else {
-        this._joinValues.push(arg as string | Nodes.Join);
-      }
-    }
+    this._joinsValues = [...value];
   }
 
   /** Mirrors: ActiveRecord::Relation#left_outer_joins_values */
@@ -7342,9 +7322,8 @@ export class Relation<T extends Base> {
     this._lockValue = source._lockValue;
     this._setOperation = source._setOperation;
     this._joinClauses = [...source._joinClauses];
-    this._joinValues = [...source._joinValues];
+    this._joinsValues = [...source._joinsValues];
     this._leftOuterJoinsValues = [...source._leftOuterJoinsValues];
-    this._namedInnerJoins = [...source._namedInnerJoins];
     this._namedInnerJoinDeps = [...source._namedInnerJoinDeps];
     this._leftOuterJoinDeps = [...source._leftOuterJoinDeps];
     this._includesAssociations = [...source._includesAssociations];

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -97,9 +97,11 @@ export class Merger {
   private mergeJoins(rel: any): void {
     // Rails: joins_values and left_outer_joins_values are separate arrays, so each
     // merge helper unions its own array independently (no interleaving in Rails).
-    // Our codebase mirrors that split: explicit SQL joins go into _joinClauses,
-    // Arel/string join nodes into _joinValues, and named left-outer-join associations
-    // into _leftOuterJoinsValues. Each is merged independently below.
+    // trails keeps explicit SQL joins in _joinClauses and every `.joins` argument
+    // in the unified _joinsValues store; the other relation's `joinsValues` is
+    // partitioned into raw join values vs named association joins (the same split
+    // `build_joins` derives) and each is merged independently below, writing back
+    // into _joinsValues. left-outer-join associations live in _leftOuterJoinsValues.
     // Arel::Nodes::InnerJoin is the type used for same-model inner joins in Rails'
     // cross-model merge path.
     const clauses: Array<{ type: string; table: string; on: string; quoted?: boolean }> =
@@ -111,13 +113,15 @@ export class Merger {
     // same join node) would otherwise duplicate the join and make its columns
     // ambiguous. Dedup structurally via the Arel node's `eql` (falling back to
     // reference/`===` for strings and nodes without it).
-    for (const v of (this.other._joinValues ?? []) as unknown[]) {
+    const otherJoinsValues = (this.other.joinsValues ?? []) as unknown[];
+    const otherRawJoins = otherJoinsValues.filter((v) => !this.other._isNamedJoinValue(v));
+    for (const v of otherRawJoins) {
       const dup = (rel._joinValues as unknown[]).some((existing) =>
         typeof (v as any)?.eql === "function" && v?.constructor === (existing as any)?.constructor
           ? (v as any).eql(existing)
           : v === existing,
       );
-      if (!dup) rel._joinValues.push(v);
+      if (!dup) rel._joinsValues.push(v);
     }
     // Rails merge_joins (merger.rb): when other.klass == relation.klass the
     // association names union directly into joins_values; otherwise Merger builds
@@ -127,13 +131,13 @@ export class Merger {
     // Rails treats as an association) build a JoinDependency on `other` whose
     // AliasTracker handles nested-through / HABTM correctly.
     const sameKlass = this.other._modelClass === rel._modelClass;
-    const otherNamed: unknown[] = this.other._namedInnerJoins ?? [];
+    const otherNamed: unknown[] = otherJoinsValues.filter((v) => this.other._isNamedJoinValue(v));
     if (sameKlass) {
       for (const v of otherNamed) {
         // joins_values |= dedups structurally-equal Hash specs (eql?/hash), so a
         // same-klass merge folds an equal spec — not by JS reference identity.
         if (!rel._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v)))
-          rel._namedInnerJoins.push(v);
+          rel._joinsValues.push(v);
       }
     } else if (otherNamed.length > 0) {
       rel._namedInnerJoinDeps.push(

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -176,9 +176,15 @@ interface QueryMethodsHost {
     // global registry scan by table name.
     klass?: unknown;
   }>;
-  _joinValues: (string | Nodes.Join)[];
+  // Unified insertion-ordered `joins_values` backing store; `joinsValues`
+  // exposes it (Rails' `@values[:joins]`). `_joinValues` / `_namedInnerJoins`
+  // are read-only getters derived from it via `_isNamedJoinValue`.
+  _joinsValues: (AssociationSpec | string | Nodes.Join)[];
+  joinsValues: (AssociationSpec | string | Nodes.Join)[];
+  _isNamedJoinValue(v: unknown): boolean;
+  readonly _joinValues: (string | Nodes.Join)[];
   _leftOuterJoinsValues: AssociationSpec[];
-  _namedInnerJoins: AssociationSpec[];
+  readonly _namedInnerJoins: AssociationSpec[];
   // Pre-built InnerJoin JoinDependencies from a cross-klass merge (Rails
   // merge_joins builds these against `other.klass`); emitted via joinConstraints
   // and walked for klass lookups alongside _namedInnerJoins.
@@ -845,8 +851,7 @@ export function resetValueForScope(host: QueryMethodsHost, scope: UnscopeType): 
       break;
     case "joins":
       host._joinClauses = [];
-      host._joinValues = [];
-      host._namedInnerJoins = [];
+      host._joinsValues = [];
       break;
     case "leftOuterJoins":
       host._joinClauses = host._joinClauses.filter((j) => j.type !== "left");
@@ -925,7 +930,8 @@ function joinsBang(this: QueryMethodsHost, ...args: (string | Nodes.Join)[]): an
   // structuralUnionEq mirrors that: === first, then deepEqual (which delegates
   // to a node's own eql for Arel nodes).
   for (const arg of args) {
-    if (!this._joinValues.some((seen) => structuralUnionEq(seen, arg))) this._joinValues.push(arg);
+    if (!this._joinsValues.some((seen) => structuralUnionEq(seen, arg)))
+      this._joinsValues.push(arg);
   }
   return this;
 }
@@ -2601,14 +2607,14 @@ export function buildJoinDependencies(this: QueryMethodsHost): JoinDependency[] 
   //   join_dependencies.unshift construct_join_dependency(select_named_joins(joins, …), nil)
   // i.e. ALL named association joins fold into a single JoinDependency (nil join
   // type, since this set is consulted for table-klass / cast-type lookups, not
-  // SQL emission). _namedInnerJoins is our joins_values and so leads the union;
+  // SQL emission). The named association joins in `joins_values` lead the union;
   // _joinClauses hold pre-resolved raw SQL (table + ON), not association names,
   // and do not contribute here.
   const joinNames: AssociationSpec[] = [];
   const addNames = (specs: ReadonlyArray<AssociationSpec>) => {
     for (const a of specs) if (!joinNames.includes(a)) joinNames.push(a);
   };
-  addNames(this._namedInnerJoins);
+  addNames(this.joinsValues.filter((v) => this._isNamedJoinValue(v)) as AssociationSpec[]);
   addNames(this._leftOuterJoinsValues);
   addNames(this._eagerLoadAssociations);
   addNames(this._includesAssociations);
@@ -2758,6 +2764,16 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
     named_join: [],
   };
 
+  // Named association joins vs raw join values, both derived from the unified
+  // `joins_values` store (Rails reads `joins_values` here and partitions with
+  // `select_named_joins`).
+  const joinsValues = this.joinsValues;
+  const namedInner = joinsValues.filter((v) => this._isNamedJoinValue(v)) as AssociationSpec[];
+  const rawJoinValues = joinsValues.filter((v) => !this._isNamedJoinValue(v)) as (
+    | string
+    | Nodes.Join
+  )[];
+
   // Mirror Rails build_join_buckets (query_methods.rb:1828–1876):
   // When left_outer_joins_values is non-empty, Rails runs select_named_joins on
   // them to build stashed_left_joins. If joins_values is also empty, it returns
@@ -2782,8 +2798,8 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
     );
 
     if (
-      this._namedInnerJoins.length === 0 &&
-      this._joinValues.length === 0 &&
+      namedInner.length === 0 &&
+      rawJoinValues.length === 0 &&
       this._joinClauses.length === 0 &&
       this._eagerLoadAssociations.length === 0
     ) {
@@ -2829,7 +2845,7 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
   }
   const hasStashed = buckets.stashed_join.length > 0;
 
-  for (const v of this._joinValues) {
+  for (const v of rawJoinValues) {
     const node: Nodes.Join =
       typeof v === "string" ? (new Nodes.StringJoin(arelSql(v.trim()) as any) as Nodes.Join) : v;
     if (!(node instanceof Nodes.LeadingJoin) && hasStashed) {
@@ -3007,13 +3023,16 @@ export function emitJoinPlan(this: QueryMethodsHost, manager: any, plan: JoinEmi
 
 /** @internal */
 export function buildJoins(this: QueryMethodsHost, arel: any, aliases?: AliasTracker): void {
+  const joinsValues = this.joinsValues;
+  const hasNamedInner = joinsValues.some((v) => this._isNamedJoinValue(v));
+  const hasRawJoins = joinsValues.some((v) => !this._isNamedJoinValue(v));
   const hasEagerAssocs =
     this._eagerLoadAssociations.length > 0 ||
     this._leftOuterJoinsValues.length > 0 ||
-    this._namedInnerJoins.length > 0 ||
+    hasNamedInner ||
     this._namedInnerJoinDeps.length > 0 ||
     this._leftOuterJoinDeps.length > 0;
-  if (this._joinClauses.length === 0 && this._joinValues.length === 0 && !hasEagerAssocs) return;
+  if (this._joinClauses.length === 0 && !hasRawJoins && !hasEagerAssocs) return;
 
   // Subquery path: buckets fold eager into stashed_join. Delegate emission to
   // the shared `build_joins` port.

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -121,14 +121,14 @@ export function mergeBang(this: any, other: any): any {
       ];
     // mergeJoins (preserve original order across all join stores)
     this._joinClauses.push(...(other._joinClauses ?? []));
-    this._joinValues.push(...(other._joinValues ?? []));
+    this._joinsValues.push(...(other._joinValues ?? []));
     for (const v of other._leftOuterJoinsValues ?? []) {
       if (!this._leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
         this._leftOuterJoinsValues.push(v);
     }
     for (const v of other._namedInnerJoins ?? []) {
       if (!this._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v)))
-        this._namedInnerJoins.push(v);
+        this._joinsValues.push(v);
     }
     this._namedInnerJoinDeps.push(...(other._namedInnerJoinDeps ?? []));
     this._leftOuterJoinDeps.push(...(other._leftOuterJoinDeps ?? []));

--- a/packages/activerecord/src/relation/value-accessor-semantics.test.ts
+++ b/packages/activerecord/src/relation/value-accessor-semantics.test.ts
@@ -41,10 +41,10 @@ describe("Relation value accessor Rails semantics", () => {
     ]);
   });
 
-  it("joins_values= places named joins ahead of raw joins (reader concat order)", () => {
+  it("joins_values= round-trips in insertion order (no named-before-raw reorder)", () => {
     const rel = relation();
     rel.joinsValues = ["RAW JOIN x", { category: {} }];
-    expect(rel.joinsValues).toEqual([{ category: {} }, "RAW JOIN x"]);
+    expect(rel.joinsValues).toEqual(["RAW JOIN x", { category: {} }]);
   });
 
   it("joins_values= overwrites prior join state", () => {


### PR DESCRIPTION
## What

Unifies `.joins` storage into a single insertion-ordered `_joinsValues` array
(mirroring Rails' one `@values[:joins]`), replacing the trails-specific split
into `_namedInnerJoins` + `_joinValues`. The `joins_values=` writer now
round-trips faithfully — **no named-before-raw reorder** (RFC 0022 acceptance #1).

## Changes

- `relation.ts`: `_joinsValues` is the single backing store. `joins_values`
  reader returns it (a copy) in insertion order; `joins_values=` assigns it
  directly. `_namedInnerJoins` / `_joinValues` become read-only getters that
  partition the store via a new `_isNamedJoinValue` predicate (hash / Symbol /
  association-name string ⇒ named; Arel node / raw SQL string ⇒ raw — the same
  rule `joins` applies at insert time). `joins`/`joins!` union into the one store
  with `structuralUnionEq` (matching Rails `joins_values |= args`).
- Join builders (`build_join_buckets`, `build_join_dependencies`, `build_joins`)
  and `merge_joins` now derive their named/raw partitions from the unified
  `this.joinsValues` accessor. `spawn`/`merge`/`association-scope` write joins
  back into `_joinsValues`.
- `value-accessor-semantics.test.ts`: the reorder test now asserts faithful
  insertion-order round-trip.

`relation.rb` / `relation/query_methods.rb` stay at **100%** api:compare. Join,
merging, `with`/CTE, disable-joins, eager-load, and value-accessor suites pass
locally.

## Scope note: the 10 `joins_values` wide-call excludes (acceptance #2)

Acceptance #2 asks to also remove the 10 `joins_values` entries from
`call-mismatches-wide-exclude.json`. The builders here **do** now read
`this.joinsValues`, but the wide-call extractor (`extractCalls`) only credits
call-*expressions*, never accessor *reads*, so the read is not recorded as a
call. Crediting value-accessor reads is a cross-package extractor change (it also
converges unrelated `select_values` / `original_value` baselines and needs
transitive `.call`-delegation crediting for the relation.ts wrapper attributions
— all measured). That belongs in its own PR with its own baseline reseed, so it
is split to a dedicated, fully-scoped RFC 0022 story
(`credit-value-accessor-reads-in-wide-call-gate`) rather than bundled here.

Closes-story: unify-join-values-storage-faithful-accessor
