### PR TITLE
fix(activerecord): pass raw Arel nodes through singular arelColumn

### DIFF
--- a/packages/activerecord/src/relation/build-arel-helpers.test.ts
+++ b/packages/activerecord/src/relation/build-arel-helpers.test.ts
@@ -124,6 +124,11 @@ describe("Relation private build-arel helpers", () => {
       expect(relation().arelColumn(lit)).toBe(lit);
     });
 
+    it("passes through a non-string Arel node without calling .match", () => {
+      const grouping = new Nodes.Grouping(new Nodes.SqlLiteral("id"));
+      expect(relation().arelColumn(grouping)).toBe(grouping);
+    });
+
     it("resolves table.column form via arelColumnWithTable", () => {
       const node = relation().arelColumn("authors.name");
       expect((node as any).relation?.name).toBe("authors");

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2259,11 +2259,14 @@ export function isTableNameMatches(this: QueryMethodsHost, from: unknown): boole
 /** @internal */
 export function arelColumn(
   this: QueryMethodsHost,
-  field: string | symbol,
+  field: string | symbol | Nodes.Node,
   fallback?: (attr: string) => unknown,
 ): unknown {
   const modelClass: any = (this as any)._modelClass;
   const table: any = modelClass?.arelTable;
+  // Rails: a raw Arel node has no columns_hash/table.column form; it falls to
+  // the block, else passes through unchanged (query_methods.rb:1996-2003).
+  if (field instanceof Nodes.Node) return fallback ? fallback(field as any) : field;
   const isSymbol = typeof field === "symbol";
   let fieldStr = isSymbol ? symbolToName(field) : field;
   fieldStr = modelClass?._attributeAliases?.[fieldStr] ?? fieldStr;


### PR DESCRIPTION
## What

Singular `arelColumn` (`query-methods.ts`) lacked the `Arel.arel_node?(field) -> field` passthrough branch that Rails' singular `arel_column` has (`vendor/rails/activerecord/lib/active_record/relation/query_methods.rb:1996-2003`). Passing a raw `Nodes.Node` fell through to `fieldStr.match(...)`, which throws because a Node has no `.match`.

This surfaced during PR #4631: the grouped-aggregate path had to route through the plural `arelColumns` (which already has the Node passthrough) to avoid crashing on a raw Arel-node group column.

## Change

- `arelColumn` now returns the field unchanged when it is a `Nodes.Node` (or yields it to the fallback block first, mirroring Rails' branch order).
- Added a unit test in `build-arel-helpers.test.ts` passing a non-string `Nodes.Grouping` node (which, unlike `SqlLiteral`, has no `.match`) and asserting identity passthrough.

Closes-story: arel-column-singular-node-passthrough