### PR TITLE
fix(schema): require both :from and :to to unwrap changeColumnDefault changes

### DIFF
--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -101,6 +101,16 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     expect(col?.default).toEqual("{}");
   });
 
+  it("change column default treats a bare to object as a literal default", async () => {
+    // Rails' extract_new_default_value only unwraps a Hash carrying BOTH :from
+    // and :to; `{ to: 1 }` without :from is the literal default, not a changes
+    // hash (schema_statements.rb:1820).
+    adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" json)`);
+    await adapter.changeColumnDefault("json_defs", "options", { to: 1 });
+    const col = (await adapter.columns("json_defs")).find((c) => c.name === "options");
+    expect(col?.default).toEqual('{"to":1}');
+  });
+
   it("change column serializes a structured json default", async () => {
     adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" TEXT)`);
     await adapter.changeColumn("json_defs", "options", "json", { default: {} });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -638,10 +638,10 @@ export class SchemaStatements {
     ) {
       return adapter.changeColumnDefault(tableName, columnName, options);
     }
-    const defaultVal =
-      typeof options === "object" && options !== null && "to" in (options as any)
-        ? (options as any).to
-        : options;
+    // Rails unwraps a Hash to its :to only when it carries BOTH :from and :to
+    // (extract_new_default_value, schema_statements.rb:1820); a bare structured
+    // default like `{ to: 1 }` without :from is the literal default.
+    const defaultVal = this.extractNewDefaultValue(options);
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     const clause = this.adapter.quoteDefaultExpression(defaultVal);
     await this.adapter.executeMutation(

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -975,13 +975,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     this.adapter.schemaCache?.clearDataSourceCacheBang(this.adapter.pool, tableName);
     const quotedTable = this._qt(tableName);
     const quotedCol = this._qi(columnName);
-    const defaultValue =
-      defaultOrChanges !== null &&
-      typeof defaultOrChanges === "object" &&
-      "from" in defaultOrChanges &&
-      "to" in defaultOrChanges
-        ? (defaultOrChanges as { from: unknown; to: unknown }).to
-        : defaultOrChanges;
+    const defaultValue = this.extractNewDefaultValue(defaultOrChanges);
     if (defaultValue == null) {
       await this.adapter.executeMutation(
         `ALTER TABLE ${quotedTable} ALTER COLUMN ${quotedCol} DROP DEFAULT`,

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.test.ts
@@ -378,6 +378,21 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.exec(`ALTER TABLE ${SCHEMA_NAME}.${TABLE_NAME} DROP COLUMN IF EXISTS rating`);
     });
 
+    it("change column default with a bare object treats it as a literal default", async () => {
+      // Rails' extract_new_default_value only unwraps a Hash carrying BOTH
+      // :from and :to; a bare `{ to: ... }` without :from is the literal
+      // default, not a changes hash (schema_statements.rb:1820).
+      await adapter.addColumn(`${SCHEMA_NAME}.${TABLE_NAME}`, "config", "json");
+      await adapter.changeColumnDefault(`${SCHEMA_NAME}.${TABLE_NAME}`, "config", { to: 1 });
+      const rows = await adapter.schemaQuery(
+        `SELECT column_default FROM information_schema.columns
+         WHERE table_schema = $1 AND table_name = $2 AND column_name = 'config'`,
+        [SCHEMA_NAME, TABLE_NAME],
+      );
+      expect(rows[0].column_default).toMatch(/"to":\s*1/);
+      await adapter.exec(`ALTER TABLE ${SCHEMA_NAME}.${TABLE_NAME} DROP COLUMN IF EXISTS config`);
+    });
+
     it("change column null", async () => {
       await adapter.addColumn(`${SCHEMA_NAME}.${TABLE_NAME}`, "flag", "integer");
       await adapter.changeColumnNull(`${SCHEMA_NAME}.${TABLE_NAME}`, "flag", false);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1665,12 +1665,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // Rails' extract_new_default_value only unwraps a Hash when it carries BOTH
     // :from and :to (schema_statements.rb:1820); a bare structured default like
     // `{}` is the literal default, not a changes hash.
-    const isChanges =
-      typeof defaultOrChanges === "object" &&
-      defaultOrChanges !== null &&
-      "from" in defaultOrChanges &&
-      "to" in defaultOrChanges;
-    const newDefault = isChanges ? (defaultOrChanges as { to: unknown }).to : defaultOrChanges;
+    const newDefault = this.schemaStatements().extractNewDefaultValue(defaultOrChanges);
     this.schemaCache?.clearDataSourceCacheBang(this.pool, tableName);
     await this.alterTable(tableName, (columns) => {
       if (columns[columnName]) {

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -26749,13 +26749,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "change_column_default",
-    "call": "extract_new_default_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "change_column_null",
     "call": "internal_exec_query",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Summary

`changeColumnDefault` extraction diverged from Rails on the abstract and PostgreSQL paths: a Hash was treated as a `{from, to}` changes hash on a looser condition (only `:to` present), so a bare structured default such as `change_column_default(:t, :c, { to: 1 })` was misread as its `.to` value instead of the literal default.

Rails' `extract_new_default_value` (`schema_statements.rb:1820`) only unwraps a Hash when it carries **both** `:from` and `:to`.

## Changes

Converge all adapters onto the single, already-Rails-faithful `extractNewDefaultValue` helper (`schema-statements.ts`) instead of per-adapter inline checks:

- Abstract `changeColumnDefault` — replaced the loose `"to" in options` check with the shared helper (the actual bug fix).
- PostgreSQL `changeColumnDefault` — collapsed the inline two-key check into the helper (behavior already matched; now deduplicated).
- SQLite `changeColumnDefault` — routed its inline copy through the helper.
- MySQL already used the helper.

Net result: one Rails-faithful implementation shared by all four adapters.

## Tests

- Existing helper unit tests already assert `{ to: 42 }` is passed through unchanged (`schema-statements-privates.test.ts`).
- Added a SQLite behavioral test asserting a bare `{ to: 1 }` default is stored as the literal `{"to":1}` JSON default (runs locally, directly exercises the fix).
- Added a matching PG behavioral test for the same scenario.

Closes-story: change-column-default-extraction-require-from-and-to


## CI note (wide call-mismatches ratchet)

Routing SQLite through the shared helper converged its baselined `change_column_default → extract_new_default_value` call-mismatch, so commit `7c58d6b` removes that one stale entry from `call-mismatches-wide-exclude.json`. That is the only converged entry — the remaining `change_column_default*` baseline rows reference other calls (`execute`, `accept`, `has_key?`) on other methods this diff does not touch, and all four adapters now make the `extract_new_default_value` call so no new mismatch is introduced. The ratchet failure visible on the earlier run (`28760510437`) is on `f5df5ab`, before that removal.
