### PR TITLE
test(schema-dumper): bump full-DB dump timeout in schema-dumping-helper

### DIFF
--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -7,7 +7,11 @@ import { adapterType } from "./test-adapter.js";
 import type { TestDatabaseAdapter } from "./test-adapter.js";
 import { itIfSupports, adapterSupports } from "./test-helpers/supports.js";
 import { fixtures } from "./test-helpers/fixtures.js";
-import { dumpAllTableSchema, dumpTableSchema } from "./test-helpers/schema-dumping-helper.js";
+import {
+  dumpAllTableSchema,
+  dumpTableSchema,
+  FULL_DUMP_TIMEOUT_MS,
+} from "./test-helpers/schema-dumping-helper.js";
 import { establishFromTestConfig } from "./test-helpers/test-database-config.js";
 
 // The first describe uses `fixtures({})` (canonical schema + reset shield);
@@ -48,8 +52,8 @@ async function withPostgresqlDatetimeType(type: string, fn: () => Promise<void>)
 // Give only the genuine full-dump cases explicit headroom via the options form
 // `it(name, { timeout }, fn)` (keeps the callback as the last arg); the
 // single-table `dumpCanonicalTable` cases stay on the default timeout, the global
-// timeout is untouched, and the (Rails-matching) test names are unchanged.
-const FULL_DUMP_TIMEOUT_MS = 30_000;
+// timeout is untouched, and the (Rails-matching) test names are unchanged. The
+// shared `FULL_DUMP_TIMEOUT_MS` lives beside `dumpAllTableSchema` in the helper.
 
 describe("SchemaDumperTest", () => {
   fixtures({}, { useTransactionalTests: false });

--- a/packages/activerecord/src/test-helpers/schema-dumping-helper.test.ts
+++ b/packages/activerecord/src/test-helpers/schema-dumping-helper.test.ts
@@ -3,7 +3,11 @@ import { Base } from "../base.js";
 import { SchemaDumper } from "../schema-dumper.js";
 import type { SchemaSource } from "../schema-dumper.js";
 import { setupHandlerSuite } from "./setup-handler-suite.js";
-import { dumpAllTableSchema, dumpTableSchema } from "./schema-dumping-helper.js";
+import {
+  dumpAllTableSchema,
+  dumpTableSchema,
+  FULL_DUMP_TIMEOUT_MS,
+} from "./schema-dumping-helper.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../connection-adapters/abstract-adapter.js";
 
 let adapter: DatabaseAdapter;
@@ -28,13 +32,6 @@ async function createSdhTable(name: string, columns = "id INTEGER PRIMARY KEY"):
   createdTables.add(name);
   await adapter.executeMutation(`CREATE TABLE ${name} (${columns})`);
 }
-
-// `dumpAllTableSchema` dumps the entire database (~330 canonical tables in the
-// shared handler DB). On PostgreSQL under CI fork load that full-DB dump exceeds
-// the 5s default and flakes — the single-table `dumpTableSchema` cases stay fast
-// because they ignore every table but the one named. Match the sibling
-// `schema-dumper.test.ts` full-dump timeout rather than nudging the global one.
-const FULL_DUMP_TIMEOUT_MS = 30_000;
 
 describe("SchemaDumpingHelper", () => {
   afterEach(async () => {

--- a/packages/activerecord/src/test-helpers/schema-dumping-helper.test.ts
+++ b/packages/activerecord/src/test-helpers/schema-dumping-helper.test.ts
@@ -29,6 +29,13 @@ async function createSdhTable(name: string, columns = "id INTEGER PRIMARY KEY"):
   await adapter.executeMutation(`CREATE TABLE ${name} (${columns})`);
 }
 
+// `dumpAllTableSchema` dumps the entire database (~330 canonical tables in the
+// shared handler DB). On PostgreSQL under CI fork load that full-DB dump exceeds
+// the 5s default and flakes — the single-table `dumpTableSchema` cases stay fast
+// because they ignore every table but the one named. Match the sibling
+// `schema-dumper.test.ts` full-dump timeout rather than nudging the global one.
+const FULL_DUMP_TIMEOUT_MS = 30_000;
+
 describe("SchemaDumpingHelper", () => {
   afterEach(async () => {
     for (const t of createdTables) {
@@ -83,7 +90,7 @@ describe("SchemaDumpingHelper", () => {
     expect(SchemaDumper.ignoreTables).toBe(before);
   });
 
-  it("dumpAllTableSchema honors the ignore list", async () => {
+  it("dumpAllTableSchema honors the ignore list", { timeout: FULL_DUMP_TIMEOUT_MS }, async () => {
     await createSdhTable("sdh_keep");
     await createSdhTable("sdh_skip");
 

--- a/packages/activerecord/src/test-helpers/schema-dumping-helper.ts
+++ b/packages/activerecord/src/test-helpers/schema-dumping-helper.ts
@@ -13,6 +13,15 @@ import type { SchemaSource } from "../schema-dumper.js";
  */
 
 /**
+ * Timeout for a whole-database dump (`dumpAllTableSchema`). The shared handler
+ * DB carries ~330 canonical tables, and on PostgreSQL under CI fork load that
+ * full dump runs just past vitest's 5s default and flakes. 30s is the ceiling
+ * both full-dump suites apply; single-table `dumpTableSchema` cases stay on the
+ * default because they ignore every table but the one named.
+ */
+export const FULL_DUMP_TIMEOUT_MS = 30_000;
+
+/**
  * Dump only the named `tables` from `source`, as a schema-DSL string.
  *
  * Mirrors `SchemaDumpingHelper#dump_table_schema(*tables)`: ignore every data


### PR DESCRIPTION
## What

The `Active Record PostgreSQL Tests (1)` CI shard failed on main @04adc499 with a single flake:

```
SchemaDumpingHelper > dumpAllTableSchema honors the ignore list
Error: Test timed out in 5000ms.
```

## Why

`dumpAllTableSchema` dumps the **entire** shared handler database (~330 canonical tables), unlike the `dumpTableSchema` cases in the same file which ignore every table but the one named. On PostgreSQL under CI fork load that full-DB dump runs just past the 5s default (locally reproduced at ~5.15s), so it flakes.

## Fix

Give that one test the 30s full-dump timeout that the sibling `schema-dumper.test.ts` already applies to its full-dump cases. Rather than re-declare the constant a second time, hoist `FULL_DUMP_TIMEOUT_MS` into `schema-dumping-helper.ts` — the module that owns the slow whole-DB `dumpAllTableSchema` — and import it from both suites so they can't drift. The fast single-table cases stay on the default timeout. Test names are unchanged.

Verified locally against PostgreSQL 17: both dump suites pass (the full-dump case at ~5.1s, now within budget).

Closes-story: red-04adc499