### PR TITLE
fix(associations): CollectionProxy#create/createBang guard on persisted owner

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -930,6 +930,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     for (const r of records) assoc.setStrictLoading(r);
   }
 
+  // Rails' `_create_record` raises before building the record or opening a
+  // transaction when the owner is unsaved (collection_association.rb:354-357).
+  private _ensurePersistedOwnerForCreate(): void {
+    if (this._record.isNewRecord()) {
+      throw new RecordNotSaved(`You cannot call create unless the parent is saved`, this._record);
+    }
+  }
+
   private _ensureThroughWritable(): void {
     if (!this._isThrough) return;
     const ctor = this._record.constructor as typeof Base;
@@ -1271,11 +1279,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._isSingular) {
       return this._createSingular(attrs, block, false);
     }
-    // Rails' `_create_record` raises before building or opening a transaction
-    // when the owner is unsaved (collection_association.rb:354-357).
-    if (this._record.isNewRecord()) {
-      throw new RecordNotSaved(`You cannot call create unless the parent is saved`, this._record);
-    }
+    this._ensurePersistedOwnerForCreate();
     this._ensureThroughWritable();
     if (this._isThrough) {
       return (await this._createThrough(
@@ -3785,11 +3789,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._isSingular) {
       return this._createSingular(attrs, block, true);
     }
-    // Rails' `_create_record` raises before building or opening a transaction
-    // when the owner is unsaved (collection_association.rb:354-357).
-    if (this._record.isNewRecord()) {
-      throw new RecordNotSaved(`You cannot call create unless the parent is saved`, this._record);
-    }
+    this._ensurePersistedOwnerForCreate();
     this._ensureThroughWritable();
     if (this._isThrough) {
       const record = this._buildThrough(attrs) as T;

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1271,6 +1271,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._isSingular) {
       return this._createSingular(attrs, block, false);
     }
+    // Rails' `_create_record` raises before building or opening a transaction
+    // when the owner is unsaved (collection_association.rb:354-357).
+    if (this._record.isNewRecord()) {
+      throw new RecordNotSaved(`You cannot call create unless the parent is saved`, this._record);
+    }
     this._ensureThroughWritable();
     if (this._isThrough) {
       return (await this._createThrough(
@@ -3780,12 +3785,13 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     if (this._isSingular) {
       return this._createSingular(attrs, block, true);
     }
+    // Rails' `_create_record` raises before building or opening a transaction
+    // when the owner is unsaved (collection_association.rb:354-357).
+    if (this._record.isNewRecord()) {
+      throw new RecordNotSaved(`You cannot call create unless the parent is saved`, this._record);
+    }
     this._ensureThroughWritable();
     if (this._isThrough) {
-      const ctor = this._record.constructor as typeof Base;
-      if (this._record.isNewRecord()) {
-        throw new RecordNotSaved(`You cannot call create unless the parent is saved`);
-      }
       const record = this._buildThrough(attrs) as T;
       if (block) block(record);
       if (!fireAssocCallbacks(this._assocDef.options.beforeAdd, this._record, record, true)) {

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -15,6 +15,7 @@ import {
   enableSti,
   registerSubclass,
   RecordNotFound,
+  RecordNotSaved,
 } from "../index.js";
 import {
   Company,
@@ -285,6 +286,32 @@ describe("HasManyAssociationsTest", () => {
     expect(await firstFirm.clientsOfFirm.toArray()).toContain(bad);
     const reloaded = (await firstFirm.clientsOfFirm.reload()) as any[];
     expect(reloaded).not.toContain(bad);
+  });
+
+  it("create with bang on has many when parent is new raises", async () => {
+    const firm = new HmFirm();
+    let error: any;
+    try {
+      await (firm as any).plainClients.createBang({ name: "Whoever" });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(RecordNotSaved);
+    expect(error.message).toBe("You cannot call create unless the parent is saved");
+    expect(error.record).toBe(firm);
+  });
+
+  it("regular create on has many when parent is new raises", async () => {
+    const firm = new HmFirm();
+    let error: any;
+    try {
+      await (firm as any).plainClients.create({ name: "Whoever" });
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(RecordNotSaved);
+    expect(error.message).toBe("You cannot call create unless the parent is saved");
+    expect(error.record).toBe(firm);
   });
 
   it("destroying", async () => {


### PR DESCRIPTION
Rails' `CollectionAssociation#_create_record` raises `RecordNotSaved` ("You cannot call create unless the parent is saved", owner) before building the record or opening a transaction when the owner is not persisted (collection_association.rb:354-357).

trails' non-through `CollectionProxy#create` / `createBang` skipped this guard — they built the record and opened a transaction / saved regardless. Only the through `createBang` path checked it. This surfaced when PR #4626 added the transaction wrap: the wrap now opens a BEGIN even for a new-record owner, where Rails would have raised first.

## Changes
- Add `owner.isNewRecord()` guard to `create` and `createBang` before any build/transaction, covering both non-through and through paths (the through `createBang` inline check is now unified into the shared guard).
- Guard raises `RecordNotSaved` with the owner as `record`, matching Rails.

## Tests
- `create with bang on has many when parent is new raises` and `regular create on has many when parent is new raises` (mirror Rails `test_create_with_bang_on_has_many_when_parent_is_new_raises` / `test_regular_create_on_has_many_when_parent_is_new_raises`), asserting message and `error.record`.
- Existing `create on new record` (through) and `buffers it into the target` tests stay green.

Closes-story: collection-create-requires-persisted-owner-guard