### PR TITLE
fix(calculations): route composite-PK eager-count id fetch through columns_for_distinct

### DIFF
--- a/packages/activerecord/src/relation/calculations.ts
+++ b/packages/activerecord/src/relation/calculations.ts
@@ -53,6 +53,11 @@ interface CalculationConnection {
   toSql(arel: unknown): string;
   quote(value: unknown): string;
   quoteTableName(name: string): string;
+  quoteColumnName(name: string): string;
+  columnsForDistinct(
+    columns: string | string[],
+    orders?: (string | Nodes.Node)[],
+  ): string | string[];
   execute(sql: string): Promise<Record<string, unknown>[]>;
   selectAll(
     sql: string,
@@ -823,6 +828,23 @@ export async function performCount(
             this._applyJoinsToManager(idSubquery, makeEagerJd());
             this._applyWheresToManager(idSubquery, table);
             this._applyOrderToManager(idSubquery, table);
+            // Rails `distinct_relation_for_primary_key` builds the DISTINCT
+            // select via `columns_for_distinct(primary_key_columns,
+            // order_values)`: PG/MySQL reject `SELECT DISTINCT id ... ORDER BY
+            // <non-selected>`, so those adapters prepend the (aliased) order
+            // expressions to the select list. Re-project through the adapter
+            // hook so the ordered composite-pk id fetch is valid cross-adapter
+            // (sqlite's base hook returns the pk columns unchanged). The pk
+            // columns keep their names, so the by-name `row[c]` tuple
+            // extraction below still finds them.
+            const pkColumns = pk.map(
+              (c: string) =>
+                `${this._conn().quoteTableName(table.name)}.${this._conn().quoteColumnName(c)}`,
+            );
+            const distinctSelect = this._conn().columnsForDistinct(pkColumns, idSubquery.orders);
+            idSubquery.projections = (
+              Array.isArray(distinctSelect) ? distinctSelect : [distinctSelect]
+            ).map((s) => new Nodes.SqlLiteral(s));
             applyFromToManager(this, idSubquery);
             if (this._limitValue !== null) idSubquery.take(this._limitValue);
             if (this._offsetValue !== null) idSubquery.skip(this._offsetValue);

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -115,6 +115,30 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     expect(countSql).toMatch(/\bid\b.*IN/i);
   });
 
+  it("eager_load(:assoc).order(non_pk_col).limit(n).count(column) routes the id fetch through columns_for_distinct", async () => {
+    await seedBooksDuplicateRevisions();
+    let count = 0;
+    const sqls = await captureSql(async () => {
+      // Order by a NON-pk column (title) that is NOT in the DISTINCT-pk select
+      // list. Without routing the ordered `SELECT DISTINCT author_id, id ...
+      // ORDER BY title` through the adapter's `columnsForDistinct` hook, PG /
+      // MySQL reject it ("ORDER BY expressions must appear in select list").
+      // titles Alpha(1,rev5) < Beta(2,rev5) < Gamma(3,rev9); limit(2) bounds to
+      // books 1 & 2 → COUNT(DISTINCT revision) over the two rev-5 rows = 1.
+      count = (await CpkBook.eagerLoad("chapters")
+        .order("cpk_books.title")
+        .limit(2)
+        .count("cpk_books.revision")) as number;
+    });
+    expect(count).toBe(1);
+    // The id-materialization query orders by the non-pk column; PG/MySQL alias
+    // it into the select list, sqlite leaves the pk projection unchanged — but
+    // in every case the ordered DISTINCT-pk fetch must run and be valid.
+    const idSql = sqls.find((s) => /DISTINCT.*cpk_books.*author_id/i.test(s) && /LIMIT 2/i.test(s));
+    expect(idSql).toBeTruthy();
+    expect(idSql).toMatch(/ORDER BY .*title/i);
+  });
+
   it("eager_load(:assoc).offset(n).count(column) bounds ROWS via the id fetch", async () => {
     await seedBooksDuplicateRevisions();
     // order+offset(1) drops book 1 (rev 5); remaining rows are books 2 (rev 5)


### PR DESCRIPTION
## What

The composite-PK sibling of the eager-count limit/offset id subquery in `calculations.ts` applies the relation's order but projects only the pk columns — it does NOT route through the adapter's `columnsForDistinct` hook (the single-PK path and Rails' `distinct_relation_for_primary_key` both do). An ordered composite-PK eager count by a non-pk column produces `SELECT DISTINCT author_id, id ... ORDER BY <non-pk col>`, which PG/MySQL reject ("ORDER BY expressions must appear in select list").

## Fix

Mirror Rails `distinct_relation_for_primary_key` → `columns_for_distinct(primary_key_columns, order_values)`: re-project the id subquery through `columnsForDistinct(pkColumns, idSubquery.orders)` before take/skip. PG/MySQL prepend the aliased order expressions; sqlite's base hook leaves the pk projection unchanged. The pk columns stay unaliased so the by-name `pk.map((c) => row[c])` tuple extraction still finds them.

## Test

Adds a composite-PK `eager_load(:assoc).order(non_pk_col).limit(n).count(column)` test. Verified it fails on PG without the re-projection and passes with it; the full file is green on sqlite, PG, and MySQL.

Closes-story: composite-pk-eager-count-limit-id-subquery-columns-for-distinct