### PR TITLE
test(relation): cover inverse_of foreign-key derivation branches

### DIFF
--- a/packages/activerecord/src/relation/derive-foreign-key-inverse-of.trails.test.ts
+++ b/packages/activerecord/src/relation/derive-foreign-key-inverse-of.trails.test.ts
@@ -1,0 +1,71 @@
+/**
+ * trails-internal coverage (not a Rails test port) for the `inverse_of`
+ * foreign-key derivation branches in `Relation#_deriveForeignKey`
+ * (`relation.ts`), a port of Rails' `Reflection#foreign_key` /
+ * `#derive_foreign_key` (reflection.rb:551-566, 812-816). When a has_one /
+ * has_many sets `inverse_of:` (and carries neither an explicit `foreignKey`
+ * nor a polymorphic `as`), derivation recurses into the inverse reflection so
+ * the join uses the inverse's own foreign key rather than the owner-name
+ * default `#{owner}_id`. These cases exercise the branches PR #4644 added but
+ * left uncovered (flagged on its round-2 review).
+ *
+ * Reachable via canonical models, asserted below:
+ *   - className-absent fallback, plural (`_singularize(name)` → camelize) and
+ *     singular (`name` → camelize) forms;
+ *   - explicitly-keyed inverse: the inverse belongs_to's `foreignKey` scalar
+ *     returned verbatim from the recursion, distinct from the owner default.
+ *
+ * NOT reachable via any canonical shape (documented, not tested):
+ *   - a *polymorphic inverse* (recursion landing on an inverse whose
+ *     `options.as` yields `#{as}_id`): every reflection carrying `as` returns
+ *     `#{as}_id` up front, before the `inverse_of` recursion, so a polymorphic
+ *     reflection is never *reached as an inverse*;
+ *   - a *composite* (`string[]`) inverse foreign key: every canonical
+ *     collection whose inverse is composite already declares its own explicit
+ *     `foreignKey`, short-circuiting before the recursion. The scalar case
+ *     below covers the same "return the inverse's key verbatim" line.
+ */
+import { describe, it, expect } from "vitest";
+import "../index.js";
+import { registerModel } from "../associations.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Human } from "../test-helpers/models/human.js";
+import { Face } from "../test-helpers/models/face.js";
+import { Interest } from "../test-helpers/models/interest.js";
+import { Book } from "../test-helpers/models/book.js";
+import { Citation } from "../test-helpers/models/citation.js";
+
+registerModel(Human);
+registerModel(Face);
+registerModel(Interest);
+registerModel(Book);
+registerModel(Citation);
+
+describe("_deriveForeignKey inverse_of branches", () => {
+  fixtures(["humans", "books"]);
+
+  // has_many :interests, inverse_of: :human — no className. The className-absent
+  // fallback singularizes ("interests" → "Interest"), then the inverse
+  // belongs_to :human derives `human_id`.
+  it("has_many inverse_of, no className (plural fallback) derives the inverse FK", () => {
+    const sql = Human.joins("interests").toSql();
+    expect(sql).toContain(`"interests"."human_id" = "humans"."id"`);
+  });
+
+  // has_one :face, inverse_of: :human — no className. The className-absent
+  // fallback camelizes the name as-is ("face" → "Face"); the inverse
+  // belongs_to :human derives `human_id`.
+  it("has_one inverse_of, no className (singular fallback) derives the inverse FK", () => {
+    const sql = Human.joins("face").toSql();
+    expect(sql).toContain(`"faces"."human_id" = "humans"."id"`);
+  });
+
+  // has_many :citations, inverse_of: :book — no className, no foreignKey. The
+  // inverse belongs_to :book declares foreignKey: "book1_id", so derivation
+  // returns "book1_id" verbatim — NOT the owner-name default "book_id".
+  it("uses the inverse belongs_to's explicit foreignKey, not the owner default", () => {
+    const sql = Book.joins("citations").toSql();
+    expect(sql).toContain(`"citations"."book1_id" = "books"."id"`);
+    expect(sql).not.toContain(`"book_id"`);
+  });
+});

--- a/packages/activerecord/src/relation/derive-foreign-key-inverse-of.trails.test.ts
+++ b/packages/activerecord/src/relation/derive-foreign-key-inverse-of.trails.test.ts
@@ -46,6 +46,10 @@ registerModel(Interest);
 registerModel(Book);
 registerModel(Citation);
 
+// Strip identifier quotes so assertions hold across adapters (sqlite/postgres
+// double-quote, MySQL/MariaDB backtick).
+const unquoted = (sql: string): string => sql.replace(/["`]/g, "");
+
 describe("_deriveForeignKey inverse_of branches", () => {
   fixtures(["humans", "books"]);
 
@@ -53,24 +57,24 @@ describe("_deriveForeignKey inverse_of branches", () => {
   // fallback singularizes ("interests" → "Interest"), then the inverse
   // belongs_to :human derives `human_id`.
   it("has_many inverse_of, no className (plural fallback) derives the inverse FK", () => {
-    const sql = Human.joins("interests").toSql();
-    expect(sql).toContain(`"interests"."human_id" = "humans"."id"`);
+    const sql = unquoted(Human.joins("interests").toSql());
+    expect(sql).toContain("interests.human_id = humans.id");
   });
 
   // has_one :face, inverse_of: :human — no className. The className-absent
   // fallback camelizes the name as-is ("face" → "Face"); the inverse
   // belongs_to :human derives `human_id`.
   it("has_one inverse_of, no className (singular fallback) derives the inverse FK", () => {
-    const sql = Human.joins("face").toSql();
-    expect(sql).toContain(`"faces"."human_id" = "humans"."id"`);
+    const sql = unquoted(Human.joins("face").toSql());
+    expect(sql).toContain("faces.human_id = humans.id");
   });
 
   // has_many :citations, inverse_of: :book — no className, no foreignKey. The
   // inverse belongs_to :book declares foreignKey: "book1_id", so derivation
   // returns "book1_id" verbatim — NOT the owner-name default "book_id".
   it("uses the inverse belongs_to's explicit foreignKey, not the owner default", () => {
-    const sql = Book.joins("citations").toSql();
-    expect(sql).toContain(`"citations"."book1_id" = "books"."id"`);
-    expect(sql).not.toContain(`"book_id"`);
+    const sql = unquoted(Book.joins("citations").toSql());
+    expect(sql).toContain("citations.book1_id = books.id");
+    expect(sql).not.toContain("citations.book_id");
   });
 });

--- a/packages/activerecord/src/relation/derive-foreign-key-inverse-of.trails.test.ts
+++ b/packages/activerecord/src/relation/derive-foreign-key-inverse-of.trails.test.ts
@@ -17,9 +17,14 @@
  *
  * NOT reachable via any canonical shape (documented, not tested):
  *   - a *polymorphic inverse* (recursion landing on an inverse whose
- *     `options.as` yields `#{as}_id`): every reflection carrying `as` returns
- *     `#{as}_id` up front, before the `inverse_of` recursion, so a polymorphic
- *     reflection is never *reached as an inverse*;
+ *     `options.as` yields `#{as}_id`). The recursion is only entered when the
+ *     OUTER reflection has no `as` (the `if (options.as)` guard returns first),
+ *     and the reflection it recurses INTO is the outer's `inverse_of` target.
+ *     Only a has_one/has_many polymorphic reflection carries `as`, and its
+ *     inverse is always a polymorphic `belongs_to` (which carries
+ *     `polymorphic: true`, not `as`) — no canonical has_one/has_many names
+ *     another has-side polymorphic reflection as its `inverse_of`, so an
+ *     `as`-bearing reflection is never the thing recursed into;
  *   - a *composite* (`string[]`) inverse foreign key: every canonical
  *     collection whose inverse is composite already declares its own explicit
  *     `foreignKey`, short-circuiting before the recursion. The scalar case


### PR DESCRIPTION
Adds trails-internal coverage (not a Rails test port) for the `inverse_of`
foreign-key derivation branches in `Relation#_deriveForeignKey` that PR #4644
added and its round-2 review flagged as acceptable-but-uncovered.

## What's covered

Reachable via canonical models, asserted on the emitted JOIN SQL:

- **className-absent fallback, plural** — `Human.joins("interests")` (has_many
  `interests`, `inverse_of: :human`, no `className`) → `interests.human_id`.
- **className-absent fallback, singular** — `Human.joins("face")` (has_one
  `face`, `inverse_of: :human`, no `className`) → `faces.human_id`.
- **explicitly-keyed inverse** — `Book.joins("citations")` (has_many
  `citations`, `inverse_of: :book`, no `foreignKey`) resolves to the inverse
  `belongs_to :book`'s `foreignKey: "book1_id"` returned verbatim, distinct
  from the owner-name default `book_id`.

## Documented as unreachable (no canonical input)

- A **polymorphic inverse** (recursion landing on a reflection whose
  `options.as` yields `#{as}_id`): any reflection carrying `as` returns
  `#{as}_id` before the `inverse_of` recursion, so a polymorphic reflection is
  never reached *as an inverse*.
- A **composite (`string[]`) inverse foreign key**: every canonical collection
  whose inverse is composite already declares its own explicit `foreignKey`,
  short-circuiting before the recursion. The scalar case covers the same
  return-verbatim line.

No production code changes; test-only.

Closes-story: cover-inverse-of-foreign-key-derivation-branches

---

## Review response (round 1)

Both findings assume `Relation#_deriveForeignKey` does not exist — that
conclusion came from `grep -rn`, which **silently returns empty on very large
files like `relation.ts`** (a known repo gotcha). `git grep` shows the method
is real and the target of this test:

- `relation.ts:2099` — `private _deriveForeignKey(...)` (the method under test,
  added by PR #4644 at 2096-2140), with 11 call sites (1070/1091/1123/1155,
  the self-recursion at 2129, and the JOIN resolvers at 2164/2209/2300/2311/2438).
- The tests reach it through `joins(...).toSql()` →
  `_resolveAssociationJoin` → `_deriveForeignKey` (2164/2209), i.e. the
  relation-side JOIN-building derivation.

This is a **distinct** implementation from `AssociationReflection#deriveForeignKey`
in `reflection.ts:828`; the story scopes this work to `relation.ts:2096-2140`
specifically. Accordingly:

1. **Docstring / describe title** correctly name `Relation#_deriveForeignKey`
   in `relation.ts` — no change.
2. **File placement under `relation/`** is correct: the exercised method lives
   in `relation.ts`, not `reflection.ts` — no change.

No behavioral concerns were raised; assertions and model usage were verified
correct by the reviewer.
