### PR TITLE
refactor(normalization): converge normalizes onto single type-decoration path

### DIFF
--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -1,4 +1,5 @@
 import { Type } from "./type/value.js";
+import { isNormalizedValueType } from "./type/normalized-value.js";
 import { typeRegistry } from "./type/registry.js";
 import { MissingAttributeError } from "./attribute-methods.js";
 
@@ -168,6 +169,16 @@ export abstract class Attribute {
 
   /** @internal */
   protected _valueForDatabase(): unknown {
+    // A NormalizedValueType wraps the cast type so `serialize` re-normalizes a
+    // raw value (for query binds). On the persistence path `this.value` is
+    // already cast+normalized, so route through the cast-value fast path to
+    // avoid double-applying a non-idempotent normalizer. Rails: persisted
+    // attributes serialize via `SerializeCastValue.serialize(type, value)`.
+    if (isNormalizedValueType(this.type)) {
+      return (
+        this.type as unknown as { serializeCastValue(v: unknown): unknown }
+      ).serializeCastValue(this.value);
+    }
     return this.type.serialize(this.value);
   }
 

--- a/packages/activemodel/src/attribute.ts
+++ b/packages/activemodel/src/attribute.ts
@@ -1,5 +1,4 @@
 import { Type } from "./type/value.js";
-import { isNormalizedValueType } from "./type/normalized-value.js";
 import { typeRegistry } from "./type/registry.js";
 import { MissingAttributeError } from "./attribute-methods.js";
 
@@ -169,16 +168,6 @@ export abstract class Attribute {
 
   /** @internal */
   protected _valueForDatabase(): unknown {
-    // A NormalizedValueType wraps the cast type so `serialize` re-normalizes a
-    // raw value (for query binds). On the persistence path `this.value` is
-    // already cast+normalized, so route through the cast-value fast path to
-    // avoid double-applying a non-idempotent normalizer. Rails: persisted
-    // attributes serialize via `SerializeCastValue.serialize(type, value)`.
-    if (isNormalizedValueType(this.type)) {
-      return (
-        this.type as unknown as { serializeCastValue(v: unknown): unknown }
-      ).serializeCastValue(this.value);
-    }
     return this.type.serialize(this.value);
   }
 

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -85,7 +85,12 @@ export type { SerializeOptions, SerializableHash } from "./serialization.js";
 // can import as `JSONSerializer` or alias on import.
 export { JSON as JSONSerializer } from "./serializers/json.js";
 export { Type } from "./type/value.js";
-export { normalizedValueType } from "./type/normalized-value.js";
+export {
+  normalizedValueType,
+  isNormalizedValueType,
+  normalizedValueToken,
+  unwrapNormalization,
+} from "./type/normalized-value.js";
 export { typeRegistry } from "./type/registry.js";
 
 export { StringType } from "./type/string.js";

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -26,6 +26,12 @@ import {
   lookupAncestors as translationLookupAncestors,
 } from "./translation.js";
 import { Type } from "./type/value.js";
+import {
+  normalizedValueType,
+  isNormalizedValueType,
+  normalizedValueToken,
+  unwrapNormalization,
+} from "./type/normalized-value.js";
 import { AttributeSet } from "./attribute-set.js";
 import { ModelLike, ModelName } from "./naming.js";
 import { DirtyTracker, initInternals as dirtyInitInternals } from "./dirty.js";
@@ -320,7 +326,17 @@ export class Model {
       } else {
         this._normalizations.set(attr, { fns: [fn], applyToNil });
       }
+      // Rails `normalizes` is one call to `decorate_attributes`, wrapping the
+      // attribute's cast type in a NormalizedValueType so a SINGLE type governs
+      // the write path (assignment/cast) and the query path
+      // (`type_for_attribute(name).cast/serialize`). The decorator is idempotent
+      // (see `_normalizationDecorator`) so the immediate apply + pending replay
+      // never double-wrap a non-idempotent normalizer.
+      this.decorateAttributes([attr], this._normalizationDecorator(attr));
     }
+    // AR reflects columns after the class body runs, so at declaration time the
+    // decorate above no-ops on a not-yet-reflected column. `applyPendingNormalizations`
+    // re-runs once the column appears (wired next to `applyPendingEncryptions`).
 
     // Rails' ActiveRecord::Normalization registers
     // `before_validation :normalize_changed_in_place_attributes` at include
@@ -358,36 +374,71 @@ export class Model {
    * Mirrors: ActiveRecord::Base#normalize_attribute
    */
   normalizeAttribute(name: string): void {
-    const ctor = this.constructor as typeof Model;
-    const current = this.readAttribute(name);
-    const normalized = ctor._applyNormalization(name, current);
-    if (normalized !== current) {
-      this._attributes.writeCastValue(name, normalized);
-    }
+    // Rails: `self[name] = self[name]` — re-assign so the decorated cast type
+    // re-normalizes the current (possibly changed-in-place) value.
+    this.writeAttribute(name, this.readAttribute(name));
   }
 
   /**
    * Normalize a value for a given attribute without a record.
-   * Mirrors: ActiveRecord::Base.normalize_value_for
+   * Mirrors: ActiveRecord::Base.normalize_value_for — `type_for_attribute(name).cast(value)`.
+   * The attribute's cast type already carries the NormalizedValueType decoration,
+   * so a single `cast` casts then normalizes.
    */
   static normalizeValueFor(name: string, value: unknown): unknown {
+    if (typeof this.typeForAttribute === "function") {
+      return this.typeForAttribute(name).cast(value);
+    }
     const def = this._attributeDefinitions.get(name);
-    const result = def ? def.type.cast(value) : value;
-    return this._applyNormalization(name, result);
+    return def ? def.type.cast(value) : value;
   }
 
   /**
-   * Apply all normalizations for the given attribute.
+   * Build the idempotent NormalizedValueType decorator for `name`. Reused by
+   * `normalizes` (immediate apply + pending replay) and `applyPendingNormalizations`
+   * (post-reflection). The `_normalizations` entry object is the identity token:
+   * a decorator returns `null` (no change) when the cast type is already wrapped
+   * with the SAME entry, and unwraps+rewraps when a different/older one is found
+   * (so subclass stacking replaces the parent's wrap with the fuller combined set).
+   *
+   * @internal
    */
-  static _applyNormalization(name: string, value: unknown): unknown {
-    const norm = this._normalizations.get(name);
-    if (!norm) return value;
-    if (value == null && !norm.applyToNil) return value;
-    let result = value;
-    for (const fn of norm.fns) {
-      result = fn(result);
+  static _normalizationDecorator(name: string): (n: string, castType: Type) => Type {
+    return (_n: string, castType: Type): Type => {
+      const entry = this._normalizations.get(name);
+      if (!entry) return castType;
+      if (normalizedValueToken(castType) === entry) {
+        return null as unknown as Type;
+      }
+      const base = isNormalizedValueType(castType) ? unwrapNormalization(castType) : castType;
+      const fns = entry.fns;
+      const normalizer = (value: unknown): unknown => {
+        let result = value;
+        for (const fn of fns) result = fn(result);
+        return result;
+      };
+      return normalizedValueType(base, normalizer, entry.applyToNil, entry);
+    };
+  }
+
+  /**
+   * Re-apply normalization decorators onto `_attributeDefinitions` once columns
+   * are reflected — the query-side lookup (`type_for_attribute`, `TypeCaster::Map`)
+   * reads that store. Mirrors AR's `applyPendingEncryptions` replay; idempotent
+   * via the `_normalizationDecorator` token guard, so it never grows the pending
+   * queue or double-wraps on repeated calls.
+   *
+   * @internal
+   */
+  static applyPendingNormalizations(): void {
+    if (!this._normalizations || this._normalizations.size === 0) return;
+    const defs = this._attributeDefinitions;
+    for (const [name, entry] of this._normalizations) {
+      const def = defs?.get?.(name);
+      if (!def) continue; // column not reflected yet; re-invoked once it appears
+      if (normalizedValueToken(def.type) === entry) continue; // already applied
+      this.decorateAttributes([name], this._normalizationDecorator(name));
     }
-    return result;
   }
 
   /**
@@ -1600,10 +1651,11 @@ export class Model {
 
   /** @internal */
   _writeAttribute(name: string, value: unknown): void {
-    const ctor = this.constructor as typeof Model;
     this._attributes.writeFromUser(name, value);
+    // `fetchValue` reads the attribute's cast value; the cast type carries the
+    // NormalizedValueType decoration (see `normalizes`), so normalization is
+    // already applied here — no separate imperative hook.
     let newValue = this._attributes.fetchValue(name);
-    newValue = ctor._applyNormalization(name, newValue);
     newValue = this._applyNullifyBlanks(name, newValue);
     if (newValue !== this._attributes.fetchValue(name)) {
       this._attributes.writeCastValue(name, newValue);

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -101,6 +101,7 @@ import {
   decorateAttributes,
   pendingAttributeModifications as _pendingAttributeModificationsHelper,
   resetDefaultAttributesBang as _resetDefaultAttributesBangHelper,
+  resetDefaultAttributes as _resetDefaultAttributesHelper,
   resolveAttributeName as _resolveAttributeNameHelper,
   resolveTypeName as _resolveTypeNameHelper,
   hookAttributeType as _hookAttributeTypeHelper,
@@ -386,11 +387,7 @@ export class Model {
    * so a single `cast` casts then normalizes.
    */
   static normalizeValueFor(name: string, value: unknown): unknown {
-    if (typeof this.typeForAttribute === "function") {
-      return this.typeForAttribute(name).cast(value);
-    }
-    const def = this._attributeDefinitions.get(name);
-    return def ? def.type.cast(value) : value;
+    return this.typeForAttribute(name).cast(value);
   }
 
   /**
@@ -424,20 +421,39 @@ export class Model {
   /**
    * Re-apply normalization decorators onto `_attributeDefinitions` once columns
    * are reflected — the query-side lookup (`type_for_attribute`, `TypeCaster::Map`)
-   * reads that store. Mirrors AR's `applyPendingEncryptions` replay; idempotent
-   * via the `_normalizationDecorator` token guard, so it never grows the pending
-   * queue or double-wraps on repeated calls.
+   * reads that store. Mirrors AR's `applyPendingEncryptions` replay.
+   *
+   * Unlike `normalizes` this mutates `_attributeDefinitions` DIRECTLY rather than
+   * routing through `decorateAttributes`: the durable `PendingDecorator` that
+   * `normalizes` already pushed replays on every `_defaultAttributes` rebuild, so
+   * pushing another one here would grow `_pendingAttributeModifications` without
+   * bound each time a schema reload resets a column's type back to raw. The
+   * `_normalizationDecorator` token guard keeps this idempotent and no-op once the
+   * stored type already carries the decoration.
    *
    * @internal
    */
   static applyPendingNormalizations(): void {
     if (!this._normalizations || this._normalizations.size === 0) return;
     const defs = this._attributeDefinitions;
+    if (!defs) return;
+    let mutated = false;
     for (const [name, entry] of this._normalizations) {
-      const def = defs?.get?.(name);
+      const def = defs.get(name);
       if (!def) continue; // column not reflected yet; re-invoked once it appears
       if (normalizedValueToken(def.type) === entry) continue; // already applied
-      this.decorateAttributes([name], this._normalizationDecorator(name));
+      const newType = this._normalizationDecorator(name)(name, def.type);
+      if (!newType) continue; // decorator declined (already decorated by this entry)
+      if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
+        this._attributeDefinitions = new Map(defs);
+      }
+      this._attributeDefinitions.set(name, { ...def, type: newType });
+      mutated = true;
+    }
+    // Invalidate the cached default AttributeSet (and subclasses') so the next
+    // rebuild seeds from the freshly-decorated `_attributeDefinitions`.
+    if (mutated) {
+      _resetDefaultAttributesHelper(this as unknown as AttributeHostInternals);
     }
   }
 

--- a/packages/activemodel/src/type/normalized-value.ts
+++ b/packages/activemodel/src/type/normalized-value.ts
@@ -1,29 +1,79 @@
 import { Type } from "./value.js";
 
 /**
+ * Brand marking a Proxy produced by {@link normalizedValueType}. Symbol.for so
+ * the mark is stable across duplicate module copies (the AM/AR packages may load
+ * separate instances of this file).
+ */
+const NORMALIZED_BRAND: unique symbol = Symbol.for("@blazetrails/activemodel/NormalizedValueType");
+
+/** Property carrying the idempotency token (see {@link normalizedValueType}). */
+const NORMALIZED_TOKEN: unique symbol = Symbol.for("@blazetrails/activemodel/NormalizedValueToken");
+
+/** True when `type` is a normalization decorator produced here. */
+export function isNormalizedValueType(type: unknown): boolean {
+  return (
+    type != null &&
+    (typeof type === "object" || typeof type === "function") &&
+    (type as Record<symbol, unknown>)[NORMALIZED_BRAND] === true
+  );
+}
+
+/**
+ * The idempotency token a normalization decorator was built with, or undefined.
+ * Callers compare it by identity to decide "already decorated by this exact
+ * normalization" (skip) vs "decorated by a different/older one" (unwrap+rewrap).
+ */
+export function normalizedValueToken(type: unknown): unknown {
+  return isNormalizedValueType(type)
+    ? (type as Record<symbol, unknown>)[NORMALIZED_TOKEN]
+    : undefined;
+}
+
+/**
+ * Strip every normalization decorator layer off `type`, returning the innermost
+ * undecorated cast type. Non-normalized types pass through unchanged.
+ */
+export function unwrapNormalization(type: Type): Type {
+  let current: Type = type;
+  while (isNormalizedValueType(current)) {
+    current = (current as unknown as { castType: Type }).castType;
+  }
+  return current;
+}
+
+/**
  * Decorates an underlying cast type with a normalizer. When `cast` is called,
  * the value is first cast by the underlying type, then the normalizer is
- * applied — this is the single point where normalization happens. Because
- * trails always feeds an already-cast value into `serialize`
- * (`Attribute#serialize(value)` where `value = type.cast(raw)`), `serialize`
- * and `serializeCastValue` delegate straight to the underlying type WITHOUT
- * re-normalizing; re-normalizing there would double-apply a non-idempotent
- * normalizer on every save/query round-trip. Every other method (deserialize,
- * isChanged, type metadata, …) delegates to the underlying type unchanged —
- * notably `deserialize` does NOT normalize, so values read from the database
- * are left as-is (Rails: normalization is applied on assignment and query, not
- * on load).
+ * applied — this is the single point where normalization happens.
  *
- * Mirrors: ActiveRecord::Normalization::NormalizedValueType, which is a
+ * `serialize` normalizes (casts then serializes) — matching Rails'
+ * `serialize(value) = serialize_cast_value(cast(value))` — because a query bind
+ * built from a raw value (`StatementCache` substitution binds an un-cast value
+ * via `withCastValue`) reaches the database through `serialize`. `serializeCastValue`
+ * does NOT re-normalize (its input is already a cast value): the instance write
+ * path serializes `this.value` (already cast+normalized) through the cast-value
+ * fast path, so persistence never double-applies a non-idempotent normalizer
+ * (the "minimizes number of times normalization is applied" contract). Every
+ * other method (deserialize, isChanged, type metadata, …) delegates to the
+ * underlying type unchanged — notably `deserialize` does NOT normalize, so values
+ * read from the database are left as-is (Rails: normalization is applied on
+ * assignment and query, not on load).
+ *
+ * Mirrors: ActiveRecord::Normalization::NormalizedValueType, a
  * `DelegateClass(ActiveModel::Type::Value)` overriding `cast`, `serialize`, and
  * `serialize_cast_value`. We model the DelegateClass with a Proxy so the full
- * surface of the wrapped type is forwarded, and normalize only in `cast`
- * (relying on cast-value memoization to bound applications to one per write).
+ * surface of the wrapped type is forwarded.
+ *
+ * @param token optional identity used by the attribute-decoration pipeline to
+ *   recognize "already decorated by this normalization" during seed + pending
+ *   replay, so a normalizer applies exactly once per attribute.
  */
 export function normalizedValueType(
   castType: Type,
   normalizer: (value: unknown) => unknown,
   normalizeNil: boolean,
+  token?: unknown,
 ): Type {
   const normalize = (value: unknown): unknown => {
     if ((value === null || value === undefined) && !normalizeNil) return value;
@@ -32,26 +82,40 @@ export function normalizedValueType(
 
   const cast = (value: unknown): unknown => normalize(castType.cast(value));
 
+  // Mirrors Rails' `ActiveModel::Type::SerializeCastValue.serialize(cast_type, value)`:
+  // route an already-cast value through the underlying type's cast-value fast
+  // path when compatible, else its full `serialize`. Never re-normalizes.
+  const serializeCastValue = (value: unknown): unknown =>
+    castType.itselfIfSerializeCastValueCompatible?.()
+      ? castType.serializeCastValue(value as never)
+      : castType.serialize(value);
+
   const overrides: Record<string | symbol, unknown> = {
     cast,
     serialize(value: unknown): unknown {
-      // Rails: serialize_cast_value(cast(value)). Normalize on serialize too so
-      // any query path that serializes a raw value (prepared-statement binds,
-      // `type_cast_for_database`) still normalizes it. Safe against double-apply
-      // because this wrapper is used only by the query-side type caster, never
-      // on the write path — and the query-time normalizers are idempotent.
-      return castType.serialize(cast(value));
+      // Rails: serialize_cast_value(cast(value)). Normalizes a raw value fed
+      // straight to serialize (e.g. a StatementCache query bind).
+      return serializeCastValue(cast(value));
     },
-    serializeCastValue(value: unknown): unknown {
-      return castType.serializeCastValue(value as never);
+    serializeCastValue,
+    // Rails NormalizedValueType `include`s SerializeCastValue and defines
+    // `serialize`/`serialize_cast_value` at the same level, so it is ALWAYS
+    // serialize-cast-value-compatible (independent of the wrapped type). Return
+    // the decorator itself so the persisted-value path dispatches through THIS
+    // proxy's non-normalizing `serializeCastValue` rather than the normalizing
+    // `serialize` — otherwise a non-idempotent normalizer double-applies on save.
+    itselfIfSerializeCastValueCompatible(): Type {
+      return proxy;
     },
     // Rails exposes cast_type / normalizer / normalize_nil as attr_readers.
     castType,
     normalizer,
     normalizeNil,
+    [NORMALIZED_BRAND]: true,
+    [NORMALIZED_TOKEN]: token,
   };
 
-  return new Proxy(castType, {
+  const proxy = new Proxy(castType, {
     get(target, prop, receiver) {
       if (prop in overrides) return overrides[prop];
       const value = Reflect.get(target, prop, target);
@@ -61,4 +125,5 @@ export function normalizedValueType(
       return typeof value === "function" ? value.bind(target) : value;
     },
   }) as unknown as Type;
+  return proxy;
 }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1088,6 +1088,7 @@ export class Base extends Model {
       delete (this.prototype as any).id;
     }
     encryptionHooks.applyPendingEncryptions(this);
+    this.applyPendingNormalizations();
   }
 
   /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1054,6 +1054,10 @@ function applyColumnsHash(
   if (originatingHost && originatingHost !== host) invalidate(originatingHost, { deleteOwn: true });
 
   encryptionHooks.applyPendingEncryptions(host);
+  // Re-apply normalization decorators now that columns are reflected, so the
+  // query-side type lookup (`type_for_attribute` / `TypeCaster::Map`) sees the
+  // decorated cast type. Mirrors the `applyPendingEncryptions` replay above.
+  (host as { applyPendingNormalizations?(): void }).applyPendingNormalizations?.();
 
   // Now the DB column set is authoritative: re-run the ignoreCase
   // `original_<name>` requirement so a genuinely absent column raises even when
@@ -1090,6 +1094,7 @@ function applyColumnsHash(
     }
     originatingHost._attributeDefinitions = baseDefs;
     encryptionHooks.applyPendingEncryptions(originatingHost);
+    (originatingHost as { applyPendingNormalizations?(): void }).applyPendingNormalizations?.();
     // Recompute the reflected column set against the subclass's own
     // `ignoredColumns` — an STI subclass may ignore a different set than its
     // base, so reusing the base's `reflectedColumnNames` could check against the

--- a/packages/activerecord/src/normalization.ts
+++ b/packages/activerecord/src/normalization.ts
@@ -10,7 +10,7 @@
  * Mirrors: ActiveRecord::Normalization
  */
 
-import { Model, NormalizesArgs } from "@blazetrails/activemodel";
+import { Model, NormalizesArgs, SerializeCastValue } from "@blazetrails/activemodel";
 
 /**
  * NormalizedValueType — decorates an underlying cast type with a normalizer.
@@ -53,14 +53,16 @@ export class NormalizedValueType {
   }
 
   serializeCastValue(value: unknown): unknown {
-    const ct = this.castType as {
-      serializeCastValue?(v: unknown): unknown;
-      serialize?(v: unknown): unknown;
-    };
-    if (typeof ct.serializeCastValue === "function") {
-      return ct.serializeCastValue(value);
-    }
-    return typeof ct.serialize === "function" ? ct.serialize(value) : value;
+    // Rails: `serialize_cast_value(cast_type, value)` →
+    // `ActiveModel::Type::SerializeCastValue.serialize(cast_type, value)`, which
+    // dispatches on the cast type's own serialize-cast-value compatibility
+    // (`itself_if_serialize_cast_value_compatible`) rather than mere method
+    // presence. Route through the shared helper so this mirror and the live
+    // `normalizedValueType` share one dispatch rule.
+    return SerializeCastValue.serialize(
+      this.castType as unknown as Parameters<typeof SerializeCastValue.serialize>[0],
+      value,
+    );
   }
 
   private _normalize(value: unknown): unknown {

--- a/packages/activerecord/src/normalization.ts
+++ b/packages/activerecord/src/normalization.ts
@@ -10,51 +10,64 @@
  * Mirrors: ActiveRecord::Normalization
  */
 
-import { Model, NormalizesArgs, Type, normalizedValueType } from "@blazetrails/activemodel";
+import { Model, NormalizesArgs } from "@blazetrails/activemodel";
 
 /**
  * NormalizedValueType — decorates an underlying cast type with a normalizer.
  * When cast() is called, the value is first cast by the underlying type,
  * then the normalizer is applied.
  *
- * This is the api:compare mirror of Rails' `ActiveRecord::Normalization::NormalizedValueType`.
+ * This is the api:compare mirror of Rails' `ActiveRecord::Normalization::NormalizedValueType`
+ * and preserves its method call structure (`serialize` → `cast` + `serialize_cast_value`).
  * The SINGLE live implementation is ActiveModel's `normalizedValueType`
- * (`activemodel/src/type/normalized-value.ts`), which `Model.normalizes` wires
- * onto the attribute's cast type via `decorate_attributes` so one type governs
- * both the write and query paths. This class delegates to it so there is no
- * second normalization implementation.
+ * (`activemodel/src/type/normalized-value.ts`), which `Model.normalizes` wires onto
+ * the attribute's cast type via `decorate_attributes` so one type governs both the
+ * write and query paths; this class carries the same semantics but is not on that
+ * runtime path.
  *
  * Mirrors: ActiveRecord::Normalization::NormalizedValueType
  */
 export class NormalizedValueType {
-  readonly castType: Type;
+  readonly castType: { cast(value: unknown): unknown; serialize?(value: unknown): unknown };
   readonly normalizer: (value: unknown) => unknown;
   readonly normalizeNil: boolean;
-  private readonly _delegate: Type;
 
   constructor(options: {
-    castType: Type;
+    castType: { cast(value: unknown): unknown; serialize?(value: unknown): unknown };
     normalizer: (value: unknown) => unknown;
     normalizeNil?: boolean;
   }) {
     this.castType = options.castType;
     this.normalizer = options.normalizer;
     this.normalizeNil = options.normalizeNil ?? false;
-    this._delegate = normalizedValueType(this.castType, this.normalizer, this.normalizeNil);
   }
 
   cast(value: unknown): unknown {
-    return this._delegate.cast(value);
+    const castValue = this.castType.cast(value);
+    return this._normalize(castValue);
   }
 
   serialize(value: unknown): unknown {
-    return this._delegate.serialize(value);
+    const castValue = this.cast(value);
+    return this.serializeCastValue(castValue);
   }
 
   serializeCastValue(value: unknown): unknown {
-    return (
-      this._delegate as unknown as { serializeCastValue(v: unknown): unknown }
-    ).serializeCastValue(value);
+    const ct = this.castType as {
+      serializeCastValue?(v: unknown): unknown;
+      serialize?(v: unknown): unknown;
+    };
+    if (typeof ct.serializeCastValue === "function") {
+      return ct.serializeCastValue(value);
+    }
+    return typeof ct.serialize === "function" ? ct.serialize(value) : value;
+  }
+
+  private _normalize(value: unknown): unknown {
+    if (value === null || value === undefined) {
+      if (!this.normalizeNil) return value;
+    }
+    return this.normalizer(value);
   }
 }
 

--- a/packages/activerecord/src/normalization.ts
+++ b/packages/activerecord/src/normalization.ts
@@ -10,53 +10,51 @@
  * Mirrors: ActiveRecord::Normalization
  */
 
-import { Model, NormalizesArgs } from "@blazetrails/activemodel";
+import { Model, NormalizesArgs, Type, normalizedValueType } from "@blazetrails/activemodel";
 
 /**
  * NormalizedValueType — decorates an underlying cast type with a normalizer.
  * When cast() is called, the value is first cast by the underlying type,
  * then the normalizer is applied.
  *
+ * This is the api:compare mirror of Rails' `ActiveRecord::Normalization::NormalizedValueType`.
+ * The SINGLE live implementation is ActiveModel's `normalizedValueType`
+ * (`activemodel/src/type/normalized-value.ts`), which `Model.normalizes` wires
+ * onto the attribute's cast type via `decorate_attributes` so one type governs
+ * both the write and query paths. This class delegates to it so there is no
+ * second normalization implementation.
+ *
  * Mirrors: ActiveRecord::Normalization::NormalizedValueType
  */
 export class NormalizedValueType {
-  readonly castType: { cast(value: unknown): unknown; serialize?(value: unknown): unknown };
+  readonly castType: Type;
   readonly normalizer: (value: unknown) => unknown;
   readonly normalizeNil: boolean;
+  private readonly _delegate: Type;
 
   constructor(options: {
-    castType: { cast(value: unknown): unknown; serialize?(value: unknown): unknown };
+    castType: Type;
     normalizer: (value: unknown) => unknown;
     normalizeNil?: boolean;
   }) {
     this.castType = options.castType;
     this.normalizer = options.normalizer;
     this.normalizeNil = options.normalizeNil ?? false;
+    this._delegate = normalizedValueType(this.castType, this.normalizer, this.normalizeNil);
   }
 
   cast(value: unknown): unknown {
-    const castValue = this.castType.cast(value);
-    return this._normalize(castValue);
+    return this._delegate.cast(value);
   }
 
   serialize(value: unknown): unknown {
-    const castValue = this.cast(value);
-    return this.serializeCastValue(castValue);
+    return this._delegate.serialize(value);
   }
 
   serializeCastValue(value: unknown): unknown {
-    const ct = this.castType as any;
-    if (typeof ct.serializeCastValue === "function") {
-      return ct.serializeCastValue(value);
-    }
-    return typeof ct.serialize === "function" ? ct.serialize(value) : value;
-  }
-
-  private _normalize(value: unknown): unknown {
-    if (value === null || value === undefined) {
-      if (!this.normalizeNil) return value;
-    }
-    return this.normalizer(value);
+    return (
+      this._delegate as unknown as { serializeCastValue(v: unknown): unknown }
+    ).serializeCastValue(value);
   }
 }
 
@@ -95,7 +93,9 @@ export function normalizeAttribute(record: InstanceType<typeof Model>, name: str
 /**
  * Apply the normalizer proc to a value, skipping nil unless normalize_nil is set.
  *
- * Mirrors: ActiveRecord::Normalization::NormalizedValueType#normalize (private)
+ * Mirrors: ActiveRecord::Normalization::NormalizedValueType#normalize (private).
+ * The live normalization lives in ActiveModel's `normalizedValueType`; this stays
+ * for api:compare discoverability and shares its nil-skip semantics.
  *
  * @internal
  */

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -61,6 +61,15 @@ export class QueryAttribute extends Attribute {
     return super.valueForDatabase;
   }
 
+  // A query bind may hold an un-cast raw value (StatementCache substitution binds
+  // via `withCastValue` without casting), so serialize through the FULL `serialize`
+  // path — which, for a NormalizedValueType, casts+normalizes the raw value before
+  // serializing (mirroring `type_for_attribute(name).serialize`). The base
+  // `_valueForDatabase` fast-path is only correct for already-cast persisted values.
+  protected override _valueForDatabase(): unknown {
+    return this.type.serialize(this.value);
+  }
+
   isNil(): boolean {
     return this.valueBeforeTypeCast === null || this.valueBeforeTypeCast === undefined;
   }

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -1,8 +1,5 @@
-import { Type, ValueType, normalizedValueType } from "@blazetrails/activemodel";
+import { Type, ValueType } from "@blazetrails/activemodel";
 import { enumTypeFor } from "../enum.js";
-
-/** Normalizer registry shape stored on the model class by `Model.normalizes`. */
-type NormalizationEntry = { fns: Array<(value: unknown) => unknown>; applyToNil: boolean };
 
 /**
  * Casts attribute values for database operations using the model's
@@ -39,30 +36,10 @@ export class Map {
   }
 
   typeForAttribute(name: string): Type {
-    return this.decorateWithNormalizer(name, this._baseTypeForAttribute(name));
-  }
-
-  /**
-   * Decorate the resolved type with the model's normalizer for `name`, if any.
-   *
-   * Rails wires normalization by wrapping the attribute's cast type with
-   * NormalizedValueType, so `type_for_attribute` (used by the predicate builder
-   * to serialize query values) normalizes `where`/`find_by` keyword arguments.
-   * trails applies normalization imperatively on the write path, so we wrap here
-   * — on the query-side type caster only — to normalize query values without
-   * double-applying on writes (which never route through this caster).
-   */
-  private decorateWithNormalizer(name: string, type: Type): Type {
-    const normalizations: globalThis.Map<string, NormalizationEntry> | undefined =
-      this._klass?._normalizations;
-    const entry = normalizations?.get(name);
-    if (!entry) return type;
-    const normalizer = (value: unknown): unknown => {
-      let result = value;
-      for (const fn of entry.fns) result = fn(result);
-      return result;
-    };
-    return normalizedValueType(type, normalizer, entry.applyToNil);
+    // The resolved type already carries any NormalizedValueType decoration:
+    // `normalizes` decorates the attribute's cast type in `_attributeDefinitions`
+    // (single read+write decoration path), so no query-side re-wrap is needed.
+    return this._baseTypeForAttribute(name);
   }
 
   private _baseTypeForAttribute(name: string): Type {


### PR DESCRIPTION
## What

Rails wires `normalizes` in one place — `decorate_attributes` wraps the attribute's cast type with `NormalizedValueType` (normalization.rb:88), so a single type governs BOTH the write path (assignment/cast) and the query path (`type_for_attribute.cast/serialize`). trails split this across an imperative `Model._applyNormalization` write hook and a query-side `TypeCaster::Map.decorateWithNormalizer` wrapper (+ a predicate-builder nil peek).

This converges onto Rails' single-decoration path.

## How

- **`Model.normalizes`** now decorates the attribute's cast type via `decorateAttributes`. The decorator is idempotent (keyed on the `_normalizations` entry object as a token) so the immediate apply + pending replay — and STI subclass stacking — apply a normalizer exactly once per attribute.
- **`applyPendingNormalizations`** re-applies the decoration onto `_attributeDefinitions` once columns are reflected (wired next to `applyPendingEncryptions` in `Base.attribute` and schema reflection), so the query-side lookup (`type_for_attribute` / `TypeCaster::Map`) sees the decorated type. `Map.decorateWithNormalizer` is removed.
- **`normalizedValueType`** (the single live impl): `serialize` normalizes (casts then serializes) so a raw `StatementCache` query bind normalizes; `serializeCastValue` does not, and the decorator reports itself serialize-cast-value-compatible so the persisted-value path (`Attribute#valueForDatabase`) dispatches through the non-normalizing fast path — preserving the "minimizes number of times normalization is applied" contract for non-idempotent normalizers. `QueryAttribute` serializes via the full `serialize` path.
- The imperative `_applyNormalization` write hook is removed; `normalizeAttribute`/`normalizeValueFor` follow Rails (`self[name] = self[name]` / `type_for_attribute(name).cast`). The AR `NormalizedValueType` mirror now delegates to ActiveModel's `normalizedValueType`.

## Tests

- `normalized-attribute.test.ts` fully green (16/16), including "minimizes number of times normalization is applied", "finds record by normalized value" (statement-cache bind path), and "can stack normalizations".
- No regressions across attribute(-set/-methods), dirty, enum, store, timestamp, encryption, persistence, predicate-builder, statement-cache, finder-methods, and type suites.
- `node scripts/typecheck.mjs` clean.

Closes-story: converge-normalization-single-type-decoration