### PR TITLE
feat(api-compare): credit value-accessor reads in wide call-set parity

### DIFF
--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -38,21 +38,7 @@
     "package": "abstractcontroller",
     "tsFile": "caching.ts",
     "rubyName": "cache",
-    "call": "cache_store",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching.ts",
-    "rubyName": "cache",
     "call": "expand_cache_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching.ts",
-    "rubyName": "cache_configured?",
-    "call": "cache_store",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -268,36 +254,8 @@
   {
     "package": "abstractcontroller",
     "tsFile": "caching/fragments.ts",
-    "rubyName": "expire_fragment",
-    "call": "cache_store",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching/fragments.ts",
-    "rubyName": "fragment_exist?",
-    "call": "cache_store",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching/fragments.ts",
-    "rubyName": "read_fragment",
-    "call": "cache_store",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching/fragments.ts",
     "rubyName": "read_fragment",
     "call": "html_safe",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "abstractcontroller",
-    "tsFile": "caching/fragments.ts",
-    "rubyName": "write_fragment",
-    "call": "cache_store",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -556,13 +514,6 @@
     "package": "actioncontroller",
     "tsFile": "base.ts",
     "rubyName": "allow_browser",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "base.ts",
-    "rubyName": "allow_browser",
     "call": "require",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -745,13 +696,6 @@
     "package": "actioncontroller",
     "tsFile": "base.ts",
     "rubyName": "process_action",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "base.ts",
-    "rubyName": "process_action",
     "call": "show_detailed_exceptions?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -871,13 +815,6 @@
     "package": "actioncontroller",
     "tsFile": "base.ts",
     "rubyName": "redirect_to",
-    "call": "status",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "base.ts",
-    "rubyName": "redirect_to",
     "call": "update",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -921,13 +858,6 @@
     "tsFile": "base.ts",
     "rubyName": "respond_to",
     "call": "negotiate_format",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "base.ts",
-    "rubyName": "respond_to",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1247,6 +1177,13 @@
   },
   {
     "package": "actioncontroller",
+    "tsFile": "metal.ts",
+    "rubyName": "performed?",
+    "call": "response_body",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
     "tsFile": "metal/allow-browser.ts",
     "rubyName": "parsed_user_agent",
     "call": "parse",
@@ -1283,13 +1220,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/allow-browser.ts",
-    "rubyName": "user_agent_version_reported?",
-    "call": "version",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/allow-browser.ts",
     "rubyName": "version_below_minimum_required?",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1299,13 +1229,6 @@
     "tsFile": "metal/allow-browser.ts",
     "rubyName": "version_below_minimum_required?",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/allow-browser.ts",
-    "rubyName": "version_below_minimum_required?",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1362,41 +1285,6 @@
     "tsFile": "metal/conditional-get.ts",
     "rubyName": "no_store",
     "call": "replace",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/content-security-policy.ts",
-    "rubyName": "content_security_policy",
-    "call": "current_content_security_policy",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/content-security-policy.ts",
-    "rubyName": "content_security_policy",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/content-security-policy.ts",
-    "rubyName": "content_security_policy_report_only",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/content-security-policy.ts",
-    "rubyName": "current_content_security_policy",
-    "call": "content_security_policy",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/content-security-policy.ts",
-    "rubyName": "current_content_security_policy",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1555,6 +1443,20 @@
   },
   {
     "package": "actioncontroller",
+    "tsFile": "metal/etag-with-template-digest.ts",
+    "rubyName": "pick_template_for_etag",
+    "call": "find_all",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/etag-with-template-digest.ts",
+    "rubyName": "pick_template_for_etag",
+    "call": "first",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
     "tsFile": "metal/flash.ts",
     "rubyName": "action_methods",
     "call": "map",
@@ -1612,29 +1514,8 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/http-authentication.ts",
-    "rubyName": "authenticate_with_http_basic",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/http-authentication.ts",
     "rubyName": "authenticate_with_http_digest",
     "call": "authenticate",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/http-authentication.ts",
-    "rubyName": "authenticate_with_http_digest",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/http-authentication.ts",
-    "rubyName": "authentication_header",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1753,13 +1634,6 @@
     "package": "actioncontroller",
     "tsFile": "metal/implicit-render.ts",
     "rubyName": "default_render",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/implicit-render.ts",
-    "rubyName": "default_render",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -1787,20 +1661,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/implicit-render.ts",
-    "rubyName": "interactive_browser_request?",
-    "call": "format",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/implicit-render.ts",
-    "rubyName": "interactive_browser_request?",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/implicit-render.ts",
     "rubyName": "method_for_action",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -1811,6 +1671,20 @@
     "rubyName": "send_action",
     "call": "default_render",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/live.ts",
+    "rubyName": "abort",
+    "call": "clear",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/live.ts",
+    "rubyName": "abort",
+    "call": "synchronize",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -1852,13 +1726,6 @@
     "tsFile": "metal/live.ts",
     "rubyName": "log_error",
     "call": "join",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/live.ts",
-    "rubyName": "log_error",
-    "call": "logger",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -1983,6 +1850,20 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/mime-responds.ts",
+    "rubyName": "any_response?",
+    "call": "fetch",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/mime-responds.ts",
+    "rubyName": "any_response?",
+    "call": "format",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "metal/mime-responds.ts",
     "rubyName": "custom",
     "call": "lookup",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -2103,20 +1984,6 @@
     "package": "actioncontroller",
     "tsFile": "metal/params-wrapper.ts",
     "rubyName": "_extract_parameters",
-    "call": "exclude",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/params-wrapper.ts",
-    "rubyName": "_extract_parameters",
-    "call": "include",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/params-wrapper.ts",
-    "rubyName": "_extract_parameters",
     "call": "slice",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -2125,13 +1992,6 @@
     "tsFile": "metal/params-wrapper.ts",
     "rubyName": "_perform_parameter_wrapping",
     "call": "merge!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/params-wrapper.ts",
-    "rubyName": "_perform_parameter_wrapping",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2153,13 +2013,6 @@
     "tsFile": "metal/params-wrapper.ts",
     "rubyName": "_wrapper_enabled?",
     "call": "key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/params-wrapper.ts",
-    "rubyName": "_wrapper_enabled?",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2193,20 +2046,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/rate-limiting.ts",
-    "rubyName": "rate_limit",
-    "call": "before_action",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/rate-limiting.ts",
-    "rubyName": "rate_limit",
-    "call": "rate_limiting",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/rate-limiting.ts",
     "rubyName": "rate_limiting",
     "call": "compact",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -2216,13 +2055,6 @@
     "tsFile": "metal/rate-limiting.ts",
     "rubyName": "rate_limiting",
     "call": "instrument",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/rate-limiting.ts",
-    "rubyName": "rate_limiting",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2278,21 +2110,7 @@
     "package": "actioncontroller",
     "tsFile": "metal/redirecting.ts",
     "rubyName": "_url_host_allowed?",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/redirecting.ts",
-    "rubyName": "_url_host_allowed?",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/redirecting.ts",
-    "rubyName": "redirect_back_or_to",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2382,20 +2200,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/rendering.ts",
-    "rubyName": "_process_variant",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/rendering.ts",
-    "rubyName": "_process_variant",
-    "call": "variant",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/rendering.ts",
     "rubyName": "_render_in_priorities",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -2424,29 +2228,8 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/rendering.ts",
-    "rubyName": "_set_vary_header",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/rendering.ts",
     "rubyName": "process_action",
     "call": "filter_map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/rendering.ts",
-    "rubyName": "process_action",
-    "call": "formats",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/rendering.ts",
-    "rubyName": "process_action",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2515,13 +2298,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "mark_for_same_origin_verification!",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "masked_authenticity_token",
     "call": "values_at",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -2531,13 +2307,6 @@
     "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "non_xhr_javascript_response?",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "non_xhr_javascript_response?",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2599,16 +2368,9 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "real_csrf_token",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "request_authenticity_tokens",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "reset",
+    "call": "delete",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -2622,13 +2384,6 @@
     "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "skip_forgery_protection",
     "call": "reverse_merge",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "unverified_request_warning_message",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -2655,20 +2410,6 @@
   {
     "package": "actioncontroller",
     "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "valid_per_form_csrf_token?",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "valid_request_origin?",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "verified_request?",
     "call": "get?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -2678,20 +2419,6 @@
     "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "verified_request?",
     "call": "head?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "verified_request?",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "metal/request-forgery-protection.ts",
-    "rubyName": "verify_same_origin_request",
-    "call": "logger",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -3230,15 +2957,22 @@
     "package": "actioncontroller",
     "tsFile": "metal/url-for.ts",
     "rubyName": "url_options",
-    "call": "request",
+    "call": "script_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
-    "tsFile": "metal/url-for.ts",
-    "rubyName": "url_options",
-    "call": "script_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "tsFile": "renderer.ts",
+    "rubyName": "env_for_request",
+    "call": "key?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "renderer.ts",
+    "rubyName": "env_for_request",
+    "call": "merge",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -3404,6 +3138,13 @@
   {
     "package": "actioncontroller",
     "tsFile": "test-case.ts",
+    "rubyName": "controller_class_name",
+    "call": "anonymous?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actioncontroller",
+    "tsFile": "test-case.ts",
     "rubyName": "create",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -3517,13 +3258,6 @@
     "package": "actioncontroller",
     "tsFile": "test-case.ts",
     "rubyName": "process_controller_response",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actioncontroller",
-    "tsFile": "test-case.ts",
-    "rubyName": "process_controller_response",
     "call": "update",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -3602,13 +3336,6 @@
     "tsFile": "http/cache.ts",
     "rubyName": "etag_matches?",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/cache.ts",
-    "rubyName": "fresh?",
-    "call": "etag",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -3852,13 +3579,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/filter-parameters.ts",
-    "rubyName": "filtered_path",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/filter-parameters.ts",
     "rubyName": "filtered_query_string",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -3888,21 +3608,7 @@
     "package": "actiondispatch",
     "tsFile": "http/filter-redirect.ts",
     "rubyName": "location_filter_match?",
-    "call": "location",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/filter-redirect.ts",
-    "rubyName": "location_filter_match?",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/filter-redirect.ts",
-    "rubyName": "location_filters",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -3930,21 +3636,7 @@
     "package": "actiondispatch",
     "tsFile": "http/filter-redirect.ts",
     "rubyName": "parameter_filtered_location",
-    "call": "location",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/filter-redirect.ts",
-    "rubyName": "parameter_filtered_location",
     "call": "parse",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/filter-redirect.ts",
-    "rubyName": "parameter_filtered_location",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -4034,13 +3726,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/mime-negotiation.ts",
-    "rubyName": "format",
-    "call": "instance",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/mime-negotiation.ts",
     "rubyName": "format_from_path_extension",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -4083,29 +3768,8 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/mime-negotiation.ts",
-    "rubyName": "formats",
-    "call": "parameters",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/mime-negotiation.ts",
-    "rubyName": "formats",
-    "call": "symbol",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/mime-negotiation.ts",
     "rubyName": "formats=",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/mime-negotiation.ts",
-    "rubyName": "formats=",
-    "call": "parameters",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -4134,20 +3798,6 @@
     "tsFile": "http/mime-negotiation.ts",
     "rubyName": "negotiate_mime",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/mime-negotiation.ts",
-    "rubyName": "params_readable?",
-    "call": "parameters",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/mime-negotiation.ts",
-    "rubyName": "valid_accept_header",
-    "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -4183,13 +3833,6 @@
     "tsFile": "http/mime-type.ts",
     "rubyName": "html?",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/mime-type.ts",
-    "rubyName": "html?",
-    "call": "symbol",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -4265,16 +3908,16 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/mime-type.ts",
-    "rubyName": "parse",
-    "call": "index",
+    "rubyName": "parse_data_with_trailing_star",
+    "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/mime-type.ts",
-    "rubyName": "parse_data_with_trailing_star",
-    "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "ref",
+    "call": "to_s",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4303,6 +3946,13 @@
     "rubyName": "register_alias",
     "call": "register",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/mime-type.ts",
+    "rubyName": "to_str",
+    "call": "to_s",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4398,13 +4048,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/parameters.ts",
-    "rubyName": "log_parse_error_once",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/parameters.ts",
     "rubyName": "parameters",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -4420,21 +4063,7 @@
     "package": "actiondispatch",
     "tsFile": "http/parameters.ts",
     "rubyName": "parse_formatted_parameters",
-    "call": "content_mime_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/parameters.ts",
-    "rubyName": "parse_formatted_parameters",
     "call": "fetch",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/parameters.ts",
-    "rubyName": "parse_formatted_parameters",
-    "call": "symbol",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -4531,20 +4160,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
-    "rubyName": "commit_csrf_token",
-    "call": "controller_instance",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "controller_class",
-    "call": "path_parameters",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
     "rubyName": "controller_class_for",
     "call": "camelize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -4559,9 +4174,23 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
-    "rubyName": "domain",
-    "call": "host",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "engine_script_name",
+    "call": "get_header",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "engine_script_name=",
+    "call": "routes",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "engine_script_name=",
+    "call": "set_header",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4569,6 +4198,55 @@
     "rubyName": "generate_content_security_policy_nonce",
     "call": "content_security_policy_nonce_generator",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "action_encoding_template",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "fetch_header",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "from_query_string",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "path_parameters",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "GET",
+    "call": "set_header",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "initialize",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4636,9 +4314,58 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
-    "rubyName": "read_body_stream",
-    "call": "read",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "POST",
+    "call": "action_encoding_template",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "fetch_header",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "from_hash",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "from_pairs",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "params_parsers",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "parse_formatted_parameters",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "http/request.ts",
+    "rubyName": "POST",
+    "call": "path_parameters",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4657,13 +4384,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
-    "rubyName": "reset_csrf_token",
-    "call": "controller_instance",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
     "rubyName": "reset_session",
     "call": "session",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -4673,48 +4393,6 @@
     "tsFile": "http/request.ts",
     "rubyName": "send_early_hints",
     "call": "call",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "send_early_hints",
-    "call": "env",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "subdomain",
-    "call": "host",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/request.ts",
-    "rubyName": "subdomains",
-    "call": "host",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/response.ts",
-    "rubyName": "assign_default_content_type_and_charset!",
-    "call": "charset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/response.ts",
-    "rubyName": "assign_default_content_type_and_charset!",
-    "call": "default_charset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "http/response.ts",
-    "rubyName": "assign_default_content_type_and_charset!",
-    "call": "mime_type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -4874,13 +4552,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "journey/formatter.ts",
-    "rubyName": "build_cache",
-    "call": "routes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/formatter.ts",
     "rubyName": "extract_parameterized_parts",
     "call": "delete_if",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -4911,13 +4582,6 @@
     "tsFile": "journey/formatter.ts",
     "rubyName": "extract_parameterized_parts",
     "call": "merge",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/formatter.ts",
-    "rubyName": "generate",
-    "call": "defaults",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -4966,21 +4630,7 @@
     "package": "actiondispatch",
     "tsFile": "journey/formatter.ts",
     "rubyName": "generate",
-    "call": "routes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/formatter.ts",
-    "rubyName": "generate",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/formatter.ts",
-    "rubyName": "match_route",
-    "call": "cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -5023,13 +4673,6 @@
     "tsFile": "journey/formatter.ts",
     "rubyName": "missing_keys",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/formatter.ts",
-    "rubyName": "missing_keys",
-    "call": "path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -5160,20 +4803,6 @@
   },
   {
     "package": "actiondispatch",
-    "tsFile": "journey/gtg/builder.ts",
-    "rubyName": "transition_table",
-    "call": "memo",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/gtg/builder.ts",
-    "rubyName": "transition_table",
-    "call": "root",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
     "tsFile": "journey/gtg/simulator.ts",
     "rubyName": "memos",
     "call": "concat",
@@ -5286,10 +4915,10 @@
   },
   {
     "package": "actiondispatch",
-    "tsFile": "journey/gtg/transition-table.ts",
-    "rubyName": "visualizer",
-    "call": "symbol",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "tsFile": "journey/nodes/node.ts",
+    "rubyName": "glob?",
+    "call": "any?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5314,34 +4943,6 @@
   },
   {
     "package": "actiondispatch",
-    "tsFile": "journey/path/pattern.ts",
-    "rubyName": "initialize",
-    "call": "root",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/path/pattern.ts",
-    "rubyName": "requirements_anchored?",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/route.ts",
-    "rubyName": "eager_load!",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/route.ts",
-    "rubyName": "glob?",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
     "tsFile": "journey/route.ts",
     "rubyName": "initialize",
     "call": "root",
@@ -5359,13 +4960,6 @@
     "tsFile": "journey/route.ts",
     "rubyName": "matches?",
     "call": "blank?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/route.ts",
-    "rubyName": "matches?",
-    "call": "constraints",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -5420,13 +5014,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "journey/route.ts",
-    "rubyName": "score",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/route.ts",
     "rubyName": "verb_matcher",
     "call": "dasherize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -5476,27 +5063,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "journey/router.ts",
-    "rubyName": "find_routes",
-    "call": "head?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "find_routes",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "find_routes",
-    "call": "path_info",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
     "rubyName": "match_head_routes",
     "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -5511,36 +5077,8 @@
   {
     "package": "actiondispatch",
     "tsFile": "journey/router.ts",
-    "rubyName": "partitioned_routes",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "partitioned_routes",
-    "call": "routes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "recognize",
-    "call": "defaults",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
     "rubyName": "recognize",
     "call": "merge",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "recognize",
-    "call": "path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -5554,21 +5092,7 @@
     "package": "actiondispatch",
     "tsFile": "journey/router.ts",
     "rubyName": "serve",
-    "call": "app",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "serve",
     "call": "chomp",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "serve",
-    "call": "defaults",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -5583,34 +5107,6 @@
     "tsFile": "journey/router.ts",
     "rubyName": "serve",
     "call": "merge",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "serve",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "serve",
-    "call": "path_info",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "serve",
-    "call": "path_parameters",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/router.ts",
-    "rubyName": "serve",
-    "call": "script_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -5650,34 +5146,6 @@
   },
   {
     "package": "actiondispatch",
-    "tsFile": "journey/routes.ts",
-    "rubyName": "add_route",
-    "call": "routes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/routes.ts",
-    "rubyName": "clear",
-    "call": "routes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/routes.ts",
-    "rubyName": "each",
-    "call": "routes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/routes.ts",
-    "rubyName": "partition_route",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
     "tsFile": "journey/visitors.ts",
     "rubyName": "evaluate",
     "call": "each",
@@ -5688,13 +5156,6 @@
     "tsFile": "journey/visitors.ts",
     "rubyName": "nary",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "journey/visitors.ts",
-    "rubyName": "visit",
-    "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -5716,27 +5177,6 @@
     "tsFile": "middleware/actionable-exceptions.ts",
     "rubyName": "actionable_request?",
     "call": "get_header",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/actionable-exceptions.ts",
-    "rubyName": "actionable_request?",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/actionable-exceptions.ts",
-    "rubyName": "actionable_request?",
-    "call": "post?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/actionable-exceptions.ts",
-    "rubyName": "call",
-    "call": "params",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -5820,13 +5260,6 @@
     "package": "actiondispatch",
     "tsFile": "middleware/cookies.ts",
     "rubyName": "cookie_jar",
-    "call": "cookies",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/cookies.ts",
-    "rubyName": "cookie_jar",
     "call": "fetch_header",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -5836,6 +5269,13 @@
     "rubyName": "cookie_jar=",
     "call": "set_header",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/cookies.ts",
+    "rubyName": "have_cookie_jar?",
+    "call": "has_header?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5868,9 +5308,9 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/cookies.ts",
-    "rubyName": "prepare_upgrade_legacy_hmac_aes_cbc_cookies?",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "serializer",
+    "call": "cookies_serializer",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5882,22 +5322,8 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/cookies.ts",
-    "rubyName": "signed_or_encrypted",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/cookies.ts",
     "rubyName": "upgrade_legacy_hmac_aes_cbc_cookies?",
     "call": "present?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/cookies.ts",
-    "rubyName": "upgrade_legacy_hmac_aes_cbc_cookies?",
-    "call": "request",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -5995,13 +5421,6 @@
     "package": "actiondispatch",
     "tsFile": "middleware/debug-exceptions.ts",
     "rubyName": "log_error",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/debug-exceptions.ts",
-    "rubyName": "log_error",
     "call": "rescue_response?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -6057,13 +5476,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/debug-exceptions.ts",
-    "rubyName": "render_for_api_request",
-    "call": "status_code",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/debug-exceptions.ts",
     "rubyName": "stderr_logger",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -6086,13 +5498,6 @@
     "package": "actiondispatch",
     "tsFile": "middleware/debug-locks.ts",
     "rubyName": "call",
-    "call": "get?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/debug-locks.ts",
-    "rubyName": "call",
     "call": "path_info",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -6107,13 +5512,6 @@
     "package": "actiondispatch",
     "tsFile": "middleware/debug-locks.ts",
     "rubyName": "render_details",
-    "call": "default_charset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/debug-locks.ts",
-    "rubyName": "render_details",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -6122,13 +5520,6 @@
     "tsFile": "middleware/debug-locks.ts",
     "rubyName": "render_details",
     "call": "select",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/debug-locks.ts",
-    "rubyName": "render_details",
-    "call": "status",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -6161,10 +5552,45 @@
   },
   {
     "package": "actiondispatch",
-    "tsFile": "middleware/debug-view.ts",
-    "rubyName": "params_valid?",
-    "call": "parameters",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "tsFile": "middleware/exception-wrapper.ts",
+    "rubyName": "build_backtrace",
+    "call": "each",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/exception-wrapper.ts",
+    "rubyName": "build_backtrace",
+    "call": "key?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/exception-wrapper.ts",
+    "rubyName": "build_backtrace",
+    "call": "map",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/exception-wrapper.ts",
+    "rubyName": "build_backtrace",
+    "call": "method_name",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/exception-wrapper.ts",
+    "rubyName": "build_backtrace",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/exception-wrapper.ts",
+    "rubyName": "build_backtrace",
+    "call": "to_s",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -6288,16 +5714,9 @@
   {
     "package": "actiondispatch",
     "tsFile": "middleware/flash.ts",
-    "rubyName": "commit_flash",
-    "call": "session",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/flash.ts",
-    "rubyName": "flash",
-    "call": "session",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "flash_hash",
+    "call": "get_header",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -6387,13 +5806,6 @@
     "package": "actiondispatch",
     "tsFile": "middleware/public-exceptions.ts",
     "rubyName": "render_format",
-    "call": "default_charset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/public-exceptions.ts",
-    "rubyName": "render_format",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -6402,13 +5814,6 @@
     "tsFile": "middleware/public-exceptions.ts",
     "rubyName": "render_html",
     "call": "exist?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/public-exceptions.ts",
-    "rubyName": "render_html",
-    "call": "locale",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -6504,17 +5909,10 @@
   },
   {
     "package": "actiondispatch",
-    "tsFile": "middleware/session/cache-store.ts",
-    "rubyName": "initialize",
-    "call": "cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/session/cache-store.ts",
-    "rubyName": "initialize",
-    "call": "options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "tsFile": "middleware/session/abstract-store.ts",
+    "rubyName": "initialize_sid",
+    "call": "delete",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -6522,6 +5920,13 @@
     "rubyName": "initialize",
     "call": "key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/session/mem-cache-store.ts",
+    "rubyName": "initialize_sid",
+    "call": "delete",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -6598,13 +6003,6 @@
     "tsFile": "middleware/show-exceptions.ts",
     "rubyName": "render_exception",
     "call": "set_header",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "middleware/show-exceptions.ts",
-    "rubyName": "render_exception",
-    "call": "status_code",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -6739,6 +6137,13 @@
     "rubyName": "insert_after",
     "call": "insert",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "middleware/stack.ts",
+    "rubyName": "last",
+    "call": "middlewares",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -7009,13 +6414,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "request/session.ts",
-    "rubyName": "destroy",
-    "call": "options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "request/session.ts",
     "rubyName": "dig",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -7040,6 +6438,13 @@
     "rubyName": "fetch",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "request/session.ts",
+    "rubyName": "find",
+    "call": "get_header",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -7116,20 +6521,6 @@
     "tsFile": "request/utils.ts",
     "rubyName": "each_param_value",
     "call": "each_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/inspector.ts",
-    "rubyName": "collect_engine_routes",
-    "call": "routes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/inspector.ts",
-    "rubyName": "collect_routes",
-    "call": "path",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -7326,13 +6717,6 @@
     "tsFile": "routing/mapper.ts",
     "rubyName": "apply_common_behavior_for",
     "call": "nested",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/mapper.ts",
-    "rubyName": "apply_common_behavior_for",
-    "call": "shallow",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -7578,13 +6962,6 @@
     "tsFile": "routing/mapper.ts",
     "rubyName": "has_named_route?",
     "call": "key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/mapper.ts",
-    "rubyName": "initialize",
-    "call": "resources_path_names",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -7838,6 +7215,13 @@
     "rubyName": "nested",
     "call": "scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "routing/mapper.ts",
+    "rubyName": "nested_scope?",
+    "call": "nested?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -8228,13 +7612,6 @@
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
     "rubyName": "set_member_mappings_for_resource",
-    "call": "actions",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/mapper.ts",
-    "rubyName": "set_member_mappings_for_resource",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -8297,13 +7674,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/mapper.ts",
-    "rubyName": "shallow_nesting_depth",
-    "call": "shallow?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/mapper.ts",
     "rubyName": "shallow_scope",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -8347,28 +7717,7 @@
     "package": "actiondispatch",
     "tsFile": "routing/polymorphic-routes.ts",
     "rubyName": "handle_list",
-    "call": "singular_route_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/polymorphic-routes.ts",
-    "rubyName": "handle_list",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/polymorphic-routes.ts",
-    "rubyName": "handle_model",
-    "call": "singular_route_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/polymorphic-routes.ts",
-    "rubyName": "plural",
-    "call": "route_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -8436,20 +7785,6 @@
   },
   {
     "package": "actiondispatch",
-    "tsFile": "routing/polymorphic-routes.ts",
-    "rubyName": "singular",
-    "call": "singular_route_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/redirection.ts",
-    "rubyName": "build_response",
-    "call": "default_charset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
     "tsFile": "routing/redirection.ts",
     "rubyName": "build_response",
     "call": "empty?",
@@ -8459,35 +7794,7 @@
     "package": "actiondispatch",
     "tsFile": "routing/redirection.ts",
     "rubyName": "build_response",
-    "call": "host",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/redirection.ts",
-    "rubyName": "build_response",
     "call": "parse",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/redirection.ts",
-    "rubyName": "build_response",
-    "call": "path_parameters",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/redirection.ts",
-    "rubyName": "build_response",
-    "call": "port",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/redirection.ts",
-    "rubyName": "build_response",
-    "call": "status",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -8619,29 +7926,8 @@
   {
     "package": "actiondispatch",
     "tsFile": "routing/route-set.ts",
-    "rubyName": "clear!",
-    "call": "formatter",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
-    "rubyName": "clear!",
-    "call": "set",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
     "rubyName": "default_env",
     "call": "chomp",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
-    "rubyName": "default_env",
-    "call": "default_url_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -8677,13 +7963,6 @@
     "tsFile": "routing/route-set.ts",
     "rubyName": "eager_load!",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
-    "rubyName": "eager_load!",
-    "call": "formatter",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -8733,20 +8012,6 @@
     "tsFile": "routing/route-set.ts",
     "rubyName": "find_script_name",
     "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
-    "rubyName": "from_requirements",
-    "call": "requirements",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
-    "rubyName": "from_requirements",
-    "call": "routes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -8908,20 +8173,6 @@
     "tsFile": "routing/route-set.ts",
     "rubyName": "generate_url_helpers",
     "call": "url_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
-    "rubyName": "new_with_config",
-    "call": "default_scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
-    "rubyName": "optimize_routes_generation?",
-    "call": "default_url_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -9117,13 +8368,6 @@
     "package": "actiondispatch",
     "tsFile": "routing/route-set.ts",
     "rubyName": "url_for",
-    "call": "default_url_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/route-set.ts",
-    "rubyName": "url_for",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -9199,20 +8443,6 @@
   },
   {
     "package": "actiondispatch",
-    "tsFile": "routing/routes-proxy.ts",
-    "rubyName": "url_options",
-    "call": "routes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/routes-proxy.ts",
-    "rubyName": "url_options",
-    "call": "scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
     "tsFile": "routing/url-for.ts",
     "rubyName": "full_url_for",
     "call": "delete",
@@ -9236,13 +8466,6 @@
     "package": "actiondispatch",
     "tsFile": "routing/url-for.ts",
     "rubyName": "optimize_routes_generation?",
-    "call": "default_url_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "routing/url-for.ts",
-    "rubyName": "optimize_routes_generation?",
     "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -9252,6 +8475,41 @@
     "rubyName": "start_application",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
+    "rubyName": "browser_options",
+    "call": "compact",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
+    "rubyName": "browser_options",
+    "call": "merge",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
+    "rubyName": "browser_options",
+    "call": "options",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
+    "rubyName": "initialize",
+    "call": "delete",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "system-testing/driver.ts",
+    "rubyName": "initialize",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -9376,13 +8634,6 @@
     "package": "actiondispatch",
     "tsFile": "testing/assertions/response.ts",
     "rubyName": "exception_if_present",
-    "call": "env",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/assertions/response.ts",
-    "rubyName": "exception_if_present",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -9467,13 +8718,6 @@
     "package": "actiondispatch",
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "assert_recognizes",
-    "call": "path_parameters",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/assertions/routing.ts",
-    "rubyName": "assert_recognizes",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -9537,20 +8781,6 @@
     "package": "actiondispatch",
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "recognized_request_for",
-    "call": "env",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/assertions/routing.ts",
-    "rubyName": "recognized_request_for",
-    "call": "host",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/assertions/routing.ts",
-    "rubyName": "recognized_request_for",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -9565,22 +8795,22 @@
     "package": "actiondispatch",
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "recognized_request_for",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/assertions/routing.ts",
-    "rubyName": "recognized_request_for",
-    "call": "port",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/assertions/routing.ts",
-    "rubyName": "recognized_request_for",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/routing.ts",
+    "rubyName": "reset_routes",
+    "call": "app",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/assertions/routing.ts",
+    "rubyName": "reset_routes",
+    "call": "redefine_method",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -9643,13 +8873,6 @@
     "tsFile": "testing/integration.ts",
     "rubyName": "create_session",
     "call": "include",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/integration.ts",
-    "rubyName": "create_session",
-    "call": "routes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -9720,27 +8943,6 @@
     "tsFile": "testing/integration.ts",
     "rubyName": "follow_redirect!",
     "call": "redirect?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/integration.ts",
-    "rubyName": "follow_redirect!",
-    "call": "request",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/integration.ts",
-    "rubyName": "follow_redirect!",
-    "call": "response",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/integration.ts",
-    "rubyName": "follow_redirect!",
-    "call": "status",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -9873,13 +9075,6 @@
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "process",
-    "call": "host",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/integration.ts",
-    "rubyName": "process",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -9935,13 +9130,6 @@
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
-    "rubyName": "process",
-    "call": "status",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/integration.ts",
     "rubyName": "reset!",
     "call": "app",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -9959,6 +9147,34 @@
     "rubyName": "response_body_if_short",
     "call": "body",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/integration.ts",
+    "rubyName": "url_options",
+    "call": "controller",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/integration.ts",
+    "rubyName": "url_options",
+    "call": "default_url_options",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/integration.ts",
+    "rubyName": "url_options",
+    "call": "reverse_merge!",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "actiondispatch",
+    "tsFile": "testing/integration.ts",
+    "rubyName": "url_options",
+    "call": "routes",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -9999,20 +9215,6 @@
     "package": "actiondispatch",
     "tsFile": "testing/test-helpers/page-dump-helper.ts",
     "rubyName": "save_page",
-    "call": "body",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/test-helpers/page-dump-helper.ts",
-    "rubyName": "save_page",
-    "call": "response",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/test-helpers/page-dump-helper.ts",
-    "rubyName": "save_page",
     "call": "write",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -10031,18 +9233,11 @@
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
-    "package": "actiondispatch",
-    "tsFile": "testing/test-response.ts",
-    "rubyName": "from_response",
-    "call": "body",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actiondispatch",
-    "tsFile": "testing/test-response.ts",
-    "rubyName": "from_response",
-    "call": "status",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "package": "actionpackversion",
+    "tsFile": "gem-version.ts",
+    "rubyName": "gem_version",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "actionview",
@@ -10767,13 +9962,6 @@
   },
   {
     "package": "actionview",
-    "tsFile": "renderer/abstract-renderer.ts",
-    "rubyName": "prepend_formats",
-    "call": "formats",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actionview",
     "tsFile": "renderer/partial-renderer.ts",
     "rubyName": "initialize",
     "call": "extract_details",
@@ -10881,13 +10069,6 @@
     "package": "actionview",
     "tsFile": "renderer/template-renderer.ts",
     "rubyName": "determine_template",
-    "call": "formats",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actionview",
-    "tsFile": "renderer/template-renderer.ts",
-    "rubyName": "determine_template",
     "call": "handler_for_extension",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -10896,13 +10077,6 @@
     "tsFile": "renderer/template-renderer.ts",
     "rubyName": "determine_template",
     "call": "key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actionview",
-    "tsFile": "renderer/template-renderer.ts",
-    "rubyName": "render",
-    "call": "format",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -10917,13 +10091,6 @@
     "tsFile": "renderer/template-renderer.ts",
     "rubyName": "render_with_layout",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actionview",
-    "tsFile": "renderer/template-renderer.ts",
-    "rubyName": "render_with_layout",
-    "call": "formats",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -10959,13 +10126,6 @@
     "tsFile": "renderer/template-renderer.ts",
     "rubyName": "resolve_layout",
     "call": "template_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actionview",
-    "tsFile": "template-details.ts",
-    "rubyName": "format_or_default",
-    "call": "format",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -11049,13 +10209,6 @@
     "package": "actionview",
     "tsFile": "template/handlers/tse.ts",
     "rubyName": "call",
-    "call": "format",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "actionview",
-    "tsFile": "template/handlers/tse.ts",
-    "rubyName": "call",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -11114,6 +10267,20 @@
     "rubyName": "alias_attribute_method_definition",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "attribute_alias",
+    "call": "attribute_aliases",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "attribute_alias",
+    "call": "to_s",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -11314,6 +10481,20 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
+    "rubyName": "generated_attribute_methods",
+    "call": "include",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "generated_attribute_methods",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "generated_attribute_methods",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -11324,6 +10505,20 @@
     "rubyName": "match",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "resolve_attribute_name",
+    "call": "attribute_aliases",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "resolve_attribute_name",
+    "call": "fetch",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -11349,20 +10544,6 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-mutation-tracker.ts",
-    "rubyName": "attr_names",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-mutation-tracker.ts",
-    "rubyName": "attribute_changed?",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-mutation-tracker.ts",
     "rubyName": "attribute_changed?",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -11377,43 +10558,8 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-mutation-tracker.ts",
-    "rubyName": "changed_in_place?",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-mutation-tracker.ts",
     "rubyName": "changes",
     "call": "merge!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-mutation-tracker.ts",
-    "rubyName": "fetch_value",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-mutation-tracker.ts",
-    "rubyName": "forget_change",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-mutation-tracker.ts",
-    "rubyName": "original_value",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-mutation-tracker.ts",
-    "rubyName": "type_cast",
-    "call": "attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -11476,13 +10622,6 @@
     "package": "activemodel",
     "tsFile": "attribute-set.ts",
     "rubyName": "accessed",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-set.ts",
-    "rubyName": "accessed",
     "call": "each_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -11496,9 +10635,9 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-set.ts",
-    "rubyName": "deep_dup",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "cast_types",
+    "call": "transform_values",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -11510,20 +10649,6 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-set.ts",
-    "rubyName": "key?",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-set.ts",
-    "rubyName": "keys",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-set.ts",
     "rubyName": "keys",
     "call": "each_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -11533,13 +10658,6 @@
     "tsFile": "attribute-set.ts",
     "rubyName": "keys",
     "call": "select",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-set.ts",
-    "rubyName": "map",
-    "call": "attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -11559,29 +10677,8 @@
   {
     "package": "activemodel",
     "tsFile": "attribute-set.ts",
-    "rubyName": "reverse_merge!",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-set.ts",
-    "rubyName": "values_before_type_cast",
-    "call": "attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-set.ts",
     "rubyName": "values_before_type_cast",
     "call": "transform_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute-set.ts",
-    "rubyName": "values_for_database",
-    "call": "attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -11624,20 +10721,6 @@
     "tsFile": "attribute-set/builder.ts",
     "rubyName": "materialize",
     "call": "each_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute.ts",
-    "rubyName": "_original_value_for_database",
-    "call": "original_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "attribute.ts",
-    "rubyName": "changed_from_assignment?",
-    "call": "original_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -11755,6 +10838,13 @@
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
+    "rubyName": "as_json",
+    "call": "merge",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "dirty.ts",
     "rubyName": "attribute_change",
     "call": "change_to_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -11804,9 +10894,16 @@
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
-    "rubyName": "attribute_was",
-    "call": "original_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "attribute_previous_change",
+    "call": "change_to_attribute",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
+    "tsFile": "dirty.ts",
+    "rubyName": "attribute_previous_change",
+    "call": "to_s",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -12030,13 +11127,6 @@
     "tsFile": "errors.ts",
     "rubyName": "add",
     "call": "append",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "errors.ts",
-    "rubyName": "add",
-    "call": "full_message",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -12295,13 +11385,6 @@
     "package": "activemodel",
     "tsFile": "nested-error.ts",
     "rubyName": "initialize",
-    "call": "attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "nested-error.ts",
-    "rubyName": "initialize",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -12345,13 +11428,6 @@
     "tsFile": "secure-password.ts",
     "rubyName": "has_secure_password",
     "call": "warn",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "serialization.ts",
-    "rubyName": "attribute_names_for_serialization",
-    "call": "attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -12902,6 +11978,13 @@
   },
   {
     "package": "activemodel",
+    "tsFile": "type/value.ts",
+    "rubyName": "initialize",
+    "call": "serialize_cast_value_compatible?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activemodel",
     "tsFile": "validations.ts",
     "rubyName": "_merge_attributes",
     "call": "symbolize_keys",
@@ -12947,13 +12030,6 @@
     "tsFile": "validations/acceptance.ts",
     "rubyName": "initialize",
     "call": "setup!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "validations/acceptance.ts",
-    "rubyName": "setup!",
-    "call": "attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -13017,13 +12093,6 @@
     "tsFile": "validations/comparison.ts",
     "rubyName": "validate_each",
     "call": "slice",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activemodel",
-    "tsFile": "validations/confirmation.ts",
-    "rubyName": "setup!",
-    "call": "attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -13414,13 +12483,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/alias-tracker.ts",
-    "rubyName": "create",
-    "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/alias-tracker.ts",
     "rubyName": "initial_count_for",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -13548,13 +12610,6 @@
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
     "rubyName": "add_constraints",
-    "call": "scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "add_constraints",
     "call": "unscope_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -13563,13 +12618,6 @@
     "tsFile": "associations/association-scope.ts",
     "rubyName": "add_constraints",
     "call": "unscope!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "apply_scope",
-    "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -13611,35 +12659,7 @@
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
     "rubyName": "get_bind_values",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "get_bind_values",
     "call": "last",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "get_bind_values",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "get_chain",
-    "call": "alias_candidate",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "get_chain",
-    "call": "arel_table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -13659,22 +12679,8 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
-    "rubyName": "get_chain",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
     "rubyName": "last_chain_scope",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "last_chain_scope",
-    "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -13688,21 +12694,7 @@
     "package": "activerecord",
     "tsFile": "associations/association-scope.ts",
     "rubyName": "next_chain_scope",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "next_chain_scope",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association-scope.ts",
-    "rubyName": "next_chain_scope",
-    "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -13743,13 +12735,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "association_scope",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "async_load_target",
     "call": "find_target",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -13764,13 +12749,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "async_load_target",
-    "call": "loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "build_record",
     "call": "build_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -13780,27 +12758,6 @@
     "tsFile": "associations/association.ts",
     "rubyName": "build_record",
     "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "enqueue_destroy_association",
-    "call": "destroy_association_async_job",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "enqueue_destroy_association",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "ensure_klass_exists!",
-    "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -13911,43 +12868,8 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "find_target?",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "find_target?",
-    "call": "loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "find_target?",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "foreign_key_for?",
     "call": "all?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "foreign_key_for?",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "foreign_key_for?",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14023,13 +12945,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "inversable?",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "invertible_for?",
     "call": "inverse_reflection_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -14065,50 +12980,15 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
+    "rubyName": "marshal_dump",
+    "call": "map",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/association.ts",
     "rubyName": "marshal_load",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "matches_foreign_key?",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "matches_foreign_key?",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "matches_foreign_key?",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "matches_foreign_key?",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "raise_on_type_mismatch!",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "raise_on_type_mismatch!",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14135,29 +13015,8 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "reset_negative_cache",
-    "call": "loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "scope",
     "call": "create",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "scope",
-    "call": "current_scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "scope",
-    "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14177,50 +13036,8 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "set_inverse_instance",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "set_inverse_instance_from_queries",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "set_strict_loading",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "set_strict_loading",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "skip_statement_cache?",
     "call": "any?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "skip_statement_cache?",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "skip_statement_cache?",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14233,22 +13050,8 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "stale_target?",
-    "call": "loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "target_scope",
     "call": "create",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "target_scope",
-    "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14263,20 +13066,6 @@
     "tsFile": "associations/association.ts",
     "rubyName": "violates_strict_loading?",
     "call": "key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "violates_strict_loading?",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "violates_strict_loading?",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14303,34 +13092,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "decrement_counters_before_last_save",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "decrement_counters_before_last_save",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "decrement_counters_before_last_save",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "default",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "foreign_key_present?",
     "call": "all?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -14340,13 +13101,6 @@
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "foreign_key_present?",
     "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "foreign_key_present?",
-    "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14409,13 +13163,6 @@
     "package": "activerecord",
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "handle_dependency",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "handle_dependency",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -14424,13 +13171,6 @@
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "invertible_for?",
     "call": "inverse_reflection_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "invertible_for?",
-    "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14445,13 +13185,6 @@
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "replace_keys",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "replace_keys",
-    "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14501,13 +13234,6 @@
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "stale_state",
     "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "stale_state",
-    "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14584,27 +13310,6 @@
     "package": "activerecord",
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "update_counters",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "update_counters",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "update_counters",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "update_counters",
     "call": "require_counter_update?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -14619,20 +13324,6 @@
     "package": "activerecord",
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "update_counters_via_scope",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "update_counters_via_scope",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-association.ts",
-    "rubyName": "update_counters_via_scope",
     "call": "unscoped",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -14641,20 +13332,6 @@
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "update_counters_via_scope",
     "call": "where!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-polymorphic-association.ts",
-    "rubyName": "inverse_reflection_for",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/belongs-to-polymorphic-association.ts",
-    "rubyName": "replace_keys",
-    "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14752,13 +13429,6 @@
     "package": "activerecord",
     "tsFile": "associations/builder/association.ts",
     "rubyName": "check_dependent_options",
-    "call": "destroy_association_async_job",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/association.ts",
-    "rubyName": "check_dependent_options",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -14779,29 +13449,8 @@
   {
     "package": "activerecord",
     "tsFile": "associations/builder/association.ts",
-    "rubyName": "define_callbacks",
-    "call": "extensions",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/association.ts",
-    "rubyName": "valid_options",
-    "call": "extensions",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/association.ts",
     "rubyName": "validate_options",
     "call": "assert_valid_keys",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/belongs-to.ts",
-    "rubyName": "add_touch_callbacks",
-    "call": "foreign_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14816,13 +13465,6 @@
     "tsFile": "associations/builder/belongs-to.ts",
     "rubyName": "define_validations",
     "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/belongs-to.ts",
-    "rubyName": "define_validations",
-    "call": "foreign_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -14844,20 +13486,6 @@
     "tsFile": "associations/builder/belongs-to.ts",
     "rubyName": "touch_record",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/belongs-to.ts",
-    "rubyName": "touch_record",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/belongs-to.ts",
-    "rubyName": "touch_record",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15018,13 +13646,6 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "concat",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "concat",
     "call": "skip_strict_loading",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -15040,13 +13661,6 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "concat_records",
     "call": "loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "concat_records",
-    "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15110,13 +13724,6 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "empty?",
     "call": "scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "empty?",
-    "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15227,20 +13834,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
-    "rubyName": "find_from_target?",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "find_from_target?",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
     "rubyName": "ids_reader",
     "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -15285,13 +13878,6 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "ids_writer",
     "call": "index_by",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "ids_writer",
-    "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15416,13 +14002,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
-    "rubyName": "null_scope?",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
     "rubyName": "remove_records",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -15446,13 +14025,6 @@
     "tsFile": "associations/collection-association.ts",
     "rubyName": "replace",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "replace",
-    "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15508,13 +14080,6 @@
     "package": "activerecord",
     "tsFile": "associations/collection-proxy.ts",
     "rubyName": "initialize",
-    "call": "extend",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-proxy.ts",
-    "rubyName": "initialize",
     "call": "extensions",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -15536,28 +14101,7 @@
     "package": "activerecord",
     "tsFile": "associations/disable-joins-association-scope.ts",
     "rubyName": "scope",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/disable-joins-association-scope.ts",
-    "rubyName": "scope",
     "call": "last_scope_chain",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/disable-joins-association-scope.ts",
-    "rubyName": "scope",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/disable-joins-association-scope.ts",
-    "rubyName": "scope",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15572,13 +14116,6 @@
     "tsFile": "associations/foreign-association.ts",
     "rubyName": "nullified_owner_attributes",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/foreign-association.ts",
-    "rubyName": "nullified_owner_attributes",
-    "call": "foreign_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15604,30 +14141,9 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "associations/foreign-association.ts",
-    "rubyName": "nullified_owner_attributes",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
     "rubyName": "count_records",
     "call": "compact",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
-    "rubyName": "count_records",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
-    "rubyName": "count_records",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15641,21 +14157,7 @@
     "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
     "rubyName": "delete_records",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
-    "rubyName": "delete_records",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
-    "rubyName": "delete_records",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15739,13 +14241,6 @@
     "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
     "rubyName": "handle_dependency",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
-    "rubyName": "handle_dependency",
     "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -15754,13 +14249,6 @@
     "tsFile": "associations/has-many-association.ts",
     "rubyName": "handle_dependency",
     "call": "query_constraints_list",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
-    "rubyName": "handle_dependency",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15802,13 +14290,6 @@
     "package": "activerecord",
     "tsFile": "associations/has-many-association.ts",
     "rubyName": "set_owner_attributes",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-association.ts",
-    "rubyName": "set_owner_attributes",
     "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -15824,13 +14305,6 @@
     "tsFile": "associations/has-many-through-association.ts",
     "rubyName": "build_record",
     "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-through-association.ts",
-    "rubyName": "build_record",
-    "call": "has_one?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -15885,13 +14359,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-many-through-association.ts",
-    "rubyName": "concat_records",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-through-association.ts",
     "rubyName": "delete_records",
     "call": "count",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -15915,27 +14382,6 @@
     "tsFile": "associations/has-many-through-association.ts",
     "rubyName": "delete_records",
     "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-through-association.ts",
-    "rubyName": "delete_records",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-through-association.ts",
-    "rubyName": "delete_records",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-many-through-association.ts",
-    "rubyName": "delete_records",
-    "call": "source_reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -16060,13 +14506,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/has-one-association.ts",
-    "rubyName": "_create_record",
-    "call": "owner",
-    "reason": "Rails `owner.persisted?` reads `owner` as a method; trails accesses it as the `this.owner` property (getter), so no `owner()` call appears."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
     "rubyName": "delete",
     "call": "enqueue_destroy_association",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -16131,13 +14570,6 @@
     "package": "activerecord",
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "delete",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "delete",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -16146,20 +14578,6 @@
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "delete",
     "call": "update_columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "handle_dependency",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "handle_dependency",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -16202,13 +14620,6 @@
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "replace",
     "call": "destroyed?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "replace",
-    "call": "has_changes_to_save?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -16278,22 +14689,43 @@
     "package": "activerecord",
     "tsFile": "associations/has-one-association.ts",
     "rubyName": "set_owner_attributes",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "set_owner_attributes",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-association.ts",
-    "rubyName": "set_owner_attributes",
     "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "foreign_key_present?",
+    "call": "all?",
+    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "foreign_key_present?",
+    "call": "belongs_to?",
+    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "foreign_key_present?",
+    "call": "foreign_key",
+    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "foreign_key_present?",
+    "call": "owner",
+    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "foreign_key_present?",
+    "call": "through_reflection",
+    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
   },
   {
     "package": "activerecord",
@@ -16301,6 +14733,48 @@
     "rubyName": "replace",
     "call": "create_through_record",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "stale_state",
+    "call": "belongs_to?",
+    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "stale_state",
+    "call": "filter_map",
+    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "stale_state",
+    "call": "foreign_key",
+    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "stale_state",
+    "call": "owner",
+    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "stale_state",
+    "call": "presence",
+    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-through-association.ts",
+    "rubyName": "stale_state",
+    "call": "through_reflection",
+    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
   },
   {
     "package": "activerecord",
@@ -16353,51 +14827,9 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "foreign_key_present?",
-    "call": "through_reflection",
-    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "foreign_key_present?",
-    "call": "belongs_to?",
-    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "foreign_key_present?",
-    "call": "foreign_key",
-    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "foreign_key_present?",
-    "call": "owner",
-    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "foreign_key_present?",
-    "call": "all?",
-    "reason": "Equivalent: foreignKeyPresent() delegates to ThroughAssociation#foreign_key_present? via the throughForeignKeyPresent mixin helper (through-association.ts), same delegation pattern as replace/stale_state/target_scope on this class."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
     "rubyName": "aliases",
     "call": "column_names",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "aliases",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -16417,20 +14849,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/join-dependency.ts",
-    "rubyName": "apply_column_aliases",
-    "call": "select_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "build",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
     "rubyName": "construct",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -16440,20 +14858,6 @@
     "tsFile": "associations/join-dependency.ts",
     "rubyName": "construct",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "construct",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency.ts",
-    "rubyName": "construct",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -16732,13 +15136,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/join-dependency/join-association.ts",
-    "rubyName": "initialize",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency/join-association.ts",
     "rubyName": "join_constraints",
     "call": "concat",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -16789,13 +15186,6 @@
     "package": "activerecord",
     "tsFile": "associations/join-dependency/join-association.ts",
     "rubyName": "join_constraints",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency/join-association.ts",
-    "rubyName": "join_constraints",
     "call": "last",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -16810,21 +15200,7 @@
     "package": "activerecord",
     "tsFile": "associations/join-dependency/join-association.ts",
     "rubyName": "join_constraints",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency/join-association.ts",
-    "rubyName": "join_constraints",
     "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency/join-association.ts",
-    "rubyName": "match?",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -16860,13 +15236,6 @@
     "tsFile": "associations/join-dependency/join-association.ts",
     "rubyName": "readonly?",
     "call": "unscoped",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/join-dependency/join-association.ts",
-    "rubyName": "strict_loading?",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -16922,13 +15291,6 @@
     "package": "activerecord",
     "tsFile": "associations/nested-error.ts",
     "rubyName": "compute_attribute",
-    "call": "attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/nested-error.ts",
-    "rubyName": "compute_attribute",
     "call": "index",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -16937,27 +15299,6 @@
     "tsFile": "associations/nested-error.ts",
     "rubyName": "compute_attribute",
     "call": "index_errors_setting",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/nested-error.ts",
-    "rubyName": "compute_attribute",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/nested-error.ts",
-    "rubyName": "initialize",
-    "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader.ts",
-    "rubyName": "call",
-    "call": "loaders",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -16993,13 +15334,6 @@
     "tsFile": "associations/preloader/association.ts",
     "rubyName": "associate_records_from_unscoped",
     "call": "present?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
-    "rubyName": "associate_records_from_unscoped",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -17055,28 +15389,7 @@
     "package": "activerecord",
     "tsFile": "associations/preloader/association.ts",
     "rubyName": "load_records",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
-    "rubyName": "load_records",
     "call": "select",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
-    "rubyName": "loaded?",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
-    "rubyName": "loader_query",
-    "call": "scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -17096,13 +15409,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/preloader/association.ts",
-    "rubyName": "run",
-    "call": "owners",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
     "rubyName": "set_inverse",
     "call": "derive_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -17117,20 +15423,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/preloader/association.ts",
-    "rubyName": "set_inverse",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
-    "rubyName": "target_for",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/association.ts",
     "rubyName": "target_for",
     "call": "wrap",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -17140,13 +15432,6 @@
     "tsFile": "associations/preloader/batch.ts",
     "rubyName": "call",
     "call": "any?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/batch.ts",
-    "rubyName": "call",
-    "call": "base_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -17174,13 +15459,6 @@
     "package": "activerecord",
     "tsFile": "associations/preloader/batch.ts",
     "rubyName": "call",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/batch.ts",
-    "rubyName": "call",
     "call": "partition",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -17189,20 +15467,6 @@
     "tsFile": "associations/preloader/batch.ts",
     "rubyName": "call",
     "call": "reject",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/batch.ts",
-    "rubyName": "call",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/batch.ts",
-    "rubyName": "initialize",
-    "call": "base_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -17236,20 +15500,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "grouped_records",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "immediate_future_classes",
-    "call": "loaders",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
     "rubyName": "immediate_future_classes",
     "call": "reject",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -17278,29 +15528,8 @@
   {
     "package": "activerecord",
     "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "polymorphic?",
-    "call": "association",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "preloaders_for_reflection",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
     "rubyName": "preloaders_for_reflection",
     "call": "group_by",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "preloaders_for_reflection",
-    "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -17314,28 +15543,7 @@
     "package": "activerecord",
     "tsFile": "associations/preloader/branch.ts",
     "rubyName": "preloaders_for_reflection",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "preloaders_for_reflection",
     "call": "preloader_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "preloaders_for_reflection",
-    "call": "scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "runnable_loaders",
-    "call": "loaders",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -17343,20 +15551,6 @@
     "tsFile": "associations/preloader/branch.ts",
     "rubyName": "runnable_loaders",
     "call": "reject",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "target_classes",
-    "call": "loaders",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/branch.ts",
-    "rubyName": "target_classes",
-    "call": "preloaded_records",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -17426,28 +15620,7 @@
     "package": "activerecord",
     "tsFile": "associations/preloader/through-association.ts",
     "rubyName": "records_by_owner",
-    "call": "owners",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/through-association.ts",
-    "rubyName": "records_by_owner",
     "call": "preload_index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/through-association.ts",
-    "rubyName": "records_by_owner",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/preloader/through-association.ts",
-    "rubyName": "records_by_owner",
-    "call": "scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -17511,20 +15684,6 @@
     "tsFile": "associations/preloader/through-association.ts",
     "rubyName": "runnable_loaders",
     "call": "through_preloaders",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/singular-association.ts",
-    "rubyName": "scope_for_create",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/singular-association.ts",
-    "rubyName": "scope_for_create",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -18007,13 +16166,6 @@
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
     "rubyName": "define_attribute_methods",
-    "call": "abstract_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
-    "rubyName": "define_attribute_methods",
     "call": "alias_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -18160,6 +16312,20 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
+    "rubyName": "initialize_generated_modules",
+    "call": "include",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods.ts",
+    "rubyName": "initialize_generated_modules",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "dangerous_attribute_method?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18181,9 +16347,9 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
-    "rubyName": "primary_key_values_present?",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "method_defined_within?",
+    "call": "owner",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -18314,13 +16480,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
-    "rubyName": "to_key",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
     "rubyName": "undefine_attribute_methods",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18405,13 +16564,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
     "rubyName": "id_before_type_cast",
     "call": "attribute_before_type_cast",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18419,48 +16571,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id_before_type_cast",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id_for_database",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id_in_database",
-    "call": "attribute_in_database",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id_in_database",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id_was",
-    "call": "attribute_was",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id_was",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
     "rubyName": "id?",
     "call": "all?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18468,43 +16578,8 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id?",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id=",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "id=",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
     "rubyName": "primary_key_values_present?",
     "call": "all?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "primary_key_values_present?",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/composite-primary-key.ts",
-    "rubyName": "primary_key_values_present?",
-    "call": "id",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -18538,6 +16613,20 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/dirty.ts",
+    "rubyName": "attribute_change_to_be_saved",
+    "call": "change_to_attribute",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/dirty.ts",
+    "rubyName": "attribute_change_to_be_saved",
+    "call": "to_s",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "attribute_in_database",
     "call": "original_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18553,22 +16642,22 @@
     "package": "activerecord",
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "attribute_names_for_partial_inserts",
-    "call": "changed_attribute_names_to_save",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/dirty.ts",
-    "rubyName": "attribute_names_for_partial_inserts",
     "call": "reject",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/dirty.ts",
-    "rubyName": "attribute_names_for_partial_updates",
-    "call": "changed_attribute_names_to_save",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "saved_change_to_attribute",
+    "call": "change_to_attribute",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/dirty.ts",
+    "rubyName": "saved_change_to_attribute",
+    "call": "to_s",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -18671,15 +16760,22 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "primary_key",
-    "call": "reset_primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "instance_method_already_implemented?",
+    "call": "include?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "primary_key_values_present?",
-    "call": "id",
+    "rubyName": "instance_method_already_implemented?",
+    "call": "primary_key",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "attribute-methods/primary-key.ts",
+    "rubyName": "primary_key",
+    "call": "reset_primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -18713,13 +16809,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "quoted_primary_key",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "reset_primary_key",
     "call": "base_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18736,20 +16825,6 @@
     "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "reset_primary_key",
     "call": "get_primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "reset_primary_key",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods/primary-key.ts",
-    "rubyName": "to_key",
-    "call": "id",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -18853,13 +16928,6 @@
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
-    "rubyName": "_record_changed?",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
     "rubyName": "associated_records_to_validate_or_save",
     "call": "custom_validation_context?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18874,20 +16942,6 @@
   {
     "package": "activerecord",
     "tsFile": "autosave-association.ts",
-    "rubyName": "association_foreign_key_changed?",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "association_foreign_key_changed?",
-    "call": "through_reflection?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
     "rubyName": "association_valid?",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18897,13 +16951,6 @@
     "tsFile": "autosave-association.ts",
     "rubyName": "association_valid?",
     "call": "append",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "association_valid?",
-    "call": "changed?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -18967,13 +17014,6 @@
     "tsFile": "autosave-association.ts",
     "rubyName": "compute_primary_key",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "autosave-association.ts",
-    "rubyName": "compute_primary_key",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -19337,13 +17377,6 @@
     "package": "activerecord",
     "tsFile": "base.ts",
     "rubyName": "all",
-    "call": "current_scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
-    "rubyName": "all",
     "call": "default_scoped",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -19658,13 +17691,6 @@
   {
     "package": "activerecord",
     "tsFile": "base.ts",
-    "rubyName": "initialize",
-    "call": "init_internals",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "base.ts",
     "rubyName": "no_touching?",
     "call": "applied_to?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -19847,6 +17873,34 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "cacheable_query",
+    "call": "compile",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "cacheable_query",
+    "call": "partial_query",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "cacheable_query",
+    "call": "prepared_statements",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "cacheable_query",
+    "call": "query",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "case_insensitive_comparison",
     "call": "can_perform_case_insensitive_comparison_for?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -19856,20 +17910,6 @@
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "case_insensitive_comparison",
     "call": "column_for_attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "case_insensitive_comparison",
-    "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "collector",
-    "call": "prepared_statements",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -19890,20 +17930,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "column_for_attribute",
-    "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "column_for_attribute",
-    "call": "schema_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "column_for_attribute",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -19912,6 +17938,55 @@
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "disconnect!",
     "call": "synchronize",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "exec_delete",
+    "call": "affected_rows",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "exec_delete",
+    "call": "internal_execute",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "exec_insert",
+    "call": "internal_exec_query",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "exec_insert",
+    "call": "sql_for_insert",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "exec_query",
+    "call": "internal_exec_query",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "exec_update",
+    "call": "affected_rows",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "exec_update",
+    "call": "internal_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -19989,13 +18064,6 @@
     "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "log",
     "call": "presence",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "preventing_writes?",
-    "call": "connection_descriptor",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -20106,6 +18174,34 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "select_all",
+    "call": "arel_from_relation",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "select_all",
+    "call": "select",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "select_all",
+    "call": "to_sql_and_binds",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
+    "rubyName": "select_value",
+    "call": "single_value_from_rows",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-adapter.ts",
     "rubyName": "steal!",
     "call": "context",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -20204,20 +18300,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "translate_exception",
-    "call": "mismatched_foreign_key",
-    "reason": "Satisfied by the delegated path: translateException calls _translateException, which builds the MismatchedForeignKey (mismatchedForeignKey); the public method only attaches the connection pool."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "translate_exception",
-    "call": "new",
-    "reason": "Satisfied by the delegated path: translateException calls _translateException, which constructs the translated error classes; the public method only attaches the connection pool."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "add_index_for_alter",
     "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -20240,28 +18322,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "build_change_column_definition",
-    "call": "collation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "build_change_column_definition",
-    "call": "comment",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "build_change_column_definition",
     "call": "create_table_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "build_change_column_definition",
-    "call": "default",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -20276,13 +18337,6 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "build_change_column_definition",
     "call": "key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "build_change_column_definition",
-    "call": "null",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -20339,13 +18393,6 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "build_insert_sql",
     "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "case_sensitive_comparison",
-    "call": "collation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -20477,6 +18524,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "extended_type_map_key",
+    "call": "emulate_booleans",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "extract_precision",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -20529,6 +18583,13 @@
     "rubyName": "initialize_type_map",
     "call": "alias_type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "mariadb?",
+    "call": "match?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -20611,21 +18672,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "rename_column_for_alter",
-    "call": "comment",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "rename_column_for_alter",
     "call": "create_table_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "rename_column_for_alter",
-    "call": "default",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -20647,13 +18694,6 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "rename_column_for_alter",
     "call": "new_column_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "rename_column_for_alter",
-    "call": "null",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -20689,13 +18729,6 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "rename_table",
     "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "rename_table",
-    "call": "schema_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -20785,9 +18818,16 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
-    "rubyName": "warning_ignored?",
-    "call": "level",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "translate_exception",
+    "call": "mismatched_foreign_key",
+    "reason": "Satisfied by the delegated path: translateException calls _translateException, which builds the MismatchedForeignKey (mismatchedForeignKey); the public method only attaches the connection pool."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
+    "rubyName": "translate_exception",
+    "call": "new",
+    "reason": "Satisfied by the delegated path: translateException calls _translateException, which constructs the translated error classes; the public method only attaches the connection pool."
   },
   {
     "package": "activerecord",
@@ -20856,13 +18896,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-handler.ts",
     "rubyName": "establish_connection",
-    "call": "connection_descriptor",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "establish_connection",
     "call": "primary_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -20871,13 +18904,6 @@
     "tsFile": "connection-adapters/abstract/connection-handler.ts",
     "rubyName": "flush_idle_connections!",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-handler.ts",
-    "rubyName": "resolve_pool_config",
-    "call": "adapter",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -20989,8 +19015,22 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "clear_reloadable_connections",
+    "call": "clear",
+    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); the `_available.clear()` / lease-clearing lives in the private `_clearReloadableConnections` core it delegates to. Same behavior, moved into the shared sync helper."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "clear_reloadable_connections",
     "call": "delete_if",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "clear_reloadable_connections",
+    "call": "disconnect!",
+    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous reload-clear — including `conn.disconnectBang()` — to the private `_clearReloadableConnections` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
   },
   {
     "package": "activerecord",
@@ -21009,9 +19049,30 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "clear_reloadable_connections",
+    "call": "with_exclusively_acquired_all_connections",
+    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); the `withExclusivelyAcquiredAllConnections` critical section lives in the private `_clearReloadableConnections` core it delegates to. Same call, moved into the shared sync helper."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "complete",
     "call": "connection_handler",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "connected?",
+    "call": "any?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "connected?",
+    "call": "synchronize",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21038,6 +19099,20 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "disconnect",
+    "call": "clear",
+    "reason": "RFC 0023 async split: the pool-state clears (_available/_checkedOut/_leases) live in the private _disconnect helper that disconnect delegates to; attribution artifact of the sync-helper/async-wrapper split."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "disconnect",
+    "call": "disconnect!",
+    "reason": "RFC 0023 async split: the per-connection conn.disconnect! (disconnectBang) loop lives in the private _disconnect helper that disconnect delegates to; attribution artifact of the sync-helper/async-wrapper split."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool.ts",
+    "rubyName": "disconnect",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -21058,16 +19133,16 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "disconnect",
-    "call": "disconnect!",
-    "reason": "RFC 0023 async split: the per-connection conn.disconnect! (disconnectBang) loop lives in the private _disconnect helper that disconnect delegates to; attribution artifact of the sync-helper/async-wrapper split."
+    "rubyName": "flush",
+    "call": "delete",
+    "reason": "flush is now async (converge-connection-pool-lifecycle-async); the idle-connection removal (`_connections.splice` / `_lastCheckinAt.delete`, Rails' `@connections.delete`) lives in the private `_flush` core it delegates to. Same behavior, moved into the shared sync helper."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "disconnect",
-    "call": "clear",
-    "reason": "RFC 0023 async split: the pool-state clears (_available/_checkedOut/_leases) live in the private _disconnect helper that disconnect delegates to; attribution artifact of the sync-helper/async-wrapper split."
+    "rubyName": "flush",
+    "call": "disconnect!",
+    "reason": "flush is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous eviction — including `conn.disconnectBang()` — to the private `_flush` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
   },
   {
     "package": "activerecord",
@@ -21115,8 +19190,8 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "pin_connection!",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "checkout",
+    "reason": "pinConnectionBang acquires the pinned connection via the sync `_acquireConnection` helper (the trails pinned-checkout path); `checkout` is now async (converge-connection-pool-checkout-lease-async) and cannot be awaited from this path."
   },
   {
     "package": "activerecord",
@@ -21234,13 +19309,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "stat",
-    "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "stat",
     "call": "synchronize",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -21269,13 +19337,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "with_connection",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "with_connection",
     "call": "connection_lease",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -21289,9 +19350,30 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "any_waiting?",
+    "call": "synchronize",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "broadcast_on_biased",
     "call": "broadcast",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "can_remove_no_wait?",
+    "call": "size",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "clear",
+    "call": "synchronize",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21306,6 +19388,13 @@
     "rubyName": "no_wait_poll",
     "call": "remove",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
+    "rubyName": "num_waiting",
+    "call": "synchronize",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21368,13 +19457,6 @@
     "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "build_fixture_sql",
     "call": "any?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "build_fixture_sql",
-    "call": "columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -21478,22 +19560,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "build_truncate_statements",
-    "call": "build_truncate_statement",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "cacheable_query",
     "call": "compile",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "cacheable_query",
-    "call": "prepared_statements",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -21563,13 +19631,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "insert",
-    "call": "last_inserted_id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "insert",
     "call": "returning_column_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -21578,13 +19639,6 @@
     "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "insert_fixture",
     "call": "build_fixture_sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "insert_fixture",
-    "call": "execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -21604,29 +19658,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "mark_transaction_written_if_write",
-    "call": "open?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "preprocess_query",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "query",
-    "call": "rows",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "raw_exec_query",
-    "call": "raw_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -21669,13 +19702,6 @@
     "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "select_all",
     "call": "arel_from_relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "select_all",
-    "call": "prepared_statements",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -21744,43 +19770,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "transaction_open?",
-    "call": "open?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "truncate",
-    "call": "build_truncate_statement",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "truncate",
-    "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "truncate_tables",
-    "call": "build_truncate_statements",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
     "rubyName": "truncate_tables",
     "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/database-statements.ts",
-    "rubyName": "truncate_tables",
-    "call": "table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -21793,13 +19784,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
-    "rubyName": "compute_if_absent",
-    "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "dirties_query_cache",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -21807,16 +19791,23 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
-    "rubyName": "disable_query_cache",
-    "call": "query_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "query_cache",
+    "call": "compute_if_absent",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
-    "rubyName": "enable_query_cache",
-    "call": "query_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "query_cache",
+    "call": "context",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/query-cache.ts",
+    "rubyName": "query_cache",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21926,15 +19917,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "quoted_columns",
-    "call": "column_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "column_options",
+    "call": "merge",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "quoted_columns",
-    "call": "columns",
+    "call": "column_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -21949,13 +19940,6 @@
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "visit_AddCheckConstraint",
     "call": "accept",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_AddColumnDefinition",
-    "call": "column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -21989,27 +19973,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_ColumnDefinition",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_CreateIndexDefinition",
-    "call": "include",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_CreateIndexDefinition",
-    "call": "index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "visit_CreateIndexDefinition",
     "call": "quote_column_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -22024,43 +19987,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_CreateIndexDefinition",
-    "call": "table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_CreateIndexDefinition",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_CreateIndexDefinition",
-    "call": "where",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "visit_DropConstraint",
     "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_ForeignKeyDefinition",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_ForeignKeyDefinition",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -22088,27 +20016,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "visit_TableDefinition",
-    "call": "as",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_TableDefinition",
-    "call": "check_constraints",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_TableDefinition",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_TableDefinition",
     "call": "concat",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -22117,13 +20024,6 @@
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "visit_TableDefinition",
     "call": "exclusion_constraints",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_TableDefinition",
-    "call": "foreign_keys",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -22284,13 +20184,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "check_constraint",
-    "call": "check_constraints",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "check_constraint",
     "call": "new_check_constraint_definition",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -22305,22 +20198,15 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "concise_options",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "concise_options",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "concise_options",
-    "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "conditional_options",
+    "call": "slice",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -22353,34 +20239,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "defined_for?",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "defined_for?",
-    "call": "include",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "foreign_key",
-    "call": "foreign_keys",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "foreign_key_options",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "foreign_key_options",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -22402,23 +20260,23 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "index",
-    "call": "indexes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "index_options",
-    "call": "index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "index_options",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
+    "rubyName": "integer_like_primary_key?",
+    "call": "include?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
+    "rubyName": "integer_like_primary_key?",
+    "call": "key?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -22486,13 +20344,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "raise_on_duplicate_column",
-    "call": "primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "raise_on_if_exist_options",
     "call": "find",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -22536,13 +20387,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "set_primary_key",
-    "call": "as",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "set_primary_key",
     "call": "except",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -22565,13 +20409,6 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "set_primary_key",
     "call": "merge!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "set_primary_key",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -22613,70 +20450,14 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-dumper.ts",
     "rubyName": "prepare_column_options",
-    "call": "comment",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
-    "rubyName": "prepare_column_options",
-    "call": "null",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
-    "rubyName": "prepare_column_options",
     "call": "present?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-dumper.ts",
-    "rubyName": "schema_collation",
-    "call": "collation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
-    "rubyName": "schema_default",
-    "call": "default",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
-    "rubyName": "schema_limit",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
     "rubyName": "schema_limit",
     "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
-    "rubyName": "schema_precision",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
-    "rubyName": "schema_type",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-dumper.ts",
-    "rubyName": "schema_type_with_virtual",
-    "call": "virtual?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -22859,13 +20640,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "assume_migrated_upto_version",
     "call": "select",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "assume_migrated_upto_version",
-    "call": "table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -23124,20 +20898,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "create_table",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "create_table",
-    "call": "comment",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "create_table",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -23146,13 +20906,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "create_table",
     "call": "execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "create_table",
-    "call": "indexes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -23174,13 +20927,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "create_table",
     "call": "present?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "create_table",
-    "call": "schema_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -23291,20 +21037,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "distinct_relation_for_primary_key",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "distinct_relation_for_primary_key",
-    "call": "table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "drop_table",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -23321,13 +21053,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "drop_table",
     "call": "quote_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "drop_table",
-    "call": "schema_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -23361,16 +21086,9 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "fetch_type_metadata",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "fetch_type_metadata",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "extract_new_default_value",
+    "call": "has_key?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23441,6 +21159,13 @@
     "rubyName": "foreign_key_options",
     "call": "squish",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/abstract/schema-statements.ts",
+    "rubyName": "foreign_keys_enabled?",
+    "call": "fetch",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23524,13 +21249,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "index_name_for_remove",
     "call": "all?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "index_name_for_remove",
-    "call": "columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -23627,16 +21345,16 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "insert_versions_sql",
-    "call": "table_name",
+    "rubyName": "join_table_name",
+    "call": "derive_join_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "join_table_name",
-    "call": "derive_join_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "options_include_default?",
+    "call": "include?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23880,13 +21598,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "rename_column_indexes",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "rename_column_indexes",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -23971,28 +21682,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "rename_table_indexes",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "rename_table_indexes",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "strip_table_name_prefix_and_suffix",
-    "call": "table_name_prefix",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "strip_table_name_prefix_and_suffix",
-    "call": "table_name_suffix",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -24250,20 +21940,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/transaction.ts",
-    "rubyName": "prepare_instances_to_run_callbacks_on",
-    "call": "run_commit_callbacks_on_first_saved_instances_in_transaction",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/transaction.ts",
-    "rubyName": "restart",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/transaction.ts",
     "rubyName": "restorable?",
     "call": "none?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -24383,9 +22059,16 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/column.ts",
-    "rubyName": "case_sensitive?",
-    "call": "collation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "unsigned?",
+    "call": "match?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql/column.ts",
+    "rubyName": "virtual?",
+    "call": "match?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -24432,13 +22115,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/database-statements.ts",
-    "rubyName": "returning_column_values",
-    "call": "rows",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/database-statements.ts",
     "rubyName": "write_query?",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -24454,20 +22130,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/explain-pretty-printer.ts",
     "rubyName": "compute_column_widths",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/explain-pretty-printer.ts",
-    "rubyName": "compute_column_widths",
-    "call": "rows",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/explain-pretty-printer.ts",
-    "rubyName": "compute_column_widths",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -24475,21 +22137,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/explain-pretty-printer.ts",
     "rubyName": "pp",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/explain-pretty-printer.ts",
-    "rubyName": "pp",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/explain-pretty-printer.ts",
-    "rubyName": "pp",
-    "call": "rows",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -24544,27 +22192,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "add_table_options!",
-    "call": "charset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "add_table_options!",
-    "call": "collation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "add_table_options!",
-    "call": "comment",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
     "rubyName": "index_in_create",
     "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -24579,34 +22206,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "visit_AddColumnDefinition",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "visit_ChangeColumnDefaultDefinition",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "visit_ChangeColumnDefaultDefinition",
-    "call": "default",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "visit_ChangeColumnDefaultDefinition",
-    "call": "null",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
     "rubyName": "visit_ChangeColumnDefaultDefinition",
     "call": "quote_column_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -24615,34 +22214,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-creation.ts",
     "rubyName": "visit_ChangeColumnDefinition",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "visit_ChangeColumnDefinition",
-    "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "visit_CreateIndexDefinition",
-    "call": "index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "visit_IndexDefinition",
-    "call": "comment",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "visit_IndexDefinition",
     "call": "quote_column_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -24650,7 +22221,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-creation.ts",
     "rubyName": "visit_IndexDefinition",
-    "call": "table",
+    "call": "quote_column_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -24658,13 +22229,6 @@
     "tsFile": "connection-adapters/mysql/schema-creation.ts",
     "rubyName": "visit_IndexDefinition",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-creation.ts",
-    "rubyName": "visit_IndexDefinition",
-    "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -24677,9 +22241,23 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
-    "rubyName": "column_spec_for_primary_key",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "extract_expression_for_virtual_column",
+    "call": "query_value",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql/schema-dumper.ts",
+    "rubyName": "extract_expression_for_virtual_column",
+    "call": "quote",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql/schema-dumper.ts",
+    "rubyName": "extract_expression_for_virtual_column",
+    "call": "quote_column_name",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -24700,20 +22278,6 @@
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "prepare_column_options",
     "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-dumper.ts",
-    "rubyName": "prepare_column_options",
-    "call": "virtual?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-dumper.ts",
-    "rubyName": "schema_collation",
-    "call": "collation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -24740,13 +22304,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
-    "rubyName": "schema_collation",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "schema_limit",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -24756,13 +22313,6 @@
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "schema_precision",
     "call": "match?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-dumper.ts",
-    "rubyName": "schema_precision",
-    "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -24893,31 +22443,17 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-statements.ts",
-    "rubyName": "new_column_from_field",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "connect",
     "call": "new_client",
-    "reason": "Rails' private connect (mysql2_adapter.rb:144) is `@raw_connection = new_client(...)`; trails' connect() delegates to _ensureClient(), which calls Mysql2Adapter.newClient() (the new_client analog) \u2014 so the call is satisfied one frame down, not inlined here."
+    "reason": "Rails' private connect (mysql2_adapter.rb:144) is `@raw_connection = new_client(...)`; trails' connect() delegates to _ensureClient(), which calls Mysql2Adapter.newClient() (the new_client analog) — so the call is satisfied one frame down, not inlined here."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "connect",
     "call": "set_pool",
-    "reason": "Rails' connect rescues ConnectionNotEstablished and re-raises `ex.set_pool(@pool)` (mysql2_adapter.rb:146-147); trails' connect() delegates to _ensureClient(), whose catch attaches the pool via translated.setPool(this.pool) \u2014 same set_pool behavior, one frame down."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql2-adapter.ts",
-    "rubyName": "disconnect!",
-    "call": "synchronize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Rails' connect rescues ConnectionNotEstablished and re-raises `ex.set_pool(@pool)` (mysql2_adapter.rb:146-147); trails' connect() delegates to _ensureClient(), whose catch attaches the pool via translated.setPool(this.pool) — same set_pool behavior, one frame down."
   },
   {
     "package": "activerecord",
@@ -24925,6 +22461,13 @@
     "rubyName": "discard!",
     "call": "synchronize",
     "reason": "Rails wraps discard! in @lock.synchronize (Ruby Mutex); trails' single-threaded async model has no lock to acquire, matching the existing disconnect!/reconnect! synchronize exclusions in this file."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2-adapter.ts",
+    "rubyName": "disconnect!",
+    "call": "synchronize",
+    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -24994,13 +22537,6 @@
     "tsFile": "connection-adapters/mysql2/database-statements.ts",
     "rubyName": "multi_statements_enabled?",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql2/database-statements.ts",
-    "rubyName": "perform_query",
-    "call": "affected_rows",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -25699,6 +23235,13 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql-adapter.ts",
+    "rubyName": "supports_optimizer_hints?",
+    "call": "extension_available?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "translate_exception",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -25716,6 +23259,20 @@
     "rubyName": "update_typemap_for_default_timezone",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/column.ts",
+    "rubyName": "virtual?",
+    "call": "present?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/database-statements.ts",
+    "rubyName": "affected_rows",
+    "call": "clear",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -25804,15 +23361,15 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
-    "rubyName": "warning_ignored?",
-    "call": "exclude?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "returning_column_values",
+    "call": "first",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "warning_ignored?",
-    "call": "level",
+    "call": "exclude?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -25848,13 +23405,6 @@
     "tsFile": "connection-adapters/postgresql/oid/array.ts",
     "rubyName": "deserialize",
     "call": "decode",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/array.ts",
-    "rubyName": "deserialize",
-    "call": "values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -26000,13 +23550,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/oid/type-map-initializer.ts",
-    "rubyName": "register_with_subtype",
-    "call": "lookup",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/oid/type-map-initializer.ts",
     "rubyName": "run",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26056,13 +23599,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/quoting.ts",
-    "rubyName": "lookup_cast_type_from_column",
-    "call": "oid",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/quoting.ts",
     "rubyName": "quote",
     "call": "check_int_in_range",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26086,13 +23622,6 @@
     "tsFile": "connection-adapters/postgresql/quoting.ts",
     "rubyName": "quote_default_expression",
     "call": "lookup_cast_type_from_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/quoting.ts",
-    "rubyName": "quote_default_expression",
-    "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -26154,13 +23683,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_AddForeignKey",
-    "call": "validate?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
     "rubyName": "visit_AddUniqueConstraint",
     "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26176,28 +23698,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-creation.ts",
     "rubyName": "visit_ChangeColumnDefaultDefinition",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_ChangeColumnDefaultDefinition",
-    "call": "default",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_ChangeColumnDefaultDefinition",
     "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_ChangeColumnDefinition",
-    "call": "column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -26217,27 +23718,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_ChangeColumnDefinition",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_CheckConstraintDefinition",
-    "call": "validate?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_ExclusionConstraintDefinition",
-    "call": "deferrable",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
     "rubyName": "visit_ExclusionConstraintDefinition",
     "call": "quote_column_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26252,36 +23732,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_ExclusionConstraintDefinition",
-    "call": "where",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_ForeignKeyDefinition",
-    "call": "deferrable",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
     "rubyName": "visit_ForeignKeyDefinition",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_UniqueConstraintDefinition",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-creation.ts",
-    "rubyName": "visit_UniqueConstraintDefinition",
-    "call": "deferrable",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -26316,13 +23768,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-definitions.ts",
     "rubyName": "defined_for?",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-definitions.ts",
-    "rubyName": "defined_for?",
     "call": "slice",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -26336,9 +23781,9 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-definitions.ts",
-    "rubyName": "exclusion_constraint",
-    "call": "exclusion_constraints",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "export_name_on_schema_dump?",
+    "call": "match?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -26356,30 +23801,9 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-definitions.ts",
-    "rubyName": "unique_constraint",
-    "call": "unique_constraints",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
     "rubyName": "exclusion_constraints_in_create",
     "call": "any?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
-    "rubyName": "exclusion_constraints_in_create",
-    "call": "deferrable",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
-    "rubyName": "exclusion_constraints_in_create",
-    "call": "where",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -26394,20 +23818,6 @@
     "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
     "rubyName": "extensions",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
-    "rubyName": "prepare_column_options",
-    "call": "array?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
-    "rubyName": "prepare_column_options",
-    "call": "enum?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -26427,13 +23837,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
-    "rubyName": "schema_expression",
-    "call": "serial?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
     "rubyName": "schema_type",
     "call": "bigint?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26441,13 +23844,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
-    "rubyName": "schema_type",
-    "call": "serial?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
     "rubyName": "schemas",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -26478,20 +23874,6 @@
     "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
     "rubyName": "unique_constraints_in_create",
     "call": "any?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
-    "rubyName": "unique_constraints_in_create",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/postgresql/schema-dumper.ts",
-    "rubyName": "unique_constraints_in_create",
-    "call": "deferrable",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -26500,6 +23882,13 @@
     "rubyName": "parts",
     "call": "compact",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/postgresql/utils.ts",
+    "rubyName": "to_s",
+    "call": "join",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -26841,13 +24230,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "copy_table",
-    "call": "collation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "copy_table",
     "call": "column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -26856,13 +24238,6 @@
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "copy_table",
     "call": "create_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "copy_table",
-    "call": "default",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -26898,13 +24273,6 @@
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "copy_table",
     "call": "lookup_cast_type_from_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "copy_table",
-    "call": "null",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -27003,13 +24371,6 @@
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "copy_table_indexes",
     "call": "select",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "copy_table_indexes",
-    "call": "where",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -27387,13 +24748,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "rename_table",
-    "call": "schema_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "rename_table",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -27548,13 +24902,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3/database-statements.ts",
     "rubyName": "default_insert_value",
-    "call": "default",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/database-statements.ts",
-    "rubyName": "default_insert_value",
     "call": "sql",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -27599,6 +24946,13 @@
     "rubyName": "reset_isolation_level",
     "call": "internal_execute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/sqlite3/database-statements.ts",
+    "rubyName": "returning_column_values",
+    "call": "first",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -27660,13 +25014,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3/schema-creation.ts",
     "rubyName": "visit_ForeignKeyDefinition",
-    "call": "deferrable",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/schema-creation.ts",
-    "rubyName": "visit_ForeignKeyDefinition",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -27689,13 +25036,6 @@
     "tsFile": "connection-adapters/sqlite3/schema-dumper.ts",
     "rubyName": "prepare_column_options",
     "call": "merge!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3/schema-dumper.ts",
-    "rubyName": "prepare_column_options",
-    "call": "virtual?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -28093,20 +25433,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
-    "rubyName": "clear_query_caches_for_current_thread",
-    "call": "connection_handler",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "connected_to",
-    "call": "abstract_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
     "rubyName": "connected_to",
     "call": "connection_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -28142,23 +25468,9 @@
   {
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
-    "rubyName": "connection_pool",
-    "call": "connection_handler",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "connects_to",
-    "call": "abstract_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "connects_to",
-    "call": "connection_handler",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "connection",
+    "call": "lease_connection",
+    "reason": "The deprecated sync `.connection` getter routes through the sync `leaseConnectionSync` escape hatch; Rails-named `leaseConnection` is async in trails (converge-connection-pool-checkout-lease-async) and cannot be awaited from a sync getter."
   },
   {
     "package": "activerecord",
@@ -28212,22 +25524,8 @@
   {
     "package": "activerecord",
     "tsFile": "connection-handling.ts",
-    "rubyName": "remove_connection",
-    "call": "connection_handler",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
     "rubyName": "resolve_config_for_connection",
     "call": "configurations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "retrieve_connection",
-    "call": "connection_handler",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -28247,13 +25545,6 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
-    "rubyName": "arel_table",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
     "rubyName": "cached_find_by_statement",
     "call": "compute_if_absent",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -28268,9 +25559,9 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
-    "rubyName": "cached_find_by_statement",
-    "call": "prepared_statements",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "configurations=",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -28285,6 +25576,13 @@
     "rubyName": "connection_class_for_self",
     "call": "connection_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
+    "rubyName": "connection_class?",
+    "call": "connection_class",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -28319,13 +25617,6 @@
     "tsFile": "core.ts",
     "rubyName": "custom_inspect_method_defined?",
     "call": "owner",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
-    "rubyName": "find",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -28485,6 +25776,20 @@
   {
     "package": "activerecord",
     "tsFile": "core.ts",
+    "rubyName": "init_internals",
+    "call": "define_attribute_methods",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
+    "rubyName": "init_internals",
+    "call": "primary_key",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "core.ts",
     "rubyName": "inspect_with_attributes",
     "call": "filter_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -28494,13 +25799,6 @@
     "tsFile": "core.ts",
     "rubyName": "inspect_with_attributes",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "core.ts",
-    "rubyName": "predicate_builder",
-    "call": "arel_table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -28549,28 +25847,7 @@
     "package": "activerecord",
     "tsFile": "counter-cache.ts",
     "rubyName": "destroy_row",
-    "call": "destroyed_by_association",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "destroy_row",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "destroy_row",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "destroy_row",
-    "call": "reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -28606,13 +25883,6 @@
     "tsFile": "counter-cache.ts",
     "rubyName": "reset_counters",
     "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "counter-cache.ts",
-    "rubyName": "reset_counters",
-    "call": "id",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -28725,13 +25995,6 @@
     "tsFile": "database-configurations.ts",
     "rubyName": "build_configs",
     "call": "configurations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "database-configurations.ts",
-    "rubyName": "build_configs",
-    "call": "default_env",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -28905,29 +26168,8 @@
   {
     "package": "activerecord",
     "tsFile": "database-configurations.ts",
-    "rubyName": "primary?",
-    "call": "default_env",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "database-configurations.ts",
     "rubyName": "resolve",
     "call": "build_db_config_from_raw_config",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "database-configurations.ts",
-    "rubyName": "resolve",
-    "call": "default_env",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "database-configurations.ts",
-    "rubyName": "resolve_symbol_connection",
-    "call": "default_env",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -29004,13 +26246,6 @@
     "package": "activerecord",
     "tsFile": "database-configurations/database-config.ts",
     "rubyName": "adapter_class",
-    "call": "adapter",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "database-configurations/database-config.ts",
-    "rubyName": "adapter_class",
     "call": "resolve",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -29023,10 +26258,10 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "database-configurations/database-config.ts",
-    "rubyName": "validate!",
-    "call": "adapter",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "tsFile": "database-configurations/hash-config.ts",
+    "rubyName": "database_tasks?",
+    "call": "fetch",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -29195,6 +26430,20 @@
     "rubyName": "configure",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption.ts",
+    "rubyName": "context",
+    "call": "default_context",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption.ts",
+    "rubyName": "current_custom_context",
+    "call": "last",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -29592,13 +26841,6 @@
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "encrypt_attribute",
-    "call": "decorate_attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "encrypt_attribute",
     "call": "default",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -29661,9 +26903,30 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "encrypts",
+    "call": "new",
+    "reason": "encrypt_attribute's `EncryptedAttributeType.new` is emitted from the shared registerEncryptedType primitive (immediate direct-set / durable decorator) after encrypts routes through encryptAttribute - same construction, different TS method."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "global_previous_schemes_for",
     "call": "filter_map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "has_encrypted_attributes?",
+    "call": "encrypted_attributes",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "has_encrypted_attributes?",
+    "call": "present?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -29697,6 +26960,13 @@
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "preserve_original_encrypted",
+    "call": "encrypts",
+    "reason": "Rails' bare `encrypts original_attribute_name` is realized via `encryptAttribute(originalName, {}, buildScheme({}))` so the original_<name> scheme reuses buildScheme's legacy-encryptor shim + defaultEncryptor fallback; the declaration still happens, just not through the public `encrypts` entry."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/encryptable-record.ts",
+    "rubyName": "preserve_original_encrypted",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -29710,13 +26980,6 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "preserve_original_encrypted",
-    "call": "encrypts",
-    "reason": "Rails' bare `encrypts original_attribute_name` is realized via `encryptAttribute(originalName, {}, buildScheme({}))` so the original_<name> scheme reuses buildScheme's legacy-encryptor shim + defaultEncryptor fallback; the declaration still happens, just not through the public `encrypts` entry."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "source_attribute_from_preserved_attribute",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -29726,13 +26989,6 @@
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "validate_column_size",
     "call": "columns_hash",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "validate_column_size",
-    "call": "limit",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -29766,23 +27022,16 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encrypted-attribute-type.ts",
-    "rubyName": "decrypt_as_text",
-    "call": "encryptor",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "decryption_options",
+    "call": "compact",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/encrypted-attribute-type.ts",
-    "rubyName": "encrypt_as_text",
-    "call": "encryptor",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encrypted-attribute-type.ts",
-    "rubyName": "encrypted?",
-    "call": "encryptor",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "encryption_options",
+    "call": "compact",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -29850,13 +27099,6 @@
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptor.ts",
-    "rubyName": "default_key_provider",
-    "call": "key_provider",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptor.ts",
     "rubyName": "force_encoding_if_needed",
     "call": "encode",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -29908,13 +27150,6 @@
     "tsFile": "encryption/extended-deterministic-queries.ts",
     "rubyName": "install_support",
     "call": "include",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/extended-deterministic-queries.ts",
-    "rubyName": "process",
-    "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -30033,13 +27268,6 @@
     "package": "activerecord",
     "tsFile": "encryption/extended-deterministic-queries.ts",
     "rubyName": "scope_for_create",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/extended-deterministic-queries.ts",
-    "rubyName": "scope_for_create",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -30091,6 +27319,20 @@
     "rubyName": "generate_random_hex_key",
     "call": "unpack",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/key-provider.ts",
+    "rubyName": "encryption_key",
+    "call": "id",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "encryption/key-provider.ts",
+    "rubyName": "encryption_key",
+    "call": "last",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -30174,13 +27416,6 @@
     "tsFile": "encryption/properties.ts",
     "rubyName": "validate_value_type",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/scheme.ts",
-    "rubyName": "default_key_provider",
-    "call": "key_provider",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -30362,13 +27597,6 @@
     "package": "activerecord",
     "tsFile": "enum.ts",
     "rubyName": "define_enum_methods",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "enum.ts",
-    "rubyName": "define_enum_methods",
     "call": "not",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -30451,6 +27679,20 @@
   },
   {
     "package": "activerecord",
+    "tsFile": "errors.ts",
+    "rubyName": "set_query",
+    "call": "call",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "errors.ts",
+    "rubyName": "set_query",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
     "tsFile": "explain-subscriber.ts",
     "rubyName": "ignore_payload?",
     "call": "include?",
@@ -30528,24 +27770,10 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "explain.ts",
-    "rubyName": "render_bind",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "inheritance.ts",
     "rubyName": "base_class?",
     "call": "base_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "compute_type",
-    "call": "new",
-    "reason": "Equivalent (different path): Rails' compute_type constructs NameError.new on an unresolved constant; #4311 dropped the redundant inline `throw new SubclassNotFound` subclass check (that constraint lives in stiClassFor/find_sti_class), so computeType now delegates the NameError construction to resolveComputedType. Pre-existing flag surfaced post-#4311."
   },
   {
     "package": "activerecord",
@@ -30560,6 +27788,13 @@
     "rubyName": "compute_type",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "inheritance.ts",
+    "rubyName": "compute_type",
+    "call": "new",
+    "reason": "Equivalent (different path): Rails' compute_type constructs NameError.new on an unresolved constant; #4311 dropped the redundant inline `throw new SubclassNotFound` subclass check (that constraint lives in stiClassFor/find_sti_class), so computeType now delegates the NameError construction to resolveComputedType. Pre-existing flag surfaced post-#4311."
   },
   {
     "package": "activerecord",
@@ -30669,20 +27904,6 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
-    "rubyName": "polymorphic_class_for",
-    "call": "store_full_class_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "polymorphic_name",
-    "call": "store_full_class_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
     "rubyName": "set_base_class",
     "call": "abstract_class?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -30711,34 +27932,6 @@
   {
     "package": "activerecord",
     "tsFile": "inheritance.ts",
-    "rubyName": "sti_class_for",
-    "call": "store_full_class_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "sti_class_for",
-    "call": "store_full_sti_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "sti_name",
-    "call": "store_full_class_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "sti_name",
-    "call": "store_full_sti_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
     "rubyName": "subclass_from_attributes",
     "call": "inheritance_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -30755,13 +27948,6 @@
     "tsFile": "inheritance.ts",
     "rubyName": "type_condition",
     "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "inheritance.ts",
-    "rubyName": "type_condition",
-    "call": "predicate_builder",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -30781,20 +27967,6 @@
   {
     "package": "activerecord",
     "tsFile": "insert-all.ts",
-    "rubyName": "ensure_valid_options_for_connection!",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "execute",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
     "rubyName": "execute",
     "call": "many?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -30802,43 +27974,8 @@
   {
     "package": "activerecord",
     "tsFile": "insert-all.ts",
-    "rubyName": "execute",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "find_unique_index_for",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "find_unique_index_for",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
     "rubyName": "find_unique_index_for",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "find_unique_index_for",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "find_unique_index_for",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -30860,13 +27997,6 @@
     "tsFile": "insert-all.ts",
     "rubyName": "has_attribute_aliases?",
     "call": "attribute_alias?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "has_attribute_aliases?",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -30895,27 +28025,6 @@
     "tsFile": "insert-all.ts",
     "rubyName": "initialize",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "initialize",
-    "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "initialize",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "initialize",
-    "call": "record_timestamps",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -30957,13 +28066,6 @@
     "package": "activerecord",
     "tsFile": "insert-all.ts",
     "rubyName": "primary_keys",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "primary_keys",
     "call": "schema_cache",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -30977,16 +28079,9 @@
   {
     "package": "activerecord",
     "tsFile": "insert-all.ts",
-    "rubyName": "readonly_columns",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "readonly_columns",
-    "call": "readonly_attributes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "resolve_attribute_alias",
+    "call": "attribute_alias",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -31013,21 +28108,7 @@
     "package": "activerecord",
     "tsFile": "insert-all.ts",
     "rubyName": "resolve_sti",
-    "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "resolve_sti",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "resolve_sti",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31068,27 +28149,6 @@
   {
     "package": "activerecord",
     "tsFile": "insert-all.ts",
-    "rubyName": "to_sql",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "unique_indexes",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
-    "rubyName": "unique_indexes",
-    "call": "schema_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "insert-all.ts",
     "rubyName": "unique_indexes",
     "call": "select",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -31105,13 +28165,6 @@
     "tsFile": "integration.ts",
     "rubyName": "cache_key",
     "call": "cache_version",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "integration.ts",
-    "rubyName": "cache_key",
-    "call": "id",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31144,20 +28197,6 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "integration.ts",
-    "rubyName": "to_param",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "count",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "internal-metadata.ts",
     "rubyName": "count",
     "call": "first",
@@ -31180,20 +28219,6 @@
   {
     "package": "activerecord",
     "tsFile": "internal-metadata.ts",
-    "rubyName": "create_entry",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "create_entry",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
     "rubyName": "create_table",
     "call": "string",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -31203,13 +28228,6 @@
     "tsFile": "internal-metadata.ts",
     "rubyName": "create_table",
     "call": "table_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "create_table",
-    "call": "table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31244,13 +28262,6 @@
     "package": "activerecord",
     "tsFile": "internal-metadata.ts",
     "rubyName": "delete_all_entries",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "delete_all_entries",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -31265,28 +28276,7 @@
     "package": "activerecord",
     "tsFile": "internal-metadata.ts",
     "rubyName": "drop_table",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "drop_table",
     "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "initialize",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "select_entry",
-    "call": "arel_table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31294,13 +28284,6 @@
     "tsFile": "internal-metadata.ts",
     "rubyName": "select_entry",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "select_entry",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31335,56 +28318,7 @@
     "package": "activerecord",
     "tsFile": "internal-metadata.ts",
     "rubyName": "update_entry",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "update_entry",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "internal-metadata.ts",
-    "rubyName": "update_entry",
     "call": "update",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "_clear_locking_column",
-    "call": "locking_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "_create_record",
-    "call": "locking_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "_create_record",
-    "call": "locking_enabled?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "_query_constraints_hash",
-    "call": "locking_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "_query_constraints_hash",
-    "call": "locking_enabled?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31397,50 +28331,8 @@
   {
     "package": "activerecord",
     "tsFile": "locking/optimistic.ts",
-    "rubyName": "_touch_row",
-    "call": "locking_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "_touch_row",
-    "call": "locking_enabled?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
     "rubyName": "_update_row",
     "call": "frozen?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "_update_row",
-    "call": "locking_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "_update_row",
-    "call": "locking_enabled?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "destroy_row",
-    "call": "locking_enabled?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "locking/optimistic.ts",
-    "rubyName": "hook_attribute_type",
-    "call": "lock_optimistically",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31470,6 +28362,20 @@
     "rubyName": "increment!",
     "call": "locking_enabled?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "locking/optimistic.ts",
+    "rubyName": "locking_column=",
+    "call": "reload_schema_from_cache",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "locking/optimistic.ts",
+    "rubyName": "locking_column=",
+    "call": "to_s",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -31516,13 +28422,6 @@
   {
     "package": "activerecord",
     "tsFile": "log-subscriber.ts",
-    "rubyName": "log_query_source",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "log-subscriber.ts",
     "rubyName": "query_source_location",
     "call": "clean_frame",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -31544,22 +28443,8 @@
   {
     "package": "activerecord",
     "tsFile": "log-subscriber.ts",
-    "rubyName": "render_bind",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "log-subscriber.ts",
     "rubyName": "sql",
     "call": "any?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "log-subscriber.ts",
-    "rubyName": "sql",
-    "call": "colorize_logging",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31628,27 +28513,6 @@
   {
     "package": "activerecord",
     "tsFile": "middleware/database-selector/resolver.ts",
-    "rubyName": "time_since_last_write_ok?",
-    "call": "context",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "middleware/database-selector/resolver.ts",
-    "rubyName": "update_context",
-    "call": "context",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "middleware/database-selector/resolver.ts",
-    "rubyName": "write_to_primary",
-    "call": "context",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "middleware/database-selector/resolver.ts",
     "rubyName": "write_to_primary",
     "call": "instrument",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -31679,13 +28543,6 @@
     "tsFile": "middleware/shard-selector.ts",
     "rubyName": "set_shard",
     "call": "fetch",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "announce",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31754,13 +28611,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "command_recorder",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "copy",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -31804,21 +28654,7 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "copy",
-    "call": "scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "copy",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "copy",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -31840,13 +28676,6 @@
     "tsFile": "migration.ts",
     "rubyName": "current_migration",
     "call": "detect",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "current_migration",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -32146,13 +28975,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "move",
-    "call": "version",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "needs_migration?",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -32230,13 +29052,6 @@
   {
     "package": "activerecord",
     "tsFile": "migration.ts",
-    "rubyName": "proper_table_name",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
     "rubyName": "protected_environment?",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -32253,13 +29068,6 @@
     "tsFile": "migration.ts",
     "rubyName": "ran?",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "ran?",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -32322,13 +29130,6 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "revert",
-    "call": "connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "revert",
     "call": "delegate",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -32343,8 +29144,22 @@
     "package": "activerecord",
     "tsFile": "migration.ts",
     "rubyName": "revert",
+    "call": "reverse",
+    "reason": "trails Migration#revert takes a single migration or block, not a splat of migration classes, so Rails' `migration_classes.reverse` has no array to reverse; the single-migration path (_run) covers it."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
+    "rubyName": "revert",
     "call": "run",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "migration.ts",
+    "rubyName": "reverting?",
+    "call": "connection",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -32400,13 +29215,6 @@
     "tsFile": "migration.ts",
     "rubyName": "run_without_lock",
     "call": "execute_migration_in_transaction",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "run_without_lock",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -32804,13 +29612,6 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
-    "rubyName": "_returning_columns_for_insert",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
     "rubyName": "attributes_builder",
     "call": "attribute_types",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -32827,13 +29628,6 @@
     "tsFile": "model-schema.ts",
     "rubyName": "attributes_builder",
     "call": "except",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "attributes_builder",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -32904,13 +29698,6 @@
     "tsFile": "model-schema.ts",
     "rubyName": "content_columns",
     "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "content_columns",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -33000,13 +29787,6 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
-    "rubyName": "quoted_table_name",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
     "rubyName": "reset_column_information",
     "call": "clear_cache!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -33084,13 +29864,6 @@
   {
     "package": "activerecord",
     "tsFile": "model-schema.ts",
-    "rubyName": "reset_table_name",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
     "rubyName": "sequence_name",
     "call": "base_class",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -33128,20 +29901,6 @@
     "tsFile": "model-schema.ts",
     "rubyName": "symbol_column_to_string",
     "call": "index_by",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "table_exists?",
-    "call": "schema_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "model-schema.ts",
-    "rubyName": "table_exists?",
-    "call": "table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -33337,13 +30096,6 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "assign_nested_attributes_for_one_to_one_association",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "assign_nested_attributes_for_one_to_one_association",
     "call": "nested_attributes_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -33414,13 +30166,6 @@
     "package": "activerecord",
     "tsFile": "nested-attributes.ts",
     "rubyName": "find_record_by_id",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "find_record_by_id",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -33429,13 +30174,6 @@
     "tsFile": "nested-attributes.ts",
     "rubyName": "has_destroy_flag?",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "nested-attributes.ts",
-    "rubyName": "raise_nested_attributes_record_not_found!",
-    "call": "id",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -33465,6 +30203,13 @@
     "rubyName": "no_touching",
     "call": "apply_to",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "no-touching.ts",
+    "rubyName": "no_touching?",
+    "call": "applied_to?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -33519,13 +30264,6 @@
     "package": "activerecord",
     "tsFile": "persistence.ts",
     "rubyName": "_delete_record",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "_delete_record",
     "call": "build_default_constraint",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -33567,29 +30305,8 @@
   {
     "package": "activerecord",
     "tsFile": "persistence.ts",
-    "rubyName": "_in_memory_query_constraints_hash",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "_insert_record",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
     "rubyName": "_insert_record",
     "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "_insert_record",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -33604,20 +30321,6 @@
     "tsFile": "persistence.ts",
     "rubyName": "_insert_record",
     "call": "with_cast_value",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "_raise_record_not_destroyed",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "_raise_record_not_destroyed",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -33658,13 +30361,6 @@
   {
     "package": "activerecord",
     "tsFile": "persistence.ts",
-    "rubyName": "apply_scoping?",
-    "call": "default_scopes?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
     "rubyName": "becomes",
     "call": "copy!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -33695,20 +30391,6 @@
     "tsFile": "persistence.ts",
     "rubyName": "build",
     "call": "collect",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "build_default_constraint",
-    "call": "default_scopes?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "composite_query_constraints_list",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -33756,13 +30438,6 @@
   {
     "package": "activerecord",
     "tsFile": "persistence.ts",
-    "rubyName": "increment!",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
     "rubyName": "instantiate",
     "call": "instantiate_instance_of",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -33786,13 +30461,6 @@
     "tsFile": "persistence.ts",
     "rubyName": "query_constraints_list",
     "call": "base_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "query_constraints_list",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -33835,13 +30503,6 @@
     "tsFile": "persistence.ts",
     "rubyName": "strict_loaded_associations",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "persistence.ts",
-    "rubyName": "strict_loaded_associations",
-    "call": "owner",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -34260,13 +30921,6 @@
   {
     "package": "activerecord",
     "tsFile": "reflection.ts",
-    "rubyName": "actual_source_reflection",
-    "call": "source_reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
     "rubyName": "add_aggregate_reflection",
     "call": "aggregate_reflections",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -34303,21 +30957,7 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "automatic_inverse_of",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "automatic_inverse_of",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "build_association",
-    "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -34331,35 +30971,7 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "check_eager_loadable!",
-    "call": "scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "check_eager_loadable!",
     "call": "squish",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "check_validity!",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "check_validity!",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "check_validity!",
-    "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -34374,20 +30986,6 @@
     "tsFile": "reflection.ts",
     "rubyName": "clear_association_scope_cache",
     "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "collect_join_reflections",
-    "call": "source_reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "collect_join_reflections",
-    "call": "through_reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -34422,13 +31020,6 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "derive_fk_query_constraints",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "derive_fk_query_constraints",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -34450,13 +31041,6 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "derive_foreign_key",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "derive_foreign_key",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -34465,27 +31049,6 @@
     "tsFile": "reflection.ts",
     "rubyName": "derive_join_table",
     "call": "derive_join_table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "derive_join_table",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "derive_join_table",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "has_scope?",
-    "call": "scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -34505,20 +31068,6 @@
   {
     "package": "activerecord",
     "tsFile": "reflection.ts",
-    "rubyName": "inverse_of",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "inverse_which_updates_counter_cache",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
     "rubyName": "join_scope",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -34527,21 +31076,7 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "join_scope",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "join_scope",
     "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "join_scope",
-    "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -34561,29 +31096,8 @@
   {
     "package": "activerecord",
     "tsFile": "reflection.ts",
-    "rubyName": "klass_join_scope",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
     "rubyName": "mapping",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "nested?",
-    "call": "source_reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "nested?",
-    "call": "through_reflection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -34652,20 +31166,6 @@
   {
     "package": "activerecord",
     "tsFile": "reflection.ts",
-    "rubyName": "scope_allows_automatic_inverse_of?",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "scope_allows_automatic_inverse_of?",
-    "call": "scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
     "rubyName": "scope_for",
     "call": "scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -34688,20 +31188,6 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "source_reflection_name",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "source_reflection_name",
-    "call": "through_reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "source_reflection_name",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -34716,20 +31202,6 @@
     "package": "activerecord",
     "tsFile": "reflection.ts",
     "rubyName": "strict_loading_violation_message",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "valid_inverse_reflection?",
-    "call": "foreign_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "reflection.ts",
-    "rubyName": "valid_inverse_reflection?",
     "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -34863,13 +31335,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "_substitute_values",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "_substitute_values",
     "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -34914,6 +31379,27 @@
     "rubyName": "aggregate_column",
     "call": "arel_column",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "alias_tracker",
+    "call": "connection_pool",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "alias_tracker",
+    "call": "create",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "alias_tracker",
+    "call": "model",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -35032,7 +31518,7 @@
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
+    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
   },
   {
     "package": "activerecord",
@@ -35046,7 +31532,7 @@
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
   },
   {
     "package": "activerecord",
@@ -35675,13 +32161,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "bind_attribute",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "bind_attribute",
     "call": "read_attribute",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -35990,6 +32469,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "build_from",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "build_from",
     "call": "as",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -36047,7 +32533,7 @@
     "tsFile": "relation.ts",
     "rubyName": "build_join_buckets",
     "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
+    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
   },
   {
     "package": "activerecord",
@@ -36061,7 +32547,7 @@
     "tsFile": "relation.ts",
     "rubyName": "build_join_buckets",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
   },
   {
     "package": "activerecord",
@@ -36124,14 +32610,14 @@
     "tsFile": "relation.ts",
     "rubyName": "build_join_dependencies",
     "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
+    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "build_join_dependencies",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
   },
   {
     "package": "activerecord",
@@ -36180,14 +32666,14 @@
     "tsFile": "relation.ts",
     "rubyName": "build_joins",
     "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
+    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "build_joins",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
   },
   {
     "package": "activerecord",
@@ -36328,6 +32814,13 @@
     "rubyName": "build_select",
     "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "build_subquery",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",
@@ -36545,6 +33038,13 @@
     "rubyName": "build_with",
     "call": "with_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "build_with_expression_from_value",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",
@@ -36872,6 +33372,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "compute_cache_version",
     "call": "build_subquery",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -36943,20 +33450,6 @@
     "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
     "call": "select_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "compute_cache_version",
-    "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "compute_cache_version",
-    "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -37130,13 +33623,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
-    "rubyName": "delete",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
     "rubyName": "delete_all",
     "call": "any?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -37147,6 +33633,13 @@
     "rubyName": "delete_all",
     "call": "apply_join_dependency",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "delete_all",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",
@@ -37188,13 +33681,6 @@
     "tsFile": "relation.ts",
     "rubyName": "delete_all",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete_all",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -37474,6 +33960,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "exec_main_query",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "exec_main_query",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -37567,6 +34060,13 @@
     "rubyName": "execute_grouped_calculation",
     "call": "alias_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "execute_grouped_calculation",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",
@@ -37831,6 +34331,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "execute_simple_calculation",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "execute_simple_calculation",
     "call": "build_count_subquery?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -37945,6 +34452,13 @@
     "rubyName": "exists?",
     "call": "apply_join_dependency",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "exists?",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",
@@ -38629,13 +35143,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "ids",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "ids",
     "call": "select_all",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -38659,6 +35166,13 @@
     "rubyName": "ids",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "in_batches",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",
@@ -38741,13 +35255,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "in_order_of",
-    "call": "order_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "in_order_of",
     "call": "order!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -38783,13 +35290,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "include?",
-    "call": "composite_primary_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "include?",
     "call": "having_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -38797,28 +35297,7 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "include?",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "include?",
-    "call": "loaded?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "include?",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "include?",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -38939,6 +35418,20 @@
     "rubyName": "many?",
     "call": "loaded?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "none?",
+    "call": "empty?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "none?",
+    "call": "present?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -39133,6 +35626,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "pluck",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "pluck",
     "call": "arel_columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -39212,6 +35712,48 @@
     "rubyName": "pluck",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "preload_associations",
+    "call": "call",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "preload_associations",
+    "call": "each",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "preload_associations",
+    "call": "includes_values",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "preload_associations",
+    "call": "new",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "preload_associations",
+    "call": "preload_values",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "preload_associations",
+    "call": "strict_loading_value",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -39365,13 +35907,6 @@
     "tsFile": "relation.ts",
     "rubyName": "references_eager_loaded_tables?",
     "call": "references_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "references_eager_loaded_tables?",
-    "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -39833,6 +36368,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "to_sql",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "to_sql",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -40008,6 +36550,13 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "update_all",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation.ts",
+    "rubyName": "update_all",
     "call": "arel_columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -40058,20 +36607,6 @@
     "tsFile": "relation.ts",
     "rubyName": "update_all",
     "call": "key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_all",
-    "call": "locking_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_all",
-    "call": "locking_enabled?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -40589,6 +37124,13 @@
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
     "rubyName": "execute_grouped_calculation",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/calculations.ts",
+    "rubyName": "execute_grouped_calculation",
     "call": "arel_columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -40848,6 +37390,13 @@
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
     "rubyName": "execute_simple_calculation",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/calculations.ts",
+    "rubyName": "execute_simple_calculation",
     "call": "build_count_subquery?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -41100,13 +37649,6 @@
     "package": "activerecord",
     "tsFile": "relation/calculations.ts",
     "rubyName": "type_cast_pluck_values",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "type_cast_pluck_values",
     "call": "default_value",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -41205,13 +37747,6 @@
     "package": "activerecord",
     "tsFile": "relation/delegation.ts",
     "rubyName": "generate_method",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/delegation.ts",
-    "rubyName": "generate_method",
     "call": "scoping",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -41295,13 +37830,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
-    "rubyName": "_order_columns",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
     "rubyName": "apply_join_dependency",
     "call": "concat",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -41346,7 +37874,7 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "apply_join_dependency",
     "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
+    "reason": "Divergent port: trails applyJoinDependency uses the preloader path (finder-methods.ts) and reads neither joins_values nor left_outer_joins_values. Genuine divergence."
   },
   {
     "package": "activerecord",
@@ -41360,7 +37888,7 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "apply_join_dependency",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Divergent port: trails applyJoinDependency uses the preloader path (finder-methods.ts) and reads neither joins_values nor left_outer_joins_values. Genuine divergence."
   },
   {
     "package": "activerecord",
@@ -41429,13 +37957,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "construct_relation_for_exists",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "construct_relation_for_exists",
     "call": "where!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -41492,13 +38013,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_one",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_one",
     "call": "squish",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -41528,20 +38042,6 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_some",
     "call": "present?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some",
-    "call": "select_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -41584,20 +38084,6 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_some_ordered",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some_ordered",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_some_ordered",
-    "call": "select_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -41688,13 +38174,6 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "find_with_ids",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "find_with_ids",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -41723,15 +38202,15 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "ordered_relation",
-    "call": "primary_key",
+    "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
-    "rubyName": "ordered_relation",
-    "call": "table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "raise_record_not_found_exception!",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",
@@ -41778,13 +38257,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
-    "rubyName": "merge",
-    "call": "relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
     "rubyName": "merge_clauses",
     "call": "from_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -41809,13 +38281,6 @@
     "rubyName": "merge_joins",
     "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_joins",
-    "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
   },
   {
     "package": "activerecord",
@@ -41906,7 +38371,7 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_outer_joins",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Body reads the private _leftOuterJoinsValues field, not the public leftOuterJoinsValues accessor; converging requires mergeOuterJoins to read the public accessor (separate source change)."
   },
   {
     "package": "activerecord",
@@ -41935,6 +38400,69 @@
     "rubyName": "merge_outer_joins",
     "call": "relation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "empty?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "find",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "includes_values",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "includes!",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "model",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "preload_values",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "preload!",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "reflect_on_all_associations",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_preloads",
+    "call": "relation",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -41996,13 +38524,6 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "replace_from_clause?",
-    "call": "base_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "replace_from_clause?",
     "call": "from_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -42011,13 +38532,6 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "replace_from_clause?",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "replace_from_clause?",
-    "call": "relation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -42038,13 +38552,6 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "build",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "build",
     "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -42053,13 +38560,6 @@
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "build",
     "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder.ts",
-    "rubyName": "build_bind_attribute",
-    "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -42247,6 +38747,20 @@
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
+    "rubyName": "handler_for",
+    "call": "detect",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder.ts",
+    "rubyName": "handler_for",
+    "call": "last",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder.ts",
     "rubyName": "initialize",
     "call": "register_handler",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -42311,21 +38825,7 @@
     "package": "activerecord",
     "tsFile": "relation/predicate-builder/array-handler.ts",
     "rubyName": "call",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/array-handler.ts",
-    "rubyName": "call",
     "call": "or",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/array-handler.ts",
-    "rubyName": "call",
-    "call": "predicate_builder",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -42333,13 +38833,6 @@
     "tsFile": "relation/predicate-builder/association-query-value.ts",
     "rubyName": "polymorphic_clause?",
     "call": "has_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/association-query-value.ts",
-    "rubyName": "queries",
-    "call": "associated_table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -42354,13 +38847,6 @@
     "tsFile": "relation/predicate-builder/association-query-value.ts",
     "rubyName": "select_clause?",
     "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/association-query-value.ts",
-    "rubyName": "select_clause?",
-    "call": "select_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -42380,16 +38866,9 @@
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
-    "rubyName": "primary_key",
-    "call": "associated_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
-    "rubyName": "queries",
-    "call": "associated_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "klass",
+    "call": "model",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -42403,20 +38882,6 @@
     "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
     "rubyName": "queries",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
-    "rubyName": "queries",
-    "call": "values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
-    "rubyName": "type_to_ids_mapping",
-    "call": "values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -42439,6 +38904,13 @@
     "rubyName": "call",
     "call": "predicate_builder",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/predicate-builder/relation-handler.ts",
+    "rubyName": "call",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",
@@ -42506,9 +38978,9 @@
   {
     "package": "activerecord",
     "tsFile": "relation/query-attribute.ts",
-    "rubyName": "with_cast_value",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "unboundable?",
+    "call": "serializable?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -42647,13 +39119,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "arel_column_with_table",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "arel_column_with_table",
     "call": "quote_table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -42683,7 +39148,7 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "associated",
     "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
+    "reason": "Divergent port: trails where.associated does not guard on existing joins_values/left_outer_joins_values before joining (Rails query_methods.rb:91), so it reads neither accessor. Genuine behavioral divergence, not a read-crediting gap."
   },
   {
     "package": "activerecord",
@@ -42697,7 +39162,7 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "associated",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Divergent port: trails where.associated does not guard on existing joins_values/left_outer_joins_values before joining (Rails query_methods.rb:91), so it reads neither accessor. Genuine behavioral divergence, not a read-crediting gap."
   },
   {
     "package": "activerecord",
@@ -42808,6 +39273,13 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_from",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_from",
     "call": "from_clause",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -42843,13 +39315,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_join_buckets",
-    "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_join_buckets",
     "call": "last",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -42858,7 +39323,7 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_join_buckets",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Body reads the private _leftOuterJoinsValues field, not the public leftOuterJoinsValues accessor whose read the gate credits; the joins_values sibling already converged. Converging requires the join builder to read the public accessor (separate source change)."
   },
   {
     "package": "activerecord",
@@ -42899,15 +39364,8 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_join_dependencies",
-    "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_join_dependencies",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Body reads the private _leftOuterJoinsValues field, not the public leftOuterJoinsValues accessor whose read the gate credits; the joins_values sibling already converged. Converging requires the join builder to read the public accessor (separate source change)."
   },
   {
     "package": "activerecord",
@@ -42941,15 +39399,8 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_joins",
-    "call": "joins_values",
-    "reason": "Split join storage: the join-building paths read the named/raw join fields (_namedInnerJoins/_joinValues) directly; the joins_values accessor concatenates them and erases the named-vs-raw distinction these builders require. See joinsValues doc in relation.ts. Flag appeared once joins_values= writer completed the accessor."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_joins",
     "call": "left_outer_joins_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Body reads the private _leftOuterJoinsValues field, not the public leftOuterJoinsValues accessor whose read the gate credits; the joins_values sibling already converged. Converging requires the join builder to read the public accessor (separate source change)."
   },
   {
     "package": "activerecord",
@@ -43066,9 +39517,9 @@
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_select",
-    "call": "table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "build_subquery",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
   {
     "package": "activerecord",
@@ -43090,13 +39541,6 @@
     "rubyName": "build_subquery",
     "call": "optimizer_hints_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_where_clause",
-    "call": "map",
-    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` — no `map` over keys applies."
   },
   {
     "package": "activerecord",
@@ -43130,6 +39574,13 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
+    "call": "map",
+    "reason": "Rails' `build_where_clause` `map` is `key.map { |k| attribute_aliases[k] }` inside `transform_keys` for composite ARRAY keys; JS object keys can't be arrays, so trails resolves single-key aliases via `aliases[key] ?? key` and composite keys via `PredicateBuilder#buildComposite` — no `map` over keys applies."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_where_clause",
     "call": "match?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -43138,13 +39589,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_where_clause",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_where_clause",
-    "call": "predicate_builder",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -43207,6 +39651,13 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_with_expression_from_value",
+    "call": "arel",
+    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/query-methods.ts",
+    "rubyName": "build_with_expression_from_value",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -43229,13 +39680,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_with_join_node",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_with_join_node",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -43278,13 +39722,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "column_references",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "column_references",
-    "call": "relation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -43348,13 +39785,6 @@
     "tsFile": "relation/query-methods.ts",
     "rubyName": "does_not_support_reverse?",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "lookup_table_klass_from_join_dependencies",
-    "call": "table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -43494,13 +39924,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "resolve_arel_attributes",
-    "call": "predicate_builder",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "resolve_arel_attributes",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -43515,13 +39938,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "reverse_sql_order",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "reverse_sql_order",
     "call": "table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -43529,13 +39945,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "sanitize_order_arguments",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "scope_association_reflection",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -43675,20 +40084,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/where-clause.ts",
-    "rubyName": "contradiction?",
-    "call": "predicates",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/where-clause.ts",
-    "rubyName": "contradiction?",
-    "call": "unboundable?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/where-clause.ts",
     "rubyName": "extract_attributes",
     "call": "each_attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -43704,21 +40099,7 @@
     "package": "activerecord",
     "tsFile": "relation/where-clause.ts",
     "rubyName": "invert",
-    "call": "predicates",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/where-clause.ts",
-    "rubyName": "invert",
     "call": "size",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/where-clause.ts",
-    "rubyName": "merge",
-    "call": "predicates",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -43730,23 +40111,9 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "relation/where-clause.ts",
-    "rubyName": "or",
-    "call": "predicates",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "result.ts",
     "rubyName": "cast_values",
     "call": "column_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "result.ts",
-    "rubyName": "cast_values",
-    "call": "columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -43768,13 +40135,6 @@
     "tsFile": "result.ts",
     "rubyName": "cast_values",
     "call": "one?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "result.ts",
-    "rubyName": "cast_values",
-    "call": "rows",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -44081,13 +40441,6 @@
   {
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
-    "rubyName": "check_parts",
-    "call": "validate?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
     "rubyName": "dump",
     "call": "trailer",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -44110,20 +40463,6 @@
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "foreign_keys",
-    "call": "column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "foreign_keys",
-    "call": "deferrable",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "foreign_keys",
     "call": "foreign_key_column_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -44132,20 +40471,6 @@
     "tsFile": "schema-dumper.ts",
     "rubyName": "foreign_keys",
     "call": "map",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "foreign_keys",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "foreign_keys",
-    "call": "validate?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -44173,20 +40498,6 @@
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "index_parts",
-    "call": "columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "index_parts",
-    "call": "comment",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "index_parts",
     "call": "default_index_type?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -44194,28 +40505,7 @@
     "package": "activerecord",
     "tsFile": "schema-dumper.ts",
     "rubyName": "index_parts",
-    "call": "include",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "index_parts",
     "call": "present?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "index_parts",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-dumper.ts",
-    "rubyName": "index_parts",
-    "call": "where",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -44446,13 +40736,6 @@
     "package": "activerecord",
     "tsFile": "schema-migration.ts",
     "rubyName": "count",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "count",
     "call": "first",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -44488,28 +40771,7 @@
     "package": "activerecord",
     "tsFile": "schema-migration.ts",
     "rubyName": "create_table",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "create_table",
     "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "create_version",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "create_version",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -44537,13 +40799,6 @@
     "package": "activerecord",
     "tsFile": "schema-migration.ts",
     "rubyName": "delete_version",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "delete_version",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -44551,13 +40806,6 @@
     "package": "activerecord",
     "tsFile": "schema-migration.ts",
     "rubyName": "delete_version",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "delete_version",
     "call": "with_connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -44565,21 +40813,7 @@
     "package": "activerecord",
     "tsFile": "schema-migration.ts",
     "rubyName": "drop_table",
-    "call": "table_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "drop_table",
     "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "initialize",
-    "call": "table_name",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -44601,20 +40835,6 @@
     "tsFile": "schema-migration.ts",
     "rubyName": "table_exists?",
     "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "versions",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "schema-migration.ts",
-    "rubyName": "versions",
-    "call": "primary_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -44689,10 +40909,10 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "scoping/default.ts",
-    "rubyName": "build_default_scope",
-    "call": "abstract_class?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "tsFile": "scoping.ts",
+    "rubyName": "scope_attributes?",
+    "call": "any?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -44746,13 +40966,6 @@
   {
     "package": "activerecord",
     "tsFile": "scoping/named.ts",
-    "rubyName": "default_extensions",
-    "call": "extensions",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping/named.ts",
     "rubyName": "scope",
     "call": "define_method",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -44776,13 +40989,6 @@
     "tsFile": "scoping/named.ts",
     "rubyName": "scope",
     "call": "method_defined_within?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "scoping/named.ts",
-    "rubyName": "scope_for_association",
-    "call": "current_scope",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -44850,20 +41056,6 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "serialization.ts",
-    "rubyName": "serializable_hash",
-    "call": "inheritance_column",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "signed-id.ts",
-    "rubyName": "combine_signed_id_purposes",
-    "call": "base_class",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "signed-id.ts",
     "rubyName": "combine_signed_id_purposes",
     "call": "compact_blank",
@@ -44886,13 +41078,6 @@
   {
     "package": "activerecord",
     "tsFile": "signed-id.ts",
-    "rubyName": "find_signed",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "signed-id.ts",
     "rubyName": "find_signed!",
     "call": "combine_signed_id_purposes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -44902,13 +41087,6 @@
     "tsFile": "signed-id.ts",
     "rubyName": "signed_id",
     "call": "combine_signed_id_purposes",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "signed-id.ts",
-    "rubyName": "signed_id",
-    "call": "id",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -44937,13 +41115,6 @@
     "tsFile": "statement-cache.ts",
     "rubyName": "create",
     "call": "call",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "statement-cache.ts",
-    "rubyName": "create",
-    "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -45049,20 +41220,6 @@
     "tsFile": "store.ts",
     "rubyName": "stored_attributes",
     "call": "merge!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "table-metadata.ts",
-    "rubyName": "associated_table",
-    "call": "arel_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "table-metadata.ts",
-    "rubyName": "associated_table",
-    "call": "klass",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -45306,13 +41463,6 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "dump_schema_cache",
-    "call": "schema_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
     "rubyName": "each_current_configuration",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -45350,13 +41500,6 @@
     "tsFile": "tasks/database-tasks.ts",
     "rubyName": "for_each",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "for_each",
-    "call": "env",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -45454,27 +41597,6 @@
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
     "rubyName": "migrate",
-    "call": "schema_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "migrate",
-    "call": "scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "migrate",
-    "call": "version",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "migrate",
     "call": "write",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -45530,9 +41652,9 @@
   {
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "migration_connection_pool",
-    "call": "connection_pool",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "migration_connection",
+    "call": "lease_connection",
+    "reason": "migrationConnection (sync) routes through `leaseConnectionSync`; Rails-named `leaseConnection` is async in trails (converge-connection-pool-checkout-lease-async) and cannot be awaited from this sync accessor."
   },
   {
     "package": "activerecord",
@@ -45657,13 +41779,6 @@
     "package": "activerecord",
     "tsFile": "tasks/database-tasks.ts",
     "rubyName": "structure_dump",
-    "call": "adapter",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "structure_dump",
     "call": "database_adapter_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -45679,13 +41794,6 @@
     "tsFile": "tasks/database-tasks.ts",
     "rubyName": "structure_dump",
     "call": "structure_dump_flags_for",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "structure_load",
-    "call": "adapter",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -45771,6 +41879,13 @@
     "rubyName": "charset",
     "call": "connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/mysql-database-tasks.ts",
+    "rubyName": "collation",
+    "call": "connection",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -45918,6 +42033,13 @@
     "rubyName": "charset",
     "call": "connection",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "tasks/postgresql-database-tasks.ts",
+    "rubyName": "collation",
+    "call": "connection",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -46196,13 +42318,6 @@
     "package": "activerecord",
     "tsFile": "test-databases.ts",
     "rubyName": "create_and_load_schema",
-    "call": "configurations",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "test-databases.ts",
-    "rubyName": "create_and_load_schema",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -46224,13 +42339,6 @@
     "package": "activerecord",
     "tsFile": "testing/query-assertions.ts",
     "rubyName": "assert_queries_count",
-    "call": "log",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "testing/query-assertions.ts",
-    "rubyName": "assert_queries_count",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -46246,13 +42354,6 @@
     "tsFile": "testing/query-assertions.ts",
     "rubyName": "assert_queries_match",
     "call": "lease_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "testing/query-assertions.ts",
-    "rubyName": "assert_queries_match",
-    "call": "log",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -46281,13 +42382,6 @@
     "tsFile": "timestamp.ts",
     "rubyName": "_create_record",
     "call": "each",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "timestamp.ts",
-    "rubyName": "_create_record",
-    "call": "record_timestamps",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -46356,20 +42450,6 @@
   {
     "package": "activerecord",
     "tsFile": "token-for.ts",
-    "rubyName": "full_purpose",
-    "call": "expires_in",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "token-for.ts",
-    "rubyName": "generate_token",
-    "call": "expires_in",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "token-for.ts",
     "rubyName": "generate_token_for",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -46407,13 +42487,6 @@
     "tsFile": "token-for.ts",
     "rubyName": "payload_for",
     "call": "as_json",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "token-for.ts",
-    "rubyName": "payload_for",
-    "call": "id",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -46462,13 +42535,6 @@
     "package": "activerecord",
     "tsFile": "touch-later.ts",
     "rubyName": "touch_later",
-    "call": "changes_to_save",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "touch-later.ts",
-    "rubyName": "touch_later",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -46477,13 +42543,6 @@
     "tsFile": "touch-later.ts",
     "rubyName": "touch_later",
     "call": "empty?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "touch-later.ts",
-    "rubyName": "touch_later",
-    "call": "foreign_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -46664,13 +42723,6 @@
   {
     "package": "activerecord",
     "tsFile": "transactions.ts",
-    "rubyName": "remember_transaction_record_state",
-    "call": "id",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "transactions.ts",
     "rubyName": "restore_transaction_record_state",
     "call": "composite_primary_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -46817,6 +42869,20 @@
   },
   {
     "package": "activerecord",
+    "tsFile": "type.ts",
+    "rubyName": "adapter_name_from",
+    "call": "adapter",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "type.ts",
+    "rubyName": "adapter_name_from",
+    "call": "connection_db_config",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
     "tsFile": "type/adapter-specific-registry.ts",
     "rubyName": "find_registration",
     "call": "select",
@@ -46923,9 +42989,9 @@
   {
     "package": "activerecord",
     "tsFile": "validations.ts",
-    "rubyName": "initialize",
-    "call": "i18n_scope",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "custom_validation_context?",
+    "call": "exclude?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -47023,20 +43089,6 @@
     "tsFile": "validations/uniqueness.ts",
     "rubyName": "validate_each",
     "call": "not",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "validations/uniqueness.ts",
-    "rubyName": "validate_each",
-    "call": "primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "validations/uniqueness.ts",
-    "rubyName": "validate_each",
-    "call": "where",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -47252,20 +43304,6 @@
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
-    "rubyName": "_instrument",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache.ts",
-    "rubyName": "_instrument",
-    "call": "silence?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache.ts",
     "rubyName": "delete_multi_entries",
     "call": "count",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -47296,20 +43334,6 @@
     "tsFile": "cache.ts",
     "rubyName": "fetch_multi",
     "call": "fetch",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache.ts",
-    "rubyName": "handle_expired_entry",
-    "call": "expires_at",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache.ts",
-    "rubyName": "handle_invalid_expires_in",
-    "call": "logger",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -47350,6 +43374,34 @@
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
+    "rubyName": "namespace_key",
+    "call": "call",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache.ts",
+    "rubyName": "namespace_key",
+    "call": "key?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache.ts",
+    "rubyName": "normalize_options",
+    "call": "each",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache.ts",
+    "rubyName": "normalize_options",
+    "call": "key?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "cache.ts",
     "rubyName": "normalize_version",
     "call": "try",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -47384,37 +43436,9 @@
   },
   {
     "package": "activesupport",
-    "tsFile": "cache/coder.ts",
-    "rubyName": "dump_compressed",
-    "call": "expires_at",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/coder.ts",
-    "rubyName": "dump_compressed",
-    "call": "version",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
     "tsFile": "cache/entry.ts",
     "rubyName": "compressed",
     "call": "compressed?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/entry.ts",
-    "rubyName": "compressed",
-    "call": "expires_at",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/entry.ts",
-    "rubyName": "compressed",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -47428,21 +43452,7 @@
     "package": "activesupport",
     "tsFile": "cache/entry.ts",
     "rubyName": "pack",
-    "call": "expires_at",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/entry.ts",
-    "rubyName": "pack",
     "call": "last",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/entry.ts",
-    "rubyName": "pack",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -47554,21 +43564,7 @@
     "package": "activesupport",
     "tsFile": "cache/file-store.ts",
     "rubyName": "modify_value",
-    "call": "expires_at",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/file-store.ts",
-    "rubyName": "modify_value",
     "call": "merged_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/file-store.ts",
-    "rubyName": "modify_value",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -47638,21 +43634,7 @@
     "package": "activesupport",
     "tsFile": "cache/memory-store.ts",
     "rubyName": "modify_value",
-    "call": "expires_at",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/memory-store.ts",
-    "rubyName": "modify_value",
     "call": "synchronize",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "cache/memory-store.ts",
-    "rubyName": "modify_value",
-    "call": "version",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -47794,6 +43776,13 @@
     "rubyName": "delete",
     "call": "clear",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "callbacks.ts",
+    "rubyName": "duplicates?",
+    "call": "matches?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -48189,13 +44178,6 @@
   },
   {
     "package": "activesupport",
-    "tsFile": "deprecation.ts",
-    "rubyName": "warn",
-    "call": "silenced",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
     "tsFile": "digest.ts",
     "rubyName": "hexdigest",
     "call": "hash_digest_class",
@@ -48242,6 +44224,20 @@
     "rubyName": "build",
     "call": "round",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "duration.ts",
+    "rubyName": "initialize",
+    "call": "any?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "duration.ts",
+    "rubyName": "initialize",
+    "call": "include?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -48319,6 +44315,13 @@
     "rubyName": "read",
     "call": "exist?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "encrypted-file.ts",
+    "rubyName": "read_env_key",
+    "call": "presence",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -48527,13 +44530,6 @@
     "package": "activesupport",
     "tsFile": "error-reporter.ts",
     "rubyName": "report",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "error-reporter.ts",
-    "rubyName": "report",
     "call": "map",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -48543,6 +44539,13 @@
     "rubyName": "report",
     "call": "merge",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "error-reporter.ts",
+    "rubyName": "set_context",
+    "call": "set",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -48687,34 +44690,6 @@
   {
     "package": "activesupport",
     "tsFile": "log-subscriber.ts",
-    "rubyName": "call",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "log-subscriber.ts",
-    "rubyName": "color",
-    "call": "colorize_logging",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "log-subscriber.ts",
-    "rubyName": "flush_all!",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "log-subscriber.ts",
-    "rubyName": "publish_event",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "log-subscriber.ts",
     "rubyName": "silenced?",
     "call": "call",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -48722,22 +44697,8 @@
   {
     "package": "activesupport",
     "tsFile": "log-subscriber.ts",
-    "rubyName": "silenced?",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "log-subscriber.ts",
     "rubyName": "subscribe_log_level",
     "call": "fetch",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activesupport",
-    "tsFile": "log-subscriber.ts",
-    "rubyName": "subscribe_log_level",
-    "call": "log_levels",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -48984,6 +44945,13 @@
     "rubyName": "convert",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activesupport",
+    "tsFile": "number-helper/number-to-phone-converter.ts",
+    "rubyName": "country_code",
+    "call": "blank?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -49676,34 +45644,6 @@
     "tsFile": "nodes/bound-sql-literal.ts",
     "rubyName": "initialize",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/casted.ts",
-    "rubyName": "value_for_database",
-    "call": "attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/homogeneous-in.ts",
-    "rubyName": "fetch_attribute",
-    "call": "attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/homogeneous-in.ts",
-    "rubyName": "invert",
-    "call": "attribute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "nodes/homogeneous-in.ts",
-    "rubyName": "invert",
-    "call": "values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -50521,20 +46461,6 @@
   {
     "package": "arel",
     "tsFile": "select-manager.ts",
-    "rubyName": "compile_delete",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
-    "rubyName": "compile_update",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
     "rubyName": "group",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -50627,13 +46553,6 @@
     "package": "arel",
     "tsFile": "select-manager.ts",
     "rubyName": "project",
-    "call": "projections",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
-    "rubyName": "project",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -50642,20 +46561,6 @@
     "tsFile": "select-manager.ts",
     "rubyName": "union",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
-    "rubyName": "where",
-    "call": "wheres",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "select-manager.ts",
-    "rubyName": "where_sql",
-    "call": "wheres",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -50758,13 +46663,6 @@
   },
   {
     "package": "arel",
-    "tsFile": "tree-manager.ts",
-    "rubyName": "where",
-    "call": "wheres",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
     "tsFile": "update-manager.ts",
     "rubyName": "group",
     "call": "each",
@@ -50789,20 +46687,6 @@
     "tsFile": "visitors/dot.ts",
     "rubyName": "quote",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/dot.ts",
-    "rubyName": "to_dot",
-    "call": "from",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/dot.ts",
-    "rubyName": "to_dot",
-    "call": "to",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -50838,13 +46722,6 @@
     "tsFile": "visitors/mysql.ts",
     "rubyName": "build_subselect",
     "call": "sql",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/mysql.ts",
-    "rubyName": "prepare_update_statement",
-    "call": "offset",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -50893,21 +46770,7 @@
     "package": "arel",
     "tsFile": "visitors/mysql.ts",
     "rubyName": "visit_Arel_Nodes_SelectStatement",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/mysql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectStatement",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/mysql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectStatement",
-    "call": "offset",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -50984,35 +46847,7 @@
     "package": "arel",
     "tsFile": "visitors/sqlite.ts",
     "rubyName": "visit_Arel_Nodes_SelectStatement",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/sqlite.ts",
-    "rubyName": "visit_Arel_Nodes_SelectStatement",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/sqlite.ts",
-    "rubyName": "visit_Arel_Nodes_SelectStatement",
-    "call": "offset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "aggregate",
-    "call": "alias",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "aggregate",
-    "call": "distinct",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51020,27 +46855,6 @@
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "build_subselect",
     "call": "first",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "build_subselect",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "build_subselect",
-    "call": "offset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "build_subselect",
-    "call": "wheres",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51062,27 +46876,6 @@
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "compile",
     "call": "accept",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "prepare_update_statement",
-    "call": "key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "require_parentheses?",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "require_parentheses?",
-    "call": "offset",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51186,13 +46979,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Comment",
-    "call": "values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_DeleteStatement",
     "call": "collect_nodes_for",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -51201,21 +46987,7 @@
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_DeleteStatement",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_DeleteStatement",
     "call": "maybe_visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_DeleteStatement",
-    "call": "wheres",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51249,13 +47021,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Exists",
-    "call": "alias",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_Extract",
     "call": "to_s",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -51265,13 +47030,6 @@
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_Filter",
     "call": "visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_Fragments",
-    "call": "values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51328,20 +47086,6 @@
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_InsertStatement",
     "call": "maybe_visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_InsertStatement",
-    "call": "select",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_InsertStatement",
-    "call": "values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51424,20 +47168,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_NamedFunction",
-    "call": "alias",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_NamedFunction",
-    "call": "distinct",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_NotEqual",
     "call": "unboundable?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -51501,48 +47231,6 @@
   {
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectCore",
-    "call": "comment",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectCore",
-    "call": "projections",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectCore",
-    "call": "wheres",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectOptions",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectOptions",
-    "call": "lock",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectOptions",
-    "call": "offset",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_SelectStatement",
     "call": "visit_Arel_Nodes_SelectCore",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -51552,13 +47240,6 @@
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_SelectStatement",
     "call": "visit_Arel_Nodes_SelectOptions",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_SelectStatement",
-    "call": "with",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51586,28 +47267,7 @@
     "package": "arel",
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_UpdateStatement",
-    "call": "limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_UpdateStatement",
     "call": "maybe_visit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_UpdateStatement",
-    "call": "values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_UpdateStatement",
-    "call": "wheres",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51615,13 +47275,6 @@
     "tsFile": "visitors/to-sql.ts",
     "rubyName": "visit_Arel_Nodes_ValuesList",
     "call": "quote",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "arel",
-    "tsFile": "visitors/to-sql.ts",
-    "rubyName": "visit_Arel_Nodes_ValuesList",
-    "call": "rows",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51844,6 +47497,13 @@
   {
     "package": "globalid",
     "tsFile": "signed-global-id.ts",
+    "rubyName": "pick_purpose",
+    "call": "fetch",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "signed-global-id.ts",
     "rubyName": "pick_verifier",
     "call": "fetch",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -51851,22 +47511,8 @@
   {
     "package": "globalid",
     "tsFile": "signed-global-id.ts",
-    "rubyName": "pick_verifier",
-    "call": "verifier",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "globalid",
-    "tsFile": "signed-global-id.ts",
     "rubyName": "raise_if_expired",
     "call": "iso8601",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "globalid",
-    "tsFile": "signed-global-id.ts",
-    "rubyName": "to_s",
-    "call": "expires_at",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -51917,6 +47563,13 @@
     "rubyName": "set_model_components",
     "call": "validate_model_id",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "globalid",
+    "tsFile": "uri/gid.ts",
+    "rubyName": "to_s",
+    "call": "query",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "globalid",
@@ -52071,6 +47724,20 @@
     "rubyName": "call",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "cascade.ts",
+    "rubyName": "initialize",
+    "call": "add",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "cascade.ts",
+    "rubyName": "initialize",
+    "call": "each",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "rack",
@@ -52236,15 +47903,15 @@
   {
     "package": "rack",
     "tsFile": "deflater.ts",
-    "rubyName": "should_deflate?",
-    "call": "has_key?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "rubyName": "initialize",
+    "call": "fetch",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "rack",
     "tsFile": "deflater.ts",
     "rubyName": "should_deflate?",
-    "call": "include?",
+    "call": "has_key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -52712,6 +48379,13 @@
   {
     "package": "rack",
     "tsFile": "mock-response.ts",
+    "rubyName": "cookie",
+    "call": "fetch",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "mock-response.ts",
     "rubyName": "identify_cookie_attributes",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -52770,13 +48444,6 @@
     "tsFile": "multipart.ts",
     "rubyName": "parse_multipart",
     "call": "parse",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "rack",
-    "tsFile": "multipart/generator.ts",
-    "rubyName": "content_for_tempfile",
-    "call": "content_type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -52860,20 +48527,6 @@
     "package": "rack",
     "tsFile": "multipart/parser.ts",
     "rubyName": "get_data",
-    "call": "content_type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "rack",
-    "tsFile": "multipart/parser.ts",
-    "rubyName": "get_data",
-    "call": "head",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "rack",
-    "tsFile": "multipart/parser.ts",
-    "rubyName": "get_data",
     "call": "last",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -52931,13 +48584,6 @@
     "tsFile": "multipart/parser.ts",
     "rubyName": "parse_boundary",
     "call": "match",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "rack",
-    "tsFile": "multipart/parser.ts",
-    "rubyName": "result",
-    "call": "content_type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -53034,6 +48680,34 @@
   {
     "package": "rack",
     "tsFile": "request.ts",
+    "rubyName": "add_header",
+    "call": "get_header",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "request.ts",
+    "rubyName": "add_header",
+    "call": "has_header?",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "request.ts",
+    "rubyName": "add_header",
+    "call": "set_header",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "request.ts",
+    "rubyName": "delete_header",
+    "call": "delete",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "rack",
+    "tsFile": "request.ts",
     "rubyName": "expand_param_pairs",
     "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -53085,13 +48759,6 @@
     "tsFile": "request.ts",
     "rubyName": "reject_trusted_ip_addresses",
     "call": "reject",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "rack",
-    "tsFile": "request.ts",
-    "rubyName": "values_at",
-    "call": "params",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -53287,13 +48954,6 @@
     "package": "rack",
     "tsFile": "show-exceptions.ts",
     "rubyName": "pretty",
-    "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "rack",
-    "tsFile": "show-exceptions.ts",
-    "rubyName": "pretty",
     "call": "path_info",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -53365,13 +49025,6 @@
     "tsFile": "static.ts",
     "rubyName": "route_file",
     "call": "index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "rack",
-    "tsFile": "tempfile-reaper.ts",
-    "rubyName": "call",
-    "call": "each",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -53728,13 +49381,6 @@
     "package": "trailties",
     "tsFile": "application/default-middleware-stack.ts",
     "rubyName": "build_stack",
-    "call": "app",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "application/default-middleware-stack.ts",
-    "rubyName": "build_stack",
     "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -53756,13 +49402,6 @@
     "package": "trailties",
     "tsFile": "application/default-middleware-stack.ts",
     "rubyName": "build_stack",
-    "call": "index_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "application/default-middleware-stack.ts",
-    "rubyName": "build_stack",
     "call": "key?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -53771,13 +49410,6 @@
     "tsFile": "application/default-middleware-stack.ts",
     "rubyName": "build_stack",
     "call": "require",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "application/default-middleware-stack.ts",
-    "rubyName": "build_stack",
-    "call": "session_options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -53902,6 +49534,13 @@
   {
     "package": "trailties",
     "tsFile": "engine/configuration.ts",
+    "rubyName": "all_eager_load_paths",
+    "call": "eager_load",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "engine/configuration.ts",
     "rubyName": "generators",
     "call": "new",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -54006,13 +49645,6 @@
   },
   {
     "package": "trailties",
-    "tsFile": "generators/actions/create-migration.ts",
-    "rubyName": "on_conflict_behavior",
-    "call": "options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
     "tsFile": "generators/app-base.ts",
     "rubyName": "deduce_implied_options",
     "call": "all?",
@@ -54077,21 +49709,7 @@
   {
     "package": "trailties",
     "tsFile": "generators/app-base.ts",
-    "rubyName": "depends_on_system_test?",
-    "call": "options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "generators/app-base.ts",
     "rubyName": "keeps?",
-    "call": "options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "generators/app-base.ts",
-    "rubyName": "sqlite3?",
     "call": "options",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -54112,13 +49730,6 @@
   {
     "package": "trailties",
     "tsFile": "generators/generated-attribute.ts",
-    "rubyName": "default",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "generators/generated-attribute.ts",
     "rubyName": "initialize",
     "call": "include?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -54128,13 +49739,6 @@
     "tsFile": "generators/generated-attribute.ts",
     "rubyName": "parse",
     "call": "include?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "generators/generated-attribute.ts",
-    "rubyName": "to_s",
-    "call": "type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -54184,13 +49788,6 @@
     "tsFile": "generators/migration.ts",
     "rubyName": "migration_template",
     "call": "to_s",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "generators/named-base.ts",
-    "rubyName": "attributes_names",
-    "call": "attributes",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -54531,10 +50128,24 @@
   },
   {
     "package": "trailties",
+    "tsFile": "generators/rails/script/script-generator.ts",
+    "rubyName": "depth",
+    "call": "size",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+  },
+  {
+    "package": "trailties",
     "tsFile": "generators/resource-helpers.ts",
     "rubyName": "controller_class_name",
     "call": "join",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "trailties",
+    "tsFile": "generators/resource-helpers.ts",
+    "rubyName": "controller_file_path",
+    "call": "join",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "trailties",
@@ -54576,13 +50187,6 @@
     "tsFile": "info-controller.ts",
     "rubyName": "routes",
     "call": "new",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "info-controller.ts",
-    "rubyName": "routes",
-    "call": "params",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -54646,20 +50250,6 @@
     "tsFile": "initializable.ts",
     "rubyName": "initializer",
     "call": "last",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "initializable.ts",
-    "rubyName": "tsort_each_child",
-    "call": "after",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "initializable.ts",
-    "rubyName": "tsort_each_child",
-    "call": "before",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -54743,22 +50333,15 @@
     "package": "trailties",
     "tsFile": "paths.ts",
     "rubyName": "expanded",
-    "call": "path",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "paths.ts",
-    "rubyName": "expanded",
     "call": "uniq!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
     "package": "trailties",
-    "tsFile": "rack/logger.ts",
-    "rubyName": "call",
-    "call": "logger",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "tsFile": "paths.ts",
+    "rubyName": "initialize",
+    "call": "eager_load!",
+    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
   },
   {
     "package": "trailties",
@@ -54800,13 +50383,6 @@
     "tsFile": "rack/logger.ts",
     "rubyName": "started_request_message",
     "call": "remote_ip",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "trailties",
-    "tsFile": "rack/silence-request.ts",
-    "rubyName": "call",
-    "call": "logger",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -54976,369 +50552,5 @@
     "rubyName": "before_initialize",
     "call": "on_load",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "stale_state",
-    "call": "belongs_to?",
-    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "stale_state",
-    "call": "filter_map",
-    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "stale_state",
-    "call": "foreign_key",
-    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "stale_state",
-    "call": "owner",
-    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "stale_state",
-    "call": "presence",
-    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/has-one-through-association.ts",
-    "rubyName": "stale_state",
-    "call": "through_reflection",
-    "reason": "Rails ThroughAssociation#stale_state calls these; TS mirrors them in staleStateImpl (through-association.ts) which HasOneThroughAssociation#staleState delegates to (same pattern as HasManyThroughAssociation)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "encryption/encryptable-record.ts",
-    "rubyName": "encrypts",
-    "call": "new",
-    "reason": "encrypt_attribute's `EncryptedAttributeType.new` is emitted from the shared registerEncryptedType primitive (immediate direct-set / durable decorator) after encrypts routes through encryptAttribute - same construction, different TS method."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "pin_connection!",
-    "call": "checkout",
-    "reason": "pinConnectionBang acquires the pinned connection via the sync `_acquireConnection` helper (the trails pinned-checkout path); `checkout` is now async (converge-connection-pool-checkout-lease-async) and cannot be awaited from this path."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-handling.ts",
-    "rubyName": "connection",
-    "call": "lease_connection",
-    "reason": "The deprecated sync `.connection` getter routes through the sync `leaseConnectionSync` escape hatch; Rails-named `leaseConnection` is async in trails (converge-connection-pool-checkout-lease-async) and cannot be awaited from a sync getter."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "tasks/database-tasks.ts",
-    "rubyName": "migration_connection",
-    "call": "lease_connection",
-    "reason": "migrationConnection (sync) routes through `leaseConnectionSync`; Rails-named `leaseConnection` is async in trails (converge-connection-pool-checkout-lease-async) and cannot be awaited from this sync accessor."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "flush",
-    "call": "disconnect!",
-    "reason": "flush is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous eviction \u2014 including `conn.disconnectBang()` \u2014 to the private `_flush` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "flush",
-    "call": "delete",
-    "reason": "flush is now async (converge-connection-pool-lifecycle-async); the idle-connection removal (`_connections.splice` / `_lastCheckinAt.delete`, Rails' `@connections.delete`) lives in the private `_flush` core it delegates to. Same behavior, moved into the shared sync helper."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "clear_reloadable_connections",
-    "call": "disconnect!",
-    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); it delegates the synchronous reload-clear \u2014 including `conn.disconnectBang()` \u2014 to the private `_clearReloadableConnections` core so the public method can await the returned async-close drains. Same call, moved into the shared sync helper."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "clear_reloadable_connections",
-    "call": "clear",
-    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); the `_available.clear()` / lease-clearing lives in the private `_clearReloadableConnections` core it delegates to. Same behavior, moved into the shared sync helper."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/connection-pool.ts",
-    "rubyName": "clear_reloadable_connections",
-    "call": "with_exclusively_acquired_all_connections",
-    "reason": "clearReloadableConnections is now async (converge-connection-pool-lifecycle-async); the `withExclusivelyAcquiredAllConnections` critical section lives in the private `_clearReloadableConnections` core it delegates to. Same call, moved into the shared sync helper."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "cacheable_query",
-    "call": "compile",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "cacheable_query",
-    "call": "partial_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "cacheable_query",
-    "call": "prepared_statements",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "cacheable_query",
-    "call": "query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "exec_delete",
-    "call": "affected_rows",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "exec_delete",
-    "call": "internal_execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "exec_insert",
-    "call": "internal_exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "exec_insert",
-    "call": "sql_for_insert",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "exec_query",
-    "call": "internal_exec_query",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "exec_update",
-    "call": "affected_rows",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "exec_update",
-    "call": "internal_execute",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "select_all",
-    "call": "arel_from_relation",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "select_all",
-    "call": "prepared_statements",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "select_all",
-    "call": "select",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "select_all",
-    "call": "to_sql_and_binds",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract-adapter.ts",
-    "rubyName": "select_value",
-    "call": "single_value_from_rows",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "compute_cache_version",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "update_all",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete_all",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "to_sql",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "exec_main_query",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "exists?",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "pluck",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "execute_simple_calculation",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "execute_grouped_calculation",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "build_subquery",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "build_from",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "build_with_expression_from_value",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "in_batches",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "execute_simple_calculation",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/calculations.ts",
-    "rubyName": "execute_grouped_calculation",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "raise_record_not_found_exception!",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/predicate-builder/relation-handler.ts",
-    "rubyName": "call",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_subquery",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_from",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_with_expression_from_value",
-    "call": "arel",
-    "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "migration.ts",
-    "rubyName": "revert",
-    "call": "reverse",
-    "reason": "trails Migration#revert takes a single migration or block, not a splat of migration classes, so Rails' `migration_classes.reverse` has no array to reverse; the single-migration path (_run) covers it."
   }
 ]

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -1180,7 +1180,7 @@
     "tsFile": "metal.ts",
     "rubyName": "performed?",
     "call": "response_body",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -1446,14 +1446,14 @@
     "tsFile": "metal/etag-with-template-digest.ts",
     "rubyName": "pick_template_for_etag",
     "call": "find_all",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
     "tsFile": "metal/etag-with-template-digest.ts",
     "rubyName": "pick_template_for_etag",
     "call": "first",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -1677,14 +1677,14 @@
     "tsFile": "metal/live.ts",
     "rubyName": "abort",
     "call": "clear",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
     "tsFile": "metal/live.ts",
     "rubyName": "abort",
     "call": "synchronize",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -1852,14 +1852,14 @@
     "tsFile": "metal/mime-responds.ts",
     "rubyName": "any_response?",
     "call": "fetch",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
     "tsFile": "metal/mime-responds.ts",
     "rubyName": "any_response?",
     "call": "format",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -2370,7 +2370,7 @@
     "tsFile": "metal/request-forgery-protection.ts",
     "rubyName": "reset",
     "call": "delete",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -2965,14 +2965,14 @@
     "tsFile": "renderer.ts",
     "rubyName": "env_for_request",
     "call": "key?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
     "tsFile": "renderer.ts",
     "rubyName": "env_for_request",
     "call": "merge",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -3140,7 +3140,7 @@
     "tsFile": "test-case.ts",
     "rubyName": "controller_class_name",
     "call": "anonymous?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actioncontroller",
@@ -3917,7 +3917,7 @@
     "tsFile": "http/mime-type.ts",
     "rubyName": "ref",
     "call": "to_s",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -3952,7 +3952,7 @@
     "tsFile": "http/mime-type.ts",
     "rubyName": "to_str",
     "call": "to_s",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4176,21 +4176,21 @@
     "tsFile": "http/request.ts",
     "rubyName": "engine_script_name",
     "call": "get_header",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "engine_script_name=",
     "call": "routes",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "engine_script_name=",
     "call": "set_header",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4204,49 +4204,49 @@
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "action_encoding_template",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "fetch_header",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "from_query_string",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "path_parameters",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "GET",
     "call": "set_header",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "initialize",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4316,56 +4316,56 @@
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "action_encoding_template",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "fetch_header",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "from_hash",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "from_pairs",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "params_parsers",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "parse_formatted_parameters",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "http/request.ts",
     "rubyName": "POST",
     "call": "path_parameters",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -4918,7 +4918,7 @@
     "tsFile": "journey/nodes/node.ts",
     "rubyName": "glob?",
     "call": "any?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5275,7 +5275,7 @@
     "tsFile": "middleware/cookies.ts",
     "rubyName": "have_cookie_jar?",
     "call": "has_header?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5310,7 +5310,7 @@
     "tsFile": "middleware/cookies.ts",
     "rubyName": "serializer",
     "call": "cookies_serializer",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5555,42 +5555,42 @@
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "each",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "key?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "map",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "method_name",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "middleware/exception-wrapper.ts",
     "rubyName": "build_backtrace",
     "call": "to_s",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5716,7 +5716,7 @@
     "tsFile": "middleware/flash.ts",
     "rubyName": "flash_hash",
     "call": "get_header",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5912,7 +5912,7 @@
     "tsFile": "middleware/session/abstract-store.ts",
     "rubyName": "initialize_sid",
     "call": "delete",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -5926,7 +5926,7 @@
     "tsFile": "middleware/session/mem-cache-store.ts",
     "rubyName": "initialize_sid",
     "call": "delete",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -6143,7 +6143,7 @@
     "tsFile": "middleware/stack.ts",
     "rubyName": "last",
     "call": "middlewares",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -6444,7 +6444,7 @@
     "tsFile": "request/session.ts",
     "rubyName": "find",
     "call": "get_header",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -7221,7 +7221,7 @@
     "tsFile": "routing/mapper.ts",
     "rubyName": "nested_scope?",
     "call": "nested?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -8481,35 +8481,35 @@
     "tsFile": "system-testing/driver.ts",
     "rubyName": "browser_options",
     "call": "compact",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "browser_options",
     "call": "merge",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "browser_options",
     "call": "options",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "initialize",
     "call": "delete",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "system-testing/driver.ts",
     "rubyName": "initialize",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -8803,14 +8803,14 @@
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "reset_routes",
     "call": "app",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/assertions/routing.ts",
     "rubyName": "reset_routes",
     "call": "redefine_method",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -9153,28 +9153,28 @@
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "controller",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "default_url_options",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "reverse_merge!",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
     "tsFile": "testing/integration.ts",
     "rubyName": "url_options",
     "call": "routes",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actiondispatch",
@@ -9237,7 +9237,7 @@
     "tsFile": "gem-version.ts",
     "rubyName": "gem_version",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "actionview",
@@ -10273,14 +10273,14 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_alias",
     "call": "attribute_aliases",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "attribute_alias",
     "call": "to_s",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10483,14 +10483,14 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "generated_attribute_methods",
     "call": "include",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "generated_attribute_methods",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10511,14 +10511,14 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "resolve_attribute_name",
     "call": "attribute_aliases",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
     "tsFile": "attribute-methods.ts",
     "rubyName": "resolve_attribute_name",
     "call": "fetch",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10637,7 +10637,7 @@
     "tsFile": "attribute-set.ts",
     "rubyName": "cast_types",
     "call": "transform_values",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10840,7 +10840,7 @@
     "tsFile": "dirty.ts",
     "rubyName": "as_json",
     "call": "merge",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -10896,14 +10896,14 @@
     "tsFile": "dirty.ts",
     "rubyName": "attribute_previous_change",
     "call": "change_to_attribute",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
     "tsFile": "dirty.ts",
     "rubyName": "attribute_previous_change",
     "call": "to_s",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -11981,7 +11981,7 @@
     "tsFile": "type/value.ts",
     "rubyName": "initialize",
     "call": "serialize_cast_value_compatible?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activemodel",
@@ -12982,7 +12982,7 @@
     "tsFile": "associations/association.ts",
     "rubyName": "marshal_dump",
     "call": "map",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -16314,14 +16314,14 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "initialize_generated_modules",
     "call": "include",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
     "rubyName": "initialize_generated_modules",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -16349,7 +16349,7 @@
     "tsFile": "attribute-methods.ts",
     "rubyName": "method_defined_within?",
     "call": "owner",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -16615,14 +16615,14 @@
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "attribute_change_to_be_saved",
     "call": "change_to_attribute",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "attribute_change_to_be_saved",
     "call": "to_s",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -16650,14 +16650,14 @@
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "saved_change_to_attribute",
     "call": "change_to_attribute",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/dirty.ts",
     "rubyName": "saved_change_to_attribute",
     "call": "to_s",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -16762,14 +16762,14 @@
     "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "include?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "attribute-methods/primary-key.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "primary_key",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -18526,7 +18526,7 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "extended_type_map_key",
     "call": "emulate_booleans",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -18589,7 +18589,7 @@
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "mariadb?",
     "call": "match?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19065,14 +19065,14 @@
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "connected?",
     "call": "any?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool.ts",
     "rubyName": "connected?",
     "call": "synchronize",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19352,7 +19352,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "any_waiting?",
     "call": "synchronize",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19366,14 +19366,14 @@
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "can_remove_no_wait?",
     "call": "size",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "clear",
     "call": "synchronize",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19394,7 +19394,7 @@
     "tsFile": "connection-adapters/abstract/connection-pool/queue.ts",
     "rubyName": "num_waiting",
     "call": "synchronize",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19793,21 +19793,21 @@
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "compute_if_absent",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "context",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/query-cache.ts",
     "rubyName": "query_cache",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -19919,7 +19919,7 @@
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "column_options",
     "call": "merge",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -20206,7 +20206,7 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "conditional_options",
     "call": "slice",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -20269,14 +20269,14 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "include?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "integer_like_primary_key?",
     "call": "key?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21088,7 +21088,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "extract_new_default_value",
     "call": "has_key?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21165,7 +21165,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "foreign_keys_enabled?",
     "call": "fetch",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -21354,7 +21354,7 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "options_include_default?",
     "call": "include?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -22061,14 +22061,14 @@
     "tsFile": "connection-adapters/mysql/column.ts",
     "rubyName": "unsigned?",
     "call": "match?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/column.ts",
     "rubyName": "virtual?",
     "call": "match?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -22243,21 +22243,21 @@
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "extract_expression_for_virtual_column",
     "call": "query_value",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "extract_expression_for_virtual_column",
     "call": "quote",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-dumper.ts",
     "rubyName": "extract_expression_for_virtual_column",
     "call": "quote_column_name",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23237,7 +23237,7 @@
     "tsFile": "connection-adapters/postgresql-adapter.ts",
     "rubyName": "supports_optimizer_hints?",
     "call": "extension_available?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23265,14 +23265,14 @@
     "tsFile": "connection-adapters/postgresql/column.ts",
     "rubyName": "virtual?",
     "call": "present?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "affected_rows",
     "call": "clear",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23363,7 +23363,7 @@
     "tsFile": "connection-adapters/postgresql/database-statements.ts",
     "rubyName": "returning_column_values",
     "call": "first",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23783,7 +23783,7 @@
     "tsFile": "connection-adapters/postgresql/schema-definitions.ts",
     "rubyName": "export_name_on_schema_dump?",
     "call": "match?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -23888,7 +23888,7 @@
     "tsFile": "connection-adapters/postgresql/utils.ts",
     "rubyName": "to_s",
     "call": "join",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -24952,7 +24952,7 @@
     "tsFile": "connection-adapters/sqlite3/database-statements.ts",
     "rubyName": "returning_column_values",
     "call": "first",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -25561,7 +25561,7 @@
     "tsFile": "core.ts",
     "rubyName": "configurations=",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -25582,7 +25582,7 @@
     "tsFile": "core.ts",
     "rubyName": "connection_class?",
     "call": "connection_class",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -25778,14 +25778,14 @@
     "tsFile": "core.ts",
     "rubyName": "init_internals",
     "call": "define_attribute_methods",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "core.ts",
     "rubyName": "init_internals",
     "call": "primary_key",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -26261,7 +26261,7 @@
     "tsFile": "database-configurations/hash-config.ts",
     "rubyName": "database_tasks?",
     "call": "fetch",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -26436,14 +26436,14 @@
     "tsFile": "encryption.ts",
     "rubyName": "context",
     "call": "default_context",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption.ts",
     "rubyName": "current_custom_context",
     "call": "last",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -26919,14 +26919,14 @@
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "has_encrypted_attributes?",
     "call": "encrypted_attributes",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/encryptable-record.ts",
     "rubyName": "has_encrypted_attributes?",
     "call": "present?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -27024,14 +27024,14 @@
     "tsFile": "encryption/encrypted-attribute-type.ts",
     "rubyName": "decryption_options",
     "call": "compact",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/encrypted-attribute-type.ts",
     "rubyName": "encryption_options",
     "call": "compact",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -27325,14 +27325,14 @@
     "tsFile": "encryption/key-provider.ts",
     "rubyName": "encryption_key",
     "call": "id",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "encryption/key-provider.ts",
     "rubyName": "encryption_key",
     "call": "last",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -27682,14 +27682,14 @@
     "tsFile": "errors.ts",
     "rubyName": "set_query",
     "call": "call",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "errors.ts",
     "rubyName": "set_query",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -28081,7 +28081,7 @@
     "tsFile": "insert-all.ts",
     "rubyName": "resolve_attribute_alias",
     "call": "attribute_alias",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -28368,14 +28368,14 @@
     "tsFile": "locking/optimistic.ts",
     "rubyName": "locking_column=",
     "call": "reload_schema_from_cache",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "locking/optimistic.ts",
     "rubyName": "locking_column=",
     "call": "to_s",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -29159,7 +29159,7 @@
     "tsFile": "migration.ts",
     "rubyName": "reverting?",
     "call": "connection",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -30209,7 +30209,7 @@
     "tsFile": "no-touching.ts",
     "rubyName": "no_touching?",
     "call": "applied_to?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -31385,21 +31385,21 @@
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "connection_pool",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "create",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "alias_tracker",
     "call": "model",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -35424,14 +35424,14 @@
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "empty?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "none?",
     "call": "present?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -35718,42 +35718,42 @@
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "call",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "each",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "includes_values",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "new",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "preload_values",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "preload_associations",
     "call": "strict_loading_value",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -38406,63 +38406,63 @@
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "empty?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "find",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "includes_values",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "includes!",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "model",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "preload_values",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "preload!",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "reflect_on_all_associations",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_preloads",
     "call": "relation",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -38749,14 +38749,14 @@
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "handler_for",
     "call": "detect",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "relation/predicate-builder.ts",
     "rubyName": "handler_for",
     "call": "last",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -38868,7 +38868,7 @@
     "tsFile": "relation/predicate-builder/polymorphic-array-value.ts",
     "rubyName": "klass",
     "call": "model",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -38980,7 +38980,7 @@
     "tsFile": "relation/query-attribute.ts",
     "rubyName": "unboundable?",
     "call": "serializable?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -40912,7 +40912,7 @@
     "tsFile": "scoping.ts",
     "rubyName": "scope_attributes?",
     "call": "any?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -41885,7 +41885,7 @@
     "tsFile": "tasks/mysql-database-tasks.ts",
     "rubyName": "collation",
     "call": "connection",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -42039,7 +42039,7 @@
     "tsFile": "tasks/postgresql-database-tasks.ts",
     "rubyName": "collation",
     "call": "connection",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -42872,14 +42872,14 @@
     "tsFile": "type.ts",
     "rubyName": "adapter_name_from",
     "call": "adapter",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
     "tsFile": "type.ts",
     "rubyName": "adapter_name_from",
     "call": "connection_db_config",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -42991,7 +42991,7 @@
     "tsFile": "validations.ts",
     "rubyName": "custom_validation_context?",
     "call": "exclude?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activerecord",
@@ -43376,28 +43376,28 @@
     "tsFile": "cache.ts",
     "rubyName": "namespace_key",
     "call": "call",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "namespace_key",
     "call": "key?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "normalize_options",
     "call": "each",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
     "tsFile": "cache.ts",
     "rubyName": "normalize_options",
     "call": "key?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -43782,7 +43782,7 @@
     "tsFile": "callbacks.ts",
     "rubyName": "duplicates?",
     "call": "matches?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -44230,14 +44230,14 @@
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "any?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
     "tsFile": "duration.ts",
     "rubyName": "initialize",
     "call": "include?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -44321,7 +44321,7 @@
     "tsFile": "encrypted-file.ts",
     "rubyName": "read_env_key",
     "call": "presence",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -44545,7 +44545,7 @@
     "tsFile": "error-reporter.ts",
     "rubyName": "set_context",
     "call": "set",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -44951,7 +44951,7 @@
     "tsFile": "number-helper/number-to-phone-converter.ts",
     "rubyName": "country_code",
     "call": "blank?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "activesupport",
@@ -47499,7 +47499,7 @@
     "tsFile": "signed-global-id.ts",
     "rubyName": "pick_purpose",
     "call": "fetch",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "globalid",
@@ -47569,7 +47569,7 @@
     "tsFile": "uri/gid.ts",
     "rubyName": "to_s",
     "call": "query",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "globalid",
@@ -47730,14 +47730,14 @@
     "tsFile": "cascade.ts",
     "rubyName": "initialize",
     "call": "add",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
     "tsFile": "cascade.ts",
     "rubyName": "initialize",
     "call": "each",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
@@ -47905,7 +47905,7 @@
     "tsFile": "deflater.ts",
     "rubyName": "initialize",
     "call": "fetch",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
@@ -48381,7 +48381,7 @@
     "tsFile": "mock-response.ts",
     "rubyName": "cookie",
     "call": "fetch",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
@@ -48682,28 +48682,28 @@
     "tsFile": "request.ts",
     "rubyName": "add_header",
     "call": "get_header",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
     "tsFile": "request.ts",
     "rubyName": "add_header",
     "call": "has_header?",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
     "tsFile": "request.ts",
     "rubyName": "add_header",
     "call": "set_header",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
     "tsFile": "request.ts",
     "rubyName": "delete_header",
     "call": "delete",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "rack",
@@ -49536,7 +49536,7 @@
     "tsFile": "engine/configuration.ts",
     "rubyName": "all_eager_load_paths",
     "call": "eager_load",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "trailties",
@@ -50131,7 +50131,7 @@
     "tsFile": "generators/rails/script/script-generator.ts",
     "rubyName": "depth",
     "call": "size",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "trailties",
@@ -50145,7 +50145,7 @@
     "tsFile": "generators/resource-helpers.ts",
     "rubyName": "controller_file_path",
     "call": "join",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "trailties",
@@ -50341,7 +50341,7 @@
     "tsFile": "paths.ts",
     "rubyName": "initialize",
     "call": "eager_load!",
-    "reason": "Value-accessor read now credited (credit-value-accessor-reads-in-wide-call-gate): this method reads accessor-backed value methods whose faithful TS mirror is a get-accessor READ; extractCalls now credits those reads, surfacing a real or bucket-(b)/(c) wide-call flag that the empty-call-set skip previously hid. Pending per-cluster burndown review."
+    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
   },
   {
     "package": "trailties",

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -279,6 +279,15 @@ describe("body call capture", () => {
     const m = cls.instanceMethods.find((m) => m.name === "run")!;
     expect(m.calls).toEqual(["joinsValues"]);
   });
+
+  it("does not credit an assignment target as a value read (write mirrors the setter)", () => {
+    // `this.joinsValues = x` mirrors Ruby's writer send `joins_values=`, not the
+    // reader `joins_values`; crediting the reader name would be unfaithful and
+    // make the call set depend on body shape. The RHS read `x.dup` still counts.
+    const cls = extractFromSource(`class Foo { reset(x) { this.joinsValues = x.dup; } }`);
+    const m = cls.instanceMethods.find((m) => m.name === "reset")!;
+    expect(m.calls).toEqual(["dup"]);
+  });
 });
 
 describe("body call capture — renamed-import aliases", () => {

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -108,12 +108,15 @@ describe("body call capture", () => {
     );
     const save = cls.instanceMethods.find((m) => m.name === "save")!;
     // PropertyAccess callee → final identifier; bare call → identifier;
-    // sorted + de-duped (runCallbacks appears twice, recorded once).
-    expect(save.calls).toEqual(["helper", "runCallbacks", "touch"]);
+    // sorted + de-duped (runCallbacks appears twice, recorded once). The
+    // intermediate read `obj.nested` in `obj.nested.touch()` is credited as
+    // `nested` — a non-callee property read mirrors a Ruby method send.
+    expect(save.calls).toEqual(["helper", "nested", "runCallbacks", "touch"]);
   });
 
   it("omits calls entirely for a body that invokes nothing", () => {
-    const cls = extractFromSource(`class Foo { id() { return this._id; } }`);
+    // No calls and no property reads — a pure arithmetic return.
+    const cls = extractFromSource(`class Foo { id() { return 1 + 2; } }`);
     const id = cls.instanceMethods.find((m) => m.name === "id")!;
     expect(id.calls).toBeUndefined();
   });
@@ -177,7 +180,8 @@ describe("body call capture", () => {
         }
       }`,
     );
-    const expected = ["constructor", "typeCast"];
+    // `_x` is the non-callee read inside `typeCast(this._x)`, credited as a call.
+    const expected = ["_x", "constructor", "typeCast"];
     expect(direct.instanceMethods.find((m) => m.name === "build")!.calls).toEqual(expected);
     expect(bound.instanceMethods.find((m) => m.name === "build")!.calls).toEqual(expected);
   });
@@ -193,6 +197,7 @@ describe("body call capture", () => {
       }`,
     );
     expect(cls.instanceMethods.find((m) => m.name === "build")!.calls).toEqual([
+      "_x",
       "constructor",
       "makePool",
     ]);
@@ -247,6 +252,32 @@ describe("body call capture", () => {
     const byName = Object.fromEntries(methods.map((m) => [m.name, m.calls]));
     expect(byName["where"]).toEqual(["buildWhere", "spawn"]);
     expect(byName["toArrow"]).toEqual(["records"]);
+  });
+
+  it("credits a get-accessor value READ as a call (Ruby reader-call semantics)", () => {
+    // `this.joinsValues` is the faithful TS mirror of Ruby's `joins_values`
+    // method send — a bare read, since Ruby has no attribute reads, only calls.
+    // The accessor-backed value read must be credited to the ported call set.
+    const cls = extractFromSource(
+      `class Foo {
+        buildJoins() {
+          const j = this.joinsValues;
+          return this.leftOuterJoinsValues.concat(j);
+        }
+      }`,
+    );
+    const m = cls.instanceMethods.find((m) => m.name === "buildJoins")!;
+    expect(m.calls).toEqual(["concat", "joinsValues", "leftOuterJoinsValues"]);
+  });
+
+  it("does not double-record a call's callee property as a value read", () => {
+    // `this.joinsValues(...)` — the callee `joinsValues` is recorded ONCE by the
+    // call branch; the read-crediting branch must skip the callee access so the
+    // name is not counted twice (it is de-duped anyway, but the branch must not
+    // fire on a callee).
+    const cls = extractFromSource(`class Foo { run() { this.joinsValues(); } }`);
+    const m = cls.instanceMethods.find((m) => m.name === "run")!;
+    expect(m.calls).toEqual(["joinsValues"]);
   });
 });
 

--- a/scripts/api-compare/extract-ts-api.test.ts
+++ b/scripts/api-compare/extract-ts-api.test.ts
@@ -288,6 +288,23 @@ describe("body call capture", () => {
     const m = cls.instanceMethods.find((m) => m.name === "reset")!;
     expect(m.calls).toEqual(["dup"]);
   });
+
+  it("does not credit a destructuring-assignment target as a value read", () => {
+    // A property access nested in a destructuring LHS is still a write, mirroring
+    // the `foo=` setter — array-pattern (`[this.foo] = arr`) and object-pattern
+    // (`({ a: this.bar } = obj)`) targets must be skipped, while the RHS reads
+    // (`arr.pop`, `obj.build`) are still credited.
+    const cls = extractFromSource(
+      `class Foo {
+        reset(arr, obj) {
+          [this.foo] = arr.pop();
+          ({ a: this.bar } = obj.build());
+        }
+      }`,
+    );
+    const m = cls.instanceMethods.find((m) => m.name === "reset")!;
+    expect(m.calls).toEqual(["build", "pop"]);
+  });
 });
 
 describe("body call capture — renamed-import aliases", () => {

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1728,6 +1728,28 @@ function extractCalls(node: ts.Node | undefined): string[] | undefined {
         // so calls-parity can flag a ported override that drops the super call.
         names.add("super");
       }
+    } else if (ts.isPropertyAccessExpression(n)) {
+      // A get-accessor READ (`this.joinsValues`) is the faithful TS mirror of a
+      // Ruby value-method call (`joins_values`) — Ruby has no attribute reads,
+      // only method sends, so a plain read IS a call there. Credit the property
+      // name so such reads count toward the ported call set, matching Ruby's
+      // reader-call semantics. Two accesses are NOT reads and are skipped:
+      //   - the callee of a CallExpression (`this.foo(...)`): the isCall branch
+      //     above already recorded `foo`, so crediting here double-records it;
+      //   - the target of an assignment (`this.foo = x`): that mirrors Ruby's
+      //     writer send `foo=`, not the reader `foo` — crediting the reader name
+      //     would be unfaithful (and makes the call set body-shape dependent).
+      const parent = n.parent;
+      const isCallCallee =
+        parent !== undefined && ts.isCallExpression(parent) && parent.expression === n;
+      const isAssignTarget =
+        parent !== undefined &&
+        ts.isBinaryExpression(parent) &&
+        parent.left === n &&
+        parent.operatorToken.kind === ts.SyntaxKind.EqualsToken;
+      if (!isCallCallee && !isAssignTarget) {
+        names.add(n.name.text);
+      }
     }
     ts.forEachChild(n, visit);
   };

--- a/scripts/api-compare/extract-ts-api.ts
+++ b/scripts/api-compare/extract-ts-api.ts
@@ -1690,6 +1690,43 @@ function collectImportAliases(sourceFile: ts.SourceFile): Map<string, string> {
  * captured: the calls-parity check only acts on SIGNIFICANT_CALLS, none of
  * which are accessor-shaped, so accessors would contribute no signal.
  */
+// Whether a property access is the write target of an assignment — either a
+// direct LHS (`this.foo = x`) or nested inside a destructuring-assignment LHS
+// (`[this.foo] = arr`, `({ a: this.foo } = obj)`). In destructuring the LHS is
+// an array/object literal (not a binding pattern, since this is an assignment
+// not a declaration), so walk up through those literal shapes until reaching the
+// enclosing `=` BinaryExpression whose `left` is the access (or its container).
+// A write mirrors Ruby's writer send `foo=`, not the reader `foo`, so callers
+// skip crediting it. Compound assignments (`+=`, `||=`) are intentionally NOT
+// matched: `self.foo += x` desugars to `self.foo = self.foo + x`, which really
+// does call the reader.
+function isAssignmentWriteTarget(access: ts.PropertyAccessExpression): boolean {
+  let node: ts.Node = access;
+  let parent = node.parent as ts.Node | undefined;
+  while (parent !== undefined) {
+    if (ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      return parent.left === node;
+    }
+    // Ascend only through the node shapes a destructuring-assignment LHS is
+    // built from; anything else means `access` is in a read position.
+    if (
+      ts.isArrayLiteralExpression(parent) ||
+      ts.isObjectLiteralExpression(parent) ||
+      ts.isPropertyAssignment(parent) ||
+      ts.isShorthandPropertyAssignment(parent) ||
+      ts.isSpreadAssignment(parent) ||
+      ts.isSpreadElement(parent) ||
+      ts.isParenthesizedExpression(parent)
+    ) {
+      node = parent;
+      parent = node.parent;
+      continue;
+    }
+    return false;
+  }
+  return false;
+}
+
 function extractCalls(node: ts.Node | undefined): string[] | undefined {
   if (!node) return undefined;
   const aliases = currentImportAliases;
@@ -1729,25 +1766,23 @@ function extractCalls(node: ts.Node | undefined): string[] | undefined {
         names.add("super");
       }
     } else if (ts.isPropertyAccessExpression(n)) {
-      // A get-accessor READ (`this.joinsValues`) is the faithful TS mirror of a
-      // Ruby value-method call (`joins_values`) — Ruby has no attribute reads,
-      // only method sends, so a plain read IS a call there. Credit the property
-      // name so such reads count toward the ported call set, matching Ruby's
+      // A property READ (`this.joinsValues`, `obj.nested`) is the faithful TS
+      // mirror of a Ruby method send: Ruby has no public field access on ANY
+      // receiver — `x.foo` is always a call to `foo` on `x`, whether `x` is
+      // `self` or another object — so a plain read IS a call there. The rule is
+      // therefore receiver-agnostic (not `this`-only): credit the property name
+      // so any read counts toward the ported call set, matching Ruby's
       // reader-call semantics. Two accesses are NOT reads and are skipped:
       //   - the callee of a CallExpression (`this.foo(...)`): the isCall branch
       //     above already recorded `foo`, so crediting here double-records it;
-      //   - the target of an assignment (`this.foo = x`): that mirrors Ruby's
+      //   - the target of an assignment (`this.foo = x`, or a destructuring LHS
+      //     `[this.foo] = arr` / `({ a: this.foo } = obj)`): that mirrors Ruby's
       //     writer send `foo=`, not the reader `foo` — crediting the reader name
       //     would be unfaithful (and makes the call set body-shape dependent).
       const parent = n.parent;
       const isCallCallee =
         parent !== undefined && ts.isCallExpression(parent) && parent.expression === n;
-      const isAssignTarget =
-        parent !== undefined &&
-        ts.isBinaryExpression(parent) &&
-        parent.left === n &&
-        parent.operatorToken.kind === ts.SyntaxKind.EqualsToken;
-      if (!isCallCallee && !isAssignTarget) {
+      if (!isCallCallee && !isAssignmentWriteTarget(n)) {
         names.add(n.name.text);
       }
     }


### PR DESCRIPTION
## What

Rails value methods (`joins_values`) are method sends; their faithful TS mirror is a get-accessor READ (`this.joinsValues`) — a `PropertyAccessExpression`, never a `CallExpression` — so `extractCalls` never credited them. Only one method in the repo previously credited a value accessor (via a host *method*), leaving ~38 value-accessor entries permanently baselined.

This adds a branch to `extractCalls` that records a **non-callee, non-write-target property access** as a call, matching Ruby's reader-call semantics. The rule is **receiver-agnostic** — Ruby has no public field access on any object, so `obj.nested` is a method send just like `this.foo`. Two access shapes are excluded:

- **callees** — the call branch already records `foo` for `this.foo(...)`, so no double-count;
- **write targets** — `this.foo = x` (and destructuring LHS `[this.foo] = arr`, `({ a: this.foo } = obj)`) mirror the `foo=` setter, not the `foo` reader. Compound assignments (`+=`, `||=`) are intentionally still credited as reads, since `self.foo += x` desugars to a reader call.

## Wide baseline reseed

The wide ratchet shifts **−868 converged / +183 newly-surfaced**:

- **Converged (dropped):** the four `joins_values` join-builders whose ported bodies actually read `this.joinsValues` — `build_joins`, `build_join_buckets`, `build_join_dependencies` (query-methods.ts) and `merge_joins` (merger.ts).
- **Newly-surfaced (183):** methods whose call set was previously empty become gate-subject once their reads count (`if (!tsCandidateSets?.length) return;`). These are baselined **in bulk with a single mechanism-level reason, NOT individually vetted** — the reason states plainly that the specific missing call may be a genuine value-accessor read or an ordinary Ruby call that merely co-occurs in the body, pending per-cluster burndown review.

The **six residual `joins_values` entries do not converge and cannot be removed** — they still flag, so removing them would fail the gate. Their reasons are corrected to the true cause:

- `relation.ts` ×4 — mixin-host attribution artifact; the real port lives in query-methods.ts (which converged), the host candidate has no resolvable body;
- query-methods `associated` / finder-methods `apply_join_dependency` — divergent ports that read neither join accessor;
- the left-outer builders read the private `_leftOuterJoinsValues` field, not the public accessor (a separate source change).

## Verification

- `pnpm api:calls:wide` — OK (7222 baselined).
- `pnpm api:calls` (narrow) and `pnpm api:compare` parity — unaffected.
- `scripts/api-compare/extract-ts-api.test.ts` — new coverage for the read-crediting rule, the no-double-record-of-callee invariant, and the direct + destructuring write-target skips; existing call-capture expectations updated for credited reads.

Closes-story: credit-value-accessor-reads-in-wide-call-gate