### PR TITLE
refactor(schema): derive typeToSql string default limit from native-types table

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -26,15 +26,18 @@ import { ArgumentError } from "@blazetrails/activemodel";
 
 /**
  * Per-adapter default column limits, mirroring the `:limit` keys carried by
- * each adapter's `NATIVE_DATABASE_TYPES` hash. Rails' `type_to_sql` derives a
- * missing limit generically via `limit ||= native[:limit]`
- * (abstract/schema_statements.rb:1404); the only non-nil default across our
- * three adapters is MySQL's `:string` (`limit: 255`, abstract_mysql_adapter.rb:33).
- * sqlite3 (`{ name: "varchar" }`, sqlite3_adapter.rb:71) and PostgreSQL
- * (`{ name: "character varying" }`, postgresql_adapter.rb:136) carry no default
- * length, so a bare `t.string` stays unbounded there. Keying the defaults off a
- * table — rather than `adapterName` branches inside each `type_to_sql` case —
- * keeps the native-type knowledge in one place and mirrors Rails' structure.
+ * each adapter's `NATIVE_DATABASE_TYPES` hash. Rails' `type_to_sql` reads that
+ * hash (`native = native_database_types[type]`) and fills a missing limit
+ * generically via `limit ||= native[:limit]` (abstract/schema_statements.rb:1404).
+ * The only non-nil default across our three adapters is MySQL's `:string`
+ * (`limit: 255`, abstract_mysql_adapter.rb:33); sqlite3 (`{ name: "varchar" }`,
+ * sqlite3_adapter.rb:71) and PostgreSQL (`{ name: "character varying" }`,
+ * postgresql_adapter.rb:136) carry none, so a bare `t.string` stays unbounded.
+ * Keying the defaults off a table — rather than `adapterName` branches inside
+ * each `type_to_sql` case — keeps the native-type knowledge in one place and
+ * mirrors Rails' structure. (Only the default *limit* varies by adapter here;
+ * PostgreSQL derives its distinct `character varying` type name in its own
+ * `typeToSql` override, so the shared visitor emits a single `VARCHAR` name.)
  */
 const NATIVE_TYPE_LIMITS: Record<
   "sqlite" | "postgres" | "mysql",

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -24,6 +24,27 @@ import { ABSTRACT_SCHEMA_QUOTER } from "./quoting.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 
+/**
+ * Per-adapter default column limits, mirroring the `:limit` keys carried by
+ * each adapter's `NATIVE_DATABASE_TYPES` hash. Rails' `type_to_sql` derives a
+ * missing limit generically via `limit ||= native[:limit]`
+ * (abstract/schema_statements.rb:1404); the only non-nil default across our
+ * three adapters is MySQL's `:string` (`limit: 255`, abstract_mysql_adapter.rb:33).
+ * sqlite3 (`{ name: "varchar" }`, sqlite3_adapter.rb:71) and PostgreSQL
+ * (`{ name: "character varying" }`, postgresql_adapter.rb:136) carry no default
+ * length, so a bare `t.string` stays unbounded there. Keying the defaults off a
+ * table — rather than `adapterName` branches inside each `type_to_sql` case —
+ * keeps the native-type knowledge in one place and mirrors Rails' structure.
+ */
+const NATIVE_TYPE_LIMITS: Record<
+  "sqlite" | "postgres" | "mysql",
+  Partial<Record<ColumnType, number>>
+> = {
+  sqlite: {},
+  postgres: {},
+  mysql: { string: 255 },
+};
+
 type Definition =
   | TableDefinition
   | AlterTable
@@ -377,20 +398,15 @@ export class SchemaCreation {
   typeToSql(type: ColumnType, options: ColumnOptions = {}): string {
     let sql: string;
     switch (type) {
-      case "string":
+      case "string": {
         // Rails derives the default limit from the adapter's native-type hash
-        // (`type_to_sql`: `limit ||= native[:limit]`). Only MySQL's
-        // `NATIVE_DATABASE_TYPES[:string]` carries `limit: 255`
-        // (abstract_mysql_adapter.rb:33); sqlite3 (`{ name: "varchar" }`,
-        // sqlite3_adapter.rb:71) and PostgreSQL (`{ name: "character varying" }`,
-        // postgresql_adapter.rb:136) have no default length, so a bare
-        // `t.string` stays unbounded (nil limit) there.
-        if (this.adapterName === "mysql") {
-          sql = `VARCHAR(${options.limit ?? 255})`;
-        } else {
-          sql = options.limit != null ? `VARCHAR(${options.limit})` : "VARCHAR";
-        }
+        // (`type_to_sql`: `limit ||= native[:limit]`). {@link NATIVE_TYPE_LIMITS}
+        // supplies that default per adapter — MySQL's `:string` is 255, sqlite3
+        // and PostgreSQL carry none, so a bare `t.string` stays unbounded there.
+        const limit = options.limit ?? NATIVE_TYPE_LIMITS[this.adapterName].string;
+        sql = limit != null ? `VARCHAR(${limit})` : "VARCHAR";
         break;
+      }
       case "text":
         sql = "TEXT";
         break;


### PR DESCRIPTION
## Summary

Replace the `adapterName === "mysql"` branch in the abstract `typeToSql` string case with a per-adapter native-limits table lookup, mirroring Rails' generic `limit ||= native[:limit]` derivation (`abstract/schema_statements.rb:1404`).

A new `NATIVE_TYPE_LIMITS` table encodes the `:limit` defaults from each adapter's `NATIVE_DATABASE_TYPES` hash: only MySQL's `:string` carries `limit: 255` (`abstract_mysql_adapter.rb:33`); sqlite3 (`sqlite3_adapter.rb:71`) and PostgreSQL (`postgresql_adapter.rb:136`) carry none, so a bare `t.string` stays unbounded there. Keeping the native-type knowledge in one table avoids the duplicated-and-easy-to-invert `adapterName` conditionals (the original #4640 gate was inverted to `!== "sqlite"`, baking MySQL's default into PostgreSQL's fallback path).

## Behavior

Preserved for all three adapters — MySQL string → `VARCHAR(255)`, sqlite3/PostgreSQL string → unbounded `VARCHAR` / `character varying`.

## Tests

Existing sqlite3/mysql/postgresql schema-creation + copy-table suites stay green (83 tests).

Closes-story: derive-typetosql-limit-from-native-types-table