### PR TITLE
test(relation): lock eager from() subquery plain-star projection

### DIFF
--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,14 +1,7 @@
 {
   "files": {
-    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
-      "unsignedDecimal",
-      "unsignedFloat"
-    ],
     "packages/activerecord/src/connection-handling.ts": [
       "connection"
-    ],
-    "packages/activesupport/src/core-ext/benchmark.ts": [
-      "ms"
     ]
   }
 }

--- a/eslint/rails-deprecated-methods.json
+++ b/eslint/rails-deprecated-methods.json
@@ -1,7 +1,14 @@
 {
   "files": {
+    "packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts": [
+      "unsignedDecimal",
+      "unsignedFloat"
+    ],
     "packages/activerecord/src/connection-handling.ts": [
       "connection"
+    ],
+    "packages/activesupport/src/core-ext/benchmark.ts": [
+      "ms"
     ]
   }
 }

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2456,6 +2456,14 @@ export function buildFrom(this: QueryMethodsHost): unknown {
     // comprehensive builder rather than the projection-only `toArel`, so the
     // subquery stays a live AST: its binds parameterize and its retryability is
     // determined by the actual child nodes (not unconditionally disabled).
+    // `build_arel` projects the qualified table star (`"comments".*`) and does
+    // NOT run `JoinDependency#apply_column_aliases` — that column-alias
+    // projection (`t0_r0…`) is applied only in Rails' `exec_queries`/`to_sql`/
+    // `pluck` paths, when the OUTER relation is eager, never in `build_from`.
+    // So the folded eager subquery here emits plain star, matching Rails and
+    // the where-subquery path (`relation-handler`); this is intentional, not a
+    // shape deviation to converge away. See the
+    // `eager-from-subquery-column-alias-projection` story.
     const subArel =
       typeof resolved.buildArel === "function" ? resolved.buildArel() : resolved.toArel();
     return subArel.as(alias);

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -442,8 +442,11 @@ describe("RelationTest", () => {
   it("eager from() subquery projects the table star, not column aliases", async () => {
     const relation = Comment.includes("post").where({ "posts.type": "Post" }).order("id");
     const sql = await (Comment.select("*").from(relation) as any).toSql();
-    expect(sql).toContain('"comments".* FROM "comments" LEFT OUTER JOIN "posts"');
-    expect(sql).not.toMatch(/t0_r0/);
+    // Adapter-agnostic: strip identifier quoting (`"` on sqlite/postgres,
+    // backticks on mysql) so the shape assertion holds on every CI adapter.
+    const unquoted = sql.replace(/["`]/g, "");
+    expect(unquoted).toContain("comments.* FROM comments LEFT OUTER JOIN posts");
+    expect(unquoted).not.toMatch(/t0_r0/);
   });
 
   it("finding with subquery with eager loading in where", async () => {

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -430,6 +430,22 @@ describe("RelationTest", () => {
     expect((await Comment.select("a.*").from(relation, "a")).map((c) => c.id)).toEqual(expected);
   });
 
+  // trails-specific SQL-shape lock. Rails `build_from` (query_methods.rb:1783)
+  // resolves an eager-loading `from(relation)` via `apply_join_dependency` and
+  // then wraps `opts.arel.as(name)`. That `arel` is the plain `build_arel` — it
+  // does NOT run `JoinDependency#apply_column_aliases`, which Rails only applies
+  // in the `exec_queries`/`to_sql`/`pluck` paths when the OUTER relation is
+  // eager. So the folded subquery projects the qualified table star
+  // (`"comments".*`), NOT the `t0_r0…` aliased column list a standalone eager
+  // `toSql()` emits. This is Rails-correct, and shared with the where-subquery
+  // path (`relation-handler`); converging to `t0_r*` here would diverge.
+  it("eager from() subquery projects the table star, not column aliases", async () => {
+    const relation = Comment.includes("post").where({ "posts.type": "Post" }).order("id");
+    const sql = await (Comment.select("*").from(relation) as any).toSql();
+    expect(sql).toContain('"comments".* FROM "comments" LEFT OUTER JOIN "posts"');
+    expect(sql).not.toMatch(/t0_r0/);
+  });
+
   it("finding with subquery with eager loading in where", async () => {
     const relation = Comment.includes("post").where({ "posts.type": "Post" });
     const expected = (await relation.toArray()).map((c) => Number(c.id)).sort((a, b) => a - b);


### PR DESCRIPTION
## What

Investigation + SQL-shape lock for the eager `from(relation)` subquery
projection.

The story asked whether to converge the eager `from()` subquery onto Rails'
`t0_r*` column-alias projection, or document the plain-star shape as an
intentional deviation. Reading Rails settles it: **plain star is Rails-correct**,
so neither convergence nor a deviation note is warranted — just a lock test and a
clarifying comment.

Rails `build_from` (`query_methods.rb:1783`) resolves an eager-loading
`from(relation)` via `apply_join_dependency` (folding `includes`/`eager_load`
into LEFT OUTER JOINs) and then wraps `opts.arel.as(name)`. That `arel` is the
plain `build_arel` — it does **not** run
`JoinDependency#apply_column_aliases`. The `t0_r0…` aliased column list is
applied only in Rails' `exec_queries` / `to_sql` / `pluck` paths, and only when
the **outer** relation is eager. So the folded subquery projects the qualified
table star (`"comments".*`), never the aliased list.

trails' `buildFrom` already matches this. Empirically:

```sql
-- Comment.includes("post").where("posts.type": "Post").order("id").toSql()  (outer eager)
SELECT "comments"."id" AS t0_r0, ... "posts"."id" AS t1_r0, ... FROM "comments" LEFT OUTER JOIN "posts" ...

-- Comment.select("*").from(relation).toSql()  (folded subquery)
SELECT * FROM (SELECT "comments".* FROM "comments" LEFT OUTER JOIN "posts" ON ... WHERE "posts"."type" = 'Post' ORDER BY id) subquery
```

The plain-star subquery is shared with the where-subquery path
(`relation-handler`). Converging to `t0_r*` here would **diverge** from Rails.

## Changes

- Add a trails-specific SQL-shape lock test asserting the folded subquery emits
  `"comments".*` and not `t0_r0`.
- Document the decision in the `buildFrom` comment.

## Tests

Both Rails-ported tests stay green:
- `finding with subquery with eager loading in from`
- `finding with subquery with eager loading in where`

Rails source: `query_methods.rb:1783` (`build_from`), `finder_methods.rb:457`
(`apply_join_dependency`), `relation.rb:1211` (`to_sql` column aliases).

Closes-story: eager-from-subquery-column-alias-projection