### PR TITLE
fix(persistence): read back all auto-populated columns on insert

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3442,28 +3442,17 @@ export class Base extends Model {
 
     this._pendingOperation = (async () => {
       // Rails Persistence#_create_record threads `_returning_columns_for_insert`
-      // into `_insert_record`. The single value trails' scalar adapters surface
-      // on INSERT (SQLite's lastInsertRowid, MySQL's insertId, or PG's first
-      // RETURNING column) is the DB-generated AUTO-INCREMENT value — unlike Rails,
-      // which reads back a full RETURNING row and zips every auto-populated column.
-      // So gate the faithful returning list to a single column for the live
-      // write-back: prefer the auto-increment column (rowid / serial / identity),
-      // else a lone returning column, else none (composite-PK falls back to the
-      // adapter's default id read-back, assigned to the first unset target).
+      // into `_insert_record` and zips EVERY auto-populated column
+      // (auto-increment PK plus DB-computed defaults) off the RETURNING row.
+      // Pass the full list to adapters that can emit RETURNING (PG, SQLite
+      // >= 3.35, MariaDB) so those non-PK columns come back on `create`.
+      // Adapters that can't (MySQL 8, older SQLite) surface only the scalar
+      // generated id, so leave `returning` null and fall back to writing that
+      // id into the first still-unset returning column below.
       const returningColumns = ctor._returningColumnsForInsert(adapter as any);
-      const insertCols = (ctor as any).columns() as {
-        name: string;
-        isAutoIncrementedByDb?(): boolean;
-      }[];
-      const autoIncColumn = insertCols.find(
-        (c) => typeof c.isAutoIncrementedByDb === "function" && c.isAutoIncrementedByDb(),
-      )?.name;
-      const returning =
-        autoIncColumn && returningColumns.includes(autoIncColumn)
-          ? [autoIncColumn]
-          : returningColumns.length === 1
-            ? returningColumns
-            : null;
+      const supportsReturning =
+        (adapter as { supportsInsertReturning?(): boolean }).supportsInsertReturning?.() ?? false;
+      const returning = supportsReturning && returningColumns.length > 0 ? returningColumns : null;
 
       // Route through the ported `_insert_record` class method
       // (ActiveRecord::Persistence::ClassMethods#_insert_record) rather than a
@@ -3490,8 +3479,8 @@ export class Base extends Model {
       if (returning) {
         // Explicit RETURNING: the adapter returns values positionally matched to
         // `returning`. Mirrors `_create_record`'s
-        // `returning_columns.zip(returning_values)`. `returning` is gated to a
-        // single column, so this preserves the single-value semantics.
+        // `returning_columns.zip(returning_values)` — every auto-populated
+        // column (PK plus DB-computed defaults) is written back.
         const returnValues = Array.isArray(rawReturn) ? rawReturn : [rawReturn];
         returning.forEach((column, i) => writeBack(column, returnValues[i]));
       } else {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1643,27 +1643,35 @@ export const DatabaseStatements = {
     _sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<number | Result> {
-    const originalSql = sql;
     // Mirror Rails' abstract `exec_insert`, which runs `sql_for_insert` before
-    // the query: append a RETURNING clause on adapters that support it so
-    // DB-populated columns (auto-increment PK, DB-computed defaults) come back
-    // on INSERT.
-    [sql, binds] = sqlForInsert.call(
-      this as unknown as DatabaseStatementsHost,
-      sql,
-      pk ?? null,
-      binds ?? [],
-      returning ?? null,
-    );
-    // sql_for_insert only ever appends, so a length change means a RETURNING
-    // clause was added. `executeMutation` (the scalar write primitive) surfaces
-    // only the generated id, so read the RETURNING row back through the query
-    // path instead, then mark the transaction dirty as `executeMutation` would
-    // (its rollback bookkeeping is skipped on the read path).
-    if (sql.length !== originalSql.length && this.internalExecQuery) {
-      const result = await this.internalExecQuery(sql, name ?? "SQL", binds);
-      this.dirtyCurrentTransaction?.();
-      return result;
+    // the query so a caller-named RETURNING column list surfaces the
+    // DB-populated columns (auto-increment PK, DB-computed defaults) on INSERT.
+    // Only engage when the caller asks for RETURNING columns and the statement
+    // does not already carry a RETURNING clause — this keeps the mixin a
+    // no-op for PostgreSQL, whose own `execInsert` override appends RETURNING
+    // itself and then delegates here via `super` (a second append would emit
+    // an invalid double `RETURNING`).
+    const wantsReturning = returning != null && returning.length > 0 && !/\sRETURNING\s/i.test(sql);
+    if (wantsReturning) {
+      const [returningSql, returningBinds] = sqlForInsert.call(
+        this as unknown as DatabaseStatementsHost,
+        sql,
+        pk ?? null,
+        binds ?? [],
+        returning ?? null,
+      );
+      // `sql_for_insert` appends a clause only on adapters that support
+      // `RETURNING`; when it does, `executeMutation` (the scalar write
+      // primitive) would surface just the generated id, so read the full
+      // RETURNING row back through the query path instead — SQLite's
+      // `executeMutation` `.run()` path drops those rows entirely. Mark the
+      // transaction dirty as `executeMutation` would, since its rollback
+      // bookkeeping is skipped on the read path.
+      if (returningSql.length !== sql.length && this.internalExecQuery) {
+        const result = await this.internalExecQuery(returningSql, name ?? "SQL", returningBinds);
+        this.dirtyCurrentTransaction?.();
+        return result;
+      }
     }
     return this.executeMutation(sql, binds, name ?? "SQL");
   },

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1629,50 +1629,14 @@ export const DatabaseStatements = {
   },
 
   async execInsert(
-    this: DatabaseStatementsDefaultsHost & {
-      supportsInsertReturning?(): boolean;
-      internalExecQuery?(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
-      dirtyCurrentTransaction?(): void;
-      primaryKey?(table: string): string | string[] | null | undefined;
-      quoteColumnName?(name: string): string;
-    },
+    this: DatabaseStatementsDefaultsHost,
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    pk?: string | false | null,
+    _pk?: string | false | null,
     _sequenceName?: string | null,
-    returning?: string[] | null,
-  ): Promise<number | Result> {
-    // Mirror Rails' abstract `exec_insert`, which runs `sql_for_insert` before
-    // the query so a caller-named RETURNING column list surfaces the
-    // DB-populated columns (auto-increment PK, DB-computed defaults) on INSERT.
-    // Only engage when the caller asks for RETURNING columns and the statement
-    // does not already carry a RETURNING clause — this keeps the mixin a
-    // no-op for PostgreSQL, whose own `execInsert` override appends RETURNING
-    // itself and then delegates here via `super` (a second append would emit
-    // an invalid double `RETURNING`).
-    const wantsReturning = returning != null && returning.length > 0 && !/\sRETURNING\s/i.test(sql);
-    if (wantsReturning) {
-      const [returningSql, returningBinds] = sqlForInsert.call(
-        this as unknown as DatabaseStatementsHost,
-        sql,
-        pk ?? null,
-        binds ?? [],
-        returning ?? null,
-      );
-      // `sql_for_insert` appends a clause only on adapters that support
-      // `RETURNING`; when it does, `executeMutation` (the scalar write
-      // primitive) would surface just the generated id, so read the full
-      // RETURNING row back through the query path instead — SQLite's
-      // `executeMutation` `.run()` path drops those rows entirely. Mark the
-      // transaction dirty as `executeMutation` would, since its rollback
-      // bookkeeping is skipped on the read path.
-      if (returningSql.length !== sql.length && this.internalExecQuery) {
-        const result = await this.internalExecQuery(returningSql, name ?? "SQL", returningBinds);
-        this.dirtyCurrentTransaction?.();
-        return result;
-      }
-    }
+    _returning?: string[] | null,
+  ): Promise<number> {
     return this.executeMutation(sql, binds, name ?? "SQL");
   },
 

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1629,13 +1629,42 @@ export const DatabaseStatements = {
   },
 
   async execInsert(
-    this: DatabaseStatementsDefaultsHost,
+    this: DatabaseStatementsDefaultsHost & {
+      supportsInsertReturning?(): boolean;
+      internalExecQuery?(sql: string, name?: string | null, binds?: unknown[]): Promise<Result>;
+      dirtyCurrentTransaction?(): void;
+      primaryKey?(table: string): string | string[] | null | undefined;
+      quoteColumnName?(name: string): string;
+    },
     sql: string,
     name?: string | null,
     binds?: unknown[],
-    _pk?: string | false | null,
+    pk?: string | false | null,
     _sequenceName?: string | null,
-  ): Promise<number> {
+    returning?: string[] | null,
+  ): Promise<number | Result> {
+    const originalSql = sql;
+    // Mirror Rails' abstract `exec_insert`, which runs `sql_for_insert` before
+    // the query: append a RETURNING clause on adapters that support it so
+    // DB-populated columns (auto-increment PK, DB-computed defaults) come back
+    // on INSERT.
+    [sql, binds] = sqlForInsert.call(
+      this as unknown as DatabaseStatementsHost,
+      sql,
+      pk ?? null,
+      binds ?? [],
+      returning ?? null,
+    );
+    // sql_for_insert only ever appends, so a length change means a RETURNING
+    // clause was added. `executeMutation` (the scalar write primitive) surfaces
+    // only the generated id, so read the RETURNING row back through the query
+    // path instead, then mark the transaction dirty as `executeMutation` would
+    // (its rollback bookkeeping is skipped on the read path).
+    if (sql.length !== originalSql.length && this.internalExecQuery) {
+      const result = await this.internalExecQuery(sql, name ?? "SQL", binds);
+      this.dirtyCurrentTransaction?.();
+      return result;
+    }
     return this.executeMutation(sql, binds, name ?? "SQL");
   },
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -3,6 +3,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
+import { sqlForInsert } from "./abstract/database-statements.js";
 import type { MysqlAdapterOptions } from "./pool-config.js";
 import {
   AbstractMysqlAdapter,
@@ -509,6 +510,41 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::DatabaseStatements#perform_query
    * (the `prepare:` keyword routing) + Rails' exec_query tolerating no-result DML.
    */
+  /**
+   * Mirrors Rails' abstract `exec_insert` → `sql_for_insert` → `internal_exec_query`
+   * for the multi-column RETURNING read-back. MariaDB supports `INSERT ...
+   * RETURNING`, but the `executeMutation` write primitive returns only the
+   * generated id, so a multi-column auto-populated-columns list (Rails
+   * `_create_record` zips every returning column) would lose the non-PK values.
+   * Route that case through `execQuery` — bind-aware, and its `withRawConnection`
+   * materializes and dirties the transaction — to hand back the full `Result`.
+   * Single-column / no-RETURNING inserts (and MySQL 8, which lacks insert
+   * returning, so `sql_for_insert` appends nothing) keep the `executeMutation`
+   * path via `super`.
+   */
+  override async execInsert(
+    sql: string,
+    name?: string | null,
+    binds: unknown[] = [],
+    pk?: string | false | null,
+    sequenceName?: string | null,
+    returning?: string[] | null,
+  ): Promise<Result | number> {
+    if (returning && returning.length > 1) {
+      const [returningSql, returningBinds] = sqlForInsert.call(
+        this as never,
+        sql,
+        pk ?? null,
+        binds,
+        returning,
+      );
+      if (/\sRETURNING\s/i.test(returningSql)) {
+        return this.execQuery(returningSql, name ?? "SQL", returningBinds);
+      }
+    }
+    return super.execInsert(sql, name, binds, pk, sequenceName, returning);
+  }
+
   override async execQuery(
     sql: string,
     name?: string | null,
@@ -2012,3 +2048,8 @@ function initializeTypeMap(m: any): never {
   mysql2CastResult;
 
 dirtiesQueryCache(Mysql2Adapter, "executeMutation");
+// The multi-column RETURNING read-back in `execInsert` runs through `execQuery`
+// (a read primitive that does not dirty the cache) rather than `executeMutation`,
+// so dirty `execInsert` too; the single-column path delegates to
+// `executeMutation` via `super`, where the double-clear is a harmless no-op.
+dirtiesQueryCache(Mysql2Adapter, "execInsert");

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2334,6 +2334,26 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           binds,
           returning,
         );
+        // A multi-column RETURNING list is the auto-populated-columns read-back
+        // (Rails `_create_record` zips every returning column). `super.execInsert`
+        // routes through `executeMutation`, which collapses the row to its first
+        // column, so run the INSERT here and hand back the whole `Result` — the
+        // same write-path scaffolding (withRawConnection materializes and dirties
+        // the transaction) the `pk === false` branch above uses. A single-column
+        // list keeps the `super`/`executeMutation` path (scalar id + prepared-
+        // statement-cache retry).
+        if (returning.length > 1) {
+          const preprocessed = this.preprocessQuery(sqlWithReturning);
+          return this.withRawConnection(async (conn) => {
+            const client = conn as unknown as pg.Client;
+            return this._instrumentedQueryOnClient(
+              client,
+              preprocessed,
+              name ?? "SQL",
+              resolvedBinds,
+            );
+          });
+        }
         return super.execInsert(sqlWithReturning, name, resolvedBinds, pk, sequenceName, returning);
       }
       return super.execInsert(sql, name, binds, pk, sequenceName, returning);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -26,6 +26,7 @@ import {
   canRemoveIndexByName,
 } from "./abstract/schema-statements.js";
 import { dirtiesQueryCache } from "./abstract/query-cache.js";
+import { sqlForInsert } from "./abstract/database-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
   ReadOnlyError,
@@ -626,6 +627,42 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
         throw translated;
       }
     });
+  }
+
+  /**
+   * Mirrors Rails' abstract `exec_insert` → `sql_for_insert` → `internal_exec_query`
+   * for the multi-column RETURNING read-back. `executeMutation` runs INSERTs via
+   * better-sqlite3's `.run()`, which discards RETURNING rows, so a multi-column
+   * auto-populated-columns list (Rails `_create_record` zips every returning
+   * column) would come back with only the generated id. Route just that case
+   * through the row-returning `internalExecQuery` (`.all()`, bind-aware, and it
+   * materializes the transaction) and mark the transaction dirty as
+   * `executeMutation` would. Single-column / no-RETURNING inserts keep the
+   * `executeMutation` path (its `lastInsertRowid` yields the id).
+   */
+  override async execInsert(
+    sql: string,
+    name?: string | null,
+    binds: unknown[] = [],
+    pk?: string | false | null,
+    _sequenceName?: string | null,
+    returning?: string[] | null,
+  ): Promise<Result | number> {
+    if (returning && returning.length > 1) {
+      const [returningSql, returningBinds] = sqlForInsert.call(
+        this as never,
+        sql,
+        pk ?? null,
+        binds,
+        returning,
+      );
+      if (/\sRETURNING\s/i.test(returningSql)) {
+        const result = await this.internalExecQuery(returningSql, name ?? "SQL", returningBinds);
+        this.dirtyCurrentTransaction();
+        return result;
+      }
+    }
+    return this.executeMutation(sql, binds, name ?? "SQL");
   }
 
   /**
@@ -3140,6 +3177,12 @@ function translateException(
 // schema changes — the trails analogue of Rails' `dirties_query_cache base,
 // :execute` for the write side.
 dirtiesQueryCache(AbstractSQLite3Adapter, "executeMutation");
+// `execInsert`'s multi-column RETURNING read-back runs through `internalExecQuery`
+// rather than `executeMutation`, so dirty it too — otherwise a subsequent read
+// could be served stale from the query cache after such an INSERT. (The
+// single-column path delegates to `executeMutation`, which is already dirtied;
+// the double-clear there is a harmless no-op.)
+dirtiesQueryCache(AbstractSQLite3Adapter, "execInsert");
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_sqlite3adapter, self)`
 // at the bottom of Rails' sqlite3_adapter.rb — lets railtie initializers

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1900,14 +1900,11 @@ describe("QueryConstraintsTest", () => {
 // three guarded defs as three adapter-gated tests (each builds its adapter's
 // `defaults` table faithfully).
 //
-// Tracked-pending-convergence under RFC 0023-surfaced-deviations: trails'
-// insert path reads back only ONE column (the auto-increment PK) on INSERT,
-// not the full RETURNING row, so DB-populated non-PK columns come back nil
-// after `create` (documented in base.ts `_createRecord`). Rails zips every
-// auto-populated column. Each test therefore `ctx.skip()`s ahead of its
-// assertions pending
-// rfcs/0023-surfaced-deviations/stories/insert-read-back-auto-populated-columns.md
-// (drop the `ctx.skip()` line to un-skip once the read-back is fixed).
+// base.ts `_createRecord` reads back every auto-populated column via a
+// multi-column RETURNING on adapters that support it (PG, SQLite >= 3.35,
+// MariaDB), mirroring Rails `_create_record`'s `returning_columns.zip(
+// returning_values)`, so DB-computed defaults are visible on the record
+// returned by `create`.
 // ==========================================================================
 describe("PersistenceTest", () => {
   registerModel(Default);
@@ -2005,8 +2002,7 @@ describe("PersistenceTest", () => {
   }
 
   // Rails: `if current_adapter?(:PostgreSQLAdapter)`.
-  it.skipIf(adapterType !== "postgres")("fills auto populated columns on creation", async (ctx) => {
-    ctx.skip(); // deviation: insert-read-back-auto-populated-columns
+  it.skipIf(adapterType !== "postgres")("fills auto populated columns on creation", async () => {
     await withDefaultsTable(async (record) => {
       expect(record.ruby_on_rails).toBe("Ruby on Rails");
       if ((Base.connection as PostgreSQLAdapter).supportsVirtualColumns()) {
@@ -2048,8 +2044,7 @@ describe("PersistenceTest", () => {
   });
 
   // Rails: `elsif current_adapter?(:SQLite3Adapter)`.
-  it.skipIf(adapterType !== "sqlite")("fills auto populated columns on creation", async (ctx) => {
-    ctx.skip(); // deviation: insert-read-back-auto-populated-columns
+  it.skipIf(adapterType !== "sqlite")("fills auto populated columns on creation", async () => {
     await withDefaultsTable((record) => {
       expect(record.ruby_on_rails).toBe("Ruby on Rails");
       expect(record.random_number).not.toBeNull();
@@ -2062,8 +2057,7 @@ describe("PersistenceTest", () => {
   });
 
   // Rails: `elsif current_adapter?(:Mysql2Adapter, :TrilogyAdapter)`.
-  it.skipIf(adapterType !== "mysql")("fills auto populated columns on creation", async (ctx) => {
-    ctx.skip(); // deviation: insert-read-back-auto-populated-columns
+  it.skipIf(adapterType !== "mysql")("fills auto populated columns on creation", async () => {
     await withDefaultsTable((record) => {
       expect(record.char1).not.toBeNull();
       const supportsDefaultExpression =

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1908,7 +1908,12 @@ describe("QueryConstraintsTest", () => {
 // ==========================================================================
 describe("PersistenceTest", () => {
   registerModel(Default);
-  fixtures([]);
+  // The adapter-specific `defaults` table is built and dropped with DDL inside
+  // each test; MySQL implicitly commits on DDL, which detonates a wrapping
+  // transactional-fixtures savepoint (ROLLBACK TO SAVEPOINT then fails). Run this
+  // suite non-transactionally — the `defaults` table is torn down in a `finally`
+  // regardless — matching the other DDL-driven suites.
+  fixtures([], { useTransactionalTests: false });
 
   async function buildDefaultsTable() {
     const connection = Base.connection;


### PR DESCRIPTION
## What

Rails' `_create_record` reads the full `RETURNING` row and zips every
auto-populated column (auto-increment PK plus DB-computed defaults) onto the
record. trails gated the returning list to a single column, so non-PK
DB-populated columns came back `nil` after `create` — only a subsequent
`reload` fetched them.

## Changes

- `base.ts` `_createRecord`: pass the full `_returningColumnsForInsert` list to
  adapters that can emit `RETURNING`; adapters that can't (MySQL 8) fall back to
  writing the scalar generated id into the first still-unset column.
- Multi-column `RETURNING` read-back is handled in **each adapter's `execInsert`**,
  using that adapter's bind-aware, transaction-materializing path that returns a
  full `Result` — because the shared `executeMutation` write primitive is scalar
  (PG returns only the first column, MariaDB errors on the syntax, SQLite's
  `.run()` drops the rows):
  - **PostgreSQL**: runs the INSERT via `withRawConnection` /
    `_instrumentedQueryOnClient` (the same scaffolding as the `pk === false`
    branch) instead of delegating the multi-column case to `super`/`executeMutation`.
  - **SQLite**: routes through `internalExecQuery` (`.all()`, bind-aware,
    materializes), dirtying the transaction as `executeMutation` would.
  - **MariaDB**: routes through `execQuery` (bind-aware; its `withRawConnection`
    materializes).
  - Single-column / no-`RETURNING` inserts keep the established `executeMutation`
    path on every adapter. `execInsert` is registered for query-cache dirtying on
    SQLite/MySQL since the read-back path bypasses `executeMutation`.
- Un-skips `fills auto populated columns on creation` on all three adapters; the
  suite runs non-transactionally because it builds/drops the `defaults` table
  with DDL and MySQL implicitly commits on DDL (which would detonate the
  transactional-fixtures savepoint).

## Verification

Ran the un-skipped test **and** the insert/transaction/query-cache regression
suites against real **SQLite**, **PostgreSQL**, **MySQL 8**, and **MariaDB 11** —
all green (the multi-column `RETURNING` read-back is exercised on PG and MariaDB).

Closes-story: insert-read-back-auto-populated-columns