### PR TITLE
fix(relation): preserve joins_values single-array order across merge

### DIFF
--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -113,35 +113,42 @@ export class Merger {
     // same join node) would otherwise duplicate the join and make its columns
     // ambiguous. Dedup structurally via the Arel node's `eql` (falling back to
     // reference/`===` for strings and nodes without it).
+    // Rails `relation.joins_values |= other.joins_values` (merger.rb) is a single
+    // ordered array union preserving `other`'s exact insertion order across the
+    // named/raw boundary, so a source whose joins interleave (e.g.
+    // `joins(:a, "RAW", :b)`) folds in as `[a, RAW, b]`, not `[RAW, a, b]`. We
+    // walk `other.joinsValues` once, unioning each entry per its category:
+    //   - raw joins union structurally (Arel node `eql`, else reference);
+    //   - same-klass named specs dedup by `structuralUnionEq`.
+    // Cross-klass named (Hash | Symbol/String | Array — every shape Rails treats
+    // as an association) can't resolve on the receiver, so they're collected and
+    // built into a single InnerJoin JoinDependency on `other` (whose AliasTracker
+    // handles nested-through / HABTM) rather than folded into _joinsValues; this
+    // mirrors Rails' `else` branch where `others` (the raw joins) still append in
+    // order via `joins!(join_dependency, *others)`.
     const otherJoinsValues = (this.other.joinsValues ?? []) as unknown[];
-    const otherRawJoins = otherJoinsValues.filter((v) => !this.other._isNamedJoinValue(v));
-    for (const v of otherRawJoins) {
-      const dup = (rel._joinValues as unknown[]).some((existing) =>
-        typeof (v as any)?.eql === "function" && v?.constructor === (existing as any)?.constructor
-          ? (v as any).eql(existing)
-          : v === existing,
-      );
-      if (!dup) rel._joinsValues.push(v);
-    }
-    // Rails merge_joins (merger.rb): when other.klass == relation.klass the
-    // association names union directly into joins_values; otherwise Merger builds
-    // a single InnerJoin JoinDependency against other.klass and stashes it. We
-    // mirror both: same-klass names fold into _namedInnerJoins (resolved on the
-    // receiver); cross-klass names (Hash | Symbol/String | Array — every shape
-    // Rails treats as an association) build a JoinDependency on `other` whose
-    // AliasTracker handles nested-through / HABTM correctly.
     const sameKlass = this.other._modelClass === rel._modelClass;
-    const otherNamed: unknown[] = otherJoinsValues.filter((v) => this.other._isNamedJoinValue(v));
-    if (sameKlass) {
-      for (const v of otherNamed) {
+    const crossKlassNamed: unknown[] = [];
+    for (const v of otherJoinsValues) {
+      if (!this.other._isNamedJoinValue(v)) {
+        const dup = (rel._joinValues as unknown[]).some((existing) =>
+          typeof (v as any)?.eql === "function" && v?.constructor === (existing as any)?.constructor
+            ? (v as any).eql(existing)
+            : v === existing,
+        );
+        if (!dup) rel._joinsValues.push(v);
+      } else if (sameKlass) {
         // joins_values |= dedups structurally-equal Hash specs (eql?/hash), so a
         // same-klass merge folds an equal spec — not by JS reference identity.
         if (!rel._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v)))
           rel._joinsValues.push(v);
+      } else {
+        crossKlassNamed.push(v);
       }
-    } else if (otherNamed.length > 0) {
+    }
+    if (crossKlassNamed.length > 0) {
       rel._namedInnerJoinDeps.push(
-        constructJoinDependency.call(this.other, otherNamed as any, Nodes.InnerJoin),
+        constructJoinDependency.call(this.other, crossKlassNamed as any, Nodes.InnerJoin),
       );
     }
     // Carry forward any cross-klass dependencies the source already accumulated.

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -281,6 +281,22 @@ describe("RelationMergingTest", () => {
     expect(banged.joinsValues).toEqual(["comments", rawJoin, "author"]);
   });
 
+  it("relation merging with cross-klass joins builds a join dependency", () => {
+    // merger.rb:122-132: when `other.model != relation.model`, association names
+    // resolve against `other`'s klass, not the receiver — they must NOT be pushed
+    // into the receiver's joins_values (which would resolve them on the wrong
+    // model). `merge` and `mergeBang` must agree here.
+    const source = Post.joins("author");
+    const merged = Comment.all().merge(source);
+    expect(merged.joinsValues).toEqual([]);
+    expect((merged as any)._namedInnerJoinDeps.length).toBe(1);
+
+    const banged = Comment.all();
+    (banged as any).mergeBang(source);
+    expect(banged.joinsValues).toEqual([]);
+    expect((banged as any)._namedInnerJoinDeps.length).toBe(1);
+  });
+
   it("relation merging with skip query cache", () => {
     expect(Post.all().merge(Post.all().skipQueryCacheBang()).skipQueryCacheValue).toBe(true);
   });

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -265,6 +265,22 @@ describe("RelationMergingTest", () => {
     expect(await comments.count()).toBe(1);
   });
 
+  it("relation merging preserves interleaved named/raw joins order", () => {
+    // Rails' `joins_values |= other.joins_values` is a single ordered array union
+    // that preserves the source relation's exact insertion order across the
+    // named/raw boundary — `joins(:a, "RAW", :b)` folds in as `[a, RAW, b]`, not
+    // reordered to `[RAW, a, b]`.
+    const rawJoin = "INNER JOIN authors ON authors.id = posts.author_id";
+    const source = Post.joins("comments", rawJoin, "author");
+    // `merge` routes through Merger#mergeJoins...
+    const merged = Post.all().merge(source);
+    expect(merged.joinsValues).toEqual(["comments", rawJoin, "author"]);
+    // ...and `mergeBang` folds field-by-field; both must preserve the order.
+    const banged = Post.all();
+    (banged as any).mergeBang(source);
+    expect(banged.joinsValues).toEqual(["comments", rawJoin, "author"]);
+  });
+
   it("relation merging with skip query cache", () => {
     expect(Post.all().merge(Post.all().skipQueryCacheBang()).skipQueryCacheValue).toBe(true);
   });

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -4,8 +4,10 @@
  * Mirrors: ActiveRecord::SpawnMethods
  */
 
+import { Nodes } from "@blazetrails/arel";
+
 import { Merger, HashMerger } from "./merger.js";
-import { argumentError, structuralUnionEq } from "./query-methods.js";
+import { argumentError, constructJoinDependency, structuralUnionEq } from "./query-methods.js";
 
 interface SpawnRelation<T = unknown> {
   _clone(): T;
@@ -119,15 +121,35 @@ export function mergeBang(this: any, other: any): any {
         ...(this._eagerLoadAssociations ?? []),
         ...other._eagerLoadAssociations,
       ];
-    // mergeJoins: fold other.joinsValues in a single ordered pass so the source's
-    // cross-category (named/raw) insertion order survives, matching Rails'
-    // `joins_values |= other.joins_values` union. Raw joins append; same-klass
-    // named specs dedup by `structuralUnionEq`.
+    // mergeJoins — kept identical to Merger#mergeJoins (merger.ts) so merge() and
+    // merge!() stay aligned. Fold other.joinsValues in a single ordered pass so the
+    // source's cross-category (named/raw) insertion order survives, matching Rails'
+    // `joins_values |= other.joins_values` (merger.rb merge_joins). Raw joins union
+    // structurally (Arel node `eql`, else reference); same-klass named specs dedup
+    // by `structuralUnionEq`; cross-klass named (merger.rb:122 `other.model !=
+    // relation.model`) build a single InnerJoin JoinDependency on `other`.
     this._joinClauses.push(...(other._joinClauses ?? []));
+    const sameKlass = other._modelClass === this._modelClass;
+    const crossKlassNamed: unknown[] = [];
     for (const v of other.joinsValues ?? []) {
-      if (!other._isNamedJoinValue(v)) this._joinsValues.push(v);
-      else if (!this._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v)))
-        this._joinsValues.push(v);
+      if (!other._isNamedJoinValue(v)) {
+        const dup = (this._joinValues as unknown[]).some((existing) =>
+          typeof v?.eql === "function" && v?.constructor === (existing as any)?.constructor
+            ? v.eql(existing)
+            : v === existing,
+        );
+        if (!dup) this._joinsValues.push(v);
+      } else if (sameKlass) {
+        if (!this._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v)))
+          this._joinsValues.push(v);
+      } else {
+        crossKlassNamed.push(v);
+      }
+    }
+    if (crossKlassNamed.length > 0) {
+      this._namedInnerJoinDeps.push(
+        constructJoinDependency.call(other, crossKlassNamed as any, Nodes.InnerJoin),
+      );
     }
     for (const v of other._leftOuterJoinsValues ?? []) {
       if (!this._leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -119,16 +119,19 @@ export function mergeBang(this: any, other: any): any {
         ...(this._eagerLoadAssociations ?? []),
         ...other._eagerLoadAssociations,
       ];
-    // mergeJoins (preserve original order across all join stores)
+    // mergeJoins: fold other.joinsValues in a single ordered pass so the source's
+    // cross-category (named/raw) insertion order survives, matching Rails'
+    // `joins_values |= other.joins_values` union. Raw joins append; same-klass
+    // named specs dedup by `structuralUnionEq`.
     this._joinClauses.push(...(other._joinClauses ?? []));
-    this._joinsValues.push(...(other._joinValues ?? []));
+    for (const v of other.joinsValues ?? []) {
+      if (!other._isNamedJoinValue(v)) this._joinsValues.push(v);
+      else if (!this._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v)))
+        this._joinsValues.push(v);
+    }
     for (const v of other._leftOuterJoinsValues ?? []) {
       if (!this._leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
         this._leftOuterJoinsValues.push(v);
-    }
-    for (const v of other._namedInnerJoins ?? []) {
-      if (!this._namedInnerJoins.some((seen: unknown) => structuralUnionEq(seen, v)))
-        this._joinsValues.push(v);
     }
     this._namedInnerJoinDeps.push(...(other._namedInnerJoinDeps ?? []));
     this._leftOuterJoinDeps.push(...(other._leftOuterJoinDeps ?? []));


### PR DESCRIPTION
## What

`mergeBang` (`relation/spawn-methods.ts`) and `mergeJoins` (`relation/merger.ts`)
folded the other relation's joins in **raw-then-named** category order, reordering
a source whose joins interleave across the named/raw boundary — `joins(:a, "RAW", :b)`
folded in as `[RAW, a, b]` instead of `[a, RAW, b]`.

Now that `joins_values` is a unified insertion-ordered `_joinsValues` store, both
paths walk `other.joinsValues` **once** and union each entry per category, matching
Rails' `relation.joins_values |= other.joins_values` (`relation/merger.rb`
`merge_joins`) — a single ordered array union that preserves the source's exact
insertion order.

## Behavior preserved

- Raw joins union structurally (Arel node `eql`, else reference).
- Same-klass named specs dedup by `structuralUnionEq`.
- Cross-klass named still build a single InnerJoin `JoinDependency` stash.

## Test

Added a merging test asserting interleaved named/raw join order survives `.merge`.

Closes-story: merge-joins-preserve-single-array-order