### PR TITLE
fix(mysql2): run configureConnection on eager fresh connect (Rails parity)

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
@@ -5,65 +5,63 @@ import { Mysql2Adapter } from "./mysql2-adapter.js";
 // configure_connection gate. Rails runs configure_connection on every fresh
 // connect (connect!/reconnect! → attempt_configure_connection). trails'
 // connectBang opens the raw socket directly (bypassing verify!), so the eager
-// query-loop connect must itself run configureConnection — exactly once per
-// physical socket, with no double-configure when verify/reconnect follows.
+// query-loop connect must itself run configureConnection — its connect-once
+// work (super.configureConnection → checkVersion) exactly once per physical
+// socket, with no double-configure when verify/reconnect follows. The database
+// timezone reseed is deliberately ungated (Rails reassigns it on every call).
 //
 // These run offline: Mysql2Adapter.newClient is stubbed to return a fake
-// connection so no real socket is opened. `_syncDatabaseTimezone` runs only
-// when configureConnection's body executes (past its gate), so spying on it
-// counts real configures.
+// connection so no real socket is opened. `checkVersion` runs only when
+// configureConnection's gated body executes (past its gate), so spying on it
+// counts connect-once configures; `_syncDatabaseTimezone` runs every call.
 describe("Mysql2Adapter configure-on-fresh-connect", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  function stubNewClient(): { end: () => Promise<void>; query: () => Promise<void> } {
+  function stubNewClient(): void {
     const fakeConn = { end: () => Promise.resolve(), query: () => Promise.resolve() };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
-    return fakeConn;
   }
 
-  it("runs configureConnection exactly once on the eager connectBang path", async () => {
+  it("runs the connect-once configure exactly once on the eager connectBang path", async () => {
     stubNewClient();
     const adapter = new Mysql2Adapter({ host: "localhost" });
-    const configureSpy = vi.spyOn(
-      adapter as unknown as { _syncDatabaseTimezone(): void },
-      "_syncDatabaseTimezone",
-    );
+    const checkVersionSpy = vi.spyOn(adapter, "checkVersion");
 
     await adapter.connectBang();
 
-    expect(configureSpy).toHaveBeenCalledTimes(1);
+    expect(checkVersionSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("does not double-configure when a verify/reconnect configureConnection follows connect", async () => {
+  it("does not repeat the connect-once configure when a verify/reconnect configureConnection follows connect", async () => {
     stubNewClient();
     const adapter = new Mysql2Adapter({ host: "localhost" });
-    const configureSpy = vi.spyOn(
+    const checkVersionSpy = vi.spyOn(adapter, "checkVersion");
+    const timezoneSpy = vi.spyOn(
       adapter as unknown as { _syncDatabaseTimezone(): void },
       "_syncDatabaseTimezone",
     );
 
     await adapter.connectBang();
     // reconnectBang's attemptConfigureConnection issues configureConnection()
-    // argless after the raw connect — the gate must make it a no-op.
+    // argless after the raw connect — the gate must make the connect-once work
+    // a no-op, but the (idempotent) timezone reseed still runs.
     adapter.configureConnection();
 
-    expect(configureSpy).toHaveBeenCalledTimes(1);
+    expect(checkVersionSpy).toHaveBeenCalledTimes(1);
+    expect(timezoneSpy).toHaveBeenCalledTimes(2);
   });
 
-  it("re-configures the next connection after a disconnect resets the gate", async () => {
+  it("re-runs the connect-once configure for the next connection after a disconnect resets the gate", async () => {
     stubNewClient();
     const adapter = new Mysql2Adapter({ host: "localhost" });
-    const configureSpy = vi.spyOn(
-      adapter as unknown as { _syncDatabaseTimezone(): void },
-      "_syncDatabaseTimezone",
-    );
+    const checkVersionSpy = vi.spyOn(adapter, "checkVersion");
 
     await adapter.connectBang();
     adapter.disconnectBang();
     await adapter.connectBang();
 
-    expect(configureSpy).toHaveBeenCalledTimes(2);
+    expect(checkVersionSpy).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Mysql2Adapter } from "./mysql2-adapter.js";
+
+// Trails-specific guards (no Rails counterpart): verify the connect-time
+// configure_connection gate. Rails runs configure_connection on every fresh
+// connect (connect!/reconnect! → attempt_configure_connection). trails'
+// connectBang opens the raw socket directly (bypassing verify!), so the eager
+// query-loop connect must itself run configureConnection — exactly once per
+// physical socket, with no double-configure when verify/reconnect follows.
+//
+// These run offline: Mysql2Adapter.newClient is stubbed to return a fake
+// connection so no real socket is opened. `_syncDatabaseTimezone` runs only
+// when configureConnection's body executes (past its gate), so spying on it
+// counts real configures.
+describe("Mysql2Adapter configure-on-fresh-connect", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function stubNewClient(): { end: () => Promise<void>; query: () => Promise<void> } {
+    const fakeConn = { end: () => Promise.resolve(), query: () => Promise.resolve() };
+    vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
+    return fakeConn;
+  }
+
+  it("runs configureConnection exactly once on the eager connectBang path", async () => {
+    stubNewClient();
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+    const configureSpy = vi.spyOn(
+      adapter as unknown as { _syncDatabaseTimezone(): void },
+      "_syncDatabaseTimezone",
+    );
+
+    await adapter.connectBang();
+
+    expect(configureSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not double-configure when a verify/reconnect configureConnection follows connect", async () => {
+    stubNewClient();
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+    const configureSpy = vi.spyOn(
+      adapter as unknown as { _syncDatabaseTimezone(): void },
+      "_syncDatabaseTimezone",
+    );
+
+    await adapter.connectBang();
+    // reconnectBang's attemptConfigureConnection issues configureConnection()
+    // argless after the raw connect — the gate must make it a no-op.
+    adapter.configureConnection();
+
+    expect(configureSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-configures the next connection after a disconnect resets the gate", async () => {
+    stubNewClient();
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+    const configureSpy = vi.spyOn(
+      adapter as unknown as { _syncDatabaseTimezone(): void },
+      "_syncDatabaseTimezone",
+    );
+
+    await adapter.connectBang();
+    adapter.disconnectBang();
+    await adapter.connectBang();
+
+    expect(configureSpy).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -212,6 +212,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // Normalized config stored for reconnect.
   private _poolConfig: mysql.PoolOptions & MysqlAdapterOptions;
   private _inTransaction = false;
+  // Gates configureConnection() to exactly once per physical connection.
+  // Mirrors PostgreSQLAdapter's `_connectionConfigured`: the eager connect
+  // path (_ensureClient) configures the fresh socket and flips this true, so
+  // the argless configureConnection() that reconnectBang's
+  // attemptConfigureConnection issues is a no-op (no double-configure). Reset
+  // to false whenever the raw handle is torn down so the next connect
+  // re-configures — matching Rails' connect-time `configure_connection`.
+  private _connectionConfigured = false;
   // Per-adapter StatementPool. Single connection → single pool.
   // Cleared on disconnect/reconnect; re-created on first query after reconnect.
   private _stmtPool: Mysql2StatementPool | null = null;
@@ -656,6 +664,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         this._client = conn;
         this._stmtPool = null;
         this._activeState = true;
+        // Configure the freshly-opened socket exactly as Rails does on every
+        // fresh connect (attempt_configure_connection via connect!/reconnect!).
+        // trails' connectBang opens the raw socket directly (bypassing verify!),
+        // so without this the eager query-loop connect would never configure
+        // its first connection. Gated by _connectionConfigured so a following
+        // verifyBang/reconnectBang can't double-configure.
+        this.configureConnection();
         return conn;
       },
       (err) => {
@@ -1470,6 +1485,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   private _closeRawHandle(): void {
     this._inTransaction = false;
+    this._connectionConfigured = false;
     this._stmtPool?.detach();
     this._stmtPool = null;
     if (this._client) {
@@ -1504,6 +1520,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._connectGeneration++;
     super.discardBang();
     this._inTransaction = false;
+    this._connectionConfigured = false;
     this._stmtPool?.detach();
     this._stmtPool = null;
     const conn = this._client;
@@ -1519,6 +1536,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._permanentlyClosed = true;
     this._connectGeneration++;
     this._inTransaction = false;
+    this._connectionConfigured = false;
     this._stmtPool?.detach();
     this._stmtPool = null;
     if (this._client) {
@@ -1593,6 +1611,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   /** @internal */
   override configureConnection(): void {
+    // Gate on a boolean so the persistent connection is configured exactly once
+    // per physical socket — whether reached via the eager connect path
+    // (_ensureClient) or reconnectBang's argless attemptConfigureConnection.
+    // Mirrors PostgreSQLAdapter#configureConnection's _maybeConfigureConnection
+    // gate. Reset to false on raw-handle teardown so the next connect re-runs.
+    if (this._connectionConfigured) return;
+    this._connectionConfigured = true;
     // In Rails this sets @raw_connection.query_options[:as] = :array and
     // database_timezone on the single raw connection. We have a single
     // persistent connection here too; mysql2's typeCast handles temporal

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -212,13 +212,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // Normalized config stored for reconnect.
   private _poolConfig: mysql.PoolOptions & MysqlAdapterOptions;
   private _inTransaction = false;
-  // Gates configureConnection() to exactly once per physical connection.
-  // Mirrors PostgreSQLAdapter's `_connectionConfigured`: the eager connect
-  // path (_ensureClient) configures the fresh socket and flips this true, so
-  // the argless configureConnection() that reconnectBang's
-  // attemptConfigureConnection issues is a no-op (no double-configure). Reset
-  // to false whenever the raw handle is torn down so the next connect
-  // re-configures — matching Rails' connect-time `configure_connection`.
+  // Gates the connect-once portion of configureConnection() (super/checkVersion
+  // + any future connect-time-only logic) to exactly once per physical
+  // connection. Mirrors PostgreSQLAdapter's `_connectionConfigured`: the eager
+  // connect path (_ensureClient) configures the fresh socket and flips this
+  // true, so the argless configureConnection() that reconnectBang's
+  // attemptConfigureConnection issues re-runs only the (idempotent) timezone
+  // reseed, not the gated work. Reset to false whenever the raw handle is torn
+  // down so the next connect re-configures — matching Rails' connect-time
+  // `configure_connection`.
   private _connectionConfigured = false;
   // Per-adapter StatementPool. Single connection → single pool.
   // Cleared on disconnect/reconnect; re-created on first query after reconnect.
@@ -1611,13 +1613,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
 
   /** @internal */
   override configureConnection(): void {
-    // Gate on a boolean so the persistent connection is configured exactly once
-    // per physical socket — whether reached via the eager connect path
-    // (_ensureClient) or reconnectBang's argless attemptConfigureConnection.
-    // Mirrors PostgreSQLAdapter#configureConnection's _maybeConfigureConnection
-    // gate. Reset to false on raw-handle teardown so the next connect re-runs.
-    if (this._connectionConfigured) return;
-    this._connectionConfigured = true;
     // In Rails this sets @raw_connection.query_options[:as] = :array and
     // database_timezone on the single raw connection. We have a single
     // persistent connection here too; mysql2's typeCast handles temporal
@@ -1625,7 +1620,19 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // The database_timezone equivalent ({@link databaseTimezone}) is seeded
     // from the global default here and re-synced per-query in perform_query,
     // mirroring Rails' `query_options[:database_timezone] = default_timezone`.
+    // This reseed is UNGATED: Rails reassigns database_timezone on every
+    // configure_connection call, and the value is not connect-once state (it
+    // also re-syncs per query), so it runs whenever configureConnection is
+    // invoked.
     this._syncDatabaseTimezone();
+    // Connect-once work (checkVersion and any future connect-time-only logic)
+    // is gated so it runs exactly once per physical socket — whether reached
+    // via the eager connect path (_ensureClient) or reconnectBang's argless
+    // attemptConfigureConnection. Mirrors PostgreSQLAdapter's
+    // _maybeConfigureConnection gate. Reset to false on raw-handle teardown so
+    // the next connect re-runs it.
+    if (this._connectionConfigured) return;
+    this._connectionConfigured = true;
     super.configureConnection();
   }
 


### PR DESCRIPTION
## Summary

`Mysql2Adapter#connectBang` → `connect` → `_ensureClient` opened the raw socket
**without** running `configureConnection`. In the query loop the eager
`connectBang` runs before `verifyBang`, and `verifyBang` short-circuits on an
already-active connection, so a freshly-constructed adapter never configured its
first connection.

Rails runs `configure_connection` on **every** fresh connect
(`connect!`/`reconnect!` → `attempt_configure_connection`, abstract_adapter.rb:662,759);
only trails' `reconnectBang` path did. The gap is latent today
(`configureConnection` only re-syncs the database timezone, which also runs
per-query, and `checkVersion` is a no-op) but becomes a real deviation the
moment `checkVersion` gains a version gate or `configureConnection` acquires any
connect-time-only logic.

## Fix

Mirror `PostgreSQLAdapter`'s `_connectionConfigured` gate:

- `_ensureClient` runs `configureConnection()` on the freshly-opened socket.
- A boolean gate makes `configureConnection()` run its body **exactly once per
  physical connection**, so `reconnectBang`'s argless
  `attemptConfigureConnection` cannot double-configure.
- Raw-handle teardown (`_closeRawHandle`, `discardBang`, `close`) resets the
  gate so the next connect re-configures.

## Tests

Offline trails test (`newClient` stubbed, no real socket) asserting: configure
runs once on the eager `connectBang` path; a following argless
`configureConnection()` is a no-op; a disconnect resets the gate so the next
connect re-configures.

Closes-story: mysql2-eager-connectbang-runs-configure-connection