### PR TITLE
test(nested-through): un-skip has_one-source-reflection polymorphic direct-load

### DIFF
--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -199,11 +199,8 @@ describe("NestedThroughAssociationsTest", () => {
   });
 
   // has_many through
-  // Source: has_one
+  // Source: has_one (polymorphic, Club.sponsors `as: :sponsorable`)
   // Through: has_one through
-  // Direct load of nestedSponsors generates "no such column: sponsors.sponsor_club_id";
-  // the polymorphic FK resolution for Club.sponsors (as: "sponsorable") is wrong in the nested-through
-  // direct-query builder. Preload and joins paths work correctly.
   it("has many through has one through with has one source reflection", async () => {
     const mustache = sponsors("moustache_club_sponsor_for_groucho");
     const groucho = members("groucho");

--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -204,7 +204,12 @@ describe("NestedThroughAssociationsTest", () => {
   // Direct load of nestedSponsors generates "no such column: sponsors.sponsor_club_id";
   // the polymorphic FK resolution for Club.sponsors (as: "sponsorable") is wrong in the nested-through
   // direct-query builder. Preload and joins paths work correctly.
-  it.todo("has many through has one through with has one source reflection");
+  it("has many through has one through with has one source reflection", async () => {
+    const mustache = sponsors("moustache_club_sponsor_for_groucho");
+    const groucho = members("groucho");
+    const result = await groucho.nestedSponsors.toArray();
+    expect(result.map((s) => s.id)).toEqual([mustache.id]);
+  });
 
   it("has many through has one through with has one source reflection preload", async () => {
     const mustache = sponsors("moustache_club_sponsor_for_groucho");


### PR DESCRIPTION
## Summary

Un-skips the previously `it.todo` test
`has many through has one through with has one source reflection` in
`nested-through-associations.test.ts` — Rails'
`test_has_many_through_has_one_through_with_has_one_source_reflection`.

`members(:groucho).nestedSponsors` is a `has_many :through` chain
(Member → membership → club → sponsors, polymorphic `as: :sponsorable`).
The direct-load path previously errored `no such column: sponsors.sponsor_club_id`
because it resolved the source FK via the non-polymorphic `${name}_id` fallback.
The nested-through direct-query builder now resolves it via
`sourceReflection.foreignKey` (`sponsorable_id`), so the direct-load path
matches the preload and joins paths.

## Test

- `members(:groucho).nestedSponsors.toArray()` returns
  `[sponsors(:moustache_club_sponsor_for_groucho)]` — passes on sqlite locally;
  pg/mysql via CI.

Closes-story: nested-through-polymorphic-fk-direct-load