### PR TITLE
refactor(test-compare): drop dead disconnected.test.ts skip ref

### DIFF
--- a/scripts/test-compare/normalize-skips.ts
+++ b/scripts/test-compare/normalize-skips.ts
@@ -809,7 +809,7 @@ function categorize(relPath: string, describeName: string, testName: string): An
   }
 
   // --- Connection-related singletons ---
-  if (p === "invalid-connection.test.ts" || p === "disconnected.test.ts") {
+  if (p === "invalid-connection.test.ts") {
     const file = path.basename(p, ".test.ts");
     return {
       blocked: "connection-pool — invalid / disconnected connection handling gap",


### PR DESCRIPTION
PR #4166 deleted `packages/activerecord/src/disconnected.test.ts`. The `disconnected.test.ts` arm at `scripts/test-compare/normalize-skips.ts:812` was left in place to keep that PR one-file-scoped; the file no longer exists, so the reference is inert dead code. This removes the `|| p === "disconnected.test.ts"` clause, keeping `invalid-connection.test.ts` handling intact.

No change to test:compare/api:compare parity metrics.

Closes-story: normalize-skips-drop-deleted-file-refs