### PR TITLE
fix(finder): converge not-found messages onto raise_record_not_found_exception!

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -130,6 +130,23 @@ export class CollectionAssociation extends Association {
     // Reuse the shared "Couldn't find all" builder (also used by performFind)
     // so there is a single not-found message source.
     if (records.length !== filteredIds.length) {
+      // Rails `ids_writer` (collection_association.rb:79-81):
+      //   found_ids = records.map { |r| r._read_attribute(primary_key) }
+      //   not_found_ids = ids - found_ids
+      //   klass.all.raise_record_not_found_exception!(ids, records.size, ids.size, primary_key, not_found_ids)
+      // The `not_found_ids` sentence is appended to the message.
+      const keyFor = (v: unknown): string =>
+        Array.isArray(v) ? v.map(String).join(",") : String(v);
+      const foundKeys = new Set(
+        records.map((r) =>
+          keyFor(
+            Array.isArray(pk)
+              ? pk.map((col: string) => (r as any)._readAttribute(col))
+              : (r as any)._readAttribute(pk),
+          ),
+        ),
+      );
+      const notFoundIds = filteredIds.filter((id) => !foundKeys.has(keyFor(id)));
       raiseNotFoundAll(
         Klass.name,
         pk,
@@ -140,6 +157,8 @@ export class CollectionAssociation extends Association {
         },
         records.length,
         filteredIds.length,
+        "",
+        notFoundIds,
       );
     }
 

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -130,11 +130,17 @@ export class CollectionAssociation extends Association {
     // Reuse the shared "Couldn't find all" builder (also used by performFind)
     // so there is a single not-found message source.
     if (records.length !== filteredIds.length) {
-      raiseNotFoundAll(Klass.name, pk, {
-        ids: filteredIds,
-        wantArray: true,
-        tuples: Array.isArray(pk) ? (filteredIds as unknown[][]) : null,
-      });
+      raiseNotFoundAll(
+        Klass.name,
+        pk,
+        {
+          ids: filteredIds,
+          wantArray: true,
+          tuples: Array.isArray(pk) ? (filteredIds as unknown[][]) : null,
+        },
+        records.length,
+        filteredIds.length,
+      );
     }
 
     this.replace(records);

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -762,9 +762,18 @@ describe("CollectionProxy#find — in-memory not-found message fidelity", () => 
     } catch (e) {
       const err = e as RecordNotFound;
       expect(err).toBeInstanceOf(RecordNotFound);
-      // In-memory scan → no `[WHERE …]` conditions clause (unlike the SQL path).
-      expect(err.message).toBe(
-        `Couldn't find all Clients with 'id': (${realId}, 999999) (found 1 results, but was looking for 2).`,
+      // Pluralized model name + found/expected suffix (this story's convergence).
+      // Rails' in-memory `find` routes through `scope.raise_record_not_found_
+      // exception!`, so the message also carries the association scope's
+      // `[WHERE …]` clause; trails' in-memory path omits it today (tracked
+      // separately: story in-memory-collection-find-conditions-clause). The
+      // regex therefore tolerates an optional conditions clause rather than
+      // ratifying its absence.
+      expect(err.message).toMatch(
+        new RegExp(
+          `^Couldn't find all Clients with 'id': \\(${realId}, 999999\\).*` +
+            `\\(found 1 results, but was looking for 2\\)\\.$`,
+        ),
       );
     }
   });

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from "vitest";
 import { throwAbort } from "@blazetrails/activesupport";
-import { Base, association, registerModel } from "../index.js";
+import { Base, association, registerModel, RecordNotFound } from "../index.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 // Opt this file into the canonical-model autoload index (Zeitwerk analog):
 // `Comment`, `Tagging`, `Tag`, and `Owner` — association targets with no
@@ -22,6 +22,7 @@ import { Tag } from "../test-helpers/models/tag.js";
 import { CpkAuthor, CpkBook } from "../test-helpers/models/cpk.js";
 import { Pet } from "../test-helpers/models/pet.js";
 import { Toy } from "../test-helpers/models/toy.js";
+import { Firm } from "../test-helpers/models/company.js";
 
 // `authors`, `posts`, `cpkAuthors`, `cpkBooks`, `pets`, and `toys` are declared
 // fixture sets below, so their models (`Author`, `Post`, `CpkAuthor`, `CpkBook`,
@@ -735,5 +736,36 @@ describe("CollectionProxy — mutated finder requery on stale new-owner seed", (
     await Post.create({ title: "drop", body: "2", author_id: authorId });
 
     expect((await proxy.first()).id).toBe(kept.id);
+  });
+});
+
+// The in-memory `CollectionProxy#find` path (loaded `inverse_of` collection,
+// scanned in memory) must emit the identical not-found message as the SQL
+// `performFind` path — Rails routes both through
+// `raise_record_not_found_exception!`, so a missing id in a multi-id lookup
+// pluralizes the model name and appends the found/expected suffix.
+// `Firm has_many :clients_of_firm, inverse_of: :firm` is the canonical loaded
+// inverse-of collection (same fixture setup as the BigInt-key-match test).
+describe("CollectionProxy#find — in-memory not-found message fidelity", () => {
+  const { companies } = fixtures(["companies"]);
+
+  it("emits the pluralized aggregate message for a missing id in a loaded inverse_of collection", async () => {
+    const firm = await Firm.find(companies("first_firm").id);
+    const proxy = association<Base>(firm, "clientsOfFirm");
+    const clients = await proxy.load();
+    expect(clients.length).toBeGreaterThan(0);
+    const realId = clients[0].id as number;
+
+    try {
+      await proxy.find([realId, 999999]);
+      expect.fail("should have thrown");
+    } catch (e) {
+      const err = e as RecordNotFound;
+      expect(err).toBeInstanceOf(RecordNotFound);
+      // In-memory scan → no `[WHERE …]` conditions clause (unlike the SQL path).
+      expect(err.message).toBe(
+        `Couldn't find all Clients with 'id': (${realId}, 999999) (found 1 results, but was looking for 2).`,
+      );
+    }
   });
 });

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3329,7 +3329,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       const castedIds = ids.map(castId);
       const uniqueFoundKeys = new Set(castedIds.map(keyForCastedId).filter((k) => byPk.has(k)));
       if (uniqueFoundKeys.size !== ids.length) {
-        raiseNotFoundAll(targetModel.name, pk, normalized);
+        raiseNotFoundAll(targetModel.name, pk, normalized, uniqueFoundKeys.size, ids.length);
       }
       // Return in DB/load order, matching performFind.
       const wantedKeys = new Set(castedIds.map(keyForCastedId));

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -1523,16 +1523,27 @@ describe("HasManyThroughAssociationsTest", () => {
     const company = await Company.find(companies("rails_core").id);
     const dev = (await Developer.first())!;
     const ids = [dev.id as number, -9999];
+    // Rails asserts the full message, including the trailing `not_found_ids`
+    // sentence (`klass.all.raise_record_not_found_exception!(…, not_found_ids)`).
     await expect(association(company, "developers").setIds(ids)).rejects.toThrow(
-      /RecordNotFound|Couldn't find/,
+      `Couldn't find all Developers with 'id': (${dev.id}, -9999) (found 1 results, but was looking for 2). Couldn't find Developer with id -9999.`,
     );
   });
 
   it("collection singular ids through setter raises exception when invalid ids set", async () => {
     const david = await Author.find(authors("david").id);
     const ids = [(categories("general") as any).name, "Unknown"];
+    // NOTE: the exact Rails message here is
+    //   "Couldn't find all Categories with 'name': (General, Unknown) (found 1
+    //    results, but was looking for 2). Couldn't find Category with name Unknown."
+    // trails' `idsWriter` currently resolves the target key as 'id' rather than
+    // Rails' `reflection.association_primary_key` ('name'), so it finds 0 and
+    // emits the wrong key. That pk-resolution divergence is tracked separately
+    // (story: idswriter-association-primary-key-resolution); this assertion stays
+    // loose until it is fixed. The `not_found_ids` suffix itself is asserted
+    // exactly by the simple-PK developers case above.
     await expect(association(david, "essayCategories").setIds(ids)).rejects.toThrow(
-      /RecordNotFound|Couldn't find/,
+      /Couldn't find all Categories.*\(found \d+ results, but was looking for 2\)\. Couldn't find/,
     );
   });
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -517,7 +517,7 @@ async function performClassUpdate(
       return record;
     }
     // Empty ids list is a no-op (Rails behaves this way; Base.find([]) would
-    // otherwise raise RecordNotFound "empty list of ids").
+    // otherwise raise RecordNotFound "without an ID").
     if (idOrAttrs.length === 0) return [];
     const attrsArr = attrs as Record<string, unknown>[];
     if (!Array.isArray(attrsArr) || attrsArr.length !== idOrAttrs.length) {

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -853,11 +853,13 @@ export async function find(this: CoreHost, ...ids: unknown[]): Promise<any> {
   // attribute definitions that lazy reflection populates.
   await this.ensureSchemaLoaded();
   if (ids.length === 0) {
+    // Rails Core#find delegates a zero-arg call to `super` → `find_with_ids`,
+    // whose `when 0` branch raises "Couldn't find <Model> without an ID"
+    // (finder_methods.rb:508), no id payload.
     throw new RecordNotFound(
-      `Couldn't find ${this.name} with an empty list of ids`,
+      `Couldn't find ${this.name} without an ID`,
       this.name,
       String(this.primaryKey),
-      [],
     );
   }
   // Rails Core#find fast-path: a single supported scalar id on a simple

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -1226,7 +1226,19 @@ describe("FinderTest", () => {
 
   it("find with ids with no id passed", async () => {
     const { Post } = makeModel();
-    expect(await Post.find([])).toEqual([]);
+    // Rails test_find_with_ids_with_no_id_passed: a zero-arg find raises
+    // RecordNotFound "Couldn't find <Model> without an ID" (find_with_ids
+    // `when 0`), carrying model + primary_key.
+    try {
+      await (Post.find as (...ids: unknown[]) => Promise<unknown>).call(Post);
+      expect.fail("should have thrown");
+    } catch (e) {
+      const err = e as RecordNotFound;
+      expect(err).toBeInstanceOf(RecordNotFound);
+      expect(err.message).toBe("Couldn't find Post without an ID");
+      expect(err.model).toBe("Post");
+      expect(err.primaryKey).toBe("id");
+    }
   });
 
   it("find with ids with id out of range", async () => {
@@ -1426,7 +1438,11 @@ describe("FinderTest", () => {
       expect.unreachable("should throw");
     } catch (e: any) {
       expect(e).toBeInstanceOf(RecordNotFound);
-      expect(e.message).toContain("999999");
+      // Rails raise_record_not_found_exception! multi-id: pluralized model
+      // name + "(found N results, but was looking for M)." suffix.
+      expect(e.message).toBe(
+        `Couldn't find all Topics with 'id': (${t.id}, 999999) (found 1 results, but was looking for 2).`,
+      );
     }
   });
 

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -65,7 +65,7 @@ describe("normalizeFindArgs — simple primary key", () => {
     });
   });
 
-  it("test_find_with_ids_with_no_id_passed", () => {
+  it("normalizeFindArgs zero-arg → RecordNotFound 'without an ID' shape", () => {
     try {
       normalizeFindArgs("Post", pk, []);
       expect.fail("should have thrown");

--- a/packages/activerecord/src/relation/finder-methods.test.ts
+++ b/packages/activerecord/src/relation/finder-methods.test.ts
@@ -65,17 +65,16 @@ describe("normalizeFindArgs — simple primary key", () => {
     });
   });
 
-  it("find() → RecordNotFound with empty-list shape", () => {
+  it("test_find_with_ids_with_no_id_passed", () => {
     try {
       normalizeFindArgs("Post", pk, []);
       expect.fail("should have thrown");
     } catch (e) {
       expect(e).toBeInstanceOf(RecordNotFound);
       const err = e as RecordNotFound;
-      expect(err.message).toBe("Couldn't find Post with an empty list of ids");
+      expect(err.message).toBe("Couldn't find Post without an ID");
       expect(err.model).toBe("Post");
       expect(err.primaryKey).toBe("id");
-      expect(err.id).toEqual([]);
     }
   });
 
@@ -263,25 +262,27 @@ describe("normalizeFindArgs — composite primary key", () => {
     }
   });
 
-  it("find() → empty-list shape, same as simple PK", () => {
-    expect(() => normalizeFindArgs("Order", pk, [])).toThrow(/empty list of ids/);
+  it("find() → without-an-ID shape, same as simple PK", () => {
+    expect(() => normalizeFindArgs("Order", pk, [])).toThrow(/without an ID/);
   });
 });
 
 describe("raiseNotFoundAll", () => {
-  it("simple PK: flatIds.join(', ') + flatIds payload", () => {
+  it("simple PK: pluralized name + found/expected suffix + flatIds payload", () => {
     const normalized = { ids: [1, 2, 3], wantArray: true, tuples: null };
     try {
-      raiseNotFoundAll("Post", "id", normalized);
+      raiseNotFoundAll("Post", "id", normalized, 2, 3);
       expect.fail("should have thrown");
     } catch (e) {
       const err = e as RecordNotFound;
-      expect(err.message).toBe("Couldn't find all Post with 'id': (1, 2, 3)");
+      expect(err.message).toBe(
+        "Couldn't find all Posts with 'id': (1, 2, 3) (found 2 results, but was looking for 3).",
+      );
       expect(err.id).toEqual([1, 2, 3]);
     }
   });
 
-  it("composite: String(tuples) (comma, no space) + tuples payload", () => {
+  it("composite: String(tuples) (comma, no space) + suffix + tuples payload", () => {
     const normalized = {
       ids: [
         [1, 2],
@@ -294,11 +295,13 @@ describe("raiseNotFoundAll", () => {
       ],
     };
     try {
-      raiseNotFoundAll("Order", ["shop_id", "id"], normalized);
+      raiseNotFoundAll("Order", ["shop_id", "id"], normalized, 1, 2);
       expect.fail("should have thrown");
     } catch (e) {
       const err = e as RecordNotFound;
-      expect(err.message).toBe("Couldn't find all Order with 'shop_id,id': (1,2,3,4)");
+      expect(err.message).toBe(
+        "Couldn't find all Orders with 'shop_id,id': (1,2,3,4) (found 1 results, but was looking for 2).",
+      );
       expect(err.id).toEqual([
         [1, 2],
         [3, 4],

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -185,6 +185,9 @@ export function normalizeFindArgs(
  *   - composite  → `String(tuples)`    , payload = tuples[][] (tuple
  *     compaction/formatting is a separate concern; the pluralize + suffix
  *     convergence applies to both kinds).
+ *
+ * `notFoundIds` (Rails' `ids_writer` passes `ids - found_ids`) appends the
+ * trailing "Couldn't find <Model> with <key> <ids>." sentence.
  */
 export function raiseNotFoundAll(
   modelName: string,
@@ -193,16 +196,49 @@ export function raiseNotFoundAll(
   resultSize: number,
   expectedSize: number,
   conditions = "",
+  notFoundIds?: unknown[],
 ): never {
   const { ids, tuples } = normalized;
   const messageIds = tuples ? String(tuples) : ids.join(", ");
   const payload = tuples ?? ids;
   throw new RecordNotFound(
-    `Couldn't find all ${pluralize(modelName)} with '${String(pk)}': (${messageIds})${conditions} (found ${resultSize} results, but was looking for ${expectedSize}).`,
+    formatNotFoundAllMessage(
+      modelName,
+      String(pk),
+      messageIds,
+      conditions,
+      resultSize,
+      expectedSize,
+      notFoundIds,
+    ),
     modelName,
     String(pk),
     payload,
   );
+}
+
+/**
+ * Compose the "Couldn't find all …" message shared by `raiseNotFoundAll` and
+ * `raiseRecordNotFoundExceptionBang`, byte-for-byte with Rails'
+ * `raise_record_not_found_exception!` `else` branch (finder_methods.rb:431-433).
+ */
+function formatNotFoundAllMessage(
+  name: string,
+  key: string,
+  messageIds: string,
+  conditions: string,
+  resultSize: number | undefined,
+  expectedSize: number | undefined,
+  notFoundIds: unknown[] | undefined,
+): string {
+  let error = `Couldn't find all ${pluralize(name)} with '${key}': `;
+  error += `(${messageIds})${conditions} (found ${resultSize} results, but was looking for ${expectedSize}).`;
+  if (notFoundIds) {
+    error +=
+      ` Couldn't find ${pluralize(name, notFoundIds.length)}` +
+      ` with ${pluralize(key, notFoundIds.length)} ${notFoundIds.join(", ")}.`;
+  }
+  return error;
 }
 
 /**
@@ -658,13 +694,15 @@ export function raiseRecordNotFoundExceptionBang(
     throw new RecordNotFound(`Couldn't find ${name} with '${k}'=${ids}${conditions}`, name, k, ids);
   }
 
-  let error = `Couldn't find all ${pluralize(name)} with '${k}': `;
-  error += `(${wrapped.join(", ")})${conditions} (found ${resultSize} results, but was looking for ${expectedSize}).`;
-  if (notFoundIds) {
-    error +=
-      ` Couldn't find ${pluralize(name, notFoundIds.length)}` +
-      ` with ${pluralize(k, notFoundIds.length)} ${notFoundIds.join(", ")}.`;
-  }
+  const error = formatNotFoundAllMessage(
+    name,
+    k,
+    wrapped.join(", "),
+    conditions,
+    resultSize,
+    expectedSize,
+    notFoundIds,
+  );
   throw new RecordNotFound(error, name, k, ids);
 }
 

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -70,8 +70,8 @@ export interface NormalizedFindIds {
  * `NormalizedFindIds` shape.
  *
  * Raises `RecordNotFound` for the deterministic input errors:
- *   - zero-arg call                     → "empty list of ids", `id: []`
- *   - explicit `find([])`               → same
+ *   - zero-arg call                     → "without an ID" (Rails `when 0`)
+ *   - explicit `find([])`               → short-circuits to `[]` (no raise)
  *   - composite PK + scalar or wrong-arity tuple →
  *     "`<Model>: composite primary key requires a <N>-element array, got <id>`"
  *
@@ -87,12 +87,9 @@ export function normalizeFindArgs(
   const composite = Array.isArray(pk);
 
   if (args.length === 0) {
-    throw new RecordNotFound(
-      `Couldn't find ${modelName} with an empty list of ids`,
-      modelName,
-      String(pk),
-      [],
-    );
+    // Rails `find_with_ids` `when 0` (finder_methods.rb:508): a zero-arg /
+    // empty-id call raises "Couldn't find <Model> without an ID" (no id payload).
+    throw new RecordNotFound(`Couldn't find ${modelName} without an ID`, modelName, String(pk));
   }
 
   const [first, ...rest] = args;
@@ -156,12 +153,9 @@ export function normalizeFindArgs(
   }
 
   if (ids.length === 0) {
-    throw new RecordNotFound(
-      `Couldn't find ${modelName} with an empty list of ids`,
-      modelName,
-      String(pk),
-      [],
-    );
+    // Post-flatten empty (e.g. `find(null)`, `find([nil])`): Rails' `compact`
+    // drops them, leaving `when 0` → "without an ID".
+    throw new RecordNotFound(`Couldn't find ${modelName} without an ID`, modelName, String(pk));
   }
 
   if (composite) {
@@ -183,22 +177,28 @@ export function normalizeFindArgs(
 }
 
 /**
- * Raise the aggregate "couldn't find all" error, matching
- * `Relation.performFind`'s message shape for the caller's PK kind:
+ * Raise the aggregate "couldn't find all" error, composing Rails'
+ * `raise_record_not_found_exception!` multi-id message byte-for-byte
+ * (finder_methods.rb:431-432): the model name is pluralized and the
+ * `(found N results, but was looking for M).` suffix is appended.
  *   - simple PK  → `flatIds.join(", ")`, payload = flatIds.
- *   - composite  → `String(tuples)`    , payload = tuples[][].
+ *   - composite  → `String(tuples)`    , payload = tuples[][] (tuple
+ *     compaction/formatting is a separate concern; the pluralize + suffix
+ *     convergence applies to both kinds).
  */
 export function raiseNotFoundAll(
   modelName: string,
   pk: string | string[],
   normalized: NormalizedFindIds,
+  resultSize: number,
+  expectedSize: number,
   conditions = "",
 ): never {
   const { ids, tuples } = normalized;
   const messageIds = tuples ? String(tuples) : ids.join(", ");
   const payload = tuples ?? ids;
   throw new RecordNotFound(
-    `Couldn't find all ${modelName} with '${String(pk)}': (${messageIds})${conditions}`,
+    `Couldn't find all ${pluralize(modelName)} with '${String(pk)}': (${messageIds})${conditions} (found ${resultSize} results, but was looking for ${expectedSize}).`,
     modelName,
     String(pk),
     payload,
@@ -287,7 +287,8 @@ export async function performFind(this: FinderRelation, ...args: unknown[]): Pro
       rel = rel.or(this.where(orConditions[i]));
     }
     const records = await rel.toArray();
-    if (records.length !== tuples.length) raiseNotFoundAll(modelName, pk, normalized, conditions);
+    if (records.length !== tuples.length)
+      raiseNotFoundAll(modelName, pk, normalized, records.length, tuples.length, conditions);
     return wantArray ? records : records[0];
   }
 
@@ -315,7 +316,8 @@ export async function performFind(this: FinderRelation, ...args: unknown[]): Pro
 
   // Simple PK, multiple: find(1, 2, 3) or find([1, 2, 3]).
   const records = await this.where({ [pk]: ids }).toArray();
-  if (records.length !== ids.length) raiseNotFoundAll(modelName, pk, normalized, conditions);
+  if (records.length !== ids.length)
+    raiseNotFoundAll(modelName, pk, normalized, records.length, ids.length, conditions);
   return records;
 }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -41751,6 +41751,13 @@
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "raise_record_not_found_exception!",
+    "call": "pluralize",
+    "reason": "bucket (b) equivalent: name.pluralize / key.pluralize are invoked via the shared formatNotFoundAllMessage helper (same file, PR #4665), which composes the Rails message for both raiseRecordNotFoundExceptionBang and raiseNotFoundAll; the call moved out of the port body but is still made."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/finder-methods.ts",
+    "rubyName": "raise_record_not_found_exception!",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
## What

Converges the bespoke `RecordNotFound` message helpers onto Rails'
single `raise_record_not_found_exception!` shape
(`finder_methods.rb:417-434`).

### Multi-id "couldn't find all" message

`raiseNotFoundAll` now:
- pluralizes the model name (`name.pluralize` → `Posts`), and
- appends `(found N results, but was looking for M).`

`resultSize`/`expectedSize` are threaded from every call site:
- `performFind` (simple-PK multi + composite tuples)
- `CollectionProxy#find` (in-memory association path)
- `CollectionAssociation#idsWriter`

Before: `Couldn't find all Post with 'id': (1, 2, 3)`
After:  `Couldn't find all Posts with 'id': (1, 2, 3) (found 2 results, but was looking for 3).`

### Zero-arg / empty-id `find()`

Rails' `find_with_ids` `when 0` branch raises
`Couldn't find <Model> without an ID` (`finder_methods.rb:508`), not the
trails "empty list of ids" wording. Fixed in `normalizeFindArgs` (both
throw sites) and the `Core#find` fast-path.

The single-id path (`raiseNotFoundSingle`) already matched Rails and is
unchanged. Composite tuple-string formatting (`String(tuples)`) is left
as-is — tuple compaction is a separate concern.

## Tests

- `test_find_with_ids_with_no_id_passed` — zero-arg `find()` raises the
  without-an-ID message + model/primary_key (mirrors Rails finder_test.rb).
- `find by ids missing one` — asserts the full pluralized + found/expected
  message end-to-end through `performFind`.
- Updated `raiseNotFoundAll` unit tests to assert the faithful message.

## Review response (round 2)

Addressed the "duplicate/incomplete builder" feedback:

- **Unified the builder.** Extracted `formatNotFoundAllMessage`, shared by
  `raiseNotFoundAll` and `raiseRecordNotFoundExceptionBang`, so the "Couldn't
  find all …" string is composed in exactly one place (no parallel format).
- **`idsWriter` now emits `not_found_ids`.** `CollectionAssociation#idsWriter`
  computes `not_found_ids = ids - found_ids` (Rails
  `collection_association.rb:79-81`) and threads it through, so the trailing
  `Couldn't find <Model> with <key> <ids>.` sentence is emitted. The simple-PK
  developers ids-setter test now asserts the **exact** Rails message
  (`has_many_through_associations_test.rb`).

### Explicitly deferred (separate 0023 stories, converge — not ratify)

Two adjacent divergences surfaced while tightening the assertions. Both are
distinct concerns from this story (message pluralize/suffix + without-an-ID) and
are registered rather than folded in:

- `idswriter-association-primary-key-resolution` — `idsWriter` resolves the
  lookup/message key as the target model `id` rather than Rails'
  `association_primary_key`, so a custom-PK through association (`Category` PK
  `name`) mis-keys. The through-setter test stays structure-tolerant until fixed.
- `in-memory-collection-find-conditions-clause` — Rails' in-memory
  `CollectionAssociation#find` raises via `scope.raise_record_not_found_
  exception!`, carrying the scope's `[WHERE …]` clause; trails' in-memory path
  omits it. The in-memory test tolerates an optional conditions clause rather
  than asserting its absence.

Closes-story: performfind-converge-raise-record-not-found-builder
