### PR TITLE
fix(parity): dynamic-import SOURCES in build-gemfile for ESM/CJS boundary

### DIFF
--- a/scripts/parity/schema/ruby/build-gemfile.ts
+++ b/scripts/parity/schema/ruby/build-gemfile.ts
@@ -13,7 +13,14 @@ import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { SOURCES } from "../../../../vendor/sources.js";
+// vendor/sources.ts resolves as CommonJS (the repo root has no
+// `"type": "module"`), but this file lives under scripts/parity, whose
+// package.json *is* `"type": "module"`. Across that ESM→CJS boundary a static
+// `import { SOURCES }` fails under tsx (the CI runner) — it can't expose the
+// named export — while a default import is `undefined` under Vitest (which
+// transforms sources.ts as ESM). A dynamic import does the interop correctly
+// under both runtimes, so resolve SOURCES that way at module-init time.
+const { SOURCES } = await import("../../../../vendor/sources.js");
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const GEMFILE_PATH = join(HERE, "Gemfile");


### PR DESCRIPTION
The **Schema Parity (Rails side)** CI job fails on main: `pnpm tsx scripts/parity/run.ts --side=rails` crashes immediately in `build-gemfile.ts` with `SyntaxError: The requested module '../../../../vendor/sources.js' does not provide an export named 'SOURCES'`.

## Root cause

`scripts/parity/package.json` declares `"type": "module"`, so `build-gemfile.ts` is ESM. But it reaches out to `vendor/sources.ts`, whose nearest package.json is the repo root — which has no `"type": "module"`, so it resolves as **CommonJS**. Across that ESM→CJS boundary:

- a static `import { SOURCES }` fails under **tsx** (the CI runner) — it can't expose the named export;
- a default import is `undefined` under **Vitest**, which transforms `sources.ts` as ESM.

## Fix

Use a top-level `await import(...)`, which performs the interop correctly under **both** runtimes. Verified: `pnpm tsx scripts/parity/run.ts --side=rails` now runs, `build-gemfile.test.ts` passes, and tsc is clean.

Closes-story: red-825396c9