### PR TITLE
fix(sqlite): thread column limit into cast type at reflection time

### DIFF
--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -493,13 +493,7 @@ describe("CustomPropertiesTest", () => {
 
   it("immutable_strings_by_default retains limit information", async () => {
     await withImmutableStrings(() => {
-      // Rails asserts `type_for_attribute("inferred_string").limit == 255`, but in
-      // trails the cast type never threads `column.limit`, so assert retention on
-      // the reflected column instead. Known gap, tracked by story 0043
-      // thread-column-limit-into-cast-type.
-      expect(
-        (OverloadedType.columnsHash() as Record<string, { limit?: number }>).inferred_string.limit,
-      ).toBe(255);
+      expect(OverloadedType.typeForAttribute("inferred_string").limit).toBe(255);
     });
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1807,9 +1807,15 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     // 1/0. Mirrors mysql2_adapter.rb's `Type.register(:string, ...)` block
     // (`Type::String.new(true: "1", false: "0")`) and its char/enum/set
     // registrations.
+    // char/varchar thread `extract_limit(sql_type)` onto the type
+    // (mysql2_adapter.rb:43-46, `register_type(%r(char)i)`), so
+    // `type_for_attribute(col).limit` reflects the column limit. enum/set
+    // register the limitless string (mysql2_adapter.rb:48-49).
+    const mysqlStringWithLimit = (sqlType: string) =>
+      new StringType({ trueString: "1", falseString: "0", limit: this.extractLimit(sqlType) });
     const mysqlString = () => new StringType({ trueString: "1", falseString: "0" });
-    m.registerType(/^char/i, undefined, mysqlString);
-    m.registerType(/^varchar/i, undefined, mysqlString);
+    m.registerType(/^char/i, undefined, mysqlStringWithLimit);
+    m.registerType(/^varchar/i, undefined, mysqlStringWithLimit);
     m.registerType(/^enum/i, undefined, mysqlString);
     m.registerType(/^set/i, undefined, mysqlString);
     m.registerType(/^binary/i, undefined, () => new BinaryType());

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1188,8 +1188,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // the column limit. `fetchTypeMetadata` strips the `(N)` off the stored
     // `sqlType`, so re-thread the limit from the column onto the cast type here.
     if (column.limit != null && base.limit == null) {
-      return new (base.constructor as new (o: { limit?: number }) => typeof base)({
+      return new (base.constructor as new (o: {
+        limit?: number;
+        precision?: number;
+        scale?: number;
+      }) => typeof base)({
         limit: column.limit,
+        precision: base.precision,
+        scale: base.scale,
       });
     }
     return base;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1175,12 +1175,22 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   lookupCastTypeFromColumn(column: {
     sqlType?: string | null;
     precision?: number | null;
+    limit?: number | null;
   }): import("@blazetrails/activemodel").Type {
     const base = this.lookupCastType(column.sqlType ?? "");
     if (column.precision != null) {
       if (base instanceof SQLiteDateTimeType)
         return new SQLiteDateTimeType({ precision: column.precision });
       if (base instanceof TimeType) return new TimeType({ precision: column.precision });
+    }
+    // Rails carries the full `sql_type` (e.g. `varchar(255)`) into
+    // `register_class_with_limit`, so `type_for_attribute(col).limit` returns
+    // the column limit. `fetchTypeMetadata` strips the `(N)` off the stored
+    // `sqlType`, so re-thread the limit from the column onto the cast type here.
+    if (column.limit != null && base.limit == null) {
+      return new (base.constructor as new (o: { limit?: number }) => typeof base)({
+        limit: column.limit,
+      });
     }
     return base;
   }


### PR DESCRIPTION
## Summary

Rails `attributes_test.rb:384` asserts the *type object* retains the column limit through immutable conversion: `type_for_attribute("inferred_string").limit == 255`. In trails this returned `undefined` because SQLite's `fetchTypeMetadata` strips the `(N)` off the stored `sqlType`, so `lookupCastType` never sees the limit.

This threads `column.limit` back onto the cast type in `lookupCastTypeFromColumn` (mirroring Rails' `register_class_with_limit`, which extracts the limit from the full `sql_type`). The immutable-string variant then copies the limit through `toImmutableString`, so `typeForAttribute(col).limit` matches Rails.

## Changes

- `sqlite3-adapter.ts`: `lookupCastTypeFromColumn` re-threads `column.limit` onto the cast type when the type doesn't already carry one.
- `attributes.test.ts`: the "immutable_strings_by_default retains limit information" test now asserts `typeForAttribute("inferred_string").limit === 255` (the Rails assertion), dropping the `columnsHash()` workaround.

Closes-story: thread-column-limit-into-cast-type

## Design note (review response): reflective rebuild vs. `register_class_with_limit`

Rails threads the limit at *lookup* time via `register_class_with_limit`
(`abstract_adapter.rb:919-924`) — type-map factories parse the matched
`sql_type` string (with `(N)` attached) through `extract_limit`; there is no
separate reconstruct step. This diff instead reflectively rebuilds the type
(`new (base.constructor as ...)(...)`) in `lookupCastTypeFromColumn`.

This is a deliberate, scoped trade-off, not an oversight. sqlite's
`fetchTypeMetadata` (`sqlite3-adapter.ts:~1136-1148`) **deliberately strips the
`(N)`** off the stored `sqlType` (the paren-stripped base is what resolves the
DSL type name), and the sqlite factories (`initializeTypeMap`, e.g. `/char/i`
at ~3047) register `StringType` singletons that never call `extractLimit`. So
no raw `varchar(255)` string reaches a limit-bearing factory — the Rails-faithful
mechanism can't be adopted without unwinding that deliberate stripping, which is
a larger change than this test-convergence story.

The reflective rebuild is safe for every `Type` reachable through sqlite's
`initializeTypeMap` today (all take only `{limit,precision,scale}`; verified in
review). The fuller convergence onto `register_class_with_limit` is tracked as a
follow-up story: **`converge-sqlite-limit-to-register-class-with-limit`** (RFC
0043).


### MySQL/MariaDB (CI follow-up)

MariaDB surfaced that the mysql cast type also didn't carry the limit (its
`columnsHash().limit` comes from an information_schema path, but the type from
`lookupCastType` didn't). Fixed at the type-map factory — the Rails-faithful
`register_class_with_limit` mechanism (`mysql2_adapter.rb:43-46`): the
`char`/`varchar` factories now thread `extractLimit(sqlType)` onto the
`StringType` (preserving its `"1"`/`"0"` boolean strings), while `enum`/`set`
stay limitless (`mysql2_adapter.rb:48-49`). The dumper already suppresses
`limit: 255` for string columns (`mysql/schema-dumper.ts:190`), so schema dumps
are unaffected. This is exactly the factory approach the design note above
describes as the fuller convergence — applied here for mysql because reflective
reconstruction would drop the type's boolean-string state.


### Review round 2 — non-blocking findings (justification)

Both are flagged as pre-existing / non-blocking; addressed here rather than
with code changes to keep this test-convergence story tightly scoped.

- **char/varchar registration lives in `AbstractMysqlAdapter#initializeTypeMap`
  rather than `Mysql2Adapter` (`mysql2_adapter.rb:38-49`).** Correct observation,
  but this placement predates this PR — the diff only threads `extractLimit`
  onto the already-present factory. No concrete non-mysql2/trilogy adapter
  subclasses `AbstractMysqlAdapter` today, so there is no live leak of
  mysql2-specific string-boolean behavior. Relocating the char/varchar/enum/set
  registrations down to the concrete adapters is a separate structural
  convergence, out of scope for this story.
- **Two anchored regexes (`/^char/i`, `/^varchar/i`) vs Rails' single unanchored
  `%r(char)i`.** Behaviorally identical for the real MySQL type names (both route
  to the same `mysqlStringWithLimit` factory), and the split matches the
  pre-existing style of the surrounding registrations (enum/set are likewise
  separate). Collapsing to one `/char/i` line would edit untouched sibling
  registrations for a purely cosmetic fidelity gain, so left as-is.
