### PR TITLE
test(transactions): relocate call-after-commit test to callbacks convention file

### DIFF
--- a/packages/activerecord/src/transaction-callbacks.test.ts
+++ b/packages/activerecord/src/transaction-callbacks.test.ts
@@ -66,6 +66,26 @@ describe("TransactionCallbacksTest", () => {
     expect(currentTransaction()).toBe(originalTxn);
   });
 
+  it("call after commit after transaction commits", async () => {
+    class Topic extends Base {
+      declare title: string;
+
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    const history: string[] = [];
+    Topic.afterCommit(function () {
+      history.push("after_commit");
+    });
+    Topic.afterRollback(function () {
+      history.push("after_rollback");
+    });
+    const first = (await Topic.find(1)) as any;
+    await first.saveBang();
+    expect(history).toEqual(["after_commit"]);
+  });
+
   it("dont call any callbacks after transaction commits for invalid record", async () => {
     class Topic extends Base {
       declare title: string;

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1773,25 +1773,3 @@ describe("ConcurrentTransactionTest", () => {
     // READ COMMITTED isolation across concurrent threads; JS is single-threaded.
   });
 });
-
-// ==========================================================================
-// trails-extra: a block-arg `tx.afterCommit(...)` registered inside an explicit
-// transaction fires once the transaction commits (no direct Rails counterpart;
-// guards the standalone `transaction(Model, (tx) => ...)` callback wiring).
-// ==========================================================================
-describe("TransactionTest", () => {
-  fixtures(["topics"]);
-
-  it("call after commit after transaction commits", async () => {
-    const log: string[] = [];
-
-    await transaction(Topic, async (tx) => {
-      tx.afterCommit(() => {
-        log.push("committed");
-      });
-      await Topic.create({ title: "Alice" });
-    });
-
-    expect(log).toEqual(["committed"]);
-  });
-});

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -103,6 +103,24 @@ describe("TransactionTest", () => {
     });
   });
 
+  // trails-extra: a block-arg `tx.afterCommit(...)` registered on the explicit
+  // `transaction(Model, (tx) => ...)` handle fires once the transaction commits.
+  // No Rails counterpart (Rails registers commit callbacks on the model, not the
+  // transaction handle); guards the standalone block-arg callback wiring — the
+  // rollback twin is covered in transaction-callbacks.test.ts.
+  it("block-arg tx.afterCommit fires after the transaction commits", async () => {
+    const log: string[] = [];
+
+    await transaction(CanonicalTopic, async (tx) => {
+      tx.afterCommit(() => {
+        log.push("committed");
+      });
+      await CanonicalTopic.create({ title: "Alice" });
+    });
+
+    expect(log).toEqual(["committed"]);
+  });
+
   describe("after_failure_actions on PreparedStatementCacheExpired", () => {
     // Mirrors Rails' TransactionManager#after_failure_actions: when a
     // transaction fails with PreparedStatementCacheExpired we must drop


### PR DESCRIPTION
Relocates the misplaced `call after commit after transaction commits` test out of the trails-extra `describe("TransactionTest")` block in `transactions.test.ts`.

- **Rails-named test → convention file.** A faithful port of `test_call_after_commit_after_transaction_commits` (`transaction_callbacks_test.rb:113`) now lives in `transaction-callbacks.test.ts`, name matching Rails verbatim, converged to a canonical `topics`-table model with class-level `afterCommit`/`afterRollback` (no bespoke `accounts` shape).
- **TS-only coverage preserved.** The original body exercised the trails-only block-arg `transaction(Model, (tx) => tx.afterCommit(...))` wiring — no Rails counterpart, and the only positive coverage of that commit path. Rather than drop it, it moves to `transactions.trails.test.ts` (the TS-only sibling) under a non-colliding name, so `test:compare` stops counting it as `extra` while the coverage survives.
- **`test:compare`:** `transactions.test.ts` extra 8→7 (the documented permanent-skips); `transaction-callbacks.test.ts` now ✓; `matched`/`missing`/`wrongDescribe`/`misplaced` unchanged for both.

Closes-story: transactions-call-after-commit-relocate