### PR TITLE
fix(postgresql): serialize pinned pg.Client queries via promise-chain mutex

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/pinned-query-serializer.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/pinned-query-serializer.trails.test.ts
@@ -1,0 +1,131 @@
+/**
+ * White-box unit tests for PostgreSQLAdapter's pinned-client query serializer
+ * (`_serializePinnedQuery`) — a trails-only primitive with no Rails counterpart.
+ *
+ * The serializer is a promise-chain mutex sharing the adapter's single
+ * `_maintenanceTail` so no two `client.query` calls on the pinned `pg.Client`
+ * ever overlap on the wire (the fix for the write-path idle-in-transaction hang;
+ * see the method's doc comment). These tests exercise the primitive directly
+ * against a fake pinned client, so they need no live PostgreSQL server and run
+ * on every CI adapter — the concurrency invariants are pure promise logic.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import { PostgreSQLAdapter } from "../../connection-adapters/postgresql-adapter.js";
+
+// The private surface we reach into. Constructing the adapter never opens a
+// socket (the constructor only stores config), so a dummy URL is fine.
+interface SerializerHarness {
+  _rawConnection: unknown;
+  _maintenanceTail: Promise<void>;
+  _serializePinnedQuery<R>(client: unknown, fn: () => Promise<R>): Promise<R>;
+  _enqueueMaintenance(fn: () => Promise<unknown>): Promise<void>;
+}
+
+function makeAdapter(): { adapter: SerializerHarness; pinned: { query: () => Promise<unknown> } } {
+  const adapter = new PostgreSQLAdapter(
+    "postgres://localhost:5432/rails_js_test",
+  ) as unknown as SerializerHarness;
+  // A minimal fake pinned client. The `_rawConnection` setter registers a
+  // dealloc serializer closure over it but never invokes it here.
+  const pinned = { query: async () => ({ rows: [] }) };
+  adapter._rawConnection = pinned;
+  return { adapter, pinned };
+}
+
+const tick = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+describe("PostgreSQLAdapter pinned-client query serializer", () => {
+  let adapter: SerializerHarness;
+  let pinned: { query: () => Promise<unknown> };
+
+  beforeEach(() => {
+    ({ adapter, pinned } = makeAdapter());
+  });
+
+  it("never runs two queries on the pinned client concurrently", async () => {
+    let active = 0;
+    let maxActive = 0;
+    const run = (id: number, ms: number): Promise<number> =>
+      adapter._serializePinnedQuery(pinned, async () => {
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        await tick(ms);
+        active -= 1;
+        return id;
+      });
+
+    // Fire many overlapping calls; the mutex must collapse them to one in
+    // flight at a time and preserve submission order.
+    const ids = [...Array(12)].map((_, i) => i);
+    const results = await Promise.all(ids.map((i) => run(i, (12 - i) % 5)));
+
+    expect(maxActive).toBe(1);
+    expect(results).toEqual(ids);
+  });
+
+  it("serializes user queries against maintenance ops on the same tail", async () => {
+    const order: string[] = [];
+    // Enqueue a maintenance op, then a query, then another maintenance op.
+    // All three chain onto _maintenanceTail, so they must run in FIFO order
+    // with no interleaving.
+    const m1 = adapter._enqueueMaintenance(async () => {
+      await tick(4);
+      order.push("m1");
+    });
+    const q = adapter._serializePinnedQuery(pinned, async () => {
+      await tick(2);
+      order.push("q");
+    });
+    const m2 = adapter._enqueueMaintenance(async () => {
+      order.push("m2");
+    });
+    await Promise.all([m1, q, m2]);
+    expect(order).toEqual(["m1", "q", "m2"]);
+  });
+
+  it("re-acquires sequentially without self-deadlock (retry-style)", async () => {
+    // Mirrors `_runQuery`'s cached-plan retry: attempt() runs, releases the
+    // gate, then attempt() runs again. Because the gate is released before the
+    // first call returns, the second acquisition never awaits its own
+    // outstanding promise.
+    let attempts = 0;
+    const attempt = (): Promise<number> =>
+      adapter._serializePinnedQuery(pinned, async () => {
+        attempts += 1;
+        await tick(1);
+        return attempts;
+      });
+    await attempt();
+    const second = await attempt();
+    expect(second).toBe(2);
+  });
+
+  it("keeps the shared tail non-rejecting after a failing query (drain-safe)", async () => {
+    // Drain barriers (`await this._maintenanceTail`) do a bare await with no
+    // catch, so a rejected in-flight query must not poison the tail.
+    await adapter
+      ._serializePinnedQuery(pinned, async () => {
+        throw new Error("boom");
+      })
+      .catch(() => {});
+    // A subsequent query still runs, and the tail resolves cleanly.
+    const ok = await adapter._serializePinnedQuery(pinned, async () => 42);
+    expect(ok).toBe(42);
+    await expect(adapter._maintenanceTail).resolves.toBeUndefined();
+  });
+
+  it("bypasses the mutex for a non-pinned (configure-time) client", async () => {
+    // Configure-time queries run on a not-yet-published client
+    // (client !== _rawConnection) and must run direct — chaining them onto the
+    // shared tail during connect/reset would deadlock the reset barrier.
+    const other = { query: async () => ({ rows: [] }) };
+    let ran = false;
+    // Park a never-settling op on the tail; a pinned query would block on it,
+    // but a non-pinned query must ignore the tail entirely.
+    adapter._maintenanceTail = new Promise<void>(() => {});
+    await adapter._serializePinnedQuery(other, async () => {
+      ran = true;
+    });
+    expect(ran).toBe(true);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1360,6 +1360,16 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * chaining them here would interleave with the maintenance tail during
    * connect.
    *
+   * A few other pinned-client sites deliberately stay direct because routing
+   * them onto the shared tail would deadlock or defeat their purpose, NOT for
+   * lack of coverage: `_maybeConfigureConnection` / the reset reconfigure run
+   * *inside* the `_inFlightReset` barrier that IS the tail (self-await), the
+   * DEALLOCATE / ROLLBACK / DISCARD ALL maintenance ops already chain via
+   * `_enqueueMaintenance`, `execRollbackDbTransaction`'s `ROLLBACK` follows a
+   * `_cancelAnyRunningQuery` that must not be made to wait on the query it just
+   * cancelled, and the memoized `server_version` bootstrap probe runs before the
+   * client is in normal service.
+   *
    * @internal
    */
   private async _serializePinnedQuery<R>(client: pg.Client, fn: () => Promise<R>): Promise<R> {
@@ -2163,7 +2173,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // "there is no parameter $1".
       const pgBinds = binds.map((v) => this._bindForPg(v));
       const rewritten = this.rewriteBinds(sql, pgBinds);
-      const result = await client.query(`${clause} ${rewritten}`, pgBinds);
+      const result = await this._serializePinnedQuery(client, () =>
+        client.query(`${clause} ${rewritten}`, pgBinds),
+      );
       const printer = new ExplainPrettyPrinter();
       return printer.pp(result.rows);
     });
@@ -3115,7 +3127,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async getAdvisoryLock(lockId: number | bigint | string): Promise<boolean> {
     const client = await this._acquireFreshClient();
     const [sql, param] = _pgAdvisoryLockSql("pg_try_advisory_lock", "locked", lockId);
-    const result = await client.query(sql, [param]);
+    const result = await this._serializePinnedQuery(client, () => client.query(sql, [param]));
     return result.rows[0]?.locked === true;
   }
 
@@ -3123,7 +3135,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     if (!this._rawConnection) return false;
     const client = await this._acquireFreshClient();
     const [sql, param] = _pgAdvisoryLockSql("pg_advisory_unlock", "unlocked", lockId);
-    const result = await client.query(sql, [param]);
+    const result = await this._serializePinnedQuery(client, () => client.query(sql, [param]));
     return result.rows[0]?.unlocked === true;
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -413,8 +413,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // (node-pg's "already executing a query" deprecation, the wire-protocol-desync
   // seam). Each op chains onto the previous; query-acquisition paths drain this
   // (alongside _inFlightReset) before yielding the socket so a pending DEALLOCATE
-  // can't race the next user query. This is the narrow maintenance-op serializer;
-  // the full per-query mutex is the sibling pg-pinned-client-query-serializer-mutex.
+  // can't race the next user query. It is ALSO the tail the full per-query mutex
+  // (`_serializePinnedQuery`) chains onto, so user queries, DEALLOCATE, ROLLBACK,
+  // and DISCARD ALL all serialize on this one chain — a single wire, no overlap.
   private _maintenanceTail: Promise<void> = Promise.resolve();
   // Accumulates PG NOTICE/WARNING messages fired during the current query.
   // Cleared before each query; processed by _flushWarnings after.
@@ -1334,6 +1335,50 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   /**
+   * Serialize a single `client.query` on the pinned `pg.Client` against every
+   * other query (and maintenance op) on that same client, so no two ever
+   * overlap on the wire. node-pg's own request queue is insufficient under the
+   * write-path query volume: two calls that interleave desync the wire protocol
+   * and leave the connection idle-in-transaction (the
+   * `client.query() … already executing a query` deprecation is that seam). This
+   * is the general per-query mutex the sibling
+   * `pg-serialize-fire-and-forget-client-query-sites` maintenance serializer
+   * anticipated (see `_maintenanceTail`).
+   *
+   * It shares the one `_maintenanceTail` chain so DEALLOCATE / ROLLBACK /
+   * DISCARD ALL and user queries all serialize on a single tail — a maintenance
+   * op enqueued mid-query lands after it, and a query issued after an eviction's
+   * DEALLOCATE lands after that. Each call chains a fresh gate onto the tail and
+   * releases it once `fn` settles; the granularity is one `client.query`, never
+   * a whole `withRawConnection` block, so re-entrant/retry paths (which re-issue
+   * sequentially) each re-acquire without ever awaiting their own outstanding
+   * gate — no self-deadlock.
+   *
+   * Configure-time queries run on a not-yet-published client
+   * (`client !== _rawConnection`) and bypass the mutex: they already run direct
+   * on `client.query()` before the connection is acquirable (RFC 0013), and
+   * chaining them here would interleave with the maintenance tail during
+   * connect.
+   *
+   * @internal
+   */
+  private async _serializePinnedQuery<R>(client: pg.Client, fn: () => Promise<R>): Promise<R> {
+    if (client !== this._rawConnection) return fn();
+    const prev = this._maintenanceTail;
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    this._maintenanceTail = prev.then(() => gate);
+    await prev.catch(() => {});
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
+  }
+
+  /**
    * Tear down the single StatementPool. Called from `close()` /
    * `reconnect()` only — commit/rollback keep the pool attached
    * because PG prepared statements are session-scoped, not
@@ -1380,24 +1425,31 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         const stmtName = this._preparedNameFor(client, sql);
         onPrepared?.(stmtName);
         // `_preparedNameFor` may have evicted an LRU entry, queueing its
-        // DEALLOCATE on the maintenance tail. Drain it before issuing this
-        // query so the DEALLOCATE lands on an idle client rather than racing
-        // the query that triggered the eviction. Mirrors Rails, where
-        // StatementPool#[]= deallocs the evicted entry inline (under the
-        // connection lock) before the new query is sent
+        // DEALLOCATE on the maintenance tail. The serializer captures that tail
+        // (with the DEALLOCATE already enqueued) and awaits it before issuing,
+        // so the DEALLOCATE lands on an idle client rather than racing the query
+        // that triggered the eviction — subsuming the old explicit drain.
+        // Mirrors Rails, where StatementPool#[]= deallocs the evicted entry
+        // inline (under the connection lock) before the new query is sent
         // (statement_pool.rb:31, postgresql_adapter.rb:307).
-        await this._maintenanceTail;
-        return (await client.query({
-          name: stmtName,
-          text: sql,
-          values: binds,
-          ...queryExtra,
-        })) as R;
+        return this._serializePinnedQuery(
+          client,
+          () =>
+            client.query({
+              name: stmtName,
+              text: sql,
+              values: binds,
+              ...queryExtra,
+            }) as Promise<R>,
+        );
       }
       if (queryExtra.rowMode) {
-        return (await client.query({ text: sql, values: binds, ...queryExtra })) as R;
+        return this._serializePinnedQuery(
+          client,
+          () => client.query({ text: sql, values: binds, ...queryExtra }) as Promise<R>,
+        );
       }
-      return (await client.query(sql, binds)) as R;
+      return this._serializePinnedQuery(client, () => client.query(sql, binds) as Promise<R>);
     };
     const isTxConn = client === this._rawConnection;
     if (isTxConn) this._queryInFlight = true;
@@ -1692,9 +1744,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             // fails and we re-run without it.
             payload.sql = withReturning;
             try {
-              if (useSavepoint) await client.query(`SAVEPOINT "${spName}"`);
+              if (useSavepoint)
+                await this._serializePinnedQuery(client, () =>
+                  client.query(`SAVEPOINT "${spName}"`),
+                );
               const result = await this._runQuery(client, withReturning, binds);
-              if (useSavepoint) await client.query(`RELEASE SAVEPOINT "${spName}"`);
+              if (useSavepoint)
+                await this._serializePinnedQuery(client, () =>
+                  client.query(`RELEASE SAVEPOINT "${spName}"`),
+                );
               payload.row_count = result.rowCount ?? 0;
               if (result.rows.length > 1) {
                 return result.rowCount ?? result.rows.length;
@@ -1713,8 +1771,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
               // originally written for.
               if (err instanceof PreparedStatementCacheExpired) throw err;
               if (useSavepoint) {
-                await client.query(`ROLLBACK TO SAVEPOINT "${spName}"`).catch(() => {});
-                await client.query(`RELEASE SAVEPOINT "${spName}"`).catch(() => {});
+                await this._serializePinnedQuery(client, () =>
+                  client.query(`ROLLBACK TO SAVEPOINT "${spName}"`),
+                ).catch(() => {});
+                await this._serializePinnedQuery(client, () =>
+                  client.query(`RELEASE SAVEPOINT "${spName}"`),
+                ).catch(() => {});
               }
               payload.sql = pgSql;
               const result = await this._runQuery(client, pgSql, binds);
@@ -2431,8 +2493,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   async exec(sql: string): Promise<void> {
     await this.withRawConnection(async (conn) => {
+      const client = conn as unknown as pg.Client;
       try {
-        await (conn as unknown as pg.Client).query(sql);
+        await this._serializePinnedQuery(client, () => client.query(sql));
       } catch (e) {
         // The bare driver `exec()` is the DDL path for schema statements.
         // Unlike `execute()`/`executeMutation()`, it bypasses bind rewriting,


### PR DESCRIPTION
## What

Adds a per-query serializer (`_serializePinnedQuery`) wrapping every `client.query` on the PG adapter's single pinned `pg.Client`, so no two queries overlap on the wire regardless of caller. It shares the existing `_maintenanceTail` chain, so user queries, `DEALLOCATE`, `ROLLBACK`, and `DISCARD ALL` all serialize on **one** tail — a single wire, no overlap.

## Why

Routing every write through the prepared-statement path raises `client.query` volume on the single pinned client. Under CI/load two calls interleave, desync the wire protocol, and leave the connection **idle-in-transaction**; PG fires `terminating connection due to idle-in-transaction timeout`, the vitest worker hangs holding its advisory DB slot, and sibling workers fail with advisory-slot exhaustion → 20-min timeout with zero test failures. node-pg's own request queue is insufficient at this volume (the `client.query() … already executing a query` deprecation is the seam).

## How

- New `_serializePinnedQuery(client, fn)`: chains a fresh gate onto `_maintenanceTail`, awaits the prior settlement, runs `fn`, releases in `finally`. Granularity is **one** `client.query`, never a whole `withRawConnection` block — so retry and savepoint paths re-acquire sequentially without ever awaiting their own outstanding gate (no self-deadlock).
- Routes `_runQuery` (all select / execute / mutation / schema paths + the cached-plan retry), `executeMutation`'s `SAVEPOINT`/`RELEASE`/`ROLLBACK TO SAVEPOINT`, the DDL `exec` path, `explain`, and `getAdvisoryLock`/`releaseAdvisoryLock` through it — every live-connection pinned-client query path.
- The explicit `await _maintenanceTail` eviction-drain in `_runQuery` is subsumed by the mutex (which captures the tail after `_preparedNameFor` enqueues the DEALLOCATE).
- A handful of sites deliberately stay **direct**, documented on the method: `_maybeConfigureConnection` / reset reconfigure run *inside* the `_inFlightReset` barrier that IS the tail (self-await), the maintenance ops already chain via `_enqueueMaintenance`, `execRollbackDbTransaction`'s `ROLLBACK` follows a cancel that must not wait on the query it cancelled, and the memoized `server_version` bootstrap probe runs pre-service. Configure-time queries run on a not-yet-published client and bypass via the `client !== _rawConnection` guard (RFC 0013).

The fire-and-forget sites (`dealloc`, `resetBang`/discard) were serialized by the dependency story (#4284); this builds the general mutex on the same tail.

## Tests

`pinned-query-serializer.trails.test.ts` — white-box unit tests driving the mutex against a fake pinned client (no live PG needed; runs in the PG CI job). Asserts: no two queries overlap (max-in-flight = 1, order preserved); FIFO ordering against maintenance ops on the shared tail; retry-style sequential re-acquire without self-deadlock; the shared tail stays non-rejecting after a failing query (drain barriers safe); non-pinned/configure-time client bypasses the mutex.

Closes-story: pg-pinned-client-query-serializer-mutex