### PR TITLE
fix(fixtures): surface precise error for unloaded plain-through join table

### DIFF
--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -326,6 +326,8 @@ describe("defineFixtures", () => {
     // canonically (resolved through resolveFixtureId, like the HABTM path).
     expect(joinInsert).toContain(String(fixtureId("david")));
     expect(joinInsert).toMatch(/, 1\)/);
+    // The preflight consulted the through table by name before inserting.
+    expect((adapter as any).tableExists).toHaveBeenCalledWith("categorizations");
   });
 
   it("plain has_many :through label: unloaded through table surfaces a precise error, not 'no such table'", async () => {

--- a/packages/activerecord/src/test-helpers/define-fixtures.test.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.test.ts
@@ -281,6 +281,70 @@ describe("defineFixtures", () => {
     expect(insertCalls[0]).toContain(String(fixtureId("trails")));
   });
 
+  // A plain `has_many :through` reflection (macro !== "hasAndBelongsToMany"): the
+  // through model (`categorizations`) is a real model whose fixture set — unlike a
+  // HABTM join model's anonymous table — is requested by name, so `sliceSchema`
+  // does NOT pull its join table in implicitly. Its label still materializes join
+  // rows through the same HasManyThroughProxy arm as HABTM.
+  function makePlainThroughAuthor() {
+    const Categorization = makeModel("categorizations", new Map());
+    const Author = makeModel(
+      "authors",
+      new Map([[fixtureId("david"), { id: fixtureId("david"), name: "David" }]]),
+    );
+    Author._reflections = {
+      categorizedPosts: {
+        macro: "hasMany",
+        isThroughReflection: () => true,
+        foreignKey: "post_id",
+        klass: { tableName: "posts" },
+        throughReflection: {
+          foreignKey: "author_id",
+          klass: Categorization,
+          tableName: "categorizations",
+        },
+      },
+    };
+    return Author;
+  }
+
+  it("plain has_many :through label: materializes join rows into the through table when it is loaded", async () => {
+    const adapter = makeAdapter();
+    (adapter as any).tableExists = vi.fn(async () => true);
+    const Author = makePlainThroughAuthor();
+
+    await defineFixtures(adapter, Author, {
+      david: { name: "David", categorizedPosts: ["welcome"] },
+    });
+
+    const joinInsert = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("INSERT INTO") && s.includes("categorizations"));
+    expect(joinInsert).toBeDefined();
+    // lhs = through_reflection.foreign_key (author_id) → owner id; rhs =
+    // association.foreign_key (post_id) → posts.welcome, which pins `id: 1`
+    // canonically (resolved through resolveFixtureId, like the HABTM path).
+    expect(joinInsert).toContain(String(fixtureId("david")));
+    expect(joinInsert).toMatch(/, 1\)/);
+  });
+
+  it("plain has_many :through label: unloaded through table surfaces a precise error, not 'no such table'", async () => {
+    const adapter = makeAdapter();
+    (adapter as any).tableExists = vi.fn(async () => false);
+    const Author = makePlainThroughAuthor();
+
+    await expect(
+      defineFixtures(adapter, Author, {
+        david: { name: "David", categorizedPosts: ["welcome"] },
+      }),
+    ).rejects.toThrow(/join table "categorizations" is not loaded/);
+    // The join-table INSERT must never have been attempted.
+    const joinInsert = (adapter.execute as ReturnType<typeof vi.fn>).mock.calls
+      .map((c: unknown[]) => c[0] as string)
+      .find((s) => s.includes("INSERT INTO") && s.includes("categorizations"));
+    expect(joinInsert).toBeUndefined();
+  });
+
   it("tableName registry: resolveModelForTable returns the model after defineFixtures", async () => {
     const adapter = makeAdapter();
     const rows = new Map([[fixtureId("david"), { id: fixtureId("david") }]]);

--- a/packages/activerecord/src/test-helpers/define-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/define-fixtures.ts
@@ -358,6 +358,11 @@ function detectHabtmParts(
  * - `targetTable` — the associated model's table, used to resolve a target label
  *   to its fixture id (CRC32 fallback);
  * - `throughModel` — the through model, consulted for timestamp filling.
+ * - `isHabtm` — whether the reflection is a HABTM (`macro ===
+ *   "hasAndBelongsToMany"`). A HABTM join model is anonymous and owns its table
+ *   (no fixture set of its own), whereas a plain `has_many :through` join table
+ *   belongs to a real model whose fixture set is requested by name. This gates
+ *   the precise "join table not loaded" guard in the join-row insertion loop.
  */
 interface ThroughLabelAssoc {
   joinTable: string;
@@ -365,6 +370,7 @@ interface ThroughLabelAssoc {
   rhsKey: string;
   targetTable: string | undefined;
   throughModel: BaseClass | undefined;
+  isHabtm: boolean;
 }
 
 /**
@@ -383,6 +389,7 @@ export function throughLabelAssociations(ModelClass: BaseClass): Map<string, Thr
   const reflections: Record<string, unknown> = (ModelClass as any)._reflections ?? {};
   for (const [name, refl] of Object.entries(reflections)) {
     const r = refl as {
+      macro?: string;
       isThroughReflection?: () => boolean;
       foreignKey?: string | string[];
       klass?: { tableName?: string };
@@ -404,7 +411,14 @@ export function throughLabelAssociations(ModelClass: BaseClass): Map<string, Thr
       ) {
         continue;
       }
-      out.set(name, { joinTable, lhsKey, rhsKey, targetTable: r.klass?.tableName, throughModel });
+      out.set(name, {
+        joinTable,
+        lhsKey,
+        rhsKey,
+        targetTable: r.klass?.tableName,
+        throughModel,
+        isHabtm: r.macro === "hasAndBelongsToMany",
+      });
     } catch {
       continue;
     }
@@ -433,14 +447,15 @@ export function throughLabelAssociations(ModelClass: BaseClass): Map<string, Thr
  * register) every transitively reachable model instead of throwing, leaking the
  * slice far past the requested sets.
  *
- * NOTE for the future wiring of {@link throughLabelAssociations} into actual
- * fixture loading: that materializer expands plain `has_many :through` labels
- * too, but this slice no longer creates those join tables implicitly. A test
- * whose fixture row expands a plain-through label must therefore also request the
- * through model's fixture set by name (so its table slices in) — otherwise the
- * load hits "no such table". HABTM labels are unaffected (their table is pulled
- * in here). Today `throughLabelAssociations` has no production caller, so there
- * is no live gap; this is a guard-rail for whoever wires it up.
+ * NOTE on the wiring of {@link throughLabelAssociations} into actual fixture
+ * loading (now live — `defineFixtures` materializes join rows from association
+ * labels): that materializer expands plain `has_many :through` labels too, but
+ * this slice does not create those join tables implicitly. A test whose fixture
+ * row expands a plain-through label must therefore also load the through model's
+ * fixture set by name (so its table exists) — otherwise `defineFixtures` throws a
+ * precise "join table \"…\" is not loaded" error naming the missing set (rather
+ * than an opaque "no such table"). HABTM labels are unaffected (their table is
+ * pulled in here).
  */
 export function throughJoinTableNames(ModelClass: BaseClass): string[] {
   const reflections: Record<string, unknown> = (ModelClass as any)._reflections ?? {};
@@ -865,7 +880,7 @@ export async function prepareModelFixtures(
   const throughLabelAssocs = throughLabelAssociations(ModelClass);
   const joinTableRows = new Map<
     string,
-    { rows: FixtureAttrs[]; throughModel: BaseClass | undefined }
+    { rows: FixtureAttrs[]; throughModel: BaseClass | undefined; isHabtm: boolean }
   >();
 
   const labels = Object.keys(fixtures);
@@ -979,6 +994,7 @@ export async function prepareModelFixtures(
           const accum = joinTableRows.get(labelAssoc.joinTable) ?? {
             rows: [],
             throughModel: labelAssoc.throughModel,
+            isHabtm: labelAssoc.isHabtm,
           };
           for (const target of targets) {
             accum.rows.push({
@@ -1222,8 +1238,25 @@ export async function prepareModelFixtures(
   // once here rather than per join table.
   if (joinTableRows.size > 0) {
     const now = currentTimeFromProperTimezone();
-    for (const [joinTable, { rows: jrows, throughModel }] of joinTableRows) {
+    for (const [joinTable, { rows: jrows, throughModel, isHabtm }] of joinTableRows) {
       if (jrows.length === 0) continue;
+      // A plain `has_many :through` join table belongs to a real through model
+      // whose fixture set — unlike a HABTM join model's anonymous table — is NOT
+      // pulled into the loaded schema implicitly (see throughJoinTableNames). If a
+      // row expands such a label but the requesting test never loaded that through
+      // set, the join table is absent; surface a precise error naming it rather
+      // than letting the INSERT fail with an opaque "no such table".
+      if (!isHabtm && typeof (adapter as any).tableExists === "function") {
+        const exists: boolean = await (adapter as any).tableExists(joinTable);
+        if (!exists) {
+          throw new Error(
+            `defineFixtures: ${tableName} fixtures expand a plain has_many :through ` +
+              `association whose join table "${joinTable}" is not loaded — the ` +
+              `requesting test must also load the "${joinTable}" fixture set by name ` +
+              `(plain-through join tables are not sliced in automatically; HABTM ones are)`,
+          );
+        }
+      }
       // Mirror Rails' HasManyThroughProxy#timestamp_column_names —
       // `through_reflection.klass.all_timestamp_attributes_in_model`: every
       // timestamp column the through model *has* (alias-resolved), gated only by


### PR DESCRIPTION
When `defineFixtures` materializes join rows from a plain `has_many :through`
association label whose through-model fixture set was never loaded, the join
table is absent and the INSERT failed with an opaque "no such table". This
wires a precise guard into the now-live through-label materializer (PR #4603
left the guard-rail NOTE for whoever wired `throughLabelAssociations` into
loading — that caller now exists in `defineFixtures`).

## What

- Preflight each plain-through join table with `tableExists` before pushing its
  rows; throw a precise error naming the missing through-model fixture set
  (acceptance criterion (b)).
- HABTM join tables (anonymous, no fixture set of their own) are exempt — they
  are sliced in automatically via `throughJoinTableNames`, so `isHabtm` gates
  the guard.
- Refreshed the stale `throughJoinTableNames` NOTE (the materializer now has a
  production caller).

## Tests

Two regression tests in `define-fixtures.test.ts` exercise a plain
`has_many :through` label expansion: one asserts join rows materialize (and the
preflight consults the through table) when it is loaded, one asserts the precise
error (not "no such table") when it is not.

## Note on acceptance criterion 3

The story lists "deriveFixtureSchema exactly `[authors, posts, categories_posts]`"
as a boundedness invariant to preserve. `deriveFixtureSchema` / `sliceSchema`
were since deleted by PR #4593 (the `fixtures()` schema arg was dropped), so
there is no derivation to re-assert. Boundedness is preserved structurally: this
PR leaves `throughJoinTableNames` HABTM-only, exactly as PR #4603 established.

Closes-story: slice-plain-through-join-tables-when-through-labels-load