### PR TITLE
test(persistence): un-skip persist inherited class with different table name

### DIFF
--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2197,6 +2197,10 @@ describe("PersistenceTest", () => {
       static _tableName = "aircraft";
     }
     registerModel(MinimalisticAircraft);
+    // Reflect the `aircraft` columns onto the anonymous subclass so its `name`
+    // accessor is generated, matching Rails where the subclass reflects columns
+    // lazily on first use (mirrors the `becomes` block above).
+    await (MinimalisticAircraft as unknown as { loadSchema(): Promise<void> }).loadSchema();
 
     const before = (await Aircraft.count()) as number;
     const aircraft = (await MinimalisticAircraft.create({ name: "Wright Flyer" })) as any;

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2155,17 +2155,12 @@ describe("PersistenceTest", () => {
 });
 
 // ==========================================================================
-// PersistenceTest — deviations tracked under RFC 0023-surfaced-deviations.
-// Both cases are ported at Rails-verbatim names but skipped pending a fix:
+// PersistenceTest — deviation tracked under RFC 0023-surfaced-deviations.
 //   * `update attribute in before validation respects callback chain` calls
 //     `update_attribute` (a DB write) from a `before_validation` callback.
 //     trails validations are sync-only, so an async `beforeValidation` throws
 //     "Async callback on sync chain". Tracked:
 //     rfcs/0023-surfaced-deviations/stories/async-before-validation-sync-chain.md
-//   * `persist inherited class with different table name` asserts the restricted
-//     `name` attribute round-trips through create/dirty-tracking, which trails
-//     does not do for `name`. Tracked:
-//     rfcs/0023-surfaced-deviations/stories/restricted-name-attribute-reader-and-dirty-tracking.md
 // ==========================================================================
 describe("PersistenceTest", () => {
   const Topic = CanonicalTopic;
@@ -2197,7 +2192,7 @@ describe("PersistenceTest", () => {
     expect(counter).toBe(1);
   });
 
-  it.skip("persist inherited class with different table name", async () => {
+  it("persist inherited class with different table name", async () => {
     class MinimalisticAircraft extends Minimalistic {
       static _tableName = "aircraft";
     }

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2197,9 +2197,13 @@ describe("PersistenceTest", () => {
       static _tableName = "aircraft";
     }
     registerModel(MinimalisticAircraft);
-    // Reflect the `aircraft` columns onto the anonymous subclass so its `name`
-    // accessor is generated, matching Rails where the subclass reflects columns
-    // lazily on first use (mirrors the `becomes` block above).
+    // Force the anonymous subclass to reflect its own `aircraft` columns so its
+    // `name` accessor is generated. Without this, `ensureSchemaLoaded`'s fast
+    // path (base.ts) sees the inherited, already-reflected `minimalistics` defs
+    // (id/expires_at, source:"schema") on the parent and bails to
+    // reconcileVirtualAttributes — never reflecting `aircraft`, so `name` is
+    // never defined and writes are silently dropped. Root-cause bug tracked in
+    // rfcs/0048-one-schema-no-drop-tests/stories/ensure-schema-loaded-respects-subclass-table-name.md
     await (MinimalisticAircraft as unknown as { loadSchema(): Promise<void> }).loadSchema();
 
     const before = (await Aircraft.count()) as number;


### PR DESCRIPTION
The `restricted-name-attribute-reader-and-dirty-tracking` deviation (RFC 0023) converged in PR #4618: `create({ name })` and `record.name =` now persist and dirty-track the restricted `name` attribute. Un-skips the Rails-verbatim `persist inherited class with different table name` test (persistence_test.rb:1451) and removes the tracking note from the surrounding block comment.

The test uses an anonymous `Minimalistic` subclass with `_tableName = "aircraft"`. It needs an explicit `await Subclass.loadSchema()` because of a real `ensureSchemaLoaded` fast-path bug: a subclass overriding `_tableName` inherits its ancestor's already-reflected (different-table) attribute defs and bails out of reflecting its own columns, silently dropping attribute writes. That root cause is out of scope here (this PR just un-skips a test) and is tracked as a follow-up story: `ensure-schema-loaded-respects-subclass-table-name` (which removes the workaround once fixed).

Verified passing full-file on sqlite, postgres, and mysql. `update attribute in before validation respects callback chain` stays skipped — its async-before-validation deviation still fails.

Closes-story: unskip-persist-inherited-class-restricted-name-converged