### PR TITLE
refactor(finder): converge apply_join_dependency onto its Rails name

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -3817,7 +3817,7 @@ export class Relation<T extends Base> {
     // thread through to the recursion (`apply_join_dependency(eager_loading: false)
     // .exists?(conditions)`) — the hardcoded `false` skips the limit/offset guard.
     if (this._eagerLoadingForSql()) {
-      return this.applyJoinDependencyForArel(false).exists(conditions);
+      return this.applyJoinDependency(false).exists(conditions);
     }
     // Mirrors Rails FinderMethods#construct_relation_for_exists
     // (finder_methods.rb:438): shape the existence probe and apply the argument's
@@ -4050,7 +4050,7 @@ export class Relation<T extends Base> {
         // Surface the same explicit NotImplementedError the cache_version path
         // raises for this shape (tracked by
         // 0023-surfaced-deviations/composite-pk-distinct-relation-materialization).
-        if (Array.isArray(basePk)) this.applyJoinDependencyForArel();
+        if (Array.isArray(basePk)) this.applyJoinDependency();
         // Rails apply_join_dependency, for a limit/offset over a collection
         // reflection, replaces the relation via distinct_relation_for_primary_key
         // (finder_methods.rb:463): execute a query to materialize the limited
@@ -4240,7 +4240,7 @@ export class Relation<T extends Base> {
     let stmtAst;
     if (typeof primaryKey === "string" || Array.isArray(primaryKey)) {
       const arel = this._eagerLoadingForSql()
-        ? this.applyJoinDependencyForArel(this._groupColumns.length === 0)._buildArel()
+        ? this.applyJoinDependency(this._groupColumns.length === 0)._buildArel()
         : this._buildArel();
       arel.source.left = table;
       const havingAst = this._havingClause.isEmpty() ? null : this._havingClause.ast;
@@ -4324,7 +4324,7 @@ export class Relation<T extends Base> {
       // implicitly here (the no-arg default, finder_methods.rb:457), so a
       // grouped delete skips the limit/offset materialization guard.
       const arel = this._eagerLoadingForSql()
-        ? this.applyJoinDependencyForArel(this._groupColumns.length === 0)._buildArel()
+        ? this.applyJoinDependency(this._groupColumns.length === 0)._buildArel()
         : this._buildArel();
       // Mirrors `relation.rb:1024` (`arel.source.left = table`): force the FROM
       // target back to the bare table before `compile_delete`. For the common
@@ -5203,7 +5203,7 @@ export class Relation<T extends Base> {
    * when `eager_loading` is truthy.
    * @internal
    */
-  applyJoinDependencyForArel(eagerLoading = true): Relation<T> {
+  applyJoinDependency(eagerLoading = true): Relation<T> {
     if (!this._eagerLoadingForSql()) return this;
     const eagerSpecs = [
       ...new Set([...this._eagerLoadAssociations, ...this._includesAssociations]),
@@ -7294,7 +7294,7 @@ export class Relation<T extends Base> {
           // `_materializeLimitedIds` (shared with the pluck eager-limit path) has
           // no composite-PK support (Rails' zip/transpose over
           // `Array(primary_key)`), so a composite PK falls through to the
-          // synchronous applyJoinDependencyForArel below, which surfaces the
+          // synchronous applyJoinDependency below, which surfaces the
           // unsupported combination as an explicit NotImplementedError rather
           // than emitting a wrong single-column `"col1,col2"` predicate.
           const limitedIds = await this._materializeLimitedIds(jd, pk);
@@ -7305,7 +7305,7 @@ export class Relation<T extends Base> {
           // Composite-PK, non-limitable eager limit/offset: unsupported here —
           // surfaces NotImplementedError rather than a wrong predicate. Tracked
           // by 0023-surfaced-deviations/composite-pk-distinct-relation-materialization.
-          collection = this.applyJoinDependencyForArel();
+          collection = this.applyJoinDependency();
         } else {
           collection = rel.leftOuterJoins(joinableSpecs);
         }
@@ -7996,16 +7996,6 @@ export class Relation<T extends Base> {
   /** @internal */
   private constructRelationForExists(conditions: unknown): any {
     return _fm.constructRelationForExists(this as any, conditions);
-  }
-
-  /** @internal */
-  private applyJoinDependency(eagerLoading: boolean): any {
-    return _fm.applyJoinDependency(this as any, eagerLoading);
-  }
-
-  /** @internal */
-  private isUsingLimitableReflections(reflections: unknown[]): boolean {
-    return _fm.isUsingLimitableReflections(reflections);
   }
 
   /** @internal */

--- a/packages/activerecord/src/relation/finder-methods.ts
+++ b/packages/activerecord/src/relation/finder-methods.ts
@@ -798,32 +798,6 @@ export function constructRelationForExists(rel: FinderRelation, conditions: unkn
 }
 
 /** @internal */
-export function applyJoinDependency(rel: FinderRelation, eagerLoading: boolean): any {
-  if (!eagerLoading) return rel;
-  // Rails: when eager loading, apply a LEFT OUTER JOIN via the join dependency.
-  // Our preloader handles this via separate queries, but we record the join type.
-  const arelRel = rel as any;
-  if (arelRel._includesAssociations?.length > 0 && arelRel._joinClauses) {
-    // Ensure eager-loaded associations use outer join semantics (Arel::Nodes::OuterJoin)
-    arelRel._joinClauses = arelRel._joinClauses.map(
-      (j: { type: string; table: string; on: string }) =>
-        j.type === "inner" && arelRel._includesAssociations.includes(j.table)
-          ? { ...j, type: "left" }
-          : j,
-    );
-    void Nodes.OuterJoin; // Rails uses Arel::Nodes::OuterJoin for eager loading joins
-  }
-  return rel;
-}
-
-/** @internal */
-export function isUsingLimitableReflections(reflections: unknown[]): boolean {
-  return (reflections as any[]).every(
-    (r) => r.macro !== "hasMany" && r.macro !== "hasAndBelongsToMany",
-  );
-}
-
-/** @internal */
 export async function findWithIds(rel: FinderRelation, ids: unknown[]): Promise<any> {
   const normalized = normalizeFindArgs(
     (rel as any)._modelClass.name,

--- a/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
+++ b/packages/activerecord/src/relation/predicate-builder/relation-handler.ts
@@ -61,8 +61,8 @@ export class RelationHandler {
   // distinct_relation_for_primary_key materialization branch
   // (finder_methods.rb:463). Matches relation.ts's own call site (~L3542).
   private applyJoinDependency(value: any): any {
-    return typeof value?.applyJoinDependencyForArel === "function"
-      ? value.applyJoinDependencyForArel(value._groupColumns?.length === 0)
+    return typeof value?.applyJoinDependency === "function"
+      ? value.applyJoinDependency(value._groupColumns?.length === 0)
       : value;
   }
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2441,15 +2441,15 @@ export function buildFrom(this: QueryMethodsHost): unknown {
     // `apply_join_dependency` first (Rails build_from). This folds the eager
     // `includes`/`eager_load` into LEFT OUTER JOINs so a WHERE that references
     // the joined table (e.g. `posts.type`) resolves inside the subquery.
-    // `applyJoinDependencyForArel` clones internally, so the caller's relation
+    // `applyJoinDependency` clones internally, so the caller's relation
     // is not mutated.
     let resolved: any = opts;
     if (
       typeof opts._eagerLoadingForSql === "function" &&
       opts._eagerLoadingForSql() &&
-      typeof opts.applyJoinDependencyForArel === "function"
+      typeof opts.applyJoinDependency === "function"
     ) {
-      resolved = opts.applyJoinDependencyForArel(opts._groupColumns?.length === 0);
+      resolved = opts.applyJoinDependency(opts._groupColumns?.length === 0);
     }
     // Rails build_from wraps `opts.arel.as(name)`, where `arel` is the full
     // `build_arel` — joins, HAVING, nested FROM, LOCK, CTEs, etc. Use the

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -31476,105 +31476,105 @@
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "concat",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "construct_join_dependency",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "distinct_relation_for_primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "eager_load_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "except",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "includes_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "joins_values",
-    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "joins!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "left_outer_joins_values",
-    "reason": "Mixin-host attribution artifact: the real port lives in relation/query-methods.ts (build_joins/build_join_buckets/build_join_dependencies now credit this.joinsValues after value-accessor read-crediting landed and dropped from the baseline). The relation.ts host candidate carries no resolvable body — a pre-existing compare double-attribution, not an accessor-read gap."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "reflections",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "select_association_list",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "skip_query_cache_if_necessary",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "using_limitable_reflections?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "apply_join_dependency",
     "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "reason": "Bucket-(b) faithful equivalent: apply_join_dependency is ported as Relation#applyJoinDependency (relation.ts, folded into build_from) — it clears the eager specs and re-applies them via leftOuterJoins (Rails' Arel::Nodes::OuterJoin outcome). Rails' internal sends are performed in helpers rather than the method body: the eager_load_values | includes_values / joins_values / left_outer_joins_values reads and the using_limitable_reflections? test live in _applyJoinDependencyIsLimitable -> _eagerReflectionsAreLimitable / _joinsReflectionsAreLimitable + usingLimitableReflections, and the has_limit_or_offset? + distinct_relation_for_primary_key / skip_query_cache_if_necessary / with_connection materialization path is the deferred branch that throws NotImplementedError (tracked by relation-handler-distinct-pk-materialization). Not a divergence."
   },
   {
     "package": "activerecord",
@@ -33365,13 +33365,6 @@
     "package": "activerecord",
     "tsFile": "relation.ts",
     "rubyName": "compute_cache_version",
-    "call": "apply_join_dependency",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "compute_cache_version",
     "call": "arel",
     "reason": "Confirmed equivalent (RFC 0047): the TS body builds the Arel manager via _buildArel/toArel (the build_arel port that arel() delegates to) rather than the memoized arel reader; surfaced when arel() gained its Rails-faithful aliases param (query_methods.rb:1594). See PR #4518."
   },
@@ -33625,13 +33618,6 @@
     "tsFile": "relation.ts",
     "rubyName": "delete_all",
     "call": "any?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "delete_all",
-    "call": "apply_join_dependency",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -34444,13 +34430,6 @@
     "tsFile": "relation.ts",
     "rubyName": "execute_simple_calculation",
     "call": "wrap",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation.ts",
-    "rubyName": "exists?",
-    "call": "apply_join_dependency",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -37830,111 +37809,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "concat",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "construct_join_dependency",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "distinct_relation_for_primary_key",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "eager_load_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "except",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "includes_values",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "joins_values",
-    "reason": "Divergent port: trails applyJoinDependency uses the preloader path (finder-methods.ts) and reads neither joins_values nor left_outer_joins_values. Genuine divergence."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "joins!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "left_outer_joins_values",
-    "reason": "Divergent port: trails applyJoinDependency uses the preloader path (finder-methods.ts) and reads neither joins_values nor left_outer_joins_values. Genuine divergence."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "model",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "reflections",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "select_association_list",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "skip_query_cache_if_necessary",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "using_limitable_reflections?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "apply_join_dependency",
-    "call": "with_connection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
     "rubyName": "construct_relation_for_exists",
     "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -38252,13 +38126,6 @@
     "tsFile": "relation/finder-methods.ts",
     "rubyName": "raise_record_not_found_exception!",
     "call": "wrap",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/finder-methods.ts",
-    "rubyName": "using_limitable_reflections?",
-    "call": "none?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## What

Rails `FinderMethods#apply_join_dependency` (`finder_methods.rb:457`) builds
the join dependency from `eager_load_values | includes_values` and reads
`joins_values` / `left_outer_joins_values` (via `select_association_list`) for
the limitable-reflections guard. trails had **two** ports of it:

1. `applyJoinDependency` in `relation/finder-methods.ts` — a **divergent, dead**
   implementation that mutated `_joinClauses` types, read neither join accessor,
   and was reachable only through a `relation.ts` wrapper that nothing called.
   Surfaced by PR #4656 as a residual wide-call mismatch.
2. `applyJoinDependencyForArel` in `relation.ts` — the **real** implementation
   (folded into `build_from`), living under a divergent trails-invented name.

## Change

**The Rails name now IS the real path.** Rename the real implementation
`applyJoinDependencyForArel` → `applyJoinDependency` (`relation.ts:5206`) and
delete the divergent finder-methods stub. The real port derives the join
dependency from the join values exactly as Rails does:

- `applyJoinDependency` clears the eager specs and re-applies them via
  `leftOuterJoins` (Rails' `Arel::Nodes::OuterJoin` outcome), guarded by
  `_applyJoinDependencyIsLimitable` (`relation.ts:5272`).
- `_applyJoinDependencyIsLimitable` mirrors Rails' two-clause
  `using_limitable_reflections?` test (`finder_methods.rb:464-470`):
  `_eagerReflectionsAreLimitable` (`eager_load_values | includes_values`) **and**
  `_joinsReflectionsAreLimitable`, which reads `_leftOuterJoinsValues` and the
  named inner joins (`joins_values`) — i.e. `select_association_list(joins_values)`
  ∪ `select_association_list(left_outer_joins_values)`.
- `usingLimitableReflections` (`relation.ts:5304`) is the real
  `using_limitable_reflections?` port (`reflections.none?(&:collection?)`).

Also delete the sibling dead duplicate `isUsingLimitableReflections`
(finder-methods port of `using_limitable_reflections?`, superseded by
`usingLimitableReflections`) and its wrapper.

## Result

- **api:compare coverage stays at 100%** for `relation/finder_methods.rb`
  (44/44) — `apply_join_dependency` now matches the real port by its Rails name.
- **Three caller-side wide-call mismatches resolve** — `compute_cache_version`,
  `delete_all`, and `exists?` now call the Rails-named `apply_join_dependency`.
- The method's own wide-call entries are **reclassified bucket-(b)**
  faithful-equivalent (Rails' internal sends are performed in the
  limitable-reflection helpers, not the method body), not a divergence.
- Net wide-call baseline shrinks by 19 entries.

All gates green (wide + narrow call-mismatch, body-pins, dependency-lint,
conventions-doc); `tsc --build` clean; `finder-methods`,
`cascaded-eager-loading`, `eager-load-nested-include`, `delete-all`,
subquery/count-fold, and `build-joins-from-subquery-dedup` suites pass.

Closes-story: converge-finder-apply-join-dependency-read-join-values
