### PR TITLE
fix(relation): read public leftOuterJoinsValues in join builders

### DIFF
--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -162,7 +162,7 @@ export class Merger {
   // same-klass names fold into _leftOuterJoinsValues; cross-klass names build a
   // JoinDependency on `other` stashed in _leftOuterJoinDeps.
   private mergeOuterJoins(rel: any): void {
-    const otherLeft: unknown[] = this.other._leftOuterJoinsValues ?? [];
+    const otherLeft: unknown[] = this.other.leftOuterJoinsValues ?? [];
     const sameKlass = this.other._modelClass === rel._modelClass;
     if (sameKlass) {
       for (const v of otherLeft) {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -184,6 +184,9 @@ interface QueryMethodsHost {
   _isNamedJoinValue(v: unknown): boolean;
   readonly _joinValues: (string | Nodes.Join)[];
   _leftOuterJoinsValues: AssociationSpec[];
+  // Public `left_outer_joins_values` value method (relation.ts getter); reads it
+  // over the backing field so extractCalls credits the Rails value-method read.
+  leftOuterJoinsValues: AssociationSpec[];
   readonly _namedInnerJoins: AssociationSpec[];
   // Pre-built InnerJoin JoinDependencies from a cross-klass merge (Rails
   // merge_joins builds these against `other.klass`); emitted via joinConstraints
@@ -2626,7 +2629,7 @@ export function buildJoinDependencies(this: QueryMethodsHost): JoinDependency[] 
     for (const a of specs) if (!joinNames.includes(a)) joinNames.push(a);
   };
   addNames(this.joinsValues.filter((v) => this._isNamedJoinValue(v)) as AssociationSpec[]);
-  addNames(this._leftOuterJoinsValues);
+  addNames(this.leftOuterJoinsValues);
   addNames(this._eagerLoadAssociations);
   addNames(this._includesAssociations);
 
@@ -2790,23 +2793,19 @@ export function buildJoinBuckets(this: QueryMethodsHost): Record<string, unknown
   // them to build stashed_left_joins. If joins_values is also empty, it returns
   // early with OuterJoin type and named_join populated. Otherwise the left-outer
   // JoinDependency is prepended to stashed_left_joins.
-  if (this._leftOuterJoinsValues.length > 0) {
+  const leftOuterJoinsValues = this.leftOuterJoinsValues;
+  if (leftOuterJoinsValues.length > 0) {
     const stashedLeft: JoinDependency[] = [];
-    assertValidLeftOuterJoinsBang(this._leftOuterJoinsValues);
+    assertValidLeftOuterJoinsBang(leftOuterJoinsValues);
     // Mirror Rails' block (query_methods.rb:1830-1836): a CTEJoin becomes an
     // OuterJoin join_node; any other non-association value raises.
-    const namedLeft = selectNamedJoins.call(
-      this,
-      this._leftOuterJoinsValues,
-      stashedLeft,
-      (left) => {
-        if (left instanceof CTEJoin) {
-          buckets.join_node.push(buildWithJoinNode.call(this, left.name, Nodes.OuterJoin));
-        } else {
-          throw argumentError("only Hash, Symbol and Array are allowed");
-        }
-      },
-    );
+    const namedLeft = selectNamedJoins.call(this, leftOuterJoinsValues, stashedLeft, (left) => {
+      if (left instanceof CTEJoin) {
+        buckets.join_node.push(buildWithJoinNode.call(this, left.name, Nodes.OuterJoin));
+      } else {
+        throw argumentError("only Hash, Symbol and Array are allowed");
+      }
+    });
 
     if (
       namedInner.length === 0 &&
@@ -3046,7 +3045,7 @@ export function buildJoins(this: QueryMethodsHost, arel: any, aliases?: AliasTra
   const hasRawJoins = joinsValues.some((v) => !this._isNamedJoinValue(v));
   const hasEagerAssocs =
     this._eagerLoadAssociations.length > 0 ||
-    this._leftOuterJoinsValues.length > 0 ||
+    this.leftOuterJoinsValues.length > 0 ||
     hasNamedInner ||
     this._namedInnerJoinDeps.length > 0 ||
     this._leftOuterJoinDeps.length > 0;

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -151,7 +151,7 @@ export function mergeBang(this: any, other: any): any {
         constructJoinDependency.call(other, crossKlassNamed as any, Nodes.InnerJoin),
       );
     }
-    for (const v of other._leftOuterJoinsValues ?? []) {
+    for (const v of other.leftOuterJoinsValues ?? []) {
       if (!this._leftOuterJoinsValues.some((seen: unknown) => structuralUnionEq(seen, v)))
         this._leftOuterJoinsValues.push(v);
     }

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -38377,13 +38377,6 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_outer_joins",
-    "call": "left_outer_joins_values",
-    "reason": "Body reads the private _leftOuterJoinsValues field, not the public leftOuterJoinsValues accessor; converging requires mergeOuterJoins to read the public accessor (separate source change)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_outer_joins",
     "call": "left_outer_joins!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -39329,13 +39322,6 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "build_join_buckets",
-    "call": "left_outer_joins_values",
-    "reason": "Body reads the private _leftOuterJoinsValues field, not the public leftOuterJoinsValues accessor whose read the gate credits; the joins_values sibling already converged. Converging requires the join builder to read the public accessor (separate source change)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_join_buckets",
     "call": "model",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -39370,13 +39356,6 @@
   {
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_join_dependencies",
-    "call": "left_outer_joins_values",
-    "reason": "Body reads the private _leftOuterJoinsValues field, not the public leftOuterJoinsValues accessor whose read the gate credits; the joins_values sibling already converged. Converging requires the join builder to read the public accessor (separate source change)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
     "rubyName": "build_joins",
     "call": "concat",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -39401,13 +39380,6 @@
     "rubyName": "build_joins",
     "call": "join_constraints",
     "reason": "Bucket (b) equivalent: unify-join-emission-build-joins extracted the single Rails build_joins emission into the shared `emitJoinPlan` helper (delegated to by both `buildJoins` and `_applyJoinsToManager`). The `join_constraints` call still happens, one frame deeper in `emitJoinPlan` (which has no Rails counterpart), so the static call-set analyzer no longer sees it directly under build_joins. Behavior is identical."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "build_joins",
-    "call": "left_outer_joins_values",
-    "reason": "Body reads the private _leftOuterJoinsValues field, not the public leftOuterJoinsValues accessor whose read the gate credits; the joins_values sibling already converged. Converging requires the join builder to read the public accessor (separate source change)."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
## Summary

The `left_outer_joins_values` reads in the join builders read the **private** `_leftOuterJoinsValues` field, which `extractCalls` credited as `_leftOuterJoinsValues` rather than the public `leftOuterJoinsValues` value method the Ruby `left_outer_joins_values` call maps to. This converges them onto the public accessor, mirroring PR #4656's `joins_values` read-crediting for the inner-join siblings.

Converged reads:
- `build_joins`, `build_join_buckets`, `build_join_dependencies` — `relation/query-methods.ts`
- `merge_outer_joins` — `relation/merger.ts`

The public `leftOuterJoinsValues` getter (relation.ts) returns the same backing store, so there is no behavioral change. Writes continue to target the private field.

Removed the four now-converged `left_outer_joins_values` baseline entries from `call-mismatches-wide-exclude.json` (the `relation.ts` mixin-host double-attribution artifacts remain, matching their still-baselined `joins_values` siblings).

## Testing
- `pnpm api:calls:wide` green (7219 baselined)
- relation + join association tests pass

Closes-story: converge-join-builders-read-public-left-outer-accessor