### PR TITLE
fix(relation): guard where.associated against re-joining existing joins

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -809,10 +809,19 @@ export class Relation<T extends Base> {
       const { tracker, jdJoins } = cloned._unifiedJoinAliasTracker(aliasLength);
       let effectiveTable = target.table;
       // Rails' guard (query_methods.rb:91) skips re-joining an association
-      // already in joins_values / left_outer_joins_values. A self-join
-      // (owner and target share a table) needs its own alias, resolved by the
-      // unified alias tracker below, so the guard only applies when the target
-      // is a distinct table whose base name the IS NOT NULL predicate can use.
+      // already in joins_values / left_outer_joins_values. In trails the
+      // no-duplicate-join outcome is reached two ways depending on the shape:
+      //   - Self-join (owner and target share a table, e.g. Comment#children):
+      //     the join loop below routes through the unified alias tracker, which
+      //     dedups the pending join-value and this where-join onto one alias
+      //     (`children_comments`) — a single join whose alias the IS NOT NULL
+      //     predicate needs. This mirrors Rails' `class_name` branch, which
+      //     emits `not(:children => …)` resolving to that same alias. Skipping
+      //     here would strand `effectiveTable` on the base owner table and
+      //     misplace the predicate, so the guard must NOT skip self-joins.
+      //   - Distinct target table (e.g. Post#author): skip the redundant join;
+      //     `effectiveTable` stays the base table name, matching Rails' non-
+      //     class_name branch `not(reflection.table_name => …)`.
       const skipJoin = skipJoinFor?.has(assocName) && target.table !== ownerTable;
       if (!skipJoin) {
         for (const join of target.joins) {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -790,7 +790,7 @@ export class Relation<T extends Base> {
    * type; throws if a different join to the same table is present (aliasing
    * not supported).
    */
-  whereAssociated(...assocNames: string[]): Relation<T> {
+  whereAssociated(assocNames: string[], skipJoinFor?: ReadonlySet<string>): Relation<T> {
     let rel: Relation<T> = this;
     for (const assocName of assocNames) {
       rel._requireAssociation(assocName);
@@ -808,19 +808,27 @@ export class Relation<T extends Base> {
       const aliasLength = (rel._conn() as any).tableAliasLength();
       const { tracker, jdJoins } = cloned._unifiedJoinAliasTracker(aliasLength);
       let effectiveTable = target.table;
-      for (const join of target.joins) {
-        const alias = _addAssocJoin(
-          cloned._joinClauses,
-          "inner",
-          join,
-          assocName,
-          rel._modelClass as any,
-          ownerTable,
-          quoteTable,
-          tracker,
-          jdJoins,
-        );
-        if (alias && join.table === target.table) effectiveTable = alias;
+      // Rails' guard (query_methods.rb:91) skips re-joining an association
+      // already in joins_values / left_outer_joins_values. A self-join
+      // (owner and target share a table) needs its own alias, resolved by the
+      // unified alias tracker below, so the guard only applies when the target
+      // is a distinct table whose base name the IS NOT NULL predicate can use.
+      const skipJoin = skipJoinFor?.has(assocName) && target.table !== ownerTable;
+      if (!skipJoin) {
+        for (const join of target.joins) {
+          const alias = _addAssocJoin(
+            cloned._joinClauses,
+            "inner",
+            join,
+            assocName,
+            rel._modelClass as any,
+            ownerTable,
+            quoteTable,
+            tracker,
+            jdJoins,
+          );
+          if (alias && join.table === target.table) effectiveTable = alias;
+        }
       }
       const tgtTable = new Table(effectiveTable);
       for (const pk of target.pks) {

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -43,8 +43,10 @@ import { foreignKey } from "@blazetrails/activesupport";
  */
 export interface WhereChainScope<R> {
   whereNot(conditions: Record<string, unknown>): R;
-  whereAssociated(...associationNames: string[]): R;
+  whereAssociated(associationNames: string[], skipJoinFor?: ReadonlySet<string>): R;
   whereMissing(...associationNames: string[]): R;
+  joinsValues: unknown[];
+  leftOuterJoinsValues: unknown[];
   exists(conditions?: unknown): Promise<boolean>;
 }
 
@@ -66,8 +68,21 @@ export class WhereChain<R = any> {
   }
 
   associated(...associationNames: string[]): R {
-    for (const name of associationNames) this.scopeAssociationReflection(name);
-    return this._scope.whereAssociated(...associationNames);
+    // Mirror Rails' guard (query_methods.rb:91): skip the join for any
+    // association already present in joins_values / left_outer_joins_values,
+    // so an already-joined association does not get a duplicate join.
+    const skipJoinFor = new Set<string>();
+    for (const name of associationNames) {
+      const reflection = this.scopeAssociationReflection(name) as { name?: string } | undefined;
+      const reflectionName = reflection?.name ?? name;
+      if (
+        this._scope.joinsValues.includes(reflectionName) ||
+        this._scope.leftOuterJoinsValues.includes(reflectionName)
+      ) {
+        skipJoinFor.add(name);
+      }
+    }
+    return this._scope.whereAssociated(associationNames, skipJoinFor);
   }
 
   missing(...associationNames: string[]): R {

--- a/packages/activerecord/src/relation/where-chain.trails.test.ts
+++ b/packages/activerecord/src/relation/where-chain.trails.test.ts
@@ -1,0 +1,36 @@
+/**
+ * trails-only extras for WhereChain that assert SQL shape rather than result
+ * membership. Rails' `where.associated` guards against re-joining an
+ * association already present in `joins_values` / `left_outer_joins_values`
+ * (query_methods.rb:91); the Rails-named coverage in where-chain.test.ts only
+ * asserts membership, so these SQL-shape tests pin the no-duplicate-join guard.
+ */
+import { describe, it, expect } from "vitest";
+import "../index.js";
+import { registerModel } from "../associations.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+import { Post } from "../test-helpers/models/post.js";
+import { Author } from "../test-helpers/models/author.js";
+
+registerModel(Post);
+registerModel(Author);
+
+const authorsJoinCount = (sql: string): number =>
+  (sql.match(/join\s+["`]?authors["`]?/gi) ?? []).length;
+
+describe("WhereChain associated join guard (trails)", () => {
+  fixtures(["posts", "authors", "authorAddresses"]);
+
+  it("does not duplicate an inner join already in joins_values", () => {
+    const sql = Post.joins("author").where().associated("author").toSql();
+    expect(authorsJoinCount(sql)).toBe(1);
+    expect(sql).toMatch(/INNER JOIN/i);
+  });
+
+  it("does not add an inner join when a left outer join is already present", () => {
+    const sql = Post.leftOuterJoins("author").where().associated("author").toSql();
+    expect(authorsJoinCount(sql)).toBe(1);
+    expect(sql).toMatch(/LEFT OUTER JOIN/i);
+    expect(sql).not.toMatch(/INNER JOIN/i);
+  });
+});

--- a/packages/activerecord/src/relation/where-chain.trails.test.ts
+++ b/packages/activerecord/src/relation/where-chain.trails.test.ts
@@ -25,6 +25,8 @@ describe("WhereChain associated join guard (trails)", () => {
     const sql = Post.joins("author").where().associated("author").toSql();
     expect(authorsJoinCount(sql)).toBe(1);
     expect(sql).toMatch(/INNER JOIN/i);
+    // The IS NOT NULL predicate still lands on the (unaliased) target table.
+    expect(sql).toMatch(/["`]?authors["`]?\.["`]?id["`]?\s+IS NOT NULL/i);
   });
 
   it("does not add an inner join when a left outer join is already present", () => {
@@ -32,5 +34,6 @@ describe("WhereChain associated join guard (trails)", () => {
     expect(authorsJoinCount(sql)).toBe(1);
     expect(sql).toMatch(/LEFT OUTER JOIN/i);
     expect(sql).not.toMatch(/INNER JOIN/i);
+    expect(sql).toMatch(/["`]?authors["`]?\.["`]?id["`]?\s+IS NOT NULL/i);
   });
 });

--- a/packages/activerecord/src/relation/where-chain.trails.test.ts
+++ b/packages/activerecord/src/relation/where-chain.trails.test.ts
@@ -11,15 +11,18 @@ import { registerModel } from "../associations.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Author } from "../test-helpers/models/author.js";
+import { Comment } from "../test-helpers/models/comment.js";
 
 registerModel(Post);
 registerModel(Author);
+registerModel(Comment);
 
 const authorsJoinCount = (sql: string): number =>
   (sql.match(/join\s+["`]?authors["`]?/gi) ?? []).length;
+const joinCount = (sql: string): number => (sql.match(/\bjoin\b/gi) ?? []).length;
 
 describe("WhereChain associated join guard (trails)", () => {
-  fixtures(["posts", "authors", "authorAddresses"]);
+  fixtures(["posts", "authors", "authorAddresses", "comments"]);
 
   it("does not duplicate an inner join already in joins_values", () => {
     const sql = Post.joins("author").where().associated("author").toSql();
@@ -35,5 +38,19 @@ describe("WhereChain associated join guard (trails)", () => {
     expect(sql).toMatch(/LEFT OUTER JOIN/i);
     expect(sql).not.toMatch(/INNER JOIN/i);
     expect(sql).toMatch(/["`]?authors["`]?\.["`]?id["`]?\s+IS NOT NULL/i);
+  });
+
+  // Self-join (Comment#children): trails converges the pending join-value and
+  // the where-join onto one aliased `children_comments` join via the alias
+  // tracker (not via the skip path, which self-joins are exempt from), so there
+  // is still exactly one join and the predicate lands on the alias.
+  it("does not duplicate a self-join already in joins_values", () => {
+    const inner = Comment.joins("children").where().associated("children").toSql();
+    expect(joinCount(inner)).toBe(1);
+    expect(inner).toMatch(/["`]?children_comments["`]?\.["`]?id["`]?\s+IS NOT NULL/i);
+
+    const loj = Comment.leftOuterJoins("children").where().associated("children").toSql();
+    expect(joinCount(loj)).toBe(1);
+    expect(loj).toMatch(/["`]?children_comments["`]?\.["`]?id["`]?\s+IS NOT NULL/i);
   });
 });

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -39154,22 +39154,8 @@
     "package": "activerecord",
     "tsFile": "relation/query-methods.ts",
     "rubyName": "associated",
-    "call": "joins_values",
-    "reason": "Divergent port: trails where.associated does not guard on existing joins_values/left_outer_joins_values before joining (Rails query_methods.rb:91), so it reads neither accessor. Genuine behavioral divergence, not a read-crediting gap."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "associated",
     "call": "joins!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/query-methods.ts",
-    "rubyName": "associated",
-    "call": "left_outer_joins_values",
-    "reason": "Divergent port: trails where.associated does not guard on existing joins_values/left_outer_joins_values before joining (Rails query_methods.rb:91), so it reads neither accessor. Genuine behavioral divergence, not a read-crediting gap."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
## What

Port Rails' `WhereChain#associated` guard (`query_methods.rb:91`): `associated()`
now reads `joinsValues` / `leftOuterJoinsValues` and threads a `skipJoinFor` set
into `whereAssociated`, which omits the redundant join for already-joined
associations while still emitting the `IS NOT NULL` predicate. Removes the
converged `associated -> joins_values` / `left_outer_joins_values` wide-call
baseline entries (the accessors are now genuinely read).

## Tests

`where-chain.trails.test.ts` (SQL-shape):
- distinct target (`joins`/`leftOuterJoins("author")` + `associated("author")`):
  exactly one `authors` join, predicate on the base table.
- self-join (`joins`/`leftOuterJoins("children")` + `associated("children")`):
  exactly one `children_comments` join, predicate on the alias.

Existing Rails-named `associated with add {joins,left joins,left outer joins}
before` coverage still passes.

## Review responses

**1. Self-join carve-out (`relation.ts`).** No duplicate self-join exists — the
generated SQL for `Comment.joins("children").where.associated("children")` (and
the `leftOuterJoins` variant) is a single `children_comments` self-join with the
predicate on that alias. trails converges via a different mechanism than Rails:
Rails skips the re-join in `associated`; trails' unified alias tracker
(`_addAssocJoin`) dedups the pending join-value and the where-join onto one
alias. Same single-join outcome, and it matches Rails' `class_name` branch,
which emits `not(:children => …)` resolving to that same aliased table. The skip
path is intentionally NOT applied to self-joins because it would strand
`effectiveTable` on the base owner table and misplace the `IS NOT NULL`
predicate (verified: forcing skip fails `associated with add left outer joins
before`). Locked in with a single-join count assertion for both join types.

**2. `skipJoinFor` snapshot vs Rails' per-iteration re-read.** No observable
divergence. `Post.joins("author").where.associated("author", "author")` emits
`INNER JOIN authors … WHERE authors.id IS NOT NULL AND authors.id IS NOT NULL` —
one join, two predicates — identical to Rails (iteration 2 skips the join and
re-adds the predicate). trails reaches the same SQL because the alias tracker
dedups the second join regardless of the snapshot timing; whereAssociated adds
its join to `_joinClauses` (not `joins_values`), so even a per-iteration re-read
of `joins_values` would not see it. Degenerate input, equivalent output.

Closes-story: where-associated-guard-existing-joins-values