### PR TITLE
fix(sqlite): converge limit-threading onto register_class_with_limit

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -3070,23 +3070,21 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     m.registerType("json", new JsonType());
     m.registerType("numeric", new DecimalWithoutScale());
     // SQLite type affinity — regex matches for flexible type names. Limit-bearing
-    // families parse the limit from the matched `sql_type` string via
-    // `extractLimit`, mirroring Rails' `register_class_with_limit`
-    // (abstract_adapter.rb:919). SQLite integers default to an 8-byte limit
-    // (SQLite3Integer#_limit) when the `sql_type` carries none.
+    // families recover the limit from the matched `sql_type` via
+    // `registerClassWithLimit`, mirroring Rails' `register_class_with_limit`
+    // (abstract_adapter.rb:919). `int` is registered separately because SQLite
+    // integers carry an 8-byte default limit (SQLite3Integer#_limit) when the
+    // `sql_type` supplies none, and `blob`/`clob` are aliases to
+    // `binary`/`text` (abstract_adapter.rb:899-900).
     m.registerType(/int/i, undefined, (k) => sqlite3Int(this.extractLimit(k)));
     // Explicit "bigint" registered after /int/i so it takes priority on exact matches.
     m.registerType("bigint", sqlite3Int(8));
-    m.registerType(/char/i, undefined, (k) => new StringType({ limit: this.extractLimit(k) }));
-    m.registerType(/text/i, undefined, (k) => new TextType({ limit: this.extractLimit(k) }));
-    m.registerType(/binary/i, undefined, (k) => new BinaryType({ limit: this.extractLimit(k) }));
-    m.registerType(/clob/i, undefined, (k) => new TextType({ limit: this.extractLimit(k) }));
-    m.registerType(/blob/i, undefined, (k) => new BinaryType({ limit: this.extractLimit(k) }));
-    m.registerType(
-      /real|floa|doub/i,
-      undefined,
-      (k) => new FloatType({ limit: this.extractLimit(k) }),
-    );
+    this.registerClassWithLimit(m, /char/i, StringType);
+    this.registerClassWithLimit(m, /text/i, TextType);
+    this.registerClassWithLimit(m, /binary/i, BinaryType);
+    m.aliasType(/clob/i, "text");
+    m.aliasType(/blob/i, "binary");
+    this.registerClassWithLimit(m, /real|floa|doub/i, FloatType);
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1166,9 +1166,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    *
    * Mirrors: ActiveRecord::ConnectionAdapters::AbstractAdapter#fetch_type_metadata.
    * Rails carries the full `sql_type` string and lets `lookup_cast_type`'s regex
-   * registrations parse precision/limit; trails' SQLite type map does not extract
-   * those, so we parse the `(N)` parameter here (precision for temporal types,
-   * limit otherwise) and store the base name in `sqlType`.
+   * registrations parse precision/limit. trails' SQLite type map extracts the
+   * limit at lookup time too (`register_class_with_limit`), so we keep the full
+   * `sql_type` in `sqlType` for limit-bearing families; temporal types keep the
+   * paren-stripped base (their precision is parsed here and threaded via
+   * `lookupCastTypeFromColumn`).
    */
   fetchTypeMetadata(sqlType: string): SqlTypeMetadata {
     const raw = sqlType || "";
@@ -1200,8 +1202,14 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       limit = null;
       baseSqlType = raw;
     }
+    // Carry the full `sql_type` (with `(N)`) so limit-bearing type-map
+    // factories (`char`/`binary`/`text`/`int`/`float`) recover the limit via
+    // `extractLimit` at lookup time — Rails' `register_class_with_limit`
+    // mechanism. Temporal types keep the paren-stripped base so their exact
+    // (parenless) type-map keys still resolve; their precision is threaded
+    // separately in `lookupCastTypeFromColumn`.
     return new SqlTypeMetadata({
-      sqlType: baseSqlType,
+      sqlType: isDtPrec ? baseSqlType : raw,
       type: dslTypeName,
       limit,
       precision,
@@ -1212,28 +1220,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   lookupCastTypeFromColumn(column: {
     sqlType?: string | null;
     precision?: number | null;
-    limit?: number | null;
   }): import("@blazetrails/activemodel").Type {
     const base = this.lookupCastType(column.sqlType ?? "");
     if (column.precision != null) {
       if (base instanceof SQLiteDateTimeType)
         return new SQLiteDateTimeType({ precision: column.precision });
       if (base instanceof TimeType) return new TimeType({ precision: column.precision });
-    }
-    // Rails carries the full `sql_type` (e.g. `varchar(255)`) into
-    // `register_class_with_limit`, so `type_for_attribute(col).limit` returns
-    // the column limit. `fetchTypeMetadata` strips the `(N)` off the stored
-    // `sqlType`, so re-thread the limit from the column onto the cast type here.
-    if (column.limit != null && base.limit == null) {
-      return new (base.constructor as new (o: {
-        limit?: number;
-        precision?: number;
-        scale?: number;
-      }) => typeof base)({
-        limit: column.limit,
-        precision: base.precision,
-        scale: base.scale,
-      });
     }
     return base;
   }
@@ -3077,14 +3069,22 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     m.registerType("binary", new BinaryType());
     m.registerType("json", new JsonType());
     m.registerType("numeric", new DecimalWithoutScale());
-    // SQLite type affinity — regex matches for flexible type names
-    m.registerType(/int/i, undefined, (k) => (/bigint/i.test(k) ? sqlite3Int(8) : sqlite3Int()));
+    // SQLite type affinity — regex matches for flexible type names. Limit-bearing
+    // families parse the limit from the matched `sql_type` string via
+    // `extractLimit`, mirroring Rails' `register_class_with_limit`
+    // (abstract_adapter.rb:919). SQLite integers default to an 8-byte limit
+    // (SQLite3Integer#_limit) when the `sql_type` carries none.
+    m.registerType(/int/i, undefined, (k) => sqlite3Int(this.extractLimit(k)));
     // Explicit "bigint" registered after /int/i so it takes priority on exact matches.
     m.registerType("bigint", sqlite3Int(8));
-    m.registerType(/char/i, undefined, () => new StringType());
-    m.registerType(/clob/i, undefined, () => new TextType());
-    m.registerType(/blob/i, undefined, () => new BinaryType());
-    m.registerType(/real|floa|doub/i, undefined, () => new FloatType());
+    m.registerType(/char/i, undefined, (k) => new StringType({ limit: this.extractLimit(k) }));
+    m.registerType(/clob/i, undefined, (k) => new TextType({ limit: this.extractLimit(k) }));
+    m.registerType(/blob/i, undefined, (k) => new BinaryType({ limit: this.extractLimit(k) }));
+    m.registerType(
+      /real|floa|doub/i,
+      undefined,
+      (k) => new FloatType({ limit: this.extractLimit(k) }),
+    );
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -3078,6 +3078,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // Explicit "bigint" registered after /int/i so it takes priority on exact matches.
     m.registerType("bigint", sqlite3Int(8));
     m.registerType(/char/i, undefined, (k) => new StringType({ limit: this.extractLimit(k) }));
+    m.registerType(/text/i, undefined, (k) => new TextType({ limit: this.extractLimit(k) }));
+    m.registerType(/binary/i, undefined, (k) => new BinaryType({ limit: this.extractLimit(k) }));
     m.registerType(/clob/i, undefined, (k) => new TextType({ limit: this.extractLimit(k) }));
     m.registerType(/blob/i, undefined, (k) => new BinaryType({ limit: this.extractLimit(k) }));
     m.registerType(

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
@@ -41,6 +41,9 @@ describe("SQLite3Adapter type-map limit threading", () => {
       ["binary(16)", "binary", 16],
       ["int(11)", "integer", 11],
       ["float(24)", "float", 24],
+      // blob/clob alias to binary/text and must thread the limit through them.
+      ["blob(8)", "binary", 8],
+      ["clob(5)", "text", 5],
     ] as const) {
       const type = castType(sqlType);
       expect(type.type()).toBe(expectedType);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+
+// trails-only coverage for the SQLite `register_class_with_limit` convergence
+// (RFC 0043 converge-sqlite-limit-to-register-class-with-limit). Rails threads a
+// column's limit at type-map lookup time — the `char`/`binary`/`text`/`int`/
+// `float` factories parse the matched `sql_type` string via `extract_limit`
+// (abstract_adapter.rb:919). These assert the full reflection path
+// (`fetchTypeMetadata` → `lookupCastTypeFromColumn`) carries the limit without
+// the reflective cast-type rebuild that previously stood in for it.
+describe("SQLite3Adapter type-map limit threading", () => {
+  let adapter: AbstractSQLite3Adapter;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sqlite-typemap-"));
+    adapter = new BetterSQLite3Adapter(path.join(tmpDir, "db.sqlite3"));
+  });
+
+  afterEach(async () => {
+    await adapter.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const castType = (sqlType: string) =>
+    adapter.lookupCastTypeFromColumn(adapter.fetchTypeMetadata(sqlType));
+
+  it("keeps the full sql_type for limit-bearing families", () => {
+    expect(adapter.fetchTypeMetadata("varchar(255)").sqlType).toBe("varchar(255)");
+  });
+
+  it("threads the parsed limit onto the cast type for each limit-bearing family", () => {
+    for (const [sqlType, expectedType, expectedLimit] of [
+      ["varchar(255)", "string", 255],
+      ["char(10)", "string", 10],
+      ["text(160)", "text", 160],
+      ["binary(16)", "binary", 16],
+      ["int(11)", "integer", 11],
+      ["float(24)", "float", 24],
+    ] as const) {
+      const type = castType(sqlType);
+      expect(type.type()).toBe(expectedType);
+      expect(type.limit).toBe(expectedLimit);
+    }
+  });
+
+  it("defaults SQLite integers to an 8-byte limit when the sql_type carries none", () => {
+    expect(castType("integer").limit).toBe(8);
+    expect(castType("bigint").limit).toBe(8);
+  });
+
+  it("resolves temporal types from the paren-stripped base and threads precision", () => {
+    const dt = castType("datetime(6)");
+    expect(dt.type()).toBe("datetime");
+    expect(dt.precision).toBe(6);
+    const time = castType("time(3)");
+    expect(time.type()).toBe("time");
+    expect(time.precision).toBe(3);
+  });
+
+  it("keeps decimal precision and scale off the full sql_type", () => {
+    const dec = castType("decimal(10,2)");
+    expect(dec.type()).toBe("decimal");
+    expect(dec.precision).toBe(10);
+    expect(dec.scale).toBe(2);
+  });
+});

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -24551,13 +24551,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/sqlite3-adapter.ts",
-    "rubyName": "initialize_type_map",
-    "call": "register_class_with_limit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/sqlite3-adapter.ts",
     "rubyName": "move_table",
     "call": "drop_table",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Summary

Converges SQLite's column-limit threading onto Rails' `register_class_with_limit` mechanism, removing the generic reflective cast-type reconstruction that PR #4668 added to `lookupCastTypeFromColumn` (and its unsound `new (base.constructor as ...)` TS cast).

Rails threads the limit at *lookup* time (`abstract_adapter.rb:919-924`): the type-map factories parse the matched `sql_type` string (with `(N)` attached) via `extract_limit`. There is no separate reconstruct-after-the-fact step.

## Changes

- `fetchTypeMetadata` now keeps the full un-stripped `sql_type` in `sqlType` for limit-bearing families (so `varchar(255)` reaches `lookupCastType`). Temporal types keep the paren-stripped base so their exact (parenless) type-map keys still resolve; their precision is threaded via `lookupCastTypeFromColumn` as before — preserving the DSL type-name resolution that depends on the stripped `sqlType`.
- The SQLite type-map factories for the limit-bearing families now recover the limit from the matched `sql_type` via the `AbstractAdapter.registerClassWithLimit` static (the same helper `AbstractAdapter#initializeTypeMap` uses) — Rails' `register_class_with_limit`:
  - `/char/i`, `/text/i`, `/binary/i`, `/real|floa|doub/i` register through `registerClassWithLimit`.
  - `/blob/i` and `/clob/i` route through `aliasType` to `binary`/`text` (`abstract_adapter.rb:899-900`), so they thread the limit through those factories rather than duplicating construction.
  - `/int/i` stays a bespoke factory because SQLite integers carry an 8-byte default limit (`SQLite3Integer#_limit`) when the `sql_type` supplies none.
  - Added the `/text/i` and `/binary/i` factories: without them bare `text(N)`/`binary(N)` columns fell through to `ValueType` once the reflective rebuild was removed.
- `lookupCastTypeFromColumn` drops the reflective rebuild and the now-unused `limit` param; the cast type already carries the limit from the factory.

## Scope note — precision (`register_class_with_precision`)

This PR converges **limit** only. Temporal **precision** still uses the old path (`fetchTypeMetadata` strips `(N)` and `lookupCastTypeFromColumn` re-applies it) because sqlite registers `datetime`/`time`/`timestamp` as exact-string keys, not precision factories. Converging that sibling mechanism (registering them via `registerClassWithPrecision` with the sqlite-specific types, then deleting the `lookupCastTypeFromColumn` override) is a larger, riskier change on the same suite and is tracked as a separate story: **`converge-sqlite-precision-to-register-class-with-precision`** (RFC 0043).

## Tests

- `attributes.test.ts` "immutable_strings_by_default retains limit information" (`typeForAttribute("inferred_string").limit === 255`) — passes unchanged.
- New `sqlite3-adapter.type-map.trails.test.ts` (trails-only): locks in the convergence end-to-end (`fetchTypeMetadata` → `lookupCastTypeFromColumn`) — the full `sql_type` is retained, every limit-bearing family (incl. `blob`/`clob` via alias) threads its parsed limit, integers default to 8, and temporal precision / decimal precision+scale still resolve. The `sqlType === "varchar(255)"` assertion fails on `main` (which stores the stripped base), so it guards the new mechanism.
- Green locally: attributes, serialized-attribute, defaults, date-time-precision, sqlite introspection / schema-statements / copy-table, schema-dumper (+trails), instantiate-schema-types, model-schema-load/sync-load, table-metadata, type-caster, types, column-definition, migration, lazy-schema-reflection. Typecheck clean.

Closes-story: converge-sqlite-limit-to-register-class-with-limit

## CI

The wide call-mismatch ratchet flagged one **stale** baseline entry — `initialize_type_map → register_class_with_limit` for `sqlite3-adapter.ts`. This is the PR's convergence made real: `initializeTypeMap` now actually calls `registerClassWithLimit` (it previously hand-rolled the types and thus omitted the call). Pruned that one now-converged entry from `call-mismatches-wide-exclude.json`, verified against a forced full-scope compare (`API_COMPARE_FORCE=1`, 5961 pairs matching CI) so exactly one entry went stale.
