### PR TITLE
fix(schema): reflect own table when subclass overrides _tableName

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1260,18 +1260,21 @@ export class Base extends Model {
     // table) but has not yet reflected reads its ancestor's map — reflected
     // against a *different* table. Bailing here would flag those foreign
     // columns as known and never reflect this class's own table. Find the class
-    // that actually owns the map; if its `tableName` differs from ours, the
-    // inherited defs describe another table, so reflect instead of bailing.
+    // that actually owns the map; if it is a table-backed class whose
+    // `tableName` differs from ours, the inherited defs describe another table,
+    // so reflect instead of bailing. The `typeof ... === "string"` guard keeps
+    // us on the fast path when the owner is a table-less root (e.g. the
+    // activemodel `Model`, which has no `tableName` getter) — that case falls
+    // through to the loop below rather than spuriously forcing a reflection.
     let defsOwner: unknown = this;
     while (defsOwner && !Object.prototype.hasOwnProperty.call(defsOwner, "_attributeDefinitions")) {
       defsOwner = Object.getPrototypeOf(defsOwner);
     }
-    if (
-      defsOwner &&
-      defsOwner !== this &&
-      (defsOwner as typeof Base).tableName !== this.tableName
-    ) {
-      return this.loadSchema();
+    if (defsOwner && defsOwner !== this) {
+      const ownerTable = (defsOwner as { tableName?: unknown }).tableName;
+      if (typeof ownerTable === "string" && ownerTable !== this.tableName) {
+        return this.loadSchema();
+      }
     }
 
     const enumNames = (this as any)._enums as Map<string, unknown> | undefined;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1254,6 +1254,26 @@ export class Base extends Model {
     // Enum-only attrs (registered by `_enum` via `this.attribute()`) must NOT
     // block reflection — they're type overlays, not full schema declarations,
     // and the model still needs the DB to discover its other columns.
+    // The bail check reads `_attributeDefinitions`, which is copy-on-write and
+    // thus inherited from an ancestor until this class mutates it. A subclass
+    // that overrides `_tableName` (a non-STI subclass pointing at a different
+    // table) but has not yet reflected reads its ancestor's map — reflected
+    // against a *different* table. Bailing here would flag those foreign
+    // columns as known and never reflect this class's own table. Find the class
+    // that actually owns the map; if its `tableName` differs from ours, the
+    // inherited defs describe another table, so reflect instead of bailing.
+    let defsOwner: unknown = this;
+    while (defsOwner && !Object.prototype.hasOwnProperty.call(defsOwner, "_attributeDefinitions")) {
+      defsOwner = Object.getPrototypeOf(defsOwner);
+    }
+    if (
+      defsOwner &&
+      defsOwner !== this &&
+      (defsOwner as typeof Base).tableName !== this.tableName
+    ) {
+      return this.loadSchema();
+    }
+
     const enumNames = (this as any)._enums as Map<string, unknown> | undefined;
     for (const [name, def] of this._attributeDefinitions) {
       const d = def as { virtual?: boolean; source?: string };

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2197,14 +2197,6 @@ describe("PersistenceTest", () => {
       static _tableName = "aircraft";
     }
     registerModel(MinimalisticAircraft);
-    // Force the anonymous subclass to reflect its own `aircraft` columns so its
-    // `name` accessor is generated. Without this, `ensureSchemaLoaded`'s fast
-    // path (base.ts) sees the inherited, already-reflected `minimalistics` defs
-    // (id/expires_at, source:"schema") on the parent and bails to
-    // reconcileVirtualAttributes — never reflecting `aircraft`, so `name` is
-    // never defined and writes are silently dropped. Root-cause bug tracked in
-    // rfcs/0048-one-schema-no-drop-tests/stories/ensure-schema-loaded-respects-subclass-table-name.md
-    await (MinimalisticAircraft as unknown as { loadSchema(): Promise<void> }).loadSchema();
 
     const before = (await Aircraft.count()) as number;
     const aircraft = (await MinimalisticAircraft.create({ name: "Wright Flyer" })) as any;


### PR DESCRIPTION
`Base.ensureSchemaLoaded`'s fast-path bail looped `this._attributeDefinitions`
and returned `reconcileVirtualAttributes` when it found a schema-sourced (or
non-enum user) attr, assuming the schema was already known. But
`_attributeDefinitions` is copy-on-write per class: a non-STI subclass that
overrides `_tableName` inherits its **ancestor's** map — reflected against a
*different* table. The bail passed on the ancestor's columns and the subclass
never reflected its own table, silently dropping attribute writes
(`create({ name })` / `record.name =` no-op; `.name` reads null).

Fix: find the class that owns `_attributeDefinitions`; if its `tableName`
differs from this class's, the inherited defs describe another table, so
reflect via `loadSchema()` instead of bailing. STI subclasses share the base's
table, so they still hit the fast path unchanged.

Removes the `await MinimalisticAircraft.loadSchema()` workaround in
persistence.test.ts's `persist inherited class with different table name`.

Verified: target test + persistence, model-schema-sync-load, attributes, enum,
attribute-methods suites all pass locally.

Closes-story: ensure-schema-loaded-respects-subclass-table-name