### PR TITLE
fix(associations): resolve idsWriter lookup key via association_primary_key

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -94,7 +94,17 @@ export class CollectionAssociation extends Association {
    */
   async idsWriter(ids: unknown[]): Promise<void> {
     const Klass = this.klass as any;
-    const pk = Klass.primaryKey ?? "id";
+    // Rails `ids_writer`: `primary_key = reflection.association_primary_key`.
+    // For a through/custom-PK association this is the association's own key
+    // (e.g. `Category.primary_key == "name"`), not the target model's `id`, so
+    // the lookup + not-found message key must come from the rich reflection.
+    const ctor = this.owner.constructor as typeof Base & {
+      _reflectOnAssociation?: (
+        n: string,
+      ) => { associationPrimaryKey?: string | string[] } | undefined;
+    };
+    const richReflection = ctor._reflectOnAssociation?.(this.reflection.name);
+    const pk = richReflection?.associationPrimaryKey ?? Klass.primaryKey ?? "id";
     const filteredIds = (Array.isArray(ids) ? ids : [ids]).filter((id) => id != null && id !== "");
 
     let records: Base[];

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -1533,17 +1533,8 @@ describe("HasManyThroughAssociationsTest", () => {
   it("collection singular ids through setter raises exception when invalid ids set", async () => {
     const david = await Author.find(authors("david").id);
     const ids = [(categories("general") as any).name, "Unknown"];
-    // NOTE: the exact Rails message here is
-    //   "Couldn't find all Categories with 'name': (General, Unknown) (found 1
-    //    results, but was looking for 2). Couldn't find Category with name Unknown."
-    // trails' `idsWriter` currently resolves the target key as 'id' rather than
-    // Rails' `reflection.association_primary_key` ('name'), so it finds 0 and
-    // emits the wrong key. That pk-resolution divergence is tracked separately
-    // (story: idswriter-association-primary-key-resolution); this assertion stays
-    // loose until it is fixed. The `not_found_ids` suffix itself is asserted
-    // exactly by the simple-PK developers case above.
     await expect(association(david, "essayCategories").setIds(ids)).rejects.toThrow(
-      /Couldn't find all Categories.*\(found \d+ results, but was looking for 2\)\. Couldn't find/,
+      "Couldn't find all Categories with 'name': (General, Unknown) (found 1 results, but was looking for 2). Couldn't find Category with name Unknown.",
     );
   });
 

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -13891,13 +13891,6 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "ids_writer",
-    "call": "reflection",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "ids_writer",
     "call": "size",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
`CollectionAssociation#idsWriter` resolved the not-found lookup + message key as
the target model's `primaryKey` (`id`). Rails' `ids_writer` uses
`reflection.association_primary_key`, which for a through/custom-PK association is
the association's own key (e.g. `Category.primary_key == "name"` for
`Author has_many :essay_categories, through: :essays`).

Symptom: `author.essay_category_ids = ["General", "Unknown"]` keyed the lookup by
`id`, found 0 records, and raised `Couldn't find all Categories with 'id': …`
instead of Rails' `… with 'name': (General, Unknown) (found 1 results, …)`.

Fix: resolve the rich reflection and use its `associationPrimaryKey`. Tighten the
through-setter test to assert the exact Rails message, mirroring
`has_many_through_associations_test.rb:1060`.

Closes-story: idswriter-association-primary-key-resolution