### PR TITLE
fix(associations): include scope conditions clause in in-memory CollectionProxy#find not-found message

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -762,16 +762,18 @@ describe("CollectionProxy#find — in-memory not-found message fidelity", () => 
     } catch (e) {
       const err = e as RecordNotFound;
       expect(err).toBeInstanceOf(RecordNotFound);
-      // Pluralized model name + found/expected suffix (this story's convergence).
-      // Rails' in-memory `find` routes through `scope.raise_record_not_found_
-      // exception!`, so the message also carries the association scope's
-      // `[WHERE …]` clause; trails' in-memory path omits it today (tracked
-      // separately: story in-memory-collection-find-conditions-clause). The
-      // regex therefore tolerates an optional conditions clause rather than
-      // ratifying its absence.
+      // Pluralized model name + found/expected suffix + the association scope's
+      // `[WHERE …]` conditions clause. Rails' in-memory `find` routes through
+      // `scope.raise_record_not_found_exception!`, so the message carries the
+      // scope's STI type filter + owner FK. Quote characters differ by adapter
+      // (double-quote vs backtick), so `.` stands in for the identifier quotes —
+      // assert structure, not exact quoting.
       expect(err.message).toMatch(
         new RegExp(
-          `^Couldn't find all Clients with 'id': \\(${realId}, 999999\\).*` +
+          `^Couldn't find all Clients with 'id': \\(${realId}, 999999\\) ` +
+            `\\[WHERE .companies.\\..type. ` +
+            `IN \\('Client', 'LargeClient', 'SpecialClient', 'VerySpecialClient'\\) ` +
+            `AND .companies.\\..client_of. = ${firm.id}\\] ` +
             `\\(found 1 results, but was looking for 2\\)\\.$`,
         ),
       );

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3321,6 +3321,12 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     const byPk = new Map<string, T>();
     for (const r of records) byPk.set(keyForRecord(r), r);
 
+    // Rails calls `scope.raise_record_not_found_exception!`, so the message
+    // carries the association scope's WHERE clause (owner FK + scope
+    // conditions + STI type). Mirror that by threading the scope's
+    // `[WHERE …]` conditions clause into the not-found raisers.
+    const conditions = (this.scope() as { _conditionsClause(): string })._conditionsClause();
+
     // Composite + any-multi: always use the "Couldn't find all" shape
     // (matches performFind). Simple-PK single-id uses "with 'pk'=id".
     if (tuples || wantArray || ids.length > 1) {
@@ -3329,7 +3335,14 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       const castedIds = ids.map(castId);
       const uniqueFoundKeys = new Set(castedIds.map(keyForCastedId).filter((k) => byPk.has(k)));
       if (uniqueFoundKeys.size !== ids.length) {
-        raiseNotFoundAll(targetModel.name, pk, normalized, uniqueFoundKeys.size, ids.length);
+        raiseNotFoundAll(
+          targetModel.name,
+          pk,
+          normalized,
+          uniqueFoundKeys.size,
+          ids.length,
+          conditions,
+        );
       }
       // Return in DB/load order, matching performFind.
       const wantedKeys = new Set(castedIds.map(keyForCastedId));
@@ -3340,7 +3353,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Simple PK, single scalar id.
     const id = ids[0];
     const match = byPk.get(keyForCastedId(castId(id)));
-    if (!match) raiseNotFoundSingle(targetModel.name, pk as string, id);
+    if (!match) raiseNotFoundSingle(targetModel.name, pk as string, id, conditions);
     return match;
   }
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3324,8 +3324,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Rails calls `scope.raise_record_not_found_exception!`, so the message
     // carries the association scope's WHERE clause (owner FK + scope
     // conditions + STI type). Mirror that by threading the scope's
-    // `[WHERE …]` conditions clause into the not-found raisers.
-    const conditions = (this.scope() as { _conditionsClause(): string })._conditionsClause();
+    // `[WHERE …]` conditions clause into the not-found raisers. Computed
+    // lazily (only when raising) — building the scope relation is wasted
+    // work on the hot path where every id is found.
+    const conditionsClause = (): string =>
+      (this.scope() as { _conditionsClause(): string })._conditionsClause();
 
     // Composite + any-multi: always use the "Couldn't find all" shape
     // (matches performFind). Simple-PK single-id uses "with 'pk'=id".
@@ -3341,7 +3344,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           normalized,
           uniqueFoundKeys.size,
           ids.length,
-          conditions,
+          conditionsClause(),
         );
       }
       // Return in DB/load order, matching performFind.
@@ -3353,7 +3356,7 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Simple PK, single scalar id.
     const id = ids[0];
     const match = byPk.get(keyForCastedId(castId(id)));
-    if (!match) raiseNotFoundSingle(targetModel.name, pk as string, id, conditions);
+    if (!match) raiseNotFoundSingle(targetModel.name, pk as string, id, conditionsClause());
     return match;
   }
 


### PR DESCRIPTION
## What

Rails' in-memory `CollectionAssociation#find` raises via `scope.raise_record_not_found_exception!` (`collection_association.rb:104`), so the not-found message carries the association **scope's** `[WHERE …]` conditions clause — owner FK, any scope conditions, and STI type. trails' in-memory `CollectionProxy#find` called the raisers with `conditions = ""`, dropping that clause.

## Changes

- `collection-proxy.ts`: compute the scope's `_conditionsClause()` once and thread it into both `raiseNotFoundAll` (aggregate) and `raiseNotFoundSingle` (single-id) in the in-memory cache path.
- `collection-proxy.test.ts`: tighten the in-memory not-found test from a conditions-tolerant regex to assert the full message including the `[WHERE …]` clause. Quote characters differ by adapter, so identifier quotes are matched with `.` (structure, not exact quoting).

Message now matches Rails, e.g.:
`Couldn't find all Clients with 'id': (3, 999999) [WHERE "companies"."type" IN ('Client', 'LargeClient', 'SpecialClient', 'VerySpecialClient') AND "companies"."client_of" = 1] (found 1 results, but was looking for 2).`

Closes-story: in-memory-collection-find-conditions-clause