### PR TITLE
refactor(adapters): make internalExecQuery bind-aware, share RETURNING read-back

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -557,6 +557,11 @@ export async function execInsertReturningReadback(
   returning: string[] | null | undefined,
 ): Promise<Result | undefined> {
   if (!returning || returning.length <= 1) return undefined;
+  // Gate on the capability flag sql_for_insert itself checks
+  // (supports_insert_returning?) rather than sniffing the generated SQL — on a
+  // backend without INSERT ... RETURNING (MySQL 8) sql_for_insert appends
+  // nothing, so the caller keeps its executeMutation fast path.
+  if (!this.supportsInsertReturning?.()) return undefined;
   const [returningSql, returningBinds] = sqlForInsert.call(
     this as never,
     sql,
@@ -564,7 +569,6 @@ export async function execInsertReturningReadback(
     binds,
     returning,
   );
-  if (!/\sRETURNING\s/i.test(returningSql)) return undefined;
   // Dispatch through the instance so SQLite's bind-aware internalExecQuery
   // override (`.all()`) is used; PG/MySQL fall to the mixed-in default.
   const run = (this.internalExecQuery ?? internalExecQuery).bind(this);

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -104,8 +104,17 @@ export interface DatabaseStatementsHost {
   internalExecute?(
     sql: string,
     name?: string,
-    opts?: { materializeTransactions?: boolean },
+    opts?: { materializeTransactions?: boolean; binds?: unknown[] },
   ): Promise<unknown>;
+  /** @internal */
+  internalExecQuery?(
+    sql: string,
+    name?: string | null,
+    binds?: unknown[],
+    opts?: { prepare?: boolean; allowRetry?: boolean },
+  ): Promise<Result>;
+  /** @internal */
+  dirtyCurrentTransaction?(): void;
   /** @internal */
   rawExecute?(sql: string, name?: string, binds?: unknown[]): Promise<unknown>;
   /** @internal */
@@ -520,6 +529,48 @@ export function execInsert(
     returning ?? null,
   );
   return internalExecQuery.call(this as DatabaseStatementsHost, sql, name ?? "SQL", binds);
+}
+
+/**
+ * Shared multi-column RETURNING read-back for exec_insert.
+ *
+ * Rails' abstract exec_insert runs sql_for_insert then internal_exec_query,
+ * returning the full RETURNING row. trails' adapters keep an executeMutation
+ * fast path for single-column / no-RETURNING inserts (lastInsertRowid +
+ * prepared-statement-cache retry), so this helper handles ONLY the multi-column
+ * auto-populated-columns read-back (Rails `_create_record` zips every returning
+ * column): it appends the RETURNING columns via sql_for_insert and runs the
+ * bound INSERT through the adapter's bind-aware internalExecQuery (which
+ * materializes the transaction) to hand back the whole Result, dirtying the
+ * transaction as executeMutation would. Returns undefined when the caller should
+ * keep its fast path (≤1 returning column, or sql_for_insert produced no
+ * RETURNING clause — e.g. MySQL 8, which lacks INSERT ... RETURNING).
+ *
+ * @internal
+ */
+export async function execInsertReturningReadback(
+  this: DatabaseStatementsHost,
+  sql: string,
+  name: string | null | undefined,
+  binds: unknown[],
+  pk: string | false | null | undefined,
+  returning: string[] | null | undefined,
+): Promise<Result | undefined> {
+  if (!returning || returning.length <= 1) return undefined;
+  const [returningSql, returningBinds] = sqlForInsert.call(
+    this as never,
+    sql,
+    pk ?? null,
+    binds,
+    returning,
+  );
+  if (!/\sRETURNING\s/i.test(returningSql)) return undefined;
+  // Dispatch through the instance so SQLite's bind-aware internalExecQuery
+  // override (`.all()`) is used; PG/MySQL fall to the mixed-in default.
+  const run = (this.internalExecQuery ?? internalExecQuery).bind(this);
+  const result = await run(returningSql, name ?? "SQL", returningBinds);
+  this.dirtyCurrentTransaction?.();
+  return result;
 }
 
 /**
@@ -1377,7 +1428,10 @@ export async function internalExecQuery(
     const tm = (this as any)._transactionManager as TransactionManager | undefined;
     if (tm) await tm.materializeTransactions();
     if (this?.internalExecute) {
-      const rawResult = await this.internalExecute(sql, sqlName);
+      // Thread binds through so a bound INSERT ... RETURNING reaches the driver
+      // (Rails internal_exec_query(sql, name, binds) → internal_execute). trails
+      // carries binds in the opts object rather than positionally.
+      const rawResult = await this.internalExecute(sql, sqlName, { binds });
       return this.castResult ? this.castResult(rawResult) : normalizeResult(rawResult);
     }
     if (binds && binds.length > 0) {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -3,7 +3,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import { ArgumentError } from "@blazetrails/activemodel";
 import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
 import type { ExplainOption } from "./abstract/database-statements.js";
-import { sqlForInsert } from "./abstract/database-statements.js";
+import { execInsertReturningReadback } from "./abstract/database-statements.js";
 import type { MysqlAdapterOptions } from "./pool-config.js";
 import {
   AbstractMysqlAdapter,
@@ -540,18 +540,15 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<Result | number> {
-    if (returning && returning.length > 1) {
-      const [returningSql, returningBinds] = sqlForInsert.call(
-        this as never,
-        sql,
-        pk ?? null,
-        binds,
-        returning,
-      );
-      if (/\sRETURNING\s/i.test(returningSql)) {
-        return this.execQuery(returningSql, name ?? "SQL", returningBinds);
-      }
-    }
+    const readback = await execInsertReturningReadback.call(
+      this as never,
+      sql,
+      name,
+      binds,
+      pk,
+      returning,
+    );
+    if (readback !== undefined) return readback;
     return super.execInsert(sql, name, binds, pk, sequenceName, returning);
   }
 
@@ -1074,7 +1071,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     {
       materializeTransactions = true,
       allowRetry = false,
-    }: { materializeTransactions?: boolean; allowRetry?: boolean } = {},
+      binds = [],
+    }: { materializeTransactions?: boolean; allowRetry?: boolean; binds?: unknown[] } = {},
   ): Promise<Mysql2RawResult> {
     sql = this.preprocessQuery(sql);
     if (materializeTransactions) {
@@ -1082,12 +1080,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       await this.materializeTransactions();
     }
     const driverSql = this.mysqlQuote(sql);
+    // Thread binds through so a bound INSERT ... RETURNING (MariaDB) reaches the
+    // driver, matching Rails internal_execute(sql, name, binds). Transaction-
+    // control callers pass none, keeping their byte-identical no-bind path.
+    const driverBinds = binds.length > 0 ? this.mysqlBinds(binds) : [];
     const txPublicInt = this.currentTransaction().userTransaction;
     const payload: Record<string, unknown> = {
       sql: driverSql,
       name,
-      binds: [],
-      type_casted_binds: [],
+      binds: driverBinds,
+      type_casted_binds: typeCastedBinds(driverBinds),
       connection: this,
       row_count: 0,
       transaction: txPublicInt.isOpen() ? txPublicInt : null,
@@ -1139,7 +1141,16 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
             // internal_execute → raw_execute → cast_result. Array-mode rows keep
             // duplicate column names that the old hash-keyed conn.query collapsed.
             const conn = rawConn as unknown as mysql.Connection;
-            const rawResult = await mysql2PerformQuery.call(this as any, conn, driverSql, [], []);
+            const prepare = this._shouldPrepare(binds);
+            if (prepare) this._trackPrepared(conn, driverSql);
+            const rawResult = await mysql2PerformQuery.call(
+              this as any,
+              conn,
+              driverSql,
+              driverBinds,
+              driverBinds,
+              { prepare },
+            );
             payload.row_count = rawResult.affectedRows;
             return rawResult;
           },

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1147,7 +1147,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
               this as any,
               conn,
               driverSql,
-              driverBinds,
+              binds,
               driverBinds,
               { prepare },
             );
@@ -1159,7 +1159,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // The loop already translated for its retry classification; guard
         // against re-translating an ActiveRecordError (see execute()).
         const translated =
-          e instanceof ActiveRecordError ? e : await this._translateAndEnrich(e, driverSql, []);
+          e instanceof ActiveRecordError
+            ? e
+            : await this._translateAndEnrich(e, driverSql, driverBinds);
         payload.exception = translated;
         payload.exception_object = translated;
         throw translated;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2126,9 +2126,17 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           payload.row_count = count;
           return result;
         } catch (e: any) {
-          payload.exception = e;
-          payload.exception_object = e;
-          throw e;
+          // A bound query is the exec_insert RETURNING read-back: translate with
+          // sql + binds here (mirroring _instrumentedQueryOnClient) so a
+          // constraint violation surfaces as RecordNotUnique/InvalidForeignKey
+          // carrying statement context. withRawConnection re-catches this AR
+          // error and passes it through unchanged; its own translate would
+          // otherwise re-wrap with null sql / empty binds. Transaction-control
+          // SQL (no binds) keeps the raw rethrow, matching pre-PR behavior.
+          const translated = hasBinds ? this._translateException(e, runSql, bindArray) : e;
+          payload.exception = translated;
+          payload.exception_object = translated;
+          throw translated;
         }
       }),
     );

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2095,8 +2095,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // Thread binds through so a bound INSERT ... RETURNING reaches the driver,
     // matching Rails internal_execute(sql, name, binds). Transaction-control
     // callers pass none, keeping their byte-identical no-bind path (no rewrite).
-    const bindArray = binds.length > 0 ? typeCastedBinds(binds).map((v) => this._bindForPg(v)) : [];
-    const runSql = binds.length > 0 ? this.rewriteBinds(sql, bindArray) : sql;
+    const hasBinds = binds.length > 0;
+    const bindArray = hasBinds ? typeCastedBinds(binds).map((v) => this._bindForPg(v)) : [];
+    const runSql = hasBinds ? this.rewriteBinds(sql, bindArray) : sql;
+    // A bound query here is the exec_insert RETURNING read-back; mirror
+    // _instrumentedQueryOnClient by resetting the notice buffer up front and
+    // flushing after, so PG WARNING/NOTICE handling (db_warnings_action) is not
+    // dropped or misattributed to the next query. Transaction-control SQL passes
+    // no binds and keeps its byte-identical path (no reset/flush/rewrite).
+    if (hasBinds) this._noticeReceiverSqlWarnings = [];
     const payload: Record<string, unknown> = {
       sql: runSql,
       name,
@@ -2105,7 +2112,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       connection: this,
       row_count: 0,
     };
-    return Notifications.instrumentAsync("sql.active_record", payload, () =>
+    const queryPromise = Notifications.instrumentAsync("sql.active_record", payload, () =>
       // materializeTransactions is handled above (not delegated to
       // withRawConnection) so transaction-control SQL — COMMIT/ROLLBACK/
       // SAVEPOINT — keeps its exact pre-existing materialize semantics and the
@@ -2125,6 +2132,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         }
       }),
     );
+    if (!hasBinds) return queryPromise;
+    const result = await queryPromise;
+    this._flushWarnings(runSql);
+    return result;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -86,6 +86,7 @@ import {
   temporalToBindString,
   extractTableRefFromInsertSql,
   sqlForInsert,
+  execInsertReturningReadback,
 } from "./abstract/database-statements.js";
 import { makeGetTypeParser } from "./postgresql/temporal-type-parsers.js";
 
@@ -2086,15 +2087,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     {
       materializeTransactions = true,
       allowRetry = false,
-    }: { materializeTransactions?: boolean; allowRetry?: boolean } = {},
+      binds = [],
+    }: { materializeTransactions?: boolean; allowRetry?: boolean; binds?: unknown[] } = {},
   ): Promise<unknown> {
     sql = preprocessQuery.call(this as any, sql);
     if (materializeTransactions) await this.materializeTransactions();
+    // Thread binds through so a bound INSERT ... RETURNING reaches the driver,
+    // matching Rails internal_execute(sql, name, binds). Transaction-control
+    // callers pass none, keeping their byte-identical no-bind path (no rewrite).
+    const bindArray = binds.length > 0 ? typeCastedBinds(binds).map((v) => this._bindForPg(v)) : [];
+    const runSql = binds.length > 0 ? this.rewriteBinds(sql, bindArray) : sql;
     const payload: Record<string, unknown> = {
-      sql,
+      sql: runSql,
       name,
-      binds: [],
-      type_casted_binds: [],
+      binds,
+      type_casted_binds: bindArray,
       connection: this,
       row_count: 0,
     };
@@ -2107,7 +2114,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       this.withRawConnection({ materializeTransactions: false, allowRetry }, async (conn) => {
         const client = conn as unknown as pg.Client;
         try {
-          const result = await this._runQuery(client, sql, [], { rowMode: "array" });
+          const result = await this._runQuery(client, runSql, bindArray, { rowMode: "array" });
           const count = result.rowCount ?? result.rows.length;
           payload.row_count = count;
           return result;
@@ -2394,6 +2401,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       });
     }
     if (this._useInsertReturning) {
+      // A multi-column RETURNING list is the auto-populated-columns read-back
+      // (Rails `_create_record` zips every returning column). The shared helper
+      // runs it through the bind-aware internalExecQuery (which materializes) and
+      // dirties the transaction, handing back the whole Result — `super`/
+      // `executeMutation` would collapse the row to its first column. A single-
+      // column list falls through to the `super`/`executeMutation` fast path
+      // (scalar id + prepared-statement-cache retry).
+      const readback = await execInsertReturningReadback.call(
+        this as never,
+        sql,
+        name,
+        binds,
+        pk,
+        returning,
+      );
+      if (readback !== undefined) return readback;
       // When the caller names RETURNING columns (a custom-named serial/identity
       // PK), append them up front via sql_for_insert so executeMutation reads the
       // DB-generated value back from the right column instead of falling back to
@@ -2408,26 +2431,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
           binds,
           returning,
         );
-        // A multi-column RETURNING list is the auto-populated-columns read-back
-        // (Rails `_create_record` zips every returning column). `super.execInsert`
-        // routes through `executeMutation`, which collapses the row to its first
-        // column, so run the INSERT here and hand back the whole `Result` — the
-        // same write-path scaffolding (withRawConnection materializes and dirties
-        // the transaction) the `pk === false` branch above uses. A single-column
-        // list keeps the `super`/`executeMutation` path (scalar id + prepared-
-        // statement-cache retry).
-        if (returning.length > 1) {
-          const preprocessed = this.preprocessQuery(sqlWithReturning);
-          return this.withRawConnection(async (conn) => {
-            const client = conn as unknown as pg.Client;
-            return this._instrumentedQueryOnClient(
-              client,
-              preprocessed,
-              name ?? "SQL",
-              resolvedBinds,
-            );
-          });
-        }
         return super.execInsert(sqlWithReturning, name, resolvedBinds, pk, sequenceName, returning);
       }
       return super.execInsert(sql, name, binds, pk, sequenceName, returning);

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -26,7 +26,7 @@ import {
   canRemoveIndexByName,
 } from "./abstract/schema-statements.js";
 import { dirtiesQueryCache } from "./abstract/query-cache.js";
-import { sqlForInsert } from "./abstract/database-statements.js";
+import { execInsertReturningReadback } from "./abstract/database-statements.js";
 import { StatementPool as GenericStatementPool } from "./statement-pool.js";
 import {
   ReadOnlyError,
@@ -648,20 +648,15 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     _sequenceName?: string | null,
     returning?: string[] | null,
   ): Promise<Result | number> {
-    if (returning && returning.length > 1) {
-      const [returningSql, returningBinds] = sqlForInsert.call(
-        this as never,
-        sql,
-        pk ?? null,
-        binds,
-        returning,
-      );
-      if (/\sRETURNING\s/i.test(returningSql)) {
-        const result = await this.internalExecQuery(returningSql, name ?? "SQL", returningBinds);
-        this.dirtyCurrentTransaction();
-        return result;
-      }
-    }
+    const readback = await execInsertReturningReadback.call(
+      this as never,
+      sql,
+      name,
+      binds,
+      pk,
+      returning,
+    );
+    if (readback !== undefined) return readback;
     return this.executeMutation(sql, binds, name ?? "SQL");
   }
 


### PR DESCRIPTION
## Summary

trails' abstract `internalExecQuery` dropped the `binds` argument whenever the
adapter defined `internalExecute` (PG, MySQL), so a bound `INSERT ... RETURNING`
failed with "there is no parameter \$1" on PG and a syntax error on MariaDB.
Only SQLite's override was bind-aware. Because of that, PR #4659 had to add
three near-identical `execInsert` overrides for the multi-column RETURNING
read-back.

This PR:

- Threads `binds` through `internalExecute` (in the opts object, matching Rails
  `internal_execute(sql, name, binds)`) on both PG and MySQL, so the mixed-in
  `internalExecQuery` is now bind-aware everywhere. Transaction-control callers
  pass no binds and keep their byte-identical no-rewrite path.
- Collapses the three per-adapter multi-column RETURNING read-backs onto a
  single shared `execInsertReturningReadback` helper: it runs `sql_for_insert`,
  executes the bound INSERT through the bind-aware `internalExecQuery` (which
  materializes the transaction), and dirties the transaction as
  `executeMutation` would.
- Single-column / no-RETURNING inserts keep the `executeMutation` fast path
  (prepared-statement-cache retry, `lastInsertRowid`).

## Testing

- `persistence.test.ts` green on SQLite, PostgreSQL 17, and MySQL 8 (incl.
  `fills auto populated columns on creation`).
- PG + MySQL adapter unit tests green.

Closes-story: internal-exec-query-bind-aware-shared-returning-readback

## Review responses (commit aea258ff4)

1. **PG read-back loses exception translation — FIXED.** `internalExecute`'s bound
   path now translates via `_translateException(e, runSql, bindArray)` before
   `withRawConnection` re-catches it (which passes the `ActiveRecordError`
   through unchanged), restoring the `sql`+`binds` enrichment the old
   `_instrumentedQueryOnClient` path gave. The error class was already correct
   (`withRawConnection` translates on `e.code`), but statement context was lost.
   Txn-control SQL keeps the raw rethrow.
2. **MySQL translate drops binds — aligned, but not a regression.** Changed the
   fallback to `_translateAndEnrich(e, driverSql, driverBinds)` for consistency
   with `execute()`/`executeMutation()`. Note this branch is defensive/dead for
   the read-back: `withRawConnection` pre-translates to an `ActiveRecordError`,
   so the `? e :` arm always wins — and the old `execQuery` read-back path had
   the identical structure, so binds were already `[]` there. No behavior change.
3. **Regex RETURNING-sniff — FIXED.** `execInsertReturningReadback` now gates on
   `supportsInsertReturning?.()` (the flag `sql_for_insert` itself checks) rather
   than pattern-matching generated SQL, and skips `sql_for_insert` on backends
   without INSERT ... RETURNING (MySQL 8).
4. **performQuery binds/typeCastedBinds — FIXED.** Pass raw `binds` then
   `driverBinds` per the `(binds, typeCastedBinds)` contract.

No constraint-violation test added through this path: the read-back only fires
for a table with DB-generated non-PK columns, and the canonical `defaults` table
(mirroring Rails `create_table :defaults`) has no unique constraint — adding one
would need a bespoke table, which the repo forbids. The fix restores the exact
pre-#4659 translation behavior, and error-class translation is covered by the
adapter error tests.
