### PR TITLE
refactor(mysql): move char/varchar/enum/set string registration to concrete Mysql2Adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1801,23 +1801,12 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
 
     // Base types (mirrors AbstractAdapter#initialize_type_map via super)
     m.registerType(/^boolean/i, undefined, () => new BooleanType());
-    // MySQL registers char/varchar/enum/set with a String type whose
-    // boolean coercions are "1"/"0" rather than the ActiveModel default
-    // "t"/"f", so a boolean assigned to a string column round-trips as
-    // 1/0. Mirrors mysql2_adapter.rb's `Type.register(:string, ...)` block
-    // (`Type::String.new(true: "1", false: "0")`) and its char/enum/set
-    // registrations.
-    // char/varchar thread `extract_limit(sql_type)` onto the type
-    // (mysql2_adapter.rb:43-46, `register_type(%r(char)i)`), so
-    // `type_for_attribute(col).limit` reflects the column limit. enum/set
-    // register the limitless string (mysql2_adapter.rb:48-49).
-    const mysqlStringWithLimit = (sqlType: string) =>
-      new StringType({ trueString: "1", falseString: "0", limit: this.extractLimit(sqlType) });
-    const mysqlString = () => new StringType({ trueString: "1", falseString: "0" });
-    m.registerType(/^char/i, undefined, mysqlStringWithLimit);
-    m.registerType(/^varchar/i, undefined, mysqlStringWithLimit);
-    m.registerType(/^enum/i, undefined, mysqlString);
-    m.registerType(/^set/i, undefined, mysqlString);
+    // NOTE: char/varchar/enum/set string registrations do NOT belong here —
+    // they bind mysql2/trilogy-specific `"1"`/`"0"` boolean-string behavior to
+    // a concrete client, so Rails registers them in the concrete
+    // `Mysql2Adapter#initialize_type_map` (mysql2_adapter.rb:40-49), not in
+    // `AbstractMysqlAdapter#initialize_type_map` (abstract_mysql_adapter.rb:711,
+    // which has no such registration). See Mysql2Adapter.initializeTypeMap.
     m.registerType(/^binary/i, undefined, () => new BinaryType());
     m.registerType(/^varbinary/i, undefined, () => new BinaryType());
     m.registerType(/^date$/i, new DateType());

--- a/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql-type-lookup.test.ts
@@ -2,19 +2,20 @@
  * Mirrors Rails activerecord/test/cases/connection_adapters/mysql_type_lookup_test.rb
  */
 import { it, expect, beforeEach } from "vitest";
-import { AbstractMysqlAdapter } from "./abstract-mysql-adapter.js";
+import { Mysql2Adapter } from "./mysql2-adapter.js";
 import { describeIfMysql } from "../adapters/abstract-mysql-adapter/test-helper.js";
 
-// Minimal subclass — only the type map is needed; no live connection.
-class TestMysqlAdapter extends AbstractMysqlAdapter {
+// Minimal subclass of the *concrete* Mysql2Adapter — char/varchar/enum/set
+// string registrations live on the concrete adapter (mysql2_adapter.rb:40-49),
+// not AbstractMysqlAdapter, so the type map under test must be the concrete
+// one. A string config constructs inert (no live connection); only the static
+// type map is exercised here.
+class TestMysqlAdapter extends Mysql2Adapter {
   constructor() {
-    super();
+    super("mysql2://localhost/test");
   }
   override isWriteQuery(sql: string): boolean {
     return /^\s*(INSERT|UPDATE|DELETE|REPLACE|CREATE|ALTER|DROP|TRUNCATE)/i.test(sql);
-  }
-  async columns(_tableName: string) {
-    return [];
   }
 }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -10,6 +10,8 @@ import {
   StatementPool as MysqlStatementPool,
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
+import { StringType } from "@blazetrails/activemodel";
+import { TypeMap } from "../type/type-map.js";
 import {
   AbstractAdapter,
   Version,
@@ -26,7 +28,6 @@ import {
   DatabaseConnectionError,
   MismatchedForeignKey,
   NoDatabaseError,
-  NotImplementedError,
   SQLWarning,
 } from "../errors.js";
 import { Result } from "../result.js";
@@ -112,6 +113,35 @@ class Mysql2StatementPool extends MysqlStatementPool {
  * connection — no inner pool layer.
  */
 export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapter {
+  /**
+   * Mirrors: Mysql2Adapter#initialize_type_map (mysql2_adapter.rb:40-49).
+   *
+   * `super` registers the shared MySQL types. On top of that the concrete
+   * mysql2 adapter binds char/varchar/enum/set to a `StringType` whose boolean
+   * coercions are `"1"`/`"0"` rather than the ActiveModel default `"t"`/`"f"`,
+   * so a boolean assigned to a string column round-trips as 1/0 — this mirrors
+   * the `Type.register(:string, adapter: :mysql2)` block. char/varchar thread
+   * `extract_limit(sql_type)` onto the type (`register_type(%r(char)i)`), so
+   * `type_for_attribute(col).limit` reflects the column limit; enum/set register
+   * the limitless string. These are NOT in AbstractMysqlAdapter because they
+   * bind mysql2-specific behavior to a concrete client.
+   */
+  static override initializeTypeMap(m: TypeMap): void {
+    super.initializeTypeMap(m);
+    m.registerType(
+      /char/i,
+      undefined,
+      (sqlType) =>
+        new StringType({ trueString: "1", falseString: "0", limit: this.extractLimit(sqlType) }),
+    );
+    m.registerType(
+      /^enum/i,
+      undefined,
+      () => new StringType({ trueString: "1", falseString: "0" }),
+    );
+    m.registerType(/^set/i, undefined, () => new StringType({ trueString: "1", falseString: "0" }));
+  }
+
   // Cached liveness state — true until a failure is observed (ping fail,
   // disconnect, permanent close). Set false by disconnectBang(); restored to
   // true by reconnectBang() and by successful activeAsync().
@@ -2058,14 +2088,6 @@ function isMysql2ConnectionError(e: unknown): boolean {
     code === "EHOSTUNREACH" ||
     code === "ENETUNREACH" ||
     code === "EPIPE"
-  );
-}
-
-/** @internal */
-function initializeTypeMap(m: any): never {
-  // @nie disposition=port-real rails=activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb:40 cluster=mysql-mysql2-adapter
-  throw new NotImplementedError(
-    "ActiveRecord::ConnectionAdapters::Mysql2Adapter#initialize_type_map is not implemented",
   );
 }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -18467,6 +18467,13 @@
   },
   {
     "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2-adapter.ts",
+    "rubyName": "initialize_type_map",
+    "call": "lookup",
+    "reason": "Equivalent (bucket b): Rails' Type.lookup(:string, adapter: :mysql2) resolves the adapter-scoped Type::String.new(true: '1', false: '0'); trails hasn't ported the adapter-scoped Type.register(:string, adapter: :mysql2) registry, so we construct that mysql2 string inline as new StringType({trueString:'1', falseString:'0'}). Relocated here from abstract-mysql-adapter.ts when the char/varchar/enum/set registrations moved to the concrete adapter (mysql2_adapter.rb:40-49)."
+  },
+  {
+    "package": "activerecord",
     "tsFile": "connection-adapters/abstract-mysql-adapter.ts",
     "rubyName": "mariadb?",
     "call": "match?",


### PR DESCRIPTION
## Summary

Move the mysql char/varchar/enum/set string cast-type registrations (with the
`"1"`/`"0"` boolean-string variant) from `AbstractMysqlAdapter#initializeTypeMap`
down to the concrete `Mysql2Adapter#initializeTypeMap`, mirroring
`mysql2_adapter.rb:40-49`.

In Rails these are registered in the concrete `Mysql2Adapter`/`TrilogyAdapter`
`initialize_type_map` (via `register_type(%r(char)i)` + the
`Type.register(:string, adapter: :mysql2)` block), **not** in
`AbstractMysqlAdapter#initialize_type_map` (`abstract_mysql_adapter.rb:711`, which
has no char/varchar/enum/set registration). A bare abstract mysql adapter has no
concrete client to bind the `"1"`/`"0"` string-boolean behavior to, so a future
non-mysql2/non-trilogy concrete subclass should not inherit it. No live bug today
(no such subclass, and no `TrilogyAdapter` exists yet in trails), but it is a real
Rails deviation surfaced in review of #4668.

## Changes

- `abstract-mysql-adapter.ts`: drop the char/varchar/enum/set string registrations
  from `initializeTypeMap`; leave a note pointing at the concrete adapter.
- `mysql2-adapter.ts`: convert the previously-throwing `Mysql2Adapter#initializeTypeMap`
  stub into a real `super`-then-register override. Uses Rails' single
  `register_type(%r(char)i)` (covering both char and varchar) plus the limitless
  enum/set registrations. The `extract_limit` limit-threading added in #4668 is
  preserved (`type_for_attribute(varchar_col).limit === 255`).
- `mysql-type-lookup.test.ts`: exercise the concrete `Mysql2Adapter` type map (as
  Rails' `MysqlTypeLookupTest` does via `lease_connection`) rather than a bare
  `AbstractMysqlAdapter` subclass. A string config constructs inert; only the static
  type map is exercised. Test names unchanged.

Verified against real MySQL 8: all 6 `MysqlTypeLookupTest` cases pass.

Closes-story: mysql-string-type-registration-belongs-in-concrete-adapter
