### PR TITLE
fix(mysql2): populate base _connection on connect so run-loop guard fires once

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
@@ -75,4 +75,20 @@ describe("Mysql2Adapter base _connection field", () => {
     await adapter.close();
     expect(connectionOf(adapter)).toBeNull();
   });
+
+  it("run loop fires connectBang once per connect, not once per query", async () => {
+    stubNewClient();
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+    const connectSpy = vi.spyOn(adapter, "connectBang");
+
+    // Each withRawConnection call hits the base run-loop guard
+    // (`_connection === null` → connectBang). With _connection populated on the
+    // first connect, subsequent queries must NOT re-fire connectBang.
+    const opts = { materializeTransactions: false, allowRetry: false } as const;
+    await adapter.withRawConnection(opts, () => undefined);
+    await adapter.withRawConnection(opts, () => undefined);
+    await adapter.withRawConnection(opts, () => undefined);
+
+    expect(connectSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { Mysql2Adapter } from "./mysql2-adapter.js";
+
+// Trails-specific guards (no Rails counterpart): verify that connectBang /
+// reconnect populate the base `_connection` field so the run loop's
+// `_connection === null` guard fires connectBang once per connect rather than
+// on every withRawConnection call — matching Rails' `@raw_connection =
+// new_client(...)` posture and the PostgreSQLAdapter. The teardown paths
+// (disconnectBang / reconnect / discardBang / close) must null `_connection`
+// so a re-open re-fires connectBang.
+//
+// These run offline: Mysql2Adapter.newClient is stubbed to return a fake
+// connection so no real socket is opened.
+describe("Mysql2Adapter base _connection field", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function stubNewClient(): void {
+    const fakeConn = { end: () => Promise.resolve(), query: () => Promise.resolve() };
+    vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
+  }
+
+  function connectionOf(adapter: Mysql2Adapter): unknown {
+    return (adapter as unknown as { _connection: unknown })._connection;
+  }
+
+  it("populates the base _connection field on connectBang", async () => {
+    stubNewClient();
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+
+    expect(connectionOf(adapter)).toBeNull();
+    await adapter.connectBang();
+    expect(connectionOf(adapter)).not.toBeNull();
+    expect(adapter.isConnected()).toBe(true);
+    expect(adapter.active).toBe(true);
+  });
+
+  it("nulls _connection on disconnectBang and repopulates it on the next connect", async () => {
+    stubNewClient();
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+
+    await adapter.connectBang();
+    adapter.disconnectBang();
+    expect(connectionOf(adapter)).toBeNull();
+
+    await adapter.connectBang();
+    expect(connectionOf(adapter)).not.toBeNull();
+  });
+
+  it("repopulates _connection across a reconnect", async () => {
+    stubNewClient();
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+
+    await adapter.connectBang();
+    await adapter.reconnect();
+    expect(connectionOf(adapter)).not.toBeNull();
+    expect(adapter.isConnected()).toBe(true);
+  });
+
+  it("nulls _connection on discardBang", async () => {
+    stubNewClient();
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+
+    await adapter.connectBang();
+    adapter.discardBang();
+    expect(connectionOf(adapter)).toBeNull();
+  });
+
+  it("nulls _connection on close", async () => {
+    stubNewClient();
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+
+    await adapter.connectBang();
+    await adapter.close();
+    expect(connectionOf(adapter)).toBeNull();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
@@ -16,9 +16,11 @@ describe("Mysql2Adapter base _connection field", () => {
     vi.restoreAllMocks();
   });
 
-  function stubNewClient(): void {
-    const fakeConn = { end: () => Promise.resolve(), query: () => Promise.resolve() };
+  function stubNewClient(): { end: ReturnType<typeof vi.fn> } {
+    const end = vi.fn(() => Promise.resolve());
+    const fakeConn = { end, query: () => Promise.resolve() };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
+    return { end };
   }
 
   function connectionOf(adapter: Mysql2Adapter): unknown {
@@ -37,12 +39,17 @@ describe("Mysql2Adapter base _connection field", () => {
   });
 
   it("nulls _connection on disconnectBang and repopulates it on the next connect", async () => {
-    stubNewClient();
+    const { end } = stubNewClient();
     const adapter = new Mysql2Adapter({ host: "localhost" });
 
     await adapter.connectBang();
     adapter.disconnectBang();
     expect(connectionOf(adapter)).toBeNull();
+    // Guards the teardown ordering: _client is unified onto the base
+    // _connection field, so _closeRawHandle() must end() the live socket
+    // BEFORE super.disconnectBang() nulls _connection — otherwise the handle is
+    // lost and the socket leaks.
+    expect(end).toHaveBeenCalledTimes(1);
 
     await adapter.connectBang();
     expect(connectionOf(adapter)).not.toBeNull();

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -183,8 +183,20 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   // shortcut. `Mysql2Adapter#reconnect` closes a nil `_client` as a no-op, so the
   // full path costs nothing extra on a fresh adapter and gains connect retries.
 
-  // Single persistent connection — mirrors Rails' @raw_connection.
-  private _client: mysql.Connection | null = null;
+  // Single persistent connection — mirrors Rails' @raw_connection. Unified onto
+  // the inherited base `_connection` slot rather than a parallel field: Rails
+  // has ONE `@raw_connection` ivar every adapter shares, so the live
+  // `mysql.Connection` lives IN `_connection`. `_client` is a thin typed
+  // accessor so the mysql2 lifecycle code reads the concrete driver handle,
+  // while the base run-loop guard (`_connection === null`), `active`,
+  // `isConnected`, and `secondsSinceLastActivity` all see the live handle with
+  // no sentinel. Mirrors PostgreSQLAdapter's `_rawConnection` accessor.
+  private get _client(): mysql.Connection | null {
+    return this._connection as unknown as mysql.Connection | null;
+  }
+  private set _client(value: mysql.Connection | null) {
+    this._connection = value as unknown as AbstractAdapter | null;
+  }
   // Serializes concurrent lazy-connect calls so only one createConnection
   // is in flight at a time. NOT nulled by disconnectBang() so close() can
   // still await it for clean teardown.
@@ -699,15 +711,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
           );
         }
         if (this._connectingPromiseGen === gen) this._connectingPromise = null;
+        // Assigns the live handle into the base `_connection` slot (via the
+        // `_client` accessor) exactly as Rails' `@raw_connection = new_client`.
+        // The base run-loop guard `_connection === null` (abstract-adapter.ts)
+        // is now satisfied, so connectBang fires once per connect rather than
+        // on every withRawConnection call.
         this._client = conn;
-        // Populate the base `_connection` field so the run loop's
-        // `_connection === null` guard (abstract-adapter.ts) fires connectBang
-        // once per connect rather than on every withRawConnection call —
-        // matching Rails' `@raw_connection = new_client(...)` posture and the
-        // PostgreSQLAdapter, which likewise keeps `_connection` non-null while
-        // connected. mysql2 keeps the real handle in `_client`; `_connection`
-        // is just the non-null sentinel the base guard reads.
-        this._connection = this;
         this._stmtPool = null;
         this._activeState = true;
         // Configure the freshly-opened socket exactly as Rails does on every
@@ -1493,8 +1502,8 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // reconnectBang's own resetTransaction({ restore: … }) can swap it back in.
     // clearCache! / @raw_connection_dirty are reconnectBang's responsibility
     // (abstract_adapter.rb reconnect!), so they are deliberately not repeated
-    // here — only the raw-handle teardown and _connection reset are.
-    this._connection = null;
+    // here — only the raw-handle teardown. `_closeRawHandle` ends the live
+    // socket then nulls `_client`, which nulls the unified base `_connection`.
     this._closeRawHandle();
     this._activeState = true;
     // Re-establish the connection eagerly and PROPAGATE any connect failure —
@@ -1516,8 +1525,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // _connectingPromise (gen mismatch) and start a fresh attempt, while
     // close() can still await the old promise for clean teardown.
     this._connectGeneration++;
-    super.disconnectBang();
+    // Tear the raw handle down FIRST: `_closeRawHandle` reads `_client` to
+    // `end()` the live socket, but `_client` is unified onto the base
+    // `_connection` field, which `super.disconnectBang()` nulls — so ending the
+    // socket must happen before super, or the handle is lost and leaks.
     this._closeRawHandle();
+    super.disconnectBang();
   }
 
   /**
@@ -1565,9 +1578,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // _ensureClient() rather than adopted onto a discarded adapter.
     this._connectGeneration++;
     super.discardBang();
-    // Base discardBang is a no-op on `_connection`; null it here so a later
-    // re-open re-fires connectBang (the run-loop guard reads `_connection`).
-    this._connection = null;
     this._inTransaction = false;
     this._connectionConfigured = false;
     this._stmtPool?.detach();
@@ -1584,7 +1594,6 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   async close(): Promise<void> {
     this._permanentlyClosed = true;
     this._connectGeneration++;
-    this._connection = null;
     this._inTransaction = false;
     this._connectionConfigured = false;
     this._stmtPool?.detach();

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -700,6 +700,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         }
         if (this._connectingPromiseGen === gen) this._connectingPromise = null;
         this._client = conn;
+        // Populate the base `_connection` field so the run loop's
+        // `_connection === null` guard (abstract-adapter.ts) fires connectBang
+        // once per connect rather than on every withRawConnection call —
+        // matching Rails' `@raw_connection = new_client(...)` posture and the
+        // PostgreSQLAdapter, which likewise keeps `_connection` non-null while
+        // connected. mysql2 keeps the real handle in `_client`; `_connection`
+        // is just the non-null sentinel the base guard reads.
+        this._connection = this;
         this._stmtPool = null;
         this._activeState = true;
         // Configure the freshly-opened socket exactly as Rails does on every
@@ -1557,6 +1565,9 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // _ensureClient() rather than adopted onto a discarded adapter.
     this._connectGeneration++;
     super.discardBang();
+    // Base discardBang is a no-op on `_connection`; null it here so a later
+    // re-open re-fires connectBang (the run-loop guard reads `_connection`).
+    this._connection = null;
     this._inTransaction = false;
     this._connectionConfigured = false;
     this._stmtPool?.detach();
@@ -1573,6 +1584,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   async close(): Promise<void> {
     this._permanentlyClosed = true;
     this._connectGeneration++;
+    this._connection = null;
     this._inTransaction = false;
     this._connectionConfigured = false;
     this._stmtPool?.detach();

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1582,6 +1582,11 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     this._connectionConfigured = false;
     this._stmtPool?.detach();
     this._stmtPool = null;
+    // Safe to read `_client` after `super.discardBang()` — unlike
+    // `disconnectBang`, the base `discardBang` (abstract-adapter.ts) is a true
+    // no-op that never touches `_connection`, so the live handle survives here
+    // (`_client` is the unified `_connection` field). No end() — discard! must
+    // not talk to the server; abandonRawSocket neutralizes the fd instead.
     const conn = this._client;
     this._client = null;
     abandonRawSocket(conn);


### PR DESCRIPTION
## Summary

Rails' `Mysql2Adapter#connect` sets `@raw_connection = new_client(...)`
(mysql2_adapter.rb:144), so after `connect!` the base run loop's
`with_raw_connection` guard (`@raw_connection.nil?`) is satisfied and does NOT
re-open on every query.

trails' `Mysql2Adapter` kept a **parallel** private `_client` and left the base
`_connection` field null, so the run-loop pre-check
`if (this._connection === null && ...) await this.connectBang()`
(abstract-adapter.ts:2097) fired `connectBang()` on **every** `withRawConnection`
call, not once per connect.

## Changes

Rather than store a `this` sentinel in `_connection`, this **unifies `_client`
onto the base `_connection` slot** — matching Rails' single `@raw_connection`
ivar and the `PostgreSQLAdapter`, whose `_rawConnection` is likewise a thin
typed accessor over the inherited `_connection` field:

- `_client` becomes a getter/setter over `_connection`, so the live
  `mysql.Connection` lives **in** `_connection`. The base run-loop guard,
  `active`, `isConnected`, and `secondsSinceLastActivity` all see the real
  handle with no sentinel.
- Drops the manual `_connection` resets in `discardBang`/`close`/`reconnect`
  (nulling `_client` now nulls `_connection`).
- Reorders `disconnectBang` so `_closeRawHandle()` ends the live socket
  **before** `super.disconnectBang()` nulls the unified field — otherwise the
  handle would be lost and the socket leak.
- `active`/`isConnected` invariants preserved (still key off `_client`, which is
  now `_connection`).

## Tests

New offline `mysql2-adapter.base-connection-field.trails.test.ts` covers
populate-on-connect, null-and-repopulate across disconnect/reconnect/discard/
close, the once-per-connect run-loop assertion, and — critically — that
`disconnectBang` actually `end()`s the live socket (guarding the teardown
ordering). Adapter-gated (ARCONN=mysql2).

Closes-story: mysql2-connectbang-populate-base-connection-field