### PR TITLE
fix(schema): reflect own table when subclass predeclares an attribute

### DIFF
--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -37,6 +37,15 @@ interface AttributeDefinition {
    * `_defaultAttributes` so the default is deserialized rather than user-cast.
    */
   defaultFromSchema?: boolean;
+  /**
+   * For `source:"schema"` defs, the `tableName` the columns were reflected
+   * against. A non-STI subclass that overrides `_tableName` and declares an
+   * `attribute()` before reflecting forks (clones) its ancestor's map, copying
+   * the ancestor's schema defs — which describe a *different* table. Recording
+   * the reflected table lets `ensureSchemaLoaded` distinguish those foreign
+   * defs from ones reflected against this class's own table.
+   */
+  reflectedTable?: string;
 }
 
 /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1266,15 +1266,46 @@ export class Base extends Model {
     // us on the fast path when the owner is a table-less root (e.g. the
     // activemodel `Model`, which has no `tableName` getter) — that case falls
     // through to the loop below rather than spuriously forcing a reflection.
+    const thisTable = this.tableName;
     let defsOwner: unknown = this;
     while (defsOwner && !Object.prototype.hasOwnProperty.call(defsOwner, "_attributeDefinitions")) {
       defsOwner = Object.getPrototypeOf(defsOwner);
     }
+    let foreignTable = false;
     if (defsOwner && defsOwner !== this) {
+      // Map still inherited: if its owner is a table-backed class whose
+      // `tableName` differs from ours, the inherited defs describe another
+      // table. (`typeof ... === "string"` keeps us on the fast path when the
+      // owner is a table-less root like activemodel `Model`.)
       const ownerTable = (defsOwner as { tableName?: unknown }).tableName;
-      if (typeof ownerTable === "string" && ownerTable !== this.tableName) {
-        return this.loadSchema();
+      foreignTable = typeof ownerTable === "string" && ownerTable !== thisTable;
+    } else if (typeof thisTable === "string") {
+      // Map already forked (defsOwner === this): a subclass overriding
+      // `_tableName` that declared an `attribute()` before reflecting copied the
+      // ancestor's schema defs. Those carry a `reflectedTable` that differs from
+      // ours — trust none of them; reflect our own table instead.
+      for (const [, def] of this._attributeDefinitions) {
+        const d = def as { source?: string; reflectedTable?: string };
+        if (
+          d.source === "schema" &&
+          typeof d.reflectedTable === "string" &&
+          d.reflectedTable !== thisTable
+        ) {
+          foreignTable = true;
+          break;
+        }
       }
+    }
+    if (foreignTable) {
+      // Reset first so the reflection actually runs against our own table. The
+      // subclass otherwise inherits the ancestor's `_schemaLoaded` /
+      // `_schemaLoadPromise` (set when the ancestor reflected — which is what
+      // put foreign schema defs in the shared map) and `loadSchema` would bail
+      // on that stale "loaded" state. `resetColumnInformation` shadows those
+      // inherited flags with own `false`/`undefined` and scrubs the copied
+      // foreign schema defs from a forked map.
+      (ModelSchema.resetColumnInformation as () => void).call(this);
+      return this.loadSchema();
     }
 
     const enumNames = (this as any)._enums as Map<string, unknown> | undefined;

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -997,6 +997,7 @@ function applyColumnsHash(
       defaultValue,
       userProvided: false,
       source: "schema",
+      ...(typeof host.tableName === "string" ? { reflectedTable: host.tableName } : {}),
       ...(colLimit != null ? { limit: colLimit } : {}),
       ...(colDefaultFunction != null ? { defaultFunction: colDefaultFunction } : {}),
     });

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2206,4 +2206,32 @@ describe("PersistenceTest", () => {
 
     expect(((await Aircraft.last()) as any).name).toBe("Wright Glider");
   });
+
+  it("persist inherited class with different table name and predeclared attribute", async () => {
+    // Reflect the ancestor first so its `_attributeDefinitions` holds
+    // schema-sourced defs for the `minimalistics` table. The subclass below
+    // then forks (clones) that map when it declares an attribute, copying
+    // those foreign defs — the residual edge PR #4680 didn't cover.
+    await Minimalistic.create({});
+
+    class MinimalisticAircraft extends Minimalistic {
+      static _tableName = "aircraft";
+      static {
+        // Declaring a virtual attribute before the first reflection forks this
+        // subclass's `_attributeDefinitions`, copying the ancestor's foreign
+        // (minimalistics-table) schema defs. The subclass must still reflect
+        // its own `aircraft` table rather than trusting those copied defs.
+        this.attribute("wingspan", "integer", { virtual: true });
+      }
+    }
+    registerModel(MinimalisticAircraft);
+
+    const before = (await Aircraft.count()) as number;
+    const aircraft = (await MinimalisticAircraft.create({ name: "Wright Flyer" })) as any;
+    aircraft.name = "Wright Glider";
+    await aircraft.save();
+    expect(await Aircraft.count()).toBe(before + 1);
+
+    expect(((await Aircraft.last()) as any).name).toBe("Wright Glider");
+  });
 });

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2206,32 +2206,4 @@ describe("PersistenceTest", () => {
 
     expect(((await Aircraft.last()) as any).name).toBe("Wright Glider");
   });
-
-  it("persist inherited class with different table name and predeclared attribute", async () => {
-    // Reflect the ancestor first so its `_attributeDefinitions` holds
-    // schema-sourced defs for the `minimalistics` table. The subclass below
-    // then forks (clones) that map when it declares an attribute, copying
-    // those foreign defs — the residual edge PR #4680 didn't cover.
-    await Minimalistic.create({});
-
-    class MinimalisticAircraft extends Minimalistic {
-      static _tableName = "aircraft";
-      static {
-        // Declaring a virtual attribute before the first reflection forks this
-        // subclass's `_attributeDefinitions`, copying the ancestor's foreign
-        // (minimalistics-table) schema defs. The subclass must still reflect
-        // its own `aircraft` table rather than trusting those copied defs.
-        this.attribute("wingspan", "integer", { virtual: true });
-      }
-    }
-    registerModel(MinimalisticAircraft);
-
-    const before = (await Aircraft.count()) as number;
-    const aircraft = (await MinimalisticAircraft.create({ name: "Wright Flyer" })) as any;
-    aircraft.name = "Wright Glider";
-    await aircraft.save();
-    expect(await Aircraft.count()).toBe(before + 1);
-
-    expect(((await Aircraft.last()) as any).name).toBe("Wright Glider");
-  });
 });

--- a/packages/activerecord/src/persistence.trails.test.ts
+++ b/packages/activerecord/src/persistence.trails.test.ts
@@ -9,13 +9,15 @@
  * `destroyBy`/`deleteBy` shorthands. Test names are kept verbatim per CLAUDE.md.
  */
 import { describe, it, expect } from "vitest";
-import { RecordInvalid } from "./index.js";
+import { RecordInvalid, registerModel } from "./index.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { repairValidations } from "./test-helpers/repair-validations.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
 import { Developer as CanonicalDeveloper } from "./test-helpers/models/developer.js";
 import { Item as CanonicalItem } from "./test-helpers/models/item.js";
 import { ClothingItem } from "./test-helpers/models/clothing-item.js";
+import { Minimalistic } from "./test-helpers/models/minimalistic.js";
+import { Aircraft } from "./test-helpers/models/aircraft.js";
 import { captureSql } from "./testing/sql-capture.js";
 
 describe("PersistenceTest (trails)", () => {
@@ -180,5 +182,60 @@ describe("PersistenceTest (trails)", () => {
 
     const reloaded = await ClothingItem.findBy({ id: clothingItem.id });
     expect(reloaded?.description).toBe("Lovely green t-shirt");
+  });
+});
+
+describe("PersistenceTest (trails)", () => {
+  fixtures(["topics"]);
+
+  // Trails-only edge with no Rails counterpart (Rails keys attribute methods
+  // per-class off the class's own `table_name`, model_schema.rb): the residual
+  // case PR #4680 left uncovered. A non-STI subclass that overrides
+  // `_tableName` AND declares an `attribute()` before its first reflection
+  // forks its own `_attributeDefinitions`, copying the ancestor's foreign
+  // schema defs. `ensureSchemaLoaded` must still reflect the subclass's own
+  // table rather than trusting those copied defs and silently dropping writes.
+  // Mirrors `persist inherited class with different table name` (the Rails
+  // test in persistence.test.ts) plus a predeclared virtual attribute.
+  it("persist inherited class with different table name and predeclared attribute", async () => {
+    // Reflect the ancestor first so its `_attributeDefinitions` holds
+    // schema-sourced defs for the `minimalistics` table — the state the
+    // subclass's map is forked from.
+    await Minimalistic.create({});
+
+    class MinimalisticAircraft extends Minimalistic {
+      static _tableName = "aircraft";
+      static {
+        this.attribute("wingspan", "integer", { virtual: true });
+      }
+    }
+    registerModel(MinimalisticAircraft);
+
+    // Evict `aircraft` from the adapter schema cache so the sync reconcile path
+    // cannot find its columns — the cold-cache condition under which the bug
+    // bites (otherwise a warm cross-file cache masks it). Only clears the
+    // sibling `Aircraft`'s reflection, not the subclass's copied foreign defs.
+    Aircraft.resetColumnInformation();
+
+    const before = (await Aircraft.count()) as number;
+    const aircraft = (await MinimalisticAircraft.create({ name: "Wright Flyer" })) as unknown as {
+      name: string | null;
+      wingspan: unknown;
+      save: () => Promise<unknown>;
+    };
+    aircraft.name = "Wright Glider";
+    await aircraft.save();
+    expect(await Aircraft.count()).toBe(before + 1);
+
+    // The subclass reflected its own `aircraft` table: the write persisted
+    // (without the fix, `reconcileVirtualAttributes` never learns `name` and the
+    // insert silently drops it, reading back `null`).
+    const last = (await Aircraft.last()) as unknown as { name: string | null } | null;
+    expect(last?.name).toBe("Wright Glider");
+    // The foreign `expires_at` column (copied from the `minimalistics` map) is
+    // gone, and the predeclared virtual attribute survives the reflection.
+    expect(MinimalisticAircraft.columnNames()).not.toContain("expires_at");
+    expect(MinimalisticAircraft.columnNames()).toContain("name");
+    expect(aircraft.wingspan).toBeNull();
   });
 });


### PR DESCRIPTION
## Problem

Follow-up to #4680. A non-STI subclass that overrides `_tableName` **and**
declares an `attribute()` before its first reflection forks its own
`_attributeDefinitions`, copying the ancestor's schema-reflected defs — which
describe a *different* table. With the map now owned by the subclass, #4680's
map-owner check no longer fires, so `ensureSchemaLoaded`'s fast path trusts
those foreign `source:"schema"` defs and bails to `reconcileVirtualAttributes`.
When the subclass's own table isn't already warm in the adapter schema cache,
`reconcileVirtualAttributes` (called with `reflect: false`) never discovers its
real columns, so the subclass never reflects its own table and silently drops
writes — the same failure mode #4680 fixed for the no-declare case.

The bug also requires the ancestor to have already reflected (that's what
populates the shared map with schema defs). In that state the subclass inherits
the ancestor's `_schemaLoaded` / `_schemaLoadPromise`, so even #4680's
owner-check path would bail inside `loadSchema` — the fix covers both entry
points.

## Fix

- Record on each `source:"schema"` def the `tableName` it was reflected against
  (`reflectedTable`).
- In `ensureSchemaLoaded`, detect a foreign-table subclass via either the map
  owner (inherited map, #4680) or a copied schema def whose `reflectedTable`
  differs (forked map). When foreign, `resetColumnInformation` first — shadowing
  the inherited stale `_schemaLoaded` / `_schemaLoadPromise` and scrubbing the
  copied foreign defs — then reflect this class's own table.

Rails keys attribute methods per-class off the class's own `table_name`
(`model_schema.rb`), so a subclass overriding `table_name` always reflects its
own table regardless of ancestor state.

## Tests

New regression in `persistence.trails.test.ts` (trails-only edge, no Rails
counterpart): reflect the ancestor, then a subclass overriding `_tableName`
declares a virtual `attribute()` before its first create. It evicts `aircraft`
from the adapter schema cache first so the reconcile path deterministically
cannot find its columns (a warm cross-file cache otherwise masks the bug),
making it a reliable fail-without-fix guard. Asserts the write persists, the
foreign `expires_at` column no longer leaks into the subclass, and the
predeclared virtual attribute survives reflection. No regression to the STI
fast-path or #4680's owner-check case.

Closes-story: ensure-schema-loaded-respects-subclass-declared-attr