### PR TITLE
fix(associations): resolve idsReader pluck key via association_primary_key

### DIFF
--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -65,21 +65,51 @@ export class CollectionAssociation extends Association {
    * Returns an array of primary key values from the target.
    */
   async idsReader(): Promise<unknown[]> {
+    // Rails `ids_reader` plucks `reflection.association_primary_key` in all
+    // three branches, not the target model's own primary key. For a
+    // custom-PK association (e.g. `Category.primary_key == "name"`, or a
+    // has_many with an explicit `primary_key:`) this is the association's own
+    // key, so the reader must resolve it off the rich reflection (as
+    // `idsWriter` does) rather than reading `klass.primaryKey`.
+    const pk = this.associationPrimaryKey();
+    const keys = Array.isArray(pk) ? pk : [pk];
+    const readKey = (r: Base): unknown => {
+      const vals = keys.map((key) =>
+        typeof (r as any)._readAttribute === "function"
+          ? (r as any)._readAttribute(key)
+          : (r as any)[key],
+      );
+      return vals.length === 1 ? vals[0] : vals;
+    };
     if (this.isLoaded()) {
-      return this.target.map((r) => this.primaryKeyValue(r));
+      return this.target.map(readKey);
     }
     if (this.target.length > 0) {
       await this.loadTarget();
-      return this.target.map((r) => this.primaryKeyValue(r));
+      return this.target.map(readKey);
     }
     if (this._associationIds) return this._associationIds;
-    const pk = (this.klass as any).primaryKey ?? "id";
     const rel = this.scope();
     if (rel && typeof rel.pluck === "function") {
-      this._associationIds = await rel.pluck(...(Array.isArray(pk) ? pk : [pk]));
+      this._associationIds = await rel.pluck(...keys);
       return this._associationIds!;
     }
     return [];
+  }
+
+  /**
+   * Resolves the association's `association_primary_key` off the rich
+   * reflection (as `idsWriter` does), falling back to the target model's
+   * primary key. Mirrors `reflection.association_primary_key`.
+   */
+  protected associationPrimaryKey(): string | string[] {
+    const ctor = this.owner.constructor as typeof Base & {
+      _reflectOnAssociation?: (
+        n: string,
+      ) => { associationPrimaryKey?: string | string[] } | undefined;
+    };
+    const richReflection = ctor._reflectOnAssociation?.(this.reflection.name);
+    return richReflection?.associationPrimaryKey ?? (this.klass as any).primaryKey ?? "id";
   }
 
   /**
@@ -98,13 +128,7 @@ export class CollectionAssociation extends Association {
     // For a through/custom-PK association this is the association's own key
     // (e.g. `Category.primary_key == "name"`), not the target model's `id`, so
     // the lookup + not-found message key must come from the rich reflection.
-    const ctor = this.owner.constructor as typeof Base & {
-      _reflectOnAssociation?: (
-        n: string,
-      ) => { associationPrimaryKey?: string | string[] } | undefined;
-    };
-    const richReflection = ctor._reflectOnAssociation?.(this.reflection.name);
-    const pk = richReflection?.associationPrimaryKey ?? Klass.primaryKey ?? "id";
+    const pk = this.associationPrimaryKey();
     const filteredIds = (Array.isArray(ids) ? ids : [ids]).filter((id) => id != null && id !== "");
 
     let records: Base[];

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -91,6 +91,9 @@ export class CollectionAssociation extends Association {
       return this.target.map(readKey);
     }
     if (this._associationIds) return this._associationIds;
+    // Rails plucks off `scope` here, not `load_target`: `scope().pluck()` must
+    // not mark the association loaded, so `record.misc_tag_ids` (a through
+    // association) does not preload `record.misc_tags`.
     const rel = this.scope();
     if (rel && typeof rel.pluck === "function") {
       this._associationIds = await rel.pluck(...keys);

--- a/packages/activerecord/src/associations/collection-association.ts
+++ b/packages/activerecord/src/associations/collection-association.ts
@@ -66,11 +66,13 @@ export class CollectionAssociation extends Association {
    */
   async idsReader(): Promise<unknown[]> {
     // Rails `ids_reader` plucks `reflection.association_primary_key` in all
-    // three branches, not the target model's own primary key. For a
-    // custom-PK association (e.g. `Category.primary_key == "name"`, or a
-    // has_many with an explicit `primary_key:`) this is the association's own
-    // key, so the reader must resolve it off the rich reflection (as
-    // `idsWriter` does) rather than reading `klass.primaryKey`.
+    // three branches. For a plain has_many this is the target model's own
+    // primary key, but for a custom-PK target (e.g. `Subscriber.primary_key
+    // == "nick"`) or a through association (where it delegates to the source
+    // reflection's `association_primary_key`, e.g. `Category.primary_key ==
+    // "name"` behind `author.essay_categories`) it is the association's own
+    // key. Resolve it off the rich reflection (as `idsWriter` does) rather
+    // than reading `klass.primaryKey`.
     const pk = this.associationPrimaryKey();
     const keys = Array.isArray(pk) ? pk : [pk];
     const readKey = (r: Base): unknown => {

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -91,11 +91,6 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     return throughTargetScope(this, super["targetScope"]());
   }
 
-  // Rails' ids_reader: scope.pluck(*reflection.association_primary_key).
-  // Using scope().pluck() (matching the base idsReader path) avoids calling
-  // doAsyncFindTarget() → loadHasMany() → syncToAssociationInstance() which
-  // would mark the association as loaded — violating the Rails contract that
-  // `record.misc_tag_ids` does not preload `miscTags`.
   protected override staleState(): unknown {
     const vals = throughStaleState(this);
     if (!vals) return null;

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -114,26 +114,6 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     return super.primaryKeyValue(record);
   }
 
-  override async idsReader(): Promise<unknown[]> {
-    if (this.isLoaded()) {
-      return this.target.map((r) => this.primaryKeyValue(r));
-    }
-    if (this.target.length > 0) {
-      return (await this.loadTarget()).map((r) => this.primaryKeyValue(r));
-    }
-    if (this._associationIds) return this._associationIds;
-    const ctor = this.owner.constructor as { _reflectOnAssociation?: (n: string) => any };
-    const refl = ctor._reflectOnAssociation?.(this.reflection.name);
-    const srcPk = refl?.sourceReflection?.associationPrimaryKey;
-    const pk = (typeof srcPk === "string" ? srcPk : null) ?? (this.klass as any).primaryKey;
-    const rel = this.scope();
-    if (rel && typeof rel.pluck === "function") {
-      this._associationIds = await rel.pluck(...(Array.isArray(pk) ? pk : [pk]));
-      return this._associationIds!;
-    }
-    return [];
-  }
-
   /**
    * Mirrors Rails' HasManyThroughAssociation#insert_record
    * (has_many_through_association.rb:24-34):

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -1490,6 +1490,12 @@ describe("HasManyThroughAssociationsTest", () => {
     );
   });
 
+  it("collection singular ids getter through with custom primary key", async () => {
+    const david = await Author.find(authors("david").id);
+    const catIds = await (david as any).essayCategoryIds;
+    expect([...catIds].sort()).toEqual([(categories("general") as any).name]);
+  });
+
   it("collection singular ids setter", async () => {
     const company = await Company.find(companies("rails_core").id);
     const dev = (await Developer.first())!;

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -13765,6 +13765,13 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "ids_writer",
+    "call": "reflection",
+    "reason": "Equivalent (bucket b): reflection.association_primary_key is resolved via the shared associationPrimaryKey() helper (reads _reflectOnAssociation(this.reflection.name)), not inline in idsWriter; mirrors the ids_reader/reflection baseline entry."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "ids_writer",
     "call": "cast",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
## Summary

`CollectionAssociation#idsReader` plucked the target model's own primary key
across all three branches (loaded, `loadTarget`, scope pluck) instead of
`reflection.association_primary_key`. For a custom-PK association (e.g.
`Category.primary_key == "name"`, or a `has_many` with an explicit
`primary_key:`) this diverged from Rails' `ids_reader`, returning `id`s rather
than the association's own key.

This is the reader-side parallel to the writer fix in #4682.

## Changes

- Resolve the pluck key off the rich reflection (as `idsWriter` now does) via a
  shared `associationPrimaryKey()` helper, applied to all three branches. The
  loaded/`loadTarget` branches now read the resolved key attribute rather than
  `primaryKeyValue(r)`.
- Drop the now-redundant `HasManyThroughAssociation#idsReader` override — Rails
  has no such override; the through reflection's `association_primary_key`
  already delegates to the source reflection, so the base handles it.
- Add a getter test asserting `author.essayCategoryIds` returns category `name`s
  (custom PK), mirroring Rails `ids_reader` behavior.

Mirrors `collection_association.rb:51-59`.

Closes-story: idsreader-association-primary-key-resolution