### PR TITLE
refactor(relation): remove non-Rails set-operation methods

### DIFF
--- a/packages/activerecord/src/adapter-connection.trails.test.ts
+++ b/packages/activerecord/src/adapter-connection.trails.test.ts
@@ -112,22 +112,6 @@ describe("AdapterConnection retryable classification (trails-only)", () => {
     const rawSubquery = PostForRetryTest.where("1 = 1");
     await PostForRetryTest.where({ id: 1 }).from(rawSubquery, "sub").limit(1);
     expect(adapter.capturedAllowRetry).toBe(false);
-
-    // A set-operation subquery now compiles as a live compound node through the
-    // outer collector, so its operands' retryability flows to the outer query
-    // (no longer forced non-retryable by per-side string concatenation): a union
-    // of two retryable SELECTs stays retryable.
-    const retryableSetOp = PostForRetryTest.where({ id: 1 }).union(
-      PostForRetryTest.where({ id: 2 }),
-    );
-    await PostForRetryTest.where({ id: 1 }).from(retryableSetOp, "sub").limit(1);
-    expect(adapter.capturedAllowRetry).toBe(true);
-
-    // A non-retryable operand (raw SQL) lowers the outer classification through
-    // that same single collector.
-    const mixedSetOp = PostForRetryTest.where("1 = 1").union(PostForRetryTest.where({ id: 2 }));
-    await PostForRetryTest.where({ id: 1 }).from(mixedSetOp, "sub").limit(1);
-    expect(adapter.capturedAllowRetry).toBe(false);
   });
 
   it("findBySql tolerates a null opts argument without throwing", async () => {

--- a/packages/activerecord/src/bind-parameter.test.ts
+++ b/packages/activerecord/src/bind-parameter.test.ts
@@ -289,22 +289,14 @@ describe("BindParameterTest", () => {
 
   // Trails-specific coverage for the over-limit inline fallback on paths beyond
   // count(): Rails funnels every arel compile through `to_sql_and_binds`
-  // (database_statements.rb:36-38), but trails compiles the main SELECT and each
-  // set-operation operand through their own helpers, which must apply the same
-  // fallback. A large multi-value `IN` now builds a real-bind `HomogeneousIn`,
-  // so without the fallback these overflow the adapter's bind-params cap.
+  // (database_statements.rb:36-38), but trails compiles the main SELECT through
+  // its own helper, which must apply the same fallback. A large multi-value `IN`
+  // now builds a real-bind `HomogeneousIn`, so without the fallback these
+  // overflow the adapter's bind-params cap.
   it("materializes a record load whose IN exceeds the bind-params cap", async () => {
     const conn = (await Topic.leaseConnection()) as any;
     const ids = Array.from({ length: conn.bindParamsLength() + 1 }, (_, i) => i + 1);
     const topics = await Topic.where({ id: ids });
-    expect(topics.length).toBe(await Topic.count());
-  });
-
-  it("materializes a set-operation whose operand IN exceeds the bind-params cap", async () => {
-    const conn = (await Topic.leaseConnection()) as any;
-    const ids = Array.from({ length: conn.bindParamsLength() + 1 }, (_, i) => i + 1);
-    const rel = Topic.where({ id: ids }).union(Topic.where({ id: ids }));
-    const topics = await rel.toArray();
     expect(topics.length).toBe(await Topic.count());
   });
 

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5463,7 +5463,21 @@ export class Relation<T extends Base> {
   }
 
   private _toSql(): string {
-    return this._toSqlWithoutSetOp();
+    // Eager loading: emit JoinDependency SQL (mirrors Rails to_sql + eager_loading?)
+    if (this._eagerLoadingForSql()) {
+      const eagerSql = this._buildEagerSql();
+      if (eagerSql !== null) return eagerSql;
+      // If _buildEagerSql returns null (e.g. unresolvable association),
+      // fall through to plain SQL so toSql() always returns something useful.
+    }
+
+    // Compile the converged `build_arel` manager directly. CTEs (`WITH`) and
+    // annotate() comments are folded into the manager AST by `_buildArel`, so a
+    // single collector numbers every bind in document order (CTE binds precede
+    // the main query's; PG `$N` placeholders fall out correctly by
+    // construction) — replacing the former post-compile string splice and its
+    // manual `$N` renumbering.
+    return this._compileSelectSql(this._buildArel());
   }
 
   // Mirrors: ActiveRecord::Relation#eager_loading?
@@ -5698,9 +5712,7 @@ export class Relation<T extends Base> {
    * Build the SelectManager for this relation: projections, joins, wheres,
    * order, distinct, limit/offset, group, having, lock, hints, and from(). Does
    * NOT apply the eager-load join dependency, annotate() comments, or CTE
-   * prefix — those remain in _toSqlWithoutSetOp. Used both for plain SELECT
-   * compilation and as each side of a set operation (where the arel Union* node
-   * composes the two managers).
+   * prefix — those are layered on in `_buildArel` / `_toSql`.
    */
   private _buildSelectManager(aliases?: AliasTracker): SelectManager {
     // `this.table` is the model's arel_table unless the relation was built on a
@@ -5751,24 +5763,6 @@ export class Relation<T extends Base> {
     if (fromNode !== undefined && fromNode !== null) manager.from(fromNode as any);
 
     return manager;
-  }
-
-  private _toSqlWithoutSetOp(): string {
-    // Eager loading: emit JoinDependency SQL (mirrors Rails to_sql + eager_loading?)
-    if (this._eagerLoadingForSql()) {
-      const eagerSql = this._buildEagerSql();
-      if (eagerSql !== null) return eagerSql;
-      // If _buildEagerSql returns null (e.g. unresolvable association),
-      // fall through to plain SQL so toSql() always returns something useful.
-    }
-
-    // Compile the converged `build_arel` manager directly. CTEs (`WITH`) and
-    // annotate() comments are folded into the manager AST by `_buildArel`, so a
-    // single collector numbers every bind in document order (CTE binds precede
-    // the main query's; PG `$N` placeholders fall out correctly by
-    // construction) — replacing the former post-compile string splice and its
-    // manual `$N` renumbering.
-    return this._compileSelectSql(this._buildArel());
   }
 
   private _combineNodes(nodes: Nodes.Node[]): Nodes.Node | null {
@@ -5913,7 +5907,7 @@ export class Relation<T extends Base> {
    * Resolve this relation to the Arel SelectStatement node used as a CTE body,
    * mirroring Rails' `build_with_expression_from_value` Relation branch
    * (`value.arel(.ast)`). `_buildSelectManager` threads joins/wheres/from/having
-   * — matching `_toSqlWithoutSetOp` minus the CTE/eager/annotate prefix — so a
+   * — matching `_toSql` minus the CTE/eager/annotate prefix — so a
    * recursive body's string JOIN survives (with_recursive). Returns null for
    * relations whose SQL `_buildSelectManager` does not fully encode (eager-load
    * bodies), letting the caller fall back to pre-rendered SQL.

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -547,10 +547,6 @@ export class Relation<T extends Base> {
    */
   _seedWherePredicates: readonly unknown[] = [];
   private _lockValue: string | null = null;
-  private _setOperation: {
-    type: "union" | "unionAll" | "intersect" | "except";
-    other: Relation<T>;
-  } | null = null;
   private _joinClauses: Array<{
     type: "inner" | "left";
     table: string;
@@ -1837,56 +1833,6 @@ export class Relation<T extends Base> {
   }
 
   /**
-   * UNION with another relation.
-   *
-   * Mirrors: ActiveRecord::Relation#union
-   */
-  union(other: Relation<T>): Relation<T> {
-    const rel = this._clone();
-    rel._setOperation = { type: "union", other };
-    return rel;
-  }
-
-  /**
-   * UNION ALL with another relation.
-   *
-   * Mirrors: ActiveRecord::Relation#union_all
-   */
-  unionAll(other: Relation<T>): Relation<T> {
-    const rel = this._clone();
-    rel._setOperation = { type: "unionAll", other };
-    return rel;
-  }
-
-  /**
-   * INTERSECT with another relation.
-   *
-   * Mirrors: ActiveRecord::Relation#intersect
-   */
-  intersect(other: Relation<T>): Relation<T> {
-    const rel = this._clone();
-    rel._setOperation = { type: "intersect", other };
-    return rel;
-  }
-
-  /**
-   * SQL `EXCEPT` set operation with another relation.
-   *
-   * trails-only — Rails has no `EXCEPT` set-operation method (it exposes
-   * `union`/`union_all`/`intersect` only). This is the SQL set-operation
-   * sibling of {@link union}/{@link intersect}; the bare `except` name is
-   * reserved for Rails' `SpawnMethods#except` value-key remover below.
-   *
-   * @internal No Rails equivalent.
-   */
-  exceptRelation(other?: Relation<T>): Relation<T> {
-    if (!other) return this._clone();
-    const rel = this._clone();
-    rel._setOperation = { type: "except", other };
-    return rel;
-  }
-
-  /**
    * Remove the specified query parts, keeping everything else.
    *
    * Mirrors: ActiveRecord::SpawnMethods#except — `relation_with
@@ -2914,8 +2860,8 @@ export class Relation<T extends Base> {
       // _compileSelectSql captures the SELECT's retryability and bind values
       // into _lastSelectRetryable/_lastSelectBinds at compile time. Reading the
       // visitor's collector here would be wrong: from(ArelNode) recompiles and
-      // resets it, and set operations compile each side separately.
-      const allowRetry = this._setOperation ? false : this._lastSelectRetryable;
+      // resets it.
+      const allowRetry = this._lastSelectRetryable;
       const result = await this._conn().selectAll(
         sql,
         `${this._modelClass.name} Load`,
@@ -2953,19 +2899,6 @@ export class Relation<T extends Base> {
       ...this._preloadAssociations,
       ...this._includesAssociations.filter((n) => !promotedIncludes.includes(n)),
     ];
-    // Set-op operands all instantiate as this model class, and the compound
-    // bypasses the eager JOIN (operands stay arity-compatible), so the *other*
-    // operand's includes/eager/preload specs load as preloads against the full
-    // result set rather than being silently dropped. (`this` is the left/loaded
-    // relation; its own specs are handled above + in the eager branch.)
-    if (this._setOperation) {
-      const other = this._setOperation.other;
-      preloadAssocs.push(
-        ...other._eagerLoadAssociations,
-        ...other._includesAssociations,
-        ...other._preloadAssociations,
-      );
-    }
     if (preloadAssocs.length > 0 && this._records.length > 0) {
       await this._preloadAssociationsForRecords(this._records, preloadAssocs);
       if (token !== this._loadToken) return [];
@@ -3589,7 +3522,7 @@ export class Relation<T extends Base> {
   /**
    * Whether an eager-load query degrades to plain SQL + preloading instead of
    * building a JoinDependency. trails can't emit the aliased eager JOIN under a
-   * composite PK, CTEs, a set operation, or a FROM override, so eager specs are
+   * composite PK, CTEs, or a FROM override, so eager specs are
    * preloaded in those cases (a capability gap — Rails always JOINs). Kept in
    * one place so the `toArray` builder (`_executeEagerLoad`), the `toSql`
    * builder (`_buildEagerSql`), and the calculation/exists raise-check
@@ -3598,12 +3531,7 @@ export class Relation<T extends Base> {
    */
   private _eagerLoadBypassesJoinDependency(): boolean {
     const basePk = (this._modelClass as any).primaryKey ?? "id";
-    return (
-      Array.isArray(basePk) ||
-      this._ctes.length > 0 ||
-      !!this._setOperation ||
-      !this._fromClause.isEmpty()
-    );
+    return Array.isArray(basePk) || this._ctes.length > 0 || !this._fromClause.isEmpty();
   }
 
   /**
@@ -5485,14 +5413,6 @@ export class Relation<T extends Base> {
     // it through the connection, which inlines binds during AST traversal via
     // the SubstituteBinds collector. No cached node, no bespoke quoter, no
     // post-hoc string pass.
-    if (this._setOperation) {
-      // The set-operation visitors wrap the compound SELECT in `( ... )` for
-      // embedded use. As a standalone statement SQLite rejects the leading
-      // paren, so strip the single enclosing pair the visitor added (operand
-      // parens for ORDER/LIMIT/OFFSET sides use no inner space, so are kept).
-      const raw = this._toSqlViaConnection(this._buildSetOperationNode());
-      return raw.replace(/^\(\s+/, "").replace(/\s+\)$/, "");
-    }
     if (this._eagerLoadingForSql()) {
       const manager = this._buildEagerOperandManager();
       if (manager !== null) {
@@ -5543,79 +5463,7 @@ export class Relation<T extends Base> {
   }
 
   private _toSql(): string {
-    if (this._setOperation) {
-      return this._toSqlSetOperation();
-    }
     return this._toSqlWithoutSetOp();
-  }
-
-  /**
-   * Compose the set operation as an Arel Union/UnionAll/Intersect/Except node
-   * from each side's fully-built SelectManager — projections, joins, wheres,
-   * from(), the eager-load join dependency, CTEs, and annotate() comments are
-   * all encoded in the operand AST — then let the visitor emit the compound
-   * through a single collector. One collector numbers every bind globally by
-   * construction, so PG `$N` placeholders are correct without post-processing:
-   * no manual right-side renumbering and no per-side bind concatenation. The
-   * cross-adapter paren difference (SQLite strips parens around compound-SELECT
-   * operands; PG/MySQL parenthesize) lives in the arel visitors, not here.
-   */
-  private _toSqlSetOperation(): string {
-    const node = this._buildSetOperationNode();
-    const v = this._arelVisitor();
-    const [raw, binds, retryable, preparable] = v.compileWithBinds(node);
-    this._lastSelectRetryable = retryable;
-    // Apply the same over-limit inline fallback the plain SELECT gets: a
-    // union/intersect/except operand can carry a large multi-value `IN`/`NOT IN`
-    // (`HomogeneousIn`) whose binds would otherwise overflow the parameter cap.
-    const compound = this._applyBindLimitFallback(
-      node,
-      raw,
-      this._typeCastBinds(binds),
-      preparable,
-    );
-    // The set-operation visitors wrap the compound SELECT in `( ... )` for
-    // embedded use (subquery / derived table). As a standalone statement
-    // SQLite rejects the leading paren, so strip the single enclosing pair the
-    // visitor added (operand-level parens for ORDER/LIMIT/OFFSET sides use no
-    // inner space and are preserved).
-    return compound.replace(/^\(\s+/, "").replace(/\s+\)$/, "");
-  }
-
-  /**
-   * Compose this relation's set operation as an Arel
-   * Union/UnionAll/Intersect/Except node from each side's operand SelectManager.
-   * Shared by the standalone `_toSqlSetOperation` path and `from()` derived-table
-   * embedding, so a `from(a.union(b), "alias")` threads through the same live AST
-   * (binds parameterized by the outer collector) rather than inlined SQL.
-   * @internal
-   */
-  _buildSetOperationNode(): Nodes.Node {
-    const leftManager = this._buildSetOperationOperandManager();
-    const rightManager = this._setOperation!.other._buildSetOperationOperandManager();
-    return leftManager[this._setOperation!.type](rightManager) as unknown as Nodes.Node;
-  }
-
-  /**
-   * Build the SelectManager for this relation as a set-operation operand: the
-   * base select projections, then folds CTEs (`WITH`) and annotate() comments
-   * into the operand AST so they thread through the compound's single collector
-   * instead of being spliced into the compiled SQL string per side.
-   *
-   * An eager-load operand is deliberately NOT compiled through its
-   * JoinDependency manager here: that emits the wide `t0_r*` aliased column list
-   * + LEFT OUTER JOINs, which (a) make the operand arity-incompatible with the
-   * other side of the UNION (DBs reject differing column counts) and (b) cannot
-   * be JoinDependency-instantiated, since the compound executes through the
-   * `_eagerLoadBypassesJoinDependency` branch and reads rows as plain models.
-   * So each operand keeps the plain projection (arity stays compatible) and the
-   * eager associations load via that bypass branch's `_preloadAssociationsForRecords`
-   * — Rails has no `Relation#union`, so there is no JD-through-union path to mirror.
-   */
-  private _buildSetOperationOperandManager(): SelectManager {
-    const manager = this._buildSelectManager();
-    this._applyCtesAndAnnotationsToManager(manager);
-    return manager;
   }
 
   // Mirrors: ActiveRecord::Relation#eager_loading?
@@ -6067,14 +5915,14 @@ export class Relation<T extends Base> {
    * (`value.arel(.ast)`). `_buildSelectManager` threads joins/wheres/from/having
    * — matching `_toSqlWithoutSetOp` minus the CTE/eager/annotate prefix — so a
    * recursive body's string JOIN survives (with_recursive). Returns null for
-   * relations whose SQL `_buildSelectManager` does not fully encode (set-op or
-   * eager-load bodies), letting the caller fall back to pre-rendered SQL.
+   * relations whose SQL `_buildSelectManager` does not fully encode (eager-load
+   * bodies), letting the caller fall back to pre-rendered SQL.
    * `nested` is accepted to mirror Rails' threading; both branches resolve to the
    * AST node since trails' Cte/UnionAll operands must be visitable nodes.
    * @internal
    */
   _cteBodyArelNode(_nested = false): Nodes.Node | null {
-    if (this._setOperation || this._eagerLoadingForSql()) return null;
+    if (this._eagerLoadingForSql()) return null;
     return this._buildSelectManager().ast as unknown as Nodes.Node;
   }
 
@@ -7465,7 +7313,6 @@ export class Relation<T extends Base> {
     this._havingClause = source._havingClause.clone();
     this._isNone = source._isNone;
     this._lockValue = source._lockValue;
-    this._setOperation = source._setOperation;
     this._joinClauses = [...source._joinClauses];
     this._joinsValues = [...source._joinsValues];
     this._leftOuterJoinsValues = [...source._leftOuterJoinsValues];

--- a/packages/activerecord/src/relation/arel-ast-convergence.test.ts
+++ b/packages/activerecord/src/relation/arel-ast-convergence.test.ts
@@ -1,15 +1,13 @@
 /**
  * Verification for RFC 0022 (relation-arel-ast-convergence).
  *
- * After the three clusters landed — CTE/UnionAll body as an arel AST
- * (`build_with_expression_from_value`), set operations as arel Union/UnionAll/
- * Intersect/Except nodes threaded through a single bind collector
- * (`_toSqlSetOperation`), and from()/pluck threaded through the SelectManager
- * (`build_from`) — the read path emits SQL by compiling one arel node through
- * the dialect visitor instead of assembling strings.
+ * After the clusters landed — CTE/UnionAll body as an arel AST
+ * (`build_with_expression_from_value`) and from()/pluck threaded through the
+ * SelectManager (`build_from`) — the read path emits SQL by compiling one arel
+ * node through the dialect visitor instead of assembling strings.
  *
- * These spot-checks drive the *relation* API (`Relation#with` / `#union` /
- * `#intersect` / `#except` / `#from`) and inspect the compiled SQL +
+ * These spot-checks drive the *relation* API (`Relation#with` / `#from`) and
+ * inspect the compiled SQL +
  * threaded binds, so a regression back to string assembly in the relation
  * layer fails here. `_toSql()` is the pre-substitution compile (public
  * `toSql()` inlines bind values for human-readable output, mirroring Rails
@@ -80,31 +78,6 @@ describe("RFC 0022 arel-AST convergence (relation layer)", () => {
       expect(sql).toContain(placeholder1);
       expect(sql).toContain(placeholder2);
       expect(bindValues(rel)).toEqual(["alice", "bob"]);
-    });
-  });
-
-  // Cluster 2: set operations are arel nodes whose binds thread through one
-  // collector (`_toSqlSetOperation`) — retired the right-side `$N` renumber.
-  describe("Relation#union / #intersect / #except bind threading", () => {
-    function unionRelation() {
-      return Post.where({ author: "alice" }).union(Post.where({ author: "bob" }));
-    }
-
-    it("numbers binds globally across both operands", () => {
-      const rel = unionRelation();
-      const sql = rawSql(rel);
-      expect(sql).toContain("UNION");
-      expect(sql).toContain(placeholder1);
-      expect(sql).toContain(placeholder2);
-      // Exactly two binds (no third operand placeholder) → one global collector.
-      expect(bindValues(rel)).toEqual(["alice", "bob"]);
-    });
-
-    it("renders intersect and except as compound SELECTs", () => {
-      const a = Post.where({ author: "alice" });
-      const b = Post.where({ author: "bob" });
-      expect(rawSql(a.intersect(b))).toContain("INTERSECT");
-      expect(rawSql(a.exceptRelation(b))).toContain("EXCEPT");
     });
   });
 

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -2437,23 +2437,10 @@ export function buildFrom(this: QueryMethodsHost): unknown {
   if (opts && typeof opts.toArel === "function") {
     name ??= "subquery";
     const alias = String(name);
-    // A set-operation relation (union/intersect/except) has no projection-only
-    // SelectManager — its SQL is a compound node. Mirror Rails `build_from` +
-    // `SelectManager#as`: wrap the compound node as a derived table whose alias
-    // is a `SqlLiteral`, so the visitor renders it bare (Rails' `quote_table_name`
-    // returns SqlLiterals unchanged) and the alias is caller-trusted like Rails —
-    // no identifier gate. Its binds parameterize through the outer collector (no
-    // string inlining / `$N`→`?` rewrite). Operands handle their own eager loading
-    // inside `_buildSetOperationNode`, so the applyJoinDependency clone below is
-    // skipped for this branch.
-    if (opts._setOperation) {
-      return new Nodes.TableAlias(opts._buildSetOperationNode(), arelSql(alias));
-    }
     // No identifier gate: Rails' `build_from` stores the caller-provided
     // `subquery_name` verbatim and wraps it in a `SqlLiteral` via
-    // `SelectManager#as`, so the alias is caller-trusted (same trust model as
-    // the set-op branch above). A regex guard here was stricter than Rails and
-    // left the two `from(Relation)` paths asymmetric.
+    // `SelectManager#as`, so the alias is caller-trusted. A regex guard here was
+    // stricter than Rails and left the two `from(Relation)` paths asymmetric.
     // When the from-value is a Relation that needs eager loading (Rails
     // `opts.eager_loading?`), derive the from clause via
     // `apply_join_dependency` first (Rails build_from). This folds the eager


### PR DESCRIPTION
## What

Removes `Relation#union`, `#unionAll`, `#intersect`, and `#exceptRelation` — none of which exist on `ActiveRecord::Relation`. They mirror `Arel::SelectManager` methods; the upstream proposals to lift them onto `Relation` were closed (e.g. rails/rails#27340). Per the project's fidelity-first stance ("always converge, never ratify"), the correct move is to remove the non-Rails surface, not extend it.

## Changes

- Delete `union` / `unionAll` / `intersect` / `exceptRelation` from `Relation`.
- Delete the machinery that existed solely to serve them: the `_setOperation` field, `_buildSetOperationNode`, `_buildSetOperationOperandManager`, `_toSqlSetOperation`, and the set-op branches threaded through `toArray`, `toSql`, `_toSql`, `_cteBodyArelNode`, `_eagerLoadBypassesJoinDependency`, `_clone`, and `query-methods.ts` `from()`.
- Remove the non-Rails tests (the set-op cluster in `arel-ast-convergence.test.ts`, the union bind-cap case in `bind-parameter.test.ts`, and the set-op retryability cases in `adapter-connection.trails.test.ts`).

## Notes

- **No internal callers** — a monorepo grep finds only `WhereClause#union` (unrelated).
- `except`/`only` Rails-semantics reconciliation was already completed in PR #4052; this is purely a removal.
- Arel-level set operations on `SelectManager` are untouched — that's where Rails exposes them.
- `api:compare` / `test:compare` delta stays non-negative (only non-Rails methods and non-Rails tests are removed).

Closes-story: relation-remove-non-rails-set-operation-methods