### PR TITLE
fix(schema): guard abstract FK mutators with use_foreign_keys?

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -312,35 +312,38 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
 
   it("addForeignKey is a no-op when use_foreign_keys? is false (Rails guard)", async () => {
     // Rails: add_foreign_key begins with `return unless use_foreign_keys?`.
+    // StubAdapter inherits AbstractAdapter.supports_foreign_keys? == false, so
+    // use_foreign_keys? is false through the real composition (no stubbing of
+    // the aggregate) — the guard must short-circuit before any SQL is emitted.
     let executed = false;
     class NoFkAdapter extends StubAdapter {
-      isUseForeignKeys() {
-        return false;
-      }
       executeMutation(_sql: string) {
         executed = true;
         return Promise.resolve(0);
       }
     }
     const stub = new NoFkAdapter();
+    expect((stub as any).isUseForeignKeys()).toBe(false);
     await stub.addForeignKey("articles", "authors", { column: "author_id" });
     expect(executed).toBe(false);
   });
 
   it("removeForeignKey is a no-op when use_foreign_keys? is false (Rails guard)", async () => {
     // Rails: remove_foreign_key begins with `return unless use_foreign_keys?`.
+    // Without the guard this would reach foreign_key_for! and raise; the guard
+    // makes it a silent no-op when the adapter doesn't support foreign keys.
     let executed = false;
     class NoFkAdapter extends StubAdapter {
-      isUseForeignKeys() {
-        return false;
-      }
       executeMutation(_sql: string) {
         executed = true;
         return Promise.resolve(0);
       }
     }
     const stub = new NoFkAdapter();
-    await stub.removeForeignKey("articles", { name: "fk_whatever" });
+    expect((stub as any).isUseForeignKeys()).toBe(false);
+    await expect(
+      stub.removeForeignKey("articles", { name: "fk_whatever" }),
+    ).resolves.toBeUndefined();
     expect(executed).toBe(false);
   });
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -266,7 +266,15 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     // themselves again, causing a stack overflow. This test uses StubAdapter, which
     // does NOT override foreignKeys or removeForeignKey, so it hits the base
     // SchemaStatements code paths (not a concrete adapter shortcut).
-    const stub = new StubAdapter();
+    // AbstractAdapter.supports_foreign_keys? is false by default (Rails), which
+    // would short-circuit removeForeignKey via the use_foreign_keys? guard; opt
+    // in so the recursion-prone base path is actually exercised.
+    class FkStub extends StubAdapter {
+      isUseForeignKeys() {
+        return true;
+      }
+    }
+    const stub = new FkStub();
     // foreignKeys base path returns [] when adapter has no override
     const fks = await stub.foreignKeys("any_table");
     expect(fks).toEqual([]);
@@ -300,6 +308,40 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     await expect(
       stub.removeForeignKey("products", { name: "wrong_name", toTable: "other", ifExists: true }),
     ).rejects.toThrow(/no foreign key/i);
+  });
+
+  it("addForeignKey is a no-op when use_foreign_keys? is false (Rails guard)", async () => {
+    // Rails: add_foreign_key begins with `return unless use_foreign_keys?`.
+    let executed = false;
+    class NoFkAdapter extends StubAdapter {
+      isUseForeignKeys() {
+        return false;
+      }
+      executeMutation(_sql: string) {
+        executed = true;
+        return Promise.resolve(0);
+      }
+    }
+    const stub = new NoFkAdapter();
+    await stub.addForeignKey("articles", "authors", { column: "author_id" });
+    expect(executed).toBe(false);
+  });
+
+  it("removeForeignKey is a no-op when use_foreign_keys? is false (Rails guard)", async () => {
+    // Rails: remove_foreign_key begins with `return unless use_foreign_keys?`.
+    let executed = false;
+    class NoFkAdapter extends StubAdapter {
+      isUseForeignKeys() {
+        return false;
+      }
+      executeMutation(_sql: string) {
+        executed = true;
+        return Promise.resolve(0);
+      }
+    }
+    const stub = new NoFkAdapter();
+    await stub.removeForeignKey("articles", { name: "fk_whatever" });
+    expect(executed).toBe(false);
   });
 
   it("validColumnDefinitionOptions includes ifExists (Rails OPTION_NAMES)", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -783,6 +783,8 @@ export class SchemaStatements {
     ) {
       return fkAdapter.addForeignKey(fromTable, toTable, options);
     }
+    // Rails: return unless use_foreign_keys?
+    if (!this.isUseForeignKeys()) return;
     // Mirrors Rails' add_foreign_key short-circuit:
     //   return if options[:if_not_exists] == true &&
     //     foreign_key_exists?(from_table, to_table, **options.slice(:column))
@@ -843,6 +845,8 @@ export class SchemaStatements {
     ) {
       return adapter.removeForeignKey(fromTable, toTableOrOptions, options);
     }
+    // Rails: return unless use_foreign_keys?
+    if (!this.isUseForeignKeys()) return;
     // Mirrors Rails remove_foreign_key(from_table, to_table = nil, **options):
     // resolve the actual constraint via foreign_key_for! (matching column /
     // name / to_table against the live foreign keys) rather than deriving a

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
@@ -141,3 +141,28 @@ describe("PostgreSQLSchemaStatements#schemaSearchPath", () => {
     ).toBeNull();
   });
 });
+
+describe("PostgreSQLSchemaStatements#addForeignKey use_foreign_keys? guard", () => {
+  it("is a no-op when the adapter does not support foreign keys (Rails super guard)", async () => {
+    // Rails PG add_foreign_key is `assert_valid_deferrable(deferrable); super`,
+    // and the abstract super begins with `return unless use_foreign_keys?`.
+    // The override replicates the abstract body inline, so it must replicate the
+    // guard too — otherwise a real PG migration (which lands in this override,
+    // not the base method) emits ADD CONSTRAINT even when FKs are disabled.
+    const executed: string[] = [];
+    const adapter = {
+      adapterName: "postgres" as const,
+      supportsForeignKeys: () => false,
+      exec: vi.fn(async (sql: string) => {
+        executed.push(sql);
+      }),
+      executeMutation: vi.fn(async (sql: string) => {
+        executed.push(sql);
+      }),
+    } as unknown as DatabaseAdapter;
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    expect(ss.isUseForeignKeys()).toBe(false);
+    await ss.addForeignKey("articles", "authors", { column: "author_id" });
+    expect(executed).toEqual([]);
+  });
+});

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1237,6 +1237,10 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // Rails: assert_valid_deferrable runs before `super` (the abstract
     // add_foreign_key, where the if_not_exists short-circuit lives).
     this.assertValidDeferrable(options.deferrable);
+    // Rails PG `add_foreign_key` is `assert_valid_deferrable(deferrable); super`,
+    // and the abstract `super` begins with `return unless use_foreign_keys?`.
+    // We replicate the abstract body inline here, so replicate the guard too.
+    if (!this.isUseForeignKeys()) return;
     if (options.ifNotExists === true) {
       const fks = await this.foreignKeys(fromTable);
       if (


### PR DESCRIPTION
## Summary

Rails' `add_foreign_key` and `remove_foreign_key` both begin with
`return unless use_foreign_keys?`
(`vendor/rails/.../abstract/schema_statements.rb:1174,1215`). The converged
abstract `SchemaStatements` bodies in trails ran unconditionally. This adds the
top guard (`if (!this.isUseForeignKeys()) return;`) to both mutators so adapters
that don't support foreign keys — or have them disabled via config — no-op,
matching Rails.

`isUseForeignKeys()` already mirrors `use_foreign_keys?`
(`supports_foreign_keys? && foreign_keys_enabled?`), so no adapter regresses:
adapters that support FKs (SQLite/PG/MySQL) still run the body.

## Tests

- New: `addForeignKey`/`removeForeignKey` no-op when `use_foreign_keys?` is false.
- Existing recursion-guard test opts into FK support (AbstractAdapter's default
  `supports_foreign_keys?` is false, per Rails) so it still exercises the base path.

Closes-story: abstract-fk-mutators-use-foreign-keys-guard