### PR TITLE
test(transactions): un-skip transaction does not apply default scope

### DIFF
--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -329,7 +329,7 @@ describe("TransactionTest", () => {
   // delegation guard (`guardBaseMethodDelegation`) throws NotImplementedError for
   // `transaction` on a Relation, so the faithful body can't run yet. Retained
   // verbatim for the un-skip; tracked alongside [[transactions-test-rollback-restores-record-state]].
-  it.skip("transaction does not apply default scope", async () => {
+  it("transaction does not apply default scope", async () => {
     // Regression test for https://github.com/rails/rails/issues/50368
     const topic = (await Topic.find((topics("fifth") as any).id)) as any;
     await (Topic.whereNot({ id: topic.id }) as any).transaction(async () => {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -323,12 +323,6 @@ describe("TransactionTest", () => {
     expect(topic.changes.title).toEqual(["The Fifth Topic of the day", "Ruby on Rails"]);
   });
 
-  // CONVERGENCE-PENDING (relation-level Relation#transaction): Rails opens the
-  // transaction directly on a scoped relation (`Topic.where.not(id:).transaction`)
-  // to prove the scope is NOT applied to finds inside. trails' relation
-  // delegation guard (`guardBaseMethodDelegation`) throws NotImplementedError for
-  // `transaction` on a Relation, so the faithful body can't run yet. Retained
-  // verbatim for the un-skip; tracked alongside [[transactions-test-rollback-restores-record-state]].
   it("transaction does not apply default scope", async () => {
     // Regression test for https://github.com/rails/rails/issues/50368
     const topic = (await Topic.find((topics("fifth") as any).id)) as any;


### PR DESCRIPTION
## Summary

`Relation#transaction` is already delegated `to: :model` in trails
(`packages/activerecord/src/relation/delegation.ts:965`, mirroring Rails'
`delegation.rb:106`), so opening a transaction on a scoped relation
(`Topic.whereNot({ id }).transaction { ... }`) does not apply the relation's
scope to finds inside the block. The only remaining work for this story was
un-skipping the Rails-parity regression test for
[rails/rails#50368](https://github.com/rails/rails/issues/50368).

## Changes

- Un-skip `transaction does not apply default scope` in `transactions.test.ts`.

Passes on sqlite locally; CI covers PG + MySQL.

Closes-story: relation-transaction-on-scoped-relation