### PR TITLE
fix(associations): hydrate CollectionProxy#toArray via load, honor stale target

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -269,6 +269,28 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
     expect(found?.title).toBe("a");
   });
 
+  it("toArray hydrates and caches the target — a second call returns the cached set", async () => {
+    // Rails `to_a` → `records` → `load_target` caches `@target` and marks the
+    // association loaded, so a subsequent `to_a` returns the cached records
+    // without re-querying. Prove the cache by inserting a matching row directly
+    // into the DB after the first load: a re-query would pick it up; the cached
+    // read must not.
+    const author = await Author.create({ name: "Cached" });
+    for (const title of ["a", "b"]) {
+      await Post.create({ title, body: title, author_id: author.id as number });
+    }
+    const proxy = association<Post>(author, "posts") as any;
+    const first = await proxy.toArray();
+    expect(first.map((p: Post) => p.title).sort()).toEqual(["a", "b"]);
+
+    // Out-of-band insert that a fresh query would return but the cache must not.
+    await Post.create({ title: "c", body: "c", author_id: author.id as number });
+    const second = await proxy.toArray();
+    expect(second.map((p: Post) => p.title).sort()).toEqual(["a", "b"]);
+    // Same cached instances, not re-materialized rows.
+    expect(second[0]).toBe(first[0]);
+  });
+
   it("toArray honors direct bang-mutation of inherited Relation state", async () => {
     // In-place bang mutations on CP (cp.whereBang/orderBang/limitBang)
     // change the inherited Relation state. `toArray()` routes through

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -759,22 +759,48 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
    * Load and return all associated records.
    */
   async toArray(): Promise<T[]> {
-    // Rails `to_a` runs `merge_target_lists` (preferring in-memory records over
-    // fresh DB rows); we apply the same merge here. We deliberately do NOT yet
-    // hydrate/cache `_target` or mark the association loaded the way Rails'
-    // `load_target` does — `toArray` stays the cache-bypassing re-query path
-    // because bang mutations (`whereBang`/etc.) must re-query with the mutated
-    // scope without hydrating the association cache. Converging `toArray` onto
-    // full `load_target` hydration is tracked separately.
-    const results = await this._execLoad();
-    return this._mergeTargetLists(results);
+    // Rails `to_a` → `CollectionProxy#records` → `load_target`
+    // (collection_proxy.rb, collection_association.rb) hydrates and caches the
+    // association target (`@target = merge_target_lists(...)`) and marks it
+    // loaded. Delegate to `load` for that full hydrate-and-cache path.
+    //
+    // Keep the cache-bypassing re-query path when either (a) an in-place bang
+    // mutation (`whereBang`/`orderBang`/...) has diverged the proxy scope — this
+    // is effectively a scoped AssociationRelation whose `to_a` runs
+    // `exec_queries` without touching the owner's cached target — or (b)
+    // `find_target?` is false: a new-record owner with no foreign key present.
+    // Rails' `load_target` only assigns/caches `@target` from a query when
+    // `find_target?` (or the target is stale); for the new-record-without-FK
+    // case it leaves the in-memory target untouched, which for a through
+    // association means re-traversing the in-memory chain (`post.author.books`
+    // …) on each read rather than caching a scoped subset.
+    if (this._cpMutated || !this._findTarget()) {
+      const results = await this._execLoad();
+      return this._mergeTargetLists(results);
+    }
+    return this.load();
   }
 
   // @ts-expect-error CP's load returns the hydrated T[] (loaded records);
   //   Relation's returns LoadedRelation<this>. CP is thenable via load()
   //   so T[] is the correct contract here. Permanent divergence.
   async load(): Promise<T[]> {
-    if (this._targetLoaded) return this._target;
+    if (this._targetLoaded) {
+      // Mirror Rails `CollectionAssociation#reader`: `if stale_target? reload`.
+      // When the owner's foreign key has changed since the target was cached
+      // (`author = other`), the cache is stale and must be re-queried. Reset the
+      // wrapper so the post-load sync re-captures the new stale state (Rails
+      // `reload` → `reset` → `load_target`); otherwise return the cache.
+      const wrapper = this._staleWrapper();
+      if (!(wrapper?.isStaleTarget?.() ?? false)) return this._target;
+      // Stale (owner FK changed since load): fall through to re-query. Clear
+      // the CP's cached target so the stale records don't survive
+      // `merge_target_lists`; leave the wrapper's loaded/stale marker intact so
+      // `Association#association_scope` sees the staleness and rebuilds its
+      // cached JOIN scope from the new foreign key (association.ts:241).
+      this._target = [];
+      this._targetLoaded = false;
+    }
     const results = await this._execLoad();
     this._target = this._mergeTargetLists(results);
     this._targetLoaded = true;
@@ -866,6 +892,18 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
 
   private get _isThrough(): boolean {
     return !!this._assocDef.options.through;
+  }
+
+  /**
+   * The owner's Association wrapper for this proxy, used to consult
+   * `isStaleTarget()` (Rails `Association#stale_target?`) so a cached target is
+   * re-queried after the owner's foreign key changes.
+   */
+  private _staleWrapper(): { isStaleTarget?: () => boolean } | undefined {
+    const rec = this._record as unknown as {
+      association?: (n: string) => { isStaleTarget?: () => boolean };
+    };
+    return typeof rec.association === "function" ? rec.association(this._assocName) : undefined;
   }
 
   /**

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -767,14 +767,20 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // Keep the cache-bypassing re-query path when either (a) an in-place bang
     // mutation (`whereBang`/`orderBang`/...) has diverged the proxy scope — this
     // is effectively a scoped AssociationRelation whose `to_a` runs
-    // `exec_queries` without touching the owner's cached target — or (b)
-    // `find_target?` is false: a new-record owner with no foreign key present.
-    // Rails' `load_target` only assigns/caches `@target` from a query when
-    // `find_target?` (or the target is stale); for the new-record-without-FK
-    // case it leaves the in-memory target untouched, which for a through
-    // association means re-traversing the in-memory chain (`post.author.books`
-    // …) on each read rather than caching a scoped subset.
-    if (this._cpMutated || !this._findTarget()) {
+    // `exec_queries` without touching the owner's cached target — or (b) the
+    // target is not yet loaded and `find_target?` is false: a new-record owner
+    // with no foreign key present. Rails' `load_target` only assigns/caches
+    // `@target` from a query when `find_target?` (or the target is stale); for
+    // the new-record-without-FK case it leaves the in-memory target untouched,
+    // which for a through association means re-traversing the in-memory chain
+    // (`post.author.books` …) on each read rather than caching a scoped subset.
+    //
+    // The `!_targetLoaded` guard is essential: `_findTarget()` short-circuits to
+    // `false` once loaded (mirroring Rails `find_target?` = `!loaded? && …`), so
+    // OR-ing on a bare `!_findTarget()` would send *every* post-load `toArray()`
+    // back down the re-query path and defeat caching entirely. `load()` is the
+    // hydrate/cache chokepoint for the already-loaded case (including staleness).
+    if (this._cpMutated || (!this._targetLoaded && !this._findTarget())) {
       const results = await this._execLoad();
       return this._mergeTargetLists(results);
     }
@@ -786,11 +792,22 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   //   so T[] is the correct contract here. Permanent divergence.
   async load(): Promise<T[]> {
     if (this._targetLoaded) {
-      // Mirror Rails `CollectionAssociation#reader`: `if stale_target? reload`.
-      // When the owner's foreign key has changed since the target was cached
-      // (`author = other`), the cache is stale and must be re-queried. Reset the
-      // wrapper so the post-load sync re-captures the new stale state (Rails
-      // `reload` → `reset` → `load_target`); otherwise return the cache.
+      // Mirror Rails `CollectionAssociation#reader` (collection_association.rb:34):
+      // `if stale_target? reload`. When the owner's foreign key has changed since
+      // the target was cached (`author = other`), the cache is stale and must be
+      // re-queried; otherwise return the cache.
+      //
+      // Rails runs this staleness check in `reader` (the `owner.pets` accessor),
+      // NOT in `load_target` — but in trails there is no separate `reader` entry
+      // point. The accessor (`association()` in associations.ts) returns the
+      // cached CollectionProxy directly, without Rails' `if stale_target? reload`.
+      // So `load()` — the single hydration chokepoint every read funnels through —
+      // is where the check must live to reproduce Rails' *observable* behavior:
+      // `owner.pets.to_a` after a foreign-key change reloads, because in Rails the
+      // `pets` accessor itself reloads before `to_a` ever runs. This does not make
+      // trails' `to_a` reload where Rails' wouldn't; it lands the same reload Rails
+      // performs one call-frame earlier, at the accessor trails collapses into the
+      // proxy.
       const wrapper = this._staleWrapper();
       if (!(wrapper?.isStaleTarget?.() ?? false)) return this._target;
       // Stale (owner FK changed since load): fall through to re-query. Clear

--- a/packages/activerecord/src/nested-attributes.test.ts
+++ b/packages/activerecord/src/nested-attributes.test.ts
@@ -1094,7 +1094,12 @@ function collectionAssociationTests(
   it("should be possible to destroy a record", async () => {
     for (const trueVariable of ["1", 1, "true", true]) {
       const { pirate, child1, child2 } = await buildSetup();
-      const record = await proxy(await Pirate.find(pirate.id)).createBang({
+      // Rails: `record = @pirate.reload.public_send(@association_name).create!(...)`
+      // — reload resets the loaded association so the new record joins the same
+      // pirate's collection (rather than a separate `find`, which would leave
+      // this pirate's cached target stale and out of sync with the DB row).
+      await pirate.reload();
+      const record = await proxy(pirate).createBang({
         name: "Grace OMalley",
       });
       const params = await alternateParams(child1, child2);

--- a/packages/activerecord/src/reflection.test.ts
+++ b/packages/activerecord/src/reflection.test.ts
@@ -214,7 +214,11 @@ describe("ReflectionTest", () => {
     expect((await h2.chefLists.toArray()).length).toBe(1);
     expect(await h2.chefLists.count()).toBe(1);
 
-    await SC2ChefList.where({ employable_list_id: hotel.id }).deleteAll();
+    // Rails clears via the association writer (`hotel.mocktail_designers = []`),
+    // which deletes the underlying chef_list join rows AND prunes the in-memory
+    // targets of both this and the through (`chef_lists`) association. A bare
+    // out-of-band `deleteAll` would leave `to_a`'s now-cached target stale.
+    await h2.mocktailDesigners.replace([]);
 
     expect((await h2.mocktailDesigners.toArray()).length).toBe(0);
     expect(await h2.mocktailDesigners.count()).toBe(0);
@@ -278,7 +282,10 @@ describe("ReflectionTest", () => {
     const bh1r = await SC3Author.find(author.id).then((a: any) => a.bestHardbacks.toArray());
     expect(bh1r.length).toBe(1);
 
-    await SC3Book.where({ author_id: author.id }).deleteAll();
+    // Rails clears via the writer (`author.best_hardbacks = []`), which deletes
+    // the through `books` join rows and empties the cached target; a bare
+    // out-of-band `deleteAll` would leave `to_a`'s now-cached target stale.
+    await a3.bestHardbacks.replace([]);
 
     expect((await a3.bestHardbacks.toArray()).length).toBe(0);
     const bh2r = await SC3Author.find(author.id).then((a: any) => a.bestHardbacks.toArray());


### PR DESCRIPTION
## Summary

Converges `CollectionProxy#toArray` onto Rails' `to_a` → `records` → `load_target` path (collection_proxy.rb, collection_association.rb): `toArray` now delegates to `load`, so the association target is hydrated, cached, and marked loaded rather than always re-querying.

The cache-bypassing re-query path is preserved in the two cases Rails does **not** cache from a query:

- an in-place bang mutation (`whereBang`/`orderBang`/…) has diverged the proxy scope (effectively a scoped `AssociationRelation` whose `to_a` runs `exec_queries` without touching the owner's cached target); and
- `find_target?` is false — a new-record owner with no foreign key present, which for a through association re-traverses the in-memory chain (`post.author.books…`) on each read.

`load` now guards the cached return with a `stale_target?` check (Rails `CollectionAssociation#reader`): when the owner's foreign key changed since load, it clears the proxy's cached target and re-queries so `Association#association_scope` rebuilds the JOIN scope from the new key.

The composite-PK target prune after `destroy`/`destroyAll` already resolves the array primary key via `_identityFor` / `constructJoinAttributes`, so the cached `_target` is pruned correctly once caching is enabled — verified by the "destroy all on composite primary key model" test.

## Testing

- `has-many-through-associations.test.ts` + `collection-proxy.test.ts` — pass (incl. the composite-PK destroy, stale-through-FK, and bang-mutation tests).
- Full `packages/activerecord/src/associations/` suite — 1740 pass.

Closes-story: toarray-load-target-hydrate-and-deletethrough-composite-pk