### PR TITLE
refactor(migration): collapse MigrationContext column DDL onto SchemaStatements

### DIFF
--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1644,6 +1644,25 @@ export class MigrationContext {
 
   constructor(private connection: DatabaseAdapter) {}
 
+  private _schema?: SchemaStatements;
+  private _schemaConn?: DatabaseAdapter;
+
+  /**
+   * The connection's real `SchemaStatements` — the single Rails-faithful source
+   * of DDL/type generation. Mirrors {@link Migration.schema}; MigrationContext
+   * routes its schema-DSL methods through this instead of hand-rolling SQL so
+   * there is one source of truth as in Rails.
+   */
+  private get schema(): SchemaStatements {
+    const conn = this.connection;
+    if (!this._schema || this._schemaConn !== conn) {
+      assertSchemaAdapter(conn);
+      this._schema = conn.schemaStatements ? conn.schemaStatements() : new SchemaStatements(conn);
+      this._schemaConn = conn;
+    }
+    return this._schema;
+  }
+
   private get _adapterName(): "sqlite" | "postgres" | "mysql" {
     return this.connection.adapterName as "sqlite" | "postgres" | "mysql";
   }
@@ -2064,58 +2083,6 @@ export class MigrationContext {
     // Non-SQLite adapters: no-op; virtual tables are SQLite-specific.
   }
 
-  private _mapType(type: string, options?: ColumnOptions): string {
-    const an = this._adapterName;
-    switch (type.toLowerCase()) {
-      case "string":
-        // PG: unlimited `character varying` (matches Rails) so changeColumn-to-string
-        // doesn't introspect a spurious limit:255 into dumps.
-        return an === "postgres" ? "character varying" : `VARCHAR(255)`;
-      case "text":
-        return "TEXT";
-      case "integer":
-        return "INTEGER";
-      case "float":
-        return an === "postgres" ? "DOUBLE PRECISION" : "REAL";
-      case "decimal":
-        return "DECIMAL(10, 0)";
-      case "boolean":
-        return "BOOLEAN";
-      case "date":
-        return "DATE";
-      case "time": {
-        const p = options?.precision;
-        if (p != null && !(p >= 0 && p <= 6))
-          throw new ArgumentError(
-            `No TIME type has precision of ${p}. The allowed range of precision is from 0 to 6`,
-          );
-        return p != null ? `TIME(${p})` : "TIME";
-      }
-      case "datetime":
-      case "timestamp": {
-        const base = an === "postgres" ? "TIMESTAMP" : "DATETIME";
-        // MigrationContext is a lightweight SQL builder used in tests; _mapType always runs here
-        // (unlike real adapter addColumn which calls typeToSql directly). The precision=6 default
-        // for datetime matches Rails' behavior, but applies to timestamp too in this simplified path.
-        // precision: undefined → Rails default of 6; precision: null → no precision suffix
-        const p = options?.precision === undefined ? 6 : options.precision;
-        if (p != null && !(p >= 0 && p <= 6))
-          throw new ArgumentError(
-            `No ${base} type has precision of ${p}. The allowed range of precision is from 0 to 6`,
-          );
-        return p != null ? `${base}(${p})` : base;
-      }
-      case "binary":
-        return an === "postgres" ? "BYTEA" : "BLOB";
-      case "primary_key":
-        if (an === "postgres") return "SERIAL PRIMARY KEY";
-        if (an === "mysql") return "BIGINT AUTO_INCREMENT PRIMARY KEY";
-        return "INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL";
-      default:
-        return type.toUpperCase();
-    }
-  }
-
   async addColumn(
     table: string,
     column: string,
@@ -2129,10 +2096,18 @@ export class MigrationContext {
       }
       return;
     }
-    await this.connection.executeMutation(
-      `ALTER TABLE "${table}" ADD COLUMN "${column}" ${this._mapType(type, _options)}`,
-    );
-    if (_options && "comment" in _options && (this.connection as any).supportsComments?.())
+    // Delegate DDL/type generation to the adapter's SchemaStatements — the
+    // single Rails-faithful source — rather than the bespoke `_mapType` builder.
+    await this.schema.addColumn(table, column, type, _options ?? {});
+    // SchemaStatements#addColumn inlines the comment for adapters that support
+    // comments in CREATE (MySQL); adapters that can't (PostgreSQL) need the
+    // separate COMMENT ON COLUMN, mirroring Rails' add_column path.
+    if (
+      _options &&
+      "comment" in _options &&
+      (this.connection as any).supportsComments?.() &&
+      !(this.connection as any).supportsCommentsInCreate?.()
+    )
       await this.changeColumnComment(table, column, (_options as any).comment ?? null);
     if (!this._columns.has(table)) this._columns.set(table, new Set());
     this._columns.get(table)!.add(column);
@@ -2161,7 +2136,7 @@ export class MigrationContext {
       }
       const allCols = [columnOrColumns, optionsOrColumn, ...rest];
       for (const col of allCols) {
-        await this.connection.executeMutation(`ALTER TABLE "${table}" DROP COLUMN "${col}"`);
+        await this.schema.removeColumn(table, col);
         this._columns.get(table)?.delete(col);
         this._columnMeta.get(table)?.delete(col);
       }
@@ -2170,17 +2145,13 @@ export class MigrationContext {
     if (optionsOrColumn?.ifExists && !this.columnExists(table, columnOrColumns)) {
       return;
     }
-    await this.connection.executeMutation(
-      `ALTER TABLE "${table}" DROP COLUMN "${columnOrColumns}"`,
-    );
+    await this.schema.removeColumn(table, columnOrColumns);
     this._columns.get(table)?.delete(columnOrColumns);
     this._columnMeta.get(table)?.delete(columnOrColumns);
   }
 
   async renameColumn(table: string, from: string, to: string): Promise<void> {
-    await this.connection.executeMutation(
-      `ALTER TABLE "${table}" RENAME COLUMN "${from}" TO "${to}"`,
-    );
+    await this.schema.renameColumn(table, from, to);
     const cols = this._columns.get(table);
     if (cols) {
       cols.delete(from);
@@ -2200,15 +2171,9 @@ export class MigrationContext {
     type: string,
     _options?: ColumnOptions,
   ): Promise<void> {
-    if (this._adapterName === "mysql") {
-      await this.connection.executeMutation(
-        `ALTER TABLE "${table}" MODIFY COLUMN "${column}" ${this._mapType(type, _options)}`,
-      );
-    } else {
-      await this.connection.executeMutation(
-        `ALTER TABLE "${table}" ALTER COLUMN "${column}" TYPE ${this._mapType(type, _options)}`,
-      );
-    }
+    // Delegate DDL/type generation to the adapter's SchemaStatements rather than
+    // the bespoke `_mapType` builder — the single Rails-faithful source.
+    await this.schema.changeColumn(table, column, type, _options ?? {});
     if (_options && "comment" in _options && (this.connection as any).supportsComments?.())
       await this.changeColumnComment(table, column, (_options as any).comment ?? null);
     const meta = this._columnMeta.get(table);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2098,17 +2098,10 @@ export class MigrationContext {
     }
     // Delegate DDL/type generation to the adapter's SchemaStatements — the
     // single Rails-faithful source — rather than the bespoke `_mapType` builder.
+    // The adapter's addColumn also owns comment application (PostgreSQL emits a
+    // separate COMMENT ON COLUMN; MySQL inlines it in the visitor), so we do not
+    // re-apply it here.
     await this.schema.addColumn(table, column, type, _options ?? {});
-    // SchemaStatements#addColumn inlines the comment for adapters that support
-    // comments in CREATE (MySQL); adapters that can't (PostgreSQL) need the
-    // separate COMMENT ON COLUMN, mirroring Rails' add_column path.
-    if (
-      _options &&
-      "comment" in _options &&
-      (this.connection as any).supportsComments?.() &&
-      !(this.connection as any).supportsCommentsInCreate?.()
-    )
-      await this.changeColumnComment(table, column, (_options as any).comment ?? null);
     if (!this._columns.has(table)) this._columns.set(table, new Set());
     this._columns.get(table)!.add(column);
     if (!this._columnMeta.has(table)) this._columnMeta.set(table, new Map());
@@ -2172,10 +2165,11 @@ export class MigrationContext {
     _options?: ColumnOptions,
   ): Promise<void> {
     // Delegate DDL/type generation to the adapter's SchemaStatements rather than
-    // the bespoke `_mapType` builder — the single Rails-faithful source.
+    // the bespoke `_mapType` builder — the single Rails-faithful source. The
+    // adapter's changeColumn also owns comment application (PostgreSQL emits a
+    // separate COMMENT ON COLUMN; MySQL inlines it via changeColumnForAlter), so
+    // we do not re-apply it here.
     await this.schema.changeColumn(table, column, type, _options ?? {});
-    if (_options && "comment" in _options && (this.connection as any).supportsComments?.())
-      await this.changeColumnComment(table, column, (_options as any).comment ?? null);
     const meta = this._columnMeta.get(table);
     if (meta && meta.has(column)) {
       const entry = meta.get(column)!;


### PR DESCRIPTION
MigrationContext reimplemented column DDL (`addColumn`, `removeColumn`, `renameColumn`, `changeColumn`) with a bespoke `_mapType` SQL/type builder and raw `ALTER TABLE` strings — a second schema-DSL engine parallel to the adapter's `SchemaStatements`. This is the "two code paths drift apart" structural root cause RFC 0051 targets (surfaced by the expression-index-name drift in PR #3521).

## What

- Add a private `schema` accessor to `MigrationContext` (mirrors `Migration#schema`) that resolves the connection's real `SchemaStatements`.
- Route `addColumn` / `removeColumn` / `renameColumn` / `changeColumn` DDL through it.
- Delete the bespoke `_mapType` type/SQL builder (its only callers were those methods).
- Comment application is left entirely to the adapter's `SchemaStatements`: `PostgreSQLSchemaStatements#addColumn`/`#changeColumn` emit a separate `COMMENT ON COLUMN` internally, and MySQL embeds the comment inline in the visitor / `changeColumnForAlter`. MigrationContext no longer re-applies it (a review-caught double-application the initial revision introduced).

The in-memory `_columns`/`_columnMeta` bookkeeping that `columns()`/`columnExists()` read is retained unchanged, so the schema-dump/loadSchema path is behavior-preserving.

`createTable` and `addIndex` were already collapsed onto the adapter. `dropTable`/`renameTable` (which carry extra semantics — `temporary`, prefix/suffix) and the bespoke introspection (`_introspectColumns` / `_normalizeIntrospectedType` / in-memory tracking) are the higher-risk remainder, registered as `collapse-migrationcontext-remaining-dsl-and-introspection`.

## Testing

`migration`, `migration.trails`, `date-time-precision`, `defaults`, `comment`, `hot-compatibility`, `timestamp`, `cache-key`, `bigint-roundtrip`, `active-record-schema`, `schema-dumper`, `database-tasks`, `schema-file-generator` all pass.

Closes-story: collapse-migrationcontext-schema-dsl-onto-schemastatements