### PR TITLE
fix(preloader): strip SQL string literals before through-condition table scan

### DIFF
--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -819,9 +819,12 @@ function rawSqlReferencesTable(node: any, tableName: string): boolean {
 /**
  * Blank out single-quoted SQL string literals (keeping length via spaces) so a
  * `<table>.` qualifier scan does not match a table name embedded in literal
- * text. Doubled single-quotes (`''`, SQL's escaped quote) are consumed as part
- * of the literal. Double-quoted tokens are SQL identifiers, not literals, so
- * they are left intact. `?` placeholders in a BoundSqlLiteral are outside any
+ * text. Both escape forms inside a literal are consumed: SQL-standard doubled
+ * single-quotes (`''`) and a backslash-escaped quote (`\'`), the latter being
+ * MySQL/MariaDB's default (`NO_BACKSLASH_ESCAPES` off) — so a literal like
+ * `'don\'t touch memberships.x'` is fully blanked rather than terminating early
+ * at the escaped quote. Double-quoted tokens are SQL identifiers, not literals,
+ * so they are left intact. `?` placeholders in a BoundSqlLiteral are outside any
  * literal and unaffected.
  * @internal
  */
@@ -830,7 +833,7 @@ function stripSqlStringLiterals(sql: string): string {
   // qualifier scan below does not match a table name inside quoted text. The
   // result is never executed as SQL.
   // eslint-disable-next-line blazetrails/no-raw-sql
-  return sql.replace(/'(?:[^']|'')*'/g, (lit) => " ".repeat(lit.length));
+  return sql.replace(/'(?:[^'\\]|''|\\.)*'/g, (lit) => " ".repeat(lit.length));
 }
 
 /**

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -795,12 +795,12 @@ function predicateReferencesTable(node: any, tableName: string): boolean {
  * True when a raw-SQL predicate node's text qualifies a column with `tableName.`.
  * Handles SqlLiteral / BoundSqlLiteral and a single Grouping wrapper.
  *
- * Heuristic: this scans the raw SQL for a `<table>.` qualifier token; it does
- * NOT parse the SQL, so a qualifier appearing inside a string literal (e.g.
- * `where("note = 'see memberships.x'")`) would be a false positive and relocate
- * a source-table predicate onto the through query. No current scope hits this;
- * raw-SQL through conditions are simple table-qualified comparisons. Arel/hash
- * predicates take the precise `fetchAttribute` path above and never reach here.
+ * Not a SQL parse but a qualifier scan: string literals are stripped first (see
+ * `stripSqlStringLiterals`) so a `<table>.` qualifier appearing inside a quoted
+ * literal — e.g. `where("note = 'see memberships.x'")` — is NOT a false positive
+ * and does not relocate a source-table predicate onto the through query.
+ * Arel/hash predicates take the precise `fetchAttribute` path above and never
+ * reach here.
  * @internal
  */
 function rawSqlReferencesTable(node: any, tableName: string): boolean {
@@ -811,8 +811,26 @@ function rawSqlReferencesTable(node: any, tableName: string): boolean {
   if (node instanceof Nodes.BoundSqlLiteral) sql = (node as any).sqlWithPlaceholders;
   else if (node instanceof Nodes.SqlLiteral) sql = (node as any).value;
   if (typeof sql !== "string") return false;
+  sql = stripSqlStringLiterals(sql);
   const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   return new RegExp(`(^|[^\\w.])${escaped}\\.`).test(sql);
+}
+
+/**
+ * Blank out single-quoted SQL string literals (keeping length via spaces) so a
+ * `<table>.` qualifier scan does not match a table name embedded in literal
+ * text. Doubled single-quotes (`''`, SQL's escaped quote) are consumed as part
+ * of the literal. Double-quoted tokens are SQL identifiers, not literals, so
+ * they are left intact. `?` placeholders in a BoundSqlLiteral are outside any
+ * literal and unaffected.
+ * @internal
+ */
+function stripSqlStringLiterals(sql: string): string {
+  // Not query construction — this blanks literals purely so the read-only
+  // qualifier scan below does not match a table name inside quoted text. The
+  // result is never executed as SQL.
+  // eslint-disable-next-line blazetrails/no-raw-sql
+  return sql.replace(/'(?:[^']|'')*'/g, (lit) => " ".repeat(lit.length));
 }
 
 /**
@@ -824,9 +842,9 @@ function rawSqlReferencesTable(node: any, tableName: string): boolean {
  *
  * Uses the same Arel `fetchAttribute` walk as `predicateReferencesTable` for
  * precise hash/Arel conditions, and the same raw-SQL qualifier scan as
- * `rawSqlReferencesTable` — extracting every `<word>.` qualifier and flagging any
- * not in `allowedTables`. The raw-SQL scan is a heuristic (a qualifier inside a
- * string literal would be a false positive); no current scope hits that, and hash
+ * `rawSqlReferencesTable` — string literals are stripped first, then every
+ * `<word>.` qualifier is extracted and any not in `allowedTables` is flagged. A
+ * `<table>.` qualifier inside a quoted literal is not a false positive; hash
  * predicates take the exact Arel path.
  * @internal
  */
@@ -860,6 +878,7 @@ function rawSqlReferencesForeignTable(node: any, allowed: Set<string>): boolean 
   if (node instanceof Nodes.BoundSqlLiteral) sql = (node as any).sqlWithPlaceholders;
   else if (node instanceof Nodes.SqlLiteral) sql = (node as any).value;
   if (typeof sql !== "string") return false;
+  sql = stripSqlStringLiterals(sql);
   const qualifierRe = /(^|[^\w.])(\w+)\s*\./g;
   let match: RegExpExecArray | null;
   while ((match = qualifierRe.exec(sql)) !== null) {

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -827,9 +827,16 @@ function rawSqlReferencesTable(node: any, tableName: string): boolean {
  * following char, so an escaped backslash (`\\`) is consumed as one unit and a
  * real close-quote right after it (`'a\\'`) still closes the literal — a
  * subsequent genuine qualifier (`... 'a\\' AND posts.x ...`) stays exposed to
- * the scan and is NOT swallowed. Double-quoted tokens are SQL identifiers, not literals,
- * so they are left intact. `?` placeholders in a BoundSqlLiteral are outside any
- * literal and unaffected.
+ * the scan and is NOT swallowed. `?` placeholders in a BoundSqlLiteral are
+ * outside any literal and unaffected.
+ *
+ * Only single-quoted literals are tokenized; double-quoted identifiers are not
+ * tracked. That leaves one narrow gap: two double-quoted identifiers each
+ * containing a stray apostrophe (e.g. `"note's"`) can have their apostrophes
+ * paired as a bogus literal, blanking a genuine qualifier between them. This
+ * needs apostrophe-bearing quoted identifiers — pathological for canonical
+ * table/column names — so it is left as an accepted limitation rather than
+ * carrying a full SQL tokenizer here.
  * @internal
  */
 function stripSqlStringLiterals(sql: string): string {

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -823,7 +823,11 @@ function rawSqlReferencesTable(node: any, tableName: string): boolean {
  * single-quotes (`''`) and a backslash-escaped quote (`\'`), the latter being
  * MySQL/MariaDB's default (`NO_BACKSLASH_ESCAPES` off) — so a literal like
  * `'don\'t touch memberships.x'` is fully blanked rather than terminating early
- * at the escaped quote. Double-quoted tokens are SQL identifiers, not literals,
+ * at the escaped quote. The `\\.` alternative pairs each backslash with its
+ * following char, so an escaped backslash (`\\`) is consumed as one unit and a
+ * real close-quote right after it (`'a\\'`) still closes the literal — a
+ * subsequent genuine qualifier (`... 'a\\' AND posts.x ...`) stays exposed to
+ * the scan and is NOT swallowed. Double-quoted tokens are SQL identifiers, not literals,
  * so they are left intact. `?` placeholders in a BoundSqlLiteral are outside any
  * literal and unaffected.
  * @internal

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -48,6 +48,16 @@ registerModel(Comment);
   scope: (rel: any) => rel.where("comments.body = 'mention posts.title here'"),
 });
 
+// Positive control: a GENUINE through-table (`posts.`) qualifier — unquoted, a
+// real column reference — must still be relocated onto the through query. Pins
+// that stripping string literals does not break the true-positive path.
+(Author as any).hasMany("commentsWithRealThroughRef", {
+  className: "Comment",
+  through: "posts",
+  source: "comments",
+  scope: (rel: any) => rel.where("posts.title = 'welcome'"),
+});
+
 describe("Preloader::ThroughAssociation#through_scope", () => {
   const { authors, posts } = fixtures(["authors", "authorAddresses", "posts", "comments"]);
 
@@ -86,6 +96,18 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     // And the through query must not carry the source predicate.
     const scope = (loader as any)._buildThroughScope();
     expect(scope.toSql()).not.toContain("mention posts.title here");
+  });
+
+  it("relocates a genuine through-table qualifier onto the through query", () => {
+    const david = authors("david");
+    const loader = throughLoader([david], "commentsWithRealThroughRef");
+    const partition = (loader as any)._partitionReflectionWhere();
+    // `posts.title` is a real column reference on the through table.
+    expect(partition.throughPredicates).toHaveLength(1);
+    expect(partition.sourcePredicates).toHaveLength(0);
+
+    const scope = (loader as any)._buildThroughScope();
+    expect(scope.toSql()).toContain("posts.title");
   });
 
   it("cascades strict loading from the preload scope onto the through query", async () => {

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -59,6 +59,18 @@ registerModel(Comment);
   scope: (rel: any) => rel.where("comments.body = 'don\\'t touch posts.title here'"),
 });
 
+// A literal ending in an escaped backslash (`'a\\'`, i.e. the string value `a\`)
+// immediately followed by a GENUINE through-table qualifier in the same raw-SQL
+// string. The `\\.` escape-pairing must consume `\\` as one unit and let the
+// quote close, so `posts.title` after it is still seen and relocated — pins that
+// the escaped-backslash-then-close-quote case is NOT over-swallowed.
+(Author as any).hasMany("commentsWithEscapedBackslashThenQualifier", {
+  className: "Comment",
+  through: "posts",
+  source: "comments",
+  scope: (rel: any) => rel.where("comments.body = 'a\\\\' AND posts.title = 'x'"),
+});
+
 // Positive control: a GENUINE through-table (`posts.`) qualifier — unquoted, a
 // real column reference — must still be relocated onto the through query. Pins
 // that stripping string literals does not break the true-positive path.
@@ -118,6 +130,19 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
 
     const scope = (loader as any)._buildThroughScope();
     expect(scope.toSql()).not.toContain("posts.title");
+  });
+
+  it("still sees a genuine qualifier after an escaped-backslash literal", () => {
+    const david = authors("david");
+    const loader = throughLoader([david], "commentsWithEscapedBackslashThenQualifier");
+    const partition = (loader as any)._partitionReflectionWhere();
+    // The `'a\\'` literal closes correctly, so the trailing `posts.title` is a
+    // real through-table qualifier and the predicate relocates.
+    expect(partition.throughPredicates).toHaveLength(1);
+    expect(partition.sourcePredicates).toHaveLength(0);
+
+    const scope = (loader as any)._buildThroughScope();
+    expect(scope.toSql()).toContain("posts.title");
   });
 
   it("relocates a genuine through-table qualifier onto the through query", () => {

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -36,6 +36,18 @@ registerModel(Comment);
   scope: (rel: any) => rel.annotate("preload-through"),
 });
 
+// A raw-SQL source-table condition whose text embeds the THROUGH table name
+// (`posts.`) inside a string literal. The through table is `posts`; a naive
+// text scan for a `posts.` qualifier would relocate this source predicate onto
+// the through query (a false positive), so this pins that string literals are
+// stripped before the qualifier scan.
+(Author as any).hasMany("commentsWithLiteralThroughRef", {
+  className: "Comment",
+  through: "posts",
+  source: "comments",
+  scope: (rel: any) => rel.where("comments.body = 'mention posts.title here'"),
+});
+
 describe("Preloader::ThroughAssociation#through_scope", () => {
   const { authors, posts } = fixtures(["authors", "authorAddresses", "posts", "comments"]);
 
@@ -60,6 +72,20 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     const [row] = await Author.where({ id: david.id }).preload("annotatedComments");
     const comments = (row.association("annotatedComments").target ?? []) as any[];
     expect(comments.length).toBeGreaterThan(0);
+  });
+
+  it("does not relocate a source predicate whose string literal embeds the through table name", () => {
+    const david = authors("david");
+    const loader = throughLoader([david], "commentsWithLiteralThroughRef");
+    const partition = (loader as any)._partitionReflectionWhere();
+    // The `posts.` token lives inside a string literal, so the predicate is a
+    // source-table condition and must stay on the source preloader.
+    expect(partition.throughPredicates).toHaveLength(0);
+    expect(partition.sourcePredicates).toHaveLength(1);
+
+    // And the through query must not carry the source predicate.
+    const scope = (loader as any)._buildThroughScope();
+    expect(scope.toSql()).not.toContain("mention posts.title here");
   });
 
   it("cascades strict loading from the preload scope onto the through query", async () => {

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -48,6 +48,17 @@ registerModel(Comment);
   scope: (rel: any) => rel.where("comments.body = 'mention posts.title here'"),
 });
 
+// Same false-positive class but with a BACKSLASH-escaped quote inside the
+// literal (`\'`) — MySQL/MariaDB's default escaping. A regex that only knows
+// `''` escaping would terminate the literal early at the backslash-escaped
+// quote and leave `posts.` exposed to the scan.
+(Author as any).hasMany("commentsWithBackslashLiteralThroughRef", {
+  className: "Comment",
+  through: "posts",
+  source: "comments",
+  scope: (rel: any) => rel.where("comments.body = 'don\\'t touch posts.title here'"),
+});
+
 // Positive control: a GENUINE through-table (`posts.`) qualifier — unquoted, a
 // real column reference — must still be relocated onto the through query. Pins
 // that stripping string literals does not break the true-positive path.
@@ -96,6 +107,17 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     // And the through query must not carry the source predicate.
     const scope = (loader as any)._buildThroughScope();
     expect(scope.toSql()).not.toContain("mention posts.title here");
+  });
+
+  it("does not relocate when a backslash-escaped-quote literal embeds the through table name", () => {
+    const david = authors("david");
+    const loader = throughLoader([david], "commentsWithBackslashLiteralThroughRef");
+    const partition = (loader as any)._partitionReflectionWhere();
+    expect(partition.throughPredicates).toHaveLength(0);
+    expect(partition.sourcePredicates).toHaveLength(1);
+
+    const scope = (loader as any)._buildThroughScope();
+    expect(scope.toSql()).not.toContain("posts.title");
   });
 
   it("relocates a genuine through-table qualifier onto the through query", () => {


### PR DESCRIPTION
## What

The through-association preloader relocates a raw-SQL WHERE condition that
references the through table onto the through query, deciding via a text scan
for a `<table>.` qualifier (`rawSqlReferencesTable` /
`rawSqlReferencesForeignTable` in `through-association.ts`). Because it scanned
the raw SQL text rather than parsing it, a `<table>.` qualifier embedded in a
string literal — e.g. `where("note = 'see memberships.x'")` — was a false
positive and would relocate a *source*-table predicate onto the through query.

## Approach

Chose acceptance-criteria option (a): make the raw-SQL attribution robust.
Added `stripSqlStringLiterals`, which blanks single-quoted string literals
(preserving length) before the qualifier scan in both raw-SQL helpers, so only
genuine column qualifiers match. The strip regex `/'(?:[^'\\]|''|\\.)*'/g`
consumes both escape forms found inside a literal: SQL-standard doubled quotes
(`''`) and a backslash-escaped char (`\'`, `\\`), the latter being
MySQL/MariaDB's default. Double-quoted identifiers and `?` placeholders are
unaffected.

Converging to Rails' single-query JOIN `through_scope` strategy (option b) —
which would remove the text-attribution apparatus entirely — was out of scope
for this ~60 LOC story and is tracked separately as
`0054-nested-through-association-fidelity/converge-through-preload-single-query-join`.

### Known limitation

Only single-quoted literals are tokenized; double-quoted identifiers are not.
Two double-quoted identifiers each containing a stray apostrophe (e.g.
`"note's"`) can pair their apostrophes as a bogus literal and blank a genuine
qualifier between them. This needs apostrophe-bearing quoted identifiers —
pathological for canonical table/column names — so it is documented in the
`stripSqlStringLiterals` docstring as an accepted limitation rather than carrying
a full SQL tokenizer here.

## Test

Added four tests in `through-association-scope.test.ts`:

- a source predicate whose string literal embeds the through table name
  (`posts.`), asserting it stays on the source preloader and is not carried onto
  the through query;
- the same false-positive class with a backslash-escaped quote inside the
  literal (`\'`, MySQL/MariaDB default);
- a genuine through-table qualifier following an escaped-backslash literal
  (`'a\\' AND posts.title …`), pinning that it stays exposed and IS relocated;
- a positive control: a genuine unquoted `posts.title` qualifier still relocates
  onto the through query.

The four `a1-eager-sti-through` `favoriteClub` tests and the existing hash/Arel
relocation tests still pass.

Closes-story: preloader-through-rawsql-condition-text-attribution

---

### Review notes

- **`\'`-escaped quotes (MySQL/MariaDB default):** fixed — the strip regex is
  `/'(?:[^'\\]|''|\\.)*'/g`, consuming both `''` and `\<char>` escape forms.
- **Escaped-backslash-then-close-quote (`'a\\'`) over-swallow:** verified NOT a
  bug. The `\\.` alternative pairs each backslash with its next char, so `\\` is
  consumed as one unit and a real close-quote right after it closes the literal;
  a genuine qualifier following it (`... 'a\\' AND posts.title ...`) stays
  exposed and is still relocated. Pinned by the
  "still sees a genuine qualifier after an escaped-backslash literal" test.
- **Double-quoted-identifier apostrophe pairing:** accepted as a documented
  limitation (see Known limitation above); pathological for canonical
  identifiers, not worth a full SQL tokenizer.
