### PR TITLE
fix(activemodel): serialize decimal attribute as scalar type="decimal" in toXml

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -19,6 +19,7 @@ import {
   type RenameKeyOptions,
   htmlEscape,
   resetCallbacks as asResetCallbacks,
+  BigDecimal,
 } from "@blazetrails/activesupport";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import {
@@ -2382,9 +2383,15 @@ export class Model {
         !(value instanceof Temporal.PlainDateTime) &&
         !(value instanceof Temporal.PlainDate) &&
         !(value instanceof Temporal.PlainTime) &&
-        !(value instanceof Temporal.ZonedDateTime)
+        !(value instanceof Temporal.ZonedDateTime) &&
+        // boundary: a decimal attribute materializes as a BigDecimal object,
+        // but Rails serializes BigDecimal#to_xml as a scalar `type="decimal"`
+        // leaf (its `to_s`), not a nested object of its digit parts.
+        !(value instanceof BigDecimal)
       ) {
         xml += `${indent}<${tag}>\n${this._hashToXml(value as Record<string, unknown>, indent + "  ", skipTypes, typeInfo.nested[key] ?? EMPTY_XML_TYPE_INFO, renameOptions)}${indent}</${tag}>\n`;
+      } else if (value instanceof BigDecimal) {
+        xml += `${indent}<${tag}${typeAttr(castTypeName ?? "decimal")}>${this._escapeXml(value.toString())}</${tag}>\n`;
         // boundary: legacy Date values serialize as ISO 8601 dateTime XML.
       } else if (value instanceof Date) {
         xml += `${indent}<${tag}${typeAttr("dateTime")}>${Number.isNaN(value.getTime()) ? "" : value.toISOString()}</${tag}>\n`;

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -858,6 +858,22 @@ describe("toXml()", () => {
     expect(xml).toContain('<id type="integer">7</id>');
   });
 
+  it("serializes a decimal attribute as a scalar type=decimal, not a nested object", () => {
+    // A decimal attribute materializes as a BigDecimal object carrying
+    // sign/intDigits/fracDigits. Rails serializes BigDecimal#to_xml as a
+    // scalar `type="decimal"` leaf (its `to_s`), not nested sub-tags.
+    class Widget extends Model {
+      static {
+        this.attribute("price", "decimal");
+      }
+    }
+    const w = new Widget({ price: "9.99" });
+    const xml = w.toXml();
+    expect(xml).toContain('<price type="decimal">9.99</price>');
+    expect(xml).not.toContain("<intDigits>");
+    expect(xml).not.toContain("<fracDigits>");
+  });
+
   it("supports custom root element", () => {
     class User extends Model {
       static {


### PR DESCRIPTION
## What

A `decimal` attribute's value in `serializableHash` is a `BigDecimal` object
(carrying `sign`/`intDigits`/`fracDigits`), not a scalar. In `Model#_hashToXml`
it therefore hit the plain-object recursion branch and serialized as nested
sub-tags (`<intDigits>`/`<fracDigits>`). Rails serializes `BigDecimal#to_xml`
as a scalar `type="decimal"` leaf.

This treats a `BigDecimal` value as a leaf, rendering its fixed-form string,
so a decimal attribute serializes as `<price type="decimal">9.99</price>`.

## Test

Regression test in `serialization.test.ts` asserting the full
`<price type="decimal">9.99</price>` tag and the absence of nested sub-tags.

Closes-story: model-toxml-decimal-scalar-serialization