### PR TITLE
fix(schema): drop type for :virtual column with no type: option (Rails no-fallback)

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
@@ -13,6 +13,20 @@ describe("SchemaCreation#typeToSql blank type guard", () => {
   });
 });
 
+describe("SchemaCreation#typeToSql virtual / nil pass-through", () => {
+  it("returns '' for a nil type (Rails type_to_sql: type.to_s of nil)", () => {
+    expect(new SchemaCreation("sqlite").typeToSql(undefined as any)).toBe("");
+  });
+
+  it("passes 'virtual' through verbatim, with no options.type/string fallback", () => {
+    // Rails' type_to_sql has no :virtual case, so type_to_sql(:virtual) → "virtual".
+    // The :virtual → options[:type] mapping is newColumnDefinition-only.
+    expect(
+      new SchemaCreation("sqlite").typeToSql("virtual" as any, { type: "integer" } as any),
+    ).toBe("virtual");
+  });
+});
+
 describe("SchemaCreation drop-constraint visitors", () => {
   it("visit_DropForeignKey emits DROP CONSTRAINT with a quoted name", () => {
     const sc = new SchemaCreation("postgres") as any;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -510,7 +510,16 @@ export class SchemaCreation {
         // fragment carrying a value list or args — e.g. enum('text','blob') or
         // set('a','b') — must keep its quoted member values, where case is
         // significant.
-        if (!type || !String(type).trim()) {
+        // Rails' `type_to_sql` returns `type.to_s` for an unrecognized type, so
+        // a nil type (e.g. `t.virtual` with no `type:`) yields `""` — the column
+        // renders with no SQL type before its generated-column `AS (...)` clause.
+        // We keep the stricter blank-string guard for an explicitly empty type
+        // string (a likely developer typo), which never arises from a nil option.
+        if (type == null) {
+          sql = "";
+          break;
+        }
+        if (!String(type).trim()) {
           throw new Error(`Column has an empty or blank type — specify a valid SQL type`);
         }
         sql = String(type);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -494,13 +494,13 @@ export class SchemaCreation {
         else if (this.adapterName === "mysql") sql = "BIGINT AUTO_INCREMENT PRIMARY KEY";
         else sql = "INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL";
         break;
-      case "virtual": {
-        // Resolve to the real column type declared via options.type (Rails pattern:
-        // newColumnDefinition maps :virtual → options[:type] before SQL generation).
-        const realType =
-          ((options as Record<string, unknown>)["type"] as ColumnType | undefined) ?? "string";
-        return this.typeToSql(realType, options);
-      }
+      // No `:virtual` case: Rails' `type_to_sql` (schema_statements.rb:1385) has
+      // no `:virtual` in `native_database_types`, so `type_to_sql(:virtual)`
+      // returns `type.to_s` → "virtual" via the pass-through below. The
+      // :virtual → options[:type] mapping happens only in `newColumnDefinition`
+      // (with no fallback), so `o.type` is never literally "virtual" by the time
+      // it reaches this visitor — a `?? options.type ?? "string"` fallback here
+      // would contradict that no-fallback semantics.
       default: {
         // Pass-through for adapter-specific type strings (e.g.
         // "timestamptz", "inet", "hstore", custom PG enum names).

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -189,6 +189,16 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
     );
   });
 
+  it("drops the type for a virtual column with no type option (Rails no-fallback)", () => {
+    const td = new MyTd("t", { id: false });
+    td.column("full_name", "virtual" as any, { as: "CONCAT(a, b)" } as any);
+    const col = td.columns.find((c) => c.name === "full_name")!;
+    expect(col.type).toBeUndefined();
+    const sql = toSql(td);
+    expect(sql).toContain("`full_name`  AS (CONCAT(a, b))");
+    expect(sql).not.toContain("varchar");
+  });
+
   it("honors id: false (no primary key column)", () => {
     const td = new MyTd("logs", { id: false });
     td.string("body");

--- a/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-definitions.ts
@@ -162,7 +162,10 @@ export class TableDefinition extends AbstractTableDefinition {
       (options as any).limit = (options as any).limit ?? 8;
       (options as any).primaryKey = true;
     } else if (resolvedType === "virtual") {
-      resolvedType = options.type ?? resolvedType;
+      // Rails: `type = options[:type]` with no fallback (mysql/schema_definitions.rb).
+      // A `t.virtual` without `type:` drops the type (nil), so the generated
+      // column renders with no SQL type before its `AS (...)` clause.
+      resolvedType = options.type as string;
     } else {
       const unsignedMatch = /^unsigned_(.+)$/.exec(resolvedType);
       if (unsignedMatch) {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -115,6 +115,19 @@ describe("TableDefinition", () => {
     expect(td.unlogged).toBe(true);
   });
 
+  it("drops the type for a virtual column with no type option (Rails no-fallback)", () => {
+    const td = new TableDefinition("articles");
+    const col = td.newColumnDefinition(
+      "full_name",
+      "virtual" as any,
+      {
+        as: "a || b",
+        stored: true,
+      } as any,
+    );
+    expect(col.type).toBeUndefined();
+  });
+
   it("newExclusionConstraintDefinition returns definition without pushing", () => {
     const td = new TableDefinition("products");
     const defn = td.newExclusionConstraintDefinition("price WITH =", { name: "pc" });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.test.ts
@@ -115,19 +115,6 @@ describe("TableDefinition", () => {
     expect(td.unlogged).toBe(true);
   });
 
-  it("drops the type for a virtual column with no type option (Rails no-fallback)", () => {
-    const td = new TableDefinition("articles");
-    const col = td.newColumnDefinition(
-      "full_name",
-      "virtual" as any,
-      {
-        as: "a || b",
-        stored: true,
-      } as any,
-    );
-    expect(col.type).toBeUndefined();
-  });
-
   it("newExclusionConstraintDefinition returns definition without pushing", () => {
     const td = new TableDefinition("products");
     const defn = td.newExclusionConstraintDefinition("price WITH =", { name: "pc" });
@@ -189,6 +176,16 @@ describe("TableDefinition#toSql", () => {
     td.string("name");
     expect(toSql(td)).toMatch(/^CREATE TABLE/);
     expect(toSql(td)).not.toContain("UNLOGGED");
+  });
+
+  it("drops the type for a virtual column with no type option (Rails no-fallback)", () => {
+    const td = new TableDefinition("articles", { id: false });
+    td.column("full_name", "virtual" as any, { as: "a || b", stored: true } as any);
+    const col = td.columns.find((c) => c.name === "full_name")!;
+    expect(col.type).toBeUndefined();
+    const sql = toSql(td);
+    expect(sql).toContain('"full_name"  GENERATED ALWAYS AS (a || b) STORED');
+    expect(sql).not.toContain("varchar");
   });
 
   it("emits exclusion constraint in CREATE TABLE", () => {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-definitions.ts
@@ -217,7 +217,10 @@ export class TableDefinition extends AbstractTableDefinition {
     options: ColumnOptions = {},
   ): ColumnDefinition {
     if ((type as string) === "virtual") {
-      type = options.type ?? type;
+      // Rails: `type = options[:type]` with no fallback (postgresql/schema_definitions.rb).
+      // Without `type:`, the type drops to nil and the generated column renders
+      // with no SQL type before its `GENERATED ALWAYS AS (...) STORED` clause.
+      type = options.type as ColumnType;
     }
     const def = super.newColumnDefinition(name, type, options);
     // Record the physical storage type for datetime-family columns so the

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.test.ts
@@ -29,6 +29,17 @@ describe("SQLite3::TableDefinition", () => {
     expect(col.type).toBe("string");
   });
 
+  it("drops the type for a virtual column with no type option (Rails no-fallback)", () => {
+    const td = new TableDefinition("articles", { id: false });
+    td.column("full_name", "virtual" as any, { as: "a || b" } as any);
+    const col = td.columns.find((c) => c.name === "full_name")!;
+    expect(col.type).toBeUndefined();
+    const sql = new SchemaCreation("sqlite", (td as any)._adapter).accept(td);
+    expect(sql).toContain('"full_name"  GENERATED ALWAYS AS (a || b)');
+    expect(sql).not.toContain("varchar");
+    expect(sql).not.toContain("VARCHAR");
+  });
+
   it("emits GENERATED ALWAYS AS ... STORED via visitor", () => {
     const td = new TableDefinition("items", { id: false });
     td.column("x", "integer");

--- a/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/schema-definitions.ts
@@ -43,7 +43,10 @@ export class TableDefinition extends AbstractTableDefinition {
     options: ColumnOptions = {},
   ): ColumnDefinition {
     if (type === ("virtual" as ColumnType)) {
-      type = options.type ?? ("string" as ColumnType);
+      // Rails: `type = options[:type]` with no fallback (sqlite3/schema_definitions.rb).
+      // Without `type:`, the type drops to nil and the generated column renders
+      // with no SQL type before its `AS (...)` clause.
+      type = options.type as ColumnType;
     }
     return super.newColumnDefinition(name, type, options);
   }


### PR DESCRIPTION
## Summary

`new_column_definition` for a `:virtual` positional type diverged from Rails in
the no-`type:` case. Rails sets `type = options[:type]` with **no fallback**
(mysql/pg/sqlite `schema_definitions.rb`), so `t.virtual` without `type:` yields
a nil type and the generated column renders with no SQL type before its
`AS (...)` clause. trails instead kept the literal `"virtual"` (mysql/pg) or
defaulted to `"string"` (sqlite), emitting a bogus `VARCHAR`.

## Changes

- Converge mysql/pg/sqlite `newColumnDefinition` to `type = options.type` with
  no fallback.
- Make the abstract `typeToSql` return `""` for a nil/undefined type, mirroring
  Rails `type_to_sql`'s `type.to_s` (nil → `""`). The stricter blank-string
  guard is retained for an *explicitly* empty type string (a likely developer
  typo), which never arises from a nil option.
- Add per-adapter tests exercising `t.virtual` with no `type:` (no Rails test
  covers this case; all Rails virtual tests pass `type:`), asserting the column
  type is dropped and no `VARCHAR` is emitted.

## Verification

- `api:compare` / `test:compare` delta non-negative (method surface unchanged).
- Adapter schema-definition, schema-creation, and schema-dumper suites pass.

Closes-story: virtual-type-no-fallback-converge