### PR TITLE
test(transactions): run failed-rollback instrumentation on non-in-memory adapters

### DIFF
--- a/packages/activerecord/src/transaction-instrumentation.test.ts
+++ b/packages/activerecord/src/transaction-instrumentation.test.ts
@@ -6,6 +6,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import type { NotificationSubscriber } from "@blazetrails/activesupport";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { topicFixtureData } from "./test-helpers/fixtures/topics.js";
+import { inMemoryDb } from "./test-adapter.js";
 
 // Mirrors `transaction_instrumentation_test.rb`, which runs under
 // `ActiveRecord::TestCase` with `self.use_transactional_tests = false` and
@@ -383,16 +384,68 @@ describe("TransactionInstrumentationTest", () => {
     expect(events).toHaveLength(1);
   });
 
-  // PERMANENT-SKIP (both cases): Rails wraps `test_transaction_instrumentation_on_failed_rollback`
-  // and `..._when_unmaterialized` in a single `unless in_memory_db?` block
+  // Rails wraps `test_transaction_instrumentation_on_failed_rollback` and
+  // `..._when_unmaterialized` in a single `unless in_memory_db?` block
   // (transaction_instrumentation_test.rb:390-417), so neither runs against an
   // in-memory database. A failed DB rollback drives `@connection.throw_away!`,
-  // discarding the connection — for the in-memory SQLite database the canonical
-  // adapter uses, that destroys the schema and breaks per-test teardown, exactly
-  // as Rails skips it. See UNPORTED_FILES.
-  it.skip("transaction instrumentation on failed rollback", () => {});
+  // discarding the connection — for an in-memory SQLite database that destroys
+  // the schema and breaks per-test teardown, so we mirror the gate and skip
+  // only when the adapter is genuinely in-memory (PG/MySQL lanes run these).
+  const describeNonInMemory = inMemoryDb() ? describe.skip : describe;
+  describeNonInMemory("failed rollback (non in-memory only)", () => {
+    it("transaction instrumentation on failed rollback", async () => {
+      const events: any[] = [];
+      Notifications.subscribe("transaction.active_record", (event: any) => {
+        events.push(event);
+      });
 
-  it.skip("transaction instrumentation on failed rollback when unmaterialized", () => {});
+      const MyError = class extends Error {};
+      // Rails stubs the leased connection's `rollback_db_transaction` to raise;
+      // the materialized transaction's ROLLBACK fails, so the manager throws the
+      // connection away and finishes the transaction as `:incomplete`.
+      const conn = Base.connection;
+      vi.spyOn(conn as any, "rollbackDbTransaction").mockImplementationOnce(async () => {
+        throw new MyError("rollback failed");
+      });
+
+      await expect(
+        Topic.transaction(async () => {
+          await topics("fifth").update({ title: "Ruby on Rails" });
+          throw new Rollback();
+        }),
+      ).rejects.toThrow(MyError);
+
+      expect(events).toHaveLength(1);
+      expect(events[0].payload.outcome).toBe("incomplete");
+    });
+
+    it("transaction instrumentation on failed rollback when unmaterialized", async () => {
+      const events: any[] = [];
+      Notifications.subscribe("transaction.active_record", (event: any) => {
+        events.push(event);
+      });
+
+      const MyError = class extends Error {};
+      // Rails stubs `transaction_manager.rollback_transaction` to simulate an
+      // error while the transaction is still unmaterialized — no BEGIN was ever
+      // issued, so no `transaction.active_record` notification fires even though
+      // the connection is discarded.
+      const conn = Base.connection;
+      vi.spyOn((conn as any).transactionManager, "rollbackTransaction").mockImplementationOnce(
+        async () => {
+          throw new MyError("rollback failed");
+        },
+      );
+
+      await expect(
+        Topic.transaction(async () => {
+          throw new Rollback();
+        }),
+      ).rejects.toThrow(MyError);
+
+      expect(events).toHaveLength(0);
+    });
+  });
 
   it("transaction instrumentation on broken subscription", async () => {
     const MyError = class extends Error {};

--- a/packages/activerecord/src/transaction-instrumentation.test.ts
+++ b/packages/activerecord/src/transaction-instrumentation.test.ts
@@ -387,64 +387,64 @@ describe("TransactionInstrumentationTest", () => {
   // Rails wraps `test_transaction_instrumentation_on_failed_rollback` and
   // `..._when_unmaterialized` in a single `unless in_memory_db?` block
   // (transaction_instrumentation_test.rb:390-417), so neither runs against an
-  // in-memory database. A failed DB rollback drives `@connection.throw_away!`,
-  // discarding the connection — for an in-memory SQLite database that destroys
-  // the schema and breaks per-test teardown, so we mirror the gate and skip
-  // only when the adapter is genuinely in-memory (PG/MySQL lanes run these).
-  const describeNonInMemory = inMemoryDb() ? describe.skip : describe;
-  describeNonInMemory("failed rollback (non in-memory only)", () => {
-    it("transaction instrumentation on failed rollback", async () => {
-      const events: any[] = [];
-      Notifications.subscribe("transaction.active_record", (event: any) => {
-        events.push(event);
-      });
+  // in-memory database: a failed DB rollback drives `@connection.throw_away!`,
+  // discarding the connection — for a bare `:memory:` SQLite DB that destroys
+  // the schema and breaks per-test teardown. We mirror the gate with
+  // `it.skipIf(inMemoryDb())`, so these skip only on a genuinely in-memory
+  // adapter and run on the PG/MySQL (and file-backed SQLite) lanes.
+  const itNonInMemory = it.skipIf(inMemoryDb());
 
-      const MyError = class extends Error {};
-      // Rails stubs the leased connection's `rollback_db_transaction` to raise;
-      // the materialized transaction's ROLLBACK fails, so the manager throws the
-      // connection away and finishes the transaction as `:incomplete`.
-      const conn = Base.connection;
-      vi.spyOn(conn as any, "rollbackDbTransaction").mockImplementationOnce(async () => {
+  itNonInMemory("transaction instrumentation on failed rollback", async () => {
+    const events: any[] = [];
+    Notifications.subscribe("transaction.active_record", (event: any) => {
+      events.push(event);
+    });
+
+    const MyError = class extends Error {};
+    // Rails stubs the leased connection's `rollback_db_transaction` to raise;
+    // the materialized transaction's ROLLBACK fails, so the manager throws the
+    // connection away and finishes the transaction as `:incomplete`.
+    const conn = Base.connection;
+    vi.spyOn(conn as any, "rollbackDbTransaction").mockImplementationOnce(async () => {
+      throw new MyError("rollback failed");
+    });
+
+    await expect(
+      Topic.transaction(async () => {
+        await topics("fifth").update({ title: "Ruby on Rails" });
+        throw new Rollback();
+      }),
+    ).rejects.toThrow(MyError);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].payload.outcome).toBe("incomplete");
+  });
+
+  itNonInMemory("transaction instrumentation on failed rollback when unmaterialized", async () => {
+    const events: any[] = [];
+    Notifications.subscribe("transaction.active_record", (event: any) => {
+      events.push(event);
+    });
+
+    const MyError = class extends Error {};
+    // Rails stubs `transaction_manager.rollback_transaction` to simulate an
+    // error while the transaction is still unmaterialized — no BEGIN was ever
+    // issued, so no `transaction.active_record` notification fires even though
+    // the connection is discarded.
+    const conn = Base.connection;
+    vi.spyOn((conn as any).transactionManager, "rollbackTransaction").mockImplementationOnce(
+      async () => {
         throw new MyError("rollback failed");
-      });
+      },
+    );
 
-      await expect(
-        Topic.transaction(async () => {
-          await topics("fifth").update({ title: "Ruby on Rails" });
-          throw new Rollback();
-        }),
-      ).rejects.toThrow(MyError);
+    await expect(
+      Topic.transaction(async () => {
+        throw new Rollback();
+      }),
+    ).rejects.toThrow(MyError);
 
-      expect(events).toHaveLength(1);
-      expect(events[0].payload.outcome).toBe("incomplete");
-    });
-
-    it("transaction instrumentation on failed rollback when unmaterialized", async () => {
-      const events: any[] = [];
-      Notifications.subscribe("transaction.active_record", (event: any) => {
-        events.push(event);
-      });
-
-      const MyError = class extends Error {};
-      // Rails stubs `transaction_manager.rollback_transaction` to simulate an
-      // error while the transaction is still unmaterialized — no BEGIN was ever
-      // issued, so no `transaction.active_record` notification fires even though
-      // the connection is discarded.
-      const conn = Base.connection;
-      vi.spyOn((conn as any).transactionManager, "rollbackTransaction").mockImplementationOnce(
-        async () => {
-          throw new MyError("rollback failed");
-        },
-      );
-
-      await expect(
-        Topic.transaction(async () => {
-          throw new Rollback();
-        }),
-      ).rejects.toThrow(MyError);
-
-      expect(events).toHaveLength(0);
-    });
+    expect(events).toHaveLength(0);
   });
 
   it("transaction instrumentation on broken subscription", async () => {

--- a/scripts/api-compare/unported-files.ts
+++ b/scripts/api-compare/unported-files.ts
@@ -850,17 +850,6 @@ export const UNPORTED_FILES: UnportedFile[] = [
       "single-database test environment.",
   },
   {
-    testFile: "transaction_instrumentation_test.rb",
-    tests: ["transaction instrumentation on failed rollback"],
-    reason:
-      "Rails gates this with `unless in_memory_db?` " +
-      "(transaction_instrumentation_test.rb:391). A failed DB rollback drives " +
-      "`@connection.throw_away!`, discarding the connection — for the in-memory " +
-      "SQLite database the canonical test adapter uses, that destroys the " +
-      "schema/data and breaks per-test fixture teardown, exactly the case Rails " +
-      "skips.",
-  },
-  {
     testFile: "database_selector_test.rb",
     tests: ["preventing writes works in a threaded environment"],
     reason:


### PR DESCRIPTION
## What

Un-skips the two `unless in_memory_db?`-gated transaction-instrumentation
cases and runs them against the CI-selected non-in-memory adapters
(PG/MySQL/file-backed sqlite lanes), mirroring
`transaction_instrumentation_test.rb:390-417`:

- `transaction instrumentation on failed rollback` — stubs the leased
  connection's `rollbackDbTransaction` to raise so the materialized ROLLBACK
  fails; the manager throws the connection away and finishes the transaction as
  `:incomplete`. Asserts the `:incomplete` outcome payload fires.
- `transaction instrumentation on failed rollback when unmaterialized` — stubs
  the transaction manager's `rollbackTransaction` to raise while the
  transaction is still unmaterialized; asserts no `transaction.active_record`
  notification fires (connection discarded, no BEGIN ever issued).

Both cases use `it.skipIf(inMemoryDb())`, keeping them flat siblings of the
rest of the `TransactionInstrumentationTest` class (they belong to the same
Rails class, just inside its `unless in_memory_db?` block) rather than in an
artificial sub-group. The gate skips only on a genuinely in-memory adapter, so
they run on PG/MySQL and file-backed SQLite.

Also drops the now-stale `unported-files.ts` entry that listed
`transaction instrumentation on failed rollback` as unported, so parity
metrics reflect the port.

## Why

Previously both were permanent `it.skip`s (PR #4358) because a failed DB
rollback drives `throwAway!`, which destroys the schema on a bare `:memory:`
SQLite DB. trails had no coverage of that path on the PG/MySQL lanes.

## Testing

- PG lane (`PG_TEST_URL=...`): both new cases run and pass.
- MySQL lane (`MYSQL_TEST_URL=...`): both run and pass.
- file-backed SQLite lane: both run and pass.
- bare `:memory:` SQLite: skipped via `inMemoryDb()`.

Closes-story: run-failed-rollback-instrumentation-on-non-in-memory-adapters
