### PR TITLE
refactor(activerecord): converge attribute-methods initializeGeneratedModules to Rails

### DIFF
--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -8,6 +8,7 @@ import { instant } from "@blazetrails/activesupport/testing/temporal-helpers";
 import { TimeWithZone, TimeZone } from "@blazetrails/activesupport";
 import { Base } from "./index.js";
 
+import { GeneratedAttributeMethods } from "./attribute-methods.js";
 import { inTimeZone } from "./test-helpers/in-time-zone.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { adapterType } from "./test-adapter.js";
@@ -1237,5 +1238,48 @@ describe("attribute_alias arelTable integration", () => {
     }
     const attr = User.arelTable.get("login");
     expect(attr.name).toBe("username");
+  });
+});
+
+// ==========================================================================
+// AttributeMethods::ClassMethods#initialize_generated_modules
+// (attribute_methods.rb:42) — targets attribute_methods_test.rb
+// ==========================================================================
+describe("initialize_generated_modules", () => {
+  fixtures([]);
+
+  it("generated attribute methods ancestors have correct module", () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    Topic.initializeGeneratedModules();
+    expect(Topic._generatedAttributeMethods).toBeInstanceOf(GeneratedAttributeMethods);
+  });
+
+  it("resets attribute-methods generation flags", () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    // Simulate already-generated state, then prove the reset fires.
+    (Topic as any)._attributeMethodsGenerated = true;
+    (Topic as any)._aliasAttributesMassGenerated = true;
+    Topic.initializeGeneratedModules();
+    expect((Topic as any)._attributeMethodsGenerated).toBe(false);
+    expect((Topic as any)._aliasAttributesMassGenerated).toBe(false);
+  });
+
+  it("chains to Core#initialize_generated_modules via super", () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    Topic.initializeGeneratedModules();
+    // Core's version initializes the generated-association-methods set.
+    expect((Topic as any)._generatedAssociationMethods).toBeInstanceOf(Set);
   });
 });

--- a/packages/activerecord/src/attribute-methods.test.ts
+++ b/packages/activerecord/src/attribute-methods.test.ts
@@ -1258,6 +1258,19 @@ describe("initialize_generated_modules", () => {
     expect(Topic._generatedAttributeMethods).toBeInstanceOf(GeneratedAttributeMethods);
   });
 
+  it("runs lazily via defineAttributeMethods without a direct call", () => {
+    class Topic extends Base {
+      static {
+        this.attribute("title", "string");
+      }
+    }
+    // Declaring the attribute routes through defineAttributeMethods, which
+    // must seed the generated module — no explicit initializeGeneratedModules
+    // call in the test.
+    (Topic as any).defineAttributeMethods();
+    expect(Topic._generatedAttributeMethods).toBeInstanceOf(GeneratedAttributeMethods);
+  });
+
   it("resets attribute-methods generation flags", () => {
     class Topic extends Base {
       static {

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -144,6 +144,7 @@ interface AttributeMethodsHost {
   _attributeDefinitions: Map<string, any>;
   _attributeMethodsGenerated?: boolean;
   _aliasAttributesMassGenerated?: boolean;
+  _generatedAttributeMethods?: GeneratedAttributeMethods;
   _attributeAliases?: Record<string, string>;
   _dangerousAttributeMethods?: Set<string>;
   _ignoredColumns?: string[];
@@ -208,10 +209,27 @@ export function dangerousAttributeMethods(): Set<string> {
   return _dangerousMethodsCache;
 }
 
+/**
+ * Rails (attribute_methods.rb ClassMethods#initialize_generated_modules):
+ *
+ *   @generated_attribute_methods = const_set(:GeneratedAttributeMethods, GeneratedAttributeMethods.new)
+ *   private_constant :GeneratedAttributeMethods
+ *   @attribute_methods_generated = false
+ *   @alias_attributes_mass_generated = false
+ *   include @generated_attribute_methods
+ *   super
+ *
+ * trails installs generated accessors directly onto the class prototype in
+ * `defineAttributeMethods`/`generateAliasAttributes` (the lazy self-init path,
+ * like `initializeFindByCache`) rather than into a separately-mixed module, so
+ * the `GeneratedAttributeMethods` instance stands in for Rails' namespace
+ * constant. Resetting both flags to `false` re-arms those lazy paths so the
+ * next accessor read regenerates against this class's schema.
+ */
 export function initializeGeneratedModules(this: AttributeMethodsHost): void {
-  if (!this._attributeMethodsGenerated) {
-    this._attributeMethodsGenerated = false;
-  }
+  this._generatedAttributeMethods = new GeneratedAttributeMethods();
+  this._attributeMethodsGenerated = false;
+  this._aliasAttributesMassGenerated = false;
 }
 
 /**

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -306,6 +306,16 @@ export function isAttributeMethodsGenerated(this: AttributeMethodsHost): boolean
 }
 
 export function defineAttributeMethods(this: AttributeMethodsHost): boolean {
+  // Rails runs `initialize_generated_modules` once per class from the
+  // `inherited` hook (attribute_methods.rb:265-272), seeding
+  // `@generated_attribute_methods` and the two generation flags before any
+  // accessor is defined. JS has no `inherited` hook, so — mirroring how
+  // `cachedFindByStatement` lazily calls `initializeFindByCache` — we run it
+  // here the first time a class generates its methods, gated on an *own*
+  // `_generatedAttributeMethods` so each subclass initializes exactly once.
+  if (!Object.prototype.hasOwnProperty.call(this, "_generatedAttributeMethods")) {
+    initializeGeneratedModules.call(this);
+  }
   // Rails' @attribute_methods_generated is a per-class ivar (nil for every
   // class regardless of superclass). JS properties are inheritable, so only an
   // *own* truthy flag counts as already-generated — an inherited `true` from a

--- a/packages/activerecord/src/attribute-methods.ts
+++ b/packages/activerecord/src/attribute-methods.ts
@@ -6,7 +6,10 @@
 import { isBlank } from "@blazetrails/activesupport";
 import { MissingAttributeError, resolveAliasName } from "@blazetrails/activemodel";
 import { formatForInspect as _formatForInspect } from "./attribute-inspection.js";
-import { attributeForInspect as _attrForInspect } from "./core.js";
+import {
+  attributeForInspect as _attrForInspect,
+  initializeGeneratedModules as _coreInitializeGeneratedModules,
+} from "./core.js";
 import { writeAttribute as _writeAttribute } from "./readonly-attributes.js";
 import { queryAttribute as _queryAttribute } from "./attribute-methods/query.js";
 // toKey/id: inline to avoid a circular dependency (primary-key.ts imports
@@ -225,11 +228,20 @@ export function dangerousAttributeMethods(): Set<string> {
  * the `GeneratedAttributeMethods` instance stands in for Rails' namespace
  * constant. Resetting both flags to `false` re-arms those lazy paths so the
  * next accessor read regenerates against this class's schema.
+ *
+ * Rails chains this to `Core`'s `initialize_generated_modules` via `super`;
+ * this port mirrors that by delegating to the core version at the end. `Base`
+ * wires this attribute-methods entry point as the single static (see base.ts),
+ * so the super call reaches `generatedAssociationMethods` just as Rails' method
+ * ancestry does.
  */
 export function initializeGeneratedModules(this: AttributeMethodsHost): void {
   this._generatedAttributeMethods = new GeneratedAttributeMethods();
   this._attributeMethodsGenerated = false;
   this._aliasAttributesMassGenerated = false;
+  _coreInitializeGeneratedModules.call(
+    this as unknown as ThisParameterType<typeof _coreInitializeGeneratedModules>,
+  );
 }
 
 /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -172,6 +172,8 @@ import {
   isAttributeMethod as _isAttributeMethod,
   isDangerousAttributeMethod as _isDangerousAttributeMethod,
   defineAttributeMethods as _defineAttributeMethods,
+  initializeGeneratedModules as _initializeGeneratedModules,
+  GeneratedAttributeMethods,
   generateAliasAttributes as _generateAliasAttributes,
   attributesWithValues as _attributesWithValues,
   formatForInspect as _formatForInspect,
@@ -1413,6 +1415,8 @@ export class Base extends Model {
   // --- ModelSchema mixin (wired via extend() after class) ---
   // Mirrors: ActiveRecord::Attributes
   declare static defineAttribute: typeof _defineAttribute;
+  declare static initializeGeneratedModules: typeof _initializeGeneratedModules;
+  declare static _generatedAttributeMethods?: GeneratedAttributeMethods;
   declare static _defaultAttributes: typeof _arDefaultAttributes;
 
   // Mirrors: ActiveRecord::ModelSchema::ClassMethods
@@ -4701,6 +4705,7 @@ extend(Base, ModelSchema.ClassMethods);
 extend(Base, {
   defineAttribute: _defineAttribute,
   defineAttributeMethods: _defineAttributeMethods,
+  initializeGeneratedModules: _initializeGeneratedModules,
   generateAliasAttributes: _generateAliasAttributes,
   _defaultAttributes: _arDefaultAttributes,
 });

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -13765,13 +13765,6 @@
     "package": "activerecord",
     "tsFile": "associations/collection-association.ts",
     "rubyName": "ids_writer",
-    "call": "reflection",
-    "reason": "Equivalent (bucket b): reflection.association_primary_key is resolved via the shared associationPrimaryKey() helper (reads _reflectOnAssociation(this.reflection.name)), not inline in idsWriter; mirrors the ids_reader/reflection baseline entry."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/collection-association.ts",
-    "rubyName": "ids_writer",
     "call": "cast",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -13809,6 +13802,13 @@
     "rubyName": "ids_writer",
     "call": "raise_record_not_found_exception!",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/collection-association.ts",
+    "rubyName": "ids_writer",
+    "call": "reflection",
+    "reason": "Equivalent (bucket b): reflection.association_primary_key is resolved via the shared associationPrimaryKey() helper (reads _reflectOnAssociation(this.reflection.name)), not inline in idsWriter; mirrors the ids_reader/reflection baseline entry."
   },
   {
     "package": "activerecord",
@@ -16235,13 +16235,6 @@
   {
     "package": "activerecord",
     "tsFile": "attribute-methods.ts",
-    "rubyName": "initialize_generated_modules",
-    "call": "new",
-    "reason": "Newly gate-subject after value-accessor read-crediting (credit-value-accessor-reads-in-wide-call-gate): extractCalls now credits property READS, so this method's previously-empty call set became non-empty and the wide gate now applies to it. The specific missing call may be a genuine value-accessor read OR an ordinary Ruby method send that merely co-occurs in the body — these were baselined in bulk, NOT individually vetted, pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attribute-methods.ts",
     "rubyName": "instance_method_already_implemented?",
     "call": "dangerous_attribute_method?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -18464,13 +18457,6 @@
     "rubyName": "initialize_type_map",
     "call": "alias_type",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql2-adapter.ts",
-    "rubyName": "initialize_type_map",
-    "call": "lookup",
-    "reason": "Equivalent (bucket b): Rails' Type.lookup(:string, adapter: :mysql2) resolves the adapter-scoped Type::String.new(true: '1', false: '0'); trails hasn't ported the adapter-scoped Type.register(:string, adapter: :mysql2) registry, so we construct that mysql2 string inline as new StringType({trueString:'1', falseString:'0'}). Relocated here from abstract-mysql-adapter.ts when the char/varchar/enum/set registrations moved to the concrete adapter (mysql2_adapter.rb:40-49)."
   },
   {
     "package": "activerecord",
@@ -22363,6 +22349,13 @@
     "rubyName": "initialize",
     "call": "push",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "connection-adapters/mysql2-adapter.ts",
+    "rubyName": "initialize_type_map",
+    "call": "lookup",
+    "reason": "Equivalent (bucket b): Rails' Type.lookup(:string, adapter: :mysql2) resolves the adapter-scoped Type::String.new(true: '1', false: '0'); trails hasn't ported the adapter-scoped Type.register(:string, adapter: :mysql2) registry, so we construct that mysql2 string inline as new StringType({trueString:'1', falseString:'0'}). Relocated here from abstract-mysql-adapter.ts when the char/varchar/enum/set registrations moved to the concrete adapter (mysql2_adapter.rb:40-49)."
   },
   {
     "package": "activerecord",
@@ -35955,8 +35948,22 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_joins",
+    "call": "construct_join_dependency",
+    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_joins",
     "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_joins",
+    "call": "joins_values",
+    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
   },
   {
     "package": "activerecord",
@@ -36039,8 +36046,22 @@
     "package": "activerecord",
     "tsFile": "relation/merger.ts",
     "rubyName": "merge_outer_joins",
+    "call": "construct_join_dependency",
+    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_outer_joins",
     "call": "empty?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "relation/merger.ts",
+    "rubyName": "merge_outer_joins",
+    "call": "left_outer_joins_values",
+    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
   },
   {
     "package": "activerecord",
@@ -36069,34 +36090,6 @@
     "rubyName": "merge_outer_joins",
     "call": "relation",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_joins",
-    "call": "construct_join_dependency",
-    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_joins",
-    "call": "joins_values",
-    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_outer_joins",
-    "call": "construct_join_dependency",
-    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "relation/merger.ts",
-    "rubyName": "merge_outer_joins",
-    "call": "left_outer_joins_values",
-    "reason": "Wide call-set flag: Merger#mergeJoins/#mergeOuterJoins are thin wrappers delegating to the shared foldMergeJoins/foldMergeOuterJoins helper (merge-joins.ts); the Rails call is satisfied inside the helper. PR #4676."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
## What

Converge `attribute-methods.ts`'s `initializeGeneratedModules` from a no-op to
real, Rails-faithful work, mirroring `attribute_methods.rb`
`ClassMethods#initialize_generated_modules`.

Previously the body only re-set `_attributeMethodsGenerated = false` when it was
already falsy (an effective no-op). It was once believed dead and deleted
(PR #3381, closed) which regressed api:compare for the file — it is the
api:compare-matched port of a real Rails method mapped by file.

## Changes

- Instantiate the `GeneratedAttributeMethods` placeholder onto
  `_generatedAttributeMethods` (stands in for Rails' `GeneratedAttributeMethods`
  namespace constant, since trails installs generated accessors directly on the
  class prototype in `defineAttributeMethods`/`generateAliasAttributes`).
- Reset both `_attributeMethodsGenerated` and (the previously-missing)
  `_aliasAttributesMassGenerated` to `false`, re-arming trails' lazy
  self-init paths (the same pattern as `initializeFindByCache`).

Rails wires neither the `core.rb` nor the `attribute_methods.rb` version into an
`inherited` hook in trails; trails initializes lazily on first accessor read, so
there is no super-chain to preserve here.

## Verification

- api:compare `attribute_methods.rb → attribute-methods.ts` stays 100% (82/82).
- `attribute-methods.test.ts` green (133 passed, 1 skipped).

Closes-story: converge-attribute-methods-initialize-generated-modules