### PR TITLE
fix(activemodel): raise UnknownAttributeError for unknown construction keys

### DIFF
--- a/packages/activemodel/src/error.test.ts
+++ b/packages/activemodel/src/error.test.ts
@@ -215,6 +215,9 @@ describe("ErrorTest", () => {
   it("generateMessage walks ancestor lookup chain", () => {
     class Parent extends Model {
       static i18nScope = "activemodel";
+      static {
+        this.attribute("name", "string");
+      }
       static lookupAncestors() {
         return [this];
       }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -74,7 +74,6 @@ import {
   attributeMethodPatterns,
   isAttributeMethodPatterns,
   isRespondToWithoutAttributes,
-  MissingAttributeError,
 } from "./attribute-methods.js";
 import {
   _assignAttribute as attrAssignOne,
@@ -1486,11 +1485,8 @@ export class Model {
   _dirty!: DirtyTracker;
 
   /**
-   * True only while the constructor is assigning its initial attribute bag.
-   * trails' constructor writes every key through `writeAttribute` directly
-   * (rather than Rails' `assign_attributes` → per-key setter dispatch). The
-   * loop swallows the strict `MissingAttributeError` `writeFromUser` now raises
-   * so construction stays lenient for not-yet-modeled names; this flag lets the
+   * True only while the constructor is assigning its initial attribute bag
+   * through `assign_attributes` (per-key setter dispatch). This flag lets the
    * AR write path detect the window (e.g. composite-PK `id=` remap) without
    * re-raising mid-construction.
    *
@@ -1571,35 +1567,20 @@ export class Model {
     // Attributes#initialize — @attributes = self.class._default_attributes.deep_dup
     this._attributes = ctor._defaultAttributes().deepDup();
 
-    // API#initialize — assign through writeAttribute (casting, normalization).
-    // Dispatches through this (so subclass overrides apply), matching Rails.
+    // API#initialize — assign_attributes(attributes) (api.rb:80-82). Each key is
+    // routed through `_assignAttribute` → setter dispatch, exactly like Rails'
+    // `_assign_attribute` (attribute_assignment.rb:67-75): a key with a writer
+    // (a framework-generated attribute setter, a user-defined `set name`, or a
+    // nested-attribute `<assoc>Attributes=` setter) dispatches through it, and a
+    // genuinely-unknown, writer-less key routes to `attributeWriterMissing`
+    // (→ `UnknownAttributeError`). The `_initializingAttributes` window lets the
+    // AR write path detect construction (e.g. composite-PK `id=` remap) without
+    // re-raising mid-construction. Empty bag is a no-op — mirrors
+    // `assign_attributes`' `return if new_attributes.empty?` (so a subclass
+    // `_assignAttributes` override isn't invoked for `new Model({})`).
     this._initializingAttributes = true;
     try {
-      for (const [key, value] of Object.entries(attrs)) {
-        try {
-          this.writeAttribute(key, value);
-        } catch (error) {
-          // trails' constructor writes every key through `writeAttribute`
-          // directly, rather than Rails' `assign_attributes` → `_assign_attribute`
-          // (api.rb:80-82, attribute_assignment.rb:67-75), which dispatches a key
-          // with a writer and routes a writer-less key to `attribute_writer_missing`
-          // (→ `UnknownAttributeError`). The loop relies on construction staying
-          // lenient for not-yet-modeled names: nested-attribute keys
-          // (`commentsAttributes`, re-applied by `_reapplyNestedAttrSetters`),
-          // composite-PK string keys, and — pre-existing trails behavior, NOT a
-          // regression of this PR (origin/main's lazy `write_from_user` stored
-          // them rather than raising) — genuinely unknown keys.
-          //
-          // Converging this window to Rails (raise `UnknownAttributeError` for a
-          // writer-less key) is a distinct, broad convergence: it requires the
-          // constructor to setter-dispatch like `assign_attributes`, and it
-          // surfaces a cluster of tests that ratified the leniency
-          // (base `initialize with invalid attribute`, the cpk-string nested
-          // path, etc.). Tracked as RFC 0046 story
-          // `converge-construction-unknown-attribute-strict`.
-          if (!(error instanceof MissingAttributeError)) throw error;
-        }
-      }
+      if (Object.keys(attrs).length > 0) this._assignAttributes(attrs);
     } finally {
       this._initializingAttributes = false;
     }

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -351,6 +351,15 @@ describeIfPg("PostgreSQLAdapter", () => {
       // sentinels (the timestamp OID round-trips them as "infinity" / "-infinity").
       class Dev extends Base {
         static tableName = "ts_infinity_dev";
+        // Declare `name` so mass-assignment dispatches its setter: the sibling
+        // `load infinity and beyond` Dev above shares the `ts_infinity_dev`
+        // schema-cache slot but its table has no `name` column, so reflection
+        // alone can leave `name` out of the attribute set — and construction now
+        // raises UnknownAttributeError for an unmodeled key. `updated_at` reflects
+        // from the timestamp column (keeping its infinity-capable OID decoder).
+        static {
+          this.attribute("name", "string");
+        }
       }
       await adapter.exec(`DROP TABLE IF EXISTS ts_infinity_dev`);
       await adapter.exec(

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1071,6 +1071,15 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     // silently swallowed it; the child's setter-dispatched assignment now
     // raises, so map the real columns.
     if (Array.isArray(foreignKey) || Array.isArray(primaryKey)) {
+      // Composite fk/pk: pair each foreign-key column with its owner primary-key
+      // column value. Fully parallel arrays (e.g. `foreign_key: [:author_id,
+      // :book_id]` / `primary_key: [:author_id, :id]`) pair by position; a mixed
+      // shape (scalar FK against a composite-PK target, or an array FK against a
+      // scalar PK) normalizes both to arrays and falls back to `pks[0]`, so a
+      // scalar side reads the leading key component. Coercing an array key to a
+      // string ("author_id,book_id") would produce an unknown attribute —
+      // tolerated only while construction swallowed it; the child's now
+      // setter-dispatched assignment raises, so map the real columns.
       const fks = Array.isArray(foreignKey) ? foreignKey : [foreignKey];
       const pks = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
       fks.forEach((fk, i) => {

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -1064,10 +1064,21 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
         this._reflectionForeignKey() ??
         `${underscore(ctor.name)}_id`);
 
-    const buildAttrs: Record<string, unknown> = {
-      ...attrs,
-      [foreignKey as string]: this._record._readAttribute(primaryKey as string),
-    };
+    const buildAttrs: Record<string, unknown> = { ...attrs };
+    // Composite key: spread each foreign-key column onto its owner primary-key
+    // column value. Coercing an array key to a string ("author_id,book_id")
+    // would produce an unknown attribute — tolerated only while construction
+    // silently swallowed it; the child's setter-dispatched assignment now
+    // raises, so map the real columns.
+    if (Array.isArray(foreignKey) || Array.isArray(primaryKey)) {
+      const fks = Array.isArray(foreignKey) ? foreignKey : [foreignKey];
+      const pks = Array.isArray(primaryKey) ? primaryKey : [primaryKey];
+      fks.forEach((fk, i) => {
+        buildAttrs[fk] = this._record._readAttribute(pks[i] ?? pks[0]);
+      });
+    } else {
+      buildAttrs[foreignKey] = this._record._readAttribute(primaryKey);
+    }
     if (asName) {
       const typeCol = this._assocDef.options.foreignType ?? `${underscore(asName)}_type`;
       buildAttrs[typeCol] = polymorphicName(ctor);

--- a/packages/activerecord/src/attribute-assignment.ts
+++ b/packages/activerecord/src/attribute-assignment.ts
@@ -17,6 +17,10 @@ import {
 
 interface AttributeAssignmentHost {
   writeAttribute(key: string, value: unknown): void;
+  // ActiveModel's `_assign_attribute` (attribute_assignment.rb:67-75): dispatch
+  // a key through its writer, or route a writer-less key to
+  // `attribute_writer_missing` (→ UnknownAttributeError). Inherited from `Model`.
+  _assignAttribute(key: string, value: unknown): void;
   constructor: unknown;
   association?: (name: string) => unknown;
 }
@@ -46,7 +50,7 @@ export function _assignAttributes(
     } else if (v !== null && typeof v === "object" && !Array.isArray(v)) {
       (nestedParameterAttributes ??= Object.create(null))[k] = v;
     } else {
-      this.writeAttribute(k, v);
+      this._assignAttribute(k, v);
     }
   }
 
@@ -67,7 +71,7 @@ export function assignNestedParameterAttributes(
   pairs: Record<string, unknown>,
 ): void {
   for (const [k, v] of Object.entries(pairs)) {
-    this.writeAttribute(k, v);
+    this._assignAttribute(k, v);
   }
 }
 

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -93,6 +93,7 @@ interface PrimaryKeyInstance {
   constructor: unknown;
   _readAttribute(name: string): unknown;
   _writeAttribute(name: string, value: unknown): void;
+  writeAttribute(name: string, value: unknown): void;
 }
 
 /**
@@ -122,11 +123,18 @@ export function setId(this: PrimaryKeyInstance, value: unknown): void {
       );
     }
     pk.forEach((col, i) => this._writeAttribute(col, (value as unknown[])[i]));
+  } else if (pk == null) {
+    // Key-less model: Rails does NOT install the PrimaryKey `id=` override
+    // without a primary key (`instance_method_already_implemented?` gates the
+    // ID_ATTRIBUTE_METHODS on `primary_key`), so `id=` is the regular writer for
+    // the literal `id` column. Mirror that by writing `id`: a model with an `id`
+    // column (`non_primary_keys`) gets the value, and one without (`dashboards`)
+    // raises MissingAttributeError like Rails. Route through the public
+    // `writeAttribute` (not the bridged `_writeAttribute`, which seeds an
+    // unreflected column and would swallow the dashboards raise).
+    this.writeAttribute("id", value);
   } else {
-    // A null pk (key-less table) reaches `_writeAttribute(null, …)`, which
-    // raises MissingAttributeError via the Null attribute — mirroring Rails
-    // `_write_attribute(@primary_key, value)` with a nil primary key.
-    this._writeAttribute(pk as string, value);
+    this._writeAttribute(pk, value);
   }
 }
 

--- a/packages/activerecord/src/attributes.test.ts
+++ b/packages/activerecord/src/attributes.test.ts
@@ -207,11 +207,11 @@ describe("CustomPropertiesTest", () => {
     const data = new OverloadedType({ non_existent_decimal: 1 });
 
     expect(data.non_existent_decimal).toEqual(new BigDecimal(1));
-    // Rails raises UnknownAttributeError constructing UnoverloadedType with a key
-    // that has no attribute; trails currently ignores unknown construction keys.
-    // Tracked by RFC 0046 converge-construction-unknown-attribute-strict.
-    const u = new UnoverloadedType({ non_existent_decimal: 1 } as any);
-    expect((u as any).non_existent_decimal).toBeUndefined();
+    // UnoverloadedType has no `non_existent_decimal` attribute, so constructing
+    // with the key raises UnknownAttributeError, like Rails.
+    expect(() => new UnoverloadedType({ non_existent_decimal: 1 } as any)).toThrow(
+      "unknown attribute 'non_existent_decimal'",
+    );
   });
 
   it("model with nonexistent attribute with default value can be saved", async () => {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -22,6 +22,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { withTimezoneConfig } from "./test-helper.js";
 import { IntegerType } from "@blazetrails/activemodel";
+import { CpkBook } from "./test-helpers/models/cpk.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
 
@@ -1265,20 +1266,13 @@ describe("BasicsTest", () => {
     expect(u.isDestroyed()).toBe(true);
   });
   it("dup for a composite primary key model", async () => {
-    class Order extends Base {
-      static {
-        this.attribute("shop_id", "integer");
-        this.attribute("id", "integer");
-        this.attribute("name", "string");
-        this.primaryKey = ["shop_id", "id"];
-      }
-    }
-    const o = new Order({ shop_id: 1, id: 42, name: "Widget" });
-    const copy = o.dup();
-    expect(copy.readAttribute("shop_id")).toBeNull();
-    expect(copy.readAttribute("id")).toBeNull();
-    expect(copy.readAttribute("name")).toBe("Widget");
-    expect(copy.isNewRecord()).toBe(true);
+    // Mirrors Rails `basic_test.rb#test_dup_for_a_composite_primary_key_model`:
+    // a persisted composite-PK record's dup preserves regular attributes and
+    // nulls the whole primary key (`[nil, nil]`). CpkBook's PK is [author_id, id].
+    const book = await CpkBook.createBang({ id: [1, 2], title: "The first book" });
+    const newBook = book.dup();
+    expect((newBook as { title: string }).title).toBe("The first book");
+    expect((newBook as { id: unknown }).id).toEqual([null, null]);
   });
   it("dup does not copy associations", async () => {
     class User extends Base {

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -244,9 +244,16 @@ describe("BasicsTest", () => {
         this.attribute("name", "string");
       }
     }
-    // Should not throw when setting unknown attributes
-    const u = new User({ name: "test", unknown: "value" } as any);
-    expect(u.name).toBe("test");
+    // Mirrors Rails: constructing with a genuinely-unknown key raises
+    // UnknownAttributeError (attribute_assignment.rb:56-58), carrying the key.
+    let error: unknown;
+    try {
+      new User({ name: "test", unknown: "value" } as any);
+    } catch (e) {
+      error = e;
+    }
+    expect((error as { name?: string })?.name).toBe("UnknownAttributeError");
+    expect((error as { attribute?: string })?.attribute).toBe("unknown");
   });
 
   it("many mutations", async () => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -690,11 +690,24 @@ function _collectNestedAttributeSetterKeys(ctor: typeof Base | undefined): Set<s
 }
 
 /**
- * Route a constructor-form composite primary key (`new Model({ id: [a, b] })`)
- * through the `id=` setter so each key column is populated. Rails dispatches all
- * `assign_attributes` keys through `public_send("#{k}=")`, but trails' Model
- * constructor writes directly via `writeAttribute`, which would store the whole
- * array in a single `id` column. Mirrors Rails' `Cpk::Book.new(id: [1, 2])`.
+ * Route a constructor-form composite primary key through the deferred `id`
+ * handling: trails holds the `id` key out of super()'s attribute loop and
+ * re-dispatches it here, once `initInternals` has run.
+ *
+ * - `id: [a, b]` goes through the `id=` setter (`setId`, mirroring
+ *   `CompositePrimaryKey#id=`), which spreads the array across the key columns.
+ * - a scalar `id` on a model-level composite PK is written straight to the `id`
+ *   column when the table has one. trails' cpk test models (`cpk_orders`,
+ *   `cpk_books`) declare a composite PK at the model level over tables that keep
+ *   a real single `id` column, and the suite's established convention passes the
+ *   key parts as scalars (`CpkBook.create({ author_id, id: 7 })`). Rails' native
+ *   `CompositePrimaryKey#id=` would raise `TypeError` on a scalar (it wants
+ *   `id: [author_id, id]`); converging that — and the many scalar-`id` cpk
+ *   fixtures/tests that depend on it — is a distinct deviation out of scope for
+ *   this unknown-attribute story, whose acceptance criteria explicitly keep
+ *   composite-PK keys constructing (deferred), not raised. A model with no `id`
+ *   column resolves to the Null attribute → MissingAttributeError, kept lenient
+ *   here (the deferred composite-PK path is never an unknown-attribute error).
  * @internal
  */
 function _applyCompositePrimaryKey(
@@ -706,19 +719,9 @@ function _applyCompositePrimaryKey(
   if (!Array.isArray(pk) || !Object.prototype.hasOwnProperty.call(attrs, "id")) return;
   const idVal = (attrs as { id: unknown }).id;
   if (Array.isArray(idVal)) {
-    // `id: [a, b]` routes through the `id=` setter, which spreads across the key
-    // columns. Held out of super() so no phantom scalar `id` attribute is made.
     (record as unknown as { id: unknown }).id = idVal;
     return;
   }
-  // A scalar `id` on a composite-PK model is not a composite assignment: the
-  // `id=` setter (setId) rejects a non-array. Write it straight to the `id`
-  // column if the model has one (e.g. a table with a real `id` column and a
-  // model-level composite PK), matching the pre-setter-dispatch constructor
-  // that wrote it via `writeAttribute` during construction. A model with no
-  // scalar `id` column resolves to the Null attribute → MissingAttributeError,
-  // which stays lenient here (the deferred composite-PK path Rails never treats
-  // as an unknown-attribute error).
   try {
     (record as unknown as { _writeAttribute: (n: string, v: unknown) => void })._writeAttribute(
       "id",
@@ -727,6 +730,29 @@ function _applyCompositePrimaryKey(
   } catch (error) {
     if (!(error instanceof MissingAttributeError)) throw error;
   }
+}
+
+/**
+ * Keys held out of super()'s setter-dispatching attribute loop and re-applied
+ * post-`initInternals`: a composite-PK `id` (→ `_applyCompositePrimaryKey`) and
+ * `<assoc>Attributes` nested-attribute keys (→ `_reapplyNestedAttrSetters`).
+ * Both dispatch setters that touch state (`id=` the key columns, the nested
+ * writer the association caches) which isn't wired until after `super()`.
+ * @internal
+ */
+function _withoutDeferredConstructionKeys(
+  ctor: typeof Base | undefined,
+  attrs: Record<string, unknown>,
+): Record<string, unknown> {
+  const drop = _collectNestedAttributeSetterKeys(ctor);
+  if (
+    Array.isArray((ctor as { primaryKey?: unknown } | undefined)?.primaryKey) &&
+    Object.prototype.hasOwnProperty.call(attrs, "id")
+  ) {
+    drop.add("id");
+  }
+  if (drop.size === 0) return attrs;
+  return Object.fromEntries(Object.entries(attrs).filter(([k]) => !drop.has(k)));
 }
 
 /**
@@ -3043,8 +3069,12 @@ export class Base extends Model {
       const wasSuppressed = suppressor._suppressInitializeCallback;
       suppressor._suppressInitializeCallback = true;
       const { multiparams, regular } = extractMultiparameterCallstack(attrs);
+      // Same deferral as the non-multiparameter branch: a composite-PK `id` or
+      // nested-attribute key sitting alongside multiparameter keys must not
+      // dispatch its setter inside super() before `initInternals` runs.
+      const regularForSuper = _withoutDeferredConstructionKeys(ctor, regular);
       try {
-        super(regular);
+        super(regularForSuper);
       } finally {
         // Always restore the flag even if super() throws, so later instances
         // on this class still fire after_initialize normally.
@@ -3059,6 +3089,7 @@ export class Base extends Model {
       // initialize_internals_callback and after_initialize, regardless of
       // callback suppression (found records run it via `new this()` too).
       _Core.initInternals.call(this as any);
+      _applyCompositePrimaryKey(this as unknown as Base, ctor, attrs);
       executeMultiparameterAssignment(this as any, multiparams);
       // Re-snapshot so mp attrs are part of the initial clean state.
       (this as any)._dirty.snapshot((this as any)._attributes);
@@ -3112,32 +3143,12 @@ export class Base extends Model {
           );
         }
       }
-      // A composite primary key passed as `id: [a, b]` must be routed solely
-      // through the `id=` setter (applied post-super by
-      // `_applyCompositePrimaryKey`). Drop it from `attrsForSuper` so super()'s
-      // raw `writeAttribute("id", …)` doesn't materialize a phantom `id`
-      // attribute for key columns not literally named `id` — Rails' dispatch
-      // (`public_send("id=")`) never creates one.
-      if (
-        Array.isArray((ctor2 as { primaryKey?: unknown }).primaryKey) &&
-        Object.prototype.hasOwnProperty.call(attrs, "id")
-      ) {
-        attrsForSuper = Object.fromEntries(
-          Object.entries(attrsForSuper).filter(([k]) => k !== "id"),
-        );
-      }
-      // Nested-attribute keys (`<assoc>Attributes`) are re-dispatched through
-      // their generated setter post-super by `_reapplyNestedAttrSetters` — once
-      // the association proxies exist. Drop them from `attrsForSuper` so super()'s
-      // `_assignAttributes` (which now dispatches setters, not raw writes) doesn't
-      // fire the nested setter mid-construction, before `initInternals` has wired
-      // the association caches.
-      const _nestedKeys = _collectNestedAttributeSetterKeys(ctor2);
-      if (_nestedKeys.size > 0) {
-        attrsForSuper = Object.fromEntries(
-          Object.entries(attrsForSuper).filter(([k]) => !_nestedKeys.has(k)),
-        );
-      }
+      // Hold the composite-PK `id` and any `<assoc>Attributes` nested-attribute
+      // keys out of super()'s setter-dispatching loop: their setters (`id=`, the
+      // nested writer) touch state that isn't wired until after super()
+      // (`initInternals`). Re-dispatched post-super by `_applyCompositePrimaryKey`
+      // and `_reapplyNestedAttrSetters`.
+      attrsForSuper = _withoutDeferredConstructionKeys(ctor2, attrsForSuper);
       const suppressor2 = ctor2 as typeof ctor2 & { _suppressInitializeCallback?: boolean };
       const hadOwn2 = Object.prototype.hasOwnProperty.call(
         suppressor2,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -29,6 +29,7 @@ import type {
 } from "@blazetrails/globalid/signed-global-id";
 import {
   Model,
+  MissingAttributeError,
   Type,
   typeRegistry,
   pushPendingDecorator,
@@ -668,6 +669,27 @@ function _extractAssociationAttrs(
 }
 
 /**
+ * Collect every `<assoc>Attributes` nested-attribute setter key registered on
+ * `ctor` and its ancestors (the same registry `_reapplyNestedAttrSetters`
+ * walks). Used to hold nested-attribute keys out of the Model constructor's
+ * setter-dispatching assignment so they fire post-super, once the association
+ * caches exist.
+ * @internal
+ */
+function _collectNestedAttributeSetterKeys(ctor: typeof Base | undefined): Set<string> {
+  const keys = new Set<string>();
+  let cls: unknown = ctor;
+  while (cls && cls !== Object) {
+    const own = Object.getOwnPropertyDescriptor(cls, "_nestedAttributeSetterKeys");
+    if (own?.value instanceof Set) {
+      for (const k of own.value as Set<string>) keys.add(k);
+    }
+    cls = Object.getPrototypeOf(cls);
+  }
+  return keys;
+}
+
+/**
  * Route a constructor-form composite primary key (`new Model({ id: [a, b] })`)
  * through the `id=` setter so each key column is populated. Rails dispatches all
  * `assign_attributes` keys through `public_send("#{k}=")`, but trails' Model
@@ -681,8 +703,29 @@ function _applyCompositePrimaryKey(
   attrs: Record<string, unknown>,
 ): void {
   const pk = (ctor as { primaryKey?: unknown }).primaryKey;
-  if (Array.isArray(pk) && Array.isArray((attrs as { id?: unknown }).id)) {
-    (record as unknown as { id: unknown }).id = (attrs as { id: unknown }).id;
+  if (!Array.isArray(pk) || !Object.prototype.hasOwnProperty.call(attrs, "id")) return;
+  const idVal = (attrs as { id: unknown }).id;
+  if (Array.isArray(idVal)) {
+    // `id: [a, b]` routes through the `id=` setter, which spreads across the key
+    // columns. Held out of super() so no phantom scalar `id` attribute is made.
+    (record as unknown as { id: unknown }).id = idVal;
+    return;
+  }
+  // A scalar `id` on a composite-PK model is not a composite assignment: the
+  // `id=` setter (setId) rejects a non-array. Write it straight to the `id`
+  // column if the model has one (e.g. a table with a real `id` column and a
+  // model-level composite PK), matching the pre-setter-dispatch constructor
+  // that wrote it via `writeAttribute` during construction. A model with no
+  // scalar `id` column resolves to the Null attribute → MissingAttributeError,
+  // which stays lenient here (the deferred composite-PK path Rails never treats
+  // as an unknown-attribute error).
+  try {
+    (record as unknown as { _writeAttribute: (n: string, v: unknown) => void })._writeAttribute(
+      "id",
+      idVal,
+    );
+  } catch (error) {
+    if (!(error instanceof MissingAttributeError)) throw error;
   }
 }
 
@@ -3077,10 +3120,22 @@ export class Base extends Model {
       // (`public_send("id=")`) never creates one.
       if (
         Array.isArray((ctor2 as { primaryKey?: unknown }).primaryKey) &&
-        Array.isArray(attrs.id)
+        Object.prototype.hasOwnProperty.call(attrs, "id")
       ) {
         attrsForSuper = Object.fromEntries(
           Object.entries(attrsForSuper).filter(([k]) => k !== "id"),
+        );
+      }
+      // Nested-attribute keys (`<assoc>Attributes`) are re-dispatched through
+      // their generated setter post-super by `_reapplyNestedAttrSetters` — once
+      // the association proxies exist. Drop them from `attrsForSuper` so super()'s
+      // `_assignAttributes` (which now dispatches setters, not raw writes) doesn't
+      // fire the nested setter mid-construction, before `initInternals` has wired
+      // the association caches.
+      const _nestedKeys = _collectNestedAttributeSetterKeys(ctor2);
+      if (_nestedKeys.size > 0) {
+        attrsForSuper = Object.fromEntries(
+          Object.entries(attrsForSuper).filter(([k]) => !_nestedKeys.has(k)),
         );
       }
       const suppressor2 = ctor2 as typeof ctor2 & { _suppressInitializeCallback?: boolean };

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -342,7 +342,7 @@ describe("PersistenceTest", () => {
         this.beforeUpdate(() => throwAbort());
       }
     }
-    const t = await Klass.create({ title: "New Topic", authorName: "Not David" });
+    const t = await Klass.create({ title: "New Topic", author_name: "Not David" });
 
     await expect((t as any).updateAttributeBang("title", "super_title")).rejects.toThrow(
       RecordNotSaved,


### PR DESCRIPTION
## Summary

Converge `Model` construction to raise `UnknownAttributeError` for a
genuinely-unknown key, mirroring Rails `ActiveModel::API#initialize` →
`assign_attributes` → `_assign_attribute` (api.rb:80-82,
attribute_assignment.rb:67-75). The constructor now routes each key through
`_assignAttribute` (setter dispatch) instead of the raw `writeAttribute` loop
that swallowed the strict `MissingAttributeError` `writeFromUser` raises since
#4027.

## Changes

- **activemodel `model.ts`**: constructor calls `this._assignAttributes(attrs)`
  (empty bag is a no-op, matching `return if new_attributes.empty?`); removed
  the broad `MissingAttributeError` swallow.
- **activerecord `attribute-assignment.ts`**: `_assignAttributes` /
  `assignNestedParameterAttributes` dispatch through `_assignAttribute` (setter
  dispatch → `attributeWriterMissing`) rather than `writeAttribute`, matching
  `ActiveRecord::AttributeAssignment`.
- **activerecord `base.ts`**: hold nested-attribute keys and composite-PK `id`
  out of `super()` (via `_withoutDeferredConstructionKeys`) so they dispatch
  post-construction — applied to **both** the regular and the multiparameter
  branches — then re-applied via `_applyCompositePrimaryKey` /
  `_reapplyNestedAttrSetters` once `initInternals` has wired the caches.
- **`collection-proxy.ts` `_buildRaw`**: spread composite foreign keys across
  their columns instead of coercing the array into a comma-joined unknown key.
- **Tests**: converge `base.test.ts > initialize with invalid attribute`,
  `base.test.ts > dup for a composite primary key model` (now mirrors Rails
  `test_dup_for_a_composite_primary_key_model` — persisted CpkBook + dup nulls
  the whole PK), `attributes.test.ts > nonexistent attribute`, and the
  `persistence.test.ts` aborted-callback test off the swallowed-leniency
  expectation to the `UnknownAttributeError` raise / real columns.

## Review response

**Blocking #1 (scalar `id` on a composite-PK model should raise `TypeError`):**
not adopted — see the expanded rationale in `_applyCompositePrimaryKey`'s
docstring. Rails' native `CompositePrimaryKey#id=` does raise on a scalar (it
wants `id: [author_id, id]`), but trails' cpk test models declare a *model-level*
composite PK over tables that keep a real single `id` column, and the suite-wide
convention passes the key parts as scalars (`CpkBook.create({ author_id, id: 7 })`
— dozens of call sites across eager/collection-proxy/has-many tests). Forcing the
raise breaks that whole cluster. It also contradicts this story's own acceptance
criterion ("composite-PK keys still construct... deferred, not raised"). The
scalar-`id`→real-`id`-column behavior is pre-existing (the old lenient
`writeAttribute` loop did the same); converging it to Rails' array-only `id=`
(plus migrating every scalar-`id` cpk fixture/test) is a distinct deviation that
belongs in its own story, not this unknown-attribute PR.

**Blocking #2 (multiparameter branch skipped the deferral):** fixed — extracted
`_withoutDeferredConstructionKeys` and applied it to `super(regular)` in the
multiparameter branch, plus a `_applyCompositePrimaryKey` call there.

**Note (composite fk/pk fallback):** kept and documented — the `pks[i] ?? pks[0]`
fallback is reachable for mixed shapes (scalar FK against a composite-PK target,
array FK against a scalar PK); dropping it regressed the cpk inverse-seeding /
eager-preload tests.

**Note (sanitizeForMassAssignment):** pre-existing; the AR constructor already
sanitizes before `super()`, so forbidden-params are still checked at AR
construction. No change.

Closes-story: converge-construction-unknown-attribute-strict