### PR TITLE
refactor(enum): port installEnumAttribute to bare attribute + decorate_attributes

### DIFF
--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -19,6 +19,7 @@ import {
 import { isStiSubclass, getStiBase } from "./inheritance.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { lookup as typeLookup } from "./type.js";
+import { cachedColumnsHash } from "./model-schema.js";
 
 type AnyClass = any;
 
@@ -31,12 +32,6 @@ interface AttributeDefinition {
   limit?: number | null;
   /** Declared via `attribute(name, type, { virtual: true })` — not DB-backed. */
   virtual?: boolean;
-  /**
-   * A user-declared type override (e.g. an enum) whose `defaultValue` came from
-   * the schema column, not a user-supplied default. Seeds via from_database in
-   * `_defaultAttributes` so the default is deserialized rather than user-cast.
-   */
-  defaultFromSchema?: boolean;
   /**
    * For `source:"schema"` defs, the `tableName` the columns were reflected
    * against. A non-STI subclass that overrides `_tableName` and declares an
@@ -138,14 +133,16 @@ export function defineAttribute(
  *
  * Mirrors: ActiveRecord::Attributes::ClassMethods#_default_attributes
  *
- * Seeds from `_attributeDefinitions` then replays user-declared `attribute()`
- * calls from the pending-modification queue. Entries with an explicit default
- * use `Attribute.fromDatabase` (schema) or `withUserDefault` (user-declared).
- * Entries without a default use `Attribute.fromDatabase(null, type)` for all
- * attributes — mirroring Rails' `columns_hash.transform_values { from_database }`.
- * Using `fromDatabase` (rather than `withCastValue`) means the type's
- * `deserialize(null)` is called, which is required for `LockingType` to return
- * 0 instead of null for new records that have no lock column default.
+ * Rails' column-seed-then-replay: seeds every real DB column via
+ * `Attribute.fromDatabase(name, column.default, type)` (so the default flows
+ * through `deserialize`), then replays the pending-modification queue —
+ * user-declared `attribute()` PendingType/PendingDefault entries and
+ * `decorate_attributes` PendingDecorators (e.g. enums) — on top. A user
+ * type-override on a real column (an enum) therefore keeps the FromDatabase
+ * attribute and its deserialized default. User-declared attributes that are NOT
+ * DB columns seed from `_attributeDefinitions`: with a default via
+ * `withUserDefault` (cast), without one via `fromDatabase(null, type)` — the
+ * latter required for `LockingType`, whose `deserialize(null)` returns 0.
  */
 export function _defaultAttributes(this: AnyClass): AttributeSet {
   // Reflect the (always-warm, RFC 0031) schema cache into `_attributeDefinitions`
@@ -183,33 +180,33 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
     // cascades here when the superclass gains new attribute declarations.
     registerWithSuperclass(cacheHost);
 
-    // Phase 1: seed from _attributeDefinitions (all entries — schema-reflected
-    // columns and direct defineAttribute() calls).
-    // For entries with a default: schema columns use fromDatabase, user-declared
-    // columns use withCastValue + withUserDefault (preserving user semantics).
-    // For entries without a default: all entries use fromDatabase(null, type),
-    // mirroring Rails' columns_hash.transform_values { Attribute.from_database(...) }.
-    // The fromDatabase path matters for LockingType: deserialize(null) → 0.
+    // Phase 1: seed schema columns via `Attribute.fromDatabase`, mirroring Rails'
+    // `columns_hash.transform_values { Attribute.from_database(col.name, col.default, type) }`.
+    // A real DB column — even one carrying a user type-override (e.g. an enum) —
+    // seeds from_database with the column's raw default so the default flows
+    // through `deserialize`, not `cast`; the user override is layered back on in
+    // phase 2 (a bare `attribute(name)` PendingType keeps the FromDatabase
+    // wrapper, `decorate_attributes` swaps the type). User-declared attributes
+    // that are NOT DB columns seed from `_attributeDefinitions`: with a default
+    // via withUserDefault (cast), without one via fromDatabase(null) — the latter
+    // matters for LockingType, where deserialize(null) → 0.
+    const columns = cachedColumnsHash(cacheHost);
     const defs: Map<string, AttributeDefinition> = cacheHost._attributeDefinitions;
     const attrMap = new Map<string, Attribute>();
     for (const [name, def] of defs) {
-      const schemaColumn =
-        (def.source ?? (def.userProvided === false ? "schema" : "user")) === "schema" ||
-        // A user-declared type override (e.g. enum) whose default originated
-        // from the schema column: seed via from_database so the default is
-        // deserialized, not user-cast. Mirrors Rails' build_from_user.
-        def.defaultFromSchema === true;
-      if (def.defaultValue != null) {
-        if (schemaColumn) {
-          attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue, def.type));
-        } else {
-          const base = Attribute.withCastValue(name, null, def.type);
-          attrMap.set(name, base.withUserDefault(def.defaultValue));
-        }
+      const source = def.source ?? (def.userProvided === false ? "schema" : "user");
+      const column = columns[name];
+      if (source === "schema") {
+        attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue ?? null, def.type));
+      } else if (column !== undefined) {
+        // User type-override on a real DB column (e.g. enum): the cached column
+        // carries the authoritative raw default; seed via from_database so it
+        // deserializes through the (overridden) type.
+        attrMap.set(name, Attribute.fromDatabase(name, column.default ?? null, def.type));
+      } else if (def.defaultValue != null) {
+        const base = Attribute.withCastValue(name, null, def.type);
+        attrMap.set(name, base.withUserDefault(def.defaultValue));
       } else {
-        // Seed via fromDatabase(null, type), mirroring Rails'
-        // columns_hash.transform_values { Attribute.from_database(col.name, col.default, type) }.
-        // This matters for LockingType: deserialize(null) → 0, not null.
         attrMap.set(name, Attribute.fromDatabase(name, null, def.type));
       }
     }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -1,6 +1,12 @@
 import type { Base } from "./base.js";
 import { camelize, isBlank, pluralize } from "@blazetrails/activesupport";
-import { ArgumentError, ValueType, IntegerType, typeRegistry } from "@blazetrails/activemodel";
+import {
+  ArgumentError,
+  ValueType,
+  IntegerType,
+  Type,
+  typeRegistry,
+} from "@blazetrails/activemodel";
 import { dangerousAttributeMethods } from "./attribute-methods.js";
 
 /** Value a label can map to — matches Rails' hash-value support for enums. */
@@ -91,39 +97,19 @@ export function installEnumAttribute(
   attribute: string,
   enumType: EnumType,
 ): void {
-  // Rails' _enum uses `attribute(name)` (bare) + `decorate_attributes` so the
-  // EnumType is layered on top of the column-seeded FromDatabase attribute,
-  // leaving the default on the deserialize path for free (enum.rb:238-247). That
-  // relies on `_default_attributes` re-seeding from `columns_hash` on every
-  // rebuild; trails instead seeds from the cached `_attributeDefinitions` map and
-  // `decorateAttributes` no-ops on a not-yet-reflected column (the def doesn't
-  // exist until schema loads), so a bare-attribute + decorate port drops the
-  // EnumType entirely for models whose enum is declared before first query.
-  // (Empirically regresses type.serialize / find-via-where.) Converging trails'
-  // `_defaultAttributes` onto Rails' column-seed-then-replay is tracked as a
-  // follow-up story. Here we register the type directly — which also matches
-  // Rails' lower-level `attribute(name, type)` form — so it lands in
-  // `_attributeDefinitions` and survives schema reflection / resetColumnInformation
-  // (schema-sourced defs get scrubbed and re-reflected as the plain column type).
-  klass.attribute(attribute, enumType);
+  // Rails' _enum uses `attribute(name)` (bare) + `decorate_attributes`, layering
+  // the EnumType on top of the column-seeded FromDatabase attribute so the enum
+  // default flows through `deserialize` for free (enum.rb:238-247). trails'
+  // `_defaultAttributes` now mirrors Rails' column-seed-then-replay
+  // (attributes.ts): phase 1 seeds the real DB column via `fromDatabase` with the
+  // column's raw default, phase 2 replays the bare `attribute` (a PendingType that
+  // keeps the FromDatabase wrapper) and this `decorateAttributes` (which swaps the
+  // type to the EnumType). cast(0) on an EnumType yields null; deserialize(0)
+  // yields the "default" label — so the column-default path is exactly what makes
+  // the enum default work, recovered here without any special-casing.
+  klass.attribute(attribute);
+  klass.decorateAttributes([attribute], (_name: string, _subtype: Type) => enumType);
 
-  // Mark the enum column's default as schema-sourced so it seeds via
-  // from_database (deserialize) rather than as a user default (cast): cast(0) on
-  // an EnumType yields null, deserialize(0) yields the "default" label. This
-  // recovers what Rails' build_from_user / decorate_attributes gives for free.
-  // The flag is honored on both declaration orderings: when the schema is
-  // already loaded, `attribute()` above merged the column default (0) onto the
-  // def, so `_defaultAttributes` seeds fromDatabase(0) directly (attributes.ts);
-  // when the enum is declared first, schema reflection later re-injects the
-  // column default onto this user-declared def (model-schema.ts). `attribute()`
-  // already invalidated the default-attributes cache, so no extra reset is
-  // needed — the mutation is visible before the next `_defaultAttributes()`.
-  const def = klass._attributeDefinitions?.get(attribute) as
-    | { defaultFromSchema?: boolean }
-    | undefined;
-  if (def != null) {
-    def.defaultFromSchema = true;
-  }
   // Define the getter after attribute() so the EnumType is already in
   // _attributeDefinitions / the pending-type queue when we overwrite whatever
   // accessor attribute() installed.

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -88,7 +88,8 @@ export function enumTypeFor(name: string, mapping: Record<string, EnumValue>): E
  * stores the label string (via EnumType.cast on write), the getter returns it,
  * and assignment runs `assertValidValue`.
  *
- * Mirrors: ActiveRecord::Enum#_enum calling `klass.attribute(name, enum_type)`.
+ * Mirrors: ActiveRecord::Enum#_enum calling `attribute(name, **options)` then
+ * `decorate_attributes([name]) { |_n, subtype| EnumType.new(...) }` (enum.rb:238-247).
  *
  * @internal
  */

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -26,7 +26,7 @@ import { TableNotSpecified } from "./errors.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
 import { FakePool } from "./connection-adapters/schema-cache.js";
-import { threadedConnectionFor } from "./connection-handling.js";
+import { threadedConnectionFor, connectionPool } from "./connection-handling.js";
 
 /**
  * Adapter for a schema-reflection read: prefer the connection threaded by the
@@ -326,23 +326,29 @@ type DatabaseAdapterLike = { schemaCache?: unknown };
  */
 export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike> {
   const target = isStiSubclass(klass) ? getStiBase(klass) : klass;
-  // Prefer the threaded (in-query) connection's warm cache — never touches
-  // `.connection`, so it is safe on the hot `new Model()` construction path.
-  try {
-    const conn = threadedConnectionFor(target) as { schemaCache?: unknown } | null;
+  const cachedFrom = (conn: { schemaCache?: unknown } | null | undefined) => {
     const cache = conn?.schemaCache as
       | { getCachedColumnsHash?: (t: string) => Record<string, ColumnLike> | undefined }
       | undefined;
-    const hash = cache?.getCachedColumnsHash?.(target.tableName);
+    return cache?.getCachedColumnsHash?.(target.tableName);
+  };
+  // Read the warm schema cache off an already-available connection — the
+  // threaded (in-query) one, else a connection the pool has already leased.
+  // Both are connection-free reads (no `.connection`), so this is safe on the
+  // hot `new Model()` path and never forces a permanent checkout.
+  try {
+    const hash =
+      cachedFrom(threadedConnectionFor(target)) ??
+      cachedFrom(connectionPool.call(target).activeConnection as { schemaCache?: unknown } | null);
     if (hash) return hash;
   } catch {
     /* fall through */
   }
-  // No threaded connection (e.g. a bare `new Book()` outside any query): fall
-  // back to `columnsHash`, which resolves the same warm cache via the model's
-  // connection. Wrapped in try/catch so a table-less model or a disallowed
-  // permanent checkout degrades to the attribute-definition view rather than
-  // raising during construction.
+  // No connection available at all (e.g. a bare `new Book()` before any query):
+  // fall back to `columnsHash`, which resolves the same warm cache via the
+  // model's connection. Wrapped in try/catch so a table-less model or a
+  // disallowed permanent checkout degrades to the attribute-definition view
+  // rather than raising during construction.
   try {
     return columnsHash.call(target);
   } catch {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -315,6 +315,42 @@ export function columnsHash(this: typeof Base): Record<string, ColumnLike> {
 type DatabaseAdapterLike = { schemaCache?: unknown };
 
 /**
+ * Connection-safe read of the cached column hash for `klass`'s table.
+ *
+ * Used by `_defaultAttributes` to seed schema columns via `Attribute.fromDatabase`
+ * (Rails' `columns_hash.transform_values { Attribute.from_database(...) }`) without
+ * ever touching `.connection` — which would permanently check out a connection on
+ * every record construction. Only reads the threaded (in-query) connection's warm
+ * schema cache; returns `{}` when none is available, so the caller falls back to
+ * the attribute-definition view.
+ */
+export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike> {
+  const target = isStiSubclass(klass) ? getStiBase(klass) : klass;
+  // Prefer the threaded (in-query) connection's warm cache — never touches
+  // `.connection`, so it is safe on the hot `new Model()` construction path.
+  try {
+    const conn = threadedConnectionFor(target) as { schemaCache?: unknown } | null;
+    const cache = conn?.schemaCache as
+      | { getCachedColumnsHash?: (t: string) => Record<string, ColumnLike> | undefined }
+      | undefined;
+    const hash = cache?.getCachedColumnsHash?.(target.tableName);
+    if (hash) return hash;
+  } catch {
+    /* fall through */
+  }
+  // No threaded connection (e.g. a bare `new Book()` outside any query): fall
+  // back to `columnsHash`, which resolves the same warm cache via the model's
+  // connection. Wrapped in try/catch so a table-less model or a disallowed
+  // permanent checkout degrades to the attribute-definition view rather than
+  // raising during construction.
+  try {
+    return columnsHash.call(target);
+  } catch {
+    return {};
+  }
+}
+
+/**
  * Return content columns (excluding PK, FKs, and timestamps).
  *
  * Mirrors: ActiveRecord::ModelSchema::ClassMethods#content_columns
@@ -941,22 +977,10 @@ function applyColumnsHash(
     }
     const existing = host._attributeDefinitions.get(name);
     if (existing && (existing.userProvided ?? true)) {
-      // A user-declared type override (e.g. an enum) whose default is meant to
-      // come from the schema column: refresh the column default onto the def so
-      // `_defaultAttributes` can seed it via from_database. The user-declared
-      // type is preserved; only the schema-sourced default is (re)injected.
-      // Mirrors Rails, where the column default lives on the column and enum's
-      // `build_from_user` preserves it.
-      if ((existing as { defaultFromSchema?: boolean }).defaultFromSchema) {
-        const colDefault = (column as { default?: unknown }).default ?? null;
-        const colDefaultFn =
-          (column as { defaultFunction?: string | null }).defaultFunction ?? null;
-        host._attributeDefinitions.set(name, {
-          ...existing,
-          defaultValue: colDefault,
-          ...(colDefaultFn != null ? { defaultFunction: colDefaultFn } : {}),
-        });
-      }
+      // A user-declared type override (e.g. an enum) preserves its type across
+      // reflection. The schema column's default is NOT merged onto the def;
+      // `_defaultAttributes` seeds it via from_database directly from the cached
+      // column (Rails' column-seed-then-replay), then replays the user override.
       continue;
     }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -319,10 +319,15 @@ type DatabaseAdapterLike = { schemaCache?: unknown };
  *
  * Used by `_defaultAttributes` to seed schema columns via `Attribute.fromDatabase`
  * (Rails' `columns_hash.transform_values { Attribute.from_database(...) }`) without
- * ever touching `.connection` — which would permanently check out a connection on
- * every record construction. Only reads the threaded (in-query) connection's warm
- * schema cache; returns `{}` when none is available, so the caller falls back to
- * the attribute-definition view.
+ * ever touching `.connection` — which under the default `permanentConnectionCheckout`
+ * would permanently lease a connection on every record construction. Reads the warm
+ * schema cache off an already-available connection only: the threaded (in-query)
+ * connection, else a connection the pool has already leased. Returns `{}` when
+ * neither is available (a bare `new Model()` with no active connection); the caller
+ * then seeds that column from its attribute definition instead. Any real DB column
+ * whose default matters here has already pinned a connection via the
+ * `!_schemaLoaded` reflection in `_defaultAttributes`, so `{}` is only reached for
+ * columns that carry no client-side default anyway.
  */
 export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike> {
   const target = isStiSubclass(klass) ? getStiBase(klass) : klass;
@@ -344,16 +349,7 @@ export function cachedColumnsHash(klass: typeof Base): Record<string, ColumnLike
   } catch {
     /* fall through */
   }
-  // No connection available at all (e.g. a bare `new Book()` before any query):
-  // fall back to `columnsHash`, which resolves the same warm cache via the
-  // model's connection. Wrapped in try/catch so a table-less model or a
-  // disallowed permanent checkout degrades to the attribute-definition view
-  // rather than raising during construction.
-  try {
-    return columnsHash.call(target);
-  } catch {
-    return {};
-  }
+  return {};
 }
 
 /**

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -16803,13 +16803,6 @@
     "package": "activerecord",
     "tsFile": "attributes.ts",
     "rubyName": "_default_attributes",
-    "call": "default",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "attributes.ts",
-    "rubyName": "_default_attributes",
     "call": "transform_values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
## Summary

Converge trails' enum installation onto Rails' actual mechanism. Rails' `_enum`
(`activerecord/lib/active_record/enum.rb:238-247`) does **not** call
`attribute(name, enum_type)`; it calls `attribute(name)` (bare) then
`decorate_attributes([name]) { |_n, subtype| EnumType.new(...) }`. This works
because Rails' `_default_attributes` seeds from `columns_hash` via
`Attribute.from_database` on every rebuild, then replays pending modifications —
so the enum default flows through `deserialize` with zero special-casing.

## Changes

- **`_defaultAttributes` (attributes.ts)** now follows Rails' column-seed-then-replay:
  phase 1 seeds real DB columns via `Attribute.fromDatabase(name, column.default, type)`
  (including columns carrying a user type-override like an enum), phase 2 replays the
  pending `PendingType`/`PendingDefault`/`PendingDecorator` queue. A user override on
  a real column keeps the FromDatabase (deserialize) attribute and its default;
  non-column user attributes seed from `_attributeDefinitions` as before.
- **`cachedColumnsHash` (model-schema.ts)** — a connection-safe helper reading the
  threaded (in-query) warm schema cache, falling back to `columnsHash`, so seeding
  never forces a permanent connection checkout on the `new Model()` path.
- **`installEnumAttribute` (enum.ts)** converted to `attribute(name)` +
  `decorateAttributes([name], (_n, _subtype) => enumType)`. Deleted the
  `defaultFromSchema` flag, its `_defaultAttributes` seed branch, and the
  `applyColumnsHash` re-injection branch.

## Testing

`enum.test.ts` (incl. the previously-regressing type.serialize / find-via-where /
build-from-where and the `new Book()` default-from-database cases), enum.trails,
relation/default scoping, locking (LockingType default 0), inheritance/STI,
attributes, attribute-methods, persistence, normalization, encryption, and the
connection permanent-checkout tests all pass on sqlite.

Closes-story: converge-enum-attribute-to-decorate-attributes