### PR TITLE
fix(mysql): collapse functional-index columns into a single SQL string

### DIFF
--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -433,9 +433,10 @@ describe("MySQL::SchemaStatements", () => {
 
   // Minimal IndexesHost: indexes() reads via schemaQuery and quotes the table
   // name. Stub schemaQuery to return the `SHOW KEYS FROM` rows MySQL yields.
-  const indexHost = (rows: Record<string, unknown>[]) => ({
+  const indexHost = (rows: Record<string, unknown>[], sortOrderSupported = true) => ({
     schemaQuery: async () => rows,
     quoteTableName: (n: string) => `\`${n}\``,
+    supportsIndexSortOrder: () => sortOrderSupported,
   });
 
   it("indexes: surfaces per-column prefix lengths from Sub_part", async () => {
@@ -527,6 +528,40 @@ describe("MySQL::SchemaStatements", () => {
     expect(idx[0].columns).toBe("(lower(`title`)), `position`(4) DESC");
     expect(idx[0].orders).toBeUndefined();
     expect(idx[0].lengths).toBeUndefined();
+  });
+
+  it("indexes: omits functional-index order when sort order is unsupported", async () => {
+    // Mirrors Rails' add_options_for_index_columns super gate on
+    // supports_index_sort_order? — false on MariaDB < 10.8.1 / MySQL < 8.0.1,
+    // which drops the DESC/ASC suffix even when Collation="D". Prefix length
+    // (via MySQL's add_index_length, ungated) is still baked in.
+    const idx = await indexes.call(
+      indexHost(
+        [
+          {
+            Key_name: "index_pages_on_lower_title_and_pos",
+            Column_name: null,
+            Expression: "lower(`title`)",
+            Non_unique: 1,
+            Index_type: "BTREE",
+            Sub_part: null,
+            Collation: "D",
+          },
+          {
+            Key_name: "index_pages_on_lower_title_and_pos",
+            Column_name: "position",
+            Expression: null,
+            Non_unique: 1,
+            Index_type: "BTREE",
+            Sub_part: 4,
+            Collation: "D",
+          },
+        ],
+        false,
+      ),
+      "pages",
+    );
+    expect(idx[0].columns).toBe("(lower(`title`)), `position`(4)");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -490,8 +490,43 @@ describe("MySQL::SchemaStatements", () => {
       ]),
       "pages",
     );
-    expect(idx[0].columns).toEqual(["(lower(`title`))"]);
-    expect(idx[0].orders).toEqual({ "(lower(`title`))": "desc" });
+    // Mirrors Rails' final `.map`: a functional index collapses its columns
+    // into a single SQL string via add_options_for_index_columns, with the
+    // DESC order baked inline and no separate orders/lengths Records.
+    expect(idx[0].columns).toBe("(lower(`title`)) DESC");
+    expect(idx[0].orders).toBeUndefined();
+    expect(idx[0].lengths).toBeUndefined();
+  });
+
+  it("indexes: collapses functional-index columns into a single SQL string", async () => {
+    const idx = await indexes.call(
+      indexHost([
+        {
+          Key_name: "index_pages_on_lower_title_and_pos",
+          Column_name: null,
+          Expression: "lower(`title`)",
+          Non_unique: 1,
+          Index_type: "BTREE",
+          Sub_part: null,
+          Collation: "A",
+        },
+        {
+          Key_name: "index_pages_on_lower_title_and_pos",
+          Column_name: "position",
+          Expression: null,
+          Non_unique: 1,
+          Index_type: "BTREE",
+          Sub_part: 4,
+          Collation: "D",
+        },
+      ]),
+      "pages",
+    );
+    // Expression columns pass through their parenthesized form; plain columns
+    // are quoted with prefix length and DESC order baked in.
+    expect(idx[0].columns).toBe("(lower(`title`)), `position`(4) DESC");
+    expect(idx[0].orders).toBeUndefined();
+    expect(idx[0].lengths).toBeUndefined();
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -871,6 +871,11 @@ export async function foreignKeys(
 interface IndexesHost {
   schemaQuery(sql: string, binds?: unknown[]): Promise<Record<string, unknown>[]>;
   quoteTableName(name: string): string;
+  // Version-gated in Rails (false on MariaDB < 10.8.1 / MySQL < 8.0.1): when
+  // false, `add_options_for_index_columns`'s `super` skips the DESC/ASC suffix
+  // (abstract/schema_statements.rb#add_index_sort_order), so a functional
+  // index's collapsed columns string must omit the order even when Collation="D".
+  supportsIndexSortOrder(): boolean;
 }
 
 /** @internal
@@ -998,7 +1003,11 @@ export async function indexes(
         const quotedColumns = new Map<string, string>(
           columns.map((c) => [c, expressions[c] ?? quoteColumnName(c)]),
         );
-        addOptionsForIndexColumns(quotedColumns, { order: orders, length: lengths });
+        addOptionsForIndexColumns(
+          quotedColumns,
+          { order: orders, length: lengths },
+          this.supportsIndexSortOrder(),
+        );
         return { ...base, columns: Array.from(quotedColumns.values()).join(", ") };
       }
       return {

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -14,7 +14,7 @@ import { Column } from "./column.js";
 import { SchemaStatements as BaseSchemaStatements } from "../abstract/schema-statements.js";
 import { SchemaCreation as MysqlSchemaCreation } from "./schema-creation.js";
 import { CreateIndexDefinition, ForeignKeyDefinition } from "../abstract/schema-definitions.js";
-import { unquoteIdentifier } from "./quoting.js";
+import { quoteColumnName, unquoteIdentifier } from "./quoting.js";
 import type { AddIndexOptions } from "../abstract/schema-definitions.js";
 
 /**
@@ -890,7 +890,7 @@ export async function indexes(
   Array<{
     table: string;
     name: string;
-    columns: string[];
+    columns: string[] | string;
     unique: boolean;
     using?: string;
     type?: string;
@@ -922,6 +922,7 @@ export async function indexes(
       comment?: string;
       lengths: Record<string, number>;
       orders: Record<string, string>;
+      expressions: Record<string, string>;
     }
   >();
   let currentIndex: string | null = null;
@@ -952,6 +953,7 @@ export async function indexes(
         comment,
         lengths: {},
         orders: {},
+        expressions: {},
       });
     }
 
@@ -966,6 +968,7 @@ export async function indexes(
       let expr = String(rawExpr).replace(/\\'/g, "'");
       if (!expr.startsWith("(")) expr = `(${expr})`;
       entry.columns.push(expr);
+      entry.expressions[expr] = expr;
       if (desc) entry.orders[expr] = "desc";
     } else {
       const column = String((r.Column_name ?? r.COLUMN_NAME) as string);
@@ -977,16 +980,33 @@ export async function indexes(
     }
   }
   return Array.from(byIndex.entries()).map(
-    ([name, { columns, unique, using, type, comment, lengths, orders }]) => ({
-      table: tableName,
-      name,
-      columns,
-      unique,
-      ...(using !== undefined ? { using } : {}),
-      ...(type !== undefined ? { type } : {}),
-      ...(comment !== undefined ? { comment } : {}),
-      ...(Object.keys(lengths).length > 0 ? { lengths } : {}),
-      ...(Object.keys(orders).length > 0 ? { orders } : {}),
-    }),
+    ([name, { columns, unique, using, type, comment, lengths, orders, expressions }]) => {
+      const base = {
+        table: tableName,
+        name,
+        unique,
+        ...(using !== undefined ? { using } : {}),
+        ...(type !== undefined ? { type } : {}),
+        ...(comment !== undefined ? { comment } : {}),
+      };
+      // Mirrors Rails' final `.map`: a functional (expression) index collapses
+      // its columns array into a single SQL string via addOptionsForIndexColumns,
+      // baking prefix length and DESC/ASC order inline. Non-expression columns
+      // are quoted; expression columns pass through their parenthesized form.
+      // The separate lengths/orders Records are consumed here and dropped.
+      if (Object.keys(expressions).length > 0) {
+        const quotedColumns = new Map<string, string>(
+          columns.map((c) => [c, expressions[c] ?? quoteColumnName(c)]),
+        );
+        addOptionsForIndexColumns(quotedColumns, { order: orders, length: lengths });
+        return { ...base, columns: Array.from(quotedColumns.values()).join(", ") };
+      }
+      return {
+        ...base,
+        columns,
+        ...(Object.keys(lengths).length > 0 ? { lengths } : {}),
+        ...(Object.keys(orders).length > 0 ? { orders } : {}),
+      };
+    },
   );
 }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1440,7 +1440,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     Array<{
       table: string;
       name: string;
-      columns: string[];
+      columns: string[] | string;
       unique: boolean;
       using?: string;
       type?: string;

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1453,6 +1453,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       {
         schemaQuery: this.schemaQuery.bind(this),
         quoteTableName: this.quoteTableName.bind(this),
+        supportsIndexSortOrder: this.supportsIndexSortOrder.bind(this),
       },
       tableName,
     );

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -22249,13 +22249,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-statements.ts",
     "rubyName": "indexes",
-    "call": "add_options_for_index_columns",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-statements.ts",
-    "rubyName": "indexes",
     "call": "delete",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -22277,13 +22270,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql/schema-statements.ts",
     "rubyName": "indexes",
-    "call": "join",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-statements.ts",
-    "rubyName": "indexes",
     "call": "last",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -22299,20 +22285,6 @@
     "tsFile": "connection-adapters/mysql/schema-statements.ts",
     "rubyName": "indexes",
     "call": "presence",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-statements.ts",
-    "rubyName": "indexes",
-    "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql/schema-statements.ts",
-    "rubyName": "indexes",
-    "call": "values",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
Mirrors Rails' MySQL `indexes` final `.map` (`mysql/schema_statements.rb:41-42,54-65`): a functional (expression) index now collapses its columns array into a single SQL string via an `addOptionsForIndexColumns` equivalent, baking the prefix length and DESC/ASC order inline. The separate `lengths` / `orders` Records are consumed here and dropped. Non-expression indexes retain the array + separate `lengths` / `orders` shape unchanged.

An `expressions` map is built during the `SHOW KEYS` row loop (mirroring Rails' `indexes.last[-1][:expressions]`), then in the final map each expression column passes through its parenthesized form while plain columns are quoted.

## Verification
- Updated the `indexes` unit tests (stubbed `SHOW KEYS` rows) to assert the collapsed single-string shape, including a mixed expression + prefix-length + DESC case.
- MySQL-gated schema-dump expression-index tests are covered by CI's mysql:8 lane (no local MySQL).

Closes-story: mysql-functional-index-columns-sql-string