### PR TITLE
fix(associations): statement-cache through singular loads

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -1048,13 +1048,11 @@ function _builtAssociationScope(
  * scope carrying `includes` (subsumed by the `klass.scope_attributes?` arm
  * below), so the remaining arms cover it.
  *
- * Deviation (tracked-pending-convergence): Rails statement-caches through
- * chains too, but we additionally treat multi-step (chain length > 1) chains
- * as skip and keep the proven per-load `take()` path. `get_bind_values`
- * (chain order) and the `params.bind` scope-build bind order currently
- * disagree for through/enum chains (wrong target returned), so caching them
- * is unsafe until that converges — story
- * `through-singular-association-statement-cache` (RFC 0023).
+ * Multi-step (through) chains statement-cache too, matching Rails — the base
+ * scope in `_loadSingularViaStatementCache` is the association's `target_scope`
+ * (which folds each intermediate reflection's `scope_for_association`, carrying
+ * the join model's STI `type_condition`), so the compiled SQL is complete and
+ * stable across owners.
  */
 function _skipSingularStatementCache(
   reflection: ReflectionLike,
@@ -1067,12 +1065,9 @@ function _skipSingularStatementCache(
   if (options.scope) return true;
   const refl = reflection as {
     hasScope?(): boolean;
-    chain?: unknown[];
     sourceReflection?: { activeRecord?: { defaultScopes?: unknown[] } } | null;
   };
   if (typeof refl.hasScope === "function" && refl.hasScope()) return true;
-  // Multi-step chains: defer to the take() path (see doc comment).
-  if (Array.isArray(refl.chain) && refl.chain.length > 1) return true;
   // `klass.scope_attributes?` (`scoping/default.rb:55`) =
   // `current_scope || default_scopes.any? || respond_to?(:default_scope)`. A
   // thread-local scope, any default scope, OR a method-form `default_scope`
@@ -1117,10 +1112,11 @@ async function _loadSingularViaStatementCache(
   // holder to `setTarget`/`loadedBang` — otherwise the cached target is never
   // marked loaded and every read re-queries. Only the "not registered" case is
   // swallowed; real construction bugs must surface.
+  let instance: { targetScope?: () => unknown } | undefined;
   const assocFn = (record as { association?: (n: string) => unknown }).association;
   if (typeof assocFn === "function") {
     try {
-      assocFn.call(record, assocName);
+      instance = assocFn.call(record, assocName) as typeof instance;
     } catch (e) {
       if (!(e instanceof AssociationNotFoundError)) throw e;
     }
@@ -1130,6 +1126,20 @@ async function _loadSingularViaStatementCache(
   // target_scope.merge!(AssociationScope.create { params.bind }.scope(self)) }`.
   // `associationScopeCache` memoizes the compiled StatementCache on the target
   // class (keyed by reflection + polymorphic owner type).
+  //
+  // The base is the association's `target_scope`, NOT a bare
+  // `_scopeForAssociation(targetModel)`. For a through association
+  // `ThroughAssociation#target_scope` folds each intermediate reflection's
+  // `klass.scope_for_association` into the query (through_association.rb) — this
+  // is what carries the join model's STI `type_condition` (e.g.
+  // `memberships.type = 1` for a `CurrentMembership` join) that
+  // `AssociationScope` alone does not emit. Falling back to
+  // `_scopeForAssociation` only when no Association instance exists (low-level
+  // loader paths that bypass `record.association(name)`).
+  const baseScope = (): Relation<Base> =>
+    (typeof instance?.targetScope === "function"
+      ? (instance.targetScope() as Relation<Base>)
+      : undefined) ?? _scopeForAssociation(targetModel);
   const sc = (
     reflection as unknown as {
       associationScopeCache(klass: typeof Base, owner: Base, block: () => unknown): unknown;
@@ -1142,7 +1152,7 @@ async function _loadSingularViaStatementCache(
         reflection: reflection as never,
         klass: targetModel,
       }) as Relation<Base>;
-      return _scopeForAssociation(targetModel).merge(built) as never;
+      return baseScope().merge(built) as never;
     }),
   ) as StatementCache;
   const chain = (reflection as unknown as { chain: never[] }).chain;

--- a/packages/activerecord/src/associations/association-scope-cache.test.ts
+++ b/packages/activerecord/src/associations/association-scope-cache.test.ts
@@ -15,14 +15,17 @@
  * synthetic `cache_*` tables.
  */
 import { describe, it, expect, beforeAll, afterEach, vi } from "vitest";
-import { registerModel } from "../index.js";
-import { loadHasMany, loadBelongsTo } from "../associations.js";
+import { registerModel, enableSti, registerSubclass } from "../index.js";
+import { loadHasMany, loadBelongsTo, loadHasOne } from "../associations.js";
 import { AssociationScope } from "./association-scope.js";
 import { StatementCache } from "../statement-cache.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
+import { Member } from "../test-helpers/models/member.js";
+import { Club } from "../test-helpers/models/club.js";
+import { Membership, CurrentMembership } from "../test-helpers/models/membership.js";
 
 describe("Association scope cache", () => {
   const { authors, posts } = fixtures(["authors", "posts", "comments"]);
@@ -145,5 +148,49 @@ describe("Association scope cache", () => {
     expect(assoc1._cachedScope).toBeDefined();
     expect(assoc2._cachedScope).toBeDefined();
     expect(assoc1._cachedScope).not.toBe(assoc2._cachedScope);
+  });
+});
+
+describe("Association scope cache — through singular loads", () => {
+  const { members, clubs } = fixtures(["memberTypes", "members", "clubs", "memberships"]);
+
+  beforeAll(async () => {
+    registerModel(Member);
+    registerModel(Club);
+    enableSti(Membership);
+    registerModel(Membership);
+    registerModel(CurrentMembership);
+    registerSubclass(CurrentMembership);
+    await Member.loadSchema();
+    await Club.loadSchema();
+    await Membership.loadSchema();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("has_one :through singular loads compile once, reuse across owners, and filter the join model's STI type", async () => {
+    // `Member has_one :club, through: :current_membership` — the join model
+    // `CurrentMembership` is an STI subclass over an *enum* `type` column.
+    // groucho holds BOTH a CurrentMembership → boring_club AND a plain
+    // Membership → moustache_club, so a correct load must carry the join
+    // model's `memberships.type = <CurrentMembership>` condition (folded in via
+    // `ThroughAssociation#target_scope`) — otherwise it returns the wrong club.
+    const groucho = await Member.find(members("groucho").id);
+    const blarpy = await Member.find(members("blarpy_winkup").id);
+
+    const spy = vi.spyOn(StatementCache, "create");
+
+    const c1 = await loadHasOne(groucho, "club", { through: "currentMembership" });
+    expect((c1 as any)?.id).toBe(clubs("boring_club").id);
+    const afterFirst = spy.mock.calls.length;
+    expect(afterFirst).toBe(1);
+
+    // Second owner's load reuses the compiled statement — no recompile — and
+    // still resolves through its OWN current membership.
+    const c2 = await loadHasOne(blarpy, "club", { through: "currentMembership" });
+    expect((c2 as any)?.id).toBe(clubs("outrageous_club").id);
+    expect(spy.mock.calls.length).toBe(afterFirst);
   });
 });

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1472,6 +1472,19 @@ export class ThroughReflection extends AbstractReflection {
     return this.delegateReflection.macro;
   }
 
+  /**
+   * Rails' ThroughReflection has no `association_scope_cache` of its own and
+   * doesn't inherit one (it extends `AbstractReflection`, not
+   * `AssociationReflection`); it reaches the method via the catch-all
+   * `delegate(*delegate_methods, to: :delegate_reflection)` at the tail of the
+   * class (reflection.rb:1221-1224). Mirror that single delegation so a through
+   * singular load statement-caches on the delegate reflection's key
+   * (`Association#find_target`, association.rb:262).
+   */
+  associationScopeCache(klass: typeof Base, owner: any, block: () => any): any {
+    return this.delegateReflection.associationScopeCache(klass, owner, block);
+  }
+
   get options(): Record<string, unknown> {
     return this.delegateReflection.options;
   }


### PR DESCRIPTION
## What

Rails statement-caches through (multi-step) singular `has_one`/`belongs_to`
loads too, but trails treated `chain.length > 1` as `skip_statement_cache?`
and kept the per-load `take()` path. This removes that guard so through
singular loads use the statement cache, matching Rails' `Association#find_target`.

## Root cause of the enum-through regression

Removing the guard alone returned the **wrong** target for the enum-typed
through case (`has-one-through-disable-joins-associations` → "disable joins
through with enum type"). `_loadSingularViaStatementCache` merged the built
`AssociationScope` into a bare `_scopeForAssociation(targetModel)`, so the
compiled statement dropped the join model's STI `type_condition`
(`memberships.type = 1`), matching any membership row for the owner.

Rails' `find_target` merges into the association's `target_scope`, and
`ThroughAssociation#target_scope` folds each intermediate reflection's
`scope_for_association` — which carries that `type_condition` — into the query.
The fix uses the association instance's `target_scope()` as the merge base, so
the compiled SQL is complete and stable across owners.

Also adds `ThroughReflection#associationScopeCache` delegating to
`delegateReflection`: Rails reaches this method via the catch-all
`delegate(*delegate_methods, to: :delegate_reflection)` at the tail of
`ThroughReflection`, since it extends `AbstractReflection` and has no
`association_scope_cache` of its own.

## Tests

- Added a focused regression test in `association-scope-cache.test.ts`: a
  `Member` holding both a `CurrentMembership → boring_club` and a plain
  `Membership → moustache_club` must resolve `has_one :club` through the current
  membership's STI type. Asserts compile-once / reuse-across-owners and correct
  per-owner target. **Verified it fails without the fix** (returns the wrong
  club) and passes with it.
- Green on SQLite locally: `has-one-through-*`, `nested-through-*`,
  `polymorphic-sti-through`, `disable-joins-nested-through`, plus
  `belongs-to`/`has-one`/`has-many-through` regression suites.

Closes-story: through-singular-association-statement-cache