### PR TITLE
fix(activemodel): derive nested toXml include type= from associated model cast type

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -52,6 +52,7 @@ import {
 } from "./callbacks.js";
 import {
   serializableHash,
+  serializableAddIncludes,
   SerializeOptions,
   asJsonThenable,
   readAttributeForSerialization as serializationReadAttributeForSerialization,
@@ -168,6 +169,75 @@ const XML_MINI_TYPE_NAMES: Record<string, string> = {
   time: "time",
   binary: "binary",
 };
+
+/**
+ * A cast-derived type map for one serialized hash level, mirroring the
+ * column-type table Rails builds per-record in its XML serializer. `types`
+ * maps each scalar attribute key to its `XmlMini` `type=` name; `nested`
+ * carries the same info for each `include`d association keyed by association
+ * name, so a nested numeric column keeps an adapter-stable `type=` attribute
+ * even though `serializableHash` flattens the association into a plain object
+ * that no longer carries its model class.
+ */
+interface XmlTypeInfo {
+  types: Record<string, string>;
+  nested: Record<string, XmlTypeInfo>;
+}
+
+const EMPTY_XML_TYPE_INFO: XmlTypeInfo = { types: {}, nested: {} };
+
+/**
+ * Build the cast-derived {@link XmlTypeInfo} for a record's serialized `hash`,
+ * recursing into each `include`d association so nested numeric columns keep an
+ * adapter-stable `type=` attribute. This mirrors the per-record column-type
+ * table Rails' XML serializer carries for every included association: the
+ * flattened hash `serializableHash` produces no longer names the associated
+ * model, so we re-resolve the association readers (already loaded — no DB
+ * query) to reach each nested model's `typeForAttribute`.
+ *
+ * Mirrors: ActiveSupport::XmlMini::TYPE_NAMES applied to each attribute's cast
+ * type, threaded through the association tree.
+ */
+function _xmlTypeInfo(
+  record: object,
+  hash: Record<string, unknown>,
+  options?: SerializeOptions,
+): XmlTypeInfo {
+  const ctor = record.constructor as typeof Model;
+  const types: Record<string, string> = {};
+  if (typeof ctor.typeForAttribute === "function") {
+    for (const key of Object.keys(hash)) {
+      const xmlName = XML_MINI_TYPE_NAMES[ctor.typeForAttribute(key).type()];
+      if (xmlName) types[key] = xmlName;
+    }
+  }
+
+  const nested: Record<string, XmlTypeInfo> = {};
+  if (options?.include != null) {
+    serializableAddIncludes(record as SerializationRecord, options, (assocName, records, opts) => {
+      const subValue = hash[assocName];
+      // A collection include flattens to an array of hashes; a singular include
+      // to one hash. Every element of a collection shares a model class, so the
+      // representative (first) record's type info applies to all `<item>`s.
+      let repRecord: unknown;
+      let repHash: unknown;
+      if (Array.isArray(subValue)) {
+        if (subValue.length === 0) return;
+        repHash = subValue[0];
+        const items = Array.isArray(records) ? records : Array.from(records as Iterable<unknown>);
+        repRecord = items[0];
+      } else {
+        repHash = subValue;
+        repRecord = records;
+      }
+      if (repRecord && typeof repRecord === "object" && repHash && typeof repHash === "object") {
+        nested[assocName] = _xmlTypeInfo(repRecord, repHash as Record<string, unknown>, opts);
+      }
+    });
+  }
+
+  return { types, nested };
+}
 
 /**
  * Model — the base class that bundles Attributes, Validations, Callbacks,
@@ -2292,35 +2362,14 @@ export class Model {
       options?.root ?? (this.constructor as typeof Model).modelName.singular,
       renameOptions,
     );
-    return `<${root}>\n${this._hashToXml(hash, "  ", options?.skipTypes ?? false, this._xmlTypeMap(hash), renameOptions)}</${root}>`;
-  }
-
-  /**
-   * Map each top-level serialized key to its Rails `XmlMini` `type=` name,
-   * derived from the attribute's cast/column type rather than the JS runtime
-   * type of the materialized value. This keeps `type="integer"` on a bigint
-   * `id` even when PG/MariaDB hand it back as a JS `BigInt`/string instead of a
-   * `number`. Keys whose cast type has no XmlMini name (strings, unknown
-   * attributes) are omitted so the serializer falls back to runtime inference.
-   *
-   * Mirrors: ActiveSupport::XmlMini::TYPE_NAMES applied to the attribute's type.
-   */
-  private _xmlTypeMap(hash: Record<string, unknown>): Record<string, string> {
-    const ctor = this.constructor as typeof Model;
-    if (typeof ctor.typeForAttribute !== "function") return {};
-    const map: Record<string, string> = {};
-    for (const key of Object.keys(hash)) {
-      const xmlName = XML_MINI_TYPE_NAMES[ctor.typeForAttribute(key).type()];
-      if (xmlName) map[key] = xmlName;
-    }
-    return map;
+    return `<${root}>\n${this._hashToXml(hash, "  ", options?.skipTypes ?? false, _xmlTypeInfo(this, hash, options), renameOptions)}</${root}>`;
   }
 
   private _hashToXml(
     hash: Record<string, unknown>,
     indent: string,
     skipTypes = false,
-    typeMap: Record<string, string> = {},
+    typeInfo: XmlTypeInfo = EMPTY_XML_TYPE_INFO,
     renameOptions: RenameKeyOptions = {},
   ): string {
     // `skip_types: true` (XmlMini) suppresses the inferred `type="..."`
@@ -2333,7 +2382,7 @@ export class Model {
       // The cast/column type name (when known) overrides JS-runtime inference so
       // the `type=` attribute is adapter-agnostic (e.g. a bigint `id` stays
       // `type="integer"` whether it arrives as a JS number, BigInt, or string).
-      const castTypeName = typeMap[key];
+      const castTypeName = typeInfo.types[key];
       if (value === null || value === undefined) {
         xml += `${indent}<${tag} nil="true"/>\n`;
       } else if (
@@ -2348,7 +2397,7 @@ export class Model {
         !(value instanceof Temporal.PlainTime) &&
         !(value instanceof Temporal.ZonedDateTime)
       ) {
-        xml += `${indent}<${tag}>\n${this._hashToXml(value as Record<string, unknown>, indent + "  ", skipTypes, {}, renameOptions)}${indent}</${tag}>\n`;
+        xml += `${indent}<${tag}>\n${this._hashToXml(value as Record<string, unknown>, indent + "  ", skipTypes, typeInfo.nested[key] ?? EMPTY_XML_TYPE_INFO, renameOptions)}${indent}</${tag}>\n`;
         // boundary: legacy Date values serialize as ISO 8601 dateTime XML.
       } else if (value instanceof Date) {
         xml += `${indent}<${tag}${typeAttr("dateTime")}>${Number.isNaN(value.getTime()) ? "" : value.toISOString()}</${tag}>\n`;
@@ -2356,7 +2405,7 @@ export class Model {
         xml += `${indent}<${tag}${typeAttr("array")}>\n`;
         for (const item of value) {
           if (typeof item === "object" && item !== null) {
-            xml += `${indent}  <item>\n${this._hashToXml(item as Record<string, unknown>, indent + "    ", skipTypes, {}, renameOptions)}${indent}  </item>\n`;
+            xml += `${indent}  <item>\n${this._hashToXml(item as Record<string, unknown>, indent + "    ", skipTypes, typeInfo.nested[key] ?? EMPTY_XML_TYPE_INFO, renameOptions)}${indent}  </item>\n`;
           } else {
             xml += `${indent}  <item>${this._escapeXml(String(item))}</item>\n`;
           }

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -217,8 +217,14 @@ function _xmlTypeInfo(
     serializableAddIncludes(record as SerializationRecord, options, (assocName, records, opts) => {
       const subValue = hash[assocName];
       // A collection include flattens to an array of hashes; a singular include
-      // to one hash. Every element of a collection shares a model class, so the
-      // representative (first) record's type info applies to all `<item>`s.
+      // to one hash. Deriving `type=` needs only the elements' column/cast
+      // types, and every element of one `has_many`/`has_one` shares them: the
+      // association targets a single model class, and STI subclasses ride the
+      // same table with the same column types. (Rails polymorphism is a
+      // `belongs_to`/singular concept, not a per-element property of a
+      // collection.) So the representative (first) record's type map applies to
+      // all `<item>`s. A record whose column types genuinely diverge from the
+      // first would just fall back to runtime inference for the mismatch.
       let repRecord: unknown;
       let repHash: unknown;
       if (Array.isArray(subValue)) {

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -811,6 +811,53 @@ describe("toXml()", () => {
     expect(xml).toContain('<rating type="float">4.5</rating>');
   });
 
+  it("derives the type attribute for a nested collection include from the associated model's cast type", () => {
+    // The same adapter-dependent deviation as the top-level case, one level
+    // down: PG/MariaDB materialize a nested bigint `id` as a JS BigInt/string,
+    // so `type="integer"` must come from the associated model's cast type, not
+    // `typeof value`. `serializableHash` flattens the association into a plain
+    // object that no longer carries its class, so toXml re-derives it.
+    class Comment extends Model {
+      static {
+        this.attribute("id", "big_integer");
+        this.attribute("body", "string");
+      }
+    }
+    class Post extends Model {
+      comments: Comment[] = [];
+      static {
+        this.attribute("id", "big_integer");
+      }
+    }
+    const comment = new Comment({ body: "Nice" });
+    comment.writeAttribute("id", "99");
+    const p = new Post({});
+    p.comments = [comment];
+    const xml = p.toXml({ include: "comments" });
+    expect(xml).toContain('<id type="integer">99</id>');
+  });
+
+  it("derives the type attribute for a nested singular include from the associated model's cast type", () => {
+    class Author extends Model {
+      static {
+        this.attribute("id", "big_integer");
+        this.attribute("name", "string");
+      }
+    }
+    class Post extends Model {
+      author: Author | null = null;
+      static {
+        this.attribute("id", "big_integer");
+      }
+    }
+    const author = new Author({ name: "Alice" });
+    author.writeAttribute("id", "7");
+    const p = new Post({});
+    p.author = author;
+    const xml = p.toXml({ include: "author" });
+    expect(xml).toContain('<id type="integer">7</id>');
+  });
+
   it("supports custom root element", () => {
     class User extends Model {
       static {


### PR DESCRIPTION
## Summary

`Model#toXml({ include: ... })` derived the XML `type=` attribute for **top-level** attributes from each attribute's cast type (PR #4574), but nested `include`d hashes still fell back to JS-runtime inference. `serializableHash` flattens each association into a plain object that no longer carries its model class, so a nested bigint `id` materialized as a JS `BigInt`/string on PG/MariaDB dropped its `type="integer"` attribute one level down — the same adapter-dependent deviation, just nested.

## Changes

- `_hashToXml` now threads a recursive `XmlTypeInfo` (per-level cast-derived type map + per-association nested maps) instead of a flat top-level `Record<string,string>`.
- New `_xmlTypeInfo` rebuilds the tree by re-resolving the already-loaded association readers (via `serializableAddIncludes` — no DB query) to reach each nested model's `typeForAttribute`, mirroring the per-record column-type table Rails' XML serializer carries for every included association.
- Collection includes (array `<item>` sub-hashes) and singular includes both carry cast-derived `type=` attributes.
- Regression tests: a nested collection include and a nested singular include, each with a bigint `id` written as a string (mirroring PG/MariaDB), asserting `<id type="integer">…</id>`.

## Scope

activemodel only. No api:compare / test:compare surface change.

Closes-story: model-toxml-nested-include-type-attr