### PR TITLE
fix(activemodel): BigIntegerType keeps safe-range integers as JS number

### DIFF
--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -473,14 +473,14 @@ describe("SerializationTest", () => {
       const b = new Blog({ name: "b" });
       setAssociationAccessors(b, {
         posts: [
-          new Post({ id: "1000000000000", title: "p1" }),
-          new Post({ id: "2000000000000", title: "p2" }),
+          new Post({ id: "10000000000000000000", title: "p1" }),
+          new Post({ id: "20000000000000000000", title: "p2" }),
         ],
       });
       const json = b.asJson({ include: "posts" });
       expect(Array.isArray(json.posts)).toBe(true);
-      // Each post's BigInt id is coerced to a string.
-      expect((json.posts as Array<{ id: string }>)[0].id).toBe("1000000000000");
+      // Each post's above-safe-range BigInt id is coerced to a string.
+      expect((json.posts as Array<{ id: string }>)[0].id).toBe("10000000000000000000");
       expect(() => JSON.stringify(json)).not.toThrow();
     });
 
@@ -517,7 +517,7 @@ describe("SerializationTest", () => {
       const r = new Row({ id: "42", name: "row-1" });
       expect(JSON.stringify(r)).toBe(r.toJson());
       const parsed = JSON.parse(JSON.stringify(r));
-      expect(parsed).toEqual({ id: "42", name: "row-1" });
+      expect(parsed).toEqual({ id: 42, name: "row-1" });
     });
 
     it("JSON.stringify(model) with large bigint id above Number.MAX_SAFE_INTEGER", () => {

--- a/packages/activemodel/src/type/big-integer.test.ts
+++ b/packages/activemodel/src/type/big-integer.test.ts
@@ -4,15 +4,15 @@ import { Types, BigIntegerType, IntegerType } from "../index.js";
 describe("BigIntegerTest", () => {
   it("type cast big integer", () => {
     const type = Types.typeRegistry.lookup("big_integer");
-    expect(type.cast("42")).toBe(42n);
+    expect(type.cast("42")).toBe(42);
     expect(type.cast(null)).toBe(null);
   });
 
   it("BigInteger small values", () => {
     const type = Types.typeRegistry.lookup("big_integer");
-    expect(type.cast("0")).toBe(0n);
-    expect(type.cast("1")).toBe(1n);
-    expect(type.cast("-1")).toBe(-1n);
+    expect(type.cast("0")).toBe(0);
+    expect(type.cast("1")).toBe(1);
+    expect(type.cast("-1")).toBe(-1);
   });
 
   it("BigInteger large values", () => {
@@ -25,13 +25,13 @@ describe("BigIntegerTest", () => {
     const type = Types.typeRegistry.lookup("big_integer");
     const cast = type.cast("123");
     const serialized = type.serialize(cast);
-    expect(cast).toBe(123n);
+    expect(cast).toBe(123);
     expect(String(serialized)).toBe(String(cast));
   });
 
   it("small values", () => {
     const type = Types.typeRegistry.lookup("big_integer");
-    expect(type.cast(42)).toBe(42n);
+    expect(type.cast(42)).toBe(42);
   });
 
   it("large values", () => {
@@ -56,28 +56,28 @@ describe("BigIntegerTest", () => {
 
   it("leading + in numeric string casts to bigint (Rails to_i accepts leading +)", () => {
     const type = new BigIntegerType();
-    expect(type.cast("+42")).toBe(42n);
+    expect(type.cast("+42")).toBe(42);
     expect(type.cast("+99999999999999999999")).toBe(BigInt("99999999999999999999"));
   });
 
   it("numeric string with trailing characters extracts leading digits (Rails to_i)", () => {
     const type = new BigIntegerType();
-    expect(type.cast("123abc")).toBe(123n);
+    expect(type.cast("123abc")).toBe(123);
     // Preserves precision for large leading-digit runs with trailing chars.
     expect(type.cast("99999999999999999999trailing")).toBe(BigInt("99999999999999999999"));
   });
 
-  it("numeric string casts to bigint", () => {
+  it("numeric string in safe range casts to number", () => {
     const type = new BigIntegerType();
-    expect(type.cast("42")).toBe(42n);
-    expect(typeof type.cast("42")).toBe("bigint");
+    expect(type.cast("42")).toBe(42);
+    expect(typeof type.cast("42")).toBe("number");
   });
 
   it("serialize returns numeric (number or bigint), never string", () => {
     const type = new BigIntegerType();
     const BIG = 2n ** 62n;
-    expect(type.serialize(42n)).toBe(42n);
-    expect(type.serialize("42")).toBe(42n);
+    expect(type.serialize(42n)).toBe(42);
+    expect(type.serialize("42")).toBe(42);
     expect(typeof type.serialize(BIG)).toBe("bigint");
     expect(type.serialize(BIG)).toBe(BIG);
   });

--- a/packages/activemodel/src/type/big-integer.ts
+++ b/packages/activemodel/src/type/big-integer.ts
@@ -3,13 +3,6 @@ import { IntegerType } from "./integer.js";
 export class BigIntegerType extends IntegerType {
   readonly name: string = "big_integer";
 
-  // Mirrors Rails: `BigInteger < Integer` inherits `Integer#type`, hardcoded
-  // `:integer`. Our `name` ("big_integer") is the type-registry key, not the
-  // reflected column type — `column.type` for a bigint is `:integer`.
-  override type(): string {
-    return "integer";
-  }
-
   // Mirrors Rails big_integer.rb:29 — serialize_cast_value returns value as-is,
   // bypassing Integer's ensureInRange. BigIntegerType is unconditionally unlimited.
   override serializeCastValue(value: number | null): number | null {
@@ -20,6 +13,13 @@ export class BigIntegerType extends IntegerType {
   // limit, so Integer's number-path range check never fires.
   protected override maxValue(): number {
     return Number.POSITIVE_INFINITY;
+  }
+
+  // Mirrors Rails: `BigInteger < Integer` inherits `Integer#type`, hardcoded
+  // `:integer`. Our `name` ("big_integer") is the type-registry key, not the
+  // reflected column type — `column.type` for a bigint is `:integer`.
+  override type(): string {
+    return "integer";
   }
 
   /**
@@ -36,10 +36,10 @@ export class BigIntegerType extends IntegerType {
    * same value all compare `===`.
    */
   protected override castValue(value: unknown): number | null {
-    if (typeof value === "bigint") return this.narrow(value);
+    if (typeof value === "bigint") return this.narrowBigInt(value);
     if (typeof value === "number") {
       if (isNaN(value) || !isFinite(value)) return null;
-      return this.narrow(BigInt(Math.trunc(value)));
+      return this.narrowBigInt(BigInt(Math.trunc(value)));
     }
     if (typeof value === "string") {
       const trimmed = value.trim();
@@ -50,20 +50,9 @@ export class BigIntegerType extends IntegerType {
       // BigInt() rejects a leading "+"; strip it first.
       const lead = trimmed.match(/^([+-]?\d+)/)?.[1];
       if (!lead) return null;
-      return this.narrow(BigInt(lead.startsWith("+") ? lead.slice(1) : lead));
+      return this.narrowBigInt(BigInt(lead.startsWith("+") ? lead.slice(1) : lead));
     }
     return super.castValue(value);
-  }
-
-  /**
-   * Collapse a `bigint` to a JS `number` when it fits float64's safe-integer
-   * range; otherwise keep the `bigint` (carried under a `number` cast, the
-   * technique the type primitives use to stay `ValueType<number>`-backed while
-   * preserving precision for out-of-range bignums).
-   */
-  private narrow(value: bigint): number {
-    const num = Number(value);
-    return Number.isSafeInteger(num) ? num : (value as unknown as number);
   }
 
   override serialize(value: unknown): unknown {

--- a/packages/activemodel/src/type/big-integer.ts
+++ b/packages/activemodel/src/type/big-integer.ts
@@ -22,12 +22,24 @@ export class BigIntegerType extends IntegerType {
     return Number.POSITIVE_INFINITY;
   }
 
-  /** @internal Rails-private helper. */
+  /**
+   * @internal Rails-private helper.
+   *
+   * Ruby has a single unbounded `Integer`, so Rails represents every id the
+   * same way regardless of magnitude. Trails is `number`-backed, so we keep a
+   * safe-range integer (`[MIN_SAFE_INTEGER, MAX_SAFE_INTEGER]`) as a plain JS
+   * `number` and only carry a `bigint` (under a `number` cast) for genuine
+   * bignums beyond float64's exact-integer range. This matches
+   * `IntegerType#castValue` and gives pg/MariaDB the same "safe-range integer
+   * is a number" contract better-sqlite3/mysql2 already honor, so a default
+   * `bigint` PK, `pluck`, collection `ids`, and an `integer` FK holding the
+   * same value all compare `===`.
+   */
   protected override castValue(value: unknown): number | null {
-    if (typeof value === "bigint") return value as unknown as number;
+    if (typeof value === "bigint") return this.narrow(value);
     if (typeof value === "number") {
       if (isNaN(value) || !isFinite(value)) return null;
-      return BigInt(Math.trunc(value)) as unknown as number;
+      return this.narrow(BigInt(Math.trunc(value)));
     }
     if (typeof value === "string") {
       const trimmed = value.trim();
@@ -38,9 +50,20 @@ export class BigIntegerType extends IntegerType {
       // BigInt() rejects a leading "+"; strip it first.
       const lead = trimmed.match(/^([+-]?\d+)/)?.[1];
       if (!lead) return null;
-      return BigInt(lead.startsWith("+") ? lead.slice(1) : lead) as unknown as number;
+      return this.narrow(BigInt(lead.startsWith("+") ? lead.slice(1) : lead));
     }
     return super.castValue(value);
+  }
+
+  /**
+   * Collapse a `bigint` to a JS `number` when it fits float64's safe-integer
+   * range; otherwise keep the `bigint` (carried under a `number` cast, the
+   * technique the type primitives use to stay `ValueType<number>`-backed while
+   * preserving precision for out-of-range bignums).
+   */
+  private narrow(value: bigint): number {
+    const num = Number(value);
+    return Number.isSafeInteger(num) ? num : (value as unknown as number);
   }
 
   override serialize(value: unknown): unknown {

--- a/packages/activemodel/src/type/integer.ts
+++ b/packages/activemodel/src/type/integer.ts
@@ -135,8 +135,7 @@ export class IntegerType extends NumericValueType {
       return Math.trunc(value);
     }
     if (typeof value === "bigint") {
-      const num = Number(value);
-      return Number.isSafeInteger(num) ? num : (value as unknown as number);
+      return this.narrowBigInt(value);
     }
     const parsed = parseInt(String(value), 10);
     return isNaN(parsed) ? null : parsed;
@@ -197,5 +196,20 @@ export class IntegerType extends NumericValueType {
    */
   protected _limit(): number {
     return this.limit ?? DEFAULT_LIMIT;
+  }
+
+  /**
+   * Collapse a `bigint` to a JS `number` when it fits float64's safe-integer
+   * range; otherwise keep the `bigint` (carried under a `number` cast, the
+   * technique the numeric type primitives use to stay `ValueType<number>`-backed
+   * while preserving precision for out-of-range bignums). `Number.isSafeInteger`
+   * on the converted value is exact at the boundary — `2**53` and any bigint
+   * that rounds down onto it both fail the guard, so no precision is lost.
+   *
+   * @internal Rails-private helper.
+   */
+  protected narrowBigInt(value: bigint): number {
+    const num = Number(value);
+    return Number.isSafeInteger(num) ? num : (value as unknown as number);
   }
 }

--- a/packages/activerecord/src/adapters/postgresql/integer.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/integer.test.ts
@@ -6,7 +6,7 @@ import { BigIntegerType } from "@blazetrails/activemodel";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 
 // Rails: 2.gigabytes = 2 * 1024 * 1024 * 1024
-const TWO_GB = 2n * 1024n * 1024n * 1024n;
+const TWO_GB = 2 * 1024 * 1024 * 1024;
 
 describeIfPg("PostgreSQLAdapter", () => {
   let adapter: PostgreSQLAdapter;

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -934,24 +934,24 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     it("create int8range", async () => {
       // Rails: assert_equal_round_trip(@new_range, :int8_range, Range.new(30, 50, true))
-      // BigIntegerType.castValue returns BigInt; bounds round-trip as 30n/50n.
+      // BigIntegerType keeps safe-range bounds as JS numbers; they round-trip as 30/50.
       const range = new Range(30, 50, true);
       const r = await PostgresqlRanges.create({ int8_range: range });
       await r.reload();
       const result = r.int8_range as Range;
       expect(result).toBeInstanceOf(Range);
-      expect(result.begin).toBe(30n);
-      expect(result.end).toBe(50n);
+      expect(result.begin).toBe(30);
+      expect(result.end).toBe(50);
       expect(result.excludeEnd).toBe(true);
     });
     it("update int8range", async () => {
       // Rails: assert_equal_round_trip => 60000...10000000; assert_nil_round_trip => 39999...39999 (empty → nil)
-      // BigIntegerType.castValue returns BigInt; bounds round-trip as bigint values.
+      // BigIntegerType keeps safe-range bounds as JS numbers.
       const range = new Range(60000, 10000000, true);
       const r = await PostgresqlRanges.create({ int8_range: range });
       await r.reload();
-      expect((r.int8_range as Range).begin).toBe(60000n);
-      expect((r.int8_range as Range).end).toBe(10000000n);
+      expect((r.int8_range as Range).begin).toBe(60000);
+      expect((r.int8_range as Range).end).toBe(10000000);
       // [39999,39999) is empty in int8range → null on reload
       r.int8_range = new Range(39999, 39999, true);
       await r.saveBang();
@@ -984,9 +984,9 @@ describeIfPg("PostgreSQLAdapter", () => {
       await PostgresqlRanges.updateAll({ int8_range: new Range(1, 100, false) });
       const first = await PostgresqlRanges.first();
       expect(first!.int8_range).toBeInstanceOf(Range);
-      expect((first!.int8_range as Range).begin).toBe(BigInt(1));
+      expect((first!.int8_range as Range).begin).toBe(1);
       // PG normalises [1,100] → [1,101) for discrete int8range (Rails: 1...101)
-      expect((first!.int8_range as Range).end).toBe(BigInt(101));
+      expect((first!.int8_range as Range).end).toBe(101);
       expect((first!.int8_range as Range).excludeEnd).toBe(true);
     });
     it("ranges correctly escape input", async () => {

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -588,7 +588,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     cacheAssoc(company, "clients", [client]);
     const saved = await company.save();
     expect(saved).toBe(true);
-    expect(Number(client.client_of)).toBe(Number(company.id));
+    expect(client.client_of).toBe(company.id);
   });
 
   it("parent should not get saved with duplicate children records", async () => {
@@ -620,7 +620,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     const saved = await company.save();
     expect(saved).toBe(true);
     expect(client.isNewRecord()).toBe(false);
-    expect(Number(client.client_of)).toBe(Number(company.id));
+    expect(client.client_of).toBe(company.id);
   });
 
   it("assign ids", async () => {
@@ -1087,7 +1087,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     cacheAssoc(firm, "account", account);
     await firm.save();
     expect(account.isNewRecord()).toBe(false);
-    expect(Number(account.firm_id)).toBe(Number(firm.id));
+    expect(account.firm_id).toBe(firm.id);
   });
 
   it("build before either saved", async () => {
@@ -1098,7 +1098,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     await firm.save();
     expect(firm.isNewRecord()).toBe(false);
     expect(account.isNewRecord()).toBe(false);
-    expect(Number(account.firm_id)).toBe(Number(firm.id));
+    expect(account.firm_id).toBe(firm.id);
   });
 
   it("assignment before parent saved", async () => {
@@ -1107,7 +1107,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     const account = new Account({ credit_limit: 300 });
     cacheAssoc(firm, "account", account);
     await firm.save();
-    expect(Number(account.firm_id)).toBe(Number(firm.id));
+    expect(account.firm_id).toBe(firm.id);
   });
 
   it("assignment before either saved", async () => {
@@ -1445,7 +1445,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     expect(log).toContain("before_save");
     expect(log).toContain("after_save");
     expect(child.isNewRecord()).toBe(false);
-    expect(Number(child._readAttribute("employable_id"))).toBe(Number(parent.id));
+    expect(child._readAttribute("employable_id")).toBe(parent.id);
     expect(child._readAttribute("employable_type")).toBe("PolyParent");
   });
   it("callbacks on child when child autosaves parent", async () => {
@@ -1562,7 +1562,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     expect(log).toContain("parent_before_save");
     expect(log).toContain("parent_after_save");
     expect(parent.isNewRecord()).toBe(false);
-    expect(Number(child._readAttribute("employable_id"))).toBe(Number(parent.id));
+    expect(child._readAttribute("employable_id")).toBe(parent.id);
     expect(child._readAttribute("employable_type")).toBe("PolyAsParent");
   });
 
@@ -1572,7 +1572,7 @@ describe("TestDefaultAutosaveAssociationOnAHasOneAssociation", () => {
     const account = await Account.create({ credit_limit: 600, firm_id: firm.id });
     cacheAssoc(firm, "account", account);
     await firm.save();
-    expect(Number(account.firm_id)).toBe(Number(firm.id));
+    expect(account.firm_id).toBe(firm.id);
   });
 });
 
@@ -1622,7 +1622,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     cacheAssoc(pirate, "ship", ship);
     await pirate.save();
     expect(ship.isNewRecord()).toBe(false);
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
   });
 
   it("changed for autosave should handle cycles", async () => {
@@ -1982,7 +1982,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     cacheAssoc(cake, "chef", chef);
     await cake.save();
     expect(chef._readAttribute("employable_type")).toBe("SwapCakeDesigner");
-    expect(Number(chef._readAttribute("employable_id"))).toBe(Number(cake.id));
+    expect(chef._readAttribute("employable_id")).toBe(cake.id);
 
     // Reassign chef to drink — polymorphic type column flips even when
     // employable_id may collide. autosave on drink should re-persist the chef.
@@ -1990,7 +1990,7 @@ describe("TestAutosaveAssociationOnAHasOneAssociation", () => {
     cacheAssoc(drink, "chef", chef);
     await drink.save();
     expect(chef._readAttribute("employable_type")).toBe("SwapDrinkDesigner");
-    expect(Number(chef._readAttribute("employable_id"))).toBe(Number(drink.id));
+    expect(chef._readAttribute("employable_id")).toBe(drink.id);
   });
 });
 
@@ -2129,7 +2129,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     cacheAssoc(post, "author", author);
     await post.save();
     expect(author.isNewRecord()).toBe(false);
-    expect(Number(post.author_id)).toBe(Number(author.id));
+    expect(post.author_id).toBe(author.id);
   });
 
   it("assignment before either saved", async () => {
@@ -2150,7 +2150,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     await post.save();
     expect(post.isNewRecord()).toBe(false);
     expect(author.isNewRecord()).toBe(false);
-    expect(Number(post.author_id)).toBe(Number(author.id));
+    expect(post.author_id).toBe(author.id);
   });
 
   it("store association in two relations with one save", async () => {
@@ -2162,19 +2162,11 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     setBilling(order, customer);
     setShipping(order, customer);
     expect(await order.save()).toBe(true);
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     await order.reload();
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     expect(await Order.count()).toBe(numOrders + 1);
     expect(await Customer.count()).toBe(numCustomers + 1);
   });
@@ -2187,19 +2179,11 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     setBilling(order, customer);
     setShipping(order, customer);
     expect(await order.save()).toBe(true);
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     await order.reload();
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     expect(await Order.count()).toBe(numOrders + 1);
     expect(await Customer.count()).toBe(numCustomers + 1);
   });
@@ -2212,24 +2196,16 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     setBilling(order, customer);
     setShipping(order, customer);
     expect(await order.save()).toBe(true);
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     await order.reload();
     customer = new Customer({ name: "C2" });
     setBilling(order, customer);
     setShipping(order, customer);
     expect(await order.save()).toBe(true);
     await order.reload();
-    expect(Number(((await order.association("billing").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
-    expect(Number(((await order.association("shipping").loadTarget()) as Base).id)).toBe(
-      Number(customer.id),
-    );
+    expect(((await order.association("billing").loadTarget()) as Base).id).toBe(customer.id);
+    expect(((await order.association("shipping").loadTarget()) as Base).id).toBe(customer.id);
     expect(await Order.count()).toBe(numOrders + 1);
     expect(await Customer.count()).toBe(numCustomers + 2);
   });
@@ -2263,7 +2239,7 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     setBelongsTo(sponsor, "sponsorable", member, { polymorphic: true });
     await sponsor.save();
     const reloaded = await PolySponsor.find(sponsor.id!);
-    expect(Number(reloaded.sponsorable_id)).toBe(Number(member.id));
+    expect(reloaded.sponsorable_id).toBe(member.id);
     expect(reloaded.sponsorable_type).toBe("PolyMember");
   });
 
@@ -2401,7 +2377,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
     cacheAssoc(ship, "pirate", pirate);
     await ship.save();
     expect(pirate.isNewRecord()).toBe(false);
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
   });
 
   it("should automatically save bang the associated model", async () => {
@@ -2519,7 +2495,7 @@ describe("TestAutosaveAssociationOnABelongsToAssociation", () => {
     const ship = new Ship({ name: "FK", pirate_id: pirate.id });
     cacheAssoc(ship, "pirate", pirate);
     await ship.save();
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
   });
 
   it("should save if previously saved", async () => {
@@ -2860,7 +2836,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await pirate.save();
     expect(pirate.catchphrase).toBe("Ahoy!");
     expect(ship.isNewRecord()).toBe(false);
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
   });
 
   it("autosave does not pass through non custom validation contexts", async () => {
@@ -2995,7 +2971,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await author.save();
     expect(book.isNewRecord()).toBe(false);
     expect(saveCount).toBe(1);
-    expect(Number(book.author_id)).toBe(Number(author.id));
+    expect(book.author_id).toBe(author.id);
   });
 
   it("autosave has one association callbacks get called once", async () => {
@@ -3036,7 +3012,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await user.save();
     expect(profile.isNewRecord()).toBe(false);
     expect(saveCount).toBe(1);
-    expect(Number(profile.author_id)).toBe(Number(user.id));
+    expect(profile.author_id).toBe(user.id);
   });
 
   it("autosave belongs to association callbacks get called once", async () => {
@@ -3077,7 +3053,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     await post.save();
     expect(author.isNewRecord()).toBe(false);
     expect(saveCount).toBe(1);
-    expect(Number(post.author_id)).toBe(Number(author.id));
+    expect(post.author_id).toBe(author.id);
   });
 
   it("default belongs_to saves new associated record and propagates the FK", async () => {
@@ -3116,7 +3092,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     cacheAssoc(post, "author", author);
     await post.save();
     expect(author.isNewRecord()).toBe(false);
-    expect(Number(post.author_id)).toBe(Number(author.id));
+    expect(post.author_id).toBe(author.id);
   });
 
   it("belongs_to autosave with mismatched composite FK/PK uses zip semantics", async () => {
@@ -3160,7 +3136,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     cacheAssoc(child, "parent", parent);
     await child.save();
     expect(parent.isNewRecord()).toBe(false);
-    expect(Number(child.parent_id)).toBe(Number(parent.id));
+    expect(child.parent_id).toBe(parent.id);
     // Trailing FK "group" was dropped from the zip; the existing
     // owner value must survive untouched (no overwrite to undefined/null).
     expect(child.group).toBe("us-west");
@@ -3251,7 +3227,7 @@ describe("TestAutosaveAssociationsInGeneral", () => {
     cacheAssoc(child, "parent", parent);
     await child.save();
     expect(parent.isNewRecord()).toBe(false);
-    expect(Number(child.author_id)).toBe(Number(parent.id));
+    expect(child.author_id).toBe(parent.id);
     // The dropped ("name", nil) pair didn't attempt to write — no throw,
     // no spurious column write.
   });
@@ -4043,7 +4019,7 @@ describe("TestDefaultAutosaveAssociationOnNewRecord", () => {
     await pirate.save();
     expect(log).toContain("pirate_created");
     expect(pirate.isNewRecord()).toBe(false);
-    expect(Number(ship.pirate_id)).toBe(Number(pirate.id));
+    expect(ship.pirate_id).toBe(pirate.id);
     expect(ship.isNewRecord()).toBe(false);
   });
 
@@ -4653,7 +4629,7 @@ describe("should update children when autosave is true and parent is new but chi
     expect(parent.isNewRecord()).toBe(false);
     const reloaded = await UcChild.find(child.id);
     expect(reloaded.name).toBe("updated");
-    expect(Number(reloaded.readAttribute("author_id"))).toBe(Number(parent.id));
+    expect(reloaded.readAttribute("author_id")).toBe(parent.id);
   });
   it("should automatically save the associated models", async () => {
     class NAutoTag extends Base {

--- a/packages/activerecord/src/numeric-data.test.ts
+++ b/packages/activerecord/src/numeric-data.test.ts
@@ -56,8 +56,8 @@ describe("NumericDataTest", () => {
     expect(typeof m1!.world_population).toBe("bigint");
     expect(m1!.world_population).toBe(2n ** 62n);
 
-    expect(typeof m1!.my_house_population).toBe("bigint");
-    expect(m1!.my_house_population).toBe(3n);
+    expect(typeof m1!.my_house_population).toBe("number");
+    expect(m1!.my_house_population).toBe(3);
 
     expect(m1!.bank_balance).toBeInstanceOf(BigDecimal);
     expect((m1!.bank_balance as BigDecimal).toString("F")).toBe("1586.43");
@@ -83,8 +83,8 @@ describe("NumericDataTest", () => {
     expect(typeof m1!.world_population).toBe("bigint");
     expect(m1!.world_population).toBe(2n ** 62n);
 
-    expect(typeof m1!.my_house_population).toBe("bigint");
-    expect(m1!.my_house_population).toBe(3n);
+    expect(typeof m1!.my_house_population).toBe("number");
+    expect(m1!.my_house_population).toBe(3);
 
     expect(m1!.bank_balance).toBeInstanceOf(BigDecimal);
     expect((m1!.bank_balance as BigDecimal).toString("F")).toBe("1586.43");


### PR DESCRIPTION
## Summary

`BigIntegerType#castValue` produced a `bigint` for every input, so on **pg**
(int8 → decimal string) and **MariaDB** (mysql2) a default `bigint` PK — and
every id-producing path fed by it (`pluck`, collection `ids`, an `integer` FK
holding the same value) — came back as `bigint`, while better-sqlite3/mysql2
kept safe-range PKs as `number`. That desynced paired `deeply-equal`
comparisons across ~20 tests (`expected [ 1n, 2n ] to deeply equal [ 1, 2 ]`).

Root cause is one layer below the `id` accessor (the approach in the closed
#4530): the type primitive. This collapses a safe-range integer
(`[MIN_SAFE_INTEGER, MAX_SAFE_INTEGER]`) to a plain JS `number` and carries a
`bigint` only for genuine bignums beyond float64's exact-integer range,
matching `IntegerType#castValue`. Because a bigint PK column feeds every id
path through the same `BigIntegerType`, fixing the type flips every path
together and preserves the symmetry the assertions depend on.

`cast` and `deserialize` now agree on representation for the same logical
value (no spurious dirty-tracking), so pg/MariaDB gain the same "safe-range
integer is a number" contract the other adapters already honor. The 31
`Number()` wrappers on `child.fk`/`parent.id` comparisons in
`autosave-association.test.ts` are removed.

## Deliberate representation convergence

This reverses PR #783's "bigint for cast" choice for safe-range values but
_aligns_ with its stated cross-adapter intent (safe-range PKs remain numbers).
Genuine-bignum precision is preserved: `bigint-roundtrip.test.ts` (2^62),
unboundable-bignum predicate threading, and pg `checkIntInRange` guards are
untouched.

## Tests

- `big-integer.test.ts` safe-range assertions converged to the `number`
  contract (Rails-verbatim test names kept; only expected values changed).
- `big-integer.test.ts`, `integer.test.ts`, `bigint-roundtrip.test.ts`,
  `autosave-association.test.ts` pass locally on sqlite.
- pg/MariaDB verification is CI-driven.

Closes-story: big-integer-safe-range-number-representation