### PR TITLE
test(postgresql): loosen schema-dump timeout for extension-migration flake

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -69,6 +69,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(await adapter.extensionEnabled("citext")).toBe(true);
       const dump = await adapter.createSchemaDumper(adapter).dump();
       expect(dump).toContain(`await ctx.enableExtension("citext");`);
+      // A full PG schema dump under 6-fork parallel load legitimately exceeds
+      // vitest's 5s default (I/O contention, not a logic bug). Bump to 60s,
+      // matching the sibling dump tests in schema-dumper.trails.test.ts. See
+      // project_schema_dumper_trails_pg_schema_migrations_flake.
     }, 60000);
     it("enable extension migration ignores prefix and suffix", async () => {
       // Rails: table_name_prefix/suffix don't affect extension names

--- a/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/extension-migration.test.ts
@@ -69,7 +69,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(await adapter.extensionEnabled("citext")).toBe(true);
       const dump = await adapter.createSchemaDumper(adapter).dump();
       expect(dump).toContain(`await ctx.enableExtension("citext");`);
-    });
+    }, 60000);
     it("enable extension migration ignores prefix and suffix", async () => {
       // Rails: table_name_prefix/suffix don't affect extension names
       // TS: same — extension names pass through unmodified


### PR DESCRIPTION
The `extension schema dump` case in `adapters/postgresql/extension-migration.test.ts` runs a full PG schema dump. Under concurrent fork load (6 workers × multiple agents) this routinely brushes the default 5000ms per-test limit and times out — a locally-observed 4816ms confirms it sits right at the ceiling. This is the same well-known PG dump-under-fork-load flake family already documented for `comment.test` and `schema-dumper.trails`.

## Fix

Give the dump test the same explicit `60000`ms per-test timeout already used by the sibling PG schema-dump tests in `schema-dumper.trails.test.ts`, following the established convention rather than inventing a new one. It's the only schema-dump case in the file.

No assertion changes, no rename — timeout only.

## Verification

`ARCONN=postgresql pnpm vitest run packages/activerecord/src/adapters/postgresql/extension-migration.test.ts` → 10/10 pass; the dump case reports ~4.8s and no longer times out.