### PR TITLE
test(transactions): lock before_validation-vs-validators save ordering deviation

### DIFF
--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -871,7 +871,8 @@ export async function save<T extends SaveRecord>(
       // The four cancellation tests don't hit this (validations pass); the
       // governing constraint is the strict-sync validation chain — see the
       // Topic wiring and `validations.ts#isValid`. Tracked for convergence:
-      // RFC 0023 story `save-runs-validations-inside-transaction`.
+      // RFC 0057-transaction-fidelity story
+      // `save-runs-validations-inside-transaction`.
       const sideEffects = self._beforeValidationSideEffects as Array<() => unknown>;
       for (const thunk of sideEffects) {
         try {

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -9,7 +9,8 @@
  * mirrors transactions_test.rb) so the convention file tracks Rails 1:1.
  */
 import { describe, it, expect, beforeAll, afterEach, afterAll, vi } from "vitest";
-import { Base, transaction } from "./index.js";
+import { throwAbort } from "@blazetrails/activesupport";
+import { Base, transaction, registerModel } from "./index.js";
 import { NullTransaction } from "./connection-adapters/abstract/transaction.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Topic as CanonicalTopic } from "./test-helpers/models/topic.js";
@@ -71,6 +72,36 @@ afterEach(async () => {
   }
 });
 
+// Minimal view of the record the before_validation-ordering tests drive: the
+// deferred cancelling hook, the save path, and the errors collection they read.
+interface AbortingTopicRecord {
+  beforeValidationForTransaction: () => Promise<void>;
+  save(): Promise<boolean | undefined>;
+  isNewRecord(): boolean;
+  errors: { size: number; include(attr: string): boolean };
+}
+
+// A CanonicalTopic subclass with a validator that always fails plus an aborting
+// async `before_validation` — the record shape that surfaces the ordering
+// deviation. Built fresh per test so the anonymous subclass registration and
+// schema reflection stay isolated.
+async function buildAbortingTopic(): Promise<AbortingTopicRecord> {
+  class AbortingTopic extends CanonicalTopic {
+    static {
+      this.validate((r: { errors: { add(a: string, b: string): void } }) =>
+        r.errors.add("title", "invalid"),
+      );
+    }
+  }
+  registerModel(AbortingTopic as unknown as Parameters<typeof registerModel>[0]);
+  await (AbortingTopic as unknown as { ensureSchemaLoaded(): Promise<void> }).ensureSchemaLoaded();
+  const record = AbortingTopic.new() as unknown as AbortingTopicRecord;
+  record.beforeValidationForTransaction = async () => {
+    throwAbort();
+  };
+  return record;
+}
+
 describe("TransactionTest", () => {
   fixtures({}, { useTransactionalTests: false });
 
@@ -119,6 +150,49 @@ describe("TransactionTest", () => {
     });
 
     expect(log).toEqual(["committed"]);
+  });
+
+  // Tracked-pending-convergence under RFC 0057-transaction-fidelity, story
+  // `save-runs-validations-inside-transaction`.
+  //
+  // Rails layers save as `Transactions#save { with_transaction_returning_status
+  // { Validations#save { perform_validations; Persistence#save } } }`
+  // (transactions.rb:360, validations.rb:47), so the ENTIRE validation pass —
+  // `before_validation` callbacks THEN the validators (`valid?`) — runs inside
+  // the save transaction, `before_validation` FIRST. A `before_validation` that
+  // `throw :abort`s therefore halts the save before any validator runs, so a
+  // record that ALSO has a failing validator reports no errors.
+  //
+  // trails' validation chain is strictly synchronous (`validations.ts#isValid`
+  // returns a boolean, never a Promise), so a `before_validation` needing async
+  // DB work can't abort from inside the chain — the canonical Topic defers its
+  // thunk into `_beforeValidationSideEffects`, which `save` drains INSIDE the
+  // transaction but AFTER `performValidations` has already run the validators
+  // (persistence.ts). The order inverts: trails reports `errors.any` where Rails
+  // reports none. Converging requires splitting the sync `valid?` pass so the
+  // async `before_validation` can await before the validators — the same
+  // sync-only-chain constraint behind `async-validations-honor-validation-context`
+  // and the deferred `_asyncValidations` path. Skipped until that architecture
+  // decision is revisited; the companion test below locks the current behaviour.
+  it.skip("aborting async before_validation halts before validators (Rails order)", async () => {
+    const record = await buildAbortingTopic();
+    // Save halts (abort) and the record stays unsaved — same as trails today.
+    expect(await record.save()).toBeFalsy();
+    expect(record.isNewRecord()).toBe(true);
+    // Rails-only delta: the abort fires *before* `valid?`, so the failing
+    // validator never runs and no error is recorded.
+    expect(record.errors.size).toBe(0);
+  });
+
+  // Regression lock for the deviation documented above: today the sync validators
+  // run BEFORE the deferred async `before_validation` abort, so the failing
+  // `title` validator DOES register its error even though the same abort halts
+  // the save. Remove / fold into the test above once the sync-chain split lands.
+  it("aborting async before_validation still records validator error (trails order)", async () => {
+    const record = await buildAbortingTopic();
+    expect(await record.save()).toBeFalsy();
+    expect(record.isNewRecord()).toBe(true);
+    expect(record.errors.include("title")).toBe(true);
   });
 
   describe("after_failure_actions on PreparedStatementCacheExpired", () => {

--- a/packages/website/docs/guides/activerecord-rails-deviations.md
+++ b/packages/website/docs/guides/activerecord-rails-deviations.md
@@ -344,6 +344,45 @@ one collection-callback semantic that trails' async-everywhere model cannot
 reproduce, and it is ratified as such rather than tracked for a convergence
 that the design forecloses.
 
+### `before_validation` ordering vs. the validators inside `save` (tracked-pending-convergence)
+
+Rails layers `save` as `Transactions#save { with_transaction_returning_status {
+Validations#save { perform_validations; Persistence#save { create_or_update } } }
+}` (`transactions.rb:360`, `validations.rb:47`), so the **entire** validation
+pass — the `before_validation` callbacks _and_ the validators (`valid?`) — runs
+_inside_ the save transaction, with `before_validation` firing _before_ the
+validators. A `before_validation` that `throw :abort`s therefore halts the save
+_before any validator runs_, and a record that _also_ has a failing validator
+reports **no** errors.
+
+trails' validation chain is strictly synchronous — `validations.ts#isValid`
+returns a `boolean`, never a `Promise` (the same constraint behind §1 and the
+deferred `_asyncValidations` uniqueness path). A `before_validation` that needs
+async DB work (Rails runs it inside the save transaction —
+`transactions_test.rb:714`) cannot `await` from inside that sync chain, so it
+defers its thunk into a per-instance `_beforeValidationSideEffects` queue that
+`save` drains _inside_ the transaction (`persistence.ts`) — but _after_
+`performValidations` has already run the validators. The order inverts:
+
+- **Rails**: aborting `before_validation` → save halted, `errors.any? == false`.
+- **trails**: validators run first → `errors.any? == true`, then the deferred
+  abort halts the save.
+
+**Observable only** when a record has BOTH a failing validator AND an aborting
+async `before_validation`; the four cancellation tests in `transactions_test.rb`
+don't hit it (their validations pass), so persistence/rollback parity holds
+across the ported suite. Guarded by two tests in `transactions.trails.test.ts`:
+a skipped test asserting the Rails order and a companion regression-lock
+asserting the current trails order.
+
+**This is NOT a wontfix.** Full convergence — moving `performValidations` inside
+`withTransactionReturningStatus` so `before_validation` fires before the
+validators, all inside the transaction — is gated on the strict-sync validation
+decision being revisited (it ripples through every synchronous `isValid` /
+`valid?` caller and interacts with the deferred async-validation drain). Tracked
+under RFC 0057-transaction-fidelity, story
+`save-runs-validations-inside-transaction`.
+
 ## 12. `Base.update(:all, ...)` sentinel is `":all"`
 
 Rails' `Model.update(id = :all, attributes)` uses Ruby's `:all` symbol


### PR DESCRIPTION
## What

Rails layers `save` as `Transactions#save { with_transaction_returning_status { Validations#save { perform_validations; Persistence#save } } }` (`transactions.rb:360`, `validations.rb:47`), so the whole validation pass — `before_validation` callbacks **then** the validators — runs inside the save transaction, `before_validation` first. An aborting async `before_validation` therefore halts the save *before* any validator runs, and a record that also has a failing validator reports **no** errors.

trails' validation chain is strictly synchronous (`validations.ts#isValid` returns a `boolean`, never a `Promise`), so an async `before_validation` defers its body into `_beforeValidationSideEffects`, drained inside the transaction but **after** `performValidations` — inverting the order for a record with BOTH a failing validator AND an aborting async `before_validation`.

Full convergence (moving `performValidations` inside `withTransactionReturningStatus`) is gated on the sync-only validation architecture being revisited — it ripples through every synchronous `isValid`/`valid?` caller and interacts with the deferred async-validation drain. This is **not** a wontfix.

## Changes

- Record it as a **tracked-pending-convergence** deviation in the ActiveRecord deviations guide (§11).
- Add a skipped Rails-order test plus a passing regression-lock for the current trails order in `transactions.trails.test.ts`.
- Point the `persistence.ts` ORDERING DEVIATION comment at RFC 0057 (was 0023).

## Tests

`pnpm vitest run packages/activerecord/src/transactions.trails.test.ts` — pass (1 relevant pass, 1 tracked skip).

Closes-story: save-runs-validations-inside-transaction