### PR TITLE
test(mysql): declare id PK on adapter-suite bespoke models

### DIFF
--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
@@ -35,8 +35,9 @@ describeIfMysql("Mysql2Adapter", () => {
     // (`_performInsert` → `_writeAttribute("id", insertedId)`) targets a real
     // column under strict `writeFromUser`, without the internal-write bridge.
     // MySQL's default `primary_key` type is `BIGINT AUTO_INCREMENT`
-    // (schema-creation.ts), so declare `bigint` to match the physical column.
-    UnsignedType.attribute("id", "bigint");
+    // (schema-creation.ts), so declare the `big_integer` type to match the
+    // physical column (registered name for BigIntegerType, not "bigint").
+    UnsignedType.attribute("id", "big_integer");
     UnsignedType.adapter = adapter;
     return UnsignedType;
   }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
@@ -27,24 +27,26 @@ describeIfMysql("Mysql2Adapter", () => {
     await adapter.close();
   });
 
-  function unsignedTypeModel(): typeof Base {
+  async function unsignedTypeModel(): Promise<typeof Base> {
     class UnsignedType extends Base {
       static _tableName = "unsigned_types";
     }
-    // Declare the auto-increment PK so the post-INSERT write-back
-    // (`_performInsert` → `_writeAttribute("id", insertedId)`) targets a real
-    // column under strict `writeFromUser`, without the internal-write bridge.
-    // MySQL's default `primary_key` type is `BIGINT AUTO_INCREMENT`
-    // (schema-creation.ts), so declare the `big_integer` type to match the
-    // physical column (registered name for BigIntegerType, not "bigint").
-    UnsignedType.attribute("id", "big_integer");
     UnsignedType.adapter = adapter;
+    // Reflect the real columns (PK included) up front so the post-INSERT
+    // write-back (`_performInsert` → `_writeAttribute("id", insertedId)`)
+    // targets a reflected `id` attribute under strict `writeFromUser`, without
+    // the internal-write bridge. Explicit warming (as in mysql-boolean's
+    // `BooleanType.loadSchema()`) keeps the reflected `unsigned` metadata the
+    // range-check assertions rely on — declaring `id` via `attribute()` would
+    // instead suppress DB reflection (ensureSchemaLoaded bails on a concrete
+    // user attr), hiding the unsigned columns.
+    await UnsignedType.loadSchema();
     return UnsignedType;
   }
 
   describe("UnsignedTypeTest", () => {
     it("unsigned int max value is in range", async () => {
-      const UnsignedType = unsignedTypeModel();
+      const UnsignedType = await unsignedTypeModel();
       const expected = await UnsignedType.create({ unsigned_integer: 4294967295 });
       expect(expected).toBeTruthy();
       const found = await UnsignedType.findBy({ unsigned_integer: 4294967295 });
@@ -52,7 +54,7 @@ describeIfMysql("Mysql2Adapter", () => {
     });
 
     it("minus value is out of range", async () => {
-      const UnsignedType = unsignedTypeModel();
+      const UnsignedType = await unsignedTypeModel();
       await expect(UnsignedType.create({ unsigned_integer: -10 })).rejects.toThrow(
         ActiveModelRangeError,
       );

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
@@ -31,6 +31,10 @@ describeIfMysql("Mysql2Adapter", () => {
     class UnsignedType extends Base {
       static _tableName = "unsigned_types";
     }
+    // Declare the auto-increment PK so the post-INSERT write-back
+    // (`_performInsert` → `_writeAttribute("id", insertedId)`) targets a real
+    // column under strict `writeFromUser`, without the internal-write bridge.
+    UnsignedType.attribute("id", "integer");
     UnsignedType.adapter = adapter;
     return UnsignedType;
   }

--- a/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
+++ b/packages/activerecord/src/adapters/abstract-mysql-adapter/unsigned-type.test.ts
@@ -34,7 +34,9 @@ describeIfMysql("Mysql2Adapter", () => {
     // Declare the auto-increment PK so the post-INSERT write-back
     // (`_performInsert` → `_writeAttribute("id", insertedId)`) targets a real
     // column under strict `writeFromUser`, without the internal-write bridge.
-    UnsignedType.attribute("id", "integer");
+    // MySQL's default `primary_key` type is `BIGINT AUTO_INCREMENT`
+    // (schema-creation.ts), so declare `bigint` to match the physical column.
+    UnsignedType.attribute("id", "bigint");
     UnsignedType.adapter = adapter;
     return UnsignedType;
   }


### PR DESCRIPTION
## What

Ensures the only construct+save bespoke model in the MySQL/MariaDB adapter
suites that rides an auto-increment table — `UnsignedType` (`unsigned_types`) —
has its real `id` primary key in the attribute set, so the post-INSERT PK
write-back (`_performInsert` → `_writeAttribute("id", insertedId)`) is strict
under `writeFromUser` and no longer depends on the internal-write bridge in
`readonly-attributes.ts`.

The model is warmed via `UnsignedType.loadSchema()` — the same pattern
`mysql-boolean.test.ts` uses for `BooleanType`. Warming reflects **all** real
columns (PK plus the `unsigned_*` columns, with their `unsigned` metadata)
before construct+save.

Note: declaring the PK via `attribute("id", …)` is **not** viable here — a
concrete user attribute makes `ensureSchemaLoaded` treat the model as
fully self-declared and skip DB reflection (`base.ts:1296`), which hides the
reflected `unsigned` columns the range-check assertions rely on. Warming is the
correct tool for a model whose columns carry reflected metadata.

## Why the other models need nothing

The remaining construct+save models — `CollationTest` (`collation_tests`) and
`EnumTest` (`enum_tests`) — sit on `id: false` tables.
`_returningColumnsForInsert` filters the PK fallback to columns that actually
exist, returning `[]` there, so those inserts never write back a PK and never
touch the bridge.

## Verification

MySQL/MariaDB CI jobs. Local vitest excludes the MySQL adapter project
(MySQL-gated). Typecheck passes.

Closes-story: declare-mysql-adapter-suite-model-columns