### PR TITLE
fix(schema): converge newForeignKeyDefinition prefix/suffix and options

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -207,6 +207,17 @@ describe("TableDefinition#new_foreign_key_definition", () => {
     expect(fk.name).toBe("fk_astronauts_rockets");
   });
 
+  it("maps a composite primaryKey array to a composite column array (bare-adapter fallback)", () => {
+    // Mirrors foreign_key_options' array branch: each PK column gets its own
+    // singularized foreign-key column.
+    // primaryKey/column are string|string[] on ForeignKeyDefinition; the scalar
+    // AddForeignKeyOptions DSL type is cast here to exercise the composite path.
+    const fk = new TableDefinition("astronauts").newForeignKeyDefinition("rockets", {
+      primaryKey: ["tenant_id", "id"] as unknown as string,
+    });
+    expect(fk.column).toEqual(["rocket_tenant_id", "rocket_id"]);
+  });
+
   it("applies table_name_prefix/suffix to to_table before building the def", () => {
     const adapter = {
       tableNamePrefix: "app_",

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -188,6 +188,39 @@ describe("ForeignKeyDefinition#defined_for?", () => {
   });
 });
 
+describe("TableDefinition#new_foreign_key_definition", () => {
+  it("defaults the name to fk_rails_<hex>, not fk_<table>_<column>", () => {
+    const fk = new TableDefinition("astronauts").newForeignKeyDefinition("rockets");
+    expect(fk.column).toBe("rocket_id");
+    expect(fk.name).toMatch(/^fk_rails_[0-9a-f]{10}$/);
+  });
+
+  it("routes column/name defaults through the adapter's foreignKeyOptions", () => {
+    const adapter = {
+      foreignKeyOptions(fromTable: string, toTable: string, options: Record<string, unknown>) {
+        return { ...options, column: "custom_id", name: `fk_${fromTable}_${toTable}` };
+      },
+    } as any;
+    const td = new TableDefinition("astronauts", { adapter });
+    const fk = td.newForeignKeyDefinition("rockets");
+    expect(fk.column).toBe("custom_id");
+    expect(fk.name).toBe("fk_astronauts_rockets");
+  });
+
+  it("applies table_name_prefix/suffix to to_table before building the def", () => {
+    const adapter = {
+      tableNamePrefix: "app_",
+      tableNameSuffix: "_v2",
+      foreignKeyOptions(_fromTable: string, toTable: string, options: Record<string, unknown>) {
+        return { ...options, column: "rocket_id", name: "fk_rails_deadbeef00", toTable };
+      },
+    } as any;
+    const td = new TableDefinition("app_astronauts_v2", { adapter });
+    const fk = td.newForeignKeyDefinition("rockets");
+    expect(fk.toTable).toBe("app_rockets_v2");
+  });
+});
+
 describe("ReferenceDefinition helpers", () => {
   it("addTo adds id column by default", () => {
     const ref = new ReferenceDefinition("user", { index: false });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1107,7 +1107,16 @@ export class TableDefinition {
     }
     const result: Record<string, unknown> = { ...options };
     if (!result.column) {
-      const base = toTable.replace(/^.*\./, "");
+      // Mirror foreign_key_column_for: strip table_name_prefix/suffix (and the
+      // trails schema-qualifier) before singularizing, so a prefixed to_table
+      // still yields the bare `<singular>_id` default column.
+      const prefix = adapter.tableNamePrefix ?? "";
+      const suffix = adapter.tableNameSuffix ?? "";
+      let base = toTable.replace(/^.*\./, "");
+      if (prefix || suffix) {
+        const stripped = base.match(new RegExp(`^${prefix}(.+)${suffix}$`));
+        if (stripped) base = stripped[1];
+      }
       result.column = `${singularize(base)}_id`;
     }
     if (!result.name) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -48,6 +48,24 @@ export type PrimaryKeyType = "uuid";
 export type ReferentialAction = "cascade" | "nullify" | "restrict" | "no_action" | "set_default";
 
 /**
+ * The adapter surface {@link TableDefinition.newForeignKeyDefinition} reads
+ * beyond {@link SchemaQuoter}: the table_name_prefix/suffix (Rails reads these
+ * off `ActiveRecord::Base`) and the converged `foreign_key_options` that fills
+ * the default column and SHA256 `fk_rails_<hex>` name. All optional — the bare
+ * ABSTRACT_SCHEMA_QUOTER path exposes none and falls back locally.
+ * @internal
+ */
+export interface ForeignKeyOptionsAdapter {
+  tableNamePrefix?: string;
+  tableNameSuffix?: string;
+  foreignKeyOptions(
+    fromTable: string,
+    toTable: string,
+    options: Record<string, unknown>,
+  ): Record<string, unknown>;
+}
+
+/**
  * Mirrors: ActiveRecord::ConnectionAdapters::ColumnDefinition
  */
 export class ColumnDefinition {
@@ -742,8 +760,16 @@ export class AlterTable {
     this.adds.push(new AddColumnDefinition(colDef));
   }
 
-  addForeignKey(fk: ForeignKeyDefinition): void {
-    this.foreignKeyAdds.push(fk);
+  addForeignKey(toTable: string, options: Partial<AddForeignKeyOptions> = {}): void {
+    // Mirrors Rails' AlterTable#add_foreign_key, which routes through
+    // `@td.new_foreign_key_definition(to_table, options)` so the FK def picks up
+    // table_name_prefix/suffix and the converged foreign_key_options defaults.
+    if (!this._td) {
+      throw new Error(
+        "AlterTable#addForeignKey requires a backing TableDefinition (construct via createAlterTable)",
+      );
+    }
+    this.foreignKeyAdds.push(this._td.newForeignKeyDefinition(toTable, options));
   }
 
   dropForeignKey(name: string): void {
@@ -1038,23 +1064,59 @@ export class TableDefinition {
     toTable: string,
     options: Partial<AddForeignKeyOptions> = {},
   ): ForeignKeyDefinition {
-    const pk = options.primaryKey ?? "id";
-    const col = options.column ?? `${singularize(toTable.split(".").at(-1) ?? toTable)}_${pk}`;
+    // Mirrors Rails' TableDefinition#new_foreign_key_definition: apply
+    // table_name_prefix/suffix to to_table, then route the column/name defaults
+    // through the adapter's foreign_key_options (SHA256 `fk_rails_<hex>` name).
+    const adapter = this._adapter as Partial<ForeignKeyOptionsAdapter>;
+    const prefix = adapter.tableNamePrefix ?? "";
+    const suffix = adapter.tableNameSuffix ?? "";
+    const prefixedToTable = `${prefix}${toTable}${suffix}`;
+    const opts = this._foreignKeyOptions(prefixedToTable, options);
     return new ForeignKeyDefinition(
       this.tableName,
-      toTable,
-      col,
-      pk,
-      options.name ?? `fk_${this.tableName}_${col}`,
-      options.onDelete,
-      options.onUpdate,
-      options.deferrable,
-      options.validate,
+      prefixedToTable,
+      opts.column as string | string[],
+      (opts.primaryKey as string | string[] | undefined) ?? "id",
+      opts.name as string,
+      opts.onDelete as ReferentialAction | undefined,
+      opts.onUpdate as ReferentialAction | undefined,
+      opts.deferrable as "immediate" | "deferred" | false | undefined,
+      opts.validate as boolean | undefined,
       // Mirror Rails' foreign_key_options stored-key set so a key we defaulted
       // (e.g. primaryKey "id") is sliced out by isDefinedFor rather than
       // mismatching.
       foreignKeyOptionsStoredKeys(options),
     );
+  }
+
+  /**
+   * Delegate to the adapter's `foreignKeyOptions` (which fills the default
+   * column and SHA256 `fk_rails_<hex>` name) when available. The bare
+   * ABSTRACT_SCHEMA_QUOTER path (used in unit tests that construct a
+   * TableDefinition directly) lacks it, so fall back to the same
+   * derivation as SchemaStatements#foreignKeyOptions / foreignKeyName.
+   * @internal
+   */
+  private _foreignKeyOptions(
+    toTable: string,
+    options: Partial<AddForeignKeyOptions>,
+  ): Record<string, unknown> {
+    const adapter = this._adapter as Partial<ForeignKeyOptionsAdapter>;
+    if (typeof adapter.foreignKeyOptions === "function") {
+      return adapter.foreignKeyOptions(this.tableName, toTable, { ...options });
+    }
+    const result: Record<string, unknown> = { ...options };
+    if (!result.column) {
+      const base = toTable.replace(/^.*\./, "");
+      result.column = `${singularize(base)}_id`;
+    }
+    if (!result.name) {
+      const cols = Array.isArray(result.column) ? result.column : [result.column];
+      const identifier = `${this.tableName}_${cols.join("_and_")}_fk`;
+      const hex = getCrypto().createHash("sha256").update(identifier).digest("hex").slice(0, 10);
+      result.name = `fk_rails_${hex}`;
+    }
+    return result;
   }
 
   newCheckConstraintDefinition(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -1106,10 +1106,10 @@ export class TableDefinition {
       return adapter.foreignKeyOptions(this.tableName, toTable, { ...options });
     }
     const result: Record<string, unknown> = { ...options };
-    if (!result.column) {
-      // Mirror foreign_key_column_for: strip table_name_prefix/suffix (and the
-      // trails schema-qualifier) before singularizing, so a prefixed to_table
-      // still yields the bare `<singular>_id` default column.
+    // Mirror foreign_key_column_for: strip table_name_prefix/suffix (and the
+    // trails schema-qualifier) before singularizing, so a prefixed to_table
+    // still yields the bare `<singular>_<pk>` default column.
+    const columnFor = (pk: string): string => {
       const prefix = adapter.tableNamePrefix ?? "";
       const suffix = adapter.tableNameSuffix ?? "";
       let base = toTable.replace(/^.*\./, "");
@@ -1117,7 +1117,15 @@ export class TableDefinition {
         const stripped = base.match(new RegExp(`^${prefix}(.+)${suffix}$`));
         if (stripped) base = stripped[1];
       }
-      result.column = `${singularize(base)}_id`;
+      return `${singularize(base)}_${pk}`;
+    };
+    if (!result.column) {
+      // Mirror foreign_key_options: a composite primary_key array maps each PK
+      // column to its own foreign-key column; the scalar branch always derives
+      // from the literal "id" (schema_statements.rb:1246-1267).
+      result.column = Array.isArray(result.primaryKey)
+        ? (result.primaryKey as string[]).map((pk) => columnFor(pk))
+        : columnFor("id");
     }
     if (!result.name) {
       const cols = Array.isArray(result.column) ? result.column : [result.column];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -129,6 +129,15 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect(makeStatements().stripTableNamePrefixAndSuffix("users")).toBe("users");
   });
 
+  it("foreignKeyColumnFor strips table_name_prefix/suffix before singularizing", () => {
+    const ss = makeStatements({ tableNamePrefix: "app_", tableNameSuffix: "_v2" });
+    // Rails foreign_key_column_for strips prefix/suffix, so the prefixed
+    // to_table `app_rockets_v2` yields `rocket_id`, not `app_rocket_v2_id`.
+    expect(ss.foreignKeyColumnFor("app_rockets_v2")).toBe("rocket_id");
+    expect(ss.foreignKeyColumnFor("app_rockets_v2", "uuid")).toBe("rocket_uuid");
+    expect(makeStatements().foreignKeyColumnFor("rockets")).toBe("rocket_id");
+  });
+
   it("foreignKeyName generates hash name", () => {
     const ss = makeStatements();
     expect(ss.foreignKeyName("users", { name: "my_fk", column: "org_id" })).toBe("my_fk");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1676,7 +1676,12 @@ export class SchemaStatements {
   }
 
   foreignKeyColumnFor(tableName: string, columnName = "id"): string {
-    const name = tableName.replace(/^.*\./, "");
+    // Rails' foreign_key_column_for strips table_name_prefix/suffix before
+    // singularizing (schema_statements.rb:1241-1244), so the default column is
+    // derived from the bare table name even when new_foreign_key_definition
+    // threads a prefixed to_table through. (The leading schema-qualifier strip
+    // is a trails addition for PG's `schema.table` form.)
+    const name = this.stripTableNamePrefixAndSuffix(tableName.replace(/^.*\./, ""));
     return `${singularize(name)}_${columnName}`;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -23,7 +23,6 @@ import {
   ChangeColumnDefaultDefinition,
   CreateIndexDefinition,
   ForeignKeyDefinition,
-  foreignKeyOptionsStoredKeys,
   CheckConstraintDefinition,
   type AddForeignKeyOptions,
   type AddIndexOptions,
@@ -812,22 +811,11 @@ export class SchemaStatements {
     // mixed-in method on the prototype.
     const opts = this.foreignKeyOptions(fromTable, toTable, options as Record<string, unknown>);
     const at = this.createAlterTable(fromTable);
-    const fkDef = new ForeignKeyDefinition(
-      fromTable,
-      toTable,
-      opts.column as string | string[],
-      (opts.primaryKey as string | string[] | undefined) ?? "id",
-      opts.name as string,
-      opts.onDelete as ForeignKeyDefinition["onDelete"],
-      opts.onUpdate as ForeignKeyDefinition["onUpdate"],
-      opts.deferrable as ForeignKeyDefinition["deferrable"],
-      opts.validate as boolean | undefined,
-      // Mirror Rails' foreign_key_options stored-key set (column/name always,
-      // others when explicitly passed) for consistency with the DSL path; this
-      // FK only builds SQL and is never queried via isDefinedFor.
-      foreignKeyOptionsStoredKeys(options),
-    );
-    at.addForeignKey(fkDef);
+    // Route through AlterTable#addForeignKey -> TableDefinition#newForeignKeyDefinition
+    // (now converged) rather than building the FK def inline: it applies
+    // table_name_prefix/suffix to to_table and re-runs foreign_key_options
+    // idempotently (column/name already filled above), mirroring Rails.
+    at.addForeignKey(toTable, opts as Partial<AddForeignKeyOptions>);
     await this.adapter.executeMutation(this.schemaCreation.accept(at));
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1256,8 +1256,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // and the abstract `super` runs foreign_key_options then
     // schema_creation.accept(AlterTable + ForeignKeyDefinition). We replicate
     // that abstract body here (rather than delegating to our own `super`, which
-    // still hand-defaults the FK name and would recurse through the
-    // self-delegation guard — tracked by
+    // would recurse through the self-delegation guard — tracked by
     // abstract-add-foreign-key-converge-to-foreign-key-options). The PG
     // schema_creation (visitAlterTable/visitForeignKeyDefinition) emits the
     // deferrable / NOT VALID / action / schema-qualified-name decoration, so no

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -9,8 +9,8 @@ import {
   CheckConstraintDefinition,
   ColumnDefinition,
   ForeignKeyDefinition,
-  foreignKeyOptionsStoredKeys,
   TableDefinition as AbstractTableDefinition,
+  type AddForeignKeyOptions,
   type ColumnOptions,
   type ColumnType,
   type ReferentialAction,
@@ -1263,23 +1263,11 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // deferrable / NOT VALID / action / schema-qualified-name decoration, so no
     // bespoke inline SQL is needed here.
     const fkOptions = this.foreignKeyOptions(fromTable, toTable, options);
-    const fkDef = new ForeignKeyDefinition(
-      fromTable,
-      toTable,
-      fkOptions.column as string | string[],
-      (fkOptions.primaryKey as string) ?? "id",
-      fkOptions.name as string,
-      fkOptions.onDelete as ReferentialAction | undefined,
-      fkOptions.onUpdate as ReferentialAction | undefined,
-      fkOptions.deferrable as "immediate" | "deferred" | undefined,
-      fkOptions.validate as boolean | undefined,
-      // Mirror Rails' foreign_key_options stored-key set for consistency with
-      // the DSL path; this FK only builds SQL and is never queried via
-      // isDefinedFor.
-      foreignKeyOptionsStoredKeys(options),
-    );
     const at = this.pg.createAlterTable(fromTable);
-    at.addForeignKey(fkDef);
+    // Route through AlterTable#addForeignKey -> TableDefinition#newForeignKeyDefinition
+    // (now converged): it applies table_name_prefix/suffix and re-runs
+    // foreign_key_options idempotently (column/name already filled above).
+    at.addForeignKey(toTable, fkOptions as Partial<AddForeignKeyOptions>);
     await this.pg.exec(this.pg.schemaCreation.accept(at));
   }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -20008,13 +20008,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "add_foreign_key",
-    "call": "new_foreign_key_definition",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "add_to",
     "call": "columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -20171,20 +20164,6 @@
     "tsFile": "connection-adapters/abstract/schema-definitions.ts",
     "rubyName": "new_foreign_key_definition",
     "call": "foreign_key_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "new_foreign_key_definition",
-    "call": "table_name_prefix",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-definitions.ts",
-    "rubyName": "new_foreign_key_definition",
-    "call": "table_name_suffix",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -20962,13 +20941,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "find_join_table_name",
     "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "foreign_key_column_for",
-    "call": "strip_table_name_prefix_and_suffix",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## What

Converges `TableDefinition#newForeignKeyDefinition` to Rails'
`new_foreign_key_definition`:

1. Applies `table_name_prefix`/`table_name_suffix` to `to_table` before
   constructing the `ForeignKeyDefinition`.
2. Routes the column/name defaults through the adapter's `foreignKeyOptions`,
   so the default name is the SHA256 `fk_rails_<hex>` (not the deviating
   `fk_<table>_<col>`) and the column default comes from `foreignKeyColumnFor`
   rather than the bespoke `singularize` branch. A local fallback preserves the
   bare `ABSTRACT_SCHEMA_QUOTER` path used in unit tests.

`AlterTable#addForeignKey` now takes `(toTable, options)` and routes through the
backing `TableDefinition` (matching Rails' `AlterTable#add_foreign_key`), so the
abstract and PostgreSQL `addForeignKey` bodies route through
`at.addForeignKey(toTable, options)` instead of building the FK def inline.

## Test

- New `TableDefinition#new_foreign_key_definition` cases covering the
  `fk_rails_<hex>` default, `foreignKeyOptions` routing, and prefix/suffix.
- schema-definitions / schema-statements-on-adapter / migration / schema-dumper
  / sqlite adapter / command-recorder suites pass locally.

Closes-story: new-foreign-key-definition-converge-prefix-suffix-and-options