### PR TITLE
refactor(activemodel): converge readAttributeForSerialization to pure send

### DIFF
--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -94,6 +94,35 @@ describe("SerializationTest", () => {
     expect(() => readAttributeForSerialization(host, "nope")).toThrow(/undefined method 'nope'/);
   });
 
+  it("read_attribute_for_serialization raises NoMethodError-style for a reader-less attributes key", () => {
+    // Rails `alias :… :send` has no `attributes`-hash fallback: a storeless host
+    // that names a key in `attributes` but exposes no reader for it fails loud
+    // like `send(:name)`, not silently serialize the hash value.
+    const host = {
+      attributes: { name: "x" },
+      constructor: { name: "Host" },
+    } as unknown as SerializationRecord;
+    expect(() => readAttributeForSerialization(host, "name")).toThrow(/undefined method 'name'/);
+  });
+
+  it("read_attribute_for_serialization invokes a method reader on an _attributes-backed record", () => {
+    // Rails `send(:greeting)` calls the method even on a record with an attribute
+    // store; a genuine method (not a declared attribute) is invoked, not read
+    // from the store.
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+      greeting(): string {
+        return "Hi " + (this.readAttribute("name") as string);
+      }
+    }
+    const p = new Person({ name: "Bob" });
+    expect(readAttributeForSerialization(p as unknown as SerializationRecord, "greeting")).toBe(
+      "Hi Bob",
+    );
+  });
+
   it("include option with empty association", () => {
     // Rails: `@user.friends = []` then `serializable_hash(include: :friends)`
     // yields `friends: []` — the accessor exists and returns an empty array.

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -156,75 +156,55 @@ export interface SerializeOptions {
  * (serialization.rb:167 `alias :read_attribute_for_serialization :send`).
  * Public in Rails (declared before the `private` section) and overridable.
  *
- * Mirrors `send(key)`, keying off member *existence* (`key in record`, the JS
- * analog of `respond_to?`): a reader that exists and returns `undefined` yields
- * `undefined` (nil) rather than raising; a value member (getter / data property,
- * including a user override of a declared attribute's reader) is returned and a
- * function member (`def name; …; end` / `attr_accessor :name`) is invoked.
+ * Pure `send(key)`: keying off member *existence* (`key in record`, the JS
+ * analog of `respond_to?`), a value member (getter / data property, including a
+ * user override of a declared attribute's reader) is returned, a function member
+ * (`def name; …; end` / `attr_accessor :name`) is invoked, a present member that
+ * yields `undefined` (nil) does not raise, and a missing member raises like
+ * `send`'s `NoMethodError`. There is no `attributes`/`readAttribute` fallback: a
+ * storeless host that surfaces values only through an `attributes` hash must
+ * expose per-key readers (Rails `attr_accessor` parity) — a reader-less key
+ * raises `NoMethodError` like Ruby `send`.
  *
- * The one divergence: on an `_attributes`-backed record (trails Model / AR), a
- * *function*-valued member means `key` names a method, not an attribute reader
- * — e.g. `attribute("toJSON")`, which cannot install a getter because `toJSON`
- * is structurally reserved by `JSON.stringify`; invoking it would recurse
- * infinitely. Such keys read the store instead (pinned by the "attribute named
- * toJSON does not shadow Model#toJSON" test). A value-returning getter still
- * wins, so a reader override is honored; only method-named attributes divert.
- *
- * When a storeless host exposes no per-key reader, trails'
- * `ActiveModel::Serializers::JSON` host contract surfaces values through the
- * `attributes` hash (the `attributes`-getter pattern its mixin tests pin across
- * several model shapes, where `attributes` is the only data source). That hash
- * backs the named reader before a name with no reader and no attribute entry
- * raises like `send`'s `NoMethodError`. A real Rails-shaped model never reaches
- * this tier — its declared attributes carry readers or are `_attributes`-backed.
+ * The one JS-structural divergence: on an `_attributes`-backed record (trails
+ * Model / AR) a declared attribute whose name collides with a framework method
+ * on the prototype — the canonical case is `attribute("toJSON")`, which
+ * `attribute()` cannot install a getter for because `toJSON` is reserved by
+ * `JSON.stringify` — resolves `record[key]` to that method, and invoking it
+ * would recurse infinitely (serializableHash → read → toJSON → asJson → …). For
+ * such a *store attribute* whose member is a function, we read the stored value
+ * instead (pinned by "attribute named toJSON does not shadow Model#toJSON"). A
+ * value-returning member still wins (reader overrides honored), and a function
+ * member that is NOT a store attribute is a genuine method and is invoked.
  */
 export function readAttributeForSerialization(record: SerializationRecord, key: string): unknown {
   const attrStore = record._attributes as AttributeStore;
   const hasStore =
     (attrStore && typeof (attrStore as { fetchValue?: unknown }).fetchValue === "function") ||
     attrStore instanceof Map;
-  const reader = (record as Record<string, unknown>)[key];
 
-  if (hasStore) {
-    // `send(key)`: a value-returning reader (generated getter or user override)
-    // wins. A function member is a method-named attribute (toJSON) that must
-    // read its stored value, not be invoked — and an absent getter (getterless
-    // declared attribute) also reads the store.
-    if (typeof reader !== "function" && key in (record as object)) return reader;
+  const inRecord = key in (record as object);
+  const reader = inRecord ? (record as Record<string, unknown>)[key] : undefined;
+
+  // `send(key)`: a value-returning member (generated getter or user override)
+  // wins.
+  if (inRecord && typeof reader !== "function") return reader;
+
+  // A store attribute reads its stored value: covers a store-backed record with
+  // no installed accessor (a bare `_attributes` Map / AttributeSet) and a
+  // reserved-name declared attribute (e.g. toJSON) whose function member would
+  // recurse if invoked.
+  if (hasStore && storeHasKey(attrStore, key)) {
     return attrStore instanceof Map
       ? attrStore.get(key)
       : (attrStore as { fetchValue(k: string): unknown }).fetchValue(key);
   }
 
-  if (key in (record as object)) {
-    return typeof reader === "function" ? (reader as () => unknown).call(record) : reader;
-  }
-  if (record.readAttribute) return record.readAttribute(key);
-  if (record.attributes && key in record.attributes) return record.attributes[key];
+  // A genuine function member is invoked (`send`); an absent member raises like
+  // `send`'s `NoMethodError`.
+  if (inRecord) return (reader as () => unknown).call(record);
   throw new Error(`undefined method '${key}' for an instance of ${record.constructor.name}`);
 }
-
-/**
- * Mirrors: ActiveModel::Serialization#attribute_names_for_serialization
- * (serialization.rb:158-160)
- *
- *   def attribute_names_for_serialization
- *     attributes.keys
- *   end
- *
- * Models can override this hook to scope which attributes appear.
- * Trails has multiple attribute storage shapes (AttributeSet via
- * `_attributes`, Map, plain object) so the fallback walks them in
- * order. Virtual attributes (acceptance/confirmation) are filtered
- * out — they aren't real attributes and shouldn't surface in JSON.
- *
- * @internal Rails-private helper.
- */
-type AttributeStore =
-  | { keys(): string[]; fetchValue(key: string): unknown }
-  | Map<string, unknown>
-  | null
-  | undefined;
 
 /** @internal */
 export function attributeNamesForSerialization(record: SerializationRecord): string[] {
@@ -254,6 +234,28 @@ export function attributeNamesForSerialization(record: SerializationRecord): str
 }
 
 /**
+ * Mirrors: ActiveModel::Serialization#attribute_names_for_serialization
+ * (serialization.rb:158-160)
+ *
+ *   def attribute_names_for_serialization
+ *     attributes.keys
+ *   end
+ *
+ * Models can override this hook to scope which attributes appear.
+ * Trails has multiple attribute storage shapes (AttributeSet via
+ * `_attributes`, Map, plain object) so the fallback walks them in
+ * order. Virtual attributes (acceptance/confirmation) are filtered
+ * out — they aren't real attributes and shouldn't surface in JSON.
+ *
+ * @internal Rails-private helper.
+ */
+type AttributeStore =
+  | { keys(): string[]; fetchValue(key: string): unknown }
+  | Map<string, unknown>
+  | null
+  | undefined;
+
+/**
  * Mirrors: ActiveModel::Serialization#serializable_attributes
  * (serialization.rb:162-164)
  *
@@ -261,10 +263,9 @@ export function attributeNamesForSerialization(record: SerializationRecord): str
  *     attribute_names.index_with { |n| read_attribute_for_serialization(n) }
  *   end
  *
- * Builds a `{ name → value }` hash by reading each attribute via the
- * attribute store fall-through (AttributeSet → Map → readAttribute →
- * plain attributes). The Rails analogue dispatches through
- * `read_attribute_for_serialization` (aliased to `send` by default).
+ * Builds a `{ name → value }` hash by dispatching each key through
+ * `read_attribute_for_serialization` (aliased to `send` by default), so a
+ * per-key reader / store attribute is read for every name.
  *
  * @internal Rails-private helper.
  */
@@ -346,6 +347,15 @@ export function serializableAddIncludes(
       callback(assocName, records, assocOpts);
     }
   }
+}
+
+/** Whether `key` is a stored attribute on an `_attributes` store (Map or AttributeSet). */
+function storeHasKey(attrStore: AttributeStore, key: string): boolean {
+  if (attrStore instanceof Map) return attrStore.has(key);
+  if (attrStore && typeof (attrStore as { keys?: unknown }).keys === "function") {
+    return (attrStore as { keys(): string[] }).keys().includes(key);
+  }
+  return false;
 }
 
 /** Whether `options` carries at least one `:include` entry to (maybe) load. */

--- a/packages/activemodel/src/serializers/json.test.ts
+++ b/packages/activemodel/src/serializers/json.test.ts
@@ -5,6 +5,12 @@ import { Model } from "../index.js";
 // Mirrors ActiveModel::Serializers::JSON (json.rb). Pinning the host
 // surface here so the mixin shape (model_name + serializable_hash +
 // as_json + from_json) doesn't regress.
+//
+// Rails' `read_attribute_for_serialization` is `alias :… :send`, so a host
+// must expose a per-key reader for every attribute name (`attr_accessor`
+// parity) — the `attributes` hash only names the keys, it is not a value
+// fallback. These test models therefore define per-key getters alongside the
+// `attributes` accessor.
 describe("Serializers::JSON host", () => {
   class Person extends JSONHost {
     static {
@@ -21,6 +27,12 @@ describe("Serializers::JSON host", () => {
     }
     _name = "";
     _age = 0;
+    get name() {
+      return this._name;
+    }
+    get age() {
+      return this._age;
+    }
   }
 
   it("modelName resolves to the subclass and is memoized per-class", () => {
@@ -78,6 +90,9 @@ describe("Serializers::JSON host", () => {
         });
       }
       _x = 0;
+      get x() {
+        return this._x;
+      }
     }
     const r = new Rooted();
     r._x = 1;
@@ -110,6 +125,9 @@ describe("Serializers::JSON host", () => {
         });
       }
       _id = 0n;
+      get id() {
+        return this._id;
+      }
     }
     const b = new Big();
     b._id = 9007199254740993n;
@@ -132,6 +150,9 @@ describe("Serializers::JSON host", () => {
         });
       }
       _name = "";
+      get name() {
+        return this._name;
+      }
     }
     const c = new CustomRooted();
     c._name = "Eve";
@@ -163,6 +184,9 @@ describe("Serializers::JSON host", () => {
         });
       }
       _v = 0;
+      get v() {
+        return this._v;
+      }
     }
     const k = new Keyed().fromJson('{"payload":{"v":7},"data":{"v":1}}');
     expect(k._v).toBe(7);
@@ -183,6 +207,9 @@ describe("Serializers::JSON host", () => {
         });
       }
       _v = 0;
+      get v() {
+        return this._v;
+      }
     }
     const d = new Defaulted().fromJson('{"defaulted":{"v":99}}');
     expect(d._v).toBe(99);


### PR DESCRIPTION
## Summary

Drops the `attributes`/`readAttribute` value fallback from
`readAttributeForSerialization` (`ActiveModel::Serialization`,
`vendor/rails/activemodel/lib/active_model/serialization.rb:167`,
`alias :read_attribute_for_serialization :send`) so it dispatches `send(key)`
for every key:

- a value member (getter / data property, incl. a user override of a declared
  attribute's reader) wins;
- a genuine function member is invoked — including a user-defined method on an
  `_attributes`-backed record (the case the reviewer flagged the old store-read
  did not serve);
- a reader-less key raises `NoMethodError` like Ruby `send`, with no
  `attributes`-hash fallback.

The one JS-structural divergence is preserved and made precise: a reserved-name
declared attribute whose getter could not be installed (canonically `toJSON`,
reserved by `JSON.stringify`) still reads its stored value — now **gated on the
key actually being a store attribute** — so serialization does not recurse. A
genuine method that is not a store attribute is invoked instead.

The `Serializers::JSON` host test models are migrated to expose per-key readers
(Rails `attr_accessor` parity) now that the `attributes`-hash fallback is gone.

## Tests

- `serialization.test.ts`: new pins for a reader-less `attributes` key raising
  `NoMethodError` and for invoking a method reader on an `_attributes`-backed
  record; `attribute named toJSON does not shadow Model#toJSON` preserved.
- activemodel + AR serialization suites pass; api:compare Data layer 100%.

Closes-story: read-attribute-for-serialization-pure-send