### PR TITLE
fix(api-compare): fold ported mirrors of unported mixins into extra-surface allowed set

### DIFF
--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -837,6 +837,70 @@ describe("buildReport — novel vs moved classification", () => {
     expect(f!.extras.map((e) => e.name)).toContain("unportedMethod");
   });
 
+  it("folds a ported mirror of an unported mixin method back into allowed (PORTED_UNPORTED_MIXIN_METHODS)", () => {
+    // ActiveRecord::AssociationNotFoundError `include DidYouMean::Correctable`,
+    // whose source (core_ext/name_error.rb) is unported — so walkMixin skips it
+    // and `detailedMessage` would show as a "moved" extra. We ported
+    // detailed_message inline (associations/errors.ts), so
+    // PORTED_UNPORTED_MIXIN_METHODS must fold it back into allowed while a
+    // genuinely-extra name stays flagged.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        "did-you-mean": {
+          classes: {},
+          modules: {
+            "DidYouMean::Correctable": rubyClass({
+              name: "Correctable",
+              file: "core_ext/name_error.rb",
+              instance: [method("detailed_message")],
+            }),
+          },
+        },
+        activerecord: {
+          classes: {
+            "ActiveRecord::AssociationNotFoundError": {
+              ...rubyClass({ name: "AssociationNotFoundError", file: "host.rb" }),
+              includes: ["DidYouMean::Correctable"],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        "did-you-mean": { classes: {}, modules: {} },
+        activerecord: {
+          classes: {
+            AssociationNotFoundError: {
+              name: "AssociationNotFoundError",
+              file: "host.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [method("detailedMessage"), method("genuinelyNovel")],
+              classMethods: [],
+            },
+          },
+          modules: {},
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: "activerecord",
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const f = report.packages[0].extraFiles.find((x) => x.tsFile === "host.ts");
+    expect(f).toBeDefined();
+    // detailedMessage folded back in; only the genuinely-novel name remains.
+    expect(f!.extras.map((e) => e.name)).toEqual(["genuinelyNovel"]);
+  });
+
   it("resolves the unported guard against a cross-package module's OWNING package", () => {
     // A cross-package `::`-qualified include where the module's source is
     // unported only in its OWN package (i18n_railtie.rb, scoped to

--- a/scripts/api-compare/extra-surface.test.ts
+++ b/scripts/api-compare/extra-surface.test.ts
@@ -901,6 +901,60 @@ describe("buildReport — novel vs moved classification", () => {
     expect(f!.extras.map((e) => e.name)).toEqual(["genuinelyNovel"]);
   });
 
+  it("folds railtie-reexported ControllerRuntime methods on the Railtie host into allowed", () => {
+    // trailtie.ts re-exports Railties::ControllerRuntime (railtie.rb:267,
+    // on_load(:action_controller) { include … }); its source
+    // controller_runtime.rb is unported, so the ported process_action /
+    // cleanup_view_runtime / append_info_to_payload mirrors would show as moved
+    // extras without the PORTED_UNPORTED_MIXIN_METHODS["ActiveRecord::Railtie"]
+    // fold-back. Guards the exact host FQN + method names against a typo.
+    const ruby: ApiManifest = {
+      source: "ruby",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {
+            "ActiveRecord::Railtie": rubyClass({ name: "Railtie", file: "railtie.rb" }),
+          },
+          modules: {},
+        },
+      },
+    };
+    const ts: ApiManifest = {
+      source: "typescript",
+      generatedAt: "",
+      packages: {
+        activerecord: {
+          classes: {},
+          modules: {
+            Trailtie: {
+              name: "Trailtie",
+              file: "trailtie.ts",
+              includes: [],
+              extends: [],
+              instanceMethods: [],
+              classMethods: [
+                method("processAction"),
+                method("cleanupViewRuntime"),
+                method("appendInfoToPayload"),
+                method("genuinelyNovel"),
+              ],
+            },
+          },
+        },
+      },
+    };
+    const report = buildReport(ruby, ts, {
+      filterPkg: "activerecord",
+      excludeGlobs: [],
+      novelOnly: false,
+      topN: 50,
+    });
+    const f = report.packages[0].extraFiles.find((x) => x.tsFile === "trailtie.ts");
+    expect(f).toBeDefined();
+    expect(f!.extras.map((e) => e.name)).toEqual(["genuinelyNovel"]);
+  });
+
   it("resolves the unported guard against a cross-package module's OWNING package", () => {
     // A cross-package `::`-qualified include where the module's source is
     // unported only in its OWN package (i18n_railtie.rb, scoped to

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -155,9 +155,10 @@ const AMBIENT_RAILTIE_MIXINS: Record<string, { includes?: string[]; methods?: st
  *
  *   - `ActiveRecord::Railtie` re-exports `Railties::ControllerRuntime`
  *     (railtie.rb:267 — `on_load(:action_controller) { include … }`); the port
- *     lives in `trailties/controller-runtime.ts`. Its source
- *     `railties/controller_runtime.rb` is unported (Railties / ActionController
- *     integration not ported yet).
+ *     lives in `trailties/controller-runtime.ts`. Its source (vendored at
+ *     `activerecord/lib/active_record/railties/controller_runtime.rb`, matched
+ *     by the `railties/controller_runtime.rb` UNPORTED_FILES pattern) is
+ *     unported (Railties / ActionController integration not ported yet).
  *   - The association error classes `include DidYouMean::Correctable`
  *     (associations/errors.rb:18,47,88); `Correctable#detailed_message` is
  *     ported inline as `detailedMessage` in `associations/errors.ts`.

--- a/scripts/api-compare/extra-surface.ts
+++ b/scripts/api-compare/extra-surface.ts
@@ -142,6 +142,35 @@ const AMBIENT_RAILTIE_MIXINS: Record<string, { includes?: string[]; methods?: st
 };
 
 /**
+ * Methods a Rails file's host class/module gains by including a mixin whose
+ * SOURCE file is on `UNPORTED_FILES` — so `collectAllowedNames`'s `walkMixin`
+ * skips the mixin (mirroring `compare.flattenIncludedMethodInfos` at
+ * compare.ts:507) and the faithful TS ports look like unexplained "moved"
+ * extras. We DID port these methods, just as standalone mirrors that don't go
+ * through the unported module, so list them here keyed by the Ruby host FQN to
+ * fold the ported names back into the host's allowed set. Applied like
+ * `AMBIENT_RAILTIE_MIXINS.methods` (raw Ruby names → `addRubyName`), but the
+ * justification is a source-unported *lexical* include rather than a railtie
+ * `on_load` injection.
+ *
+ *   - `ActiveRecord::Railtie` re-exports `Railties::ControllerRuntime`
+ *     (railtie.rb:267 — `on_load(:action_controller) { include … }`); the port
+ *     lives in `trailties/controller-runtime.ts`. Its source
+ *     `railties/controller_runtime.rb` is unported (Railties / ActionController
+ *     integration not ported yet).
+ *   - The association error classes `include DidYouMean::Correctable`
+ *     (associations/errors.rb:18,47,88); `Correctable#detailed_message` is
+ *     ported inline as `detailedMessage` in `associations/errors.ts`.
+ *     Correctable's source `core_ext/name_error.rb` is unported (Ruby NameError
+ *     machinery with no JS analog). Keyed on one host class since `allowed` is
+ *     unioned per-file across every entity in errors.rb.
+ */
+const PORTED_UNPORTED_MIXIN_METHODS: Record<string, string[]> = {
+  "ActiveRecord::Railtie": ["process_action", "cleanup_view_runtime", "append_info_to_payload"],
+  "ActiveRecord::AssociationNotFoundError": ["detailed_message"],
+};
+
+/**
  * `rubyMethodToTs` for any method, plus the trails `Q`-suffix predicate form.
  * trails encodes a Ruby `?` predicate with a trailing `Q` in TS
  * (`connected_to?` → `connectedToQ`), sometimes stacked on the is-prefix form
@@ -452,6 +481,8 @@ function collectAllowedNames(
       for (const inc of ambient.includes ?? []) walkMixin(inc, fqn);
       for (const name of ambient.methods ?? []) addRubyName(name);
     }
+
+    for (const name of PORTED_UNPORTED_MIXIN_METHODS[fqn] ?? []) addRubyName(name);
   }
   return allowed;
 }


### PR DESCRIPTION
## Summary

PR #3999 applied the `isSourceUnported` guard to `extra-surface.ts`'s
`collectAllowedNames` walkMixin (mirroring `flattenIncludedMethodInfos` at
`compare.ts:507`). With the guard in place the extra-surface report surfaced
**4 previously-masked moved extras** — TS methods that ARE ported but whose
owning Rails mixin source file is on `UNPORTED_FILES`, so they no longer get
pulled into the host's `allowed` set:

- `Railties::ControllerRuntime` methods (`process_action` /
  `cleanup_view_runtime` / `append_info_to_payload`) on `trailtie.ts`
  (railtie.rb:267 `on_load(:action_controller) { include … }`; port lives in
  `trailties/controller-runtime.ts`). Source `railties/controller_runtime.rb`
  is unported (Railties / ActionController not ported).
- `detailedMessage` on `associations/errors.ts` — mirrors
  `DidYouMean::Correctable#detailed_message` (associations/errors.rb includes
  Correctable). Source `core_ext/name_error.rb` is unported (Ruby NameError
  machinery, no JS analog).

## Resolution

Both are deliberate standalone mirrors we ported without routing through the
unported module. Added `PORTED_UNPORTED_MIXIN_METHODS` (keyed by Ruby host FQN)
to fold the ported method names back into the host's allowed set — an
extra-surface-local allowlist that does **not** touch `UNPORTED_FILES` (so
api:compare / test:compare totals are unaffected).

- Extra-surface no longer reports the 4 as unexplained moved extras.
- Novel totals unchanged (all 4 were `moved`, not `novel`).

Added a unit test covering the fold-back.

Closes-story: reconcile-unported-mixin-ported-extras