### PR TITLE
fix(enum): surface {name}BeforeTypeCast/ForDatabase for enum columns

### DIFF
--- a/packages/activerecord/src/attribute-methods/before-type-cast.ts
+++ b/packages/activerecord/src/attribute-methods/before-type-cast.ts
@@ -34,7 +34,7 @@ export function attributesBeforeTypeCast(record: BeforeTypeCastRecord): Record<s
 interface DatabaseRecord {
   _attributes: {
     valuesForDatabase?(): Record<string, unknown>;
-    getAttribute?(name: string): { valueForDatabase?(): unknown } | undefined;
+    getAttribute?(name: string): { valueForDatabase?: unknown } | undefined;
     keys?(): Iterable<string>;
   };
   readAttribute(name: string): unknown;
@@ -47,7 +47,9 @@ interface DatabaseRecord {
 export function readAttributeForDatabase(record: DatabaseRecord, attrName: string): unknown {
   const name = record.constructor._attributeAliases?.[attrName] ?? attrName;
   const attr = record._attributes.getAttribute?.(name);
-  if (attr?.valueForDatabase) return attr.valueForDatabase();
+  // `valueForDatabase` is a getter (Attribute), so read it as a property — the
+  // enum column serializes its label to the stored integer here (e.g. 2).
+  if (attr && "valueForDatabase" in attr) return attr.valueForDatabase;
   // Fallback: use valuesForDatabase bulk method
   if (record._attributes.valuesForDatabase) {
     return record._attributes.valuesForDatabase()[name];

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -419,10 +419,32 @@ describe("EnumTest", () => {
   });
 
   // Rails: `status_before_type_cast` returns the raw stored integer.
-  it.skip("attribute_before_type_cast", () => {});
+  it("attribute_before_type_cast", () => {
+    expect((book as any).statusBeforeTypeCast).toBe(2);
+    expect((book as any).status).toBe("published");
+
+    (book as any).status = "published";
+
+    expect((book as any).statusBeforeTypeCast).toBe("published");
+    expect((book as any).status).toBe("published");
+  });
   // Rails: `status_for_database` returns the serialized integer.
-  it.skip("attribute_for_database", () => {});
-  it.skip("attributes_for_database", () => {});
+  it("attribute_for_database", () => {
+    expect((book as any).statusForDatabase).toBe(2);
+    expect((book as any).status).toBe("published");
+
+    (book as any).status = "published";
+
+    expect((book as any).statusForDatabase).toBe(2);
+    expect((book as any).status).toBe("published");
+  });
+  it("attributes_for_database", () => {
+    expect((book as any).attributesForDatabase().status).toBe(2);
+
+    (book as any).status = "published";
+
+    expect((book as any).attributesForDatabase().status).toBe(2);
+  });
 
   it("invalid definition values raise an ArgumentError", () => {
     // Rails wraps each in `Class.new(ActiveRecord::Base) { self.table_name =


### PR DESCRIPTION
Enum columns already flowed through the generic `BeforeTypeCast` / `ForDatabase` surface, but `readAttributeForDatabase` invoked the `valueForDatabase` **getter** as a function. For a truthy stored value (an enum label serializing to a non-zero integer, e.g. `published` → `2`) that branch was taken and threw `attr.valueForDatabase is not a function`; falsy values silently fell through to the bulk path. Reading it as a property fixes the latent bug for all attributes and makes enum `status_for_database` return the serialized integer per Rails.

Per `vendor/rails/activerecord/test/cases/enum_test.rb`:
- `status_before_type_cast` → raw stored value (integer `2`, or the label after a user write)
- `status_for_database` → serialized integer (`2`)
- `attributes_for_database["status"]` → `2`

Un-skips the three `enum.test.ts` cases (`attribute_before_type_cast`, `attribute_for_database`, `attributes_for_database`) with Rails-verbatim bodies.

Closes-story: enum-before-type-cast-and-for-database