### PR TITLE
fix(recorder): normalize camelCase column shorthand to snake_case type

### DIFF
--- a/packages/activerecord/src/migration/command-recorder.test.ts
+++ b/packages/activerecord/src/migration/command-recorder.test.ts
@@ -504,6 +504,16 @@ describe("CommandRecorder", () => {
         { cmd: "removeColumn", args: ["fruits", "seq", "serial", {}] },
       ]);
     });
+
+    it("records the snake_case type for PG bitVarying (multi-word shorthand)", async () => {
+      const recorder = new CommandRecorder({ columnMethodNames: () => ["bitVarying"] });
+      await recorder.changeTable("fruits", async (t) => {
+        await (t as any).bitVarying("mask");
+      });
+      expect(recorder.commands).toEqual([
+        { cmd: "addColumn", args: ["fruits", "mask", "bit_varying", {}] },
+      ]);
+    });
   });
 
   describe("change_table surfaces adapter ColumnMethods shorthands (MySQL unsigned/blob)", () => {
@@ -511,11 +521,10 @@ describe("CommandRecorder", () => {
     // `t.mediumtext`, `t.longblob`, ... inside change_table — shorthands the
     // adapter advertises via columnMethodNames() beyond NATIVE_DATABASE_TYPES.
     //
-    // NOTE: the generic proxy records the camelCase method name as the column
-    // type (`unsignedInteger`), whereas Rails records the snake symbol
-    // (`:unsigned_integer`). That recorder-side normalization is tracked
-    // separately in story recorder-camelcase-column-type-normalization
-    // (RFC 0023); the assertions below document current behavior.
+    // The proxy normalizes the camelCase method name back to the snake symbol
+    // Rails' `define_column_methods` records (`unsignedInteger` ->
+    // `unsigned_integer`); single-token shorthands (mediumtext, longblob) are
+    // unchanged.
     const mysqlLike = {
       columnMethodNames: () => ["unsignedInteger", "mediumtext", "longblob"],
     };
@@ -528,7 +537,7 @@ describe("CommandRecorder", () => {
         await (t as any).longblob("payload");
       });
       expect(recorder.commands).toEqual([
-        { cmd: "addColumn", args: ["fruits", "qty", "unsignedInteger", {}] },
+        { cmd: "addColumn", args: ["fruits", "qty", "unsigned_integer", {}] },
         { cmd: "addColumn", args: ["fruits", "notes", "mediumtext", {}] },
         { cmd: "addColumn", args: ["fruits", "payload", "longblob", {}] },
       ]);
@@ -544,7 +553,7 @@ describe("CommandRecorder", () => {
       });
       expect(recorder.commands).toEqual([
         { cmd: "removeColumn", args: ["fruits", "notes", "mediumtext", {}] },
-        { cmd: "removeColumn", args: ["fruits", "qty", "unsignedInteger", {}] },
+        { cmd: "removeColumn", args: ["fruits", "qty", "unsigned_integer", {}] },
       ]);
     });
   });

--- a/packages/activerecord/src/migration/command-recorder.ts
+++ b/packages/activerecord/src/migration/command-recorder.ts
@@ -5,6 +5,7 @@
  */
 
 import { ArgumentError } from "@blazetrails/activemodel";
+import { underscore } from "@blazetrails/activesupport";
 import { IrreversibleMigration } from "../migration.js";
 import {
   findJoinTableName as _findJoinTableName,
@@ -868,7 +869,14 @@ export function withAdapterColumnMethods<T extends object>(
           if (names.length === 0) {
             throw new ArgumentError(`Missing column name(s) for ${prop}`);
           }
-          const results = names.map((name) => col.column(name, prop, options));
+          // Rails' `define_column_methods` generates `def type(...);
+          // column(name, :type, ...)` where `:type` is the snake_case native
+          // type name. trails uses camelCase JS method names, so normalize
+          // multi-word shorthands (`unsignedInteger` -> `unsigned_integer`,
+          // `bitVarying` -> `bit_varying`) back to the snake symbol Rails would
+          // record. Single-token shorthands (serial, jsonb, ...) are unchanged.
+          const type = underscore(prop);
+          const results = names.map((name) => col.column(name, type, options));
           // Table#column is async (non-recording path); RecorderTableProxy#column
           // is sync. Return a Promise when any call is thenable so callers can
           // await, mirroring Rails' synchronous per-name iteration.


### PR DESCRIPTION
## What

`withAdapterColumnMethods` recorded the accessed camelCase property name
verbatim as the column type (`col.column(name, prop, options)`). For
multi-word adapter shorthands this diverged from Rails' `define_column_methods`,
which records the snake_case native type symbol (e.g. `unsigned_integer`,
`bit_varying`).

Now the proxy runs `prop` through `underscore()` before recording:
`unsignedInteger` -> `unsigned_integer`, `bitVarying` -> `bit_varying`.
Single-token shorthands (serial, bigserial, jsonb, mediumtext, longblob, ...)
have no uppercase and pass through unchanged.

## Tests

Updated the MySQL unsigned round-trip recording test to assert the snake_case
recorded type, and added a PG `bitVarying` -> `bit_varying` case.

Rails refs:
- `abstract/schema_definitions.rb:332` define_column_methods generator
- `mysql/schema_definitions.rb:255` maps unsignedInteger -> "unsigned_integer"

Closes-story: recorder-camelcase-column-type-normalization