### PR TITLE
fix(activemodel): serializableHash coerces scalar only/except via Array()

### DIFF
--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -469,9 +469,9 @@ describe("SerializationTest", () => {
     }
     const p = new Person({ name: "Alice", age: 25, email: "a@b.com" });
     const result = p.serializableHash({ only: ["email", "name"] });
-    const keys = Object.keys(result);
-    expect(keys).toContain("email");
-    expect(keys).toContain("name");
+    // Rails `Array(only) & attribute_names` orders by the `only:` list, not the
+    // model's declared `name, age, email` order.
+    expect(Object.keys(result)).toEqual(["email", "name"]);
     expect(result.age).toBeUndefined();
   });
 

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -200,6 +200,45 @@ describe("SerializationTest", () => {
     expect(hash["age"]).toBeUndefined();
   });
 
+  it("only include with scalar coerces via Array() like an array", () => {
+    // Rails `Array(only).map(&:to_s)`: `only: "name"` equals `only: ["name"]`
+    // (serialization.rb:130). trails must not substring-match a scalar string.
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("age", "integer");
+      }
+    }
+    const p = new Person({ name: "Alice", age: 25 });
+    const hash = p.serializableHash({ only: "name" });
+    expect(hash["name"]).toBe("Alice");
+    expect(hash["age"]).toBeUndefined();
+  });
+
+  it("except include with scalar coerces via Array() like an array", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("age", "integer");
+      }
+    }
+    const p = new Person({ name: "Alice", age: 25 });
+    const hash = p.serializableHash({ except: "age" });
+    expect(hash["name"]).toBe("Alice");
+    expect(hash["age"]).toBeUndefined();
+  });
+
+  it("asJson accepts a scalar only like the array form", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+        this.attribute("age", "integer");
+      }
+    }
+    const p = new Person({ name: "Alice", age: 25 });
+    expect(p.asJson({ only: "name" })).toEqual(p.asJson({ only: ["name"] }));
+  });
+
   it("should raise NoMethodError for non existing method", () => {
     class Person extends Model {
       static {

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -62,10 +62,12 @@ export function serializableHash(
       ? instanceAttrNames.call(record)
       : attributeNamesForSerialization(record);
 
-  if (options.only) {
-    keys = keys.filter((k) => options.only!.includes(k));
-  } else if (options.except) {
-    keys = keys.filter((k) => !options.except!.includes(k));
+  if (options.only != null) {
+    const only = rubyArray(options.only);
+    keys = keys.filter((k) => only.includes(k));
+  } else if (options.except != null) {
+    const except = rubyArray(options.except);
+    keys = keys.filter((k) => !except.includes(k));
   }
 
   const result = serializableAttributes(record, keys);
@@ -139,8 +141,10 @@ export interface Serialization {
  * Serialization options.
  */
 export interface SerializeOptions {
-  only?: string[];
-  except?: string[];
+  // Rails coerces via `Array(only).map(&:to_s)`, so a scalar (`only: "name"`)
+  // and a list (`only: ["name"]`) are equivalent. See `rubyArray`.
+  only?: string | string[];
+  except?: string | string[];
   methods?: string[];
   // Mirrors Rails `:include` polymorphism: a single name, an array of
   // names, a hash of name → opts, or — like `include: [:posts, { comments: {} }]`
@@ -693,6 +697,18 @@ function _coerceForJson(
     return out;
   }
   return value;
+}
+
+/**
+ * Ruby `Array(x).map(&:to_s)`: coerce `only`/`except` to a list of strings.
+ * `nil`/`undefined` → `[]`, a scalar → `[scalar]`, a list → itself, with every
+ * entry stringified so `only: :name` (symbol), `only: "name"`, and
+ * `only: ["name"]` all behave identically (serialization.rb:130-133).
+ */
+function rubyArray(value: string | string[] | null | undefined): string[] {
+  if (value == null) return [];
+  const list = Array.isArray(value) ? value : [value];
+  return list.map((entry) => String(entry));
 }
 
 /**

--- a/packages/activemodel/src/serialization.ts
+++ b/packages/activemodel/src/serialization.ts
@@ -63,9 +63,15 @@ export function serializableHash(
       : attributeNamesForSerialization(record);
 
   if (options.only != null) {
-    const only = rubyArray(options.only);
-    keys = keys.filter((k) => only.includes(k));
+    // Rails: `Array(only).map(&:to_s) & attribute_names`. `Array#&` orders by
+    // the left operand and dedupes, so the result follows `only`'s order — not
+    // the model's declared order — keeping only names the model actually has.
+    const present = new Set(keys);
+    const seen = new Set<string>();
+    keys = rubyArray(options.only).filter((k) => present.has(k) && !seen.has(k) && seen.add(k));
   } else if (options.except != null) {
+    // Rails: `attribute_names -= Array(except).map(&:to_s)` keeps
+    // `attribute_names`' order, dropping the excluded names.
     const except = rubyArray(options.except);
     keys = keys.filter((k) => !except.includes(k));
   }


### PR DESCRIPTION
## What

`ActiveModel::Serialization#serializable_hash` coerces `only:`/`except:` with
Ruby `Array(x).map(&:to_s)`, so a scalar (`only: :name`) and a list
(`only: [:name]`) are equivalent. trails' `serializableHash` assumed an array
and called `.includes(k)` on the raw option, so a scalar string
(`only: "name"`) substring-matched instead of equality-matching.

## Changes

- Add `rubyArray` helper mirroring `Array(x).map(&:to_s)` (nil → `[]`, scalar →
  `[scalar]`, list → itself, entries stringified).
- Apply it to the `only`/`except` filters in `serializableHash`.
- Converge the `only` branch to Rails `Array#&` order semantics: the result now
  follows the `only:` list's order (deduped, intersected with the model's
  attribute names) rather than the declared attribute order — matching
  `test_method_serializable_hash_should_work_with_only_option_with_order_of_given_keys`.
  The `except` branch already matched `-=` (keeps attribute order).
- Widen `SerializeOptions.only`/`except` to `string | string[]`.
- Cover scalar `only`/`except` and `asJson({ only: "name" })` parity; tighten the
  order test to assert exact key order. Existing array-form callers unchanged.

Rails ref: `activemodel/lib/active_model/serialization.rb:129-133`.

Closes-story: serializable-hash-scalar-only-except-array-coercion