### PR TITLE
fix(postgresql): converge indexExists expression match and NullPool on errors

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -13,9 +13,10 @@
  * drops it in a finally.
  *
  * test_serial_sequence / test_default_sequence_name run against the canonical
- * `accounts` table ("public.accounts_id_seq"), as in Rails, loaded through the
- * `fixtures(["accounts"])` helper (Rails' ambient `accounts` fixture, with
- * `use_transactional_tests = false`). The `error.connection_pool`
+ * `accounts` table ("public.accounts_id_seq"), as in Rails, where the table is
+ * laid globally by test/schema/schema.rb. trails provisions it through the
+ * canonical `fixtures(["accounts"])` surface, scoped to just those two tests so
+ * the rest of the file doesn't seed it. The `error.connection_pool`
  * (NullPool / pool identity) assertions from Rails' connection-error,
  * serial-sequence, and invalid-index tests are ported faithfully — a standalone
  * trails adapter carries a NullPool that connect-time and query-time errors
@@ -104,13 +105,6 @@ async function withExtensionEnabled(
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
-  // Rails' PostgreSQLAdapterTest runs with `use_transactional_tests = false`
-  // and the ambient `accounts` fixture (test_serial_sequence /
-  // test_default_sequence_name assert `public.accounts_id_seq`). Load the
-  // canonical `accounts` through the fixtures helper on the shared connection —
-  // the same physical DB the standalone `adapter` below connects to.
-  fixtures(["accounts"], { useTransactionalTests: false });
-
   let adapter: PostgreSQLAdapter;
   let savedWarningsAction: typeof PostgreSQLAdapter.dbWarningsAction;
   let savedWarningsIgnore: typeof PostgreSQLAdapter.dbWarningsIgnore;
@@ -337,19 +331,27 @@ describeIfPg("PostgreSQLAdapter", () => {
       });
     });
 
-    it("serial sequence", async () => {
-      expect(await adapter.serialSequence("accounts", "id")).toBe("public.accounts_id_seq");
-      const error = await adapter.serialSequence("zomg", "id").then(
-        () => null,
-        (e) => e,
-      );
-      expect(error).toBeInstanceOf(StatementInvalid);
-      expect((error as StatementInvalid).connectionPool).toBe(adapter.pool);
-    });
+    // Rails' `accounts` table exists globally from test/schema/schema.rb; these
+    // two tests read only the `id` column's sequence, no fixture rows. Provision
+    // the canonical `accounts` through the fixtures helper scoped to just this
+    // pair (not the whole file) so the ~60 unrelated tests don't seed/reseed it.
+    describe("serial_sequence", () => {
+      fixtures(["accounts"], { useTransactionalTests: false });
 
-    it("default sequence name", async () => {
-      expect(await adapter.defaultSequenceName("accounts", "id")).toBe("public.accounts_id_seq");
-      expect(await adapter.defaultSequenceName("accounts")).toBe("public.accounts_id_seq");
+      it("serial sequence", async () => {
+        expect(await adapter.serialSequence("accounts", "id")).toBe("public.accounts_id_seq");
+        const error = await adapter.serialSequence("zomg", "id").then(
+          () => null,
+          (e) => e,
+        );
+        expect(error).toBeInstanceOf(StatementInvalid);
+        expect((error as StatementInvalid).connectionPool).toBe(adapter.pool);
+      });
+
+      it("default sequence name", async () => {
+        expect(await adapter.defaultSequenceName("accounts", "id")).toBe("public.accounts_id_seq");
+        expect(await adapter.defaultSequenceName("accounts")).toBe("public.accounts_id_seq");
+      });
     });
 
     it("default sequence name bad table", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -12,26 +12,20 @@
  * `withExampleTable`: it creates the ephemeral `ex` table, runs the block, and
  * drops it in a finally.
  *
- * Tracked deviations (RFC 0023 surfaced-deviations, story
- * pg-adapter-test-port-surfaced-deviations):
- *   - test_serial_sequence / test_default_sequence_name use the ambient
- *     `accounts` fixture ("public.accounts_id_seq"). trails adapter tests have
- *     no ambient fixtures, and recreating the shared canonical `accounts` in
- *     the parallel PG lane would corrupt sibling suites, so the identical
- *     sequence-name derivation is exercised against the ephemeral `ex` table
- *     ("public.ex_id_seq"). Ratified: the sequence-name derivation under test is
- *     table-agnostic, so `ex` exercises the same code path as `accounts`;
- *     loading a private-schema `accounts` fixture here would only re-verify the
- *     fixtures machinery, not the adapter behavior. The `error.connection_pool`
- *     (NullPool / pool identity) assertions from Rails' connection-error,
- *     serial-sequence, and invalid-index tests are now ported faithfully — a
- *     standalone trails adapter carries a NullPool that connect-time and
- *     query-time errors surface via `connection_pool`.
+ * test_serial_sequence / test_default_sequence_name run against the canonical
+ * `accounts` table ("public.accounts_id_seq"), as in Rails. `ensureCanonicalTables`
+ * lays the canonical `accounts` only if absent (idempotent, no drop), so it
+ * cannot corrupt sibling suites in the shared PG lane. The `error.connection_pool`
+ * (NullPool / pool identity) assertions from Rails' connection-error,
+ * serial-sequence, and invalid-index tests are ported faithfully — a standalone
+ * trails adapter carries a NullPool that connect-time and query-time errors
+ * surface via `connection_pool`.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
+import { ensureCanonicalTables } from "../../test-helpers/canonical-schema.js";
 import * as Arel from "@blazetrails/arel";
 import {
   ConnectionFailed,
@@ -337,22 +331,20 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("serial sequence", async () => {
-      await withExampleTable(adapter, async () => {
-        expect(await adapter.serialSequence("ex", "id")).toBe("public.ex_id_seq");
-        const error = await adapter.serialSequence("zomg", "id").then(
-          () => null,
-          (e) => e,
-        );
-        expect(error).toBeInstanceOf(StatementInvalid);
-        expect((error as StatementInvalid).connectionPool).toBe(adapter.pool);
-      });
+      await ensureCanonicalTables(adapter, ["accounts"]);
+      expect(await adapter.serialSequence("accounts", "id")).toBe("public.accounts_id_seq");
+      const error = await adapter.serialSequence("zomg", "id").then(
+        () => null,
+        (e) => e,
+      );
+      expect(error).toBeInstanceOf(StatementInvalid);
+      expect((error as StatementInvalid).connectionPool).toBe(adapter.pool);
     });
 
     it("default sequence name", async () => {
-      await withExampleTable(adapter, async () => {
-        expect(await adapter.defaultSequenceName("ex", "id")).toBe("public.ex_id_seq");
-        expect(await adapter.defaultSequenceName("ex")).toBe("public.ex_id_seq");
-      });
+      await ensureCanonicalTables(adapter, ["accounts"]);
+      expect(await adapter.defaultSequenceName("accounts", "id")).toBe("public.accounts_id_seq");
+      expect(await adapter.defaultSequenceName("accounts")).toBe("public.accounts_id_seq");
     });
 
     it("default sequence name bad table", async () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -14,25 +14,19 @@
  *
  * Tracked deviations (RFC 0023 surfaced-deviations, story
  * pg-adapter-test-port-surfaced-deviations):
- *   - test_connection_error / test_reconnection_error /
- *     test_reconnect_after_bad_connection_on_check_version / test_bad_connection
- *     / test_bad_connection_to_postgres_database / test_serial_sequence /
- *     test_invalid_index assert on `error.connection_pool` (NullPool / pool
- *     identity). A standalone trails adapter connects lazily and wraps a
- *     `pg.Client`, so those pool-identity assertions are not applicable; the
- *     bodies exercise the equivalent trails path and assert the translated error
- *     class instead.
  *   - test_serial_sequence / test_default_sequence_name use the ambient
  *     `accounts` fixture ("public.accounts_id_seq"). trails adapter tests have
  *     no ambient fixtures, and recreating the shared canonical `accounts` in
  *     the parallel PG lane would corrupt sibling suites, so the identical
  *     sequence-name derivation is exercised against the ephemeral `ex` table
- *     ("public.ex_id_seq").
- *   - test_expression_index also asserts
- *     `index_exists?(expr, name: "expression") == true`; trails `indexExists`
- *     returns false for expression indexes. That sub-assertion is deferred
- *     pending an impl fix; the index columns are asserted faithfully. See story
- *     pg-adapter-test-port-surfaced-deviations.
+ *     ("public.ex_id_seq"). Ratified: the sequence-name derivation under test is
+ *     table-agnostic, so `ex` exercises the same code path as `accounts`;
+ *     loading a private-schema `accounts` fixture here would only re-verify the
+ *     fixtures machinery, not the adapter behavior. The `error.connection_pool`
+ *     (NullPool / pool identity) assertions from Rails' connection-error,
+ *     serial-sequence, and invalid-index tests are now ported faithfully — a
+ *     standalone trails adapter carries a NullPool that connect-time and
+ *     query-time errors surface via `connection_pool`.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
@@ -46,6 +40,7 @@ import {
   SQLWarning,
   StatementInvalid,
 } from "../../errors.js";
+import { NullPool } from "../../connection-adapters/abstract/connection-pool.js";
 import { QueryAttribute } from "../../relation/query-attribute.js";
 import { Value, Integer } from "../../type.js";
 import { withSecondAdapter } from "../../test-helpers/second-connection.js";
@@ -141,7 +136,12 @@ describeIfPg("PostgreSQLAdapter", () => {
   describe("PostgreSQLAdapterTest", () => {
     it("connection error", async () => {
       const bad = new PostgreSQLAdapter("postgres://localhost:59999/nonexistent");
-      await expect(bad.execute("SELECT 1")).rejects.toThrow();
+      const error = await bad.execute("SELECT 1").then(
+        () => null,
+        (e) => e,
+      );
+      expect(error).toBeInstanceOf(ConnectionNotEstablished);
+      expect((error as ConnectionNotEstablished).connectionPool).toBeInstanceOf(NullPool);
       await bad.close();
     });
 
@@ -163,8 +163,13 @@ describeIfPg("PostgreSQLAdapter", () => {
         .mockImplementation((() => fakeClient) as never);
       const a = new PostgreSQLAdapter(PG_TEST_URL);
       try {
-        await expect(a.execute("SELECT 1")).rejects.toBeInstanceOf(ConnectionNotEstablished);
-        await expect(a.execute("SELECT 1")).rejects.toThrow("actual bad connection error");
+        const error = await a.execute("SELECT 1").then(
+          () => null,
+          (e) => e,
+        );
+        expect(error).toBeInstanceOf(ConnectionNotEstablished);
+        expect((error as Error).message).toContain("actual bad connection error");
+        expect((error as ConnectionNotEstablished).connectionPool).toBe(a.pool);
       } finally {
         clientSpy.mockRestore();
         await a.close().catch(() => {});
@@ -179,7 +184,11 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("bad connection to postgres database", async () => {
       const bad = new PostgreSQLAdapter("postgres://localhost:59999/nonexistent");
-      await expect(bad.execute("SELECT 1")).rejects.toThrow();
+      const error = await bad.execute("SELECT 1").then(
+        () => null,
+        (e) => e,
+      );
+      expect((error as ConnectionNotEstablished).connectionPool).toBe(bad.pool);
       await bad.close();
     });
 
@@ -330,7 +339,12 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("serial sequence", async () => {
       await withExampleTable(adapter, async () => {
         expect(await adapter.serialSequence("ex", "id")).toBe("public.ex_id_seq");
-        await expect(adapter.serialSequence("zomg", "id")).rejects.toBeInstanceOf(StatementInvalid);
+        const error = await adapter.serialSequence("zomg", "id").then(
+          () => null,
+          (e) => e,
+        );
+        expect(error).toBeInstanceOf(StatementInvalid);
+        expect((error as StatementInvalid).connectionPool).toBe(adapter.pool);
       });
     });
 
@@ -569,8 +583,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         await adapter.addIndex("ex", expr, { name: "expression" });
         const index = (await adapter.indexes("ex")).find((idx) => idx.name === "expression");
         expect(index!.columns).toBe(expr);
-        // Deferred: Rails also asserts index_exists?(expr, name: "expression") == true;
-        // trails indexExists returns false for expression indexes (see header).
+        expect(await adapter.indexExists("ex", expr, { name: "expression" })).toBe(true);
       });
     });
 
@@ -604,7 +617,7 @@ describeIfPg("PostgreSQLAdapter", () => {
         }
         expect(error).toBeInstanceOf(RecordNotUnique);
         expect((error as Error).message).toMatch(/could not create unique index/);
-        // (Rails also asserts error.connection_pool identity — omitted, see header.)
+        expect((error as RecordNotUnique).connectionPool).toBe(adapter.pool);
 
         // A failed CONCURRENTLY unique index is left behind but marked invalid.
         expect(await adapter.indexExists("ex", "number", { name: "invalid_index" })).toBe(true);

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.test.ts
@@ -13,9 +13,9 @@
  * drops it in a finally.
  *
  * test_serial_sequence / test_default_sequence_name run against the canonical
- * `accounts` table ("public.accounts_id_seq"), as in Rails. `ensureCanonicalTables`
- * lays the canonical `accounts` only if absent (idempotent, no drop), so it
- * cannot corrupt sibling suites in the shared PG lane. The `error.connection_pool`
+ * `accounts` table ("public.accounts_id_seq"), as in Rails, loaded through the
+ * `fixtures(["accounts"])` helper (Rails' ambient `accounts` fixture, with
+ * `use_transactional_tests = false`). The `error.connection_pool`
  * (NullPool / pool identity) assertions from Rails' connection-error,
  * serial-sequence, and invalid-index tests are ported faithfully — a standalone
  * trails adapter carries a NullPool that connect-time and query-time errors
@@ -25,7 +25,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
 import { itIfSupports } from "../../test-helpers/supports.js";
-import { ensureCanonicalTables } from "../../test-helpers/canonical-schema.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
 import * as Arel from "@blazetrails/arel";
 import {
   ConnectionFailed,
@@ -104,6 +104,13 @@ async function withExtensionEnabled(
 }
 
 describeIfPg("PostgreSQLAdapter", () => {
+  // Rails' PostgreSQLAdapterTest runs with `use_transactional_tests = false`
+  // and the ambient `accounts` fixture (test_serial_sequence /
+  // test_default_sequence_name assert `public.accounts_id_seq`). Load the
+  // canonical `accounts` through the fixtures helper on the shared connection —
+  // the same physical DB the standalone `adapter` below connects to.
+  fixtures(["accounts"], { useTransactionalTests: false });
+
   let adapter: PostgreSQLAdapter;
   let savedWarningsAction: typeof PostgreSQLAdapter.dbWarningsAction;
   let savedWarningsIgnore: typeof PostgreSQLAdapter.dbWarningsIgnore;
@@ -331,7 +338,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("serial sequence", async () => {
-      await ensureCanonicalTables(adapter, ["accounts"]);
       expect(await adapter.serialSequence("accounts", "id")).toBe("public.accounts_id_seq");
       const error = await adapter.serialSequence("zomg", "id").then(
         () => null,
@@ -342,7 +348,6 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("default sequence name", async () => {
-      await ensureCanonicalTables(adapter, ["accounts"]);
       expect(await adapter.defaultSequenceName("accounts", "id")).toBe("public.accounts_id_seq");
       expect(await adapter.defaultSequenceName("accounts")).toBe("public.accounts_id_seq");
     });

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -393,6 +393,15 @@ export class ConnectionPool implements ReapablePool {
               (pool.activeConnection ?? pool.connections[0])?.adapterName ??
               adapterNameFromConfig(pool.dbConfig.adapter)
             );
+          // Don't fabricate a method for serialization/promise probes. When this
+          // proxy is reachable from an error's `connectionPool` (Rails stamps
+          // the pool onto every translated error), a serializer or `await`
+          // walks keys like `then`/`toJSON`/`Symbol.*`; returning a callable
+          // there would run `conn.then()` etc. against a raw connection that has
+          // no such method (`conn[prop] is not a function`).
+          if (typeof prop === "symbol" || prop === "then" || prop === "toJSON") {
+            return undefined;
+          }
           return (...args: unknown[]) => {
             return pool.withConnection((conn) => (conn as any)[prop](...args));
           };

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1498,9 +1498,12 @@ export class SchemaStatements {
       if (options?.valid !== undefined && (idx as { valid?: boolean }).valid !== options.valid)
         return false;
       if (targetCols == null) return true;
-      return (
-        targetCols.length === idx.columns.length && targetCols.every((c, i) => c === idx.columns[i])
-      );
+      // Mirrors Rails `Array(self.columns) == Array(columns).map(&:to_s)`:
+      // an expression index carries its columns as a single String, which
+      // `Array()` wraps into a one-element array, so a matching expression
+      // passed as `column_name` compares equal.
+      const idxCols = Array.isArray(idx.columns) ? idx.columns : [idx.columns];
+      return targetCols.length === idxCols.length && targetCols.every((c, i) => c === idxCols[i]);
     });
   }
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -49,6 +49,7 @@ import type { InsertBuilder } from "../insert-all.js";
 import type { AdapterName } from "./abstract-adapter.js";
 import type { PostgreSQLAdapterOptions } from "./pool-config.js";
 import {
+  AdapterError,
   ConnectionFailed,
   ConnectionNotEstablished,
   DatabaseAlreadyExists,
@@ -1176,7 +1177,21 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // ConnectionNotEstablished / NoDatabaseError (mirrors Rails' connect →
       // new_client) rather than surfacing the raw pg driver error. newClient
       // tears the partial client down on failure.
-      const newClient = await PostgreSQLAdapter.newClient(this._pgClientOptions!);
+      let newClient: pg.Client;
+      try {
+        newClient = await PostgreSQLAdapter.newClient(this._pgClientOptions!);
+      } catch (error) {
+        // Mirrors Rails' `PostgreSQLAdapter#connect`: `rescue
+        // ConnectionNotEstablished => ex; raise ex.set_pool(@pool)`. Attach the
+        // originating pool (a NullPool for a standalone adapter) so
+        // `error.connection_pool` is set on a connect-time failure.
+        if (error instanceof ConnectionNotEstablished) {
+          error.setPool(this.pool);
+        } else if (error instanceof AdapterError) {
+          error.setConnectionPool(this.pool);
+        }
+        throw error;
+      }
       // Guard against a close / disconnect / discard / reconnect
       // that raced with the in-flight connect(). If the adapter was
       // torn down between the await above and this point, do NOT
@@ -4158,6 +4173,20 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * `ConnectionAdapters::PostgreSQL::DatabaseStatements#translate_exception`.
    */
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
+    const translated = this._translateExceptionClass(e, sql, binds);
+    // Mirrors Rails' translate_exception_class, which stamps the originating
+    // pool onto every translated error (`error.connection_pool = pool`). For a
+    // standalone adapter that pool is a NullPool. Use setPool/setConnectionPool
+    // (both guarded) so a pool attached at raise-time isn't overwritten.
+    if (translated instanceof ConnectionNotEstablished) {
+      translated.setPool(this.pool);
+    } else if (translated instanceof AdapterError) {
+      translated.setConnectionPool(this.pool);
+    }
+    return translated;
+  }
+
+  private _translateExceptionClass(e: unknown, sql: string, binds: unknown[]): Error {
     if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });
     const code = (e as { code?: string }).code;
     const msg = e.message;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1182,13 +1182,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         newClient = await PostgreSQLAdapter.newClient(this._pgClientOptions!);
       } catch (error) {
         // Mirrors Rails' `PostgreSQLAdapter#connect`: `rescue
-        // ConnectionNotEstablished => ex; raise ex.set_pool(@pool)`. Attach the
-        // originating pool (a NullPool for a standalone adapter) so
-        // `error.connection_pool` is set on a connect-time failure.
+        // ConnectionNotEstablished => ex; raise ex.set_pool(@pool)`. Rails
+        // rescues ONLY ConnectionNotEstablished (which includes
+        // DatabaseConnectionError). A NoDatabaseError from new_client is a
+        // StatementInvalid, which Rails' connect does not rescue — it
+        // propagates with connection_pool == nil — so it must not be stamped.
         if (error instanceof ConnectionNotEstablished) {
           error.setPool(this.pool);
-        } else if (error instanceof AdapterError) {
-          error.setConnectionPool(this.pool);
         }
         throw error;
       }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4173,7 +4173,63 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * `ConnectionAdapters::PostgreSQL::DatabaseStatements#translate_exception`.
    */
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
-    const translated = this._buildTranslatedException(e, sql, binds);
+    const build = (): Error => {
+      if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });
+      const code = (e as { code?: string }).code;
+      const msg = e.message;
+      const cause = e;
+      switch (code) {
+        case "23505": // unique_violation
+          return new RecordNotUnique(msg, { sql, binds, cause });
+        case "23503": // foreign_key_violation
+          return new InvalidForeignKey(msg, { sql, binds, cause });
+        case "23502": // not_null_violation
+          return new NotNullViolation(msg, { sql, binds, cause });
+        case "22001": // string_data_right_truncation
+          return new ValueTooLong(msg, { sql, binds, cause });
+        case "22003": // numeric_value_out_of_range
+          return new ActiveRecordRangeError(msg, { sql, binds, cause });
+        case "40001": // serialization_failure
+          return new SerializationFailure(msg, { sql, binds, cause });
+        case "40P01": // deadlock_detected
+          return new Deadlocked(msg, { sql, binds, cause });
+        case "42P04": // duplicate_database
+          return new DatabaseAlreadyExists(msg, { sql, binds, cause });
+        case "55P03": // lock_not_available
+          return new LockWaitTimeout(msg, { sql, binds, cause });
+        case "57014": // query_canceled
+          return new QueryCanceled(msg, { sql, binds, cause });
+        case "57P01": // admin_shutdown (pg_terminate_backend or server restart)
+          return new ConnectionNotEstablished(msg, { cause });
+        default:
+          // A severed connection (08xxx, "Connection terminated", pg's
+          // "Client has encountered a connection error", …) surfaces as a
+          // generic Error or non-DatabaseError; map it to ConnectionNotEstablished
+          // so callers see the lost connection rather than a raw driver error.
+          //
+          // Rails' translate_exception (postgresql_adapter.rb:801-821) additionally
+          // splits a libpq PG::ConnectionBad whose message ends with "\n" into
+          // ConnectionFailed (vs ConnectionNotEstablished for the pg-internal case).
+          // That distinction is a libpq PQerrorMessage artifact; node-pg is pure JS
+          // with no libpq layer and doesn't carry the pg-internal/libpq split, so
+          // there is no reliable signal to reproduce it — every severed-connection
+          // error maps to ConnectionNotEstablished here.
+          if (PostgreSQLAdapter._isConnectionError(e)) {
+            return new ConnectionNotEstablished(msg, { cause });
+          }
+          // Only wrap node-postgres `DatabaseError`s. The SQLSTATE
+          // 5-char shape alone isn't enough — Node system errors like
+          // `EPIPE` / `EBADF` also match it, so gating on
+          // instanceof pg.DatabaseError avoids re-tagging socket /
+          // network failures as StatementInvalid with misleading
+          // sql/binds attached.
+          if (e instanceof pg.DatabaseError && e instanceof StatementInvalid === false) {
+            return new StatementInvalid(msg, { sql, binds, cause });
+          }
+          return e;
+      }
+    };
+    const translated = build();
     // Mirrors Rails' PostgreSQLAdapter#translate_exception, which builds every
     // translated error with `connection_pool: @pool`. For a standalone adapter
     // that pool is a NullPool. Use setPool/setConnectionPool (both guarded) so
@@ -4184,63 +4240,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       translated.setConnectionPool(this.pool);
     }
     return translated;
-  }
-
-  private _buildTranslatedException(e: unknown, sql: string, binds: unknown[]): Error {
-    if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });
-    const code = (e as { code?: string }).code;
-    const msg = e.message;
-    const cause = e;
-    switch (code) {
-      case "23505": // unique_violation
-        return new RecordNotUnique(msg, { sql, binds, cause });
-      case "23503": // foreign_key_violation
-        return new InvalidForeignKey(msg, { sql, binds, cause });
-      case "23502": // not_null_violation
-        return new NotNullViolation(msg, { sql, binds, cause });
-      case "22001": // string_data_right_truncation
-        return new ValueTooLong(msg, { sql, binds, cause });
-      case "22003": // numeric_value_out_of_range
-        return new ActiveRecordRangeError(msg, { sql, binds, cause });
-      case "40001": // serialization_failure
-        return new SerializationFailure(msg, { sql, binds, cause });
-      case "40P01": // deadlock_detected
-        return new Deadlocked(msg, { sql, binds, cause });
-      case "42P04": // duplicate_database
-        return new DatabaseAlreadyExists(msg, { sql, binds, cause });
-      case "55P03": // lock_not_available
-        return new LockWaitTimeout(msg, { sql, binds, cause });
-      case "57014": // query_canceled
-        return new QueryCanceled(msg, { sql, binds, cause });
-      case "57P01": // admin_shutdown (pg_terminate_backend or server restart)
-        return new ConnectionNotEstablished(msg, { cause });
-      default:
-        // A severed connection (08xxx, "Connection terminated", pg's
-        // "Client has encountered a connection error", …) surfaces as a
-        // generic Error or non-DatabaseError; map it to ConnectionNotEstablished
-        // so callers see the lost connection rather than a raw driver error.
-        //
-        // Rails' translate_exception (postgresql_adapter.rb:801-821) additionally
-        // splits a libpq PG::ConnectionBad whose message ends with "\n" into
-        // ConnectionFailed (vs ConnectionNotEstablished for the pg-internal case).
-        // That distinction is a libpq PQerrorMessage artifact; node-pg is pure JS
-        // with no libpq layer and doesn't carry the pg-internal/libpq split, so
-        // there is no reliable signal to reproduce it — every severed-connection
-        // error maps to ConnectionNotEstablished here.
-        if (PostgreSQLAdapter._isConnectionError(e)) {
-          return new ConnectionNotEstablished(msg, { cause });
-        }
-        // Only wrap node-postgres `DatabaseError`s. The SQLSTATE
-        // 5-char shape alone isn't enough — Node system errors like
-        // `EPIPE` / `EBADF` also match it, so gating on
-        // instanceof pg.DatabaseError avoids re-tagging socket /
-        // network failures as StatementInvalid with misleading
-        // sql/binds attached.
-        if (e instanceof pg.DatabaseError && e instanceof StatementInvalid === false) {
-          return new StatementInvalid(msg, { sql, binds, cause });
-        }
-        return e;
-    }
   }
 
   async dropDatabase(name: string): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4173,11 +4173,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    * `ConnectionAdapters::PostgreSQL::DatabaseStatements#translate_exception`.
    */
   private _translateException(e: unknown, sql: string, binds: unknown[]): Error {
-    const translated = this._translateExceptionClass(e, sql, binds);
-    // Mirrors Rails' translate_exception_class, which stamps the originating
-    // pool onto every translated error (`error.connection_pool = pool`). For a
-    // standalone adapter that pool is a NullPool. Use setPool/setConnectionPool
-    // (both guarded) so a pool attached at raise-time isn't overwritten.
+    const translated = this._buildTranslatedException(e, sql, binds);
+    // Mirrors Rails' PostgreSQLAdapter#translate_exception, which builds every
+    // translated error with `connection_pool: @pool`. For a standalone adapter
+    // that pool is a NullPool. Use setPool/setConnectionPool (both guarded) so
+    // a pool attached at raise-time isn't overwritten.
     if (translated instanceof ConnectionNotEstablished) {
       translated.setPool(this.pool);
     } else if (translated instanceof AdapterError) {
@@ -4186,7 +4186,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return translated;
   }
 
-  private _translateExceptionClass(e: unknown, sql: string, binds: unknown[]): Error {
+  private _buildTranslatedException(e: unknown, sql: string, binds: unknown[]): Error {
     if (!(e instanceof Error)) return new StatementInvalid(String(e), { sql, binds, cause: e });
     const code = (e as { code?: string }).code;
     const msg = e.message;


### PR DESCRIPTION
Converges the three deviations deferred from the postgresql-adapter port (PR #4359,
story `pg-adapter-test-port-surfaced-deviations`), restoring the corresponding
assertions in `postgresql-adapter.test.ts`.

## 1. `indexExists` matches expression indexes by name

Rails' `Index#defined_for?` compares `Array(self.columns) == Array(columns).map(&:to_s)`.
An expression index carries its columns as a single String, which `Array()`
wraps into a one-element array. trails compared `targetCols.length` against
`idx.columns.length` — a char count when `idx.columns` is a string — so it
returned false. Now `idx.columns` is wrapped like Rails' `Array()`.
`test_expression_index` restores `index_exists?(expr, name: "expression") == true`.

## 2. Standalone-adapter errors carry a NullPool

Mirroring Rails' `PostgreSQLAdapter#connect` (`rescue ConnectionNotEstablished
=> ex; raise ex.set_pool(@pool)`), connect-time failures attach the adapter's
pool (a `NullPool` for a standalone adapter) — narrowed to `ConnectionNotEstablished`
only, so a `NoDatabaseError` propagates with a nil pool as in Rails. Translated
query exceptions likewise stamp the originating pool, matching Rails'
`translate_exception` (`connection_pool: @pool` on every branch).
`test_connection_error`, `test_reconnection_error`,
`test_bad_connection_to_postgres_database`, `test_serial_sequence`, and
`test_invalid_index` restore their `error.connection_pool` assertions.

## 3. Sequence tests run against the canonical `accounts` table

`test_serial_sequence` / `test_default_sequence_name` now assert
`public.accounts_id_seq` against the canonical `accounts` table, as in Rails.
The ambient `accounts` fixture is loaded through the canonical
`fixtures(["accounts"], { useTransactionalTests: false })` surface — matching
Rails' `use_transactional_tests = false` and the sibling `bytea` adapter suite.

## Supporting fixes surfaced by the pool stamping

- **Adapter-proxy serialization safety** (`connection-pool.ts`): once errors carry
  the live `ConnectionPool` (Rails-faithful), an unhandled rejection could reach
  the pool's adapter proxy during serialization; its `get`-trap fabricated a
  callable for any key, so a serializer/`await` probing `then`/`toJSON`/`Symbol.*`
  ran `conn.then()`/`conn.toJSON()` against a raw connection (`conn[prop] is not a
  function`). The trap now returns `undefined` for symbol keys and `then`/`toJSON`.
- **`translate_exception` call-parity**: the SQLSTATE switch stays inlined in the
  Rails-mapped `_translateException` (as a local closure) so every error-constructor
  call remains attributed to it for the `api:compare` wide call-mismatch ratchet,
  while the pool stamp runs on the built error.

All 67 tests in `postgresql-adapter.test.ts` pass; the `hot-compatibility.test.ts`
PG suite (which triggered the serialization crash) is clean. No test-name changes.

Closes-story: pg-adapter-test-port-surfaced-deviations
