### PR TITLE
feat(dirty): changedAttributes exposes name->old-value map

### DIFF
--- a/packages/activemodel/src/attribute-methods.test.ts
+++ b/packages/activemodel/src/attribute-methods.test.ts
@@ -321,7 +321,7 @@ describe("AttributeMethodsTest", () => {
     const p = new Person({ name: "Alice" });
     p.changesApplied();
     p.writeAttribute("nickname", "Ally");
-    expect(p.changedAttributes).toEqual(["name"]);
+    expect(p.changedAttributeNamesToSave).toEqual(["name"]);
     expect(p.changes).toEqual({ name: ["Alice", "Ally"] });
   });
 

--- a/packages/activemodel/src/attributes-dirty.test.ts
+++ b/packages/activemodel/src/attributes-dirty.test.ts
@@ -70,8 +70,8 @@ describe("AttributesDirtyTest", () => {
   it("list of changed attribute keys", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
     p.writeAttribute("name", "Bob");
-    expect(p.changedAttributes).toContain("name");
-    expect(p.changedAttributes).not.toContain("age");
+    expect(p.changedAttributeNamesToSave).toContain("name");
+    expect(p.changedAttributeNamesToSave).not.toContain("age");
   });
 
   it("changes to attribute values", () => {

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -58,8 +58,8 @@ describe("DirtyTest", () => {
   it("list of changed attribute keys", () => {
     const p = new DirtyPerson({ name: "Alice", age: 25 });
     p.writeAttribute("name", "Bob");
-    expect(p.changedAttributes).toContain("name");
-    expect(p.changedAttributes).not.toContain("age");
+    expect(p.changedAttributeNamesToSave).toContain("name");
+    expect(p.changedAttributeNamesToSave).not.toContain("age");
   });
 
   it("changes to attribute values", () => {
@@ -173,7 +173,7 @@ describe("DirtyTest", () => {
     const b = new Bare();
     // Should not throw
     expect(b.changed).toBe(false);
-    expect(b.changedAttributes).toEqual([]);
+    expect(b.changedAttributeNamesToSave).toEqual([]);
   });
 
   class Person extends Model {
@@ -245,14 +245,14 @@ describe("Dirty Tracking", () => {
   it("not changed initially", () => {
     const p = new Person({ name: "dean", age: 30 });
     expect(p.changed).toBe(false);
-    expect(p.changedAttributes).toEqual([]);
+    expect(p.changedAttributeNamesToSave).toEqual([]);
   });
 
   it("setting attribute will result in change", () => {
     const p = new Person({ name: "dean" });
     p.writeAttribute("name", "sam");
     expect(p.changed).toBe(true);
-    expect(p.changedAttributes).toContain("name");
+    expect(p.changedAttributeNamesToSave).toContain("name");
   });
 
   it("attributeWas returns original value", () => {
@@ -475,13 +475,13 @@ describe("clearAttributeChanges clears forced-dirty state", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio", NaN);
-    expect(m.changedAttributes).toContain("ratio");
+    expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.clearAttributeChanges(["ratio"]);
     // After clearAttributeChanges, _forcedNames must also be cleared so a
     // subsequent type-equal write does not re-appear as dirty.
     m.writeAttribute("ratio", "NaN");
-    expect(m.changedAttributes).not.toContain("ratio");
+    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
 });
 
@@ -498,12 +498,12 @@ describe("clearAttributeChanges", () => {
     p.changesApplied();
     p.writeAttribute("name", "Bob");
     p.writeAttribute("age", 31);
-    expect(p.changedAttributes).toContain("name");
-    expect(p.changedAttributes).toContain("age");
+    expect(p.changedAttributeNamesToSave).toContain("name");
+    expect(p.changedAttributeNamesToSave).toContain("age");
 
     p.clearAttributeChanges(["name"]);
-    expect(p.changedAttributes).not.toContain("name");
-    expect(p.changedAttributes).toContain("age");
+    expect(p.changedAttributeNamesToSave).not.toContain("name");
+    expect(p.changedAttributeNamesToSave).toContain("age");
   });
 });
 
@@ -738,7 +738,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const item = new Item({ count: 10 });
     item.changesApplied();
     item.writeAttribute("count", "abc");
-    expect(item.changedAttributes).toContain("count");
+    expect(item.changedAttributeNamesToSave).toContain("count");
   });
 
   it("force-change is cleared by restoreAttributes — forced flag must not survive restore", () => {
@@ -752,13 +752,13 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio", NaN);
-    expect(m.changedAttributes).toContain("ratio");
+    expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.restoreAttributes();
     // After restoreAttributes(), _forcedNames must be cleared so a subsequent
     // type-equal write does not re-appear as dirty.
     m.writeAttribute("ratio", "NaN");
-    expect(m.changedAttributes).not.toContain("ratio");
+    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
 
   it("force-change is cleared by changesApplied — forced state must not leak across save boundaries", () => {
@@ -772,13 +772,13 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m._dirty.forceChange("ratio", NaN);
-    expect(m.changedAttributes).toContain("ratio");
+    expect(m.changedAttributeNamesToSave).toContain("ratio");
 
     m.changesApplied();
     // After changesApplied(), _forcedNames must be cleared so the next
     // type-equal write does not appear dirty.
     m.writeAttribute("ratio", "NaN");
-    expect(m.changedAttributes).not.toContain("ratio");
+    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
 
   it("force-change survives a subsequent type-equal write — NaN-to-NaN case", () => {
@@ -795,7 +795,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     m.changesApplied();
     m._dirty.forceChange("ratio", NaN); // mirrors attribute_will_change!
     m.writeAttribute("ratio", "NaN"); // type-equal write
-    expect(m.changedAttributes).toContain("ratio");
+    expect(m.changedAttributeNamesToSave).toContain("ratio");
     // The "was" side must be the cloned pre-mutation snapshot from forceChange,
     // not the snapshot original, to preserve Rails' attribute_will_change! semantics.
     expect(m.changes["ratio"]).toEqual([NaN, NaN]);
@@ -815,7 +815,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     // exercises the fixed isEqualNan path (now compares against the cast value,
     // not the raw string).
     m.writeAttribute("ratio", "NaN");
-    expect(m.changedAttributes).not.toContain("ratio");
+    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
     expect(m.changes).not.toHaveProperty("ratio");
   });
 
@@ -833,7 +833,7 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const item = new Item({ count: 1 });
     item.changesApplied();
     item.writeAttribute("count", true);
-    expect(item.changedAttributes).toContain("count");
+    expect(item.changedAttributeNamesToSave).toContain("count");
   });
 
   it("float attribute NaN → non-NaN → NaN clears dirty state on revert", () => {
@@ -847,9 +847,9 @@ describe("numeric type.isChanged integration via dirty tracking", () => {
     const m = new Metric({ ratio: NaN });
     m.changesApplied();
     m.writeAttribute("ratio", 1.0);
-    expect(m.changedAttributes).toContain("ratio");
+    expect(m.changedAttributeNamesToSave).toContain("ratio");
     m.writeAttribute("ratio", "NaN");
-    expect(m.changedAttributes).not.toContain("ratio");
+    expect(m.changedAttributeNamesToSave).not.toContain("ratio");
   });
 });
 

--- a/packages/activemodel/src/dirty.test.ts
+++ b/packages/activemodel/src/dirty.test.ts
@@ -126,9 +126,13 @@ describe("DirtyTest", () => {
 
   it("previous value is preserved when changed after save", () => {
     const p = new DirtyPerson({ name: "Alice" });
+    expect(p.changedAttributes).toEqual({});
     p.writeAttribute("name", "Bob");
+    // Rails asserts `changed_attributes` — a name->old-value hash.
+    expect(p.changedAttributes).toEqual({ name: "Alice" });
     p.changesApplied();
     p.writeAttribute("name", "Charlie");
+    expect(p.changedAttributes).toEqual({ name: "Bob" });
     expect(p.previousChanges).toEqual({ name: ["Alice", "Bob"] });
     expect(p.changes).toEqual({ name: ["Bob", "Charlie"] });
   });

--- a/packages/activemodel/src/dirty.ts
+++ b/packages/activemodel/src/dirty.ts
@@ -25,7 +25,7 @@ import {
  */
 export interface Dirty {
   readonly changed: boolean;
-  readonly changedAttributes: string[];
+  readonly changedAttributes: Record<string, unknown>;
   readonly changes: Record<string, [unknown, unknown]>;
   readonly previousChanges: Record<string, [unknown, unknown]>;
   readonly mutationsFromDatabase: Record<string, [unknown, unknown]>;
@@ -162,7 +162,14 @@ export class DirtyTracker {
     }
   }
 
-  get changedAttributes(): string[] {
+  /**
+   * Names of all attributes with pending (unsaved) changes.
+   *
+   * Mirrors: ActiveModel::AttributeMutationTracker#changed_attribute_names
+   * (surfaced by Rails' `changed_attribute_names_to_save`), NOT
+   * `changed_attributes` — see `changedAttributes` for the name->old-value map.
+   */
+  get changedAttributeNames(): string[] {
     const names = Array.from(this._changedAttributes.keys());
     this._attrs?.forEach((attr, name) => {
       if (!this._changedAttributes.has(name) && attr.type.isMutable() && attr.changedInPlace()) {
@@ -170,6 +177,25 @@ export class DirtyTracker {
       }
     });
     return names;
+  }
+
+  /**
+   * Map of each changed attribute's name to its *old* (pre-change) value.
+   *
+   * Mirrors: ActiveModel::Dirty#changed_attributes
+   * -> `mutations_from_database.changed_values`, a name->original-value hash.
+   */
+  get changedAttributes(): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    for (const [name, change] of this._changedAttributes) {
+      result[name] = change[0];
+    }
+    this._attrs?.forEach((attr, name) => {
+      if (!Object.hasOwn(result, name) && attr.type.isMutable() && attr.changedInPlace()) {
+        result[name] = attr.originalValue;
+      }
+    });
+    return result;
   }
 
   get changes(): Record<string, [unknown, unknown]> {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1979,7 +1979,12 @@ export class Model {
     return this._dirty.changed;
   }
 
-  get changedAttributes(): string[] {
+  /**
+   * Map of each changed attribute's name to its old (pre-change) value.
+   *
+   * Mirrors: ActiveModel::Dirty#changed_attributes
+   */
+  get changedAttributes(): Record<string, unknown> {
     return this._dirty.changedAttributes;
   }
 
@@ -2088,7 +2093,7 @@ export class Model {
    * Mirrors: ActiveModel::Dirty#changed_attribute_names_to_save
    */
   get changedAttributeNamesToSave(): string[] {
-    return this.changedAttributes;
+    return this._dirty.changedAttributeNames;
   }
 
   /**
@@ -2109,7 +2114,7 @@ export class Model {
    */
   get attributesInDatabase(): Record<string, unknown> {
     const result: Record<string, unknown> = {};
-    for (const name of this.changedAttributes) {
+    for (const name of this._dirty.changedAttributeNames) {
       result[name] = this.attributeInDatabase(name);
     }
     return result;

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -1024,6 +1024,6 @@ describe("fromJson", () => {
     u.changesApplied();
     u.fromJson('{"name":"Updated"}');
     expect(u.changed).toBe(true);
-    expect(u.changedAttributes).toContain("name");
+    expect(u.changedAttributeNamesToSave).toContain("name");
   });
 });

--- a/packages/activerecord/src/attribute-methods/dirty.ts
+++ b/packages/activerecord/src/attribute-methods/dirty.ts
@@ -11,7 +11,7 @@ import { Temporal } from "@blazetrails/activesupport/temporal";
 
 interface DirtyRecord {
   changed: boolean;
-  changedAttributes: string[];
+  changedAttributes: Record<string, unknown>;
   changes: Record<string, [unknown, unknown]>;
   previousChanges: Record<string, [unknown, unknown]>;
   readAttribute(name: string): unknown;

--- a/packages/activerecord/src/dirty.test.ts
+++ b/packages/activerecord/src/dirty.test.ts
@@ -88,7 +88,7 @@ async function withTravel(offsetMs: number, fn: () => Promise<void>): Promise<vo
 function checkPirateAfterSaveFailure(pirate: Rec): void {
   expect(pirate.changed).toBe(true);
   expect(pirate.attributeChanged("parrot_id")).toBe(true);
-  expect(pirate.changedAttributes).toEqual(["parrot_id"]);
+  expect(pirate.changedAttributeNamesToSave).toEqual(["parrot_id"]);
   expect(pirate.attributeWas("parrot_id")).toBeNull();
 }
 
@@ -430,18 +430,18 @@ describe("DirtyTest", () => {
   it("object should be changed if any attribute is changed", async () => {
     const pirate = new Pirate() as Rec;
     expect(pirate.changed).toBe(false);
-    expect(pirate.changedAttributes).toEqual([]);
+    expect(pirate.changedAttributeNamesToSave).toEqual([]);
     expect(pirate.changes).toEqual({});
 
     pirate.catchphrase = "arrr";
     expect(pirate.changed).toBe(true);
     expect(pirate.attributeWas("catchphrase")).toBeNull();
-    expect(pirate.changedAttributes).toEqual(["catchphrase"]);
+    expect(pirate.changedAttributeNamesToSave).toEqual(["catchphrase"]);
     expect(pirate.changes).toEqual({ catchphrase: [null, "arrr"] });
 
     await pirate.save();
     expect(pirate.changed).toBe(false);
-    expect(pirate.changedAttributes).toEqual([]);
+    expect(pirate.changedAttributeNamesToSave).toEqual([]);
     expect(pirate.changes).toEqual({});
   });
 
@@ -472,7 +472,7 @@ describe("DirtyTest", () => {
     const parrot = await Parrot.createBang({ name: "Lorre" });
     pirate.parrot = parrot;
     expect(pirate.changed).toBe(true);
-    expect(pirate.changedAttributes).toEqual(["parrot_id"]);
+    expect(pirate.changedAttributeNamesToSave).toEqual(["parrot_id"]);
   });
 
   it("attribute should be compared with type cast", () => {

--- a/packages/activerecord/src/encryption/encryptable-record.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.ts
@@ -518,8 +518,8 @@ export class EncryptableRecord {
       modelClass.beforeSave((record: any) => {
         const isNew =
           typeof record.isNewRecord === "function" ? record.isNewRecord() : !record.isPersisted?.();
-        const changed: string[] = Array.isArray(record.changedAttributes)
-          ? record.changedAttributes
+        const changed: string[] = Array.isArray(record.changedAttributeNamesToSave)
+          ? record.changedAttributeNamesToSave
           : [];
         if (!isNew && !changed.includes(name)) return;
         record.writeAttribute(originalName, record.readAttribute(name));
@@ -674,10 +674,10 @@ export class EncryptableRecord {
   static cantModifyEncryptedAttributesWhenFrozen(record: any): void {
     const klass = record.constructor;
     const encryptedAttrs: Set<string> = klass._encryptedAttributes ?? new Set();
-    // changedAttributes is a string[] in this codebase (from DirtyTracker).
+    // changedAttributeNamesToSave is the string[] of changed attribute names.
     // Iterate changed once and check Set membership — O(n+m) vs O(n×m).
-    const changed: string[] = Array.isArray(record.changedAttributes)
-      ? record.changedAttributes
+    const changed: string[] = Array.isArray(record.changedAttributeNamesToSave)
+      ? record.changedAttributeNamesToSave
       : [];
     for (const attr of changed) {
       if (encryptedAttrs.has(attr)) {

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -213,9 +213,14 @@ describe("EnumTest", () => {
     // Rails also asserts `@book.cover = "hard"` — `cover` enum not on canonical Book.
   });
 
-  // Rails reads `@book.changed_attributes[:status]` (old-value hash); trails'
-  // `changedAttributes` is a string[] of names, not a name→old-value map.
-  it.skip("enum changed attributes", () => {});
+  it("enum changed attributes", () => {
+    const oldStatus = (book as any).status;
+    const oldLanguage = (book as any).language;
+    (book as any).status = "proposed";
+    (book as any).language = "spanish";
+    expect(book.changedAttributes["status"]).toBe(oldStatus);
+    expect(book.changedAttributes["language"]).toBe(oldLanguage);
+  });
 
   it("enum value after write symbol", () => {
     (book as any).status = "proposed";

--- a/packages/activerecord/src/locking/pessimistic.ts
+++ b/packages/activerecord/src/locking/pessimistic.ts
@@ -22,7 +22,7 @@ export async function lockBang<T extends Base>(
     if (this.changed) {
       // Mirrors Rails' squished message order: the save/reload guidance first,
       // then `Changed attributes: #{changed.map(&:inspect).join(', ')}.` last.
-      const dirtyAttrs = this.changedAttributes.map((a) => `"${a}"`).join(", ");
+      const dirtyAttrs = this.changedAttributeNamesToSave.map((a) => `"${a}"`).join(", ");
       throw new Error(
         "Locking a record with unpersisted changes is not supported. Use " +
           "`save` to persist the changes, or `reload` to discard them " +

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -1772,7 +1772,7 @@ describe("PersistenceTest", () => {
     const company = new Company({ name: "37signals" }) as any;
     const client = company.becomes(Client);
     expect(client.name).toBe("37signals");
-    expect(client.changedAttributes).toEqual(["name"]);
+    expect(client.changedAttributeNamesToSave).toEqual(["name"]);
   });
 });
 

--- a/packages/activerecord/src/timestamp.test.ts
+++ b/packages/activerecord/src/timestamp.test.ts
@@ -79,7 +79,7 @@ describe("TimestampTest", () => {
     expect(developer.salary).toBe(previousSalary + 10000);
     expect(developer.attributeChanged("salary")).toBe(true);
     expect(developer.changed).toBe(true);
-    expect(developer.changedAttributes).toEqual(["salary"]);
+    expect(developer.changedAttributeNamesToSave).toEqual(["salary"]);
     expect((developer as any).isSavedChanges()).toBe(true);
     expect(Object.keys(developer.savedChanges).sort()).toEqual([
       "legacy_updated_at",


### PR DESCRIPTION
## What

Aligns `changedAttributes` with Rails `ActiveModel::Dirty#changed_attributes`,
which returns a `name -> original(old) value` hash rather than a bare list of
attribute names.

- `DirtyTracker.changedAttributes` (and `Model#changedAttributes`) now return
  `Record<string, unknown>` mapping each changed attribute to its old value
  (Rails `mutations_from_database.changed_values`).
- The former names-array behavior moves to `DirtyTracker.changedAttributeNames`,
  surfaced through the existing `Model#changedAttributeNamesToSave` (Rails
  `changed`). Internal callers (`pessimistic`, `encryptable-record`,
  `attributesInDatabase`) updated to use it.
- Existing tests that asserted the names array switched to
  `changedAttributeNamesToSave` (all mirror Rails `changed`).
- Un-skips `enum.test.ts` "enum changed attributes".

## Rails refs

- `activemodel/lib/active_model/dirty.rb` — `changed_attributes` /
  `changed_attribute_names_to_save`.
- `vendor/rails/activerecord/test/cases/enum_test.rb:209-217`.

Closes-story: enum-changed-attributes-old-value-hash
