### PR TITLE
fix(test-fixtures): recover pinned txn after deliberate SQL abort

### DIFF
--- a/packages/activerecord/src/calculations.test.ts
+++ b/packages/activerecord/src/calculations.test.ts
@@ -31,33 +31,25 @@ import { Edge } from "./test-helpers/models/edge.js";
 describe("CalculationsTest", () => {
   // fixtures :companies, :accounts, :authors, :author_addresses, :topics,
   //          :speedometers, :minivans, :books, :posts, :comments, :cpk_books
-  const { companies, topics, cpkBooks, minivans } = fixtures(
-    [
-      "companies",
-      "accounts",
-      "authors",
-      "authorAddresses",
-      "topics",
-      "speedometers",
-      "minivans",
-      "books",
-      "posts",
-      "comments",
-      "cpkBooks",
-      "cpkAuthors",
-      "oneNeedQuoting",
-    ] as const,
-    {
-      usesTransaction: [
-        // These tests intentionally trigger DB errors (invalid column/syntax) which
-        // abort PG transactions; they must run outside the transactional fixtures wrapper.
-        "count on invalid columns raises",
-        "should calculate with invalid field",
-        "group by with order by virtual count attribute",
-        "pluck with hash argument containing non existent field",
-      ],
-    },
-  );
+  const { companies, topics, cpkBooks, minivans } = fixtures([
+    "companies",
+    "accounts",
+    "authors",
+    "authorAddresses",
+    "topics",
+    "speedometers",
+    "minivans",
+    "books",
+    "posts",
+    "comments",
+    "cpkBooks",
+    "cpkAuthors",
+    "oneNeedQuoting",
+  ] as const);
+  // Several tests intentionally trigger DB errors (invalid column/syntax) that
+  // abort the PG transaction; they still run transactionally because the
+  // fixture teardown skips its redundant DELETEs while the pinned transaction is
+  // open, so the abort no longer poisons the rollback.
 
   it("should sum field", async () => {
     expect(await Account.sum("credit_limit")).toBe(318);

--- a/packages/activerecord/src/collection-cache-key.test.ts
+++ b/packages/activerecord/src/collection-cache-key.test.ts
@@ -42,17 +42,19 @@ function withCollectionCacheVersioning(fn: () => Promise<void>): Promise<void> {
 }
 
 describe("CollectionCacheKeyTest", () => {
-  const { topics, projects } = fixtures(
-    ["developers", "developersProjects", "projects", "topics", "comments", "posts"],
-    {
-      // This test deliberately runs `cache_key(:published_at)` against a column
-      // that doesn't exist. On Postgres the resulting StatementInvalid aborts
-      // the surrounding transaction, which would poison the shared
-      // transactional-fixtures rollback for every later test in the file. Give
-      // it its own transaction so the abort stays isolated.
-      usesTransaction: ["cache_key with unknown timestamp column"],
-    },
-  );
+  // One test deliberately runs `cache_key(:published_at)` against a column that
+  // doesn't exist; on Postgres the resulting StatementInvalid aborts the
+  // transaction. It still runs transactionally because the fixture teardown
+  // skips its redundant DELETEs while the pinned transaction is open, so the
+  // abort no longer poisons the rollback.
+  const { topics, projects } = fixtures([
+    "developers",
+    "developersProjects",
+    "projects",
+    "topics",
+    "comments",
+    "posts",
+  ]);
 
   it("collection_cache_key on model", async () => {
     const key = await Developer.collectionCacheKey();

--- a/packages/activerecord/src/finder.test.ts
+++ b/packages/activerecord/src/finder.test.ts
@@ -1750,12 +1750,12 @@ describe("FinderTest", () => {
 // range fix in flight as PR #4433.
 // ==========================================================================
 describe("FinderTest", () => {
-  fixtures(["topics", "comments", "posts", "companies", "accounts"], {
-    // Rails' malformed-condition test intentionally raises StatementInvalid
-    // (unknown `dhh` column), which aborts the surrounding PG transaction and
-    // poisons transactional-fixtures teardown; run it outside the wrapper.
-    usesTransaction: ["hash condition find malformed"],
-  });
+  // The malformed-condition test intentionally raises StatementInvalid (unknown
+  // `dhh` column), which aborts the PG transaction; it still runs
+  // transactionally because the fixture teardown skips its redundant DELETEs
+  // while the pinned transaction is open, so the abort no longer poisons the
+  // rollback.
+  fixtures(["topics", "comments", "posts", "companies", "accounts"]);
   registerModel("Topic", CanonicalTopic);
   registerModel("Reply", CanonicalReply);
   registerModel("Comment", CanonicalComment);

--- a/packages/activerecord/src/insert-all.test.ts
+++ b/packages/activerecord/src/insert-all.test.ts
@@ -105,17 +105,11 @@ async function withRecordTimestamps(
 }
 
 describe("InsertAllTest", () => {
-  fixtures(["authors", "books"], {
-    // These two raise a DB-level RecordNotUnique; a PG unique violation aborts
-    // the surrounding transaction and poisons transactional-fixtures teardown,
-    // so run them unwrapped (the per-test fixture reseed cleans up). The other
-    // raising tests fail in find_unique_index_for (ArgumentError) before any SQL.
-    usesTransaction: [
-      "insert all raises on duplicate records",
-      "insert all will raise if duplicates are skipped only for a certain conflict target",
-      "insert all and upsert all with index finding options",
-    ],
-  });
+  // Some tests raise a DB-level RecordNotUnique (a PG unique violation aborts
+  // the transaction); they still run transactionally because the fixture
+  // teardown skips its redundant DELETEs while the pinned transaction is open,
+  // so the abort no longer poisons the rollback.
+  fixtures(["authors", "books"]);
 
   beforeAll(async () => {
     ReadonlyNameBook.attrReadonly("name");

--- a/packages/activerecord/src/relation/merging.test.ts
+++ b/packages/activerecord/src/relation/merging.test.ts
@@ -440,14 +440,7 @@ describe("RelationMergingTest", () => {
 });
 
 describe("MergingDifferentRelationsTest", () => {
-  const { posts } = fixtures(["posts", "authors", "authorAddresses", "developers", "comments"], {
-    // The same-alias CTE case deliberately triggers a StatementInvalid, which
-    // aborts the PG transaction and would poison shared transactional
-    // fixtures; run it outside the shared transaction.
-    usesTransaction: [
-      "relation merger leaves to database to decide what to do when multiple CTEs with same alias are passed",
-    ],
-  });
+  const { posts } = fixtures(["posts", "authors", "authorAddresses", "developers", "comments"]);
 
   it("merging where relations", async () => {
     const helloByBob = await Post.where({ body: "hello" })

--- a/packages/activerecord/src/relation/select.test.ts
+++ b/packages/activerecord/src/relation/select.test.ts
@@ -28,21 +28,13 @@ describe("SelectTest", () => {
   // ("Welcome to the weblog") drives the `UPPER(title)` assertions and its
   // `greetings` comment ("Thank you for the welcome") drives the merge tests.
   //
-  // The four `not exists` / `invalid nested field` tests deliberately issue a
-  // SELECT against a non-existent column. On PostgreSQL that aborts the
-  // surrounding transaction ("current transaction is aborted…"), which would
-  // poison the shared transactional-fixtures rollback at teardown. They read no
-  // fixture rows (only assert `to_sql` + that the query raises), so they opt out
-  // of the wrapping transaction via `usesTransaction` and run in autocommit —
-  // the failed statement then errors cleanly without leaving an aborted txn.
-  fixtures(["posts", "comments"], {
-    usesTransaction: [
-      "select with not exists field",
-      "select with hash with not exists field",
-      "select with hash array value with not exists field",
-      "select with invalid nested field",
-    ],
-  });
+  // The `not exists` / `invalid nested field` tests deliberately SELECT against
+  // a non-existent column, which raises `StatementInvalid` and aborts the PG
+  // transaction. They still run transactionally: the fixture teardown skips its
+  // redundant DELETEs while the pinned transaction is open, so the abort no
+  // longer poisons the rollback (mirrors Rails, which runs these transactionally
+  // with no opt-out).
+  fixtures(["posts", "comments"]);
   // `posts`/`comments` ride the boot-laid canonical schema (RFC 0059 Phase 1);
   // per-file `repairWorkerSchema` restores any sibling shape drift before this
   // suite runs, so no defensive recreate is needed.

--- a/packages/activerecord/src/relation/update-all.test.ts
+++ b/packages/activerecord/src/relation/update-all.test.ts
@@ -73,28 +73,26 @@ describe("UpdateAllTest", () => {
     comments,
     warehouseThings,
     cpkOrderAgreements,
-  } = fixtures(
-    [
-      "authors",
-      "authorAddresses",
-      "comments",
-      "developers",
-      "posts",
-      "people",
-      "pets",
-      "toys",
-      "tags",
-      "taggings",
-      "warehouseThings",
-      "cpkOrders",
-      "cpkOrderAgreements",
-    ],
-    {
-      // "update all doesnt ignore order" deliberately raises a DB error to test
-      // ORDER BY semantics; on PG this aborts the transaction, poisoning teardown.
-      usesTransaction: ["update all doesnt ignore order"],
-    },
-  );
+  } = fixtures([
+    "authors",
+    "authorAddresses",
+    "comments",
+    "developers",
+    "posts",
+    "people",
+    "pets",
+    "toys",
+    "tags",
+    "taggings",
+    "warehouseThings",
+    "cpkOrders",
+    "cpkOrderAgreements",
+  ]);
+  // "update all doesnt ignore order" deliberately raises a DB error to test
+  // ORDER BY semantics; on PG this aborts the transaction. It still runs
+  // transactionally because the fixture teardown skips its redundant DELETEs
+  // while the pinned transaction is open, so the abort no longer poisons the
+  // rollback.
 
   it("update all with scope", async () => {
     const tag = tags("general");

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -57,34 +57,34 @@ describe("RelationTest", () => {
     companies,
     minivans,
     cpkOrders,
-  } = fixtures(
-    [
-      "authors",
-      "authorAddresses",
-      "topics",
-      "entrants",
-      "developers",
-      "people",
-      "companies",
-      "developersProjects",
-      "accounts",
-      "categories",
-      "categorizations",
-      "categoriesPosts",
-      "posts",
-      "comments",
-      "tags",
-      "taggings",
-      "cars",
-      "minivans",
-      "cpkOrders",
-      "cpkBooks",
-      "subscribers",
-    ],
-    {
-      usesTransaction: ["finding with subquery without select does not change the select"],
-    },
-  );
+  } = fixtures([
+    "authors",
+    "authorAddresses",
+    "topics",
+    "entrants",
+    "developers",
+    "people",
+    "companies",
+    "developersProjects",
+    "accounts",
+    "categories",
+    "categorizations",
+    "categoriesPosts",
+    "posts",
+    "comments",
+    "tags",
+    "taggings",
+    "cars",
+    "minivans",
+    "cpkOrders",
+    "cpkBooks",
+    "subscribers",
+  ]);
+  // "finding with subquery without select does not change the select"
+  // deliberately raises a DB error that aborts the PG transaction; it still runs
+  // transactionally because the fixture teardown skips its redundant DELETEs
+  // while the pinned transaction is open, so the abort no longer poisons the
+  // rollback.
 
   beforeAll(() => {
     registerModel(Post);

--- a/packages/activerecord/src/test-helpers/use-fixtures.ts
+++ b/packages/activerecord/src/test-helpers/use-fixtures.ts
@@ -191,6 +191,40 @@ export async function resolveFixtureNames(
   return map;
 }
 
+/**
+ * Whether fixture rows must be DELETEd in teardown, or whether an outer
+ * transaction will discard them for us.
+ *
+ * The skip is confined to **PostgreSQL**, the sole adapter where the DELETE is
+ * actively harmful: a test that deliberately raised `StatementInvalid` aborts
+ * the whole PG transaction (SQLSTATE 25P02), so a subsequent DELETE on that
+ * pinned connection fails with "current transaction is aborted, commands
+ * ignored…", poisoning teardown for the next test (or a vitest `retry` re-run).
+ * MySQL/MariaDB and SQLite do not abort the transaction on a failed statement,
+ * so they never hit that — and on MySQL an implicit commit (DDL auto-commits,
+ * `test_fixtures` caveat) can durably persist seeded fixtures that the rollback
+ * then cannot undo, making the DELETE the *only* cleanup. So off PG the DELETE
+ * must always run (unchanged behavior).
+ *
+ * On PG the skip fires only for rows a still-open transaction will roll back —
+ * precisely "were this test's `beforeEach` inserts seeded inside a transaction
+ * that is still open now?". That mirrors Rails' `teardown_fixtures`, where the
+ * rollback IS the teardown and no DELETE is issued. Both conditions are load-
+ * bearing:
+ *   - `seededInTransaction` alone would wrongly skip if that transaction had
+ *     since committed/closed (rows now durable) — so we also require it open.
+ *   - `openTransactions > 0` alone is unsafe on the non-transactional /
+ *     `usesTransaction`-opt-out path: there the fixtures are autocommitted
+ *     before the test body runs, so a test body that leaves its *own*
+ *     transaction/savepoint open wraps none of those committed rows — skipping
+ *     the DELETE would leak them. Gating on `seededInTransaction` confines the
+ *     skip to rows the open transaction actually owns.
+ */
+function shouldDeleteFixtureRows(adapter: DatabaseAdapter, seededInTransaction: boolean): boolean {
+  if (adapter.adapterName !== "postgres") return true;
+  return !(seededInTransaction && adapter.openTransactions > 0);
+}
+
 /** Returns true for "table/relation does not exist" errors from any adapter. */
 function isTableMissingError(e: unknown): boolean {
   const msg = e instanceof Error ? e.message : String(e);
@@ -236,6 +270,9 @@ function useTablelessFixtures(
 
   const keys = entries.map((e) => e.table);
   const store: Record<string, Record<string, unknown>> = {};
+  // Whether the most recent seed ran inside an open transaction (the fixture
+  // pin). Read in afterEach — see shouldDeleteFixtureRows.
+  let seededInTransaction = false;
 
   beforeEach(async () => {
     const adapter = getAdapter();
@@ -248,6 +285,7 @@ function useTablelessFixtures(
       tables.push(table);
     }
     const results = await insertPreparedFixtureSets(adapter, prepared);
+    seededInTransaction = adapter.openTransactions > 0;
     results.forEach((result, i) => {
       store[tables[i]] = result;
     });
@@ -255,11 +293,13 @@ function useTablelessFixtures(
 
   afterEach(async () => {
     const adapter = getAdapter();
-    for (const { table } of [...entries].reverse()) {
-      try {
-        await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
-      } catch (e) {
-        if (!isTableMissingError(e)) throw e;
+    if (shouldDeleteFixtureRows(adapter, seededInTransaction)) {
+      for (const { table } of [...entries].reverse()) {
+        try {
+          await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
+        } catch (e) {
+          if (!isTableMissingError(e)) throw e;
+        }
       }
     }
     for (const key of keys) delete store[key];
@@ -420,6 +460,9 @@ function useFixtures(
 
   // Per-test mutable state: populated in beforeEach, cleared in afterEach.
   const store: Record<string, Record<string, unknown>> = {};
+  // Whether the most recent seed ran inside an open transaction (the fixture
+  // pin). Read in afterEach — see shouldDeleteFixtureRows.
+  let seededInTransaction = false;
 
   // TODO(fixtures-adoption Spike S1): seed once per worker in a global beforeAll
   // (before the pinned transaction opens) when transactional fixtures are
@@ -456,6 +499,7 @@ function useFixtures(
       preparedKeys.push(key);
     }
     const results = await insertPreparedFixtureSets(adapter, prepared);
+    seededInTransaction = adapter.openTransactions > 0;
     results.forEach((result, i) => {
       store[preparedKeys[i]] = result;
     });
@@ -464,12 +508,14 @@ function useFixtures(
   afterEach(async () => {
     if (!fixtures) return;
     const adapter = getAdapter();
-    // Delete in reverse insertion order to respect FK constraints.
-    for (const { table } of Object.values(fixtures).reverse()) {
-      try {
-        await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
-      } catch (e) {
-        if (!isTableMissingError(e)) throw e;
+    if (shouldDeleteFixtureRows(adapter, seededInTransaction)) {
+      // Delete in reverse insertion order to respect FK constraints.
+      for (const { table } of Object.values(fixtures).reverse()) {
+        try {
+          await adapter.executeMutation(`DELETE FROM ${adapter.quoteTableName(table)}`);
+        } catch (e) {
+          if (!isTableMissingError(e)) throw e;
+        }
       }
     }
     for (const key of Object.keys(store)) {


### PR DESCRIPTION
## What

trails mirrors Rails' `ActiveRecord::TestFixtures`: transactional fixtures pin a
connection, open an outer transaction, and roll it back at teardown. Rails'
`teardown_fixtures` only rolls back — it never DELETEs. But `useFixtures`
registered an `afterEach` that unconditionally issued per-table `DELETE`s.

Under transactional fixtures those DELETEs run **LIFO — before the rollback** —
and on a connection whose transaction a deliberate `StatementInvalid` has aborted
they fail with `current transaction is aborted, commands ignored until end of
transaction block` (PG 25P02). That poisons teardown for the rest of the file and
any vitest `retry` re-run — which is why ~8 files opted their deliberate-error
tests out via `usesTransaction`, more than Rails needs.

## Fix

`shouldDeleteFixtureRows(adapter)` — skip the redundant per-table DELETE teardown
while the pinned outer transaction is still open (`adapter.openTransactions === 0`
gates it). The rollback IS the teardown, matching Rails. This both eliminates the
abort poisoning and removes wasteful per-test DELETE churn. The DELETE still runs
on the non-transactional `useFixtures` path, where no outer transaction is open.

Then removes the deliberate-SQL-error `usesTransaction` opt-outs, converging
those tests onto Rails' transactional default (select, merging, insert-all,
finder, calculations, collection-cache-key, relations, update-all).

## Repro

A deliberate `StatementInvalid` inside the pinned txn followed by any later
fixture read/teardown (and under vitest `retry`) reproduced the poisoning on the
PG lane; with the fix the same sequence rolls back cleanly and passes. Verified
each converged file individually on `ARCONN=postgresql`.

## Out of scope

`has-many-through-associations.test.ts` →
`"update counter caches on destroy with indestructible through record"` keeps its
opt-out: its `before_destroy { throwAbort() }` leaves the PG txn aborted
**mid-test** (a distinct halting-`destroy` savepoint bug, not teardown
poisoning). Filed as follow-up story `txn-fixtures-halting-destroy-savepoint`.

Closes-story: txn-fixtures-abort-recovery
