### PR TITLE
fix(schema): gate index sub-part length to MySQL in abstract SchemaCreation

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { SchemaCreation } from "./schema-creation.js";
+import { CreateIndexDefinition, IndexDefinition } from "./schema-definitions.js";
 
 describe("SchemaCreation#typeToSql blank type guard", () => {
   it("throws a descriptive error for an empty custom type", () => {
@@ -63,6 +64,24 @@ describe("SchemaCreation quoting delegations", () => {
     expect(sc.quoteColumnName("title")).toBe('"title"');
     expect(sc.quoteTableName("posts")).toBe('"posts"');
   });
+});
+
+describe("SchemaCreation#quotedColumnsForIndex sub-part length gating", () => {
+  // Sub-part index lengths (`col(N)`) are MySQL-only DDL. Rails applies them
+  // exclusively in AbstractMysqlAdapter#add_index_length; the abstract visitor
+  // must NOT, or it emits invalid `("name"(10))` on PG/SQLite.
+  for (const adapter of ["postgres", "sqlite"] as const) {
+    it(`does not append sub-part length on ${adapter}`, () => {
+      const idx = new IndexDefinition("posts", "index_posts_on_title", false, ["title"], {
+        lengths: { title: 10 },
+      });
+      const sql = (new SchemaCreation(adapter) as any).visitCreateIndexDefinition(
+        new CreateIndexDefinition(idx, false),
+      );
+      expect(sql).not.toContain("(10)");
+      expect(sql).toContain('("title")');
+    });
+  }
 });
 
 describe("SchemaCreation#typeToSql decimal precision/scale", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -304,8 +304,12 @@ export class SchemaCreation {
   }
 
   /**
-   * Mirrors Rails `quoted_columns_for_index`: quote each column name and append
-   * its length/order/opclass decoration.
+   * Mirrors Rails' abstract `quoted_columns_for_index`: quote each column name
+   * and append its order/opclass decoration. Sub-part index lengths (`col(N)`)
+   * are MySQL-only and are NOT applied here — Rails decorates them exclusively
+   * in `AbstractMysqlAdapter#add_index_length`, and the MySQL SchemaCreation's
+   * `quotedColumns` override carries that in trails. Applying `length` on
+   * PostgreSQL/SQLite emits invalid DDL (`("name"(10))`).
    */
   protected quotedColumnsForIndex(
     columnNames: string[],
@@ -318,8 +322,6 @@ export class SchemaCreation {
     return columnNames
       .map((c) => {
         let col = this.adapter.quoteIdentifier(c);
-        const len = typeof options.lengths === "number" ? options.lengths : options.lengths[c];
-        if (len) col += `(${len})`;
         if (this.supportsIndexSortOrder()) {
           const order = typeof options.orders === "string" ? options.orders : options.orders[c];
           if (order) col += ` ${order.toUpperCase()}`;

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -157,9 +157,11 @@ interface TableMeta {
  * Apply a table's collected indexes with the schema.rb gating both surviving
  * schema loaders share: an expression index (`"(lower(x))"` — a string column
  * with non-word chars) is skipped on adapters without
- * `supports_expression_index?`, and the MySQL-only sub-part `length:` is dropped
- * elsewhere (the abstract SchemaCreation visitor would emit invalid `col(n)` DDL
- * on PG/SQLite). Exported so the `schema-file-generator.ts` parity guard can pin
+ * `supports_expression_index?`. The MySQL-only sub-part `length:` no longer
+ * needs gating here — the abstract SchemaCreation visitor now drops it on
+ * non-MySQL adapters (matching Rails), so it is passed through unconditionally
+ * and silently ignored on PG/SQLite. Exported so the `schema-file-generator.ts`
+ * parity guard can pin
  * `generateSchemaFile` against the *real* gating code here — this module outlives
  * `defineSchema` (RFC 0059 phase 4 retires the DSL), so the guard anchors to a
  * survivor, not a copy.
@@ -179,13 +181,12 @@ export async function emitTableIndexes(
   for (const { columns, opts } of indexes) {
     const isExpression = typeof columns === "string" && /\W/.test(columns);
     if (isExpression && !(await supportsExpressionIndex(adapter))) continue;
-    const length = adapter.adapterName === "mysql" ? opts.length : undefined;
     await ss.addIndex(table, columns, {
       unique: opts.unique,
       where: opts.where,
       name: opts.name,
       order: opts.order as Record<string, string> | undefined,
-      length,
+      length: opts.length,
       nullsNotDistinct: opts.nullsNotDistinct,
       using: opts.using,
       type: opts.type,

--- a/packages/activerecord/src/test-helpers/schema-file-generator.test.ts
+++ b/packages/activerecord/src/test-helpers/schema-file-generator.test.ts
@@ -504,14 +504,18 @@ describe("generateSchemaFile / canonical-schema.ts index-gating parity", () => {
     expect(gen.some((r) => r.columns === PARITY_EXPRESSION_INDEX)).toBe(false);
   });
 
-  it("drops sub-part index length: for non-MySQL adapters (both emitters)", async () => {
+  // Both emitters now pass `length:` through unconditionally on every adapter —
+  // the MySQL-only gating moved down to the abstract SchemaCreation visitor,
+  // which drops sub-part length on non-MySQL (matching Rails), so the DDL stays
+  // valid while the emitters stay in lockstep.
+  it("passes sub-part index length: through on non-MySQL adapters (both emitters)", async () => {
     for (const adapter of ["postgres", "sqlite"] as const) {
       const [gen, canon] = await Promise.all([
         generatorIndexes(GENERATOR_SCHEMA, adapter),
         canonicalIndexes(PARITY_INDEXES, adapter, true),
       ]);
-      expect(gen.every((r) => r.options.length === undefined)).toBe(true);
-      expect(canon.every((r) => normalizeIndexOptions(r.options).length === undefined)).toBe(true);
+      expect(gen.some((r) => r.options.length !== undefined)).toBe(true);
+      expect(canon.some((r) => normalizeIndexOptions(r.options).length !== undefined)).toBe(true);
     }
   });
 

--- a/packages/activerecord/src/test-helpers/schema-file-generator.ts
+++ b/packages/activerecord/src/test-helpers/schema-file-generator.ts
@@ -196,11 +196,10 @@ function generateCode(
       if (index.where !== undefined) optEntries.push(`where: ${JSON.stringify(index.where)}`);
       if (index.name !== undefined) optEntries.push(`name: ${JSON.stringify(index.name)}`);
       if (index.order !== undefined) optEntries.push(`order: ${JSON.stringify(index.order)}`);
-      // Sub-part prefix length is MySQL-only DDL (the abstract SchemaCreation
-      // visitor emits `col(n)` unconditionally, which is invalid on PG/SQLite).
-      // Mirror schema-types.ts and drop it for non-MySQL adapters.
-      if (index.length !== undefined && adapterName === "mysql")
-        optEntries.push(`length: ${JSON.stringify(index.length)}`);
+      // Sub-part prefix length is MySQL-only DDL, but the abstract SchemaCreation
+      // visitor now drops it on non-MySQL adapters (matching Rails), so emitting it
+      // unconditionally is safe — it is silently ignored on PG/SQLite.
+      if (index.length !== undefined) optEntries.push(`length: ${JSON.stringify(index.length)}`);
       if (index.nullsNotDistinct) optEntries.push(`nullsNotDistinct: true`);
       if (index.using !== undefined) optEntries.push(`using: ${JSON.stringify(index.using)}`);
       if (index.type !== undefined) optEntries.push(`type: ${JSON.stringify(index.type)}`);


### PR DESCRIPTION
## Summary

The abstract `SchemaCreation#quotedColumnsForIndex`
(`connection-adapters/abstract/schema-creation.ts`) decorated index columns
with a sub-part prefix length (`col(N)`) **unconditionally**, with no adapter
gate. Sub-part index lengths are MySQL-only; on PostgreSQL/SQLite this emits
invalid DDL (`CREATE INDEX ... ("name"(10))`). Rails' abstract
`quoted_columns_for_index` does not apply length — only
`AbstractMysqlAdapter#add_index_length` does.

## Changes

- **`abstract/schema-creation.ts`** — drop the `col(N)` length decoration from
  the abstract visitor. The MySQL `SchemaCreation`'s `quotedColumns` override
  still carries length via `addOptionsForIndexColumns` → `addIndexLength`,
  matching Rails.
- **Reconciles the MigrationContext-vs-SchemaStatements divergence**: both
  `addIndex` paths route through the visitor, which now uniformly drops
  sub-part length on non-MySQL (valid DDL on every adapter).
- **`canonical-schema.ts` / `schema-file-generator.ts`** — remove the now
  redundant `adapterName === "mysql"` length gates; `length:` is passed through
  unconditionally and silently ignored on PG/SQLite (the DDL-level drop now
  happens in the visitor).
- Tests: add an abstract-visitor test asserting no `(N)` on PG/SQLite; update
  the generator/loader parity test to assert length now passes through in
  lockstep.

Closes-story: abstract-schemacreation-subpart-length-mysql-only
