### PR TITLE
test(postgresql): declare real PK columns on bespoke adapter-suite models

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/array.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/array.test.ts
@@ -94,6 +94,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       }
       class PgArraySerialized extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArraySerialized.loadSchema();
       serialize(PgArraySerialized, "tags", { coder: MyTags });
@@ -112,6 +116,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.addColumn("pg_arrays", "score", "integer", { array: true, default: [4, 4, 2] });
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       // Rails: assert_equal([4, 4, 2], PgArray.column_defaults["score"])
@@ -126,6 +134,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       });
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       // Rails: assert_equal(["foo", "bar"], PgArray.column_defaults["names"])
@@ -221,6 +233,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.changeColumnDefault("pg_arrays", "tags", []);
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       // Rails: assert_equal [], PgArray.column_defaults["tags"]
@@ -292,6 +308,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("with multi dimensional empty strings", async () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const arr = [
@@ -309,6 +329,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("with arbitrary whitespace", async () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const arr = [
@@ -365,6 +389,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       await (adapter as any).insertFixture({ tags: tagValues }, "pg_arrays");
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const last = await (PgArrays as any).last();
@@ -374,6 +402,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("attribute for inspect for array field", async () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const record = new PgArrays();
@@ -385,6 +417,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("attribute for inspect for array field for large array", async () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const record = new PgArrays();
@@ -452,6 +488,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       // Rails: x = PgArray.create!(hstores: [{ a: "a" }, { b: "b" }]); x.hstores.first["a"] = "c"
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const x = await (PgArrays as any).create({
@@ -472,6 +512,10 @@ describeIfPg("PostgreSQLAdapter", () => {
         class PgArrays extends Base {
           static tableName = "pg_arrays";
           static timeZoneAwareAttributes = true;
+          static {
+            // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+            this.attribute("id", "integer");
+          }
         }
         await PgArrays.loadSchema();
         const timeString = "2020-06-15T10:00:00-07:00";
@@ -496,6 +540,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("assigning non array value", async () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const record = new PgArrays({ tags: "not-an-array" } as any);
@@ -509,6 +557,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("assigning empty string", async () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const record = new PgArrays({ tags: "" } as any);
@@ -522,6 +574,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("assigning valid pg array literal", async () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const record = new PgArrays({ tags: "{1,2,3}" } as any);
@@ -536,6 +592,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     it("where by attribute with array", async () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const tags = ["black", "blue"];
@@ -555,6 +615,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       class PgArrays extends Base {
         static tableName = "pg_arrays";
         static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
           this.validatesUniqueness("tags");
         }
       }
@@ -585,6 +647,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       // Rails: time = Time.now.change(usec: 123); record = PgArray.create!(timestamps: [time])
       class PgArrays extends Base {
         static tableName = "pg_arrays";
+        static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
+        }
       }
       await PgArrays.loadSchema();
       const time = Temporal.Now.instant()

--- a/packages/activerecord/src/adapters/postgresql/bytea.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/bytea.test.ts
@@ -14,6 +14,8 @@ import { Column as PgColumn } from "../../connection-adapters/postgresql/column.
 class ByteaDataType extends Base {
   static {
     this.tableName = "bytea_data_type";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
   }
 }
 

--- a/packages/activerecord/src/adapters/postgresql/citext.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/citext.test.ts
@@ -12,6 +12,8 @@ import type { Column as PgColumn } from "../../connection-adapters/postgresql/co
 class Citext extends Base {
   static {
     this.tableName = "citexts";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
   }
   declare cival: string;
 }

--- a/packages/activerecord/src/adapters/postgresql/composite.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/composite.test.ts
@@ -12,6 +12,8 @@ import { ValueType } from "@blazetrails/activemodel";
 class PostgresqlComposite extends Base {
   static {
     this.tableName = "postgresql_composites";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
   }
 }
 

--- a/packages/activerecord/src/adapters/postgresql/datatype.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/datatype.test.ts
@@ -46,6 +46,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       static tableName = "postgresql_times";
       static {
         this.adapter = a;
+        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+        this.attribute("id", "integer");
         this.attribute("time_interval", "string");
         this.attribute("scaled_time_interval", "interval");
       }
@@ -68,6 +70,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       static tableName = "postgresql_oids";
       static {
         this.adapter = a;
+        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+        this.attribute("id", "integer");
       }
     }
     await PostgresqlOid.loadSchema();

--- a/packages/activerecord/src/adapters/postgresql/domain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/domain.test.ts
@@ -13,6 +13,8 @@ import { Column as PgColumn } from "../../connection-adapters/postgresql/column.
 class PostgresqlDomain extends Base {
   static {
     this.tableName = "postgresql_domains";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
   }
 }
 

--- a/packages/activerecord/src/adapters/postgresql/enum.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/enum.test.ts
@@ -13,7 +13,7 @@ import { fixtures } from "../../test-helpers/fixtures.js";
 class PostgresqlEnum extends Base {
   static {
     this.tableName = "postgresql_enums";
-    // Declare the PK for strict writeFromUser (raw-created table, not warmed).
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
     this.attribute("id", "integer");
     this.enum(
       "current_mood",

--- a/packages/activerecord/src/adapters/postgresql/explain.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/explain.test.ts
@@ -46,6 +46,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       // queries.
       class ExRelation extends Base {
         static {
+          this.attribute("id", "integer");
           this.attribute("name", "string");
         }
       }
@@ -63,11 +64,13 @@ describeIfPg("PostgreSQLAdapter", () => {
       const { registerModel } = await import("../../index.js");
       class ExAuthor extends Base {
         static {
+          this.attribute("id", "integer");
           this.attribute("name", "string");
         }
       }
       class ExBook extends Base {
         static {
+          this.attribute("id", "integer");
           this.attribute("title", "string");
           this.attribute("ex_author_id", "integer");
         }
@@ -136,11 +139,13 @@ describeIfPg("PostgreSQLAdapter", () => {
       const { registerModel } = await import("../../index.js");
       class OpAuthor extends Base {
         static {
+          this.attribute("id", "integer");
           this.attribute("name", "string");
         }
       }
       class OpPost extends Base {
         static {
+          this.attribute("id", "integer");
           this.attribute("title", "string");
           this.attribute("op_author_id", "integer");
         }

--- a/packages/activerecord/src/adapters/postgresql/hstore.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/hstore.test.ts
@@ -28,6 +28,8 @@ class TagCollection {
 class Hstore extends Base {
   static {
     this.tableName = "hstores";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
     this.storeAccessor("settings", { accessors: ["language", "timezone"] });
   }
 }

--- a/packages/activerecord/src/adapters/postgresql/infinity.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/infinity.test.ts
@@ -42,6 +42,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       static tableName = "postgresql_infinities";
       static {
         this.adapter = a;
+        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+        this.attribute("id", "integer");
       }
     }
     await PostgresqlInfinity.loadSchema();
@@ -129,6 +131,8 @@ describeIfPg("PostgreSQLAdapter", () => {
           static timeZoneAwareAttributes = true;
           static {
             this.adapter = a;
+            // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+            this.attribute("id", "integer");
           }
         }
         await PostgresqlInfinity.loadSchema();

--- a/packages/activerecord/src/adapters/postgresql/interval.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/interval.test.ts
@@ -14,6 +14,8 @@ import { Column as PostgreSQLColumn } from "../../connection-adapters/postgresql
 class IntervalDataType extends Base {
   static {
     this.tableName = "interval_data_types";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
     this.attribute("legacy_term", "string");
   }
 }

--- a/packages/activerecord/src/adapters/postgresql/json.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/json.test.ts
@@ -85,6 +85,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         class JsonStringCast extends Base {
           static {
             this.tableName = "json_string_cast";
+            // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+            this.attribute("id", "integer");
           }
         }
         JsonStringCast.adapter = adapter;

--- a/packages/activerecord/src/adapters/postgresql/ltree.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/ltree.test.ts
@@ -14,6 +14,8 @@ import type { TableDefinition as PgTableDefinition } from "../../connection-adap
 class Ltree extends Base {
   static {
     this.tableName = "ltrees";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
   }
   declare path: string;
 }

--- a/packages/activerecord/src/adapters/postgresql/money.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/money.test.ts
@@ -16,6 +16,8 @@ import type { Column as PgColumn } from "../../connection-adapters/postgresql/co
 class PostgresqlMoney extends Base {
   static {
     this.tableName = "postgresql_moneys";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
     this.validates("depth", { numericality: true });
   }
 }

--- a/packages/activerecord/src/adapters/postgresql/network.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/network.test.ts
@@ -13,6 +13,8 @@ import type { TableDefinition as PgTableDefinition } from "../../connection-adap
 class PostgresqlNetworkAddress extends Base {
   static {
     this.tableName = "postgresql_network_addresses";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
   }
 }
 

--- a/packages/activerecord/src/adapters/postgresql/numbers.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/numbers.test.ts
@@ -10,6 +10,8 @@ import { Base } from "../../index.js";
 class PostgresqlNumber extends Base {
   static {
     this.tableName = "postgresql_numbers";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
   }
 }
 

--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -61,6 +61,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     await adapter.loadAdditionalTypes();
     class PostgresqlRangesCls extends Base {
       static tableName = "postgresql_ranges";
+      static {
+        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+        this.attribute("id", "integer");
+      }
     }
     await PostgresqlRangesCls.loadSchema();
     PostgresqlRanges = PostgresqlRangesCls;
@@ -69,6 +73,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       static tableName = "postgresql_ranges";
       static timeZoneAwareAttributes = true;
       static timeZoneAwareTypes = [...Base.timeZoneAwareTypes, "tsrange", "tstzrange"];
+      static {
+        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+        this.attribute("id", "integer");
+      }
     }
     await PostgresqlRangesTzCls.loadSchema();
     PostgresqlRangesTz = PostgresqlRangesTzCls;

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -921,6 +921,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       class Article extends Base {
         static {
           this.tableName = '"my.schema".articles';
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
         }
       }
       await Article.loadSchema();

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -358,6 +358,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         // raises UnknownAttributeError for an unmodeled key. `updated_at` reflects
         // from the timestamp column (keeping its infinity-capable OID decoder).
         static {
+          // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "integer");
           this.attribute("name", "string");
         }
       }

--- a/packages/activerecord/src/adapters/postgresql/uuid.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/uuid.test.ts
@@ -343,6 +343,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         class UuidAssocPost extends Base {
           static tableName = "uuid_assoc_posts";
           static {
+            // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
+            this.attribute("id", "uuid");
             this.hasMany("uuidAssocComments", {
               className: "UuidAssocComment",
               foreignKey: "uuid_assoc_post_id",
@@ -352,6 +354,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         class UuidAssocComment extends Base {
           static tableName = "uuid_assoc_comments";
           static {
+            // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
+            this.attribute("id", "uuid");
             this.belongsTo("uuidAssocPost", {
               className: "UuidAssocPost",
               foreignKey: "uuid_assoc_post_id",
@@ -629,6 +633,8 @@ describeIfPg("PostgreSQLAdapter", () => {
         class UuidUniq extends Base {
           static tableName = "uuid_uniqueness_validation_test";
           static {
+            // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+            this.attribute("id", "integer");
             this.validatesUniqueness("guid", { caseSensitive: false });
           }
         }
@@ -885,6 +891,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidPostCls extends Base {
         static tableName = "pg_uuid_posts";
         static {
+          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "uuid");
           this.hasMany("uuidComments", {
             className: "UuidCommentInverse",
             foreignKey: "uuid_post_id",
@@ -895,6 +903,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidCommentCls extends Base {
         static tableName = "pg_uuid_comments";
         static {
+          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "uuid");
           this.belongsTo("uuidPost", {
             className: "UuidPostInverse",
             foreignKey: "uuid_post_id",
@@ -963,6 +973,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidForumCls extends Base {
         static tableName = "pg_uuid_dj_forums";
         static {
+          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "uuid");
           // Rails: has_many :uuid_posts, -> { order("title DESC") } — the
           // ordering scope exercises the delegate-cache path the test name calls out.
           this.hasMany("uuidPosts", {
@@ -986,6 +998,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidPostCls extends Base {
         static tableName = "pg_uuid_dj_posts";
         static {
+          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "uuid");
           this.belongsTo("uuidForum", {
             className: "UuidForumDj",
             foreignKey: "uuid_forum_id",
@@ -999,6 +1013,8 @@ describeIfPg("PostgreSQLAdapter", () => {
       class UuidCommentCls extends Base {
         static tableName = "pg_uuid_dj_comments";
         static {
+          // Declare the real uuid PK so strict writeFromUser's post-INSERT id write-back has a known column.
+          this.attribute("id", "uuid");
           this.belongsTo("uuidPost", {
             className: "UuidPostDj",
             foreignKey: "uuid_post_id",

--- a/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/virtual-column.test.ts
@@ -39,6 +39,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
     class VirtualColumnCls extends Base {
       static tableName = "virtual_columns";
+      static {
+        // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+        this.attribute("id", "integer");
+      }
     }
     await VirtualColumnCls.loadSchema();
     VirtualColumn = VirtualColumnCls;

--- a/packages/activerecord/src/adapters/postgresql/xml.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/xml.test.ts
@@ -12,6 +12,8 @@ import { Base } from "../../index.js";
 class XmlDataType extends Base {
   static {
     this.tableName = "xml_data_type";
+    // Declare the real PK so strict writeFromUser's post-INSERT id write-back has a known column.
+    this.attribute("id", "integer");
   }
 }
 


### PR DESCRIPTION
## Summary

The PG adapter test suites build bespoke `class X extends Base` models on
raw-created tables. Under strict `AttributeSet#writeFromUser` (PR #4027) the
post-INSERT primary-key write-back only survives an incomplete attribute set
via the internal-write bridge in `readonly-attributes.ts` `_writeAttribute`
(`catch (MissingAttributeError) → writeCastValue`).

This declares each construct+save model's **real** primary key so the id is a
known name independent of test-local `loadSchema()` warming:

- `integer` for the `serial` / `createTable` tables,
- `uuid` for the `gen_random_uuid()` PK tables (never inventing an integer
  `id` for a uuid PK),

mirroring the existing `PostgresqlEnum` declaration. Reflection-dependent
models keep their explicit `loadSchema()` call — which overrides the
declaration-suppresses-reflection path (PR #4714) — so typed-column
assertions are unaffected.

## Verification

- Established via SQLite probes (with the bridge temporarily disabled) that a
  `loadSchema()`-only model already saves its `id`/timestamps without the
  bridge, and that a declared-`id` model does so with no `loadSchema()` at all,
  while explicit `loadSchema()` still reflects the model's other real columns.
- All 21 changed files transform/collect cleanly under `ARCONN=postgresql`
  (tests skip locally without a live PG); eslint/prettier/tsc pass via the
  pre-commit hook.
- PostgreSQL CI job exercises the live paths. Bridge removal is cross-checked
  by the `remove-internal-write-bridge-converge-write-attribute-strict` story.

Closes-story: declare-pg-adapter-suite-model-columns