### PR TITLE
test(activerecord): mark canonical-schema loaders @internal + guard direct test use

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -22,6 +22,7 @@ import testFixtureParity from "./eslint/test-fixture-parity.mjs";
 import requireTableTeardown from "./eslint/require-table-teardown.mjs";
 import noRawSql from "./eslint/no-raw-sql.mjs";
 import noStandaloneAssociations from "./eslint/no-standalone-associations.mjs";
+import noInternalCanonicalLoaders from "./eslint/no-internal-canonical-loaders.mjs";
 import noExplicitAnyDisable from "./eslint/no-explicit-any-disable.mjs";
 import { readFileSync } from "node:fs";
 
@@ -156,6 +157,7 @@ export default defineConfig(
           "require-table-teardown": requireTableTeardown,
           "no-raw-sql": noRawSql,
           "no-standalone-associations": noStandaloneAssociations,
+          "no-internal-canonical-loaders": noInternalCanonicalLoaders,
           "no-explicit-any-disable": noExplicitAnyDisable,
           // Off by default — opt in per project (see eslint/manifest-complete.mjs).
           "manifest-complete": manifestComplete,
@@ -410,6 +412,19 @@ export default defineConfig(
     files: ["packages/*/src/**/*.ts"],
     rules: {
       "blazetrails/no-standalone-associations": "error",
+    },
+  },
+
+  // ── no-internal-canonical-loaders: a *.test.ts must not import the internal
+  //    canonical-schema loaders (ensureCanonicalTables, loadCanonicalSchema)
+  //    directly — wire the canonical schema + fixtures through `fixtures({ ... })`.
+  //    rebuildCanonicalTables is intentionally allowed (documented shared shield).
+  //    Only canonical-schema.test.ts may import them, to test them directly
+  //    (allowlisted in the rule). See eslint/no-internal-canonical-loaders.mjs. ──
+  {
+    files: ["packages/activerecord/src/**/*.test.ts"],
+    rules: {
+      "blazetrails/no-internal-canonical-loaders": "error",
     },
   },
 

--- a/eslint/no-internal-canonical-loaders.mjs
+++ b/eslint/no-internal-canonical-loaders.mjs
@@ -1,0 +1,84 @@
+/**
+ * ESLint rule: no-internal-canonical-loaders
+ *
+ * The sanctioned public surface for wiring the canonical AR test schema +
+ * fixtures into a `*.test.ts` file is the `fixtures({ ... })` helper — one call
+ * that wires the handler, transactional fixtures, and the canonical schema.
+ *
+ * The lower-level canonical loaders in
+ * `packages/activerecord/src/test-helpers/canonical-schema.ts` —
+ * `ensureCanonicalTables` and `loadCanonicalSchema` — are internal plumbing that
+ * `fixtures()` and a couple of internal setup paths (the boot/template global
+ * setup, the adapter-suite setup, `encryption/test-helpers.ts`) call. They are
+ * NOT for direct use in test files; reaching for them re-invents schema wiring
+ * that `fixtures({})` already owns. This rule fails any `*.test.ts` that imports
+ * them directly.
+ *
+ * `rebuildCanonicalTables` is intentionally NOT banned: it is the documented
+ * anti-contamination shield that test files legitimately call in a `beforeAll`
+ * to restore a canonical table a sibling file left in a reduced shape on the
+ * shared per-worker DB (see its JSDoc). It has no `fixtures({})` equivalent.
+ *
+ * Allowlist: the loaders' own unit test (`canonical-schema.test.ts`) imports
+ * them to test them directly. Non-`*.test.ts` internal helpers are already out
+ * of scope because this rule is wired to test files only.
+ */
+
+import path from "path";
+
+/** Repo-relative path under packages/; null if outside the repo tree. */
+export function repoRel(filename) {
+  const norm = filename.replace(/\\/g, "/");
+  const m = norm.match(/(?:^|\/)(packages\/.+)$/);
+  return m ? m[1] : null;
+}
+
+// Symbols that must not be imported directly into a test file.
+export const BANNED = new Set(["ensureCanonicalTables", "loadCanonicalSchema"]);
+
+// Test files permitted to import the banned loaders (they test them directly).
+export const ALLOW = new Set(["packages/activerecord/src/test-helpers/canonical-schema.test.ts"]);
+
+/** True when `source` resolves to the canonical-schema test helper module. */
+function isCanonicalSchemaModule(source) {
+  // Match any relative path ending in test-helpers/canonical-schema(.js).
+  return /(?:^|\/)test-helpers\/canonical-schema(?:\.js)?$/.test(source);
+}
+
+/** @type {import("eslint").Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid importing internal canonical-schema loaders (ensureCanonicalTables, loadCanonicalSchema) into a *.test.ts file; wire the canonical schema + fixtures through `fixtures({ ... })` instead.",
+    },
+    schema: [],
+    messages: {
+      banned:
+        "`{{name}}` is internal canonical-schema plumbing — do not import it into a test file. Wire the canonical schema + fixtures through the `fixtures({ ... })` helper instead. (Only `canonical-schema.test.ts` may import it, to test it directly.)",
+    },
+  },
+
+  create(context) {
+    const filename = context.filename ?? context.getFilename();
+    const rel = repoRel(filename) ?? path.basename(filename);
+    if (ALLOW.has(rel)) return {};
+
+    return {
+      ImportDeclaration(node) {
+        if (typeof node.source.value !== "string") return;
+        if (!isCanonicalSchemaModule(node.source.value)) return;
+        for (const spec of node.specifiers) {
+          if (spec.type !== "ImportSpecifier") continue;
+          const name = spec.imported.name;
+          if (BANNED.has(name)) {
+            context.report({ node: spec, messageId: "banned", data: { name } });
+          }
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint/no-internal-canonical-loaders.mjs
+++ b/eslint/no-internal-canonical-loaders.mjs
@@ -41,8 +41,11 @@ export const ALLOW = new Set(["packages/activerecord/src/test-helpers/canonical-
 
 /** True when `source` resolves to the canonical-schema test helper module. */
 function isCanonicalSchemaModule(source) {
-  // Match any relative path ending in test-helpers/canonical-schema(.js).
-  return /(?:^|\/)test-helpers\/canonical-schema(?:\.js)?$/.test(source);
+  // Match on the module basename regardless of directory depth so a
+  // same-directory import from inside test-helpers/ (`./canonical-schema.js`)
+  // is caught, not just the `../../test-helpers/canonical-schema.js` form. The
+  // repo has a single canonical-schema module, so basename matching is safe.
+  return /(?:^|\/)canonical-schema(?:\.js)?$/.test(source);
 }
 
 /** @type {import("eslint").Rule.RuleModule} */

--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -24,7 +24,8 @@ tester.run("no-internal-canonical-loaders", rule, {
       filename: FILENAME,
       code: 'import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";',
     },
-    // The loaders' own unit test may import them to test them directly.
+    // The loaders' own unit test may import them directly — via the real
+    // same-directory specifier it actually uses.
     {
       filename: OWN_TEST,
       code: 'import { ensureCanonicalTables, loadCanonicalSchema } from "./canonical-schema.js";',
@@ -51,6 +52,14 @@ tester.run("no-internal-canonical-loaders", rule, {
       filename: "packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts",
       code: 'import { ensureCanonicalTables } from "../../test-helpers/canonical-schema.js";',
       errors: [{ messageId: "banned", data: { name: "ensureCanonicalTables" } }],
+    },
+    // Same-directory sibling test inside test-helpers/ (not the allowlisted own
+    // test) — the most likely place to reach for the loaders via
+    // `./canonical-schema.js`. Must still be caught.
+    {
+      filename: "packages/activerecord/src/test-helpers/schema-file-generator.test.ts",
+      code: 'import { loadCanonicalSchema } from "./canonical-schema.js";',
+      errors: [{ messageId: "banned", data: { name: "loadCanonicalSchema" } }],
     },
     // Both banned symbols in one import → one report each.
     {

--- a/eslint/no-internal-canonical-loaders.test.mjs
+++ b/eslint/no-internal-canonical-loaders.test.mjs
@@ -1,0 +1,65 @@
+import { RuleTester } from "eslint";
+import rule from "./no-internal-canonical-loaders.mjs";
+
+const FILENAME = "packages/activerecord/src/dirty.test.ts";
+const OWN_TEST = "packages/activerecord/src/test-helpers/canonical-schema.test.ts";
+
+const tester = new RuleTester({
+  languageOptions: {
+    parser: (await import("typescript-eslint")).parser,
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+tester.run("no-internal-canonical-loaders", rule, {
+  valid: [
+    // The sanctioned surface — fixtures({}) — is never flagged.
+    {
+      filename: FILENAME,
+      code: 'import { fixtures } from "./test-helpers/fixtures.js";',
+    },
+    // rebuildCanonicalTables is the documented anti-contamination shield — allowed.
+    {
+      filename: FILENAME,
+      code: 'import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";',
+    },
+    // The loaders' own unit test may import them to test them directly.
+    {
+      filename: OWN_TEST,
+      code: 'import { ensureCanonicalTables, loadCanonicalSchema } from "./canonical-schema.js";',
+    },
+    // A banned symbol imported from an unrelated module is not the loader.
+    {
+      filename: FILENAME,
+      code: 'import { loadCanonicalSchema } from "./some-other-module.js";',
+    },
+  ],
+  invalid: [
+    {
+      filename: FILENAME,
+      code: 'import { ensureCanonicalTables } from "./test-helpers/canonical-schema.js";',
+      errors: [{ messageId: "banned", data: { name: "ensureCanonicalTables" } }],
+    },
+    {
+      filename: FILENAME,
+      code: 'import { loadCanonicalSchema } from "./test-helpers/canonical-schema.js";',
+      errors: [{ messageId: "banned", data: { name: "loadCanonicalSchema" } }],
+    },
+    // Deeper relative path (adapters/mysql2/*.test.ts reaching up two levels).
+    {
+      filename: "packages/activerecord/src/adapters/mysql2/mysql2-adapter.test.ts",
+      code: 'import { ensureCanonicalTables } from "../../test-helpers/canonical-schema.js";',
+      errors: [{ messageId: "banned", data: { name: "ensureCanonicalTables" } }],
+    },
+    // Both banned symbols in one import → one report each.
+    {
+      filename: FILENAME,
+      code: 'import { ensureCanonicalTables, loadCanonicalSchema } from "./test-helpers/canonical-schema.js";',
+      errors: [
+        { messageId: "banned", data: { name: "ensureCanonicalTables" } },
+        { messageId: "banned", data: { name: "loadCanonicalSchema" } },
+      ],
+    },
+  ],
+});

--- a/packages/activerecord/src/test-helpers/canonical-schema.ts
+++ b/packages/activerecord/src/test-helpers/canonical-schema.ts
@@ -2089,6 +2089,11 @@ async function buildCanonicalRegistry(): Promise<CanonicalTableDef[]> {
  * Lay the full canonical AR test schema onto a freshly-created (empty) database.
  * The template DB is built once at boot, so — unlike `defineSchema` — this issues
  * no drops, no signature-cache bookkeeping, and no schema-cache warming.
+ *
+ * @internal Plumbing for the boot/template setup paths only. Do NOT call this
+ * from a `*.test.ts` file — wire the canonical schema + fixtures through the
+ * `fixtures({ ... })` helper, which is the sanctioned public test surface. The
+ * `blazetrails/no-internal-canonical-loaders` ESLint rule enforces this.
  */
 export async function loadCanonicalSchema(adapter: DatabaseAdapter): Promise<void> {
   const { ss, typeMap } = await prepareSchema(adapter);
@@ -2144,6 +2149,12 @@ export async function rebuildCanonicalTables(
  * would clobber data other suites rely on: existing tables are left untouched
  * and only genuinely-missing ones are created. Throws on an unknown name for the
  * same reason {@link rebuildCanonicalTables} does.
+ *
+ * @internal Low-level plumbing for shared internal setup helpers (e.g.
+ * `encryption/test-helpers.ts`). Do NOT call this from a `*.test.ts` file — wire
+ * the canonical schema + fixtures through the `fixtures({ ... })` helper, which
+ * is the sanctioned public test surface. The
+ * `blazetrails/no-internal-canonical-loaders` ESLint rule enforces this.
  */
 export async function ensureCanonicalTables(
   adapter: DatabaseAdapter,


### PR DESCRIPTION
## What

Make the internal canonical-schema loaders internal-only so agents can't reach for them in new tests. The sanctioned public surface for wiring the canonical AR test schema + fixtures into a `*.test.ts` is the `fixtures({ ... })` helper (one call wires the handler, transactional fixtures, and the canonical schema).

## Changes

- **`@internal` JSDoc** on `ensureCanonicalTables` and `loadCanonicalSchema` in `test-helpers/canonical-schema.ts` — both are plumbing that `fixtures()` and a couple of internal setup paths (template/adapter-suite boot, `encryption/test-helpers.ts`) call.
- **New ESLint rule `blazetrails/no-internal-canonical-loaders`** (+ unit test), wired to `packages/activerecord/src/**/*.test.ts`. It fails any test file that imports those loaders directly. Modeled on the existing `blazetrails/*` local-plugin rules, matching the reviewer request to extend the existing lint mechanism rather than invent a new one.
- Allowlist: `canonical-schema.test.ts` (imports them to test them directly). Non-`*.test.ts` internal helpers are naturally out of scope since the rule only targets test files.

## Deliberate scope call: `rebuildCanonicalTables` is NOT banned or `@internal`

The task named `rebuildCanonicalTables` as a sibling to lock down, but I checked each first: `rebuildCanonicalTables` is the **documented anti-contamination shield** that ~10 test files legitimately call in a `beforeAll` to restore a canonical table a sibling file left in a reduced shape on the shared per-worker DB (see its JSDoc: "Test files use it as an anti-contamination shield"). It has no `fixtures({})` equivalent. Banning it would break existing sanctioned usage, so it stays a test-facing helper.

## Verification

- No `*.test.ts` currently imports the banned loaders directly (`git grep` — only comments reference them; `canonical-schema.test.ts` is the sole importer and is allowlisted). Nothing to migrate.
- New rule unit test: 8 cases pass (valid: `fixtures`, `rebuildCanonicalTables`, own test, unrelated module; invalid: each banned symbol, deep relative path, both-in-one-import).
- Synthetic probe confirms the rule fires on a fresh test importing `ensureCanonicalTables`; sanctioned files (`canonical-schema.test.ts`, shield users) lint clean.
- Pre-commit lint + `tsc --build` typecheck passed.
