### PR TITLE
fix(serialize): decorate reflected type so where binds coder payload

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -330,7 +330,10 @@ import {
   writeStoreAttributeMethod as _writeStoreAttributeMethod,
   storeAccessorForMethod as _storeAccessorForMethod,
 } from "./store.js";
-import { serialize as _serializeAttribute } from "./serialize.js";
+import {
+  serialize as _serializeAttribute,
+  applyPendingSerializations as _applyPendingSerializations,
+} from "./serialize.js";
 import { YAMLColumn as _YAMLColumn } from "./coders/yaml-column.js";
 
 // Break store→serialize→json→store circular dep by injecting serialize into store at init.
@@ -1160,6 +1163,7 @@ export class Base extends Model {
     }
     encryptionHooks.applyPendingEncryptions(this);
     this.applyPendingNormalizations();
+    _applyPendingSerializations(this as unknown as typeof Base);
   }
 
   /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -24,6 +24,7 @@ import { modelRegistry } from "./associations.js";
 import { realPool } from "./connection-adapters/abstract/connection-pool.js";
 import { TableNotSpecified } from "./errors.js";
 import { encryptionHooks } from "./encryption-hooks.js";
+import { applyPendingSerializations } from "./serialize.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
 import { FakePool } from "./connection-adapters/schema-cache.js";
 import { threadedConnectionFor, connectionPool } from "./connection-handling.js";
@@ -1085,6 +1086,7 @@ function applyColumnsHash(
   // query-side type lookup (`type_for_attribute` / `TypeCaster::Map`) sees the
   // decorated cast type. Mirrors the `applyPendingEncryptions` replay above.
   (host as { applyPendingNormalizations?(): void }).applyPendingNormalizations?.();
+  applyPendingSerializations(host as unknown as typeof Base);
 
   // Now the DB column set is authoritative: re-run the ignoreCase
   // `original_<name>` requirement so a genuinely absent column raises even when
@@ -1122,6 +1124,7 @@ function applyColumnsHash(
     originatingHost._attributeDefinitions = baseDefs;
     encryptionHooks.applyPendingEncryptions(originatingHost);
     (originatingHost as { applyPendingNormalizations?(): void }).applyPendingNormalizations?.();
+    applyPendingSerializations(originatingHost as unknown as typeof Base);
     // Recompute the reflected column set against the subclass's own
     // `ignoredColumns` — an STI subclass may ignore a different set than its
     // base, so reusing the base's `reflectedColumnNames` could check against the

--- a/packages/activerecord/src/serialization.test.ts
+++ b/packages/activerecord/src/serialization.test.ts
@@ -127,17 +127,13 @@ describe("SerializationTest", () => {
 
   it("find records by serialized attributes through join", async () => {
     const author = await Author.create({ name: "David" });
-    // `title` is coderless-`serialize`-wrapped, so the stored value is the
-    // default (YAML) coder's encoded form (`YAML.dump("Hello") == "Hello\n"`).
-    // Assign/query that pre-serialized string so the persisted value and the
-    // join predicate compare equal.
     await (
       author as unknown as { serializedPosts: { create(attrs: object): Promise<unknown> } }
-    ).serializedPosts.create({ title: "Hello\n" });
+    ).serializedPosts.create({ title: "Hello" });
 
     const results = await Author.joins("serializedPosts").where({
       name: "David",
-      serialized_posts: { title: "Hello\n" },
+      serialized_posts: { title: "Hello" },
     });
     expect(results.length).toBe(1);
   });

--- a/packages/activerecord/src/serialize.ts
+++ b/packages/activerecord/src/serialize.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { type Type, ArgumentError } from "@blazetrails/activemodel";
+import { type Type, ArgumentError, resetDefaultAttributes } from "@blazetrails/activemodel";
 import { Json } from "./type/json.js";
 import { Serialized, type Coder } from "./type/serialized.js";
 import {
@@ -146,7 +146,11 @@ export function serialize(
     modelClass.defaultColumnSerializer,
   );
 
-  modelClass.decorateAttributes([attribute], (name: string, castType: Type): Type => {
+  const decorator = (name: string, castType: Type): Type => {
+    // Already wrapped by this same coder (post-reflection replay) — no-op so the
+    // decoration stays idempotent and we don't stack a fresh Serialized each time
+    // a schema reload resets the column's type back to its raw DB form.
+    if (castType instanceof Serialized && castType.coder === coder) return castType;
     // `castType instanceof Json` (computed here, where Json is already imported)
     // catches both Type::Json and its OID::Jsonb subclass — Rails' `is_a?(Json)`.
     if (
@@ -158,5 +162,82 @@ export function serialize(
     // must wrap the underlying cast type, not stack a second Serialized.
     const subtype = castType instanceof Serialized ? castType.subtype : castType;
     return new Serialized(subtype, coder);
-  });
+  };
+
+  // Track the coder so `applyPendingSerializations` can re-wrap the reflected DB
+  // type once columns load: `decorateAttributes` replays into the default
+  // attribute set, but the raw `_attributeDefinitions` store that
+  // `type_for_attribute` / `TypeCaster::Map` read is only decorated for columns
+  // already reflected at declaration time. Without the replay a `serialize`d
+  // column resolves to its bare DB type on the query side, so `where` binds the
+  // un-encoded value instead of the coder's payload. Mirrors AR's
+  // `applyPendingNormalizations` / `applyPendingEncryptions` post-reflection hooks.
+  registerColumnSerializer(modelClass, attribute, coder, decorator);
+
+  modelClass.decorateAttributes([attribute], decorator);
+}
+
+interface SerializerEntry {
+  coder: Coder;
+  decorator: (name: string, castType: Type) => Type;
+}
+
+/** @internal */
+export function columnSerializers(modelClass: typeof Base): Map<string, SerializerEntry> {
+  const cls = modelClass as unknown as { _columnSerializers?: Map<string, SerializerEntry> };
+  // Fork per-class (copying the parent's entries) so a subclass `serialize` never
+  // mutates the shared base map — mirrors `_normalizations`' own-property guard.
+  if (!Object.prototype.hasOwnProperty.call(modelClass, "_columnSerializers")) {
+    const parent = Object.getPrototypeOf(modelClass) as {
+      _columnSerializers?: Map<string, SerializerEntry>;
+    };
+    cls._columnSerializers = new Map(parent?._columnSerializers ?? undefined);
+  }
+  return cls._columnSerializers!;
+}
+
+function registerColumnSerializer(
+  modelClass: typeof Base,
+  attribute: string,
+  coder: Coder,
+  decorator: (name: string, castType: Type) => Type,
+): void {
+  columnSerializers(modelClass).set(attribute, { coder, decorator });
+}
+
+/**
+ * Re-apply serialize decorators onto `_attributeDefinitions` once columns are
+ * reflected, so the query-side lookup (`type_for_attribute`, `TypeCaster::Map`)
+ * sees the `Serialized` cast type. Mirrors AR's `applyPendingNormalizations`
+ * replay — mutates `_attributeDefinitions` directly rather than routing through
+ * `decorateAttributes` (whose durable pending decorator already replays on every
+ * `_defaultAttributes` rebuild). The coder-identity guard keeps it idempotent.
+ *
+ * @internal
+ */
+export function applyPendingSerializations(modelClass: typeof Base): void {
+  const cls = modelClass as unknown as {
+    _columnSerializers?: Map<string, SerializerEntry>;
+    _attributeDefinitions?: Map<string, { name: string; type: Type }>;
+  };
+  const serializers = cls._columnSerializers;
+  if (!serializers || serializers.size === 0) return;
+  const defs = cls._attributeDefinitions;
+  if (!defs) return;
+  let mutated = false;
+  for (const [name, entry] of serializers) {
+    const def = defs.get(name);
+    if (!def) continue; // column not reflected yet; re-invoked once it appears
+    if (def.type instanceof Serialized && def.type.coder === entry.coder) continue; // applied
+    const newType = entry.decorator(name, def.type);
+    if (newType === def.type) continue;
+    if (!Object.prototype.hasOwnProperty.call(modelClass, "_attributeDefinitions")) {
+      cls._attributeDefinitions = new Map(defs);
+    }
+    cls._attributeDefinitions!.set(name, { ...def, type: newType });
+    mutated = true;
+  }
+  if (mutated) {
+    resetDefaultAttributes(modelClass as any);
+  }
 }

--- a/packages/activerecord/src/serialize.ts
+++ b/packages/activerecord/src/serialize.ts
@@ -182,8 +182,7 @@ interface SerializerEntry {
   decorator: (name: string, castType: Type) => Type;
 }
 
-/** @internal */
-export function columnSerializers(modelClass: typeof Base): Map<string, SerializerEntry> {
+function columnSerializers(modelClass: typeof Base): Map<string, SerializerEntry> {
   const cls = modelClass as unknown as { _columnSerializers?: Map<string, SerializerEntry> };
   // Fork per-class (copying the parent's entries) so a subclass `serialize` never
   // mutates the shared base map — mirrors `_normalizations`' own-property guard.
@@ -228,7 +227,9 @@ export function applyPendingSerializations(modelClass: typeof Base): void {
   for (const [name, entry] of serializers) {
     const def = defs.get(name);
     if (!def) continue; // column not reflected yet; re-invoked once it appears
-    if (def.type instanceof Serialized && def.type.coder === entry.coder) continue; // applied
+    // The decorator returns the same type reference when it's already wrapped by
+    // this coder (idempotency guard), so this both no-ops the applied case and
+    // re-wraps a freshly-reflected raw column.
     const newType = entry.decorator(name, def.type);
     if (newType === def.type) continue;
     if (!Object.prototype.hasOwnProperty.call(modelClass, "_attributeDefinitions")) {

--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -302,16 +302,40 @@ describe("SerializedAttributeTest", () => {
     expect((found as any).content).toEqual(settings);
   });
 
-  it.skip("where by serialized attribute with array", () => {
-    // PERMANENT-SKIP: needs serialized-attribute where support.
+  it("where by serialized attribute with array", async () => {
+    class ArrayTopic extends Topic {
+      static {
+        serialize(this, "content", { type: Array });
+      }
+    }
+    const settings = [{ color: "green" }];
+    const topic = await ArrayTopic.create({ content: settings as any });
+    const found = await ArrayTopic.where({ content: settings }).take();
+    expect((found as any)?.id).toBe(topic.id);
   });
 
-  it.skip("where by serialized attribute with hash", () => {
-    // PERMANENT-SKIP: needs serialized-attribute where support.
+  it("where by serialized attribute with hash", async () => {
+    class HashTopic extends Topic {
+      static {
+        serialize(this, "content", { type: HashObject });
+      }
+    }
+    const settings = { color: "green" };
+    const topic = await HashTopic.create({ content: settings as any });
+    const found = await HashTopic.where({ content: settings }).take();
+    expect((found as any)?.id).toBe(topic.id);
   });
 
-  it.skip("where by serialized attribute with hash in array", () => {
-    // PERMANENT-SKIP: needs serialized-attribute where support.
+  it("where by serialized attribute with hash in array", async () => {
+    class HashTopic extends Topic {
+      static {
+        serialize(this, "content", { type: HashObject });
+      }
+    }
+    const settings = { color: "green" };
+    const topic = await HashTopic.create({ content: settings as any });
+    const found = await HashTopic.where({ content: [settings, { herring: "red" }] }).take();
+    expect((found as any)?.id).toBe(topic.id);
   });
 
   it("serialized default class", async () => {


### PR DESCRIPTION
## Summary

Querying a `serialize`-wrapped column bound the plain, un-encoded value instead
of the coder's `dump` payload, so `where(serialized_col: "Hello")` matched zero
rows against the stored serialized blob. Callers had to pre-encode the query
value (e.g. query `"Hello\n"`, the YAML-dumped form).

Root cause: `serialize` wraps the attribute's cast type through
`decorateAttributes`, which replays into the default attribute set but **not**
the raw `_attributeDefinitions` store that `type_for_attribute` /
`TypeCaster::Map` read on the query side. A column serialized before its schema
reflected therefore resolved to its bare DB type in the predicate builder.

Fix: track each serialized column's coder and re-apply the decorator onto
`_attributeDefinitions` once columns are reflected (`applyPendingSerializations`),
mirroring the existing `applyPendingNormalizations` / `applyPendingEncryptions`
post-reflection hooks. The coder-identity guard keeps the replay idempotent.

Matches `serialization_test.rb:100-105`.

## Tests

- Re-ported `serialization.test.ts` `find records by serialized attributes
  through join` to query the plain value `"Hello"` (dropped the `"Hello\n"`
  workaround).
- Un-skipped the three `serialized-attribute.test.ts` `where by serialized
  attribute with array / hash / hash in array` tests (previously PERMANENT-SKIP
  "needs serialized-attribute where support") and ported them to query plain
  values, matching `serialized_attribute_test.rb:230-249`.

Closes-story: serialize-column-where-predicate-coder-dump