### PR TITLE
fix(savepoints): thread materializeTransactions:true so savepoint ops dirty parent frame

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/savepoints.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/savepoints.ts
@@ -58,9 +58,12 @@ export function currentSavepointName(this: CurrentSavepointNameHost): string | n
  */
 export async function createSavepoint(this: SavepointHost, name?: string): Promise<void> {
   const spName = name ?? this.currentSavepointName();
-  await this.internalExecute(createSavepointSql(spName), "TRANSACTION", {
-    materializeTransactions: false,
-  });
+  // materializeTransactions defaults to true, matching Rails savepoints.rb:11-20
+  // (internal_execute's default). The re-entrant materialize pass is a no-op —
+  // createSavepoint runs inside materializeBang, where the
+  // `_materializingTransactions` guard is already set — and internalExecute's
+  // finally then dirties the current frame (Rails' with_raw_connection ensure).
+  await this.internalExecute(createSavepointSql(spName), "TRANSACTION");
 }
 
 /**
@@ -70,9 +73,12 @@ export async function createSavepoint(this: SavepointHost, name?: string): Promi
  */
 export async function execRollbackToSavepoint(this: SavepointHost, name?: string): Promise<void> {
   const spName = name ?? this.currentSavepointName();
-  await this.internalExecute(execRollbackToSavepointSql(spName), "TRANSACTION", {
-    materializeTransactions: false,
-  });
+  // materializeTransactions:true (default) per Rails savepoints.rb. The
+  // committing/rolling-back savepoint frame is already popped, so
+  // internalExecute's finally dirties the real PARENT frame — Rails
+  // with_raw_connection's `ensure dirty_current_transaction` — making the
+  // parent non-restorable if this savepoint op hit a reconnect mid-flight.
+  await this.internalExecute(execRollbackToSavepointSql(spName), "TRANSACTION");
 }
 
 /**
@@ -82,9 +88,10 @@ export async function execRollbackToSavepoint(this: SavepointHost, name?: string
  */
 export async function releaseSavepoint(this: SavepointHost, name?: string): Promise<void> {
   const spName = name ?? this.currentSavepointName();
-  await this.internalExecute(releaseSavepointSql(spName), "TRANSACTION", {
-    materializeTransactions: false,
-  });
+  // materializeTransactions:true (default) per Rails savepoints.rb. See
+  // execRollbackToSavepoint — the popped-frame → parent-dirty semantics apply
+  // identically to RELEASE SAVEPOINT.
+  await this.internalExecute(releaseSavepointSql(spName), "TRANSACTION");
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1107,8 +1107,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_execute
-  // Overrides the abstract mixin default so TRANSACTION SQL (materializeTransactions=false)
-  // skips materializeTransactions() — calling it would trigger re-entrant SAVEPOINT emission.
+  // materializeTransactions is handled here (before the loop) instead of inside
+  // withRawConnection, and the loop is passed false, so transaction-control SQL
+  // keeps its exact pre-existing materialize semantics. The Rails ensure —
+  // with_raw_connection's `dirty_current_transaction if materialize_transactions`
+  // (abstract_adapter.rb:1046) — is relocated to this method's own finally so it
+  // still fires when the param is true (savepoint statements, savepoints.rb:11-20).
   // Returns the raw {rows, fields, affectedRows} so internalExecQuery's `castResult`
   // (and execUpdate/execDelete's affectedRows) can build a Result — the Rails-faithful
   // query_value/update path. Transaction-control callers ignore the return.
@@ -1122,125 +1126,115 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     }: { materializeTransactions?: boolean; allowRetry?: boolean; binds?: unknown[] } = {},
   ): Promise<Mysql2RawResult> {
     sql = this.preprocessQuery(sql);
-    if (materializeTransactions) {
-      this._syncDatabaseTimezone();
-      await this.materializeTransactions();
-    }
-    const driverSql = this.mysqlQuote(sql);
-    // Thread binds through so a bound INSERT ... RETURNING (MariaDB) reaches the
-    // driver, matching Rails internal_execute(sql, name, binds). Transaction-
-    // control callers pass none, keeping their byte-identical no-bind path.
-    const driverBinds = binds.length > 0 ? this.mysqlBinds(binds) : [];
-    const txPublicInt = this.currentTransaction().userTransaction;
-    const payload: Record<string, unknown> = {
-      sql: driverSql,
-      name,
-      binds: driverBinds,
-      type_casted_binds: typeCastedBinds(driverBinds),
-      connection: this,
-      row_count: 0,
-      transaction: txPublicInt.isOpen() ? txPublicInt : null,
-    };
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
-      try {
-        // materializeTransactions is run BEFORE the loop (above) and we pass
-        // `false` into withRawConnection — the same materialize-outside-the-loop
-        // split PostgreSQLAdapter#internalExecute uses (postgresql-adapter.ts),
-        // which this story converges mysql2 onto. The leaf still gains the
-        // retry/verify/reconnect loop, so callers thread allowRetry in a single
-        // call (matching Rails abstract_mysql_adapter.rb:227-239).
-        //
-        // Divergence note: because the flag is `false` here, the loop's
-        // `finally dirtyCurrentTransaction()` (abstract-adapter.ts) never fires
-        // for this leaf. In Rails, COMMIT/ROLLBACK pass materialize_transactions:
-        // true (abstract_mysql_adapter.rb:242-248) so with_raw_connection's
-        // `ensure dirty_current_transaction if materialize_transactions`
-        // (abstract_adapter.rb:1046) fires on commit/rollback. trails does not,
-        // but this is pre-existing and shared with PG, NOT introduced here:
-        // pre-this-PR mysql2 internalExecute used the direct getConn path with no
-        // withRawConnection, so it never dirtied here either.
-        //
-        // The suppressed dirty has no observable effect on the COMMIT/ROLLBACK
-        // path: real COMMIT/ROLLBACK SQL is only ever issued by the bottom-of-
-        // stack RealTransaction (SavepointTransaction#commit/rollback issue
-        // RELEASE/ROLLBACK TO SAVEPOINT instead — transaction.ts:832,898), and
-        // TransactionManager#_commitTransactionInner pops the committing frame
-        // BEFORE calling transaction.commit() → commitDbTransaction()
-        // (transaction.ts:1108-1117). So by the time this COMMIT runs the stack
-        // is empty, currentTransaction is NULL_TRANSACTION, and
-        // dirtyCurrentTransaction() is a no-op — there is no parent frame to
-        // dirty. (Nested RELEASE/ROLLBACK TO SAVEPOINT, where a real parent frame
-        // does remain, go through createSavepoint/releaseSavepoint/
-        // rollbackToSavepoint below, whose materializeTransactions:false is
-        // likewise pre-existing and unchanged by this PR — Rails passes true
-        // there per savepoints.rb:11-20, a separate long-standing trails/PG
-        // deviation, not this story's scope.)
-        //
-        // Error translation + invalidateTransaction live in the withRawConnection
-        // loop and the outer catch below — mirroring execute()/executeMutation()
-        // — so the block stays a bare leaf and does not double-translate or
-        // double-invalidate.
-        return await this.withRawConnection(
-          { materializeTransactions: false, allowRetry },
-          async (rawConn) => {
-            // Route the read path through the shared array-mode performQuery seam
-            // (rowsAsArray + single CALL/multi-result unwrap), mirroring Rails'
-            // internal_execute → raw_execute → cast_result. Array-mode rows keep
-            // duplicate column names that the old hash-keyed conn.query collapsed.
-            const conn = rawConn as unknown as mysql.Connection;
-            const prepare = this._shouldPrepare(binds);
-            if (prepare) this._trackPrepared(conn, driverSql);
-            const rawResult = await mysql2PerformQuery.call(
-              this as any,
-              conn,
-              driverSql,
-              binds,
-              driverBinds,
-              { prepare },
-            );
-            payload.row_count = rawResult.affectedRows;
-            return rawResult;
-          },
-        );
-      } catch (e: any) {
-        // The loop already translated for its retry classification; guard
-        // against re-translating an ActiveRecordError (see execute()).
-        const translated =
-          e instanceof ActiveRecordError
-            ? e
-            : await this._translateAndEnrich(e, driverSql, driverBinds);
-        payload.exception = translated;
-        payload.exception_object = translated;
-        throw translated;
+    try {
+      if (materializeTransactions) {
+        this._syncDatabaseTimezone();
+        await this.materializeTransactions();
       }
-    });
+      const driverSql = this.mysqlQuote(sql);
+      // Thread binds through so a bound INSERT ... RETURNING (MariaDB) reaches the
+      // driver, matching Rails internal_execute(sql, name, binds). Transaction-
+      // control callers pass none, keeping their byte-identical no-bind path.
+      const driverBinds = binds.length > 0 ? this.mysqlBinds(binds) : [];
+      const txPublicInt = this.currentTransaction().userTransaction;
+      const payload: Record<string, unknown> = {
+        sql: driverSql,
+        name,
+        binds: driverBinds,
+        type_casted_binds: typeCastedBinds(driverBinds),
+        connection: this,
+        row_count: 0,
+        transaction: txPublicInt.isOpen() ? txPublicInt : null,
+      };
+      return await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+        try {
+          // materializeTransactions is run BEFORE the loop (above) and we pass
+          // `false` into withRawConnection — the same materialize-outside-the-loop
+          // split PostgreSQLAdapter#internalExecute uses (postgresql-adapter.ts).
+          // The leaf still gains the retry/verify/reconnect loop, so callers thread
+          // allowRetry in a single call (matching Rails abstract_mysql_adapter.rb:227-239).
+          //
+          // Because the split moved materialize out of withRawConnection, the
+          // loop's `finally dirtyCurrentTransaction()` (abstract-adapter.ts) never
+          // fires for this leaf. Rails' equivalent `ensure dirty_current_transaction
+          // if materialize_transactions` (abstract_adapter.rb:1046) is relocated to
+          // this method's own finally so a savepoint statement (materialize:true,
+          // savepoints.rb:11-20) still dirties the current — parent, for a popped
+          // RELEASE/ROLLBACK TO SAVEPOINT frame — transaction on every exit. COMMIT/
+          // ROLLBACK pass materialize:false and so do not dirty (nor would it matter:
+          // _commitTransactionInner pops the committing frame first, transaction.ts:
+          // 1108-1117, leaving currentTransaction the NULL_TRANSACTION no-op).
+          //
+          // Error translation + invalidateTransaction live in the withRawConnection
+          // loop and the outer catch below — mirroring execute()/executeMutation()
+          // — so the block stays a bare leaf and does not double-translate or
+          // double-invalidate.
+          return await this.withRawConnection(
+            { materializeTransactions: false, allowRetry },
+            async (rawConn) => {
+              // Route the read path through the shared array-mode performQuery seam
+              // (rowsAsArray + single CALL/multi-result unwrap), mirroring Rails'
+              // internal_execute → raw_execute → cast_result. Array-mode rows keep
+              // duplicate column names that the old hash-keyed conn.query collapsed.
+              const conn = rawConn as unknown as mysql.Connection;
+              const prepare = this._shouldPrepare(binds);
+              if (prepare) this._trackPrepared(conn, driverSql);
+              const rawResult = await mysql2PerformQuery.call(
+                this as any,
+                conn,
+                driverSql,
+                binds,
+                driverBinds,
+                { prepare },
+              );
+              payload.row_count = rawResult.affectedRows;
+              return rawResult;
+            },
+          );
+        } catch (e: any) {
+          // The loop already translated for its retry classification; guard
+          // against re-translating an ActiveRecordError (see execute()).
+          const translated =
+            e instanceof ActiveRecordError
+              ? e
+              : await this._translateAndEnrich(e, driverSql, driverBinds);
+          payload.exception = translated;
+          payload.exception_object = translated;
+          throw translated;
+        }
+      });
+    } finally {
+      // Rails' with_raw_connection `ensure dirty_current_transaction if
+      // materialize_transactions` (abstract_adapter.rb:1046), relocated here
+      // because the materialize pass runs outside withRawConnection (above).
+      // Fires on every exit path, so a retryable savepoint failure mid-flight
+      // leaves the parent frame dirty → isRestorable() refuses to restore it.
+      if (materializeTransactions) this.dirtyCurrentTransaction();
+    }
   }
 
   /**
    * Create a savepoint (nested transaction).
    */
   async createSavepoint(name: string): Promise<void> {
-    await this.internalExecute(`SAVEPOINT \`${name}\``, "TRANSACTION", {
-      materializeTransactions: false,
-    });
+    // materializeTransactions defaults to true, matching Rails savepoints.rb:11-20.
+    // internalExecute's finally then dirties the current transaction (Rails'
+    // with_raw_connection ensure) — see internalExecute above.
+    await this.internalExecute(`SAVEPOINT \`${name}\``, "TRANSACTION");
   }
 
   /**
    * Release a savepoint.
    */
   async releaseSavepoint(name: string): Promise<void> {
-    await this.internalExecute(`RELEASE SAVEPOINT \`${name}\``, "TRANSACTION", {
-      materializeTransactions: false,
-    });
+    await this.internalExecute(`RELEASE SAVEPOINT \`${name}\``, "TRANSACTION");
   }
 
   /**
    * Rollback to a savepoint.
    */
   async rollbackToSavepoint(name: string): Promise<void> {
-    await this.internalExecute(`ROLLBACK TO SAVEPOINT \`${name}\``, "TRANSACTION", {
-      materializeTransactions: false,
-    });
+    await this.internalExecute(`ROLLBACK TO SAVEPOINT \`${name}\``, "TRANSACTION");
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2079,8 +2079,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_execute
-  // Overrides the abstract mixin default so TRANSACTION SQL (materializeTransactions=false)
-  // skips materializeTransactions() — calling it would trigger re-entrant SAVEPOINT emission.
+  // materializeTransactions is handled here (before the loop) instead of inside
+  // withRawConnection, so transaction-control SQL keeps its exact pre-existing
+  // materialize semantics. Rails' with_raw_connection `ensure
+  // dirty_current_transaction if materialize_transactions` (abstract_adapter.rb:1046)
+  // is relocated to this method's own finally so a savepoint statement
+  // (materialize:true, savepoints.rb:11-20) still dirties the current — parent, for a
+  // popped RELEASE/ROLLBACK TO SAVEPOINT frame — transaction on every exit.
   override async internalExecute(
     sql: string,
     name: string = "SQL",
@@ -2091,86 +2096,91 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     }: { materializeTransactions?: boolean; allowRetry?: boolean; binds?: unknown[] } = {},
   ): Promise<unknown> {
     sql = preprocessQuery.call(this as any, sql);
-    if (materializeTransactions) await this.materializeTransactions();
-    // Thread binds through so a bound INSERT ... RETURNING reaches the driver,
-    // matching Rails internal_execute(sql, name, binds). Transaction-control
-    // callers pass none, keeping their byte-identical no-bind path (no rewrite).
-    const hasBinds = binds.length > 0;
-    const bindArray = hasBinds ? typeCastedBinds(binds).map((v) => this._bindForPg(v)) : [];
-    const runSql = hasBinds ? this.rewriteBinds(sql, bindArray) : sql;
-    // A bound query here is the exec_insert RETURNING read-back; mirror
-    // _instrumentedQueryOnClient by resetting the notice buffer up front and
-    // flushing after, so PG WARNING/NOTICE handling (db_warnings_action) is not
-    // dropped or misattributed to the next query. Transaction-control SQL passes
-    // no binds and keeps its byte-identical path (no reset/flush/rewrite).
-    if (hasBinds) this._noticeReceiverSqlWarnings = [];
-    const payload: Record<string, unknown> = {
-      sql: runSql,
-      name,
-      binds,
-      type_casted_binds: bindArray,
-      connection: this,
-      row_count: 0,
-    };
-    const queryPromise = Notifications.instrumentAsync("sql.active_record", payload, () =>
-      // materializeTransactions is handled above (not delegated to
-      // withRawConnection) so transaction-control SQL — COMMIT/ROLLBACK/
-      // SAVEPOINT — keeps its exact pre-existing materialize semantics and the
-      // loop's `finally dirtyCurrentTransaction()` does not fire on txn-control
-      // SQL. The leaf still gains the retry/verify/reconnect loop.
-      this.withRawConnection({ materializeTransactions: false, allowRetry }, async (conn) => {
-        const client = conn as unknown as pg.Client;
-        try {
-          const result = await this._runQuery(client, runSql, bindArray, { rowMode: "array" });
-          const count = result.rowCount ?? result.rows.length;
-          payload.row_count = count;
-          return result;
-        } catch (e: any) {
-          // A bound query is the exec_insert RETURNING read-back: translate with
-          // sql + binds here (mirroring _instrumentedQueryOnClient) so a
-          // constraint violation surfaces as RecordNotUnique/InvalidForeignKey
-          // carrying statement context. withRawConnection re-catches this AR
-          // error and passes it through unchanged; its own translate would
-          // otherwise re-wrap with null sql / empty binds. Transaction-control
-          // SQL (no binds) keeps the raw rethrow, matching pre-PR behavior.
-          const translated = hasBinds ? this._translateException(e, runSql, bindArray) : e;
-          payload.exception = translated;
-          payload.exception_object = translated;
-          throw translated;
-        }
-      }),
-    );
-    if (!hasBinds) return queryPromise;
-    const result = await queryPromise;
-    this._flushWarnings(runSql);
-    return result;
+    try {
+      if (materializeTransactions) await this.materializeTransactions();
+      // Thread binds through so a bound INSERT ... RETURNING reaches the driver,
+      // matching Rails internal_execute(sql, name, binds). Transaction-control
+      // callers pass none, keeping their byte-identical no-bind path (no rewrite).
+      const hasBinds = binds.length > 0;
+      const bindArray = hasBinds ? typeCastedBinds(binds).map((v) => this._bindForPg(v)) : [];
+      const runSql = hasBinds ? this.rewriteBinds(sql, bindArray) : sql;
+      // A bound query here is the exec_insert RETURNING read-back; mirror
+      // _instrumentedQueryOnClient by resetting the notice buffer up front and
+      // flushing after, so PG WARNING/NOTICE handling (db_warnings_action) is not
+      // dropped or misattributed to the next query. Transaction-control SQL passes
+      // no binds and keeps its byte-identical path (no reset/flush/rewrite).
+      if (hasBinds) this._noticeReceiverSqlWarnings = [];
+      const payload: Record<string, unknown> = {
+        sql: runSql,
+        name,
+        binds,
+        type_casted_binds: bindArray,
+        connection: this,
+        row_count: 0,
+      };
+      const result = await Notifications.instrumentAsync("sql.active_record", payload, () =>
+        // materializeTransactions is handled above (not delegated to
+        // withRawConnection) so transaction-control SQL — COMMIT/ROLLBACK/
+        // SAVEPOINT — keeps its exact pre-existing materialize semantics. The
+        // loop's own `finally dirtyCurrentTransaction()` does not fire (false is
+        // passed); this method's finally handles it instead. The leaf still gains
+        // the retry/verify/reconnect loop.
+        this.withRawConnection({ materializeTransactions: false, allowRetry }, async (conn) => {
+          const client = conn as unknown as pg.Client;
+          try {
+            const runResult = await this._runQuery(client, runSql, bindArray, { rowMode: "array" });
+            const count = runResult.rowCount ?? runResult.rows.length;
+            payload.row_count = count;
+            return runResult;
+          } catch (e: any) {
+            // A bound query is the exec_insert RETURNING read-back: translate with
+            // sql + binds here (mirroring _instrumentedQueryOnClient) so a
+            // constraint violation surfaces as RecordNotUnique/InvalidForeignKey
+            // carrying statement context. withRawConnection re-catches this AR
+            // error and passes it through unchanged; its own translate would
+            // otherwise re-wrap with null sql / empty binds. Transaction-control
+            // SQL (no binds) keeps the raw rethrow, matching pre-PR behavior.
+            const translated = hasBinds ? this._translateException(e, runSql, bindArray) : e;
+            payload.exception = translated;
+            payload.exception_object = translated;
+            throw translated;
+          }
+        }),
+      );
+      if (hasBinds) this._flushWarnings(runSql);
+      return result;
+    } finally {
+      // Rails' with_raw_connection `ensure dirty_current_transaction if
+      // materialize_transactions` (abstract_adapter.rb:1046), relocated here
+      // because the materialize pass runs outside withRawConnection (above).
+      // Fires on every exit path, so a retryable savepoint failure mid-flight
+      // leaves the parent frame dirty → isRestorable() refuses to restore it.
+      if (materializeTransactions) this.dirtyCurrentTransaction();
+    }
   }
 
   /**
    * Create a savepoint (nested transaction).
    */
   async createSavepoint(name: string): Promise<void> {
-    await this.internalExecute(`SAVEPOINT "${name}"`, "TRANSACTION", {
-      materializeTransactions: false,
-    });
+    // materializeTransactions defaults to true, matching Rails savepoints.rb:11-20.
+    // internalExecute's finally then dirties the current transaction (Rails'
+    // with_raw_connection ensure) — see internalExecute above.
+    await this.internalExecute(`SAVEPOINT "${name}"`, "TRANSACTION");
   }
 
   /**
    * Release a savepoint.
    */
   async releaseSavepoint(name: string): Promise<void> {
-    await this.internalExecute(`RELEASE SAVEPOINT "${name}"`, "TRANSACTION", {
-      materializeTransactions: false,
-    });
+    await this.internalExecute(`RELEASE SAVEPOINT "${name}"`, "TRANSACTION");
   }
 
   /**
    * Rollback to a savepoint.
    */
   async rollbackToSavepoint(name: string): Promise<void> {
-    await this.internalExecute(`ROLLBACK TO SAVEPOINT "${name}"`, "TRANSACTION", {
-      materializeTransactions: false,
-    });
+    await this.internalExecute(`ROLLBACK TO SAVEPOINT "${name}"`, "TRANSACTION");
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -720,8 +720,12 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   }
 
   // Mirrors: ActiveRecord::ConnectionAdapters::DatabaseStatements#internal_execute
-  // Overrides the abstract mixin default so TRANSACTION SQL (materializeTransactions=false)
-  // skips materializeTransactions() — calling it would trigger re-entrant SAVEPOINT emission.
+  // materializeTransactions defaults to true; transaction-control SQL passes false
+  // to keep its byte-identical no-materialize path. Rails' with_raw_connection
+  // `ensure dirty_current_transaction if materialize_transactions`
+  // (abstract_adapter.rb:1046) is relocated to this method's finally so a savepoint
+  // statement (materialize:true, savepoints.rb:11-20) dirties the current — parent,
+  // for a popped RELEASE/ROLLBACK TO SAVEPOINT frame — transaction on every exit.
   override async internalExecute(
     sql: string,
     name: string = "SQL",
@@ -729,26 +733,30 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
   ): Promise<unknown> {
     sql = this.preprocessQuery(sql);
     await this.ensureConnected();
-    if (materializeTransactions) await this.materializeTransactions();
-    const payload: Record<string, unknown> = {
-      sql,
-      name,
-      binds: [],
-      type_casted_binds: [],
-      connection: this,
-      row_count: 0,
-    };
-    return Notifications.instrumentAsync("sql.active_record", payload, async () => {
-      try {
-        await this.driver.exec(sql);
-        return 0;
-      } catch (e: any) {
-        const translated = this._translateException(e, sql, []);
-        payload.exception = translated;
-        payload.exception_object = translated;
-        throw translated;
-      }
-    });
+    try {
+      if (materializeTransactions) await this.materializeTransactions();
+      const payload: Record<string, unknown> = {
+        sql,
+        name,
+        binds: [],
+        type_casted_binds: [],
+        connection: this,
+        row_count: 0,
+      };
+      return await Notifications.instrumentAsync("sql.active_record", payload, async () => {
+        try {
+          await this.driver.exec(sql);
+          return 0;
+        } catch (e: any) {
+          const translated = this._translateException(e, sql, []);
+          payload.exception = translated;
+          payload.exception_object = translated;
+          throw translated;
+        }
+      });
+    } finally {
+      if (materializeTransactions) this.dirtyCurrentTransaction();
+    }
   }
 
   /**
@@ -887,27 +895,24 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * Create a savepoint (nested transaction).
    */
   async createSavepoint(name: string): Promise<void> {
-    await this.internalExecute(`SAVEPOINT "${name}"`, "TRANSACTION", {
-      materializeTransactions: false,
-    });
+    // materializeTransactions defaults to true, matching Rails savepoints.rb:11-20.
+    // internalExecute's finally then dirties the current transaction (Rails'
+    // with_raw_connection ensure) — see internalExecute above.
+    await this.internalExecute(`SAVEPOINT "${name}"`, "TRANSACTION");
   }
 
   /**
    * Release a savepoint.
    */
   async releaseSavepoint(name: string): Promise<void> {
-    await this.internalExecute(`RELEASE SAVEPOINT "${name}"`, "TRANSACTION", {
-      materializeTransactions: false,
-    });
+    await this.internalExecute(`RELEASE SAVEPOINT "${name}"`, "TRANSACTION");
   }
 
   /**
    * Rollback to a savepoint.
    */
   async rollbackToSavepoint(name: string): Promise<void> {
-    await this.internalExecute(`ROLLBACK TO SAVEPOINT "${name}"`, "TRANSACTION", {
-      materializeTransactions: false,
-    });
+    await this.internalExecute(`ROLLBACK TO SAVEPOINT "${name}"`, "TRANSACTION");
   }
 
   /**

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -242,6 +242,10 @@ describe("savepoint statements dirty the current transaction (trails ensure relo
   // popped — so isRestorable() refuses to restore a parent whose child savepoint
   // op may have partially executed after a reconnect. Exercised here on sqlite
   // (which shares the internalExecute finally); the mysql2/PG paths are the same.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("createSavepoint dirties the current (parent) transaction frame", async () => {
     const { adapter } = makeSQLiteTopic();
     const tm = adapter.transactionManager;
@@ -266,11 +270,10 @@ describe("savepoint statements dirty the current transaction (trails ensure relo
       // dirty the parent, mirroring Rails' `ensure` firing on the raise path.
       const driver = (adapter as unknown as { driver: { exec: (s: string) => Promise<unknown> } })
         .driver;
-      const spy = vi
-        .spyOn(driver, "exec")
-        .mockRejectedValueOnce(new Error("server closed the connection unexpectedly"));
+      vi.spyOn(driver, "exec").mockRejectedValueOnce(
+        new Error("server closed the connection unexpectedly"),
+      );
       await expect(adapter.rollbackToSavepoint("sp_x")).rejects.toThrow();
-      spy.mockRestore();
       expect(tm.isRestorable()).toBe(false);
     });
   });

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -232,6 +232,50 @@ describe("TransactionTest", () => {
   });
 });
 
+describe("savepoint statements dirty the current transaction (trails ensure relocation)", () => {
+  // trails-specific: mysql2/PG/sqlite internalExecute run materializeTransactions
+  // OUTSIDE withRawConnection, so Rails' `ensure dirty_current_transaction if
+  // materialize_transactions` (abstract_adapter.rb:1046) is relocated to
+  // internalExecute's own finally. A savepoint statement (materialize:true, per
+  // savepoints.rb:11-20) therefore dirties the current transaction — the PARENT
+  // frame for a RELEASE/ROLLBACK TO SAVEPOINT whose committing frame was already
+  // popped — so isRestorable() refuses to restore a parent whose child savepoint
+  // op may have partially executed after a reconnect. Exercised here on sqlite
+  // (which shares the internalExecute finally); the mysql2/PG paths are the same.
+  it("createSavepoint dirties the current (parent) transaction frame", async () => {
+    const { adapter } = makeSQLiteTopic();
+    const tm = adapter.transactionManager;
+    await tm.withinNewTransaction({}, async () => {
+      // BEGIN is emitted with materializeTransactions:false, so the frame is
+      // materialized but clean.
+      await tm.materializeTransactions();
+      expect(tm.isRestorable()).toBe(true);
+      await adapter.createSavepoint("sp1");
+      expect(tm.isRestorable()).toBe(false);
+    });
+  });
+
+  it("a savepoint statement failing mid-flight still dirties the parent (ensure fires on the error path)", async () => {
+    const { adapter } = makeSQLiteTopic();
+    const tm = adapter.transactionManager;
+    await tm.withinNewTransaction({}, async () => {
+      await tm.materializeTransactions();
+      expect(tm.isRestorable()).toBe(true);
+      // Simulate a reconnect/connection-loss mid savepoint op: the raw driver
+      // rejects, the statement throws — and internalExecute's finally must still
+      // dirty the parent, mirroring Rails' `ensure` firing on the raise path.
+      const driver = (adapter as unknown as { driver: { exec: (s: string) => Promise<unknown> } })
+        .driver;
+      const spy = vi
+        .spyOn(driver, "exec")
+        .mockRejectedValueOnce(new Error("server closed the connection unexpectedly"));
+      await expect(adapter.rollbackToSavepoint("sp_x")).rejects.toThrow();
+      spy.mockRestore();
+      expect(tm.isRestorable()).toBe(false);
+    });
+  });
+});
+
 describe("rememberTransactionRecordState / restoreTransactionRecordState (Story K)", () => {
   it("rememberTransactionRecordState populates _startTransactionState with level and attributes", async () => {
     const { rememberTransactionRecordState } = await import("./transactions.js");


### PR DESCRIPTION
## What

Rails' savepoint statements — `create_savepoint` / `release_savepoint` /
`exec_rollback_to_savepoint` (`savepoints.rb:11-20`) — call `internal_execute`
with the **default** `materialize_transactions: true`. Inside
`with_raw_connection`, `ensure dirty_current_transaction if
materialize_transactions` (`abstract_adapter.rb:1046`) fires on every exit
path. For a nested RELEASE / ROLLBACK TO SAVEPOINT the committing frame is
popped by `_commitTransactionInner` **before** the SQL runs, so the dirtied
frame is the real **parent** — so `isRestorable()` refuses to restore a parent
whose child savepoint op may have partially executed after a reconnect.

trails' mysql2 / PG / sqlite savepoint methods passed
`materializeTransactions: false`, so this parent-dirtying never happened.

## Decision: converge

- Savepoint methods now pass the Rails default `materializeTransactions: true`
  (mysql2, PG, sqlite, and the shared `abstract/savepoints.ts` mixin).
- Rails' `with_raw_connection` ensure-dirty is **relocated** into each adapter's
  `internalExecute` `finally` (gated on the same flag). The materialize pass
  already runs *outside* `withRawConnection` in the trails split, so the loop's
  own `finally dirtyCurrentTransaction()` can't fire — the relocated finally
  restores it without a double-materialize.
- The re-entrant materialize during `create_savepoint` (called from
  `materializeBang`) is a no-op via the existing `_materializingTransactions`
  guard, keeping the materialize-outside-the-loop split intact.

## Tests

Added two sqlite-based tests in `transactions.trails.test.ts` (the sqlite
`internalExecute` shares the same relocated finally; mysql2/PG paths are
identical):

- `createSavepoint` dirties the current (parent) frame → `isRestorable()` false.
- A savepoint statement that fails mid-flight (simulated connection loss) still
  dirties the parent — the ensure fires on the error path.

Existing `transactions.test.ts` / `transaction-instrumentation.test.ts` /
`sqlite3-adapter.transactions.test.ts` pass unchanged.

Closes-story: savepoint-internalexecute-materialize-transactions-parent-dirty