### PR TITLE
fix(postgresql): materialize lazy transaction on unprepared read

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -107,7 +107,11 @@ describe("PostgreSQLAdapter#execQuery", () => {
     expect(result.columnTypes.guid).toBeInstanceOf(Uuid);
   });
 
-  it("does not materialize a pending lazy transaction", async () => {
+  it("materializes a pending lazy transaction", async () => {
+    // Mirrors Rails' raw_execute (materialize_transactions defaults true): the
+    // general read path materializes any pending lazy transaction so a SELECT
+    // inside `transaction { }` emits BEGIN. Only SCHEMA/transaction-control
+    // internal calls opt out.
     adapter = makeAdapter(async () => ({ rows: [], fields: [] }));
     const materializeSpy = vi
       .spyOn(
@@ -116,7 +120,7 @@ describe("PostgreSQLAdapter#execQuery", () => {
       )
       .mockResolvedValue(undefined);
     await adapter.execQuery("SELECT 1");
-    expect(materializeSpy).not.toHaveBeenCalled();
+    expect(materializeSpy).toHaveBeenCalled();
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -932,10 +932,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     options?: { prepare?: boolean; allowRetry?: boolean },
   ): Promise<Result> {
     sql = this.preprocessQuery(sql);
-    // Note: we do NOT call materializeTransactions() here. If a lazy tx
-    // is pending but un-materialized, a SELECT sees pre-tx state — which
-    // is correct read-before-write semantics.
-
     // Release the query client BEFORE any loadAdditionalTypes call —
     // that path re-enters execute() and acquires its own pooled client,
     // and holding both would consume 2 connections per query during
@@ -965,8 +961,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       payload,
       async () => {
         try {
+          // Materialize the pending lazy transaction before the query, mirroring
+          // Rails' raw_execute (materialize_transactions defaults true). A no-bind
+          // unprepared SELECT inside an open lazy transaction thus emits BEGIN,
+          // matching sqlite/MySQL and the Rails
+          // `unprepared statement materializes transaction` assertion.
           const r = await this.withRawConnection(
-            { materializeTransactions: false, allowRetry: options?.allowRetry ?? false },
+            { materializeTransactions: true, allowRetry: options?.allowRetry ?? false },
             async (conn) => {
               const client = conn as unknown as pg.Client;
               try {

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -1469,19 +1469,13 @@ describe("TransactionTest", () => {
     });
   });
 
-  // CONVERGENCE-PENDING (lazy-transaction materialization on an unprepared
-  // statement): Rails runs this on every adapter and expects
+  // Rails runs this on every adapter and expects
   // `Topic.transaction { Topic.where("1=1").first }` to emit BEGIN|COMMIT
-  // (transactions_test.rb:1485). On sqlite trails materializes and passes, but
-  // on PG/MySQL trails does not materialize the pending lazy transaction for a
-  // no-bind unprepared SELECT, so no BEGIN is emitted and the assertion finds
-  // zero queries. Rather than gate to sqlite (which would silently pass there
-  // and hide the PG/MySQL gap), this is an explicit skipped faithful port that
-  // surfaces the divergence on every adapter; tracked by
-  // [[transactions-test-rollback-restores-record-state]] (see
-  // thread-collector-preparable-for-statement-cache). Un-skip once the PG/MySQL
-  // unprepared-statement materialization path converges.
-  it.skip("unprepared statement materializes transaction", async () => {
+  // (transactions_test.rb:1485): a no-bind unprepared SELECT inside an open
+  // lazy transaction materializes it. The read path funnels through
+  // `with_raw_connection` (materializeTransactions defaults true), so the
+  // pending lazy transaction is materialized on sqlite, PG, and MySQL alike.
+  it("unprepared statement materializes transaction", async () => {
     await assertQueriesMatch(/BEGIN|COMMIT/i, undefined, true, async () => {
       await Topic.transaction(async () => {
         await Topic.where("1=1").first();


### PR DESCRIPTION
## Summary

On PostgreSQL, a no-bind unprepared `SELECT` inside an open **lazy**
transaction never materialized it — no `BEGIN` was emitted — so Rails'
`test_unprepared_statement_materializes_transaction`
(`transactions_test.rb:1485`) failed on PG while passing on sqlite/MySQL.

Root cause: `PostgreSQLAdapter#execQuery` pinned
`materializeTransactions: false` on its `withRawConnection`, diverging from
Rails' `raw_execute` (where `materialize_transactions` defaults **true** for
every query, reads included) and from the abstract/MySQL read path. Defaulting
it to `true` makes `Topic.transaction { Topic.where("1=1").first }` emit
`BEGIN … COMMIT` on PG, matching Rails and the other adapters.

The faithful port of the test (previously an unconditional `it.skip`) is
un-skipped.

## Testing

Against **live** databases (Docker PG 17 / MySQL 8):

- `unprepared statement materializes transaction`: passes on sqlite, PG, MySQL.
- Full `transactions.test.ts`: 89 passed / 13 skipped on both PG and MySQL;
  sqlite green.
- `tsc --build` clean.

(Verified the failure reproduces on real PG before the fix — the SQLite
fallback that runs when `PG_TEST_URL` is unset had masked it.)

Closes-story: unprepared-statement-materializes-lazy-transaction-pg-mysql