### PR TITLE
refactor(migration): move version/timestamp validation to migration-load path

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1983,23 +1983,17 @@ describe("MigrationTest", () => {
         expect(new LongV().version).toBe("123456789012345");
       });
 
-      it("migration raises if timestamp is future date", async () => {
+      it("migration raises if timestamp is future date", () => {
         const savedValidate = Migrator.validateMigrationTimestamps;
         try {
           Migrator.validateMigrationTimestamps = true;
-          // A timestamp far in the future (year 9999) is definitely > tomorrow
-          const ts = "99991231235959";
-          class FutureM extends Migration {
-            static version = ts;
-            async change() {}
-          }
-          const futureAdapter = Base.connection;
-          expect(
-            () =>
-              new Migrator(futureAdapter, [
-                { name: "test_migration", version: ts, migration: () => new FutureM() },
-              ]),
-          ).toThrow(/Invalid timestamp/);
+          // Rails validates the timestamp at migration *load* time
+          // (MigrationContext#migrations), so exercise the fromPath loader
+          // rather than the Migrator constructor. The fixture's version
+          // (year 9999) is definitely > tomorrow.
+          const dir = new URL("./test-helpers/migrations/future_timestamp", import.meta.url)
+            .pathname;
+          expect(() => Migrator.fromPath(dir, Base.connection)).toThrow(/Invalid timestamp/);
         } finally {
           Migrator.validateMigrationTimestamps = savedValidate;
         }

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1993,7 +1993,9 @@ describe("MigrationTest", () => {
           // (year 9999) is definitely > tomorrow.
           const dir = new URL("./test-helpers/migrations/future_timestamp", import.meta.url)
             .pathname;
-          expect(() => Migrator.fromPath(dir, Base.connection)).toThrow(/Invalid timestamp/);
+          expect(() => Migrator.fromPath(dir, Base.connection)).toThrow(
+            /Invalid timestamp 99991231235959 for migration file: future_timestamp_migration/,
+          );
         } finally {
           Migrator.validateMigrationTimestamps = savedValidate;
         }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -3010,6 +3010,7 @@ export class Migrator {
         },
       });
     }
+    helper._validateLoadedMigrations(proxies);
     return proxies.sort((a, b) => {
       const va = BigInt(a.version),
         vb = BigInt(b.version);
@@ -3044,6 +3045,7 @@ export class Migrator {
         },
       });
     }
+    helper._validateLoadedMigrations(proxies);
     // Rails MigrationContext#migrations: `migrations.sort_by(&:version)` —
     // numeric (not lexicographic) so "10" sorts after "2".
     return proxies.sort((a, b) => {
@@ -3063,10 +3065,32 @@ export class Migrator {
     });
   }
 
+  /**
+   * Load-time validation, mirroring the per-file checks in Rails'
+   * `MigrationContext#migrations` (migration.rb:1303-1308): reject a
+   * non-numeric version and, when timestamp validation is enabled, a version
+   * that isn't a valid migration timestamp. Called from the file-load paths
+   * (`fromPath` / `discoverMigrations`) so the layering matches Rails, where
+   * these checks never live in `Migrator#validate`.
+   *
+   * @internal
+   */
+  private _validateLoadedMigrations(migrations: MigrationProxy[]): void {
+    const validateTs = this.isValidateTimestamp();
+    for (const m of migrations) {
+      if (!m.version || !/^\d+$/.test(m.version)) {
+        throw new MigrationError(
+          `Invalid migration version: ${m.version}. Version must be a numeric string.`,
+        );
+      }
+      if (validateTs && !this.isValidMigrationTimestamp(m.version)) {
+        throw new InvalidMigrationTimestampError(m.version, m.name);
+      }
+    }
+  }
+
   /** @internal */
   private validate(migrations: MigrationProxy[]): void {
-    const validateTs = this.isValidateTimestamp();
-
     // Rails' Migrator#validate checks duplicate names before touching
     // versions, and tolerates a nil version. Mirror that ordering so a list of
     // same-name, version-less migrations raises DuplicateMigrationNameError
@@ -3083,17 +3107,6 @@ export class Migrator {
     for (const m of migrations) {
       if (nameCounts.get(m.name)! > 1) {
         throw new DuplicateMigrationNameError(m.name);
-      }
-    }
-
-    for (const m of migrations) {
-      if (!m.version || !/^\d+$/.test(m.version)) {
-        throw new MigrationError(
-          `Invalid migration version: ${m.version}. Version must be a numeric string.`,
-        );
-      }
-      if (validateTs && !this.isValidMigrationTimestamp(m.version)) {
-        throw new InvalidMigrationTimestampError(m.version, m.name);
       }
     }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2997,6 +2997,7 @@ export class Migrator {
       const parsed = helper.parseMigrationFilename(file);
       if (!parsed) continue;
       const [version, rawName, scope] = parsed;
+      helper._validateLoadedMigration(version, rawName);
       const name = camelize(rawName);
       proxies.push({
         version,
@@ -3010,7 +3011,6 @@ export class Migrator {
         },
       });
     }
-    helper._validateLoadedMigrations(proxies);
     return proxies.sort((a, b) => {
       const va = BigInt(a.version),
         vb = BigInt(b.version);
@@ -3032,6 +3032,7 @@ export class Migrator {
       const parsed = helper.parseMigrationFilename(file);
       if (!parsed) continue;
       const [version, rawName, scope] = parsed;
+      helper._validateLoadedMigration(version, rawName);
       const name = camelize(rawName);
       proxies.push({
         version,
@@ -3045,7 +3046,6 @@ export class Migrator {
         },
       });
     }
-    helper._validateLoadedMigrations(proxies);
     // Rails MigrationContext#migrations: `migrations.sort_by(&:version)` —
     // numeric (not lexicographic) so "10" sorts after "2".
     return proxies.sort((a, b) => {
@@ -3066,26 +3066,25 @@ export class Migrator {
   }
 
   /**
-   * Load-time validation, mirroring the per-file checks in Rails'
-   * `MigrationContext#migrations` (migration.rb:1303-1308): reject a
-   * non-numeric version and, when timestamp validation is enabled, a version
-   * that isn't a valid migration timestamp. Called from the file-load paths
-   * (`fromPath` / `discoverMigrations`) so the layering matches Rails, where
-   * these checks never live in `Migrator#validate`.
+   * Per-file load-time validation, mirroring the checks Rails runs inside
+   * `MigrationContext#migrations` (migration.rb:1303-1308) as each file is
+   * parsed: reject a non-numeric version and, when timestamp validation is
+   * enabled, a version that isn't a valid migration timestamp. Runs on the
+   * raw (pre-camelize) name so the error names the file like Rails, and is
+   * called from the file-load paths (`fromPath` / `discoverMigrations`) — not
+   * from `validate`, matching Rails' layering where these checks never live
+   * in `Migrator#validate`.
    *
    * @internal
    */
-  private _validateLoadedMigrations(migrations: MigrationProxy[]): void {
-    const validateTs = this.isValidateTimestamp();
-    for (const m of migrations) {
-      if (!m.version || !/^\d+$/.test(m.version)) {
-        throw new MigrationError(
-          `Invalid migration version: ${m.version}. Version must be a numeric string.`,
-        );
-      }
-      if (validateTs && !this.isValidMigrationTimestamp(m.version)) {
-        throw new InvalidMigrationTimestampError(m.version, m.name);
-      }
+  private _validateLoadedMigration(version: string, name: string): void {
+    if (!version || !/^\d+$/.test(version)) {
+      throw new MigrationError(
+        `Invalid migration version: ${version}. Version must be a numeric string.`,
+      );
+    }
+    if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(version)) {
+      throw new InvalidMigrationTimestampError(version, name);
     }
   }
 

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -2995,7 +2995,7 @@ export class Migrator {
     const proxies: MigrationProxy[] = [];
     for (const file of helper.migrationFiles(dirs)) {
       const parsed = helper.parseMigrationFilename(file);
-      if (!parsed) continue;
+      if (!parsed) throw new IllegalMigrationNameError(file);
       const [version, rawName, scope] = parsed;
       helper._validateLoadedMigration(version, rawName);
       const name = camelize(rawName);
@@ -3030,7 +3030,7 @@ export class Migrator {
     const proxies: MigrationProxy[] = [];
     for (const file of helper.migrationFiles([dir])) {
       const parsed = helper.parseMigrationFilename(file);
-      if (!parsed) continue;
+      if (!parsed) throw new IllegalMigrationNameError(file);
       const [version, rawName, scope] = parsed;
       helper._validateLoadedMigration(version, rawName);
       const name = camelize(rawName);
@@ -3066,23 +3066,19 @@ export class Migrator {
   }
 
   /**
-   * Per-file load-time validation, mirroring the checks Rails runs inside
-   * `MigrationContext#migrations` (migration.rb:1303-1308) as each file is
-   * parsed: reject a non-numeric version and, when timestamp validation is
-   * enabled, a version that isn't a valid migration timestamp. Runs on the
-   * raw (pre-camelize) name so the error names the file like Rails, and is
-   * called from the file-load paths (`fromPath` / `discoverMigrations`) — not
-   * from `validate`, matching Rails' layering where these checks never live
-   * in `Migrator#validate`.
+   * Per-file load-time timestamp validation, mirroring the check Rails runs
+   * inside `MigrationContext#migrations` (migration.rb:1305-1307) as each file
+   * is parsed: when timestamp validation is enabled, reject a version that
+   * isn't a valid migration timestamp. The illegal-name check for an
+   * unparseable filename lives at the parse site (Rails migration.rb:1304).
+   * Runs on the raw (pre-camelize) name so the error names the file like
+   * Rails, and is called from the file-load paths (`fromPath` /
+   * `discoverMigrations`) — not from `validate`, matching Rails' layering
+   * where these checks never live in `Migrator#validate`.
    *
    * @internal
    */
   private _validateLoadedMigration(version: string, name: string): void {
-    if (!version || !/^\d+$/.test(version)) {
-      throw new MigrationError(
-        `Invalid migration version: ${version}. Version must be a numeric string.`,
-      );
-    }
     if (this.isValidateTimestamp() && !this.isValidMigrationTimestamp(version)) {
       throw new InvalidMigrationTimestampError(version, name);
     }

--- a/packages/activerecord/src/test-helpers/migrations/future_timestamp/99991231235959_future_timestamp_migration.ts
+++ b/packages/activerecord/src/test-helpers/migrations/future_timestamp/99991231235959_future_timestamp_migration.ts
@@ -1,0 +1,9 @@
+import { Migration } from "../../../migration.js";
+
+export class FutureTimestampMigration extends Migration {
+  async up(): Promise<void> {}
+
+  async down(): Promise<void> {}
+}
+
+export default new FutureTimestampMigration();


### PR DESCRIPTION
## What

trails' `Migrator#validate` ran the per-migration **version-format** check
(`Invalid migration version: ...`) and the **timestamp** validation
(`InvalidMigrationTimestampError`) inside `validate()`.

In Rails these checks do NOT live in `Migrator#validate`
(`migration.rb:1557-1562`, which only does name-dup then version-dup via
`group_by`). Version-format/timestamp validation happens at migration **load
time** in `MigrationContext#migrations` (`migration.rb:1303-1308`), before
`validate` is ever called.

This PR restores that layering:

- Extracts the version-format + timestamp checks into a dedicated
  `_validateLoadedMigrations`, called from the file-load paths
  (`fromPath` / `discoverMigrations`) — trails' equivalent of
  `MigrationContext#migrations`.
- Leaves `Migrator#validate` mirroring Rails: name-dup then version-dup only.
- Converges the `MigrationValidationTest` "migration raises if timestamp is
  future date" test to exercise the loader (`Migrator.fromPath`) with a
  fixture migration file, matching Rails' `with_temp_migration_files` +
  `@migrator.up` flow, instead of injecting a proxy into the constructor.

## Testing

`pnpm vitest run packages/activerecord/src/migrator.test.ts packages/activerecord/src/migration.test.ts` — all pass.

Closes-story: migrator-validate-scope-to-name-version-dup-only