### PR TITLE
fix(serialization): value-equality for Serialized isChanged so nil assignment isn't dirty

### DIFF
--- a/packages/activerecord/src/serialized-attribute.test.ts
+++ b/packages/activerecord/src/serialized-attribute.test.ts
@@ -454,12 +454,8 @@ describe("SerializedAttributeTest", () => {
       }
     }
     // Rails: Topic.new(content: nil) with content_changed? → false.
-    // In Rails, nil casts to [] (the Array default) and the record is not dirty.
-    // Deviation: trails marks explicitly-assigned nil as changed before casting,
-    // so new ArrayTopic({ content: null }) returns attributeChanged("content") = true.
-    // This mirrors only the partial invariant (fresh record with no explicit
-    // content assignment is not dirty). The explicit-nil case is a tracked deviation.
-    const topic = new ArrayTopic();
+    // nil casts to [] (the Array default) and the record is not dirty.
+    const topic = new ArrayTopic({ content: null } as any);
     expect(topic.attributeChanged("content")).toBe(false);
   });
 

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -135,7 +135,12 @@ export class Serialized extends ValueType {
   // not a change. JS `!==` is reference equality and would flag them as
   // changed, marking `Topic.new(content: nil)` dirty. Restore Ruby's value
   // semantics for the value-comparable defaults (Array/Hash), matching the
-  // same distinction `isValueComparable` draws for `default_value?`.
+  // same distinction `isValueComparable`/`canonicalKey` already draw for
+  // `default_value?`. Sharing that scope is deliberate: a coder whose `load`
+  // returns a non-Array/Hash value with its own value-based `==` (e.g.
+  // Date/Time) still falls through to reference equality — a narrow edge no
+  // serialized coder here hits — and `canonicalKey`'s key-order sensitivity
+  // is inherited from the default-detection path, not newly introduced.
   override isChanged(
     oldValue: unknown,
     newValue: unknown,

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -128,6 +128,30 @@ export class Serialized extends ValueType {
     return dumped;
   }
 
+  // Rails' Type::Serialized inherits `changed?` from Type::Value, which is
+  // `old_value != new_value`. In Ruby that `!=` is value equality, so two
+  // structurally-equal deserialized collections (e.g. the `[]` Array default
+  // an explicit `nil` assignment casts to vs. the record's original `[]`) are
+  // not a change. JS `!==` is reference equality and would flag them as
+  // changed, marking `Topic.new(content: nil)` dirty. Restore Ruby's value
+  // semantics for the value-comparable defaults (Array/Hash), matching the
+  // same distinction `isValueComparable` draws for `default_value?`.
+  override isChanged(
+    oldValue: unknown,
+    newValue: unknown,
+    _newValueBeforeTypeCast?: unknown,
+  ): boolean {
+    if (oldValue === newValue) return false;
+    if (isValueComparable(oldValue) && isValueComparable(newValue)) {
+      try {
+        return canonicalKey(oldValue) !== canonicalKey(newValue);
+      } catch {
+        return true;
+      }
+    }
+    return true;
+  }
+
   override isChangedInPlace(rawOldValue: unknown, value: unknown): boolean {
     if (value === null || value === undefined) return false;
     const rawNewValue = encoded(this, value);


### PR DESCRIPTION
## Summary

Rails' `Type::Serialized` inherits `changed?` from `Type::Value` (`old_value != new_value`), which in Ruby is **value** equality — so an explicit `nil` assignment casting to the `[]` Array default is not a change against the record's original `[]`, and `Topic.new(content: nil).content_changed?` is `false`.

Trails used JS `!==` (reference equality), so the freshly-loaded `[]` from casting `nil` differed by identity from the original `[]` and the attribute was marked dirty. This overrides `Serialized#isChanged` to restore Ruby's value semantics for the value-comparable collection defaults (Array/Hash), reusing the same `isValueComparable`/`canonicalKey` distinction the type already draws for `default_value?`.

The deviation guard in the `nil is not changed when serialized with a class` test (Rails name, preserved) is removed — it now asserts the full Rails invariant with `new ArrayTopic({ content: null })`.

## Testing

- `serialized-attribute.test.ts`, `dirty.test.ts` (AR + activemodel) pass.

Closes-story: serialize-nil-assignment-marks-changed-before-cast