### PR TITLE
fix(associations): resolve composite source association_primary_key in HMT primaryKeyValue

### DIFF
--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -97,16 +97,23 @@ export class HasManyThroughAssociation extends HasManyAssociation {
     return vals.length === 1 ? vals[0] : JSON.stringify(vals);
   }
 
+  /**
+   * Resolve the record's key by the association's `association_primary_key`
+   * (for a through reflection this delegates to
+   * `sourceReflection.associationPrimaryKey`, `reflection.ts:1710-1711`), not
+   * the target model's own `klass.primaryKey`. Converges the delete/find
+   * comparison paths in `CollectionAssociation` onto the same resolution
+   * `idsReader` uses via the shared `associationPrimaryKey()` helper, so a
+   * composite (array) source PK compares by every source-key column instead of
+   * falling back to the target model's PK.
+   */
   protected override primaryKeyValue(record: Base): unknown {
-    const ctor = this.owner.constructor as { _reflectOnAssociation?: (n: string) => any };
-    const refl = ctor._reflectOnAssociation?.(this.reflection.name);
-    const srcPk = refl?.sourceReflection?.associationPrimaryKey;
-    if (typeof srcPk === "string") {
-      return typeof (record as any)._readAttribute === "function"
-        ? (record as any)._readAttribute(srcPk)
-        : (record as any)[srcPk];
-    }
-    return super.primaryKeyValue(record);
+    const pk = this.associationPrimaryKey();
+    const read = (key: string) =>
+      typeof (record as any)._readAttribute === "function"
+        ? (record as any)._readAttribute(key)
+        : (record as any)[key];
+    return Array.isArray(pk) ? pk.map(read) : read(pk);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-many-through-association.ts
+++ b/packages/activerecord/src/associations/has-many-through-association.ts
@@ -100,7 +100,7 @@ export class HasManyThroughAssociation extends HasManyAssociation {
   /**
    * Resolve the record's key by the association's `association_primary_key`
    * (for a through reflection this delegates to
-   * `sourceReflection.associationPrimaryKey`, `reflection.ts:1710-1711`), not
+   * `sourceReflection.associationPrimaryKey`, `reflection.ts:1723-1724`), not
    * the target model's own `klass.primaryKey`. Converges the delete/find
    * comparison paths in `CollectionAssociation` onto the same resolution
    * `idsReader` uses via the shared `associationPrimaryKey()` helper, so a

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -2355,6 +2355,29 @@ describe("HasManyThroughAssociationsTest", () => {
     );
   });
 
+  it("through association resolves composite source association primary key", async () => {
+    // Sharded::BlogPost#tags is has_many through blog_post_tags; the source
+    // belongs_to :tag targets a query-constraints model (Sharded::Tag,
+    // [blog_id, id]), so the association_primary_key is composite [blog_id, id]
+    // even though Tag's own primary_key is the single "id". primaryKeyValue —
+    // used by the delete/find comparison paths in CollectionAssociation — must
+    // key off the composite association_primary_key, not the target model's PK.
+    const blogPost = await ShardedBlogPost.find(shardedBlogPosts("great_post_blog_one").id);
+    const tags = await (blogPost as any).tags.toArray();
+    expect(tags.length).toBeGreaterThan(0);
+    const tag = tags[0];
+
+    const assoc = (blogPost as any).association("tags");
+    const key = assoc.primaryKeyValue(tag);
+    expect(Array.isArray(key)).toBe(true);
+    expect([...key].map(Number)).toEqual([Number(tag.blog_id), Number(tag.id)]);
+
+    // delete-by-record drops the join row and prunes the composite-keyed target.
+    await (blogPost as any).tags.delete(tag);
+    const remaining = await (blogPost as any).tags.reload();
+    expect(remaining.map((t: any) => Number(t.id))).not.toContain(Number(tag.id));
+  });
+
   it("loading cpk association with unpersisted owner", async () => {
     const order = await CpkOrder.create({ shop_id: 1 });
     const book = new (await import("../test-helpers/models/cpk.js").then(

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -2376,6 +2376,16 @@ describe("HasManyThroughAssociationsTest", () => {
     await (blogPost as any).tags.delete(tag);
     const remaining = await (blogPost as any).tags.reload();
     expect(remaining.map((t: any) => Number(t.id))).not.toContain(Number(tag.id));
+
+    // No behavior change for the single-PK case: a through whose source
+    // association_primary_key is the target model's own scalar "id" still
+    // resolves to that single value (not wrapped in an array).
+    const post = await Post.find(posts("welcome").id);
+    const people = await (post as any).people.toArray();
+    expect(people.length).toBeGreaterThan(0);
+    const singleKey = (post as any).association("people").primaryKeyValue(people[0]);
+    expect(Array.isArray(singleKey)).toBe(false);
+    expect(Number(singleKey)).toBe(Number(people[0].id));
   });
 
   it("loading cpk association with unpersisted owner", async () => {


### PR DESCRIPTION
## What

`HasManyThroughAssociation#primaryKeyValue` resolved the source reflection's
`associationPrimaryKey` only when it was a `string`, falling back to
`super.primaryKeyValue` (the target model's own `klass.primaryKey`) for a
composite (array) source PK. That made the delete/find comparison paths in
`CollectionAssociation` (`removeRecords`, in-memory `find`, `coerceToRecords`,
`isInclude`, ~9 call sites) key off the wrong column for a through association
whose source `association_primary_key` is composite.

This converges the override onto the shared base `associationPrimaryKey()`
helper (the same resolution `idsReader` uses since PR #4688), which for a
through reflection delegates to `sourceReflection.associationPrimaryKey`
(`reflection.ts:1723-1724`) and handles the composite case. No behavior change
for the string / single-PK case.

## Test

Adds a canonical-model assertion on `Sharded::BlogPost#tags` (through
`blog_post_tags`, source `belongs_to :tag` on a query-constraints model): the
association's `primaryKeyValue` resolves the composite `[blog_id, id]` key
(previously the single `id`), and a delete-by-record round trip prunes the
composite-keyed target.

Closes-story: hmt-primary-key-value-composite-source-pk-resolution
