### PR TITLE
fix(preloader): raise ConfigurationError for raw join scope on has_many-through

### DIFF
--- a/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-hasmany-raw-join-scope.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Preloader::ThroughAssociation#through_scope — has_many-through raw string /
+ * Arel join handling.
+ *
+ * Rails' `through_scope` passes the reflection scope's FULL `joins_values` to
+ * `joins!(source_reflection.name => joins)`
+ * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb:132-134)
+ * whenever the reflection where_clause is non-empty — this branch is NOT gated on
+ * collection, so a **has_many**-through raises the same error a has_one-through does
+ * (companion to through-association-raw-join-scope.test.ts, PR #4526).
+ * `joins_values` may hold raw SQL strings / Arel join nodes; `JoinDependency.walk_tree`
+ * symbolizes a raw string hash-value into a bogus association name and
+ * `find_reflection` raises `ActiveRecord::ConfigurationError`
+ * (join_dependency.rb:224-226). Verified against a live Rails console:
+ *
+ *   has_many :raw_clubs, -> { joins("INNER JOIN categories …").where("…") },
+ *            through: :membership, source: :club
+ *   Member.preload(:raw_clubs).to_a
+ *   # => ActiveRecord::ConfigurationError: Can't join 'Club' to association
+ *   #    named 'INNER JOIN categories …'; perhaps you misspelled it?
+ *
+ * So the fidelity behavior is to raise, not to silently defer the raw join to the
+ * source-preloader stage (where it is valid SQL against the source base table) — a
+ * lenient deviation Rails itself rejects. We mirror Rails by nesting the scope's raw
+ * `_joinValues` under the source reflection name; trails' join builder rejects
+ * `{source => [<raw string>]}` with the identical `ConfigurationError`.
+ *
+ * No canonical has_many-through model scope uses a raw join, so this pins the
+ * raw-join equivalent by declaring one on the canonical Member model.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel, enableSti } from "../../index.js";
+import { ConfigurationError } from "../../errors.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
+import { Preloader } from "../preloader.js";
+import { ThroughAssociation } from "./through-association.js";
+import { Member } from "../../test-helpers/models/member.js";
+import { Club } from "../../test-helpers/models/club.js";
+import { Membership, CurrentMembership } from "../../test-helpers/models/membership.js";
+import { Category } from "../../test-helpers/models/category.js";
+
+registerModel(Member);
+registerModel(Club);
+enableSti(Membership);
+registerModel(Membership);
+registerModel(CurrentMembership);
+enableSti(Category);
+registerModel(Category);
+
+type JoinWhere = {
+  joins: (sql: string) => JoinWhere;
+  where: (sql: string) => JoinWhere;
+};
+type HasManyHost = {
+  hasMany: (name: string, options: Record<string, unknown>) => void;
+};
+
+// A has_many-through mirroring `clubs` (Member → favoriteMemberships → club) but
+// whose scope reaches `categories` via a RAW string join instead of a symbol
+// association — the case real Rails raises on for has_many-through too.
+(Member as unknown as HasManyHost).hasMany("rawClubs", {
+  through: "favoriteMemberships",
+  source: "club",
+  scope: (rel: JoinWhere) =>
+    rel
+      .joins("INNER JOIN categories ON categories.id = clubs.category_id")
+      .where("categories.name = 'General'"),
+});
+
+describe("Preloader::ThroughAssociation#through_scope has_many raw-join handling", () => {
+  const { members } = fixtures(["memberTypes", "members", "clubs", "memberships", "categories"]);
+
+  function throughLoader(owners: Member[], name: string): ThroughAssociation {
+    const loaders = new Preloader({
+      records: owners,
+      associations: [name],
+      associateByDefault: false,
+    }).loaders;
+    const loader = loaders.find((l) => l instanceof ThroughAssociation);
+    if (!loader) throw new Error("expected a ThroughAssociation loader");
+    return loader;
+  }
+
+  it("nests the reflection scope's raw join under the source reflection, as Rails does", () => {
+    const groucho = members("groucho");
+    const loader = throughLoader([groucho], "rawClubs");
+    expect(() =>
+      (loader as unknown as { _buildThroughScope: () => { toSql: () => string } })
+        ._buildThroughScope()
+        .toSql(),
+    ).toThrow(ConfigurationError);
+  });
+
+  it("raises ConfigurationError on preload, matching Rails", async () => {
+    const groucho = members("groucho");
+    await expect(Member.where({ id: groucho.id }).preload("rawClubs")).rejects.toThrow(
+      ConfigurationError,
+    );
+  });
+});

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -411,6 +411,28 @@ export class ThroughAssociation extends Association {
         // intermediate rows. Source/target predicates stay at the source-preloader
         // stage (see `_getSourcePreloaders`); adding a source join here would only
         // risk fanning out through rows.
+        //
+        // But a reflection scope carrying a RAW string / Arel-node join in its own
+        // `_joinValues` bucket (`.joins("INNER JOIN …")`) is NOT gated on collection
+        // in Rails' through_scope: `joins!(source_reflection.name => values[:joins])`
+        // runs whenever the reflection where_clause is non-empty
+        // (through_association.rb:132-134). `JoinDependency.walk_tree` symbolizes the
+        // raw string into a bogus association name and `find_reflection` raises
+        // `ActiveRecord::ConfigurationError` (join_dependency.rb:224-226) — real Rails
+        // raises on a has_many-through preload here too, not just has_one. Mirror the
+        // has_one branch below: nest the scope's raw `_joinValues` under the source
+        // reflection name so the through-query build raises the SAME ConfigurationError
+        // our join builder throws for `{source => [<raw string>]}`, rather than
+        // silently deferring the raw join to the source-preloader stage (a lenient
+        // deviation Rails itself rejects). Symbol-association joins live in
+        // `_namedInnerJoins` and are carried without error at the source stage.
+        const sourceRefl = this._sourceReflection;
+        const reflScopeVals = this._reflectionScope;
+        const nestedRawJoinValues: any[] = reflScopeVals?._joinValues ?? [];
+        const whereNonEmpty = throughPredicates.length > 0 || sourcePredicates.length > 0;
+        if (sourceRefl && whereNonEmpty && nestedRawJoinValues.length > 0) {
+          scope = scope.joins({ [sourceRefl.name]: [...nestedRawJoinValues] });
+        }
         if (throughPredicates.length > 0) {
           scope._whereClause = new WhereClause([
             ...scope._whereClause.predicates,


### PR DESCRIPTION
Follow-up from PR #4526 (has_one-through raw-join scope). Rails' `through_scope`
nests the reflection scope's full `joins_values` under the source reflection
(`joins!(source_reflection.name => joins)`) whenever the reflection where_clause
is non-empty — this branch is **not** gated on collection, so a
**has_many**-through with a raw string / Arel-node join scope raises
`ActiveRecord::ConfigurationError` just like has_one-through does.
`JoinDependency.walk_tree` symbolizes the raw string into a bogus association
name and `find_reflection` raises.

The has_many (collection) branch of `_buildThroughScope` previously only copied
through-table predicates and silently deferred the raw join to the
source-preloader stage (valid SQL against the source base table), returning rows
instead of raising — a lenient deviation. This nests the scope's raw
`_joinValues` under the source reflection name (mirroring the has_one branch) so
the through-query build raises the same `ConfigurationError`.

## Testing
- New `through-association-hasmany-raw-join-scope.test.ts` (canonical Member →
  favoriteMemberships → club has_many, raw-join scope) asserts the raise on both
  `_buildThroughScope().toSql()` and `preload`.
- No regression: preloader, has-many-through, has-one-through, nested-through,
  and eager suites pass locally (symbol-association joins still carried).

## Known limitation (pre-existing, tracked separately)
The raw `_joinValues` read uses the flattened `_reflectionScope` rather than
`_ownReflectionScope()`. For a **nested** through, that could mis-attribute a
sub-chain's raw join to the outer through-scope build. This is **not** a
regression from this PR — the read is identical and pre-existing in the has_one
branch (#4526), and no canonical scope carries a raw SQL join on a nested
through (nested-through suites pass). Deliberately kept out of scope to preserve
the one-story-per-PR boundary; registered as follow-up story
`through-preloader-raw-join-use-own-reflection-scope-nested` (RFC 0054), which
will route both branches through `_ownReflectionScope()` and add nested-through
raw-join fixtures.

Closes-story: hasmany-through-preloader-raise-raw-string-arel-join-scope