### PR TITLE
fix(relation): propagate preload/includes across model boundary through merge

### DIFF
--- a/packages/activerecord/src/relation/merge-preloads.ts
+++ b/packages/activerecord/src/relation/merge-preloads.ts
@@ -1,0 +1,65 @@
+// Shared preload/includes/eager_load folding used by BOTH Merger (merge()) and
+// mergeBang (merge!()) so the two paths cannot drift — mirroring how the join
+// folds live in merge-joins.ts. Rails' merge! and merge share the one
+// Merger#merge code path; trails hand-duplicates the field-by-field copy in
+// mergeBang, so the branching logic here lives in one place and applies to both.
+
+// Minimal structural view of the preload-related fields these helpers touch.
+// Kept local (rather than `any`) so the shared module stays off the
+// no-explicit-any burndown allowlist (RFC 0037).
+interface PreloadFoldRelation {
+  _modelClass: {
+    name?: string;
+    reflectOnAllAssociations(): Array<{ name: string; className: string }>;
+  };
+  _preloadAssociations: unknown[];
+  _includesAssociations: unknown[];
+  _eagerLoadAssociations: unknown[];
+}
+
+// Rails merges :eager_load as a NORMAL_VALUE through Merger#merge's generic loop
+// (merger.rb:52-68) — it is NOT part of merge_preloads. eager_load!
+// (query_methods.rb) always unions (`eager_load_values |= args`), never gated on
+// model equality and never nested under a reflection, so it crosses the model
+// boundary untouched.
+export function foldMergeEagerLoad(target: PreloadFoldRelation, source: PreloadFoldRelation): void {
+  const otherEager = source._eagerLoadAssociations ?? [];
+  if (otherEager.length > 0) {
+    target._eagerLoadAssociations = [...(target._eagerLoadAssociations ?? []), ...otherEager];
+  }
+}
+
+// Mirrors Rails' Merger#merge_preloads (merger.rb:96-115). Same-model merges
+// union the preload/includes values straight across. A cross-model merge (e.g.
+// Comment.joins(:post).merge(Post.preload(:readers))) instead nests them under
+// the reflection on the receiver whose class_name is the other model's name, so
+// Comment preloads `{ post: [:readers] }` — carrying Post's preload through the
+// association boundary rather than asking Comment to preload `:readers`.
+export function foldMergePreloads(target: PreloadFoldRelation, source: PreloadFoldRelation): void {
+  const otherPreloads = source._preloadAssociations ?? [];
+  const otherIncludes = source._includesAssociations ?? [];
+  if (otherPreloads.length === 0 && otherIncludes.length === 0) return;
+
+  if (source._modelClass === target._modelClass) {
+    if (otherPreloads.length > 0) {
+      target._preloadAssociations = [...(target._preloadAssociations ?? []), ...otherPreloads];
+    }
+    if (otherIncludes.length > 0) {
+      target._includesAssociations = [...(target._includesAssociations ?? []), ...otherIncludes];
+    }
+    return;
+  }
+
+  const otherName = source._modelClass?.name;
+  const reflection = target._modelClass
+    .reflectOnAllAssociations()
+    .find((r) => r.className === otherName);
+  if (!reflection) return;
+
+  if (otherPreloads.length > 0) {
+    target._preloadAssociations.push({ [reflection.name]: otherPreloads });
+  }
+  if (otherIncludes.length > 0) {
+    target._includesAssociations.push({ [reflection.name]: otherIncludes });
+  }
+}

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -3,6 +3,7 @@ import { assertValidKeys } from "@blazetrails/activesupport";
 
 import { arelColumns } from "./query-methods.js";
 import { foldMergeJoins, foldMergeOuterJoins } from "./merge-joins.js";
+import { reflectOnAllAssociations } from "../reflection.js";
 
 /**
  * Merges two Relations together, combining their conditions,
@@ -74,24 +75,44 @@ export class Merger {
     rel._selectBang(...columns);
   }
 
+  // Mirrors Rails' Merger#merge_preloads (merger.rb). Same-model merges union
+  // the preload/includes values straight across. A cross-model merge (e.g.
+  // Comment.joins(:post).merge(Post.preload(:readers))) instead nests them under
+  // the reflection on the receiver whose class_name is the other model's name,
+  // so Comment preloads `{ post: [:readers] }` — carrying Post's preload through
+  // the association boundary rather than asking Comment to preload `:readers`.
   private mergePreloads(rel: any): void {
-    if (this.other._preloadAssociations && this.other._preloadAssociations.length > 0) {
-      rel._preloadAssociations = [
-        ...(rel._preloadAssociations ?? []),
-        ...this.other._preloadAssociations,
-      ];
+    const otherPreloads = this.other._preloadAssociations ?? [];
+    const otherIncludes = this.other._includesAssociations ?? [];
+    const otherEager = this.other._eagerLoadAssociations ?? [];
+    if (otherPreloads.length === 0 && otherIncludes.length === 0 && otherEager.length === 0) {
+      return;
     }
-    if (this.other._includesAssociations && this.other._includesAssociations.length > 0) {
-      rel._includesAssociations = [
-        ...(rel._includesAssociations ?? []),
-        ...this.other._includesAssociations,
-      ];
+
+    if (this.other._modelClass === rel._modelClass) {
+      if (otherPreloads.length > 0) {
+        rel._preloadAssociations = [...(rel._preloadAssociations ?? []), ...otherPreloads];
+      }
+      if (otherIncludes.length > 0) {
+        rel._includesAssociations = [...(rel._includesAssociations ?? []), ...otherIncludes];
+      }
+      if (otherEager.length > 0) {
+        rel._eagerLoadAssociations = [...(rel._eagerLoadAssociations ?? []), ...otherEager];
+      }
+      return;
     }
-    if (this.other._eagerLoadAssociations && this.other._eagerLoadAssociations.length > 0) {
-      rel._eagerLoadAssociations = [
-        ...(rel._eagerLoadAssociations ?? []),
-        ...this.other._eagerLoadAssociations,
-      ];
+
+    const otherName = this.other._modelClass?.name;
+    const reflection = reflectOnAllAssociations(rel._modelClass).find(
+      (r: any) => r.className === otherName,
+    );
+    if (!reflection) return;
+
+    if (otherPreloads.length > 0) {
+      rel._preloadAssociations.push({ [reflection.name]: otherPreloads });
+    }
+    if (otherIncludes.length > 0) {
+      rel._includesAssociations.push({ [reflection.name]: otherIncludes });
     }
   }
 

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -3,7 +3,6 @@ import { assertValidKeys } from "@blazetrails/activesupport";
 
 import { arelColumns } from "./query-methods.js";
 import { foldMergeJoins, foldMergeOuterJoins } from "./merge-joins.js";
-import { reflectOnAllAssociations } from "../reflection.js";
 
 /**
  * Merges two Relations together, combining their conditions,
@@ -103,9 +102,9 @@ export class Merger {
     }
 
     const otherName = this.other._modelClass?.name;
-    const reflection = reflectOnAllAssociations(rel._modelClass).find(
-      (r: any) => r.className === otherName,
-    );
+    const reflection = rel._modelClass
+      .reflectOnAllAssociations()
+      .find((r: any) => r.className === otherName);
     if (!reflection) return;
 
     if (otherPreloads.length > 0) {

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -3,6 +3,7 @@ import { assertValidKeys } from "@blazetrails/activesupport";
 
 import { arelColumns } from "./query-methods.js";
 import { foldMergeJoins, foldMergeOuterJoins } from "./merge-joins.js";
+import { foldMergeEagerLoad, foldMergePreloads } from "./merge-preloads.js";
 
 /**
  * Merges two Relations together, combining their conditions,
@@ -75,53 +76,16 @@ export class Merger {
     rel._selectBang(...columns);
   }
 
-  // Rails merges :eager_load as a NORMAL_VALUE through Merger#merge's generic
-  // loop (merger.rb:52-68) — it is NOT part of merge_preloads. eager_load!
-  // (query_methods.rb) always unions (`eager_load_values |= args`), never gated
-  // on model equality and never nested under a reflection, so it crosses the
-  // model boundary untouched. Kept out of mergePreloads to mirror that split.
+  // Thin wrappers over the shared folders (merge-preloads.ts) so merge() and
+  // merge!() (spawn-methods mergeBang) fold preload/includes/eager_load through
+  // the same code and cannot drift, while api:compare still maps merger.rb's
+  // merge_preloads to this file.
   private mergeEagerLoad(rel: any): void {
-    if (this.other._eagerLoadAssociations && this.other._eagerLoadAssociations.length > 0) {
-      rel._eagerLoadAssociations = [
-        ...(rel._eagerLoadAssociations ?? []),
-        ...this.other._eagerLoadAssociations,
-      ];
-    }
+    foldMergeEagerLoad(rel, this.other);
   }
 
-  // Mirrors Rails' Merger#merge_preloads (merger.rb:96-115). Same-model merges
-  // union the preload/includes values straight across. A cross-model merge (e.g.
-  // Comment.joins(:post).merge(Post.preload(:readers))) instead nests them under
-  // the reflection on the receiver whose class_name is the other model's name,
-  // so Comment preloads `{ post: [:readers] }` — carrying Post's preload through
-  // the association boundary rather than asking Comment to preload `:readers`.
   private mergePreloads(rel: any): void {
-    const otherPreloads = this.other._preloadAssociations ?? [];
-    const otherIncludes = this.other._includesAssociations ?? [];
-    if (otherPreloads.length === 0 && otherIncludes.length === 0) return;
-
-    if (this.other._modelClass === rel._modelClass) {
-      if (otherPreloads.length > 0) {
-        rel._preloadAssociations = [...(rel._preloadAssociations ?? []), ...otherPreloads];
-      }
-      if (otherIncludes.length > 0) {
-        rel._includesAssociations = [...(rel._includesAssociations ?? []), ...otherIncludes];
-      }
-      return;
-    }
-
-    const otherName = this.other._modelClass?.name;
-    const reflection = rel._modelClass
-      .reflectOnAllAssociations()
-      .find((r: any) => r.className === otherName);
-    if (!reflection) return;
-
-    if (otherPreloads.length > 0) {
-      rel._preloadAssociations.push({ [reflection.name]: otherPreloads });
-    }
-    if (otherIncludes.length > 0) {
-      rel._includesAssociations.push({ [reflection.name]: otherIncludes });
-    }
+    foldMergePreloads(rel, this.other);
   }
 
   // Thin wrappers over the shared folders (merge-joins.ts) so merge() and

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -30,6 +30,7 @@ export class Merger {
     this.mergeSingleValues(rel);
     this.mergeClauses(rel);
     this.mergeCtes(rel);
+    this.mergeEagerLoad(rel);
     this.mergePreloads(rel);
     this.mergeJoins(rel);
     this.mergeOuterJoins(rel);
@@ -74,8 +75,22 @@ export class Merger {
     rel._selectBang(...columns);
   }
 
-  // Mirrors Rails' Merger#merge_preloads (merger.rb). Same-model merges union
-  // the preload/includes values straight across. A cross-model merge (e.g.
+  // Rails merges :eager_load as a NORMAL_VALUE through Merger#merge's generic
+  // loop (merger.rb:52-68) — it is NOT part of merge_preloads. eager_load!
+  // (query_methods.rb) always unions (`eager_load_values |= args`), never gated
+  // on model equality and never nested under a reflection, so it crosses the
+  // model boundary untouched. Kept out of mergePreloads to mirror that split.
+  private mergeEagerLoad(rel: any): void {
+    if (this.other._eagerLoadAssociations && this.other._eagerLoadAssociations.length > 0) {
+      rel._eagerLoadAssociations = [
+        ...(rel._eagerLoadAssociations ?? []),
+        ...this.other._eagerLoadAssociations,
+      ];
+    }
+  }
+
+  // Mirrors Rails' Merger#merge_preloads (merger.rb:96-115). Same-model merges
+  // union the preload/includes values straight across. A cross-model merge (e.g.
   // Comment.joins(:post).merge(Post.preload(:readers))) instead nests them under
   // the reflection on the receiver whose class_name is the other model's name,
   // so Comment preloads `{ post: [:readers] }` — carrying Post's preload through
@@ -83,10 +98,7 @@ export class Merger {
   private mergePreloads(rel: any): void {
     const otherPreloads = this.other._preloadAssociations ?? [];
     const otherIncludes = this.other._includesAssociations ?? [];
-    const otherEager = this.other._eagerLoadAssociations ?? [];
-    if (otherPreloads.length === 0 && otherIncludes.length === 0 && otherEager.length === 0) {
-      return;
-    }
+    if (otherPreloads.length === 0 && otherIncludes.length === 0) return;
 
     if (this.other._modelClass === rel._modelClass) {
       if (otherPreloads.length > 0) {
@@ -94,9 +106,6 @@ export class Merger {
       }
       if (otherIncludes.length > 0) {
         rel._includesAssociations = [...(rel._includesAssociations ?? []), ...otherIncludes];
-      }
-      if (otherEager.length > 0) {
-        rel._eagerLoadAssociations = [...(rel._eagerLoadAssociations ?? []), ...otherEager];
       }
       return;
     }

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -7,6 +7,7 @@
 import { Merger, HashMerger } from "./merger.js";
 import { argumentError } from "./query-methods.js";
 import { foldMergeJoins, foldMergeOuterJoins } from "./merge-joins.js";
+import { foldMergeEagerLoad, foldMergePreloads } from "./merge-preloads.js";
 
 interface SpawnRelation<T = unknown> {
   _clone(): T;
@@ -104,22 +105,12 @@ export function mergeBang(this: any, other: any): any {
     ) {
       this._fromClause = other._fromClause;
     }
-    // mergePreloads
-    if (other._preloadAssociations?.length > 0)
-      this._preloadAssociations = [
-        ...(this._preloadAssociations ?? []),
-        ...other._preloadAssociations,
-      ];
-    if (other._includesAssociations?.length > 0)
-      this._includesAssociations = [
-        ...(this._includesAssociations ?? []),
-        ...other._includesAssociations,
-      ];
-    if (other._eagerLoadAssociations?.length > 0)
-      this._eagerLoadAssociations = [
-        ...(this._eagerLoadAssociations ?? []),
-        ...other._eagerLoadAssociations,
-      ];
+    // mergeEagerLoad / mergePreloads — shared with Merger (merger.ts) via the
+    // foldMerge* helpers so merge() and merge!() fold preload/includes/eager_load
+    // identically (same-model union vs cross-model reflection-nesting) and can't
+    // drift.
+    foldMergeEagerLoad(this, other);
+    foldMergePreloads(this, other);
     // mergeJoins / mergeOuterJoins — shared with Merger (merger.ts) via the
     // foldMerge* helpers so merge() and merge!() fold joins identically and can't
     // drift.

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -931,6 +931,18 @@ describe("RelationTest", () => {
     // reflection, so it crosses the model boundary untouched.
     const merged = Comment.joins("post").merge(Post.eagerLoad("readers")) as any;
     expect(merged._eagerLoadAssociations).toContain("readers");
+
+    // merge! (in-place) shares Merger#merge in Rails; trails routes both through
+    // the same foldMerge* helpers, so the cross-model reflection-nesting applies
+    // identically — the bang path must nest `{ post: [:readers] }`, not ask
+    // Comment to preload `:readers` directly.
+    const bang = Comment.joins("post") as any;
+    bang.mergeBang(Post.preload("readers").where({ title: "Uhuu" }));
+    expect(bang._preloadAssociations).toEqual([{ post: ["readers"] }]);
+    const bangComment = (await bang.toArray())[0];
+    const bangPost = bangComment.association("post");
+    expect(bangPost.isLoaded()).toBe(true);
+    expect(bangPost.target.association("readers").isLoaded()).toBe(true);
   });
 
   it("preloading with associations default scopes and merges", async () => {

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -899,10 +899,32 @@ describe("RelationTest", () => {
     expect(await query.size()).toBe(1);
   });
 
-  it.skip("preloading with associations and merges", async () => {
-    // BLOCKED: relations — Rails asserts result_comment.post.readers is already loaded
-    // (no extra queries) after Comment.joins(:post).merge(Post.preload(:readers)...).
-    // Cross-model preload propagation through merge is not yet implemented in Trails.
+  it("preloading with associations and merges", async () => {
+    const post = await Post.createBang({ title: "Uhuu", body: "body" });
+    const reader = await Reader.createBang({ post_id: post.id, person_id: 1 });
+    const comment = await Comment.createBang({ post_id: post.id, body: "body" });
+
+    const postRel = Post.preload("readers").joins("readers").where({ title: "Uhuu" });
+    let resultComment = (await Comment.joins("post").merge(postRel))[0];
+    expect(Number(resultComment.id)).toBe(Number(comment.id));
+
+    let postAssoc = (resultComment as any).association("post");
+    expect(postAssoc.isLoaded()).toBe(true);
+    expect(Number(postAssoc.target.id)).toBe(Number(post.id));
+    const readersAssoc = postAssoc.target.association("readers");
+    expect(readersAssoc.isLoaded()).toBe(true);
+    expect(readersAssoc.target.map((r: any) => Number(r.id))).toEqual([Number(reader.id)]);
+
+    const postRel2 = Post.includes("readers").where({ title: "Uhuu" });
+    resultComment = (await Comment.joins("post").merge(postRel2).first())!;
+    expect(Number(resultComment.id)).toBe(Number(comment.id));
+
+    postAssoc = (resultComment as any).association("post");
+    expect(postAssoc.isLoaded()).toBe(true);
+    expect(Number(postAssoc.target.id)).toBe(Number(post.id));
+    const readersAssoc2 = postAssoc.target.association("readers");
+    expect(readersAssoc2.isLoaded()).toBe(true);
+    expect(readersAssoc2.target.map((r: any) => Number(r.id))).toEqual([Number(reader.id)]);
   });
 
   it("preloading with associations default scopes and merges", async () => {

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -925,6 +925,12 @@ describe("RelationTest", () => {
     const readersAssoc2 = postAssoc.target.association("readers");
     expect(readersAssoc2.isLoaded()).toBe(true);
     expect(readersAssoc2.target.map((r: any) => Number(r.id))).toEqual([Number(reader.id)]);
+
+    // Rails merges :eager_load as a NORMAL_VALUE (merger.rb) — a straight union
+    // via eager_load!, never gated on model equality nor nested under a
+    // reflection, so it crosses the model boundary untouched.
+    const merged = Comment.joins("post").merge(Post.eagerLoad("readers")) as any;
+    expect(merged._eagerLoadAssociations).toContain("readers");
   });
 
   it("preloading with associations default scopes and merges", async () => {


### PR DESCRIPTION
## Summary

`Merger#merge_preloads` in Rails nests a cross-model relation's preload/includes under the receiver's reflection whose `class_name` matches the other model, so `Comment.joins(:post).merge(Post.preload(:readers)...)` preloads `{ post: [:readers] }` on the comment rather than asking `Comment` to preload `:readers` directly. Trails previously copied the preload values straight across (only correct same-model).

This mirrors Rails: same-model merges still union the values; cross-model merges find the reflection on the receiver whose `className` is the other model's name and nest the other side's preload/includes under `reflection.name`.

Un-skips `preloading with associations and merges` in `relations.test.ts` (BLOCKED since PR #4215) and asserts both the `preload` and `includes` branches leave `result_comment.post.readers` already loaded.

## Testing

- `pnpm exec vitest run packages/activerecord/src/relations.test.ts -t "merges"` — passes (both cross-model and default-scope merge tests).

Closes-story: relations-cross-model-preload-through-merge