### PR TITLE
fix(schema-cache): re-establish eager warm after resetColumnInformation

### DIFF
--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -451,6 +451,44 @@ describe("SchemaCacheTest", () => {
     expect(cache.isCached("users")).toBe(false);
   });
 
+  it("refreshBang overwrites a warm entry in place without a cold window", async () => {
+    // Backs the eager-warm re-establish after resetColumnInformation: unlike
+    // clearDataSourceCacheBang, the prior DB-sourced entry stays cached the
+    // whole time (isCached never flips false), then converges to the fresh
+    // reflection once the async refresh settles.
+    const cache = new SchemaCache();
+    cache.setColumns("users", [makeColumn("id", "integer")]);
+    cache.setPrimaryKeys("users", "id");
+    expect(cache.isCached("users")).toBe(true);
+
+    const fakeConn = {
+      primaryKey: async () => "id",
+      dataSourceExists: async () => true,
+      columns: async () => [
+        makeColumn("id", "integer", { primaryKey: true }),
+        makeColumn("name", "varchar(255)"),
+      ],
+      indexes: async () => [{ name: "idx_users_name", columns: ["name"] }],
+    };
+    const refresh = cache.refreshBang(new FakePool(fakeConn), "users");
+    // Still warm (old shape) while the refresh is in flight.
+    expect(cache.isCached("users")).toBe(true);
+    await refresh;
+
+    expect(Object.keys(cache.getCachedColumnsHash("users")!)).toEqual(["id", "name"]);
+    expect((await cache.indexes(null, "users")).length).toBe(1);
+  });
+
+  it("refreshBang clears the entry when the table no longer exists", async () => {
+    const cache = new SchemaCache();
+    cache.setColumns("gone", [makeColumn("id", "integer")]);
+    expect(cache.isCached("gone")).toBe(true);
+
+    const fakeConn = { dataSourceExists: async () => false };
+    await cache.refreshBang(new FakePool(fakeConn), "gone");
+    expect(cache.isCached("gone")).toBe(false);
+  });
+
   it("records touched tables between recordTouchedTables and takeTouchedTables", () => {
     const cache = new SchemaCache();
     // No recording window: clears are not tracked.

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -489,6 +489,45 @@ describe("SchemaCacheTest", () => {
     expect(cache.isCached("gone")).toBe(false);
   });
 
+  it("refreshBang lets the latest-initiated refresh win regardless of resolution order", async () => {
+    // Two overlapping refreshes (e.g. a quick double reset): the second one is
+    // initiated later, so its result must win even if the first's DB round-trip
+    // resolves last — otherwise a stale reflection would clobber the newer one
+    // and leave the cache warm-but-stale with no further trigger to correct it.
+    const cache = new SchemaCache();
+    cache.setColumns("users", [makeColumn("id", "integer")]);
+
+    // First (older) refresh: slow columns() that resolves after the second.
+    let releaseSlow: () => void;
+    const slow = new Promise<void>((r) => (releaseSlow = r));
+    const slowConn = {
+      dataSourceExists: async () => true,
+      primaryKey: async () => "id",
+      columns: async () => {
+        await slow;
+        return [makeColumn("id", "integer"), makeColumn("stale", "varchar(255)")];
+      },
+      indexes: async () => [],
+    };
+    // Second (newer) refresh: resolves immediately with the winning shape.
+    const fastConn = {
+      dataSourceExists: async () => true,
+      primaryKey: async () => "id",
+      columns: async () => [makeColumn("id", "integer"), makeColumn("fresh", "varchar(255)")],
+      indexes: async () => [],
+    };
+
+    const older = cache.refreshBang(new FakePool(slowConn), "users");
+    const newer = cache.refreshBang(new FakePool(fastConn), "users");
+    await newer;
+    expect(Object.keys(cache.getCachedColumnsHash("users")!)).toEqual(["id", "fresh"]);
+
+    // Now let the older, stale refresh finish — it must no-op, not overwrite.
+    releaseSlow!();
+    await older;
+    expect(Object.keys(cache.getCachedColumnsHash("users")!)).toEqual(["id", "fresh"]);
+  });
+
   it("records touched tables between recordTouchedTables and takeTouchedTables", () => {
     const cache = new SchemaCache();
     // No recording window: clears are not tracked.

--- a/packages/activerecord/src/connection-adapters/schema-cache.test.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.test.ts
@@ -489,6 +489,63 @@ describe("SchemaCacheTest", () => {
     expect(cache.isCached("gone")).toBe(false);
   });
 
+  it("refreshBang clears the entry when reflection fails", async () => {
+    // A transient failure (connection error / failed lease) should fall back to
+    // clearing so the next async load re-reflects rather than serving a
+    // now-untrustworthy entry. refreshBang swallows the error internally.
+    const cache = new SchemaCache();
+    cache.setColumns("users", [makeColumn("id", "integer")]);
+    expect(cache.isCached("users")).toBe(true);
+
+    const fakeConn = {
+      dataSourceExists: async () => true,
+      primaryKey: async () => "id",
+      columns: async () => {
+        throw new Error("boom");
+      },
+      indexes: async () => [],
+    };
+    await cache.refreshBang(new FakePool(fakeConn), "users");
+    expect(cache.isCached("users")).toBe(false);
+  });
+
+  it("refreshBang failure does not wipe a newer refresh's data", async () => {
+    // The failure fallback is generation-gated too: an older refresh that
+    // rejects AFTER a newer one has already written must NOT clear the fresh
+    // entry, or it would reintroduce the race on the error path.
+    const cache = new SchemaCache();
+    cache.setColumns("users", [makeColumn("id", "integer")]);
+
+    let releaseSlow: () => void;
+    const slow = new Promise<void>((r) => (releaseSlow = r));
+    const failingOlderConn = {
+      dataSourceExists: async () => true,
+      primaryKey: async () => "id",
+      columns: async () => {
+        await slow;
+        throw new Error("older refresh failed late");
+      },
+      indexes: async () => [],
+    };
+    const newerConn = {
+      dataSourceExists: async () => true,
+      primaryKey: async () => "id",
+      columns: async () => [makeColumn("id", "integer"), makeColumn("fresh", "varchar(255)")],
+      indexes: async () => [],
+    };
+
+    const older = cache.refreshBang(new FakePool(failingOlderConn), "users");
+    const newer = cache.refreshBang(new FakePool(newerConn), "users");
+    await newer;
+    expect(Object.keys(cache.getCachedColumnsHash("users")!)).toEqual(["id", "fresh"]);
+
+    // Older refresh now rejects — its gated fallback must not clear the entry.
+    releaseSlow!();
+    await older;
+    expect(cache.isCached("users")).toBe(true);
+    expect(Object.keys(cache.getCachedColumnsHash("users")!)).toEqual(["id", "fresh"]);
+  });
+
   it("refreshBang lets the latest-initiated refresh win regardless of resolution order", async () => {
     // Two overlapping refreshes (e.g. a quick double reset): the second one is
     // initiated later, so its result must win even if the first's DB round-trip

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -232,6 +232,54 @@ export class SchemaCache {
     });
   }
 
+  /**
+   * Re-introspect a single table and overwrite its cached columns / primary
+   * keys / indexes **in place**, without the intermediate delete that
+   * {@link clearDataSourceCacheBang} performs. Unlike {@link add} it bypasses
+   * the per-entry `has` guards, so it re-reads even a table that is already
+   * warm.
+   *
+   * Used to re-establish the eager warm after `resetColumnInformation`
+   * (model-schema.ts) under {@link SchemaReflection.eagerLoadSchemaCache}:
+   * keeping the prior DB-sourced entry live until the fresh reflection lands
+   * means a synchronous `Model.columnNames()` issued between the reset and the
+   * refresh settling still takes the warm, DB-sourced branch — excluding
+   * virtual `attribute()` declarations — rather than going cold. When the table
+   * no longer exists its entry is cleared.
+   *
+   * @internal trails-only — Rails has no analogue because
+   * `reset_column_information` reflects synchronously on the next `column_names`
+   * access (`schema_cache.columns`), which the async layer cannot.
+   */
+  async refreshBang(pool: unknown, tableName: string): Promise<void> {
+    if (isSchemaCacheIgnoredTable(tableName)) return;
+    await withConnection(pool, async (connection) => {
+      // Ask the connection directly rather than `this.dataSourceExists`, whose
+      // cached `true` (warmed alongside the columns we're refreshing) would
+      // never re-detect a table dropped since. When the connection can't answer,
+      // assume it still exists and refresh the columns anyway.
+      const exists =
+        typeof connection.dataSourceExists === "function"
+          ? await connection.dataSourceExists(tableName)
+          : true;
+      if (!exists) {
+        this.clearDataSourceCacheBang(connection, tableName);
+        return;
+      }
+      // Primary keys first so setColumns' reconcilePrimaryKeyFlags sees the
+      // fresh authoritative key (mirrors `add`'s ordering).
+      if (typeof connection.primaryKey === "function") {
+        this.setPrimaryKeys(tableName, (await connection.primaryKey(tableName)) ?? null);
+      }
+      if (typeof connection.columns === "function") {
+        this.setColumns(tableName, await connection.columns(tableName));
+      }
+      if (typeof connection.indexes === "function") {
+        this._indexes.set(tableName, await connection.indexes(tableName));
+      }
+    });
+  }
+
   async columns(pool: unknown, tableName: string): Promise<Column[] | undefined> {
     if (isSchemaCacheIgnoredTable(tableName)) {
       throw new StatementInvalid(`Table '${tableName}' doesn't exist`);
@@ -609,11 +657,18 @@ export class SchemaReflection {
    * on-disk cache (if any) as a base, then tops it up by introspection.
    *
    * Off by default — the boot-time introspection cost is opt-in, mirroring how
-   * Rails apps choose between a committed dump and live reflection. Note the
-   * documented async limitation: after `resetColumnInformation` clears a
-   * table's entry, the warm is NOT synchronously re-established (the adapter
-   * data-source cache cannot reload without awaiting); the model stays cold for
-   * that table until the next async schema load or a fresh connection.
+   * Rails apps choose between a committed dump and live reflection.
+   *
+   * The warm is also re-established after `resetColumnInformation`
+   * (model-schema.ts): rather than clearing the table's entry (which would go
+   * cold), the reset kicks off a fire-and-forget {@link SchemaCache#refreshBang}
+   * that re-introspects and overwrites the entry **in place**. The prior
+   * DB-sourced entry stays live until the fresh reflection lands, so a
+   * synchronous `Model.columnNames()` issued right after the reset still
+   * excludes virtual `attribute()` declarations without an intervening
+   * `await ensureSchemaLoaded()`, and a later schema change is picked up once
+   * the refresh settles. (The flag-off default still clears, matching Rails'
+   * `clear_data_source_cache!`.)
    */
   static eagerLoadSchemaCache = false;
 

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -273,41 +273,55 @@ export class SchemaCache {
     const generation = (this._refreshGeneration.get(tableName) ?? 0) + 1;
     this._refreshGeneration.set(tableName, generation);
     const isLatest = () => this._refreshGeneration.get(tableName) === generation;
-    await withConnection(pool, async (connection) => {
-      // Ask the connection directly rather than `this.dataSourceExists`, whose
-      // cached `true` (warmed alongside the columns we're refreshing) would
-      // never re-detect a table dropped since. When the connection can't answer,
-      // assume it still exists and refresh the columns anyway.
-      const exists =
-        typeof connection.dataSourceExists === "function"
-          ? await connection.dataSourceExists(tableName)
-          : true;
-      if (!exists) {
-        if (isLatest()) this.clearDataSourceCacheBang(connection, tableName);
-        return;
-      }
-      // Gather all three reflections before touching the cache so the write is
-      // a single consistent block. The `typeof` guards mirror the existing
-      // `primaryKeys`/`columns`/`indexes` methods (and `add`); every real
-      // adapter inherits all three from abstract SchemaStatements, so a partial
-      // reflection never happens in production.
-      const pk =
-        typeof connection.primaryKey === "function"
-          ? ((await connection.primaryKey(tableName)) ?? null)
-          : undefined;
-      const cols =
-        typeof connection.columns === "function" ? await connection.columns(tableName) : undefined;
-      const idx =
-        typeof connection.indexes === "function" ? await connection.indexes(tableName) : undefined;
-      // Re-check after every await: a newer refresh may have started (and
-      // possibly already written) while ours was in flight; leave its result.
-      if (!isLatest()) return;
-      // Primary keys first so setColumns' reconcilePrimaryKeyFlags sees the
-      // fresh authoritative key (mirrors `add`'s ordering).
-      if (pk !== undefined) this.setPrimaryKeys(tableName, pk);
-      if (cols !== undefined) this.setColumns(tableName, cols);
-      if (idx !== undefined) this._indexes.set(tableName, idx);
-    });
+    try {
+      await withConnection(pool, async (connection) => {
+        // Ask the connection directly rather than `this.dataSourceExists`, whose
+        // cached `true` (warmed alongside the columns we're refreshing) would
+        // never re-detect a table dropped since. When the connection can't
+        // answer, assume it still exists and refresh the columns anyway.
+        const exists =
+          typeof connection.dataSourceExists === "function"
+            ? await connection.dataSourceExists(tableName)
+            : true;
+        if (!exists) {
+          if (isLatest()) this.clearDataSourceCacheBang(connection, tableName);
+          return;
+        }
+        // Gather all three reflections before touching the cache so the write is
+        // a single consistent block. The `typeof` guards mirror the existing
+        // `primaryKeys`/`columns`/`indexes` methods (and `add`); every real
+        // adapter inherits all three from abstract SchemaStatements, so a partial
+        // reflection never happens in production.
+        const pk =
+          typeof connection.primaryKey === "function"
+            ? ((await connection.primaryKey(tableName)) ?? null)
+            : undefined;
+        const cols =
+          typeof connection.columns === "function"
+            ? await connection.columns(tableName)
+            : undefined;
+        const idx =
+          typeof connection.indexes === "function"
+            ? await connection.indexes(tableName)
+            : undefined;
+        // Re-check after every await: a newer refresh may have started (and
+        // possibly already written) while ours was in flight; leave its result.
+        if (!isLatest()) return;
+        // Primary keys first so setColumns' reconcilePrimaryKeyFlags sees the
+        // fresh authoritative key (mirrors `add`'s ordering).
+        if (pk !== undefined) this.setPrimaryKeys(tableName, pk);
+        if (cols !== undefined) this.setColumns(tableName, cols);
+        if (idx !== undefined) this._indexes.set(tableName, idx);
+      });
+    } catch {
+      // Reflection failed (e.g. a transient connection error or a failed lease).
+      // Fall back to clearing so the next async load re-reflects rather than
+      // serving a now-untrustworthy entry — but ONLY if we're still the latest
+      // refresh. Clearing unconditionally would let a stale, failed refresh wipe
+      // out a newer refresh's already-written good data, reintroducing the very
+      // race the generation gate prevents on the success path.
+      if (isLatest()) this.clearDataSourceCacheBang(null, tableName);
+    }
   }
 
   async columns(pool: unknown, tableName: string): Promise<Column[] | undefined> {

--- a/packages/activerecord/src/connection-adapters/schema-cache.ts
+++ b/packages/activerecord/src/connection-adapters/schema-cache.ts
@@ -75,6 +75,12 @@ export class SchemaCache {
   private _primaryKeys = new Map<string, string | string[] | null>();
   private _dataSourceExists = new Map<string, boolean>();
   private _indexes = new Map<string, unknown[]>();
+  // Monotonic per-table counter bumped at the start of every `refreshBang` so
+  // overlapping fire-and-forget refreshes serialize deterministically: a
+  // later-initiated refresh always wins regardless of DB round-trip ordering.
+  // Never reset (not even by clearDataSourceCacheBang) — resetting could let an
+  // older in-flight refresh's captured generation collide with a fresh one.
+  private _refreshGeneration = new Map<string, number>();
   private _version: string | number | null = null;
   // When non-null, records the name of every table passed to
   // `clearDataSourceCacheBang` — i.e. every table touched by DDL
@@ -247,12 +253,26 @@ export class SchemaCache {
    * virtual `attribute()` declarations — rather than going cold. When the table
    * no longer exists its entry is cleared.
    *
+   * Overlapping refreshes on the same table serialize via a per-table
+   * generation counter: the latest-initiated refresh always wins, so a stale
+   * reflection whose round-trip resolves last no-ops instead of clobbering the
+   * newer one.
+   *
    * @internal trails-only — Rails has no analogue because
    * `reset_column_information` reflects synchronously on the next `column_names`
    * access (`schema_cache.columns`), which the async layer cannot.
    */
   async refreshBang(pool: unknown, tableName: string): Promise<void> {
     if (isSchemaCacheIgnoredTable(tableName)) return;
+    // Claim a generation up front (synchronously, before any await) so a second
+    // refresh started while this one is in flight supersedes it: our writes
+    // below are gated on still owning the latest generation, so a stale
+    // reflection whose round-trip resolves last no-ops instead of clobbering
+    // the newer one and leaving the cache warm-but-stale. Rails sidesteps this
+    // by reflecting synchronously inline in `reset_column_information`.
+    const generation = (this._refreshGeneration.get(tableName) ?? 0) + 1;
+    this._refreshGeneration.set(tableName, generation);
+    const isLatest = () => this._refreshGeneration.get(tableName) === generation;
     await withConnection(pool, async (connection) => {
       // Ask the connection directly rather than `this.dataSourceExists`, whose
       // cached `true` (warmed alongside the columns we're refreshing) would
@@ -263,20 +283,30 @@ export class SchemaCache {
           ? await connection.dataSourceExists(tableName)
           : true;
       if (!exists) {
-        this.clearDataSourceCacheBang(connection, tableName);
+        if (isLatest()) this.clearDataSourceCacheBang(connection, tableName);
         return;
       }
+      // Gather all three reflections before touching the cache so the write is
+      // a single consistent block. The `typeof` guards mirror the existing
+      // `primaryKeys`/`columns`/`indexes` methods (and `add`); every real
+      // adapter inherits all three from abstract SchemaStatements, so a partial
+      // reflection never happens in production.
+      const pk =
+        typeof connection.primaryKey === "function"
+          ? ((await connection.primaryKey(tableName)) ?? null)
+          : undefined;
+      const cols =
+        typeof connection.columns === "function" ? await connection.columns(tableName) : undefined;
+      const idx =
+        typeof connection.indexes === "function" ? await connection.indexes(tableName) : undefined;
+      // Re-check after every await: a newer refresh may have started (and
+      // possibly already written) while ours was in flight; leave its result.
+      if (!isLatest()) return;
       // Primary keys first so setColumns' reconcilePrimaryKeyFlags sees the
       // fresh authoritative key (mirrors `add`'s ordering).
-      if (typeof connection.primaryKey === "function") {
-        this.setPrimaryKeys(tableName, (await connection.primaryKey(tableName)) ?? null);
-      }
-      if (typeof connection.columns === "function") {
-        this.setColumns(tableName, await connection.columns(tableName));
-      }
-      if (typeof connection.indexes === "function") {
-        this._indexes.set(tableName, await connection.indexes(tableName));
-      }
+      if (pk !== undefined) this.setPrimaryKeys(tableName, pk);
+      if (cols !== undefined) this.setColumns(tableName, cols);
+      if (idx !== undefined) this._indexes.set(tableName, idx);
     });
   }
 

--- a/packages/activerecord/src/model-schema-sync-load.test.ts
+++ b/packages/activerecord/src/model-schema-sync-load.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { ValueType } from "@blazetrails/activemodel";
 import { Base } from "./base.js";
 import { resetColumnInformation } from "./model-schema.js";
+import { SchemaReflection } from "./connection-adapters/schema-cache.js";
 
 class UuidType extends ValueType {
   override readonly name = "uuid" as unknown as "value";
@@ -316,5 +317,87 @@ describe("sync loadSchema / columnsHash", () => {
 
     expect(Post._attributeDefinitions.has("guid")).toBe(false);
     expect(Post._attributeDefinitions.get("title")?.source).toBe("user");
+  });
+
+  // A schemaCache that starts warm and tracks whether resetColumnInformation
+  // cleared it (cold) or refreshed it in place (stays warm), so columnsHash's
+  // warm branch is exercised for both.
+  function makeResettableAdapter(cols: Record<string, unknown>) {
+    let warm = true;
+    const calls = { refresh: 0, clear: 0 };
+    return {
+      calls,
+      isWarm: () => warm,
+      adapter: {
+        schemaCache: {
+          isCached: () => warm,
+          getCachedColumnsHash: () => (warm ? cols : undefined),
+          dataSourceExists: async () => true,
+          columnsHash: async () => cols,
+          clearDataSourceCacheBang: () => {
+            calls.clear += 1;
+            warm = false;
+          },
+          refreshBang: async () => {
+            calls.refresh += 1;
+            warm = true;
+          },
+        },
+        lookupCastTypeFromColumn: () => null,
+      },
+    };
+  }
+
+  it("resetColumnInformation re-establishes the eager warm in place under eagerLoadSchemaCache", () => {
+    const prev = SchemaReflection.eagerLoadSchemaCache;
+    SchemaReflection.eagerLoadSchemaCache = true;
+    try {
+      class Post extends Base {
+        static override tableName = "posts";
+        static {
+          // A virtual attribute() with no backing DB column — must NOT leak
+          // into columnNames() after the reset.
+          this.attribute("extra", "string");
+        }
+      }
+      const cols = { id: { sqlType: "integer", name: "id", default: null } };
+      const built = makeResettableAdapter(cols);
+      (Post as unknown as { adapter: unknown }).adapter = built.adapter;
+      expect(Post.columnNames()).toEqual(["id"]);
+
+      // Assigning the adapter already runs one reset; count only the explicit
+      // reset below.
+      built.calls.refresh = 0;
+      built.calls.clear = 0;
+      (resetColumnInformation as unknown as (this: typeof Base) => void).call(Post);
+
+      // Refreshed in place (not cleared): the entry stays warm, so a
+      // synchronous columnNames() still excludes the virtual attribute.
+      expect(built.calls.refresh).toBe(1);
+      expect(built.calls.clear).toBe(0);
+      expect(built.isWarm()).toBe(true);
+      expect(Post.columnNames()).toEqual(["id"]);
+    } finally {
+      SchemaReflection.eagerLoadSchemaCache = prev;
+    }
+  });
+
+  it("resetColumnInformation clears the data source cache when eager warming is off (default)", () => {
+    expect(SchemaReflection.eagerLoadSchemaCache).toBe(false);
+    class Post extends Base {
+      static override tableName = "posts";
+    }
+    const cols = { id: { sqlType: "integer", name: "id", default: null } };
+    const built = makeResettableAdapter(cols);
+    (Post as unknown as { adapter: unknown }).adapter = built.adapter;
+    Post.columnsHash();
+
+    built.calls.refresh = 0;
+    built.calls.clear = 0;
+    (resetColumnInformation as unknown as (this: typeof Base) => void).call(Post);
+
+    expect(built.calls.clear).toBe(1);
+    expect(built.calls.refresh).toBe(0);
+    expect(built.isWarm()).toBe(false);
   });
 });

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -769,17 +769,16 @@ function clearAdapterDataSourceCache(host: SchemaHost): void {
   // rather than going cold, and the refresh overwrites the entry once the
   // async reflection lands so a later schema change is still picked up.
   // Fire-and-forget for the same reason as the boot warm — reset_column_
-  // information is sync and cannot block on introspection. On a reflection
-  // failure, fall back to a plain clear so the next async load re-reflects
-  // rather than serving a now-untrustworthy entry forever.
+  // information is sync and cannot block on introspection. refreshBang handles
+  // its own failure fallback internally (a generation-gated clear), so the
+  // caller only swallows the settled promise; clearing here would bypass that
+  // gate and let a stale failed refresh wipe a newer one's good data.
   if (
     SchemaReflection.eagerLoadSchemaCache &&
     connectionSource &&
     typeof cache?.refreshBang === "function"
   ) {
-    void cache.refreshBang(connectionSource, table).catch(() => {
-      cache?.clearDataSourceCacheBang?.(null, table);
-    });
+    void cache.refreshBang(connectionSource, table).catch(() => {});
     return;
   }
   if (typeof cache?.clearDataSourceCacheBang === "function") {

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -26,7 +26,7 @@ import { TableNotSpecified } from "./errors.js";
 import { encryptionHooks } from "./encryption-hooks.js";
 import { applyPendingSerializations } from "./serialize.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
-import { FakePool } from "./connection-adapters/schema-cache.js";
+import { FakePool, SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { threadedConnectionFor, connectionPool } from "./connection-handling.js";
 
 /**
@@ -724,14 +724,21 @@ function clearAdapterDataSourceCache(host: SchemaHost): void {
   // for that form here would clear a table named `null` and leave a floating
   // Promise. Both branches below resolve the raw cache, matching what the
   // adapter's own `schemaCache` getter returns (abstract-adapter.ts).
-  type Cache = { clearDataSourceCacheBang?: (connection: unknown, name: string) => void };
+  type Cache = {
+    clearDataSourceCacheBang?: (connection: unknown, name: string) => void;
+    refreshBang?: (pool: unknown, name: string) => Promise<void>;
+  };
   let cache: Cache | null | undefined;
   let table: string | undefined;
+  // The pool (or directly-assigned adapter) to introspect through when
+  // re-establishing the eager warm; unused on the flag-off clear path.
+  let connectionSource: unknown;
   try {
     table = (host as unknown as { tableName?: string }).tableName;
     const direct = (host as unknown as { _adapter?: { schemaCache?: Cache } })._adapter;
     if (direct?.schemaCache) {
       cache = direct.schemaCache;
+      connectionSource = direct;
     } else {
       // Pooled path: read the pool config's raw SchemaCache directly (the slot
       // the adapter getter shares), NOT `schemaCache()` whose fallback is the
@@ -743,11 +750,32 @@ function clearAdapterDataSourceCache(host: SchemaHost): void {
         }
       ).connectionPool?.();
       cache = pool?.poolConfig?.schemaCache;
+      connectionSource = pool;
     }
   } catch {
     return;
   }
-  if (table && typeof cache?.clearDataSourceCacheBang === "function") {
+  if (!table) return;
+  // Under eager warming, re-establish the warm in place instead of clearing:
+  // a synchronous columnNames() right after the reset then still takes the
+  // warm, DB-sourced branch (excluding virtual attribute() declarations)
+  // rather than going cold, and the refresh overwrites the entry once the
+  // async reflection lands so a later schema change is still picked up.
+  // Fire-and-forget for the same reason as the boot warm — reset_column_
+  // information is sync and cannot block on introspection. On a reflection
+  // failure, fall back to a plain clear so the next async load re-reflects
+  // rather than serving a now-untrustworthy entry forever.
+  if (
+    SchemaReflection.eagerLoadSchemaCache &&
+    connectionSource &&
+    typeof cache?.refreshBang === "function"
+  ) {
+    void cache.refreshBang(connectionSource, table).catch(() => {
+      cache?.clearDataSourceCacheBang?.(null, table);
+    });
+    return;
+  }
+  if (typeof cache?.clearDataSourceCacheBang === "function") {
     cache.clearDataSourceCacheBang(null, table);
   }
 }

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -712,11 +712,18 @@ export function symbolColumnToString(this: SchemaHost, name: string): string | u
  * `schema_cache.clear_data_source_cache!(table_name)` step in Rails'
  * `reset_column_information` (model_schema.rb).
  *
- * Resolved WITHOUT leasing a connection — Rails keeps `reset_column_information`
- * inert (`active_connection&.`, schema_cache reached via the pool). We prefer a
- * directly-assigned adapter (`Base.adapter=` bypasses the pool), else the
- * pool-level schema cache; both skip `leaseConnection()`. Best-effort: a model
- * with no pool/table simply has nothing to clear.
+ * The cache is resolved WITHOUT leasing a connection — Rails keeps
+ * `reset_column_information` inert (`active_connection&.`, schema_cache reached
+ * via the pool). We prefer a directly-assigned adapter (`Base.adapter=` bypasses
+ * the pool), else the pool-level schema cache; both skip `leaseConnection()`.
+ * Best-effort: a model with no pool/table simply has nothing to clear.
+ *
+ * Exception: under {@link SchemaReflection.eagerLoadSchemaCache} the entry is
+ * refreshed in place (fire-and-forget {@link SchemaCache#refreshBang}) instead
+ * of cleared, so a synchronous read right after the reset stays warm — see the
+ * branch below. That path DOES lease a connection to re-introspect, matching
+ * eager warming's live-reflection contract; the default (flag-off) path remains
+ * inert and connection-free.
  */
 function clearAdapterDataSourceCache(host: SchemaHost): void {
   // The raw, sync SchemaCache — `clearDataSourceCacheBang(connection, name)`.


### PR DESCRIPTION
## Problem

Under `SchemaReflection.eagerLoadSchemaCache`, the eager warm (DB-introspection at connection/boot, added by #3373) was re-established only at the *initial* connection. `resetColumnInformation` (model-schema.ts) cleared a table's adapter data-source cache entry and left it cold, so the next synchronous `Model.columnNames()` / `columnsHash()` fell to the synthesized branch and could re-leak virtual `attribute()` declarations until an async schema load re-warmed the table — the gap noted in the `eagerLoadSchemaCache` JSDoc.

Rails avoids this because `reset_column_information` reflects synchronously on the next `column_names` access; trails' async layer cannot block.

## Change

- Add `SchemaCache#refreshBang(pool, table)` — re-introspects a single table and overwrites its columns / primary-keys / indexes **in place**, without the intermediate delete that `clearDataSourceCacheBang` performs (so it re-reads even a warm table, and detects a dropped table by asking the connection directly). trails-only; no Rails analogue.
- Under `eagerLoadSchemaCache`, `resetColumnInformation` fires a best-effort (fire-and-forget) `refreshBang` instead of clearing. The prior DB-sourced entry stays live until the fresh reflection lands, so a synchronous `columnNames()` right after the reset still excludes virtual attributes without an intervening `await ensureSchemaLoaded()`, and a later schema change is picked up once the refresh settles. On reflection failure it falls back to a plain clear.
- The flag-off default path is unchanged — still `clearDataSourceCacheBang`, matching Rails' `clear_data_source_cache!`.
- JSDoc on `eagerLoadSchemaCache` updated to describe the re-establish (replacing the "NOT synchronously re-established" note).

## Tests

- `SchemaCache#refreshBang` overwrites a warm entry in place with no cold window; clears when the table is gone.
- `resetColumnInformation` re-establishes the eager warm in place under `eagerLoadSchemaCache` (sync `columnNames()` still excludes a virtual `attribute()`); clears when the flag is off.

## Review follow-ups

- **Overlapping fire-and-forget refreshes (race).** `refreshBang` now claims a monotonic per-table generation up front (synchronously, before any await) and gates every write on still owning the latest generation. Two close-together resets no longer race on `setColumns`/`setPrimaryKeys`/`_indexes`: the latest-initiated refresh deterministically wins, so a stale reflection whose round-trip resolves last no-ops instead of clobbering the newer one. Covered by a new test (`refreshBang lets the latest-initiated refresh win regardless of resolution order`).
- **Partial-method connections.** The `typeof connection.X === "function"` guards mirror the existing `columns`/`primaryKeys`/`indexes` methods and `add()`. Every real adapter inherits all three from abstract `SchemaStatements`, so a partial reflection can't occur in production; reflections are now also gathered before writing so the update is a single consistent block. Documented inline.
- **Failure path bypassed the generation gate (round 3).** The eager-warm caller's `.catch` cleared the entry unconditionally, so an older refresh that rejected *after* a newer one had already written good data would wipe it back to cold — the same race, on the error branch. Fixed by moving the failure fallback inside `refreshBang` and gating it on `isLatest()`; the caller now only swallows the settled promise. New tests: `refreshBang clears the entry when reflection fails` and `refreshBang failure does not wipe a newer refresh's data`.

Closes-story: reestablish-schema-warm-after-reset-column-information

