### PR TITLE
fix(associations): route composite has_many :through shapes through the JOIN scope

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3620,26 +3620,25 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
   private _buildThroughScope(): any {
     const ctor = this._record.constructor as typeof Base;
     // Rails' scope IS the JOIN-based AssociationScope relation: delegate to it
-    // for the shapes it can route. Most composite-key shapes stay on the
-    // IN-subquery fallback below (they trip its ConfigurationError guards), as
-    // do other unroutable shapes (nested/polymorphic). The one composite case
-    // that DOES route to `buildThroughJoinScope` is a composite source FK on a
-    // hasMany source (see the `Array.isArray(sourceFk)` branch below): the
-    // single-column IN-subquery can't express that tuple match, and the
-    // JOIN-based scope handles the composite ON clause safely even with a
-    // composite owner PK.
+    // for every shape it can route, composite keys included. The chain-based
+    // `buildThroughJoinScope` emits the full composite ON clause, so composite
+    // owner PK, composite target PK, composite belongsTo-source FK, and
+    // composite through-model PK all build correctly here — the single-column
+    // IN-subquery fallback below can't express those tuple matches and would
+    // throw. Only shapes `_routeThroughViaAssociationScope` still declines
+    // (polymorphic-has_many sources, unsaved nested-through) fall through to
+    // that fallback, where the composite guards remain as a loud backstop.
     const refl = (ctor as any)._reflectOnAssociation?.(this._assocName);
-    const ownerPkComposite = Array.isArray((ctor as any).primaryKey);
-    const targetPkComposite = Array.isArray((this.model as any).primaryKey);
-    if (
-      refl &&
-      !ownerPkComposite &&
-      !targetPkComposite &&
-      _routeThroughViaAssociationScope(this._record, refl, this._assocDef.options)
-    ) {
+    if (refl && _routeThroughViaAssociationScope(this._record, refl, this._assocDef.options)) {
       const joinRel = buildThroughJoinScope(this._record, this._assocName, this._assocDef.options);
       return joinRel ?? (this.model as any).all().none(); // null FK → empty, as below
     }
+    // Below is the single-column IN-subquery fallback, reached only for shapes
+    // `_routeThroughViaAssociationScope` declines (polymorphic-has_many sources,
+    // unsaved nested-through). Every composite shape it CAN route now takes the
+    // JOIN path above, so the composite ConfigurationError guards below are
+    // backstops for the residual unroutable composite shapes the single-column
+    // subquery genuinely can't express — not the common composite-key path.
     const associations: AssociationDefinition[] = (ctor as any)._associations ?? [];
     const throughAssoc = associations.find((a: any) => a.name === this._assocDef.options.through);
     if (!throughAssoc) {

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -810,6 +810,78 @@ describe("HasManyThroughAssociationsTest", () => {
       const found = orderTags.find((ot: any) => Number(ot.tag_id) === Number((tag as any).id));
       expect(found.attached_reason).toBe("This is our loyal customer");
     });
+
+    // TS-only: guard the JOIN routing for the remaining composite through
+    // shapes. All three used to trip a `ConfigurationError` in the
+    // single-column IN-subquery fallback (composite target FK / composite-PK
+    // target / composite through-model PK); routing through
+    // `buildThroughJoinScope` builds Rails' chain-based composite scope
+    // instead. The assertions read the generated JOIN SQL (adapter-agnostic
+    // via quoteTableName) so they hold under SQLite / PG / MariaDB.
+
+    // has_many :order_agreements, through: :order — composite belongsTo through
+    // (`order`, FK [shop_id, order_id]) anchoring a scalar source. The owner's
+    // composite key surfaces as a two-column predicate on the JOINed order row.
+    it("composite through-key has_many through routes via join scope", async () => {
+      const { CpkBookWithOrderAgreements, CpkOrderAgreement } =
+        await import("../test-helpers/models/cpk.js");
+      const order = await CpkOrder.create({ shop_id: 1 });
+      const book = await CpkBookWithOrderAgreements.create({ id: [1, 2] });
+      (book as any).order = order;
+      await book.save();
+      const agreement = await CpkOrderAgreement.create({ order_id: (order as any).idValue });
+
+      const sql = await (book as any).orderAgreements.toSql();
+      const orderAgreementsFk = quoteTableName("cpk_order_agreements.order_id");
+      const orderId = quoteTableName("cpk_orders.id");
+      const orderShopId = quoteTableName("cpk_orders.shop_id");
+      // JOIN, not IN-subquery: the ON matches the source FK to the through PK…
+      expect(sql).toMatch(new RegExp(`INNER JOIN ${quoteTableName("cpk_orders")}`, "i"));
+      expect(sql).toMatch(new RegExp(`${orderAgreementsFk} = ${orderId}`, "i"));
+      // …and the composite owner key constrains BOTH columns of the through row.
+      expect(sql).toMatch(new RegExp(`${orderShopId} =`, "i"));
+      expect(sql).toMatch(new RegExp(`${orderId} =`, "i"));
+
+      const rows = await (book as any).orderAgreements.toArray();
+      expect(rows.map((a: any) => a.id)).toEqual([agreement.id]);
+    });
+
+    // has_many :orders, through: :order_tags — composite-PK through model
+    // (cpk_order_tags, PK [order_id, tag_id]) with a composite-PK target
+    // (cpk_orders, PK [shop_id, id]). Routes through the JOIN scope instead of
+    // the throwing IN-subquery fallback.
+    it("composite-pk target and through model has_many through routes via join scope", async () => {
+      const tag = cpkTags("cpk_tag_loyal_customer");
+      const sql = await (tag as any).orders.toSql();
+      const ordersId = quoteTableName("cpk_orders.id");
+      const orderTagsOrderId = quoteTableName("cpk_order_tags.order_id");
+      const orderTagsTagId = quoteTableName("cpk_order_tags.tag_id");
+      expect(sql).toMatch(new RegExp(`INNER JOIN ${quoteTableName("cpk_order_tags")}`, "i"));
+      expect(sql).toMatch(new RegExp(`${ordersId} = ${orderTagsOrderId}`, "i"));
+      expect(sql).toMatch(new RegExp(`${orderTagsTagId} =`, "i"));
+
+      const orders = await (tag as any).orders.toArray();
+      expect(orders.length).toBeGreaterThan(0);
+    });
+
+    // has_many :chapters, through: :book — composite source FK
+    // (cpk_chapters, FK [author_id, book_id]) yields the full composite ON
+    // clause. Owner (cpk_orders) also has a composite PK.
+    it("composite source fk has_many through routes via join scope", async () => {
+      const { CpkOrderWithSingularBookChapters } = await import("../test-helpers/models/cpk.js");
+      const order = await CpkOrderWithSingularBookChapters.create({ id: [5, 6] });
+      await (order as any).createBook({ id: [7, 8] });
+
+      const sql = await (order as any).chapters.toSql();
+      const chapAuthorId = quoteTableName("cpk_chapters.author_id");
+      const chapBookId = quoteTableName("cpk_chapters.book_id");
+      const bookAuthorId = quoteTableName("cpk_books.author_id");
+      const bookId = quoteTableName("cpk_books.id");
+      // Full composite ON clause on the source join.
+      expect(sql).toMatch(new RegExp(`${chapAuthorId} = ${bookAuthorId}`, "i"));
+      expect(sql).toMatch(new RegExp(`${chapBookId} = ${bookId}`, "i"));
+      await expect((order as any).chapters.toArray()).resolves.toBeInstanceOf(Array);
+    });
   });
 
   it("destroy all on association clears scope", async () => {


### PR DESCRIPTION
## Summary

Route composite `has_many :through` shapes through the chain-based JOIN scope
(`buildThroughJoinScope` → Rails' `AssociationScope`) instead of the
single-column IN-subquery fallback, converging the generated SQL to Rails'
composite ON/WHERE form.

`_buildThroughScope`'s top gate previously excluded `ownerPkComposite ||
targetPkComposite` from the JOIN route, forcing every composite-key through
association onto the IN-subquery fallback. That fallback is a Rails divergence:
it anchors on a single scalar column, so it (a) emits a scalar IN-subquery where
Rails emits a composite JOIN, and (b) trips `ConfigurationError` guards for the
residual composite shapes that have no scalar column to anchor on (composite
belongsTo-source FK, composite-PK target with no scalar source primaryKey,
composite through-model PK). Rails builds all of these via the general
chain-based `AssociationScope`, which `buildThroughJoinScope` already wraps.

## Changes

- Remove the composite owner/target-PK exclusion from the `_buildThroughScope`
  top gate so every composite shape `_routeThroughViaAssociationScope` accepts
  takes the JOIN route. This also aligns `scope()` with `CollectionProxy#count`,
  which already gated composite routing on `_routeThroughViaAssociationScope`.
- The fallback's composite `ConfigurationError` guards now serve only as
  backstops for shapes the router still declines (polymorphic-has_many sources,
  unsaved nested-through), where a single-column subquery genuinely can't
  express the tuple match. Comments updated to say so.
- Add TS-only guard tests asserting the generated JOIN SQL (adapter-agnostic via
  `quoteTableName`, so it holds under SQLite / PG / MariaDB) for three canonical
  composite shapes:
  - `order_agreements through: :order` — composite belongsTo through-key; the
    composite owner key surfaces as a two-column predicate on the JOINed row.
  - `orders through: :order_tags` — composite-PK target (`cpk_orders`) and
    composite-PK through model (`cpk_order_tags`).
  - `chapters through: :book` — composite source FK yields the full composite
    ON clause; owner is also composite-PK.

## Testing

- `has-many-through-associations.test.ts` — 172 passed (3 new).
- No regressions: `has-one-through-associations`, `collection-proxy-count`,
  `disable-joins-composite-key`, `disable-joins-composite-nested`,
  `cp-count-disable-joins-through`, `has-many/has-one-through-disable-joins`,
  `disable-joins-routing-widening`, `disable-joins-association-scope` — all green.

Closes-story: route-composite-through-in-subquery-shapes-via-join-scope
