### PR TITLE
test(store): un-skip write→revert accessor change test

### DIFF
--- a/packages/activerecord/src/store.test.ts
+++ b/packages/activerecord/src/store.test.ts
@@ -123,10 +123,7 @@ describe("StoreTest", () => {
     expect((john as any).colorChanged()).toBe(false);
   });
 
-  // trails: Serialized#isChanged uses reference equality for HWIA, so a
-  // write→revert produces two different HWIA references that compare as changed.
-  // Rails uses Ruby's == which compares by content. Tracked for convergence.
-  it.skip("updating the store and changing it back won't mark accessor as changed", () => {
+  it("updating the store and changing it back won't mark accessor as changed", () => {
     john.color = "red";
     expect((john as any).colorWas()).toBe("black");
     john.color = "black";


### PR DESCRIPTION
`Serialized#isChanged` already compares HWIA by content (via `canonicalKey`),
so a write→revert of a store accessor is correctly recognized as no change.
The `store_test.rb` parity test asserting this was left `it.skip` in PR #4205
with a convergence comment that no longer applies — un-skip it.

Verified passing: `pnpm vitest run packages/activerecord/src/store.test.ts`.

Closes-story: serialized-is-changed-hwia-content-equality