### PR TITLE
fix(associations): route composite through-write via construct_join_attributes

### DIFF
--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -2279,46 +2279,34 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
             sourceRefl?.isPolymorphic?.()
               ? sourceRefl.associationPrimaryKeyFor?.(this.model)
               : sourceRefl?.associationPrimaryKey;
-          let sourceJoinAttrs: Record<string, unknown>;
-          if (Array.isArray(sourceFk)) {
-            const sourcePk = resolveSourcePk();
-            const sourcePkCols = Array.isArray(sourcePk) ? sourcePk : sourcePk ? [sourcePk] : [];
-            if (sourcePkCols.length !== sourceFk.length) {
-              throw new ConfigurationError(
-                `Through association "${this._assocName}" has a composite source foreign key ` +
-                  `(${sourceFk.join(", ")}) whose length does not match the target primary key ` +
-                  `(${sourcePkCols.join(", ")}).`,
-              );
-            }
-            sourceJoinAttrs = {};
-            for (let i = 0; i < sourceFk.length; i++) {
-              sourceJoinAttrs[sourceFk[i]] = record._readAttribute(sourcePkCols[i]);
-            }
-          } else {
-            const targetPk = (record.constructor as typeof Base).primaryKey;
-            let targetPkCol: string;
-            if (Array.isArray(targetPk)) {
-              // Mirrors BelongsToReflection#association_primary_key: use options[:primary_key]
-              // when set, or fall back to "id" when it is part of the composite PK.
-              const srcPk = resolveSourcePk();
-              if (typeof srcPk === "string") {
-                targetPkCol = srcPk;
-              } else if (targetPk.includes("id")) {
-                targetPkCol = "id";
-              } else {
-                throw new ConfigurationError(
-                  `Through association "${this._assocName}" has a composite-PK target "${(record.constructor as typeof Base).name}" but no scalar primaryKey on the source reflection. Specify primaryKey: "<col>" on the source belongs_to.`,
-                );
-              }
-            } else {
-              // Use the source reflection's association_primary_key when set —
-              // e.g. a belongs_to with primaryKey: "name" means the join FK
-              // references category.name, not category.id. For a polymorphic
-              // source, resolveSourcePk() keys off `this.model` (reflection.klass).
-              const srcPk = resolveSourcePk();
-              targetPkCol = (typeof srcPk === "string" ? srcPk : null) ?? targetPk;
-            }
-            sourceJoinAttrs = { [sourceFk]: record._readAttribute(targetPkCol) };
+          // Mirrors Rails' ThroughAssociation#construct_join_attributes
+          // (through_association.rb:57-66): fill the join FK columns from the
+          // source reflection's `association_primary_key`, read off the pushed
+          // record, pairing columns positionally. `association_primary_key`
+          // (BelongsToReflection#association_primary_key, reflection.rb:927-938 —
+          // ported at reflection.ts:1375) already resolves the shape correctly:
+          // an explicit array `primaryKey` or query-constraint key stays
+          // composite, and only a plain composite PK collapses to its "id"
+          // component. So this reads that value verbatim — no extra scalar-FK
+          // collapse, which would wrongly flatten an explicit composite key.
+          // A composite belongsTo source therefore writes every FK component
+          // (matching Rails' `{ source_reflection.name => records }` belongs_to
+          // assignment); the composite-PK target no longer trips a trails-only
+          // ConfigurationError. The remaining throw is a genuine arity mismatch
+          // (a scalar FK against a still-composite key is a malformed source).
+          const sourceFkCols = Array.isArray(sourceFk) ? sourceFk : [sourceFk];
+          const rawSourcePk = resolveSourcePk() ?? (record.constructor as typeof Base).primaryKey;
+          const sourcePkCols = Array.isArray(rawSourcePk) ? rawSourcePk : [rawSourcePk];
+          if (sourceFkCols.length !== sourcePkCols.length) {
+            throw new ConfigurationError(
+              `Through association "${this._assocName}" has a source foreign key ` +
+                `(${sourceFkCols.join(", ")}) whose length does not match the source ` +
+                `association_primary_key (${sourcePkCols.join(", ")}).`,
+            );
+          }
+          const sourceJoinAttrs: Record<string, unknown> = {};
+          for (let i = 0; i < sourceFkCols.length; i++) {
+            sourceJoinAttrs[sourceFkCols[i]] = record._readAttribute(sourcePkCols[i]);
           }
           // Polymorphic source (e.g. `source: :taggable, source_type: "Post"`):
           // set the join's `<source>_type` column so the belongs_to resolves to

--- a/packages/activerecord/src/associations/has-many-through-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-through-associations.test.ts
@@ -811,6 +811,25 @@ describe("HasManyThroughAssociationsTest", () => {
       expect(found.attached_reason).toBe("This is our loyal customer");
     });
 
+    // TS-only: guard the write (construct_join_attributes) path for a
+    // composite-PK target has_many :through. Pushing an order into a tag's
+    // `orders` builds the join row (cpk_order_tags) via the source belongs_to's
+    // association_primary_key — the converged path no longer trips a trails-only
+    // `ConfigurationError` for the composite-PK target, mirroring Rails' single
+    // `construct_join_attributes` build for every shape.
+    it("appends a composite-pk target record through a join model", async () => {
+      const order = await CpkOrder.create({ shop_id: 1, status: "open" });
+      const tag = cpkTags("cpk_tag_loyal_customer");
+      await (tag as any).orders.push(order);
+      const joinRow = await CpkOrderTag.findBy({
+        order_id: (order as any).idValue,
+        tag_id: (tag as any).id,
+      });
+      expect(joinRow).not.toBeNull();
+      const orders = await (tag as any).orders.reload();
+      expect(orders.map((o: any) => Number(o.idValue))).toContain(Number((order as any).idValue));
+    });
+
     // TS-only: guard the JOIN routing for the remaining composite through
     // shapes. All three used to trip a `ConfigurationError` in the
     // single-column IN-subquery fallback (composite target FK / composite-PK

--- a/packages/activerecord/src/test-helpers/models/cpk.ts
+++ b/packages/activerecord/src/test-helpers/models/cpk.ts
@@ -322,7 +322,7 @@ export class CpkOrderAgreement extends Base {
   static _tableName = "cpk_order_agreements";
 
   static {
-    this.belongsTo("order", { className: "CpkOrder", primaryKey: "id" });
+    this.belongsTo("order", { className: "CpkOrder" });
   }
 }
 
@@ -343,7 +343,7 @@ export class CpkOrderTag extends Base {
 
   static {
     this.belongsTo("tag", { className: "CpkTag" });
-    this.belongsTo("order", { className: "CpkOrder", primaryKey: "id" });
+    this.belongsTo("order", { className: "CpkOrder" });
   }
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #4744 (which routed composite `has_many :through` *read* scopes
through `buildThroughJoinScope`). This converges the sibling **write** path —
`CollectionProxy#_pushThrough`'s join-row build — which still raised trails-only
`ConfigurationError`s for composite shapes that had no scalar column to anchor
on (composite source FK, composite-PK target with no scalar source primaryKey).

Rails has no such branch: `ThroughAssociation#construct_join_attributes`
(`through_association.rb:57`) fills the join FK columns from the source
reflection's `association_primary_key` for **every** shape.

## Changes

- Port `construct_join_attributes` faithfully in `_pushThrough`: pair the source
  FK columns with the association's `association_primary_key` columns
  positionally. A composite belongsTo source writes every FK component (mirroring
  Rails' `{ source_reflection.name => records }` belongs_to assignment); a scalar
  FK against a composite key collapses to the named `primaryKey` or the `"id"`
  component exactly as `BelongsToReflection#association_primary_key` does. The
  only remaining throw is a genuine FK/PK arity mismatch.
- Drop the now-unnecessary trails-only `primaryKey: "id"` deviations on
  `Cpk::OrderTag` / `Cpk::OrderAgreement`'s `belongs_to :order` (Rails' models
  omit them), converging the canonical models.
- Add a construction test asserting a composite-PK-target join row is written
  (Rails behavior) instead of the removed `ConfigurationError`.

## Scope / residual shapes

Every composite shape `_routeThroughViaAssociationScope` accepts now routes
through the JOIN scope on both the read (#4744) and write (this PR) paths, and
the corresponding trails-only composite `ConfigurationError`s are gone. The
remaining IN-subquery fallback in `_buildThroughScope` is reached only for
router-*declined* shapes — polymorphic-has_many sources and
polymorphic-belongsTo-without-`sourceType` (the latter is invalid in Rails for
`has_many :through`). Routing those needs `AssociationScope` inversion machinery
that isn't a small change, so it is tracked as its own story:
`route-residual-polymorphic-through-shapes-via-join-scope`
(RFC 0054). The fallback's composite backstop guards are only reachable via
those unroutable shapes.

## Testing

- `has-many-through-associations.test.ts` — 174 passed (1 new).
- No regressions across `associations`, `has-one-through-associations`,
  `autosave-association`, `eager`, `persistence`, `nested-attributes`,
  `primary-keys`, `batches`, `disable-joins-composite-*`,
  `collection-proxy-count`, `association-scope`, cpk relation suites, and
  `use-fixtures` (canonical-model change surface).

Closes-story: through-scope-join-route-composite-and-residual-shapes