### PR TITLE
refactor(enum): resolve subtype lazily from reflected column type

### DIFF
--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -379,20 +379,25 @@ describe("Enum subtype resolved from a schema-reflected column type", () => {
   it("delegates the enum subtype to the reflected decimal column, not the integer mapping shape", () => {
     const type = enumTypeOf(NumericEnum, "decimal_number");
     expect(type).toBeInstanceOf(EnumType);
+    // `subtype`/`subtypeType().type()` is "decimal" — the reflected column
+    // family — where mapping-shape inference (all-numbers) would have said
+    // "integer". Assert the reflected type string, not a concrete class:
+    // adapters reflect their own decimal variant (e.g. MySQL's
+    // DecimalWithoutScale), all of whose `type()` is "decimal".
     expect(type!.subtype).toBe("decimal");
-    expect(type!.subtypeType()).toBeInstanceOf(DecimalType);
+    expect(type!.subtypeType().type()).toBe("decimal");
   });
 
   it("serializes labels through the reflected decimal subtype on both read paths", () => {
     // castEnumValue (predicate/read) and TypeCaster::Map (query) must both
-    // resolve the reflected EnumType, coercing the mapped value through decimal.
-    expect(castEnumValue(NumericEnum, "decimal_number", "mid")).toEqual(
-      new DecimalType().serialize(1),
-    );
+    // resolve the reflected EnumType and serialize the mapped value through the
+    // reflected subtype — not the integer inference. Compare against the
+    // reflected subtype's own serialize so this holds across adapters (whose
+    // decimal serialize output differs).
+    const subtype = enumTypeOf(NumericEnum, "decimal_number")!.subtypeType();
+    expect(castEnumValue(NumericEnum, "decimal_number", "mid")).toEqual(subtype.serialize(1));
     const caster = new MapCaster(NumericEnum);
-    expect(caster.typeCastForDatabase("decimal_number", "mid")).toEqual(
-      new DecimalType().serialize(1),
-    );
+    expect(caster.typeCastForDatabase("decimal_number", "mid")).toEqual(subtype.serialize(1));
   });
 });
 

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -15,6 +15,7 @@ import {
 } from "./enum.js";
 import { ArgumentError, DecimalType } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
+import { Map as MapCaster } from "./type-caster/map.js";
 
 describe("Enum name conflict detection", () => {
   // Rails' `detect_enum_conflict!(name, name)` uses `dangerous_attribute_method?`,
@@ -335,5 +336,13 @@ describe("Enum subtype resolved from the reflected column type", () => {
     // registered EnumType, coercing through the decimal subtype exactly as the
     // reflected DecimalType would.
     expect(castEnumValue(Book, "status", "written")).toEqual(new DecimalType().serialize(1));
+  });
+
+  it("serializes through the reflected subtype on the query type-caster path too", () => {
+    // The predicate builder's TypeCaster::Map serialize path must resolve the
+    // same reflected EnumType (not the pre-reflection one), so where(status:)
+    // round-trips the label through the decimal subtype.
+    const caster = new MapCaster(Book);
+    expect(caster.typeCastForDatabase("status", "written")).toEqual(new DecimalType().serialize(1));
   });
 });

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -368,6 +368,18 @@ describe("Enum subtype resolved from a schema-reflected column type", () => {
     }
   }
 
+  // A default-only `attribute(name, { default })` (no explicit type) must still
+  // resolve the subtype from the reflected column — Rails pushes only a
+  // PendingDefault, so the column type governs. A prior version marked any
+  // user-provided def as "explicitly typed" and skipped reflection here.
+  class DefaultOnlyNumericEnum extends Base {
+    static _tableName = "numeric_data";
+    static {
+      this.attribute("decimal_number", { default: 0 });
+      this.enum("decimal_number", { low: 0, mid: 1, high: 2 });
+    }
+  }
+
   // Deliberately do NOT await `NumericEnum.loadSchema()` here: `enumTypeOf`
   // must reflect synchronously from the warm schema cache on its own (the same
   // sync path `Base.typeForAttribute` uses). Awaiting the async loader first
@@ -398,6 +410,16 @@ describe("Enum subtype resolved from a schema-reflected column type", () => {
     expect(castEnumValue(NumericEnum, "decimal_number", "mid")).toEqual(subtype.serialize(1));
     const caster = new MapCaster(NumericEnum);
     expect(caster.typeCastForDatabase("decimal_number", "mid")).toEqual(subtype.serialize(1));
+  });
+
+  it("resolves the reflected subtype for a default-only attribute (no explicit type)", () => {
+    const type = enumTypeOf(DefaultOnlyNumericEnum, "decimal_number");
+    expect(type).toBeInstanceOf(EnumType);
+    // A default-only attribute is NOT "explicitly typed", so reflection still
+    // supplies the column subtype ("decimal") rather than the integer the
+    // mapping shape implies.
+    expect(type!.subtype).toBe("decimal");
+    expect(type!.subtypeType().type()).toBe("decimal");
   });
 });
 

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -4,18 +4,21 @@
  * `assertValidEnumDefinitionValues`, `assertValidEnumOptions`,
  * `detectNegativeEnumConditionsBang`, and the `setEnumWarn` warning hook).
  */
-import { describe, it, expect, afterEach, vi } from "vitest";
+import { describe, it, expect, afterEach, beforeAll, vi } from "vitest";
 import {
   assertValidEnumDefinitionValues,
   assertValidEnumOptions,
   castEnumValue,
   detectNegativeEnumConditionsBang,
+  enumTypeOf,
   EnumType,
   setEnumWarn,
 } from "./enum.js";
 import { ArgumentError, DecimalType } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
 import { Map as MapCaster } from "./type-caster/map.js";
+import { fixtures } from "./test-helpers/fixtures.js";
+import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
 
 describe("Enum name conflict detection", () => {
   // Rails' `detect_enum_conflict!(name, name)` uses `dangerous_attribute_method?`,
@@ -344,5 +347,47 @@ describe("Enum subtype resolved from the reflected column type", () => {
     // round-trips the label through the decimal subtype.
     const caster = new MapCaster(Book);
     expect(caster.typeCastForDatabase("status", "written")).toEqual(new DecimalType().serialize(1));
+  });
+});
+
+// The harder case the explicit-`attribute(...)` block above does NOT cover: an
+// enum whose subtype comes purely from SCHEMA REFLECTION. `numeric_data`'s
+// `decimal_number` is a real `decimal` column, so an integer-valued enum on it
+// must delegate to the reflected `DecimalType`, even though (a) mapping-shape
+// inference would guess `integer` and (b) reflection skips the userProvided
+// enum def, leaving `_attributeDefinitions` carrying the pre-reflection integer
+// EnumType — so the reflected subtype only lives in the replayed AttributeSet.
+describe("Enum subtype resolved from a schema-reflected column type", () => {
+  fixtures(["books"]);
+
+  class NumericEnum extends Base {
+    static _tableName = "numeric_data";
+    static {
+      this.enum("decimal_number", { low: 0, mid: 1, high: 2 });
+    }
+  }
+
+  beforeAll(async () => {
+    await rebuildCanonicalTables(Base.connection, ["numeric_data"]);
+    await NumericEnum.loadSchema();
+  });
+
+  it("delegates the enum subtype to the reflected decimal column, not the integer mapping shape", () => {
+    const type = enumTypeOf(NumericEnum, "decimal_number");
+    expect(type).toBeInstanceOf(EnumType);
+    expect(type!.subtype).toBe("decimal");
+    expect(type!.subtypeType()).toBeInstanceOf(DecimalType);
+  });
+
+  it("serializes labels through the reflected decimal subtype on both read paths", () => {
+    // castEnumValue (predicate/read) and TypeCaster::Map (query) must both
+    // resolve the reflected EnumType, coercing the mapped value through decimal.
+    expect(castEnumValue(NumericEnum, "decimal_number", "mid")).toEqual(
+      new DecimalType().serialize(1),
+    );
+    const caster = new MapCaster(NumericEnum);
+    expect(caster.typeCastForDatabase("decimal_number", "mid")).toEqual(
+      new DecimalType().serialize(1),
+    );
   });
 });

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -8,10 +8,12 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import {
   assertValidEnumDefinitionValues,
   assertValidEnumOptions,
+  castEnumValue,
   detectNegativeEnumConditionsBang,
+  EnumType,
   setEnumWarn,
 } from "./enum.js";
-import { ArgumentError } from "@blazetrails/activemodel";
+import { ArgumentError, DecimalType } from "@blazetrails/activemodel";
 import { Base } from "./index.js";
 
 describe("Enum name conflict detection", () => {
@@ -299,5 +301,39 @@ describe("Enum private validators", () => {
       detectNegativeEnumConditionsBang(["notDraft", "published"]);
       expect(spy).not.toHaveBeenCalled();
     });
+  });
+});
+
+// Rails resolves the enum subtype lazily inside `decorate_attributes` from the
+// column's real `Type::Value` (enum.rb:239-246), NOT from the mapping's value
+// shapes. When a column type differs from what the mapping implies — here an
+// integer-valued enum on a `decimal`-typed attribute — the EnumType must
+// delegate to the reflected column type, not the integer that eager
+// mapping-shape inference would have guessed. No canonical model exercises
+// this (all canonical enum columns match their mapping shapes), so this is a
+// trails-only regression guard for the reflected-type resolution.
+describe("Enum subtype resolved from the reflected column type", () => {
+  class Book extends Base {
+    static _tableName = "books";
+    static {
+      this.attribute("status", "decimal");
+      this.enum("status", { proposed: 0, written: 1, published: 2 });
+    }
+  }
+
+  it("delegates the enum subtype to the reflected decimal type, not the mapping shape", () => {
+    const type = Book.typeForAttribute("status");
+    expect(type).toBeInstanceOf(EnumType);
+    // Eager mapping-shape inference (all-numbers) would have picked "integer";
+    // resolving from the reflected column type yields the real "decimal".
+    expect((type as EnumType).subtype).toBe("decimal");
+    expect((type as EnumType).subtypeType()).toBeInstanceOf(DecimalType);
+  });
+
+  it("serializes an enum label through the reflected decimal subtype", () => {
+    // castEnumValue serializes the label to its stored value via the single
+    // registered EnumType, coercing through the decimal subtype exactly as the
+    // reflected DecimalType would.
+    expect(castEnumValue(Book, "status", "written")).toEqual(new DecimalType().serialize(1));
   });
 });

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -19,6 +19,7 @@ import { Base } from "./index.js";
 import { Map as MapCaster } from "./type-caster/map.js";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { rebuildCanonicalTables } from "./test-helpers/canonical-schema.js";
+import { Book } from "./test-helpers/models/book.js";
 
 describe("Enum name conflict detection", () => {
   // Rails' `detect_enum_conflict!(name, name)` uses `dangerous_attribute_method?`,
@@ -391,6 +392,30 @@ describe("Enum subtype resolved from a schema-reflected column type", () => {
     const caster = new MapCaster(NumericEnum);
     expect(caster.typeCastForDatabase("decimal_number", "mid")).toEqual(
       new DecimalType().serialize(1),
+    );
+  });
+});
+
+// The `enumTypeOf` serialize path must preserve `Base.typeForAttribute`'s
+// `assertEnumTypeDeclared` guard: a typeless enum (no backing column, no
+// explicit `attribute` type) raises rather than silently serializing through
+// the mapping-shape fallback. Rails raises from the enum `decorate_attributes`
+// block when the subtype is `ActiveModel::Type.default_value` (enum.rb:240-245).
+describe("Enum with an undeclared type raises on the serialize path", () => {
+  // Reflect `books` so `typeless_genre` resolves to a NullColumn (no synthesize
+  // fallback), the condition under which the guard fires.
+  fixtures(["books"]);
+
+  class TypelessBook extends Book {
+    static {
+      this.enum("typeless_genre", { adventure: 0, comic: 1 });
+    }
+  }
+
+  it("castEnumValue raises for an enum with no column and no explicit type", async () => {
+    await TypelessBook.loadSchema();
+    expect(() => castEnumValue(TypelessBook, "typeless_genre", "comic")).toThrow(
+      /Undeclared attribute type for enum 'typeless_genre' in/,
     );
   });
 });

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -367,9 +367,12 @@ describe("Enum subtype resolved from a schema-reflected column type", () => {
     }
   }
 
+  // Deliberately do NOT await `NumericEnum.loadSchema()` here: `enumTypeOf`
+  // must reflect synchronously from the warm schema cache on its own (the same
+  // sync path `Base.typeForAttribute` uses). Awaiting the async loader first
+  // would mask a regression where the helper fire-and-forgets reflection.
   beforeAll(async () => {
     await rebuildCanonicalTables(Base.connection, ["numeric_data"]);
-    await NumericEnum.loadSchema();
   });
 
   it("delegates the enum subtype to the reflected decimal column, not the integer mapping shape", () => {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -923,6 +923,11 @@ export function enumTypeOf(klass: typeof Base, attribute: string): EnumType | nu
   // reflection stashes `enumReflectedSubtype` and rebuilds `_defaultAttributes`
   // before we read it, so the reflected subtype is already in place.
   reflectSchemaSync.call(klass);
+  // Mirror `Base.typeForAttribute`'s guard: a typeless enum (no backing column,
+  // no explicit `attribute` type) must raise rather than silently serialize
+  // through the pre-reflection fallback (Rails raises from the enum
+  // `decorate_attributes` block, enum.rb:240-245).
+  assertEnumTypeDeclared(klass, resolved);
   const type = host._defaultAttributes().getAttribute(resolved).type;
   return type instanceof EnumType ? type : null;
 }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -527,8 +527,22 @@ export function _enum(
   // explicitly typed via `attribute(name, type)` is queued for a deferred check
   // (`_enumsPendingTypeCheck`) that `typeForAttribute` runs post-loadSchema and
   // clears once a backing column is confirmed. See `assertEnumTypeDeclared`.
+  // "Explicitly typed" means the user declared a concrete attribute *type*
+  // (`attribute(name, "integer")`), NOT merely a default (`attribute(name,
+  // { default })`) or nothing. Rails pushes a `PendingType` only when a type is
+  // present (attribute_registration.rb:12-18); a default-only / type-less
+  // attribute keeps the fallback `value` type until the column reflects, so its
+  // subtype must still come from the column (enum decorates the column type,
+  // enum.rb:238-248). Requiring a user-provided def AND a concrete (non-`value`)
+  // type distinguishes the two: a default-only attribute's type is still the
+  // `value` default at `enum` time, so it is treated as column-reflected.
   const existingDef = (this as any)._attributeDefinitions?.get(attrName);
-  const explicitlyTyped = existingDef?.source === "user" || existingDef?.userProvided === true;
+  const existingTypeName =
+    typeof existingDef?.type?.type === "function" ? existingDef.type.type() : undefined;
+  const explicitlyTyped =
+    (existingDef?.source === "user" || existingDef?.userProvided === true) &&
+    existingTypeName != null &&
+    existingTypeName !== "value";
   const pendingHost = this as unknown as { _enumsPendingTypeCheck?: Set<string> };
   if (!explicitlyTyped) {
     if (!Object.prototype.hasOwnProperty.call(this, "_enumsPendingTypeCheck")) {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -61,7 +61,15 @@ function subtypeInstance(subtype: string): ValueType<unknown> {
  * so the EnumType always delegates cast/serialize/deserialize to the actual
  * column type.
  *
- * Two edge cases mirror the surrounding replay machinery rather than Rails
+ * The reflected column type is the authoritative source. trails' column-seed-
+ * then-replay seeds the enum override itself (not the raw column type, unlike
+ * Rails), so the `reflected` argument the decorator receives at replay time is
+ * the pre-reflection EnumType, not the column's `Type::Value`. Schema
+ * reflection therefore stashes the real column cast type on the attribute def
+ * as `enumReflectedSubtype` (model-schema.ts, where the adapter is in hand);
+ * prefer it when present.
+ *
+ * Two fallbacks mirror the surrounding replay machinery rather than Rails
  * directly: an already-decorated EnumType is unwrapped to its own subtype (a
  * re-replay), and — because trails' decorator also runs eagerly at
  * class-definition time, before the schema is reflected — a still-default
@@ -69,16 +77,23 @@ function subtypeInstance(subtype: string): ValueType<unknown> {
  * shapes so pre-reflection casts are not identity no-ops.
  */
 function enumTypeFrom(
+  klass: typeof Base,
+  attribute: string,
   name: string,
   mapping: Record<string, EnumValue>,
   reflected: Type,
   raiseOnInvalidValues: boolean,
 ): EnumType {
+  const defs = (klass as unknown as { _attributeDefinitions?: Map<string, unknown> })
+    ._attributeDefinitions;
+  const stashed = (defs?.get(attribute) as { enumReflectedSubtype?: Type } | undefined)
+    ?.enumReflectedSubtype;
+  const source = stashed ?? reflected;
   let subtype: ValueType<unknown>;
-  if (reflected instanceof EnumType) {
-    subtype = reflected.subtypeType();
+  if (source instanceof EnumType) {
+    subtype = source.subtypeType();
   } else {
-    const rv = reflected as ValueType<unknown>;
+    const rv = source as ValueType<unknown>;
     subtype = rv.type() === "value" ? subtypeInstance(inferSubtype(Object.values(mapping))) : rv;
   }
   return new EnumType(name, new Map(Object.entries(mapping)), subtype, raiseOnInvalidValues);
@@ -135,7 +150,7 @@ export function installEnumAttribute(
   // _defaultAttributes replay, so once the schema is loaded `reflected` is the
   // column's real Type::Value and the EnumType delegates to it.
   klass.decorateAttributes([attribute], (_name: string, reflected: Type) =>
-    enumTypeFrom(name, mapping, reflected, raiseOnInvalidValues),
+    enumTypeFrom(klass, attribute, name, mapping, reflected, raiseOnInvalidValues),
   );
 
   // Define the getter after attribute() so the EnumType is already in
@@ -881,18 +896,26 @@ export function assertEnumTypeDeclared(klass: typeof Base, name: string): void {
 /**
  * Fetch the single registered EnumType for an enum attribute — the one source
  * of truth built lazily from the reflected column type via the
- * `decorateAttributes` decorator. Resolves through `typeForAttribute` (the
- * replayed AttributeSet), so it returns the reflected-subtype EnumType rather
- * than the pre-reflection one that a userProvided `_attributeDefinitions` entry
- * still carries. Returns null when the attribute isn't an enum on this class.
+ * `decorateAttributes` decorator. Resolves through the replayed AttributeSet
+ * (`_defaultAttributes`), NOT `_attributeDefinitions`: reflection skips a
+ * userProvided enum def, so its `type` stays the pre-reflection (mapping-shape-
+ * inferred) EnumType, whereas the replayed decorator rebuilds the EnumType from
+ * the reflected column subtype. Returns null when the attribute isn't an enum
+ * on this class.
  *
  * @internal
  */
 export function enumTypeOf(klass: typeof Base, attribute: string): EnumType | null {
-  if (!klass._enums?.has(attribute)) return null;
-  const type = (klass as unknown as { typeForAttribute(n: string): Type }).typeForAttribute(
-    attribute,
-  );
+  const host = klass as unknown as {
+    _enums?: Map<string, unknown>;
+    _attributeAliases?: Record<string, string>;
+    loadSchema(): void;
+    _defaultAttributes(): { getAttribute(n: string): { type: Type } };
+  };
+  const resolved = host._attributeAliases?.[attribute] ?? attribute;
+  if (!host._enums?.has(resolved)) return null;
+  host.loadSchema();
+  const type = host._defaultAttributes().getAttribute(resolved).type;
   return type instanceof EnumType ? type : null;
 }
 

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -561,6 +561,18 @@ export function _enum(
     options && "default" in options ? { default: options.default } : undefined,
   );
 
+  // Record whether the user explicitly typed the enum's attribute (e.g.
+  // `attribute("state", "integer")` before `enum`). Rails resolves the enum
+  // subtype from the attribute's *declared* type — an explicit type wins over
+  // the column's reflected type — so schema reflection must NOT override an
+  // explicitly-typed enum's subtype with the column type (e.g. a TINYINT(1)
+  // that MySQL reflects as boolean). See the `enumTypeExplicit` gate in
+  // model-schema's `applyColumnsHash`.
+  const enumDef = (
+    this as unknown as { _attributeDefinitions?: Map<string, unknown> }
+  )._attributeDefinitions?.get(attrName) as { enumTypeExplicit?: boolean } | undefined;
+  if (enumDef) enumDef.enumTypeExplicit = explicitlyTyped;
+
   // Rails' `_enum` takes `scopes: true, instance_methods: true` keyword
   // defaults; `scopes: false` suppresses per-value scope generation and
   // `instance_methods: false` suppresses predicate/bang generation.

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -52,35 +52,43 @@ function subtypeInstance(subtype: string): ValueType<unknown> {
 }
 
 /**
+ * Resolve the enum's storage subtype from the reflected attribute type — the
+ * single source of truth, mirroring Rails' `decorate_attributes` block
+ * (`subtype = subtype.subtype if EnumType === subtype; EnumType.new(name,
+ * enum_values, subtype, ...)`, enum.rb:239-246). The `reflected` type is
+ * whatever the attribute currently resolves to when the pending decorator
+ * replays: after the schema is loaded that is the column's real `Type::Value`,
+ * so the EnumType always delegates cast/serialize/deserialize to the actual
+ * column type.
+ *
+ * Two edge cases mirror the surrounding replay machinery rather than Rails
+ * directly: an already-decorated EnumType is unwrapped to its own subtype (a
+ * re-replay), and — because trails' decorator also runs eagerly at
+ * class-definition time, before the schema is reflected — a still-default
+ * `value` type falls back to inferring the subtype from the mapping's value
+ * shapes so pre-reflection casts are not identity no-ops.
+ */
+function enumTypeFrom(
+  name: string,
+  mapping: Record<string, EnumValue>,
+  reflected: Type,
+  raiseOnInvalidValues: boolean,
+): EnumType {
+  let subtype: ValueType<unknown>;
+  if (reflected instanceof EnumType) {
+    subtype = reflected.subtypeType();
+  } else {
+    const rv = reflected as ValueType<unknown>;
+    subtype = rv.type() === "value" ? subtypeInstance(inferSubtype(Object.values(mapping))) : rv;
+  }
+  return new EnumType(name, new Map(Object.entries(mapping)), subtype, raiseOnInvalidValues);
+}
+
+/**
  * Enum definition — maps symbolic names to integer values.
  *
  * Mirrors: ActiveRecord::Enum
  */
-
-/**
- * EnumType cache keyed on the `_enums` mapping object. Each enum stores one
- * stable mapping Record in `_enums`, so keying on its identity lets the
- * read/serialize helpers reuse a single EnumType instead of reallocating one
- * per call.
- */
-const enumTypeCache = new WeakMap<object, EnumType>();
-
-/**
- * Build (and cache) an EnumType for the deserialize/serialize helpers below
- * from the canonical `_enums` mapping. The subtype only governs the
- * integer/string coercion fallback, so infer it from the mapping's value
- * types — uniform numbers mean an integer-backed column, anything else a
- * string-backed one.
- */
-export function enumTypeFor(name: string, mapping: Record<string, EnumValue>): EnumType {
-  const cached = enumTypeCache.get(mapping);
-  if (cached) return cached;
-  const entries = Object.entries(mapping);
-  const subtype = inferSubtype(entries.map(([, v]) => v));
-  const enumType = new EnumType(name, new Map(entries), subtype);
-  enumTypeCache.set(mapping, enumType);
-  return enumType;
-}
 
 /**
  * Register an EnumType in the attribute set and install the label-returning
@@ -97,7 +105,9 @@ export function enumTypeFor(name: string, mapping: Record<string, EnumValue>): E
 export function installEnumAttribute(
   klass: typeof Base,
   attribute: string,
-  enumType: EnumType,
+  name: string,
+  mapping: Record<string, EnumValue>,
+  raiseOnInvalidValues: boolean,
   attributeOptions?: { default?: unknown },
 ): void {
   // Rails' _enum uses `attribute(name)` (bare) + `decorate_attributes`, layering
@@ -120,7 +130,13 @@ export function installEnumAttribute(
   } else {
     klass.attribute(attribute);
   }
-  klass.decorateAttributes([attribute], (_name: string, _subtype: Type) => enumType);
+  // Rails resolves the subtype lazily inside the decorate block from the
+  // reflected column type (enum.rb:239-246); the decorator re-runs on every
+  // _defaultAttributes replay, so once the schema is loaded `reflected` is the
+  // column's real Type::Value and the EnumType delegates to it.
+  klass.decorateAttributes([attribute], (_name: string, reflected: Type) =>
+    enumTypeFrom(name, mapping, reflected, raiseOnInvalidValues),
+  );
 
   // Define the getter after attribute() so the EnumType is already in
   // _attributeDefinitions / the pending-type queue when we overwrite whatever
@@ -178,12 +194,11 @@ export class EnumType extends ValueType<string> {
   private _reverseMapping: ReadonlyMap<EnumValue, string>;
   private _raiseOnInvalidValues: boolean;
   private _subtypeType: ValueType<unknown>;
-  readonly subtype: string;
 
   constructor(
     name: string,
     mapping: ReadonlyMap<string, EnumValue>,
-    subtype: string,
+    subtype: ValueType<unknown>,
     raiseOnInvalidValues = true,
   ) {
     super();
@@ -198,14 +213,18 @@ export class EnumType extends ValueType<string> {
     }
     this._reverseMapping = reverse;
     this._raiseOnInvalidValues = raiseOnInvalidValues;
-    this.subtype = subtype;
-    this._subtypeType = subtypeInstance(subtype);
+    // Rails passes the column's real `Type::Value` instance into `EnumType.new`
+    // and stores it as `subtype`; cast/serialize/deserialize delegate to it.
+    this._subtypeType = subtype;
   }
 
-  // Rails' EnumType does `delegate :type, to: :subtype` — callers that
-  // ask what an enum column's storage type is want the underlying
-  // column type (e.g. "integer"), not the enum's attribute name. Our
-  // subtype is already the type string, so return it directly.
+  // Rails' EnumType does `delegate :type, to: :subtype` — callers that ask what
+  // an enum column's storage type is want the underlying column type (e.g.
+  // "integer"), so delegate to the subtype's own `type()`.
+  get subtype(): string {
+    return this._subtypeType.type();
+  }
+
   override type(): string {
     return this.subtype;
   }
@@ -504,39 +523,23 @@ export function _enum(
     pendingHost._enumsPendingTypeCheck.delete(attrName);
   }
 
-  // Read subtype from _attributeDefinitions directly — never call typeForAttribute()
-  // here, because typeForAttribute() triggers loadSchema(), which sets _schemaLoaded
-  // prematurely and blocks the real DB schema reflection from running later.
-  // Resolve it now from user-declared defs (e.g. `attribute("status", "string")`)
-  // and fall back to "integer" otherwise.
-  let subtype: string;
-  try {
-    const t: string = existingDef?.type?.type?.() ?? "value";
-    // No user-declared attribute type yet (schema not reflected): infer the
-    // storage subtype from the mapping's value shapes (booleans → boolean,
-    // strings → string, numbers → integer).
-    subtype =
-      t === "value"
-        ? inferSubtype(Object.values(mapping))
-        : /integer/i.test(t) || t === "smallint"
-          ? "integer"
-          : t;
-  } catch {
-    subtype = "integer";
-  }
-
-  // Register EnumType so typeForAttribute() returns it for predicate-builder
+  // Register the EnumType so typeForAttribute() returns it for predicate-builder
   // serialization — e.g. where({status: "draft"}) serializes "draft" → 0 — and
   // install the label-returning accessor via the shared installEnumAttribute.
+  // The subtype is NOT resolved here: installEnumAttribute wires a
+  // `decorateAttributes` decorator that builds the EnumType lazily from the
+  // reflected column type on each replay (Rails' `decorate_attributes` model),
+  // so we never eagerly guess it from the mapping shape.
   // Mirrors Rails `EnumType.new(..., raise_on_invalid_values: !validate)`: with
   // `validate:` set, an invalid assignment is caught by the inclusion validator
   // rather than raising on write, so the type must not raise.
   const validate = options?.validate ?? false;
-  const enumType = new EnumType(name, new Map(Object.entries(mapping)), subtype, !validate);
   installEnumAttribute(
     this,
     attrName,
-    enumType,
+    name,
+    mapping,
+    !validate,
     options && "default" in options ? { default: options.default } : undefined,
   );
 
@@ -876,6 +879,20 @@ export function assertEnumTypeDeclared(klass: typeof Base, name: string): void {
 }
 
 /**
+ * Fetch the single registered EnumType for an enum attribute — the one source
+ * of truth built lazily from the reflected column type via the
+ * `decorateAttributes` decorator. Returns null when the attribute isn't an
+ * enum on this class.
+ */
+function enumTypeOf(klass: typeof Base, attribute: string): EnumType | null {
+  if (!klass._enums?.has(attribute)) return null;
+  const type = (klass as unknown as { typeForAttribute(n: string): Type }).typeForAttribute(
+    attribute,
+  );
+  return type instanceof EnumType ? type : null;
+}
+
+/**
  * Get the human-readable enum value for an attribute.
  * Delegates to EnumType.deserialize for the mapping lookup.
  */
@@ -890,7 +907,7 @@ export function readEnumValue(record: Base, attribute: string): string | null {
   const stored = record.readAttribute(attribute);
   if (typeof stored === "string" && Object.prototype.hasOwnProperty.call(mapping, stored))
     return stored;
-  return enumTypeFor(attribute, mapping).deserialize(stored);
+  return enumTypeOf(ctor, attribute)?.deserialize(stored) ?? null;
 }
 
 /**
@@ -902,10 +919,7 @@ export function castEnumValue(
   attribute: string,
   value: unknown,
 ): number | string | boolean | null {
-  const mapping = modelClass._enums?.get(attribute);
-  if (!mapping) return null;
-
-  return enumTypeFor(attribute, mapping).serialize(value);
+  return enumTypeOf(modelClass, attribute)?.serialize(value) ?? null;
 }
 
 /**

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -9,6 +9,9 @@ import {
 } from "@blazetrails/activemodel";
 import { dangerousAttributeMethods } from "./attribute-methods.js";
 import { isDangerousClassMethod } from "./scoping/named.js";
+// The synchronous schema reflector (warm-cache path), NOT the async
+// `Base.loadSchema()` — mirrors what `Base.typeForAttribute` calls.
+import { loadSchema as reflectSchemaSync } from "./model-schema.js";
 
 /** Value a label can map to — matches Rails' hash-value support for enums. */
 type EnumValue = number | string | boolean | null;
@@ -909,12 +912,17 @@ export function enumTypeOf(klass: typeof Base, attribute: string): EnumType | nu
   const host = klass as unknown as {
     _enums?: Map<string, unknown>;
     _attributeAliases?: Record<string, string>;
-    loadSchema(): void;
     _defaultAttributes(): { getAttribute(n: string): { type: Type } };
   };
   const resolved = host._attributeAliases?.[attribute] ?? attribute;
   if (!host._enums?.has(resolved)) return null;
-  host.loadSchema();
+  // Reflect synchronously from the warm schema cache before reading the
+  // attribute set — the SAME path `Base.typeForAttribute` uses (base.ts). The
+  // public `Base.loadSchema()` is async and would fire-and-forget, letting a
+  // caller read the pre-reflection (mapping-inferred) EnumType; this sync
+  // reflection stashes `enumReflectedSubtype` and rebuilds `_defaultAttributes`
+  // before we read it, so the reflected subtype is already in place.
+  reflectSchemaSync.call(klass);
   const type = host._defaultAttributes().getAttribute(resolved).type;
   return type instanceof EnumType ? type : null;
 }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -881,10 +881,14 @@ export function assertEnumTypeDeclared(klass: typeof Base, name: string): void {
 /**
  * Fetch the single registered EnumType for an enum attribute — the one source
  * of truth built lazily from the reflected column type via the
- * `decorateAttributes` decorator. Returns null when the attribute isn't an
- * enum on this class.
+ * `decorateAttributes` decorator. Resolves through `typeForAttribute` (the
+ * replayed AttributeSet), so it returns the reflected-subtype EnumType rather
+ * than the pre-reflection one that a userProvided `_attributeDefinitions` entry
+ * still carries. Returns null when the attribute isn't an enum on this class.
+ *
+ * @internal
  */
-function enumTypeOf(klass: typeof Base, attribute: string): EnumType | null {
+export function enumTypeOf(klass: typeof Base, attribute: string): EnumType | null {
   if (!klass._enums?.has(attribute)) return null;
   const type = (klass as unknown as { typeForAttribute(n: string): Type }).typeForAttribute(
     attribute,

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1057,8 +1057,14 @@ function applyColumnsHash(
       // 301-302, model_schema.rb:622-629) — so the enum subtype carries the
       // same tz-conversion / optimistic-locking wrappers Rails passes into
       // `EnumType.new`. Stash it on the def so `enumTypeFrom` delegates to it.
+      //
+      // Skip when the enum's attribute was EXPLICITLY typed (`attribute(name,
+      // type)` before `enum`): Rails uses the declared type, which wins over
+      // the column's reflected type — overriding it here would, e.g., coerce an
+      // integer enum on a MySQL `TINYINT(1)` column through boolean and break
+      // the round-trip.
       const enums = (host as unknown as { _enums?: Map<string, unknown> })._enums;
-      if (enums?.has(name)) {
+      if (enums?.has(name) && !(existing as { enumTypeExplicit?: boolean }).enumTypeExplicit) {
         (existing as { enumReflectedSubtype?: Type }).enumReflectedSubtype = reflectedTypeForColumn(
           host,
           adapter,

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1018,6 +1018,20 @@ function applyColumnsHash(
       // reflection. The schema column's default is NOT merged onto the def;
       // `_defaultAttributes` seeds it via from_database directly from the cached
       // column (Rails' column-seed-then-replay), then replays the user override.
+      //
+      // Enums are the exception that still needs the reflected column type:
+      // Rails resolves the enum subtype from the column's real `Type::Value`
+      // inside `decorate_attributes` (enum.rb:239-246). Our column-seed-then-
+      // replay seeds the override itself, so the reflected type would never
+      // reach the enum decorator otherwise. Compute it here (the adapter is in
+      // hand) and stash it on the def so `enumTypeFrom` delegates to it.
+      const enums = (host as unknown as { _enums?: Map<string, unknown> })._enums;
+      if (enums?.has(name) && typeof adapter.lookupCastTypeFromColumn === "function") {
+        const reflected = adapter.lookupCastTypeFromColumn(column) as Type | null;
+        if (reflected) {
+          (existing as { enumReflectedSubtype?: Type }).enumReflectedSubtype = reflected;
+        }
+      }
       continue;
     }
 

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -955,6 +955,34 @@ function getColumnsHash(host: SchemaHost): Record<string, unknown> {
 }
 
 /**
+ * Rails' `ActiveRecord::Attributes#type_for_column`: the adapter's cast type
+ * for a column, run through `ModelSchema`'s immutable-string conversion
+ * (model_schema.rb:622-629) and then `hook_attribute_type` (attributes.rb:
+ * 301-302), which layers tz-conversion / optimistic-locking wrappers. Shared by
+ * the non-enum schema-def path and the enum-subtype stash so both seed the same
+ * reflected type. Falls back to the `value` type when the adapter yields none.
+ */
+function reflectedTypeForColumn(
+  host: { immutableStringsByDefault?: boolean; hookAttributeType?: (n: string, t: Type) => Type },
+  adapter: { lookupCastTypeFromColumn?: (c: unknown) => unknown },
+  name: string,
+  column: unknown,
+): Type {
+  const castType =
+    typeof adapter.lookupCastTypeFromColumn === "function"
+      ? adapter.lookupCastTypeFromColumn(column)
+      : null;
+  let type = (castType as Type | null) ?? typeRegistry.lookup("value");
+  // Only mutable StringType responds to toImmutableString, mirroring Ruby's
+  // `type.respond_to?(:to_immutable_string)` guard.
+  if (host.immutableStringsByDefault) {
+    const toImmutable = (type as { toImmutableString?: () => Type }).toImmutableString;
+    if (typeof toImmutable === "function") type = toImmutable.call(type);
+  }
+  return host.hookAttributeType?.(name, type) ?? type;
+}
+
+/**
  * Sync worker: apply a columns hash (already fetched from the schema
  * cache) to `_attributeDefinitions`. Shared by sync `loadSchema` and
  * async `loadSchemaFromAdapter`.
@@ -1024,33 +1052,24 @@ function applyColumnsHash(
       // inside `decorate_attributes` (enum.rb:239-246). Our column-seed-then-
       // replay seeds the override itself, so the reflected type would never
       // reach the enum decorator otherwise. Compute it here (the adapter is in
-      // hand) and stash it on the def so `enumTypeFrom` delegates to it.
+      // hand) via the SAME `type_for_column` pipeline the non-enum path uses —
+      // immutable-string conversion + `hook_attribute_type` (attributes.rb:
+      // 301-302, model_schema.rb:622-629) — so the enum subtype carries the
+      // same tz-conversion / optimistic-locking wrappers Rails passes into
+      // `EnumType.new`. Stash it on the def so `enumTypeFrom` delegates to it.
       const enums = (host as unknown as { _enums?: Map<string, unknown> })._enums;
-      if (enums?.has(name) && typeof adapter.lookupCastTypeFromColumn === "function") {
-        const reflected = adapter.lookupCastTypeFromColumn(column) as Type | null;
-        if (reflected) {
-          (existing as { enumReflectedSubtype?: Type }).enumReflectedSubtype = reflected;
-        }
+      if (enums?.has(name)) {
+        (existing as { enumReflectedSubtype?: Type }).enumReflectedSubtype = reflectedTypeForColumn(
+          host,
+          adapter,
+          name,
+          column,
+        );
       }
       continue;
     }
 
-    const castType =
-      typeof adapter.lookupCastTypeFromColumn === "function"
-        ? adapter.lookupCastTypeFromColumn(column)
-        : null;
-    let type = (castType as Type | null) ?? typeRegistry.lookup("value");
-
-    // Rails type_for_column: convert string types to their immutable variant
-    // when `immutable_strings_by_default` is set (model_schema.rb:623-626).
-    // Only mutable StringType responds to toImmutableString, mirroring
-    // Ruby's `type.respond_to?(:to_immutable_string)` guard.
-    if ((host as { immutableStringsByDefault?: boolean }).immutableStringsByDefault) {
-      const toImmutable = (type as { toImmutableString?: () => Type }).toImmutableString;
-      if (typeof toImmutable === "function") type = toImmutable.call(type);
-    }
-
-    type = host.hookAttributeType?.(name, type) ?? type;
+    let type = reflectedTypeForColumn(host, adapter, name, column);
 
     // Preserve encryption wrappers across schema reflection. Both
     // EncryptedAttributeType variants implement `WrappedType`; any

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -1,5 +1,4 @@
 import { Type, ValueType } from "@blazetrails/activemodel";
-import { enumTypeFor } from "../enum.js";
 
 /**
  * Casts attribute values for database operations using the model's
@@ -15,22 +14,12 @@ export class Map {
   }
 
   typeCastForDatabase(attrName: string, value: unknown): unknown {
-    // Rails splits type casting across two casters: `model.type_caster`
-    // (TypeCaster::Map → `klass.type_for_attribute`, EnumType-aware, used by
-    // `in_order_of`) and the predicate builder's `TypeCaster::Connection`
-    // (raw schema column type, enum-unaware). We share one Map class across
-    // both because our `arelTable` predicate builder relies on Map to serialize
-    // e.g. EncryptedAttributeType. Enums aren't decorated onto
-    // `_attributeDefinitions` (our enum stores the raw subtype in memory and
-    // presents labels via accessors), so to reproduce Rails' Map/Connection
-    // behavioral split we resolve EnumType only on the serialize path here —
-    // mapping keys → integers for the database form, mirroring
-    // `type_caster.type_cast_for_database`. The `typeForAttribute` cast path
-    // (used by the predicate builder) stays the raw subtype, so
-    // `whereValuesHash` / `scopeForCreate` round-trip the raw value our
-    // accessors expect.
-    const enumMapping = this._klass._enums?.get(attrName);
-    if (enumMapping) return enumTypeFor(attrName, enumMapping).serialize(value);
+    // Rails' `model.type_caster` (TypeCaster::Map → `klass.type_for_attribute`)
+    // is EnumType-aware: an enum attribute resolves to its registered EnumType,
+    // whose `serialize` maps the label → the stored database value. Enums are
+    // decorated onto `_attributeDefinitions` via `decorateAttributes`, so
+    // `typeForAttribute` already returns that EnumType — no separate enum path
+    // is needed here.
     const type = this.typeForAttribute(attrName);
     return type.serialize(value);
   }

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -1,4 +1,5 @@
 import { Type, ValueType } from "@blazetrails/activemodel";
+import { enumTypeOf } from "../enum.js";
 
 /**
  * Casts attribute values for database operations using the model's
@@ -15,11 +16,15 @@ export class Map {
 
   typeCastForDatabase(attrName: string, value: unknown): unknown {
     // Rails' `model.type_caster` (TypeCaster::Map → `klass.type_for_attribute`)
-    // is EnumType-aware: an enum attribute resolves to its registered EnumType,
-    // whose `serialize` maps the label → the stored database value. Enums are
-    // decorated onto `_attributeDefinitions` via `decorateAttributes`, so
-    // `typeForAttribute` already returns that EnumType — no separate enum path
-    // is needed here.
+    // is EnumType-aware: an enum attribute serializes the label → its stored
+    // database value. Resolve the enum through `enumTypeOf` (the replayed
+    // AttributeSet) rather than the local `_attributeDefinitions` O(1) cache:
+    // that cache keeps the pre-reflection EnumType, whose subtype was inferred
+    // from the mapping shape, whereas the AttributeSet carries the EnumType
+    // built from the reflected column type. `whereValuesHash` / `scopeForCreate`
+    // round-trip the label through the same reflected type.
+    const enumType = enumTypeOf(this._klass, attrName);
+    if (enumType) return enumType.serialize(value);
     const type = this.typeForAttribute(attrName);
     return type.serialize(value);
   }


### PR DESCRIPTION
## What

Resolve the enum storage subtype from the reflected column type (Rails' `decorate_attributes` model, enum.rb:239-246) instead of eagerly from the mapping's value shapes, and collapse the two independent resolution paths into a single source of truth.

## Why

`enum-boolean-nil-string-value-support` (#4409) gave `EnumType` a real subtype but resolved it **eagerly at macro time**: `_enum` inferred it from the mapping shape, and `enumTypeFor` (the `TypeCaster::Map` serialize path) inferred it independently. When a column's reflected DB type diverges from what the mapping shape implies (e.g. an integer-valued enum on a `decimal` column), the inferred subtype didn't match the real column type, so cast/serialize/deserialize diverged from Rails.

## How

- `installEnumAttribute` wires a `decorateAttributes` decorator that builds the `EnumType` lazily via `enumTypeFrom`. `EnumType` now takes the subtype `ValueType` instance directly (Rails-faithful) and derives its `subtype` string from it.
- **Schema-reflected resolution.** trails' column-seed-then-replay seeds the enum *override* (not the raw column type, unlike Rails), and reflection skips userProvided defs — so the reflected column type never reached the decorator for a plain schema-backed enum. Fixed at reflection time (`applyColumnsHash`, where the adapter is in hand): when a column backs an enum, its reflected cast type (`lookupCastTypeFromColumn`) is stashed on the def as `enumReflectedSubtype`, and `enumTypeFrom` prefers it. A pre-reflection/`value` type falls back to mapping-shape inference; an already-decorated `EnumType` is unwrapped to its own subtype.
- **Single reader.** Removed `enumTypeFor`/its cache. `readEnumValue`, `castEnumValue`, and `TypeCaster::Map` now fetch the one registered EnumType via `enumTypeOf`, which resolves through the replayed AttributeSet (`_defaultAttributes`) — the reflected-subtype EnumType — not the stale `_attributeDefinitions` entry.
- **Tests.** An explicit-`attribute("status","decimal")` case and a genuinely schema-reflected case (integer enum on the real `numeric_data.decimal_number` column) both assert delegation to the reflected `DecimalType` across the subtype, `castEnumValue`, and query-caster paths. Reverting the reflection-time stash makes the schema-reflected test fail (`'integer'` vs `'decimal'`).

Closes-story: enum-subtype-from-reflected-column-type