### PR TITLE
refactor(schema): route removeForeignKey/removeCheckConstraint drops through createAlterTable

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -859,9 +859,13 @@ export class SchemaStatements {
       column: opts.column,
       name: opts.name,
     });
-    await this.adapter.executeMutation(
-      `ALTER TABLE ${this._qi(fromTable)} DROP CONSTRAINT ${this._qi(fk.name)}`,
-    );
+    // Rails: at = create_alter_table from_table; at.drop_foreign_key fk.name;
+    //        execute schema_creation.accept(at)
+    // Route through AlterTable so adapters emit dialect-specific DROP syntax
+    // (MySQL/MariaDB `DROP FOREIGN KEY`) rather than a hardcoded `DROP CONSTRAINT`.
+    const at = this.createAlterTable(fromTable);
+    at.dropForeignKey(fk.name);
+    await this.adapter.executeMutation(this.schemaCreation.accept(at));
   }
 
   async addCheckConstraint(
@@ -927,9 +931,13 @@ export class SchemaStatements {
         `Table '${tableName}' has no check constraint for ${expression ?? JSON.stringify(opts)}`,
       );
     }
-    await this.adapter.executeMutation(
-      `ALTER TABLE ${this._qi(tableName)} DROP CONSTRAINT ${this._qi(chk.name)}`,
-    );
+    // Rails: at = create_alter_table table_name; at.drop_check_constraint chk.name;
+    //        execute schema_creation.accept(at)
+    // Route through AlterTable so adapters emit dialect-specific DROP syntax
+    // (MySQL `DROP CHECK`) rather than a hardcoded `DROP CONSTRAINT`.
+    const at = this.createAlterTable(tableName);
+    at.dropCheckConstraint(chk.name);
+    await this.adapter.executeMutation(this.schemaCreation.accept(at));
   }
 
   async addTimestamps(tableName: string, options: ColumnOptions = {}): Promise<void> {

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -21234,13 +21234,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "remove_check_constraint",
-    "call": "accept",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_check_constraint",
     "call": "check_constraint_exists?",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
@@ -21249,20 +21242,6 @@
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "remove_check_constraint",
     "call": "check_constraint_for!",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_check_constraint",
-    "call": "create_alter_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_check_constraint",
-    "call": "drop_check_constraint",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {
@@ -21360,28 +21339,7 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "remove_foreign_key",
-    "call": "accept",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_foreign_key",
-    "call": "create_alter_table",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_foreign_key",
     "call": "delete",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "remove_foreign_key",
-    "call": "drop_foreign_key",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## Summary

Base `removeForeignKey`/`removeCheckConstraint` emitted a hardcoded
`ALTER TABLE <t> DROP CONSTRAINT <name>` string. Rails routes both through
`create_alter_table` + `at.drop_foreign_key(name)` / `at.drop_check_constraint(name)`
+ `execute schema_creation.accept(at)`, so an adapter can emit dialect-specific
DROP syntax (MySQL/MariaDB `DROP FOREIGN KEY` / `DROP CHECK`) rather than the
generic `DROP CONSTRAINT` that only the ANSI-tolerant adapters accept.

This change builds the drop via `createAlterTable(fromTable)` +
`AlterTable#dropForeignKey` / `dropCheckConstraint` and `schemaCreation.accept(at)`,
mirroring Rails. The `AlterTable` drop nodes and adapter visitors (MySQL
`DROP FOREIGN KEY` / `DROP CHECK`, PG/base `DROP CONSTRAINT`) already existed;
this wires the base schema-statements path into them.

## Testing

- `schema-creation.test.ts` (abstract/mysql/postgresql) — 67 passing
- `schema-statements-on-adapter.test.ts`, `command-recorder.test.ts` — 92 passing

Closes-story: remove-fk-check-drop-via-alter-table