### PR TITLE
fix(preloader): resolve multi-level nested joined tables for has_one-through predicate carry

### DIFF
--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -88,9 +88,11 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     // because `_resolveNestedTableNames` now resolves it two levels deep, the
     // predicate qualifying it rides the through query's WHERE too (without the
     // recursive resolution it would be deferred to the source-preloader stage).
-    expect(sql).toMatch(/JOIN "categories"/);
-    expect(sql).toMatch(/JOIN "categorizations"/);
-    expect(sql).toMatch(/WHERE.*"categorizations"\."author_id"/);
+    // Identifier quoting is adapter-specific (`"x"` on SQLite/PG, `` `x` `` on
+    // MariaDB), so match the bare table/column names.
+    expect(sql).toMatch(/JOIN .categories./);
+    expect(sql).toMatch(/JOIN .categorizations./);
+    expect(sql).toMatch(/WHERE.*categorizations.\..author_id/);
   });
 
   type AssocHost = {

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Preloader::ThroughAssociation#through_scope — multi-level nested join carry.
+ *
+ * Rails' `through_scope` nests the whole reflection-scope structural spec under
+ * the source reflection name — `joins!/left_outer_joins!/includes!(source => …)`
+ * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb:120-142)
+ * — so a scope whose `.left_joins(category: :categorizations)` reaches a
+ * TWO-levels-deep table (`categorizations`, via club → category →
+ * categorizations) realizes that deeper join on the through query, and a
+ * predicate qualifying it (`categorizations.author_id = …`) constrains which
+ * through row wins on the through query itself rather than deferring to the
+ * source-preloader stage.
+ *
+ * trails widens the has_one-through query's resolvable-table set with the tables
+ * the scope's joins/includes reach; `_resolveNestedTableNames` now walks nested
+ * hash specs recursively, resolving each level against the correct klass, so the
+ * two-level `categorizations` table enters the set. No canonical has_one-through
+ * model scope reaches two levels, so this pins the behavior by declaring one on
+ * the canonical Member model (mirroring `general_club`).
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel, enableSti } from "../../index.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
+import { Preloader } from "../preloader.js";
+import { ThroughAssociation } from "./through-association.js";
+import { Member } from "../../test-helpers/models/member.js";
+import { Club } from "../../test-helpers/models/club.js";
+import { Membership, CurrentMembership } from "../../test-helpers/models/membership.js";
+import { Category } from "../../test-helpers/models/category.js";
+import { Categorization } from "../../test-helpers/models/categorization.js";
+
+registerModel(Member);
+registerModel(Club);
+enableSti(Membership);
+registerModel(Membership);
+registerModel(CurrentMembership);
+enableSti(Category);
+registerModel(Category);
+registerModel(Categorization);
+
+type NestedRel = {
+  leftJoins: (spec: Record<string, unknown>) => NestedRel;
+  where: (spec: Record<string, unknown>) => NestedRel;
+};
+type HasOneHost = {
+  hasOne: (name: string, options: Record<string, unknown>) => void;
+};
+
+// A has_one-through mirroring `general_club` (Member → current_membership →
+// club) but whose scope reaches `categorizations` — two levels deep from the
+// source klass Club (club → category → categorizations) — and predicates on it.
+// `categorizations.author_id = 1` (david) matches category `general`, so
+// groucho's through row (boring_club, category general) survives.
+(Member as unknown as HasOneHost).hasOne("davidCategorizedClub", {
+  through: "currentMembership",
+  source: "club",
+  scope: (rel: NestedRel) =>
+    rel.leftJoins({ category: "categorizations" }).where({ categorizations: { author_id: 1 } }),
+});
+
+describe("Preloader::ThroughAssociation#through_scope multi-level nested join carry", () => {
+  const { members, clubs } = fixtures([
+    "memberTypes",
+    "members",
+    "clubs",
+    "memberships",
+    "categories",
+    "categorizations",
+    "authors",
+  ]);
+
+  function throughScopeSql(owners: Member[], name: string): string {
+    const loader = new Preloader({
+      records: owners,
+      associations: [name],
+      associateByDefault: false,
+    }).loaders.find((l) => l instanceof ThroughAssociation);
+    if (!loader) throw new Error("expected a ThroughAssociation loader");
+    return (loader as unknown as { _buildThroughScope: () => { toSql: () => string } })
+      ._buildThroughScope()
+      .toSql();
+  }
+
+  it("nests the two-level scope join under the source reflection on the through query", () => {
+    const groucho = members("groucho");
+    const sql = throughScopeSql([groucho], "davidCategorizedClub");
+    // The deeper `categorizations` join is realized on the through query and,
+    // because `_resolveNestedTableNames` now resolves it two levels deep, the
+    // predicate qualifying it rides the through query's WHERE too (without the
+    // recursive resolution it would be deferred to the source-preloader stage).
+    expect(sql).toMatch(/JOIN "categories"/);
+    expect(sql).toMatch(/JOIN "categorizations"/);
+    expect(sql).toMatch(/WHERE.*"categorizations"\."author_id"/);
+  });
+
+  type AssocHost = {
+    id: number;
+    association: (name: string) => {
+      loadTarget: () => Promise<{ id: number } | null>;
+      target: { id: number } | null;
+    };
+  };
+  const assoc = (m: unknown) => (m as AssocHost).association("davidCategorizedClub");
+
+  it("loading with scope including a two-level nested join", async () => {
+    let member = (await Member.first()) as unknown as AssocHost;
+    expect(member?.id).toBe(members("groucho").id);
+    expect((await assoc(member).loadTarget())?.id).toBe(clubs("boring_club").id);
+
+    member = (await Member.preload("davidCategorizedClub").first()) as unknown as AssocHost;
+    expect(member?.id).toBe(members("groucho").id);
+    expect(assoc(member).target?.id).toBe(clubs("boring_club").id);
+
+    member = (await Member.eagerLoad("davidCategorizedClub").first()) as unknown as AssocHost;
+    expect(member?.id).toBe(members("groucho").id);
+    expect(assoc(member).target?.id).toBe(clubs("boring_club").id);
+  });
+});

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -28,6 +28,7 @@ import { Club } from "../../test-helpers/models/club.js";
 import { Membership, CurrentMembership } from "../../test-helpers/models/membership.js";
 import { Category } from "../../test-helpers/models/category.js";
 import { Categorization } from "../../test-helpers/models/categorization.js";
+import { quoteTableName, escapeRegExp } from "../../test-helpers/quote-regex.js";
 
 registerModel(Member);
 registerModel(Club);
@@ -88,11 +89,13 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     // because `_resolveNestedTableNames` now resolves it two levels deep, the
     // predicate qualifying it rides the through query's WHERE too (without the
     // recursive resolution it would be deferred to the source-preloader stage).
-    // Identifier quoting is adapter-specific (`"x"` on SQLite/PG, `` `x` `` on
-    // MariaDB), so match the bare table/column names.
-    expect(sql).toMatch(/JOIN .categories./);
-    expect(sql).toMatch(/JOIN .categorizations./);
-    expect(sql).toMatch(/WHERE.*categorizations.\..author_id/);
+    // Quote identifiers via the active adapter (Rails' `quote_table_name`
+    // pattern) so the assertions run on SQLite/PG (`"x"`) and MariaDB (`` `x` ``).
+    expect(sql).toMatch(new RegExp(`JOIN ${escapeRegExp(quoteTableName("categories"))}`));
+    expect(sql).toMatch(new RegExp(`JOIN ${escapeRegExp(quoteTableName("categorizations"))}`));
+    expect(sql).toMatch(
+      new RegExp(`WHERE.*${escapeRegExp(quoteTableName("categorizations.author_id"))}`),
+    );
   });
 
   type AssocHost = {

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -637,43 +637,62 @@ export class ThroughAssociation extends Association {
    * set with the tables the reflection scope joins via its own
    * `.joins`/`.leftJoins`/`.includes`, so a predicate qualifying one of them can
    * ride the through query (Rails' nested through_scope carry-over,
-   * through_association.rb:120-142). Resolution is single-level against the source
-   * klass — deeper hash nesting collects the first-level key only, which covers
-   * the canonical scopes; an unresolvable (e.g. polymorphic) association is
-   * skipped, leaving its predicate at the source-preloader stage.
+   * through_association.rb:120-142). Resolution walks nested hash/array specs
+   * recursively: each level's key resolves against the current klass, and its
+   * value recurses against that association's klass, so a two-or-more-levels-deep
+   * table (e.g. `.joins({ category: :subcategory })` reaching `subcategories`)
+   * enters the resolvable set. Rails nests the whole spec under the source
+   * reflection name, realizing the deeper join on the through query. An
+   * unresolvable (e.g. polymorphic) association is skipped, leaving its predicate
+   * at the source-preloader stage.
    * @internal
    */
   private _resolveNestedTableNames(sourceRefl: AssociationLikeReflection, specs: any[]): string[] {
-    let klass: typeof Base;
+    let sourceKlass: typeof Base;
     try {
-      klass = sourceRefl.klass;
+      sourceKlass = sourceRefl.klass;
     } catch {
       return [];
     }
-    const names: string[] = [];
-    const collect = (spec: any): void => {
+    const tables: string[] = [];
+    const walk = (klass: typeof Base, spec: any): void => {
       if (spec == null) return;
       if (typeof spec === "string") {
-        names.push(spec);
+        this._collectNestedTable(klass, spec, tables);
       } else if (Array.isArray(spec)) {
-        for (const s of spec) collect(s);
+        for (const s of spec) walk(klass, s);
       } else if (typeof spec === "object") {
-        for (const key of Object.keys(spec)) names.push(key);
+        for (const key of Object.keys(spec)) {
+          const nextKlass = this._collectNestedTable(klass, key, tables);
+          if (nextKlass) walk(nextKlass, spec[key]);
+        }
       }
     };
-    for (const spec of specs) collect(spec);
-
-    const tables: string[] = [];
-    for (const name of names) {
-      try {
-        const r = (klass as any)._reflectOnAssociation?.(name);
-        const t = r?.klass?.tableName;
-        if (typeof t === "string") tables.push(t);
-      } catch {
-        /* polymorphic / unresolved association — leave predicate at source stage */
-      }
-    }
+    for (const spec of specs) walk(sourceKlass, spec);
     return tables;
+  }
+
+  /**
+   * Resolve `name` as an association on `klass`, push its table into `tables`,
+   * and return its klass so the caller can recurse into a deeper spec. Returns
+   * null for an unresolvable (e.g. polymorphic) association.
+   * @internal
+   */
+  private _collectNestedTable(
+    klass: typeof Base,
+    name: string,
+    tables: string[],
+  ): typeof Base | null {
+    try {
+      const r = (klass as any)._reflectOnAssociation?.(name);
+      const nextKlass = r?.klass;
+      const t = nextKlass?.tableName;
+      if (typeof t === "string") tables.push(t);
+      return (nextKlass as typeof Base) ?? null;
+    } catch {
+      /* polymorphic / unresolved association — leave predicate at source stage */
+      return null;
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

Follow-up from #4521. The has_one-through preloader widens the through query's
resolvable-table set with the tables a reflection scope's
`includes`/`joins`/`left_outer_joins` reach (`_resolveNestedTableNames`), so a
predicate qualifying one of them rides the through query rather than deferring
to the source-preloader stage.

That resolution was **single-level**: a nested hash spec
(`.leftJoins({ category: :categorizations })`) collected only the first-level
key (`categorizations` never entered the set), so a predicate on a
two-or-more-levels-deep table was not copied onto the through query. Rails nests
the whole spec under `source_reflection.name`, realizing the deeper join on the
through query (through_association.rb:120-142).

## Fix

`_resolveNestedTableNames` now walks nested hash/array specs recursively,
resolving each level against the correct klass (source klass, then each nested
association's klass), so a two-level joined table enters the resolvable set and
its predicate constrains the through row on the through query.

Confirmed through query for the new `davidCategorizedClub` scope
(`.leftJoins({ category: :categorizations }).where(categorizations: { author_id: 1 })`):

```
SELECT "memberships".* FROM "memberships"
  LEFT OUTER JOIN "clubs" ON "clubs"."id" = "memberships"."club_id"
  LEFT OUTER JOIN "categories" ON "categories"."id" = "clubs"."category_id"
  LEFT OUTER JOIN "categorizations" ON "categorizations"."category_id" = "categories"."id"
  WHERE "memberships"."type" = 1 AND "categorizations"."author_id" = 1
```

## Test

New trails-only test declares a canonical-Member has_one-through
(`davidCategorizedClub`) whose scope reaches `categorizations` two levels deep
(club → category → categorizations), pinning the through-query SQL and the
direct / preload / eager_load reads. No regression in has_one_through /
has_many_through / nested-through / preloader / eager suites.

Closes-story: hasone-through-preloader-resolve-multilevel-nested-tables