### PR TITLE
fix(adapters): Rails fixed-6 microsecond datetime literals on sqlite/mysql

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/precision-roundtrip.test.ts
@@ -29,9 +29,9 @@ describe("formatInstantForSql", () => {
     expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55");
   });
 
-  it("preserves millisecond precision", () => {
+  it("pads millisecond precision to a fixed 6-digit microsecond field", () => {
     const v = Temporal.Instant.from("2026-04-26T14:23:55.123Z");
-    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55.123");
+    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55.123000");
   });
 
   it("preserves microsecond precision", () => {
@@ -39,9 +39,9 @@ describe("formatInstantForSql", () => {
     expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55.123456");
   });
 
-  it("preserves nanosecond precision", () => {
+  it("caps fractional seconds at microseconds (drops nanoseconds)", () => {
     const v = Temporal.Instant.from("2026-04-26T14:23:55.123456789Z");
-    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55.123456789");
+    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55.123456");
   });
 
   it("preserves the smallest possible non-zero value (1 µs)", () => {
@@ -68,9 +68,9 @@ describe("formatPlainDateTimeForSql", () => {
     expect(formatPlainDateTimeForSql(v)).toBe("2024-12-31 23:59:59.999999");
   });
 
-  it("preserves nanosecond precision", () => {
+  it("caps fractional seconds at microseconds, omitting a sub-µs-only value", () => {
     const v = Temporal.PlainDateTime.from("2024-01-01T00:00:00.000000001");
-    expect(formatPlainDateTimeForSql(v)).toBe("2024-01-01 00:00:00.000000001");
+    expect(formatPlainDateTimeForSql(v)).toBe("2024-01-01 00:00:00");
   });
 });
 
@@ -103,15 +103,13 @@ describe("formatPlainTimeForSql", () => {
     );
   });
 
-  it("preserves nanoseconds", () => {
-    expect(formatPlainTimeForSql(Temporal.PlainTime.from("00:00:00.000000001"))).toBe(
-      "00:00:00.000000001",
-    );
+  it("caps fractional seconds at microseconds, omitting a sub-µs-only value", () => {
+    expect(formatPlainTimeForSql(Temporal.PlainTime.from("00:00:00.000000001"))).toBe("00:00:00");
   });
 
-  it("omits trailing zeros beyond the precision present", () => {
-    // millisecond only — 3 fractional digits
-    expect(formatPlainTimeForSql(Temporal.PlainTime.from("12:00:00.100"))).toBe("12:00:00.100");
+  it("pads to a fixed 6-digit microsecond field", () => {
+    // millisecond only — padded out to 6 digits
+    expect(formatPlainTimeForSql(Temporal.PlainTime.from("12:00:00.100"))).toBe("12:00:00.100000");
   });
 });
 
@@ -167,6 +165,28 @@ describe("MySQL-safe formatters (clamped to 6 fractional digits)", () => {
   it("formatPlainTimeForSqlMysql preserves microseconds", () => {
     const v = Temporal.PlainTime.from("14:23:55.000001");
     expect(formatPlainTimeForSqlMysql(v)).toBe("14:23:55.000001");
+  });
+});
+
+// Rails `quoted_date` fixed-6 microsecond field (abstract/quoting.rb:194-195):
+// `.5` → `.500000`, and usec == 0 omits the fractional part entirely.
+describe("SQLite/MySQL fixed-6 microsecond field (quoted_date parity)", () => {
+  it("emits a fixed 6-digit field for a half-second (.5 → .500000)", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55.5Z");
+    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55.500000");
+    expect(formatInstantForSqlMysql(v)).toBe("2026-04-26 14:23:55.500000");
+  });
+
+  it("omits the fractional part when usec == 0", () => {
+    const v = Temporal.Instant.from("2026-04-26T14:23:55Z");
+    expect(formatInstantForSql(v)).toBe("2026-04-26 14:23:55");
+    expect(formatInstantForSqlMysql(v)).toBe("2026-04-26 14:23:55");
+  });
+
+  it("omits the fractional part for a whole-second PlainTime (.000 → omitted)", () => {
+    const v = Temporal.PlainTime.from("14:23:55.000");
+    expect(formatPlainTimeForSql(v)).toBe("14:23:55");
+    expect(formatPlainTimeForSqlMysql(v)).toBe("14:23:55");
   });
 });
 

--- a/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
@@ -66,11 +66,9 @@ export function formatPlainDateForSql(value: Temporal.PlainDate): string {
  *   ...
  *   # PG#quoted_date then suffixes " BC" for proleptic years <= 0.
  *
- * Differs from {@link formatInstantForSql} in two Rails-faithful ways: the
- * fractional part is a fixed 6-digit microsecond field (not a trimmed 3/6/9 group)
- * and is capped at microseconds — matching PG's `timestamp` resolution — so a
- * nil-precision nanosecond value never reaches the wire as 7–9 digits. The " BC"
- * suffix is what the abstract formatters omit.
+ * Shares the fixed-6 microsecond fraction ({@link microsecondFraction}) with the
+ * abstract/MySQL formatters; the only PG-specific behavior is the " BC" suffix
+ * appended for proleptic years <= 0.
  */
 function pgDateTimeLiteral(
   year: number,

--- a/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/sql-datetime.ts
@@ -25,19 +25,22 @@ export function defaultSqlTimezone(): string {
 }
 
 /**
- * Format a `Temporal.Instant` for SQL as `YYYY-MM-DD HH:MM:SS[.fffffffff]`.
- * Respects `ActiveRecord.default_timezone`:
- * UTC when the setting is `"utc"`, otherwise the host system's local timezone.
- * Preserves up to nanosecond precision; trailing zero groups are trimmed.
+ * Format a `Temporal.Instant` for SQL as `YYYY-MM-DD HH:MM:SS[.ffffff]`,
+ * faithful to the abstract `quoted_date` (abstract/quoting.rb:193-197): the
+ * fractional part is a fixed 6-digit microsecond field emitted only when
+ * `usec > 0`, and precision is capped at microseconds (nanoseconds dropped).
+ * Respects `ActiveRecord.default_timezone`: UTC when the setting is `"utc"`,
+ * otherwise the host system's local timezone.
  */
 export function formatInstantForSql(value: Temporal.Instant): string {
   return formatZonedComponents(value.toZonedDateTimeISO(defaultSqlTimezone()));
 }
 
 /**
- * Format a `Temporal.PlainDateTime` for SQL as `YYYY-MM-DD HH:MM:SS[.fffffffff]`.
- * No timezone conversion — the value is naive by definition. Fractional digits
- * are trimmed to the smallest non-zero 3-digit group (ms/µs/ns).
+ * Format a `Temporal.PlainDateTime` for SQL as `YYYY-MM-DD HH:MM:SS[.ffffff]`.
+ * No timezone conversion — the value is naive by definition. Fractional part is
+ * a fixed 6-digit microsecond field when `usec > 0`, capped at microseconds
+ * (see {@link formatInstantForSql}).
  */
 export function formatPlainDateTimeForSql(value: Temporal.PlainDateTime): string {
   return formatPlainComponents(value);
@@ -81,8 +84,7 @@ function pgDateTimeLiteral(
   const isBc = year <= 0;
   const yyyy = String(isBc ? -year + 1 : year).padStart(4, "0");
   const p2 = (n: number) => String(n).padStart(2, "0");
-  let s = `${yyyy}-${p2(month)}-${p2(day)} ${p2(hour)}:${p2(min)}:${p2(sec)}`;
-  if (usec > 0) s += `.${String(usec).padStart(6, "0")}`;
+  const s = `${yyyy}-${p2(month)}-${p2(day)} ${p2(hour)}:${p2(min)}:${p2(sec)}${microsecondFraction(usec)}`;
   return isBc ? `${s} BC` : s;
 }
 
@@ -119,8 +121,9 @@ export function formatPlainDateForSqlPostgres(value: Temporal.PlainDate): string
 }
 
 /**
- * Format a `Temporal.PlainTime` for SQL as `HH:MM:SS[.fffffffff]`.
- * Fractional digits are trimmed to the smallest non-zero 3-digit group.
+ * Format a `Temporal.PlainTime` for SQL as `HH:MM:SS[.ffffff]`. Fractional part
+ * is a fixed 6-digit microsecond field when `usec > 0`, capped at microseconds
+ * (see {@link formatInstantForSql}).
  */
 export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
   return formatTimeComponents(
@@ -129,49 +132,18 @@ export function formatPlainTimeForSql(value: Temporal.PlainTime): string {
     value.second,
     value.millisecond,
     value.microsecond,
-    value.nanosecond,
   );
 }
 
 /**
- * MySQL-safe variants of the formatters. MySQL TIME/DATETIME/TIMESTAMP support
- * at most 6 fractional digits (microseconds); emitting 7–9 nanosecond digits
- * in strict SQL mode causes an error rather than silent truncation.
+ * MySQL variants. Since the abstract formatters already emit Rails' fixed-6
+ * microsecond field capped at microseconds — the same resolution MySQL
+ * TIME/DATETIME/TIMESTAMP support — the MySQL path is identical. Kept as named
+ * exports so adapter call sites document intent.
  */
-export function formatInstantForSqlMysql(value: Temporal.Instant): string {
-  const zdt = value.toZonedDateTimeISO(defaultSqlTimezone());
-  return (
-    formatDatePrefix(zdt) +
-    formatTimeComponents(zdt.hour, zdt.minute, zdt.second, zdt.millisecond, zdt.microsecond, 0, 6)
-  );
-}
-
-export function formatPlainDateTimeForSqlMysql(value: Temporal.PlainDateTime): string {
-  return (
-    formatDatePrefix(value) +
-    formatTimeComponents(
-      value.hour,
-      value.minute,
-      value.second,
-      value.millisecond,
-      value.microsecond,
-      0,
-      6,
-    )
-  );
-}
-
-export function formatPlainTimeForSqlMysql(value: Temporal.PlainTime): string {
-  return formatTimeComponents(
-    value.hour,
-    value.minute,
-    value.second,
-    value.millisecond,
-    value.microsecond,
-    0,
-    6,
-  );
-}
+export const formatInstantForSqlMysql = formatInstantForSql;
+export const formatPlainDateTimeForSqlMysql = formatPlainDateTimeForSql;
+export const formatPlainTimeForSqlMysql = formatPlainTimeForSql;
 
 function formatDatePrefix(v: { year: number; month: number; day: number }): string {
   return `${padYear(v.year)}-${String(v.month).padStart(2, "0")}-${String(v.day).padStart(2, "0")} `;
@@ -185,54 +157,33 @@ function padYear(year: number): string {
 function formatZonedComponents(zdt: Temporal.ZonedDateTime): string {
   return (
     formatDatePrefix(zdt) +
-    formatTimeComponents(
-      zdt.hour,
-      zdt.minute,
-      zdt.second,
-      zdt.millisecond,
-      zdt.microsecond,
-      zdt.nanosecond,
-    )
+    formatTimeComponents(zdt.hour, zdt.minute, zdt.second, zdt.millisecond, zdt.microsecond)
   );
 }
 
 function formatPlainComponents(pdt: Temporal.PlainDateTime): string {
-  const base = formatDatePrefix(pdt);
   return (
-    base +
-    formatTimeComponents(
-      pdt.hour,
-      pdt.minute,
-      pdt.second,
-      pdt.millisecond,
-      pdt.microsecond,
-      pdt.nanosecond,
-    )
+    formatDatePrefix(pdt) +
+    formatTimeComponents(pdt.hour, pdt.minute, pdt.second, pdt.millisecond, pdt.microsecond)
   );
 }
 
-function formatTimeComponents(
-  h: number,
-  min: number,
-  s: number,
-  ms: number,
-  us: number,
-  ns: number,
-  maxFracDigits = 9,
-): string {
+/**
+ * Build the `HH:MM:SS` base and append Rails' fixed 6-digit microsecond field
+ * when non-zero. Sub-microsecond precision (nanoseconds) is dropped, matching
+ * the abstract `quoted_date` cap and MySQL's fractional-seconds resolution.
+ */
+function formatTimeComponents(h: number, min: number, s: number, ms: number, us: number): string {
   const hh = String(h).padStart(2, "0");
   const mm = String(min).padStart(2, "0");
   const ss = String(s).padStart(2, "0");
-  const base = `${hh}:${mm}:${ss}`;
-  // Clamp sub-second components to maxFracDigits before building the string.
-  const effectiveUs = maxFracDigits >= 6 ? us : 0;
-  const effectiveNs = maxFracDigits >= 9 ? ns : 0;
-  if (ms === 0 && effectiveUs === 0 && effectiveNs === 0) return base;
-  const frac9 =
-    String(ms).padStart(3, "0") +
-    String(effectiveUs).padStart(3, "0") +
-    String(effectiveNs).padStart(3, "0");
-  const frac =
-    effectiveNs !== 0 ? frac9 : effectiveUs !== 0 ? frac9.slice(0, 6) : frac9.slice(0, 3);
-  return `${base}.${frac.slice(0, maxFracDigits)}`;
+  return `${hh}:${mm}:${ss}${microsecondFraction(ms * 1000 + us)}`;
+}
+
+/**
+ * Rails `quoted_date`'s fractional-seconds rule (abstract/quoting.rb:194-195):
+ * append `.` + `sprintf("%06d", usec)` when `usec > 0`, otherwise nothing.
+ */
+function microsecondFraction(usec: number): string {
+  return usec > 0 ? `.${String(usec).padStart(6, "0")}` : "";
 }


### PR DESCRIPTION
## What

Make the abstract (SQLite) and MySQL datetime SQL literal formatters faithful
to Rails' `quoted_date` (`abstract/quoting.rb:194-195`): append a **fixed
6-digit microsecond field only when `usec > 0`**, and cap precision at
microseconds (dropping any nanoseconds).

Before, these paths emitted a trimmed 3/6/9-digit fractional group (`.500`,
`.123`) and the abstract path could emit 7–9 nanosecond digits for a
nil-precision value. PR #3956 already made the PostgreSQL path faithful; this
extends the same rule to sqlite/mysql, which was explicitly scoped out there.

## How

- Extract a shared `microsecondFraction(usec)` helper implementing Rails'
  `sprintf("%06d", usec)` rule; the PG literal (`pgDateTimeLiteral`) now uses it
  too, so there's one source of truth.
- Rewrite `formatTimeComponents` to build `HH:MM:SS` + the fixed-6 fraction from
  `ms*1000 + us`, dropping the old trim / `maxFracDigits` / nanosecond logic.
- Since the abstract path now matches MySQL's fractional resolution, the MySQL
  variants (`formatInstantForSqlMysql`, etc.) alias the abstract ones.
- PG behavior unchanged.

## Tests

Updated `precision-roundtrip.test.ts` for the new behavior and added explicit
`quoted_date` parity coverage: `.5 → .500000`, `usec == 0` omission, and the µs
cap on both sqlite and mysql formatters.

The array-literal `quoteSqlValue(raw, true)` sites in `base.ts` were left as-is:
that path routes through `quoteArrayLiteral` (arel package), which does not
thread a `dialect` to elements, so passing one would be a no-op — out of scope
for this change.

Closes-story: sqlite-mysql-datetime-literal-fixed-6-microseconds
