### PR TITLE
test(enum): un-skip where() numeric-string and label-array enum cases

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -120,33 +120,42 @@ describe("EnumTest", () => {
     expect((await Book.whereNot({ status: written }).first())?.id).toBe(book.id);
   });
 
-  // Surfaced gap: every assertion uses `Book.statuses[...].to_s` (a numeric
-  // string like "2"), and `where({ status: "2" })` doesn't serialize the
-  // numeric string through EnumType in the predicate builder (it matches
-  // `IS NULL` instead). Plus the `cover` tail. Pending under
-  // 0023-surfaced-deviations/enum-canonical-book-gaps.
-  it.skip("find via where with values.to_s", () => {});
+  it("find via where with values.to_s", async () => {
+    book = books("awdr");
+    const published = String((Book as any).statuses.published);
+    const written = String((Book as any).statuses.written);
+
+    expect((await Book.where({ status: published }).first())?.id).toBe(book.id);
+    expect((await Book.where({ status: written }).first())?.id).not.toBe(book.id);
+    expect((await Book.where({ status: [published, published] }).first())?.id).toBe(book.id);
+    expect((await Book.where({ status: [written, written] }).first())?.id).not.toBe(book.id);
+    expect((await Book.whereNot({ status: published }).first())?.id).not.toBe(book.id);
+    expect((await Book.whereNot({ status: written }).first())?.id).toBe(book.id);
+    expect((await Book.where({ cover: (Book as any).covers.soft }).first())?.id).toBe(book.id);
+  });
 
   // Ruby symbols map to trails' label strings.
   it("find via where with symbols", async () => {
     book = books("awdr");
     expect((await Book.where({ status: "published" }).first())?.id).toBe(book.id);
     expect((await Book.where({ status: "written" }).first())?.id).not.toBe(book.id);
+    expect((await Book.where({ status: ["published", "published"] }).first())?.id).toBe(book.id);
+    expect((await Book.where({ status: ["written", "written"] }).first())?.id).not.toBe(book.id);
     expect((await Book.whereNot({ status: "published" }).first())?.id).not.toBe(book.id);
     expect((await Book.whereNot({ status: "written" }).first())?.id).toBe(book.id);
-    // Pending: array-of-label `where({ status: ["published", ...] })` (the
-    // predicate builder doesn't map enum labels per array element),
-    // `last_read: forgotten`, `status: prohibited` (nil), and `cover` matches.
+    // Pending: `last_read: forgotten`, `status: prohibited` (nil), and `cover`
+    // matches.
   });
 
   it("find via where with strings", async () => {
     book = books("awdr");
     expect((await Book.where({ status: "published" }).first())?.id).toBe(book.id);
     expect((await Book.where({ status: "written" }).first())?.id).not.toBe(book.id);
+    expect((await Book.where({ status: ["published", "published"] }).first())?.id).toBe(book.id);
+    expect((await Book.where({ status: ["written", "written"] }).first())?.id).not.toBe(book.id);
     expect((await Book.whereNot({ status: "published" }).first())?.id).not.toBe(book.id);
     expect((await Book.whereNot({ status: "written" }).first())?.id).toBe(book.id);
-    // Pending: array-of-label `where`, `last_read: "forgotten"`, and
-    // `status: "prohibited"` (nil).
+    // Pending: `last_read: "forgotten"` and `status: "prohibited"` (nil).
   });
 
   // Rails uses 64-bit out-of-range labels and beginless/endless ranges.


### PR DESCRIPTION
## What

`where({ status: "2" })` (numeric-string) and `where({ status: ["published", ...] })` (label array) already serialize each value through `EnumType` in the predicate builder on `main`. This un-skips the tracked-pending `find via where with values.to_s` case and adds the array-of-label assertions to the symbol/string cases, mirroring `enum_test.rb:104-138`, then drops their pending notes.

Test-only convergence — no runtime change was needed; the serialization path already handles both shapes. Verified with `pnpm vitest run enum.test` (77 passed).

## Acceptance criteria

- [x] `where({ enumCol: "<numeric-string>" })` matches the mapped integer; `where({ enumCol: ["<label>", ...] })` maps each element through the enum type.
- [x] Un-skip `find via where with values.to_s` and the array-of-label assertions in the symbol/string cases; drop pending notes.

Closes-story: where-enum-serializes-numeric-string-and-label-arrays