### PR TITLE
fix(schema): isForeignKeysEnabled reads adapter._config, not nonexistent .config

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -347,6 +347,44 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(executed).toBe(false);
   });
 
+  it("addForeignKey/removeForeignKey no-op when config foreign_keys:false despite supports_foreign_keys?", async () => {
+    // Rails: use_foreign_keys? == supports_foreign_keys? && foreign_keys_enabled?,
+    // where foreign_keys_enabled? reads @config.fetch(:foreign_keys, true). An
+    // adapter that supports FKs but is configured `foreign_keys: false` must
+    // still no-op the FK mutators. isForeignKeysEnabled reads the adapter's real
+    // config hash (_config), so this exercises the config-driven disable path.
+    let executed = false;
+    class DisabledFkAdapter extends StubAdapter {
+      constructor() {
+        super();
+        (this as any)._config = { foreignKeys: false };
+      }
+      supportsForeignKeys() {
+        return true;
+      }
+      executeMutation(_sql: string) {
+        executed = true;
+        return Promise.resolve(0);
+      }
+    }
+    const stub = new DisabledFkAdapter();
+    expect(stub.supportsForeignKeys()).toBe(true);
+    expect((stub as any).isForeignKeysEnabled()).toBe(false);
+    expect((stub as any).isUseForeignKeys()).toBe(false);
+    await stub.addForeignKey("articles", "authors", { column: "author_id" });
+    await expect(
+      stub.removeForeignKey("articles", { name: "fk_whatever" }),
+    ).resolves.toBeUndefined();
+    expect(executed).toBe(false);
+  });
+
+  it("isForeignKeysEnabled defaults to true when config omits foreign_keys (Rails fetch default)", () => {
+    // Rails: foreign_keys_enabled? is @config.fetch(:foreign_keys, true), so a
+    // config with no :foreign_keys key yields true.
+    const stub = new StubAdapter();
+    expect((stub as any).isForeignKeysEnabled()).toBe(true);
+  });
+
   it("validColumnDefinitionOptions includes ifExists (Rails OPTION_NAMES)", () => {
     const stub = new StubAdapter();
     const opts = (stub as any).validColumnDefinitionOptions() as string[];

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -154,7 +154,7 @@ describe("SchemaStatements privates (PR 8)", () => {
 
   it("isForeignKeysEnabled reads config.foreignKeys", () => {
     expect(makeStatements().isForeignKeysEnabled()).toBe(true);
-    expect(makeStatements({ config: { foreignKeys: false } }).isForeignKeysEnabled()).toBe(false);
+    expect(makeStatements({ _config: { foreignKeys: false } }).isForeignKeysEnabled()).toBe(false);
   });
 
   it("checkConstraintName", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2449,7 +2449,10 @@ export class SchemaStatements {
   /** @internal */
   isForeignKeysEnabled(): boolean {
     const adapter = this.adapter as any;
-    return adapter.config?.foreignKeys !== false;
+    // Rails: `foreign_keys_enabled?` is `@config.fetch(:foreign_keys, true)`.
+    // AbstractAdapter stores its config in `_config` (there is no `config`
+    // getter), so read the real config hash; a missing key defaults to true.
+    return adapter._config?.foreignKeys !== false;
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.test.ts
@@ -266,7 +266,7 @@ describe("MySQL::TableDefinition#toSql via SchemaCreation.accept", () => {
   it("skips FK emission when host adapter has foreignKeys disabled", () => {
     const host = {
       supportsForeignKeys: () => true,
-      config: { foreignKeys: false },
+      _config: { foreignKeys: false },
     };
     const td = new MyTd("posts", { adapter: host });
     td.bigint("author_id");

--- a/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-creation.ts
@@ -57,8 +57,6 @@ export interface VisitorHostAdapter {
    * synchronously and yields false when cold — warm via `getDatabaseVersion`. */
   supportsIndexSortOrder?(): boolean;
   isMariadb?(): boolean;
-  /** Mirrors `SchemaStatements#isForeignKeysEnabled` (`adapter.config?.foreignKeys !== false`). */
-  config?: { foreignKeys?: boolean };
   /** Quoting surface consulted polymorphically by the visitor when the real adapter is
    * threaded; absent on the host-less (unit-test) path, which falls back to the standalone
    * MySQL helpers in {@link mysqlSchemaQuoter}. */
@@ -206,11 +204,14 @@ export class SchemaCreation extends AbstractSchemaCreation {
   }
 
   /** @internal Mirrors Rails' `use_foreign_keys?` (`supports_foreign_keys? &&
-   * foreign_keys_enabled?`). The enabled half reads `adapter.config.foreignKeys`, matching
+   * foreign_keys_enabled?`). The enabled half reads `adapter._config.foreignKeys`, matching
    * `SchemaStatements#isForeignKeysEnabled`. */
   protected useForeignKeys(): boolean {
     const supports = this._hostAdapter?.supportsForeignKeys?.() ?? true;
-    const enabled = this._hostAdapter?.config?.foreignKeys !== false;
+    // `_config` is protected on the real adapter, so read it via a narrow cast
+    // (mirrors `SchemaStatements#isForeignKeysEnabled`).
+    const host = this._hostAdapter as { _config?: { foreignKeys?: boolean } } | undefined;
+    const enabled = host?._config?.foreignKeys !== false;
     return supports && enabled;
   }
 

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -454,6 +454,14 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         "when initializing an Active Record adapter with a config hash, that should be the only argument",
       );
     }
+    // Mirrors Rails abstract_adapter.rb — `@config = config`. Persist the full
+    // config hash so config-driven getters (`foreign_keys_enabled?`,
+    // default_timezone, etc.) read the real values rather than the empty
+    // default. The object branch below destructures adapter-level keys off it,
+    // but the untouched hash is what `_config`-reading helpers consult.
+    if (typeof config === "object" && config !== null) {
+      this._config = { ...(config as Record<string, unknown>) };
+    }
     if (typeof config === "string") {
       let waitTimeout: number | undefined;
       let uri = config;

--- a/packages/activerecord/src/connection-adapters/pool-config.ts
+++ b/packages/activerecord/src/connection-adapters/pool-config.ts
@@ -294,6 +294,9 @@ export interface TrailsAdapterOptions {
   // Mirrors: database.yml `advisory_locks` — set false to disable advisory
   // locking (read by `advisoryLocksEnabled?`). Defaults to true.
   advisoryLocks?: boolean | string;
+  // Mirrors: database.yml `foreign_keys` — set false to disable foreign-key DDL
+  // (read by `foreignKeysEnabled?` / `isUseForeignKeys`). Defaults to true.
+  foreignKeys?: boolean;
 }
 
 /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -493,6 +493,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         "when initializing an Active Record adapter with a config hash, that should be the only argument",
       );
     }
+    // Mirrors Rails abstract_adapter.rb — `@config = config`. Persist the full
+    // config hash so config-driven getters (`foreign_keys_enabled?`,
+    // default_timezone, etc.) read the real values rather than the empty
+    // default. The object branch below destructures adapter-level keys off it,
+    // but the untouched hash is what `_config`-reading helpers consult.
+    if (typeof config === "object" && config !== null) {
+      this._config = { ...(config as Record<string, unknown>) };
+    }
     if (typeof config === "string") {
       this._minMessages = "warning";
       this._sessionVariables = {};

--- a/packages/activerecord/src/connection-adapters/raw-connection-overload.test.ts
+++ b/packages/activerecord/src/connection-adapters/raw-connection-overload.test.ts
@@ -159,3 +159,38 @@ describe("deprecated raw-connection initialize overload", () => {
     });
   });
 });
+
+// Rails: `AbstractAdapter#initialize` stores `@config = config`, and
+// `foreign_keys_enabled?` reads `@config.fetch(:foreign_keys, true)`
+// (schema_statements.rb:1783). The concrete adapters must persist the config
+// hash into `_config` so a `foreignKeys: false` config actually disables FK DDL
+// through the real constructor path — not just a test stub.
+describe("config-hash constructor retains foreignKeys in _config", () => {
+  type FkGuards = {
+    isForeignKeysEnabled(): boolean;
+    isUseForeignKeys(): boolean;
+  };
+  const guards = (adapter: PostgreSQLAdapter | Mysql2Adapter) => adapter as unknown as FkGuards;
+
+  it("PostgreSQLAdapter honors foreignKeys:false and defaults to true", () => {
+    const disabled = new PostgreSQLAdapter({ foreignKeys: false });
+    expect(disabled.supportsForeignKeys()).toBe(true);
+    expect(guards(disabled).isForeignKeysEnabled()).toBe(false);
+    expect(guards(disabled).isUseForeignKeys()).toBe(false);
+
+    const enabled = new PostgreSQLAdapter({});
+    expect(guards(enabled).isForeignKeysEnabled()).toBe(true);
+    expect(guards(enabled).isUseForeignKeys()).toBe(true);
+  });
+
+  it("Mysql2Adapter honors foreignKeys:false and defaults to true", () => {
+    const disabled = new Mysql2Adapter({ foreignKeys: false, _fakeConnection: true } as never);
+    expect(disabled.supportsForeignKeys()).toBe(true);
+    expect(guards(disabled).isForeignKeysEnabled()).toBe(false);
+    expect(guards(disabled).isUseForeignKeys()).toBe(false);
+
+    const enabled = new Mysql2Adapter({ _fakeConnection: true } as never);
+    expect(guards(enabled).isForeignKeysEnabled()).toBe(true);
+    expect(guards(enabled).isUseForeignKeys()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

`SchemaStatements#isForeignKeysEnabled()` read `adapter.config?.foreignKeys`, but
`AbstractAdapter` stores its config in `_config` and exposes no `config` getter,
so the config-driven FK-disable path was inert — an adapter configured
`foreign_keys: false` still emitted `ADD/DROP CONSTRAINT`.

Rails: `foreign_keys_enabled?` is `@config.fetch(:foreign_keys, true)`
(`schema_statements.rb:1783`), and `use_foreign_keys?` gates FK DDL on it
(`schema_statements.rb:1545`) — reading the adapter's real config hash, which
Rails populates via `@config = config` in `AbstractAdapter#initialize`.

## Changes

- `isForeignKeysEnabled()` now reads `adapter._config?.foreignKeys` (default true
  when absent, matching Rails' `fetch(..., true)`).
- Fixed the identical latent bug in the MySQL `SchemaCreation#useForeignKeys`
  visitor path (also fed the real adapter via `this.adapter`).
- **Persisted the config hash into `_config` in the PG and MySQL constructors**
  (`this._config = { ...config }`, mirroring sqlite3's existing
  `this._config = { ...options }` and Rails' `@config = config`). Previously
  these adapters destructured the config hash but never stored it, so
  `_config` stayed `{}` and `foreignKeys: false` never reached the getter on a
  real connection.
- Declared `foreignKeys?: boolean` on the shared `TrailsAdapterOptions`
  (mirrors database.yml `foreign_keys`).

## Tests

- Real-adapter constructor path: `new PostgreSQLAdapter({ foreignKeys: false })`
  and `new Mysql2Adapter({ foreignKeys: false, ... })` no-op FK DDL even though
  `supportsForeignKeys()` is true; default (no key) stays true.
- Abstract path: adapter with `foreignKeys: false` no-ops
  `addForeignKey`/`removeForeignKey` through the real composition.
- MySQL `SchemaCreation` visitor skips FK emission when disabled.

Closes-story: foreign-keys-enabled-reads-adapter-config
