### PR TITLE
refactor(schema): drop duplicate tableAliasLength from SchemaStatements

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -351,6 +351,9 @@ export interface AbstractAdapter {
     fn?: (t: Table) => void | Promise<void>,
   ): Promise<void>;
   tableAliasFor(tableName: string): string;
+  // Provided by the DatabaseLimits mixin (included below); tableAliasFor
+  // resolves it through here rather than a duplicate on SchemaStatements.
+  tableAliasLength(): number;
   nativeDatabaseTypes(): Record<string, unknown>;
   dataSources(): Promise<string[]>;
   isDataSourceExists(name: string): Promise<boolean>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -89,6 +89,18 @@ class SqliteCapturingAdapter extends AbstractAdapter {
 }
 
 describe("SchemaStatements mixed into AbstractAdapter", () => {
+  it("tableAliasFor resolves tableAliasLength via the DatabaseLimits mixin", () => {
+    // SchemaStatements no longer defines tableAliasLength (Rails keeps it only
+    // in DatabaseLimits); the mixed-in adapter still resolves it to 64.
+    const stub = new StubAdapter();
+    expect(stub.tableAliasLength()).toBe(64);
+    expect(stub.tableAliasFor("a.very.long.schema.qualified.table.name")).toBe(
+      "a_very_long_schema_qualified_table_name",
+    );
+    const long = "x".repeat(80);
+    expect(stub.tableAliasFor(long)).toBe("x".repeat(64));
+  });
+
   it("columns() sqlite arm quotes the table name so an embedded quote does not break the PRAGMA", async () => {
     const sqlite = new SqliteCapturingAdapter();
     await sqlite.columns("things");

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -1547,13 +1547,16 @@ export class SchemaStatements {
     return null;
   }
 
-  tableAliasFor(tableName: string): string {
+  // Rails: `table_alias_length` lives only in DatabaseLimits; SchemaStatements
+  // merely uses it (schema_statements.rb:28-29). Resolve it via the mixin host
+  // rather than defining a duplicate that would silently diverge from
+  // DatabaseLimits if an adapter overrode maxIdentifierLength.
+  tableAliasFor(
+    this: SchemaStatements & { tableAliasLength(): number },
+    tableName: string,
+  ): string {
     const maxLen = this.tableAliasLength();
     return tableName.slice(0, maxLen).replace(/\./g, "_");
-  }
-
-  protected tableAliasLength(): number {
-    return 64;
   }
 
   async dataSources(): Promise<string[]> {


### PR DESCRIPTION
## Summary

Rails defines `table_alias_length` **only** in `DatabaseLimits`
(`database_limits.rb:16`, returning `max_identifier_length`); `SchemaStatements`
merely _uses_ it in `table_alias_for` (`schema_statements.rb:28-29`). trails
duplicated it as a `protected tableAliasLength()` on `SchemaStatements`.

Surfaced during #4519: when `include()` flipped to last-included-wins, this
became a real mixin-vs-mixin collision on `AbstractAdapter` (SchemaStatements
included before DatabaseLimits). It is value-safe today (both return 64, no
adapter overrides `maxIdentifierLength`) but is a latent divergence — the two
would silently disagree, include-order-dependent, the moment an adapter
overrode `maxIdentifierLength`.

## Changes

- Remove `tableAliasLength` from `abstract/schema-statements.ts`; `tableAliasFor`
  now resolves it via the DatabaseLimits mixin host (typed `this`).
- Declare `tableAliasLength()` as a mixed-in member on `AbstractAdapter`
  alongside `tableAliasFor`.
- Add a test asserting `tableAliasFor` still resolves to 64 through the mixin.

No behavior change: all adapters still resolve to 64.

Closes-story: schema-statements-duplicate-table-alias-length

## Out of scope (registered as follow-up)

Codex review flagged that Rails' MySQL `SchemaStatements#table_alias_length`
returns 256 (`mysql/schema_statements.rb:135`), and that
`DatabaseLimits#table_alias_length` should dispatch to the *receiver's*
`max_identifier_length` (`abstract/database_limits.rb:15-17`). Both are real
fidelity gaps but **pre-date this PR** — MySQL already resolved to 64 on `main`
(there was never a MySQL override; the mysql host interface only *declares*
`tableAliasLength`). This story's acceptance criteria explicitly mandate "no
behavior change; all still resolve to 64 today", so converging MySQL to 256
belongs in its own PR. Registered as story
`mysql-table-alias-length-256-and-receiver-dispatch` (RFC 0051). This refactor
does not block that follow-up — the mixin path lets the MySQL adapter add a
concrete `tableAliasLength()` override.
