### PR TITLE
fix(type): unscaled/scale-0 decimal reads back arbitrary-precision, not lossy number

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -385,19 +385,19 @@ describe("MigrationTest", () => {
     expect(byName("my_house_population").precision).toBe(2);
 
     try {
-      // Mirrors models/big_number.rb: my_house_population is :integer. Rails
-      // also reads the scale-0 `world_population` column back as an exact
-      // Integer; in trails a scale-0/unscaled decimal read without an explicit
-      // attribute override comes back as a lossy JS number (e.g. 2**62 rounds to
-      // 4611686018427388000), so — exactly as models/numeric_data.rb does for
-      // the same column — declare it :big_integer to get the exact round-trip.
-      // value_of_e (DECIMAL, no precision/scale) is left to the raw column type;
-      // its per-adapter cast (PG exact / SQLite float / others Integer) diverges
-      // in trails (see below) and is asserted only for non-nil here.
+      // Mirrors the inline BigNumber model in migration_test.rb: value_of_e is
+      // declared :integer only on adapters other than PG/SQLite (i.e. MySQL);
+      // my_house_population is always :integer. world_population carries NO
+      // override — Rails reads the scale-0 decimal column back as an exact
+      // Integer, and trails matches now that DecimalWithoutScale inherits
+      // BigIntegerType's arbitrary-precision cast (2**62 round-trips without
+      // JS-number precision loss).
+      const adapterName = adapter.adapterName;
+      const isPgOrSqlite = adapterName === "postgres" || adapterName === "sqlite";
       class BigNumber extends Base {
         static _tableName = "big_numbers";
         static {
-          this.attribute("world_population", "big_integer");
+          if (!isPgOrSqlite) this.attribute("value_of_e", "integer");
           this.attribute("my_house_population", "integer");
           this.adapter = adapter;
         }
@@ -423,6 +423,8 @@ describe("MigrationTest", () => {
       expect((b as any).value_of_e).not.toBeNull();
 
       // world_population round-trips exactly (no precision loss) as Rails' 2**62.
+      // 2**62 exceeds float64's exact-integer range, so DecimalWithoutScale
+      // carries it as a bigint (Rails' unbounded Integer).
       expect(typeof (b as any).world_population).toBe("bigint");
       expect((b as any).world_population).toBe(2n ** 62n);
       expect((b as any).my_house_population).toBe(3);
@@ -433,12 +435,24 @@ describe("MigrationTest", () => {
       expect((b as any).big_bank_balance).toBeInstanceOf(BigDecimal);
       expect(((b as any).big_bank_balance as BigDecimal).toString("F")).toBe("1000234000567.95");
 
-      // Rails additionally asserts value_of_e's exact per-adapter type/value (PG:
-      // BigDecimal 2.71828…; SQLite: BigDecimal float; others: Integer 2). trails'
-      // read of an unscaled decimal column diverges (SQLite returns the truncated
-      // JS number 2, not a float BigDecimal), so the detailed per-adapter value
-      // assertion is omitted pending the decimal-read fidelity story
-      // (0023-surfaced-deviations/unscaled-decimal-read-fidelity).
+      // value_of_e is DECIMAL with precision/scale left out; by the SQL standard
+      // it should truncate to an Integer, but adapters diverge (see Rails'
+      // per-adapter branch):
+      const valueOfE = (b as any).value_of_e;
+      if (adapterName === "postgres") {
+        // PG promotes bare `decimal` to full compile-time precision/scale.
+        expect(valueOfE).toBeInstanceOf(BigDecimal);
+        expect((valueOfE as BigDecimal).toString("F")).toBe("2.7182818284590452353602875");
+      } else if (adapterName === "sqlite") {
+        // SQLite3 stores a float, read back as a BigDecimal within 1e-14.
+        expect(valueOfE).toBeInstanceOf(BigDecimal);
+        expect(
+          Math.abs(Number((valueOfE as BigDecimal).toString("F")) - 2.71828182845905),
+        ).toBeLessThan(0.00000000000001);
+      } else {
+        // SQL standard: an Integer (2), via the :integer attribute override.
+        expect(valueOfE).toBe(2);
+      }
     } finally {
       await ctx.dropTable("big_numbers", { ifExists: true });
     }

--- a/packages/activerecord/src/type/decimal-without-scale.test.ts
+++ b/packages/activerecord/src/type/decimal-without-scale.test.ts
@@ -41,6 +41,15 @@ describe("DecimalWithoutScale", () => {
     expect(type.cast("9999999999")).toBe(9999999999);
   });
 
+  it("carries genuine bignums as bigint without precision loss", () => {
+    const type = new DecimalWithoutScale();
+    // Rails' DecimalWithoutScale < BigInteger reads back an unbounded Integer;
+    // 2**62 exceeds float64's exact-integer range, so it must stay a bigint
+    // (routing through a plain JS number would round to 4611686018427388000).
+    expect(type.cast(2n ** 62n)).toBe(2n ** 62n);
+    expect(type.cast("4611686018427387904")).toBe(2n ** 62n);
+  });
+
   it("typeCastForSchema quotes the value as a string", () => {
     const type = new DecimalWithoutScale();
     expect(type.typeCastForSchema("1.5")).toBe('"1.5"');

--- a/packages/activerecord/src/type/decimal-without-scale.ts
+++ b/packages/activerecord/src/type/decimal-without-scale.ts
@@ -10,18 +10,12 @@ import { BigIntegerType } from "@blazetrails/activemodel";
 export class DecimalWithoutScale extends BigIntegerType {
   override readonly name: string = "decimal";
 
-  // BigIntegerType.castValue returns bigint; DecimalWithoutScale must return
-  // plain number (Ruby to_i semantics) because NUMERIC-without-scale columns
-  // are consumed as numbers by the rest of the stack.
-  protected override castValue(value: unknown): number | null {
-    if (typeof value === "number") {
-      if (isNaN(value) || !isFinite(value)) return null;
-      return Math.trunc(value);
-    }
-    if (typeof value === "bigint") return Number(value);
-    const parsed = parseInt(String(value), 10);
-    return isNaN(parsed) ? null : parsed;
-  }
+  // Rails: `DecimalWithoutScale < BigInteger`, so an unscaled/scale-0 decimal
+  // reads back as an unbounded Ruby Integer. Inherit BigIntegerType.castValue
+  // unchanged — it keeps safe-range values as JS `number` and only carries a
+  // `bigint` for genuine bignums beyond float64's exact-integer range (e.g.
+  // 2**62), so no JS-number precision loss. An earlier override truncated to a
+  // lossy plain `number`; that divergence is what this type must not have.
 
   override type(): string {
     return "decimal";


### PR DESCRIPTION
## What

`DecimalWithoutScale` (unscaled / scale-0 decimal column, no model attribute
override) overrode `castValue` to truncate to a plain JS `number`, losing
precision for large integers (`2**62` → `4611686018427388000`). Rails'
`DecimalWithoutScale < BigInteger` reads such a column back as an unbounded
Ruby Integer.

Remove the override so `DecimalWithoutScale` inherits `BigIntegerType.castValue`
unchanged: safe-range values stay JS `number`, genuine bignums (beyond
float64's exact-integer range) carry a `bigint` — no precision loss.

## Test

Restore the per-adapter `value_of_e` and bare `world_population` assertions in
`migration.test.ts` "add table with decimals" to match Rails
(`migration_test.rb#test_add_table_with_decimals`), dropping the
`:big_integer` / non-nil-only workaround:

- `world_population` (scale-0 decimal, no override) → `bigint` `2**62`.
- `value_of_e` (bare decimal): PG full-precision `BigDecimal`; SQLite float
  `BigDecimal` within 1e-14; MySQL `Integer` `2` (via `:integer` override,
  mirroring the inline Rails `BigNumber` model).

Closes-story: unscaled-decimal-read-fidelity