### PR TITLE
fix(schema): tableName= setter resets _schemaLoaded to force re-reflection

### DIFF
--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1459,6 +1459,13 @@ export function tableName(this: SchemaHost, value?: string): string {
       // the next query rebuilds against the new table.
       (this as { _predicateBuilder?: unknown })._predicateBuilder = null;
       (this as { _findByStatementCache?: unknown })._findByStatementCache = undefined;
+      // Rails reset_column_information also reloads the schema so the new
+      // table's columns are re-reflected. A subclass created with a different
+      // table_name (e.g. `Class.new(Minimalistic) { self.table_name = "aircraft" }`)
+      // inherits the parent's `_schemaLoaded = true` through the prototype
+      // chain and would otherwise never reflect its own table. Shadow the
+      // inherited flag with an own `false` so the next load re-reflects.
+      (this as { _schemaLoaded?: boolean })._schemaLoaded = false;
     }
   }
   return resolveTableName.call(this as any);

--- a/packages/activerecord/src/persistence.test.ts
+++ b/packages/activerecord/src/persistence.test.ts
@@ -2194,7 +2194,9 @@ describe("PersistenceTest", () => {
 
   it("persist inherited class with different table name", async () => {
     class MinimalisticAircraft extends Minimalistic {
-      static _tableName = "aircraft";
+      static {
+        this.tableName = "aircraft";
+      }
     }
     registerModel(MinimalisticAircraft);
 


### PR DESCRIPTION
Rails' `table_name=` runs `reset_column_information` in a connected context, which forces re-reflection of the new table's schema. Trails' `tableName` setter only reset `_predicateBuilder` and `_findByStatementCache`, not `_schemaLoaded`.

This caused a subclass created with a different table name (e.g. `class Sub extends Minimalistic { static { this.tableName = "aircraft"; } }`) to inherit the parent's `_schemaLoaded = true` through the prototype chain and never re-reflect its own table — leaving attribute accessors as Null type and throwing `MissingAttributeError` on write.

Fix: the `tableName` setter now shadows the inherited flag with an own `_schemaLoaded = false` when the table name changes, forcing re-reflection on the next load. The existing `persist inherited class with different table name` test is converged off its `static _tableName` workaround to the real `this.tableName =` setter form.

Closes-story: persistence-tablename-setter-schema-reset