### PR TITLE
feat(type): resolve mysql2 string via adapter-scoped Type.lookup

### DIFF
--- a/packages/activerecord/src/connection-adapters/adapter-scoped-string-registration.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-scoped-string-registration.trails.test.ts
@@ -1,0 +1,36 @@
+/**
+ * trails-only: importing the mysql2 adapter registers the adapter-scoped
+ * `:string`/`:immutable_string`/`:unsigned_integer` cast types via
+ * `Type.register(name, adapter: :mysql2)` (mysql2_adapter.rb:190-198). These
+ * assert the registrations resolve through `Type.lookup(:string, adapter:
+ * :mysql2)` — the path `Mysql2Adapter.initializeTypeMap` uses for
+ * char/varchar/enum/set — without a live MySQL connection. Rails covers the
+ * end-to-end map in mysql_type_lookup_test (adapter-gated in trails).
+ */
+import { it, expect } from "vitest";
+// Side-effect import: loading the concrete adapter runs its module-level
+// `Type.register(..., adapter: "mysql2")` calls.
+import "./mysql2-adapter.js";
+import { StringType, ImmutableStringType as ImmutableString } from "@blazetrails/activemodel";
+import { lookup } from "../type.js";
+import { UnsignedInteger } from "../type/unsigned-integer.js";
+
+it("mysql2 :string coerces booleans to 1/0 and threads limit", () => {
+  const type = lookup("string", { adapter: "mysql2", limit: 255 }) as StringType;
+  expect(type).toBeInstanceOf(StringType);
+  expect(type.limit).toBe(255);
+  expect(type.trueString).toBe("1");
+  expect(type.falseString).toBe("0");
+});
+
+it("mysql2 :immutable_string coerces booleans to 1/0", () => {
+  const type = lookup("immutable_string", { adapter: "mysql2" }) as ImmutableString;
+  expect(type).toBeInstanceOf(ImmutableString);
+  expect(type.trueString).toBe("1");
+  expect(type.falseString).toBe("0");
+});
+
+it("mysql2 :unsigned_integer resolves to UnsignedInteger", () => {
+  const type = lookup("unsigned_integer", { adapter: "mysql2" });
+  expect(type).toBeInstanceOf(UnsignedInteger);
+});

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -117,14 +117,18 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    * Mirrors: Mysql2Adapter#initialize_type_map (mysql2_adapter.rb:40-49).
    *
    * `super` registers the shared MySQL types. On top of that the concrete
-   * mysql2 adapter binds char/varchar/enum/set to a `StringType` whose boolean
-   * coercions are `"1"`/`"0"` rather than the ActiveModel default `"t"`/`"f"`,
-   * so a boolean assigned to a string column round-trips as 1/0 — this mirrors
-   * the `Type.register(:string, adapter: :mysql2)` block. char/varchar thread
-   * `extract_limit(sql_type)` onto the type (`register_type(%r(char)i)`), so
-   * `type_for_attribute(col).limit` reflects the column limit; enum/set register
-   * the limitless string. These are NOT in AbstractMysqlAdapter because they
-   * bind mysql2-specific behavior to a concrete client.
+   * mysql2 adapter resolves char/varchar/enum/set through
+   * `Type.lookup(:string, adapter: :mysql2)`, which returns the adapter-scoped
+   * `StringType` whose boolean coercions are `"1"`/`"0"` rather than the
+   * ActiveModel default `"t"`/`"f"` (see the module-level `Type.register` calls
+   * below), so a boolean assigned to a string column round-trips as 1/0.
+   * char/varchar thread `extract_limit(sql_type)` through the `limit:` kwarg
+   * (`register_type(%r(char)i)`), so `type_for_attribute(col).limit` reflects
+   * the column limit; enum/set look up the limitless string. These are NOT in
+   * AbstractMysqlAdapter because they bind mysql2-specific behavior to a
+   * concrete client.
+   *
+   * @internal
    */
   static override initializeTypeMap(m: TypeMap): void {
     super.initializeTypeMap(m);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -10,8 +10,10 @@ import {
   StatementPool as MysqlStatementPool,
   type MysqlPreparedStatement,
 } from "./abstract-mysql-adapter.js";
-import { StringType } from "@blazetrails/activemodel";
+import { StringType, ImmutableStringType } from "@blazetrails/activemodel";
 import { TypeMap } from "../type/type-map.js";
+import * as Type from "../type.js";
+import { UnsignedInteger } from "../type/unsigned-integer.js";
 import {
   AbstractAdapter,
   Version,
@@ -126,18 +128,12 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
    */
   static override initializeTypeMap(m: TypeMap): void {
     super.initializeTypeMap(m);
-    m.registerType(
-      /char/i,
-      undefined,
-      (sqlType) =>
-        new StringType({ trueString: "1", falseString: "0", limit: this.extractLimit(sqlType) }),
-    );
-    m.registerType(
-      /^enum/i,
-      undefined,
-      () => new StringType({ trueString: "1", falseString: "0" }),
-    );
-    m.registerType(/^set/i, undefined, () => new StringType({ trueString: "1", falseString: "0" }));
+    m.registerType(/char/i, undefined, (sqlType) => {
+      const limit = this.extractLimit(sqlType);
+      return Type.lookup("string", { adapter: "mysql2", limit });
+    });
+    m.registerType(/^enum/i, Type.lookup("string", { adapter: "mysql2" }));
+    m.registerType(/^set/i, Type.lookup("string", { adapter: "mysql2" }));
   }
 
   // Cached liveness state — true until a failure is observed (ping fail,
@@ -2142,3 +2138,24 @@ dirtiesQueryCache(Mysql2Adapter, "executeMutation");
 // so dirty `execInsert` too; the single-column path delegates to
 // `executeMutation` via `super`, where the double-clear is a harmless no-op.
 dirtiesQueryCache(Mysql2Adapter, "execInsert");
+
+// Mirrors: mysql2_adapter.rb:190-198 — adapter-scoped type registrations. The
+// mysql2 `:string`/`:immutable_string` types coerce booleans to `"1"`/`"0"`
+// (not the ActiveModel default `"t"`/`"f"`) so a boolean assigned to a string
+// column round-trips as 1/0; `initializeTypeMap` resolves char/varchar/enum/set
+// through `Type.lookup(:string, adapter: :mysql2)`.
+Type.register("immutable_string", null, { adapter: "mysql2" }, (_symbol, args?) => {
+  return new ImmutableStringType({
+    trueString: "1",
+    falseString: "0",
+    ...((args as Record<string, unknown>) ?? {}),
+  });
+});
+Type.register("string", null, { adapter: "mysql2" }, (_symbol, args?) => {
+  return new StringType({
+    trueString: "1",
+    falseString: "0",
+    ...((args as Record<string, unknown>) ?? {}),
+  });
+});
+Type.register("unsigned_integer", UnsignedInteger, { adapter: "mysql2" });

--- a/packages/activerecord/src/type.ts
+++ b/packages/activerecord/src/type.ts
@@ -106,7 +106,10 @@ export function register(
   _registry.register(typeName, klass, options, block);
 }
 
-export function lookup(symbol: string, options?: { adapter?: string }): Type {
+export function lookup(
+  symbol: string,
+  options?: { adapter?: string; [key: string]: unknown },
+): Type {
   const adapter = options?.adapter ?? currentAdapterName();
   return _registry.lookup(symbol, { ...options, adapter });
 }

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -22248,13 +22248,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/mysql2-adapter.ts",
-    "rubyName": "initialize_type_map",
-    "call": "lookup",
-    "reason": "Equivalent (bucket b): Rails' Type.lookup(:string, adapter: :mysql2) resolves the adapter-scoped Type::String.new(true: '1', false: '0'); trails hasn't ported the adapter-scoped Type.register(:string, adapter: :mysql2) registry, so we construct that mysql2 string inline as new StringType({trueString:'1', falseString:'0'}). Relocated here from abstract-mysql-adapter.ts when the char/varchar/enum/set registrations moved to the concrete adapter (mysql2_adapter.rb:40-49)."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/mysql2-adapter.ts",
     "rubyName": "new_client",
     "call": "db_error",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## What

Ports the adapter-scoped `Type.register` / `Type.lookup` usage for mysql2's
string cast type so `Mysql2Adapter.initializeTypeMap` resolves char/varchar/
enum/set through `Type.lookup("string", { adapter: "mysql2", limit })` instead
of constructing a `StringType` inline.

The adapter-scoped registry (`AdapterSpecificRegistry`, `Registration`,
`Type.register`/`Type.lookup` with the `adapter:` keyword) was already ported;
this wires mysql2 onto it:

- Registers `:string`, `:immutable_string`, and `:unsigned_integer` for
  `adapter: :mysql2` at module scope, mirroring `mysql2_adapter.rb:190-198`.
  The mysql2 string/immutable-string types coerce booleans to `"1"`/`"0"`.
- `initializeTypeMap` now calls `Type.lookup(:string, adapter: :mysql2, limit)`
  for char/varchar and `Type.lookup(:string, adapter: :mysql2)` for enum/set,
  mirroring `mysql2_adapter.rb:40-49`.
- Widens `Type.lookup`'s options type to thread extra kwargs (`limit`).
- Removes the now-satisfied `mysql2-adapter.ts` / `initialize_type_map` /
  `lookup` entry from `call-mismatches-wide-exclude.json`.

`type_for_attribute(varchar_col).limit === 255` behavior is preserved
(verified locally against the static type map).

Closes-story: port-adapter-scoped-type-register-lookup-registry
