### PR TITLE
test(base): port 'column types typecast' to instantiate-with-types shape

### DIFF
--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -123,22 +123,43 @@ export class AttributeSet {
   ): void {
     this.assertNotFrozen();
     const existing = this.attributes.get(name);
-    if (existing && type == null) {
+    if (existing) {
       this.attributes.set(name, existing.withValueFromDatabase(value));
     } else {
-      // Either an unknown column (e.g. a computed/aliased extra `select`) with no
-      // declared cast type, or a supplied override type that must win even for a
-      // known column. Rails' LazyAttributeHash resolves each name via
-      // `additional_types[name] || types[name]`, so the result set's
-      // `column_types` slice takes precedence over the schema type when present;
-      // thread it here when supplied, falling back to the identity `value` type.
-      // Mirrors ActiveModel::AttributeSet::Builder#build_from_database.
+      // An unknown column (e.g. a computed/aliased extra `select`) is not in the
+      // schema, so there is no declared cast type. Rails type-casts it with the
+      // result set's `column_types` slice; thread that type here when supplied,
+      // falling back to the identity `value` type. Mirrors
+      // ActiveModel::AttributeSet::Builder#build_from_database casting unknown
+      // keys via `types[name]`.
       // `fromDatabase` is typed for the full `Type`, but only `deserialize` is
       // exercised for an unknown column — one localized cast here keeps the
       // public param structural and the call sites cast-free.
       const colType = (type as import("./type/value.js").Type) ?? typeRegistry.lookup("value");
       this.attributes.set(name, Attribute.fromDatabase(name, value, colType));
     }
+  }
+
+  /**
+   * Force a database value to be cast through the supplied `type`, replacing any
+   * existing (schema-declared) attribute. Unlike {@link writeFromDatabase}, whose
+   * known-column path keeps the declared cast type, this always wins — mirroring
+   * how Rails' `LazyAttributeHash` resolves each name via
+   * `additional_types[name] || types[name]`, letting an explicit per-attribute
+   * `types` override supersede the schema type. Used only by the public
+   * `instantiate(attributes, types)` entry point; the result-set hydration path
+   * still ignores column types for known columns.
+   */
+  overrideFromDatabase(
+    name: string,
+    value: unknown,
+    type: { deserialize(value: unknown): unknown },
+  ): void {
+    this.assertNotFrozen();
+    this.attributes.set(
+      name,
+      Attribute.fromDatabase(name, value, type as import("./type/value.js").Type),
+    );
   }
 
   writeFromUser(name: string, value: unknown): unknown {

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -123,15 +123,16 @@ export class AttributeSet {
   ): void {
     this.assertNotFrozen();
     const existing = this.attributes.get(name);
-    if (existing) {
+    if (existing && type == null) {
       this.attributes.set(name, existing.withValueFromDatabase(value));
     } else {
-      // An unknown column (e.g. a computed/aliased extra `select`) is not in the
-      // schema, so there is no declared cast type. Rails type-casts it with the
-      // result set's `column_types` slice; thread that type here when supplied,
-      // falling back to the identity `value` type. Mirrors
-      // ActiveModel::AttributeSet::Builder#build_from_database casting unknown
-      // keys via `types[name]`.
+      // Either an unknown column (e.g. a computed/aliased extra `select`) with no
+      // declared cast type, or a supplied override type that must win even for a
+      // known column. Rails' LazyAttributeHash resolves each name via
+      // `additional_types[name] || types[name]`, so the result set's
+      // `column_types` slice takes precedence over the schema type when present;
+      // thread it here when supplied, falling back to the identity `value` type.
+      // Mirrors ActiveModel::AttributeSet::Builder#build_from_database.
       // `fromDatabase` is typed for the full `Type`, but only `deserialize` is
       // exercised for an unknown column — one localized cast here keeps the
       // public param structural and the call sites cast-free.

--- a/packages/activerecord/src/base.test.ts
+++ b/packages/activerecord/src/base.test.ts
@@ -21,7 +21,7 @@ import { Notifications, Logger, TimeWithZone } from "@blazetrails/activesupport"
 import { Temporal } from "@blazetrails/activesupport/temporal";
 import { fixtures } from "./test-helpers/fixtures.js";
 import { withTimezoneConfig } from "./test-helper.js";
-import { IntegerType } from "@blazetrails/activemodel";
+import { IntegerType, Type } from "@blazetrails/activemodel";
 import { CpkBook } from "./test-helpers/models/cpk.js";
 
 vi.stubEnv("AR_NO_AUTO_SCHEMA", "1");
@@ -610,13 +610,29 @@ describe("BasicsTest", () => {
   });
 
   it("column types typecast", async () => {
-    class Developer extends Base {
-      static {
-        this.attribute("salary", "integer");
+    // Rails base_test.rb#test_column_types_typecast: instantiate a record with a
+    // per-attribute `types` override — a custom Type::Value subclass whose cast
+    // always returns "t.lo" — and assert the override wins over the column's
+    // declared type for `author_name`.
+    class Topic extends Base {}
+    const seed = await Topic.create({
+      title: "The First Topic",
+      author_name: "David",
+    } as any);
+    expect((seed as any).author_name).not.toBe("t.lo");
+
+    const attrs = { ...(seed as any).attributes };
+    delete attrs.id;
+
+    class Typecast extends Type {
+      readonly name = "typecast";
+      cast() {
+        return "t.lo";
       }
     }
-    const p = await Developer.create({ salary: "5" } as any);
-    expect((p as any).salary).toBe(5);
+
+    const topic = Topic.instantiate(attrs, { author_name: new Typecast() }) as any;
+    expect(topic.author_name).toBe("t.lo");
   });
 
   it("typecasting aliases", async () => {

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2852,6 +2852,7 @@ export class Base extends Model {
     row: Record<string, unknown>,
     block?: (record: InstanceType<T>) => void,
     columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
+    overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
   ): InstanceType<T> {
     // Delegate to the correct STI subclass when the row carries a present
     // inheritance-column value that names a different class. `inheritance_column`
@@ -2872,6 +2873,7 @@ export class Base extends Model {
         row,
         block as ((record: Base) => void) | undefined,
         columnTypes,
+        overrideTypes,
       ) as InstanceType<T>;
     }
 
@@ -2917,7 +2919,12 @@ export class Base extends Model {
     // Rails' `instantiate(record, column_types)` slice in find_by_sql /
     // JoinDependency#instantiate.
     for (const [key, value] of Object.entries(row)) {
-      record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
+      const override = overrideTypes?.[key];
+      if (override) {
+        record._attributes.overrideFromDatabase(key, value, override);
+      } else {
+        record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
+      }
     }
     // A SELECT that projects only a subset of columns yields a row with just
     // those keys, so hasAttribute() must reflect what was loaded rather than

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -609,6 +609,7 @@ function directInstantiate(
   row: Record<string, unknown>,
   block?: (record: Base) => void,
   columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
+  overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
 ): Base {
   const hadOwnSuppress = Object.prototype.hasOwnProperty.call(klass, "_suppressInitializeCallback");
   const prevSuppress = klass._suppressInitializeCallback;
@@ -639,7 +640,12 @@ function directInstantiate(
   // — mirrors the non-STI Base._instantiate path. Building via `new klass(row)`
   // instead ran every column through the user cast, which rejects raw DB values.
   for (const [key, value] of Object.entries(row)) {
-    record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
+    const override = overrideTypes?.[key];
+    if (override) {
+      record._attributes.overrideFromDatabase(key, value, override);
+    } else {
+      record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
+    }
   }
   narrowToProjectedColumns(klass, record, row);
   record._newRecord = false;
@@ -669,8 +675,15 @@ export function instantiateSti(
   row: Record<string, unknown>,
   block?: (record: Base) => void,
   columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
+  overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
 ): Base {
-  return directInstantiate(discriminateClassForRecord(baseClass, row), row, block, columnTypes);
+  return directInstantiate(
+    discriminateClassForRecord(baseClass, row),
+    row,
+    block,
+    columnTypes,
+    overrideTypes,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -56,6 +56,7 @@ interface PersistenceHost {
     row: Record<string, unknown>,
     block?: (record: any) => void,
     columnTypes?: Record<string, { deserialize(value: unknown): unknown }>,
+    overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
   ): any;
   /** @internal */
   discriminateClassForRecord?(attributes: Record<string, unknown>): PersistenceHost;
@@ -149,13 +150,17 @@ export function instantiate(
   const klass = this.discriminateClassForRecord
     ? this.discriminateClassForRecord(attributes)
     : this;
-  // Schema cast types come from the model's attribute definitions; `columnTypes`
-  // only supplies types for extra/computed select columns absent from the schema,
-  // mirroring Rails' `instantiate(record, column_types)`. Thread the block so it
-  // runs before the find/initialize callbacks (Rails' `init_with_attributes`).
+  // The public `instantiate(attributes, types)` entry supplies an explicit
+  // per-attribute `types` map that must override the schema cast type even for a
+  // known column — Rails' `LazyAttributeHash` resolves `additional_types[name] ||
+  // types[name]`. Pass it as `overrideTypes` (not the result-set `columnTypes`
+  // slice, which the query path threads through `_instantiate` directly and which
+  // is ignored for known columns). Thread the block so it runs before the
+  // find/initialize callbacks (Rails' `init_with_attributes`).
   return klass._instantiate(
     attributes,
     block,
+    undefined,
     columnTypes as Record<string, { deserialize(value: unknown): unknown }>,
   );
 }


### PR DESCRIPTION
Ports `packages/activerecord/src/base.test.ts` "column types typecast" to match
Rails `base_test.rb#test_column_types_typecast`, which exercises the
per-instantiate `types` override rather than create-time column casting.

The test builds a `Topic` from canonical `topics`, then calls
`Base.instantiate(attrs, { author_name: new Typecast() })` with a custom
`Type` subclass whose `cast` returns `"t.lo"`, and asserts the override wins
over the column's declared type for a known column.

## Making the override apply

Rails' `LazyAttributeHash` resolves each name via
`additional_types.fetch(name, types[name])`, so an explicit `types` map
supersedes the schema type for a known column that is present in the values.
trails' result-set hydration path, however, deliberately *ignores* column types
for known columns (its equivalent of Rails'
`column_types.reject { |k,_| attribute_types.key?(k) }`), because the query path
threads the adapter's `column_types` for every column.

So rather than change the shared `writeFromDatabase` (which would re-cast every
reflected column through the raw result type and break enum/bigint/timezone/
serialized casting), this adds an additive `AttributeSet#overrideFromDatabase`
and threads the explicit map as `overrideTypes` **only** from the public
`instantiate(attributes, types)` entry point. The query path calls
`_instantiate` directly and is unaffected.

## Note on omitted keys (re: review)

The override intentionally applies only to keys *present* in the attributes
hash. This matches Rails: for an omitted key, `builder.rb`'s
`default_attribute` / `assign_default_value` takes the
`elsif types.key?(name)` branch, and when `default_attributes[name]` exists
(true for every real schema column) it does `attr.dup` — the schema-typed
default — **not** `Attribute.uninitialized(name, override_type)`. The override
type reaches an omitted key only when it has no schema default. So
`instantiate({ title }, { author_name: custom })` keeps `author_name`'s schema
type in Rails, exactly as here.

Closes-story: port-column-types-typecast-to-instantiate-types-override