### PR TITLE
test(schema-dumper): scope SchemaDumperAdapterTest dumps to own tables

### DIFF
--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -202,15 +202,11 @@ describe("SchemaDumperAdapterTest", () => {
       t.string("title", { null: false });
       t.text("body");
     });
-    const result = await TopLevelDumper.dump(adapter);
+    const result = await TopLevelDumper.dumpTableSchema(adapter, "horses");
     expect(result).toContain("horses");
     expect(result).toContain('"title"');
     expect(result).toContain('"body"');
-    // Adapter-introspection dumps walk the entire canonical schema (~200
-    // tables) on the shared PG worker DB; under 6-fork parallel load this
-    // legitimately exceeds vitest's 5s default. Bump to 60s (I/O contention,
-    // not a logic bug). See project_schema_dumper_trails_pg_schema_migrations_flake.
-  }, 60000);
+  });
 
   it("dumps schema with indexes from adapter", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
@@ -218,19 +214,19 @@ describe("SchemaDumperAdapterTest", () => {
       t.integer("post_id");
     });
     await ctx.addIndex("testings", "post_id", { name: "index_testings_on_post_id" });
-    const result = await TopLevelDumper.dump(adapter);
+    const result = await TopLevelDumper.dumpTableSchema(adapter, "testings");
     expect(result).toContain("addIndex");
     expect(result).toContain("index_testings_on_post_id");
-  }, 60000);
+  });
 
   it("adapter-backed dump emits precision: null for datetime column without precision", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
     await ctx.createTable("octopi", {}, (t) => {
       t.datetime("happened_at", { precision: null });
     });
-    const result = await TopLevelDumper.dump(adapter);
+    const result = await TopLevelDumper.dumpTableSchema(adapter, "octopi");
     expect(result).toMatch(/t\.datetime\("happened_at"[^}]*precision\s*:\s*null/);
-  }, 60000);
+  });
 
   it("adapter-backed dump preserves explicit string limit through AdapterSchemaSource", async () => {
     // Guards the U2 type/sqlType split: emitTable resolves the limit from the
@@ -241,9 +237,9 @@ describe("SchemaDumperAdapterTest", () => {
     await ctx.createTable("barcodes", {}, (t) => {
       t.string("code", { limit: 10 });
     });
-    const result = await TopLevelDumper.dump(adapter);
+    const result = await TopLevelDumper.dumpTableSchema(adapter, "barcodes");
     expect(result).toMatch(/t\.string\("code"[^}]*limit\s*:\s*10/);
-  }, 60000);
+  });
 
   it("skips internal tables when dumping from adapter", async () => {
     const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");


### PR DESCRIPTION
## Summary

`SchemaDumperAdapterTest` in `schema-dumper.trails.test.ts` rode the full
canonical schema and its adapter-introspection cases dumped **all ~200
canonical tables** via `TopLevelDumper.dump(adapter)`, blowing vitest's 5s
default under 6-worker PG fork load. PR #4628 masked it with a `60000ms`
per-test timeout band-aid.

This scopes the four scopeable cases to `dumpTableSchema(adapter, table)` —
the clean pattern the sibling `scope-full-schema-dump-tests-off-empty-db`
(PR #4547) introduced — so each test introspects only the table it built,
and drops the `60000ms` timeout from those cases:

- `dumps schema from adapter introspection` → `horses`
- `dumps schema with indexes from adapter` → `testings`
- `adapter-backed dump emits precision: null for datetime column without precision` → `octopi`
- `adapter-backed dump preserves explicit string limit through AdapterSchemaSource` → `barcodes`

`skips internal tables when dumping from adapter` stays a full-DB dump (its
`not.toContain("schema_migrations")` / `ar_internal_metadata` assertions test
full-DB internal-table filtering) and keeps its timeout headroom.

All assertions intact; no tests renamed.

## Verification

Green on PG locally: `ARCONN=postgresql pnpm vitest run packages/activerecord/src/schema-dumper.trails.test.ts -t "SchemaDumperAdapterTest"` — 10 passed.

Closes-story: scope-schema-dumper-adapter-test-dumps