### PR TITLE
fix(sqlite): bind integer-valued number as SQLITE_INTEGER, not FLOAT

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
@@ -34,4 +34,10 @@ describe("SQLite3Adapter integer bind serialization", () => {
     const rows = await adapter.execute("SELECT typeof(?) AS t", [1.5]);
     expect(rows[0].t).toBe("real");
   });
+
+  it("binds a boolean as SQLITE_INTEGER", async () => {
+    const rows = await adapter.execute("SELECT typeof(?) AS t, LOWER(?) AS l", [true, true]);
+    expect(rows[0].t).toBe("integer");
+    expect(rows[0].l).toBe("1");
+  });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
+import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+
+// The better-sqlite3 driver binds every JS number as SQLITE_FLOAT, so an
+// integer-valued bind like `1` would serialize as `real` and `LOWER(?)` would
+// yield `'1.0'` — diverging from MRI's sqlite3 gem, which binds a Ruby Integer
+// as SQLITE_INTEGER (`LOWER(1) => '1'`). The adapter's type cast converts
+// integer-valued numbers to BigInt so they bind as SQLITE_INTEGER.
+describe("SQLite3Adapter integer bind serialization", () => {
+  let adapter: AbstractSQLite3Adapter;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "trails-sqlite-intbind-"));
+    adapter = new BetterSQLite3Adapter(path.join(tmpDir, "db.sqlite3"));
+  });
+
+  afterEach(async () => {
+    await adapter.close();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("binds an integer-valued number as SQLITE_INTEGER", async () => {
+    const rows = await adapter.execute("SELECT typeof(?) AS t, LOWER(?) AS l", [1, 1]);
+    expect(rows[0].t).toBe("integer");
+    expect(rows[0].l).toBe("1");
+  });
+
+  it("binds a non-integer number as SQLITE_FLOAT", async () => {
+    const rows = await adapter.execute("SELECT typeof(?) AS t", [1.5]);
+    expect(rows[0].t).toBe("real");
+  });
+});

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -5,7 +5,7 @@ import type {
   SqliteOpenConfig,
   SqliteStatement,
 } from "../sqlite-adapter.js";
-import { Nodes, Visitors } from "@blazetrails/arel";
+import { Visitors } from "@blazetrails/arel";
 import type { AbstractAdapter as DatabaseAdapter } from "./abstract-adapter.js";
 import type { InsertBuilder } from "../insert-all.js";
 import type { AdapterName } from "./abstract-adapter.js";
@@ -178,44 +178,6 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
 
   get schemaCreation(): SQLite3SchemaCreation {
     return (this._sqlite3SchemaCreation ??= new SQLite3SchemaCreation("sqlite", this));
-  }
-
-  /**
-   * Mirrors: AbstractAdapter#case_insensitive_comparison
-   * (abstract_adapter.rb:814) — look up the column and only wrap both sides in
-   * `LOWER()` when `can_perform_case_insensitive_comparison_for?` is true,
-   * otherwise fall back to plain equality.
-   *
-   * Rails' SQLite3Adapter inherits the abstract `can_perform...? => true`, so on
-   * MRI a `LOWER(int_col) = LOWER(?)` comparison still matches: the sqlite3 gem
-   * binds a Ruby Integer as SQLITE_INTEGER, and `LOWER(1)` yields the text `'1'`
-   * on both sides. Our better-sqlite3 driver binds a JS number as SQLITE_FLOAT,
-   * so `LOWER(?)` yields `'1.0'` and never matches `LOWER(int_col)` = `'1'` —
-   * silently missing integer scope/attribute collisions
-   * (uniqueness_validation_test.rb `test_validate_case_insensitive_uniqueness`,
-   * `:parent_id`). Restricting the `LOWER()` form to text columns converges the
-   * behavior with Rails without touching the driver's numeric binding.
-   * @internal
-   */
-  override async caseInsensitiveComparison(
-    attribute: Nodes.Attribute,
-    value: unknown,
-  ): Promise<Nodes.Node> {
-    const column = await this.columnForAttribute(attribute);
-    if (column && this.canPerformCaseInsensitiveComparisonFor(column)) {
-      return attribute.lower().eq((attribute.relation as any).lower(value));
-    }
-    return attribute.eq(value);
-  }
-
-  /**
-   * Only text columns can be meaningfully lowercased; non-text columns (integer,
-   * float, date, …) fall back to plain equality. See caseInsensitiveComparison
-   * for why this diverges structurally from Rails' unconditional `true`.
-   * @internal
-   */
-  override canPerformCaseInsensitiveComparisonFor(column: { type?: string | null }): boolean {
-    return column.type === "string" || column.type === "text";
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -215,8 +215,8 @@ describe("SQLite3::Quoting", () => {
 
   describe("typeCast", () => {
     it("converts booleans to 1/0", () => {
-      expect(typeCast(true)).toBe(1);
-      expect(typeCast(false)).toBe(0);
+      expect(typeCast(true)).toBe(1n);
+      expect(typeCast(false)).toBe(0n);
     });
 
     it("converts non-finite numbers to null", () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -224,9 +224,15 @@ describe("SQLite3::Quoting", () => {
       expect(typeCast(NaN)).toBe(null);
     });
 
-    it("passes through strings and numbers", () => {
+    it("passes through strings and floats", () => {
       expect(typeCast("hello")).toBe("hello");
-      expect(typeCast(42)).toBe(42);
+      expect(typeCast(4.2)).toBe(4.2);
+    });
+
+    it("converts integer-valued numbers to BigInt so they bind as SQLITE_INTEGER", () => {
+      expect(typeCast(42)).toBe(42n);
+      expect(typeCast(0)).toBe(0n);
+      expect(typeCast(-7)).toBe(-7n);
     });
 
     it("returns null for symbol without description", () => {

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -177,8 +177,16 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
     // Ruby Integer as SQLITE_INTEGER, so `LOWER(1)` yields `'1'`. Handing the
     // driver a BigInt makes it bind SQLITE_INTEGER, converging the text-forcing
     // (e.g. `LOWER(col) = LOWER(?)`) path with Rails. Non-integer numbers keep
-    // binding as float. Rails: SQLite3::Quoting#_type_cast leaves the numeric
-    // type distinction to the type-cast layer above the driver.
+    // binding as float.
+    //
+    // Fidelity boundary: MRI keys the INTEGER/FLOAT choice off the Ruby object
+    // class (Integer vs Float) set by the type-cast layer, whereas here both
+    // arrive as an indistinguishable JS number, so we key off the value. A
+    // whole-valued Float (e.g. a `2.0` from a float/decimal column) therefore
+    // binds as INTEGER rather than FLOAT — observable only through a
+    // text-forcing function (`LOWER(2.0)` → `'2'` not `'2.0'`), which is not a
+    // path AR generates for numeric columns; numeric comparisons coerce and are
+    // unaffected.
     return Number.isInteger(value) ? BigInt(value) : value;
   }
   if (typeof value === "string" || typeof value === "bigint") return value;

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -169,7 +169,18 @@ export function quoteDefaultExpression(this: QuotingDispatchHost | void, value: 
 export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   if (value === null || value === undefined) return null;
   if (typeof value === "boolean") return value ? unquotedTrue() : unquotedFalse();
-  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "number") {
+    if (!Number.isFinite(value)) return null;
+    // better-sqlite3 binds every JS number as SQLITE_FLOAT (there is no
+    // integer/float distinction in JS), so an integer-valued number like `1`
+    // binds as `real` and `LOWER(?)` yields `'1.0'`. MRI's sqlite3 gem binds a
+    // Ruby Integer as SQLITE_INTEGER, so `LOWER(1)` yields `'1'`. Handing the
+    // driver a BigInt makes it bind SQLITE_INTEGER, converging the text-forcing
+    // (e.g. `LOWER(col) = LOWER(?)`) path with Rails. Non-integer numbers keep
+    // binding as float. Rails: SQLite3::Quoting#_type_cast leaves the numeric
+    // type distinction to the type-cast layer above the driver.
+    return Number.isInteger(value) ? BigInt(value) : value;
+  }
   if (typeof value === "string" || typeof value === "bigint") return value;
   // Rails SQLite3::Quoting#_type_cast: `when BigDecimal then value.to_f` — a
   // float, NOT the abstract adapter's `value.to_s("F")` string. (quote() still

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -168,7 +168,14 @@ export function quoteDefaultExpression(this: QuotingDispatchHost | void, value: 
 
 export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
   if (value === null || value === undefined) return null;
-  if (typeof value === "boolean") return value ? unquotedTrue() : unquotedFalse();
+  // Rails routes booleans through `type_cast` to `unquoted_true` /
+  // `unquoted_false`, which SQLite defines as the Ruby Integers `1` / `0`
+  // (sqlite3/quoting.rb) — so they bind as SQLITE_INTEGER just like any other
+  // integer. Return BigInt so better-sqlite3 binds INTEGER rather than FLOAT;
+  // otherwise `LOWER(?)` on a boolean bind would serialize `1.0` / `0.0` and a
+  // `case_sensitive: false` uniqueness check on a boolean column would miss
+  // collisions (the same divergence the integer branch below fixes).
+  if (typeof value === "boolean") return BigInt(value ? unquotedTrue() : unquotedFalse());
   if (typeof value === "number") {
     if (!Number.isFinite(value)) return null;
     // better-sqlite3 binds every JS number as SQLITE_FLOAT (there is no

--- a/packages/activerecord/src/log-subscriber.trails.test.ts
+++ b/packages/activerecord/src/log-subscriber.trails.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+import { LogSubscriber } from "./log-subscriber.js";
+import {
+  LogSubscriber as BaseLogSubscriber,
+  NotificationEvent as Event,
+  Logger,
+} from "@blazetrails/activesupport";
+import { Temporal } from "@blazetrails/activesupport/temporal";
+
+// Trails-only: integer binds type-cast to BigInt (so SQLite binds them as
+// SQLITE_INTEGER). Rails renders a bound Integer bare via `binds.inspect`,
+// while a JSON serializer would quote it. These tests pin that a BigInt bind
+// logs as bare digits AND that a string bind which resembles the internal
+// bigint marker is never corrupted into a bare number.
+class CapturingLogger extends Logger {
+  messages: string[] = [];
+  constructor() {
+    super(null);
+  }
+  override debug(message?: string | (() => string)): boolean {
+    this.messages.push(typeof message === "function" ? message() : (message ?? ""));
+    return true;
+  }
+}
+
+class TestSubscriber extends LogSubscriber {
+  static logger: Logger | null = null;
+  override get logger(): Logger | null {
+    return TestSubscriber.logger;
+  }
+}
+
+function makeEvent(payload: Record<string, unknown>): Event {
+  const start = Temporal.Now.instant();
+  const event = new Event("sql.active_record", start, payload);
+  event.finish(start);
+  Object.defineProperty(event, "duration", { get: () => 0.0, configurable: true });
+  return event;
+}
+
+describe("LogSubscriber bigint bind rendering (trails)", () => {
+  let logger: CapturingLogger;
+  let subscriber: TestSubscriber;
+
+  beforeEach(() => {
+    logger = new CapturingLogger();
+    TestSubscriber.logger = logger;
+    BaseLogSubscriber.colorizeLogging = false;
+    LogSubscriber.colorizeLogging = false;
+    subscriber = new TestSubscriber();
+  });
+
+  afterEach(() => {
+    TestSubscriber.logger = null;
+  });
+
+  it("renders a bigint bind as bare digits", () => {
+    subscriber.sql(
+      makeEvent({
+        sql: "select * from topics where id = ?",
+        name: "SQL",
+        binds: [null],
+        type_casted_binds: [10n],
+      }),
+    );
+    expect(logger.messages[0]).toContain("[[null,10]]");
+  });
+
+  it("does not corrupt a string bind that resembles the bigint marker", () => {
+    subscriber.sql(
+      makeEvent({
+        sql: "select * from topics where title = ?",
+        name: "SQL",
+        binds: [null],
+        type_casted_binds: ["@bigint@123@bigint@"],
+      }),
+    );
+    expect(logger.messages[0]).toContain('[[null,"@bigint@123@bigint@"]]');
+  });
+
+  it("renders bigint bare while preserving a colliding string in the same log", () => {
+    subscriber.sql(
+      makeEvent({
+        sql: "select * from topics where id = ? and title = ?",
+        name: "SQL",
+        binds: [null, null],
+        type_casted_binds: [7n, "@bigint@7@bigint@"],
+      }),
+    );
+    expect(logger.messages[0]).toContain('[[null,7],[null,"@bigint@7@bigint@"]]');
+  });
+});

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -30,19 +30,24 @@ function byteLength(value: unknown): number {
  * bind values. Integer binds now type-cast to BigInt (SQLite binds them as
  * SQLITE_INTEGER), and Rails renders a bound Integer bare — `[["id", 10]]` —
  * so we emit the exact decimal digits unquoted rather than JSON's quoted
- * `"10"`. The replacer wraps each bigint's digits in a NUL-delimited sentinel,
- * then a final pass strips the surrounding quotes and sentinel. A real string
- * bind containing NUL is escaped by JSON.stringify (as \u0000), so the
- * sentinel can never collide with user data.
+ * `"10"` (Rails renders binds via `binds.inspect`, log_subscriber.rb:65-78).
+ *
+ * We wrap each bigint's digits in a marker, then strip the marker plus its
+ * surrounding quotes. The marker is plain ASCII (JSON never escapes it, so it
+ * appears identically in the output) and is extended until it is provably
+ * absent from a probe serialization of the same data — so the unwrap only ever
+ * matches our own sentinels and can never corrupt a string bind that resembles
+ * the marker. (A fixed sentinel is reproducible by user data; this one is not.)
  */
-const BIGINT_SENTINEL = String.fromCharCode(0);
 function safeJsonStringify(value: unknown): string {
-  const s = JSON.stringify(value, (_key, v) =>
-    typeof v === "bigint" ? `${BIGINT_SENTINEL}${v.toString()}${BIGINT_SENTINEL}` : v,
+  const probe = JSON.stringify(value, (_key, v) => (typeof v === "bigint" ? v.toString() : v));
+  let marker = "@bigint@";
+  while (probe.includes(marker)) marker += "@";
+  const wrapped = JSON.stringify(value, (_key, v) =>
+    typeof v === "bigint" ? `${marker}${v.toString()}${marker}` : v,
   );
-  // JSON.stringify escapes the NUL sentinel to the literal \u0000 sequence in
-  // the output, so unwrap that escaped form (not a raw NUL) back to bare digits.
-  return s.replace(/"\\u0000(-?\d+)\\u0000"/g, "$1");
+  const escaped = marker.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return wrapped.replace(new RegExp(`"${escaped}(-?\\d+)${escaped}"`, "g"), "$1");
 }
 
 let _baseResolver: (() => any) | null = null;

--- a/packages/activerecord/src/log-subscriber.ts
+++ b/packages/activerecord/src/log-subscriber.ts
@@ -26,11 +26,23 @@ function byteLength(value: unknown): number {
 }
 
 /**
- * JSON.stringify that handles bigint values (converts to string)
- * so logging never throws on valid bind values.
+ * JSON.stringify that handles bigint values so logging never throws on valid
+ * bind values. Integer binds now type-cast to BigInt (SQLite binds them as
+ * SQLITE_INTEGER), and Rails renders a bound Integer bare — `[["id", 10]]` —
+ * so we emit the exact decimal digits unquoted rather than JSON's quoted
+ * `"10"`. The replacer wraps each bigint's digits in a NUL-delimited sentinel,
+ * then a final pass strips the surrounding quotes and sentinel. A real string
+ * bind containing NUL is escaped by JSON.stringify (as \u0000), so the
+ * sentinel can never collide with user data.
  */
+const BIGINT_SENTINEL = String.fromCharCode(0);
 function safeJsonStringify(value: unknown): string {
-  return JSON.stringify(value, (_key, v) => (typeof v === "bigint" ? v.toString() : v));
+  const s = JSON.stringify(value, (_key, v) =>
+    typeof v === "bigint" ? `${BIGINT_SENTINEL}${v.toString()}${BIGINT_SENTINEL}` : v,
+  );
+  // JSON.stringify escapes the NUL sentinel to the literal \u0000 sequence in
+  // the output, so unwrap that escaped form (not a raw NUL) back to bare digits.
+  return s.replace(/"\\u0000(-?\d+)\\u0000"/g, "$1");
 }
 
 let _baseResolver: (() => any) | null = null;


### PR DESCRIPTION
## Summary

better-sqlite3 binds every JS `number` as `SQLITE_FLOAT` (JS has no
integer/float distinction), so an integer-valued bind like `1` serialized as
`typeof(?) => 'real'` and `LOWER(?) => '1.0'`. MRI's sqlite3 gem binds a Ruby
`Integer` as `SQLITE_INTEGER`, so `LOWER(1) => '1'`. This only surfaced where a
bind flows through a text-forcing function like `LOWER()` — the uniqueness
case-insensitive path (`LOWER(col) = LOWER(?)`) was the first victim (integer
`parent_id` collision silently missed, worked around in #4616).

## Changes

- `sqlite3/quoting.ts` `typeCast`: convert integer-valued finite numbers to
  `BigInt`, which better-sqlite3 binds as `SQLITE_INTEGER`. Non-integer numbers
  keep binding as float; `BigDecimal`/decimal handling is unchanged.
- Drop the `#4616` SQLite `caseInsensitiveComparison` /
  `canPerformCaseInsensitiveComparisonFor` overrides — the base adapter now
  emits `LOWER(col) = LOWER(?)` unconditionally, matching Rails'
  `sqlite3_adapter.rb` (which never overrides
  `can_perform_case_insensitive_comparison_for?`).
- New `sqlite3-adapter.integer-bind.test.ts` asserts `typeof(?) => 'integer'`
  and `LOWER(?) => '1'` for an integer bind, and `'real'` for `1.5`.

`uniqueness-validation.test.ts` "validate case insensitive uniqueness" stays
green via the driver fix rather than the workaround.

Closes-story: sqlite-integer-bind-serializes-as-float
