### PR TITLE
refactor(schema): abstract SchemaCreation quotedColumns delegates to connection

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -266,6 +266,21 @@ export interface AbstractAdapter {
     columnName: string | string[],
     options?: Record<string, unknown>,
   ): Promise<[IndexDefinition, string | undefined, boolean]>;
+  /** @internal */
+  quotedColumnsForIndex(columnNames: string[], options?: Record<string, unknown>): string;
+  /** @internal */
+  optionsForIndexColumns(
+    options: string | Record<string, string> | undefined,
+  ): (col: string) => string | undefined;
+  /** @internal */
+  addOptionsForIndexColumns(
+    quotedColumns: Map<string, string>,
+    options?: {
+      order?: string | Record<string, string>;
+      opclass?: string | Record<string, string>;
+      length?: number | Record<string, number>;
+    },
+  ): Map<string, string>;
   removeIndex(
     tableName: string,
     columnOrOptions?:

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.test.ts
@@ -84,6 +84,53 @@ describe("SchemaCreation#quotedColumnsForIndex sub-part length gating", () => {
   }
 });
 
+describe("SchemaCreation#quotedColumns delegates to the connection", () => {
+  // Rails' abstract SchemaCreation delegates :quoted_columns_for_index to @conn
+  // (schema_creation.rb:18). When a real adapter is threaded as the host, the
+  // visitor must route column quoting through it rather than re-deriving the
+  // order/opclass decoration inline — that's the single source of truth
+  // (SchemaStatements#quoted_columns_for_index -> add_options_for_index_columns).
+  const host = {
+    quoteIdentifier: (c: string) => `"${c}"`,
+    quoteTableName: (t: string) => `"${t}"`,
+    quoteDefaultExpression: (v: unknown) => String(v),
+    quotedColumnsForIndex(cols: string[], options: any) {
+      // Stand-in for the connection's decoration, incl. PG opclass folding.
+      // Mirrors options_for_index_columns: a String opclass applies to every
+      // column, a Record keys per-column (IndexDefinition#conciseOptions
+      // collapses a uniform Record to a String).
+      const opc = (c: string) =>
+        typeof options.opclass === "string" ? options.opclass : options.opclass?.[c];
+      return cols.map((c) => `"${c}" ${opc(c) ?? "DEFAULT_OPS"}`).join(", ");
+    },
+  };
+
+  it("routes an array column set through host.quotedColumnsForIndex", () => {
+    const idx = new IndexDefinition("posts", "index_posts_on_title", false, ["title"], {
+      opclasses: { title: "text_pattern_ops" },
+    });
+    const sql = (new SchemaCreation("postgres", host as any) as any).visitCreateIndexDefinition(
+      new CreateIndexDefinition(idx, false),
+    );
+    expect(sql).toContain('("title" text_pattern_ops)');
+  });
+
+  it("emits a String column set verbatim without delegating", () => {
+    const idx = new IndexDefinition(
+      "posts",
+      "index_posts_on_expr",
+      false,
+      "lower(title)" as any,
+      {},
+    );
+    const sql = (new SchemaCreation("postgres", host as any) as any).visitCreateIndexDefinition(
+      new CreateIndexDefinition(idx, false),
+    );
+    expect(sql).toContain("(lower(title))");
+    expect(sql).not.toContain("DEFAULT_OPS");
+  });
+});
+
 describe("SchemaCreation#typeToSql decimal precision/scale", () => {
   it("raises when a decimal scale is given without a precision", () => {
     expect(() => new SchemaCreation("sqlite").typeToSql("decimal", { scale: 2 })).toThrow(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -297,12 +297,12 @@ export class SchemaCreation {
    * Rails delegates `quoted_columns_for_index` to `@conn`
    * (abstract/schema_creation.rb:18), whose single source of truth is
    * `SchemaStatements#quoted_columns_for_index` → `add_options_for_index_columns`
-   * (sort order in the base, opclass folded in by the PG override). When the
-   * real adapter is threaded as the host it exposes that method, so route
-   * through it. Fall back to inline identifier quoting + sort-order/opclass
-   * decoration on the host-less unit-test path (only the SchemaQuoter shim is
-   * wired). Sub-part index lengths (`col(N)`) are MySQL-only and are never
-   * applied here — MySQL uses its own SchemaCreation `quotedColumns` override.
+   * (sort order in the base, opclass folded in by the PG override, sub-part
+   * length by MySQL). When the real adapter is threaded as the host it exposes
+   * that method, so route through it — this is the sole decoration path for
+   * every concrete adapter. Fall back to bare identifier quoting on the
+   * host-less unit-test path (only the SchemaQuoter shim is wired), mirroring
+   * the parallel `quotedIncludeColumns` delegation.
    * @internal
    */
   protected quotedColumnsForIndex(
@@ -319,18 +319,7 @@ export class SchemaCreation {
     if (typeof host.quotedColumnsForIndex === "function") {
       return host.quotedColumnsForIndex(columnNames, options);
     }
-    return columnNames
-      .map((c) => {
-        let col = this.adapter.quoteIdentifier(c);
-        if (this.supportsIndexSortOrder()) {
-          const order = typeof options.order === "string" ? options.order : options.order?.[c];
-          if (order) col += ` ${order.toUpperCase()}`;
-        }
-        const opc = typeof options.opclass === "string" ? options.opclass : options.opclass?.[c];
-        if (this.adapterName === "postgres" && opc) col += ` ${opc}`;
-        return col;
-      })
-      .join(", ");
+    return columnNames.map((c) => this.adapter.quoteIdentifier(c)).join(", ");
   }
 
   protected visitForeignKeyDefinition(o: ForeignKeyDefinition): string {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-creation.ts
@@ -16,6 +16,7 @@ import {
   AddColumnDefinition,
   AlterTable,
   CreateIndexDefinition,
+  IndexDefinition,
   ForeignKeyDefinition,
   CheckConstraintDefinition,
   TableDefinition,
@@ -283,18 +284,7 @@ export class SchemaCreation {
       `${this.adapter.quoteIdentifier(index.name)} ON ${this.adapter.quoteTableName(index.table)}`,
     );
     if (this.supportsIndexUsing() && index.using) parts.push(`USING ${index.using}`);
-    // Rails `quoted_columns`: a String column set is an expression, emitted
-    // verbatim (e.g. "remind_at, place_id", "(data->'foo')"); otherwise each
-    // column is quoted with its length/order/opclass decoration.
-    const columns =
-      typeof index.columns === "string"
-        ? index.columns
-        : this.quotedColumnsForIndex(index.columns, {
-            lengths: index.lengths,
-            orders: index.orders,
-            opclasses: index.opclasses,
-          });
-    parts.push(`(${columns})`);
+    parts.push(`(${this.quotedColumns(index)})`);
     if (this.supportsIndexInclude() && index.include && index.include.length > 0) {
       parts.push(`INCLUDE (${this.quotedIncludeColumns(index.include)})`);
     }
@@ -304,30 +294,39 @@ export class SchemaCreation {
   }
 
   /**
-   * Mirrors Rails' abstract `quoted_columns_for_index`: quote each column name
-   * and append its order/opclass decoration. Sub-part index lengths (`col(N)`)
-   * are MySQL-only and are NOT applied here — Rails decorates them exclusively
-   * in `AbstractMysqlAdapter#add_index_length`, and the MySQL SchemaCreation's
-   * `quotedColumns` override carries that in trails. Applying `length` on
-   * PostgreSQL/SQLite emits invalid DDL (`("name"(10))`).
+   * Rails delegates `quoted_columns_for_index` to `@conn`
+   * (abstract/schema_creation.rb:18), whose single source of truth is
+   * `SchemaStatements#quoted_columns_for_index` → `add_options_for_index_columns`
+   * (sort order in the base, opclass folded in by the PG override). When the
+   * real adapter is threaded as the host it exposes that method, so route
+   * through it. Fall back to inline identifier quoting + sort-order/opclass
+   * decoration on the host-less unit-test path (only the SchemaQuoter shim is
+   * wired). Sub-part index lengths (`col(N)`) are MySQL-only and are never
+   * applied here — MySQL uses its own SchemaCreation `quotedColumns` override.
+   * @internal
    */
   protected quotedColumnsForIndex(
     columnNames: string[],
     options: {
-      lengths: number | Record<string, number>;
-      orders: string | Record<string, string>;
-      opclasses: string | Record<string, string>;
+      length?: number | Record<string, number>;
+      order?: string | Record<string, string>;
+      opclass?: string | Record<string, string>;
     },
   ): string {
+    const host = this.adapter as SchemaQuoter & {
+      quotedColumnsForIndex?(cols: string[], options: Record<string, unknown>): string;
+    };
+    if (typeof host.quotedColumnsForIndex === "function") {
+      return host.quotedColumnsForIndex(columnNames, options);
+    }
     return columnNames
       .map((c) => {
         let col = this.adapter.quoteIdentifier(c);
         if (this.supportsIndexSortOrder()) {
-          const order = typeof options.orders === "string" ? options.orders : options.orders[c];
+          const order = typeof options.order === "string" ? options.order : options.order?.[c];
           if (order) col += ` ${order.toUpperCase()}`;
         }
-        const opc =
-          typeof options.opclasses === "string" ? options.opclasses : options.opclasses[c];
+        const opc = typeof options.opclass === "string" ? options.opclass : options.opclass?.[c];
         if (this.adapterName === "postgres" && opc) col += ` ${opc}`;
         return col;
       })
@@ -564,10 +563,16 @@ export class SchemaCreation {
     return `ADD ${this.visitCheckConstraintDefinition(o)}`;
   }
 
-  /** @internal */
-  protected quotedColumns(o: { columns: string | string[] }): string {
-    if (typeof o.columns === "string") return o.columns;
-    return o.columns.map((c) => this.adapter.quoteIdentifier(c)).join(", ");
+  /**
+   * Rails' `quoted_columns` (abstract/schema_creation.rb:133): a String column
+   * set is an expression emitted verbatim (e.g. "remind_at, place_id",
+   * "(data->'foo')"); otherwise delegate to `quoted_columns_for_index`.
+   * @internal
+   */
+  protected quotedColumns(o: IndexDefinition): string {
+    return typeof o.columns === "string"
+      ? o.columns
+      : this.quotedColumnsForIndex(o.columns, o.columnOptions());
   }
 
   /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -2197,7 +2197,11 @@ export class SchemaStatements {
   /** @internal */
   addOptionsForIndexColumns(
     quotedColumns: Map<string, string>,
-    options: { order?: string | Record<string, string> } = {},
+    options: {
+      order?: string | Record<string, string>;
+      opclass?: string | Record<string, string>;
+      length?: number | Record<string, number>;
+    } = {},
   ): Map<string, string> {
     const adapter = this.adapter as any;
     if (typeof adapter.supportsIndexSortOrder === "function" && adapter.supportsIndexSortOrder()) {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4611,26 +4611,40 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return () => this.changeColumnNull(tableName, columnName, nullable, defaultValue);
   }
 
-  /** @internal */
+  /**
+   * Mirrors PostgreSQL::SchemaStatements#add_index_opclass
+   * (postgresql/schema_statements.rb:1066): appends each column's operator class
+   * to its quoted form.
+   * @internal
+   */
   addIndexOpclass(
-    quotedColumns: Record<string, string>,
-    options: Record<string, unknown> = {},
-  ): void {
-    const opclasses = options.opclass as Record<string, string> | undefined;
-    if (!opclasses) return;
-    for (const [name] of Object.entries(quotedColumns)) {
-      const opclass = opclasses[name];
-      if (opclass) quotedColumns[name] += ` ${opclass}`;
+    quotedColumns: Map<string, string>,
+    options: { opclass?: string | Record<string, string> } = {},
+  ): Map<string, string> {
+    const opclasses = this.optionsForIndexColumns(options.opclass);
+    for (const [name] of quotedColumns) {
+      const opclass = opclasses(name);
+      if (opclass) quotedColumns.set(name, `${quotedColumns.get(name)} ${opclass}`);
     }
+    return quotedColumns;
   }
 
-  /** @internal */
+  /**
+   * Mirrors PostgreSQL::SchemaStatements#add_options_for_index_columns
+   * (postgresql/schema_statements.rb:1073): folds in opclass, then falls through
+   * to the base (sort order) via `super`.
+   * @internal
+   */
   addOptionsForIndexColumns(
-    quotedColumns: Record<string, string>,
-    options: Record<string, unknown> = {},
-  ): Record<string, string> {
-    this.addIndexOpclass(quotedColumns, options);
-    return quotedColumns;
+    quotedColumns: Map<string, string>,
+    options: {
+      order?: string | Record<string, string>;
+      opclass?: string | Record<string, string>;
+      length?: number | Record<string, number>;
+    } = {},
+  ): Map<string, string> {
+    quotedColumns = this.addIndexOpclass(quotedColumns, options);
+    return super.addOptionsForIndexColumns(quotedColumns, options);
   }
 
   async exclusionConstraints(tableName: string): Promise<ExclusionConstraintDefinition[]> {

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -340,12 +340,19 @@ export interface SchemaStatements {
     defaultValue?: unknown,
   ): unknown;
   /** @internal */
-  addIndexOpclass(quotedColumns: Record<string, string>, options?: Record<string, unknown>): void;
+  addIndexOpclass(
+    quotedColumns: Map<string, string>,
+    options?: { opclass?: string | Record<string, string> },
+  ): Map<string, string>;
   /** @internal */
   addOptionsForIndexColumns(
-    quotedColumns: Record<string, string>,
-    options?: Record<string, unknown>,
-  ): Record<string, string>;
+    quotedColumns: Map<string, string>,
+    options?: {
+      order?: string | Record<string, string>;
+      opclass?: string | Record<string, string>;
+      length?: number | Record<string, number>;
+    },
+  ): Map<string, string>;
   /** @internal */
   exclusionConstraintName(tableName: string, options?: Record<string, unknown>): string;
   /** @internal */

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -19791,20 +19791,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "quoted_columns",
-    "call": "column_options",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "quoted_columns",
-    "call": "quoted_columns_for_index",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "visit_AddCheckConstraint",
     "call": "accept",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
@@ -19842,13 +19828,6 @@
     "tsFile": "connection-adapters/abstract/schema-creation.ts",
     "rubyName": "visit_CreateIndexDefinition",
     "call": "quote_column_name",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-creation.ts",
-    "rubyName": "visit_CreateIndexDefinition",
-    "call": "quoted_columns",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },
   {


### PR DESCRIPTION
## Summary

Rails' abstract `SchemaCreation` delegates index-column quoting to the
connection (`delegate :quoted_columns_for_index, to: :@conn`,
`abstract/schema_creation.rb:18`); the single source of truth is
`SchemaStatements#quoted_columns_for_index` → `add_options_for_index_columns`.
trails had **two independent copies** — the Rails-faithful `SchemaStatements`
one and a separate inline reimplementation in `schema-creation.ts` (quote +
sort-order + PG opclass) — which could drift (surfaced in #4728).

This routes the abstract `quotedColumns` through the connection's
`quotedColumnsForIndex` (host adapter), keeping the `String === o.columns`
short-circuit and an inline host-less fallback for the SchemaQuoter unit-test
path. PG opclass decoration is folded into PostgreSQL's
`addOptionsForIndexColumns` override (`add_index_opclass` then `super` for
sort order), mirroring Rails' `postgresql/schema_statements.rb:1066-1076`.

## Changes

- `abstract/schema-creation.ts`: `quotedColumns(o)` delegates to
  `quotedColumnsForIndex`, which routes to the host adapter's method (falls
  back to inline quoting when only the SchemaQuoter shim is wired).
- `postgresql-adapter.ts`: `addIndexOpclass` / `addOptionsForIndexColumns`
  are now `Map`-based and call `super` for sort order (previously `Record`-based
  dead copies that dropped sort order).
- `abstract-adapter.ts`: declare the mixed-in `quotedColumnsForIndex` /
  `optionsForIndexColumns` / `addOptionsForIndexColumns` on the interface.

## Testing

- `schema-creation.test.ts`, `mysql/schema-statements.test.ts`,
  `migration.test.ts`, `schema-dumper.test.ts` pass locally.
- PG opclass CREATE INDEX / dump coverage in
  `adapters/postgresql/schema.test.ts` + `active-schema.test.ts` (CI-gated).
- api:compare non-negative.

Closes-story: abstract-schema-creation-quoted-columns-for-index-delegate
