### PR TITLE
feat(schema): widen AddForeignKeyOptions column/primaryKey to composite arrays

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -216,6 +216,17 @@ describe("TableDefinition#new_foreign_key_definition", () => {
     expect(fk.column).toEqual(["rocket_tenant_id", "rocket_id"]);
   });
 
+  it("add_composite_foreign_key_raises_if_column_and_primary_key_sizes_mismatch", () => {
+    // Mirrors foreign_key_options' arity guard (schema_statements.rb:1258-1266):
+    // a composite primaryKey must be matched by an equal-arity column.
+    expect(() =>
+      new TableDefinition("astronauts").newForeignKeyDefinition("rockets", {
+        column: "rocket_id",
+        primaryKey: ["tenant_id", "id"],
+      }),
+    ).toThrow(":column must reference all the :primary_key columns");
+  });
+
   it("applies table_name_prefix/suffix to to_table before building the def", () => {
     const adapter = {
       tableNamePrefix: "app_",

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.test.ts
@@ -210,10 +210,8 @@ describe("TableDefinition#new_foreign_key_definition", () => {
   it("maps a composite primaryKey array to a composite column array (bare-adapter fallback)", () => {
     // Mirrors foreign_key_options' array branch: each PK column gets its own
     // singularized foreign-key column.
-    // primaryKey/column are string|string[] on ForeignKeyDefinition; the scalar
-    // AddForeignKeyOptions DSL type is cast here to exercise the composite path.
     const fk = new TableDefinition("astronauts").newForeignKeyDefinition("rockets", {
-      primaryKey: ["tenant_id", "id"] as unknown as string,
+      primaryKey: ["tenant_id", "id"],
     });
     expect(fk.column).toEqual(["rocket_tenant_id", "rocket_id"]);
   });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -103,8 +103,8 @@ export class CreateIndexDefinition {
  * Mirrors: ActiveRecord::ConnectionAdapters::ForeignKeyDefinition
  */
 export interface AddForeignKeyOptions {
-  column?: string;
-  primaryKey?: string;
+  column?: string | string[];
+  primaryKey?: string | string[];
   name?: string;
   onDelete?: ReferentialAction;
   onUpdate?: ReferentialAction;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-definitions.ts
@@ -119,6 +119,29 @@ export interface ReferenceForeignKeyOptions extends AddForeignKeyOptions {
 }
 
 /**
+ * Mirror Rails' composite-arity guard (schema_statements.rb:1258-1266): once
+ * `foreign_key_options` has filled the default `column`, a composite FK
+ * (either `column` or `primaryKey` given as an array) must reference exactly as
+ * many `column`s as `primaryKey`s. `Array(nil)` is empty in Ruby, so a lone
+ * array with no counterpart also mismatches.
+ * @internal
+ */
+export function assertCompositeForeignKeyArity(
+  toTable: string,
+  column: unknown,
+  primaryKey: unknown,
+): void {
+  if (!Array.isArray(column) && !Array.isArray(primaryKey)) return;
+  const size = (v: unknown): number => (Array.isArray(v) ? v.length : v == null ? 0 : 1);
+  if (size(primaryKey) !== size(column)) {
+    throw new ArgumentError(
+      `For composite primary keys, specify :column and :primary_key, where ` +
+        `:column must reference all the :primary_key columns from ${JSON.stringify(toTable)}`,
+    );
+  }
+}
+
+/**
  * Lookup options accepted by ForeignKeyDefinition#isDefinedFor / foreignKeyFor,
  * mirroring the keyword args Rails `defined_for?` matches generically.
  */
@@ -1133,6 +1156,7 @@ export class TableDefinition {
       const hex = getCrypto().createHash("sha256").update(identifier).digest("hex").slice(0, 10);
       result.name = `fk_rails_${hex}`;
     }
+    assertCompositeForeignKeyArity(toTable, result.column, result.primaryKey);
     return result;
   }
 

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -24,6 +24,7 @@ import {
   CreateIndexDefinition,
   ForeignKeyDefinition,
   CheckConstraintDefinition,
+  assertCompositeForeignKeyArity,
   type AddForeignKeyOptions,
   type AddIndexOptions,
   type ColumnType,
@@ -1725,6 +1726,8 @@ export class SchemaStatements {
         column: result.column as string | string[],
       });
     }
+
+    assertCompositeForeignKeyArity(toTable, result.column, result.primaryKey);
 
     return result;
   }


### PR DESCRIPTION
## What

Widen the public `AddForeignKeyOptions.column` and `.primaryKey` DSL types from
scalar `string` to `string | string[]` (inherited by
`ReferenceForeignKeyOptions`), matching Rails' `add_foreign_key` /
`foreign_key_options` (which accept composite arrays) and the existing
`ForeignKeyDefinition` field types.

## Why

Surfaced in PR #4716: the runtime paths (`SchemaStatements#foreignKeyOptions`
and the `newForeignKeyDefinition` bare-adapter fallback) already handle the
array branch, but the scalar DSL type forced a well-typed caller to cast a
composite key. The composite-key regression test had to write
`["tenant_id","id"] as unknown as string`; this widening removes that cast.

## Changes

- `AddForeignKeyOptions.column` / `.primaryKey` → `string | string[]`.
- Drop the `as unknown as string` cast in the composite-key test.
- Mirror Rails' composite-arity guard (schema_statements.rb:1258-1266): once the
  default `column` is filled, a composite FK must reference exactly as many
  `column`s as `primaryKey`s, else raise `ArgumentError`. Widening the type made
  mismatched arrays (`{ column: "rocket_id", primaryKey: ["tenant_id","id"] }`)
  well-typed, so both normalization paths (`SchemaStatements#foreignKeyOptions`
  and the bare-adapter `TableDefinition` fallback) now call a shared
  `assertCompositeForeignKeyArity` helper. Ports Rails'
  `test_add_composite_foreign_key_raises_if_column_and_primary_key_sizes_mismatch`.

Verified downstream consumers typecheck under the widened type.
`schema-definitions.test.ts`: 43/43 passing.

Closes-story: add-foreign-key-options-accept-composite-arrays