### PR TITLE
refactor(relation): converge merge/merge! onto a single Merger#merge path

### DIFF
--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -71,6 +71,30 @@ describe("RelationTest", () => {
     expect(CanonPost.all().merge({ readonly: true } as any).isReadonly).toBe(true);
   });
 
+  // No like-named Rails test: guards trails' merge/merge! structure, which
+  // mirrors Rails' `merge` = `spawn.merge!` (spawn_methods.rb). `merge` clones
+  // first so the receiver is untouched; `merge!` runs the one Merger#merge
+  // algorithm in place, returning the same object. Both must land the same
+  // conditions — a regression that re-splits the two paths is caught here.
+  it("merge is non-destructive while mergeBang mutates in place through one path", () => {
+    const base = CanonPost.all().where({ title: "a" });
+    const baseSqlBefore = base.toSql();
+
+    const merged = base.merge(CanonPost.where({ type: "SpecialPost" }));
+    // merge() left the receiver untouched (spawn cloned first)...
+    expect(base.toSql()).toBe(baseSqlBefore);
+    // ...and produced the combined conditions on a fresh relation.
+    expect(merged.toSql()).toContain("title");
+    expect(merged.toSql()).toContain("type");
+
+    // mergeBang() mutates the receiver in place and returns it (same object),
+    // landing the identical conditions merge() produced on its clone.
+    const target = CanonPost.all().where({ title: "a" });
+    const returned = (target as any).mergeBang(CanonPost.where({ type: "SpecialPost" }));
+    expect(returned).toBe(target);
+    expect(target.toSql()).toBe(merged.toSql());
+  });
+
   it("dotted string order passes through as raw SQL (Rails treats all string orders as SqlLiteral)", () => {
     class Post extends Base {
       static _tableName = "posts";

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -95,6 +95,21 @@ describe("RelationTest", () => {
     expect(target.toSql()).toBe(merged.toSql());
   });
 
+  // No like-named Rails test: guards Rails' `|=` union for the preload/includes/
+  // eager_load merge folds (merger.rb / query_methods.rb) — a repeated spec across
+  // a merge must dedup structurally, not accumulate duplicate specs the preloader
+  // then double-loads.
+  it("merge unions preload/includes/eager_load specs without duplicating", () => {
+    const preloadMerged = CanonPost.preload("comments").merge(CanonPost.preload("comments"));
+    expect((preloadMerged as any)._preloadAssociations).toEqual(["comments"]);
+
+    const includesMerged = CanonPost.includes("comments").merge(CanonPost.includes("comments"));
+    expect((includesMerged as any)._includesAssociations).toEqual(["comments"]);
+
+    const eagerMerged = CanonPost.eagerLoad("comments").merge(CanonPost.eagerLoad("comments"));
+    expect((eagerMerged as any)._eagerLoadAssociations).toEqual(["comments"]);
+  });
+
   // No like-named Rails test: guards the documented proc-merge path
   // (`Post.where(...).merge(-> { ... })`, spawn_methods.rb). Through the single
   // path `merge` = `spawn.merge!` and `merge!` runs the block via

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -95,6 +95,22 @@ describe("RelationTest", () => {
     expect(target.toSql()).toBe(merged.toSql());
   });
 
+  // No like-named Rails test: guards the merge/merge! Array dispatch
+  // (spawn_methods.rb:33-51). `merge` special-cases an Array as `records & other`
+  // (the receiver's records intersected by AR equality — async in trails, so a
+  // Promise of the intersection); `merge!` never treats an Array as a Hash and
+  // raises. A JS Array is `typeof "object"`, so this guards against it wrongly
+  // routing into HashMerger.
+  it("merge with an array returns the records intersection while mergeBang rejects it", async () => {
+    const a = await CanonPost.createBang({ title: "ary-a", body: "b" });
+    await CanonPost.createBang({ title: "ary-b", body: "b" });
+
+    const intersection = await (CanonPost.where({ title: ["ary-a", "ary-b"] }) as any).merge([a]);
+    expect(intersection.map((p: any) => Number(p.id))).toEqual([Number(a.id)]);
+
+    expect(() => (CanonPost.all() as any).mergeBang([a])).toThrow(/not an ActiveRecord::Relation/);
+  });
+
   // No like-named Rails test: guards Rails' `|=` union for the preload/includes/
   // eager_load merge folds (merger.rb / query_methods.rb) — a repeated spec across
   // a merge must dedup structurally, not accumulate duplicate specs the preloader

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -95,6 +95,23 @@ describe("RelationTest", () => {
     expect(target.toSql()).toBe(merged.toSql());
   });
 
+  // No like-named Rails test: guards the documented proc-merge path
+  // (`Post.where(...).merge(-> { ... })`, spawn_methods.rb). Through the single
+  // path `merge` = `spawn.merge!` and `merge!` runs the block via
+  // `instance_exec(&other)` — trails routes a function argument to
+  // `other.call(this)` on the spawned clone, so the receiver stays untouched and
+  // the block's returned relation carries the added condition.
+  it("merge evaluates a proc against the spawned relation", () => {
+    const base = CanonPost.all().where({ title: "a" });
+    const baseSqlBefore = base.toSql();
+    const merged = (base as any).merge(function (this: any) {
+      return this.where({ type: "SpecialPost" });
+    });
+    expect(base.toSql()).toBe(baseSqlBefore);
+    expect(merged.toSql()).toContain("title");
+    expect(merged.toSql()).toContain("type");
+  });
+
   it("dotted string order passes through as raw SQL (Rails treats all string orders as SqlLiteral)", () => {
     class Post extends Base {
       static _tableName = "posts";

--- a/packages/activerecord/src/relation.trails.test.ts
+++ b/packages/activerecord/src/relation.trails.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect, beforeAll } from "vitest";
 import { Nodes, Table as ArelTable } from "@blazetrails/arel";
 import { Base } from "./index.js";
 import { registerModel, modelRegistry } from "./associations.js";
+import { performMerge } from "./relation/spawn-methods.js";
 
 import { fixtures } from "./test-helpers/fixtures.js";
 import { Post as CanonPost } from "./test-helpers/models/post.js";
@@ -107,6 +108,16 @@ describe("RelationTest", () => {
 
     const intersection = await (CanonPost.where({ title: ["ary-a", "ary-b"] }) as any).merge([a]);
     expect(intersection.map((p: any) => Number(p.id))).toEqual([Number(a.id)]);
+
+    // Rails `records & other` is Array#& — set-style, so a receiver that loads
+    // `a` twice (e.g. a join that duplicates the row) still yields it once. Drive
+    // performMerge with a stub receiver whose records include the duplicate.
+    const dupReceiver = { toArray: async () => [a, a] };
+    const deduped = await (performMerge as (this: unknown, o: unknown) => Promise<any[]>).call(
+      dupReceiver,
+      [a],
+    );
+    expect(deduped.map((p: any) => Number(p.id))).toEqual([Number(a.id)]);
 
     expect(() => (CanonPost.all() as any).mergeBang([a])).toThrow(/not an ActiveRecord::Relation/);
   });

--- a/packages/activerecord/src/relation/merge-joins.ts
+++ b/packages/activerecord/src/relation/merge-joins.ts
@@ -3,13 +3,12 @@ import { Nodes } from "@blazetrails/arel";
 import type { AssociationSpec } from "./query-methods.js";
 import { constructJoinDependency, structuralUnionEq } from "./query-methods.js";
 
-// Shared join-folding passes used by BOTH Merger (merge()) and mergeBang
-// (merge!()) so the two paths cannot drift — a future edit to the dedup/branching
-// logic lands in one place and applies to both. See PR #4660 which converged the
-// logic but left it hand-duplicated between Merger#mergeJoins/#mergeOuterJoins
-// and mergeBang's inline block. Merger keeps thin mergeJoins/mergeOuterJoins
-// wrappers (so api:compare still maps merger.rb's merge_joins/merge_outer_joins);
-// mergeBang calls both helpers directly.
+// Join-folding passes for the single merge path (Merger#merge). Both `merge` and
+// `merge!` now funnel through Merger — `merge` is `spawn.merge!` and `merge!`
+// runs Merger#merge in place (spawn-methods.ts) — so there is one caller. Kept as
+// dedicated functions here (rather than inlined) so the dedup/branching logic
+// stays isolated and reviewable; Merger keeps thin mergeJoins/mergeOuterJoins
+// wrappers so api:compare still maps merger.rb's merge_joins/merge_outer_joins.
 
 // Minimal structural view of the join-related fields these helpers touch on a
 // Relation. Kept local (rather than `any`) so the shared module stays off the

--- a/packages/activerecord/src/relation/merge-preloads.ts
+++ b/packages/activerecord/src/relation/merge-preloads.ts
@@ -1,0 +1,64 @@
+// Preload/includes/eager_load folding for the single merge path (Merger#merge).
+// Both `merge` and `merge!` funnel through Merger now (see spawn-methods.ts), so
+// there is one caller; kept as dedicated functions (like merge-joins.ts) so the
+// same-model-union / cross-model-reflection-nesting branching stays isolated.
+
+// Minimal structural view of the preload-related fields these helpers touch.
+// Kept local (rather than `any`) so the shared module stays off the
+// no-explicit-any burndown allowlist (RFC 0037).
+interface PreloadFoldRelation {
+  _modelClass: {
+    name?: string;
+    reflectOnAllAssociations(): Array<{ name: string; className: string }>;
+  };
+  _preloadAssociations: unknown[];
+  _includesAssociations: unknown[];
+  _eagerLoadAssociations: unknown[];
+}
+
+// Rails merges :eager_load as a NORMAL_VALUE through Merger#merge's generic loop
+// (merger.rb:52-68) — it is NOT part of merge_preloads. eager_load!
+// (query_methods.rb) always unions (`eager_load_values |= args`), never gated on
+// model equality and never nested under a reflection, so it crosses the model
+// boundary untouched.
+export function foldMergeEagerLoad(target: PreloadFoldRelation, source: PreloadFoldRelation): void {
+  const otherEager = source._eagerLoadAssociations ?? [];
+  if (otherEager.length > 0) {
+    target._eagerLoadAssociations = [...(target._eagerLoadAssociations ?? []), ...otherEager];
+  }
+}
+
+// Mirrors Rails' Merger#merge_preloads (merger.rb:96-115). Same-model merges
+// union the preload/includes values straight across. A cross-model merge (e.g.
+// Comment.joins(:post).merge(Post.preload(:readers))) instead nests them under
+// the reflection on the receiver whose class_name is the other model's name, so
+// Comment preloads `{ post: [:readers] }` — carrying Post's preload through the
+// association boundary rather than asking Comment to preload `:readers`.
+export function foldMergePreloads(target: PreloadFoldRelation, source: PreloadFoldRelation): void {
+  const otherPreloads = source._preloadAssociations ?? [];
+  const otherIncludes = source._includesAssociations ?? [];
+  if (otherPreloads.length === 0 && otherIncludes.length === 0) return;
+
+  if (source._modelClass === target._modelClass) {
+    if (otherPreloads.length > 0) {
+      target._preloadAssociations = [...(target._preloadAssociations ?? []), ...otherPreloads];
+    }
+    if (otherIncludes.length > 0) {
+      target._includesAssociations = [...(target._includesAssociations ?? []), ...otherIncludes];
+    }
+    return;
+  }
+
+  const otherName = source._modelClass?.name;
+  const reflection = target._modelClass
+    .reflectOnAllAssociations()
+    .find((r) => r.className === otherName);
+  if (!reflection) return;
+
+  if (otherPreloads.length > 0) {
+    target._preloadAssociations.push({ [reflection.name]: otherPreloads });
+  }
+  if (otherIncludes.length > 0) {
+    target._includesAssociations.push({ [reflection.name]: otherIncludes });
+  }
+}

--- a/packages/activerecord/src/relation/merge-preloads.ts
+++ b/packages/activerecord/src/relation/merge-preloads.ts
@@ -3,6 +3,8 @@
 // there is one caller; kept as dedicated functions (like merge-joins.ts) so the
 // same-model-union / cross-model-reflection-nesting branching stays isolated.
 
+import { structuralUnionEq } from "./query-methods.js";
+
 // Minimal structural view of the preload-related fields these helpers touch.
 // Kept local (rather than `any`) so the shared module stays off the
 // no-explicit-any burndown allowlist (RFC 0037).
@@ -16,36 +18,44 @@ interface PreloadFoldRelation {
   _eagerLoadAssociations: unknown[];
 }
 
-// Rails merges :eager_load as a NORMAL_VALUE through Merger#merge's generic loop
-// (merger.rb:52-68) — it is NOT part of merge_preloads. eager_load!
-// (query_methods.rb) always unions (`eager_load_values |= args`), never gated on
-// model equality and never nested under a reflection, so it crosses the model
-// boundary untouched.
-export function foldMergeEagerLoad(target: PreloadFoldRelation, source: PreloadFoldRelation): void {
-  const otherEager = source._eagerLoadAssociations ?? [];
-  if (otherEager.length > 0) {
-    target._eagerLoadAssociations = [...(target._eagerLoadAssociations ?? []), ...otherEager];
+// Rails unions these association-value arrays with `|=` (preload_values |= …,
+// includes_values |= …, eager_load_values |= …), which dedups by eql?/hash —
+// structural for Symbol/String/Hash specs alike. Mirror that: append each
+// incoming spec only when no structurally-equal entry is already present, so a
+// repeated `preload(:x)`/`includes(:x)`/`eager_load(:x)` across a merge folds to
+// one, matching Rails rather than pushing duplicate specs the preloader then
+// double-loads. Same helper (structuralUnionEq) the join folds use.
+function unionAppend(target: unknown[], incoming: readonly unknown[]): void {
+  for (const spec of incoming) {
+    if (!target.some((seen) => structuralUnionEq(seen, spec))) target.push(spec);
   }
 }
 
+// Rails merges :eager_load as a NORMAL_VALUE through Merger#merge's generic loop
+// (merger.rb:52-68) — it is NOT part of merge_preloads. eager_load!
+// (query_methods.rb:295-297) always unions (`eager_load_values |= args`), never
+// gated on model equality and never nested under a reflection, so it crosses the
+// model boundary untouched.
+export function foldMergeEagerLoad(target: PreloadFoldRelation, source: PreloadFoldRelation): void {
+  unionAppend(target._eagerLoadAssociations, source._eagerLoadAssociations ?? []);
+}
+
 // Mirrors Rails' Merger#merge_preloads (merger.rb:96-115). Same-model merges
-// union the preload/includes values straight across. A cross-model merge (e.g.
-// Comment.joins(:post).merge(Post.preload(:readers))) instead nests them under
-// the reflection on the receiver whose class_name is the other model's name, so
-// Comment preloads `{ post: [:readers] }` — carrying Post's preload through the
-// association boundary rather than asking Comment to preload `:readers`.
+// union the preload/includes values straight across (`|=`). A cross-model merge
+// (e.g. Comment.joins(:post).merge(Post.preload(:readers))) instead nests them
+// under the reflection on the receiver whose class_name is the other model's
+// name, so Comment preloads `{ post: [:readers] }` — carrying Post's preload
+// through the association boundary rather than asking Comment to preload
+// `:readers`. Rails applies that nested spec via `preload!`/`includes!`, which
+// also union (`|=`), so it too dedups against an already-present identical nest.
 export function foldMergePreloads(target: PreloadFoldRelation, source: PreloadFoldRelation): void {
   const otherPreloads = source._preloadAssociations ?? [];
   const otherIncludes = source._includesAssociations ?? [];
   if (otherPreloads.length === 0 && otherIncludes.length === 0) return;
 
   if (source._modelClass === target._modelClass) {
-    if (otherPreloads.length > 0) {
-      target._preloadAssociations = [...(target._preloadAssociations ?? []), ...otherPreloads];
-    }
-    if (otherIncludes.length > 0) {
-      target._includesAssociations = [...(target._includesAssociations ?? []), ...otherIncludes];
-    }
+    unionAppend(target._preloadAssociations, otherPreloads);
+    unionAppend(target._includesAssociations, otherIncludes);
     return;
   }
 
@@ -56,9 +66,9 @@ export function foldMergePreloads(target: PreloadFoldRelation, source: PreloadFo
   if (!reflection) return;
 
   if (otherPreloads.length > 0) {
-    target._preloadAssociations.push({ [reflection.name]: otherPreloads });
+    unionAppend(target._preloadAssociations, [{ [reflection.name]: otherPreloads }]);
   }
   if (otherIncludes.length > 0) {
-    target._includesAssociations.push({ [reflection.name]: otherIncludes });
+    unionAppend(target._includesAssociations, [{ [reflection.name]: otherIncludes }]);
   }
 }

--- a/packages/activerecord/src/relation/merger.ts
+++ b/packages/activerecord/src/relation/merger.ts
@@ -3,6 +3,7 @@ import { assertValidKeys } from "@blazetrails/activesupport";
 
 import { arelColumns } from "./query-methods.js";
 import { foldMergeJoins, foldMergeOuterJoins } from "./merge-joins.js";
+import { foldMergeEagerLoad, foldMergePreloads } from "./merge-preloads.js";
 
 /**
  * Merges two Relations together, combining their conditions,
@@ -21,8 +22,14 @@ export class Merger {
     this.values = typeof other.values === "function" ? other.values() : {};
   }
 
+  // Rails' Merger#merge mutates the relation it is given and returns it
+  // (merger.rb) — it does NOT clone. Non-destructive `merge` gets its fresh copy
+  // from `spawn` before ever reaching here (SpawnMethods#merge = `spawn.merge!`),
+  // while `merge!` hands `self` straight in. Mirroring that in-place contract is
+  // what lets both entry points share this single algorithm; see mergeBang /
+  // performMerge in spawn-methods.ts.
   merge(): any {
-    const rel = this.relation._clone();
+    const rel = this.relation;
     this.mergeUnscope(rel);
     this.mergeWhereClause(rel);
     this.mergeSelectValues(rel);
@@ -30,6 +37,7 @@ export class Merger {
     this.mergeSingleValues(rel);
     this.mergeClauses(rel);
     this.mergeCtes(rel);
+    this.mergeEagerLoad(rel);
     this.mergePreloads(rel);
     this.mergeJoins(rel);
     this.mergeOuterJoins(rel);
@@ -74,31 +82,19 @@ export class Merger {
     rel._selectBang(...columns);
   }
 
-  private mergePreloads(rel: any): void {
-    if (this.other._preloadAssociations && this.other._preloadAssociations.length > 0) {
-      rel._preloadAssociations = [
-        ...(rel._preloadAssociations ?? []),
-        ...this.other._preloadAssociations,
-      ];
-    }
-    if (this.other._includesAssociations && this.other._includesAssociations.length > 0) {
-      rel._includesAssociations = [
-        ...(rel._includesAssociations ?? []),
-        ...this.other._includesAssociations,
-      ];
-    }
-    if (this.other._eagerLoadAssociations && this.other._eagerLoadAssociations.length > 0) {
-      rel._eagerLoadAssociations = [
-        ...(rel._eagerLoadAssociations ?? []),
-        ...this.other._eagerLoadAssociations,
-      ];
-    }
+  // Thin wrappers over the folders (merge-preloads.ts); api:compare still maps
+  // merger.rb's merge_preloads to this file. Both merge() and merge!() run
+  // through Merger#merge, so these fire on every merge.
+  private mergeEagerLoad(rel: any): void {
+    foldMergeEagerLoad(rel, this.other);
   }
 
-  // Thin wrappers over the shared folders (merge-joins.ts) so merge() and
-  // merge!() (spawn-methods mergeBang) fold joins through the same code and
-  // cannot drift, while api:compare still maps merger.rb's merge_joins /
-  // merge_outer_joins to this file.
+  private mergePreloads(rel: any): void {
+    foldMergePreloads(rel, this.other);
+  }
+
+  // Thin wrappers over the folders (merge-joins.ts); api:compare still maps
+  // merger.rb's merge_joins / merge_outer_joins to this file.
   private mergeJoins(rel: any): void {
     foldMergeJoins(rel, this.other);
   }

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -28,18 +28,29 @@ export function performSpawn<T extends SpawnRelation<T>>(this: T): T {
  * Mirrors: ActiveRecord::SpawnMethods#merge
  */
 export function performMerge<T extends SpawnRelation<T>>(this: T, other: any): T {
-  // Mirrors Rails SpawnMethods#merge (spawn_methods.rb:33-41): raise on a
-  // *falsey* argument (`nil`/`false` — Ruby falsiness is only nil/false), then
-  // `spawn.merge!(other)`. The single merge algorithm lives in merge! (mergeBang
-  // → Merger#merge); `merge` is just the non-destructive wrapper that clones
-  // first via `spawn`, so the two entry points share one code path and cannot
-  // drift. (Rails' Array branch returns `records & other`; trails does not
-  // implement that set-intersection path and lets an Array fall through to
-  // merge!'s HashMerger, matching prior behavior.)
+  // Mirrors Rails SpawnMethods#merge (spawn_methods.rb:33-41): an Array returns
+  // `records & other`; a *falsey* argument raises (Ruby falsiness is only
+  // nil/false); otherwise `spawn.merge!(other)`. The single merge algorithm lives
+  // in merge! (mergeBang → Merger#merge); `merge` is just the non-destructive
+  // wrapper that clones first via `spawn`, so the two entry points share one code
+  // path and cannot drift.
+  if (Array.isArray(other)) {
+    // Rails intersects the receiver's loaded `records` with the array by AR
+    // equality (==/eql? — class + id). trails loads records asynchronously, so
+    // this resolves to a Promise of the intersection rather than a sync array.
+    return recordsIntersection(this, other) as unknown as T;
+  }
   if (other === null || other === undefined || other === false) {
     throw argumentError(`invalid argument: ${other === false ? "false" : "nil"}.`);
   }
   return (this as any).spawn().mergeBang(other) as T;
+}
+
+async function recordsIntersection(rel: any, other: readonly unknown[]): Promise<unknown[]> {
+  const records: any[] = await rel.toArray();
+  return records.filter((r) =>
+    other.some((o) => (typeof r?.isEqual === "function" ? r.isEqual(o) : r === o)),
+  );
 }
 
 /**
@@ -55,7 +66,11 @@ export function mergeBang(this: any, other: any): any {
   if (other && typeof other === "object" && "_whereClause" in other) {
     return new Merger(this, other).merge();
   }
-  if (other && typeof other === "object") {
+  // Rails merge! (spawn_methods.rb:43-51) hash-merges only a *Hash*. A JS Array is
+  // `typeof "object"`, so exclude it explicitly — an Array is not a Hash and, not
+  // being a Relation or proc either, falls through to the ArgumentError below.
+  // (Rails handles arrays earlier in `merge`; they never reach merge!.)
+  if (other && typeof other === "object" && !Array.isArray(other)) {
     return new HashMerger(this, other).merge();
   }
   if (typeof other === "function") {

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -6,7 +6,6 @@
 
 import { Merger, HashMerger } from "./merger.js";
 import { argumentError } from "./query-methods.js";
-import { foldMergeJoins, foldMergeOuterJoins } from "./merge-joins.js";
 
 interface SpawnRelation<T = unknown> {
   _clone(): T;
@@ -29,115 +28,44 @@ export function performSpawn<T extends SpawnRelation<T>>(this: T): T {
  * Mirrors: ActiveRecord::SpawnMethods#merge
  */
 export function performMerge<T extends SpawnRelation<T>>(this: T, other: any): T {
-  // Mirrors SpawnMethods#merge!: a Hash routes through HashMerger, a
-  // Relation through Merger, and a proc/lambda is instance-exec'd against
-  // the spawned relation. A bare Relation is detected by its `_whereClause`.
-  // Rails `merge` (spawn_methods.rb:33-41) raises `invalid argument: #{inspect}.`
-  // for a *falsey* argument (`nil`/`false`) before ever dispatching to `merge!`.
-  // Ruby falsiness is only nil/false (not 0/"" /NaN).
+  // Mirrors Rails SpawnMethods#merge (spawn_methods.rb:33-41): raise on a
+  // *falsey* argument (`nil`/`false` — Ruby falsiness is only nil/false), then
+  // `spawn.merge!(other)`. The single merge algorithm lives in merge! (mergeBang
+  // → Merger#merge); `merge` is just the non-destructive wrapper that clones
+  // first via `spawn`, so the two entry points share one code path and cannot
+  // drift. (Rails' Array branch returns `records & other`; trails does not
+  // implement that set-intersection path and lets an Array fall through to
+  // merge!'s HashMerger, matching prior behavior.)
   if (other === null || other === undefined || other === false) {
     throw argumentError(`invalid argument: ${other === false ? "false" : "nil"}.`);
   }
-  if (typeof other === "function") {
-    // Mirrors merge!'s `instance_exec(&other)` (spawn_methods.rb:48-49): the
-    // block runs with the spawned relation as receiver (`this`), receives no
-    // positional args (an arity>=1 proc's first param is `undefined`, as Ruby
-    // passes `nil`), and its return value is used verbatim — Rails does NOT
-    // `|| self`.
-    return (other as (this: T) => T).call(this._clone());
-  }
-  if (typeof other === "object" && "_whereClause" in other) {
-    return new Merger(this, other).merge() as T;
-  }
-  if (typeof other === "object") {
-    return new HashMerger(this, other).merge() as T;
-  }
-  // Rails `merge!`'s final `else` for a truthy non-Hash/Relation/proc argument
-  // (spawn_methods.rb:43-51): `raise ArgumentError, "#{other.inspect} is not an
-  // ActiveRecord::Relation"`.
-  throw argumentError(`${String(other)} is not an ActiveRecord::Relation`);
+  return (this as any).spawn().mergeBang(other) as T;
 }
 
 /**
- * In-place merge — mutates this relation directly.
+ * In-place merge — mutates this relation directly and returns it.
  *
- * Mirrors: ActiveRecord::SpawnMethods#merge!
+ * Mirrors: ActiveRecord::SpawnMethods#merge!. A Relation routes through Merger
+ * (which mutates `this` in place), a Hash through HashMerger, a proc/lambda is
+ * instance-exec'd against `this`, and anything else raises. This is the one
+ * merge algorithm; `merge` (performMerge) reaches it via `spawn.merge!`.
  */
 export function mergeBang(this: any, other: any): any {
+  // A bare Relation is detected by its `_whereClause`.
   if (other && typeof other === "object" && "_whereClause" in other) {
-    // Mirror Merger#merge field-by-field so merge() and merge!() stay aligned.
-    if (!other._whereClause.isEmpty())
-      this._whereClause = this._whereClause.merge(other._whereClause);
-    // mergeSelectValues: null vs [] is meaningful ([] = explicit clear)
-    if (other._selectColumns != null) this._selectColumns = [...other._selectColumns];
-    // mergeMultiValues
-    if (other._orderClauses?.length > 0) this._orderClauses = [...other._orderClauses];
-    if (other._groupColumns?.length > 0) this._groupColumns.push(...other._groupColumns);
-    if (other._annotations?.length > 0) this._annotations.push(...other._annotations);
-    if (other._referencesValues) {
-      for (const ref of other._referencesValues) {
-        if (!this._referencesValues.includes(ref)) this._referencesValues.push(ref);
-      }
-    }
-    if (other._manualReferences) {
-      for (const ref of other._manualReferences) {
-        if (!this._manualReferences.includes(ref)) this._manualReferences.push(ref);
-      }
-    }
-    // mergeSingleValues
-    if (other._limitValue != null) this._limitValue = other._limitValue;
-    if (other._offsetValue != null) this._offsetValue = other._offsetValue;
-    if (other._isDistinct) this._isDistinct = true;
-    if (other._lockValue) this._lockValue = other._lockValue;
-    if (other._isReadonly) this._isReadonly = true;
-    if (other._skipQueryCache) this._skipQueryCache = true;
-    if (other._isStrictLoading !== undefined) this._isStrictLoading = other._isStrictLoading;
-    // mergeClauses
-    if (other._havingClause && !other._havingClause.isEmpty())
-      this._havingClause = this._havingClause.merge(other._havingClause);
-    if (
-      (!this._fromClause || this._fromClause.isEmpty?.()) &&
-      other._fromClause &&
-      !other._fromClause.isEmpty?.() &&
-      // Rails replace_from_clause? also requires same base_class (see Merger).
-      this._modelClass?.baseClass === other._modelClass?.baseClass
-    ) {
-      this._fromClause = other._fromClause;
-    }
-    // mergePreloads
-    if (other._preloadAssociations?.length > 0)
-      this._preloadAssociations = [
-        ...(this._preloadAssociations ?? []),
-        ...other._preloadAssociations,
-      ];
-    if (other._includesAssociations?.length > 0)
-      this._includesAssociations = [
-        ...(this._includesAssociations ?? []),
-        ...other._includesAssociations,
-      ];
-    if (other._eagerLoadAssociations?.length > 0)
-      this._eagerLoadAssociations = [
-        ...(this._eagerLoadAssociations ?? []),
-        ...other._eagerLoadAssociations,
-      ];
-    // mergeJoins / mergeOuterJoins — shared with Merger (merger.ts) via the
-    // foldMerge* helpers so merge() and merge!() fold joins identically and can't
-    // drift.
-    foldMergeJoins(this, other);
-    foldMergeOuterJoins(this, other);
-    // mergeCtes — append the other relation's common table expressions
-    if (other._ctes?.length > 0) this._ctes = [...this._ctes, ...other._ctes];
-    // sticky none
-    if (other._isNone) this._isNone = true;
-  } else if (typeof other === "object" && other !== null) {
-    const merged = new HashMerger(this, other).merge();
-    if (merged && merged._whereClause) {
-      this._whereClause = merged._whereClause;
-    }
-  } else if (typeof other === "function") {
-    other.call(this);
+    return new Merger(this, other).merge();
   }
-  return this;
+  if (other && typeof other === "object") {
+    return new HashMerger(this, other).merge();
+  }
+  if (typeof other === "function") {
+    // Rails `instance_exec(&other)` (spawn_methods.rb:48-49): the block runs with
+    // this relation as receiver and its return value is used verbatim.
+    return other.call(this);
+  }
+  // Rails merge!'s final `else` (spawn_methods.rb:43-51): a non-Hash/Relation/proc
+  // argument raises `ArgumentError, "#{other.inspect} is not an ActiveRecord::Relation"`.
+  throw argumentError(`${String(other)} is not an ActiveRecord::Relation`);
 }
 
 export const SpawnMethods = {

--- a/packages/activerecord/src/relation/spawn-methods.ts
+++ b/packages/activerecord/src/relation/spawn-methods.ts
@@ -48,9 +48,19 @@ export function performMerge<T extends SpawnRelation<T>>(this: T, other: any): T
 
 async function recordsIntersection(rel: any, other: readonly unknown[]): Promise<unknown[]> {
   const records: any[] = await rel.toArray();
-  return records.filter((r) =>
-    other.some((o) => (typeof r?.isEqual === "function" ? r.isEqual(o) : r === o)),
-  );
+  // Rails `records & other` is `Array#&` — a set-style intersection that also
+  // *dedups* by AR equality (==/eql?/hash: class + id), so a joined relation that
+  // loads the same record twice still yields it once. filter() alone would keep
+  // those duplicates, so track seen records and skip a repeat.
+  const eq = (a: any, o: unknown): boolean =>
+    typeof a?.isEqual === "function" ? a.isEqual(o) : a === o;
+  const result: unknown[] = [];
+  for (const r of records) {
+    if (!other.some((o) => eq(r, o))) continue;
+    if (result.some((seen) => eq(r, seen))) continue;
+    result.push(r);
+  }
+  return result;
 }
 
 /**

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -899,10 +899,50 @@ describe("RelationTest", () => {
     expect(await query.size()).toBe(1);
   });
 
-  it.skip("preloading with associations and merges", async () => {
-    // BLOCKED: relations — Rails asserts result_comment.post.readers is already loaded
-    // (no extra queries) after Comment.joins(:post).merge(Post.preload(:readers)...).
-    // Cross-model preload propagation through merge is not yet implemented in Trails.
+  it("preloading with associations and merges", async () => {
+    const post = await Post.createBang({ title: "Uhuu", body: "body" });
+    const reader = await Reader.createBang({ post_id: post.id, person_id: 1 });
+    const comment = await Comment.createBang({ post_id: post.id, body: "body" });
+
+    const postRel = Post.preload("readers").joins("readers").where({ title: "Uhuu" });
+    let resultComment = (await Comment.joins("post").merge(postRel))[0];
+    expect(Number(resultComment.id)).toBe(Number(comment.id));
+
+    let postAssoc = (resultComment as any).association("post");
+    expect(postAssoc.isLoaded()).toBe(true);
+    expect(Number(postAssoc.target.id)).toBe(Number(post.id));
+    const readersAssoc = postAssoc.target.association("readers");
+    expect(readersAssoc.isLoaded()).toBe(true);
+    expect(readersAssoc.target.map((r: any) => Number(r.id))).toEqual([Number(reader.id)]);
+
+    const postRel2 = Post.includes("readers").where({ title: "Uhuu" });
+    resultComment = (await Comment.joins("post").merge(postRel2).first())!;
+    expect(Number(resultComment.id)).toBe(Number(comment.id));
+
+    postAssoc = (resultComment as any).association("post");
+    expect(postAssoc.isLoaded()).toBe(true);
+    expect(Number(postAssoc.target.id)).toBe(Number(post.id));
+    const readersAssoc2 = postAssoc.target.association("readers");
+    expect(readersAssoc2.isLoaded()).toBe(true);
+    expect(readersAssoc2.target.map((r: any) => Number(r.id))).toEqual([Number(reader.id)]);
+
+    // Rails merges :eager_load as a NORMAL_VALUE (merger.rb) — a straight union
+    // via eager_load!, never gated on model equality nor nested under a
+    // reflection, so it crosses the model boundary untouched.
+    const merged = Comment.joins("post").merge(Post.eagerLoad("readers")) as any;
+    expect(merged._eagerLoadAssociations).toContain("readers");
+
+    // merge! (in-place) shares Merger#merge in Rails; trails routes both through
+    // the same foldMerge* helpers, so the cross-model reflection-nesting applies
+    // identically — the bang path must nest `{ post: [:readers] }`, not ask
+    // Comment to preload `:readers` directly.
+    const bang = Comment.joins("post") as any;
+    bang.mergeBang(Post.preload("readers").where({ title: "Uhuu" }));
+    expect(bang._preloadAssociations).toEqual([{ post: ["readers"] }]);
+    const bangComment = (await bang.toArray())[0];
+    const bangPost = bangComment.association("post");
+    expect(bangPost.isLoaded()).toBe(true);
+    expect(bangPost.target.association("readers").isLoaded()).toBe(true);
   });
 
   it("preloading with associations default scopes and merges", async () => {


### PR DESCRIPTION
## Summary

Rails has **one** merge algorithm (`spawn_methods.rb`): `merge!` is `Merger#merge`
(which mutates the relation in place and returns it), and `merge` is just
`spawn.merge!` — clone first, then run the identical `merge!`. So the two entry
points cannot diverge.

trails had this **inverted**: `performMerge` (merge) held the algorithm by
constructing a `Merger` that cloned *internally*, while `mergeBang` (merge!)
hand-duplicated the whole field-by-field copy. That split caused real drift — the
cross-model preload/includes reflection-nesting from #4742 landed in `Merger` but
was missing from `mergeBang`. #4742 papered over it by extracting shared fold
helpers; that fix was then **reverted** on `main`. This PR removes the root cause
instead and re-delivers the capability.

### Change

- `Merger#merge` now mutates `this.relation` in place and returns it (no internal
  `_clone`), matching Rails' in-place contract.
- `mergeBang` (merge!) is now a thin dispatcher: Relation→`Merger`, Hash→`HashMerger`,
  proc→`call(this)`, else→raise (mirrors `spawn_methods.rb:43-51`). The ~55-line
  hand-duplicated field copy is **deleted**. A JS Array is excluded from the Hash
  branch so `merge!([…])` raises like Rails (an Array is not a Hash).
- `performMerge` (merge) mirrors `spawn_methods.rb:33-41`: an Array returns
  `records & other` (async in trails → a Promise of the intersection by AR
  equality), a falsey argument raises, else `spawn().mergeBang(other)`.
- Both non-Array entry points now run the single `Merger#merge`, so the cross-model
  preload/eager propagation applies identically to `merge` and `merge!` — no
  possibility of drift.

### Behavior

- Re-delivers the reverted #4742: `Comment.joins(:post).merge(Post.preload(:readers)...)`
  leaves `.post.readers` already loaded (same-model union / cross-model
  reflection-nesting for preload & includes; unconditional union for eager_load).
- Association-value merges now **union with `|=`** (structural dedup via the same
  `structuralUnionEq` the join folds use), matching `preload_values |= …` /
  `includes_values |= …` / `eager_load_values |= …` — a repeated spec folds to one.
- `merge` stays non-destructive (receiver untouched via `spawn`); `merge!` mutates
  in place and returns the same object.

### Non-goals

- Porting Rails' `spawn` `already_in_scope?` scope-registry check (trails `spawn`
  == `_clone` today) — separate scoping work; behavior unchanged.

## Testing

- `relations.test.ts` "preloading with associations and merges" (preload / includes
  / eager_load + `merge!` cross-model path).
- New `relation.trails.test.ts` invariants: `merge` non-destructive vs `merge!`
  in-place; proc-merge against the spawned relation; `|=` spec dedup; Array
  dispatch (`merge([…])` → intersection, `merge!([…])` → raise).
- `relations` / `relation` / `relation.trails` / `associations` / scoping suites
  green (locally).

Closes-story: converge-merge-onto-single-merger-path