### PR TITLE
fix(test-helpers): fail loudly when ARCONN selects a live backend without its *_TEST_URL

### DIFF
--- a/packages/activerecord/src/test-helpers/test-database-config.test.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.test.ts
@@ -52,6 +52,7 @@ describe("buildTestDatabaseConfig", () => {
   });
 
   it("picks mysql when MYSQL_TEST_URL is set and PG_TEST_URL is absent", async () => {
+    vi.stubEnv("ARCONN", "mysql2");
     vi.stubEnv("PG_TEST_URL", "");
     vi.stubEnv("MYSQL_TEST_URL", "mysql2://localhost/trails_test");
     const { adapter } = await buildTestDatabaseConfig();

--- a/packages/activerecord/src/test-helpers/test-database-config.test.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.test.ts
@@ -18,6 +18,7 @@ describe("buildTestDatabaseConfig", () => {
   });
 
   it("defaults to sqlite when no URL env vars are set", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("PG_TEST_URL", "");
     vi.stubEnv("MYSQL_TEST_URL", "");
     const { adapter, envConfig } = await buildTestDatabaseConfig();
@@ -27,6 +28,7 @@ describe("buildTestDatabaseConfig", () => {
   });
 
   it("inherits Rails' default pool size (5) on the file-backed lane", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("PG_TEST_URL", "");
     vi.stubEnv("MYSQL_TEST_URL", "");
     vi.stubEnv("AR_TEST_WORKER_DB", "/tmp/ar-test-worker.sqlite3");
@@ -35,6 +37,7 @@ describe("buildTestDatabaseConfig", () => {
   });
 
   it("pins pool 1 on a bare :memory: primary", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("PG_TEST_URL", "");
     vi.stubEnv("MYSQL_TEST_URL", "");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
@@ -53,5 +56,34 @@ describe("buildTestDatabaseConfig", () => {
     vi.stubEnv("MYSQL_TEST_URL", "mysql2://localhost/trails_test");
     const { adapter } = await buildTestDatabaseConfig();
     expect(adapter).toBe("mysql");
+  });
+
+  it("throws when ARCONN=postgresql but PG_TEST_URL is absent", async () => {
+    vi.stubEnv("ARCONN", "postgresql");
+    vi.stubEnv("PG_TEST_URL", "");
+    vi.stubEnv("MYSQL_TEST_URL", "");
+    await expect(buildTestDatabaseConfig()).rejects.toThrow(/ARCONN=postgresql but PG_TEST_URL/);
+  });
+
+  it("throws when ARCONN=mysql2 but MYSQL_TEST_URL is absent", async () => {
+    vi.stubEnv("ARCONN", "mysql2");
+    vi.stubEnv("PG_TEST_URL", "");
+    vi.stubEnv("MYSQL_TEST_URL", "");
+    await expect(buildTestDatabaseConfig()).rejects.toThrow(/ARCONN=mysql2 but MYSQL_TEST_URL/);
+  });
+
+  it("does not throw when ARCONN=postgresql and PG_TEST_URL is set", async () => {
+    vi.stubEnv("ARCONN", "postgresql");
+    vi.stubEnv("PG_TEST_URL", "postgresql://localhost/trails_test");
+    const { adapter } = await buildTestDatabaseConfig();
+    expect(adapter).toBe("postgres");
+  });
+
+  it("does not throw when ARCONN=sqlite3 and no URL env vars are set", async () => {
+    vi.stubEnv("ARCONN", "sqlite3");
+    vi.stubEnv("PG_TEST_URL", "");
+    vi.stubEnv("MYSQL_TEST_URL", "");
+    const { adapter } = await buildTestDatabaseConfig();
+    expect(adapter).toBe("sqlite");
   });
 });

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -27,12 +27,44 @@ export interface TestDatabaseConfig {
   envConfig: HashConfig | UrlConfig;
 }
 
+/**
+ * Guard against a silent SQLite fallback when `ARCONN` selects a live backend.
+ *
+ * `ARCONN` only drives which tests vitest includes (`vitest.config.ts`); the
+ * backend is chosen here from `PG_TEST_URL` / `MYSQL_TEST_URL`. When `ARCONN`
+ * is `postgresql`/`mysql2` but the matching `*_TEST_URL` is absent, the SELECTs
+ * would run against SQLite while the run pretends to be the PG/MySQL job — a
+ * false green that hides adapter-specific divergences. Fail loudly instead.
+ */
+function assertTestUrlPresentForArconn(pgUrl?: string, mysqlUrl?: string): void {
+  const arconn = getEnv("ARCONN");
+  if (arconn === "postgresql" && !pgUrl) {
+    // Test-helper invariant with no Rails error counterpart — a bare Error is intentional.
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(
+      "ARCONN=postgresql but PG_TEST_URL is not set: the test backend would " +
+        "silently fall back to SQLite, running against the wrong database. " +
+        "Set PG_TEST_URL to a live PostgreSQL, or unset ARCONN to run on SQLite.",
+    );
+  }
+  if (arconn === "mysql2" && !mysqlUrl) {
+    // Test-helper invariant with no Rails error counterpart — a bare Error is intentional.
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(
+      "ARCONN=mysql2 but MYSQL_TEST_URL is not set: the test backend would " +
+        "silently fall back to SQLite, running against the wrong database. " +
+        "Set MYSQL_TEST_URL to a live MySQL, or unset ARCONN to run on SQLite.",
+    );
+  }
+}
+
 function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfig } {
   const pgUrl = getEnv("PG_TEST_URL");
+  const mysqlUrl = getEnv("MYSQL_TEST_URL");
+  assertTestUrlPresentForArconn(pgUrl, mysqlUrl);
   if (pgUrl) {
     return { adapter: "postgres", envConfig: new UrlConfig("test", "primary", pgUrl) };
   }
-  const mysqlUrl = getEnv("MYSQL_TEST_URL");
   if (mysqlUrl) {
     return { adapter: "mysql", envConfig: new UrlConfig("test", "primary", mysqlUrl) };
   }
@@ -105,11 +137,12 @@ export async function buildTestDatabaseConfig(): Promise<TestDatabaseConfig> {
 export async function establishFromTestConfig(): Promise<void> {
   if (Base.isConnectedQ()) return;
   const pgUrl = getEnv("PG_TEST_URL");
+  const mysqlUrl = getEnv("MYSQL_TEST_URL");
+  assertTestUrlPresentForArconn(pgUrl, mysqlUrl);
   if (pgUrl) {
     await Base.establishConnection(pgUrl);
     return;
   }
-  const mysqlUrl = getEnv("MYSQL_TEST_URL");
   if (mysqlUrl) {
     await Base.establishConnection(mysqlUrl);
     return;


### PR DESCRIPTION
## Problem

`ARCONN` only drives which tests vitest includes (`vitest.config.ts`); the
actual backend is chosen by `test-database-config.ts` from `PG_TEST_URL` /
`MYSQL_TEST_URL`, **silently falling back to SQLite** when neither is set. So
`ARCONN=postgresql pnpm vitest ...` without `PG_TEST_URL` runs the SELECTs
against SQLite while pretending to be the PG job — a false green that hides
adapter-specific divergences (this masked the real PG failure fixed in #4733).

## Change

Guard both env-sniff entry points (`resolve()` and `establishFromTestConfig()`):
when `ARCONN=postgresql`/`mysql2` but the matching `*_TEST_URL` is absent, throw
a loud error instead of silently resolving to SQLite. SQLite runs (no `ARCONN`,
or `ARCONN=sqlite3`) are unaffected.

Covered by focused tests in `test-database-config.test.ts`.

Closes-story: arconn-without-test-url-must-not-silently-fall-back-to-sqlite