### PR TITLE
perf(callbacks): memoize CallbackChain.compile compiled sequence

### DIFF
--- a/packages/activesupport/src/callbacks.trails.test.ts
+++ b/packages/activesupport/src/callbacks.trails.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest";
+import { CallbackChain, Callback } from "./callbacks.js";
+
+// trails-only coverage: CallbackChain.compile() memoizes the folded
+// CallbackSequence (Rails' @all_callbacks), rebuilding only on chain mutation.
+// No Rails counterpart test — this pins our internal optimization so a future
+// refactor can't silently reintroduce per-run refolding.
+describe("CallbackChain compile memoization (trails)", () => {
+  const makeCallback = (name: string) => new Callback(name, () => {}, "before", {}, {});
+
+  it("returns the same compiled sequence on repeated calls", () => {
+    const chain = new CallbackChain("save");
+    chain.append(makeCallback("a"));
+    expect(chain.compile()).toBe(chain.compile());
+  });
+
+  it("rebuilds after append", () => {
+    const chain = new CallbackChain("save");
+    chain.append(makeCallback("a"));
+    const first = chain.compile();
+    chain.append(makeCallback("b"));
+    expect(chain.compile()).not.toBe(first);
+  });
+
+  it("rebuilds after prepend", () => {
+    const chain = new CallbackChain("save");
+    chain.append(makeCallback("a"));
+    const first = chain.compile();
+    chain.prepend(makeCallback("b"));
+    expect(chain.compile()).not.toBe(first);
+  });
+
+  it("rebuilds after insert", () => {
+    const chain = new CallbackChain("save");
+    chain.append(makeCallback("a"));
+    const first = chain.compile();
+    chain.insert(0, makeCallback("b"));
+    expect(chain.compile()).not.toBe(first);
+  });
+
+  it("rebuilds after delete", () => {
+    const chain = new CallbackChain("save");
+    const cb = makeCallback("a");
+    chain.append(cb);
+    chain.append(makeCallback("b"));
+    const first = chain.compile();
+    chain.delete(cb);
+    expect(chain.compile()).not.toBe(first);
+  });
+
+  it("rebuilds after remove", () => {
+    const chain = new CallbackChain("save");
+    chain.append(makeCallback("a"));
+    const first = chain.compile();
+    chain.remove("before");
+    expect(chain.compile()).not.toBe(first);
+  });
+
+  it("rebuilds after clear", () => {
+    const chain = new CallbackChain("save");
+    chain.append(makeCallback("a"));
+    const first = chain.compile();
+    chain.clear();
+    expect(chain.compile()).not.toBe(first);
+  });
+});

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -887,6 +887,12 @@ export class CallbackChain {
   /** True when a custom (non-default) terminator was supplied at define time. */
   private readonly _hasCustomTerminator: boolean;
   private chain: Callback[];
+  // Memoized compiled sequence (Rails' @all_callbacks). Reset to undefined on
+  // every chain mutation (append/prepend/insert/delete/remove/clear), matching
+  // Rails' @all_callbacks = nil reset points. No mutex: Rails guards the rebuild
+  // with @mutex.synchronize for thread safety, but JS is single-threaded so
+  // runCallbacks never re-enters compile() concurrently — the lock is moot.
+  private _allCallbacks: CallbackSequence | undefined;
 
   constructor(name: string, config: DefineCallbacksOptions = {}) {
     this._hasCustomTerminator = typeof config.terminator === "function";
@@ -911,31 +917,38 @@ export class CallbackChain {
   }
 
   insert(idx: number, cb: Callback): void {
+    this._allCallbacks = undefined;
     this.chain.splice(idx, 0, cb);
   }
 
   delete(cb: Callback): void {
+    this._allCallbacks = undefined;
     const i = this.chain.indexOf(cb);
     if (i !== -1) this.chain.splice(i, 1);
   }
 
   append(callback: Callback): void {
+    this._allCallbacks = undefined;
     this.chain.push(callback);
   }
 
   prepend(callback: Callback): void {
+    this._allCallbacks = undefined;
     this.chain.unshift(callback);
   }
 
   remove(kind: CallbackKind, filter?: AnyCallback | string | symbol | CallbackObject): void {
+    this._allCallbacks = undefined;
     this.chain = this.chain.filter((cb) => !cb.matches(kind, filter));
   }
 
   clear(): void {
+    this._allCallbacks = undefined;
     this.chain = [];
   }
 
   compile(): CallbackSequence {
+    if (this._allCallbacks) return this._allCallbacks;
     // Mirrors Rails CallbackChain#compile: fold the chain in reverse, applying
     // each callback's compiled filter onto the sequence. before/after mutate the
     // (single) final sequence's lists; around wraps it in a new nested sequence.
@@ -944,6 +957,7 @@ export class CallbackChain {
       seq = this.chain[i].compiled.apply(seq);
     }
     seq._callbackChain = this;
+    this._allCallbacks = seq;
     return seq;
   }
 


### PR DESCRIPTION
Mirror Rails' `CallbackChain#compile` `@all_callbacks` memoization: cache the folded `CallbackSequence` and rebuild only when the chain mutates (append/prepend/insert/delete/remove/clear reset the memo). Previously `compile()` re-folded the whole chain on every `runCallbacks` — a hot path hit on every save/validate/destroy.

No mutex needed: Rails guards the rebuild with `@mutex.synchronize` for thread safety, but JS is single-threaded so `compile()` never re-enters concurrently — documented as a deviation in the field comment.

## Testing
- `packages/activesupport/src/callbacks.test.ts` (128) and `callback-inheritance.test.ts` (11) green.
- AR `callbacks.test.ts` (21) + `transaction-callbacks.test.ts` (62) green.

Closes-story: callbackchain-memoize-compiled-sequence