### PR TITLE
feat(callbacks): invoke haltedCallbackHook when a before callback halts

### DIFF
--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1503,6 +1503,46 @@ describe("CallbackDefaultTerminatorTest", () => {
     expect(target.count).toBe(1);
     expect(target.halted).toBe(second);
   });
+  it("default termination invokes hook through around chain", () => {
+    // Chains with around callbacks route through the bespoke `_invoke` engine
+    // rather than the compiled Before#call path; the hook must fire there too.
+    const second = () => throwAbort();
+    const target = {
+      log: [] as string[],
+      halted: undefined as unknown,
+      name: undefined as unknown,
+      haltedCallbackHook(filter: unknown, name: string) {
+        this.halted = filter;
+        this.name = name;
+      },
+    };
+    defineCallbacks(target, "save");
+    setCallback(target, "save", "around", (t: any, next: () => void) => {
+      t.log.push("around");
+      next();
+    });
+    setCallback(target, "save", "before", second);
+    runCallbacks(target, "save");
+    expect(target.halted).toBe(second);
+    expect(target.name).toBe("save");
+  });
+  it("async termination invokes hook through around chain", async () => {
+    const second = async () => {
+      await Promise.resolve();
+      throwAbort();
+    };
+    const target = {
+      halted: undefined as unknown,
+      haltedCallbackHook(filter: unknown, _name: string) {
+        this.halted = filter;
+      },
+    };
+    defineCallbacks(target, "save");
+    setCallback(target, "save", "around", (_t: any, next: () => void) => next());
+    setCallback(target, "save", "before", second);
+    await runCallbacks(target, "save");
+    expect(target.halted).toBe(second);
+  });
   it("block never called if abort is thrown", () => {
     const target = { ran: false };
     defineCallbacks(target, "save");

--- a/packages/activesupport/src/callbacks.test.ts
+++ b/packages/activesupport/src/callbacks.test.ts
@@ -1448,11 +1448,21 @@ describe("CallbackTerminatorTest", () => {
     expect(target.log).not.toContain("body");
   });
   it("termination invokes hook", () => {
-    const target = { log: [] as string[], halted: false };
+    const second = () => "halt";
+    const target = {
+      log: [] as string[],
+      halted: undefined as unknown,
+      callbackName: undefined as unknown,
+      haltedCallbackHook(filter: unknown, name: string) {
+        this.halted = filter;
+        this.callbackName = name;
+      },
+    };
     defineCallbacks(target, "save", { terminator: haltTerminator });
-    setCallback(target, "save", "before", () => "halt");
+    setCallback(target, "save", "before", second);
     runCallbacks(target, "save");
-    expect(target.halted).toBe(false); // hook not invoked automatically
+    expect(target.halted).toBe(second);
+    expect(target.callbackName).toBe("save");
   });
   it("block never called if terminated", () => {
     const target = { ran: false };
@@ -1476,14 +1486,22 @@ describe("CallbackDefaultTerminatorTest", () => {
     expect(target.ran).toBe(false);
   });
   it("default termination invokes hook", () => {
-    const target = { count: 0 };
-    defineCallbacks(target, "save");
-    setCallback(target, "save", "before", (t: any) => {
+    const second = (t: any) => {
       t.count++;
       throwAbort();
-    });
+    };
+    const target = {
+      count: 0,
+      halted: undefined as unknown,
+      haltedCallbackHook(filter: unknown, _name: string) {
+        this.halted = filter;
+      },
+    };
+    defineCallbacks(target, "save");
+    setCallback(target, "save", "before", second);
     runCallbacks(target, "save");
     expect(target.count).toBe(1);
+    expect(target.halted).toBe(second);
   });
   it("block never called if abort is thrown", () => {
     const target = { ran: false };

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -964,6 +964,18 @@ export class CallbackChain {
     return this.chain.length === 0;
   }
 
+  /**
+   * Fire Rails' `halted_callback_hook(filter, name)` on the target for the
+   * before callback that halted the chain. Mirrors `Filters::Before#call`;
+   * kept here because the bespoke around-chain engine (`_invoke`) does not
+   * compile through `Before#call`. See `Before#halt` for the compiled path.
+   */
+  private _notifyHalt(target: object, entry: Callback): void {
+    const hook = (target as { haltedCallbackHook?: (filter: unknown, name: string) => void })
+      .haltedCallbackHook;
+    if (typeof hook === "function") hook.call(target, entry.filter, entry.name);
+  }
+
   _invoke(
     target: object,
     block?: () => unknown,
@@ -1010,6 +1022,7 @@ export class CallbackChain {
 
       if (aborted) {
         halted = true;
+        this._notifyHalt(target, entry);
         break;
       }
 
@@ -1051,6 +1064,7 @@ export class CallbackChain {
             // Rails scopes `catch(:abort)` to the default terminator). An async
             // before rejecting with the sentinel halts; real errors propagate.
             if (!isAbortSignal(e) || terminatorFn === false) throw e;
+            this._notifyHalt(target, entry);
             return this._runAfters(afters, true, skipAfterIfTerminated, target, opts, false);
           }
           for (const rem of remaining) {
@@ -1072,16 +1086,20 @@ export class CallbackChain {
               }
             } catch (e) {
               if (!isAbortSignal(e) || terminatorFn === false) throw e;
+              this._notifyHalt(target, rem);
               return this._runAfters(afters, true, skipAfterIfTerminated, target, opts, false);
             }
             try {
               if (isThenable(remVal)) await remVal;
             } catch (e) {
               if (!isAbortSignal(e) || terminatorFn === false) throw e;
+              this._notifyHalt(target, rem);
               return this._runAfters(afters, true, skipAfterIfTerminated, target, opts, false);
             }
-            if (remSyncHalt)
+            if (remSyncHalt) {
+              this._notifyHalt(target, rem);
               return this._runAfters(afters, true, skipAfterIfTerminated, target, opts, false);
+            }
           }
           return this._runAroundAndAfter(
             arounds,
@@ -1101,6 +1119,7 @@ export class CallbackChain {
         // `aborted`), matching Rails 5+ default_terminator. A `false` return no
         // longer halts. A custom terminator owns its own halt decision.
         halted = true;
+        this._notifyHalt(target, entry);
         break;
       }
     }

--- a/packages/activesupport/src/callbacks.ts
+++ b/packages/activesupport/src/callbacks.ts
@@ -434,7 +434,7 @@ export class Before {
             `Use the default terminator (halt via throwAbort()) or make all before callbacks synchronous.`,
         );
       }
-      if (halt) env.halted = true;
+      if (halt) this.halt(env);
       return env;
     }
 
@@ -444,7 +444,7 @@ export class Before {
       cbResult = resultLambda();
     } catch (e) {
       if (!isAbortSignal(e)) throw e;
-      env.halted = true;
+      this.halt(env);
       return env;
     }
     if (!isThenable(cbResult)) return env;
@@ -459,10 +459,23 @@ export class Before {
       () => env,
       (e) => {
         if (!isAbortSignal(e)) throw e;
-        env.halted = true;
+        this.halt(env);
         return env;
       },
     );
+  }
+
+  /**
+   * Mark the chain halted and fire Rails' `halted_callback_hook(filter, name)`
+   * on the target (a private no-op the including class may override to log or
+   * instrument which callback halted). Mirrors `Before#call`'s
+   * `target.send :halted_callback_hook, filter, name`.
+   */
+  private halt(env: FilterEnvironment): void {
+    env.halted = true;
+    const hook = (env.target as { haltedCallbackHook?: (filter: unknown, name: string) => void })
+      .haltedCallbackHook;
+    if (typeof hook === "function") hook.call(env.target, this.filter, this.name);
   }
 
   apply(seq: CallbackSequence): CallbackSequence {
@@ -1659,6 +1672,11 @@ export function CallbacksMixin<TBase extends new (...args: any[]) => object>(Bas
     ): boolean | Promise<boolean> {
       return runCallbacks(this, name, block, opts);
     }
+
+    // A hook invoked every time a before callback is halted. Overridable in
+    // implementors (Rails: ActiveSupport::Callbacks#halted_callback_hook) to
+    // provide better debugging/logging. Default is a no-op.
+    haltedCallbackHook(_filter: unknown, _name: string): void {}
   }
 
   return WithCallbacks;


### PR DESCRIPTION
## What

Mirror Rails' `Filters::Before#call`, which invokes
`target.send(:halted_callback_hook, filter, name)` when a before callback halts
the chain (`vendor/rails/activesupport/lib/active_support/callbacks.rb`). trails
stored `filter`/`name` on the `Before` filter but never fired the hook — on
**either** the compiled sequence path or the bespoke around-chain engine.

- **Compiled path** (`Before#halt`): sets `env.halted` **and** fires
  `haltedCallbackHook(filter, name)` across all three halt paths (custom
  terminator, sync abort, async abort).
- **Around-chain engine** (`CallbackChain#_invoke`): chains containing around
  callbacks route through the bespoke engine, not `Before#call`. Rails compiles
  `Filters::Before` for those chains too, so the hook must fire there as well —
  otherwise halting a before callback on a transaction-wrapped AR save chain
  would silently skip the hook. `_notifyHalt` is wired into all five `_invoke`
  halt spots.
- `CallbacksMixin` gains the default no-op `haltedCallbackHook` so overriding is
  opt-in (Rails' ActiveModel has no override, so nothing to wire there).

## Tests

- Rewrote the two placeholder tests (`termination invokes hook`,
  `default termination invokes hook`) to assert the hook fires with the halting
  filter/name — matching Rails'
  `CallbackTerminatorTest#test_termination_invokes_hook` and
  `CallbackDefaultTerminatorTest#test_default_termination_invokes_hook`.
- Added sync + async around-chain coverage for the `_invoke` path.

Closes-story: callbacks-invoke-halted-callback-hook