### PR TITLE
refactor(migration): collapse CTAS column introspection onto adapter columns()

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -1266,8 +1266,9 @@ describe("MigrationTest", () => {
     expect(rows).toHaveLength(1);
     expect(ctx.columnExists("table_from_query_testings", "person_id")).toBe(true);
 
-    // _introspectColumns / _normalizeIntrospectedType should populate
-    // _columnMeta with a Rails-canonical type (not the raw catalog string).
+    // The CTAS column derivation reads back through the adapter's own
+    // `columns()` (Rails `new_column_from_field`), so the persisted type is the
+    // Rails-canonical name (not the raw catalog string).
     const cols = ctx.columns("table_from_query_testings");
     const pid = cols.find((c) => c.name === "person_id");
     expect(pid?.type).toBe("integer");

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -3,8 +3,8 @@
  *
  * These guard trails-internal implementation details (the `_connectionOverride`
  * / `_poolOverride` connection routing, the async `migration()` proxy, and the
- * `_normalizeIntrospectedType` / `_introspectColumns` catalog-introspection
- * helpers) that have no counterpart in Rails' migration_test.rb. Relocated here
+ * `_indexes` schema-dump bookkeeping) that have no counterpart in Rails'
+ * migration_test.rb. Relocated here
  * verbatim from migration.test.ts under RFC 0043 so the convention file tracks
  * Rails 1:1 while the invariants stay covered.
  */
@@ -91,85 +91,6 @@ describe("MigrationTest", () => {
     expect(await migrator.currentVersion()).toBe(1);
   });
 
-  it("_normalizeIntrospectedType maps catalog rows to Rails-canonical types", () => {
-    const N = (
-      MigrationContext as unknown as {
-        _normalizeIntrospectedType: (
-          raw: string,
-          a?: "sqlite" | "postgres" | "mysql",
-          opts?: { emulateBooleans?: boolean },
-        ) => { type: string; limit?: number; precision?: number; scale?: number };
-      }
-    )._normalizeIntrospectedType;
-
-    // MySQL boolean emulation + integer byte limits + enum/set/year/bit
-    expect(N("tinyint(1)", "mysql")).toEqual({ type: "boolean" });
-    // emulateBooleans=false falls back to a 1-byte integer (mysql-type-lookup parity).
-    expect(N("tinyint(1)", "mysql", { emulateBooleans: false })).toEqual({
-      type: "integer",
-      limit: 1,
-    });
-    expect(N("tinyint", "mysql")).toEqual({ type: "integer", limit: 1 });
-    expect(N("smallint", "mysql")).toEqual({ type: "integer", limit: 2 });
-    expect(N("mediumint", "mysql")).toEqual({ type: "integer", limit: 3 });
-    expect(N("int(11)", "mysql")).toEqual({ type: "integer", limit: 4 });
-    // MySQL `year` is registered as plain IntegerType (abstract-mysql-adapter.ts:1422).
-    expect(N("year", "mysql")).toEqual({ type: "integer" });
-    expect(N("enum('a','b')", "mysql")).toEqual({ type: "string" });
-    expect(N("set('a','b')", "mysql")).toEqual({ type: "string" });
-    expect(N("bit(8)", "mysql")).toEqual({ type: "binary", limit: 8 });
-
-    // Strings vs text vs citext
-    expect(N("varchar(255)", "mysql")).toEqual({ type: "string", limit: 255 });
-    expect(N("text", "mysql")).toEqual({ type: "text" });
-    expect(N("longtext", "mysql")).toEqual({ type: "text" });
-    expect(N("citext", "postgres")).toEqual({ type: "citext" });
-
-    // Decimal: one-arg → precision, two-arg → precision+scale
-    expect(N("decimal(10)", "mysql")).toEqual({ type: "decimal", precision: 10 });
-    expect(N("numeric(10,2)", "postgres")).toEqual({ type: "decimal", precision: 10, scale: 2 });
-
-    // Float byte limits — mirror per-adapter type maps:
-    //  - MySQL: float→24, double→53, real==double (53)
-    //  - PG (type-map-init.ts:138-139): float4→24, float8→no limit;
-    //    real==float4 → 24, double precision==float8 → no limit
-    //  - SQLite (sqlite3-adapter.ts:2224): all float-like → no limit
-    expect(N("float", "mysql")).toEqual({ type: "float", limit: 24 });
-    expect(N("double", "mysql")).toEqual({ type: "float", limit: 53 });
-    expect(N("real", "mysql")).toEqual({ type: "float", limit: 53 });
-    expect(N("float4", "postgres")).toEqual({ type: "float", limit: 24 });
-    expect(N("real", "postgres")).toEqual({ type: "float", limit: 24 });
-    expect(N("float8", "postgres")).toEqual({ type: "float" });
-    expect(N("double precision", "postgres")).toEqual({ type: "float" });
-    expect(N("float", "sqlite")).toEqual({ type: "float" });
-
-    // SQLite integer collapses to dynamic 8-byte int (sqlite3-adapter.ts:2188).
-    expect(N("integer", "sqlite")).toEqual({ type: "integer", limit: 8 });
-    expect(N("bigint", "sqlite")).toEqual({ type: "integer", limit: 8 });
-
-    // Date/time precision propagation
-    expect(N("datetime(6)", "mysql")).toEqual({ type: "datetime", precision: 6 });
-    expect(N("time(3)", "mysql")).toEqual({ type: "time", precision: 3 });
-    expect(N("time with time zone", "postgres")).toEqual({ type: "time" });
-    // PG schema-dumper.ts:117-118 distinguishes `timestamptz` DSL from `datetime`.
-    expect(N("timestamp with time zone", "postgres")).toEqual({ type: "timestamptz" });
-    expect(N("timestamptz", "postgres")).toEqual({ type: "timestamptz" });
-    expect(N("timestamp", "postgres")).toEqual({ type: "datetime" });
-
-    // PG bit / bit varying are their own types (NOT binary like MySQL).
-    // bit varying is stored as the SQL form so schema-dumper.ts:142-143
-    // resolves it to the bitVarying DSL.
-    expect(N("bit", "postgres")).toEqual({ type: "bit" });
-    expect(N("bit varying", "postgres")).toEqual({ type: "bit varying" });
-    expect(N("varbit", "postgres")).toEqual({ type: "bit varying" });
-
-    // Binary / uuid / json
-    expect(N("bytea", "postgres")).toEqual({ type: "binary" });
-    expect(N("blob", "mysql")).toEqual({ type: "binary" });
-    expect(N("uuid", "postgres")).toEqual({ type: "uuid" });
-    expect(N("jsonb", "postgres")).toEqual({ type: "jsonb" });
-  });
-
   it("addIndex bookkeeping reduces a single-column expression index name", async () => {
     // Regression: MigrationContext#addIndex delegates the DDL to the adapter but
     // records the resolved name into `_indexes` for the schema dump. That name
@@ -246,32 +167,5 @@ describe("MigrationTest", () => {
     );
     await sqliteCtx.addIndex("users", "email", { using: "hash" });
     expect(sqliteCtx.indexes("users").find((i) => i.columns.includes("email"))?.using).toBe("hash");
-  });
-
-  it("_introspectColumns handles PG ARRAY + USER-DEFINED + datetime_precision rows", async () => {
-    // Stub the adapter to feed PG-shaped catalog rows through the live
-    // _introspectColumns code path (sqlite test adapter can't return them).
-    const stub = {
-      adapterName: "postgres" as const,
-      quoteTableName: (n: string) => `"${n}"`,
-      execute: async () => [
-        { column_name: "tags", data_type: "ARRAY", udt_name: "_int4" },
-        { column_name: "score", data_type: "numeric", numeric_precision: 10, numeric_scale: 2 },
-        { column_name: "doc", data_type: "USER-DEFINED", udt_name: "citext" },
-        { column_name: "made_at", data_type: "timestamp with time zone", datetime_precision: 6 },
-        { column_name: "name", data_type: "character varying", character_maximum_length: 100 },
-      ],
-    };
-    const ctx = new MigrationContext(stub as unknown as DatabaseAdapter);
-    const cols = await (
-      ctx as unknown as { _introspectColumns: (n: string) => Promise<unknown[]> }
-    )._introspectColumns("things");
-    expect(cols).toEqual([
-      { name: "tags", type: "integer", limit: 4, array: true },
-      { name: "score", type: "decimal", precision: 10, scale: 2 },
-      { name: "doc", type: "citext" },
-      { name: "made_at", type: "timestamptz", precision: 6 },
-      { name: "name", type: "string", limit: 100 },
-    ]);
   });
 });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1595,9 +1595,16 @@ export class MigrationContext {
       string,
       {
         type: string;
+        // Raw adapter SQL type (`"bigint"`, `"varchar(255)"` …). The dumpers key
+        // `bigint?`/`schemaType`/`schemaLimit` off `Column#sql_type`, so it must
+        // survive the CTAS copy — a reflected `bigint` whose cast type is
+        // `integer` still dumps as `t.bigint` only via this string.
+        sqlType?: string | null;
         primaryKey?: boolean;
         null?: boolean;
         default?: unknown;
+        collation?: string | null;
+        comment?: string | null;
         limit?: number | null;
         precision?: number | null;
         scale?: number | null;
@@ -1765,9 +1772,12 @@ export class MigrationContext {
       string,
       {
         type: string;
+        sqlType?: string | null;
         primaryKey?: boolean;
         null?: boolean;
         default?: unknown;
+        collation?: string | null;
+        comment?: string | null;
         limit?: number | null;
         precision?: number | null;
         scale?: number | null;
@@ -1814,6 +1824,13 @@ export class MigrationContext {
         cols.add(col.name);
         meta.set(col.name, {
           type: col.type ?? "string",
+          // Carry the raw `sql_type` so the dumper's `bigint?`/`schemaType`
+          // detection keys off the same string Rails does (`Column#sql_type`).
+          sqlType: col.sqlType,
+          null: col.null ?? undefined,
+          default: col.default,
+          collation: col.collation,
+          comment: col.comment,
           ...(col.limit != null ? { limit: col.limit } : {}),
           ...(col.precision != null ? { precision: col.precision } : {}),
           ...(col.scale != null ? { scale: col.scale } : {}),
@@ -2234,9 +2251,12 @@ export class MigrationContext {
   columns(tableName: string): Array<{
     name: string;
     type: string;
+    sqlType?: string | null;
     primaryKey?: boolean;
     null?: boolean;
     default?: unknown;
+    collation?: string | null;
+    comment?: string | null;
     limit?: number | null;
     precision?: number | null;
     scale?: number | null;

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1584,7 +1584,8 @@ export class MigrationContext {
   // synchronous and served from these in-memory maps. Collapsing them onto the
   // adapter's async introspection requires making those readers async, which
   // ripples into the synchronous `SchemaDumper.dump(ctx)` protocol and its
-  // exact-output dump assertions — deferred to its own coordinated PR rather
+  // exact-output dump assertions — deferred to the RFC 0051 follow-up story
+  // `collapse-migrationcontext-introspection-onto-adapter-remaining` rather
   // than silently retained here.
   private _tables = new Set<string>();
   private _columns = new Map<string, Set<string>>();

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1578,6 +1578,14 @@ export abstract class Migration {
  * Mirrors: ActiveRecord::MigrationContext
  */
 export class MigrationContext {
+  // TRACKED DIVERGENCE (RFC 0051 follow-up): the CTAS column derivation now
+  // reads back through the adapter's real `SchemaStatements#columns`, but the
+  // `columns()`/`indexes()`/`tables()`/`columnExists()` read API is still
+  // synchronous and served from these in-memory maps. Collapsing them onto the
+  // adapter's async introspection requires making those readers async, which
+  // ripples into the synchronous `SchemaDumper.dump(ctx)` protocol and its
+  // exact-output dump assertions — deferred to its own coordinated PR rather
+  // than silently retained here.
   private _tables = new Set<string>();
   private _columns = new Map<string, Set<string>>();
   private _columnMeta = new Map<
@@ -1665,197 +1673,6 @@ export class MigrationContext {
 
   private get _adapterName(): "sqlite" | "postgres" | "mysql" {
     return this.connection.adapterName as "sqlite" | "postgres" | "mysql";
-  }
-
-  /** @internal Query catalog for column names+types — used after CTAS where columns derive from the SELECT. */
-  private async _introspectColumns(name: string): Promise<
-    {
-      name: string;
-      type: string;
-      limit?: number;
-      precision?: number;
-      scale?: number;
-      array?: boolean;
-    }[]
-  > {
-    const a = this._adapterName;
-    const qt = this.connection.quoteTableName(name);
-    let sql: string;
-    if (a === "sqlite") {
-      sql = `PRAGMA table_info(${qt})`;
-    } else if (a === "postgres") {
-      const [s, t] = name.includes(".") ? name.split(".", 2) : ["public", name];
-      const e = (x: string) => x.replace(/'/g, "''");
-      // Pull udt_name for user-defined types (citext, hstore, …) which
-      // surface as "USER-DEFINED" via data_type, plus size fields for
-      // limit/precision/scale propagation.
-      sql = `SELECT column_name, data_type, udt_name, character_maximum_length, numeric_precision, numeric_scale, datetime_precision FROM information_schema.columns WHERE table_schema = '${e(s)}' AND table_name = '${e(t)}' ORDER BY ordinal_position`;
-    } else {
-      sql = `SHOW COLUMNS FROM ${qt}`;
-    }
-    const rows = await this.connection.execute(sql);
-    return rows.map((r) => {
-      const x = r;
-      const colName = (x.name ?? x.column_name ?? x.Field) as string;
-      // SQLite: type; PG: data_type (with udt_name for USER-DEFINED); MySQL: Type
-      let rawType = ((x.type ?? x.data_type ?? x.Type) as string | undefined) ?? "";
-      let isArray = false;
-      if (a === "postgres") {
-        // PG reports array columns as data_type='ARRAY' + udt_name='_int4'
-        // etc. — strip the leading underscore and surface as the base type
-        // plus array:true (schema-dumper/array.test.ts pattern).
-        if (rawType.toUpperCase() === "ARRAY" && typeof x.udt_name === "string") {
-          rawType = x.udt_name.replace(/^_/, "");
-          isArray = true;
-        } else if (rawType.toUpperCase() === "USER-DEFINED" && x.udt_name) {
-          rawType = String(x.udt_name);
-        }
-      }
-      // Mirror the configured MySQL emulateBooleans setting rather than
-      // hard-coding Rails' default — abstract-mysql-adapter exposes it.
-      const emulateBooleans =
-        a === "mysql"
-          ? ((this.connection as { emulateBooleans?: boolean }).emulateBooleans ?? true)
-          : true;
-      const normalized = MigrationContext._normalizeIntrospectedType(rawType, a, {
-        emulateBooleans,
-      });
-      // Prefer PG's authoritative size columns when present — they sit in
-      // information_schema rather than baked into the type string.
-      if (a === "postgres") {
-        const charLen = x.character_maximum_length;
-        const numPrec = x.numeric_precision;
-        const numScale = x.numeric_scale;
-        const dtPrec = x.datetime_precision;
-        if (typeof charLen === "number") normalized.limit = charLen;
-        // numeric_precision is meaningless for floats per PG type-map-init
-        // (float4 carries a fixed limit, float8 carries nothing) — only fill
-        // it for decimal.
-        if (typeof numPrec === "number" && normalized.type === "decimal") {
-          normalized.precision = numPrec;
-          if (typeof numScale === "number") normalized.scale = numScale;
-        }
-        if (
-          typeof dtPrec === "number" &&
-          (normalized.type === "datetime" ||
-            normalized.type === "time" ||
-            normalized.type === "timestamptz")
-        )
-          normalized.precision = dtPrec;
-      }
-      return { name: colName, ...normalized, ...(isArray ? { array: true } : {}) };
-    });
-  }
-
-  /**
-   * @internal Map raw catalog types (PG/MySQL/SQLite) to Rails-canonical
-   * names plus precision/scale/limit. Mirrors the per-adapter type-lookup
-   * registrations (mysql-type-lookup, postgresql/oid). Callers may pass
-   * `emulateBooleans` (default true) so MySQL `tinyint(1)` follows the
-   * adapter's configured emulation mode; `_introspectColumns` threads in
-   * the live `abstract-mysql-adapter#emulateBooleans` value.
-   */
-  static _normalizeIntrospectedType(
-    raw: string,
-    adapter: "sqlite" | "postgres" | "mysql" = "sqlite",
-    opts: { emulateBooleans?: boolean } = {},
-  ): {
-    type: string;
-    limit?: number;
-    precision?: number;
-    scale?: number;
-  } {
-    const emulateBooleans = opts.emulateBooleans ?? true;
-    const t = raw.toLowerCase().trim();
-    if (!t) return { type: "string" };
-    // MySQL boolean emulation must run before modifier stripping.
-    if (/^tinyint\s*\(\s*1\s*\)/.test(t))
-      return emulateBooleans ? { type: "boolean" } : { type: "integer", limit: 1 };
-    // enum/set carry a literal value list, not a length.
-    if (/^enum\s*\(/.test(t) || /^set\s*\(/.test(t)) return { type: "string" };
-    const parenMatch = t.match(/^([a-z_ ]+?)\s*\((\d+)(?:\s*,\s*(\d+))?\)/);
-    const head = (parenMatch?.[1] ?? t.replace(/\s+unsigned\b.*$/, "")).trim();
-    const arg1 = parenMatch ? Number(parenMatch[2]) : undefined;
-    const arg2 = parenMatch && parenMatch[3] != null ? Number(parenMatch[3]) : undefined;
-    const limit = arg1 !== undefined && arg2 === undefined ? { limit: arg1 } : {};
-    // decimal(N) / decimal(N,M) — one-arg is precision (Rails decimal_columns).
-    const decSizes =
-      arg1 !== undefined
-        ? arg2 !== undefined
-          ? { precision: arg1, scale: arg2 }
-          : { precision: arg1 }
-        : {};
-    // datetime(N) / time(N) — N is fractional-seconds precision.
-    const precOnly = arg1 !== undefined && arg2 === undefined ? { precision: arg1 } : {};
-    // Per-adapter integer byte limits, mirroring the canonical type maps:
-    //  - postgresql/type-map-init.ts:134-136 (int2=2, int4=4, int8=8)
-    //  - mysql-type-lookup tests (tinyint=1, smallint=2, mediumint=3, int=4)
-    //  - sqlite3-adapter.ts:2188 (sqlite3Int defaults to limit 8)
-    // SQLite collapses everything to its dynamic integer; don't pretend
-    // otherwise. PG/MySQL share byte-sized variants below.
-    const intByteLimit: Record<string, number | undefined> = {
-      tinyint: 1,
-      smallint: 2,
-      int2: 2,
-      mediumint: 3,
-      int: 4,
-      integer: 4,
-      int4: 4,
-      year: 4,
-    };
-    if (/^(varchar|character varying|character|char|nvarchar|nchar)$/.test(head))
-      return { type: "string", ...limit };
-    if (/^(text|tinytext|mediumtext|longtext|clob)$/.test(head)) return { type: "text" };
-    if (/^citext$/.test(head)) return { type: "citext" };
-    if (/^(int|integer|int4|int2|smallint|mediumint|tinyint|serial|smallserial|year)$/.test(head)) {
-      if (adapter === "sqlite") return { type: "integer", limit: 8 };
-      // MySQL `year` is registered as a plain IntegerType with no limit
-      // (abstract-mysql-adapter.ts:1422). Other integer aliases keep their
-      // adapter-registered byte limit.
-      if (head === "year") return { type: "integer" };
-      return { type: "integer", limit: intByteLimit[head] ?? 4 };
-    }
-    if (/^(bigint|int8|bigserial)$/.test(head))
-      return adapter === "sqlite" ? { type: "integer", limit: 8 } : { type: "bigint" };
-    // Float byte-limits: PG float4 has limit 24 and float8 has no limit
-    // (postgresql/type-map-init.ts:138-139). SQLite registers all float-like
-    // declarations as FloatType() with no limit (sqlite3-adapter.ts:2224).
-    // MySQL retains the float/double precision split.
-    if (/^float4$/.test(head)) return { type: "float", limit: 24 };
-    if (/^float8$/.test(head)) return { type: "float" };
-    if (/^float$/.test(head))
-      return adapter === "mysql" ? { type: "float", limit: 24 } : { type: "float" };
-    if (/^real$/.test(head))
-      return adapter === "mysql" ? { type: "float", limit: 53 } : { type: "float", limit: 24 };
-    if (/^(double|double precision)$/.test(head))
-      return adapter === "mysql" ? { type: "float", limit: 53 } : { type: "float" };
-    if (/^(numeric|decimal|number)$/.test(head)) return { type: "decimal", ...decSizes };
-    if (/^(bool|boolean)$/.test(head)) return { type: "boolean" };
-    // PG registers `bit`/`varbit` as standalone Bit/BitVarying types
-    // (postgresql/type-map-init.ts); MySQL `bit` is a binary blob per
-    // mysql-type-lookup. PG `bit varying` arrives via information_schema.
-    if (/^bit$/.test(head))
-      return adapter === "postgres" ? { type: "bit", ...limit } : { type: "binary", ...limit };
-    // Store the raw SQL form 'bit varying' so SchemaDumper SQL_TYPE_MAP
-    // (schema-dumper.ts:142-143) resolves it to the bitVarying DSL helper.
-    if (/^(varbit|bit varying)$/.test(head)) return { type: "bit varying", ...limit };
-    if (/^date$/.test(head)) return { type: "date" };
-    if (/^(time|time without time zone)$/.test(head)) return { type: "time", ...precOnly };
-    if (/^(timetz|time with time zone)$/.test(head)) return { type: "time", ...precOnly };
-    // Distinguish PG timestamptz from naive datetime — schema-dumper.ts:117-118
-    // maps `timestamp with time zone` to the `timestamptz` SQL_TYPE_MAP entry
-    // (the emitter then falls back to `t.column(..., "timestamptz")` since
-    // `timestamptz` isn't in DSL_HELPER_METHODS). Separate from the `datetime`
-    // DSL used for naive timestamps.
-    if (/^(timestamptz|timestamp with time zone)$/.test(head))
-      return { type: "timestamptz", ...precOnly };
-    if (/^(datetime|timestamp|timestamp without time zone)$/.test(head))
-      return { type: "datetime", ...precOnly };
-    if (/^uuid$/.test(head)) return { type: "uuid" };
-    if (/^(json|jsonb)$/.test(head)) return { type: head };
-    if (/^(bytea|blob|tinyblob|mediumblob|longblob|binary|varbinary)$/.test(head))
-      return { type: "binary", ...limit };
-    return { type: head };
   }
 
   async createTable(
@@ -1986,10 +1803,21 @@ export class MigrationContext {
       });
     }
     if (options?.as != null) {
-      for (const col of await this._introspectColumns(name)) {
-        const { name: c, ...rest } = col;
-        cols.add(c);
-        meta.set(c, rest);
+      // CTAS columns derive from the SELECT rather than `td.columns`, so read
+      // them back through the adapter's own `columns()` — the single
+      // Rails-faithful introspection path (`new_column_from_field` →
+      // `fetch_type_metadata`, so the catalog type is normalized through the
+      // adapter's type map) — instead of a bespoke catalog query + type
+      // normalizer.
+      for (const col of await this.connection.columns(name)) {
+        cols.add(col.name);
+        meta.set(col.name, {
+          type: col.type ?? "string",
+          ...(col.limit != null ? { limit: col.limit } : {}),
+          ...(col.precision != null ? { precision: col.precision } : {}),
+          ...(col.scale != null ? { scale: col.scale } : {}),
+          ...((col as { array?: boolean }).array ? { array: true } : {}),
+        });
       }
     }
     this._columns.set(name, cols);

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1609,6 +1609,7 @@ export class MigrationContext {
         precision?: number | null;
         scale?: number | null;
         array?: boolean;
+        isEnum?: boolean;
         datetimePhysicalType?: string;
       }
     >
@@ -1782,6 +1783,7 @@ export class MigrationContext {
         precision?: number | null;
         scale?: number | null;
         array?: boolean;
+        isEnum?: boolean;
         datetimePhysicalType?: string;
       }
     >();
@@ -1835,6 +1837,9 @@ export class MigrationContext {
           ...(col.precision != null ? { precision: col.precision } : {}),
           ...(col.scale != null ? { scale: col.scale } : {}),
           ...((col as { array?: boolean }).array ? { array: true } : {}),
+          // PG `Column#enum?` (cast type "enum") survives CTAS but isn't a base
+          // Column field; the dumper emits `enum_type:` only when this is set.
+          ...(col.type === "enum" ? { isEnum: true } : {}),
         });
       }
     }
@@ -2261,6 +2266,7 @@ export class MigrationContext {
     precision?: number | null;
     scale?: number | null;
     array?: boolean;
+    isEnum?: boolean;
     datetimePhysicalType?: string;
   }> {
     const meta = this._columnMeta.get(tableName);


### PR DESCRIPTION
## What

`MigrationContext.createTable`'s `as:` (CTAS) branch derived its columns via a
bespoke `_introspectColumns` (hand-rolled `PRAGMA table_info` / `information_schema.columns`
/ `SHOW COLUMNS`) plus a `_normalizeIntrospectedType` catalog-type normalizer.
This reads the columns back through the adapter's own `columns()` instead — the
single Rails-faithful introspection path (`new_column_from_field` →
`fetch_type_metadata`, so the catalog type is normalized through the adapter's
type map). Both bespoke helpers (~190 LOC) and their trails-only unit tests are
deleted.

## Tracked divergence (deliberate)

The synchronous `columns()` / `indexes()` / `tables()` / `columnExists()` read
API and its in-memory `_tables` / `_columns` / `_columnMeta` / `_indexes` maps
are **retained** and documented as a tracked divergence in a comment above the
`_tables` field. Collapsing those readers onto the adapter's async introspection
requires making them async, which ripples into the synchronous
`SchemaDumper.dump(ctx)` protocol and its exact-output dump assertions — deferred
to the follow-up story `collapse-migrationcontext-introspection-onto-adapter-remaining`
(registered under RFC 0051), which captures the full context.

## Tests

`migration.test.ts`, `migration.trails.test.ts`, `schema-dumper.test.ts`,
`date-time-precision.test.ts`, `time-precision.test.ts`, `defaults.test.ts`,
`comment.test.ts`, `bigint-roundtrip.test.ts` pass locally on sqlite. The CTAS
test (`create table with query`) still asserts `person_id` reflects as `integer`.

Closes-story: collapse-migrationcontext-introspection-onto-adapter