### PR TITLE
refactor(migration): collapse MigrationContext introspection onto adapter

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -304,7 +304,22 @@ export interface AbstractAdapter {
     options?: { name?: string; unique?: boolean; valid?: boolean },
   ): Promise<boolean>;
   tableExists(tableName: string): Promise<boolean>;
-  columnExists(tableName: string, columnName: string): Promise<boolean>;
+  // Rails' `column_exists?(table, column, type = nil, **options)` narrows the
+  // match by column `type` and the columnOptionsKeys when given.
+  columnExists(
+    tableName: string,
+    columnName: string,
+    type?: string | null,
+    options?: {
+      limit?: unknown;
+      precision?: unknown;
+      scale?: unknown;
+      default?: unknown;
+      null?: unknown;
+      collation?: unknown;
+      comment?: unknown;
+    },
+  ): Promise<boolean>;
   tables(): Promise<string[]>;
   views(): Promise<string[]>;
   viewExists(viewName: string): Promise<boolean>;

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -613,13 +613,38 @@ export class SchemaStatements {
     return rows.length > 0;
   }
 
-  async columnExists(tableName: string, columnName: string): Promise<boolean> {
+  async columnExists(
+    tableName: string,
+    columnName: string,
+    type?: string | null,
+    options: {
+      limit?: unknown;
+      precision?: unknown;
+      scale?: unknown;
+      default?: unknown;
+      null?: unknown;
+      collation?: unknown;
+      comment?: unknown;
+    } = {},
+  ): Promise<boolean> {
     // Rails' column_exists? loads the table's columns and matches the name in
-    // Ruby (schema_statements.rb), never interpolating the column name into SQL —
-    // so an arbitrary value (quotes/operators) simply matches nothing. The
-    // schema.table qualification is honored by columns() below.
+    // Ruby (schema_statements.rb:132-141), never interpolating the column name
+    // into SQL — so an arbitrary value (quotes/operators) simply matches
+    // nothing. The schema.table qualification is honored by columns() below.
+    // An optional `type` plus any of the `columnOptionsKeys`
+    // (limit/precision/scale/default/null/collation/comment) narrow the match,
+    // each ANDed like Rails' `checks.all?`.
     const cols = await this.columns(tableName);
-    return cols.some((c) => c.name === columnName);
+    const optionKeys = this.columnOptionsKeys() as Array<keyof typeof options>;
+    return cols.some((c) => {
+      if (c.name !== columnName) return false;
+      if (type != null && (c as { type?: unknown }).type !== type) return false;
+      for (const key of optionKeys) {
+        if (key in options && (c as unknown as Record<string, unknown>)[key] !== options[key])
+          return false;
+      }
+      return true;
+    });
   }
 
   async changeColumnDefault(

--- a/packages/activerecord/src/date-time-precision.test.ts
+++ b/packages/activerecord/src/date-time-precision.test.ts
@@ -239,7 +239,7 @@ describe("DateTimePrecisionTest", () => {
       await ctx.createTable("foos", { force: true }, (t) => {
         t.timestamps({ precision: 6 });
       });
-      const output = SchemaDumper.dump(ctx) as string;
+      const output = await SchemaDumper.dumpTableSchema(adapter, "foos");
       expect(output).toMatch(/t\.datetime\("created_at",\s*\{[^}]*null:\s*false/);
       expect(output).not.toMatch(/precision/);
     },
@@ -252,7 +252,7 @@ describe("DateTimePrecisionTest", () => {
       await ctx.createTable("foos", { force: true }, (t) => {
         t.timestamps({ precision: null });
       });
-      const output = SchemaDumper.dump(ctx) as string;
+      const output = await SchemaDumper.dumpTableSchema(adapter, "foos");
       expect(output).toMatch(/t\.datetime\("created_at".*precision.*null/);
       expect(output).toMatch(/t\.datetime\("updated_at".*precision.*null/);
     },

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -239,8 +239,8 @@ describe("MigrationTest", () => {
       });
 
       await ctx.renameTable("old", "new");
-      expect(ctx.tableExists("pre_old_suf")).toBe(false);
-      expect(ctx.tableExists("pre_new_suf")).toBe(true);
+      expect(await ctx.tableExists("pre_old_suf")).toBe(false);
+      expect(await ctx.tableExists("pre_new_suf")).toBe(true);
     } finally {
       await ctx.dropTable("pre_old_suf", "pre_new_suf", { ifExists: true });
     }
@@ -375,7 +375,7 @@ describe("MigrationTest", () => {
     });
 
     // The persisted column precision/scale survive the create_table path.
-    const cols = ctx.columns("big_numbers");
+    const cols = await ctx.columns("big_numbers");
     const byName = (n: string) => cols.find((c) => c.name === n)!;
     expect(byName("bank_balance").precision).toBe(10);
     expect(byName("bank_balance").scale).toBe(2);
@@ -544,7 +544,7 @@ describe("MigrationTest", () => {
     await ctx.createTable("binary_testings", {}, (t) => {
       t.column("data", "binary", { null: false });
     });
-    const cols = ctx.columns("binary_testings");
+    const cols = await ctx.columns("binary_testings");
     const dataColumn = cols.find((c) => c.name === "data");
     expect(dataColumn).toBeDefined();
     expect(dataColumn!.type).toBe("binary");
@@ -775,7 +775,7 @@ describe("MigrationTest", () => {
       await ctx.createTable("things", { ifNotExists: true }, (t) => {
         t.string("name");
       });
-      expect(ctx.tableExists("things")).toBe(true);
+      expect(await ctx.tableExists("things")).toBe(true);
     } finally {
       await ctx.dropTable("things", { ifExists: true });
     }
@@ -809,7 +809,7 @@ describe("MigrationTest", () => {
       await ctx.createTable("things", { ifNotExists: true }, (t) => {
         t.string("name");
       });
-      expect(ctx.tableExists("things")).toBe(true);
+      expect(await ctx.tableExists("things")).toBe(true);
     } finally {
       await ctx.dropTable("things", { ifExists: true });
     }
@@ -817,11 +817,11 @@ describe("MigrationTest", () => {
 
   it("create table with force true does not drop nonexisting table", async () => {
     const { ctx } = await freshContext();
-    expect(ctx.tableExists("nonexistent")).toBe(false);
+    expect(await ctx.tableExists("nonexistent")).toBe(false);
     await ctx.createTable("nonexistent", { force: true }, (t) => {
       t.string("name");
     });
-    expect(ctx.tableExists("nonexistent")).toBe(true);
+    expect(await ctx.tableExists("nonexistent")).toBe(true);
   });
 
   it("remove column with if exists set", async () => {
@@ -1264,12 +1264,12 @@ describe("MigrationTest", () => {
     });
     const rows = await adapter.execute(`SELECT * FROM table_from_query_testings`);
     expect(rows).toHaveLength(1);
-    expect(ctx.columnExists("table_from_query_testings", "person_id")).toBe(true);
+    expect(await ctx.columnExists("table_from_query_testings", "person_id")).toBe(true);
 
     // The CTAS column derivation reads back through the adapter's own
     // `columns()` (Rails `new_column_from_field`), so the persisted type is the
     // Rails-canonical name (not the raw catalog string).
-    const cols = ctx.columns("table_from_query_testings");
+    const cols = await ctx.columns("table_from_query_testings");
     const pid = cols.find((c) => c.name === "person_id");
     expect(pid?.type).toBe("integer");
 
@@ -1306,11 +1306,11 @@ describe("MigrationTest", () => {
         t.string("name");
         t.column("foo", "bar" as any);
       });
-      expect(ctx.columnExists("something", "foo")).toBe(true);
+      expect(await ctx.columnExists("something", "foo")).toBe(true);
       await ctx.removeColumn("something", "foo");
-      expect(ctx.columnExists("something", "foo")).toBe(false);
-      expect(ctx.columnExists("something", "name")).toBe(true);
-      expect(ctx.columnExists("something", "number")).toBe(true);
+      expect(await ctx.columnExists("something", "foo")).toBe(false);
+      expect(await ctx.columnExists("something", "name")).toBe(true);
+      expect(await ctx.columnExists("something", "number")).toBe(true);
       await ctx.dropTable("something");
     },
   );

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -3,7 +3,7 @@
  *
  * These guard trails-internal implementation details (the `_connectionOverride`
  * / `_poolOverride` connection routing, the async `migration()` proxy, and the
- * `_indexes` schema-dump bookkeeping) that have no counterpart in Rails'
+ * adapter-delegating DDL methods) that have no counterpart in Rails'
  * migration_test.rb. Relocated here
  * verbatim from migration.test.ts under RFC 0043 so the convention file tracks
  * Rails 1:1 while the invariants stay covered.
@@ -91,36 +91,29 @@ describe("MigrationTest", () => {
     expect(await migrator.currentVersion()).toBe(1);
   });
 
-  it("addIndex bookkeeping reduces a single-column expression index name", async () => {
-    // Regression: MigrationContext#addIndex delegates the DDL to the adapter but
-    // records the resolved name into `_indexes` for the schema dump. That name
-    // must match the DDL the adapter emitted. `indexNameOptions` only reduces an
-    // expression column ("lower(email)" → "lower_email") when it sees a bare
-    // String — a pre-arrayified `["lower(email)"]` fails its `typeof === "string"`
-    // check and leaks the raw parenthesised name into the dump. Guards that
-    // addIndex derives the bookkeeping name from the original `columns`.
+  it("addIndex delegates the un-arrayified expression column to the adapter", async () => {
+    // Regression: MigrationContext#addIndex delegates the DDL to the adapter
+    // without pre-arrayifying an expression column. `indexNameOptions` only
+    // reduces an expression column ("lower(email)" → "lower_email") when it sees
+    // a bare String — a pre-arrayified `["lower(email)"]` fails its
+    // `typeof === "string"` check and leaks the raw parenthesised name into the
+    // DDL. Guards that the adapter receives the original `columns`.
     const ss = new SchemaStatements({} as unknown as DatabaseAdapter);
     const ddlColumns: unknown[] = [];
     const stub = {
       adapterName: "sqlite" as const,
+      getDatabaseVersion: async () => "3.0.0",
       addIndex: async (_t: string, columns: string | string[]) => {
         ddlColumns.push(columns);
       },
       indexName: (t: string, o: { column?: string | string[]; name?: string }) =>
         ss.indexName(t, o),
       indexNameOptions: (c: string | string[]) => ss.indexNameOptions(c),
-      // addIndex now sources the `_indexes` bookkeeping from the adapter-built
-      // IndexDefinition, so the stub delegates to the real `addIndexOptions`.
-      addIndexOptions: (t: string, c: string | string[], o: Record<string, unknown>) =>
-        ss.addIndexOptions(t, c, o),
-      supportsIndexSortOrder: () => true,
     };
     const ctx = new MigrationContext(stub as unknown as DatabaseAdapter);
     await ctx.addIndex("users", "lower(email)");
     // The adapter (and thus the real DDL) receives the un-arrayified column.
     expect(ddlColumns[0]).toBe("lower(email)");
-    const idx = ctx.indexes("users").find((i) => i.columns.includes("lower(email)"));
-    expect(idx?.name).toBe("index_users_on_lower_email");
   });
 
   it("dropTable delegates to the adapter drop_table, forwarding options", async () => {
@@ -128,8 +121,7 @@ describe("MigrationTest", () => {
     // (the adapter's own drop_table) rather than a bare SchemaStatements
     // instance, so the dialect overrides that emit `temporary:`/`force:
     // "cascade"` (e.g. MySQL's `DROP TEMPORARY TABLE ... CASCADE`) are reached.
-    // The options object is forwarded verbatim; the in-memory bookkeeping is
-    // still pruned per table name.
+    // The options object is forwarded verbatim.
     const calls: unknown[][] = [];
     const stub = {
       dropTable: async (...args: unknown[]) => {
@@ -163,52 +155,6 @@ describe("MigrationTest", () => {
     ctx.tableNameSuffix = "_suf";
     await ctx.renameTable("old", "new");
     expect(calls).toEqual([["pre_old_suf", "pre_new_suf"]]);
-  });
-
-  it("addIndex bookkeeping stores using per default_index_type?", async () => {
-    // Regression: MigrationContext#addIndex records `using` into `_indexes` for
-    // the schema dump. Rails stores `using` unconditionally (add_index_options);
-    // the dumper prints it only when `!default_index_type?(index)` — nil-only on
-    // the abstract adapter (so sqlite, which does not override, keeps a non-nil
-    // `using`), and nil-or-`:btree` on postgres/mysql. Mirror that per-adapter
-    // predicate here, not a postgres-only adapter-name check.
-    const ss = new SchemaStatements({} as unknown as DatabaseAdapter);
-    const makeStub = (an: "sqlite" | "mysql", defaultIndexType: (u?: string) => boolean) => ({
-      adapterName: an,
-      addIndex: async () => {},
-      indexName: (t: string, o: { column?: string | string[]; name?: string }) =>
-        ss.indexName(t, o),
-      indexNameOptions: (c: string | string[]) => ss.indexNameOptions(c),
-      addIndexOptions: (t: string, c: string | string[], o: Record<string, unknown>) =>
-        ss.addIndexOptions(t, c, o),
-      defaultIndexType,
-    });
-    // postgres/mysql: `using == :btree || using.nil?`; abstract/sqlite: `using.nil?`.
-    const mysqlDefault = (u?: string) => u === "btree" || u == null;
-    const sqliteDefault = (u?: string) => u == null;
-
-    const mysqlCtx = new MigrationContext(
-      makeStub("mysql", mysqlDefault) as unknown as DatabaseAdapter,
-    );
-    await mysqlCtx.addIndex("users", "email", { using: "hash" });
-    expect(mysqlCtx.indexes("users").find((i) => i.columns.includes("email"))?.using).toBe("hash");
-
-    const btreeCtx = new MigrationContext(
-      makeStub("mysql", mysqlDefault) as unknown as DatabaseAdapter,
-    );
-    await btreeCtx.addIndex("users", "email", { using: "btree" });
-    expect(
-      btreeCtx.indexes("users").find((i) => i.columns.includes("email"))?.using,
-    ).toBeUndefined();
-
-    // sqlite does NOT override default_index_type?, so a non-nil `using`
-    // round-trips (matches Rails: dumper prints `using:` whenever `using` is
-    // non-nil there).
-    const sqliteCtx = new MigrationContext(
-      makeStub("sqlite", sqliteDefault) as unknown as DatabaseAdapter,
-    );
-    await sqliteCtx.addIndex("users", "email", { using: "hash" });
-    expect(sqliteCtx.indexes("users").find((i) => i.columns.includes("email"))?.using).toBe("hash");
   });
 
   // Rails' IllegalMigrationNameError message carries an explanatory suffix

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -116,6 +116,21 @@ describe("MigrationTest", () => {
     expect(ddlColumns[0]).toBe("lower(email)");
   });
 
+  it("columnExists forwards type and columnOptionsKeys to the adapter", async () => {
+    // Regression: MigrationContext#columnExists is the live adapter-backed
+    // introspection path, so it must expose Rails' full
+    // `column_exists?(table, column, type = nil, **options)` surface and forward
+    // `type` + the columnOptionsKeys (schema_statements.rb:132-141) rather than
+    // matching on name alone. Ride the canonical `people` table
+    // (`first_name` string, null: false — schema.rb:933).
+    const ctx = new MigrationContext(Base.connection);
+    expect(await ctx.columnExists("people", "first_name")).toBe(true);
+    expect(await ctx.columnExists("people", "first_name", "string")).toBe(true);
+    expect(await ctx.columnExists("people", "first_name", "integer")).toBe(false);
+    expect(await ctx.columnExists("people", "first_name", "string", { null: false })).toBe(true);
+    expect(await ctx.columnExists("people", "first_name", "string", { null: true })).toBe(false);
+  });
+
   it("dropTable delegates to the adapter drop_table, forwarding options", async () => {
     // Regression: MigrationContext#dropTable routes through `this.connection`
     // (the adapter's own drop_table) rather than a bare SchemaStatements

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1942,8 +1942,13 @@ export class MigrationContext {
 
   async indexExists(
     table: string,
-    column: string | string[],
-    options?: { unique?: boolean; name?: string },
+    // `column` may be null for a named expression index (Rails' `defined_for?`
+    // matches on name alone when columns are blank).
+    column: string | string[] | null | undefined,
+    // Forward the adapter's full option surface — `valid:` distinguishes a
+    // failed CONCURRENTLY index (PostgreSQL), mirroring Rails `index_exists?`'s
+    // `**options` → `IndexDefinition#defined_for?`.
+    options?: { unique?: boolean; name?: string; valid?: boolean },
   ): Promise<boolean> {
     return this.connection.indexExists(table, column, options);
   }

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -75,6 +75,21 @@ function _extractNewCommentValue(
 
 // Registry for AR config injected by Base — breaks the migration ↔ base import cycle.
 /** @internal */
+/**
+ * The `columnOptionsKeys` (limit/precision/scale/default/null/collation/comment)
+ * that Rails' `column_exists?(table, column, type = nil, **options)` matches
+ * against, in addition to the name and optional `type`.
+ */
+export interface ColumnExistsOptions {
+  limit?: unknown;
+  precision?: unknown;
+  scale?: unknown;
+  default?: unknown;
+  null?: unknown;
+  collation?: unknown;
+  comment?: unknown;
+}
+
 export interface MigrationArConfig {
   tableNamePrefix: string;
   tableNameSuffix: string;
@@ -564,8 +579,13 @@ export abstract class Migration {
     return this.schema.tableExists(this._pt(tableName));
   }
 
-  async columnExists(tableName: string, columnName: string): Promise<boolean> {
-    return this.schema.columnExists(this._pt(tableName), columnName);
+  async columnExists(
+    tableName: string,
+    columnName: string,
+    type?: string | null,
+    options?: ColumnExistsOptions,
+  ): Promise<boolean> {
+    return this.schema.columnExists(this._pt(tableName), columnName, type, options);
   }
 
   async changeColumnDefault(
@@ -1659,9 +1679,11 @@ export class MigrationContext {
         ifExists: true,
       });
     }
-    if (options?.ifNotExists && (await this.tableExists(name))) {
-      return;
-    }
+    // Rails' create_table does not short-circuit in Ruby when the table exists:
+    // it threads `if_not_exists` into the definition so schema_creation emits
+    // `CREATE TABLE IF NOT EXISTS` (a no-op at the DB when present) and still
+    // iterates `td.indexes` with `if_not_exists: td.if_not_exists`
+    // (schema_statements.rb#create_table).
     const tdOpts = {
       id: options?.as != null ? false : options?.id,
       primaryKey: options?.primaryKey,
@@ -1671,6 +1693,7 @@ export class MigrationContext {
       charset: options?.charset,
       collation: options?.collation,
       as: options?.as,
+      ifNotExists: options?.ifNotExists,
     };
     const td =
       this.connection.createTableDefinition?.(name, tdOpts) ??
@@ -1733,7 +1756,10 @@ export class MigrationContext {
         using: idx.using,
         nullsNotDistinct: idx.nullsNotDistinct,
         include: idx.include,
-        ifNotExists: idx.ifNotExists,
+        // Rails forces the table-level `if_not_exists` onto each block index
+        // (`add_index(..., if_not_exists: td.if_not_exists)`), so an existing
+        // table's indexes are re-added idempotently rather than raising.
+        ifNotExists: options?.ifNotExists ?? idx.ifNotExists,
         comment: idx.comment,
       });
     }
@@ -1939,8 +1965,16 @@ export class MigrationContext {
     return this.connection.tableExists(name);
   }
 
-  async columnExists(table: string, column: string): Promise<boolean> {
-    return this.connection.columnExists(table, column);
+  async columnExists(
+    table: string,
+    column: string,
+    // Rails' `column_exists?(table, column, type = nil, **options)` narrows the
+    // match by column `type` and the `columnOptionsKeys`
+    // (limit/precision/scale/default/null/collation/comment) when given.
+    type?: string | null,
+    options?: ColumnExistsOptions,
+  ): Promise<boolean> {
+    return this.connection.columnExists(table, column, type, options);
   }
 
   async indexExists(

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -1880,7 +1880,10 @@ export class MigrationContext {
 
   async removeIndex(
     table: string,
-    options: { column?: string | string[]; name?: string },
+    // Forward the adapter's full `remove_index` option surface: `ifExists`
+    // short-circuits before name resolution (Rails
+    // `remove_index`'s `return if options[:if_exists] && !index_exists?`).
+    options: { column?: string | string[]; name?: string; ifExists?: boolean },
   ): Promise<void> {
     // Rails' `Migration` delegates to `connection.remove_index`, which resolves
     // the concrete index name (schema-split of an explicit `:name`, raising on a

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -51,7 +51,6 @@ export {
 } from "./migration/compatibility.js";
 
 import { ActiveRecordError } from "./errors.js";
-import { pgRealTypeUnlessAliased } from "./connection-adapters/postgresql/pg-datetime-config.js";
 
 // Mirrors Rails AbstractAdapter#extract_new_comment_value (alias of extract_new_default_value).
 // For {from,to} hashes, returns `to` (which may be null to clear a comment).
@@ -105,16 +104,6 @@ function _crc32(str: string): number {
     }
   }
   return (crc ^ 0xffffffff) >>> 0;
-}
-
-// `IndexDefinition` concise-ifies per-column option maps (order/length) but
-// keeps an empty `{}` when the option is absent; the `_indexes` bookkeeping and
-// the schema dump expect `undefined` there, so collapse the empty map.
-function _emptyOptionToUndefined<T>(value: T): T | undefined {
-  if (value != null && typeof value === "object" && Object.keys(value).length === 0) {
-    return undefined;
-  }
-  return value;
 }
 
 // Migration error classes. Rails defines these in migration.rb, so
@@ -1577,66 +1566,17 @@ export abstract class Migration {
 
 /**
  * MigrationContext — wraps an adapter with schema-aware migration methods
- * and synchronous schema inspection, for use in tests and programmatic migrations.
+ * and async schema inspection, for use in tests and programmatic migrations.
+ *
+ * The `columns()`/`indexes()`/`tables()`/`columnExists()`/`tableExists()`/
+ * `indexExists()` readers delegate to the connection's real
+ * `SchemaStatements` introspection (Rails' `new_column_from_field` et al.)
+ * rather than any in-memory declared-schema bookkeeping, so a
+ * MigrationContext reflects the live database exactly as the adapter does.
  *
  * Mirrors: ActiveRecord::MigrationContext
  */
 export class MigrationContext {
-  // TRACKED DIVERGENCE (RFC 0051 follow-up): the CTAS column derivation now
-  // reads back through the adapter's real `SchemaStatements#columns`, but the
-  // `columns()`/`indexes()`/`tables()`/`columnExists()` read API is still
-  // synchronous and served from these in-memory maps. Collapsing them onto the
-  // adapter's async introspection requires making those readers async, which
-  // ripples into the synchronous `SchemaDumper.dump(ctx)` protocol and its
-  // exact-output dump assertions — deferred to the RFC 0051 follow-up story
-  // `collapse-migrationcontext-introspection-onto-adapter-remaining` rather
-  // than silently retained here.
-  private _tables = new Set<string>();
-  private _columns = new Map<string, Set<string>>();
-  private _columnMeta = new Map<
-    string,
-    Map<
-      string,
-      {
-        type: string;
-        // Raw adapter SQL type (`"bigint"`, `"varchar(255)"` …). The dumpers key
-        // `bigint?`/`schemaType`/`schemaLimit` off `Column#sql_type`, so it must
-        // survive the CTAS copy — a reflected `bigint` whose cast type is
-        // `integer` still dumps as `t.bigint` only via this string.
-        sqlType?: string | null;
-        primaryKey?: boolean;
-        null?: boolean;
-        default?: unknown;
-        collation?: string | null;
-        comment?: string | null;
-        limit?: number | null;
-        precision?: number | null;
-        scale?: number | null;
-        array?: boolean;
-        isEnum?: boolean;
-        datetimePhysicalType?: string;
-      }
-    >
-  >();
-  private _indexes = new Map<
-    string,
-    {
-      // A String for an expression index (kept verbatim), a column-name array
-      // otherwise — mirrors the adapter's `IndexDefinition#columns`.
-      columns: string | string[];
-      unique: boolean;
-      name?: string;
-      where?: string;
-      // Concise per-column sort order: a scalar when uniform, a Record otherwise.
-      orders?: string | Record<string, string>;
-      using?: string;
-      type?: string;
-      lengths?: number | Record<string, number>;
-      nullsNotDistinct?: boolean;
-      include?: string[];
-      comment?: string;
-    }[]
-  >();
   private _tableNamePrefix: string | null = null;
   private _tableNameSuffix: string | null = null;
 
@@ -1719,7 +1659,7 @@ export class MigrationContext {
         ifExists: true,
       });
     }
-    if (options?.ifNotExists && this.tableExists(name)) {
+    if (options?.ifNotExists && (await this.tableExists(name))) {
       return;
     }
     const tdOpts = {
@@ -1761,13 +1701,10 @@ export class MigrationContext {
         await adapterWithComments.changeTableComment(name, options.comment);
       }
     }
-    this._tables.add(name);
-    const cols = new Set<string>();
-    // CTAS ignores td.columns — actual columns come from the SELECT (introspected below).
+    // For adapters that apply column comments as a separate statement (not
+    // inline in CREATE TABLE), emit them now — this is real DDL. CTAS ignores
+    // td.columns (its columns come from the SELECT), so there are none to comment.
     const tdCols = options?.as != null ? [] : td.columns;
-    for (const col of tdCols) {
-      cols.add(col.name);
-    }
     if (this.connection.supportsComments?.() && !this.connection.supportsCommentsInCreate?.()) {
       for (const col of tdCols) {
         const cc = (col.options as { comment?: unknown }).comment;
@@ -1776,92 +1713,10 @@ export class MigrationContext {
       }
     }
 
-    // Store column metadata
-    const meta = new Map<
-      string,
-      {
-        type: string;
-        sqlType?: string | null;
-        primaryKey?: boolean;
-        null?: boolean;
-        default?: unknown;
-        collation?: string | null;
-        comment?: string | null;
-        limit?: number | null;
-        precision?: number | null;
-        scale?: number | null;
-        array?: boolean;
-        isEnum?: boolean;
-        datetimePhysicalType?: string;
-      }
-    >();
-    const compositePk =
-      Array.isArray(options?.primaryKey) && options.primaryKey.length > 0
-        ? new Set(options.primaryKey)
-        : null;
-    if (
-      options?.id !== false &&
-      !compositePk &&
-      options?.primaryKey !== false &&
-      options?.as == null
-    ) {
-      const idType = typeof options?.id === "string" ? options.id : "integer";
-      const idName = typeof options?.primaryKey === "string" ? options.primaryKey : "id";
-      meta.set(idName, { type: idType, primaryKey: true });
-    }
-    for (const col of tdCols) {
-      if (meta.has(col.name)) continue;
-      meta.set(col.name, {
-        type: col.type,
-        primaryKey: col.options.primaryKey || compositePk?.has(col.name) || undefined,
-        null: col.options.null,
-        default: col.options.default,
-        limit: col.options.limit,
-        precision: col.options.precision,
-        scale: col.options.scale,
-        array: (col.options as { array?: boolean }).array,
-        datetimePhysicalType: (col as { datetimePhysicalType?: string }).datetimePhysicalType,
-      });
-    }
-    if (options?.as != null) {
-      // CTAS columns derive from the SELECT rather than `td.columns`, so read
-      // them back through the adapter's own `columns()` — the single
-      // Rails-faithful introspection path (`new_column_from_field` →
-      // `fetch_type_metadata`, so the catalog type is normalized through the
-      // adapter's type map) — instead of a bespoke catalog query + type
-      // normalizer.
-      for (const col of await this.connection.columns(name)) {
-        cols.add(col.name);
-        meta.set(col.name, {
-          type: col.type ?? "string",
-          // Carry the raw `sql_type` so the dumper's `bigint?`/`schemaType`
-          // detection keys off the same string Rails does (`Column#sql_type`).
-          sqlType: col.sqlType,
-          null: col.null ?? undefined,
-          default: col.default,
-          collation: col.collation,
-          comment: col.comment,
-          ...(col.limit != null ? { limit: col.limit } : {}),
-          ...(col.precision != null ? { precision: col.precision } : {}),
-          ...(col.scale != null ? { scale: col.scale } : {}),
-          ...((col as { array?: boolean }).array ? { array: true } : {}),
-          // PG `Column#enum?` (cast type "enum") survives CTAS but isn't a base
-          // Column field; the dumper emits `enum_type:` only when this is set.
-          ...(col.type === "enum" ? { isEnum: true } : {}),
-        });
-      }
-    }
-    this._columns.set(name, cols);
-    this._columnMeta.set(name, meta);
-
-    // Create indexes from table definition — skip for adapters that emit them inline in CREATE TABLE
+    // Create indexes from table definition — skip for adapters that emit them
+    // inline in CREATE TABLE.
     const adapterWithIndexInCreate = this.connection as { supportsIndexesInCreate?: () => boolean };
     if (adapterWithIndexInCreate.supportsIndexesInCreate?.()) {
-      for (const idx of td.indexes) {
-        const indexName = idx.name ?? `index_${name}_on_${idx.columns.join("_and_")}`;
-        if (!this._indexes.has(name)) this._indexes.set(name, []);
-        this._indexes.get(name)!.push({ ...idx, name: indexName, orders: {} });
-      }
       return;
     }
     for (const idx of td.indexes) {
@@ -1895,18 +1750,8 @@ export class MigrationContext {
     // `IF EXISTS` is emitted only when `ifExists: true` is passed, matching
     // Rails' drop_table (which does not default it). Routing through
     // `this.connection` (not a bare SchemaStatements instance) is what reaches
-    // those adapter overrides. We keep the in-memory bookkeeping in sync for
-    // the bespoke introspection that columns()/indexes()/tables() read.
-    const last = args[args.length - 1];
-    const hasOptions = last !== null && typeof last === "object";
-    const names = (hasOptions ? args.slice(0, -1) : args) as string[];
+    // those adapter overrides.
     await (this.connection.dropTable as (...a: typeof args) => Promise<void>)(...args);
-    for (const name of names) {
-      this._tables.delete(name);
-      this._columns.delete(name);
-      this._columnMeta.delete(name);
-      this._indexes.delete(name);
-    }
   }
 
   async enableExtension(name: string, options?: Record<string, unknown>): Promise<void> {
@@ -1929,7 +1774,6 @@ export class MigrationContext {
   async createVirtualTable(name: string, moduleName: string, args: string[]): Promise<void> {
     if (typeof (this.connection as any).createVirtualTable === "function") {
       await (this.connection as any).createVirtualTable(name, moduleName, args);
-      this._tables.add(name);
     }
     // Non-SQLite adapters: no-op; virtual tables are SQLite-specific.
   }
@@ -1941,10 +1785,7 @@ export class MigrationContext {
     _options?: ColumnOptions & { ifNotExists?: boolean },
   ): Promise<void> {
     const ifNotExists = _options?.ifNotExists ?? false;
-    if (this._columns.has(table) && this._columns.get(table)!.has(column)) {
-      if (!ifNotExists) {
-        throw new Error(`Column "${column}" already exists in table "${table}"`);
-      }
+    if (ifNotExists && (await this.columnExists(table, column))) {
       return;
     }
     // Delegate DDL/type generation to the adapter's SchemaStatements — the
@@ -1953,18 +1794,6 @@ export class MigrationContext {
     // separate COMMENT ON COLUMN; MySQL inlines it in the visitor), so we do not
     // re-apply it here.
     await this.schema.addColumn(table, column, type, _options ?? {});
-    if (!this._columns.has(table)) this._columns.set(table, new Set());
-    this._columns.get(table)!.add(column);
-    if (!this._columnMeta.has(table)) this._columnMeta.set(table, new Map());
-    this._columnMeta.get(table)!.set(column, {
-      type,
-      null: _options?.null,
-      default: _options?.default,
-      limit: _options?.limit,
-      precision: _options?.precision,
-      scale: _options?.scale,
-      array: (_options as { array?: boolean } | undefined)?.array,
-    });
   }
 
   async removeColumn(
@@ -1981,32 +1810,17 @@ export class MigrationContext {
       const allCols = [columnOrColumns, optionsOrColumn, ...rest];
       for (const col of allCols) {
         await this.schema.removeColumn(table, col);
-        this._columns.get(table)?.delete(col);
-        this._columnMeta.get(table)?.delete(col);
       }
       return;
     }
-    if (optionsOrColumn?.ifExists && !this.columnExists(table, columnOrColumns)) {
+    if (optionsOrColumn?.ifExists && !(await this.columnExists(table, columnOrColumns))) {
       return;
     }
     await this.schema.removeColumn(table, columnOrColumns);
-    this._columns.get(table)?.delete(columnOrColumns);
-    this._columnMeta.get(table)?.delete(columnOrColumns);
   }
 
   async renameColumn(table: string, from: string, to: string): Promise<void> {
     await this.schema.renameColumn(table, from, to);
-    const cols = this._columns.get(table);
-    if (cols) {
-      cols.delete(from);
-      cols.add(to);
-    }
-    const meta = this._columnMeta.get(table);
-    if (meta && meta.has(from)) {
-      const entry = meta.get(from)!;
-      meta.delete(from);
-      meta.set(to, entry);
-    }
   }
 
   async changeColumn(
@@ -2021,24 +1835,6 @@ export class MigrationContext {
     // separate COMMENT ON COLUMN; MySQL inlines it via changeColumnForAlter), so
     // we do not re-apply it here.
     await this.schema.changeColumn(table, column, type, _options ?? {});
-    const meta = this._columnMeta.get(table);
-    if (meta && meta.has(column)) {
-      const entry = meta.get(column)!;
-      meta.set(column, {
-        ...entry,
-        type,
-        null: _options?.null !== undefined ? _options.null : entry.null,
-        default: _options?.default !== undefined ? _options.default : entry.default,
-        limit: _options?.limit !== undefined ? _options.limit : entry.limit,
-        precision:
-          _options?.precision !== undefined
-            ? _options.precision
-            : type === "datetime" || type === "timestamp"
-              ? 6
-              : entry.precision,
-        scale: _options?.scale !== undefined ? _options.scale : entry.scale,
-      });
-    }
   }
 
   async changeTableComment(name: string, comment: string | null): Promise<void> {
@@ -2047,23 +1843,6 @@ export class MigrationContext {
 
   async changeColumnComment(table: string, col: string, comment: string | null): Promise<void> {
     await (this.connection as any).changeColumnComment(table, col, comment);
-  }
-
-  /**
-   * Split a possibly schema-qualified name into `[schema, bareName]` via the
-   * adapter's quote-aware parser (Rails `extract_schema_qualified_name`), so a
-   * quoted dotted identifier isn't mis-split. Only PostgreSQL carries
-   * schema-qualified DDL names; other adapters treat the whole string as bare.
-   */
-  private _splitSchemaQualified(name: string): [string | null, string] {
-    const conn = this.connection as {
-      adapterName: string;
-      extractSchemaQualifiedName?: (s: string) => [string | null, string];
-    };
-    if (conn.adapterName === "postgres" && typeof conn.extractSchemaQualifiedName === "function") {
-      return conn.extractSchemaQualifiedName(name);
-    }
-    return [null, name];
   }
 
   async addIndex(
@@ -2083,16 +1862,12 @@ export class MigrationContext {
       comment?: string;
     },
   ): Promise<void> {
-    const an = this._adapterName;
-    // Warm the cached database version before issuing the index DDL or reading
-    // the capability predicates below. Several `supports*` predicates read
-    // `databaseVersion` synchronously: MySQL's `supportsIndexSortOrder` (the
-    // `DESC`/`ASC` suffix, MariaDB reconstruct parity #4397) yields false when
-    // unset, while PostgreSQL's `supportsIndexInclude` (≥ 11) and
-    // `supportsNullsNotDistinct` (≥ 15) *throw* when unset. MigrationContext#
-    // addIndex runs on the shared-worker schema-reconstruct path on a
-    // freshly-leased connection whose version is still cold, so warm it here for
-    // every adapter before the gating below reads those predicates.
+    // Warm the cached database version before issuing the index DDL. PostgreSQL's
+    // `supportsIndexInclude` (≥ 11) and `supportsNullsNotDistinct` (≥ 15) *throw*
+    // when the version is unset, and the adapter's addIndex reads them to emit
+    // `INCLUDE`/`NULLS NOT DISTINCT`. MigrationContext#addIndex runs on the
+    // shared-worker schema-reconstruct path on a freshly-leased connection whose
+    // version is still cold, so warm it here for every adapter.
     await this.connection.getDatabaseVersion?.();
     // Rails' `Migration` delegates the DDL — and the default index-name
     // derivation (index_name → generate_index_name, incl. the identifier-length
@@ -2101,65 +1876,6 @@ export class MigrationContext {
     // Rails-faithful copy and long table+column combos get the `idx_on_...<hash>`
     // form the direct `connection.add_index` path already produces.
     await this.connection.addIndex(table, columns, options ?? {});
-    // Source the in-memory `_indexes` bookkeeping the schema dump reads from the
-    // same `IndexDefinition` the adapter resolved for the DDL, rather than
-    // re-deriving the index name and re-gating the persisted metadata per
-    // adapter here. `addIndexOptions` (Rails' `add_index_options`) is the
-    // adapter's single copy of "what was built": it resolves the columns
-    // (an expression column stays a verbatim String), the index name
-    // (schema-strip + expression reduction + hash fallback), and the concise
-    // per-column option maps exactly as the executed `addIndex` did.
-    const [idx] = await this.connection.addIndexOptions(table, columns, options ?? {});
-    // The DDL visitor only emits each option where the backend supports it, so
-    // gate the stored metadata on the same adapter capabilities to match what
-    // was actually persisted: partial `WHERE` (dropped on MySQL), sort order
-    // (version-gated on MySQL/MariaDB — the #4397 reconstruct parity, warmed
-    // above via `getDatabaseVersion`), and `NULLS NOT DISTINCT` / covering
-    // `INCLUDE` (Postgres). The `typeof` guards keep this resilient to the
-    // minimal stub adapters some tests pass. `using` follows the dumper's own
-    // gate — `!default_index_type?(index)` (schema_dumper.rb#indexes) — which is
-    // nil-only on the abstract adapter (so a non-default `using` on sqlite still
-    // round-trips) and nil-or-`btree` on Postgres/MySQL. Rails stores `using`
-    // unconditionally (`add_index_options`); only the dump is gated, so mirror
-    // that predicate here rather than an adapter-name check.
-    const supportsPartialIndex =
-      typeof this.connection.supportsPartialIndex === "function"
-        ? this.connection.supportsPartialIndex()
-        : true;
-    const supportsSortOrder =
-      typeof this.connection.supportsIndexSortOrder === "function"
-        ? this.connection.supportsIndexSortOrder()
-        : true;
-    const supportsNullsNotDistinct =
-      typeof this.connection.supportsNullsNotDistinct === "function"
-        ? this.connection.supportsNullsNotDistinct()
-        : false;
-    const supportsIndexInclude =
-      typeof this.connection.supportsIndexInclude === "function"
-        ? this.connection.supportsIndexInclude()
-        : false;
-    const usingStored =
-      idx.using != null &&
-      !(typeof this.connection.defaultIndexType === "function"
-        ? this.connection.defaultIndexType(idx.using)
-        : idx.using == null)
-        ? idx.using
-        : undefined;
-    const comment = idx.comment?.trim() ? idx.comment : undefined;
-    if (!this._indexes.has(table)) this._indexes.set(table, []);
-    this._indexes.get(table)!.push({
-      columns: idx.columns,
-      unique: idx.unique,
-      name: idx.name,
-      where: supportsPartialIndex ? idx.where : undefined,
-      orders: supportsSortOrder ? _emptyOptionToUndefined(idx.orders) : undefined,
-      using: usingStored,
-      type: idx.type,
-      lengths: _emptyOptionToUndefined(idx.lengths),
-      nullsNotDistinct: supportsNullsNotDistinct ? idx.nullsNotDistinct : undefined,
-      include: supportsIndexInclude ? idx.include : undefined,
-      comment,
-    });
   }
 
   async removeIndex(
@@ -2172,24 +1888,6 @@ export class MigrationContext {
     // and drops it in the right schema. Delegate rather than reimplementing that
     // name derivation — the adapter carries the single Rails-faithful copy.
     await this.connection.removeIndex(table, options);
-    // Mirror the drop in the in-memory `_indexes` the schema dump reads. Resolve
-    // the stored name the way `addIndex` recorded it: an explicit `:name`
-    // verbatim (PostgreSQL may carry a schema qualifier, so match the bare form
-    // too), else the adapter-derived default from the columns.
-    let stored = options.name;
-    if (stored == null && options.column != null) {
-      stored = this.connection.indexName(table, this.connection.indexNameOptions(options.column));
-    }
-    if (stored != null) {
-      const [, bareName] = this._splitSchemaQualified(stored);
-      const tableIndexes = this._indexes.get(table);
-      if (tableIndexes) {
-        this._indexes.set(
-          table,
-          tableIndexes.filter((i) => i.name !== stored && i.name !== bareName),
-        );
-      }
-    }
   }
 
   async renameTable(from: string, to: string): Promise<void> {
@@ -2201,26 +1899,8 @@ export class MigrationContext {
     // `ALTER TABLE ... RENAME TO`. Routing through `this.connection` (not a
     // bare SchemaStatements instance, whose abstract fallback misses those
     // side effects) is what reaches those overrides. MigrationContext keeps the
-    // prefix/suffix application the adapters do not perform, plus the in-memory
-    // bookkeeping the bespoke introspection reads.
+    // prefix/suffix application the adapters do not perform.
     await this.connection.renameTable(fullFrom, fullTo);
-    this._tables.delete(fullFrom);
-    this._tables.add(fullTo);
-    const cols = this._columns.get(fullFrom);
-    if (cols) {
-      this._columns.delete(fullFrom);
-      this._columns.set(fullTo, cols);
-    }
-    const meta = this._columnMeta.get(fullFrom);
-    if (meta) {
-      this._columnMeta.delete(fullFrom);
-      this._columnMeta.set(fullTo, meta);
-    }
-    const indexes = this._indexes.get(fullFrom);
-    if (indexes) {
-      this._indexes.delete(fullFrom);
-      this._indexes.set(fullTo, indexes);
-    }
   }
 
   async reversible(
@@ -2245,74 +1925,43 @@ export class MigrationContext {
     await fn();
   }
 
-  tableExists(name: string): boolean {
-    return this._tables.has(name);
+  // The introspection readers delegate to the connection's real introspection
+  // — the single Rails-faithful reflection path (`columns` →
+  // `new_column_from_field` → `fetch_type_metadata`, so catalog types are
+  // normalized through the adapter's type map; `indexes`, `data_source_exists?`
+  // …) — so a MigrationContext reflects the live database rather than any
+  // declared-schema bookkeeping.
+
+  async tableExists(name: string): Promise<boolean> {
+    return this.connection.tableExists(name);
   }
 
-  columnExists(table: string, column: string): boolean {
-    return this._columns.get(table)?.has(column) ?? false;
+  async columnExists(table: string, column: string): Promise<boolean> {
+    return this.connection.columnExists(table, column);
   }
 
-  indexExists(table: string, column: string): boolean {
-    return this._indexes.get(table)?.some((i) => i.columns.includes(column)) ?? false;
+  async indexExists(
+    table: string,
+    column: string | string[],
+    options?: { unique?: boolean; name?: string },
+  ): Promise<boolean> {
+    return this.connection.indexExists(table, column, options);
   }
 
-  tables(): string[] {
-    return Array.from(this._tables).sort();
+  async tables(): Promise<string[]> {
+    return this.connection.tables();
   }
 
-  columns(tableName: string): Array<{
-    name: string;
-    type: string;
-    sqlType?: string | null;
-    primaryKey?: boolean;
-    null?: boolean;
-    default?: unknown;
-    collation?: string | null;
-    comment?: string | null;
-    limit?: number | null;
-    precision?: number | null;
-    scale?: number | null;
-    array?: boolean;
-    isEnum?: boolean;
-    datetimePhysicalType?: string;
-  }> {
-    const meta = this._columnMeta.get(tableName);
-    if (meta) {
-      const isPg = this._adapterName === "postgres";
-      return Array.from(meta.entries()).map(([name, info]) => {
-        // PostgreSQL: rewrite datetime-family columns against the live
-        // datetime_type, mirroring what re-introspecting the stored physical
-        // type would yield (PostgreSQL::OID::DateTime#real_type_unless_aliased).
-        if (isPg && info.datetimePhysicalType) {
-          return { name, ...info, type: pgRealTypeUnlessAliased(info.datetimePhysicalType) };
-        }
-        return { name, ...info };
-      });
-    }
-    const cols = this._columns.get(tableName);
-    if (!cols) return [];
-    return Array.from(cols).map((name) => ({ name, type: "string" }));
+  async columns(tableName: string): Promise<import("./connection-adapters/column.js").Column[]> {
+    return this.connection.columns(tableName);
   }
 
-  indexes(tableName: string): Array<{
-    columns: string | string[];
-    unique: boolean;
-    name?: string;
-    where?: string;
-    orders?: string | Record<string, string>;
-    using?: string;
-    nullsNotDistinct?: boolean;
-    include?: string[];
-  }> {
-    const idxs = this._indexes.get(tableName);
-    if (!idxs) return [];
-    return idxs.map((i) => ({
-      ...i,
-      // Preserve an expression index's verbatim String; clone the array form.
-      columns: typeof i.columns === "string" ? i.columns : [...i.columns],
-      include: i.include ? [...i.include] : undefined,
-    }));
+  async indexes(
+    tableName: string,
+  ): Promise<Array<{ name: string; columns: string | string[]; unique: boolean }>> {
+    return this.connection.indexes(tableName) as Promise<
+      Array<{ name: string; columns: string | string[]; unique: boolean }>
+    >;
   }
 }
 

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -540,8 +540,9 @@ describe("SchemaDumperTest", () => {
     // keeps `lower(first_name || ' ' || last_name)` verbatim, PostgreSQL
     // normalizes it to `lower((((first_name)::text || ' '::text) || …))`. Assert
     // the lowercased expression over both columns rather than a byte-exact form,
-    // and that the embedded space literal is still escaped in the dumped string.
-    expect(output).toMatch(/lower\(.*first_name.*last_name.*\).*idx_users_full_name/s);
+    // but still require the quoted `' '` space literal between them so the
+    // escaping is verified (mirrors Rails schema_dumper_test.rb:318).
+    expect(output).toMatch(/lower\(.*first_name.*' '.*last_name.*\).*idx_users_full_name/s);
   });
   it.skipIf(adapterType !== "mysql")(
     "schema dump includes length for mysql binary fields",

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -419,10 +419,16 @@ describe("SchemaDumperTest", () => {
   });
 
   it("schema dump with regexp ignored table", async () => {
-    await ctx.createTable("users", { force: true }, (t) => t.string("name"));
-    await ctx.createTable("temp_cache", { force: true }, (t) => t.string("val"));
+    // The `ignoreTables` filter runs during table enumeration, so drive the
+    // dumper from a mock async SchemaSource of just the two tables under test
+    // rather than a full-DB dump of the shared canonical schema.
+    const source = {
+      tables: async () => ["users", "temp_cache"],
+      columns: async () => [{ name: "name", type: "string" }],
+      indexes: async () => [],
+    };
     SchemaDumper.ignoreTables = [/^temp_/];
-    const output = SchemaDumper.dump(ctx);
+    const output = await SchemaDumper.dump(source as any);
     expect(output).toContain("users");
     expect(output).not.toContain("temp_cache");
   });
@@ -440,7 +446,7 @@ describe("SchemaDumperTest", () => {
       t.string("key", { null: false });
     });
     await ctx.addIndex("string_key_objects", "key", { unique: true });
-    const output = SchemaDumper.dump(ctx);
+    const output = await SchemaDumper.dumpTableSchema(Base.connection, "string_key_objects");
     expect(output).toMatch(/createTable\("string_key_objects",\s*\{[^}]*id:\s*false/);
   });
 
@@ -528,7 +534,7 @@ describe("SchemaDumperTest", () => {
     await ctx.addIndex("users", "lower(first_name || ' ' || last_name)", {
       name: "idx_users_full_name",
     });
-    const output = SchemaDumper.dump(ctx);
+    const output = await SchemaDumper.dumpTableSchema(Base.connection, "users");
     expect(output).toContain("idx_users_full_name");
     expect(output).toContain("lower(first_name");
   });
@@ -615,7 +621,7 @@ describe("SchemaDumperTest", () => {
     await ctx.createTable("defaults", {}, (t) => {
       t.bigint("bigint_default", { default: 0 });
     });
-    const output = SchemaDumper.dump(ctx);
+    const output = await SchemaDumper.dumpTableSchema(Base.connection, "defaults");
     expect(output).toMatch(/t\.bigint\("bigint_default",\s*\{[^}]*default:\s*0[^}]*\}/);
   });
 
@@ -807,13 +813,15 @@ describe("SchemaDumperTest", () => {
   });
 
   it("schema dump with table name prefix and suffix", async () => {
-    await ctx.createTable("myapp_users_v1", {}, (t) => {
-      t.string("name");
-    });
-    const output = SchemaDumper.dump(ctx, {
+    const source = {
+      tables: async () => ["myapp_users_v1"],
+      columns: async (_t: string) => [{ name: "id", type: "integer", primaryKey: true }],
+      indexes: async () => [],
+    };
+    const output = await SchemaDumper.dump(source as any, {
       tableNamePrefix: "myapp_",
       tableNameSuffix: "_v1",
-    }) as string;
+    });
     expect(output).toContain('"users"');
     expect(output).not.toContain("myapp_users_v1");
   });
@@ -829,14 +837,13 @@ describe("SchemaDumperTest", () => {
     expect(output).not.toContain("app.prefix_users");
   });
   it("schema dump with table name prefix and ignoring tables", async () => {
-    await ctx.createTable("myapp_users", {}, (t) => {
-      t.string("name");
-    });
-    await ctx.createTable("myapp_posts", {}, (t) => {
-      t.string("title");
-    });
+    const source = {
+      tables: async () => ["myapp_users", "myapp_posts"],
+      columns: async (_t: string) => [{ name: "id", type: "integer", primaryKey: true }],
+      indexes: async () => [],
+    };
     SchemaDumper.ignoreTables = ["posts"];
-    const output = SchemaDumper.dump(ctx, { tableNamePrefix: "myapp_" }) as string;
+    const output = await SchemaDumper.dump(source as any, { tableNamePrefix: "myapp_" });
     expect(output).toContain('"users"');
     expect(output).not.toContain('"posts"');
     expect(output).not.toContain("myapp_");
@@ -849,7 +856,7 @@ describe("SchemaDumperTest", () => {
         t.string("title");
         t.timestamps();
       });
-      const output = SchemaDumper.dump(ctx);
+      const output = await SchemaDumper.dumpTableSchema(Base.connection, "posts");
       expect(output).toContain("datetime");
       expect(output).toContain("created_at");
       expect(output).toContain("updated_at");
@@ -866,7 +873,7 @@ describe("SchemaDumperTest", () => {
           t.column("without_time_zone", "timestamp");
           t.column("with_time_zone", "timestamptz");
         });
-        const output = SchemaDumper.dump(ctx) as string;
+        const output = await SchemaDumper.dumpTableSchema(Base.connection, "timestamps");
         expect(output).toContain('t.datetime("this_should_remain_datetime"');
         expect(output).toContain('t.datetime("this_is_an_alias_of_datetime"');
         expect(output).toContain('t.timestamp("without_time_zone"');
@@ -896,13 +903,13 @@ describe("SchemaDumperTest", () => {
         t.column("with_time_zone", "timestamptz");
       });
 
-      let output = SchemaDumper.dump(ctx) as string;
+      let output = await SchemaDumper.dumpTableSchema(Base.connection, "timestamps");
       expect(output).toContain('t.datetime("default_format"');
       expect(output).toContain('t.datetime("without_time_zone"');
       expect(output).toContain('t.timestamptz("with_time_zone"');
 
       await withPostgresqlDatetimeType("timestamptz", async () => {
-        output = SchemaDumper.dump(ctx) as string;
+        output = await SchemaDumper.dumpTableSchema(Base.connection, "timestamps");
         expect(output).toContain('t.timestamp("default_format"');
         expect(output).toContain('t.timestamp("without_time_zone"');
         expect(output).toContain('t.datetime("with_time_zone"');
@@ -918,7 +925,7 @@ describe("SchemaDumperTest", () => {
         t.timestamp("also_without_time_zone");
         (t as any).timestamptz("with_time_zone");
       });
-      const output = SchemaDumper.dump(ctx) as string;
+      const output = await SchemaDumper.dumpTableSchema(Base.connection, "timestamps");
       expect(output).toContain('t.datetime("default_format"');
       expect(output).toContain('t.datetime("without_time_zone"');
       expect(output).toContain('t.datetime("also_without_time_zone"');
@@ -933,7 +940,7 @@ describe("SchemaDumperTest", () => {
         t.string("title");
       });
       await ctx.addColumn("posts", "created_at", "datetime");
-      const output = SchemaDumper.dump(ctx);
+      const output = await SchemaDumper.dumpTableSchema(Base.connection, "posts");
       expect(output).toContain("datetime");
       expect(output).toContain("created_at");
     },
@@ -963,7 +970,7 @@ describe("SchemaDumperTest", () => {
         t.string("title");
       });
       await ctx.addColumn("posts", "posted_at", "datetime");
-      const output = SchemaDumper.dump(ctx);
+      const output = await SchemaDumper.dumpTableSchema(Base.connection, "posts");
       expect(output).toContain("datetime");
       expect(output).toContain("posted_at");
     },
@@ -988,7 +995,7 @@ describe("SchemaDumperDefaultsTest", () => {
       t.datetime("datetime_with_default", { default: "2014-06-05 07:17:04" });
       t.decimal("decimal_with_default", { precision: 3, scale: 2, default: 2.78 });
     });
-    const output = SchemaDumper.dump(ctx);
+    const output = await SchemaDumper.dumpTableSchema(Base.connection, "dump_defaults");
     expect(output).toMatch(/string.*"string_with_default".*default: "Hello!"/);
     expect(output).toMatch(/date.*"date_with_default".*default: "2014-06-05"/);
     expect(output).toMatch(/datetime.*"datetime_with_default".*default:/);
@@ -1000,7 +1007,7 @@ describe("SchemaDumperDefaultsTest", () => {
     await ctx.createTable("dump_defaults", { force: true }, (t) => {
       t.text("text_with_default", { default: "John" });
     });
-    const output = SchemaDumper.dump(ctx);
+    const output = await SchemaDumper.dumpTableSchema(Base.connection, "dump_defaults");
     expect(output).toMatch(/text.*"text_with_default".*default: "John"/);
   });
 

--- a/packages/activerecord/src/schema-dumper.test.ts
+++ b/packages/activerecord/src/schema-dumper.test.ts
@@ -536,7 +536,12 @@ describe("SchemaDumperTest", () => {
     });
     const output = await SchemaDumper.dumpTableSchema(Base.connection, "users");
     expect(output).toContain("idx_users_full_name");
-    expect(output).toContain("lower(first_name");
+    // Real introspection returns the backend's stored expression form — sqlite
+    // keeps `lower(first_name || ' ' || last_name)` verbatim, PostgreSQL
+    // normalizes it to `lower((((first_name)::text || ' '::text) || …))`. Assert
+    // the lowercased expression over both columns rather than a byte-exact form,
+    // and that the embedded space literal is still escaped in the dumped string.
+    expect(output).toMatch(/lower\(.*first_name.*last_name.*\).*idx_users_full_name/s);
   });
   it.skipIf(adapterType !== "mysql")(
     "schema dump includes length for mysql binary fields",

--- a/packages/activerecord/src/time-precision.test.ts
+++ b/packages/activerecord/src/time-precision.test.ts
@@ -139,7 +139,7 @@ describe("TimePrecisionTest", () => {
       t.time("start", { precision: 4 });
       t.time("finish", { precision: 6 });
     });
-    const output = SchemaDumper.dump(ctx) as string;
+    const output = await SchemaDumper.dumpTableSchema(adapter, "foos");
     expect(output).toMatch(/t\.time\("start",\s*\{[^}]*precision:\s*4/);
     expect(output).toMatch(/t\.time\("finish",\s*\{[^}]*precision:\s*6/);
   });

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -20673,13 +20673,6 @@
   {
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "column_exists?",
-    "call": "type",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "columns",
     "call": "column_definitions",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
## Summary

Follow-up to #4773 (RFC 0051). Collapses `MigrationContext`'s remaining
bespoke, synchronous introspection onto the adapter's real async
reflection.

`MigrationContext#columns` / `#indexes` / `#tables` / `#columnExists` /
`#tableExists` / `#indexExists` now delegate to the connection's live
introspection (Rails `new_column_from_field` → `fetch_type_metadata`,
`indexes`, `data_source_exists?`, …) instead of the in-memory
`_tables` / `_columns` / `_columnMeta` / `_indexes` maps. Those maps and
every mutation site — createTable / addColumn / removeColumn /
renameColumn / changeColumn / dropTable / renameTable / addIndex /
removeIndex / createVirtualTable — are removed, so a MigrationContext
reflects the live database exactly as the adapter does. The
tracked-divergence comment above the old `_tables` field is retired.

## Ripple

The readers become **async**, so the sync `SchemaDumper.dump(ctx)`
call sites converge to the async dump path:

- single-bespoke-table dumps → `dumpTableSchema(adapter, name)` (the
  established Rails-faithful single-table path already used elsewhere in
  these files);
- enumeration / ignore-pattern / prefix-suffix dumps → a mock async
  `SchemaSource`, matching the existing mock-source pattern in
  `schema-dumper.test.ts`, so they no longer enumerate the ~330 shared
  canonical tables (avoids the PG dump-timeout flake);
- the ~14 sync `ctx.columns()/columnExists()/tableExists()` sites in
  `migration.test.ts` gain `await`.

The two trails `addIndex bookkeeping …` tests asserted
declared-but-not-persisted `_indexes` metadata that real introspection
cannot recover; one is removed, the other narrowed to the
un-arrayified-column DDL delegation it also guarded.

## Notes

- Deletion-heavy mechanical collapse (~510 deletions / ~115 insertions).
  Slightly over the 500-LOC default, but the change is atomic — removing
  the maps requires touching every mutator + reader + their call sites in
  one commit — and can't be split without leaving the tree non-compiling.
- Verified on sqlite: migration, migration.trails, schema-dumper,
  date-time-precision, time-precision, comment, defaults,
  active-record-schema, bigint-roundtrip, hot-compatibility,
  schema-introspection.trails, schema-dumper.trails, cache-key, timestamp.
- PG/MySQL adapter behavior is CI-gated.

Closes-story: collapse-migrationcontext-introspection-onto-adapter-remaining

---

## Reviewer notes (Codex review)

All raised comments are now **fixed in code** (the two originally deferred as
adapter/DDL-layer work were folded in once it was confirmed the infrastructure
already existed):

**1. `createTable(ifNotExists)` short-circuited before block indexes — FIXED.**
`TableDefinition` already carries `ifNotExists` and `schema_creation` already
emits `CREATE TABLE IF NOT EXISTS` (schema-creation.ts:151,281). Threaded
`ifNotExists` into the definition, dropped the TS short-circuit, and iterate
`td.indexes` with the table-level `if_not_exists` — matching Rails' create_table
control flow (schema_statements.rb:301,309-314).

**2. `columnExists` was name-only — FIXED.** Widened the adapter
`SchemaStatements#columnExists` to Rails' `column_exists?(table, column, type =
nil, **options)`, matching the optional `type` and the `columnOptionsKeys`
(limit/precision/scale/default/null/collation/comment) over `columns()`.
`Migration#columnExists` and `MigrationContext#columnExists` forward the full
signature; the abstract adapter interface is widened to match. Covered by a new
trails test over the canonical `people` table.

**3. `indexExists` dropped `valid:` — FIXED.** Forwards `{ unique, name, valid }`
and a nullable column, matching `SchemaStatements#indexExists`.

**4. `removeIndex` dropped `ifExists:` — FIXED.** Forwards `{ column, name,
ifExists }`, matching Rails `remove_index`'s
`return if options[:if_exists] && !index_exists?`.

The two follow-up stories filed in earlier rounds
(`columnexists-type-and-options-matching`,
`createtable-if-not-exists-preserves-block-indexes`) are closed as superseded by
this PR.
