### PR TITLE
fix(connection-pool): deny serializer/matcher probe keys on adapter proxy

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -440,6 +440,17 @@ export class ConnectionPool implements ReapablePool {
           if (typeof prop === "symbol" || ADAPTER_PROXY_PROBE_KEYS.has(prop)) {
             return undefined;
           }
+          // Only dispatch names a real connection exposes as a method. When a
+          // connection already exists (it does whenever a translated error was
+          // raised — a query was mid-flight), an unrecognised probe key not in
+          // the deny set still resolves to a non-callable instead of a
+          // dispatcher that would blow up on `conn[prop] is not a function`.
+          // With no connection yet, fabricate optimistically so first-use
+          // dispatch (schemaMigration etc.) still works.
+          const sample = pool.activeConnection ?? pool.connections[0];
+          if (sample && typeof (sample as any)[prop] !== "function") {
+            return undefined;
+          }
           return (...args: unknown[]) => {
             return pool.withConnection((conn) => (conn as any)[prop](...args));
           };

--- a/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/connection-pool.ts
@@ -70,6 +70,43 @@ export class NullConfig {
 const NULL_CONFIG = new NullConfig();
 
 /**
+ * Property keys a serializer, test matcher, or framework may probe on an
+ * arbitrary object while walking it (vitest error serialization, `await`,
+ * `JSON.stringify`, asymmetric matchers, React element checks, DOM sniffing).
+ *
+ * The adapter proxy (`_getAdapterProxy`) is reachable from any translated
+ * error via its `connectionPool`; if the `get` trap fabricated a callable for
+ * these keys, the probe would dispatch to a raw connection that has no such
+ * method (`conn[prop] is not a function`). The trap returns `undefined` for
+ * every key here — and for all symbol keys — so probes see a non-callable.
+ * Add new probe keys here rather than sprinkling checks in the trap.
+ */
+const ADAPTER_PROXY_PROBE_KEYS = new Set<string>([
+  // Promise / thenable duck-typing
+  "then",
+  "catch",
+  "finally",
+  // JSON / serializer hooks
+  "toJSON",
+  "toString",
+  "valueOf",
+  "inspect",
+  // vitest / jest asymmetric matchers and mock sniffing
+  "asymmetricMatch",
+  "$$typeof",
+  "_isMockFunction",
+  "getMockName",
+  // React / DOM element checks
+  "nodeType",
+  "nodeName",
+  "tagName",
+  // Object plumbing a walker may touch
+  "constructor",
+  "prototype",
+  "hasOwnProperty",
+]);
+
+/**
  * Mirrors: ActiveRecord::ConnectionAdapters::NullPool
  */
 export class NullPool implements AbstractPool {
@@ -393,13 +430,14 @@ export class ConnectionPool implements ReapablePool {
               (pool.activeConnection ?? pool.connections[0])?.adapterName ??
               adapterNameFromConfig(pool.dbConfig.adapter)
             );
-          // Don't fabricate a method for serialization/promise probes. When this
-          // proxy is reachable from an error's `connectionPool` (Rails stamps
-          // the pool onto every translated error), a serializer or `await`
-          // walks keys like `then`/`toJSON`/`Symbol.*`; returning a callable
-          // there would run `conn.then()` etc. against a raw connection that has
-          // no such method (`conn[prop] is not a function`).
-          if (typeof prop === "symbol" || prop === "then" || prop === "toJSON") {
+          // Don't fabricate a method for serialization/matcher/framework probes.
+          // When this proxy is reachable from an error's `connectionPool` (Rails
+          // stamps the pool onto every translated error), a serializer, `await`,
+          // or an asymmetric matcher walks keys like `then`/`toJSON`/`Symbol.*`/
+          // `asymmetricMatch`; returning a callable there would run `conn.then()`
+          // etc. against a raw connection that has no such method
+          // (`conn[prop] is not a function`). See ADAPTER_PROXY_PROBE_KEYS.
+          if (typeof prop === "symbol" || ADAPTER_PROXY_PROBE_KEYS.has(prop)) {
             return undefined;
           }
           return (...args: unknown[]) => {

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -590,3 +590,49 @@ it("inspect does not show secrets", async () => {
   expect(pool2.inspect()).toMatch(/shard="shard_one"/);
   expect(pool2.inspect()).toMatch(/role="reading"/);
 });
+
+it("adapter proxy does not fabricate methods for serialization/matcher probe keys", async () => {
+  const pool = makePool();
+  const proxy = (
+    pool as unknown as { _getAdapterProxy(): Record<PropertyKey, unknown> }
+  )._getAdapterProxy();
+
+  // Keys a serializer / asymmetric matcher / framework walker may probe. None
+  // may resolve to a callable that would dispatch to a raw connection.
+  for (const key of [
+    "then",
+    "toJSON",
+    "asymmetricMatch",
+    "$$typeof",
+    "nodeType",
+    "constructor",
+    "hasOwnProperty",
+  ]) {
+    expect(typeof proxy[key]).not.toBe("function");
+    expect(proxy[key]).toBeUndefined();
+  }
+  expect(proxy[Symbol.iterator]).toBeUndefined();
+
+  // The pool is stamped onto every translated error, so a serializer or matcher
+  // reaches this proxy. Walking it (JSON.stringify invokes `toJSON`; an
+  // asymmetric matcher invokes `asymmetricMatch`) must not throw
+  // `conn[prop] is not a function`.
+  expect(() => JSON.stringify(proxy)).not.toThrow();
+  expect(proxy).not.toEqual(expect.objectContaining({ id: 1 }));
+});
+
+it("adapter proxy still dispatches genuine adapter methods to the connection", async () => {
+  const pool = makePool();
+  const proxy = (
+    pool as unknown as {
+      _getAdapterProxy(): { adapterName: string; quoteTableName(name: string): Promise<string> };
+    }
+  )._getAdapterProxy();
+
+  // adapterName is served directly off the proxy (no checkout).
+  expect(typeof proxy.adapterName).toBe("string");
+
+  // A real adapter method fabricates a callable and dispatches through the pool.
+  const quoted = await proxy.quoteTableName("people");
+  expect(quoted).toContain("people");
+});

--- a/packages/activerecord/src/connection-pool.test.ts
+++ b/packages/activerecord/src/connection-pool.test.ts
@@ -636,3 +636,16 @@ it("adapter proxy still dispatches genuine adapter methods to the connection", a
   const quoted = await proxy.quoteTableName("people");
   expect(quoted).toContain("people");
 });
+
+it("adapter proxy does not fabricate a method for an unknown probe key once a connection exists", async () => {
+  const pool = makePool();
+  // Materialise a connection (as when a query is mid-flight and an error is
+  // translated). An arbitrary probe key not in the deny set must now resolve to
+  // a non-callable, since the live connection has no such method.
+  await pool.checkout();
+  const proxy = (
+    pool as unknown as { _getAdapterProxy(): Record<PropertyKey, unknown> }
+  )._getAdapterProxy();
+  expect(proxy.someMatcherProbeKey).toBeUndefined();
+  await pool.disconnect();
+});


### PR DESCRIPTION
## Context

PR #4725 made translated adapter errors carry the live `ConnectionPool`
(Rails-faithful `connection_pool: @pool`), so the pool — and its
`_getAdapterProxy()` — is reachable from any thrown error. When such an error
becomes an unhandled rejection, vitest serializes it and walks into the proxy;
the `get` trap fabricated a callable for **every** key, so a probe of a
non-method key ran `pool.withConnection((conn) => conn[prop](...))` against a
raw connection → `TypeError: conn[prop] is not a function`.

#4725 patched only the specific probes observed (`symbol`, `then`, `toJSON`),
so the same crash class could recur on any other probe key a serializer /
matcher / framework walks (`asymmetricMatch`, `$$typeof`, `nodeType`, …).

## Change

Two-layer, principled guard in the proxy `get` trap:

1. **Deny a maintained set** — `ADAPTER_PROXY_PROBE_KEYS` (plus all symbol keys)
   covers promise/JSON/matcher/React/DOM probe keys; each returns `undefined`
   (a non-callable) instead of a fabricated dispatcher.
2. **Only dispatch real method names** — when a connection already exists (it
   does whenever a translated error was raised), any *unrecognised* key not in
   the deny set that the live connection doesn't expose as a method also
   resolves to `undefined`. With no connection yet, the trap fabricates
   optimistically so first-use dispatch (schemaMigration / internalMetadata /
   migrationContext) still works.

## Tests

- Probing serializer/matcher/framework keys returns a non-callable; serializing
  the proxy does not throw `conn[prop] is not a function`.
- An unknown probe key resolves to `undefined` once a connection exists.
- Genuine adapter methods (`adapterName`, `quoteTableName`) still dispatch.

Closes-story: connection-pool-adapter-proxy-serialization-probe-safety