### PR TITLE
fix(encryption): defer bare-encrypts fallback encryptor to first use

### DIFF
--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -21,7 +21,7 @@
 import { registerEncryptionHooks } from "./encryption-hooks.js";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
-import { Encryptor as CoreEncryptor, type EncryptorLike } from "./encryption/encryptor.js";
+import type { EncryptorLike } from "./encryption/encryptor.js";
 import { Aes256Gcm as AesGcmCipher } from "./encryption/cipher/aes256-gcm.js";
 export { Cipher } from "./encryption/cipher.js";
 import { EncryptableRecord } from "./encryption/encryptable-record.js";
@@ -126,52 +126,6 @@ class LegacyEncryptorShim implements EncryptorLike {
   }
 }
 
-/** True when any encryption key material is configured on the global config. */
-function hasConfiguredKeyMaterial(): boolean {
-  const { primaryKey, deterministicKey, keyDerivationSalt } = Configurable.config;
-  return (
-    primaryKey !== undefined || deterministicKey !== undefined || keyDerivationSalt !== undefined
-  );
-}
-
-/**
- * The fallback encryptor for a bare `encrypts` (no scheme options, no explicit
- * encryptor) whose class-init ran before `Configurable.configure` set any keys.
- *
- * `buildScheme` cannot decide real-vs-legacy at declaration time in that case:
- * the model's static block declares `encrypts` at import, but the test/app
- * configures keys later, so an eager `AR_ENC:` legacy shim would be baked in
- * permanently and never encrypt for real (the reflected `encrypts("name")`
- * columns on `EncryptedBook*` hit exactly this). Defer the choice to each
- * operation: use the real key-based `Encryptor` once keys are configured, and
- * fall back to the legacy base64 placeholder only while none are — preserving
- * the never-configured tests that rely on `AR_ENC:`.
- */
-class LazyDefaultEncryptor implements EncryptorLike {
-  private readonly real = new CoreEncryptor();
-  private readonly legacy = new LegacyEncryptorShim(defaultEncryptor);
-
-  private active(): EncryptorLike {
-    return hasConfiguredKeyMaterial() ? this.real : this.legacy;
-  }
-
-  encrypt(clearText: string, options?: Record<string, unknown>): string {
-    return this.active().encrypt(clearText, options);
-  }
-
-  decrypt(encryptedText: string, options?: Record<string, unknown>): string {
-    return this.active().decrypt(encryptedText, options);
-  }
-
-  isEncrypted(text: string): boolean {
-    return this.active().isEncrypted(text);
-  }
-
-  isBinary(): boolean {
-    return this.active().isBinary();
-  }
-}
-
 /**
  * The options bag `Base.encrypts` accepts. Mirrors Rails' kwargs:
  * full `SchemeOptions` (key, keyProvider, deterministic, downcase,
@@ -186,34 +140,27 @@ export interface EncryptsOptions extends Omit<SchemeOptions, "encryptor"> {
 function buildScheme(options: EncryptsOptions): Scheme {
   const { encryptor, previousSchemes: localPrevious = [], ...schemeOptions } = options;
 
-  const hasSchemeOptions =
-    schemeOptions.key !== undefined ||
-    schemeOptions.keyProvider !== undefined ||
-    schemeOptions.deterministic !== undefined ||
-    schemeOptions.downcase !== undefined ||
-    schemeOptions.ignoreCase !== undefined ||
-    localPrevious.length > 0 ||
-    schemeOptions.compress !== undefined ||
-    schemeOptions.compressor !== undefined ||
-    schemeOptions.supportUnencryptedData !== undefined;
-
-  // Switch to the real Scheme whenever any encryption key material is configured.
-  // If config is incomplete (e.g. only keyDerivationSalt set, no primaryKey),
-  // Scheme._defaultKeyProvider() returns undefined and Encryptor raises
-  // "No encryption key provided" at serialize/deserialize time — still more
-  // informative than silently storing AR_ENC:base64 data.
+  // A legacy `{ encrypt, decrypt }` pair is adapted via the shim as a scheme
+  // encryptor. Otherwise build a real `Scheme` with NO encryptor context
+  // property — mirroring Rails' `Scheme.new(..., **context_properties)` where a
+  // bare `encrypts` contributes no `:encryptor` property. Two consequences that
+  // an eager encryptor shim would break:
   //
-  // When neither scheme options nor keys are configured *at declaration time*,
-  // the key material may still arrive before first use (a model whose static
-  // block `encrypts` runs at import, configured later by the test/app). Bake in
-  // a LazyDefaultEncryptor rather than an eager legacy shim so that path
-  // encrypts for real once keys land, while never-configured callers keep the
-  // `AR_ENC:` placeholder.
+  //   1. The scheme resolves its key provider and encryptor lazily at
+  //      serialize/deserialize time, so a model whose static block runs
+  //      `encrypts` at import (before `Configurable.configure`) still encrypts
+  //      for real once keys land — no placeholder is baked in at declaration.
+  //   2. `Scheme#with_context` just yields (no `:encryptor` override), so
+  //      `EncryptedAttributeType#encryptor` reads the *current* context
+  //      encryptor — letting `withoutEncryption` (NullEncryptor) and
+  //      `protectingEncryptedData` (EncryptingOnlyEncryptor) take effect.
+  //
+  // When keys are never configured, the real Encryptor raises "No encryption
+  // key provided" at first use — matching Rails, and more informative than
+  // silently storing `AR_ENC:base64` data.
   const coreOpts: SchemeOptions = encryptor
     ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }
-    : hasSchemeOptions || hasConfiguredKeyMaterial()
-      ? schemeOptions
-      : { encryptor: new LazyDefaultEncryptor() };
+    : schemeOptions;
 
   // Only pass locally-declared previous schemes — global ones are resolved lazily
   // in EncryptedAttributeType at serialize/deserialize time.
@@ -232,8 +179,8 @@ interface PendingEncryption {
  *
  * Routes each attribute through the shared `EncryptableRecord.encryptAttribute`
  * (single declaration path, mirroring Rails' single `encrypts`), passing a
- * scheme built by `buildScheme` so the legacy `{ encrypt, decrypt }` shim and
- * defaultEncryptor fallback are preserved on the primary path.
+ * scheme built by `buildScheme` so the legacy `{ encrypt, decrypt }` shim is
+ * preserved on the primary path.
  *
  * The actual type wrapping is deferred (Rails' `decorate_attributes` /
  * PendingDecorator) — `encryptAttribute` records pending encryptions that

--- a/packages/activerecord/src/encryption.ts
+++ b/packages/activerecord/src/encryption.ts
@@ -21,7 +21,7 @@
 import { registerEncryptionHooks } from "./encryption-hooks.js";
 import { EncryptedAttributeType } from "./encryption/encrypted-attribute-type.js";
 import { Scheme, type SchemeOptions } from "./encryption/scheme.js";
-import type { EncryptorLike } from "./encryption/encryptor.js";
+import { Encryptor as CoreEncryptor, type EncryptorLike } from "./encryption/encryptor.js";
 import { Aes256Gcm as AesGcmCipher } from "./encryption/cipher/aes256-gcm.js";
 export { Cipher } from "./encryption/cipher.js";
 import { EncryptableRecord } from "./encryption/encryptable-record.js";
@@ -126,6 +126,52 @@ class LegacyEncryptorShim implements EncryptorLike {
   }
 }
 
+/** True when any encryption key material is configured on the global config. */
+function hasConfiguredKeyMaterial(): boolean {
+  const { primaryKey, deterministicKey, keyDerivationSalt } = Configurable.config;
+  return (
+    primaryKey !== undefined || deterministicKey !== undefined || keyDerivationSalt !== undefined
+  );
+}
+
+/**
+ * The fallback encryptor for a bare `encrypts` (no scheme options, no explicit
+ * encryptor) whose class-init ran before `Configurable.configure` set any keys.
+ *
+ * `buildScheme` cannot decide real-vs-legacy at declaration time in that case:
+ * the model's static block declares `encrypts` at import, but the test/app
+ * configures keys later, so an eager `AR_ENC:` legacy shim would be baked in
+ * permanently and never encrypt for real (the reflected `encrypts("name")`
+ * columns on `EncryptedBook*` hit exactly this). Defer the choice to each
+ * operation: use the real key-based `Encryptor` once keys are configured, and
+ * fall back to the legacy base64 placeholder only while none are — preserving
+ * the never-configured tests that rely on `AR_ENC:`.
+ */
+class LazyDefaultEncryptor implements EncryptorLike {
+  private readonly real = new CoreEncryptor();
+  private readonly legacy = new LegacyEncryptorShim(defaultEncryptor);
+
+  private active(): EncryptorLike {
+    return hasConfiguredKeyMaterial() ? this.real : this.legacy;
+  }
+
+  encrypt(clearText: string, options?: Record<string, unknown>): string {
+    return this.active().encrypt(clearText, options);
+  }
+
+  decrypt(encryptedText: string, options?: Record<string, unknown>): string {
+    return this.active().decrypt(encryptedText, options);
+  }
+
+  isEncrypted(text: string): boolean {
+    return this.active().isEncrypted(text);
+  }
+
+  isBinary(): boolean {
+    return this.active().isBinary();
+  }
+}
+
 /**
  * The options bag `Base.encrypts` accepts. Mirrors Rails' kwargs:
  * full `SchemeOptions` (key, keyProvider, deterministic, downcase,
@@ -156,15 +202,18 @@ function buildScheme(options: EncryptsOptions): Scheme {
   // Scheme._defaultKeyProvider() returns undefined and Encryptor raises
   // "No encryption key provided" at serialize/deserialize time — still more
   // informative than silently storing AR_ENC:base64 data.
-  const { primaryKey, deterministicKey, keyDerivationSalt } = Configurable.config;
-  const hasConfiguredKeys =
-    primaryKey !== undefined || deterministicKey !== undefined || keyDerivationSalt !== undefined;
-
+  //
+  // When neither scheme options nor keys are configured *at declaration time*,
+  // the key material may still arrive before first use (a model whose static
+  // block `encrypts` runs at import, configured later by the test/app). Bake in
+  // a LazyDefaultEncryptor rather than an eager legacy shim so that path
+  // encrypts for real once keys land, while never-configured callers keep the
+  // `AR_ENC:` placeholder.
   const coreOpts: SchemeOptions = encryptor
     ? { ...schemeOptions, encryptor: new LegacyEncryptorShim(encryptor) }
-    : hasSchemeOptions || hasConfiguredKeys
+    : hasSchemeOptions || hasConfiguredKeyMaterial()
       ? schemeOptions
-      : { encryptor: new LegacyEncryptorShim(defaultEncryptor) };
+      : { encryptor: new LazyDefaultEncryptor() };
 
   // Only pass locally-declared previous schemes — global ones are resolved lazily
   // in EncryptedAttributeType at serialize/deserialize time.

--- a/packages/activerecord/src/encryption/contexts.test.ts
+++ b/packages/activerecord/src/encryption/contexts.test.ts
@@ -42,10 +42,10 @@ describe("ActiveRecord::Encryption::ContextsTest", () => {
     // writes outside the per-test BEGIN/ROLLBACK savepoint that the
     // transactional `fixtures([])` wiring relies on. The sibling handler-suite
     // encryption test (uniqueness-validations.test.ts) hand-rolls models for
-    // the same reason. They are also defined after configureEncryption so
-    // encrypts() builds the scheme against the configured key material
-    // (otherwise buildScheme falls back to the legacy AR_ENC placeholder
-    // encryptor).
+    // the same reason. They are defined after configureEncryption for clarity;
+    // the scheme now resolves its key provider lazily at serialize time, so the
+    // ordering is no longer load-bearing (a bare `encrypts` declared before
+    // configure still encrypts for real once keys land).
     EncryptedPost = class EncryptedPost extends Base {
       static {
         this._tableName = "posts";

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -32,6 +32,7 @@ import { itIfSupports } from "../test-helpers/supports.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { EncryptableRecord } from "./encryptable-record.js";
 import {
+  EncryptedBook,
   EncryptedBookNormalizedFirst,
   EncryptedBookNormalizedSecond,
 } from "../test-helpers/models/book-encrypted.js";
@@ -490,9 +491,13 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("support encrypted attributes defined on columns with default values", async () => {
-    const Book = makeEncryptedBook(await freshAdapter());
-    new Book();
-    const book = await Book.create({});
+    // Rides the canonical reflection-based `EncryptedBook` (name via schema
+    // reflection, non-null default `<untitled>`), mirroring Rails'
+    // `EncryptedBook.create!`. The reflected column default is threaded into the
+    // EncryptedAttributeType and round-trips through the plaintext-default guard
+    // on first read — no `Failed to deserialize encrypted message`.
+    await freshAdapter();
+    const book = await EncryptedBook.create({});
     await assertEncryptedAttribute(book, "name", "<untitled>");
   });
 

--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -17,8 +17,6 @@ import {
   makeEncryptedBookWithCustomCompressor,
   makeEncryptedTrafficLight,
   makeEncryptedTrafficLightWithStoreState,
-  makeEncryptedBookNormalizedFirst,
-  makeEncryptedBookNormalizedSecond,
   makeKeyProvider,
   assertEncryptedAttribute,
   ciphertextFor,
@@ -33,6 +31,10 @@ import { Configurable } from "./configurable.js";
 import { itIfSupports } from "../test-helpers/supports.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { EncryptableRecord } from "./encryptable-record.js";
+import {
+  EncryptedBookNormalizedFirst,
+  EncryptedBookNormalizedSecond,
+} from "../test-helpers/models/book-encrypted.js";
 import { isEncryptedAttribute } from "../encryption.js";
 import { RecordInvalid } from "../index.js";
 
@@ -781,16 +783,17 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     // ciphertext on PG/MariaDB (see the `serialized binary data can be encrypted`
     // skip). Until that impl gap closes we ride only the `name` half; a persisted
     // `logo` ciphertext would trip the record's reload, so it stays omitted.
-    // One adapter for both models: they share the canonical `encrypted_books`
-    // table, so re-installing the schema for a second adapter would reset the id
-    // sequence and collide with the first row's PK on PG.
-    const adp = await freshAdapter();
-    let book = await makeEncryptedBookNormalizedFirst(adp).create({ name: "Book" });
+    // Rides the canonical reflection-based `EncryptedBookNormalized{First,Second}`
+    // (name obtained via schema reflection, non-null default `<untitled>`), not
+    // an explicit `attribute("name", ...)` declaration — the reflected + bare
+    // `encrypts` path that a class-init-before-configure model exercises.
+    await freshAdapter();
+    let book = await EncryptedBookNormalizedFirst.create({ name: "Book" });
     await assertEncryptedAttribute(book, "name", "book");
     // TRACKED-PENDING-CONVERGENCE (binary text-ciphertext round-trip):
     // await assertEncryptedAttribute(book, "logo", "book");
 
-    book = await makeEncryptedBookNormalizedSecond(adp).create({ name: "Book" });
+    book = await EncryptedBookNormalizedSecond.create({ name: "Book" });
     await assertEncryptedAttribute(book, "name", "book");
     // await assertEncryptedAttribute(book, "logo", "book");
   });

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -552,68 +552,6 @@ export function makeEncryptedBookAttribute(adapter: DatabaseAdapter) {
   } as any;
 }
 
-// Mirrors Ruby's `value.to_s.downcase` on an ASCII-8BIT string: only ASCII
-// A–Z bytes are lowercased; bytes > 0x7F are preserved bit-for-bit (Ruby's
-// downcase on a binary string does not perform Unicode case folding).
-// For our `logo: binary` attribute the cast type yields a Uint8Array,
-// so we lowercase bytes directly and return a Uint8Array to preserve the
-// binary cast type through normalization (which writes back via
-// writeCastValue after casting).
-function _downcaseLikeRails(v: unknown): unknown {
-  if (v == null) return v;
-  if (v instanceof Uint8Array) {
-    const out = new Uint8Array(v.length);
-    for (let i = 0; i < v.length; i++) {
-      const b = v[i];
-      out[i] = b >= 0x41 && b <= 0x5a ? b + 0x20 : b;
-    }
-    return out;
-  }
-  return String(v).toLowerCase();
-}
-
-/**
- * EncryptedBookNormalizedFirst: declares normalizes before encrypts on both
- * `name` and `logo`. Mirrors Rails' EncryptedBookNormalizedFirst — exercises
- * normalize-then-encrypt order.
- */
-export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
-  return class EncryptedBookNormalizedFirst extends Base {
-    static {
-      this._tableName = "encrypted_books";
-      this.attribute("id", "integer");
-      this.attribute("name", "string", { default: "<untitled>" });
-      this.attribute("logo", "binary");
-      this.adapter = adapter;
-      this.normalizes("name", _downcaseLikeRails);
-      this.encrypts("name");
-      this.normalizes("logo", _downcaseLikeRails);
-      this.encrypts("logo");
-    }
-  } as any;
-}
-
-/**
- * EncryptedBookNormalizedSecond: declares encrypts before normalizes on both
- * `name` and `logo`. Mirrors Rails' EncryptedBookNormalizedSecond — exercises
- * encrypt-then-normalize order.
- */
-export function makeEncryptedBookNormalizedSecond(adapter: DatabaseAdapter) {
-  return class EncryptedBookNormalizedSecond extends Base {
-    static {
-      this._tableName = "encrypted_books";
-      this.attribute("id", "integer");
-      this.attribute("name", "string", { default: "<untitled>" });
-      this.attribute("logo", "binary");
-      this.adapter = adapter;
-      this.encrypts("name");
-      this.normalizes("name", _downcaseLikeRails);
-      this.encrypts("logo");
-      this.normalizes("logo", _downcaseLikeRails);
-    }
-  } as any;
-}
-
 // ─── Assertion helpers ────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## What

A model whose `encrypts("name")` (bare — no scheme options, no explicit
encryptor) is declared in a class-init static block **at import time**, before
`Configurable.configure` sets keys, never encrypted for real: `buildScheme`
baked in an eager `AR_ENC:` legacy base64 placeholder permanently. The
reflection-based canonical `EncryptedBookNormalized{First,Second}` models hit
exactly this — `valuesForDatabase()` stored the plaintext unchanged.

The deserialize-default seam the story originally described (default
`<untitled>` seeded via `deserialize` → decrypt throws) is already handled on
main by the `EncryptedAttributeType` default guard (#4435/#4442/#4444). What
remained was that bare `encrypts` declared before configure never encrypted.

## How

Build a real `Scheme` with **no** encryptor for the non-legacy path, mirroring
Rails' `Scheme.new(..., **context_properties)` where a bare `encrypts`
contributes no `:encryptor` property. The scheme then:

1. resolves its key provider and encryptor **lazily** at serialize/deserialize
   time, so a class-init-before-configure `encrypts` encrypts for real once keys
   land — no placeholder baked in at declaration; and
2. leaves `Scheme#with_context` yielding (no `:encryptor` override), so
   `EncryptedAttributeType#encryptor` reads the **current** context encryptor —
   letting `withoutEncryption` (NullEncryptor) and `protectingEncryptedData`
   (EncryptingOnlyEncryptor) take effect.

Never-configured keys now raise "No encryption key provided" at first use,
matching Rails — no suite relies on the removed `AR_ENC:` fallback.

Test convergence onto the canonical reflection-based models (retiring the
same-named `attribute()`-declaring factory helpers added in #4419):

- `encrypts normalized data` → `EncryptedBookNormalized{First,Second}`
  (matches Rails' `create!(name: "Book")` assertions verbatim; `logo` binary
  halves stay commented behind the tracked text-ciphertext round-trip gap).
- `support encrypted attributes defined on columns with default values` →
  canonical `EncryptedBook` (mirrors Rails' `EncryptedBook.create!`), directly
  exercising the story's headline criterion: a reflected encrypted column's
  non-null schema default (`<untitled>`) reads back on first read with no
  `Failed to deserialize encrypted message`.

## Review resolution (Codex)

First revision installed a `LazyDefaultEncryptor` as a scheme-level encryptor,
which made `Scheme#with_context` push it as an `:encryptor` context override and
shadow `withoutEncryption` / `protectingEncryptedData` (Rails' bare `encrypts`
never does this — `contexts.rb:50-58`, `scheme.rb:70-75`,
`encrypted_attribute_type.rb:136-151`). Replaced with the real-Scheme-no-encryptor
approach above, which resolves lazily **and** respects the context APIs.
Verified: under `withoutEncryption`, a bare reflected `encrypts` model now stores
plaintext, not ciphertext.

## Tests

`encryption/` (31 files, 320 tests), `sti-attribute-routing`, `calculations`,
`use-fixtures` pass locally on sqlite. `tsc --build` clean. 44+/102− LOC.

Closes-story: reflected-encrypted-column-schema-default-deserialize