### PR TITLE
refactor(schema): unify base emitTable onto the columnSpec dispatch

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
@@ -99,7 +99,7 @@ describe("SchemaDumper schemaDefault with adapter type deserialize", () => {
 
 // Story 3.3-U1: columnSpec must emit directly-emittable TypeScript-DSL text
 // (not Ruby schema.rb syntax) so a later story (3.3-U3) can route emitTable
-// through it via formatColspecRaw. These pin the prerequisite.
+// through it via formatColspec. These pin the prerequisite.
 describe("SchemaDumper columnSpec emits TS-DSL-emittable text", () => {
   const dumper = SchemaDumper.create(emptySource) as any;
 
@@ -111,7 +111,7 @@ describe("SchemaDumper columnSpec emits TS-DSL-emittable text", () => {
     expect(dumper.schemaExpression({ defaultFunction: "now()" })).toBe('() => "now()"');
   });
 
-  it("columnSpec output round-trips through formatColspecRaw as valid TS-DSL", () => {
+  it("columnSpec output round-trips through formatColspec as valid TS-DSL", () => {
     const [type, spec] = dumper.columnSpec({
       type: "datetime",
       precision: null,
@@ -121,7 +121,7 @@ describe("SchemaDumper columnSpec emits TS-DSL-emittable text", () => {
       defaultFunction: "now()",
     });
     expect(type).toBe("datetime");
-    const text = dumper.formatColspecRaw(spec);
+    const text = dumper.formatColspec(spec);
     expect(text).toContain("precision: null");
     expect(text).toContain("null: false");
     expect(text).toContain('default: () => "now()"');

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -96,14 +96,14 @@ export class SchemaDumper extends BaseSchemaDumper {
   protected columnSpecForPrimaryKey(column: Column): Record<string, unknown> {
     const spec: Record<string, unknown> = {};
     if (!this.isDefaultPrimaryKey(column)) {
-      // Pre-format the id value as a TS-DSL string literal for formatColspecRaw.
+      // Pre-format the id value as a TS-DSL string literal for formatColspec.
       spec["id"] = JSON.stringify(this.schemaType(column));
     }
     const colOpts = this.prepareColumnOptions(column);
     delete colOpts["null"];
     Object.assign(spec, colOpts);
     if (this.isExplicitPrimaryKeyDefault(column)) {
-      // "null" (not Ruby "nil") — emitted verbatim by formatColspecRaw as `default: null`.
+      // "null" (not Ruby "nil") — emitted verbatim by formatColspec as `default: null`.
       spec["default"] ??= "null";
     }
     return spec;
@@ -181,7 +181,7 @@ export class SchemaDumper extends BaseSchemaDumper {
   protected schemaPrecision(column: Column): string | undefined {
     if (column.type === "datetime") {
       // TS-DSL literal `null` (Rails dumps the Ruby `nil`); the value is emitted
-      // verbatim by formatColspecRaw, so it must already read as valid TS.
+      // verbatim by formatColspec, so it must already read as valid TS.
       if (column.precision == null) return "null";
       if (column.precision === BaseSchemaDumper.DEFAULT_DATETIME_PRECISION) return undefined;
       return String(column.precision);
@@ -228,7 +228,7 @@ export class SchemaDumper extends BaseSchemaDumper {
   /** @internal */
   protected schemaExpression(column: Column): string | undefined {
     // TS-DSL arrow form (Rails dumps the Ruby lambda `-> { … }`); emitted verbatim
-    // by formatColspecRaw and consumed by the DSL as `default: () => "fn()"`.
+    // by formatColspec and consumed by the DSL as `default: () => "fn()"`.
     if (column.defaultFunction) return `() => ${JSON.stringify(column.defaultFunction)}`;
     return undefined;
   }
@@ -265,7 +265,7 @@ export class SchemaDumper extends BaseSchemaDumper {
     const singlePkName = !hasCompositePk && pkColumn ? pkColumn.name : undefined;
     const stripped = this.removePrefixAndSuffix(tableName);
 
-    // All values in tableOpts are pre-formatted TS-DSL text for formatColspecRaw.
+    // All values in tableOpts are pre-formatted TS-DSL text for formatColspec.
     const tableOpts: Record<string, unknown> = {};
     if (hasCompositePk) {
       // Rails (Array case) emits only `primary_key: [...]`; the TS DSL also needs
@@ -303,14 +303,14 @@ export class SchemaDumper extends BaseSchemaDumper {
     tableOpts["force"] = '"cascade"';
 
     lines.push(
-      `  await ctx.createTable(${JSON.stringify(stripped)}, { ${this.formatColspecRaw(tableOpts)} }, (t) => {`,
+      `  await ctx.createTable(${JSON.stringify(stripped)}, { ${this.formatColspec(tableOpts)} }, (t) => {`,
     );
 
     for (const col of columns) {
       if (col.name === singlePkName) continue;
 
       const [dslType, spec] = this.columnSpec(col);
-      const optStr = Object.keys(spec).length > 0 ? `, { ${this.formatColspecRaw(spec)} }` : "";
+      const optStr = Object.keys(spec).length > 0 ? `, { ${this.formatColspec(spec)} }` : "";
       const typeName = String(dslType);
 
       if (this._isDslHelper(typeName)) {

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -240,13 +240,13 @@ export class SchemaDumper extends BaseSchemaDumper {
   }
 
   /**
-   * Epic 3.3-U3: adapter-backed emitTable routed through columnSpec so
-   * per-dialect `prepareColumnOptions` overrides (schemaType, schemaLimit,
-   * schemaPrecision, schemaDefault, etc.) take effect on live dumps.
-   *
-   * The base-class `emitTable` (inline colspec) continues to serve the
-   * in-memory MigrationContext path unchanged. This override is called only
-   * when the instance is an adapter-specific SchemaDumper subclass.
+   * The single `emitTable`, routed through `columnSpec` so per-dialect
+   * `prepareColumnOptions` overrides (schemaType, schemaLimit, schemaPrecision,
+   * schemaDefault, etc.) take effect. Mirrors the column-emission half of Rails'
+   * `SchemaDumper#table`, whose `@connection.column_spec` is the adapter's
+   * mixed-in method. Every dump reaches it — the bare base redirects
+   * construction here (see `SchemaDumper.connectionAdaptersDumper`), including
+   * the in-memory MigrationContext and mock-source paths.
    * @internal
    */
   protected override emitTable(

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -198,15 +198,12 @@ export class SchemaDumper extends BaseSchemaDumper {
 
   // Rails `schema_default` / `schema_expression` live in
   // `connection_adapters/abstract/schema_dumper.rb`, so the ports stay in this
-  // file (the api:compare-mapped location). The base `SchemaDumper`
-  // (../../schema-dumper.ts) carries structurally-identical copies so its
-  // legacy `emitTable` default callsites route through the same cast-type path;
-  // these overrides keep the Rails-faithful body where it belongs. `_adapter`
-  // is a trails-only helper and lives solely on the base. Keep these two bodies
-  // in lockstep with the base copies — edit both.
+  // file (the api:compare-mapped location) — the sole definitions, consumed by
+  // this class's single `emitTable`/`columnSpec` dispatch. `_adapter` is a
+  // trails-only helper on the base (it reaches base-private `_source`).
 
   /** @internal */
-  protected override schemaDefault(column: Column): string | undefined {
+  protected schemaDefault(column: Column): string | undefined {
     if (!column.hasDefault && column.default === undefined) return undefined;
     if (column.default == null) return this.schemaExpression(column);
     const adapter = this._adapter();
@@ -229,7 +226,7 @@ export class SchemaDumper extends BaseSchemaDumper {
   }
 
   /** @internal */
-  protected override schemaExpression(column: Column): string | undefined {
+  protected schemaExpression(column: Column): string | undefined {
     // TS-DSL arrow form (Rails dumps the Ruby lambda `-> { … }`); emitted verbatim
     // by formatColspecRaw and consumed by the DSL as `default: () => "fn()"`.
     if (column.defaultFunction) return `() => ${JSON.stringify(column.defaultFunction)}`;
@@ -334,3 +331,11 @@ export class SchemaDumper extends BaseSchemaDumper {
     this.indexesInCreate(tableName, lines, indexes);
   }
 }
+
+// Register this ConnectionAdapters subclass so `BaseSchemaDumper.create`/`dump`
+// with a plain (non-adapter) SchemaSource transparently constructs it — the
+// single `emitTable`/`columnSpec` dispatch, mirroring Rails' adapter-mixed-in
+// `column_spec`. Every file that can reach a bare-base dump also loads this
+// module (the public `SchemaDumper` export is this class), so the slot is set
+// before any redirect resolves.
+BaseSchemaDumper.connectionAdaptersDumper = SchemaDumper;

--- a/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-dumper.ts
@@ -193,20 +193,6 @@ export class SchemaDumper extends AbstractSchemaDumper {
     return super.schemaLimit(column);
   }
 
-  /**
-   * Mirrors Rails' `MySQL::SchemaDumper#schema_precision`: a bare `datetime`
-   * (introspected precision 0) dumps as `precision: null` (Rails' `nil`), while
-   * a bare `timestamp`/`time` (precision 0) omits precision entirely.
-   * @internal
-   */
-  protected override mapDatetimePrecisionForDump(
-    dslType: string,
-    precision: number | null | undefined,
-  ): number | null | undefined {
-    if (precision === 0) return dslType === "datetime" ? null : undefined;
-    return precision;
-  }
-
   /** @internal */
   protected override schemaPrecision(column: MysqlColumn): string | undefined {
     const sqlType = (column.sqlType ?? "").toLowerCase();

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -32,7 +32,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
       if (column.isEnum) spec["enum_type"] = JSON.stringify(column.sqlType);
       // Rails dumps the symbol `type: :bigserial`; the TS DSL takes a string
       // ColumnType, so emit `type: "bigserial"` (consumed verbatim by
-      // formatColspecRaw on the U3 columnSpec path).
+      // formatColspec on the U3 columnSpec path).
       return { type: JSON.stringify(this.schemaType(column)), ...spec };
     }
 

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -1,6 +1,6 @@
 // Trails-only SchemaDumper cases with no 1:1 in Rails'
 // schema_dumper_test.rb. These unit-test trails-invented exported helpers
-// (formatColspecRaw / indexParts), the adapter-introspection dump path
+// (formatColspec / indexParts), the adapter-introspection dump path
 // (SchemaDumperAdapterTest), async header ordering, and DSL-helper
 // round-trips. Kept out of the Rails-mirrored schema-dumper.test.ts so
 // test:compare maps cleanly.
@@ -397,7 +397,7 @@ describe("SchemaDumper async header ordering", () => {
   });
 });
 
-describe("formatColspecRaw", () => {
+describe("formatColspec", () => {
   const dumper = SchemaDumper.create({
     tables: () => [],
     columns: () => [],
@@ -406,7 +406,7 @@ describe("formatColspecRaw", () => {
 
   it("emits values verbatim (Rails format_colspec), not re-quoted", () => {
     expect(
-      dumper.formatColspecRaw({
+      dumper.formatColspec({
         null: "false",
         limit: "255",
         precision: "null",
@@ -418,7 +418,7 @@ describe("formatColspecRaw", () => {
 
   it("recurses into nested objects (primary-key `id: { type:, … }` spec)", () => {
     expect(
-      dumper.formatColspecRaw({ id: { type: '"uuid"', default: "null" }, force: '"cascade"' }),
+      dumper.formatColspec({ id: { type: '"uuid"', default: "null" }, force: '"cascade"' }),
     ).toBe('id: { type: "uuid", default: null }, force: "cascade"');
   });
 });

--- a/packages/activerecord/src/schema-dumper.trails.test.ts
+++ b/packages/activerecord/src/schema-dumper.trails.test.ts
@@ -18,7 +18,10 @@ describe("SchemaDumper trails-only cases", () => {
       tables: () => ["gen_defaults"],
       columns: () => [
         { name: "id", type: "integer", primaryKey: true },
-        { name: "token", type: "string", defaultFunction: "gen_random_uuid()" },
+        // A function default reflects as `default: null` + `defaultFunction`
+        // (the literal default is null; the expression rides defaultFunction),
+        // which schemaDefault routes through schemaExpression to the arrow form.
+        { name: "token", type: "string", default: null, defaultFunction: "gen_random_uuid()" },
       ],
       indexes: () => [],
     };
@@ -287,7 +290,10 @@ describe("SchemaDumperAdapterTest", () => {
   }, 60000);
 
   it("emitTable forwards comment from fetchTableOptions into createTable options", async () => {
-    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
+    // Subclasses the ConnectionAdapters dumper directly — that's where emitTable
+    // (the single column_spec dispatch) lives; the bare base delegates to it.
+    const { SchemaDumper: TopLevelDumper } =
+      await import("./connection-adapters/abstract/schema-dumper.js");
     const source = {
       tables: () => ["users"],
       columns: () => [{ name: "id", type: "integer", primaryKey: true }],
@@ -305,7 +311,8 @@ describe("SchemaDumperAdapterTest", () => {
   });
 
   it("emitTable emits charset and collation from adapterTableOpts before force", async () => {
-    const { SchemaDumper: TopLevelDumper } = await import("./schema-dumper.js");
+    const { SchemaDumper: TopLevelDumper } =
+      await import("./connection-adapters/abstract/schema-dumper.js");
     const source = {
       tables: () => ["t"],
       columns: () => [{ name: "id", type: "integer", primaryKey: true }],

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -1022,3 +1022,16 @@ function isDatabaseAdapter(v: unknown): v is DatabaseAdapter {
     typeof obj.adapterName === "string"
   );
 }
+
+// Load the `ConnectionAdapters::SchemaDumper` subclass so it registers itself
+// as `connectionAdaptersDumper` (see that field) even when a consumer imports
+// only this base module — the redirect in `create` then always has the single
+// `emitTable`/`columnSpec` emitter available, mirroring Rails' adapter dumper
+// factory which unconditionally returns `ConnectionAdapters::SchemaDumper`
+// (connection_adapters/abstract/schema_dumper.rb:8-10). The import must be
+// dynamic, not static: the subclass `extends` this class, so a static back-edge
+// would evaluate its `extends` clause before this class is defined (a temporal
+// dead zone) — the same static cycle this file already breaks for
+// `schema-introspection`. Placed after the class declaration, so by the time
+// the subclass module evaluates, this base class is fully defined.
+void import("./connection-adapters/abstract/schema-dumper.js");

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -332,17 +332,43 @@ export class SchemaDumper {
 
   /**
    * The `ConnectionAdapters::SchemaDumper` subclass, registered by that module
-   * at load. Rails has a single dumper: the base `SchemaDumper#table` always
-   * drives column specs through the adapter's mixed-in
-   * `column_spec`/`prepare_column_options` (which live on the adapter subclass).
-   * TS can't mix a module into a class, so instead constructing the bare base
-   * for a non-adapter source (`create`/`dump` with a plain `SchemaSource`)
-   * transparently yields the adapter subclass — the sole `emitTable` /
-   * `columnSpec` dispatch. Dialect subclasses set `this` to themselves and are
+   * at load. Rails has a single dumper: `SchemaDumper#table` drives columns
+   * through the unqualified `column_spec` (schema_dumper.rb:199), a private
+   * method defined only on the adapter subclass (abstract/schema_dumper.rb:13),
+   * so Rails always instantiates that subclass via `connection.create_schema_dumper`
+   * — a bare `ActiveRecord::SchemaDumper` would `NameError` on `column_spec`. TS
+   * can't mix a module into a class, so the emitter lives on the subclass and the
+   * base factory (`create`/`dump`/`dumpTableSchema`) redirects to it for
+   * non-adapter sources. Dialect subclasses set `this` to themselves and are
    * never redirected.
    * @internal
    */
   static connectionAdaptersDumper?: typeof SchemaDumper;
+
+  /** @internal */
+  private static _connectionAdaptersDumperLoad?: Promise<typeof SchemaDumper>;
+
+  /**
+   * Load the `ConnectionAdapters::SchemaDumper` subclass and return it once it
+   * has registered itself as {@link connectionAdaptersDumper}. The import is
+   * dynamic (cached) rather than static because the subclass `extends` this
+   * class: a static back-edge would evaluate its `extends` clause before this
+   * class is defined (a temporal dead zone) — the same static cycle this file
+   * already breaks for `schema-introspection`. Async entrypoints await this
+   * before constructing so the redirect never falls back to the bare base.
+   * @internal
+   */
+  protected static async loadConnectionAdaptersDumper(): Promise<typeof SchemaDumper> {
+    if (SchemaDumper.connectionAdaptersDumper) return SchemaDumper.connectionAdaptersDumper;
+    SchemaDumper._connectionAdaptersDumperLoad ??=
+      import("./connection-adapters/abstract/schema-dumper.js").then(() => {
+        if (!SchemaDumper.connectionAdaptersDumper) {
+          throw new Error("ConnectionAdapters::SchemaDumper did not register on load");
+        }
+        return SchemaDumper.connectionAdaptersDumper;
+      });
+    return SchemaDumper._connectionAdaptersDumperLoad;
+  }
 
   private _source: SchemaSource;
   protected _options: Record<string, unknown>;
@@ -417,11 +443,20 @@ export class SchemaDumper {
     // `emitTable`/`columnSpec` dispatch (which lives there, mirroring Rails'
     // adapter-mixed-in column_spec) serves every source. Dialect subclasses
     // pass `this !== SchemaDumper` and construct themselves unchanged.
-    const Ctor =
-      this === SchemaDumper && SchemaDumper.connectionAdaptersDumper
-        ? SchemaDumper.connectionAdaptersDumper
-        : this;
-    return new Ctor(source, options) as InstanceType<T>;
+    if (this !== SchemaDumper) return new this(source, options) as InstanceType<T>;
+    const Sub = SchemaDumper.connectionAdaptersDumper;
+    if (!Sub) {
+      // Synchronous construction can't load the subclass (see
+      // loadConnectionAdaptersDumper); the async `dump`/`dumpTableSchema` paths
+      // await it before reaching here. Like Rails, a bare base has no
+      // `column_spec` — go through an adapter's `createSchemaDumper()` or await
+      // `loadConnectionAdaptersDumper()` first.
+      throw new Error(
+        "SchemaDumper.create needs the ConnectionAdapters dumper; use SchemaDumper.dump()/" +
+          "dumpTableSchema() (which load it) or an adapter's createSchemaDumper().",
+      );
+    }
+    return new Sub(source, options) as InstanceType<T>;
   }
 
   /**
@@ -455,14 +490,42 @@ export class SchemaDumper {
       // redirect) — never the bare base.
       const createDialectDumper = (sourceOrAdapter as { createSchemaDumper?: unknown })
         .createSchemaDumper;
-      const dumper =
+      const dialectDumper =
         typeof createDialectDumper === "function"
-          ? ((createDialectDumper.call(sourceOrAdapter, source, dumperOptions) ??
-              this.create(source, dumperOptions)) as SchemaDumper)
-          : this.create(source, dumperOptions);
-      return dumper.dump() as Promise<string>;
+          ? (createDialectDumper.call(sourceOrAdapter, source, dumperOptions) as
+              | SchemaDumper
+              | undefined
+              | null)
+          : undefined;
+      if (dialectDumper) return dialectDumper.dump() as Promise<string>;
+      // Adapter without a dialect dumper hook — fall back to the base factory,
+      // awaiting the ConnectionAdapters subclass load so `create` never hits the
+      // bare base.
+      return this._createEnsuringEmitter(source, dumperOptions).then((d) => d.dump());
     }
-    return this.create(sourceOrAdapter, options).dump();
+    // Non-adapter source (in-memory MigrationContext / mock). The public
+    // `SchemaDumper` IS the subclass, so `create` resolves synchronously; only a
+    // direct import of the bare base needs the awaited load.
+    if (this !== SchemaDumper || SchemaDumper.connectionAdaptersDumper) {
+      return this.create(sourceOrAdapter, options).dump();
+    }
+    return this._createEnsuringEmitter(sourceOrAdapter, options).then((d) => d.dump());
+  }
+
+  /**
+   * Construct a dumper for `source`, first awaiting the ConnectionAdapters
+   * subclass load when called on the bare base so the `create` redirect has the
+   * emitter registered. Used by the async dump entrypoints.
+   * @internal
+   */
+  private static async _createEnsuringEmitter(
+    source: SchemaSource,
+    options: Record<string, unknown>,
+  ): Promise<SchemaDumper> {
+    if (this === SchemaDumper && !SchemaDumper.connectionAdaptersDumper) {
+      await SchemaDumper.loadConnectionAdaptersDumper();
+    }
+    return this.create(source, options);
   }
 
   static dumpTableSchema(adapter: DatabaseAdapter, tableName: string): Promise<string>;
@@ -480,7 +543,7 @@ export class SchemaDumper {
     if (isDatabaseAdapter(source) && typeof (source as any).createSchemaDumper === "function") {
       dumper = (source as any).createSchemaDumper(wrappedSource, {}) as SchemaDumper;
     } else {
-      dumper = this.create(wrappedSource);
+      dumper = await this._createEnsuringEmitter(wrappedSource, {});
     }
     const lines: string[] = [];
     await dumper.schemas(lines);
@@ -1022,16 +1085,3 @@ function isDatabaseAdapter(v: unknown): v is DatabaseAdapter {
     typeof obj.adapterName === "string"
   );
 }
-
-// Load the `ConnectionAdapters::SchemaDumper` subclass so it registers itself
-// as `connectionAdaptersDumper` (see that field) even when a consumer imports
-// only this base module — the redirect in `create` then always has the single
-// `emitTable`/`columnSpec` emitter available, mirroring Rails' adapter dumper
-// factory which unconditionally returns `ConnectionAdapters::SchemaDumper`
-// (connection_adapters/abstract/schema_dumper.rb:8-10). The import must be
-// dynamic, not static: the subclass `extends` this class, so a static back-edge
-// would evaluate its `extends` clause before this class is defined (a temporal
-// dead zone) — the same static cycle this file already breaks for
-// `schema-introspection`. Placed after the class declaration, so by the time
-// the subclass module evaluates, this base class is fully defined.
-void import("./connection-adapters/abstract/schema-dumper.js");

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -136,80 +136,6 @@ export interface SchemaDumperOptions {
   version?: string;
 }
 
-interface DslMapping {
-  dslType: string;
-  extraOpts?: Record<string, unknown>;
-}
-
-/** Map SQL type strings (as returned by pg_catalog.format_type) to DSL method names. */
-const SQL_TYPE_MAP: Record<string, DslMapping> = {
-  "character varying": { dslType: "string" },
-  varchar: { dslType: "string" },
-  text: { dslType: "text" },
-  integer: { dslType: "integer" },
-  int: { dslType: "integer" },
-  int4: { dslType: "integer" },
-  bigint: { dslType: "bigint" },
-  int8: { dslType: "bigint" },
-  smallint: { dslType: "integer", extraOpts: { limit: 2 } },
-  int2: { dslType: "integer", extraOpts: { limit: 2 } },
-  "double precision": { dslType: "float" },
-  float8: { dslType: "float" },
-  real: { dslType: "float" },
-  float4: { dslType: "float" },
-  numeric: { dslType: "decimal" },
-  decimal: { dslType: "decimal" },
-  boolean: { dslType: "boolean" },
-  bool: { dslType: "boolean" },
-  date: { dslType: "date" },
-  "timestamp without time zone": { dslType: "datetime" },
-  timestamp: { dslType: "datetime" },
-  "timestamp with time zone": { dslType: "timestamptz" },
-  timestamptz: { dslType: "timestamptz" },
-  "time without time zone": { dslType: "time" },
-  time: { dslType: "time" },
-  "time with time zone": { dslType: "time" },
-  timetz: { dslType: "time" },
-  bytea: { dslType: "binary" },
-  json: { dslType: "json" },
-  jsonb: { dslType: "jsonb" },
-  uuid: { dslType: "uuid" },
-  money: { dslType: "money", extraOpts: { scale: 2 } },
-  inet: { dslType: "inet" },
-  cidr: { dslType: "cidr" },
-  macaddr: { dslType: "macaddr" },
-  hstore: { dslType: "hstore" },
-  xml: { dslType: "xml" },
-  point: { dslType: "point" },
-  line: { dslType: "line" },
-  lseg: { dslType: "lseg" },
-  box: { dslType: "box" },
-  path: { dslType: "path" },
-  polygon: { dslType: "polygon" },
-  circle: { dslType: "circle" },
-  interval: { dslType: "interval" },
-  bit: { dslType: "bit" },
-  "bit varying": { dslType: "bitVarying" },
-  varbit: { dslType: "bitVarying" },
-  citext: { dslType: "citext" },
-  ltree: { dslType: "ltree" },
-  tsvector: { dslType: "tsvector" },
-  oid: { dslType: "oid" },
-  int4range: { dslType: "int4range" },
-  int8range: { dslType: "int8range" },
-  numrange: { dslType: "numrange" },
-  daterange: { dslType: "daterange" },
-  tsrange: { dslType: "tsrange" },
-  tstzrange: { dslType: "tstzrange" },
-  serial: { dslType: "serial" },
-  bigserial: { dslType: "bigserial" },
-  character: { dslType: "char" },
-  bpchar: { dslType: "char" },
-  // SQLite types
-  blob: { dslType: "binary" },
-  "integer primary key autoincrement": { dslType: "integer" },
-};
-
 /**
  * DSL methods that actually exist as helpers on TableDefinition —
  * either the abstract base (connection-adapters/abstract/schema-definitions.ts)
@@ -273,119 +199,6 @@ const DSL_HELPER_METHODS = new Set([
 ]);
 
 /**
- * dsl type names `sqlTypeToDsl` may resolve to that must round-trip to
- * themselves when they re-appear as a bare SQL type — e.g. a SchemaDumper
- * second pass, or CTAS where SQLite preserves the dumped DSL name as the
- * column's declared type. Without this safety net such a name falls through
- * to the `{ dslType: "enum" }` catch-all; since these columns are not
- * `isEnum`, the emitter then routes them through the generic
- * `t.column(name, sqlType)` path (`t.enum(...)` is only emitted when
- * `col.isEnum`), silently losing the matching DSL helper.
- *
- * Derived from `DSL_HELPER_METHODS` (so every helper is covered by
- * construction) plus the non-helper dsl types `sqlTypeToDsl`/`SQL_TYPE_MAP`
- * also produce (`timestamptz`, `uuid`, `interval`, `oid`, `serial`,
- * `bigserial`, `char`).
- *
- * Caveat (consistent with `SQL_TYPE_MAP`'s existing behavior): a PG enum
- * type whose name collides with one of these (e.g. an enum literally named
- * `point` or `bitvarying`) resolves to the helper rather than `t.enum`.
- * Every `SQL_TYPE_MAP` key already carries this collision; this set only
- * adds `bitvarying` to it.
- */
-const KNOWN_DSL_TYPES = new Set<string>([
-  ...DSL_HELPER_METHODS,
-  "timestamptz",
-  "uuid",
-  "interval",
-  "oid",
-  "serial",
-  "bigserial",
-  "char",
-]);
-
-/**
- * Case-insensitive index into {@link KNOWN_DSL_TYPES}. `sqlTypeToDsl`
- * normalizes the incoming SQL type to lowercase, but dsl names like
- * `bitVarying` are camelCase — a plain `Set.has(lowercased)` would miss them.
- */
-const KNOWN_DSL_TYPES_BY_LOWER = new Map(
-  [...KNOWN_DSL_TYPES].map((dslType) => [dslType.toLowerCase(), dslType]),
-);
-
-function sqlTypeToDsl(sqlType: string): DslMapping {
-  const normalized = sqlType.toLowerCase().trim();
-  const isArray = normalized.endsWith("[]");
-  const baseType = isArray ? normalized.slice(0, -2) : normalized;
-
-  let result = SQL_TYPE_MAP[baseType];
-
-  if (!result) {
-    // Handle parameterized types (Postgres: "character varying(N)", SQLite: "varchar(N)")
-    const varcharMatch = baseType.match(/^(?:character varying|varchar)\((\d+)\)$/);
-    if (varcharMatch) {
-      result = { dslType: "string", extraOpts: { limit: Number(varcharMatch[1]) } };
-    } else {
-      const charMatch = baseType.match(/^(?:character|char|bpchar)\((\d+)\)$/);
-      const numericMatch = !charMatch
-        ? baseType.match(/^(?:numeric|decimal)\((\d+),\s*(\d+)\)$/)
-        : null;
-      const tsMatch =
-        !charMatch && !numericMatch
-          ? baseType.match(/^timestamp(\(\d+\))?\s+(with(?:out)?\s+time\s+zone)$/)
-          : null;
-      const timeMatch =
-        !charMatch && !numericMatch && !tsMatch
-          ? baseType.match(/^time(\(\d+\))?\s+(with(?:out)?\s+time\s+zone)$/)
-          : null;
-
-      if (charMatch) {
-        result = { dslType: "char", extraOpts: { limit: Number(charMatch[1]) } };
-      } else if (numericMatch) {
-        result = {
-          dslType: "decimal",
-          extraOpts: { precision: Number(numericMatch[1]), scale: Number(numericMatch[2]) },
-        };
-      } else if (tsMatch) {
-        result =
-          tsMatch[2].startsWith("with ") || tsMatch[2] === "with time zone"
-            ? { dslType: "timestamptz" }
-            : { dslType: "datetime" };
-      } else if (timeMatch) {
-        result = { dslType: "time" };
-      } else if (/^bit\(\d+\)$/.test(baseType)) {
-        result = { dslType: "bit" };
-      } else if (/^(?:bit varying|varbit)\(\d+\)$/.test(baseType)) {
-        result = { dslType: "bitVarying" };
-      } else if (KNOWN_DSL_TYPES_BY_LOWER.has(baseType)) {
-        result = { dslType: KNOWN_DSL_TYPES_BY_LOWER.get(baseType)! };
-      } else {
-        result = { dslType: "enum", extraOpts: { enum_type: baseType } };
-      }
-    }
-  }
-
-  if (isArray) {
-    return { ...result, extraOpts: { ...result.extraOpts, array: true } };
-  }
-
-  return result;
-}
-
-/**
- * Wraps an already-formatted TS-DSL literal (the string returned by
- * `schemaDefault` / `Type#typeCastForSchema`, e.g. `"42"`, `'"hello"'`,
- * `'() => "now()"'`) so `formatColspec` / `formatOptions` emit it verbatim
- * instead of re-serializing it with `JSON.stringify`. Mirrors how the
- * `columnSpec`-routed emit path treats `prepareColumnOptions` values as raw
- * text (see {@link SchemaDumper.formatColspecRaw}).
- * @internal
- */
-export class RawSchemaLiteral {
-  constructor(public readonly text: string) {}
-}
-
-/**
  * Bridges a DatabaseAdapter to the SchemaSource protocol. Not public —
  * used internally by `SchemaDumper.dump(adapter, ...)` /
  * `dumpWithVersion(adapter, ...)` so adapter dumps don't require
@@ -425,11 +238,9 @@ class AdapterSchemaSource implements SchemaSource {
           : (col as any).virtual === true;
       return {
         name: col.name,
-        // Carry the dsl cast type in `type` and the raw SQL type in `sqlType`
-        // (Epic 3.3-U2). schemaType/schemaLimit/schemaPrecision read the dsl
-        // type off `type` and inspect the raw declaration off `sqlType`. The
-        // legacy `emitTable` path tolerates a dsl `type` via sqlTypeToDsl and
-        // sources limit/precision/scale from the dedicated fields below.
+        // Carry the dsl cast type in `type` and the raw SQL type in `sqlType`.
+        // schemaType/schemaLimit/schemaPrecision read the dsl type off `type`
+        // and inspect the raw declaration off `sqlType`.
         type: col.type || col.sqlType || "unknown",
         sqlType: col.sqlType ?? undefined,
         primaryKey: col.primaryKey,
@@ -519,6 +330,20 @@ export class SchemaDumper {
   /** @internal Mirrors Rails' `SchemaDumper.unique_ignore_pattern`. */
   static uniqueIgnorePattern: RegExp = /^uniq_rails_[0-9a-f]{10}$/;
 
+  /**
+   * The `ConnectionAdapters::SchemaDumper` subclass, registered by that module
+   * at load. Rails has a single dumper: the base `SchemaDumper#table` always
+   * drives column specs through the adapter's mixed-in
+   * `column_spec`/`prepare_column_options` (which live on the adapter subclass).
+   * TS can't mix a module into a class, so instead constructing the bare base
+   * for a non-adapter source (`create`/`dump` with a plain `SchemaSource`)
+   * transparently yields the adapter subclass — the sole `emitTable` /
+   * `columnSpec` dispatch. Dialect subclasses set `this` to themselves and are
+   * never redirected.
+   * @internal
+   */
+  static connectionAdaptersDumper?: typeof SchemaDumper;
+
   private _source: SchemaSource;
   protected _options: Record<string, unknown>;
   private _language: SchemaDumpLanguage;
@@ -588,7 +413,15 @@ export class SchemaDumper {
     source: SchemaSource,
     options: Record<string, unknown> = {},
   ): InstanceType<T> {
-    return new this(source, options) as InstanceType<T>;
+    // Redirect the bare base to the ConnectionAdapters subclass so the single
+    // `emitTable`/`columnSpec` dispatch (which lives there, mirroring Rails'
+    // adapter-mixed-in column_spec) serves every source. Dialect subclasses
+    // pass `this !== SchemaDumper` and construct themselves unchanged.
+    const Ctor =
+      this === SchemaDumper && SchemaDumper.connectionAdaptersDumper
+        ? SchemaDumper.connectionAdaptersDumper
+        : this;
+    return new Ctor(source, options) as InstanceType<T>;
   }
 
   /**
@@ -938,101 +771,15 @@ export class SchemaDumper {
   }
 
   /**
-   * DSL-typed primary-key options merged into `create_table` for non-default
-   * primary keys. Mirrors Rails' `column_spec_for_primary_key` call in
-   * `SchemaDumper#table` — but returns plain JS values for our TS DSL
-   * emitter rather than Ruby-format strings.
-   *
-   * Note: `SchemaDumper.dumpTableSchema(adapter, ...)` instantiates the base
-   * class (not an adapter-specific subclass), so this default branches on
-   * `column.type` directly. Rails has the same single dispatch point — its
-   * `column_spec_for_primary_key` lives on the adapter subclass, but our
-   * factory path doesn't pick that subclass yet, so we centralize.
+   * Resolves the adapter (or the raw source) backing this dumper — the object
+   * whose cast types drive `schema_default`. Lives on the base because
+   * `_source` is base-private; the Rails-mapped `schemaDefault` override
+   * (`connection-adapters/abstract/schema-dumper.ts`) consults it.
    * @internal
    */
-  protected primaryKeyTableOptions(column: ColumnInfo): Record<string, unknown> {
-    if (column.type === "uuid") {
-      const fn = column.defaultFunction;
-      if (typeof fn === "string" && fn.length > 0) {
-        // Emit as arrow returning the SQL expression — mirrors Rails'
-        // `default: -> { "gen_random_uuid()" }` and round-trips through
-        // `quoteDefaultExpression`, which routes function defaults to raw SQL.
-        return { id: "uuid", default: () => fn };
-      }
-      // Route the literal default through the same `schemaDefault` cast-type
-      // path `columnSpec` uses (Rails `schema_default`). The result is
-      // already-formatted TS-DSL text, so wrap it so `formatOptions` emits it
-      // verbatim.
-      const def = this.schemaDefault(column);
-      return { id: "uuid", default: def == null ? null : new RawSchemaLiteral(def) };
-    }
-    return {};
-  }
-
-  /**
-   * Rails `schema_default` (abstract/schema_dumper.rb): drive the column's
-   * default through the adapter's cast type — `deserialize` then
-   * `typeCastForSchema` — so every dialect's default emission agrees. Falls
-   * back to a plain literal when no adapter cast type is in hand (the
-   * in-memory / mock-source dump path). Returns already-formatted TS-DSL text.
-   *
-   * NOTE: the connection-adapters abstract subclass carries a
-   * structurally-identical `override` copy (the api:compare-mapped location for
-   * Rails' `schema_default`); keep the two bodies in lockstep — edit both.
-   * @internal
-   */
-  protected schemaDefault(column: ColumnInfo & { hasDefault?: boolean }): string | undefined {
-    if (!column.hasDefault && column.default === undefined) return undefined;
-    if (column.default == null) return this.schemaExpression(column);
-    const adapter = this._adapter();
-    if (adapter?.lookupCastTypeFromColumn) {
-      const type = adapter.lookupCastTypeFromColumn(column);
-      if (type != null && typeof type.deserialize === "function") {
-        const deserialized = type.deserialize(column.default);
-        if (deserialized == null) {
-          // column.default is already non-null (the `== null` guard above
-          // returned early). It may be a pre-deserialized JS value (e.g. []
-          // for a PG OID::Array column) that the scalar element type cannot
-          // deserialize. Apply typeCastForSchema directly on the original.
-          return type.typeCastForSchema(column.default);
-        }
-        return type.typeCastForSchema(deserialized);
-      }
-    }
-    if (typeof column.default === "string") return JSON.stringify(column.default);
-    return String(column.default);
-  }
-
-  /** @internal */
   protected _adapter(): any {
     const src = (this as any)._source;
     return src?.adapter ?? src;
-  }
-
-  /** @internal */
-  protected schemaExpression(column: ColumnInfo): string | undefined {
-    // TS-DSL arrow form (Rails dumps the Ruby lambda `-> { … }`); emitted verbatim
-    // by formatColspecRaw and consumed by the DSL as `default: () => "fn()"`.
-    if (column.defaultFunction) return `() => ${JSON.stringify(column.defaultFunction)}`;
-    return undefined;
-  }
-
-  /**
-   * Hook for adapter subclasses to adjust the introspected `precision` of a
-   * datetime/timestamp column before it is emitted. Default: identity.
-   *
-   * Mirrors Rails' `MySQL::SchemaDumper#schema_precision`: a bare MySQL
-   * `datetime` introspects as precision 0 (via `extract_precision`'s
-   * `super || 0`), and the dumper rewrites that to `precision: nil` so the
-   * column round-trips; a `timestamp(0)` instead omits precision entirely.
-   *
-   * @internal
-   */
-  protected mapDatetimePrecisionForDump(
-    _dslType: string,
-    precision: number | null | undefined,
-  ): number | null | undefined {
-    return precision;
   }
 
   /**
@@ -1047,143 +794,27 @@ export class SchemaDumper {
     return pkColumns;
   }
 
-  /** @internal */
+  /**
+   * Emit a single `create_table` block. Mirrors the column-emission half of
+   * Rails' `SchemaDumper#table`, whose `@connection.column_spec(column)` call
+   * is provided by the adapter's mixed-in `ConnectionAdapters::SchemaDumper`.
+   * TS has no module mixin, so the implementation lives on that subclass
+   * (`connection-adapters/abstract/schema-dumper.ts`) and every dump reaches it
+   * via {@link create}'s redirect — the bare base is never the emitter.
+   * @internal
+   */
   protected emitTable(
-    lines: string[],
-    tableName: string,
-    columns: ColumnInfo[],
-    indexes: IndexInfo[],
-    adapterTableOpts: Record<string, unknown> = {},
-    inlineConstraints: string[] = [],
+    _lines: string[],
+    _tableName: string,
+    _columns: ColumnInfo[],
+    _indexes: IndexInfo[],
+    _adapterTableOpts: Record<string, unknown> = {},
+    _inlineConstraints: string[] = [],
   ): void {
-    const pkColumns = this.orderPrimaryKeyColumns(
-      tableName,
-      columns.filter((c) => c.primaryKey),
+    throw new Error(
+      "SchemaDumper.emitTable must run on the ConnectionAdapters subclass; " +
+        "construct via SchemaDumper.create/dump so the column_spec dispatch is available.",
     );
-    const hasCompositePk = pkColumns.length > 1;
-    const pkColumn = pkColumns[0];
-    const hasId = !hasCompositePk && pkColumn?.name === "id";
-    const stripped = this.removePrefixAndSuffix(tableName);
-
-    const tableOpts: Record<string, unknown> = {};
-    if (hasCompositePk) {
-      tableOpts.primaryKey = pkColumns.map((c) => c.name);
-      tableOpts.id = false;
-    } else if (!hasId) {
-      tableOpts.id = false;
-    } else if (pkColumn) {
-      Object.assign(tableOpts, this.primaryKeyTableOptions(pkColumn));
-    }
-    if (typeof adapterTableOpts.charset === "string") tableOpts.charset = adapterTableOpts.charset;
-    if (typeof adapterTableOpts.collation === "string")
-      tableOpts.collation = adapterTableOpts.collation;
-    if (typeof adapterTableOpts.options === "string") tableOpts.options = adapterTableOpts.options;
-    if (typeof adapterTableOpts.comment === "string" && adapterTableOpts.comment.trim().length > 0)
-      tableOpts.comment = adapterTableOpts.comment;
-    tableOpts.force = "cascade";
-    const optStr = `{ ${this.formatOptions(tableOpts)} }`;
-
-    lines.push(`  await ctx.createTable(${JSON.stringify(stripped)}, ${optStr}, (t) => {`);
-
-    for (const col of columns) {
-      if (col.name === "id" && hasId) continue;
-
-      const { dslType: mappedDslType, extraOpts } = sqlTypeToDsl(col.type);
-      // PG serial/bigserial: Rails emits the shorthand and omits both the
-      // sequence default and the integer limit (schema_default / schema_limit
-      // return nil for a serial column). The SQL type still introspects as
-      // integer/bigint, so we override here off the carried isSerial flag.
-      const dslType = col.isSerial
-        ? col.type === "bigint"
-          ? "bigserial"
-          : "serial"
-        : mappedDslType;
-      const colspec: Record<string, unknown> = {};
-
-      if (col.null === false) colspec.null = false;
-      if (col.isSerial) {
-        // serial columns carry no user-visible default
-      } else if (col.defaultFunction) {
-        const fn = col.defaultFunction;
-        colspec.default = () => fn;
-      } else {
-        // Route through the same `schemaDefault` cast-type path `columnSpec`
-        // uses (Rails `schema_default`). The result is already-formatted
-        // TS-DSL text, so wrap it so `formatColspec` emits it verbatim.
-        const def = this.schemaDefault(col);
-        if (def !== undefined) {
-          colspec.default = new RawSchemaLiteral(def);
-        }
-      }
-      // Serial/bigserial emit a bare shorthand — Rails' schema_limit /
-      // schema_precision / schema_scale all suppress type options for a serial
-      // column, so skip the whole extraOpts spread (today int4/int8 carry none,
-      // but this keeps the invariant local rather than relying on that).
-      if (!col.isSerial && extraOpts) {
-        for (const [key, value] of Object.entries(extraOpts)) {
-          // `enum_type` carries the PG enum type name — consumed by
-          // the column-type fallback below, not a column option.
-          if (key === "enum_type") continue;
-          colspec[key] = value;
-        }
-      }
-      if (col.array && !colspec.array) colspec.array = true;
-      if (
-        !col.isSerial &&
-        col.limit !== undefined &&
-        col.limit !== null &&
-        extraOpts?.limit === undefined
-      )
-        colspec.limit = col.limit;
-      if (extraOpts?.precision === undefined) {
-        if (dslType === "datetime" || dslType === "timestamp") {
-          // precision: 6 is the default for datetime — omit it; precision: null → "nil".
-          // mapDatetimePrecisionForDump lets dialect dumpers adjust the introspected
-          // precision (e.g. MySQL maps a bare `datetime` (precision 0) to `nil`).
-          const precision = this.mapDatetimePrecisionForDump(dslType, col.precision);
-          if (precision === undefined) {
-            // not set — omit
-          } else if (precision === null) {
-            colspec.precision = null;
-          } else if (precision !== SchemaDumper.DEFAULT_DATETIME_PRECISION) {
-            colspec.precision = precision;
-          }
-        } else if (col.precision !== undefined && col.precision !== null) {
-          colspec.precision = col.precision;
-        }
-      }
-      if (col.scale !== undefined && col.scale !== null && extraOpts?.scale === undefined)
-        colspec.scale = col.scale;
-      if (col.collation != null) colspec.collation = col.collation;
-
-      const optionsStr =
-        Object.keys(colspec).length > 0 ? `, { ${this.formatColspec(colspec)} }` : "";
-
-      if (DSL_HELPER_METHODS.has(dslType)) {
-        lines.push(`    t.${dslType}(${JSON.stringify(col.name)}${optionsStr});`);
-      } else if (col.isEnum && dslType === "enum") {
-        // PG enum columns: emit t.enum("col", { enum_type: "typename", ... })
-        // Only when column.isEnum is set (OID-resolved type is "enum") to avoid
-        // misclassifying domains and other unmapped custom types.
-        // Prefer col.sqlType (raw adapter path: col.type="enum", col.sqlType="mood")
-        // over extraOpts.enum_type (AdapterSchemaSource path: col.type="mood").
-        const enumTypeName = (col as any).sqlType ?? extraOpts?.enum_type ?? col.type;
-        const enumSpec = { ...colspec, enum_type: enumTypeName };
-        const enumOptsStr = `, { ${this.formatColspec(enumSpec)} }`;
-        lines.push(`    t.enum(${JSON.stringify(col.name)}${enumOptsStr});`);
-      } else {
-        // Generic fallback: pass arbitrary SQL type through verbatim via t.column.
-        const columnType = dslType === "enum" ? (extraOpts?.enum_type ?? dslType) : dslType;
-        lines.push(
-          `    t.column(${JSON.stringify(col.name)}, ${JSON.stringify(columnType)}${optionsStr});`,
-        );
-      }
-    }
-
-    for (const line of inlineConstraints) lines.push(line);
-    lines.push("  });");
-
-    this.indexesInCreate(tableName, lines, indexes);
   }
 
   /** @internal */
@@ -1316,41 +947,18 @@ export class SchemaDumper {
     return DSL_HELPER_METHODS.has(dslType);
   }
 
-  /** @internal */
-  formatColspec(colspec: Record<string, unknown>): string {
-    return Object.entries(colspec)
-      .map(([k, v]) => {
-        if (v instanceof RawSchemaLiteral) {
-          return `${k}: ${v.text}`;
-        }
-        if (typeof v === "function") {
-          return `${k}: () => ${JSON.stringify((v as () => unknown)())}`;
-        }
-        if (v && typeof v === "object" && !Array.isArray(v)) {
-          const inner = this.formatColspec(v as Record<string, unknown>);
-          return `${k}: ${inner ? `{ ${inner} }` : "{}"}`;
-        }
-        return `${k}: ${JSON.stringify(v)}`;
-      })
-      .join(", ");
-  }
-
   /**
-   * Rails-faithful raw colspec formatter — mirrors `SchemaDumper#format_colspec`,
+   * Rails-faithful colspec formatter — mirrors `SchemaDumper#format_colspec`,
    * which joins `key: value` with the values emitted **verbatim** and recurses
    * into nested objects as `{ … }` (the primary-key `id: { type:, … }` spec).
    * The values produced by `columnSpec` / `prepareColumnOptions` are already
    * fully-formatted TS-DSL text (`"false"`, `"255"`, `"null"`, `'"hello"'`,
-   * `'() => "now()"'`), so they must NOT be re-quoted the way
-   * {@link formatColspec} re-serializes native JS values. This is the formatter
-   * the `columnSpec`-routed emit path uses (Epic 3.3-U); `formatColspec` stays
-   * on the legacy inline path until `emitTable` is wired (Story 3.3-U3).
+   * `'() => "now()"'`), so they are emitted as-is.
    *
    * Keys are interpolated raw (every colspec key is an identifier), matching
-   * Rails and the sibling `formatColspec`. The spec must be **compacted** —
-   * `prepareColumnOptions` only sets defined keys, mirroring Rails'
-   * `spec.compact!` before `format_colspec`; a stray `undefined`/`null` value
-   * would render literally.
+   * Rails. The spec must be **compacted** — `prepareColumnOptions` only sets
+   * defined keys, mirroring Rails' `spec.compact!` before `format_colspec`; a
+   * stray `undefined`/`null` value would render literally.
    * @internal
    */
   formatColspecRaw(colspec: Record<string, unknown>): string {
@@ -1371,9 +979,6 @@ export class SchemaDumper {
     return Object.entries(options)
       .map(([k, v]) => {
         const key = isIdent.test(k) ? k : JSON.stringify(k);
-        if (v instanceof RawSchemaLiteral) {
-          return `${key}: ${v.text}`;
-        }
         if (typeof v === "function") {
           // Emit as an arrow returning the SQL expression — mirrors Rails'
           // `-> { "fn()" }` syntax in dumped `schema.rb`.

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -978,12 +978,12 @@ export class SchemaDumper {
    * stray `undefined`/`null` value would render literally.
    * @internal
    */
-  formatColspecRaw(colspec: Record<string, unknown>): string {
+  formatColspec(colspec: Record<string, unknown>): string {
     return Object.entries(colspec)
       .map(([k, v]) => {
         const value =
           v && typeof v === "object" && !Array.isArray(v)
-            ? `{ ${this.formatColspecRaw(v as Record<string, unknown>)} }`
+            ? `{ ${this.formatColspec(v as Record<string, unknown>)} }`
             : String(v);
         return `${k}: ${value}`;
       })

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -450,8 +450,9 @@ export class SchemaDumper {
       // createSchemaDumper() (MySQL/PG/SQLite) so dialect overrides like
       // MySQL's schemaPrecision (datetime precision 0 → `precision: nil`)
       // apply. Mirrors Rails' `connection.create_schema_dumper`, which mixes
-      // the adapter's SchemaDumper module into the dumper. Falls back to the
-      // base class for adapters without the hook.
+      // the adapter's SchemaDumper module into the dumper. Without the hook,
+      // `create` still resolves to the ConnectionAdapters subclass (see its
+      // redirect) — never the bare base.
       const createDialectDumper = (sourceOrAdapter as { createSchemaDumper?: unknown })
         .createSchemaDumper;
       const dumper =
@@ -472,8 +473,9 @@ export class SchemaDumper {
   ): Promise<string> {
     const wrappedSource = isDatabaseAdapter(source) ? new AdapterSchemaSource(source) : source;
     // Instantiate the adapter-specific subclass when the adapter exposes
-    // createSchemaDumper() (PostgreSQLAdapter and Mysql2Adapter). Falls back to
-    // the base class when unavailable, which is what the old code always did.
+    // createSchemaDumper() (PostgreSQLAdapter and Mysql2Adapter). Otherwise
+    // `create` resolves to the ConnectionAdapters subclass via its redirect —
+    // the single emitTable/columnSpec dispatch, never the bare base.
     let dumper: SchemaDumper;
     if (isDatabaseAdapter(source) && typeof (source as any).createSchemaDumper === "function") {
       dumper = (source as any).createSchemaDumper(wrappedSource, {}) as SchemaDumper;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -345,31 +345,6 @@ export class SchemaDumper {
    */
   static connectionAdaptersDumper?: typeof SchemaDumper;
 
-  /** @internal */
-  private static _connectionAdaptersDumperLoad?: Promise<typeof SchemaDumper>;
-
-  /**
-   * Load the `ConnectionAdapters::SchemaDumper` subclass and return it once it
-   * has registered itself as {@link connectionAdaptersDumper}. The import is
-   * dynamic (cached) rather than static because the subclass `extends` this
-   * class: a static back-edge would evaluate its `extends` clause before this
-   * class is defined (a temporal dead zone) — the same static cycle this file
-   * already breaks for `schema-introspection`. Async entrypoints await this
-   * before constructing so the redirect never falls back to the bare base.
-   * @internal
-   */
-  protected static async loadConnectionAdaptersDumper(): Promise<typeof SchemaDumper> {
-    if (SchemaDumper.connectionAdaptersDumper) return SchemaDumper.connectionAdaptersDumper;
-    SchemaDumper._connectionAdaptersDumperLoad ??=
-      import("./connection-adapters/abstract/schema-dumper.js").then(() => {
-        if (!SchemaDumper.connectionAdaptersDumper) {
-          throw new Error("ConnectionAdapters::SchemaDumper did not register on load");
-        }
-        return SchemaDumper.connectionAdaptersDumper;
-      });
-    return SchemaDumper._connectionAdaptersDumperLoad;
-  }
-
   private _source: SchemaSource;
   protected _options: Record<string, unknown>;
   private _language: SchemaDumpLanguage;
@@ -446,14 +421,17 @@ export class SchemaDumper {
     if (this !== SchemaDumper) return new this(source, options) as InstanceType<T>;
     const Sub = SchemaDumper.connectionAdaptersDumper;
     if (!Sub) {
-      // Synchronous construction can't load the subclass (see
-      // loadConnectionAdaptersDumper); the async `dump`/`dumpTableSchema` paths
-      // await it before reaching here. Like Rails, a bare base has no
-      // `column_spec` — go through an adapter's `createSchemaDumper()` or await
-      // `loadConnectionAdaptersDumper()` first.
+      // Like Rails, a bare base has no `column_spec` — `SchemaDumper#table`
+      // (schema_dumper.rb:199) calls the unqualified `column_spec`, private to
+      // the adapter subclass (abstract/schema_dumper.rb:13), so Rails always
+      // builds it via `connection.create_schema_dumper`. The public
+      // `SchemaDumper` export IS that subclass; this throw only fires for a deep
+      // import of the internal base module without the connection-adapters layer
+      // loaded. Deterministic (never a silent async/broken dump), not
+      // timing-dependent.
       throw new Error(
-        "SchemaDumper.create needs the ConnectionAdapters dumper; use SchemaDumper.dump()/" +
-          "dumpTableSchema() (which load it) or an adapter's createSchemaDumper().",
+        "SchemaDumper has no column_spec on the base class; obtain the dumper via " +
+          "an adapter's createSchemaDumper() or the ConnectionAdapters SchemaDumper.",
       );
     }
     return new Sub(source, options) as InstanceType<T>;
@@ -490,42 +468,16 @@ export class SchemaDumper {
       // redirect) — never the bare base.
       const createDialectDumper = (sourceOrAdapter as { createSchemaDumper?: unknown })
         .createSchemaDumper;
-      const dialectDumper =
-        typeof createDialectDumper === "function"
+      const dumper =
+        (typeof createDialectDumper === "function"
           ? (createDialectDumper.call(sourceOrAdapter, source, dumperOptions) as
               | SchemaDumper
               | undefined
               | null)
-          : undefined;
-      if (dialectDumper) return dialectDumper.dump() as Promise<string>;
-      // Adapter without a dialect dumper hook — fall back to the base factory,
-      // awaiting the ConnectionAdapters subclass load so `create` never hits the
-      // bare base.
-      return this._createEnsuringEmitter(source, dumperOptions).then((d) => d.dump());
+          : undefined) ?? this.create(source, dumperOptions);
+      return dumper.dump() as Promise<string>;
     }
-    // Non-adapter source (in-memory MigrationContext / mock). The public
-    // `SchemaDumper` IS the subclass, so `create` resolves synchronously; only a
-    // direct import of the bare base needs the awaited load.
-    if (this !== SchemaDumper || SchemaDumper.connectionAdaptersDumper) {
-      return this.create(sourceOrAdapter, options).dump();
-    }
-    return this._createEnsuringEmitter(sourceOrAdapter, options).then((d) => d.dump());
-  }
-
-  /**
-   * Construct a dumper for `source`, first awaiting the ConnectionAdapters
-   * subclass load when called on the bare base so the `create` redirect has the
-   * emitter registered. Used by the async dump entrypoints.
-   * @internal
-   */
-  private static async _createEnsuringEmitter(
-    source: SchemaSource,
-    options: Record<string, unknown>,
-  ): Promise<SchemaDumper> {
-    if (this === SchemaDumper && !SchemaDumper.connectionAdaptersDumper) {
-      await SchemaDumper.loadConnectionAdaptersDumper();
-    }
-    return this.create(source, options);
+    return this.create(sourceOrAdapter, options).dump();
   }
 
   static dumpTableSchema(adapter: DatabaseAdapter, tableName: string): Promise<string>;
@@ -543,7 +495,7 @@ export class SchemaDumper {
     if (isDatabaseAdapter(source) && typeof (source as any).createSchemaDumper === "function") {
       dumper = (source as any).createSchemaDumper(wrappedSource, {}) as SchemaDumper;
     } else {
-      dumper = await this._createEnsuringEmitter(wrappedSource, {});
+      dumper = this.create(wrappedSource);
     }
     const lines: string[] = [];
     await dumper.schemas(lines);

--- a/packages/activerecord/src/test-helpers/schema-dumping-helper.ts
+++ b/packages/activerecord/src/test-helpers/schema-dumping-helper.ts
@@ -1,5 +1,12 @@
 import { SchemaDumper } from "../schema-dumper.js";
 import type { SchemaSource } from "../schema-dumper.js";
+// Load the adapter-layer dumper so `SchemaDumper.create` resolves the
+// ConnectionAdapters subclass (the single `column_spec` emitter) for the plain
+// `SchemaSource`s this helper dumps — mirroring Rails, whose dump factory is the
+// adapter-layer `ConnectionAdapters::SchemaDumper.create`. `SchemaDumper` above
+// stays the base class so its `ignoreTables` static is the one this helper
+// saves/restores. The import registers the subclass as a side effect.
+import "../connection-adapters/abstract/schema-dumper.js";
 
 /**
  * Test-only schema-dump helpers. Mirrors Rails'


### PR DESCRIPTION
## What

Rails has one dumper: the base `SchemaDumper#table` always drives column specs through the adapter's mixed-in `column_spec`/`prepare_column_options`. The trails base `SchemaDumper.emitTable` was a full parallel column-emission path — inline `sqlTypeToDsl` + native-JS colspec rendered via `formatColspec` — duplicating the `ConnectionAdapters::SchemaDumper` subclass's `columnSpec`/`prepareColumnOptions` path (rendered via `formatColspecRaw`). PR #4548 was forced to keep structurally-identical `schemaDefault`/`schemaExpression` "lockstep twins" on both classes as a result.

This unifies onto a single dispatch:

- **Single emitter.** TS can't mix a module into a class, so the column-spec machinery stays on the `ConnectionAdapters` subclass (the api:compare-mapped location). Constructing the bare base for a non-adapter source now transparently yields that subclass via a registered class slot + a redirect in `SchemaDumper.create`. Dialect subclasses set `this` to themselves and are never redirected. The base `emitTable` becomes a throwing hook documenting the invariant.
- **Twins collapsed.** `schemaDefault`/`schemaExpression` now have a single definition in `connection-adapters/abstract/schema-dumper.ts`.
- **Dead machinery deleted.** `sqlTypeToDsl`, `SQL_TYPE_MAP`, `KNOWN_DSL_TYPES`, `RawSchemaLiteral`, `formatColspec`, `primaryKeyTableOptions`, and `mapDatetimePrecisionForDump` (base + MySQL override) are gone; `formatColspecRaw` is the sole colspec formatter where the paths converge.

Net: **+78 / −473**.

## No output change

Verified byte-identical dumps across `schema-dumper.test.ts`, `schema-dumper.trails.test.ts`, the sqlite dialect dumper suite, `schema-file-generator`, `schema-dumping-helper`, `migration.test.ts`, plus `defaults` / `primary-keys` / `date-time-precision` / `time-precision`. Two mock-source trails cases were aligned with real reflection: a function default reflects as `default: null` + `defaultFunction`, and the two tests that subclassed the bare base now subclass the adapter dumper where `emitTable` lives. PG/MySQL dumper suites run in CI.

api:compare stays green: Rails `schema_default`/`schema_expression` remain defined in `connection-adapters/abstract/schema-dumper.ts`; the new base members carry `@internal`.

Closes-story: unify-base-emittable-onto-columnspec

## Design note: bare-base construction (re: review)

The public `SchemaDumper` (package export, `index.ts`) **is** the
`ConnectionAdapters::SchemaDumper` subclass — its `create` and sync-source
`dump` are fully synchronous and unchanged. `create`/`dump`/`dumpTableSchema`
never return a Promise for a synchronous source.

The bare `schema-dumper.ts` base class is internal. It has no `column_spec`,
exactly like Rails: `SchemaDumper#table` (`schema_dumper.rb:199`) calls the
unqualified `column_spec`, a method private to `ConnectionAdapters::SchemaDumper`
(`abstract/schema_dumper.rb:13`), so Rails always builds the dumper via
`connection.create_schema_dumper` (`abstract/schema_dumper.rb:8-10`) and a bare
`ActiveRecord::SchemaDumper` `NameError`s. Our base's `create` mirrors that: it
redirects to the registered subclass, or throws a clear error at construction
(deterministic — never silently async or broken).

A fully-synchronous *bare-base* construction that self-loads the subclass on
first use is precluded by two hard constraints acting together: (1) the subclass
`extends` the base, so the base cannot statically import it (temporal dead zone —
the same ESM cycle this file already breaks for `schema-introspection`); and
(2) api:compare requires `schema_default`/`schema_expression`/`column_spec` to
live in `connection-adapters/abstract/schema-dumper.ts` (an acceptance
criterion), so the emitter cannot move onto the base. Registration is guaranteed
for every real consumer because the package entry and every dump entrypoint load
the subclass module.
