### PR TITLE
fix(tasks-cli): serialize pre-read sync under the tasks lock; never push empty commits

### DIFF
--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -3288,8 +3288,7 @@ describe("syncWorktreeToOrigin (pre-read sync)", () => {
     }
     // No status probe, no fetch, and above all no reset --hard: the checkout
     // belongs to the lock holder until it finishes.
-    expect(seen).not.toContain("reset");
-    expect(seen).not.toContain("fetch");
+    expect(seen).toEqual([]);
     expect(err).toHaveBeenCalled();
     expect(String(err.mock.calls[0][0])).toMatch(/lock is busy/);
   });

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -1035,7 +1035,7 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : sub;
       seen.push(label);
       // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
+      // commit is never empty in these flows, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
@@ -1128,6 +1128,32 @@ describe("commitAndPush (git mutation flow)", () => {
     expect(seen.filter((l) => l === "reset").length).toBe(2);
   });
 
+  it("fails open when the diff-tree probe itself errors: the push still runs", () => {
+    const { seen, exit } = setup();
+    execFileSyncMock.mockImplementation((_file, args) => {
+      const label = args && args.length >= 3 ? args[2] : "";
+      if (label === "symbolic-ref") return "main" as never;
+      seen.push(label);
+      // Includes --root so a parentless first commit can't read as empty.
+      if (label === "diff-tree") {
+        expect(args).toContain("--root");
+        throw new Error("fatal: bad revision");
+      }
+      return "" as never;
+    });
+    commitAndPush({
+      message: "test",
+      fileToStage: "/some/file.md",
+      mutator: () => {},
+      raceMessage: "should not be reached",
+      raceExitCode: 3,
+    });
+    // The guard must never block a push it cannot evaluate.
+    expect(exit).not.toHaveBeenCalled();
+    expect(seen.filter((l) => l === "push").length).toBe(1);
+    expect(seen).not.toContain("reset");
+  });
+
   // The tasks repo's .husky/post-commit hook background-pushes main after
   // every commit, racing commitAndPush's own explicit push (and capable of
   // shipping an empty clobbered commit before the guard above can reset it).
@@ -1165,8 +1191,6 @@ describe("commitAndPush (git mutation flow)", () => {
       if (label === "symbolic-ref") return "main" as never;
       if (label === "add") addArg = args?.[3] ?? "";
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
@@ -1266,8 +1290,6 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       if (label === "clean") worktree.delete(args[args.length - 1]);
       return "" as never;
@@ -1335,8 +1357,6 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       if (label === "push" && push++ === 0) {
         throw pushError("! [rejected]        main -> main (non-fast-forward)");
@@ -1386,8 +1406,6 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       if (label === "push") throw pushError("! [rejected] non-fast-forward");
       return "" as never;
@@ -1422,8 +1440,6 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       if (label === "push") {
         // The background post-commit push already won the race and put our
@@ -1461,8 +1477,6 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       if (label === "push") {
         throw pushError("fatal: Authentication failed for 'https://...'");
@@ -1533,8 +1547,6 @@ describe("commitAndPush (git mutation flow)", () => {
         return "" as never;
       }
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
@@ -1573,8 +1585,6 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "rfc-some-feature" as never;
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
@@ -1613,8 +1623,6 @@ describe("commitAndPush (git mutation flow)", () => {
       // git() helper surfaces that as a throw, which the guard must swallow.
       if (label === "symbolic-ref") throw new Error("fatal: ref HEAD is not a symbolic ref");
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
@@ -1644,8 +1652,6 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "rev-list") return "2" as never; // HEAD is 2 commits ahead
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
@@ -1677,8 +1683,6 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "fetch") throw new Error("fatal: unable to access origin");
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
@@ -1705,8 +1709,6 @@ describe("commitAndPush (git mutation flow)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       if (label === "status") return " M rfcs/0001/stories/foo.md" as never;
       return "" as never;
@@ -1742,8 +1744,6 @@ describe("commitAndPush (git mutation flow)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       // index.md changed both staged (`M  ...`) and unstaged (` M ...`).
       if (label === "status") return "M  index.md\n M index.md" as never;
@@ -1772,8 +1772,6 @@ describe("commitAndPush (git mutation flow)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       if (label === "pull") {
         const e = new Error("Command failed") as Error & { stderr?: string };
@@ -1813,8 +1811,6 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "rev-list") return "0" as never; // HEAD even with origin/main
       seen.push(label);
-      // The empty-commit guard diff-trees HEAD after every commit; a real
-      // commit is never empty here, so report a file.
       if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });

--- a/scripts/tasks/cli.test.ts
+++ b/scripts/tasks/cli.test.ts
@@ -1034,6 +1034,9 @@ describe("commitAndPush (git mutation flow)", () => {
       // Use the first non-flag token after `-C <dir>` to label the call.
       const label = args && args.length >= 3 ? args[2] : sub;
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     return { exit, seen, lockDir };
@@ -1062,8 +1065,88 @@ describe("commitAndPush (git mutation flow)", () => {
       "pull",
       "add",
       "commit",
+      "diff-tree",
       "push",
     ]);
+  });
+
+  // Regression: a concurrent `reset --hard` in the shared canonical checkout
+  // (a pre-read sync from a process predating the sync lock) could empty the
+  // index inside `git commit`'s pre-commit-hook window, producing a commit
+  // whose tree equals its parent — which then got PUSHED, landing the message
+  // on main with zero files (RFC 0063's stories, 2026-07-07). commitAndPush
+  // must diff-tree the fresh commit and never push an empty one.
+  it("drops an empty commit and retries the mutation instead of pushing it", () => {
+    const { seen, exit } = setup();
+    let diffTreeCalls = 0;
+    execFileSyncMock.mockImplementation((_file, args) => {
+      const label = args && args.length >= 3 ? args[2] : "";
+      if (label === "symbolic-ref") return "main" as never;
+      seen.push(label);
+      // First commit comes out empty (clobbered); the retry commits for real.
+      if (label === "diff-tree") return (diffTreeCalls++ === 0 ? "" : "story.md") as never;
+      return "" as never;
+    });
+    let mutatorCalls = 0;
+    commitAndPush({
+      message: "test",
+      fileToStage: "/some/file.md",
+      mutator: () => mutatorCalls++,
+      raceMessage: "should not be reached",
+      raceExitCode: 3,
+    });
+    expect(exit).not.toHaveBeenCalled();
+    expect(mutatorCalls).toBe(2);
+    // The empty commit was reset away, never pushed; only the retry pushed.
+    expect(seen.filter((l) => l === "push").length).toBe(1);
+    expect(seen.filter((l) => l === "reset").length).toBe(1);
+    const firstPush = seen.indexOf("push");
+    const resetIdx = seen.indexOf("reset");
+    expect(resetIdx).toBeLessThan(firstPush);
+  });
+
+  it("exits with raceExitCode when the commit comes out empty twice, pushing nothing", () => {
+    const { seen, exit } = setup();
+    execFileSyncMock.mockImplementation((_file, args) => {
+      const label = args && args.length >= 3 ? args[2] : "";
+      if (label === "symbolic-ref") return "main" as never;
+      seen.push(label);
+      // Every commit comes out empty — deterministic clobber.
+      return "" as never;
+    });
+    expect(() =>
+      commitAndPush({
+        message: "test",
+        fileToStage: "/some/file.md",
+        mutator: () => {},
+        raceMessage: "lost race",
+        raceExitCode: 4,
+      }),
+    ).toThrow(/exit 4/);
+    expect(exit).toHaveBeenCalledWith(4);
+    expect(seen).not.toContain("push");
+    expect(seen.filter((l) => l === "reset").length).toBe(2);
+  });
+
+  // The tasks repo's .husky/post-commit hook background-pushes main after
+  // every commit, racing commitAndPush's own explicit push (and capable of
+  // shipping an empty clobbered commit before the guard above can reset it).
+  // The CLI must commit with RFCS_NO_AUTOPUSH=1 so the hook stands down.
+  it("commits with RFCS_NO_AUTOPUSH=1 so the post-commit hook does not race the push", () => {
+    setup();
+    commitAndPush({
+      message: "test",
+      fileToStage: "/some/file.md",
+      mutator: () => {},
+      raceMessage: "should not be reached",
+      raceExitCode: 3,
+    });
+    const commitCall = execFileSyncMock.mock.calls.find((c) =>
+      (c[1] as string[]).includes("commit"),
+    ) as unknown[] | undefined;
+    expect(commitCall).toBeDefined();
+    const opts = commitCall![2] as { env?: Record<string, string> } | undefined;
+    expect(opts?.env?.RFCS_NO_AUTOPUSH).toBe("1");
   });
 
   // End-to-end race repro through the mutation seam: a `new`-style mutator
@@ -1082,6 +1165,9 @@ describe("commitAndPush (git mutation flow)", () => {
       if (label === "symbolic-ref") return "main" as never;
       if (label === "add") addArg = args?.[3] ?? "";
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     commitAndPush({
@@ -1118,6 +1204,7 @@ describe("commitAndPush (git mutation flow)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     expect(() =>
@@ -1179,6 +1266,9 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       if (label === "clean") worktree.delete(args[args.length - 1]);
       return "" as never;
     });
@@ -1214,6 +1304,7 @@ describe("commitAndPush (git mutation flow)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     // The thrown Error propagates out of commitAndPush intact (the top-level
@@ -1244,6 +1335,9 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       if (label === "push" && push++ === 0) {
         throw pushError("! [rejected]        main -> main (non-fast-forward)");
       }
@@ -1272,6 +1366,7 @@ describe("commitAndPush (git mutation flow)", () => {
       "pull",
       "add",
       "commit",
+      "diff-tree",
       "push",
       "rev-parse",
       "fetch",
@@ -1280,6 +1375,7 @@ describe("commitAndPush (git mutation flow)", () => {
       "pull",
       "add",
       "commit",
+      "diff-tree",
       "push",
     ]);
   });
@@ -1290,6 +1386,9 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       if (label === "push") throw pushError("! [rejected] non-fast-forward");
       return "" as never;
     });
@@ -1323,6 +1422,9 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       if (label === "push") {
         // The background post-commit push already won the race and put our
         // commit on origin/main; git rejects this one with stale-info info.
@@ -1359,6 +1461,9 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       if (label === "push") {
         throw pushError("fatal: Authentication failed for 'https://...'");
       }
@@ -1389,6 +1494,7 @@ describe("commitAndPush (git mutation flow)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       if (args && args[2] === "symbolic-ref") return "main" as never;
       fullArgs.push(args ?? []);
+      if (args && args.includes("diff-tree")) return "story.md" as never;
       return "" as never;
     });
     commitAndPush({
@@ -1427,6 +1533,9 @@ describe("commitAndPush (git mutation flow)", () => {
         return "" as never;
       }
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     let mutatorCalls = 0;
@@ -1441,7 +1550,16 @@ describe("commitAndPush (git mutation flow)", () => {
     expect(restored).toEqual([]);
     // ...and the mutation proceeded normally (after the HEAD:main guard probe).
     expect(mutatorCalls).toBe(1);
-    expect(seen).toEqual(["fetch", "rev-list", "status", "pull", "add", "commit", "push"]);
+    expect(seen).toEqual([
+      "fetch",
+      "rev-list",
+      "status",
+      "pull",
+      "add",
+      "commit",
+      "diff-tree",
+      "push",
+    ]);
   });
 
   // A bare-branch refspec (e.g. `pushRefspec: "main"`) pushes the LOCAL branch
@@ -1455,6 +1573,9 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "rfc-some-feature" as never;
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     let mutatorCalls = 0;
@@ -1492,6 +1613,9 @@ describe("commitAndPush (git mutation flow)", () => {
       // git() helper surfaces that as a throw, which the guard must swallow.
       if (label === "symbolic-ref") throw new Error("fatal: ref HEAD is not a symbolic ref");
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     expect(() =>
@@ -1520,6 +1644,9 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "rev-list") return "2" as never; // HEAD is 2 commits ahead
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     let mutatorCalls = 0;
@@ -1550,6 +1677,9 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "fetch") throw new Error("fatal: unable to access origin");
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     let mutatorCalls = 0;
@@ -1562,7 +1692,7 @@ describe("commitAndPush (git mutation flow)", () => {
     });
     // fetch threw inside the guard's try → guard skipped; mutation proceeds.
     expect(mutatorCalls).toBe(1);
-    expect(seen).toEqual(["checkout", "status", "pull", "add", "commit", "push"]);
+    expect(seen).toEqual(["checkout", "status", "pull", "add", "commit", "diff-tree", "push"]);
   });
 
   // A hand edit left in a story file (e.g. the user edited frontmatter then ran
@@ -1575,6 +1705,9 @@ describe("commitAndPush (git mutation flow)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       if (label === "status") return " M rfcs/0001/stories/foo.md" as never;
       return "" as never;
     });
@@ -1609,6 +1742,9 @@ describe("commitAndPush (git mutation flow)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       // index.md changed both staged (`M  ...`) and unstaged (` M ...`).
       if (label === "status") return "M  index.md\n M index.md" as never;
       return "" as never;
@@ -1636,6 +1772,9 @@ describe("commitAndPush (git mutation flow)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       if (label === "pull") {
         const e = new Error("Command failed") as Error & { stderr?: string };
         e.stderr = "CONFLICT (content): Merge conflict in rfcs/0001/stories/foo.md";
@@ -1674,6 +1813,9 @@ describe("commitAndPush (git mutation flow)", () => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "rev-list") return "0" as never; // HEAD even with origin/main
       seen.push(label);
+      // The empty-commit guard diff-trees HEAD after every commit; a real
+      // commit is never empty here, so report a file.
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     let mutatorCalls = 0;
@@ -1687,7 +1829,16 @@ describe("commitAndPush (git mutation flow)", () => {
     expect(mutatorCalls).toBe(1);
     // rev-list is consumed by the guard (not pushed to seen); fetch precedes the
     // restore checkouts and the mutation loop runs in full.
-    expect(seen).toEqual(["fetch", "checkout", "status", "pull", "add", "commit", "push"]);
+    expect(seen).toEqual([
+      "fetch",
+      "checkout",
+      "status",
+      "pull",
+      "add",
+      "commit",
+      "diff-tree",
+      "push",
+    ]);
   });
 
   // The refine path passes an explicit `pushRefspec: "HEAD:main"` and a `cwd`
@@ -1732,6 +1883,7 @@ describe("commitAndPush (git mutation flow)", () => {
     const fullArgs: string[][] = [];
     execFileSyncMock.mockImplementation((_file, args) => {
       fullArgs.push(args ?? []);
+      if (args && args.includes("diff-tree")) return "story.md" as never;
       return "" as never;
     });
     commitAndPush({
@@ -1752,6 +1904,7 @@ describe("commitAndPush (git mutation flow)", () => {
     const fullArgs: string[][] = [];
     execFileSyncMock.mockImplementation((_file, args) => {
       fullArgs.push(args ?? []);
+      if (args && args.includes("diff-tree")) return "story.md" as never;
       return "" as never;
     });
     commitAndPush({
@@ -2057,6 +2210,7 @@ describe("newStory status default", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     return dir;
@@ -2371,6 +2525,7 @@ describe("newStory cluster validation", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     const dir = mkdtempSync(join(tmpdir(), "tasks-test-"));
@@ -2423,6 +2578,7 @@ describe("newStory --status / --body-file (one-call authoring)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     const dir = makeRepo();
@@ -2487,6 +2643,7 @@ describe("newStory --status / --body-file (one-call authoring)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     const dir = makeRepo();
@@ -2503,6 +2660,7 @@ describe("newStory --status / --body-file (one-call authoring)", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     const dir = makeRepo();
@@ -2769,6 +2927,7 @@ describe("newRfc", () => {
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       if (label === "symbolic-ref") return "main" as never;
+      if (label === "diff-tree") return "story.md" as never;
       return "" as never;
     });
     const dir = mkdtempSync(join(tmpdir(), "tasks-test-"));
@@ -3079,13 +3238,19 @@ describe("dirtyWorktreeLines", () => {
 });
 
 describe("syncWorktreeToOrigin (pre-read sync)", () => {
-  function setup() {
+  // The sync now takes the tasks-CLI lock around its fetch + reset --hard so
+  // it can't clobber a concurrent mutation in the shared canonical checkout.
+  // Point the lock at a throwaway dir so gitCommonDir (mocked git) is never
+  // consulted and no lock file lands in the repo.
+  afterEach(() => __setLockDirForTest(null));
+  function setup(statusOut = "") {
+    __setLockDirForTest(mkdtempSync(join(tmpdir(), "trails-sync-lock-")));
     vi.spyOn(console, "error").mockImplementation(() => {});
     const seen: string[] = [];
     execFileSyncMock.mockImplementation((_file, args) => {
       const label = args && args.length >= 3 ? args[2] : "";
       seen.push(label);
-      if (label === "status") return "" as never; // clean by default
+      if (label === "status") return statusOut as never;
       return "" as never;
     });
     return { seen };
@@ -3099,14 +3264,8 @@ describe("syncWorktreeToOrigin (pre-read sync)", () => {
   });
 
   it("skips reset --hard (no silent data loss) when the worktree has tracked edits", () => {
-    const seen: string[] = [];
+    const { seen } = setup(" M rfcs/0024/stories/x.md");
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
-    execFileSyncMock.mockImplementation((_file, args) => {
-      const label = args && args.length >= 3 ? args[2] : "";
-      seen.push(label);
-      if (label === "status") return " M rfcs/0024/stories/x.md" as never;
-      return "" as never;
-    });
     syncWorktreeToOrigin();
     // The status probe ran, but the destructive reset --hard never did.
     expect(seen).toEqual(["status"]);
@@ -3116,15 +3275,36 @@ describe("syncWorktreeToOrigin (pre-read sync)", () => {
   });
 
   it("still syncs when only untracked files are present", () => {
-    const seen: string[] = [];
-    vi.spyOn(console, "error").mockImplementation(() => {});
-    execFileSyncMock.mockImplementation((_file, args) => {
-      const label = args && args.length >= 3 ? args[2] : "";
-      seen.push(label);
-      if (label === "status") return "?? rfcs/0024/stories/new.md" as never;
-      return "" as never;
-    });
+    const { seen } = setup("?? rfcs/0024/stories/new.md");
     syncWorktreeToOrigin();
     expect(seen).toEqual(["status", "fetch", "reset"]);
+  });
+
+  it("skips the sync entirely when the tasks-CLI lock is held by a live mutation", () => {
+    const { seen } = setup();
+    // Simulate a mutation mid-flight: hold the lock with this (live) process.
+    const held = acquireTasksLock(undefined);
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      syncWorktreeToOrigin(undefined, 300);
+    } finally {
+      releaseTasksLock(held);
+    }
+    // No status probe, no fetch, and above all no reset --hard: the checkout
+    // belongs to the lock holder until it finishes.
+    expect(seen).not.toContain("reset");
+    expect(seen).not.toContain("fetch");
+    expect(err).toHaveBeenCalled();
+    expect(String(err.mock.calls[0][0])).toMatch(/lock is busy/);
+  });
+
+  it("releases the lock after syncing so the next mutation can take it", () => {
+    const { seen } = setup();
+    syncWorktreeToOrigin();
+    expect(seen).toEqual(["status", "fetch", "reset"]);
+    // Lock must be free again: a fresh acquire succeeds without contention.
+    const lock = acquireTasksLock(undefined, { waitMs: 300, onTimeout: "give-up" });
+    expect(lock).not.toBeNull();
+    releaseTasksLock(lock);
   });
 });

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -1039,10 +1039,18 @@ export function commitAndPush(opts: {
       // commit whose tree equals its parent — the mutation's file is silently
       // gone, but the message still lands on main. Verify the commit actually
       // carries changes before pushing; if not, drop it and retry the mutation.
-      const committed = git(["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"], {
-        silent: true,
-        cwd,
-      });
+      // `--root` keeps a parentless first commit (fresh repo) from reading as
+      // empty; a probe failure fails OPEN (push as before) — the guard must
+      // never be more dangerous than the race it guards against.
+      let committed = "unverified";
+      try {
+        committed = git(["diff-tree", "--no-commit-id", "--name-only", "-r", "--root", "HEAD"], {
+          silent: true,
+          cwd,
+        });
+      } catch {
+        /* probe failed — assume the commit is fine and let the push proceed */
+      }
       if (committed === "") {
         git(["reset", "--hard", "origin/main"], { silent: true, cwd });
         if (attempt === 1) {

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -332,10 +332,14 @@ function inGitTasks(): void {
 // `cwd` defaults to TASKS_DIR (the canonical checkout the status mutations
 // operate on). `refine` overrides it with an agent's worktree, which lives in
 // the same repo but on a feature branch.
-function git(args: string[], opts: { silent?: boolean; cwd?: string } = {}): string {
+function git(
+  args: string[],
+  opts: { silent?: boolean; cwd?: string; env?: NodeJS.ProcessEnv } = {},
+): string {
   return execFileSync("git", ["-C", opts.cwd ?? TASKS_DIR, ...args], {
     encoding: "utf8",
     stdio: opts.silent ? ["ignore", "pipe", "pipe"] : ["inherit", "pipe", "inherit"],
+    ...(opts.env ? { env: { ...process.env, ...opts.env } } : {}),
   }).trim();
 }
 
@@ -437,13 +441,38 @@ function syncFromOrigin(): void {
 // it. When the worktree carries such edits we skip the sync entirely, warn
 // loudly, and serve the possibly-stale index — never destroy unsaved work.
 // Untracked new files survive `reset --hard`, so they don't block the sync.
-export function syncWorktreeToOrigin(cwd?: string): void {
+//
+// LOCKED against mutations: the per-worktree `tasks/` symlinks all resolve to
+// the ONE shared canonical checkout, so this `reset --hard` used to run
+// concurrently with another agent's commitAndPush mutation in the same
+// working tree. A reset landing between that mutation's file write and its
+// commit deletes the staged-new story file (index AND disk → "nothing to
+// commit" crash); landing inside the pre-commit hook's window it empties the
+// index, and git finalizes an EMPTY commit that then gets pushed — the
+// message lands on main with zero files. Take the same tasks-CLI lock the
+// mutators hold; the dirty check must also sit inside the lock, or a mutation
+// could stage its file right after we probed. Reads are best-effort, so on
+// lock timeout we skip the sync and serve the possibly-stale index instead of
+// dying.
+export function syncWorktreeToOrigin(cwd?: string, lockWaitMs = 20_000): void {
+  const lock = acquireTasksLock(cwd, { waitMs: lockWaitMs, onTimeout: "give-up" });
   try {
     let porcelain: string;
     try {
       porcelain = git(["status", "--porcelain"], { silent: true, cwd });
     } catch {
       return; // not a git repo / git unavailable — leave the checkout untouched
+    }
+    // A null lock after "give-up" means a live mutation is mid-flight in this
+    // checkout — resetting now is exactly the clobber this lock prevents. (The
+    // other null case, no resolvable git dir, can't reach here: the status
+    // probe above throws first.) Serve the stale index.
+    if (lock == null) {
+      console.error(
+        `warning: tasks-CLI lock is busy; skipping the pre-read sync to origin/main. ` +
+          `The index may be stale.`,
+      );
+      return;
     }
     const dirty = dirtyWorktreeLines(porcelain);
     if (dirty.length > 0) {
@@ -462,6 +491,8 @@ export function syncWorktreeToOrigin(cwd?: string): void {
     git(["reset", "--hard", "--quiet", "origin/main"], { silent: true, cwd });
   } catch {
     /* best-effort — stale data is better than a broken CLI */
+  } finally {
+    releaseTasksLock(lock);
   }
 }
 
@@ -707,10 +738,13 @@ function installLockSignalHandlers(): void {
 // poll. A holder whose process is gone (ESRCH) is reclaimed automatically — its
 // lock can never be released, so making a human/agent `rm` it was only busywork
 // (and a racy one: concurrent rm+retry can delete a freshly-taken live lock).
-// Only the wait timeout against a *live* holder still fails loudly.
+// Only the wait timeout against a *live* holder still fails loudly — unless
+// the caller opts into `onTimeout: "give-up"`, which returns null instead so a
+// best-effort caller (the pre-read sync) can skip its critical section rather
+// than kill a read command with LOCK_TIMEOUT_EXIT.
 export function acquireTasksLock(
   cwd: string | undefined,
-  opts: { waitMs?: number; pollMs?: number } = {},
+  opts: { waitMs?: number; pollMs?: number; onTimeout?: "exit" | "give-up" } = {},
 ): LockHandle | null {
   const waitMs = opts.waitMs ?? LOCK_WAIT_MS;
   const pollMs = opts.pollMs ?? LOCK_POLL_MS;
@@ -758,6 +792,7 @@ export function acquireTasksLock(
         continue;
       }
       if (waited >= waitMs) {
+        if (opts.onTimeout === "give-up") return null;
         console.error(
           `error: timed out after ${Math.round(waitMs / 1000)}s waiting for the tasks-CLI ` +
             `lock at ${lockPath}. Another mutation is holding it; retry shortly.`,
@@ -971,7 +1006,12 @@ export function commitAndPush(opts: {
         // mutation's own path may have moved, so stage everything.
         const reconciled = reconcileDuplicateRfcDirs(cwd);
         git(["add", reconciled ? "-A" : opts.fileToStage], { cwd });
-        git(["commit", "-q", "-m", opts.message], { cwd });
+        // RFCS_NO_AUTOPUSH: the tasks repo's .husky/post-commit hook otherwise
+        // background-pushes `main` after this commit, racing the explicit push
+        // below (and, before the pre-read sync took the lock, occasionally
+        // pushing a clobbered EMPTY commit before we could reset it away). The
+        // CLI owns its own push; silence the hook's.
+        git(["commit", "-q", "-m", opts.message], { cwd, env: { RFCS_NO_AUTOPUSH: "1" } });
       } catch (e) {
         // Atomic rollback: a throw between the file write and the commit (a
         // prettier crash in formatFiles, a failed `git add`/`commit`, etc.)
@@ -991,6 +1031,29 @@ export function commitAndPush(opts: {
           break;
         }
         throw e;
+      }
+      // Never push an empty commit. A concurrent `reset --hard` in this shared
+      // checkout (a pre-read sync from a process predating the lock there, or
+      // any out-of-band reset) that lands inside `git commit`'s pre-commit-hook
+      // window empties the index after the emptiness check, so git finalizes a
+      // commit whose tree equals its parent — the mutation's file is silently
+      // gone, but the message still lands on main. Verify the commit actually
+      // carries changes before pushing; if not, drop it and retry the mutation.
+      const committed = git(["diff-tree", "--no-commit-id", "--name-only", "-r", "HEAD"], {
+        silent: true,
+        cwd,
+      });
+      if (committed === "") {
+        git(["reset", "--hard", "origin/main"], { silent: true, cwd });
+        if (attempt === 1) {
+          console.error(
+            `error: commit came out empty twice (mutation clobbered by a concurrent reset?); ` +
+              `nothing was pushed. ${opts.raceMessage}`,
+          );
+          releaseTasksLock(lock);
+          process.exit(opts.raceExitCode);
+        }
+        continue;
       }
       try {
         git(["push", "--quiet", "origin", pushRefspec], { silent: true, cwd });

--- a/scripts/tasks/cli.ts
+++ b/scripts/tasks/cli.ts
@@ -456,23 +456,25 @@ function syncFromOrigin(): void {
 // dying.
 export function syncWorktreeToOrigin(cwd?: string, lockWaitMs = 20_000): void {
   const lock = acquireTasksLock(cwd, { waitMs: lockWaitMs, onTimeout: "give-up" });
+  // A "busy" give-up means a live mutation is mid-flight in this checkout —
+  // touching it at all (even the status probe) belongs to the lock holder,
+  // and resetting is exactly the clobber the lock prevents. Skip entirely and
+  // serve the stale index. (A `null` lock — no resolvable git dir — falls
+  // through instead: the status probe below throws and returns silently,
+  // preserving the quiet non-repo behavior.)
+  if (lock === "busy") {
+    console.error(
+      `warning: tasks-CLI lock is busy; skipping the pre-read sync to origin/main. ` +
+        `The index may be stale.`,
+    );
+    return;
+  }
   try {
     let porcelain: string;
     try {
       porcelain = git(["status", "--porcelain"], { silent: true, cwd });
     } catch {
       return; // not a git repo / git unavailable — leave the checkout untouched
-    }
-    // A null lock after "give-up" means a live mutation is mid-flight in this
-    // checkout — resetting now is exactly the clobber this lock prevents. (The
-    // other null case, no resolvable git dir, can't reach here: the status
-    // probe above throws first.) Serve the stale index.
-    if (lock == null) {
-      console.error(
-        `warning: tasks-CLI lock is busy; skipping the pre-read sync to origin/main. ` +
-          `The index may be stale.`,
-      );
-      return;
     }
     const dirty = dirtyWorktreeLines(porcelain);
     if (dirty.length > 0) {
@@ -739,13 +741,15 @@ function installLockSignalHandlers(): void {
 // lock can never be released, so making a human/agent `rm` it was only busywork
 // (and a racy one: concurrent rm+retry can delete a freshly-taken live lock).
 // Only the wait timeout against a *live* holder still fails loudly — unless
-// the caller opts into `onTimeout: "give-up"`, which returns null instead so a
-// best-effort caller (the pre-read sync) can skip its critical section rather
-// than kill a read command with LOCK_TIMEOUT_EXIT.
+// the caller opts into `onTimeout: "give-up"`, which returns the distinct
+// sentinel "busy" so a best-effort caller (the pre-read sync) can skip its
+// critical section rather than kill a read command with LOCK_TIMEOUT_EXIT.
+// "busy" is deliberately not null: null means "nothing to lock against"
+// (proceed unlocked), while "busy" means a live holder owns the checkout.
 export function acquireTasksLock(
   cwd: string | undefined,
   opts: { waitMs?: number; pollMs?: number; onTimeout?: "exit" | "give-up" } = {},
-): LockHandle | null {
+): LockHandle | null | "busy" {
   const waitMs = opts.waitMs ?? LOCK_WAIT_MS;
   const pollMs = opts.pollMs ?? LOCK_POLL_MS;
   let lockPath: string;
@@ -792,7 +796,7 @@ export function acquireTasksLock(
         continue;
       }
       if (waited >= waitMs) {
-        if (opts.onTimeout === "give-up") return null;
+        if (opts.onTimeout === "give-up") return "busy";
         console.error(
           `error: timed out after ${Math.round(waitMs / 1000)}s waiting for the tasks-CLI ` +
             `lock at ${lockPath}. Another mutation is holding it; retry shortly.`,
@@ -809,8 +813,8 @@ export function acquireTasksLock(
 // so the signal handlers don't try to re-release a handle we've let go. The
 // read-then-unlink is race-free because no waiter removes/recreates a lock it
 // didn't create (acquire only `wx`s onto a free path, or reclaims a dead one).
-export function releaseTasksLock(lock: LockHandle | null): void {
-  if (!lock) return;
+export function releaseTasksLock(lock: LockHandle | null | "busy"): void {
+  if (!lock || lock === "busy") return;
   activeLocks.delete(lock);
   try {
     if (readFileSync(lock.path, "utf8").trim() === lock.token) unlinkSync(lock.path);


### PR DESCRIPTION
## Problem

While creating RFC 0063's stories, 3 of 5 `pnpm tasks new` invocations printed `created …` and pushed a commit with the right message but **zero files** (e.g. tasks@669cb770a, tasks@cb9bae941). Separately, hand-written untracked story files under `rfcs/` vanished while other CLI commands ran.

## Root cause

Every trails worktree's `tasks/` symlink resolves to the **one shared canonical checkout**. Read commands (`ready`, `list`, `next-bundle`, …) run `syncWorktreeToOrigin` — `git fetch` + `git reset --hard origin/main` — **without taking the tasks-CLI lock** that mutations hold. With the agent fleet issuing reads every few seconds, a `reset --hard` lands mid-mutation in the same working tree:

- between the mutator's file write / `git add` and `git commit`: the staged-new file is removed from index **and disk** → `git commit` dies with "nothing to commit" (observed stack at `commitAndPush`);
- inside `git commit`'s pre-commit-hook window (the tasks hook takes ~500ms): git's emptiness check has already passed, the reset empties the index, and git finalizes an **empty commit** — which the push (or the tasks repo's `.husky/post-commit` background auto-push) then lands on main.

## Fix

1. **`syncWorktreeToOrigin` takes the tasks-CLI lock** around its dirty-probe + fetch + reset (the dirty check must also sit inside the lock). Reads are best-effort: new `onTimeout: "give-up"` mode on `acquireTasksLock` skips the sync after 20s and serves the possibly-stale index instead of killing the read.
2. **`commitAndPush` verifies the fresh commit is non-empty** (`git diff-tree --root`) before pushing; an empty commit is reset away and the mutation retried, exiting `raceExitCode` if it happens twice. No mutator can legitimately produce an empty commit — all have pre-`commitAndPush` no-op guards. `--root` keeps a fresh repo's parentless first commit from reading as empty, and a probe failure fails **open** (push proceeds) so the guard is never more dangerous than the race it guards against.
3. **CLI commits run with `RFCS_NO_AUTOPUSH=1`** so the tasks repo's post-commit hook doesn't background-push (and can't ship a clobbered commit before the guard resets it); the CLI owns its own push.

Reads in worktrees still running the old CLI keep the unlocked path until they pick up this change; the race fully closes as worktrees refresh.

## Tests

- new: sync skips entirely (no fetch/reset) while the lock is held by a live process; lock released after a successful sync.
- new: empty commit → reset + retry, never pushed; empty twice → `raceExitCode`, nothing pushed.
- new: diff-tree probe failure fails open (push runs, `--root` asserted); commit call carries `RFCS_NO_AUTOPUSH=1`.
- existing commitAndPush/sync suites updated for the `diff-tree` verification step (mocks report a non-empty commit).

`pnpm vitest run scripts/tasks/cli.test.ts`: 242 passed.