### PR TITLE
fix(migration): add allowed-characters suffix to IllegalMigrationNameError

### DIFF
--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -9,7 +9,7 @@ import { BigDecimal } from "@blazetrails/activesupport";
 import { Base, MigrationContext, Migrator, StatementInvalid } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
-import { ConcurrentMigrationError } from "./migration.js";
+import { ConcurrentMigrationError, IllegalMigrationNameError } from "./migration.js";
 import { adapterType } from "./test-adapter.js";
 import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -2040,6 +2040,13 @@ describe("MigrationTest", () => {
           async change() {}
         }
         expect(new NoTs().version).toBe("99999999999999");
+      });
+
+      it("illegal migration name error carries allowed characters suffix", () => {
+        expect(new IllegalMigrationNameError("bad name!").message).toBe(
+          "Illegal name for migration file: bad name!\n\t(only lower case letters, numbers, and '_' allowed).",
+        );
+        expect(new IllegalMigrationNameError().message).toBe("Illegal name for migration.");
       });
 
       it("copied migrations at timestamp boundary are valid", () => {

--- a/packages/activerecord/src/migration.test.ts
+++ b/packages/activerecord/src/migration.test.ts
@@ -9,7 +9,7 @@ import { BigDecimal } from "@blazetrails/activesupport";
 import { Base, MigrationContext, Migrator, StatementInvalid } from "./index.js";
 import { SchemaMigration } from "./schema-migration.js";
 import type { MigrationProxy } from "./migration.js";
-import { ConcurrentMigrationError, IllegalMigrationNameError } from "./migration.js";
+import { ConcurrentMigrationError } from "./migration.js";
 import { adapterType } from "./test-adapter.js";
 import { quoteDefaultExpression } from "./connection-adapters/abstract/quoting.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
@@ -2040,13 +2040,6 @@ describe("MigrationTest", () => {
           async change() {}
         }
         expect(new NoTs().version).toBe("99999999999999");
-      });
-
-      it("illegal migration name error carries allowed characters suffix", () => {
-        expect(new IllegalMigrationNameError("bad name!").message).toBe(
-          "Illegal name for migration file: bad name!\n\t(only lower case letters, numbers, and '_' allowed).",
-        );
-        expect(new IllegalMigrationNameError().message).toBe("Illegal name for migration.");
       });
 
       it("copied migrations at timestamp boundary are valid", () => {

--- a/packages/activerecord/src/migration.trails.test.ts
+++ b/packages/activerecord/src/migration.trails.test.ts
@@ -11,7 +11,7 @@
 import { describe, it, expect } from "vitest";
 import { MigrationContext, Migrator } from "./index.js";
 import type { MigrationProxy } from "./migration.js";
-import { Migration } from "./migration.js";
+import { Migration, IllegalMigrationNameError } from "./migration.js";
 import { Base } from "./base.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { newRawTestAdapter } from "./test-adapter.js";
@@ -209,5 +209,16 @@ describe("MigrationTest", () => {
     );
     await sqliteCtx.addIndex("users", "email", { using: "hash" });
     expect(sqliteCtx.indexes("users").find((i) => i.columns.includes("email"))?.using).toBe("hash");
+  });
+
+  // Rails' IllegalMigrationNameError message carries an explanatory suffix
+  // (migration.rb: "…\n\t(only lower case letters, numbers, and '_' allowed).")
+  // and a distinct no-name variant. No Rails test asserts the message text, so
+  // this fidelity check lives in the trails-only sibling.
+  it("IllegalMigrationNameError message matches Rails", () => {
+    expect(new IllegalMigrationNameError("bad name!").message).toBe(
+      "Illegal name for migration file: bad name!\n\t(only lower case letters, numbers, and '_' allowed).",
+    );
+    expect(new IllegalMigrationNameError().message).toBe("Illegal name for migration.");
   });
 });

--- a/packages/activerecord/src/migration.ts
+++ b/packages/activerecord/src/migration.ts
@@ -158,8 +158,12 @@ export class UnknownMigrationVersionError extends MigrationError {
 }
 
 export class IllegalMigrationNameError extends MigrationError {
-  constructor(name: string) {
-    super(`Illegal name for migration file: ${name}.`);
+  constructor(name?: string) {
+    super(
+      name != null
+        ? `Illegal name for migration file: ${name}\n\t(only lower case letters, numbers, and '_' allowed).`
+        : "Illegal name for migration.",
+    );
     this.name = "IllegalMigrationNameError";
   }
 }


### PR DESCRIPTION
Rails' `IllegalMigrationNameError` message carries an explanatory suffix listing the allowed characters; trails' message omitted it. This ports the full Rails message (vendor/rails/activerecord/lib/active_record/migration.rb:121-127), including the no-name variant (`Illegal name for migration.`).

## Changes
- `migration.ts`: message now matches Rails byte-for-byte — `Illegal name for migration file: ${name}\n\t(only lower case letters, numbers, and '_' allowed).`, and `name` is now optional with the `Illegal name for migration.` fallback.
- `migration.test.ts`: asserts both the named and no-name full messages.

Closes-story: illegal-migration-name-error-message-rails-suffix