### PR TITLE
fix(primary-key): raise TypeError for scalar id= on composite PK

### DIFF
--- a/packages/activerecord/src/associations.test.ts
+++ b/packages/activerecord/src/associations.test.ts
@@ -78,7 +78,7 @@ describe("AssociationsTest", () => {
     // book is created THROUGH order.books so it lives in the association's
     // in-memory target before the reload — exercises the CPK reconciliation path.
     const order = await CpkOrder.create({ shop_id: 1, status: "paid" });
-    const book = await (order as any).books.create({ author_id: 3, id: 4, title: "Book" });
+    const book = await (order as any).books.create({ id: [3, 4], title: "Book" });
     // Update the book in DB behind the in-memory instance so persisted/in-memory diverge
     const dbBook = await CpkBook.where({ author_id: 3, id: 4 }).first();
     await dbBook!.updateColumns({ title: "A different title" });
@@ -2815,10 +2815,9 @@ describe("AssociationsTest", () => {
   });
 
   it("loading cpk association when persisted and in memory differ", async () => {
-    const order = await CpkOrder.create({ shop_id: 1, id: 2, status: "paid" });
+    const order = await CpkOrder.create({ id: [1, 2], status: "paid" });
     await CpkBook.create({
-      author_id: 3,
-      id: 4,
+      id: [3, 4],
       shop_id: 1,
       order_id: 2,
       title: "Book",

--- a/packages/activerecord/src/associations/belongs-to-inverse-seed-composite-pk.test.ts
+++ b/packages/activerecord/src/associations/belongs-to-inverse-seed-composite-pk.test.ts
@@ -66,7 +66,7 @@ describe("belongs_to inverse seeding with a composite-PK target", () => {
 
   it("seeds the holder without resolving the target class from the registry", () => {
     const child = new CpkSeedChild();
-    const parent = new CompositePkParent({ shop_id: 1, id: 2 });
+    const parent = new CompositePkParent({ id: [1, 2] });
 
     expect(() => child.association("compositePkParent").setTarget(parent)).not.toThrow();
 
@@ -77,7 +77,7 @@ describe("belongs_to inverse seeding with a composite-PK target", () => {
 
   it("reads the target PK from the held instance, not the registry", () => {
     const child = new CpkSeedChild();
-    const parent = new CompositePkParent({ shop_id: 1, id: 2 });
+    const parent = new CompositePkParent({ id: [1, 2] });
 
     // Build the holder first (constructor-level checkKlass resolves the class);
     // the spy only guards the setTarget → staleState → foreignKeyNames path.
@@ -94,7 +94,7 @@ describe("belongs_to inverse seeding with a composite-PK target", () => {
 
   it("scalar FK + composite-PK target collapses to id component on assignment", () => {
     const child = new CpkSeedChild();
-    const parent = new CompositePkParent({ shop_id: 7, id: 42 });
+    const parent = new CompositePkParent({ id: [7, 42] });
 
     (child.association("compositePkParent") as unknown as { writer(target: unknown): void }).writer(
       parent,
@@ -105,7 +105,7 @@ describe("belongs_to inverse seeding with a composite-PK target", () => {
 
   it("infers id as the association primary key for a [tenant_key, id]-PK target", () => {
     const child = new CpkSeedChild();
-    const parent = new CompositePkParent({ shop_id: 7, id: 42 });
+    const parent = new CompositePkParent({ id: [7, 42] });
 
     const holder = child.association("compositePkParent") as unknown as {
       associationPrimaryKeys(target: unknown): string[];

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -680,8 +680,8 @@ describe("CollectionProxy#targetsByPrimaryKey — non-default primary keys", () 
 
   it("keys loaded targets by their composite primary key", async () => {
     const owner = await CpkAuthor.create({ name: "o" });
-    await CpkBook.create({ author_id: owner.id as number, id: 7, title: "a" });
-    await CpkBook.create({ author_id: owner.id as number, id: 9, title: "b" });
+    await CpkBook.create({ id: [owner.id as number, 7], title: "a" });
+    await CpkBook.create({ id: [owner.id as number, 9], title: "b" });
     const proxy = association<CpkBook>(owner, "books") as any;
     await proxy.load();
     const byKey = proxy.targetsByPrimaryKey() as Map<string, CpkBook>;
@@ -704,7 +704,7 @@ describe("CollectionProxy#targetsByPrimaryKey — non-default primary keys", () 
 
   it("skips a composite new record whose key parts are unassigned", async () => {
     const owner = await CpkAuthor.create({ name: "o" });
-    await CpkBook.create({ author_id: owner.id as number, id: 7, title: "a" });
+    await CpkBook.create({ id: [owner.id as number, 7], title: "a" });
     const proxy = association<CpkBook>(owner, "books") as any;
     await proxy.load();
     // `id` unassigned → null part in the composite key array.

--- a/packages/activerecord/src/associations/eager.test.ts
+++ b/packages/activerecord/src/associations/eager.test.ts
@@ -1009,7 +1009,7 @@ describe("EagerAssociationTest", () => {
   it("preloading belongs_to with cpk", async () => {
     // CpkOrder's PK is composite (["shop_id", "id"]), so `order.id` is the
     // `[shop_id, id]` array; the `order_id` FK column wants the scalar `id`.
-    const order = await CpkOrder.create({ shop_id: 2, id: 2 });
+    const order = await CpkOrder.create({ id: [2, 2] });
     const orderId = (order as any).id[1];
     const orderAgreement = await CpkOrderAgreement.create({ order_id: orderId });
 
@@ -1022,7 +1022,7 @@ describe("EagerAssociationTest", () => {
   });
 
   it("preloading has_many with cpk", async () => {
-    const order = await CpkOrder.create({ shop_id: 2, id: 2 });
+    const order = await CpkOrder.create({ id: [2, 2] });
     const orderId = (order as any).id[1];
     const orderAgreement = await CpkOrderAgreement.create({ order_id: orderId });
 
@@ -1035,11 +1035,10 @@ describe("EagerAssociationTest", () => {
   });
 
   it("preloading has_one with cpk", async () => {
-    const order = await CpkOrder.create({ shop_id: 2, id: 2 });
+    const order = await CpkOrder.create({ id: [2, 2] });
     const orderId = (order as any).id[1];
     const book = await CpkBook.create({
-      author_id: 1,
-      id: 3,
+      id: [1, 3],
       shop_id: order.shop_id,
       order_id: orderId,
     });

--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -7241,8 +7241,7 @@ describe("HasManyAssociationsTest", () => {
     const orderId = (order as any).idValue;
     const mk = (authorId: number, id: number) =>
       CpkBook.create({
-        author_id: authorId,
-        id,
+        id: [authorId, id],
         shop_id: shopId,
         order_id: orderId,
         title: `b${authorId}-${id}`,

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -89,6 +89,16 @@ export function idForDatabase(this: PrimaryKeyRecord): unknown {
 // Instance accessor methods
 // ---------------------------------------------------------------------------
 
+/**
+ * Ruby `Object#inspect`-style rendering for the `id=` TypeError message, mirroring
+ * `CompositePrimaryKey#id=`'s `#{value.inspect}`.
+ */
+function inspectValue(value: unknown): string {
+  if (value === null || value === undefined) return "nil";
+  if (typeof value === "string") return JSON.stringify(value);
+  return String(value);
+}
+
 interface PrimaryKeyInstance {
   constructor: unknown;
   _readAttribute(name: string): unknown;
@@ -119,7 +129,7 @@ export function setId(this: PrimaryKeyInstance, value: unknown): void {
   if (Array.isArray(pk)) {
     if (!Array.isArray(value)) {
       throw new TypeError(
-        `Expected an array for composite primary key [${pk.join(", ")}], got ${value === null ? "null" : typeof value}`,
+        `Expected value matching [${pk.map((col) => JSON.stringify(col)).join(", ")}], got ${inspectValue(value)}.`,
       );
     }
     pk.forEach((col, i) => this._writeAttribute(col, (value as unknown[])[i]));

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -127,12 +127,17 @@ export function setId(this: PrimaryKeyInstance, value: unknown): void {
   const ctor = this.constructor as any;
   const pk = ctor.primaryKey as string | string[] | null;
   if (Array.isArray(pk)) {
-    if (!Array.isArray(value)) {
+    // Rails: `raise TypeError unless value.is_a?(Enumerable)` then
+    // `@primary_key.zip(value)`. Mirror Ruby's Enumerable with the codebase's
+    // Array-or-Set analogue (see sanitization.ts `isEnumerable`) — deliberately
+    // not arbitrary iterables, so a String is a scalar that raises like Ruby.
+    if (!Array.isArray(value) && !(value instanceof Set)) {
       throw new TypeError(
         `Expected value matching [${pk.map((col) => JSON.stringify(col)).join(", ")}], got ${inspectValue(value)}.`,
       );
     }
-    pk.forEach((col, i) => this._writeAttribute(col, (value as unknown[])[i]));
+    const values = Array.isArray(value) ? value : [...value];
+    pk.forEach((col, i) => this._writeAttribute(col, values[i]));
   } else if (pk == null) {
     // Key-less model: Rails does NOT install the PrimaryKey `id=` override
     // without a primary key (`instance_method_already_implemented?` gates the

--- a/packages/activerecord/src/attribute-methods/primary-key.ts
+++ b/packages/activerecord/src/attribute-methods/primary-key.ts
@@ -136,8 +136,11 @@ export function setId(this: PrimaryKeyInstance, value: unknown): void {
         `Expected value matching [${pk.map((col) => JSON.stringify(col)).join(", ")}], got ${inspectValue(value)}.`,
       );
     }
+    // Rails' `@primary_key.zip(value)` pads short values with nil, so
+    // `id = [1]` writes nil to the trailing key part rather than leaving it
+    // untouched. Coerce past-the-end elements to null (not undefined) to match.
     const values = Array.isArray(value) ? value : [...value];
-    pk.forEach((col, i) => this._writeAttribute(col, values[i]));
+    pk.forEach((col, i) => this._writeAttribute(col, i < values.length ? values[i] : null));
   } else if (pk == null) {
     // Key-less model: Rails does NOT install the PrimaryKey `id=` override
     // without a primary key (`instance_method_already_implemented?` gates the

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -678,7 +678,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     registerModel("AiCpkOrder", AiCpkOrder);
     registerModel("AiCpkOrderAgreement", AiCpkOrderAgreement);
 
-    const order = await AiCpkOrder.create({ shop_id: 1, id: 1, status: "paid" });
+    const order = await AiCpkOrder.create({ id: [1, 1], status: "paid" });
     const a1 = await AiCpkOrderAgreement.create({ signature: "signed" });
     const a2 = await AiCpkOrderAgreement.create({ signature: "signed" });
     const orderAgreements = [a1.id, a2.id];
@@ -742,17 +742,15 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     registerModel("AiCpkTwoOrder", AiCpkTwoOrder);
     registerModel("AiCpkTwoBook", AiCpkTwoBook);
 
-    const order = await AiCpkTwoOrder.create({ shop_id: 1, id: 1, status: "paid" });
+    const order = await AiCpkTwoOrder.create({ id: [1, 1], status: "paid" });
     const b1 = await AiCpkTwoBook.create({
-      author_id: 1,
-      id: 1,
+      id: [1, 1],
       title: "First",
       shop_id: 0,
       order_id: 0,
     });
     const b2 = await AiCpkTwoBook.create({
-      author_id: 1,
-      id: 2,
+      id: [1, 2],
       title: "Second",
       shop_id: 0,
       order_id: 0,
@@ -809,7 +807,7 @@ describe("TestDefaultAutosaveAssociationOnAHasManyAssociation", () => {
     registerModel("CpkOrderPk", CpkOrderPk);
     registerModel("CpkBookFk", CpkBookFk);
     // has_one with single-column FK on CPK parent (like OrderWithPrimaryKeyAssociatedBook)
-    const order = new CpkOrderPk({ shop_id: 5, id: 7, status: "open" });
+    const order = new CpkOrderPk({ id: [5, 7], status: "open" });
     const book = new CpkBookFk({ signature: "My Book" });
     cacheAssoc(order, "cpkBookFk", book);
     const saved = await order.save();
@@ -2311,8 +2309,8 @@ describe("TestDefaultAutosaveAssociationOnABelongsToAssociation", () => {
     registerModel("CpkOrder2", CpkOrder2);
     registerModel("CpkBook2", CpkBook2);
     // Provide explicit composite PK values (Rails: Order.create!(id: [1, 2], ...))
-    const order = new CpkOrder2({ shop_id: 1, id: 2, status: "pending" });
-    const book = new CpkBook2({ author_id: 77, id: 77, title: "Composite Key Book" });
+    const order = new CpkOrder2({ id: [1, 2], status: "pending" });
+    const book = new CpkBook2({ id: [77, 77], title: "Composite Key Book" });
     cacheAssoc(order, "cpkBook2", book);
     const saved = await order.save();
     expect(saved).toBe(true);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -29,7 +29,6 @@ import type {
 } from "@blazetrails/globalid/signed-global-id";
 import {
   Model,
-  MissingAttributeError,
   Type,
   pushPendingDecorator,
   type AttributeOptions,
@@ -768,20 +767,10 @@ function _collectNestedAttributeSetterKeys(ctor: typeof Base | undefined): Set<s
  * handling: trails holds the `id` key out of super()'s attribute loop and
  * re-dispatches it here, once `initInternals` has run.
  *
- * - `id: [a, b]` goes through the `id=` setter (`setId`, mirroring
- *   `CompositePrimaryKey#id=`), which spreads the array across the key columns.
- * - a scalar `id` on a model-level composite PK is written straight to the `id`
- *   column when the table has one. trails' cpk test models (`cpk_orders`,
- *   `cpk_books`) declare a composite PK at the model level over tables that keep
- *   a real single `id` column, and the suite's established convention passes the
- *   key parts as scalars (`CpkBook.create({ author_id, id: 7 })`). Rails' native
- *   `CompositePrimaryKey#id=` would raise `TypeError` on a scalar (it wants
- *   `id: [author_id, id]`); converging that — and the many scalar-`id` cpk
- *   fixtures/tests that depend on it — is a distinct deviation out of scope for
- *   this unknown-attribute story, whose acceptance criteria explicitly keep
- *   composite-PK keys constructing (deferred), not raised. A model with no `id`
- *   column resolves to the Null attribute → MissingAttributeError, kept lenient
- *   here (the deferred composite-PK path is never an unknown-attribute error).
+ * `id: [a, b]` goes through the `id=` setter (`setId`, mirroring
+ * `CompositePrimaryKey#id=`), which spreads the array across the key columns. A
+ * scalar `id` on a model-level composite PK raises `TypeError` there, matching
+ * Rails (which wants `id: [author_id, id]`, not a bare scalar).
  * @internal
  */
 function _applyCompositePrimaryKey(
@@ -791,19 +780,9 @@ function _applyCompositePrimaryKey(
 ): void {
   const pk = (ctor as { primaryKey?: unknown }).primaryKey;
   if (!Array.isArray(pk) || !Object.prototype.hasOwnProperty.call(attrs, "id")) return;
-  const idVal = (attrs as { id: unknown }).id;
-  if (Array.isArray(idVal)) {
-    (record as unknown as { id: unknown }).id = idVal;
-    return;
-  }
-  try {
-    (record as unknown as { _writeAttribute: (n: string, v: unknown) => void })._writeAttribute(
-      "id",
-      idVal,
-    );
-  } catch (error) {
-    if (!(error instanceof MissingAttributeError)) throw error;
-  }
+  // Dispatch through the `id=` setter (`setId`): an array spreads across the key
+  // columns; a scalar raises TypeError, matching `CompositePrimaryKey#id=`.
+  (record as unknown as { id: unknown }).id = (attrs as { id: unknown }).id;
 }
 
 /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -768,9 +768,9 @@ function _collectNestedAttributeSetterKeys(ctor: typeof Base | undefined): Set<s
  * re-dispatches it here, once `initInternals` has run.
  *
  * `id: [a, b]` goes through the `id=` setter (`setId`, mirroring
- * `CompositePrimaryKey#id=`), which spreads the array across the key columns. A
- * scalar `id` on a model-level composite PK raises `TypeError` there, matching
- * Rails (which wants `id: [author_id, id]`, not a bare scalar).
+ * `CompositePrimaryKey#id=`), which zips the Enumerable (array/set) across the
+ * key columns. A scalar `id` on a model-level composite PK raises `TypeError`
+ * there, matching Rails (which wants `id: [author_id, id]`, not a bare scalar).
  * @internal
  */
 function _applyCompositePrimaryKey(

--- a/packages/activerecord/src/batches.test.ts
+++ b/packages/activerecord/src/batches.test.ts
@@ -1144,9 +1144,9 @@ describe("EachTest", () => {
     // Fixture cpk_orders have null shop_ids (schema uses single-pk id); create
     // explicit records with non-null composite keys so start: works correctly.
     await CpkOrder.deleteAll();
-    await CpkOrder.create({ shop_id: 1, id: 1, status: "paid" });
-    await CpkOrder.create({ shop_id: 1, id: 2, status: "paid" });
-    await CpkOrder.create({ shop_id: 2, id: 3, status: "cancelled" });
+    await CpkOrder.create({ id: [1, 1], status: "paid" });
+    await CpkOrder.create({ id: [1, 2], status: "paid" });
+    await CpkOrder.create({ id: [2, 3], status: "cancelled" });
     const allOrders = await CpkOrder.order(...(CpkOrder.primaryKey as string[]));
     const order = allOrders[1]; // second
     let firstRelation: any = null;
@@ -1160,9 +1160,9 @@ describe("EachTest", () => {
 
   it(".in_batches should end at the finish option when using composite primary key", async () => {
     await CpkOrder.deleteAll();
-    await CpkOrder.create({ shop_id: 1, id: 1, status: "paid" });
-    await CpkOrder.create({ shop_id: 1, id: 2, status: "paid" });
-    await CpkOrder.create({ shop_id: 2, id: 3, status: "cancelled" });
+    await CpkOrder.create({ id: [1, 1], status: "paid" });
+    await CpkOrder.create({ id: [1, 2], status: "paid" });
+    await CpkOrder.create({ id: [2, 3], status: "cancelled" });
     const allOrders = await CpkOrder.order(...(CpkOrder.primaryKey as string[]));
     const order = allOrders[allOrders.length - 2]; // second_to_last
     const batches: any[] = [];
@@ -1177,9 +1177,9 @@ describe("EachTest", () => {
 
   it(".in_batches with scope and using composite primary key", async () => {
     await CpkOrder.deleteAll();
-    await CpkOrder.create({ shop_id: 1, id: 1, status: "paid" });
-    await CpkOrder.create({ shop_id: 1, id: 2, status: "paid" });
-    await CpkOrder.create({ shop_id: 2, id: 3, status: "cancelled" });
+    await CpkOrder.create({ id: [1, 1], status: "paid" });
+    await CpkOrder.create({ id: [1, 2], status: "paid" });
+    await CpkOrder.create({ id: [2, 3], status: "cancelled" });
     const allOrders = await CpkOrder.order(...(CpkOrder.primaryKey as string[]));
     const [order1, order2] = allOrders;
     const [shopId, id] = (order1 as any).id as [number, number];
@@ -1199,9 +1199,9 @@ describe("EachTest", () => {
   });
 
   it(".find_each with multiple column ordering and using composite primary key", async () => {
-    await CpkBook.create({ author_id: 1, id: 1 });
-    await CpkBook.create({ author_id: 2, id: 1 });
-    await CpkBook.create({ author_id: 2, id: 2 });
+    await CpkBook.create({ id: [1, 1] });
+    await CpkBook.create({ id: [2, 1] });
+    await CpkBook.create({ id: [2, 2] });
     const books = await CpkBook.order({ author_id: "asc", id: "desc" });
     const bookIds = books.map((b: any) => JSON.stringify(b.id));
     let index = 0;
@@ -1213,9 +1213,9 @@ describe("EachTest", () => {
   });
 
   it(".in_batches should start from the start option when using composite primary key with multiple column ordering", async () => {
-    await CpkBook.create({ author_id: 1, id: 1 });
-    await CpkBook.create({ author_id: 1, id: 2 });
-    await CpkBook.create({ author_id: 1, id: 3 });
+    await CpkBook.create({ id: [1, 1] });
+    await CpkBook.create({ id: [1, 2] });
+    await CpkBook.create({ id: [1, 3] });
     const secondBook = await CpkBook.order({ author_id: "asc", id: "desc" }).offset(1).first();
     let firstRelation: any = null;
     for await (const rel of CpkBook.inBatches({
@@ -1231,9 +1231,9 @@ describe("EachTest", () => {
   });
 
   it(".in_batches should end at the finish option when using composite primary key with multiple column ordering", async () => {
-    await CpkBook.create({ author_id: 1, id: 1 });
-    await CpkBook.create({ author_id: 1, id: 2 });
-    await CpkBook.create({ author_id: 1, id: 3 });
+    await CpkBook.create({ id: [1, 1] });
+    await CpkBook.create({ id: [1, 2] });
+    await CpkBook.create({ id: [1, 3] });
     const secondBook = await CpkBook.order({ author_id: "asc", id: "desc" }).offset(1).first();
     const batches: any[] = [];
     for await (const rel of CpkBook.inBatches({
@@ -1249,9 +1249,9 @@ describe("EachTest", () => {
   });
 
   it(".in_batches with scope and multiple column ordering and using composite primary key", async () => {
-    await CpkBook.create({ author_id: 1, id: 1 });
-    await CpkBook.create({ author_id: 1, id: 2 });
-    await CpkBook.create({ author_id: 1, id: 3 });
+    await CpkBook.create({ id: [1, 1] });
+    await CpkBook.create({ id: [1, 2] });
+    await CpkBook.create({ id: [1, 3] });
     const [book1, book2] = await CpkBook.order({ author_id: "asc", id: "desc" }).limit(2);
     const [authorId, id] = (book1 as any).id as [number, number];
     let firstRelation: any = null;

--- a/packages/activerecord/src/nested-attributes.trails.test.ts
+++ b/packages/activerecord/src/nested-attributes.trails.test.ts
@@ -37,7 +37,7 @@ describe("nested attributes (trails-only)", () => {
   it("builds a new belongs_to record with a composite foreign key", async () => {
     CpkBook.acceptsNestedAttributesFor("order");
 
-    const book = await CpkBook.createBang({ author_id: 1, id: 1, title: "T" });
+    const book = await CpkBook.createBang({ id: [1, 1], title: "T" });
     cols(book).orderAttributes = { shop_id: 7, status: "open" };
     await book.save();
 
@@ -52,7 +52,7 @@ describe("nested attributes (trails-only)", () => {
   });
 
   it("find with duplicate composite ids uniqs to a single wrapped record", async () => {
-    await CpkBook.createBang({ author_id: 1, id: 1, title: "Dup" });
+    await CpkBook.createBang({ id: [1, 1], title: "Dup" });
 
     // Rails `find_with_ids` applies `ids.compact.uniq` to the composite tuple
     // list too, so `find([[1, 1], [1, 1]])` collapses to one tuple and returns
@@ -66,7 +66,7 @@ describe("nested attributes (trails-only)", () => {
   });
 
   it("find with variadic duplicate composite ids uniqs to a bare record", async () => {
-    await CpkBook.createBang({ author_id: 2, id: 2, title: "VarDup" });
+    await CpkBook.createBang({ id: [2, 2], title: "VarDup" });
 
     // Rails `expects_array = ids.first.first.is_a?(Array)` is false for a
     // variadic call, so `find([2, 2], [2, 2])` dedupes to one tuple and

--- a/packages/activerecord/src/primary-keys.test.ts
+++ b/packages/activerecord/src/primary-keys.test.ts
@@ -602,7 +602,7 @@ describe("CompositePrimaryKeyTest", () => {
     const book = new CpkBook();
     expect(() => {
       book.id = 1 as unknown as number[];
-    }).toThrow(TypeError);
+    }).toThrow(new TypeError('Expected value matching ["author_id", "id"], got 1.'));
   });
 
   it("id was composite", () => {

--- a/packages/activerecord/src/primary-keys.trails.test.ts
+++ b/packages/activerecord/src/primary-keys.trails.test.ts
@@ -19,4 +19,12 @@ describe("CompositePrimaryKey#id= — Enumerable acceptance (trails-only)", () =
       book.id = "1" as unknown as number[];
     }).toThrow(new TypeError('Expected value matching ["author_id", "id"], got "1".'));
   });
+
+  it("pads a short value with null like Ruby's zip", () => {
+    // `@primary_key.zip([1])` yields `[[author_id, 1], [id, nil]]`, so the
+    // trailing key part is written nil, not left untouched.
+    const book = new CpkBook();
+    book.id = [1] as unknown as number[];
+    expect(book.id).toEqual([1, null]);
+  });
 });

--- a/packages/activerecord/src/primary-keys.trails.test.ts
+++ b/packages/activerecord/src/primary-keys.trails.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { CpkBook } from "./test-helpers/models/cpk.js";
+
+// Rails' `CompositePrimaryKey#id=` guards on `value.is_a?(Enumerable)` and then
+// `@primary_key.zip(value)`. A JS Set is the codebase's Enumerable analogue
+// (see sanitization.ts `isEnumerable`), so it must zip like an array rather
+// than raise. Strings and true scalars still raise (see the mirrored Rails
+// test in primary-keys.test.ts).
+describe("CompositePrimaryKey#id= — Enumerable acceptance (trails-only)", () => {
+  it("zips a Set across the key columns like an array", () => {
+    const book = new CpkBook();
+    book.id = new Set([1, 2]) as unknown as number[];
+    expect(book.id).toEqual([1, 2]);
+  });
+
+  it("raises TypeError for a String scalar (not Enumerable in Ruby)", () => {
+    const book = new CpkBook();
+    expect(() => {
+      book.id = "1" as unknown as number[];
+    }).toThrow(new TypeError('Expected value matching ["author_id", "id"], got "1".'));
+  });
+});

--- a/packages/activerecord/src/relation/composite-where.test.ts
+++ b/packages/activerecord/src/relation/composite-where.test.ts
@@ -27,9 +27,9 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("compiles `where(['c1','c2'], [[v1a,v1b], [v2a,v2b]])` to OR-of-AND of column equalities", async () => {
-    await CpkBook.create({ author_id: 1, id: 100, title: "match-1" });
-    await CpkBook.create({ author_id: 2, id: 200, title: "match-2" });
-    await CpkBook.create({ author_id: 1, id: 999, title: "no-match" });
+    await CpkBook.create({ id: [1, 100], title: "match-1" });
+    await CpkBook.create({ id: [2, 200], title: "match-2" });
+    await CpkBook.create({ id: [1, 999], title: "no-match" });
 
     const matched = await (CpkBook as any)
       .where(
@@ -44,7 +44,7 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("returns no rows when all tuples are filtered (empty after null-strip → none())", async () => {
-    await CpkBook.create({ author_id: 1, id: 100, title: "exists" });
+    await CpkBook.create({ id: [1, 100], title: "exists" });
     const matched = await (CpkBook as any)
       .where(
         ["author_id", "id"],
@@ -58,8 +58,8 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("filters null/undefined-bearing tuples instead of emitting IS NULL (SQL tuple-equality semantics)", async () => {
-    await CpkBook.create({ author_id: 1, id: 100, title: "valid" });
-    await CpkBook.create({ author_id: 2, id: 200, title: "also-valid" });
+    await CpkBook.create({ id: [1, 100], title: "valid" });
+    await CpkBook.create({ id: [2, 200], title: "also-valid" });
     // [1, null] is filtered out; [2, 200] remains.
     const matched = await (CpkBook as any)
       .where(
@@ -74,8 +74,8 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("single-column case (cols.length === 1) still works (degenerate composite)", async () => {
-    await CpkBook.create({ author_id: 1, id: 100, title: "a" });
-    await CpkBook.create({ author_id: 1, id: 200, title: "b" });
+    await CpkBook.create({ id: [1, 100], title: "a" });
+    await CpkBook.create({ id: [1, 200], title: "b" });
     const matched = await (CpkBook as any).where(["author_id"], [[1]]).toArray();
     expect(matched.map((r: any) => r.title).sort()).toEqual(["a", "b"]);
   });
@@ -170,8 +170,8 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("Base.whereNot(cols, tuples) routes through Relation#whereNot composite form", async () => {
-    await CpkBook.create({ author_id: 1, id: 100, title: "exclude" });
-    await CpkBook.create({ author_id: 2, id: 200, title: "keep" });
+    await CpkBook.create({ id: [1, 100], title: "exclude" });
+    await CpkBook.create({ id: [2, 200], title: "keep" });
     const matched = await (CpkBook as any).whereNot(["author_id", "id"], [[1, 100]]).toArray();
     expect(matched.map((r: any) => r.title)).toEqual(["keep"]);
   });
@@ -202,9 +202,9 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("whereNot(cols, tuples) negates the OR-of-AND grouping", async () => {
-    await CpkBook.create({ author_id: 1, id: 100, title: "exclude-me" });
-    await CpkBook.create({ author_id: 2, id: 200, title: "exclude-me-2" });
-    await CpkBook.create({ author_id: 3, id: 300, title: "keep" });
+    await CpkBook.create({ id: [1, 100], title: "exclude-me" });
+    await CpkBook.create({ id: [2, 200], title: "exclude-me-2" });
+    await CpkBook.create({ id: [3, 300], title: "keep" });
 
     const matched = await (CpkBook as any)
       .all()
@@ -220,8 +220,8 @@ describe("Relation#where — composite-key form", () => {
   });
 
   it("whereNot(cols, tuples) on all-filtered tuples is a no-op (matches Rails' empty-hash behavior)", async () => {
-    await CpkBook.create({ author_id: 1, id: 100, title: "a" });
-    await CpkBook.create({ author_id: 2, id: 200, title: "b" });
+    await CpkBook.create({ id: [1, 100], title: "a" });
+    await CpkBook.create({ id: [2, 200], title: "b" });
     // All tuples have a null component → filtered out → no predicate
     // added → all rows returned.
     const matched = await (CpkBook as any)

--- a/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-count-aggregate-build-joins-fold.trails.test.ts
@@ -41,11 +41,11 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
 
   async function seedBooksWithChapters(): Promise<void> {
     await CpkAuthor.create({ id: 1, name: "Author One" });
-    await CpkBook.create({ author_id: 1, id: 1, title: "Alpha", revision: 1 });
-    await CpkBook.create({ author_id: 1, id: 2, title: "Beta", revision: 2 });
+    await CpkBook.create({ id: [1, 1], title: "Alpha", revision: 1 });
+    await CpkBook.create({ id: [1, 2], title: "Beta", revision: 2 });
     // Two chapters on book 1 would fan the row count to 3 without DISTINCT.
-    await CpkChapter.create({ author_id: 1, id: 10, book_id: 1, title: "ch-1" });
-    await CpkChapter.create({ author_id: 1, id: 11, book_id: 1, title: "ch-2" });
+    await CpkChapter.create({ id: [1, 10], book_id: 1, title: "ch-1" });
+    await CpkChapter.create({ id: [1, 11], book_id: 1, title: "ch-2" });
   }
 
   it("eager_load(:assoc).count on a composite-PK model de-duplicates via DISTINCT", async () => {
@@ -82,13 +82,13 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
     // ROWS (Rails) from bounding distinct VALUES: limit(2) by pk order picks
     // books 1 & 2 (rev 5, 5) → COUNT(DISTINCT revision) = 1, whereas truncating
     // the distinct value list {5, 9} to 2 would (wrongly) yield 2.
-    await CpkBook.create({ author_id: 1, id: 1, title: "Alpha", revision: 5 });
-    await CpkBook.create({ author_id: 1, id: 2, title: "Beta", revision: 5 });
-    await CpkBook.create({ author_id: 1, id: 3, title: "Gamma", revision: 9 });
+    await CpkBook.create({ id: [1, 1], title: "Alpha", revision: 5 });
+    await CpkBook.create({ id: [1, 2], title: "Beta", revision: 5 });
+    await CpkBook.create({ id: [1, 3], title: "Gamma", revision: 9 });
     // Chapters on book 1 fan the LEFT OUTER JOIN so the DISTINCT-pk id fetch
     // must de-duplicate.
-    await CpkChapter.create({ author_id: 1, id: 10, book_id: 1, title: "ch-1" });
-    await CpkChapter.create({ author_id: 1, id: 11, book_id: 1, title: "ch-2" });
+    await CpkChapter.create({ id: [1, 10], book_id: 1, title: "ch-1" });
+    await CpkChapter.create({ id: [1, 11], book_id: 1, title: "ch-2" });
   }
 
   it("eager_load(:assoc).limit(n).count(column) bounds ROWS via a DISTINCT-pk id fetch, then re-counts", async () => {
@@ -153,11 +153,11 @@ describe("CpkBook eager count / aggregate build_joins fold", () => {
 
   async function seedBooksWithOrders(): Promise<void> {
     await CpkAuthor.create({ id: 1, name: "Author One" });
-    await CpkOrder.create({ shop_id: 1, id: 100, status: "open" });
-    await CpkOrder.create({ shop_id: 1, id: 200, status: "open" });
-    await CpkBook.create({ author_id: 1, id: 1, shop_id: 1, order_id: 100, title: "Alpha" });
-    await CpkBook.create({ author_id: 1, id: 2, shop_id: 1, order_id: 100, title: "Beta" });
-    await CpkBook.create({ author_id: 1, id: 3, shop_id: 1, order_id: 200, title: "Gamma" });
+    await CpkOrder.create({ id: [1, 100], status: "open" });
+    await CpkOrder.create({ id: [1, 200], status: "open" });
+    await CpkBook.create({ id: [1, 1], shop_id: 1, order_id: 100, title: "Alpha" });
+    await CpkBook.create({ id: [1, 2], shop_id: 1, order_id: 100, title: "Beta" });
+    await CpkBook.create({ id: [1, 3], shop_id: 1, order_id: 200, title: "Gamma" });
   }
 
   // Re-key a Map<Order record, value> by the order's `id` component, coercing

--- a/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
+++ b/packages/activerecord/src/relation/cpk-eager-pluck-cache-version-composite-fk-collection.trails.test.ts
@@ -52,10 +52,10 @@ describe("CpkBook eager pluck / cache_version over a composite-FK collection", (
   async function seedBooks(): Promise<void> {
     await CpkAuthor.create({ id: 1, name: "Author One" });
     await CpkAuthor.create({ id: 2, name: "Author Two" });
-    await CpkBook.create({ author_id: 1, id: 1, title: "Alpha", revision: 1 });
-    await CpkBook.create({ author_id: 1, id: 2, title: "Beta", revision: 2 });
-    await CpkBook.create({ author_id: 2, id: 3, title: "Gamma", revision: 3 });
-    await CpkChapter.create({ author_id: 1, id: 10, book_id: 1, title: "ch-1" });
+    await CpkBook.create({ id: [1, 1], title: "Alpha", revision: 1 });
+    await CpkBook.create({ id: [1, 2], title: "Beta", revision: 2 });
+    await CpkBook.create({ id: [2, 3], title: "Gamma", revision: 3 });
+    await CpkChapter.create({ id: [1, 10], book_id: 1, title: "ch-1" });
   }
 
   it("eagerLoad('chapters') builds a composite FK↔PK tuple JOIN node", () => {

--- a/packages/activerecord/src/relation/where-chain.test.ts
+++ b/packages/activerecord/src/relation/where-chain.test.ts
@@ -219,7 +219,7 @@ describe("WhereChainTest", () => {
 
   it("associated with composite primary key", async () => {
     const author = await CpkAuthor.create({ name: "Cpk" });
-    await CpkBook.create({ author_id: (author as any).id, id: 2 });
+    await CpkBook.create({ id: [(author as any).id, 2] });
     expect(await CpkAuthor.all().where().associated("books").exists()).toBe(true);
   });
 
@@ -366,7 +366,7 @@ describe("WhereChainTest", () => {
   });
 
   it("missing with composite primary key", async () => {
-    await CpkBook.create({ author_id: 1, id: 2 });
+    await CpkBook.create({ id: [1, 2] });
     expect(await CpkBook.all().where().missing("author").exists()).toBe(true);
   });
 

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -173,8 +173,8 @@ describe("WhereTest", () => {
   });
 
   it("where with tuple syntax on composite models", async () => {
-    const bookOne = await CpkBook.create({ author_id: 1, id: 2 });
-    const bookTwo = await CpkBook.create({ author_id: 3, id: 4 });
+    const bookOne = await CpkBook.create({ id: [1, 2] });
+    const bookTwo = await CpkBook.create({ id: [3, 4] });
 
     const r1 = await CpkBook.where(["author_id", "id"], [[1, 2]]);
     expect(ids(r1)).toStrictEqual([(bookOne as any).id]);
@@ -204,8 +204,8 @@ describe("WhereTest", () => {
   });
 
   it("where with tuple syntax and regular syntax combined", async () => {
-    const bookOne = await CpkBook.create({ author_id: 1, id: 2, title: "The Alchemist" });
-    const bookTwo = await CpkBook.create({ author_id: 3, id: 4, title: "The Alchemist" });
+    const bookOne = await CpkBook.create({ id: [1, 2], title: "The Alchemist" });
+    const bookTwo = await CpkBook.create({ id: [3, 4], title: "The Alchemist" });
 
     const r1 = await CpkBook.where({ title: "The Alchemist" });
     expect(sortedIds(r1)).toStrictEqual([(bookOne as any).id, (bookTwo as any).id].slice().sort());
@@ -244,12 +244,11 @@ describe("WhereTest", () => {
   });
 
   it("where with nil cpk association", async () => {
-    const order = await CpkOrder.create({ shop_id: 1, id: 2 });
+    const order = await CpkOrder.create({ id: [1, 2] });
     // Rails: order.books.create!(id: [3, 4]) — composite Book PK [author_id, id]
     // plus the order FK [shop_id, order_id] inherited from the order.
     const book = await CpkBook.create({
-      author_id: 3,
-      id: 4,
+      id: [3, 4],
       shop_id: (order as any).readAttribute("shop_id"),
       order_id: (order as any).readAttribute("id"),
     });

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -199,7 +199,7 @@ describe("TokenForTest", () => {
   it("finds record with a composite primary key", async () => {
     // Rails: Cpk::Book.create!(id: [1, 3], shop_id: 2) — composite PK is
     // [author_id, id]; assign the components our mass-assignment understands.
-    const book = await CpkBook.create({ author_id: 1, id: 3, shop_id: 2 });
+    const book = await CpkBook.create({ id: [1, 3], shop_id: 2 });
     const token = (book as any).generateTokenFor("test");
 
     expect((await (CpkBook as any).findByTokenFor("test", token)).id).toEqual((book as any).id);

--- a/packages/activerecord/src/token-for.test.ts
+++ b/packages/activerecord/src/token-for.test.ts
@@ -197,8 +197,7 @@ describe("TokenForTest", () => {
   });
 
   it("finds record with a composite primary key", async () => {
-    // Rails: Cpk::Book.create!(id: [1, 3], shop_id: 2) — composite PK is
-    // [author_id, id]; assign the components our mass-assignment understands.
+    // Rails: Cpk::Book.create!(id: [1, 3], shop_id: 2) — composite PK [author_id, id].
     const book = await CpkBook.create({ id: [1, 3], shop_id: 2 });
     const token = (book as any).generateTokenFor("test");
 


### PR DESCRIPTION
## What

Converge `setId` (`ActiveRecord::AttributeMethods::CompositePrimaryKey#id=`) so that assigning a non-array value to a model-level composite primary key raises `TypeError` instead of writing the scalar straight to the literal `id` column.

- `setId` now raises `TypeError` with the Rails message (`Expected value matching ["author_id", "id"], got 1.`, using `primary_key.inspect`) for a non-array value on a composite PK.
- `_applyCompositePrimaryKey`'s scalar-write branch is removed; the deferred composite-PK `id` path dispatches through the `id=` setter, so arrays spread across the key columns and scalars raise.
- Every scalar-`id` cpk construction/create call site in the test suite is migrated to the Rails array form (`id: [a, b]`), matching e.g. `Cpk::Order.create!(id: [1, 2])`.

## Rails parity

`primary_keys_test.rb:426` `test_assigning_a_non_array_value_to_model_with_composite_primary_key_raises` asserts the exact message; our `primary-keys.test.ts` test now asserts it too.

Closes-story: converge-cpk-scalar-id-assignment-typeerror