### PR TITLE
fix(type): make Serialized canonicalKey key-order insensitive

### DIFF
--- a/packages/activerecord/src/type/serialized.trails.test.ts
+++ b/packages/activerecord/src/type/serialized.trails.test.ts
@@ -8,6 +8,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { StringType } from "@blazetrails/activemodel";
+import { HashWithIndifferentAccess } from "@blazetrails/activesupport";
 import { Serialized, type Coder } from "./serialized.js";
 
 const jsonCoder: Coder = {
@@ -26,6 +27,12 @@ describe("Serialized#isChanged", () => {
   it("normalizes nested object key order", () => {
     const oldValue = { outer: { x: 1, y: 2 }, list: [{ p: 1, q: 2 }] };
     const newValue = { list: [{ q: 2, p: 1 }], outer: { y: 2, x: 1 } };
+    expect(type.isChanged(oldValue, newValue)).toBe(false);
+  });
+
+  it("normalizes key order through HashWithIndifferentAccess toHash unwrap", () => {
+    const oldValue = new HashWithIndifferentAccess({ a: 1, b: 2 });
+    const newValue = new HashWithIndifferentAccess({ b: 2, a: 1 });
     expect(type.isChanged(oldValue, newValue)).toBe(false);
   });
 });

--- a/packages/activerecord/src/type/serialized.trails.test.ts
+++ b/packages/activerecord/src/type/serialized.trails.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Trails-specific unit coverage for Serialized change detection.
+ *
+ * Rails' Type::Value#changed? compares old/new with Ruby `!=`, which for Hash
+ * is the order-insensitive Hash#==. canonicalKey drives that comparison here,
+ * so two content-equal hashes built with keys in a different insertion order
+ * must not report as changed.
+ */
+import { describe, it, expect } from "vitest";
+import { StringType } from "@blazetrails/activemodel";
+import { Serialized, type Coder } from "./serialized.js";
+
+const jsonCoder: Coder = {
+  dump: (value) => (value == null ? null : JSON.stringify(value)),
+  load: (value) => (value == null ? {} : typeof value === "string" ? JSON.parse(value) : value),
+};
+
+describe("Serialized#isChanged", () => {
+  const type = new Serialized(new StringType(), jsonCoder);
+
+  it("treats same key/value pairs in a different insertion order as unchanged", () => {
+    expect(type.isChanged({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(false);
+    expect(type.isChanged({ a: 1, b: 2 }, { b: 3, a: 1 })).toBe(true);
+  });
+
+  it("normalizes nested object key order", () => {
+    const oldValue = { outer: { x: 1, y: 2 }, list: [{ p: 1, q: 2 }] };
+    const newValue = { list: [{ q: 2, p: 1 }], outer: { y: 2, x: 1 } };
+    expect(type.isChanged(oldValue, newValue)).toBe(false);
+  });
+});

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -29,14 +29,38 @@ function isValueComparable(value: unknown): boolean {
  * interface) so their contents — not their Map-backed internal shape — drive
  * the comparison.
  *
+ * Object keys are emitted in sorted order so that two content-equal hashes
+ * built with keys in a different insertion order canonicalize identically —
+ * matching Ruby's order-insensitive `Hash#==` (the semantics `Type::Value#==`
+ * relies on for change detection). `JSON.stringify` iterates keys in insertion
+ * order, so the normalization has to happen before stringifying rather than in
+ * a replacer.
+ *
  * @internal
  */
 function canonicalKey(value: unknown): string {
-  return JSON.stringify(value, (_k, v) =>
-    v && typeof v === "object" && typeof (v as { toHash?: unknown }).toHash === "function"
-      ? (v as { toHash(): unknown }).toHash()
-      : v,
-  );
+  return JSON.stringify(normalize(value));
+}
+
+/**
+ * Recursively unwraps `toHash()`-bearing objects and sorts plain-object keys so
+ * the resulting structure has a canonical, insertion-order-independent shape.
+ *
+ * @internal
+ */
+function normalize(value: unknown): unknown {
+  if (value === null || typeof value !== "object") return value;
+  if (typeof (value as { toHash?: unknown }).toHash === "function") {
+    return normalize((value as { toHash(): unknown }).toHash());
+  }
+  if (Array.isArray(value)) return value.map(normalize);
+  const proto = Object.getPrototypeOf(value);
+  if (proto !== Object.prototype && proto !== null) return value;
+  const sorted: Record<string, unknown> = {};
+  for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+    sorted[key] = normalize((value as Record<string, unknown>)[key]);
+  }
+  return sorted;
 }
 
 export interface Coder {
@@ -139,8 +163,9 @@ export class Serialized extends ValueType {
   // `default_value?`. Sharing that scope is deliberate: a coder whose `load`
   // returns a non-Array/Hash value with its own value-based `==` (e.g.
   // Date/Time) still falls through to reference equality — a narrow edge no
-  // serialized coder here hits — and `canonicalKey`'s key-order sensitivity
-  // is inherited from the default-detection path, not newly introduced.
+  // serialized coder here hits. `canonicalKey` sorts object keys, so two
+  // content-equal hashes built in a different insertion order compare equal,
+  // matching Ruby's order-insensitive `Hash#==`.
   override isChanged(
     oldValue: unknown,
     newValue: unknown,


### PR DESCRIPTION
## Context

`canonicalKey` in `packages/activerecord/src/type/serialized.ts` was
`JSON.stringify`-based and therefore key-insertion-order sensitive. PR #4736
widened its use from `default_value?` detection to driving general
`Serialized#isChanged` value-equality, so two content-equal hashes built with
keys in a different insertion order (`{a:1,b:2}` vs `{b:2,a:1}`) reported as
changed — diverging from Ruby's order-insensitive `Hash#==`
(`vendor/rails/activemodel/lib/active_model/type/value.rb`).

## Change

`canonicalKey` now normalizes before stringifying: recursively unwrap
`toHash()`-bearing objects and sort plain-object keys. `default_value?`
detection shares the same helper, so its behavior stays consistent.

Added a trails unit test asserting order-insensitive `isChanged`. Existing
serialized-attribute suite passes unchanged.

Closes-story: serialized-canonicalkey-order-insensitive-equality