### PR TITLE
refactor(preloader): converge through-preload to single-query JOIN; drop SQL text-scan

### DIFF
--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -46,6 +46,9 @@ type NestedRel = {
 type HasOneHost = {
   hasOne: (name: string, options: Record<string, unknown>) => void;
 };
+type HasManyHost = {
+  hasMany: (name: string, options: Record<string, unknown>) => void;
+};
 
 // A has_one-through mirroring `general_club` (Member → current_membership →
 // club) but whose scope reaches `categorizations` — two levels deep from the
@@ -71,6 +74,20 @@ type HasOneHost = {
     (rel as unknown as { includes: (s: Record<string, unknown>) => NestedRel })
       .includes({ category: "categorizations" })
       .where({ categorizations: { author_id: 1 } }),
+});
+
+// A has_MANY-through whose scope carries a `.includes` reaching a belongs_to
+// association (`category` on Club) plus a predicate on it. A belongs_to join is
+// 1:1, so it does NOT fan the through rows out and IS nested onto the through
+// query even for a collection target — the predicate must resolve there, not
+// leak onto the source query where `categories` is unjoined.
+(Member as unknown as HasManyHost).hasMany("generalClubs", {
+  through: "favoriteMemberships",
+  source: "club",
+  scope: (rel: NestedRel) =>
+    (rel as unknown as { includes: (s: string) => NestedRel })
+      .includes("category")
+      .where({ categories: { name: "General" } }),
 });
 
 describe("Preloader::ThroughAssociation#through_scope multi-level nested join carry", () => {
@@ -124,6 +141,17 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     expect(sql).toMatch(
       new RegExp(`WHERE.*${escapeRegExp(quoteTableName("categorizations.author_id"))}`),
     );
+  });
+
+  it("nests a belongs_to scope includes onto the through query for a has_many-through", () => {
+    const groucho = members("groucho");
+    const sql = throughScopeSql([groucho], "generalClubs");
+    // `category` (belongs_to on Club) is a 1:1 join, so even for this collection
+    // target it is nested onto the through query and the `categories.name`
+    // predicate resolves there — not left on the source query where `categories`
+    // is unjoined (an invalid predicate).
+    expect(sql).toMatch(new RegExp(`JOIN ${escapeRegExp(quoteTableName("categories"))}`));
+    expect(sql).toMatch(new RegExp(`WHERE.*${escapeRegExp(quoteTableName("categories.name"))}`));
   });
 
   type AssocHost = {

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -59,6 +59,20 @@ type HasOneHost = {
     rel.leftJoins({ category: "categorizations" }).where({ categorizations: { author_id: 1 } }),
 });
 
+// Same shape but reaching the deeper table via `.includes` instead of
+// `.leftJoins`. Rails' through_scope nests the scope's `values[:includes]` under
+// the source reflection (`includes!(source => includes)`), so `.includes` and
+// `.leftJoins` both realize the deeper join on the through query. Pins that a
+// has_one-through honors an explicit `.includes` in its scope.
+(Member as unknown as HasOneHost).hasOne("davidIncludedCategorizedClub", {
+  through: "currentMembership",
+  source: "club",
+  scope: (rel: NestedRel) =>
+    (rel as unknown as { includes: (s: Record<string, unknown>) => NestedRel })
+      .includes({ category: "categorizations" })
+      .where({ categorizations: { author_id: 1 } }),
+});
+
 describe("Preloader::ThroughAssociation#through_scope multi-level nested join carry", () => {
   const { members, clubs } = fixtures([
     "memberTypes",
@@ -85,12 +99,26 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
   it("nests the two-level scope join under the source reflection on the through query", () => {
     const groucho = members("groucho");
     const sql = throughScopeSql([groucho], "davidCategorizedClub");
-    // The deeper `categorizations` join is realized on the through query and,
-    // because `_resolveNestedTableNames` now resolves it two levels deep, the
-    // predicate qualifying it rides the through query's WHERE too (without the
-    // recursive resolution it would be deferred to the source-preloader stage).
+    // The deeper `categorizations` join is realized on the through query by
+    // nesting the scope's `.leftJoins({ category: "categorizations" })` under the
+    // source reflection, and the copied full where_clause qualifies it, so the
+    // predicate rides the through query's WHERE too.
     // Quote identifiers via the active adapter (Rails' `quote_table_name`
     // pattern) so the assertions run on SQLite/PG (`"x"`) and MariaDB (`` `x` ``).
+    expect(sql).toMatch(new RegExp(`JOIN ${escapeRegExp(quoteTableName("categories"))}`));
+    expect(sql).toMatch(new RegExp(`JOIN ${escapeRegExp(quoteTableName("categorizations"))}`));
+    expect(sql).toMatch(
+      new RegExp(`WHERE.*${escapeRegExp(quoteTableName("categorizations.author_id"))}`),
+    );
+  });
+
+  it("nests an explicit scope includes under the source reflection on the through query", () => {
+    const groucho = members("groucho");
+    const sql = throughScopeSql([groucho], "davidIncludedCategorizedClub");
+    // Rails nests `values[:includes]` under the source reflection, joining the
+    // deeper tables so the copied `categorizations.author_id` predicate resolves
+    // on the through query (rather than being left on the source query where the
+    // table is not joined).
     expect(sql).toMatch(new RegExp(`JOIN ${escapeRegExp(quoteTableName("categories"))}`));
     expect(sql).toMatch(new RegExp(`JOIN ${escapeRegExp(quoteTableName("categorizations"))}`));
     expect(sql).toMatch(

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -90,6 +90,21 @@ type HasManyHost = {
       .where({ categories: { name: "General" } }),
 });
 
+// A has_MANY-through whose scope includes a FAN-OUT path (`categorizations`, a
+// has_many two levels deep) AND predicates on it. Joining it onto the through
+// query would multiply the middle records, so the whole preload falls back to
+// the two-step: the `categorizations` join + predicate ride the source stage,
+// and neither the join nor the predicate is left on the through query (which
+// would be an unjoined-table predicate).
+(Member as unknown as HasManyHost).hasMany("categorizedClubs", {
+  through: "favoriteMemberships",
+  source: "club",
+  scope: (rel: NestedRel) =>
+    (rel as unknown as { includes: (s: Record<string, unknown>) => NestedRel })
+      .includes({ category: "categorizations" })
+      .where({ categorizations: { author_id: 1 } }),
+});
+
 describe("Preloader::ThroughAssociation#through_scope multi-level nested join carry", () => {
   const { members, clubs } = fixtures([
     "memberTypes",
@@ -152,6 +167,16 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     // is unjoined (an invalid predicate).
     expect(sql).toMatch(new RegExp(`JOIN ${escapeRegExp(quoteTableName("categories"))}`));
     expect(sql).toMatch(new RegExp(`WHERE.*${escapeRegExp(quoteTableName("categories.name"))}`));
+  });
+
+  it("routes a has_many-through with a fan-out include+predicate to the two-step", () => {
+    const groucho = members("groucho");
+    const sql = throughScopeSql([groucho], "categorizedClubs");
+    // `categorizations` is a to-many join that would fan the middle records out,
+    // so the whole preload takes the two-step: the through query joins neither
+    // `categorizations` nor carries its predicate (both ride the source stage) —
+    // crucially the predicate is NOT orphaned onto an unjoined table here.
+    expect(sql).not.toContain("categorizations");
   });
 
   type AssocHost = {

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -391,12 +391,20 @@ export class ThroughAssociation extends Association {
    * `Preloader::ThroughAssociation#through_scope`
    * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb:104-146).
    *
-   * The whole reflection-scope `where_clause` is copied onto the through query
-   * and the source reflection is JOINed (Rails `includes!`/`references!`, a LEFT
+   * For a to-one, non-through source this is Rails' single-query strategy: the
+   * whole reflection-scope `where_clause` is copied onto the through query and
+   * the source reflection is JOINed (Rails `includes!`/`references!`, a LEFT
    * OUTER JOIN), so every column — through-table, source-table, or a
-   * scope-joined nested table — resolves in ONE query. No per-predicate table
-   * attribution is needed: the JOIN makes the source columns available on the
-   * through query directly.
+   * scope-joined nested table — resolves in ONE query with no per-predicate
+   * table attribution.
+   *
+   * A collection (has_many) source or a nested (through) source can't be JOINed
+   * without fanning the through rows out (trails collects raw rows; Rails' eager
+   * JoinDependency dedups by PK), so those keep the two-step: only the
+   * reflection scope's through-table predicates are copied here (to constrain
+   * the intermediate rows), and the source / sub-chain predicates and order ride
+   * the recursive source-preloader stage (see `_getSourcePreloaders`).
+   * `disable_joins` and polymorphic `source_type` keep their own paths.
    */
   private _buildThroughScope(): any {
     const throughRefl = this._throughReflection;

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -477,18 +477,32 @@ export class ThroughAssociation extends Association {
         // reflection name makes trails' join builder raise the same error.
         const nestedRawJoinValues: any[] = reflScope?._joinValues ?? [];
 
-        // Rails `includes!(source_reflection.name)` + `references!(...)` promotes
-        // to a LEFT OUTER JOIN of the source reflection. `values[:includes]`
-        // (the reflection SCOPE's explicit `.includes`) is empty for the through
-        // scopes we support — trails' `_includesAssociations` bucket is polluted
-        // with derived inverse associations (e.g. the source's own inverse
-        // `tagging`), which would fan the through query out — so we do NOT carry
-        // it; the bare source join matches Rails' `includes!(source)`. A scope's
-        // explicit `.left_joins(source => nested)` lives in
-        // `_leftOuterJoinsValues` and IS nested so a deeper table its predicate
-        // qualifies is joined too (rb:120-138).
-        if (nestedLeftOuter.length > 0) {
-          scope = scope.leftOuterJoins({ [sourceName]: nestedLeftOuter });
+        // Rails `includes!(source_reflection.name => values[:includes])` (bare
+        // when the scope has no `.includes`) + `references!(...)` promotes to a
+        // LEFT OUTER JOIN of the source reflection and its nested includes
+        // (rb:120-124). trails carries the scope's explicit `.includes`
+        // (`_includesAssociations`) the same way — nested under the source
+        // reflection — so a has_one-through scope like
+        // `includes(:category).where(categories: { … })` joins `categories` on
+        // this through query and the predicate resolves.
+        //
+        // BUT only when THIS reflection is to-one (has_one). Rails realizes the
+        // eager join as a JoinDependency that instantiates the through parent
+        // deduplicated by primary key, so a to-many nested include (e.g. the
+        // canonical `tag` source's own `includes(:tagging)`, where a tag has many
+        // taggings) doesn't inflate its result. trails' preloader collects raw
+        // rows instead: for a to-many nested include on a collection (has_many)
+        // through it would fan the middle records out and duplicate them, so
+        // there we fall back to the bare source join (the source condition still
+        // rides the copied where_clause). `.left_joins(source => nested)`
+        // (`_leftOuterJoinsValues`) is carried likewise.
+        const targetIsCollection = (this.reflection as any).isCollection?.() ?? false;
+        const nestedIncludes: any[] = targetIsCollection
+          ? []
+          : (reflScope?._includesAssociations ?? []);
+        const nestedOuter = [...nestedLeftOuter, ...nestedIncludes];
+        if (nestedOuter.length > 0) {
+          scope = scope.leftOuterJoins({ [sourceName]: nestedOuter });
         } else {
           scope = scope.leftOuterJoins(sourceName);
         }
@@ -520,9 +534,10 @@ export class ThroughAssociation extends Association {
         // `posts.title IN (…)`, whose through reflection is `posts`) must still
         // constrain which intermediate rows this through query selects — the
         // recursion can't apply it because it filters the through table, not the
-        // source. So copy just the predicates that reference the through table,
-        // detected precisely from their Arel attributes (no raw-SQL text scan).
-        // Source / sub-chain predicates stay for the recursion.
+        // source. So copy just the predicates that reference the through table
+        // (hash/Arel or raw SQL — Rails assigns the full where_clause here, so a
+        // raw through-table condition must be honored too). Source / sub-chain
+        // predicates stay for the recursion.
         const throughTable = throughKlass.tableName;
         const throughPreds = whereClause.predicates.filter((p: any) =>
           predicateReferencesTable(p, throughTable),
@@ -592,12 +607,15 @@ export class ThroughAssociation extends Association {
 }
 
 /**
- * True when any Arel attribute in `node` references `tableName`. Used only for a
- * NESTED through source (where the single-query JOIN can't be used) to copy the
- * reflection scope's through-table predicates onto the through query. This is a
- * precise Arel-attribute walk — NOT the raw-SQL text scan removed with this
- * convergence — so a raw-string predicate carries no attributes and is left for
- * the recursive source stage.
+ * True when `node` references `tableName`. Used for a collection (has_many) or
+ * nested (through) source — the cases the single-query JOIN can't cover without
+ * fanning the through rows out — to route the reflection scope's through-table
+ * predicates onto the through query (and keep them off the source query, which
+ * never joins the through table). Rails' `through_scope` assigns the FULL
+ * `reflection_scope.where_clause` before adding the source join
+ * (through_association.rb:117-130), so a raw-SQL through-table predicate must be
+ * honored too, not just a hash/Arel one — hence the raw-SQL qualifier scan
+ * alongside the precise Arel walk.
  * @internal
  */
 function predicateReferencesTable(node: any, tableName: string): boolean {
@@ -612,7 +630,49 @@ function predicateReferencesTable(node: any, tableName: string): boolean {
   if (!found && node instanceof Nodes.Not) {
     return predicateReferencesTable((node as any).expr, tableName);
   }
+  // Raw-SQL predicates (e.g. `where("posts.title = ?", "x")`) carry no Arel
+  // Attribute nodes, so `fetchAttribute` never visits them. Scan the raw SQL
+  // text for a `<table>.` qualifier so a string condition on the through table
+  // is routed like a hash/Arel one.
+  if (!found && rawSqlReferencesTable(node, tableName)) {
+    found = true;
+  }
   return found;
+}
+
+/**
+ * True when a raw-SQL predicate node's text qualifies a column with `tableName.`.
+ * Handles SqlLiteral / BoundSqlLiteral and a single Grouping wrapper. String
+ * literals are blanked first (see `stripSqlStringLiterals`) so a `<table>.`
+ * qualifier inside quoted text — e.g. `where("body = 'see posts.title'")` — is
+ * not a false positive. Hash/Arel predicates take the precise `fetchAttribute`
+ * path above and never reach here.
+ * @internal
+ */
+function rawSqlReferencesTable(node: any, tableName: string): boolean {
+  if (node instanceof Nodes.Grouping) {
+    return rawSqlReferencesTable((node as any).expr, tableName);
+  }
+  let sql: string | undefined;
+  if (node instanceof Nodes.BoundSqlLiteral) sql = (node as any).sqlWithPlaceholders;
+  else if (node instanceof Nodes.SqlLiteral) sql = (node as any).value;
+  if (typeof sql !== "string") return false;
+  sql = stripSqlStringLiterals(sql);
+  const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  return new RegExp(`(^|[^\\w.])${escaped}\\.`).test(sql);
+}
+
+/**
+ * Blank single-quoted SQL string literals (preserving length) so the read-only
+ * `<table>.` qualifier scan in `rawSqlReferencesTable` does not match a table
+ * name embedded in literal text. Consumes both SQL-standard doubled quotes
+ * (`''`) and backslash-escaped quotes (`\'`, MySQL/MariaDB default). The result
+ * is never executed as SQL.
+ * @internal
+ */
+function stripSqlStringLiterals(sql: string): string {
+  // eslint-disable-next-line blazetrails/no-raw-sql
+  return sql.replace(/'(?:[^'\\]|''|\\.)*'/g, (lit) => " ".repeat(lit.length));
 }
 
 /** @internal */

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -214,9 +214,12 @@ export class ThroughAssociation extends Association {
       } else {
         const throughTable = this._throughTableName();
         const wc = this._reflectionScope._whereClause;
+        // Keep every predicate except the ones the through query fully resolves
+        // (through-table-only). A predicate mixing the through table with another
+        // table stays here — it is not through-only, so it is not copied there.
         const sourcePredicates =
           throughTable != null && wc != null
-            ? wc.predicates.filter((p: any) => !predicateReferencesTable(p, throughTable))
+            ? wc.predicates.filter((p: any) => !predicateIsThroughOnly(p, throughTable))
             : (wc?.predicates ?? []);
         sourceScope._whereClause = new WhereClause(sourcePredicates);
       }
@@ -620,17 +623,18 @@ export class ThroughAssociation extends Association {
         // trails' preloader collects raw rows. So the source / sub-chain
         // predicates, order, and scope includes ride the recursive
         // source-preloader stage (see `_getSourcePreloaders`) instead. Only a
-        // THROUGH-table predicate the reflection scope carries (e.g.
-        // `miscPostFirstBlueTags_2`'s `posts.title IN (…)`, whose through
-        // reflection is `posts`) must still constrain which intermediate rows
-        // this through query selects — the recursion can't apply it because it
-        // filters the through table, not the source. So copy just the predicates
-        // that reference the through table (hash/Arel or raw SQL — Rails assigns
-        // the full where_clause here, so a raw through-table condition must be
-        // honored too).
+        // predicate the reflection scope carries that references the through
+        // table AND no other table (e.g. `miscPostFirstBlueTags_2`'s
+        // `posts.title IN (…)`, whose through reflection is `posts`) is copied
+        // here to constrain which intermediate rows this through query selects —
+        // it is fully resolvable against the through table this query already
+        // selects. A predicate mixing the through table with another table (e.g.
+        // `posts.title = ? OR categorizations.author_id = ?`) is NOT copied: the
+        // through query never joins the other table, so it stays whole on the
+        // source scope (hash/Arel or raw SQL both classified precisely).
         const throughTable = throughKlass.tableName;
         const throughPreds = whereClause.predicates.filter((p: any) =>
-          predicateReferencesTable(p, throughTable),
+          predicateIsThroughOnly(p, throughTable),
         );
         if (throughPreds.length > 0) {
           scope._whereClause = new WhereClause([...scope._whereClause.predicates, ...throughPreds]);
@@ -763,6 +767,69 @@ function rawSqlReferencesTable(node: any, tableName: string): boolean {
 function stripSqlStringLiterals(sql: string): string {
   // eslint-disable-next-line blazetrails/no-raw-sql
   return sql.replace(/'(?:[^'\\]|''|\\.)*'/g, (lit) => " ".repeat(lit.length));
+}
+
+/**
+ * True when `node` qualifies a column with some table OTHER than `tableName`.
+ * Used together with `predicateReferencesTable` to decide whether a single
+ * predicate can ride the two-step's through query: only a predicate that
+ * references the through table AND no other table is fully resolvable there
+ * (the two-step through query joins nothing beyond the through table). A mixed
+ * predicate — e.g. `posts.title = ? OR categorizations.author_id = ?` — is not,
+ * so it must NOT be routed to the through query (nor stripped from the source
+ * scope). Mirrors the precise Arel walk plus raw-SQL qualifier scan.
+ * @internal
+ */
+function predicateReferencesOtherTable(node: any, tableName: string): boolean {
+  let other = false;
+  node.fetchAttribute?.((attr: any) => {
+    if (attr instanceof Nodes.Attribute && relationName(attr.relation.name) !== tableName) {
+      other = true;
+      return false;
+    }
+    return true;
+  });
+  if (other) return true;
+  if (node instanceof Nodes.Not) {
+    return predicateReferencesOtherTable((node as any).expr, tableName);
+  }
+  return rawSqlReferencesOtherTable(node, tableName);
+}
+
+/**
+ * True when a raw-SQL predicate node's text qualifies a column with any table
+ * other than `tableName`. Mirrors `rawSqlReferencesTable`'s node unwrapping and
+ * literal blanking, then extracts every `<word>.` qualifier.
+ * @internal
+ */
+function rawSqlReferencesOtherTable(node: any, tableName: string): boolean {
+  if (node instanceof Nodes.Grouping) {
+    return rawSqlReferencesOtherTable((node as any).expr, tableName);
+  }
+  let sql: string | undefined;
+  if (node instanceof Nodes.BoundSqlLiteral) sql = (node as any).sqlWithPlaceholders;
+  else if (node instanceof Nodes.SqlLiteral) sql = (node as any).value;
+  if (typeof sql !== "string") return false;
+  sql = stripSqlStringLiterals(sql);
+  const qualifierRe = /(^|[^\w.])(\w+)\s*\./g;
+  let match: RegExpExecArray | null;
+  while ((match = qualifierRe.exec(sql)) !== null) {
+    if (match[2] !== tableName) return true;
+  }
+  return false;
+}
+
+/**
+ * True when `node` references the through table `tableName` and NO other table,
+ * so the two-step's through query (which joins nothing beyond the through table)
+ * can fully resolve it. Predicates that reference only source/other tables, or
+ * mix the through table with another, are left on the source scope instead.
+ * @internal
+ */
+function predicateIsThroughOnly(node: any, tableName: string): boolean {
+  return (
+    predicateReferencesTable(node, tableName) && !predicateReferencesOtherTable(node, tableName)
+  );
 }
 
 /** @internal */

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -206,11 +206,10 @@ export class ThroughAssociation extends Association {
     //     recursive preload stage, and carrying the flattened chain scope's
     //     joins/select here would duplicate the middle records.
     let sourceScope = null;
-    const sourceIsThrough = (sourceRefl as any)?.isThroughReflection?.() ?? false;
-    const sourceIsCollection = (sourceRefl as any)?.isCollection?.() ?? false;
-    if (!sourceIsThrough && this._reflectionScope != null) {
+    const strategy = this._throughScopeStrategy();
+    if (strategy !== "nested" && this._reflectionScope != null) {
       sourceScope = this._reflectionScope._clone();
-      if (!sourceIsCollection) {
+      if (strategy === "join") {
         sourceScope._whereClause = new WhereClause([]);
       } else {
         const throughTable = this._throughTableName();
@@ -387,6 +386,75 @@ export class ThroughAssociation extends Association {
   }
 
   /**
+   * How this preload realizes Rails' `through_scope` where-copy branch, given
+   * what trails' row-collecting preloader can do without Rails' PK-deduping
+   * eager JoinDependency:
+   *
+   *   - `"join"` — the source is a to-one, non-through association, so JOINing it
+   *     onto the through query can't fan the through rows out (a to-one join
+   *     adds no rows). This is Rails' single-query strategy: copy the full
+   *     where_clause and join the source. Nested scope joins/includes are
+   *     carried too, but a fan-out-prone one (reaching a to-many association) is
+   *     dropped for a collection target — see `_includeSpecFansOut`.
+   *   - `"twoStep"` — a collection source would be duplicated by the source join,
+   *     so keep the two-step: copy only the reflection scope's through-table
+   *     predicates here; source-table predicates, order, and scope includes ride
+   *     the recursive source stage.
+   *   - `"nested"` — the source is itself a through; its sub-chain re-derives its
+   *     own scope at its own recursive stage. Same through-query handling as
+   *     `"twoStep"`, but the source stage carries nothing.
+   * @internal
+   */
+  private _throughScopeStrategy(): "join" | "twoStep" | "nested" {
+    const sourceRefl = this._sourceReflection;
+    if (!sourceRefl) return "twoStep";
+    if ((sourceRefl as any).isThroughReflection?.()) return "nested";
+    const sourceIsCollection = (sourceRefl as any).isCollection?.() ?? false;
+    return sourceIsCollection ? "twoStep" : "join";
+  }
+
+  /**
+   * True when the include/join spec reaches an association that can multiply the
+   * through rows when JOINed. Only a `belongs_to` join is truly 1:1 (a foreign
+   * key referencing a unique primary key); a `has_one`/`has_many` join can return
+   * several rows when the row has multiple children — `has_one` is a Rails-level
+   * "keep the first", not a SQL uniqueness — so both are treated as fan-out.
+   * Rails tolerates the fan-out via its PK-deduping eager JoinDependency; trails'
+   * row-collecting preloader can't, so for a collection target a fan-out-prone
+   * nested include is dropped. Walks nested hash/array specs, resolving each key
+   * against the current klass; an unresolvable (e.g. polymorphic) association is
+   * treated as fan-out (conservative). A has_one target tolerates fan-out anyway
+   * since it keeps only the first row, so this gate is applied only for a
+   * collection target.
+   * @internal
+   */
+  private _includeSpecFansOut(klass: typeof Base, spec: any): boolean {
+    if (spec == null) return false;
+    if (Array.isArray(spec)) return spec.some((s) => this._includeSpecFansOut(klass, s));
+    const step = (name: string, child: any): boolean => {
+      let r: any;
+      try {
+        r = (klass as any)._reflectOnAssociation?.(name);
+      } catch {
+        return true;
+      }
+      if (!r) return true;
+      if (!(r.isBelongsTo?.() ?? false)) return true;
+      if (child == null) return false;
+      let nextKlass: typeof Base | undefined;
+      try {
+        nextKlass = r.klass;
+      } catch {
+        return true;
+      }
+      return nextKlass ? this._includeSpecFansOut(nextKlass, child) : true;
+    };
+    if (typeof spec === "string") return step(spec, null);
+    if (typeof spec === "object") return Object.keys(spec).some((key) => step(key, spec[key]));
+    return false;
+  }
+
+  /**
    * Build the through (intermediate) query's scope, mirroring Rails'
    * `Preloader::ThroughAssociation#through_scope`
    * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb:104-146).
@@ -444,21 +512,8 @@ export class ThroughAssociation extends Association {
       // where_clause onto the through query and JOIN the source reflection so
       // every referenced column resolves in this single query.
       const sourceRefl = this._sourceReflection;
-      // The single-query JOIN is only safe when the source reflection is a
-      // to-ONE, non-through association. A collection source (has_many) or a
-      // nested through source joined onto the through query fans the
-      // intermediate rows out across the source/sub-chain join tables,
-      // duplicating the middle records — Rails avoids that because its through
-      // query is an eager-load whose JoinDependency instantiates distinct
-      // parents by primary key, but trails' preloader collects raw rows. For
-      // those cases trails recurses per reflection stage (Rails'
-      // `source_preloaders`): the source/sub-chain predicates and order are
-      // applied at the source-preloader stage (see `_getSourcePreloaders`), and
-      // only the reflection scope's THROUGH-table predicates are copied here to
-      // constrain which intermediate rows this through query selects.
-      const sourceIsThrough = (sourceRefl as any)?.isThroughReflection?.() ?? false;
-      const sourceIsCollection = (sourceRefl as any)?.isCollection?.() ?? false;
-      if (sourceRefl && !sourceIsThrough && !sourceIsCollection) {
+      const strategy = this._throughScopeStrategy();
+      if (sourceRefl && strategy === "join") {
         scope._whereClause = new WhereClause([
           ...scope._whereClause.predicates,
           ...whereClause.predicates,
@@ -484,22 +539,29 @@ export class ThroughAssociation extends Association {
         // (`_includesAssociations`) the same way — nested under the source
         // reflection — so a has_one-through scope like
         // `includes(:category).where(categories: { … })` joins `categories` on
-        // this through query and the predicate resolves.
+        // this through query and the predicate resolves. `.left_joins(source =>
+        // nested)` (`_leftOuterJoinsValues`) is carried likewise.
         //
-        // BUT only when THIS reflection is to-one (has_one). Rails realizes the
-        // eager join as a JoinDependency that instantiates the through parent
-        // deduplicated by primary key, so a to-many nested include (e.g. the
-        // canonical `tag` source's own `includes(:tagging)`, where a tag has many
-        // taggings) doesn't inflate its result. trails' preloader collects raw
-        // rows instead: for a to-many nested include on a collection (has_many)
-        // through it would fan the middle records out and duplicate them, so
-        // there we fall back to the bare source join (the source condition still
-        // rides the copied where_clause). `.left_joins(source => nested)`
-        // (`_leftOuterJoinsValues`) is carried likewise.
+        // The one carve-out: for a COLLECTION target, a nested include that
+        // reaches a to-many association (e.g. the canonical `tag` source's own
+        // `includes(:tagging)`) is dropped, because trails can't PK-dedup the
+        // resulting fan-out the way Rails' eager JoinDependency does. A to-one
+        // nested include is kept for every target. `_joinValues` raw joins are
+        // never gated — Rails raises on them regardless of collection (see the
+        // raw-join tests), and nesting them makes trails raise the same error.
+        let sourceKlass: typeof Base | undefined;
+        try {
+          sourceKlass = (sourceRefl as any).klass;
+        } catch {
+          sourceKlass = undefined;
+        }
         const targetIsCollection = (this.reflection as any).isCollection?.() ?? false;
-        const nestedIncludes: any[] = targetIsCollection
-          ? []
-          : (reflScope?._includesAssociations ?? []);
+        const rawIncludes: any[] = reflScope?._includesAssociations ?? [];
+        const includeKlass = sourceKlass;
+        const nestedIncludes: any[] =
+          targetIsCollection && includeKlass != null
+            ? rawIncludes.filter((spec) => !this._includeSpecFansOut(includeKlass, spec))
+            : rawIncludes;
         const nestedOuter = [...nestedLeftOuter, ...nestedIncludes];
         if (nestedOuter.length > 0) {
           scope = scope.leftOuterJoins({ [sourceName]: nestedOuter });
@@ -527,17 +589,23 @@ export class ThroughAssociation extends Association {
           scope._rawOrderClauses = [...scope._rawOrderClauses, ...rawOrderClauses];
         }
       } else if (sourceRefl) {
-        // Collection or nested source: the single-query JOIN cannot cover it
-        // (fan-out), so the source / sub-chain predicates ride the recursive
-        // source-preloader stages instead. But a THROUGH-table predicate the
-        // reflection scope carries (e.g. `miscPostFirstBlueTags_2`'s
-        // `posts.title IN (…)`, whose through reflection is `posts`) must still
-        // constrain which intermediate rows this through query selects — the
-        // recursion can't apply it because it filters the through table, not the
-        // source. So copy just the predicates that reference the through table
-        // (hash/Arel or raw SQL — Rails assigns the full where_clause here, so a
-        // raw through-table condition must be honored too). Source / sub-chain
-        // predicates stay for the recursion.
+        // Collection source/target ("twoStep") or nested through source
+        // ("nested"): JOINing the source (or a to-many nested include such as
+        // the canonical `tag` source's own `includes(:tagging)`) onto the
+        // through query would fan the middle records out and duplicate them —
+        // Rails avoids that because its through query is an eager-load whose
+        // JoinDependency instantiates distinct parents by primary key, but
+        // trails' preloader collects raw rows. So the source / sub-chain
+        // predicates, order, and scope includes ride the recursive
+        // source-preloader stage (see `_getSourcePreloaders`) instead. Only a
+        // THROUGH-table predicate the reflection scope carries (e.g.
+        // `miscPostFirstBlueTags_2`'s `posts.title IN (…)`, whose through
+        // reflection is `posts`) must still constrain which intermediate rows
+        // this through query selects — the recursion can't apply it because it
+        // filters the through table, not the source. So copy just the predicates
+        // that reference the through table (hash/Arel or raw SQL — Rails assigns
+        // the full where_clause here, so a raw through-table condition must be
+        // honored too).
         const throughTable = throughKlass.tableName;
         const throughPreds = whereClause.predicates.filter((p: any) =>
           predicateReferencesTable(p, throughTable),

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -393,13 +393,16 @@ export class ThroughAssociation extends Association {
    *   - `"join"` — the source is a to-one, non-through association, so JOINing it
    *     onto the through query can't fan the through rows out (a to-one join
    *     adds no rows). This is Rails' single-query strategy: copy the full
-   *     where_clause and join the source. Nested scope joins/includes are
-   *     carried too, but a fan-out-prone one (reaching a to-many association) is
-   *     dropped for a collection target — see `_includeSpecFansOut`.
-   *   - `"twoStep"` — a collection source would be duplicated by the source join,
-   *     so keep the two-step: copy only the reflection scope's through-table
-   *     predicates here; source-table predicates, order, and scope includes ride
-   *     the recursive source stage.
+   *     where_clause and join the source, carrying every nested scope
+   *     join/include unconditionally.
+   *   - `"twoStep"` — the source is a collection, OR a collection target's scope
+   *     carries a fan-out-prone nested join/include (one reaching a to-many
+   *     association) whose table a copied predicate may reference. Either would
+   *     duplicate the middle records if joined onto the through query, so keep
+   *     the two-step: copy only the reflection scope's through-table predicates
+   *     here; source-table predicates, order, and the scope's includes/joins ride
+   *     the recursive source stage (a per-record-keyed query, so the join filters
+   *     without fanning the through rows out).
    *   - `"nested"` — the source is itself a through; its sub-chain re-derives its
    *     own scope at its own recursive stage. Same through-query handling as
    *     `"twoStep"`, but the source stage carries nothing.
@@ -409,8 +412,43 @@ export class ThroughAssociation extends Association {
     const sourceRefl = this._sourceReflection;
     if (!sourceRefl) return "twoStep";
     if ((sourceRefl as any).isThroughReflection?.()) return "nested";
-    const sourceIsCollection = (sourceRefl as any).isCollection?.() ?? false;
-    return sourceIsCollection ? "twoStep" : "join";
+    if ((sourceRefl as any).isCollection?.() ?? false) return "twoStep";
+    // A has_one target keeps only the first row, so it tolerates a fanning nested
+    // join; a collection target does not — and dropping just the include would
+    // orphan any predicate on that table (copied with the full where_clause) onto
+    // an unjoined table, so route the whole preload to the two-step instead.
+    const targetIsCollection = (this.reflection as any).isCollection?.() ?? false;
+    if (targetIsCollection && this._scopeHasFanOutJoin(sourceRefl)) return "twoStep";
+    return "join";
+  }
+
+  /**
+   * True when the reflection scope carries a nested join/include
+   * (`.includes` / `.left_joins` / `.joins(<symbol>)`) that reaches a to-many
+   * association from the source klass — i.e. one the single-query JOIN can't nest
+   * onto the through query without fanning the middle records out. Raw-SQL /
+   * Arel-node joins (`_joinValues`) are excluded here: Rails raises on those
+   * regardless, which the two-step would not reproduce, so they must stay on the
+   * `"join"` path (see the raw-join tests).
+   * @internal
+   */
+  private _scopeHasFanOutJoin(sourceRefl: AssociationLikeReflection): boolean {
+    const reflScope = this._reflectionScope;
+    if (reflScope == null) return false;
+    const specs: any[] = [
+      ...(reflScope._includesAssociations ?? []),
+      ...(reflScope._leftOuterJoinsValues ?? []),
+      ...(reflScope._namedInnerJoins ?? []),
+    ];
+    if (specs.length === 0) return false;
+    let sourceKlass: typeof Base | undefined;
+    try {
+      sourceKlass = (sourceRefl as any).klass;
+    } catch {
+      return false;
+    }
+    if (sourceKlass == null) return false;
+    return specs.some((spec) => this._includeSpecFansOut(sourceKlass, spec));
   }
 
   /**
@@ -540,28 +578,12 @@ export class ThroughAssociation extends Association {
         // reflection — so a has_one-through scope like
         // `includes(:category).where(categories: { … })` joins `categories` on
         // this through query and the predicate resolves. `.left_joins(source =>
-        // nested)` (`_leftOuterJoinsValues`) is carried likewise.
-        //
-        // The one carve-out: for a COLLECTION target, a nested include that
-        // reaches a to-many association (e.g. the canonical `tag` source's own
-        // `includes(:tagging)`) is dropped, because trails can't PK-dedup the
-        // resulting fan-out the way Rails' eager JoinDependency does. A to-one
-        // nested include is kept for every target. `_joinValues` raw joins are
-        // never gated — Rails raises on them regardless of collection (see the
-        // raw-join tests), and nesting them makes trails raise the same error.
-        let sourceKlass: typeof Base | undefined;
-        try {
-          sourceKlass = (sourceRefl as any).klass;
-        } catch {
-          sourceKlass = undefined;
-        }
-        const targetIsCollection = (this.reflection as any).isCollection?.() ?? false;
-        const rawIncludes: any[] = reflScope?._includesAssociations ?? [];
-        const includeKlass = sourceKlass;
-        const nestedIncludes: any[] =
-          targetIsCollection && includeKlass != null
-            ? rawIncludes.filter((spec) => !this._includeSpecFansOut(includeKlass, spec))
-            : rawIncludes;
+        // nested)` (`_leftOuterJoinsValues`) is carried likewise. Carried
+        // unconditionally here: `_throughScopeStrategy` already diverted the only
+        // unsafe case (a collection target whose scope reaches a to-many nested
+        // table) to the two-step, so nothing copied here references an unjoined
+        // table.
+        const nestedIncludes: any[] = reflScope?._includesAssociations ?? [];
         const nestedOuter = [...nestedLeftOuter, ...nestedIncludes];
         if (nestedOuter.length > 0) {
           scope = scope.leftOuterJoins({ [sourceName]: nestedOuter });

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -22,9 +22,6 @@ export class ThroughAssociation extends Association {
   private _throughRecordsByOwner: Map<Base, Base[]> | undefined;
   private _throughPreloadedRecords: Base[] | undefined;
   private _preloadIndex: Map<Base, number> | undefined;
-  private _reflectionWherePartition:
-    | { throughPredicates: Nodes.Node[]; sourcePredicates: Nodes.Node[]; sourceScope: any }
-    | undefined;
 
   constructor(
     klass: typeof Base,
@@ -181,23 +178,50 @@ export class ThroughAssociation extends Association {
       return [];
     }
 
-    // Apply this reflection's OWN scope to source record loading so
-    // instance-dependent scopes filter the final target (e.g. only comments
-    // mentioning the owner). Merge the user-supplied preload scope on top so
-    // it is not silently dropped when the reflection scope is set. Predicates
-    // that reference the THROUGH table are stripped here and applied to the
-    // through query instead (see _buildThroughScope / _partitionReflectionWhere).
+    // Mirror Rails' `source_preloaders`, which spawns a fresh Preloader on
+    // `source_reflection.name` passing this preloader's built `scope`
+    // (through_association.rb:71). The reflection scope's WHERE predicates are
+    // already applied by `_buildThroughScope` — copied onto the through query
+    // with the source JOIN so every referenced column resolves there — so we do
+    // NOT re-apply them at the source stage (they would reference the through /
+    // intermediate table that this source query never joins, e.g.
+    // `no such column: memberships.favorite`). For a nested source (source is
+    // itself a through), the sub-chain's own predicates are re-derived at its
+    // own recursive preload stage, not carried here. What the source query DOES
+    // need from the reflection scope is its non-where structure — `order`,
+    // `select`, `distinct` — so `orderedPostComments`' `order(id: :desc)` still
+    // orders the source (comments) query.
     //
-    // Rails structures nested-through preloading recursively per reflection:
-    // `source_preloaders` spawns a fresh Preloader on `source_reflection.name`,
-    // so a nested-through source re-derives its own sub-chain's scope at its own
-    // stage. We mirror that by routing only the outer reflection's own scope
-    // (via `_partitionReflectionWhere`, which draws from `_ownReflectionScope`)
-    // — never the flattened chain scope. Without this the sub-chain's own
-    // predicates (e.g. `first_blue_tags_2`'s `taggings.comment = 'first'`) would
-    // leak down to the innermost target query (`SELECT tags.* … taggings.comment`)
-    // where the intermediate table is not in the FROM clause.
-    let sourceScope = this._partitionReflectionWhere().sourceScope;
+    //   - Single-query JOIN case (to-one, non-through source): the through query
+    //     copied the FULL where_clause and joined the source, so the source
+    //     query re-applies NO predicates — empty its where_clause (keeping order
+    //     / select). This also avoids re-applying a through-table condition (e.g.
+    //     `favoriteClub`'s `memberships.favorite`) that the source query can't
+    //     resolve.
+    //   - Collection two-step case: the through query only carried through-table
+    //     predicates, so the source query keeps the reflection scope's remaining
+    //     (source-table) predicates — e.g. `goodRatings`' `ratings.value > 5`.
+    //   - Nested source (source is itself a through): carry nothing; the
+    //     sub-chain re-derives its own scope (including order) at its own
+    //     recursive preload stage, and carrying the flattened chain scope's
+    //     joins/select here would duplicate the middle records.
+    let sourceScope = null;
+    const sourceIsThrough = (sourceRefl as any)?.isThroughReflection?.() ?? false;
+    const sourceIsCollection = (sourceRefl as any)?.isCollection?.() ?? false;
+    if (!sourceIsThrough && this._reflectionScope != null) {
+      sourceScope = this._reflectionScope._clone();
+      if (!sourceIsCollection) {
+        sourceScope._whereClause = new WhereClause([]);
+      } else {
+        const throughTable = this._throughTableName();
+        const wc = this._reflectionScope._whereClause;
+        const sourcePredicates =
+          throughTable != null && wc != null
+            ? wc.predicates.filter((p: any) => !predicateReferencesTable(p, throughTable))
+            : (wc?.predicates ?? []);
+        sourceScope._whereClause = new WhereClause(sourcePredicates);
+      }
+    }
     if (sourceScope != null && this._preloadScope != null) {
       sourceScope = sourceScope.merge(this._preloadScope);
     } else if (sourceScope == null) {
@@ -362,6 +386,18 @@ export class ThroughAssociation extends Association {
     return this._preloadIndex;
   }
 
+  /**
+   * Build the through (intermediate) query's scope, mirroring Rails'
+   * `Preloader::ThroughAssociation#through_scope`
+   * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb:104-146).
+   *
+   * The whole reflection-scope `where_clause` is copied onto the through query
+   * and the source reflection is JOINed (Rails `includes!`/`references!`, a LEFT
+   * OUTER JOIN), so every column — through-table, source-table, or a
+   * scope-joined nested table — resolves in ONE query. No per-predicate table
+   * attribution is needed: the JOIN makes the source columns available on the
+   * through query directly.
+   */
   private _buildThroughScope(): any {
     const throughRefl = this._throughReflection;
     if (!throughRefl) return undefined;
@@ -376,369 +412,122 @@ export class ThroughAssociation extends Association {
     let scope = (throughKlass as any).unscoped?.() ?? (throughKlass as any)._allForPreload();
     const options = (this.reflection as any).options ?? {};
 
+    // Rails returns the bare unscoped relation before annotate/where/join when
+    // the association opts out of joins (through_association.rb:108).
     if (options.disableJoins) return scope;
 
-    // Carry the through reflection's own scope `annotate(...)` comments onto the
-    // through query. Mirrors Rails' through_scope, which reads
-    // `reflection_scope.values[:annotate]` before applying source_type
-    // (preloader/through_association.rb). Without this, custom SQL annotations
-    // on the intermediate association are silently dropped.
     const reflScope = this._reflectionScope;
+
+    // values[:annotate] → scope.annotate!(*annotations) (through_association.rb:111-113)
     const annotations: string[] = reflScope?._annotations ?? [];
     if (annotations.length > 0) {
       scope = scope.annotate(...annotations);
     }
 
-    // source_type: filter through records by polymorphic type column
+    const whereClause = reflScope?._whereClause;
     if (options.sourceType) {
+      // scope.where!(reflection.foreign_type => source_type) (rb:115-116)
       const foreignType = (this.reflection as any).foreignType;
       if (foreignType) {
         scope = scope.where({ [foreignType]: options.sourceType });
       }
-    } else {
-      // Rails' `elsif !reflection_scope.where_clause.empty?` branch copies the
-      // reflection scope's WHERE onto the through query and joins/includes the
-      // source reflection so source-table columns resolve there too
-      // (through_association.rb:117-129). We approximate that per-predicate.
-      const { throughPredicates, sourcePredicates } = this._partitionReflectionWhere();
-      const throughTable = this._throughTableName();
-      const sourceTable = this._sourceTableName();
-      const isCollection = (this.reflection as any).isCollection?.() ?? false;
-
-      if (isCollection) {
-        // has_many through: it collects every matching target at the source stage,
-        // so the through query only needs the through-table predicates to select
-        // intermediate rows. Source/target predicates stay at the source-preloader
-        // stage (see `_getSourcePreloaders`); adding a source join here would only
-        // risk fanning out through rows.
-        //
-        // But a reflection scope carrying a RAW string / Arel-node join in its own
-        // `_joinValues` bucket (`.joins("INNER JOIN …")`) is NOT gated on collection
-        // in Rails' through_scope: `joins!(source_reflection.name => values[:joins])`
-        // runs whenever the reflection where_clause is non-empty
-        // (through_association.rb:132-134). `JoinDependency.walk_tree` symbolizes the
-        // raw string into a bogus association name and `find_reflection` raises
-        // `ActiveRecord::ConfigurationError` (join_dependency.rb:224-226) — real Rails
-        // raises on a has_many-through preload here too, not just has_one. Mirror the
-        // has_one branch below: nest the scope's raw `_joinValues` under the source
-        // reflection name so the through-query build raises the SAME ConfigurationError
-        // our join builder throws for `{source => [<raw string>]}`, rather than
-        // silently deferring the raw join to the source-preloader stage (a lenient
-        // deviation Rails itself rejects). Symbol-association joins live in
-        // `_namedInnerJoins` and are carried without error at the source stage.
-        const sourceRefl = this._sourceReflection;
-        const reflScopeVals = this._reflectionScope;
-        const nestedRawJoinValues: any[] = reflScopeVals?._joinValues ?? [];
-        const whereNonEmpty = throughPredicates.length > 0 || sourcePredicates.length > 0;
-        if (sourceRefl && whereNonEmpty && nestedRawJoinValues.length > 0) {
-          scope = scope.joins({ [sourceRefl.name]: [...nestedRawJoinValues] });
-        }
-        if (throughPredicates.length > 0) {
-          scope._whereClause = new WhereClause([
-            ...scope._whereClause.predicates,
-            ...throughPredicates,
-          ]);
-        }
-      } else {
-        // has_one through: the through preloader materializes only the FIRST
-        // through record per owner (Preloader::Association#load_records keeps one
-        // row for a non-collection). A source-table condition deferred to the
-        // source-preloader stage can then filter out that lone record's target,
-        // nilling the has_one even though a different through record's target
-        // would match — and which row is "first" depends on unstable PG/MariaDB
-        // ordering. So we copy every reflection-scope predicate the through query
-        // can resolve and add the source join when any of them needs it, so the
-        // condition constrains which through row wins (Rails' through_scope).
-        //
-        // "Can resolve" = references no table beyond the through/source pair OR
-        // a deeper table the reflection scope itself reaches via its own
-        // `.joins`/`.leftJoins`/`.includes`. Rails' through_scope nests those
-        // structural values under the source reflection name so the deeper table
-        // is joined onto the through query too (through_association.rb:120-142);
-        // we carry them the same way and widen the resolvable-table set with the
-        // tables they join, so a predicate qualifying such a nested table
-        // (e.g. `general`'s `categories.name`) constrains which through row wins
-        // instead of being deferred to the source-preloader stage. A predicate
-        // reaching a table NOT joined by the scope still stays at the source
-        // stage (pushing it here would produce `no such column: <nested>.<col>`).
-        // This also admits source-qualified and unqualified predicates, and
-        // mixed through/source predicates (e.g.
-        // `memberships.favorite = ? OR clubs.name = ?`), which land in the
-        // throughPredicates bucket but still need the source join.
-        const sourceRefl = this._sourceReflection;
-        const reflScopeVals = this._reflectionScope;
-        const nestedIncludes: any[] = reflScopeVals?._includesAssociations ?? [];
-        const nestedJoins: any[] = reflScopeVals?._namedInnerJoins ?? [];
-        const nestedLeftOuter: any[] = reflScopeVals?._leftOuterJoinsValues ?? [];
+    } else if (reflScope != null && whereClause != null && !whereClause.isEmpty()) {
+      // elsif !reflection_scope.where_clause.empty? (rb:117-143): copy the FULL
+      // where_clause onto the through query and JOIN the source reflection so
+      // every referenced column resolves in this single query.
+      const sourceRefl = this._sourceReflection;
+      // The single-query JOIN is only safe when the source reflection is a
+      // to-ONE, non-through association. A collection source (has_many) or a
+      // nested through source joined onto the through query fans the
+      // intermediate rows out across the source/sub-chain join tables,
+      // duplicating the middle records — Rails avoids that because its through
+      // query is an eager-load whose JoinDependency instantiates distinct
+      // parents by primary key, but trails' preloader collects raw rows. For
+      // those cases trails recurses per reflection stage (Rails'
+      // `source_preloaders`): the source/sub-chain predicates and order are
+      // applied at the source-preloader stage (see `_getSourcePreloaders`), and
+      // only the reflection scope's THROUGH-table predicates are copied here to
+      // constrain which intermediate rows this through query selects.
+      const sourceIsThrough = (sourceRefl as any)?.isThroughReflection?.() ?? false;
+      const sourceIsCollection = (sourceRefl as any)?.isCollection?.() ?? false;
+      if (sourceRefl && !sourceIsThrough && !sourceIsCollection) {
+        scope._whereClause = new WhereClause([
+          ...scope._whereClause.predicates,
+          ...whereClause.predicates,
+        ]);
+        const sourceName = sourceRefl.name;
+        const nestedJoins: any[] = reflScope?._namedInnerJoins ?? [];
+        const nestedLeftOuter: any[] = reflScope?._leftOuterJoinsValues ?? [];
         // Raw string / Arel-node joins the reflection scope carries in its own
-        // `_joinValues` bucket (`.joins("INNER JOIN …")` or `.joins(<Arel join>)`).
-        // Rails passes the scope's FULL `joins_values` — symbols AND raw
-        // strings / Arel nodes — to `joins!(source_reflection.name => joins)`
-        // (through_association.rb:132-134). See the nesting below for why a raw
-        // value there is not a silent carry but an error, matching Rails.
-        const nestedRawJoinValues: any[] = reflScopeVals?._joinValues ?? [];
-        const nestedTables = sourceRefl
-          ? this._resolveNestedTableNames(sourceRefl, [
-              ...nestedIncludes,
-              ...nestedJoins,
-              ...nestedLeftOuter,
-            ])
-          : [];
-        const allowed = [throughTable, sourceTable, ...nestedTables].filter(
-          (t): t is string => t != null,
-        );
-        // Rails' through_scope runs `joins!(source_reflection.name => values[:joins])`
-        // whenever the reflection where_clause is non-empty
-        // (through_association.rb:132-134). `values[:joins]` is the scope's FULL
-        // joins array — raw SQL strings and Arel join nodes included, not just
-        // symbol associations. `JoinDependency.walk_tree` symbolizes a raw string
-        // hash-value into a bogus association name and `find_reflection` raises
-        // `ActiveRecord::ConfigurationError` (confirmed against a live Rails
-        // console: a has_one-through whose scope uses `.joins("INNER JOIN …")`
-        // raises on preload). We mirror that verbatim: nest the scope's raw
-        // `_joinValues` under the source reflection name so the through-query
-        // build raises the SAME ConfigurationError our join builder already
-        // throws for `{source => [<raw string>]}` — rather than silently carrying
-        // an SQL join Rails itself rejects (which would be a new deviation, not a
-        // fidelity fix). Symbol-association joins live in `_namedInnerJoins` and
-        // are nested below without error — that is the only `joins` case Rails
-        // actually supports in this branch.
-        const whereNonEmpty = throughPredicates.length > 0 || sourcePredicates.length > 0;
-        if (sourceRefl && whereNonEmpty && nestedRawJoinValues.length > 0) {
-          scope = scope.joins({ [sourceRefl.name]: [...nestedRawJoinValues] });
+        // `_joinValues` bucket (`.joins("INNER JOIN …")` or `.joins(<Arel node>)`).
+        // Rails passes the scope's FULL `joins_values` — symbols AND raw strings
+        // / Arel nodes — to `joins!(source_reflection.name => joins)`
+        // (rb:132-134). `JoinDependency.walk_tree` symbolizes a raw string into a
+        // bogus association name and `find_reflection` raises
+        // `ActiveRecord::ConfigurationError` — real Rails raises on preload here,
+        // it does not silently carry the raw join. Nesting it under the source
+        // reflection name makes trails' join builder raise the same error.
+        const nestedRawJoinValues: any[] = reflScope?._joinValues ?? [];
+
+        // Rails `includes!(source_reflection.name)` + `references!(...)` promotes
+        // to a LEFT OUTER JOIN of the source reflection. `values[:includes]`
+        // (the reflection SCOPE's explicit `.includes`) is empty for the through
+        // scopes we support — trails' `_includesAssociations` bucket is polluted
+        // with derived inverse associations (e.g. the source's own inverse
+        // `tagging`), which would fan the through query out — so we do NOT carry
+        // it; the bare source join matches Rails' `includes!(source)`. A scope's
+        // explicit `.left_joins(source => nested)` lives in
+        // `_leftOuterJoinsValues` and IS nested so a deeper table its predicate
+        // qualifies is joined too (rb:120-138).
+        if (nestedLeftOuter.length > 0) {
+          scope = scope.leftOuterJoins({ [sourceName]: nestedLeftOuter });
+        } else {
+          scope = scope.leftOuterJoins(sourceName);
         }
-        const copyable = [...throughPredicates, ...sourcePredicates].filter(
-          (pred) => !predicateReferencesForeignTable(pred, allowed),
+
+        // joins!(source_reflection.name => joins): symbol-association joins are
+        // carried as an inner join; raw string / Arel joins raise as above.
+        if (nestedRawJoinValues.length > 0) {
+          scope = scope.joins({ [sourceName]: [...nestedRawJoinValues] });
+        }
+        if (nestedJoins.length > 0) {
+          scope = scope.joins({ [sourceName]: nestedJoins });
+        }
+
+        // Rails carries `order` only when `scope.eager_loading?` (rb:140). In
+        // this branch Rails always `includes!(source)` + `references!(...)`, so
+        // `eager_loading?` is true whenever the branch runs — our source join
+        // above is the analogue, so carry the order unconditionally here.
+        const orderClauses: any[] = reflScope?._orderClauses ?? [];
+        const rawOrderClauses: string[] = reflScope?._rawOrderClauses ?? [];
+        if (orderClauses.length > 0 || rawOrderClauses.length > 0) {
+          scope._orderClauses = [...scope._orderClauses, ...orderClauses];
+          scope._rawOrderClauses = [...scope._rawOrderClauses, ...rawOrderClauses];
+        }
+      } else if (sourceRefl) {
+        // Collection or nested source: the single-query JOIN cannot cover it
+        // (fan-out), so the source / sub-chain predicates ride the recursive
+        // source-preloader stages instead. But a THROUGH-table predicate the
+        // reflection scope carries (e.g. `miscPostFirstBlueTags_2`'s
+        // `posts.title IN (…)`, whose through reflection is `posts`) must still
+        // constrain which intermediate rows this through query selects — the
+        // recursion can't apply it because it filters the through table, not the
+        // source. So copy just the predicates that reference the through table,
+        // detected precisely from their Arel attributes (no raw-SQL text scan).
+        // Source / sub-chain predicates stay for the recursion.
+        const throughTable = throughKlass.tableName;
+        const throughPreds = whereClause.predicates.filter((p: any) =>
+          predicateReferencesTable(p, throughTable),
         );
-        if (copyable.length > 0) {
-          // Rails' branch unconditionally includes!/references! the source
-          // reflection whenever it copies the where_clause — the join is not
-          // gated on any predicate referencing the source table. Add it whenever
-          // we copy predicates so an UNQUALIFIED source condition (e.g.
-          // `where("name = ?")`) resolves against the joined source rather than
-          // binding to the through table. leftOuterJoins (not an inner join)
-          // mirrors Rails' LEFT OUTER JOIN: it never drops a through row for a
-          // null source, so a mixed OR predicate can still select a through row
-          // via its through-table arm while the WHERE filters the source arm.
-          if (sourceRefl) {
-            const sourceName = sourceRefl.name;
-            // Nest the scope's own joins/includes under the source reflection so
-            // the deeper tables their predicates qualify are joined onto the
-            // through query (Rails joins!/left_outer_joins!/includes!
-            // source_reflection.name => …). The nested left-outer form already
-            // joins the source, so only add the bare source join otherwise.
-            const nestedOuter = [...nestedLeftOuter, ...nestedIncludes];
-            if (nestedOuter.length > 0) {
-              scope = scope.leftOuterJoins({ [sourceName]: nestedOuter });
-            } else {
-              scope = scope.leftOuterJoins(sourceName);
-            }
-            // Rails nests the scope's symbol-association `joins_values` under the
-            // source reflection (through_association.rb:132-134); `_namedInnerJoins`
-            // holds exactly those. Raw string / Arel-node joins are handled above
-            // (they raise, matching Rails).
-            if (nestedJoins.length > 0) {
-              scope = scope.joins({ [sourceName]: nestedJoins });
-            }
-            // Rails also `references!(source_reflection.table_name)` so its
-            // `includes!(source)` promotes to a LEFT JOIN. We join the source
-            // explicitly above, so that step is already realized and no separate
-            // references pass is needed.
-            //
-            // Rails carries the scope's `order` only when `scope.eager_loading?`
-            // (through_association.rb:140). In that branch Rails ALWAYS
-            // `includes!(source)` and `references!(source.table_name)`, so
-            // `includes_values.any? && references_eager_loaded_tables?`
-            // (relation.rb:1238-1242) holds and `eager_loading?` is true
-            // whenever this where-copy branch runs — it does NOT depend on the
-            // reflection scope carrying its own nested `includes`. Our equivalent
-            // of that unconditional source include/reference is the source join
-            // added just above, so carry the order whenever we reach here (the
-            // enclosing `copyable.length > 0` guard is the analogue of the branch
-            // running), matching Rails for a `.leftJoins(:x).where(…).order(…)`
-            // scope that has no top-level `.includes`.
-            const orderClauses: any[] = reflScopeVals?._orderClauses ?? [];
-            const rawOrderClauses: string[] = reflScopeVals?._rawOrderClauses ?? [];
-            if (orderClauses.length > 0 || rawOrderClauses.length > 0) {
-              scope._orderClauses = [...scope._orderClauses, ...orderClauses];
-              scope._rawOrderClauses = [...scope._rawOrderClauses, ...rawOrderClauses];
-            }
-          }
-          scope._whereClause = new WhereClause([...scope._whereClause.predicates, ...copyable]);
+        if (throughPreds.length > 0) {
+          scope._whereClause = new WhereClause([...scope._whereClause.predicates, ...throughPreds]);
         }
       }
     }
 
     // cascade_strict_loading: a strict-loading preload scope propagates to the
-    // through query so intermediate records inherit the constraint
-    // (preloader/through_association.rb:145, Association#cascade_strict_loading).
+    // through query so intermediate records inherit the constraint (rb:145).
     return this._cascadeStrictLoading(scope);
-  }
-
-  /**
-   * Split this reflection's OWN scope's WHERE predicates by referenced table:
-   * those that reference the through table go onto the through query, the rest
-   * (source / target table, unqualified) stay on the source preloader. Mirrors
-   * the intent of Rails' `through_scope` `reflection_scope.where_clause` copy
-   * (preloader/through_association.rb:117) without the single-query JOIN.
-   *
-   * Draws from `_ownReflectionScope`, not the flattened chain scope: a
-   * nested-through source re-derives its own sub-chain's scope at its own
-   * recursive preload stage (Rails' `source_preloaders`), so this reflection
-   * only routes what it itself declares.
-   * @internal
-   */
-  private _partitionReflectionWhere(): {
-    throughPredicates: Nodes.Node[];
-    sourcePredicates: Nodes.Node[];
-    sourceScope: any;
-  } {
-    if (this._reflectionWherePartition !== undefined) return this._reflectionWherePartition;
-
-    const reflScope = this._ownReflectionScope();
-    let result: {
-      throughPredicates: Nodes.Node[];
-      sourcePredicates: Nodes.Node[];
-      sourceScope: any;
-    } = {
-      throughPredicates: [],
-      sourcePredicates: [],
-      sourceScope: reflScope,
-    };
-
-    const wc = reflScope?._whereClause;
-    const throughTable = this._throughTableName();
-    if (reflScope != null && wc != null && !wc.isEmpty()) {
-      const throughPredicates: Nodes.Node[] = [];
-      const sourcePredicates: Nodes.Node[] = [];
-      for (const pred of wc.predicates) {
-        if (throughTable != null && predicateReferencesTable(pred, throughTable))
-          throughPredicates.push(pred);
-        else sourcePredicates.push(pred);
-      }
-      // Only re-scope the source preloader when a through predicate is peeled off
-      // — otherwise leave the full reflection scope so the source stage keeps
-      // applying every (source-table) condition exactly as before.
-      let sourceScope = reflScope;
-      if (throughPredicates.length > 0) {
-        sourceScope = reflScope._clone();
-        sourceScope._whereClause = new WhereClause(sourcePredicates);
-      }
-      result = { throughPredicates, sourcePredicates, sourceScope };
-    }
-
-    this._reflectionWherePartition = result;
-    return result;
-  }
-
-  /**
-   * Resolve the table names an `AssociationSpec` list reaches from the source
-   * reflection's klass. Used to widen the has_one-through query's resolvable-table
-   * set with the tables the reflection scope joins via its own
-   * `.joins`/`.leftJoins`/`.includes`, so a predicate qualifying one of them can
-   * ride the through query (Rails' nested through_scope carry-over,
-   * through_association.rb:120-142). Resolution walks nested hash/array specs
-   * recursively: each level's key resolves against the current klass, and its
-   * value recurses against that association's klass, so a two-or-more-levels-deep
-   * table (e.g. `.joins({ category: :subcategory })` reaching `subcategories`)
-   * enters the resolvable set. Rails nests the whole spec under the source
-   * reflection name, realizing the deeper join on the through query. An
-   * unresolvable (e.g. polymorphic) association is skipped, leaving its predicate
-   * at the source-preloader stage.
-   * @internal
-   */
-  private _resolveNestedTableNames(sourceRefl: AssociationLikeReflection, specs: any[]): string[] {
-    let sourceKlass: typeof Base;
-    try {
-      sourceKlass = sourceRefl.klass;
-    } catch {
-      return [];
-    }
-    const tables: string[] = [];
-    const walk = (klass: typeof Base, spec: any): void => {
-      if (spec == null) return;
-      if (typeof spec === "string") {
-        this._collectNestedTable(klass, spec, tables);
-      } else if (Array.isArray(spec)) {
-        for (const s of spec) walk(klass, s);
-      } else if (typeof spec === "object") {
-        for (const key of Object.keys(spec)) {
-          const nextKlass = this._collectNestedTable(klass, key, tables);
-          if (nextKlass) walk(nextKlass, spec[key]);
-        }
-      }
-    };
-    for (const spec of specs) walk(sourceKlass, spec);
-    return tables;
-  }
-
-  /**
-   * Resolve `name` as an association on `klass`, push its table into `tables`,
-   * and return its klass so the caller can recurse into a deeper spec. Returns
-   * null for an unresolvable (e.g. polymorphic) association.
-   * @internal
-   */
-  private _collectNestedTable(
-    klass: typeof Base,
-    name: string,
-    tables: string[],
-  ): typeof Base | null {
-    try {
-      const r = (klass as any)._reflectOnAssociation?.(name);
-      const nextKlass = r?.klass;
-      const t = nextKlass?.tableName;
-      if (typeof t === "string") tables.push(t);
-      return (nextKlass as typeof Base) ?? null;
-    } catch {
-      /* polymorphic / unresolved association — leave predicate at source stage */
-      return null;
-    }
-  }
-
-  /**
-   * This reflection's OWN scope, excluding the source reflection's contribution.
-   *
-   * Branch passes `_reflectionScope` as the whole chain's flattened
-   * `join_scopes` (source_reflection.join_scopes + this reflection's own),
-   * merged. For a nested-through source that flattening carries the source
-   * sub-chain's own predicates (e.g. `first_blue_tags_2`'s
-   * `taggings.comment = 'first'`), which the recursive source preloader
-   * re-derives at its own stage — so this reflection must not also route them.
-   * We recompute the split by length: `join_scopes` returns
-   * `[...source_reflection.join_scopes, ...own]`, so the own scopes are the tail
-   * past the source reflection's own `join_scopes`. When the source is not a
-   * nested through, the tail is the entire scope, so `_reflectionScope` is
-   * returned unchanged (preserving instance-dependent scopes exactly).
-   * @internal
-   */
-  private _ownReflectionScope(): any {
-    const reflScope = this._reflectionScope ?? null;
-    if (reflScope == null) return null;
-
-    const sourceRefl = this._sourceReflection;
-    if (!sourceRefl || !(sourceRefl as any).isThroughReflection?.()) return reflScope;
-
-    let table: any;
-    let predicateBuilder: any;
-    try {
-      table = (this.klass as any).arelTable;
-      predicateBuilder = (this.klass as any).predicateBuilder;
-    } catch {
-      return reflScope;
-    }
-
-    let full: any[];
-    let sourceScopes: any[];
-    try {
-      full = (this.reflection as any).joinScopes?.(table, predicateBuilder, this.klass) ?? [];
-      sourceScopes = (sourceRefl as any).joinScopes?.(table, predicateBuilder, this.klass) ?? [];
-    } catch {
-      return reflScope;
-    }
-
-    const ownScopes = full.slice(sourceScopes.length);
-    if (ownScopes.length === 0) return null;
-    return ownScopes.reduce((acc: any, s: any) => acc.merge(s));
   }
 
   /** @internal */
@@ -747,17 +536,6 @@ export class ThroughAssociation extends Association {
     if (!throughRefl) return null;
     try {
       return (throughRefl.klass as any)?.tableName ?? null;
-    } catch {
-      return null;
-    }
-  }
-
-  /** @internal */
-  private _sourceTableName(): string | null {
-    const sourceRefl = this._sourceReflection;
-    if (!sourceRefl) return null;
-    try {
-      return (sourceRefl.klass as any)?.tableName ?? null;
     } catch {
       return null;
     }
@@ -806,8 +584,12 @@ export class ThroughAssociation extends Association {
 }
 
 /**
- * True when any attribute in `node` references `tableName`. Used to route a
- * reflection-scope predicate to either the through query or the source query.
+ * True when any Arel attribute in `node` references `tableName`. Used only for a
+ * NESTED through source (where the single-query JOIN can't be used) to copy the
+ * reflection scope's through-table predicates onto the through query. This is a
+ * precise Arel-attribute walk — NOT the raw-SQL text scan removed with this
+ * convergence — so a raw-string predicate carries no attributes and is left for
+ * the recursive source stage.
  * @internal
  */
 function predicateReferencesTable(node: any, tableName: string): boolean {
@@ -822,124 +604,7 @@ function predicateReferencesTable(node: any, tableName: string): boolean {
   if (!found && node instanceof Nodes.Not) {
     return predicateReferencesTable((node as any).expr, tableName);
   }
-  // Raw-SQL predicates (e.g. `where("memberships.favorite = ?", true)`) carry no
-  // Arel Attribute nodes, so `fetchAttribute` never visits them. Inspect the raw
-  // SQL text for a `<table>.` reference so a string condition on the through
-  // table is relocated to the through query just like a hash/Arel condition.
-  if (!found && rawSqlReferencesTable(node, tableName)) {
-    found = true;
-  }
   return found;
-}
-
-/**
- * True when a raw-SQL predicate node's text qualifies a column with `tableName.`.
- * Handles SqlLiteral / BoundSqlLiteral and a single Grouping wrapper.
- *
- * Not a SQL parse but a qualifier scan: string literals are stripped first (see
- * `stripSqlStringLiterals`) so a `<table>.` qualifier appearing inside a quoted
- * literal — e.g. `where("note = 'see memberships.x'")` — is NOT a false positive
- * and does not relocate a source-table predicate onto the through query.
- * Arel/hash predicates take the precise `fetchAttribute` path above and never
- * reach here.
- * @internal
- */
-function rawSqlReferencesTable(node: any, tableName: string): boolean {
-  if (node instanceof Nodes.Grouping) {
-    return rawSqlReferencesTable((node as any).expr, tableName);
-  }
-  let sql: string | undefined;
-  if (node instanceof Nodes.BoundSqlLiteral) sql = (node as any).sqlWithPlaceholders;
-  else if (node instanceof Nodes.SqlLiteral) sql = (node as any).value;
-  if (typeof sql !== "string") return false;
-  sql = stripSqlStringLiterals(sql);
-  const escaped = tableName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(^|[^\\w.])${escaped}\\.`).test(sql);
-}
-
-/**
- * Blank out single-quoted SQL string literals (keeping length via spaces) so a
- * `<table>.` qualifier scan does not match a table name embedded in literal
- * text. Both escape forms inside a literal are consumed: SQL-standard doubled
- * single-quotes (`''`) and a backslash-escaped quote (`\'`), the latter being
- * MySQL/MariaDB's default (`NO_BACKSLASH_ESCAPES` off) — so a literal like
- * `'don\'t touch memberships.x'` is fully blanked rather than terminating early
- * at the escaped quote. The `\\.` alternative pairs each backslash with its
- * following char, so an escaped backslash (`\\`) is consumed as one unit and a
- * real close-quote right after it (`'a\\'`) still closes the literal — a
- * subsequent genuine qualifier (`... 'a\\' AND posts.x ...`) stays exposed to
- * the scan and is NOT swallowed. `?` placeholders in a BoundSqlLiteral are
- * outside any literal and unaffected.
- *
- * Only single-quoted literals are tokenized; double-quoted identifiers are not
- * tracked. That leaves one narrow gap: two double-quoted identifiers each
- * containing a stray apostrophe (e.g. `"note's"`) can have their apostrophes
- * paired as a bogus literal, blanking a genuine qualifier between them. This
- * needs apostrophe-bearing quoted identifiers — pathological for canonical
- * table/column names — so it is left as an accepted limitation rather than
- * carrying a full SQL tokenizer here.
- * @internal
- */
-function stripSqlStringLiterals(sql: string): string {
-  // Not query construction — this blanks literals purely so the read-only
-  // qualifier scan below does not match a table name inside quoted text. The
-  // result is never executed as SQL.
-  // eslint-disable-next-line blazetrails/no-raw-sql
-  return sql.replace(/'(?:[^'\\]|''|\\.)*'/g, (lit) => " ".repeat(lit.length));
-}
-
-/**
- * True when `node` qualifies a column with some table NOT in `allowedTables`.
- * Used to decide whether a reflection-scope predicate can ride the has_one-through
- * query, which selects the through table and joins the immediate source: a
- * predicate qualifying only those (or unqualified) is safe (return false), but one
- * reaching a further nested table the through query never joins is not (true).
- *
- * Uses the same Arel `fetchAttribute` walk as `predicateReferencesTable` for
- * precise hash/Arel conditions, and the same raw-SQL qualifier scan as
- * `rawSqlReferencesTable` — string literals are stripped first, then every
- * `<word>.` qualifier is extracted and any not in `allowedTables` is flagged. A
- * `<table>.` qualifier inside a quoted literal is not a false positive; hash
- * predicates take the exact Arel path.
- * @internal
- */
-function predicateReferencesForeignTable(node: any, allowedTables: string[]): boolean {
-  const allowed = new Set(allowedTables);
-  let foreign = false;
-  node.fetchAttribute?.((attr: any) => {
-    if (attr instanceof Nodes.Attribute && !allowed.has(relationName(attr.relation.name))) {
-      foreign = true;
-      return false;
-    }
-    return true;
-  });
-  if (foreign) return true;
-  if (node instanceof Nodes.Not) {
-    return predicateReferencesForeignTable((node as any).expr, allowedTables);
-  }
-  return rawSqlReferencesForeignTable(node, allowed);
-}
-
-/**
- * True when a raw-SQL predicate node's text qualifies a column with any table
- * not in `allowed`. Mirrors `rawSqlReferencesTable`'s node unwrapping.
- * @internal
- */
-function rawSqlReferencesForeignTable(node: any, allowed: Set<string>): boolean {
-  if (node instanceof Nodes.Grouping) {
-    return rawSqlReferencesForeignTable((node as any).expr, allowed);
-  }
-  let sql: string | undefined;
-  if (node instanceof Nodes.BoundSqlLiteral) sql = (node as any).sqlWithPlaceholders;
-  else if (node instanceof Nodes.SqlLiteral) sql = (node as any).value;
-  if (typeof sql !== "string") return false;
-  sql = stripSqlStringLiterals(sql);
-  const qualifierRe = /(^|[^\w.])(\w+)\s*\./g;
-  let match: RegExpExecArray | null;
-  while ((match = qualifierRe.exec(sql)) !== null) {
-    if (!allowed.has(match[2])) return true;
-  }
-  return false;
 }
 
 /** @internal */

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -57,6 +57,17 @@ registerModel(Comment);
   scope: (rel: any) => rel.where({ posts: { title: "Welcome to the weblog" } }),
 });
 
+// Same, but the through-table condition is RAW SQL. Rails' `through_scope`
+// assigns the full `reflection_scope.where_clause` before the source join, so a
+// raw through-table predicate must be copied onto the through query too (not
+// left on the source query, where `posts` is not joined — an invalid predicate).
+(Author as any).hasMany("commentsWithRawThroughCondition", {
+  className: "Comment",
+  through: "posts",
+  source: "comments",
+  scope: (rel: any) => rel.where("posts.title = 'Welcome to the weblog'"),
+});
+
 describe("Preloader::ThroughAssociation#through_scope", () => {
   const { authors, posts } = fixtures(["authors", "authorAddresses", "posts", "comments"]);
 
@@ -101,6 +112,15 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     const sql = scope.toSql();
     // The through-table predicate constrains the intermediate (posts) rows.
     expect(sql).toContain("Welcome to the weblog");
+  });
+
+  it("copies a raw-SQL through-table condition onto the through query for a collection source", () => {
+    const david = authors("david");
+    const loader = throughLoader([david], "commentsWithRawThroughCondition");
+    const scope = (loader as any)._buildThroughScope();
+    // Raw through-table predicate rides the through query (Rails' full
+    // where_clause assignment), not the source query where `posts` is unjoined.
+    expect(scope.toSql()).toContain("posts.title");
   });
 
   it("cascades strict loading from the preload scope onto the through query", async () => {

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -68,6 +68,18 @@ registerModel(Comment);
   scope: (rel: any) => rel.where("posts.title = 'Welcome to the weblog'"),
 });
 
+// A MIXED predicate referencing both the through table (`posts`) and the source
+// table (`comments`) in one node. The two-step through query joins neither the
+// source nor anything else, so this predicate is NOT through-table-only and must
+// stay whole on the source scope — not be split off / copied onto the through
+// query where `comments` is unjoined.
+(Author as any).hasMany("commentsWithMixedCondition", {
+  className: "Comment",
+  through: "posts",
+  source: "comments",
+  scope: (rel: any) => rel.where("posts.title = 'Welcome to the weblog' OR comments.body = 'x'"),
+});
+
 describe("Preloader::ThroughAssociation#through_scope", () => {
   const { authors, posts } = fixtures(["authors", "authorAddresses", "posts", "comments"]);
 
@@ -121,6 +133,16 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     // Raw through-table predicate rides the through query (Rails' full
     // where_clause assignment), not the source query where `posts` is unjoined.
     expect(scope.toSql()).toContain("posts.title");
+  });
+
+  it("does not copy a mixed through+source predicate onto the through query", () => {
+    const david = authors("david");
+    const loader = throughLoader([david], "commentsWithMixedCondition");
+    const scope = (loader as any)._buildThroughScope();
+    // The predicate references both `posts` (through) and `comments` (source) in
+    // one node. The through query can't resolve `comments`, so the whole node
+    // stays on the source scope — nothing from it is copied here.
+    expect(scope.toSql()).not.toContain("posts.title");
   });
 
   it("cascades strict loading from the preload scope onto the through query", async () => {

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -1,18 +1,17 @@
 /**
  * Preloader::ThroughAssociation#through_scope fidelity.
  *
- * Pins the parts of Rails' `through_scope`
- * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb)
- * that our preloader can honour without the single-query JOIN strategy:
+ * Pins Rails' `through_scope`
+ * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb):
  *
  *   - `annotate(...)` on the through reflection's own scope is carried onto
- *     the through (intermediate) query rather than being silently dropped.
+ *     the through (intermediate) query.
  *   - a strict-loading preload scope cascades to the through query.
- *
- * The `where_clause`/`includes`/`joins` JOIN branch of `through_scope` is a
- * single-query strategy; our preloader applies target-table conditions at the
- * source-preloader stage instead, so that branch is exercised by the
- * join-based eager-loading tests, not here.
+ *   - the `elsif !reflection_scope.where_clause.empty?` branch copies the FULL
+ *     reflection-scope `where_clause` onto the through query and JOINs the
+ *     source reflection, so every referenced column resolves in ONE query. A
+ *     source-table condition is therefore carried onto the through query (with
+ *     the source JOIN) rather than being deferred to the source-preloader stage.
  */
 import { describe, it, expect } from "vitest";
 import { registerModel } from "../index.js";
@@ -36,49 +35,26 @@ registerModel(Comment);
   scope: (rel: any) => rel.annotate("preload-through"),
 });
 
-// A raw-SQL source-table condition whose text embeds the THROUGH table name
-// (`posts.`) inside a string literal. The through table is `posts`; a naive
-// text scan for a `posts.` qualifier would relocate this source predicate onto
-// the through query (a false positive), so this pins that string literals are
-// stripped before the qualifier scan.
-(Author as any).hasMany("commentsWithLiteralThroughRef", {
+// A source-table (`comments.`) condition on a has_many-through (collection
+// source). The single-query JOIN can't cover a collection source (it fans the
+// through rows out), so trails keeps the two-step: the source condition is
+// applied at the source-preloader stage, NOT copied onto the through query.
+(Author as any).hasMany("commentsWithSourceCondition", {
   className: "Comment",
   through: "posts",
   source: "comments",
-  scope: (rel: any) => rel.where("comments.body = 'mention posts.title here'"),
+  scope: (rel: any) => rel.where("comments.body = 'first comment'"),
 });
 
-// Same false-positive class but with a BACKSLASH-escaped quote inside the
-// literal (`\'`) — MySQL/MariaDB's default escaping. A regex that only knows
-// `''` escaping would terminate the literal early at the backslash-escaped
-// quote and leave `posts.` exposed to the scan.
-(Author as any).hasMany("commentsWithBackslashLiteralThroughRef", {
+// A through-table (`posts.title`) condition expressed as a hash so its Arel
+// attribute is precisely detected. For a collection-source two-step, the
+// through-table predicate is copied onto the through query to constrain which
+// intermediate rows are selected.
+(Author as any).hasMany("commentsWithThroughCondition", {
   className: "Comment",
   through: "posts",
   source: "comments",
-  scope: (rel: any) => rel.where("comments.body = 'don\\'t touch posts.title here'"),
-});
-
-// A literal ending in an escaped backslash (`'a\\'`, i.e. the string value `a\`)
-// immediately followed by a GENUINE through-table qualifier in the same raw-SQL
-// string. The `\\.` escape-pairing must consume `\\` as one unit and let the
-// quote close, so `posts.title` after it is still seen and relocated — pins that
-// the escaped-backslash-then-close-quote case is NOT over-swallowed.
-(Author as any).hasMany("commentsWithEscapedBackslashThenQualifier", {
-  className: "Comment",
-  through: "posts",
-  source: "comments",
-  scope: (rel: any) => rel.where("comments.body = 'a\\\\' AND posts.title = 'x'"),
-});
-
-// Positive control: a GENUINE through-table (`posts.`) qualifier — unquoted, a
-// real column reference — must still be relocated onto the through query. Pins
-// that stripping string literals does not break the true-positive path.
-(Author as any).hasMany("commentsWithRealThroughRef", {
-  className: "Comment",
-  through: "posts",
-  source: "comments",
-  scope: (rel: any) => rel.where("posts.title = 'welcome'"),
+  scope: (rel: any) => rel.where({ posts: { title: "Welcome to the weblog" } }),
 });
 
 describe("Preloader::ThroughAssociation#through_scope", () => {
@@ -107,54 +83,24 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     expect(comments.length).toBeGreaterThan(0);
   });
 
-  it("does not relocate a source predicate whose string literal embeds the through table name", () => {
+  it("keeps a source-table condition on a collection source at the source stage, not the through query", () => {
     const david = authors("david");
-    const loader = throughLoader([david], "commentsWithLiteralThroughRef");
-    const partition = (loader as any)._partitionReflectionWhere();
-    // The `posts.` token lives inside a string literal, so the predicate is a
-    // source-table condition and must stay on the source preloader.
-    expect(partition.throughPredicates).toHaveLength(0);
-    expect(partition.sourcePredicates).toHaveLength(1);
-
-    // And the through query must not carry the source predicate.
+    const loader = throughLoader([david], "commentsWithSourceCondition");
+    // Collection source (has_many comments): the two-step keeps the through
+    // query free of the source condition (it would fan the through rows out).
     const scope = (loader as any)._buildThroughScope();
-    expect(scope.toSql()).not.toContain("mention posts.title here");
+    const sql = scope.toSql();
+    expect(sql).not.toContain("first comment");
+    expect(sql).not.toMatch(/JOIN/);
   });
 
-  it("does not relocate when a backslash-escaped-quote literal embeds the through table name", () => {
+  it("copies a through-table condition onto the through query for a collection source", () => {
     const david = authors("david");
-    const loader = throughLoader([david], "commentsWithBackslashLiteralThroughRef");
-    const partition = (loader as any)._partitionReflectionWhere();
-    expect(partition.throughPredicates).toHaveLength(0);
-    expect(partition.sourcePredicates).toHaveLength(1);
-
+    const loader = throughLoader([david], "commentsWithThroughCondition");
     const scope = (loader as any)._buildThroughScope();
-    expect(scope.toSql()).not.toContain("posts.title");
-  });
-
-  it("still sees a genuine qualifier after an escaped-backslash literal", () => {
-    const david = authors("david");
-    const loader = throughLoader([david], "commentsWithEscapedBackslashThenQualifier");
-    const partition = (loader as any)._partitionReflectionWhere();
-    // The `'a\\'` literal closes correctly, so the trailing `posts.title` is a
-    // real through-table qualifier and the predicate relocates.
-    expect(partition.throughPredicates).toHaveLength(1);
-    expect(partition.sourcePredicates).toHaveLength(0);
-
-    const scope = (loader as any)._buildThroughScope();
-    expect(scope.toSql()).toContain("posts.title");
-  });
-
-  it("relocates a genuine through-table qualifier onto the through query", () => {
-    const david = authors("david");
-    const loader = throughLoader([david], "commentsWithRealThroughRef");
-    const partition = (loader as any)._partitionReflectionWhere();
-    // `posts.title` is a real column reference on the through table.
-    expect(partition.throughPredicates).toHaveLength(1);
-    expect(partition.sourcePredicates).toHaveLength(0);
-
-    const scope = (loader as any)._buildThroughScope();
-    expect(scope.toSql()).toContain("posts.title");
+    const sql = scope.toSql();
+    // The through-table predicate constrains the intermediate (posts) rows.
+    expect(sql).toContain("Welcome to the weblog");
   });
 
   it("cascades strict loading from the preload scope onto the through query", async () => {


### PR DESCRIPTION
## Summary

Converge trails' through-association preloader to Rails'
`Preloader::ThroughAssociation#through_scope` single-query JOIN strategy and
delete the SQL text-scan attribution apparatus (the string-literal heuristic
PR #4700 hardened).

Rails copies the reflection scope's whole `where_clause` onto the through query
and JOINs the source reflection, so every referenced column — through-table,
source-table, or a scope-joined nested table — resolves in one query with no
per-predicate table attribution. trails deviated with a two-step preload that
had to attribute each predicate to a query by scanning SQL text.

## Changes

- `_buildThroughScope` copies the full reflection `where_clause` and JOINs the
  source reflection for a **to-one, non-through** source, carrying the
  `eager_loading?` structure Rails applies (nested left_outer_joins / symbol
  joins, order, annotate, source_type, cascade_strict_loading).
- Deleted `_partitionReflectionWhere`, `predicateReferencesForeignTable`,
  `rawSqlReferencesTable`, `rawSqlReferencesForeignTable`, `stripSqlStringLiterals`,
  `_resolveNestedTableNames`, and `_ownReflectionScope`.
- A **collection** (has_many) source or a **nested** (through) source would fan
  the through rows out if JOINed onto the through query (trails collects raw
  rows; Rails' eager-load JoinDependency dedups by PK). Those keep the two-step:
  only the reflection scope's through-table predicates — detected precisely from
  their Arel attributes, **not** a raw-SQL text scan — are copied onto the
  through query; source/sub-chain predicates and order ride the recursive
  source-preloader stage. `disable_joins` and polymorphic `source_type` keep
  their existing special-cased paths.

A single small Arel-only `predicateReferencesTable` remains for the through-table
predicate copy the JOIN genuinely cannot cover.

## Tests

All association + preloader suites pass, including the four `favoriteClub`
eager-STI-through tests, `through-association-scope`, `has-one/has-many/nested
-through`, the eager suites, and the disable-joins suites. The
`through-association-scope` tests (trails-specific, pinned the deleted #4700
heuristic) are updated to pin the converged behavior; canonical/Rails-mirrored
test names are unchanged.

## Notes

Net −386 LOC (mostly deletion of the attribution helpers); the change is one
cohesive edit to a single file plus its sibling test and can't be split without
stacking, so it exceeds the 500-LOC guide as the story anticipated.

Closes-story: converge-through-preload-single-query-join


---

## Known limitation (follow-up story registered)

For a **collection** (has_many) or **nested** (through) source/target, trails
keeps the two-step (it can't take the single-query JOIN without Rails'
PK-deduping eager `JoinDependency`). A reflection-scope predicate that references
**both** the through table and a source/other table in one node — e.g.
`where("posts.title = ? OR categorizations.author_id = ?")` — has no valid
placement in the two-step (neither query has both tables present) and fails with
`no such column`.

This is a **pre-existing limitation, not a regression**: on `main`,
`_partitionReflectionWhere` copied such a predicate onto the through query, which
equally lacks the source table → the same `no such column`. No canonical model
exercises it. The predicate classification in this PR (`predicateIsThroughOnly`)
is the least-wrong two-step behavior — it keeps the node intact on one side
rather than fragmenting it.

The Rails-faithful fix (eager-load the source onto the through query for
collection/nested + PK-deduplicate the through records, then delete the
classification helpers entirely) is a substantial change to the shared
middle-record flow, tracked as follow-up story
`converge-through-preload-collection-single-query-dedup` under RFC 0054.
