### PR TITLE
test(savepoints): mysql2/PG reconnect-mid-savepoint parent-dirty live-adapter tests

### DIFF
--- a/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
@@ -1,0 +1,78 @@
+/**
+ * trails-only live-adapter coverage with no Rails counterpart: a savepoint
+ * statement that reconnects mid-flight through `withRawConnection`'s
+ * retry/reconnect loop still dirties the popped frame's real PARENT, so
+ * `transactionManager.isRestorable()` becomes false.
+ *
+ * PR #4732 converged the mysql2/PG/sqlite savepoint statements onto Rails'
+ * default `materialize_transactions: true` and relocated Rails'
+ * `with_raw_connection` `ensure dirty_current_transaction if
+ * materialize_transactions` (abstract_adapter.rb:1046) into each adapter's
+ * `internalExecute` finally. Its regression test runs on sqlite, which has no
+ * reconnect loop; this file exercises the genuine reconnect path that only the
+ * live mysql2/PG adapters have. Kept in a `.trails` file so test:compare maps
+ * cleanly (no such Rails test exists).
+ */
+import { it, expect, beforeEach, afterEach, vi } from "vitest";
+import {
+  describeIfMysql,
+  Mysql2Adapter,
+  MYSQL_TEST_URL,
+} from "../abstract-mysql-adapter/test-helper.js";
+import { ConnectionFailed } from "../../errors.js";
+
+// The retry-loop seams `withRawConnection` drives are not on the public adapter
+// surface; narrow to just the two the fault injection needs.
+interface RetryLoopSeams {
+  reconnect(): void | Promise<void>;
+  rawConnectionForBlock(): Promise<unknown>;
+}
+
+// The savepoint statement is issued through the retry-enabled `internalExecute`
+// leaf (allowRetry:true) so `withRawConnection`'s reconnect loop actually
+// engages — `createSavepoint`/`rollbackToSavepoint` pass allowRetry:false, but
+// they share the exact same `internalExecute` finally under test here.
+describeIfMysql("Mysql2Adapter savepoint reconnect dirties parent (trails)", () => {
+  let adapter: Mysql2Adapter;
+
+  beforeEach(() => {
+    adapter = new Mysql2Adapter(MYSQL_TEST_URL);
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await adapter.close();
+  });
+
+  it("a savepoint reconnecting mid-flight dirties the parent; a materialize:false op does not", async () => {
+    const tm = adapter.transactionManager;
+    await tm.withinNewTransaction({}, async () => {
+      await tm.materializeTransactions();
+      expect(tm.isRestorable()).toBe(true);
+
+      // Fault the FIRST raw connection acquisition per savepoint op with a
+      // retryable ConnectionFailed, so `withRawConnection` reconnects
+      // (restoring the still-clean outer BEGIN) and retries the SAVEPOINT.
+      const seams = adapter as unknown as RetryLoopSeams;
+      const reconnect = vi.spyOn(seams, "reconnect");
+      const rawForBlock = vi
+        .spyOn(seams, "rawConnectionForBlock")
+        .mockRejectedValueOnce(new ConnectionFailed("Lost connection to MySQL server"));
+
+      // materialize:false — the withRawConnection loop's own (suppressed) finally
+      // must NOT dirty the parent on the reconnect path.
+      await adapter.internalExecute("SAVEPOINT `sp_clean`", "TRANSACTION", {
+        materializeTransactions: false,
+        allowRetry: true,
+      });
+      expect(reconnect).toHaveBeenCalledTimes(1);
+      expect(tm.isRestorable()).toBe(true);
+
+      // materialize:true (the savepoint default) — the relocated internalExecute
+      // finally dirties the parent on the very same reconnect path.
+      rawForBlock.mockRejectedValueOnce(new ConnectionFailed("Lost connection to MySQL server"));
+      await adapter.internalExecute("SAVEPOINT `sp_dirty`", "TRANSACTION", { allowRetry: true });
+      expect(reconnect).toHaveBeenCalledTimes(2);
+      expect(tm.isRestorable()).toBe(false);
+    });
+  });
+});

--- a/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/savepoint-reconnect.trails.test.ts
@@ -1,17 +1,17 @@
 /**
  * trails-only live-adapter coverage with no Rails counterpart: a savepoint
- * statement that reconnects mid-flight through `withRawConnection`'s
- * retry/reconnect loop still dirties the popped frame's real PARENT, so
- * `transactionManager.isRestorable()` becomes false.
+ * statement dirties the popped frame's real PARENT, so
+ * `transactionManager.isRestorable()` becomes false — on the success path, on
+ * the error path, and (only the live mysql2/PG adapters have this) when
+ * `withRawConnection`'s retry loop genuinely reconnects mid-flight.
  *
  * PR #4732 converged the mysql2/PG/sqlite savepoint statements onto Rails'
  * default `materialize_transactions: true` and relocated Rails'
  * `with_raw_connection` `ensure dirty_current_transaction if
  * materialize_transactions` (abstract_adapter.rb:1046) into each adapter's
  * `internalExecute` finally. Its regression test runs on sqlite, which has no
- * reconnect loop; this file exercises the genuine reconnect path that only the
- * live mysql2/PG adapters have. Kept in a `.trails` file so test:compare maps
- * cleanly (no such Rails test exists).
+ * reconnect loop; this file exercises the live-adapter reconnect path. Kept in
+ * a `.trails` file so test:compare maps cleanly (no such Rails test exists).
  */
 import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import {
@@ -28,11 +28,7 @@ interface RetryLoopSeams {
   rawConnectionForBlock(): Promise<unknown>;
 }
 
-// The savepoint statement is issued through the retry-enabled `internalExecute`
-// leaf (allowRetry:true) so `withRawConnection`'s reconnect loop actually
-// engages — `createSavepoint`/`rollbackToSavepoint` pass allowRetry:false, but
-// they share the exact same `internalExecute` finally under test here.
-describeIfMysql("Mysql2Adapter savepoint reconnect dirties parent (trails)", () => {
+describeIfMysql("Mysql2Adapter savepoint statements dirty the parent (trails)", () => {
   let adapter: Mysql2Adapter;
 
   beforeEach(() => {
@@ -43,15 +39,50 @@ describeIfMysql("Mysql2Adapter savepoint reconnect dirties parent (trails)", () 
     await adapter.close();
   });
 
+  it("createSavepoint dirties the current (parent) transaction frame", async () => {
+    const tm = adapter.transactionManager;
+    await tm.withinNewTransaction({}, async () => {
+      // BEGIN is emitted with materializeTransactions:false, so the frame is
+      // materialized but clean.
+      await tm.materializeTransactions();
+      expect(tm.isRestorable()).toBe(true);
+      await adapter.createSavepoint("sp1");
+      expect(tm.isRestorable()).toBe(false);
+    });
+  });
+
+  it("a savepoint statement failing mid-flight still dirties the parent (ensure fires on the error path)", async () => {
+    const tm = adapter.transactionManager;
+    await tm.withinNewTransaction({}, async () => {
+      await tm.materializeTransactions();
+      expect(tm.isRestorable()).toBe(true);
+      // rollbackToSavepoint passes allowRetry:false, so a mid-flight
+      // ConnectionFailed is not retried — it propagates. internalExecute's
+      // finally must still dirty the parent, mirroring Rails' `ensure` on raise.
+      const seams = adapter as unknown as RetryLoopSeams;
+      vi.spyOn(seams, "rawConnectionForBlock").mockRejectedValueOnce(
+        new ConnectionFailed("Lost connection to MySQL server"),
+      );
+      await expect(adapter.rollbackToSavepoint("sp_x")).rejects.toBeInstanceOf(ConnectionFailed);
+      expect(tm.isRestorable()).toBe(false);
+    });
+  });
+
+  // The savepoint statement is issued through the retry-enabled `internalExecute`
+  // leaf (allowRetry:true) so `withRawConnection`'s reconnect loop actually
+  // engages — createSavepoint/rollbackToSavepoint pass allowRetry:false, but they
+  // share the exact same `internalExecute` finally under test here. A SAVEPOINT
+  // (not RELEASE/ROLLBACK) is retried because the outer BEGIN is still clean, so
+  // reconnect restores it and the retry lands on a live transaction.
   it("a savepoint reconnecting mid-flight dirties the parent; a materialize:false op does not", async () => {
     const tm = adapter.transactionManager;
     await tm.withinNewTransaction({}, async () => {
       await tm.materializeTransactions();
       expect(tm.isRestorable()).toBe(true);
 
-      // Fault the FIRST raw connection acquisition per savepoint op with a
-      // retryable ConnectionFailed, so `withRawConnection` reconnects
-      // (restoring the still-clean outer BEGIN) and retries the SAVEPOINT.
+      // Fault the first raw connection acquisition per op with a retryable
+      // ConnectionFailed, so `withRawConnection` reconnects (restoring the
+      // still-clean outer BEGIN) and retries the SAVEPOINT.
       const seams = adapter as unknown as RetryLoopSeams;
       const reconnect = vi.spyOn(seams, "reconnect");
       const rawForBlock = vi

--- a/packages/activerecord/src/adapters/postgresql/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/savepoint-reconnect.trails.test.ts
@@ -1,0 +1,76 @@
+/**
+ * trails-only live-adapter coverage with no Rails counterpart: a savepoint
+ * statement that reconnects mid-flight through `withRawConnection`'s
+ * retry/reconnect loop still dirties the popped frame's real PARENT, so
+ * `transactionManager.isRestorable()` becomes false.
+ *
+ * PR #4732 converged the mysql2/PG/sqlite savepoint statements onto Rails'
+ * default `materialize_transactions: true` and relocated Rails'
+ * `with_raw_connection` `ensure dirty_current_transaction if
+ * materialize_transactions` (abstract_adapter.rb:1046) into each adapter's
+ * `internalExecute` finally. Its regression test runs on sqlite, which has no
+ * reconnect loop; this file exercises the genuine reconnect path that only the
+ * live mysql2/PG adapters have. Kept in a `.trails` file so test:compare maps
+ * cleanly (no such Rails test exists).
+ */
+import { it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
+import { ConnectionFailed } from "../../errors.js";
+
+// The retry-loop seams `withRawConnection` drives are not on the public adapter
+// surface; narrow to just the two the fault injection needs.
+interface RetryLoopSeams {
+  reconnect(): void | Promise<void>;
+  rawConnectionForBlock(): Promise<unknown>;
+}
+
+// The savepoint statement is issued through the retry-enabled `internalExecute`
+// leaf (allowRetry:true) so `withRawConnection`'s reconnect loop actually
+// engages — `createSavepoint`/`rollbackToSavepoint` pass allowRetry:false, but
+// they share the exact same `internalExecute` finally under test here.
+describeIfPg("PostgreSQLAdapter savepoint reconnect dirties parent (trails)", () => {
+  let adapter: PostgreSQLAdapter;
+
+  beforeEach(() => {
+    adapter = new PostgreSQLAdapter(PG_TEST_URL);
+  });
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    await adapter.close();
+  });
+
+  it("a savepoint reconnecting mid-flight dirties the parent; a materialize:false op does not", async () => {
+    const tm = adapter.transactionManager;
+    await tm.withinNewTransaction({}, async () => {
+      await tm.materializeTransactions();
+      expect(tm.isRestorable()).toBe(true);
+
+      // Fault the FIRST raw connection acquisition per savepoint op with a
+      // retryable ConnectionFailed, so `withRawConnection` reconnects
+      // (restoring the still-clean outer BEGIN) and retries the SAVEPOINT.
+      const seams = adapter as unknown as RetryLoopSeams;
+      const reconnect = vi.spyOn(seams, "reconnect");
+      const rawForBlock = vi
+        .spyOn(seams, "rawConnectionForBlock")
+        .mockRejectedValueOnce(new ConnectionFailed("server closed the connection unexpectedly"));
+
+      // materialize:false — the withRawConnection loop's own (suppressed) finally
+      // must NOT dirty the parent on the reconnect path.
+      await adapter.internalExecute('SAVEPOINT "sp_clean"', "TRANSACTION", {
+        materializeTransactions: false,
+        allowRetry: true,
+      });
+      expect(reconnect).toHaveBeenCalledTimes(1);
+      expect(tm.isRestorable()).toBe(true);
+
+      // materialize:true (the savepoint default) — the relocated internalExecute
+      // finally dirties the parent on the very same reconnect path.
+      rawForBlock.mockRejectedValueOnce(
+        new ConnectionFailed("server closed the connection unexpectedly"),
+      );
+      await adapter.internalExecute('SAVEPOINT "sp_dirty"', "TRANSACTION", { allowRetry: true });
+      expect(reconnect).toHaveBeenCalledTimes(2);
+      expect(tm.isRestorable()).toBe(false);
+    });
+  });
+});

--- a/packages/activerecord/src/adapters/postgresql/savepoint-reconnect.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/savepoint-reconnect.trails.test.ts
@@ -1,17 +1,17 @@
 /**
  * trails-only live-adapter coverage with no Rails counterpart: a savepoint
- * statement that reconnects mid-flight through `withRawConnection`'s
- * retry/reconnect loop still dirties the popped frame's real PARENT, so
- * `transactionManager.isRestorable()` becomes false.
+ * statement dirties the popped frame's real PARENT, so
+ * `transactionManager.isRestorable()` becomes false — on the success path, on
+ * the error path, and (only the live mysql2/PG adapters have this) when
+ * `withRawConnection`'s retry loop genuinely reconnects mid-flight.
  *
  * PR #4732 converged the mysql2/PG/sqlite savepoint statements onto Rails'
  * default `materialize_transactions: true` and relocated Rails'
  * `with_raw_connection` `ensure dirty_current_transaction if
  * materialize_transactions` (abstract_adapter.rb:1046) into each adapter's
  * `internalExecute` finally. Its regression test runs on sqlite, which has no
- * reconnect loop; this file exercises the genuine reconnect path that only the
- * live mysql2/PG adapters have. Kept in a `.trails` file so test:compare maps
- * cleanly (no such Rails test exists).
+ * reconnect loop; this file exercises the live-adapter reconnect path. Kept in
+ * a `.trails` file so test:compare maps cleanly (no such Rails test exists).
  */
 import { it, expect, beforeEach, afterEach, vi } from "vitest";
 import { describeIfPg, PostgreSQLAdapter, PG_TEST_URL } from "./test-helper.js";
@@ -24,11 +24,7 @@ interface RetryLoopSeams {
   rawConnectionForBlock(): Promise<unknown>;
 }
 
-// The savepoint statement is issued through the retry-enabled `internalExecute`
-// leaf (allowRetry:true) so `withRawConnection`'s reconnect loop actually
-// engages — `createSavepoint`/`rollbackToSavepoint` pass allowRetry:false, but
-// they share the exact same `internalExecute` finally under test here.
-describeIfPg("PostgreSQLAdapter savepoint reconnect dirties parent (trails)", () => {
+describeIfPg("PostgreSQLAdapter savepoint statements dirty the parent (trails)", () => {
   let adapter: PostgreSQLAdapter;
 
   beforeEach(() => {
@@ -39,15 +35,50 @@ describeIfPg("PostgreSQLAdapter savepoint reconnect dirties parent (trails)", ()
     await adapter.close();
   });
 
+  it("createSavepoint dirties the current (parent) transaction frame", async () => {
+    const tm = adapter.transactionManager;
+    await tm.withinNewTransaction({}, async () => {
+      // BEGIN is emitted with materializeTransactions:false, so the frame is
+      // materialized but clean.
+      await tm.materializeTransactions();
+      expect(tm.isRestorable()).toBe(true);
+      await adapter.createSavepoint("sp1");
+      expect(tm.isRestorable()).toBe(false);
+    });
+  });
+
+  it("a savepoint statement failing mid-flight still dirties the parent (ensure fires on the error path)", async () => {
+    const tm = adapter.transactionManager;
+    await tm.withinNewTransaction({}, async () => {
+      await tm.materializeTransactions();
+      expect(tm.isRestorable()).toBe(true);
+      // rollbackToSavepoint passes allowRetry:false, so a mid-flight
+      // ConnectionFailed is not retried — it propagates. internalExecute's
+      // finally must still dirty the parent, mirroring Rails' `ensure` on raise.
+      const seams = adapter as unknown as RetryLoopSeams;
+      vi.spyOn(seams, "rawConnectionForBlock").mockRejectedValueOnce(
+        new ConnectionFailed("server closed the connection unexpectedly"),
+      );
+      await expect(adapter.rollbackToSavepoint("sp_x")).rejects.toBeInstanceOf(ConnectionFailed);
+      expect(tm.isRestorable()).toBe(false);
+    });
+  });
+
+  // The savepoint statement is issued through the retry-enabled `internalExecute`
+  // leaf (allowRetry:true) so `withRawConnection`'s reconnect loop actually
+  // engages — createSavepoint/rollbackToSavepoint pass allowRetry:false, but they
+  // share the exact same `internalExecute` finally under test here. A SAVEPOINT
+  // (not RELEASE/ROLLBACK) is retried because the outer BEGIN is still clean, so
+  // reconnect restores it and the retry lands on a live transaction.
   it("a savepoint reconnecting mid-flight dirties the parent; a materialize:false op does not", async () => {
     const tm = adapter.transactionManager;
     await tm.withinNewTransaction({}, async () => {
       await tm.materializeTransactions();
       expect(tm.isRestorable()).toBe(true);
 
-      // Fault the FIRST raw connection acquisition per savepoint op with a
-      // retryable ConnectionFailed, so `withRawConnection` reconnects
-      // (restoring the still-clean outer BEGIN) and retries the SAVEPOINT.
+      // Fault the first raw connection acquisition per op with a retryable
+      // ConnectionFailed, so `withRawConnection` reconnects (restoring the
+      // still-clean outer BEGIN) and retries the SAVEPOINT.
       const seams = adapter as unknown as RetryLoopSeams;
       const reconnect = vi.spyOn(seams, "reconnect");
       const rawForBlock = vi


### PR DESCRIPTION
## What

Follow-up to #4732, which converged the mysql2/PG/sqlite savepoint statements
onto Rails' default `materialize_transactions: true` and relocated Rails'
`with_raw_connection` `ensure dirty_current_transaction if
materialize_transactions` (`abstract_adapter.rb:1046`) into each adapter's
`internalExecute` finally. #4732's regression test runs on **sqlite**, which
has no reconnect loop. This PR adds the **live mysql2/PG** coverage the story
asked for: a savepoint statement dirties the popped frame's real PARENT, so
`transactionManager.isRestorable()` becomes `false`.

## How

Two ARCONN-gated `.trails` suites (PG under `describeIfPg`, mysql2 under
`describeIfMysql`), each with three tests:

1. **success path** — the real `createSavepoint` dirties the (clean, materialized)
   parent → `isRestorable()` `false`.
2. **error path** — the real `rollbackToSavepoint` hits a mid-flight
   `ConnectionFailed` (allowRetry:false, so it propagates); `internalExecute`'s
   finally still dirties the parent → `isRestorable()` `false`.
3. **genuine reconnect path** — a `SAVEPOINT` issued through the retry-enabled
   `internalExecute` leaf faults its first raw-connection acquisition, so
   `withRawConnection` actually reconnects (asserted via a `reconnect` spy),
   restores the still-clean outer `BEGIN`, and retries. The op runs twice to pin
   attribution:
   - `materializeTransactions:false` (the `withRawConnection` loop's own,
     suppressed finally) → parent stays clean → `isRestorable()` `true`.
   - `materializeTransactions:true` (the savepoint default → the relocated
     `internalExecute` finally) → parent dirtied → `isRestorable()` `false`.

Test 3 confirms the relocated `internalExecute` finally — not the loop's
suppressed finally — is what produces the dirty parent on the reconnect path.
(A `SAVEPOINT`, not `RELEASE`/`ROLLBACK TO SAVEPOINT`, is used for the *successful*
reconnect because once the parent is dirtied a `RELEASE`/`ROLLBACK` can no longer
be restore-replayed on reconnect — documented inline.)

## Testing

- `ARCONN=postgresql`, live PostgreSQL 17: 3/3 pass.
- `ARCONN=mysql2`, live MySQL 8.4: 3/3 pass.
- `transaction-instrumentation.test.ts` under PG: passes unchanged.

Closes-story: savepoint-reconnect-parent-dirty-live-adapter-tests