### PR TITLE
fix(locking): destroy-path stale check raises on affected !== 1

### DIFF
--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3965,7 +3965,7 @@ export class Base extends Model {
         const adapter = ConnectionHandling.threadedConnectionFor(ctor) ?? ctor.connection;
         const [deleteSql, deleteBinds] = adapter.toSqlAndBinds(dm);
         const affected = await adapter.execDelete(deleteSql, `${ctor.name} Destroy`, deleteBinds);
-        if (ctor.lockingEnabled && affected === 0) {
+        if (ctor.lockingEnabled && affected !== 1) {
           throw new StaleObjectError(this, "destroy");
         }
         didDelete = affected > 0;


### PR DESCRIPTION
## What

`base.ts` destroy path (`_destroyRow`) raised `StaleObjectError` only when `affected === 0`. Rails' `Locking::Optimistic#destroy_row` (`optimistic.rb:127-128`) raises whenever `affected_rows != 1`. This mirrors the UPDATE-path fix in PR #4720.

A PK-keyed single-row DELETE can only affect 0 or 1 rows, so this is a literal-fidelity fix (low severity), but it aligns the guard with Rails.

## Testing

`pnpm vitest run packages/activerecord/src/locking.test.ts` — green (53 passed, 4 skipped).

Closes-story: destroy-path-optimistic-lock-stale-check-affected-not-one