### PR TITLE
fix(activemodel): sanitize forbidden attributes at Model construction

### DIFF
--- a/packages/activemodel/src/attribute-assignment.test.ts
+++ b/packages/activemodel/src/attribute-assignment.test.ts
@@ -1,5 +1,31 @@
 import { describe, it, expect } from "vitest";
 import { Model, ArgumentError } from "./index.js";
+import { ForbiddenAttributesError } from "./forbidden-attributes-protection.js";
+
+// Mirrors Rails' ProtectedParams stub (attribute_assignment_test.rb): a
+// params-like wrapper exposing `permitted?` and `to_h`. Trails dispatches on
+// the camelCase `permitted` / `toH` members.
+class ProtectedParams {
+  private parameters: Record<string, unknown>;
+  private _permitted = false;
+
+  constructor(attributes: Record<string, unknown>) {
+    this.parameters = attributes;
+  }
+
+  permitted(): boolean {
+    return this._permitted;
+  }
+
+  permitBang(): this {
+    this._permitted = true;
+    return this;
+  }
+
+  toH(): Record<string, unknown> {
+    return this.parameters;
+  }
+}
 
 describe("AttributeAssignmentTest", () => {
   it("simple assignment alias", () => {
@@ -152,23 +178,26 @@ describe("AttributeAssignmentTest", () => {
     class Person extends Model {
       static {
         this.attribute("name", "string");
+        this.attribute("description", "string");
       }
     }
-    const p = new Person({});
-    // In our implementation, all attributes are permitted
-    p.assignAttributes({ name: "test" });
-    expect(p.readAttribute("name")).toBe("test");
+    const params = new ProtectedParams({ name: "Guille", description: "m" });
+    expect(() => new Person(params as unknown as Record<string, unknown>)).toThrow(
+      ForbiddenAttributesError,
+    );
   });
 
   it("permitted attributes can be used for mass assignment", () => {
     class Person extends Model {
       static {
         this.attribute("name", "string");
+        this.attribute("description", "string");
       }
     }
-    const p = new Person({});
-    p.assignAttributes({ name: "test" });
-    expect(p.readAttribute("name")).toBe("test");
+    const params = new ProtectedParams({ name: "Guille", description: "desc" }).permitBang();
+    const p = new Person(params as unknown as Record<string, unknown>);
+    expect(p.readAttribute("name")).toBe("Guille");
+    expect(p.readAttribute("description")).toBe("desc");
   });
 
   it("assigning no attributes should not raise, even if the hash is un-permitted", () => {

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1657,20 +1657,29 @@ export class Model {
     // Attributes#initialize — @attributes = self.class._default_attributes.deep_dup
     this._attributes = ctor._defaultAttributes().deepDup();
 
-    // API#initialize — assign_attributes(attributes) (api.rb:80-82). Each key is
-    // routed through `_assignAttribute` → setter dispatch, exactly like Rails'
-    // `_assign_attribute` (attribute_assignment.rb:67-75): a key with a writer
-    // (a framework-generated attribute setter, a user-defined `set name`, or a
-    // nested-attribute `<assoc>Attributes=` setter) dispatches through it, and a
-    // genuinely-unknown, writer-less key routes to `attributeWriterMissing`
+    // API#initialize — assign_attributes(attributes) (api.rb:80-82), which runs
+    // `sanitize_for_mass_assignment` (ForbiddenAttributesProtection) before the
+    // per-key dispatch: an unpermitted `ActionController::Parameters`-like bag
+    // raises `ForbiddenAttributesError` at construction, a permitted one is
+    // unwrapped via `to_h`, and a plain hash passes through untouched. Each key
+    // is then routed through `_assignAttribute` → setter dispatch, exactly like
+    // Rails' `_assign_attribute` (attribute_assignment.rb:67-75): a key with a
+    // writer (a framework-generated attribute setter, a user-defined `set name`,
+    // or a nested-attribute `<assoc>Attributes=` setter) dispatches through it,
+    // and a genuinely-unknown, writer-less key routes to `attributeWriterMissing`
     // (→ `UnknownAttributeError`). The `_initializingAttributes` window lets the
     // AR write path detect construction (e.g. composite-PK `id=` remap) without
     // re-raising mid-construction. Empty bag is a no-op — mirrors
     // `assign_attributes`' `return if new_attributes.empty?` (so a subclass
-    // `_assignAttributes` override isn't invoked for `new Model({})`).
+    // `_assignAttributes` override isn't invoked for `new Model({})`, and neither
+    // is sanitization). The ActiveRecord `Base` constructor sanitizes before
+    // `super()`, converting any params wrapper to a plain hash, so this second
+    // sanitize on the AR path no-ops rather than double-checking.
     this._initializingAttributes = true;
     try {
-      if (Object.keys(attrs).length > 0) this._assignAttributes(attrs);
+      if (Object.keys(attrs).length > 0) {
+        this._assignAttributes(this.sanitizeForMassAssignment(attrs));
+      }
     } finally {
       this._initializingAttributes = false;
     }


### PR DESCRIPTION
## What

Route the `Model` constructor's initial attribute assignment through `sanitizeForMassAssignment`, mirroring Rails `ActiveModel::API#initialize` → `assign_attributes` → `sanitize_for_mass_assignment` (ForbiddenAttributesProtection) (`vendor/rails/activemodel/lib/active_model/attribute_assignment.rb:29-37`, `api.rb:80-82`).

Previously the trails `Model` constructor called `this._assignAttributes(attrs)` directly, skipping sanitization — so `new Model(unpermittedParams)` did NOT raise `ForbiddenAttributesError` the way Rails does. This was a pre-existing gap, not a regression.

## Behavior

- `new Model(unpermittedParamsLikeObject)` now raises `ForbiddenAttributesError`.
- A permitted params object still constructs (unwrapped via `toH`).
- An empty bag stays a no-op (`return if new_attributes.empty?`).

The ActiveRecord `Base` constructor already sanitizes before `super()`, converting any params wrapper to a plain hash, so this second sanitize on the AR path no-ops rather than double-checking.

## Tests

Converged the two watered-down forbidden/permitted construction tests in `attribute-assignment.test.ts` to Rails fidelity (`new Person(ProtectedParams)`), matching `vendor/rails/activemodel/test/cases/attribute_assignment_test.rb:123-138`.

Closes-story: model-construction-sanitize-forbidden-attributes

## Reviewer notes (Codex review, scope)

Two review comments identify real behavioral gaps that are **pre-existing and owned by separate stories** — intentionally out of scope here (this story only routes construction through the existing sanitize entry):

1. **`sanitizeForMassAssignment` gates on `typeof permitted === "function"`, but the real `ActionController::Parameters.permitted` is a boolean getter** — tracked by story `sanitize-mass-assignment-permitted-getter` (RFC 0023, `ready`); already documented at `attribute-assignment.ts:130-135` and linked from this story's context. Fixing it changes `sanitizeForMassAssignment` itself, affecting every mass-assignment caller (`assignAttributes`, AR `update`, AR construction), not just construction.

2. **Empty-bag gate uses `Object.keys(attrs).length` rather than delegating to a wrapper's `empty?`** — this is the same convention the AR `Base` constructor (`base.ts:3063`) and `assignAttributes` (`model.ts:2497`) already use; not introduced by this PR.

This PR's acceptance criteria are met against the Rails-test-shaped stub (`ProtectedParams` with a `permitted?` method + `to_h`), mirroring Rails' own `activemodel/test/cases/attribute_assignment_test.rb:28-46`. Real `Parameters` wrapper recognition is deferred to story (1) above.
