### PR TITLE
fix(enum): raise when enum precedes alias_attribute on same name

### DIFF
--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -81,6 +81,22 @@ export class PendingDefault implements PendingModification {
   }
 }
 
+/**
+ * Depth counter set while a PendingDecorator replays during
+ * `_default_attributes` materialization. trails also applies decorators eagerly
+ * to `_attributeDefinitions` at declaration time (a back-compat convenience Rails
+ * lacks); a decorator that must mirror Rails' replay-only behavior — e.g. the
+ * enum decorator's "Undeclared attribute type" raise, which Rails fires inside
+ * its `decorate_attributes` block only on materialization — consults
+ * `isDecoratorReplay()` to run solely on the deferred replay, not the eager pass.
+ */
+let _decoratorReplayDepth = 0;
+
+/** True while a PendingDecorator is replaying during materialization. @internal */
+export function isDecoratorReplay(): boolean {
+  return _decoratorReplayDepth > 0;
+}
+
 /** @internal Rails-private helper. */
 export class PendingDecorator implements PendingModification {
   constructor(
@@ -93,7 +109,13 @@ export class PendingDecorator implements PendingModification {
     const targets = this.names ?? attributeSet.keys();
     for (const name of targets) {
       const existing = attributeSet.getAttribute(name);
-      const newType = this.decorator(name, existing.type);
+      _decoratorReplayDepth++;
+      let newType: Type;
+      try {
+        newType = this.decorator(name, existing.type);
+      } finally {
+        _decoratorReplayDepth--;
+      }
       if (newType) {
         attributeSet.set(name, existing.withType(newType));
       }

--- a/packages/activemodel/src/attribute-registration.ts
+++ b/packages/activemodel/src/attribute-registration.ts
@@ -21,7 +21,7 @@ export interface AttributeRegistrationClassMethods {
     options?: AttributeOptions,
   ): void;
   _defaultAttributes(): AttributeSet;
-  decorateAttributes(names: string[] | null, decorator: (name: string, type: Type) => Type): void;
+  decorateAttributes(names: string[] | null, decorator: AttributeDecorator): void;
   attributeTypes(): Record<string, Type>;
   typeForAttribute(name: string): Type;
 }
@@ -44,10 +44,21 @@ export interface AttributeHostInternals {
 // Mirrors: ActiveModel::AttributeRegistration::ClassMethods private structs
 // ---------------------------------------------------------------------------
 
+/**
+ * A decorator receives the attribute name and its current type, and optionally
+ * the *materializing* class (`host`) — the class whose AttributeSet is being
+ * built. Rails' `decorate_attributes` block resolves against that class's
+ * attributes, so a superclass's decorator replayed into a subclass sees the
+ * subclass's columns. trails threads `host` through so a decorator (e.g. enum's
+ * "Undeclared attribute type" check) can key off the materializing subclass
+ * rather than the class the decorator was declared on.
+ */
+export type AttributeDecorator = (name: string, type: Type, host?: unknown) => Type;
+
 /** @internal Rails-private helper. */
 export interface PendingModification {
   /** @internal */
-  applyTo(attributeSet: AttributeSet): void;
+  applyTo(attributeSet: AttributeSet, host?: unknown): void;
 }
 
 /** @internal Rails-private helper. */
@@ -101,18 +112,18 @@ export function isDecoratorReplay(): boolean {
 export class PendingDecorator implements PendingModification {
   constructor(
     readonly names: string[] | null,
-    readonly decorator: (name: string, type: Type) => Type,
+    readonly decorator: AttributeDecorator,
   ) {}
 
   /** @internal */
-  applyTo(attributeSet: AttributeSet): void {
+  applyTo(attributeSet: AttributeSet, host?: unknown): void {
     const targets = this.names ?? attributeSet.keys();
     for (const name of targets) {
       const existing = attributeSet.getAttribute(name);
       _decoratorReplayDepth++;
       let newType: Type;
       try {
-        newType = this.decorator(name, existing.type);
+        newType = this.decorator(name, existing.type, host);
       } finally {
         _decoratorReplayDepth--;
       }
@@ -155,7 +166,7 @@ type HostAsClass = new (...args: unknown[]) => unknown;
 export function decorateAttributes(
   this: AttributeHostInternals,
   names: string[] | null,
-  decorator: (name: string, type: Type) => Type,
+  decorator: AttributeDecorator,
 ): void {
   // Push to pending queue so _defaultAttributes replays in declaration order.
   pushPendingDecorator(this, names, decorator);
@@ -171,7 +182,7 @@ export function decorateAttributes(
   for (const name of targetNames) {
     const def = defs.get(name);
     if (def) {
-      const newType = decorator(name, def.type);
+      const newType = decorator(name, def.type, this);
       if (newType) defs.set(name, { ...def, type: newType });
     }
   }
@@ -261,7 +272,7 @@ export function applyPendingAttributeModifications(
   attributeSet: AttributeSet,
 ): void {
   for (const mod of collectPendingModifications(cls)) {
-    mod.applyTo(attributeSet);
+    mod.applyTo(attributeSet, cls);
   }
 }
 
@@ -407,7 +418,7 @@ export function pushPendingDefault(
 export function pushPendingDecorator(
   cls: AttributeHostInternals,
   names: string[] | null,
-  decorator: (name: string, type: Type) => Type,
+  decorator: AttributeDecorator,
 ): void {
   pendingAttributeModifications.call(cls).push(new PendingDecorator(names, decorator));
 }

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -35,6 +35,7 @@ export {
 } from "./attribute-mutation-tracker.js";
 export {
   applyPendingAttributeModifications,
+  isDecoratorReplay,
   pushPendingDecorator,
   resetDefaultAttributes,
   registerWithSuperclass,

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1206,12 +1206,13 @@ export class Base extends Model {
    */
   static override typeForAttribute(name: string): Type {
     (ModelSchema.loadSchema as any).call(this);
-    // An `enum` declared before its `alias_attribute` keys a phantom attribute
-    // Rails rejects. Check the *un-resolved* name (the phantom): resolving the
-    // alias first would look past it to the backing column. Mirrors Rails
-    // materializing `attribute_types`, which replays the phantom decorate and
-    // raises (enum.rb:240-245).
-    _EnumModule.assertEnumAliasDeclaredBefore(this as unknown as typeof Base, name);
+    // Check the *un-resolved* name first: an `enum` declared before its
+    // `alias_attribute` keys a phantom attribute under the un-aliased name, and
+    // resolving the alias first would look past that phantom to the real backing
+    // column. `assertEnumTypeDeclared` raises only when the name has no column of
+    // its own (Rails' `subtype == default_value` condition, enum.rb:240-245), so
+    // a column-backed enum whose name is later aliased is unaffected.
+    _EnumModule.assertEnumTypeDeclared(this as unknown as typeof Base, name);
     // Rails resolves attribute aliases first
     // (`attr_name = attribute_aliases[attr_name] || attr_name`).
     const resolved = (this as any)._attributeAliases?.[name] ?? name;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -1206,6 +1206,12 @@ export class Base extends Model {
    */
   static override typeForAttribute(name: string): Type {
     (ModelSchema.loadSchema as any).call(this);
+    // An `enum` declared before its `alias_attribute` keys a phantom attribute
+    // Rails rejects. Check the *un-resolved* name (the phantom): resolving the
+    // alias first would look past it to the backing column. Mirrors Rails
+    // materializing `attribute_types`, which replays the phantom decorate and
+    // raises (enum.rb:240-245).
+    _EnumModule.assertEnumAliasDeclaredBefore(this as unknown as typeof Base, name);
     // Rails resolves attribute aliases first
     // (`attr_name = attribute_aliases[attr_name] || attr_name`).
     const resolved = (this as any)._attributeAliases?.[name] ?? name;

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -649,6 +649,10 @@ describe("EnumTest", () => {
     await expect((Klass as any).create({ status: "written" })).rejects.toThrow(
       /Undeclared attribute type for enum 'aliased_status' in Klass/,
     );
+    // Also raises via type_for_attribute (Rails materializes attribute_types).
+    expect(() => (Klass as any).typeForAttribute("aliased_status")).toThrow(
+      /Undeclared attribute type for enum 'aliased_status' in Klass/,
+    );
   });
 
   it("query state by predicate with prefix", () => {

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -661,6 +661,26 @@ describe("EnumTest", () => {
     );
   });
 
+  // A column-backed enum whose name is LATER reused as an alias target must not
+  // raise: Rails' decorate block only raises when the decorated subtype is the
+  // default (no column), and a real column reflects its own subtype at replay
+  // regardless of a later alias. Guards against a coarse "pending ∩ alias-key"
+  // heuristic false-positiving a legitimate column-backed enum.
+  it("column-backed enum whose name is later aliased does not raise", async () => {
+    class Klass extends Base {
+      static _tableName = "books";
+      static {
+        this.enum("nullable_status", ["single", "married"] as any);
+        this.aliasAttribute("nullable_status", "status");
+      }
+    }
+    registerModel(Klass);
+
+    expect(() => (Klass as any).typeForAttribute("nullable_status")).not.toThrow();
+    const record: any = await (Klass as any).create({});
+    expect(() => record.isSingle()).not.toThrow();
+  });
+
   it("query state by predicate with prefix", () => {
     expect((book as any).isAuthorVisibilityVisible()).toBe(true);
     expect((book as any).isAuthorVisibilityInvisible()).toBe(false);

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -666,7 +666,7 @@ describe("EnumTest", () => {
   // default (no column), and a real column reflects its own subtype at replay
   // regardless of a later alias. Guards against a coarse "pending ∩ alias-key"
   // heuristic false-positiving a legitimate column-backed enum.
-  it("column-backed enum whose name is later aliased does not raise", async () => {
+  it("column-backed enum whose name is later aliased does not raise", () => {
     class Klass extends Base {
       static _tableName = "books";
       static {
@@ -676,9 +676,34 @@ describe("EnumTest", () => {
     }
     registerModel(Klass);
 
+    // Materialize (typeForAttribute + a fresh instance's predicate) without
+    // persisting — aliasing the enum name onto another real column would list it
+    // twice in an INSERT, which is orthogonal to the raise being tested.
     expect(() => (Klass as any).typeForAttribute("nullable_status")).not.toThrow();
-    const record: any = await (Klass as any).create({});
-    expect(() => record.isSingle()).not.toThrow();
+    expect(() => new (Klass as any)().isSingle()).not.toThrow();
+  });
+
+  // An enum declared on an abstract parent with no column of its own must defer
+  // to its concrete subclass's columns (Rails replays the superclass decorator
+  // into the subclass attribute set). A concrete subclass that DOES back the enum
+  // (Lion has lions.gender via Cat) stays green; one that does NOT raises against
+  // its own columns — not silently install, and not throw TableNotSpecified on the
+  // abstract parent's tableless schema.
+  it("enum on abstract parent resolves against concrete subclass columns", () => {
+    class AbstractParent extends Base {
+      static {
+        this._abstractClass = true;
+        this.enum("typeless_genre", ["adventure", "comic"] as any);
+      }
+    }
+    class Concrete extends AbstractParent {
+      static _tableName = "books"; // books has no `typeless_genre` column
+    }
+    registerModel(Concrete);
+
+    expect(() => (Concrete as any).typeForAttribute("typeless_genre")).toThrow(
+      /Undeclared attribute type for enum 'typeless_genre' in Concrete/,
+    );
   });
 
   it("query state by predicate with prefix", () => {

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -632,6 +632,25 @@ describe("EnumTest", () => {
     expect(record.aliased_status).toBe("proposed");
   });
 
+  // Real Rails raises "Undeclared attribute type for enum" when `enum` is
+  // declared BEFORE `alias_attribute` on the same name: the enum keys a phantom
+  // attribute with no backing column. The raise fires lazily, on first use.
+  // (No dedicated Rails test — Rails treats it as the undeclared-type case.)
+  it("enum declared before alias_attribute raises on first use", async () => {
+    class Klass extends Base {
+      static _tableName = "books";
+      static {
+        this.enum("aliased_status", ["proposed", "written", "published"] as any);
+        this.aliasAttribute("aliased_status", "status");
+      }
+    }
+    registerModel(Klass);
+
+    await expect((Klass as any).create({ status: "written" })).rejects.toThrow(
+      /Undeclared attribute type for enum 'aliased_status' in Klass/,
+    );
+  });
+
   it("query state by predicate with prefix", () => {
     expect((book as any).isAuthorVisibilityVisible()).toBe(true);
     expect((book as any).isAuthorVisibilityInvisible()).toBe(false);

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -653,6 +653,12 @@ describe("EnumTest", () => {
     expect(() => (Klass as any).typeForAttribute("aliased_status")).toThrow(
       /Undeclared attribute type for enum 'aliased_status' in Klass/,
     );
+    // And via the enum helper path (predicate → castEnumValue → enumTypeOf),
+    // which keys off the un-aliased enum name: Rails routes type casting through
+    // type_for_attribute, whose decorate block raises.
+    expect(() => new (Klass as any)().isProposed()).toThrow(
+      /Undeclared attribute type for enum 'aliased_status' in Klass/,
+    );
   });
 
   it("query state by predicate with prefix", () => {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -6,6 +6,7 @@ import {
   IntegerType,
   Type,
   typeRegistry,
+  isDecoratorReplay,
 } from "@blazetrails/activemodel";
 import { dangerousAttributeMethods } from "./attribute-methods.js";
 import { isDangerousClassMethod } from "./scoping/named.js";
@@ -153,18 +154,21 @@ export function installEnumAttribute(
   // _defaultAttributes replay, so once the schema is loaded `reflected` is the
   // column's real Type::Value and the EnumType delegates to it.
   klass.decorateAttributes([attribute], (_name: string, reflected: Type) => {
-    // Rails raises inside the `decorate_attributes` block when an enum's name
-    // resolves through `attribute_aliases` to no declared type. trails resolves
-    // an `alias_attribute` target eagerly in `_enum` (attrName above): if the
-    // alias existed when `enum` ran, `attribute` is already the real column and
-    // this decorator seeds the backing column type. But when `enum` is declared
-    // BEFORE `alias_attribute` on the same name, the alias didn't exist yet, so
-    // `attribute` is the un-aliased name with no column of its own — a phantom
-    // that Rails rejects. The eager (class-definition-time) application of this
-    // decorator runs before `alias_attribute`, so the alias is absent and the
-    // guard is a no-op; only the deferred replay (first use, after both macros)
-    // sees the alias and raises — matching Rails' lazy timing.
-    assertEnumAliasDeclaredBefore(klass, attribute);
+    // Rails raises inside the `decorate_attributes` block when the decorated
+    // subtype is `ActiveModel::Type.default_value` — an enum name with no backing
+    // column and no explicit type (enum.rb:240-245). Rails only ever runs this
+    // block on `_default_attributes` materialization, but trails ALSO applies
+    // decorators eagerly to `_attributeDefinitions` at declaration time (a
+    // back-compat convenience), when every enum's subtype is still the bare
+    // default — so gate the raise on `isDecoratorReplay()` to fire solely on the
+    // deferred replay, matching Rails' timing and avoiding a false positive on
+    // column-backed enums at class-definition time (including a subclass of an
+    // already-schema-loaded model). `assertEnumTypeDeclared` keys off the real
+    // column, so an `enum` declared before its `alias_attribute` (a phantom
+    // un-aliased name with no column) raises while a column-backed enum does not.
+    if (isDecoratorReplay()) {
+      assertEnumTypeDeclared(klass, attribute);
+    }
     return enumTypeFrom(klass, attribute, name, mapping, reflected, raiseOnInvalidValues);
   });
 
@@ -958,31 +962,6 @@ function undeclaredEnumTypeError(klass: typeof Base, name: string): Error {
 }
 
 /**
- * Raise when an enum was declared before the `alias_attribute` that would give
- * its name a backing column — the anti-Rails order. Detected by the enum name
- * being both a pending type-check target (no column/explicit type of its own at
- * `enum` time) AND, now, a registered attribute alias: the alias was added after
- * `enum`, so the enum keys a phantom attribute Rails rejects. Called from the
- * enum decorator's deferred replay so the raise fires on first use, mirroring
- * Rails raising inside its `decorate_attributes` block (enum.rb:240-245).
- *
- * @internal
- */
-export function assertEnumAliasDeclaredBefore(klass: typeof Base, name: string): void {
-  const host = klass as unknown as {
-    _enumsPendingTypeCheck?: Set<string>;
-    _attributeAliases?: Record<string, string>;
-  };
-  if (!host._enumsPendingTypeCheck?.has(name)) return;
-  if (
-    !host._attributeAliases ||
-    !Object.prototype.hasOwnProperty.call(host._attributeAliases, name)
-  )
-    return;
-  throw undeclaredEnumTypeError(klass, name);
-}
-
-/**
  * Fetch the single registered EnumType for an enum attribute — the one source
  * of truth built lazily from the reflected column type via the
  * `decorateAttributes` decorator. Resolves through the replayed AttributeSet
@@ -1000,13 +979,15 @@ export function enumTypeOf(klass: typeof Base, attribute: string): EnumType | nu
     _attributeAliases?: Record<string, string>;
     _defaultAttributes(): { getAttribute(n: string): { type: Type } };
   };
-  // Guard the *un-resolved* name before resolving the alias: an `enum` declared
+  // Check the *un-resolved* name before resolving the alias: an `enum` declared
   // before its `alias_attribute` keys a phantom `_enums` entry under the
   // un-aliased name, so resolving first would look past it to the backing column
-  // and silently return null. Mirrors Rails' type casting always routing through
-  // `type_for_attribute(name)`, whose `decorate_attributes` block raises
-  // (type_caster/map.rb:10-16, enum.rb:240-245).
-  assertEnumAliasDeclaredBefore(klass, attribute);
+  // and silently return null. `assertEnumTypeDeclared` raises only when the name
+  // has no column of its own (Rails' `subtype == default_value` condition), so a
+  // column-backed enum whose name is later aliased is unaffected. Mirrors Rails
+  // routing type casting through `type_for_attribute(name)`, whose
+  // `decorate_attributes` block raises (type_caster/map.rb:10-16, enum.rb:240-245).
+  assertEnumTypeDeclared(klass, attribute);
   const resolved = host._attributeAliases?.[attribute] ?? attribute;
   if (!host._enums?.has(resolved)) return null;
   // Reflect synchronously from the warm schema cache before reading the

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -152,9 +152,21 @@ export function installEnumAttribute(
   // reflected column type (enum.rb:239-246); the decorator re-runs on every
   // _defaultAttributes replay, so once the schema is loaded `reflected` is the
   // column's real Type::Value and the EnumType delegates to it.
-  klass.decorateAttributes([attribute], (_name: string, reflected: Type) =>
-    enumTypeFrom(klass, attribute, name, mapping, reflected, raiseOnInvalidValues),
-  );
+  klass.decorateAttributes([attribute], (_name: string, reflected: Type) => {
+    // Rails raises inside the `decorate_attributes` block when an enum's name
+    // resolves through `attribute_aliases` to no declared type. trails resolves
+    // an `alias_attribute` target eagerly in `_enum` (attrName above): if the
+    // alias existed when `enum` ran, `attribute` is already the real column and
+    // this decorator seeds the backing column type. But when `enum` is declared
+    // BEFORE `alias_attribute` on the same name, the alias didn't exist yet, so
+    // `attribute` is the un-aliased name with no column of its own — a phantom
+    // that Rails rejects. The eager (class-definition-time) application of this
+    // decorator runs before `alias_attribute`, so the alias is absent and the
+    // guard is a no-op; only the deferred replay (first use, after both macros)
+    // sees the alias and raises — matching Rails' lazy timing.
+    assertEnumAliasDeclaredBefore(klass, attribute);
+    return enumTypeFrom(klass, attribute, name, mapping, reflected, raiseOnInvalidValues);
+  });
 
   // Define the getter after attribute() so the EnumType is already in
   // _attributeDefinitions / the pending-type queue when we overwrite whatever
@@ -502,12 +514,10 @@ export function _enum(
   // `alias_attribute` MUST precede `enum` (the order Rails' own suite uses).
   // Declaring `enum` first keys everything off the un-aliased name, which has no
   // column of its own; real Rails raises `Undeclared attribute type for enum` on
-  // first use (verified against vendored Rails). trails does NOT yet raise on
-  // this order — it silently registers a phantom attribute — because the raise
-  // must fire from the deferred decorator, which trails also applies eagerly at
-  // class-definition time (before the schema loads), so a naive check
-  // false-positives every column-backed enum. Converging to Rails' raise is
-  // tracked as a follow-up (see enum-before-alias-must-raise).
+  // first use (verified against vendored Rails). trails converges via
+  // `assertEnumAliasDeclaredBefore`, run from the enum decorator's deferred
+  // replay (not its eager class-definition-time application, which runs before
+  // `alias_attribute` and so never sees the alias) — matching Rails' lazy timing.
   const attrName =
     (this as unknown as { _attributeAliases?: Record<string, string> })._attributeAliases?.[
       attribute
@@ -935,11 +945,41 @@ export function assertEnumTypeDeclared(klass: typeof Base, name: string): void {
     host._enumsPendingTypeCheck!.delete(name);
     return;
   }
-  throw new Error(
+  throw undeclaredEnumTypeError(klass, name);
+}
+
+/** The Rails "Undeclared attribute type for enum" RuntimeError message. */
+function undeclaredEnumTypeError(klass: typeof Base, name: string): Error {
+  return new Error(
     `Undeclared attribute type for enum '${name}' in ${klass.name}. Enums must be` +
       " backed by a database column or declared with an explicit type" +
       " via `attribute`.",
   );
+}
+
+/**
+ * Raise when an enum was declared before the `alias_attribute` that would give
+ * its name a backing column — the anti-Rails order. Detected by the enum name
+ * being both a pending type-check target (no column/explicit type of its own at
+ * `enum` time) AND, now, a registered attribute alias: the alias was added after
+ * `enum`, so the enum keys a phantom attribute Rails rejects. Called from the
+ * enum decorator's deferred replay so the raise fires on first use, mirroring
+ * Rails raising inside its `decorate_attributes` block (enum.rb:240-245).
+ *
+ * @internal
+ */
+export function assertEnumAliasDeclaredBefore(klass: typeof Base, name: string): void {
+  const host = klass as unknown as {
+    _enumsPendingTypeCheck?: Set<string>;
+    _attributeAliases?: Record<string, string>;
+  };
+  if (!host._enumsPendingTypeCheck?.has(name)) return;
+  if (
+    !host._attributeAliases ||
+    !Object.prototype.hasOwnProperty.call(host._attributeAliases, name)
+  )
+    return;
+  throw undeclaredEnumTypeError(klass, name);
 }
 
 /**

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -153,27 +153,30 @@ export function installEnumAttribute(
   // reflected column type (enum.rb:239-246); the decorator re-runs on every
   // _defaultAttributes replay, so once the schema is loaded `reflected` is the
   // column's real Type::Value and the EnumType delegates to it.
-  klass.decorateAttributes([attribute], (_name: string, reflected: Type) => {
+  klass.decorateAttributes([attribute], (_name: string, reflected: Type, host?: unknown) => {
     // Rails raises inside the `decorate_attributes` block when the decorated
     // subtype is `ActiveModel::Type.default_value` — an enum name with no backing
-    // column and no explicit type (enum.rb:240-245). Rails only ever runs this
-    // block on `_default_attributes` materialization, but trails ALSO applies
-    // decorators eagerly to `_attributeDefinitions` at declaration time (a
-    // back-compat convenience), when every enum's subtype is still the bare
-    // default — so gate the raise on `isDecoratorReplay()` to fire solely on the
-    // deferred replay, matching Rails' timing and avoiding a false positive on
-    // column-backed enums at class-definition time (including a subclass of an
-    // already-schema-loaded model). `assertEnumTypeDeclared` keys off the real
-    // column, so an `enum` declared before its `alias_attribute` (a phantom
-    // un-aliased name with no column) raises while a column-backed enum does not.
+    // column and no explicit type (enum.rb:240-245). trails can't mirror that via
+    // the `reflected` subtype: its alias-aware column-seeding hands the aliased
+    // phantom the *target* column's type at replay (so `reflected.type()` is e.g.
+    // "integer", not "value"). Instead check the real column via
+    // `assertEnumTypeDeclared` (an alias-unaware `columnForAttribute` lookup).
     //
-    // Skip abstract classes: `klass` is the *declaring* class, and an enum
-    // declared on an abstract parent (e.g. `Cat`, no table) has no columns of its
-    // own — `columnForAttribute` would throw `TableNotSpecified`. Rails resolves
-    // such an enum against the concrete subclass's columns at that subclass's
-    // materialization, so the abstract parent must defer rather than raise.
-    if (isDecoratorReplay() && !klass.abstractClass) {
-      assertEnumTypeDeclared(klass, attribute);
+    // Resolve the check against the *materializing* class (`host`), not the
+    // declaring `klass`: Rails replays a superclass's pending decorator into the
+    // subclass's attribute set (attribute_registration.rb:81-87), so a concrete
+    // subclass of an abstract parent (e.g. `Lion` < abstract `Cat`) checks its own
+    // columns — while an abstract parent that declares an enum defers until a
+    // concrete subclass materializes rather than throwing `TableNotSpecified` on
+    // its own tableless schema.
+    //
+    // Two trails-specific gates: `isDecoratorReplay()` skips the eager
+    // class-definition-time application (a back-compat convenience Rails lacks,
+    // when the subtype is still the bare default), and `!target.abstractClass`
+    // skips the rare direct materialization of an abstract class itself.
+    const target = (host as typeof Base | undefined) ?? klass;
+    if (isDecoratorReplay() && !target.abstractClass) {
+      assertEnumTypeDeclared(target, attribute);
     }
     return enumTypeFrom(klass, attribute, name, mapping, reflected, raiseOnInvalidValues);
   });

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -519,9 +519,11 @@ export function _enum(
   // Declaring `enum` first keys everything off the un-aliased name, which has no
   // column of its own; real Rails raises `Undeclared attribute type for enum` on
   // first use (verified against vendored Rails). trails converges via
-  // `assertEnumAliasDeclaredBefore`, run from the enum decorator's deferred
-  // replay (not its eager class-definition-time application, which runs before
-  // `alias_attribute` and so never sees the alias) — matching Rails' lazy timing.
+  // `assertEnumTypeDeclared` on the un-aliased name — mirroring Rails' `subtype
+  // == ActiveModel::Type.default_value` branch (enum.rb:240-245) — run from the
+  // enum decorator's deferred replay (gated by `isDecoratorReplay()`, so it never
+  // fires on trails' eager class-definition-time decorator application), matching
+  // Rails' lazy timing.
   const attrName =
     (this as unknown as { _attributeAliases?: Record<string, string> })._attributeAliases?.[
       attribute

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -1000,6 +1000,13 @@ export function enumTypeOf(klass: typeof Base, attribute: string): EnumType | nu
     _attributeAliases?: Record<string, string>;
     _defaultAttributes(): { getAttribute(n: string): { type: Type } };
   };
+  // Guard the *un-resolved* name before resolving the alias: an `enum` declared
+  // before its `alias_attribute` keys a phantom `_enums` entry under the
+  // un-aliased name, so resolving first would look past it to the backing column
+  // and silently return null. Mirrors Rails' type casting always routing through
+  // `type_for_attribute(name)`, whose `decorate_attributes` block raises
+  // (type_caster/map.rb:10-16, enum.rb:240-245).
+  assertEnumAliasDeclaredBefore(klass, attribute);
   const resolved = host._attributeAliases?.[attribute] ?? attribute;
   if (!host._enums?.has(resolved)) return null;
   // Reflect synchronously from the warm schema cache before reading the

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -166,7 +166,13 @@ export function installEnumAttribute(
     // already-schema-loaded model). `assertEnumTypeDeclared` keys off the real
     // column, so an `enum` declared before its `alias_attribute` (a phantom
     // un-aliased name with no column) raises while a column-backed enum does not.
-    if (isDecoratorReplay()) {
+    //
+    // Skip abstract classes: `klass` is the *declaring* class, and an enum
+    // declared on an abstract parent (e.g. `Cat`, no table) has no columns of its
+    // own — `columnForAttribute` would throw `TableNotSpecified`. Rails resolves
+    // such an enum against the concrete subclass's columns at that subclass's
+    // materialization, so the abstract parent must defer rather than raise.
+    if (isDecoratorReplay() && !klass.abstractClass) {
       assertEnumTypeDeclared(klass, attribute);
     }
     return enumTypeFrom(klass, attribute, name, mapping, reflected, raiseOnInvalidValues);


### PR DESCRIPTION
## What

Real Rails **raises** `Undeclared attribute type for enum '<name>' in <Model>`
when `enum :x` is declared **before** `alias_attribute :x, :col` on the same
name — the enum keys a phantom attribute with no backing column. trails
silently registered the phantom instead. This converges to Rails.

## How

Guard the enum decorator's **deferred** replay via `assertEnumAliasDeclaredBefore`:
an enum name that is both a pending type-check target *and* a registered
attribute alias was declared before its alias, so raise on **first use**
(matching Rails' lazy timing, inside its `decorate_attributes` block,
enum.rb:240-245).

The decorator's **eager** class-definition-time application runs *before*
`alias_attribute`, so the alias is absent and the guard is a no-op there — no
false positives for column-backed or explicitly-typed enums. The supported
order (`alias_attribute` then `enum`) stays green.

## Tests

- New regression test `enum declared before alias_attribute raises on first use`
  mirroring the vendored-Rails repro (sqlite, `books.status`).
- Existing `enum with alias_attribute` (supported order) and
  `raises for attributes with undeclared type` stay green; full enum.test.ts
  and enum.trails.test.ts pass.

Closes-story: enum-before-alias-must-raise