### PR TITLE
fix(schema-statements): match composite FK column by value in ifNotExists

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -84,6 +84,7 @@ import type {
   ForeignKeyDefinition,
   IndexDefinition,
   AddForeignKeyOptions,
+  ForeignKeyLookupOptions,
   AddIndexOptions,
   ColumnType,
   ColumnOptions,
@@ -327,6 +328,11 @@ export interface AbstractAdapter {
   primaryKey(tableName: string): Promise<string | string[] | null>;
   indexes(tableName: string): Promise<unknown[]>;
   foreignKeys(tableName: string): Promise<ForeignKeyDefinition[]>;
+  foreignKeyExists(
+    fromTable: string,
+    toTable?: string | ForeignKeyLookupOptions,
+    options?: Omit<ForeignKeyLookupOptions, "toTable">,
+  ): Promise<boolean>;
   addForeignKey(fromTable: string, toTable: string, options?: AddForeignKeyOptions): Promise<void>;
   removeForeignKey(
     fromTable: string,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-on-adapter.test.ts
@@ -448,4 +448,36 @@ describe("SchemaStatements mixed into AbstractAdapter", () => {
     expect(cols).toEqual(["author_id", "editor_id"]);
     await adapter.dropTable("articles", "authors");
   });
+
+  it("addForeignKey with ifNotExists is a no-op when a composite FK already exists", async () => {
+    // The composite `column: [...]` must match the existing FK by value, not by
+    // array identity. foreignKeys() reports composite columns as arrays (Rails
+    // parity), and the ifNotExists guard routes through foreignKeyExists ->
+    // isDefinedFor for an element-wise compare.
+    adapter = new BetterSQLite3Adapter(":memory:");
+    await adapter.createTable("rockets", { primaryKey: ["tenant_id", "id"] }, (t) => {
+      t.integer("tenant_id");
+      t.integer("id");
+    });
+    await adapter.createTable("astronauts", (t) => {
+      t.integer("rocket_id");
+      t.integer("rocket_tenant_id");
+    });
+    await adapter.addForeignKey("astronauts", "rockets", {
+      column: ["rocket_tenant_id", "rocket_id"],
+      primaryKey: ["tenant_id", "id"],
+    });
+    expect((await adapter.foreignKeys("astronauts"))[0].column).toEqual([
+      "rocket_tenant_id",
+      "rocket_id",
+    ]);
+    const before = (await adapter.foreignKeys("astronauts")).length;
+    await adapter.addForeignKey("astronauts", "rockets", {
+      column: ["rocket_tenant_id", "rocket_id"],
+      primaryKey: ["tenant_id", "id"],
+      ifNotExists: true,
+    });
+    expect((await adapter.foreignKeys("astronauts")).length).toBe(before);
+    await adapter.dropTable("astronauts", "rockets");
+  });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements-privates.test.ts
@@ -308,6 +308,53 @@ describe("SchemaStatements privates (PR 8)", () => {
     expect(await ss.foreignKeyExists("users")).toBe(true);
   });
 
+  it("foreignKeyExists matches a composite column by value, not reference", async () => {
+    const ss = makeStatements();
+    const fk = new ForeignKeyDefinition(
+      "astronauts",
+      "rockets",
+      ["rocket_tenant_id", "rocket_id"],
+      ["tenant_id", "id"],
+      "fk_rails_composite",
+    );
+    vi.spyOn(ss, "foreignKeys").mockResolvedValue([fk]);
+
+    // A distinct array instance with the same elements must still match.
+    expect(
+      await ss.foreignKeyExists("astronauts", "rockets", {
+        column: ["rocket_tenant_id", "rocket_id"],
+      }),
+    ).toBe(true);
+    expect(
+      await ss.foreignKeyExists("astronauts", "rockets", {
+        column: ["rocket_id", "rocket_tenant_id"],
+      }),
+    ).toBe(false);
+  });
+
+  it("addForeignKey with ifNotExists is a no-op when a composite FK already exists", async () => {
+    const ss = makeStatements();
+    const fk = new ForeignKeyDefinition(
+      "astronauts",
+      "rockets",
+      ["rocket_tenant_id", "rocket_id"],
+      ["tenant_id", "id"],
+      "fk_rails_composite",
+    );
+    vi.spyOn(ss, "foreignKeys").mockResolvedValue([fk]);
+    const executeMutation = (ss as any).adapter.executeMutation as ReturnType<typeof vi.fn>;
+    executeMutation.mockClear();
+
+    await ss.addForeignKey("astronauts", "rockets", {
+      column: ["rocket_tenant_id", "rocket_id"],
+      primaryKey: ["tenant_id", "id"],
+      ifNotExists: true,
+    });
+
+    // The composite column matches by value, so no ALTER TABLE is issued.
+    expect(executeMutation).not.toHaveBeenCalled();
+  });
+
   it("foreignKeyForBang throws when not found", async () => {
     const ss = makeStatements();
     vi.spyOn(ss, "foreignKeys").mockResolvedValue([]);

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -816,13 +816,11 @@ export class SchemaStatements {
     // foreign_key_exists? matches via foreign_keys(from).detect { defined_for? },
     // scoping on to_table plus column when one is given.
     if (options.ifNotExists === true) {
-      const fks = await this.foreignKeys(fromTable);
-      if (
-        fks.some(
-          (fk) =>
-            fk.toTable === toTable && (options.column == null || fk.column === options.column),
-        )
-      ) {
+      // foreignKeyExists routes through foreignKeyFor/isDefinedFor, which
+      // compares `column` element-wise, so composite (array) columns match by
+      // value rather than by array identity (a bare `===` is always false for
+      // distinct array instances).
+      if (await this.foreignKeyExists(fromTable, toTable, { column: options.column })) {
         return;
       }
     }

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -4000,8 +4000,8 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     fromTable: string,
     toTable: string,
     options: {
-      column?: string;
-      primaryKey?: string;
+      column?: string | string[];
+      primaryKey?: string | string[];
       name?: string;
       onDelete?: ReferentialAction;
       onUpdate?: ReferentialAction;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -127,8 +127,8 @@ import {
   TableDefinition as AbstractTableDefinition,
   type ColumnOptions,
   type ColumnType,
-  type ReferentialAction,
   type ForeignKeyLookupOptions,
+  type AddForeignKeyOptions,
 } from "./abstract/schema-definitions.js";
 import { SchemaCreation as PgSchemaCreation } from "./postgresql/schema-creation.js";
 import { SchemaDumper as PgSchemaDumper } from "./postgresql/schema-dumper.js";
@@ -3999,16 +3999,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   async addForeignKey(
     fromTable: string,
     toTable: string,
-    options: {
-      column?: string | string[];
-      primaryKey?: string | string[];
-      name?: string;
-      onDelete?: ReferentialAction;
-      onUpdate?: ReferentialAction;
-      deferrable?: "immediate" | "deferred";
-      validate?: boolean;
-      ifNotExists?: boolean;
-    } = {},
+    options: AddForeignKeyOptions = {},
   ): Promise<void> {
     // Rails: PostgreSQL::SchemaStatements#add_foreign_key is just
     //   assert_valid_deferrable(options[:deferrable]); super

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { PostgreSQLSchemaStatements } from "./schema-statements-class.js";
+import { ForeignKeyDefinition } from "../abstract/schema-definitions.js";
 import type { AbstractAdapter as DatabaseAdapter } from "../abstract-adapter.js";
 
 function makeFakeAdapter() {
@@ -163,6 +164,36 @@ describe("PostgreSQLSchemaStatements#addForeignKey use_foreign_keys? guard", () 
     const ss = new PostgreSQLSchemaStatements(adapter);
     expect(ss.isUseForeignKeys()).toBe(false);
     await ss.addForeignKey("articles", "authors", { column: "author_id" });
+    expect(executed).toEqual([]);
+  });
+
+  it("with ifNotExists is a no-op when a composite FK already exists", async () => {
+    // A composite `column: [...]` must match the existing FK by value, not by
+    // array identity — the guard routes through foreignKeyExists -> isDefinedFor
+    // for an element-wise compare, so the duplicate ADD CONSTRAINT is skipped.
+    const executed: string[] = [];
+    const adapter = {
+      adapterName: "postgres" as const,
+      supportsForeignKeys: () => true,
+      executeMutation: vi.fn(async (sql: string) => {
+        executed.push(sql);
+      }),
+    } as unknown as DatabaseAdapter;
+    const ss = new PostgreSQLSchemaStatements(adapter);
+    const fk = new ForeignKeyDefinition(
+      "astronauts",
+      "rockets",
+      ["rocket_tenant_id", "rocket_id"],
+      ["tenant_id", "id"],
+      "fk_rails_composite",
+    );
+    vi.spyOn(ss, "foreignKeys").mockResolvedValue([fk]);
+
+    await ss.addForeignKey("astronauts", "rockets", {
+      column: ["rocket_tenant_id", "rocket_id"],
+      primaryKey: ["tenant_id", "id"],
+      ifNotExists: true,
+    });
     expect(executed).toEqual([]);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -1194,13 +1194,13 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
         const toTable = unquoteIdentifier(row.to_table as string);
         const conkey = String(row.conkey).replace(/[{}]/g, "").split(",").map(Number);
         const confkey = String(row.confkey).replace(/[{}]/g, "").split(",").map(Number);
-        let column: string;
-        let primaryKey: string;
+        // Rails returns composite column/primary_key as arrays and a bare
+        // string for single-column FKs (postgresql/schema_statements.rb#foreign_keys).
+        let column: string | string[];
+        let primaryKey: string | string[];
         if (conkey.length > 1) {
-          const cols = await this.columnNamesFromColumnNumbers(Number(row.conrelid), conkey);
-          const pks = await this.columnNamesFromColumnNumbers(Number(row.confrelid), confkey);
-          column = cols.join(",");
-          primaryKey = pks.join(",");
+          column = await this.columnNamesFromColumnNumbers(Number(row.conrelid), conkey);
+          primaryKey = await this.columnNamesFromColumnNumbers(Number(row.confrelid), confkey);
         } else {
           column = unquoteIdentifier(row.column as string);
           primaryKey = row.primary_key as string;
@@ -1224,8 +1224,8 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     fromTable: string,
     toTable: string,
     options: {
-      column?: string;
-      primaryKey?: string;
+      column?: string | string[];
+      primaryKey?: string | string[];
       name?: string;
       onDelete?: ReferentialAction;
       onUpdate?: ReferentialAction;
@@ -1242,13 +1242,11 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // We replicate the abstract body inline here, so replicate the guard too.
     if (!this.isUseForeignKeys()) return;
     if (options.ifNotExists === true) {
-      const fks = await this.foreignKeys(fromTable);
-      if (
-        fks.some(
-          (fk) =>
-            fk.toTable === toTable && (options.column == null || fk.column === options.column),
-        )
-      ) {
+      // foreignKeyExists routes through foreignKeyFor/isDefinedFor, which
+      // compares `column` element-wise, so composite (array) columns match by
+      // value rather than by array identity (a bare `===` is always false for
+      // distinct array instances). Mirrors the abstract addForeignKey guard.
+      if (await this.foreignKeyExists(fromTable, toTable, { column: options.column })) {
         return;
       }
     }

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements-class.ts
@@ -13,7 +13,6 @@ import {
   type AddForeignKeyOptions,
   type ColumnOptions,
   type ColumnType,
-  type ReferentialAction,
 } from "../abstract/schema-definitions.js";
 import { HashLookupTypeMap } from "../../type/hash-lookup-type-map.js";
 import { Column } from "./column.js";
@@ -1223,16 +1222,7 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
   override async addForeignKey(
     fromTable: string,
     toTable: string,
-    options: {
-      column?: string | string[];
-      primaryKey?: string | string[];
-      name?: string;
-      onDelete?: ReferentialAction;
-      onUpdate?: ReferentialAction;
-      deferrable?: "immediate" | "deferred";
-      validate?: boolean;
-      ifNotExists?: boolean;
-    } = {},
+    options: AddForeignKeyOptions = {},
   ): Promise<void> {
     // Rails: assert_valid_deferrable runs before `super` (the abstract
     // add_foreign_key, where the if_not_exists short-circuit lives).
@@ -1259,7 +1249,11 @@ export class PostgreSQLSchemaStatements extends SchemaStatements {
     // schema_creation (visitAlterTable/visitForeignKeyDefinition) emits the
     // deferrable / NOT VALID / action / schema-qualified-name decoration, so no
     // bespoke inline SQL is needed here.
-    const fkOptions = this.foreignKeyOptions(fromTable, toTable, options);
+    const fkOptions = this.foreignKeyOptions(
+      fromTable,
+      toTable,
+      options as Record<string, unknown>,
+    );
     const at = this.pg.createAlterTable(fromTable);
     // Route through AlterTable#addForeignKey -> TableDefinition#newForeignKeyDefinition
     // (now converged): it applies table_name_prefix/suffix and re-runs

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-statements.ts
@@ -5,6 +5,7 @@
  */
 
 import type {
+  AddForeignKeyOptions,
   ChangeColumnDefinition,
   ChangeColumnDefaultDefinition,
   CheckConstraintDefinition,
@@ -203,19 +204,7 @@ export interface SchemaStatements {
     tableName: string,
     options: { column?: string | string[]; name?: string; _usesLegacyIndexName?: boolean },
   ): string;
-  addForeignKey(
-    fromTable: string,
-    toTable: string,
-    options?: {
-      column?: string;
-      primaryKey?: string;
-      name?: string;
-      onDelete?: "cascade" | "nullify" | "restrict" | "no_action" | "set_default";
-      onUpdate?: "cascade" | "nullify" | "restrict" | "no_action" | "set_default";
-      deferrable?: "immediate" | "deferred";
-      validate?: boolean;
-    },
-  ): Promise<void>;
+  addForeignKey(fromTable: string, toTable: string, options?: AddForeignKeyOptions): Promise<void>;
   checkConstraints(tableName: string): Promise<CheckConstraintDefinition[]>;
   addExclusionConstraint(
     tableName: string,

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1762,13 +1762,18 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
       const toTable = first.table as string;
       const onDelete = this._extractFkAction(first.on_delete as string);
       const onUpdate = this._extractFkAction(first.on_update as string);
-      const column =
-        group.length === 1 ? (first.from as string) : group.map((r) => r.from as string).join(",");
-      const primaryKey =
-        group.length === 1 ? (first.to as string) : group.map((r) => r.to as string).join(",");
-      const nameKey = column.replace(/,/g, "_");
-      const name = namesByColumn.get(column) ?? `fk_${bare}_${nameKey}`;
-      const deferrable = deferrableByKey.get(`${toTable},${column},${primaryKey}`);
+      // Rails returns composite column/primary_key as arrays and a bare string
+      // for single-column FKs (sqlite3_adapter.rb#foreign_keys). The name and
+      // deferrable maps are still keyed on the comma-joined column list.
+      const fromCols = group.map((r) => r.from as string);
+      const toCols = group.map((r) => r.to as string);
+      const column = fromCols.length === 1 ? fromCols[0] : fromCols;
+      const primaryKey = toCols.length === 1 ? toCols[0] : toCols;
+      const columnKey = fromCols.join(",");
+      const primaryKeyKey = toCols.join(",");
+      const nameKey = columnKey.replace(/,/g, "_");
+      const name = namesByColumn.get(columnKey) ?? `fk_${bare}_${nameKey}`;
+      const deferrable = deferrableByKey.get(`${toTable},${columnKey},${primaryKeyKey}`);
       results.push(
         // Rails' SQLite foreign_keys options hash carries on_delete/on_update/
         // deferrable/column/primary_key but no :name (we synthesize one for the
@@ -2155,13 +2160,11 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     options: AddForeignKeyOptions = {},
   ): Promise<void> {
     if (options.ifNotExists === true) {
-      const fks = await this.foreignKeys(fromTable);
-      if (
-        fks.some(
-          (fk) =>
-            fk.toTable === toTable && (options.column == null || fk.column === options.column),
-        )
-      ) {
+      // foreignKeyExists routes through foreignKeyFor/isDefinedFor, which
+      // compares `column` element-wise, so composite (array) columns match by
+      // value rather than by array identity (a bare `===` is always false for
+      // distinct array instances). Mirrors the abstract addForeignKey guard.
+      if (await this.foreignKeyExists(fromTable, toTable, { column: options.column })) {
         return;
       }
     }

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -20338,13 +20338,6 @@
     "package": "activerecord",
     "tsFile": "connection-adapters/abstract/schema-statements.ts",
     "rubyName": "add_foreign_key",
-    "call": "foreign_key_exists?",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "connection-adapters/abstract/schema-statements.ts",
-    "rubyName": "add_foreign_key",
     "call": "slice",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
   },


### PR DESCRIPTION
## What

`addForeignKey`'s `ifNotExists` branch matched existing FK columns with a
scalar `===`. For a composite `column: [...]`, `fk.column === options.column`
is a reference comparison — always false for distinct array instances — so a
matching composite FK was never detected and `ifNotExists: true` failed to
suppress a duplicate add.

The abstract, SQLite, and PostgreSQL paths each held their own inline `===`
guard, so all three are fixed to route through `foreignKeyExists` →
`foreignKeyFor` → `ForeignKeyDefinition#isDefinedFor`, which compares
`column`/`primaryKey` element-wise (arrays by value), mirroring Rails'
`foreign_keys(from).detect { |fk| fk.defined_for?(...) }` and the
`add_foreign_key` `if_not_exists` path (`options.slice(:column)`).

Two supporting fidelity fixes surfaced while making the guard actually match on
real adapters:

- **SQLite & PostgreSQL `foreignKeys` introspection** collapsed composite
  `column`/`primaryKey` into comma-joined strings; Rails returns **arrays** for
  composite FKs (`sqlite3_adapter.rb#foreign_keys`,
  `postgresql/schema_statements.rb#foreign_keys`). Both now emit arrays, so the
  element-wise compare can match.
- The two PostgreSQL `addForeignKey` overrides now take the shared
  `AddForeignKeyOptions` (`column`/`primaryKey: string | string[]`) instead of
  a scalar-only inline shape, so TypeScript callers can pass composite arrays.

## Tests

- Abstract: `foreignKeyExists matches a composite column by value, not reference`
  and an `addForeignKey ifNotExists` no-op (proven to fail without the fix).
- SQLite (`schema-statements-on-adapter`): end-to-end composite `ifNotExists`
  no-op, asserting `foreignKeys` reports the composite column as an array.
- PostgreSQL (`schema-statements-class`): composite `ifNotExists` no-op via a
  mocked composite-array FK.

Closes-story: foreign-key-exists-composite-column-value-match