### PR TITLE
fix(serialized): broaden isChanged value-equality to value-== coders (Date/Time)

### DIFF
--- a/packages/activerecord/src/type/serialized.trails.test.ts
+++ b/packages/activerecord/src/type/serialized.trails.test.ts
@@ -41,6 +41,19 @@ describe("Serialized#isChanged", () => {
     expect(type.isChanged(new Date("2026-07-08"), new Date("2026-07-09"))).toBe(true);
   });
 
+  it("dispatches to an explicit equals method, honoring cross-class value equality", () => {
+    // Mirrors ActiveSupport::TimeWithZone#== comparing by UTC instant across
+    // Date/Time-like kinds via its own equality method.
+    class Instant {
+      constructor(readonly ms: number) {}
+      equals(other: unknown) {
+        return other instanceof Date ? this.ms === other.getTime() : false;
+      }
+    }
+    expect(type.isChanged(new Instant(100), new Date(100))).toBe(false);
+    expect(type.isChanged(new Instant(100), new Date(200))).toBe(true);
+  });
+
   it("does not equate unrelated classes that yield the same valueOf primitive", () => {
     class Cents {
       valueOf() {

--- a/packages/activerecord/src/type/serialized.trails.test.ts
+++ b/packages/activerecord/src/type/serialized.trails.test.ts
@@ -41,6 +41,17 @@ describe("Serialized#isChanged", () => {
     expect(type.isChanged(new Date("2026-07-08"), new Date("2026-07-09"))).toBe(true);
   });
 
+  it("does not equate unrelated classes that yield the same valueOf primitive", () => {
+    class Cents {
+      valueOf() {
+        return 100;
+      }
+    }
+    const cents = new Cents();
+    const sameMillis = new Date(100);
+    expect(type.isChanged(cents, sameMillis)).toBe(true);
+  });
+
   it("falls back to reference equality for identity-== object_class instances", () => {
     class Custom {}
     const oldValue = new Custom();

--- a/packages/activerecord/src/type/serialized.trails.test.ts
+++ b/packages/activerecord/src/type/serialized.trails.test.ts
@@ -65,6 +65,11 @@ describe("Serialized#isChanged", () => {
     expect(type.isChanged(cents, sameMillis)).toBe(true);
   });
 
+  it("reports changed (not throws) for a null-prototype hash vs a Date", () => {
+    const nullProto = Object.assign(Object.create(null), { a: 1 });
+    expect(type.isChanged(nullProto, new Date(100))).toBe(true);
+  });
+
   it("falls back to reference equality for identity-== object_class instances", () => {
     class Custom {}
     const oldValue = new Custom();

--- a/packages/activerecord/src/type/serialized.trails.test.ts
+++ b/packages/activerecord/src/type/serialized.trails.test.ts
@@ -35,4 +35,17 @@ describe("Serialized#isChanged", () => {
     const newValue = new HashWithIndifferentAccess({ b: 2, a: 1 });
     expect(type.isChanged(oldValue, newValue)).toBe(false);
   });
+
+  it("treats two value-equal Dates as unchanged, matching Ruby Date#==", () => {
+    expect(type.isChanged(new Date("2026-07-08"), new Date("2026-07-08"))).toBe(false);
+    expect(type.isChanged(new Date("2026-07-08"), new Date("2026-07-09"))).toBe(true);
+  });
+
+  it("falls back to reference equality for identity-== object_class instances", () => {
+    class Custom {}
+    const oldValue = new Custom();
+    const newValue = new Custom();
+    expect(type.isChanged(oldValue, newValue)).toBe(true);
+    expect(type.isChanged(oldValue, oldValue)).toBe(false);
+  });
 });

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -24,6 +24,23 @@ function isValueComparable(value: unknown): boolean {
 }
 
 /**
+ * Whether a non-collection object carries value-based equality, mirroring a
+ * Ruby object whose `==` compares by value rather than identity (e.g.
+ * `Date`/`Time`). The JS analog is an object whose `valueOf()` returns a
+ * primitive other than the object itself: `Date.prototype.valueOf` yields a
+ * number, whereas the default `Object.prototype.valueOf` returns `this` (so a
+ * plain custom `object_class` instance falls through to reference equality,
+ * matching Ruby's default `Object#==`).
+ *
+ * @internal
+ */
+function hasValueEquality(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  const primitive = (value as { valueOf(): unknown }).valueOf();
+  return primitive !== value && (primitive === null || typeof primitive !== "object");
+}
+
+/**
  * Structural JSON key used to compare a value against the coder's default.
  * Unwraps objects that expose `toHash()` (the HashWithIndifferentAccess
  * interface) so their contents — not their Map-backed internal shape — drive
@@ -147,10 +164,9 @@ export class Serialized extends ValueType {
   // same distinction `isValueComparable`/`canonicalKey` already draw for
   // `default_value?`. Sharing that scope is deliberate: a coder whose `load`
   // returns a non-Array/Hash value with its own value-based `==` (e.g.
-  // Date/Time) still falls through to reference equality — a narrow edge no
-  // serialized coder here hits. `canonicalKey` sorts object keys, so two
-  // content-equal hashes built in a different insertion order compare equal,
-  // matching Ruby's order-insensitive `Hash#==`.
+  // Date/Time) is compared through `hasValueEquality` below. `canonicalKey`
+  // sorts object keys, so two content-equal hashes built in a different
+  // insertion order compare equal, matching Ruby's order-insensitive `Hash#==`.
   override isChanged(
     oldValue: unknown,
     newValue: unknown,
@@ -163,6 +179,14 @@ export class Serialized extends ValueType {
       } catch {
         return true;
       }
+    }
+    // A coder whose `load` returns a value-== object (e.g. Date/Time) mirrors
+    // Ruby's `old_value != new_value` dispatching to that object's own `==`.
+    if (hasValueEquality(oldValue) && hasValueEquality(newValue)) {
+      return !Object.is(
+        (oldValue as { valueOf(): unknown }).valueOf(),
+        (newValue as { valueOf(): unknown }).valueOf(),
+      );
     }
     return true;
   }

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -181,8 +181,16 @@ export class Serialized extends ValueType {
       }
     }
     // A coder whose `load` returns a value-== object (e.g. Date/Time) mirrors
-    // Ruby's `old_value != new_value` dispatching to that object's own `==`.
-    if (hasValueEquality(oldValue) && hasValueEquality(newValue)) {
+    // Ruby's `old_value != new_value` dispatching to that object's own `==`. A
+    // Ruby value type's `==` (e.g. `Date#==`) only compares against its own
+    // kind, so require the operands share a constructor before value-comparing
+    // by `valueOf()` — two unrelated classes that happen to yield the same
+    // primitive are not equal, matching Ruby.
+    if (
+      hasValueEquality(oldValue) &&
+      hasValueEquality(newValue) &&
+      (oldValue as object).constructor === (newValue as object).constructor
+    ) {
       return !Object.is(
         (oldValue as { valueOf(): unknown }).valueOf(),
         (newValue as { valueOf(): unknown }).valueOf(),

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -34,6 +34,22 @@ function isValueComparable(value: unknown): boolean {
  *
  * @internal
  */
+/**
+ * Whether a value exposes an explicit `equals(other)` method — our convention
+ * for a Ruby object that overrides `==`. Used to dispatch change detection to
+ * the value's own equality (e.g. ActiveSupport::TimeWithZone, which compares by
+ * UTC instant across Date/Time-like operands) rather than a primitive fallback.
+ *
+ * @internal
+ */
+function hasEquals(value: unknown): value is { equals(other: unknown): boolean } {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    typeof (value as { equals?: unknown }).equals === "function"
+  );
+}
+
 function hasValueEquality(value: unknown): boolean {
   if (value === null || typeof value !== "object") return false;
   const primitive = (value as { valueOf(): unknown }).valueOf();
@@ -180,12 +196,19 @@ export class Serialized extends ValueType {
         return true;
       }
     }
-    // A coder whose `load` returns a value-== object (e.g. Date/Time) mirrors
-    // Ruby's `old_value != new_value` dispatching to that object's own `==`. A
-    // Ruby value type's `==` (e.g. `Date#==`) only compares against its own
-    // kind, so require the operands share a constructor before value-comparing
-    // by `valueOf()` — two unrelated classes that happen to yield the same
-    // primitive are not equal, matching Ruby.
+    // A coder whose `load` returns a value-== object mirrors Ruby's
+    // `old_value != new_value` dispatching to that object's own `==`. When the
+    // value defines an explicit `equals` (our convention for Ruby `==`, e.g.
+    // ActiveSupport::TimeWithZone whose `<=>`/`==` compares by UTC instant
+    // across Date/Time-like kinds), dispatch to it so cross-class time-like
+    // equality is honored.
+    if (hasEquals(oldValue)) return !oldValue.equals(newValue);
+    if (hasEquals(newValue)) return !newValue.equals(oldValue);
+    // Otherwise a value object without an explicit `==` but with a primitive
+    // `valueOf` (e.g. Date) compares by that primitive. A Ruby value type's
+    // `==` only compares against its own kind, so require a shared constructor:
+    // two unrelated classes that happen to yield the same primitive are not
+    // equal, matching Ruby.
     if (
       hasValueEquality(oldValue) &&
       hasValueEquality(newValue) &&

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -201,9 +201,9 @@ export class Serialized extends ValueType {
     // value defines an explicit `equals` (our convention for Ruby `==`, e.g.
     // ActiveSupport::TimeWithZone whose `<=>`/`==` compares by UTC instant
     // across Date/Time-like kinds), dispatch to it so cross-class time-like
-    // equality is honored.
+    // equality is honored. Rails' `old_value != new_value` calls the *left*
+    // operand's `==`, so dispatch on `oldValue` only — never `newValue`.
     if (hasEquals(oldValue)) return !oldValue.equals(newValue);
-    if (hasEquals(newValue)) return !newValue.equals(oldValue);
     // Otherwise a value object without an explicit `==` but with a primitive
     // `valueOf` (e.g. Date) compares by that primitive. A Ruby value type's
     // `==` only compares against its own kind, so require a shared constructor:

--- a/packages/activerecord/src/type/serialized.ts
+++ b/packages/activerecord/src/type/serialized.ts
@@ -52,7 +52,12 @@ function hasEquals(value: unknown): value is { equals(other: unknown): boolean }
 
 function hasValueEquality(value: unknown): boolean {
   if (value === null || typeof value !== "object") return false;
-  const primitive = (value as { valueOf(): unknown }).valueOf();
+  // A null-prototype object (which isValueComparable treats as hash-like) does
+  // not inherit Object.prototype.valueOf, so guard the lookup rather than
+  // throwing when such a value reaches this fallback.
+  const valueOf = (value as { valueOf?: unknown }).valueOf;
+  if (typeof valueOf !== "function") return false;
+  const primitive = valueOf.call(value);
   return primitive !== value && (primitive === null || typeof primitive !== "object");
 }
 


### PR DESCRIPTION
## Summary

`Serialized#isChanged` restored Ruby value-equality only for `isValueComparable`
values (Array / HashWithIndifferentAccess / plain object). Rails'
`Type::Value#changed?` is `old_value != new_value`, which dispatches to each
object's own `==`. A serialized coder whose `load` returns a non-collection
value with value-based `==` (e.g. `Date`/`Time`) got reference-equality here.

This adds a `hasValueEquality` path: a non-collection object whose `valueOf()`
returns a primitive other than itself (Date/Time) is compared by that value,
while a plain custom `object_class` instance (default `Object.prototype.valueOf`
returns `this`) keeps reference equality, matching Ruby's default `Object#==`.

## Tests

- Two value-equal `Date`s report `isChanged` = false; different days = true.
- Identity-`==` `object_class` instances keep reference equality.
- No regression for Array/Hash/plain-object cases.

Closes-story: serialized-ischanged-value-equality-scoped-to-array-hash