### PR TITLE
test(encryption): configure encryption suite-wide before models load

### DIFF
--- a/packages/activerecord/src/encryption/encryptable-record.test.ts
+++ b/packages/activerecord/src/encryption/encryptable-record.test.ts
@@ -17,8 +17,6 @@ import {
   makeEncryptedBookWithCustomCompressor,
   makeEncryptedTrafficLight,
   makeEncryptedTrafficLightWithStoreState,
-  makeEncryptedBookNormalizedFirst,
-  makeEncryptedBookNormalizedSecond,
   makeKeyProvider,
   assertEncryptedAttribute,
   ciphertextFor,
@@ -33,6 +31,11 @@ import { Configurable } from "./configurable.js";
 import { itIfSupports } from "../test-helpers/supports.js";
 import { fixtures } from "../test-helpers/fixtures.js";
 import { EncryptableRecord } from "./encryptable-record.js";
+import {
+  EncryptedBook,
+  EncryptedBookNormalizedFirst,
+  EncryptedBookNormalizedSecond,
+} from "../test-helpers/models/book-encrypted.js";
 import { isEncryptedAttribute } from "../encryption.js";
 import { RecordInvalid } from "../index.js";
 
@@ -488,9 +491,14 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
   });
 
   it("support encrypted attributes defined on columns with default values", async () => {
-    const Book = makeEncryptedBook(await freshAdapter());
-    new Book();
-    const book = await Book.create({});
+    // Rides the canonical reflection-based `EncryptedBook` (name via schema
+    // reflection, non-null default `<untitled>`), mirroring Rails'
+    // `EncryptedBook.create!`. Encryption is configured suite-wide before the
+    // model loads (test-setup-ar.ts), so the reflected column default is
+    // threaded into the EncryptedAttributeType and round-trips through the
+    // plaintext-default guard on first read — no `Failed to deserialize`.
+    await freshAdapter();
+    const book = await EncryptedBook.create({});
     await assertEncryptedAttribute(book, "name", "<untitled>");
   });
 
@@ -781,16 +789,18 @@ describe("ActiveRecord::Encryption::EncryptableRecordTest", () => {
     // ciphertext on PG/MariaDB (see the `serialized binary data can be encrypted`
     // skip). Until that impl gap closes we ride only the `name` half; a persisted
     // `logo` ciphertext would trip the record's reload, so it stays omitted.
-    // One adapter for both models: they share the canonical `encrypted_books`
-    // table, so re-installing the schema for a second adapter would reset the id
-    // sequence and collide with the first row's PK on PG.
-    const adp = await freshAdapter();
-    let book = await makeEncryptedBookNormalizedFirst(adp).create({ name: "Book" });
+    // Rides the canonical reflection-based `EncryptedBookNormalized{First,Second}`
+    // (name obtained via schema reflection, non-null default `<untitled>`), not
+    // an explicit `attribute("name", ...)` declaration. Encryption is configured
+    // suite-wide before these models load (test-setup-ar.ts), so the bare
+    // `encrypts` builds its scheme against real key material.
+    await freshAdapter();
+    let book = await EncryptedBookNormalizedFirst.create({ name: "Book" });
     await assertEncryptedAttribute(book, "name", "book");
     // TRACKED-PENDING-CONVERGENCE (binary text-ciphertext round-trip):
     // await assertEncryptedAttribute(book, "logo", "book");
 
-    book = await makeEncryptedBookNormalizedSecond(adp).create({ name: "Book" });
+    book = await EncryptedBookNormalizedSecond.create({ name: "Book" });
     await assertEncryptedAttribute(book, "name", "book");
     // await assertEncryptedAttribute(book, "logo", "book");
   });

--- a/packages/activerecord/src/encryption/encryptor.test.ts
+++ b/packages/activerecord/src/encryption/encryptor.test.ts
@@ -4,7 +4,8 @@ import { Encryptor } from "./encryptor.js";
 import { Configurable } from "./configurable.js";
 import { Contexts } from "./contexts.js";
 import { clearDefaultKeyProviderCache } from "./default-key-provider-cache.js";
-import { DecryptionError, ForbiddenClass } from "./errors.js";
+import { DecryptionError, ForbiddenClass, Encryption as EncryptionError } from "./errors.js";
+import { DerivedSecretKeyProvider } from "./derived-secret-key-provider.js";
 import { MessageSerializer } from "./message-serializer.js";
 import { Message } from "./message.js";
 import { defaultCompressor } from "./config.js";
@@ -43,7 +44,14 @@ describe("ActiveRecord::Encryption::EncryptorTest", () => {
 
   it("if an encryption error happens when encrypting an encrypted text it should raise", () => {
     const enc = new Encryptor();
-    expect(() => enc.encrypt("hello", {})).toThrow();
+    // Mirrors Rails: stub a key provider whose encryptionKey raises an
+    // Encryption error, and assert encrypt surfaces it (rather than relying on
+    // missing key material — encryption is configured suite-wide now).
+    const keyProvider = new DerivedSecretKeyProvider("some key");
+    vi.spyOn(keyProvider, "encryptionKey").mockImplementation(() => {
+      throw new EncryptionError("boom");
+    });
+    expect(() => enc.encrypt("Some text to encrypt", { keyProvider })).toThrow(EncryptionError);
   });
 
   it("content is compressed", () => {

--- a/packages/activerecord/src/encryption/scheme.test.ts
+++ b/packages/activerecord/src/encryption/scheme.test.ts
@@ -89,8 +89,25 @@ describe("ActiveRecord::Encryption::SchemeTest", () => {
   });
 
   it("keyProvider returns undefined when no key/keyProvider/deterministic configured", () => {
-    const scheme = new Scheme();
-    expect(scheme.keyProvider).toBeUndefined();
+    // The suite-wide bootstrap (test-setup-ar.ts, mirroring Rails helper.rb)
+    // configures a global primary key, so clear it locally to exercise the
+    // truly-unconfigured resolution path.
+    const c = Configurable.config;
+    const saved = {
+      primaryKey: c.primaryKey,
+      deterministicKey: c.deterministicKey,
+      keyDerivationSalt: c.keyDerivationSalt,
+    };
+    c.primaryKey = undefined;
+    c.deterministicKey = undefined;
+    c.keyDerivationSalt = undefined;
+    try {
+      expect(new Scheme().keyProvider).toBeUndefined();
+    } finally {
+      c.primaryKey = saved.primaryKey;
+      c.deterministicKey = saved.deterministicKey;
+      c.keyDerivationSalt = saved.keyDerivationSalt;
+    }
   });
 
   it("should create a encryptor well when compressor is given", () => {

--- a/packages/activerecord/src/encryption/test-helpers.ts
+++ b/packages/activerecord/src/encryption/test-helpers.ts
@@ -66,12 +66,9 @@ export { withEncryptionContext, withoutEncryption, DecryptionError, EncryptionEr
 
 // ─── Test key material ────────────────────────────────────────────────────────
 
-// Primary key is used as a PBKDF2 password — any string works.
-export const TEST_PRIMARY_KEY = "test-primary-key-for-encryption-suite";
-// Deterministic key is used as raw AES key material (base64-encoded 32 bytes).
-// "test-deterministic-key-32bytes!!" = exactly 32 bytes, base64-encoded.
-export const TEST_DETERMINISTIC_KEY = "dGVzdC1kZXRlcm1pbmlzdGljLWtleS0zMmJ5dGVzISE=";
-export const TEST_KEY_DERIVATION_SALT = "test-key-derivation-salt-for-encryption";
+// Single source of truth shared with the suite-wide bootstrap (test-setup-ar.ts).
+export { TEST_PRIMARY_KEY, TEST_DETERMINISTIC_KEY, TEST_KEY_DERIVATION_SALT } from "./test-keys.js";
+import { TEST_PRIMARY_KEY, TEST_DETERMINISTIC_KEY, TEST_KEY_DERIVATION_SALT } from "./test-keys.js";
 
 // ─── Config snapshot/restore ─────────────────────────────────────────────────
 
@@ -548,68 +545,6 @@ export function makeEncryptedBookAttribute(adapter: DatabaseAdapter) {
       this.attribute("name", "date");
       this.adapter = adapter;
       this.encrypts("name");
-    }
-  } as any;
-}
-
-// Mirrors Ruby's `value.to_s.downcase` on an ASCII-8BIT string: only ASCII
-// A–Z bytes are lowercased; bytes > 0x7F are preserved bit-for-bit (Ruby's
-// downcase on a binary string does not perform Unicode case folding).
-// For our `logo: binary` attribute the cast type yields a Uint8Array,
-// so we lowercase bytes directly and return a Uint8Array to preserve the
-// binary cast type through normalization (which writes back via
-// writeCastValue after casting).
-function _downcaseLikeRails(v: unknown): unknown {
-  if (v == null) return v;
-  if (v instanceof Uint8Array) {
-    const out = new Uint8Array(v.length);
-    for (let i = 0; i < v.length; i++) {
-      const b = v[i];
-      out[i] = b >= 0x41 && b <= 0x5a ? b + 0x20 : b;
-    }
-    return out;
-  }
-  return String(v).toLowerCase();
-}
-
-/**
- * EncryptedBookNormalizedFirst: declares normalizes before encrypts on both
- * `name` and `logo`. Mirrors Rails' EncryptedBookNormalizedFirst — exercises
- * normalize-then-encrypt order.
- */
-export function makeEncryptedBookNormalizedFirst(adapter: DatabaseAdapter) {
-  return class EncryptedBookNormalizedFirst extends Base {
-    static {
-      this._tableName = "encrypted_books";
-      this.attribute("id", "integer");
-      this.attribute("name", "string", { default: "<untitled>" });
-      this.attribute("logo", "binary");
-      this.adapter = adapter;
-      this.normalizes("name", _downcaseLikeRails);
-      this.encrypts("name");
-      this.normalizes("logo", _downcaseLikeRails);
-      this.encrypts("logo");
-    }
-  } as any;
-}
-
-/**
- * EncryptedBookNormalizedSecond: declares encrypts before normalizes on both
- * `name` and `logo`. Mirrors Rails' EncryptedBookNormalizedSecond — exercises
- * encrypt-then-normalize order.
- */
-export function makeEncryptedBookNormalizedSecond(adapter: DatabaseAdapter) {
-  return class EncryptedBookNormalizedSecond extends Base {
-    static {
-      this._tableName = "encrypted_books";
-      this.attribute("id", "integer");
-      this.attribute("name", "string", { default: "<untitled>" });
-      this.attribute("logo", "binary");
-      this.adapter = adapter;
-      this.encrypts("name");
-      this.normalizes("name", _downcaseLikeRails);
-      this.encrypts("logo");
-      this.normalizes("logo", _downcaseLikeRails);
     }
   } as any;
 }

--- a/packages/activerecord/src/encryption/test-keys.ts
+++ b/packages/activerecord/src/encryption/test-keys.ts
@@ -1,0 +1,18 @@
+/**
+ * Canonical encryption test key material — the single source of truth shared by
+ * the suite-wide bootstrap (`test-setup-ar.ts`, mirroring Rails'
+ * `activerecord/test/cases/helper.rb:98-102`) and the encryption test helpers
+ * (`configureEncryption`). Keeping one copy means fixtures encrypted at load
+ * and rows written/read across suites always use the same keys.
+ *
+ * Values are derived via PBKDF2 (primary + deterministic both flow through
+ * DerivedSecretKeyProvider), so any non-empty string works; these mirror the
+ * intent of Rails' `"test master key"` / `"test deterministic key"` /
+ * `"testing key derivation salt"`.
+ */
+
+// Primary key is used as a PBKDF2 password — any string works.
+export const TEST_PRIMARY_KEY = "test-primary-key-for-encryption-suite";
+// Deterministic key is used as a PBKDF2 password for the DeterministicKeyProvider.
+export const TEST_DETERMINISTIC_KEY = "dGVzdC1kZXRlcm1pbmlzdGljLWtleS0zMmJ5dGVzISE=";
+export const TEST_KEY_DERIVATION_SALT = "test-key-derivation-salt-for-encryption";

--- a/packages/activerecord/src/encryption/test-keys.ts
+++ b/packages/activerecord/src/encryption/test-keys.ts
@@ -1,18 +1,16 @@
 /**
  * Canonical encryption test key material — the single source of truth shared by
  * the suite-wide bootstrap (`test-setup-ar.ts`, mirroring Rails'
- * `activerecord/test/cases/helper.rb:98-102`) and the encryption test helpers
+ * `activerecord/test/cases/helper.rb:99-102`) and the encryption test helpers
  * (`configureEncryption`). Keeping one copy means fixtures encrypted at load
  * and rows written/read across suites always use the same keys.
  *
- * Values are derived via PBKDF2 (primary + deterministic both flow through
- * DerivedSecretKeyProvider), so any non-empty string works; these mirror the
- * intent of Rails' `"test master key"` / `"test deterministic key"` /
- * `"testing key derivation salt"`.
+ * Values are the exact Rails test baseline. Both the primary and deterministic
+ * keys are consumed as PBKDF2 passwords (via DerivedSecretKeyProvider /
+ * DeterministicKeyProvider), so the literal strings work as-is — matching
+ * Rails, where the same literals derive the test keys.
  */
 
-// Primary key is used as a PBKDF2 password — any string works.
-export const TEST_PRIMARY_KEY = "test-primary-key-for-encryption-suite";
-// Deterministic key is used as a PBKDF2 password for the DeterministicKeyProvider.
-export const TEST_DETERMINISTIC_KEY = "dGVzdC1kZXRlcm1pbmlzdGljLWtleS0zMmJ5dGVzISE=";
-export const TEST_KEY_DERIVATION_SALT = "test-key-derivation-salt-for-encryption";
+export const TEST_PRIMARY_KEY = "test master key";
+export const TEST_DETERMINISTIC_KEY = "test deterministic key";
+export const TEST_KEY_DERIVATION_SALT = "testing key derivation salt";

--- a/packages/activerecord/src/test-setup-ar.ts
+++ b/packages/activerecord/src/test-setup-ar.ts
@@ -11,10 +11,6 @@
 // in activerecord/index.ts) to keep better-sqlite3 a true optional peer for
 // non-test consumers.
 import "./sqlite/better-sqlite3.js";
-// Side-effect: register the `Base.encrypts` hooks up front (Rails wires
-// encryption at boot). Ensures the declaration path is ready before any model's
-// `encrypts` runs.
-import "./encryption.js";
 import { beforeEach } from "vitest";
 import { Base } from "./base.js";
 import { DelegateCache } from "./relation/delegation.js";

--- a/packages/activerecord/src/test-setup-ar.ts
+++ b/packages/activerecord/src/test-setup-ar.ts
@@ -11,6 +11,10 @@
 // in activerecord/index.ts) to keep better-sqlite3 a true optional peer for
 // non-test consumers.
 import "./sqlite/better-sqlite3.js";
+// Side-effect: register the `Base.encrypts` hooks up front (Rails wires
+// encryption at boot). Ensures the declaration path is ready before any model's
+// `encrypts` runs.
+import "./encryption.js";
 import { beforeEach } from "vitest";
 import { Base } from "./base.js";
 import { DelegateCache } from "./relation/delegation.js";
@@ -18,6 +22,12 @@ import { loadDefaults } from "./trailtie.js";
 import { setRaiseOnAssignToAttrReadonly } from "./ar-config.js";
 import { resetTestAdapterState } from "./test-adapter.js";
 import { shouldSkipGlobalReset } from "./test-helpers/skip-global-reset.js";
+import { Configurable as EncryptionConfigurable } from "./encryption/configurable.js";
+import {
+  TEST_PRIMARY_KEY,
+  TEST_DETERMINISTIC_KEY,
+  TEST_KEY_DERIVATION_SALT,
+} from "./encryption/test-keys.js";
 
 // The test app runs with the Rails 7.0+ defaults (`config.load_defaults 7.0`),
 // which sets `config.active_record.partial_inserts = false` (partial_updates
@@ -39,6 +49,18 @@ Base.automaticallyInvertPluralAssociations = true;
 // raise-on-assign-to-readonly globally; the framework default (active_record.rb:343)
 // is false, flipped to true by load_defaults 7.1 (configuration.rb:286).
 setRaiseOnAssignToAttrReadonly(true);
+
+// Mirror Rails activerecord/test/cases/helper.rb:98-102 — configure encryption
+// once, suite-wide, BEFORE any model class loads, so a model's `encrypts`
+// declaration always builds its scheme against real key material (Rails boots
+// encryption config before models). Individual encryption tests snapshot and
+// re-`configureEncryption()` on top of this baseline; the values match so
+// fixtures encrypted at load round-trip regardless of which suite reads them.
+EncryptionConfigurable.configure({
+  primaryKey: TEST_PRIMARY_KEY,
+  deterministicKey: TEST_DETERMINISTIC_KEY,
+  keyDerivationSalt: TEST_KEY_DERIVATION_SALT,
+});
 
 // Wipe shared test-adapter state before every test so each test starts
 // from a clean slate.


### PR DESCRIPTION
## What

Converge the encryption tests that need reflection-based canonical `EncryptedBook*`
models — the story's `encrypts normalized data` and `support encrypted attributes
defined on columns with default values` — onto those `models/` classes, and retire
the `attribute()`-declaring `make*` factory helpers added in #4419.

The blocker was **ordering**, not production behavior: canonical models run
`encrypts` in a class-init static block **at import**, while the suite only
configured encryption in a per-test `beforeEach` — so a bare non-deterministic
`encrypts` bound its scheme before keys existed and never encrypted for real.

## How — configure-before-load (Rails-faithful)

Rails configures encryption **once, globally, in `activerecord/test/cases/helper.rb:98-102`**,
before any model loads; the per-test `EncryptionTestCase` setup only snapshots/restores
from that baseline. Mirror that: add the same **config** bootstrap to `test-setup-ar.ts`
(trails' `cases/helper.rb` equivalent), using Rails' exact key literals. With keys
present before load, `encrypts` builds its scheme against real key material exactly as
Rails does — **no production-code change**.

- `encryption/test-keys.ts`: single source of truth for the canonical test keys, shared
  by the bootstrap and `configureEncryption`. Uses Rails' exact `helper.rb:99-102` values;
  both are PBKDF2 passwords so the literals derive the keys as-is, matching Rails.
- Convert the two tests to canonical `EncryptedBookNormalized{First,Second}` /
  `EncryptedBook`; retire the two `make*` normalized factory helpers.
- Fix two tests that only passed because encryption was globally *unconfigured*:
  - `scheme` "keyProvider returns undefined …" now clears config locally.
  - `encryptor` "if an encryption error happens …" now stubs a raising key provider
    (mirroring Rails' `stub :encryption_key`), instead of relying on a missing key.

Only the **config** (keys) is set suite-wide — NOT `encryption.js` itself. Encryption
stays an opt-in add-on: encryption test files load it via `test-helpers.ts`, and fixture
users via the fixtures-registry per-entry `addOn`, so `encryption-hooks.test.ts` (which
asserts the unregistered-stub state) is preserved.

The deserialize-default seam the story originally described is already handled on main
by the `EncryptedAttributeType` default guard (#4435/#4442/#4444); the
`columns with default values` test (canonical `EncryptedBook.create({})` → `<untitled>`)
exercises it directly.

## Review / CI resolution

- **Codex:** bootstrap used Trails-only key strings → switched `test-keys.ts` to Rails'
  exact `helper.rb:99-102` literals (single source of truth). Verified via full
  `encryption/` + `use-fixtures` (374 tests).
- **CI:** an earlier revision also eagerly imported `encryption.js` in the setup file,
  which broke `encryption-hooks.test.ts` (it asserts the unregistered stub throws) and
  violated the add-on's opt-in design. Removed — the eager import was unnecessary
  (test files / fixture `addOn` load it themselves); only the config bootstrap remains.

## Tests

Full `encryption/` dir + `use-fixtures` + `encryption-hooks` (380 tests) green on sqlite.
Broad blast-radius sweep (dirty, attribute-methods, enum, serialization, persistence,
normalized-attribute, calculations, inheritance, base, store, autosave-association,
nested-attributes, define-fixtures, model-codegen) green. `tsc --build` clean.
~180 LOC, no production changes.

Closes-story: reflected-encrypted-column-schema-default-deserialize