### PR TITLE
refactor(delegation): per-model prototype carriers for remaining delegate classes

### DIFF
--- a/packages/activerecord/src/association-relation.ts
+++ b/packages/activerecord/src/association-relation.ts
@@ -6,6 +6,7 @@ import type { Association } from "./associations/association.js";
 import { setAssociationRelationFactory } from "./associations/_scope-slots.js";
 import { _cacheSingularTarget } from "./associations.js";
 import { _registerRelationFamily } from "./relation/uncacheable-methods-slot.js";
+import { associationRelationClassFor } from "./relation/delegation.js";
 import { rebaseNewOwnerSeed } from "./associations/new-owner-seed-rebase.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 
@@ -52,7 +53,8 @@ export class AssociationRelation<T extends Base> extends Relation<T> {
    * through the association.
    */
   protected _newRelation(): Relation<T> {
-    return new AssociationRelation<T>(this.model, this._association);
+    const Ctor = associationRelationClassFor(this.model);
+    return new Ctor(this.model, this._association);
   }
 
   /**
@@ -333,6 +335,7 @@ _registerRelationFamily(
   "associationRelation",
   AssociationRelation as unknown as new (...a: never[]) => unknown,
 );
-setAssociationRelationFactory(
-  (klass, assoc) => new AssociationRelation(klass as typeof Base, assoc as Association),
-);
+setAssociationRelationFactory((klass, assoc) => {
+  const Ctor = associationRelationClassFor(klass as typeof Base);
+  return new Ctor(klass as typeof Base, assoc as Association);
+});

--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -3173,7 +3173,13 @@ export function association<T extends Base = Base>(
         "`association()` call.",
     );
   }
-  const proxy = new _CollectionProxyCtor(record, assocName, assocDef) as CollectionProxy<T> & {
+  // Route through the CollectionProxy per-model subclass carrier (its `_create`
+  // factory) so generated relation methods resolve as real methods on the proxy.
+  const proxy = (
+    _CollectionProxyCtor as unknown as {
+      _create: (r: Base, n: string, d: AssociationDefinition) => CollectionProxy<T>;
+    }
+  )._create(record, assocName, assocDef) as CollectionProxy<T> & {
     _hydrateFromPreload: (records: T[]) => void;
   };
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -3,7 +3,11 @@ import { Relation } from "../relation.js";
 import { concatRecordsLoop } from "./collection-association.js";
 import type { PrettyPrinter } from "../pretty-print.js";
 import type { AssociationRelation as AssociationRelationType } from "../association-relation.js";
-import { wrapWithScopeProxy } from "../relation/delegation.js";
+import {
+  wrapWithScopeProxy,
+  associationRelationClassFor,
+  collectionProxyClassFor,
+} from "../relation/delegation.js";
 import { _registerRelationFamily } from "../relation/uncacheable-methods-slot.js";
 
 // Late-bound AssociationRelation constructor to break circular imports
@@ -452,14 +456,46 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
     this._targetLoaded = true;
   }
 
-  constructor(record: Base, assocName: string, assocDef: AssociationDefinition) {
+  /**
+   * @internal Resolve the target model an association's proxy scopes to —
+   * preferring the rich reflection's namespace-aware klass, else `className`.
+   * Shared by the constructor and {@link _create} so the per-model carrier is
+   * chosen from the exact same model the constructed instance reports as
+   * `.model`.
+   */
+  static _targetModelFor(
+    record: Base,
+    assocName: string,
+    assocDef: AssociationDefinition,
+  ): typeof Base {
     const className = assocDef.options.className ?? camelize(singularize(assocName));
-    // Prefer the rich reflection's klass so namespace-relative resolution applies.
     const ownerCtor = record.constructor as typeof Base & {
       _reflectOnAssociation?: (n: string) => { klass?: typeof Base } | null;
     };
     const richKlass = ownerCtor._reflectOnAssociation?.(assocName)?.klass;
-    const targetModel = richKlass ?? resolveModel(className);
+    return richKlass ?? resolveModel(className);
+  }
+
+  /**
+   * @internal Construct a CollectionProxy from the target model's per-model
+   * subclass carrier (`collectionProxyClassFor`), so generated relation methods
+   * resolve as real methods on it (Rails' `delegate.include
+   * generated_relation_methods`). The carrier subclass inherits this
+   * constructor unchanged.
+   */
+  static _create<T extends Base = Base>(
+    record: Base,
+    assocName: string,
+    assocDef: AssociationDefinition,
+  ): CollectionProxy<T> {
+    const targetModel = this._targetModelFor(record, assocName, assocDef);
+    const Ctor = collectionProxyClassFor(targetModel);
+    return new Ctor(record, assocName, assocDef) as CollectionProxy<T>;
+  }
+
+  constructor(record: Base, assocName: string, assocDef: AssociationDefinition) {
+    // Prefer the rich reflection's klass so namespace-relative resolution applies.
+    const targetModel = CollectionProxy._targetModelFor(record, assocName, assocDef);
     super(targetModel, targetModel.arelTable);
     this._record = record;
     this._assocName = assocName;
@@ -3588,7 +3624,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           "deep-importing './associations/collection-proxy.js'.",
       );
     }
-    const ar = new _AssociationRelationCtor(rel.model, this);
+    const Ctor = associationRelationClassFor(rel.model as typeof Base);
+    const ar = new Ctor(rel.model, this);
     ar._copyStateFrom(rel);
     // Re-apply the association's `extend:` modules — mirrors Rails
     // `CollectionAssociation#scope`, which extends the freshly built scope
@@ -4206,7 +4243,8 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
           "association-relation.ts must be loaded first",
       );
     }
-    return new _AssociationRelationCtor(this.model, this) as Relation<T>;
+    const Ctor = associationRelationClassFor(this.model);
+    return new Ctor(this.model, this) as Relation<T>;
   }
 }
 

--- a/packages/activerecord/src/associations/disable-joins-association-scope.ts
+++ b/packages/activerecord/src/associations/disable-joins-association-scope.ts
@@ -5,6 +5,7 @@ import {
   type ValueTransformation,
 } from "./association-scope.js";
 import { DisableJoinsAssociationRelation } from "../disable-joins-association-relation.js";
+import { disableJoinsAssociationRelationClassFor } from "../relation/delegation.js";
 import type { Relation } from "../relation.js";
 import type { ExceptKey } from "../relation/query-methods.js";
 import type { Base } from "../base.js";
@@ -328,10 +329,11 @@ export class DisableJoinsAssociationScope extends AssociationScope {
       // Branch over key arity so we hit DJAR's correlated overloads.
       // At this point `joinIds` is already shape-matched to `keyCols`
       // by the single-vs-composite branches in `_addConstraintsDj`.
+      const Ctor = disableJoinsAssociationRelationClassFor(klass);
       const split =
         keyCols.length === 1
-          ? new DisableJoinsAssociationRelation<Base>(klass, keyCols[0], joinIds as unknown[])
-          : new DisableJoinsAssociationRelation<Base>(klass, keyCols, joinIds as unknown[][]);
+          ? new Ctor(klass, keyCols[0], joinIds as unknown[])
+          : new Ctor(klass, keyCols, joinIds as unknown[][]);
       const sourceWhere = (scope as { _whereClause?: { predicates?: unknown[] } })._whereClause;
       const splitWhere = (split as unknown as { _whereClause?: { predicates: unknown[] } })
         ._whereClause;

--- a/packages/activerecord/src/disable-joins-association-relation.ts
+++ b/packages/activerecord/src/disable-joins-association-relation.ts
@@ -1,6 +1,7 @@
 import { Relation } from "./relation.js";
 import { argumentError } from "./relation/query-methods.js";
 import { _registerRelationFamily } from "./relation/uncacheable-methods-slot.js";
+import { disableJoinsAssociationRelationClassFor } from "./relation/delegation.js";
 import { normalizeAssociationKey } from "./associations/key-normalization.js";
 import type { Base } from "./base.js";
 
@@ -289,7 +290,8 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     klass: typeof Base,
     chainWalker: () => Promise<{ relation: Relation<T> }>,
   ): DisableJoinsAssociationRelation<T> {
-    return new DisableJoinsAssociationRelation<T>(klass, "", [], chainWalker);
+    const Ctor = disableJoinsAssociationRelationClassFor(klass);
+    return new Ctor(klass, "", [], chainWalker);
   }
 
   /**
@@ -468,19 +470,10 @@ export class DisableJoinsAssociationRelation<T extends Base> extends Relation<T>
     // the public `chainWalker?` slot — same runtime position, same
     // module.
     const trusted = payload as unknown as () => Promise<{ relation: Relation<T> }>;
+    const Ctor = disableJoinsAssociationRelationClassFor(this.model);
     const clone = this._composite
-      ? new DisableJoinsAssociationRelation<T>(
-          this.model,
-          this.key as string[],
-          this._storedIds as unknown[][],
-          trusted,
-        )
-      : new DisableJoinsAssociationRelation<T>(
-          this.model,
-          this.key as string,
-          this._storedIds as unknown[],
-          trusted,
-        );
+      ? new Ctor(this.model, this.key as string[], this._storedIds as unknown[][], trusted)
+      : new Ctor(this.model, this.key as string, this._storedIds as unknown[], trusted);
     return clone as unknown as Relation<T>;
   }
 

--- a/packages/activerecord/src/relation/delegation.trails.test.ts
+++ b/packages/activerecord/src/relation/delegation.trails.test.ts
@@ -1,17 +1,30 @@
 /**
  * trails-only mechanism tests for the per-model prototype-carrier delegation
- * (story `delegation-generated-methods-per-model-prototype-carrier`). These
- * assert the *mechanism* — that generated relation methods resolve as real
- * methods via a per-model `Relation` subclass prototype carrier — rather than
- * observable behavior (covered by the Rails-mirrored `delegation.test.ts`).
+ * (stories `delegation-generated-methods-per-model-prototype-carrier` and
+ * `delegation-remaining-delegate-class-prototype-carriers`). These assert the
+ * *mechanism* — that generated relation methods resolve as real methods via
+ * per-model subclass prototype carriers for all four delegate classes
+ * (`Relation`, `AssociationRelation`, `DisableJoinsAssociationRelation`,
+ * `CollectionProxy`) — rather than observable behavior (covered by the
+ * Rails-mirrored `delegation.test.ts`).
  */
 import { describe, it, expect } from "vitest";
-import { generateRelationMethod, relationClassFor, uncacheableMethods } from "./delegation.js";
+import {
+  generateRelationMethod,
+  relationClassFor,
+  associationRelationClassFor,
+  disableJoinsAssociationRelationClassFor,
+  collectionProxyClassFor,
+  uncacheableMethods,
+} from "./delegation.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
-// Loading CollectionProxy registers it with the relation family so
-// `uncacheableMethods()` sees the subclass-only methods (`target`, …).
+// Loading these registers each delegate class with the relation family so the
+// carrier resolvers find their base ctor and `uncacheableMethods()` sees the
+// subclass-only methods (`target`, …).
 import { CollectionProxy } from "../associations/collection-proxy.js";
+import "../association-relation.js";
+import "../disable-joins-association-relation.js";
 
 describe("generated relation methods — per-model prototype carrier", () => {
   it("installs a generated delegator as a real method on the per-model carrier", () => {
@@ -63,6 +76,75 @@ describe("generated relation methods — per-model prototype carrier", () => {
     const carrier = relationClassFor(Post as never).prototype as Record<string, unknown>;
     for (const name of uncacheable) {
       expect(Object.prototype.hasOwnProperty.call(carrier, name)).toBe(false);
+    }
+  });
+});
+
+describe("generated relation methods — remaining delegate-class carriers", () => {
+  const allCarriersFor = (model: never) => [
+    relationClassFor(model),
+    associationRelationClassFor(model),
+    disableJoinsAssociationRelationClassFor(model),
+    collectionProxyClassFor(model),
+  ];
+
+  it("feeds one generated method to all four per-model carriers (propagation)", () => {
+    // Realize all four carriers first, then generate: the single
+    // `generatedRelationMethods(model)` module must propagate the new method to
+    // every already-registered carrier (Rails' `delegate.include
+    // generated_relation_methods` across each subclass).
+    const carriers = allCarriersFor(Post as never);
+    const fn = () => "shared";
+    generateRelationMethod(Post as never, "sharedAcrossCarriers", fn);
+    for (const carrier of carriers) {
+      const proto = carrier.prototype as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(proto, "sharedAcrossCarriers")).toBe(true);
+      expect(proto.sharedAcrossCarriers).toBe(fn);
+    }
+  });
+
+  it("installs already-generated methods when a carrier is created later (includeInto catch-up)", () => {
+    // Generate BEFORE the Comment association/proxy carriers exist: creating them
+    // must back-fill the stored method as a real own property (the `includeInto`
+    // catch-up loop), not miss it.
+    generateRelationMethod(Comment as never, "lateCarrierGenerated", () => "late");
+    for (const carrier of [
+      associationRelationClassFor(Comment as never),
+      disableJoinsAssociationRelationClassFor(Comment as never),
+      collectionProxyClassFor(Comment as never),
+    ]) {
+      const proto = carrier.prototype as Record<string, unknown>;
+      expect(Object.prototype.hasOwnProperty.call(proto, "lateCarrierGenerated")).toBe(true);
+    }
+  });
+
+  it("each carrier reports its base delegate class name (per-model subclass stays anonymous)", () => {
+    // Rails' ClassSpecificRelation::ClassMethods#name returns `superclass.name`,
+    // so `#inspect` (`this.constructor.name`) reads the base class name.
+    expect(associationRelationClassFor(Post as never).name).toBe("AssociationRelation");
+    expect(disableJoinsAssociationRelationClassFor(Post as never).name).toBe(
+      "DisableJoinsAssociationRelation",
+    );
+    expect(collectionProxyClassFor(Post as never).name).toBe("CollectionProxy");
+  });
+
+  it("gives distinct models distinct carriers per delegate class (no cross-model leakage)", () => {
+    expect(associationRelationClassFor(Post as never)).not.toBe(
+      associationRelationClassFor(Comment as never),
+    );
+    expect(collectionProxyClassFor(Post as never)).not.toBe(
+      collectionProxyClassFor(Comment as never),
+    );
+  });
+
+  it("never generates an uncacheable method onto any of the four carriers", () => {
+    const uncacheable = uncacheableMethods();
+    expect(uncacheable.has("target")).toBe(true); // guard: not a vacuous loop
+    for (const carrier of allCarriersFor(Post as never)) {
+      const proto = carrier.prototype as Record<string, unknown>;
+      for (const name of uncacheable) {
+        expect(Object.prototype.hasOwnProperty.call(proto, name)).toBe(false);
+      }
     }
   });
 });

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -321,45 +321,119 @@ export function includeRelationMethods(carrier: object, methods: GeneratedRelati
 }
 
 /**
- * Per-model prototype carrier for the Relation delegate class. Rails builds a
- * per-model delegate subclass and `include`s the model's
- * `GeneratedRelationMethods` module into it (`relation_class_for`,
- * delegation.rb:32-45,144). trails' analogue is a lazily-created per-model
- * `Relation` subclass whose prototype carries the generated methods: relations
- * built for `modelClass` (via `Base._buildDefaultRelation` &c.) are constructed
- * from this subclass, so a generated delegator resolves as a real method by
- * ordinary prototype lookup — no side-table consulted in the `Proxy` `get` trap.
+ * Constructor of any relation-family delegate class. Varargs because the four
+ * carriers differ in shape (`Relation(model, table?)`,
+ * `AssociationRelation(model, association)`,
+ * `DisableJoinsAssociationRelation(model, key, ids, walker?)`,
+ * `CollectionProxy(record, name, def)`) — the per-model subclass inherits the
+ * base constructor unchanged, so construction is signature-agnostic here.
+ */
+type FamilyCtor = new (...args: any[]) => any;
+
+/**
+ * Build (once, memoized in `cache`) a per-model subclass of a relation-family
+ * delegate class and `include` the model's `GeneratedRelationMethods` module
+ * into its prototype. Rails builds a per-model delegate subclass and `include`s
+ * the model's generated module into it (`relation_class_for`,
+ * delegation.rb:32-45,144); Rails then `include`s that **same** module into
+ * *every* delegate subclass (`DelegateCache#include_relation_methods`,
+ * delegation.rb:57-60), so `AssociationRelation` / `CollectionProxy` /
+ * `DisableJoinsAssociationRelation` all carry the generated methods too.
+ *
+ * trails' analogue: a lazily-created per-model subclass whose prototype carries
+ * the generated methods. Instances built for `modelClass` from this subclass
+ * resolve a generated delegator as a real method by ordinary prototype lookup —
+ * no side-table consulted in either `Proxy` `get` trap. Every carrier for a
+ * given model shares the one `generatedRelationMethods(modelClass)` module, so a
+ * `generate` (from either proxy's miss path) propagates to all of them.
  *
  * The carrier is the subclass **prototype**, set once at subclass creation, so
- * no per-instance `Object.setPrototypeOf` runs on the relation construction hot
- * path (the V8 megamorphic-deopt the parent story flagged).
- *
- * Mirrors: ActiveRecord::Delegation::ClassMethods#relation_class_for
+ * no per-instance `Object.setPrototypeOf` runs on the construction hot path (the
+ * V8 megamorphic-deopt the parent story flagged).
  */
-const _relationClassByModel = new WeakMap<typeof Base, RelationCtor>();
-
-export function relationClassFor(modelClass: typeof Base): RelationCtor {
-  let subclass = _relationClassByModel.get(modelClass);
+function perModelCarrier(
+  cache: WeakMap<typeof Base, FamilyCtor>,
+  modelClass: typeof Base,
+  base: FamilyCtor | undefined,
+): FamilyCtor {
+  let subclass = cache.get(modelClass);
   if (!subclass) {
-    // The `relation` family slot is always registered (relation.ts, at module
-    // init) before any relation is constructed, so this cast is safe at runtime.
-    const baseRelation = _relationFamilySlot.relation as unknown as new (
-      ...args: never[]
-    ) => object;
-    subclass = class extends baseRelation {} as RelationCtor;
+    // The family slot is always registered at its class module's init, before
+    // any instance is constructed for that class, so `base` is set here.
+    const baseCtor = base as unknown as new (...args: never[]) => object;
+    subclass = class extends baseCtor {} as FamilyCtor;
     // A class expression assigned to a `let` infers `.name` from the variable
-    // (`"subclass"`), which would leak through `Relation#inspect`'s
+    // (`"subclass"`), which would leak through `#inspect`'s
     // `this.constructor.name`. Rails' `ClassSpecificRelation::ClassMethods#name`
     // (delegation.rb:111-115) returns `superclass.name` so a per-model delegate
-    // still reports the base relation class name — mirror that here.
+    // still reports the base class name — mirror that here.
     Object.defineProperty(subclass, "name", {
-      value: (baseRelation as { name: string }).name,
+      value: (baseCtor as { name: string }).name,
       configurable: true,
     });
-    _relationClassByModel.set(modelClass, subclass);
+    cache.set(modelClass, subclass);
     includeRelationMethods(subclass.prototype, generatedRelationMethods(modelClass));
   }
   return subclass;
+}
+
+/**
+ * Per-model prototype carrier for the `Relation` delegate class. Relations
+ * built for `modelClass` (via `Base._buildDefaultRelation` &c.) are constructed
+ * from this subclass.
+ *
+ * Mirrors: ActiveRecord::Delegation::ClassMethods#relation_class_for
+ */
+const _relationClassByModel = new WeakMap<typeof Base, FamilyCtor>();
+
+export function relationClassFor(modelClass: typeof Base): RelationCtor {
+  return perModelCarrier(
+    _relationClassByModel,
+    modelClass,
+    _relationFamilySlot.relation,
+  ) as RelationCtor;
+}
+
+/**
+ * Per-model prototype carrier for the `AssociationRelation` delegate class.
+ * `blog.posts.where(...)` and other association-relation construction sites are
+ * built from this subclass so generated methods resolve as real methods on them.
+ */
+const _associationRelationClassByModel = new WeakMap<typeof Base, FamilyCtor>();
+
+export function associationRelationClassFor(modelClass: typeof Base): FamilyCtor {
+  return perModelCarrier(
+    _associationRelationClassByModel,
+    modelClass,
+    _relationFamilySlot.associationRelation,
+  );
+}
+
+/**
+ * Per-model prototype carrier for the `DisableJoinsAssociationRelation` delegate
+ * class.
+ */
+const _disableJoinsAssociationRelationClassByModel = new WeakMap<typeof Base, FamilyCtor>();
+
+export function disableJoinsAssociationRelationClassFor(modelClass: typeof Base): FamilyCtor {
+  return perModelCarrier(
+    _disableJoinsAssociationRelationClassByModel,
+    modelClass,
+    _relationFamilySlot.disableJoinsAssociationRelation,
+  );
+}
+
+/**
+ * Per-model prototype carrier for the `CollectionProxy` delegate class.
+ */
+const _collectionProxyClassByModel = new WeakMap<typeof Base, FamilyCtor>();
+
+export function collectionProxyClassFor(modelClass: typeof Base): FamilyCtor {
+  return perModelCarrier(
+    _collectionProxyClassByModel,
+    modelClass,
+    _relationFamilySlot.collectionProxy,
+  );
 }
 
 /**
@@ -567,11 +641,12 @@ export function wrapWithScopeProxy<T extends object>(rel: T): T {
 
       // Generated relation methods (Rails' GeneratedRelationMethods) now resolve
       // as real methods via the top-of-trap `Reflect.get` above: they live on
-      // the per-model `Relation` subclass prototype (`relationClassFor`), which
-      // is this `target`'s prototype, so no explicit side-table branch is needed
-      // here. The `uncacheableMethods` gate below is therefore load-bearing — a
-      // subclass-only method (e.g. CollectionProxy#target) is never generated,
-      // so a generated copy can never shadow it.
+      // the per-model subclass prototype (`relationClassFor` /
+      // `associationRelationClassFor` / `disableJoinsAssociationRelationClassFor`),
+      // which is this `target`'s prototype, so no explicit side-table branch is
+      // needed here. The `uncacheableMethods` gate below is therefore
+      // load-bearing — a subclass-only method (e.g. CollectionProxy#target) is
+      // never generated, so a generated copy can never shadow it.
       if (modelClass._scopes.has(prop)) {
         return (...args: any[]) => {
           const scopeFn = modelClass._scopes.get(prop)!;

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -372,6 +372,20 @@ function perModelCarrier(
       configurable: true,
     });
     cache.set(modelClass, subclass);
+    // Only the model's OWN generated module is included — deliberately NOT the
+    // Rails `include_relation_methods` superclass recursion
+    // (`superclass.include_relation_methods(delegate) unless base_class?`,
+    // delegation.rb:57-60). Rails can safely inherit an ancestor's generated
+    // module because its generated body is model-agnostic — `def m(...); scoping
+    // { model.m(...) }; end` reads `self.model` dynamically (delegation.rb:76-88).
+    // trails' delegator instead CAPTURES a specific `modelClass` + bound class
+    // method and scopes/guards that captured model (`classMethodDelegator`), so
+    // installing a parent model's delegator onto an STI child carrier would
+    // dispatch to the parent model — wrong scope and wrong STI type-condition.
+    // The child instead re-derives a correctly-bound delegator onto its own
+    // module via the `Proxy` miss path (keyed by the relation's real
+    // `_modelClass`), yielding identical observable behavior to Rails at the cost
+    // of one extra miss-path pass per (subclass, method).
     includeRelationMethods(subclass.prototype, generatedRelationMethods(modelClass));
   }
   return subclass;


### PR DESCRIPTION
## Summary

Follow-up to `delegation-generated-methods-per-model-prototype-carrier` (which landed the **Relation** carrier). This converges the remaining three delegate classes — `AssociationRelation`, `DisableJoinsAssociationRelation`, and `CollectionProxy` — onto per-model subclass prototype carriers.

A generic `perModelCarrier` helper builds a lazily-created per-model subclass and `include`s the model's single `GeneratedRelationMethods` module into its prototype (Rails' `delegate.include generated_relation_methods` across every delegate subclass). Generated relation methods now resolve as **real methods** on these instances via ordinary prototype lookup, instead of re-running the Proxy miss path's `classMethodDelegator` on every call. All four carriers for a given model share the one `generatedRelationMethods(modelClass)` module, so a `generate` from either proxy's miss path propagates to all of them.

## Changes

- `relation/delegation.ts`: extract `perModelCarrier`; add `associationRelationClassFor`, `disableJoinsAssociationRelationClassFor`, `collectionProxyClassFor` (refactor `relationClassFor` onto the shared helper).
- Route construction sites:
  - `association-relation.ts` (`_newRelation`, factory)
  - `disable-joins-association-relation.ts` (`deferred`, `_newRelation`) and `disable-joins-association-scope.ts`
  - `associations/collection-proxy.ts` (`_wrapAsAssociationRelation`, `_newRelation`) + new `CollectionProxy._create` factory (sharing target-model resolution with the constructor via `_targetModelFor`) so the carrier is chosen from the exact model the instance reports as `.model`; `associations.ts` routes proxy construction through it. Proxy construction is cached per (record, association), so the resolver runs only on first access — no construction-hot-path regression.

## Invariants

- `uncacheableMethods` gate stays load-bearing: the empty per-model subclasses add no own methods, so the computed set is unchanged and a generated `target` still can never shadow `CollectionProxy#target`. With a CP carrier now in the proxy's prototype chain, this gate is genuinely exercised cross-carrier — `DelegationCachingTest` holds.
- No observable behavior change; no `instanceof`/`.constructor ===` identity checks on these classes exist to break, and the subclass `.name` is pinned to the base class name.

## Testing

Typecheck + lint clean. Extended `relation/delegation.trails.test.ts` with a mechanism suite for the three new carriers: one `generate` propagates to all four carriers; a carrier created after a `generate` back-fills via `includeInto`; each carrier reports its base delegate class name; distinct models get distinct carriers; no uncacheable method lands as an own property on any carrier.

Passing: `delegation`, `delegation.trails` (10 tests), `collection-proxy(-count)`, `disable-joins-*`, `named-scoping`, `has-many-associations`, `has-many-through-associations`.

Closes-story: delegation-remaining-delegate-class-prototype-carriers

## Review notes

**Re: `perModelCarrier` not mirroring Rails' `include_relation_methods` superclass recursion (delegation.rb:57-60).** Deliberate, and required for STI correctness. Rails' generated method body is model-agnostic — `def m(...); scoping { model.m(...) }; end` reads `self.model` dynamically (delegation.rb:76-88) — so an ancestor's generated module is safe to inherit down the STI chain. trails' `classMethodDelegator` instead **captures** a specific `modelClass` + bound class method and scopes/guards that captured model, so installing a parent model's delegator onto an STI **child** carrier would dispatch to the parent — wrong scope and wrong STI type-condition. Each subclass therefore re-derives a correctly-bound delegator onto its **own** module via the Proxy miss path (keyed by the relation's real `_modelClass`), yielding behavior identical to Rails at the cost of one extra miss-path pass per (subclass, method). Documented at the include site in `perModelCarrier`.

