### PR TITLE
fix(enum): detect Relation-method and :id class-method conflicts

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -501,9 +501,52 @@ describe("EnumTest", () => {
       );
     });
   });
-  it.skip("reserved enum values", () => {});
-  it.skip("reserved enum values for relation", () => {});
-  it.skip("can use id as a value with a prefix or suffix", () => {});
+  it("reserved enum values", () => {
+    class Klass extends Base {
+      static _tableName = "books";
+      static {
+        this.enum("status", ["proposed", "written", "published"] as any);
+      }
+    }
+
+    // Each value generates a method conflicting with an AR method: `new` → a
+    // scope clashing with the class method, `valid`/`save` → `valid?`/`save!`,
+    // `proposed` → an existing enum value, and `id` → AR querying.
+    const conflicts = ["new", "valid", "save", "proposed", "id"];
+    conflicts.forEach((value, i) => {
+      expect(() => (Klass as any).enum(`status_${i}`, [value])).toThrow(
+        /You tried to define an enum named .* on the model/,
+      );
+    });
+  });
+  it("reserved enum values for relation", () => {
+    // A value whose scope name matches a Relation instance method conflicts
+    // with the message reporting `source: ActiveRecord::Relation`. Rails samples
+    // `[:records, :to_ary, :scope_for_create]`; trails' Relation has no `to_ary`
+    // (Ruby's array-coercion hook has no TS equivalent), so `scoping` — another
+    // Relation instance method — stands in for it.
+    const relationMethodSamples = ["records", "scoping", "scope_for_create"];
+    relationMethodSamples.forEach((value) => {
+      expect(() => {
+        class Klass extends Base {
+          static _tableName = "books";
+        }
+        (Klass as any).enum("category", ["other", value]);
+      }).toThrow(/You tried to define an enum named .* on the model/);
+    });
+  });
+  it("can use id as a value with a prefix or suffix", () => {
+    expect(() => {
+      class Klass extends Base {
+        static _tableName = "books";
+        static {
+          this.enum("status_1", ["id"] as any, { prefix: true });
+          this.enum("status_2", ["id"] as any, { suffix: true });
+        }
+      }
+      void Klass;
+    }).not.toThrow();
+  });
   it("overriding enum method should not raise", () => {
     expect(() => {
       class Klass extends Base {

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -8,7 +8,7 @@ import {
   typeRegistry,
 } from "@blazetrails/activemodel";
 import { dangerousAttributeMethods } from "./attribute-methods.js";
-import { isDangerousClassMethod } from "./scoping/named.js";
+import { isDangerousClassMethod, isRelationInstanceMethod } from "./scoping/named.js";
 // The synchronous schema reflector (warm-cache path), NOT the async
 // `Base.loadSchema()` — mirrors what `Base.typeForAttribute` calls.
 import { loadSchema as reflectSchemaSync } from "./model-schema.js";
@@ -694,10 +694,12 @@ export function _enum(
       // RESTRICTED_CLASS_METHODS plus methods `Base` itself defines), never a
       // scope inherited from a parent enum or a user static on the model/an
       // ancestor.
-      if (isDangerousClassMethod(fullName))
-        raiseConflictError.call(this, attribute, fullName, { type: "class" });
-      if (isDangerousClassMethod(notScopeName))
-        raiseConflictError.call(this, attribute, notScopeName, { type: "class" });
+      // Route through the class-method conflict detector so the value scope and
+      // its auto `not*` scope consult all three Rails sub-branches (dangerous
+      // class method, Relation instance method, and the `id` special-case), each
+      // raising with the correct type/source rather than the generic scope error.
+      detectEnumConflictBang.call(this, attribute, fullName, true);
+      detectEnumConflictBang.call(this, attribute, notScopeName, true);
     }
     if (friendlyName !== fullName) {
       const {
@@ -715,10 +717,8 @@ export function _enum(
           raiseConflictError.call(this, attribute, friendlyBang, { source: "another enum" });
       }
       if (scopesEnabled) {
-        if (isDangerousClassMethod(friendlyName))
-          raiseConflictError.call(this, attribute, friendlyName, { type: "class" });
-        if (isDangerousClassMethod(notFriendlyName))
-          raiseConflictError.call(this, attribute, notFriendlyName, { type: "class" });
+        detectEnumConflictBang.call(this, attribute, friendlyName, true);
+        detectEnumConflictBang.call(this, attribute, notFriendlyName, true);
       }
     }
   }
@@ -877,6 +877,22 @@ export function detectEnumConflictBang(
     // reserved names like `columns` (defined on `Base`) still raise.
     if (isDangerousClassMethod(methodName)) {
       raiseConflictError.call(this, enumName, methodName, { type: "class" });
+    }
+    // Sub-branch 2 (enum.rb:377-378): a class method that `Relation` defines as
+    // an instance method — e.g. `records`, `to_ary`, `scope_for_create` — is a
+    // conflict because the generated scope shadows it. Rails reports
+    // `source: Relation.name` ("ActiveRecord::Relation").
+    if (isRelationInstanceMethod(methodName)) {
+      raiseConflictError.call(this, enumName, methodName, {
+        type: "class",
+        source: "ActiveRecord::Relation",
+      });
+    }
+    // Sub-branch 3 (enum.rb:379-380): a scope literally named `id` conflicts
+    // with AR querying. Rails raises the *instance*-type message here (default
+    // type/source), matching `method_name.to_sym == :id`.
+    if (methodName === "id") {
+      raiseConflictError.call(this, enumName, methodName);
     }
     return;
   }

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -689,15 +689,13 @@ export function _enum(
       if (definedNames.has(fullName))
         raiseConflictError.call(this, attribute, fullName, { type: "class" });
       definedNames.add(fullName);
-      // The value/`not*` scope names are class methods, so they only conflict
-      // with a *dangerous* class method (`dangerous_class_method?` —
-      // RESTRICTED_CLASS_METHODS plus methods `Base` itself defines), never a
-      // scope inherited from a parent enum or a user static on the model/an
-      // ancestor.
-      // Route through the class-method conflict detector so the value scope and
-      // its auto `not*` scope consult all three Rails sub-branches (dangerous
-      // class method, Relation instance method, and the `id` special-case), each
-      // raising with the correct type/source rather than the generic scope error.
+      // The value/`not*` scope names are class methods, so route them through
+      // the class-method conflict detector, which consults all three Rails
+      // sub-branches (a *dangerous* class method — RESTRICTED_CLASS_METHODS plus
+      // methods `Base` itself defines; a Relation instance method; and the `id`
+      // special-case), each raising with the correct type/source rather than the
+      // generic scope error. A scope inherited from a parent enum or a plain
+      // user static on the model/an ancestor is NOT a conflict.
       detectEnumConflictBang.call(this, attribute, fullName, true);
       detectEnumConflictBang.call(this, attribute, notScopeName, true);
     }

--- a/packages/activerecord/src/scoping/named.ts
+++ b/packages/activerecord/src/scoping/named.ts
@@ -48,7 +48,7 @@ export function isDangerousClassMethod(name: string): boolean {
  * Mirrors `method_defined_within?(name, Relation)`: true when `Relation`
  * defines an instance method with this name that is not inherited from `Object`.
  */
-function isRelationInstanceMethod(name: string): boolean {
+export function isRelationInstanceMethod(name: string): boolean {
   let proto: any = Relation.prototype;
   while (proto && proto !== Object.prototype) {
     if (Object.prototype.hasOwnProperty.call(proto, name)) return true;


### PR DESCRIPTION
Rails' `detect_enum_conflict!` class-method form has three sub-branches (`vendor/rails/activerecord/lib/active_record/enum.rb:374-380`): `dangerous_class_method?`, `method_defined_within?(Relation)`, and `method_name.to_sym == :id`. PR #4734 converged only the first in trails.

This PR adds the remaining two to `detectEnumConflictBang`:

- **Relation-method** — a class method that `Relation` defines as an instance method (e.g. `records`, `scope_for_create`) raises with `source: ActiveRecord::Relation`.
- **`:id`** — a scope literally named `id` raises the instance-type message, matching AR-querying collision.

The inline `_enum` value/`not*` scope conflict checks now route through `detectEnumConflictBang` so they raise the Rails enum message instead of the generic scope error. `isRelationInstanceMethod` is exported from `scoping/named.ts`.

Un-skips the Rails tests `reserved enum values`, `reserved enum values for relation`, and `can use id as a value with a prefix or suffix`. `to_ary` (Ruby array-coercion, no TS equivalent) is replaced by `scoping` in the relation sample.

Closes-story: enum-detect-conflict-relation-and-id-class-branches