### PR TITLE
fix(database-limits): MySQL table alias length 256 and receiver-dispatched limits

### DIFF
--- a/packages/activerecord/src/associations/alias-tracker.test.ts
+++ b/packages/activerecord/src/associations/alias-tracker.test.ts
@@ -1,0 +1,22 @@
+/**
+ * Tests for AliasTracker.create's alias-length resolution.
+ *
+ * Mirrors: ActiveRecord::Associations::AliasTracker.create
+ * (alias_tracker.rb:9-25 — `new(connection.table_alias_length, aliases)`).
+ */
+import { describe, it, expect } from "vitest";
+import { AliasTracker } from "./alias-tracker.js";
+
+describe("AliasTracker.create", () => {
+  it("uses the connection's tableAliasLength method (MySQL would give 256)", () => {
+    const connection = { tableAliasLength: () => 256 };
+    const tracker = AliasTracker.create(connection, "posts", []);
+    // 256-cap: a 200-char candidate is aliased without truncation.
+    expect(tracker.aliasNameFor("a".repeat(200))).toBe("a".repeat(200));
+  });
+
+  it("falls back to the DatabaseLimits default (64) when no length is available", () => {
+    const tracker = AliasTracker.create(null, "posts", []);
+    expect(tracker.aliasNameFor("a".repeat(200))).toBe("a".repeat(64));
+  });
+});

--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -36,10 +36,19 @@ export class AliasTracker {
     aliases?: Map<string, number>,
     quoter?: Quoting,
   ): AliasTracker {
+    // Rails: `pool.with_connection { |c| new(c.table_alias_length, ...) }`
+    // (alias_tracker.rb:24) — always the connection's alias length, so MySQL
+    // gets 256. Honor a connection-like arg's `tableAliasLength` (method or
+    // number) directly; a bare pool whose connection is only reachable via the
+    // async `withConnection` can't be resolved synchronously here, so it falls
+    // back to the base default (see the connection-threading follow-up story).
+    const tal = pool?.tableAliasLength;
     const tableAliasLength =
-      typeof pool?.withConnection === "function"
-        ? DEFAULT_TABLE_ALIAS_LENGTH
-        : (pool?.tableAliasLength ?? DEFAULT_TABLE_ALIAS_LENGTH);
+      typeof tal === "function"
+        ? tal.call(pool)
+        : typeof tal === "number"
+          ? tal
+          : DEFAULT_TABLE_ALIAS_LENGTH;
 
     const map = aliases ? new Map(aliases) : new Map<string, number>();
     map.set(initialTable, 1);

--- a/packages/activerecord/src/associations/alias-tracker.ts
+++ b/packages/activerecord/src/associations/alias-tracker.ts
@@ -4,10 +4,12 @@
  * Mirrors: ActiveRecord::Associations::AliasTracker
  */
 import { Table, Nodes } from "@blazetrails/arel";
-import { tableAliasLength as getTableAliasLength } from "../connection-adapters/abstract/database-limits.js";
+import { maxIdentifierLength } from "../connection-adapters/abstract/database-limits.js";
 import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
 
-const DEFAULT_TABLE_ALIAS_LENGTH = getTableAliasLength();
+// DatabaseLimits' table_alias_length defaults to max_identifier_length; use the
+// abstract default directly (the free tableAliasLength now dispatches via `this`).
+const DEFAULT_TABLE_ALIAS_LENGTH = maxIdentifierLength();
 
 export class AliasTracker {
   readonly aliases: Map<string, number>;

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -777,3 +777,17 @@ describe("AbstractMysqlAdapter#changeColumnComment (#1568)", () => {
     expect(calls).toEqual([["users", "name", "", { comment: null }]]);
   });
 });
+
+describe("AbstractMysqlAdapter#tableAliasLength", () => {
+  it("table alias length", async () => {
+    // Rails' MySQL SchemaStatements#table_alias_length returns 256
+    // (mysql/schema_statements.rb:135), not max_identifier_length (64).
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as InstanceType<
+      typeof AbstractMysqlAdapter
+    >;
+    expect(adapter.tableAliasLength()).toBe(256);
+    const long = "a".repeat(300);
+    expect(adapter.tableAliasFor(long)).toBe("a".repeat(256));
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -328,6 +328,14 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation(this));
   }
 
+  // Rails' MySQL SchemaStatements#table_alias_length returns a hardcoded 256
+  // (mysql/schema_statements.rb:135, per
+  // https://dev.mysql.com/doc/refman/en/identifiers.html), NOT
+  // max_identifier_length (64). Override the DatabaseLimits mixin default.
+  tableAliasLength(): number {
+    return 256;
+  }
+
   /**
    * Quote a value using MySQL-family escape rules (`\0 \n \r \Z \\ ''`
    * via MYSQL_ESCAPE_MAP, booleans as `1/0`, Dates as

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -83,6 +83,7 @@ import {
   isRowFormatDynamicByDefault,
   newColumnFromField,
   quotedScope,
+  tableAliasLength as mysqlTableAliasLength,
 } from "./mysql/schema-statements.js";
 import type { Column as MysqlColumn } from "./mysql/column.js";
 import { TypeMap } from "../type/type-map.js";
@@ -328,12 +329,11 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return (this._mysqlSchemaCreation ??= new MysqlSchemaCreation(this));
   }
 
-  // Rails' MySQL SchemaStatements#table_alias_length returns a hardcoded 256
-  // (mysql/schema_statements.rb:135, per
-  // https://dev.mysql.com/doc/refman/en/identifiers.html), NOT
-  // max_identifier_length (64). Override the DatabaseLimits mixin default.
+  // Rails maps MySQL::SchemaStatements#table_alias_length (256, not the
+  // DatabaseLimits default of 64). Thin wrapper delegating to the
+  // Rails-layout implementation in mysql/schema-statements.
   tableAliasLength(): number {
-    return 256;
+    return mysqlTableAliasLength();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/database-limits.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-limits.test.ts
@@ -12,16 +12,25 @@ describe("DatabaseLimits", () => {
     expect(maxIdentifierLength()).toBe(64);
   });
 
+  const host = { maxIdentifierLength };
+
   it("tableNameLength", () => {
-    expect(tableNameLength()).toBe(maxIdentifierLength());
+    expect(tableNameLength.call(host)).toBe(maxIdentifierLength());
   });
 
   it("tableAliasLength", () => {
-    expect(tableAliasLength()).toBe(maxIdentifierLength());
+    expect(tableAliasLength.call(host)).toBe(maxIdentifierLength());
   });
 
   it("indexNameLength", () => {
-    expect(indexNameLength()).toBe(maxIdentifierLength());
+    expect(indexNameLength.call(host)).toBe(maxIdentifierLength());
+  });
+
+  it("tableNameLength, tableAliasLength, indexNameLength dispatch to the receiver's maxIdentifierLength", () => {
+    const overridden = { maxIdentifierLength: () => 30 };
+    expect(tableNameLength.call(overridden)).toBe(30);
+    expect(tableAliasLength.call(overridden)).toBe(30);
+    expect(indexNameLength.call(overridden)).toBe(30);
   });
 
   it("bindParamsLength", () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-limits.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-limits.ts
@@ -4,20 +4,29 @@
  * Mirrors: ActiveRecord::ConnectionAdapters::DatabaseLimits
  */
 
+/** Host for the DatabaseLimits mixin — the concrete adapter `this` resolves to. */
+export interface DatabaseLimitsHost {
+  maxIdentifierLength(): number;
+}
+
 export function maxIdentifierLength(): number {
   return 64;
 }
 
-export function tableNameLength(): number {
-  return maxIdentifierLength();
+// Rails' DatabaseLimits derives these from `max_identifier_length` on the
+// receiver (database_limits.rb:11-23), so an adapter overriding
+// `max_identifier_length` propagates through. Dispatch via `this` — not the
+// module-level `maxIdentifierLength` — to preserve that.
+export function tableNameLength(this: DatabaseLimitsHost): number {
+  return this.maxIdentifierLength();
 }
 
-export function tableAliasLength(): number {
-  return maxIdentifierLength();
+export function tableAliasLength(this: DatabaseLimitsHost): number {
+  return this.maxIdentifierLength();
 }
 
-export function indexNameLength(): number {
-  return maxIdentifierLength();
+export function indexNameLength(this: DatabaseLimitsHost): number {
+  return this.maxIdentifierLength();
 }
 
 /** @internal */

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -11,7 +11,6 @@
 import { NotImplementedError } from "../../errors.js";
 import { joinTableName as _joinTableName } from "../../migration/join-table.js";
 import { ArgumentError } from "@blazetrails/activemodel";
-import { tableNameLength, indexNameLength } from "./database-limits.js";
 import type { AbstractAdapter as DatabaseAdapter, AdapterName } from "../abstract-adapter.js";
 import {
   TableDefinition,
@@ -2546,7 +2545,9 @@ export class SchemaStatements {
 
   /** @internal */
   validateIndexLengthBang(tableName: string, newName: string, _internal = false): void {
-    const limit = indexNameLength();
+    // Resolve through the adapter (which carries the DatabaseLimits mixin) so an
+    // adapter overriding indexNameLength/maxIdentifierLength propagates here.
+    const limit = (this.adapter as unknown as { indexNameLength(): number }).indexNameLength();
     if (newName.length > limit) {
       throw new ArgumentError(
         `Index name '${newName}' on table '${tableName}' is too long; the limit is ${limit} characters`,
@@ -2556,7 +2557,7 @@ export class SchemaStatements {
 
   /** @internal */
   validateTableLengthBang(tableName: string): void {
-    const limit = tableNameLength();
+    const limit = (this.adapter as unknown as { tableNameLength(): number }).tableNameLength();
     if (tableName.length > limit) {
       throw new ArgumentError(
         `Table name '${tableName}' is too long; the limit is ${limit} characters`,

--- a/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-statements.ts
@@ -33,6 +33,7 @@ import {
   type ForeignKeyLookupOptions,
 } from "./schema-definitions.js";
 import { SchemaCreation } from "./schema-creation.js";
+import { maxIdentifierLength } from "./database-limits.js";
 import type { SchemaQuoter } from "./assert-schema-adapter.js";
 import { Column } from "../column.js";
 import { SqlTypeMetadata } from "../sql-type-metadata.js";
@@ -2546,8 +2547,10 @@ export class SchemaStatements {
   /** @internal */
   validateIndexLengthBang(tableName: string, newName: string, _internal = false): void {
     // Resolve through the adapter (which carries the DatabaseLimits mixin) so an
-    // adapter overriding indexNameLength/maxIdentifierLength propagates here.
-    const limit = (this.adapter as unknown as { indexNameLength(): number }).indexNameLength();
+    // adapter overriding indexNameLength/maxIdentifierLength propagates here,
+    // falling back to the DatabaseLimits base default for a bare adapter.
+    const adapter = this.adapter as unknown as { indexNameLength?(): number };
+    const limit = adapter.indexNameLength ? adapter.indexNameLength() : maxIdentifierLength();
     if (newName.length > limit) {
       throw new ArgumentError(
         `Index name '${newName}' on table '${tableName}' is too long; the limit is ${limit} characters`,
@@ -2557,7 +2560,8 @@ export class SchemaStatements {
 
   /** @internal */
   validateTableLengthBang(tableName: string): void {
-    const limit = (this.adapter as unknown as { tableNameLength(): number }).tableNameLength();
+    const adapter = this.adapter as unknown as { tableNameLength?(): number };
+    const limit = adapter.tableNameLength ? adapter.tableNameLength() : maxIdentifierLength();
     if (tableName.length > limit) {
       throw new ArgumentError(
         `Table name '${tableName}' is too long; the limit is ${limit} characters`,

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.test.ts
@@ -12,6 +12,7 @@ import {
   addOptionsForIndexColumns,
   dataSourceSql,
   quotedScope,
+  tableAliasLength,
   extractSchemaQualifiedName,
   typeWithSizeToSql,
   limitToSize,
@@ -632,5 +633,12 @@ describe("parseMysqlName", () => {
     expect(() => parseMysqlName("``")).toThrow(/Invalid MySQL identifier/);
     expect(() => parseMysqlName("``.widgets")).toThrow(/Invalid MySQL identifier/);
     expect(() => parseMysqlName("`db`.``")).toThrow(/Invalid MySQL identifier/);
+  });
+});
+
+describe("MySQL::SchemaStatements#tableAliasLength", () => {
+  it("table alias length", () => {
+    // mysql/schema_statements.rb:135 — 256, not max_identifier_length (64).
+    expect(tableAliasLength()).toBe(256);
   });
 });

--- a/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/schema-statements.ts
@@ -360,6 +360,18 @@ export function addOptionsForIndexColumns(
   return quotedColumns;
 }
 
+/**
+ * Mirrors: ActiveRecord::ConnectionAdapters::MySQL::SchemaStatements#table_alias_length
+ *
+ * MySQL caps table aliases at 256 (https://dev.mysql.com/doc/refman/en/identifiers.html),
+ * not max_identifier_length (64). Overrides the DatabaseLimits default.
+ *
+ * @internal
+ */
+export function tableAliasLength(): number {
+  return 256;
+}
+
 /** @internal */
 export function dataSourceSql(
   this: QuotedScopeHost,

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2406,6 +2406,24 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     return this._maxIdentifierLength;
   }
 
+  // trails' `maxIdentifierLength` is async (it queries `SHOW
+  // max_identifier_length`), so the DatabaseLimits mixin's receiver-dispatch
+  // (`this.maxIdentifierLength()`) would hand these callers a Promise instead
+  // of a number. The alias-length consumers (relation join-alias tracking) are
+  // synchronous, so resolve the cached limit synchronously — the real value
+  // once `maxIdentifierLength` has been queried, else the abstract default 64.
+  tableAliasLength(): number {
+    return this._maxIdentifierLength ?? 64;
+  }
+
+  tableNameLength(): number {
+    return this._maxIdentifierLength ?? 64;
+  }
+
+  indexNameLength(): number {
+    return this._maxIdentifierLength ?? 64;
+  }
+
   // Mirrors: PostgreSQLAdapter#session_auth= (postgresql_adapter.rb:625)
   // Returns a Promise so callers can await the SET SESSION AUTHORIZATION round-trip.
   async sessionAuth(user: string): Promise<void> {

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2411,17 +2411,19 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   // (`this.maxIdentifierLength()`) would hand these callers a Promise instead
   // of a number. The alias-length consumers (relation join-alias tracking) are
   // synchronous, so resolve the cached limit synchronously — the real value
-  // once `maxIdentifierLength` has been queried, else the abstract default 64.
+  // once `maxIdentifierLength` has been queried, else PostgreSQL's default
+  // (NAMEDATALEN-1 = 63), matching the `?? "63"` fallback maxIdentifierLength
+  // itself uses (postgresql_adapter.rb:619-622) rather than the abstract 64.
   tableAliasLength(): number {
-    return this._maxIdentifierLength ?? 64;
+    return this._maxIdentifierLength ?? 63;
   }
 
   tableNameLength(): number {
-    return this._maxIdentifierLength ?? 64;
+    return this._maxIdentifierLength ?? 63;
   }
 
   indexNameLength(): number {
-    return this._maxIdentifierLength ?? 64;
+    return this._maxIdentifierLength ?? 63;
   }
 
   // Mirrors: PostgreSQLAdapter#session_auth= (postgresql_adapter.rb:625)

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -12379,8 +12379,8 @@
     "package": "activerecord",
     "tsFile": "associations/alias-tracker.ts",
     "rubyName": "create",
-    "call": "call",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
+    "call": "with_connection",
+    "reason": "Rails' create wraps `pool.with_connection { |c| new(c.table_alias_length, ...) }` (alias_tracker.rb:10-24). trails' withConnection is async while create is synchronous, so create resolves the connection's tableAliasLength directly instead. Threading the connection through the sync tracker-construction sites is tracked by story thread-connection-table-alias-length-into-tracker-construction (RFC 0051)."
   },
   {
     "package": "activerecord",


### PR DESCRIPTION
## What

Converges two Rails-fidelity gaps in the `tableAliasLength` dispatch chain
(surfaced by Codex review on #4756):

1. **MySQL alias length is 256, not 64.** Rails' MySQL
   `SchemaStatements#table_alias_length` returns a hardcoded `256`
   (`mysql/schema_statements.rb:135`, per
   <https://dev.mysql.com/doc/refman/en/identifiers.html>), not
   `max_identifier_length` (64). Added a concrete `tableAliasLength()` override
   on the MySQL adapter.

2. **DatabaseLimits methods dispatch through the receiver.** Rails'
   `DatabaseLimits#table_name_length` / `#table_alias_length` /
   `#index_name_length` derive from `max_identifier_length` on the receiver
   (`database_limits.rb:11-23`). trails called the module-level free function, so
   an adapter override would not propagate. Converted to `this`-dispatch, and
   routed the `validate*Bang` limit lookups through the adapter.

   PostgreSQL's `maxIdentifierLength` is async in trails, so it gets sync
   `tableAliasLength`/`tableNameLength`/`indexNameLength` overrides to keep the
   synchronous alias-length callers (relation join-alias tracking) working —
   preserving the current 64 default until the real limit is queried.

## Tests

- MySQL `tableAliasLength()` returns 256 and `tableAliasFor` truncates at 256.
- `DatabaseLimits` limit methods dispatch to the receiver's
  `maxIdentifierLength` (stub override → propagates).
- Non-MySQL adapters still resolve to 64.

Closes-story: mysql-table-alias-length-256-and-receiver-dispatch

## Codex review responses

- **PG uncached limit → 63.** `tableAliasLength`/`tableNameLength`/`indexNameLength`
  now default to **63** (NAMEDATALEN-1, the value `maxIdentifierLength` itself
  falls back to at `postgresql_adapter.rb:619-622`) rather than the abstract 64,
  so uncached PG validation/truncation matches Rails' real server limit.
- **`AliasTracker.create` alias length.** Now honors a connection-like arg's
  `tableAliasLength` (method or number), mirroring `new(connection.table_alias_length, …)`
  (`alias_tracker.rb:24`) — a MySQL connection yields 256. A bare pool whose
  connection is only reachable via the async `withConnection` still can't be
  resolved synchronously here. Fully threading `connection.tableAliasLength` into
  the synchronous tracker-construction sites (`JoinDependency`, `AssociationScope`,
  which today hardcode 64) is a broader change tracked as follow-up story
  `thread-connection-table-alias-length-into-tracker-construction` (RFC 0051).
