### PR TITLE
feat(lint): guard unawaited isValid/validate in boolean position

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -631,4 +631,33 @@ export default defineConfig(
       "@typescript-eslint/no-unnecessary-type-assertion": "error",
     },
   },
+
+  // ── no-misused-promises: boolean-position guard (RFC 0063 async-validation) ──
+  // Before `isValid()`/`validate()` flip to returning `Promise<boolean>`, lint
+  // must catch a forgotten `await`: `if (record.isValid())` on an un-awaited
+  // Promise is always truthy and fails silently. `checksConditionals` (default
+  // on) makes a Promise used in a boolean position — condition, `!`, `&&`, `||`,
+  // ternary — a hard error, which is exactly the flip's footgun. Scoped to the
+  // two packages the flip touches (src + tests). The rule needs type info — the
+  // projectService block above supplies it.
+  //
+  // The other two sub-checks are turned OFF, each for cause:
+  //  - checksVoidReturn: 12 pre-existing sites pass an async callback / override
+  //    an adapter method typed to return void. Those are legitimate patterns
+  //    unrelated to the validation flip, and fixing them means runtime changes
+  //    this story forbids. Follow-up: lint-guard-misused-promises-void-return.
+  //  - checksSpreads: 1 pre-existing site (collection-proxy.test.ts) spreads a
+  //    Promise into an object. Same follow-up burden; off for now.
+  // A `no-floating-promises` companion (177 dropped-Promise sites, ~170 in
+  // tests) is deferred to its own burndown story — enabling it would require
+  // the runtime `await`/`void` edits this story forbids.
+  {
+    files: ["packages/activemodel/src/**/*.ts", "packages/activerecord/src/**/*.ts"],
+    rules: {
+      "@typescript-eslint/no-misused-promises": [
+        "error",
+        { checksConditionals: true, checksVoidReturn: false, checksSpreads: false },
+      ],
+    },
+  },
 );


### PR DESCRIPTION
Before `isValid()`/`validate()` flip to returning `Promise<boolean>` (RFC 0063), lint must catch a forgotten `await`: `if (record.isValid())` on an un-awaited Promise is always truthy and fails silently. The flip stories depend on this landing first.

## What

Enable `@typescript-eslint/no-misused-promises` with `checksConditionals` over `packages/activemodel` and `packages/activerecord` (src + tests). A Promise in a boolean position is now a hard lint error. Verified all boolean-position forms are caught — `if (p())`, `!p()`, `p() && x`, `p() || x`, `p() ? a : b`, `while (p())` — each flags *"Expected non-Promise value in a boolean conditional."*

The rule is type-aware; the existing `projectService` block supplies the type info. Lint over both packages (src + tests) is clean.

## Deferred (own burndown story)

Clearing these needs runtime `await`/`void` edits this guard-only change forbids ("No runtime code changes"):

- `checksVoidReturn` — 12 pre-existing sites (async callbacks / adapter overrides typed void)
- `checksSpreads` — 1 site (collection-proxy.test.ts)
- `@typescript-eslint/no-floating-promises` — ~177 dropped-Promise sites (~170 in tests)

The boolean-position guard above is the actual silent footgun of the flip; the dropped-on-floor net is broader and lands separately. Tracked in `lint-guard-floating-promises-burndown`.

## Notes

- Config only — no runtime code changes.
- Unrelated pre-existing: a full `pnpm lint` surfaces one `blazetrails/expected-fixtures` error in `encryption/encrypted-fixtures.test.ts`. It reproduces on unmodified `main` (the `expected-fixtures` deps manifest is regenerated by `prelint` from vendored Rails, not committed), is independent of this change, and is out of scope here.

Closes-story: lint-guard-unawaited-isvalid