### PR TITLE
refactor(serialization): route Model#_hashToXml nested recursion through XmlMini.toTag

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -14,13 +14,11 @@ import {
 } from "./validations.js";
 import { sanitizeForbiddenAttributes as forbiddenSanitize } from "./forbidden-attributes-protection.js";
 import {
-  underscore,
-  singularize,
   renameKey,
   toTag,
+  IndentedXmlStringBuilder,
   type RenameKeyOptions,
-  type XmlBuilder,
-  htmlEscape,
+  type XmlTypeInfo,
   resetCallbacks as asResetCallbacks,
 } from "@blazetrails/activesupport";
 import {
@@ -172,32 +170,14 @@ const XML_MINI_TYPE_NAMES: Record<string, string> = {
 };
 
 /**
- * A cast-derived type map for one serialized hash level, mirroring the
- * column-type table Rails builds per-record in its XML serializer. `types`
- * maps each scalar attribute key to its `XmlMini` `type=` name; `nested`
- * carries the same info for each `include`d association keyed by association
- * name, so a nested numeric column keeps an adapter-stable `type=` attribute
- * even though `serializableHash` flattens the association into a plain object
- * that no longer carries its model class.
+ * The empty {@link XmlTypeInfo} used when a level has no cast types (a bare
+ * hash with no association metadata). `types` maps each scalar attribute key to
+ * its `XmlMini` `type=` name and `nested` carries the same table for each
+ * `include`d association, mirroring the per-record column-type table Rails
+ * builds in its XML serializer — needed because `serializableHash` flattens
+ * associations into plain objects that no longer name their model class.
  */
-interface XmlTypeInfo {
-  types: Record<string, string>;
-  nested: Record<string, XmlTypeInfo>;
-}
-
 const EMPTY_XML_TYPE_INFO: XmlTypeInfo = { types: {}, nested: {} };
-
-/**
- * Whether a serialized value is a plain `{}` record (the trails analog of a
- * Ruby Hash) rather than a class instance. Only plain records are expanded into
- * nested XML tags; Date/Temporal/BigDecimal/TimeWithZone and any other instance
- * serialize as a single leaf, matching XmlMini's `respond_to?(:to_xml)` gate.
- */
-function isPlainRecord(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === Object.prototype || proto === null;
-}
 
 /**
  * Build the cast-derived {@link XmlTypeInfo} for a record's serialized `hash`,
@@ -2390,84 +2370,33 @@ export class Model {
     // `skip_types: true` (XmlMini) suppresses the inferred `type="..."`
     // attribute on every tag; the `nil="true"` marker is a separate attribute
     // and stays. (active_support/core_ext/array/conversions.rb / xml_mini.rb)
-    let xml = "";
-    // An indentation-aware leaf sink for the shared XmlMini `toTag` funnel,
-    // which resolves the `type=` name, applies formatting, emits `nil="true"`,
-    // and calls `renameKey`. `openTag`/`closeTag` are unused: only leaves are
-    // routed through `toTag` here — nested plain-object hashes keep their own
-    // recursion below so the per-attribute cast types (`typeInfo.nested`) can be
-    // threaded, which `toTag` (one type per value) cannot carry.
-    const leafBuilder = (leafIndent: string): XmlBuilder => ({
-      tag: (name, content, attributes = {}) => {
-        const attrs = Object.entries(attributes)
-          .map(([k, v]) => ` ${k}="${this._escapeXml(v)}"`)
-          .join("");
-        xml +=
-          content == null
-            ? `${leafIndent}<${name}${attrs}/>\n`
-            : `${leafIndent}<${name}${attrs}>${this._escapeXml(content)}</${name}>\n`;
-      },
-      openTag: () => {},
-      closeTag: () => {},
-    });
-    const builder = leafBuilder(indent);
+    //
+    // Every value — leaf, nested hash, or array — routes through the shared
+    // XmlMini `toTag` funnel, so `renameKey`/`type=`/`nil=` have a single call
+    // site. `toTag`'s `emitHash`/`emitArray` recurse into the depth-aware
+    // builder for the pretty-printed layout, and the per-level cast types ride
+    // along in `typeInfo` (bigint ids / string-materialized decimals keep an
+    // adapter-agnostic `type=`). Keys are camelCase, so `underscoreKeys` lets
+    // `renameKey` see `_`/space separators to dasherize.
+    const builder = new IndentedXmlStringBuilder(indent);
     for (const [key, value] of Object.entries(hash)) {
-      const tagKey = underscore(key);
       // The cast/column type name (when known) overrides JS-runtime inference so
-      // the `type=` attribute is adapter-agnostic (e.g. a bigint `id` stays
-      // `type="integer"` whether it arrives as a JS number, BigInt, or string).
-      const castTypeName = typeInfo.types[key];
-      const emit = (type?: string) =>
-        toTag(tagKey, value, { builder, type, skipTypes, ...renameOptions });
-      if (isPlainRecord(value)) {
-        // A plain `{}` record is the trails analog of a Ruby Hash: expand it.
-        // Non-plain objects (Date, Temporal, BigDecimal, an ActiveSupport
-        // TimeWithZone, or any other class instance) fall through to `toTag`,
-        // which serializes each as a single typed leaf — never a nested hash.
-        const tag = renameKey(tagKey, renameOptions);
-        xml += `${indent}<${tag}>\n${this._hashToXml(value, indent + "  ", skipTypes, typeInfo.nested[key] ?? EMPTY_XML_TYPE_INFO, renameOptions)}${indent}</${tag}>\n`;
-      } else if (Array.isArray(value)) {
-        const tag = renameKey(tagKey, renameOptions);
-        const arrayType = skipTypes ? "" : ` type="array"`;
-        if (value.length === 0) {
-          // Rails emits an empty array as the self-closing `<tag type="array"/>`.
-          xml += `${indent}<${tag}${arrayType}/>\n`;
-        } else {
-          xml += `${indent}<${tag}${arrayType}>\n`;
-          // Array children are named for the singularized (renamed) root, per
-          // Array#to_xml (`children = root.singularize`) — e.g. `<tag>` under
-          // `<tags type="array">`, not a generic `<item>`.
-          const children = singularize(tag);
-          const itemBuilder = leafBuilder(indent + "  ");
-          for (const item of value) {
-            if (isPlainRecord(item)) {
-              xml += `${indent}  <${children}>\n${this._hashToXml(item, indent + "    ", skipTypes, typeInfo.nested[key] ?? EMPTY_XML_TYPE_INFO, renameOptions)}${indent}  </${children}>\n`;
-            } else {
-              // Route every scalar element through `toTag` so it keeps Rails'
-              // inferred `type=`, `nil="true"`, and per-type formatting (a Date
-              // element stays a `dateTime` leaf, not an expanded hash).
-              toTag(children, item, { builder: itemBuilder, skipTypes, ...renameOptions });
-            }
-          }
-          xml += `${indent}</${tag}>\n`;
-        }
-      } else if (typeof value === "number") {
-        // ActiveModel serializes every JS `number` as `integer` (it cannot see
-        // the DB scale); a float column supplies its cast type explicitly.
-        emit(castTypeName ?? "integer");
-      } else {
-        // Every remaining leaf — nil, boolean, BigDecimal, Date, the Temporal
-        // types, and strings — is typed by `toTag`'s own inference, with the
-        // cast/column type (bigint ids, string-materialized decimals) overriding
-        // it so the `type=` attribute stays adapter-agnostic.
-        emit(castTypeName);
-      }
+      // the `type=` attribute is adapter-agnostic. A leaf JS `number` with no
+      // cast type defaults to `integer` — ActiveModel cannot see the DB scale,
+      // and a float/decimal column supplies its own type. (Containers are
+      // objects, so this default never fires for them.)
+      let type = typeInfo.types[key];
+      if (type == null && typeof value === "number") type = "integer";
+      toTag(key, value, {
+        builder,
+        type,
+        skipTypes,
+        typeInfo: typeInfo.nested[key] ?? EMPTY_XML_TYPE_INFO,
+        underscoreKeys: true,
+        ...renameOptions,
+      });
     }
-    return xml;
-  }
-
-  private _escapeXml(str: string): string {
-    return htmlEscape(str).toString();
+    return builder.target();
   }
 
   /**

--- a/packages/activemodel/src/serialization.test.ts
+++ b/packages/activemodel/src/serialization.test.ts
@@ -926,6 +926,41 @@ describe("toXml()", () => {
     expect(xml).toContain('<id type="integer">7</id>');
   });
 
+  it("indents a nested include two spaces deeper than its wrapper", () => {
+    // The nested-hash branch routes through XmlMini.toTag's depth-aware builder,
+    // so a singular include is wrapped in its own tag and each attribute sits
+    // two spaces deeper — the same pretty-printed layout the inline recursion
+    // produced before this path was consolidated onto the shared funnel.
+    class Author extends Model {
+      static {
+        this.attribute("id", "big_integer");
+        this.attribute("name", "string");
+      }
+    }
+    class Post extends Model {
+      author: Author | null = null;
+      static {
+        this.attribute("id", "big_integer");
+      }
+    }
+    const author = new Author({ name: "Alice" });
+    author.writeAttribute("id", "7");
+    const p = new Post({});
+    p.writeAttribute("id", "1");
+    p.author = author;
+    expect(p.toXml({ include: "author" })).toBe(
+      [
+        "<post>",
+        '  <id type="integer">1</id>',
+        "  <author>",
+        '    <id type="integer">7</id>',
+        "    <name>Alice</name>",
+        "  </author>",
+        "</post>",
+      ].join("\n"),
+    );
+  });
+
   it("serializes a decimal attribute as a scalar type=decimal, not a nested object", () => {
     // A decimal attribute materializes as a BigDecimal object carrying
     // sign/intDigits/fracDigits. Rails serializes BigDecimal#to_xml as a

--- a/packages/activesupport/src/index.ts
+++ b/packages/activesupport/src/index.ts
@@ -169,9 +169,11 @@ export {
   renameKey,
   toTag,
   XmlStringBuilder,
+  IndentedXmlStringBuilder,
   type RenameKeyOptions,
   type ToTagOptions,
   type XmlBuilder,
+  type XmlTypeInfo,
 } from "./xml-mini.js";
 
 export {

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -1,4 +1,4 @@
-import { camelize, singularize } from "./inflector.js";
+import { camelize, singularize, underscore } from "./inflector.js";
 import { htmlEscape } from "./core-ext/string/output-safety.js";
 import { BigDecimal } from "./core-ext/big-decimal/conversions.js";
 import { Temporal } from "./temporal.js";
@@ -62,11 +62,36 @@ export interface XmlBuilder {
   closeTag(name: string): void;
 }
 
+/**
+ * A per-level cast-type table threaded through `to_tag`'s container recursion so
+ * nested attributes keep an adapter-agnostic `type=` (a bigint id stays
+ * `type="integer"` whether it arrives as a number, BigInt, or string). `types`
+ * maps a hash key to its explicit `type=` name; `nested` carries the same table
+ * for each container-valued key. Rails has no analog — its serialized hash still
+ * holds typed Ruby objects — but trails' flattened hash loses the cast type, so
+ * ActiveModel resolves it up front and threads it here.
+ */
+export interface XmlTypeInfo {
+  types: Record<string, string | undefined>;
+  nested: Record<string, XmlTypeInfo>;
+}
+
 export interface ToTagOptions extends RenameKeyOptions {
   /** The sink the emitted tag(s) are written to. */
   builder: XmlBuilder;
   /** Explicit `type=` name; suppresses runtime type inference when set. */
   type?: string;
+  /**
+   * Cast types for a container's children, threaded through `emitHash`/
+   * `emitArray` so nested attributes keep an adapter-agnostic `type=`.
+   */
+  typeInfo?: XmlTypeInfo;
+  /**
+   * Underscore each tag key before {@link renameKey} runs. ActiveModel's
+   * serialized keys are camelCase; Rails' are already snake_case, so this is
+   * off by default and set only by `Model#toXml`.
+   */
+  underscoreKeys?: boolean;
   /** Suppress the inferred `type=` attribute (any truthy value, per Rails). */
   skipTypes?: boolean | number;
   /** Overrides `DEFAULT_ENCODINGS[type]` for the `encoding=` attribute. */
@@ -182,6 +207,16 @@ function keyToString(key: unknown): string {
 }
 
 /**
+ * The final tag name for a key: {@link renameKey} applied to the stringified
+ * key, optionally underscored first (ActiveModel's camelCase keys) so
+ * `dasherize` has `_`/space separators to rewrite.
+ */
+function renameTag(key: unknown, options: ToTagOptions): string {
+  const name = keyToString(key);
+  return renameKey(options.underscoreKeys ? underscore(name) : name, options);
+}
+
+/**
  * Whether a value is the trails analog of a Ruby `Hash` for `to_tag`. Rails
  * only routes an object through `Hash#to_xml` (field expansion) when it
  * `respond_to?(:to_xml)` — a plain Hash does, an arbitrary object does not.
@@ -232,7 +267,7 @@ export function toTag(key: unknown, value: unknown, options: ToTagOptions): void
   let typeName = explicitType ?? inferTypeName(value);
   if (typeName === "datetime") typeName = "dateTime";
 
-  const renamed = renameKey(keyToString(key), options);
+  const renamed = renameTag(key, options);
   const attributes: Record<string, string> = {};
   if (!(options.skipTypes || typeName == null)) attributes.type = typeName;
   if (value == null) attributes.nil = "true";
@@ -255,7 +290,7 @@ export function toTag(key: unknown, value: unknown, options: ToTagOptions): void
  * at this level and not forwarded to the element tags.
  */
 function emitArray(key: unknown, values: unknown[], options: ToTagOptions): void {
-  const root = renameKey(keyToString(key), options);
+  const root = renameTag(key, options);
   const attributes: Record<string, string> = options.skipTypes ? {} : { type: "array" };
   // Rails special-cases an empty array to `builder.tag!(root, attributes)` with
   // no block — the self-closing `<root type="array"/>` form.
@@ -279,10 +314,13 @@ function emitArray(key: unknown, values: unknown[], options: ToTagOptions): void
  * `to_tag`, which renames the entry key.
  */
 function emitHash(key: unknown, hash: Record<string, unknown>, options: ToTagOptions): void {
-  const root = renameKey(keyToString(key), options);
+  const root = renameTag(key, options);
+  const info = options.typeInfo;
   options.builder.openTag(root, {});
   for (const [k, v] of Object.entries(hash)) {
-    toTag(k, v, { ...options, type: undefined, root: k });
+    // Resolve each child's explicit `type=` and next-level table from this
+    // level's `typeInfo` so nested cast types survive the descent.
+    toTag(k, v, { ...options, type: info?.types[k], typeInfo: info?.nested[k], root: k });
   }
   options.builder.closeTag(root);
 }
@@ -316,6 +354,53 @@ export class XmlStringBuilder implements XmlBuilder {
 
   closeTag(name: string): void {
     this.buffer += `</${name}>`;
+  }
+
+  /** The accumulated XML. Mirrors: `Builder::XmlMarkup#target!`. */
+  target(): string {
+    return this.buffer;
+  }
+}
+
+/**
+ * A depth-aware XML sink: each tag is emitted on its own line, indented two
+ * spaces per open container and terminated by a newline. `openTag`/`closeTag`
+ * track nesting so `to_tag`'s `emitHash`/`emitArray` produce the pretty-printed
+ * layout ActiveModel's `Model#toXml` emits. Mirrors `Builder::XmlMarkup` with
+ * `:indent => 2`.
+ */
+export class IndentedXmlStringBuilder implements XmlBuilder {
+  private buffer = "";
+  private depth = 0;
+
+  constructor(private readonly baseIndent = "") {}
+
+  private indent(): string {
+    return this.baseIndent + "  ".repeat(this.depth);
+  }
+
+  private attributeString(attributes: Record<string, string>): string {
+    return Object.entries(attributes)
+      .map(([k, v]) => ` ${k}="${htmlEscape(v).toString()}"`)
+      .join("");
+  }
+
+  tag(name: string, content?: string | null, attributes: Record<string, string> = {}): void {
+    const attrs = this.attributeString(attributes);
+    this.buffer +=
+      content == null
+        ? `${this.indent()}<${name}${attrs}/>\n`
+        : `${this.indent()}<${name}${attrs}>${htmlEscape(content).toString()}</${name}>\n`;
+  }
+
+  openTag(name: string, attributes: Record<string, string> = {}): void {
+    this.buffer += `${this.indent()}<${name}${this.attributeString(attributes)}>\n`;
+    this.depth += 1;
+  }
+
+  closeTag(name: string): void {
+    this.depth -= 1;
+    this.buffer += `${this.indent()}</${name}>\n`;
   }
 
   /** The accumulated XML. Mirrors: `Builder::XmlMarkup#target!`. */

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -325,6 +325,13 @@ function emitHash(key: unknown, hash: Record<string, unknown>, options: ToTagOpt
   options.builder.closeTag(root);
 }
 
+/** Render `attrs` as ` k="v"` pairs with escaped values, in insertion order. */
+function attributeString(attributes: Record<string, string>): string {
+  return Object.entries(attributes)
+    .map(([k, v]) => ` ${k}="${htmlEscape(v).toString()}"`)
+    .join("");
+}
+
 /**
  * Compact XML sink mirroring `Builder::XmlMarkup`'s default (no indentation),
  * escaping text content and attribute values. Used as the `to_tag` builder in
@@ -333,14 +340,8 @@ function emitHash(key: unknown, hash: Record<string, unknown>, options: ToTagOpt
 export class XmlStringBuilder implements XmlBuilder {
   private buffer = "";
 
-  private attributeString(attributes: Record<string, string>): string {
-    return Object.entries(attributes)
-      .map(([k, v]) => ` ${k}="${htmlEscape(v).toString()}"`)
-      .join("");
-  }
-
   tag(name: string, content?: string | null, attributes: Record<string, string> = {}): void {
-    const attrs = this.attributeString(attributes);
+    const attrs = attributeString(attributes);
     if (content == null) {
       this.buffer += `<${name}${attrs}/>`;
     } else {
@@ -349,7 +350,7 @@ export class XmlStringBuilder implements XmlBuilder {
   }
 
   openTag(name: string, attributes: Record<string, string> = {}): void {
-    this.buffer += `<${name}${this.attributeString(attributes)}>`;
+    this.buffer += `<${name}${attributeString(attributes)}>`;
   }
 
   closeTag(name: string): void {
@@ -379,14 +380,8 @@ export class IndentedXmlStringBuilder implements XmlBuilder {
     return this.baseIndent + "  ".repeat(this.depth);
   }
 
-  private attributeString(attributes: Record<string, string>): string {
-    return Object.entries(attributes)
-      .map(([k, v]) => ` ${k}="${htmlEscape(v).toString()}"`)
-      .join("");
-  }
-
   tag(name: string, content?: string | null, attributes: Record<string, string> = {}): void {
-    const attrs = this.attributeString(attributes);
+    const attrs = attributeString(attributes);
     this.buffer +=
       content == null
         ? `${this.indent()}<${name}${attrs}/>\n`
@@ -394,7 +389,7 @@ export class IndentedXmlStringBuilder implements XmlBuilder {
   }
 
   openTag(name: string, attributes: Record<string, string> = {}): void {
-    this.buffer += `${this.indent()}<${name}${this.attributeString(attributes)}>\n`;
+    this.buffer += `${this.indent()}<${name}${attributeString(attributes)}>\n`;
     this.depth += 1;
   }
 

--- a/packages/activesupport/src/xml-mini.ts
+++ b/packages/activesupport/src/xml-mini.ts
@@ -207,13 +207,15 @@ function keyToString(key: unknown): string {
 }
 
 /**
- * The final tag name for a key: {@link renameKey} applied to the stringified
- * key, optionally underscored first (ActiveModel's camelCase keys) so
- * `dasherize` has `_`/space separators to rewrite.
+ * The stringified key, underscored first when `underscoreKeys` is set
+ * (ActiveModel's camelCase keys) so a later `dasherize` has `_`/space
+ * separators to rewrite. The result is still passed through {@link renameKey}
+ * at each call site (kept a direct call there to mirror Rails' `to_tag`/
+ * `Hash#to_xml`/`Array#to_xml`, which each call `rename_key`).
  */
-function renameTag(key: unknown, options: ToTagOptions): string {
+function tagKey(key: unknown, options: ToTagOptions): string {
   const name = keyToString(key);
-  return renameKey(options.underscoreKeys ? underscore(name) : name, options);
+  return options.underscoreKeys ? underscore(name) : name;
 }
 
 /**
@@ -267,7 +269,7 @@ export function toTag(key: unknown, value: unknown, options: ToTagOptions): void
   let typeName = explicitType ?? inferTypeName(value);
   if (typeName === "datetime") typeName = "dateTime";
 
-  const renamed = renameTag(key, options);
+  const renamed = renameKey(tagKey(key, options), options);
   const attributes: Record<string, string> = {};
   if (!(options.skipTypes || typeName == null)) attributes.type = typeName;
   if (value == null) attributes.nil = "true";
@@ -290,7 +292,7 @@ export function toTag(key: unknown, value: unknown, options: ToTagOptions): void
  * at this level and not forwarded to the element tags.
  */
 function emitArray(key: unknown, values: unknown[], options: ToTagOptions): void {
-  const root = renameTag(key, options);
+  const root = renameKey(tagKey(key, options), options);
   const attributes: Record<string, string> = options.skipTypes ? {} : { type: "array" };
   // Rails special-cases an empty array to `builder.tag!(root, attributes)` with
   // no block — the self-closing `<root type="array"/>` form.
@@ -314,7 +316,7 @@ function emitArray(key: unknown, values: unknown[], options: ToTagOptions): void
  * `to_tag`, which renames the entry key.
  */
 function emitHash(key: unknown, hash: Record<string, unknown>, options: ToTagOptions): void {
-  const root = renameTag(key, options);
+  const root = renameKey(tagKey(key, options), options);
   const info = options.typeInfo;
   options.builder.openTag(root, {});
   for (const [k, v] of Object.entries(hash)) {


### PR DESCRIPTION
## What

Routes `Model#_hashToXml`'s nested-hash and array-of-objects recursion through
the shared `XmlMini.toTag` funnel (`emitHash`/`emitArray`), completing the
single-funnel goal started in #4752 (which only routed leaves).

Two blockers are cleared:

1. **Depth-aware builder.** New `IndentedXmlStringBuilder` (activesupport)
   tracks nesting via `openTag`/`closeTag`, so `toTag`'s container recursion
   produces the same pretty-printed, two-space-indented layout `_hashToXml`
   emitted inline. `_hashToXml` now constructs one builder and lets `toTag`
   write leaves *and* containers into it.
2. **Nested cast-type channel.** New `XmlTypeInfo` type threaded through
   `ToTagOptions.typeInfo`; `emitHash`/`emitArray` resolve each child's explicit
   `type=` and next-level table from it, so nested bigint ids / string-
   materialized decimals keep an adapter-agnostic `type=`.

A new `underscoreKeys` option lets `toTag` underscore camelCase ActiveModel keys
before `renameKey` runs (Rails keys are already snake_case, so it defaults off).

The leaf `number → integer` default stays in `_hashToXml` (it is an
ActiveModel-only quirk from losing the DB scale; generic `Hash#to_xml` must not
force it).

`renameKey`/`type=`/`nil=` now have a single call site. Dead helpers
(`isPlainRecord`, `_escapeXml`, the local `XmlTypeInfo`) removed.

## Testing

- `activemodel/serialization.test.ts`, `activesupport/xml-mini.test.ts`,
  `activerecord` delegation + relations `to_xml` tests — all green.

Closes-story: model-hashtoxml-route-nested-through-totag
