### PR TITLE
fix(instantiate): materialize override types for absent no-default keys

### DIFF
--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -162,26 +162,6 @@ export class AttributeSet {
     );
   }
 
-  /**
-   * Materialize an override type for a key absent from the values hash and
-   * lacking a schema default, as an uninitialized attribute — mirroring
-   * `LazyAttributeHash#[]`'s final branch (builder.rb:170-177): when a name is
-   * in `additional_types`/`types` but not in the values hash, Rails returns
-   * `attr.dup` if a `default_attributes[name]` exists (schema type kept, the
-   * override is NOT applied) and otherwise `Attribute.uninitialized(name,
-   * type)` with the resolved override type. A schema-declared column is already
-   * materialized in the set (warm schema cache), so its presence here is the
-   * `attr.dup` branch — we leave it untouched.
-   */
-  overrideUninitialized(name: string, type: { deserialize(value: unknown): unknown }): void {
-    this.assertNotFrozen();
-    if (this.attributes.has(name)) return;
-    this.attributes.set(
-      name,
-      Attribute.uninitialized(name, type as import("./type/value.js").Type),
-    );
-  }
-
   writeFromUser(name: string, value: unknown): unknown {
     this.assertNotFrozen();
     // Rails one-liner (attribute_set.rb:58-61):
@@ -344,13 +324,26 @@ export class AttributeSet {
    * SELECT projects only a subset of columns: unselected columns are absent
    * from the materialized set, so `has`/`keys` no longer report them.
    *
+   * `overrideTypes` threads the per-query `additional_types` (Rails' second
+   * `build_from_database` arg): a narrowed column becomes
+   * `Attribute.uninitialized(name, additional_types.fetch(name, types[name]))`
+   * (builder.rb:76-87), so an override supplied for a column absent from the
+   * projected row wins over the declared schema type — matching Rails' resolved
+   * `type` in the `elsif types.key?(name)` / `else Attribute.uninitialized`
+   * branch. Absent that, the declared type is preserved.
+   *
    * @internal Rails-private helper.
    */
-  narrowTo(names: Iterable<string>): void {
+  narrowTo(
+    names: Iterable<string>,
+    overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
+  ): void {
     this.assertNotFrozen();
     const keep = names instanceof Set ? names : new Set(names);
     for (const [name, attr] of this.attributes) {
-      if (!keep.has(name)) this.attributes.set(name, Attribute.uninitialized(name, attr.type));
+      if (keep.has(name)) continue;
+      const type = (overrideTypes?.[name] as import("./type/value.js").Type) ?? attr.type;
+      this.attributes.set(name, Attribute.uninitialized(name, type));
     }
   }
 

--- a/packages/activemodel/src/attribute-set.ts
+++ b/packages/activemodel/src/attribute-set.ts
@@ -162,6 +162,26 @@ export class AttributeSet {
     );
   }
 
+  /**
+   * Materialize an override type for a key absent from the values hash and
+   * lacking a schema default, as an uninitialized attribute — mirroring
+   * `LazyAttributeHash#[]`'s final branch (builder.rb:170-177): when a name is
+   * in `additional_types`/`types` but not in the values hash, Rails returns
+   * `attr.dup` if a `default_attributes[name]` exists (schema type kept, the
+   * override is NOT applied) and otherwise `Attribute.uninitialized(name,
+   * type)` with the resolved override type. A schema-declared column is already
+   * materialized in the set (warm schema cache), so its presence here is the
+   * `attr.dup` branch — we leave it untouched.
+   */
+  overrideUninitialized(name: string, type: { deserialize(value: unknown): unknown }): void {
+    this.assertNotFrozen();
+    if (this.attributes.has(name)) return;
+    this.attributes.set(
+      name,
+      Attribute.uninitialized(name, type as import("./type/value.js").Type),
+    );
+  }
+
   writeFromUser(name: string, value: unknown): unknown {
     this.assertNotFrozen();
     // Rails one-liner (attribute_set.rb:58-61):

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -208,7 +208,7 @@ describe("UnknownPrimaryKeyTest", () => {
   });
 });
 
-describe("instantiate override types for absent no-default keys (trails)", () => {
+describe("instantiate override types for absent keys (trails)", () => {
   fixtures([]);
 
   class Typecast extends Type {
@@ -219,7 +219,11 @@ describe("instantiate override types for absent no-default keys (trails)", () =>
   }
 
   interface AttrProbe {
-    _attributes: { getAttribute(name: string): { isInitialized(): boolean; type: unknown } };
+    _attributes: {
+      getAttribute(name: string): { isInitialized(): boolean; type: unknown };
+      has(name: string): boolean;
+      keys(): string[];
+    };
   }
   const seedAttrs = async (): Promise<Record<string, unknown>> => {
     class Topic extends Base {}
@@ -231,26 +235,13 @@ describe("instantiate override types for absent no-default keys (trails)", () =>
     return attrs;
   };
 
-  // Rails' LazyAttributeHash materializes every `types`/`additional_types` key,
-  // not just those present in the values hash: an override key absent from the
-  // attributes with no schema default becomes Attribute.uninitialized carrying
-  // the override type (builder.rb:170-177). trails previously applied overrides
-  // only while iterating keys present in the row, dropping this edge.
-  it("materializes an override type for an absent key lacking a schema default", async () => {
-    class Topic extends Base {}
-    const attrs = await seedAttrs();
-
-    const topic = Topic.instantiate(attrs, {
-      computed_col: new Typecast(),
-    }) as unknown as AttrProbe;
-    const attr = topic._attributes.getAttribute("computed_col");
-    // Materialized as uninitialized carrying the override type (no schema
-    // default existed for this purely-computed key).
-    expect(attr.isInitialized()).toBe(false);
-    expect(attr.type).toBeInstanceOf(Typecast);
-  });
-
-  it("keeps the schema type for a real column omitted from attrs", async () => {
+  // builder.rb's `elsif types.key?(name)` / `else Attribute.uninitialized(name,
+  // type)` branch: a schema column absent from the values hash with no default
+  // (every non-PK column, since attributes_builder passes
+  // `_default_attributes.except(column_names - [primary_key])`) is materialized
+  // uninitialized, and `type = additional_types.fetch(name, types[name])`, so a
+  // per-query override wins over the declared schema type.
+  it("materializes an override type for a schema column absent from the projected row", async () => {
     class Topic extends Base {}
     const attrs = await seedAttrs();
     delete attrs.author_name;
@@ -258,9 +249,25 @@ describe("instantiate override types for absent no-default keys (trails)", () =>
     const topic = Topic.instantiate(attrs, {
       author_name: new Typecast(),
     }) as unknown as AttrProbe;
-    // The absent real column falls to the attr.dup branch: schema type kept,
-    // override NOT applied, so the custom cast type never reaches the set.
-    expect(topic._attributes.getAttribute("author_name").type).not.toBeInstanceOf(Typecast);
+    const attr = topic._attributes.getAttribute("author_name");
+    expect(attr.isInitialized()).toBe(false);
+    expect(attr.type).toBeInstanceOf(Typecast);
+  });
+
+  // builder.rb only materializes `values.each_key` and `types.each_key`;
+  // `additional_types` is consulted only for names already sourced from values
+  // or schema `types`. An override-only key that is neither in the row nor a
+  // schema column is therefore never materialized (its `default_attribute`
+  // falls to the `else Attribute.null` branch) — it must not appear in the set.
+  it("does not materialize an override-only key absent from the row and schema", async () => {
+    class Topic extends Base {}
+    const attrs = await seedAttrs();
+
+    const topic = Topic.instantiate(attrs, {
+      computed_col: new Typecast(),
+    }) as unknown as AttrProbe;
+    expect(topic._attributes.has("computed_col")).toBe(false);
+    expect(topic._attributes.keys()).not.toContain("computed_col");
   });
 });
 

--- a/packages/activerecord/src/base.trails.test.ts
+++ b/packages/activerecord/src/base.trails.test.ts
@@ -10,6 +10,8 @@ import { describe, it, expect } from "vitest";
 import { Base, UnknownPrimaryKey } from "./index.js";
 import { quoteSqlValue } from "./base.js";
 import { Temporal } from "@blazetrails/activesupport/temporal";
+import { Type } from "@blazetrails/activemodel";
+import { fixtures } from "./test-helpers/fixtures.js";
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 
 describe("quoteSqlValue", () => {
@@ -203,6 +205,62 @@ describe("UnknownPrimaryKeyTest", () => {
       "Unknown primary key for table dummies in model Dummy.\nNo PK configured.",
     );
     expect(err.model).toBe(Dummy);
+  });
+});
+
+describe("instantiate override types for absent no-default keys (trails)", () => {
+  fixtures([]);
+
+  class Typecast extends Type {
+    readonly name = "typecast";
+    cast() {
+      return "t.lo";
+    }
+  }
+
+  interface AttrProbe {
+    _attributes: { getAttribute(name: string): { isInitialized(): boolean; type: unknown } };
+  }
+  const seedAttrs = async (): Promise<Record<string, unknown>> => {
+    class Topic extends Base {}
+    const seed = await Topic.create({ title: "The First Topic" } as Partial<Topic>);
+    const attrs = {
+      ...(seed as unknown as AttrProbe & { attributes: Record<string, unknown> }).attributes,
+    };
+    delete attrs.id;
+    return attrs;
+  };
+
+  // Rails' LazyAttributeHash materializes every `types`/`additional_types` key,
+  // not just those present in the values hash: an override key absent from the
+  // attributes with no schema default becomes Attribute.uninitialized carrying
+  // the override type (builder.rb:170-177). trails previously applied overrides
+  // only while iterating keys present in the row, dropping this edge.
+  it("materializes an override type for an absent key lacking a schema default", async () => {
+    class Topic extends Base {}
+    const attrs = await seedAttrs();
+
+    const topic = Topic.instantiate(attrs, {
+      computed_col: new Typecast(),
+    }) as unknown as AttrProbe;
+    const attr = topic._attributes.getAttribute("computed_col");
+    // Materialized as uninitialized carrying the override type (no schema
+    // default existed for this purely-computed key).
+    expect(attr.isInitialized()).toBe(false);
+    expect(attr.type).toBeInstanceOf(Typecast);
+  });
+
+  it("keeps the schema type for a real column omitted from attrs", async () => {
+    class Topic extends Base {}
+    const attrs = await seedAttrs();
+    delete attrs.author_name;
+
+    const topic = Topic.instantiate(attrs, {
+      author_name: new Typecast(),
+    }) as unknown as AttrProbe;
+    // The absent real column falls to the attr.dup branch: schema type kept,
+    // override NOT applied, so the custom cast type never reaches the set.
+    expect(topic._attributes.getAttribute("author_name").type).not.toBeInstanceOf(Typecast);
   });
 });
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2933,20 +2933,20 @@ export class Base extends Model {
         record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
       }
     }
-    // Rails' LazyAttributeHash also materializes override keys absent from the
-    // values hash: one with no schema default becomes Attribute.uninitialized
-    // carrying the override type (builder.rb:170-177). Schema columns keep their
-    // declared type (the attr.dup branch), handled inside overrideUninitialized.
-    if (overrideTypes) {
-      for (const [key, type] of Object.entries(overrideTypes)) {
-        if (!(key in row)) record._attributes.overrideUninitialized(key, type);
-      }
-    }
     // A SELECT that projects only a subset of columns yields a row with just
     // those keys, so hasAttribute() must reflect what was loaded rather than
     // the full schema. Mirrors Rails' attributes_builder narrowing (see
     // narrowToProjectedColumns). Shared with the STI path in inheritance.ts.
-    narrowToProjectedColumns(this as unknown as typeof Base, record as unknown as Base, row);
+    // `overrideTypes` is threaded so a schema column absent from the row adopts
+    // the per-query override type when narrowed to uninitialized (builder.rb's
+    // `else Attribute.uninitialized(name, type)` branch, where `type` resolves
+    // via `additional_types.fetch(name, types[name])`).
+    narrowToProjectedColumns(
+      this as unknown as typeof Base,
+      record as unknown as Base,
+      row,
+      overrideTypes,
+    );
     record._newRecord = false;
     (record as any)._dirty.snapshot(record._attributes);
     record.changesApplied();

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -2933,6 +2933,15 @@ export class Base extends Model {
         record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
       }
     }
+    // Rails' LazyAttributeHash also materializes override keys absent from the
+    // values hash: one with no schema default becomes Attribute.uninitialized
+    // carrying the override type (builder.rb:170-177). Schema columns keep their
+    // declared type (the attr.dup branch), handled inside overrideUninitialized.
+    if (overrideTypes) {
+      for (const [key, type] of Object.entries(overrideTypes)) {
+        if (!(key in row)) record._attributes.overrideUninitialized(key, type);
+      }
+    }
     // A SELECT that projects only a subset of columns yields a row with just
     // those keys, so hasAttribute() must reflect what was loaded rather than
     // the full schema. Mirrors Rails' attributes_builder narrowing (see

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -581,6 +581,7 @@ export function narrowToProjectedColumns(
   klass: typeof Base,
   record: Base,
   row: Record<string, unknown>,
+  overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
 ): void {
   const pk = (klass as any).primaryKey as string | string[] | undefined;
   const pkSet = new Set(Array.isArray(pk) ? pk : pk != null ? [pk] : []);
@@ -591,14 +592,17 @@ export function narrowToProjectedColumns(
   if (narrowable.length === 0) return;
   const attrs = (record as any)._attributes as {
     keys(): Iterable<string>;
-    narrowTo(names: Iterable<string>): void;
+    narrowTo(
+      names: Iterable<string>,
+      overrideTypes?: Record<string, { deserialize(value: unknown): unknown }>,
+    ): void;
   };
   const keep = new Set(rowKeys);
   const drop = new Set(narrowable);
   for (const name of attrs.keys()) {
     if (!drop.has(name)) keep.add(name);
   }
-  attrs.narrowTo(keep);
+  attrs.narrowTo(keep, overrideTypes);
 }
 
 /**
@@ -647,14 +651,7 @@ function directInstantiate(
       record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
     }
   }
-  // Materialize override keys absent from the row with no schema default as
-  // Attribute.uninitialized (mirrors Base._instantiate / LazyAttributeHash).
-  if (overrideTypes) {
-    for (const [key, type] of Object.entries(overrideTypes)) {
-      if (!(key in row)) record._attributes.overrideUninitialized(key, type);
-    }
-  }
-  narrowToProjectedColumns(klass, record, row);
+  narrowToProjectedColumns(klass, record, row, overrideTypes);
   record._newRecord = false;
   (record as any)._dirty.snapshot(record._attributes);
   record.changesApplied();

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -647,6 +647,13 @@ function directInstantiate(
       record._attributes.writeFromDatabase(key, value, columnTypes?.[key]);
     }
   }
+  // Materialize override keys absent from the row with no schema default as
+  // Attribute.uninitialized (mirrors Base._instantiate / LazyAttributeHash).
+  if (overrideTypes) {
+    for (const [key, type] of Object.entries(overrideTypes)) {
+      if (!(key in row)) record._attributes.overrideUninitialized(key, type);
+    }
+  }
   narrowToProjectedColumns(klass, record, row);
   record._newRecord = false;
   (record as any)._dirty.snapshot(record._attributes);


### PR DESCRIPTION
## What

Rails' `LazyAttributeSet` materializes only `values.each_key` and
`types.each_key` (`builder.rb:60-66`); `additional_types` (the per-query
`column_types` override) is consulted only for a name already sourced from the
values hash or the schema `types`. `default_attribute` then branches:

- present in values → `from_database(name, value, additional_types.fetch(name, types[name]))`
- `elsif types.key?(name)` (a schema column) → `attr.dup` if a
  `default_attributes[name]` exists, else `Attribute.uninitialized(name, type)`
  with `type = additional_types.fetch(name, types[name])`
- `else` → `Attribute.null(name)`

Because `attributes_builder` passes
`default_attributes = _default_attributes.except(column_names - [primary_key])`,
the `attr.dup` branch covers only the PK (and virtual attrs); every **non-PK
schema column** absent from the row falls to `Attribute.uninitialized(name,
type)`, so a per-query override **wins over the declared schema type** there.
An **override-only key** that is neither in the row nor a schema column is
never materialized.

## How

- Thread `overrideTypes` through `narrowToProjectedColumns` → `AttributeSet#
  narrowTo`: when a schema column absent from the projected row is reset to
  uninitialized, adopt `overrideTypes[name]` if supplied, else keep the
  declared type. PK/virtual attrs are excluded from narrowing (the `attr.dup`
  branch). Override-only, non-schema keys are never materialized.
- Trails-sibling tests in `base.trails.test.ts`: (1) an override applied to a
  schema column absent from the row wins over the schema type; (2) an
  override-only key absent from the row and schema is not materialized.

Supersedes the initial approach (which wrongly materialized override-only keys
as uninitialized) per the Codex review.

Closes-story: instantiate-override-types-materialize-absent-nodefault-keys
