### PR TITLE
refactor(attributes): seed _default_attributes from reflected type_for_column

### DIFF
--- a/packages/activerecord/src/attributes.ts
+++ b/packages/activerecord/src/attributes.ts
@@ -199,10 +199,20 @@ export function _defaultAttributes(this: AnyClass): AttributeSet {
       if (source === "schema") {
         attrMap.set(name, Attribute.fromDatabase(name, def.defaultValue ?? null, def.type));
       } else if (column !== undefined) {
-        // User type-override on a real DB column (e.g. enum): the cached column
-        // carries the authoritative raw default; seed via from_database so it
-        // deserializes through the (overridden) type.
-        attrMap.set(name, Attribute.fromDatabase(name, column.default ?? null, def.type));
+        // User type-override on a real DB column (e.g. enum, serialize,
+        // normalizes, encryption): seed with the REFLECTED column type, not the
+        // override's own type, mirroring Rails' `type_for_column(connection,
+        // column)` seed (attributes.rb:241-245). The cached column carries the
+        // authoritative raw default; from_database deserializes it through the
+        // reflected type. The user override is layered back on in phase 2 —
+        // decorators receive the reflected type as their `subtype`, and an
+        // explicit `attribute(name, type)` PendingType still wins over the seed.
+        // `reflectedColumnType` is stashed by applyColumnsHash (model-schema.ts)
+        // where the adapter is in hand; fall back to the def's own type before
+        // the schema has reflected.
+        const seedType =
+          (def as { reflectedColumnType?: typeof def.type }).reflectedColumnType ?? def.type;
+        attrMap.set(name, Attribute.fromDatabase(name, column.default ?? null, seedType));
       } else if (def.defaultValue != null) {
         const base = Attribute.withCastValue(name, null, def.type);
         attrMap.set(name, base.withUserDefault(def.defaultValue));

--- a/packages/activerecord/src/enum.trails.test.ts
+++ b/packages/activerecord/src/enum.trails.test.ts
@@ -381,6 +381,20 @@ describe("Enum subtype resolved from a schema-reflected column type", () => {
     }
   }
 
+  // An EXPLICIT `attribute(name, type)` before `enum` must win over the
+  // reflected column type — Rails pushes a PendingType(type) that overrides the
+  // `type_for_column` seed during the phase-2 replay, so the enum decorator sees
+  // the declared type, not the column's. Here the declared "integer" must beat
+  // the reflected "decimal" column (mirrors the MySQL TINYINT(1) → integer case
+  // that must not coerce through the reflected boolean, exercised on sqlite).
+  class ExplicitNumericEnum extends Base {
+    static _tableName = "numeric_data";
+    static {
+      this.attribute("decimal_number", "integer");
+      this.enum("decimal_number", { low: 0, mid: 1, high: 2 });
+    }
+  }
+
   // Deliberately do NOT await `NumericEnum.loadSchema()` here: `enumTypeOf`
   // must reflect synchronously from the warm schema cache on its own (the same
   // sync path `Base.typeForAttribute` uses). Awaiting the async loader first
@@ -421,6 +435,15 @@ describe("Enum subtype resolved from a schema-reflected column type", () => {
     // mapping shape implies.
     expect(type!.subtype).toBe("decimal");
     expect(type!.subtypeType().type()).toBe("decimal");
+  });
+
+  it("keeps an explicitly-typed enum's declared subtype over the reflected column", () => {
+    const type = enumTypeOf(ExplicitNumericEnum, "decimal_number");
+    expect(type).toBeInstanceOf(EnumType);
+    // The declared "integer" wins over the reflected "decimal" column: the
+    // explicit `attribute(...)` PendingType overrides the `type_for_column` seed.
+    expect(type!.subtype).toBe("integer");
+    expect(type!.subtypeType().type()).toBe("integer");
   });
 });
 

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -65,13 +65,12 @@ function subtypeInstance(subtype: string): ValueType<unknown> {
  * so the EnumType always delegates cast/serialize/deserialize to the actual
  * column type.
  *
- * The reflected column type is the authoritative source. trails' column-seed-
- * then-replay seeds the enum override itself (not the raw column type, unlike
- * Rails), so the `reflected` argument the decorator receives at replay time is
- * the pre-reflection EnumType, not the column's `Type::Value`. Schema
- * reflection therefore stashes the real column cast type on the attribute def
- * as `enumReflectedSubtype` (model-schema.ts, where the adapter is in hand);
- * prefer it when present.
+ * trails' column-seed-then-replay now seeds the override attribute with the
+ * reflected `type_for_column` in phase 1 of `_defaultAttributes`
+ * (attributes.ts), so the `reflected` argument the decorator receives at replay
+ * time is already the column's real `Type::Value` — no per-def stash needed,
+ * mirroring Rails' block verbatim (`subtype = subtype.subtype if EnumType ===
+ * subtype`).
  *
  * Two fallbacks mirror the surrounding replay machinery rather than Rails
  * directly: an already-decorated EnumType is unwrapped to its own subtype (a
@@ -81,23 +80,18 @@ function subtypeInstance(subtype: string): ValueType<unknown> {
  * shapes so pre-reflection casts are not identity no-ops.
  */
 function enumTypeFrom(
-  klass: typeof Base,
-  attribute: string,
+  _klass: typeof Base,
+  _attribute: string,
   name: string,
   mapping: Record<string, EnumValue>,
   reflected: Type,
   raiseOnInvalidValues: boolean,
 ): EnumType {
-  const defs = (klass as unknown as { _attributeDefinitions?: Map<string, unknown> })
-    ._attributeDefinitions;
-  const stashed = (defs?.get(attribute) as { enumReflectedSubtype?: Type } | undefined)
-    ?.enumReflectedSubtype;
-  const source = stashed ?? reflected;
   let subtype: ValueType<unknown>;
-  if (source instanceof EnumType) {
-    subtype = source.subtypeType();
+  if (reflected instanceof EnumType) {
+    subtype = reflected.subtypeType();
   } else {
-    const rv = source as ValueType<unknown>;
+    const rv = reflected as ValueType<unknown>;
     subtype = rv.type() === "value" ? subtypeInstance(inferSubtype(Object.values(mapping))) : rv;
   }
   return new EnumType(name, new Map(Object.entries(mapping)), subtype, raiseOnInvalidValues);
@@ -619,18 +613,6 @@ export function _enum(
     options && "default" in options ? { default: options.default } : undefined,
   );
 
-  // Record whether the user explicitly typed the enum's attribute (e.g.
-  // `attribute("state", "integer")` before `enum`). Rails resolves the enum
-  // subtype from the attribute's *declared* type — an explicit type wins over
-  // the column's reflected type — so schema reflection must NOT override an
-  // explicitly-typed enum's subtype with the column type (e.g. a TINYINT(1)
-  // that MySQL reflects as boolean). See the `enumTypeExplicit` gate in
-  // model-schema's `applyColumnsHash`.
-  const enumDef = (
-    this as unknown as { _attributeDefinitions?: Map<string, unknown> }
-  )._attributeDefinitions?.get(attrName) as { enumTypeExplicit?: boolean } | undefined;
-  if (enumDef) enumDef.enumTypeExplicit = explicitlyTyped;
-
   // Rails' `_enum` takes `scopes: true, instance_methods: true` keyword
   // defaults; `scopes: false` suppresses per-value scope generation and
   // `instance_methods: false` suppresses predicate/bang generation.
@@ -1019,7 +1001,7 @@ export function enumTypeOf(klass: typeof Base, attribute: string): EnumType | nu
   // attribute set — the SAME path `Base.typeForAttribute` uses (base.ts). The
   // public `Base.loadSchema()` is async and would fire-and-forget, letting a
   // caller read the pre-reflection (mapping-inferred) EnumType; this sync
-  // reflection stashes `enumReflectedSubtype` and rebuilds `_defaultAttributes`
+  // reflection seeds the reflected column type and rebuilds `_defaultAttributes`
   // before we read it, so the reflected subtype is already in place.
   reflectSchemaSync.call(klass);
   // Mirror `Base.typeForAttribute`'s guard: a typeless enum (no backing column,

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -80,8 +80,6 @@ function subtypeInstance(subtype: string): ValueType<unknown> {
  * shapes so pre-reflection casts are not identity no-ops.
  */
 function enumTypeFrom(
-  _klass: typeof Base,
-  _attribute: string,
   name: string,
   mapping: Record<string, EnumValue>,
   reflected: Type,
@@ -172,7 +170,7 @@ export function installEnumAttribute(
     if (isDecoratorReplay() && !target.abstractClass) {
       assertEnumTypeDeclared(target, attribute);
     }
-    return enumTypeFrom(klass, attribute, name, mapping, reflected, raiseOnInvalidValues);
+    return enumTypeFrom(name, mapping, reflected, raiseOnInvalidValues);
   });
 
   // Define the getter after attribute() so the EnumType is already in

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -1047,31 +1047,24 @@ function applyColumnsHash(
       // `_defaultAttributes` seeds it via from_database directly from the cached
       // column (Rails' column-seed-then-replay), then replays the user override.
       //
-      // Enums are the exception that still needs the reflected column type:
-      // Rails resolves the enum subtype from the column's real `Type::Value`
-      // inside `decorate_attributes` (enum.rb:239-246). Our column-seed-then-
-      // replay seeds the override itself, so the reflected type would never
-      // reach the enum decorator otherwise. Compute it here (the adapter is in
-      // hand) via the SAME `type_for_column` pipeline the non-enum path uses —
-      // immutable-string conversion + `hook_attribute_type` (attributes.rb:
-      // 301-302, model_schema.rb:622-629) — so the enum subtype carries the
-      // same tz-conversion / optimistic-locking wrappers Rails passes into
-      // `EnumType.new`. Stash it on the def so `enumTypeFrom` delegates to it.
-      //
-      // Skip when the enum's attribute was EXPLICITLY typed (`attribute(name,
-      // type)` before `enum`): Rails uses the declared type, which wins over
-      // the column's reflected type — overriding it here would, e.g., coerce an
-      // integer enum on a MySQL `TINYINT(1)` column through boolean and break
-      // the round-trip.
-      const enums = (host as unknown as { _enums?: Map<string, unknown> })._enums;
-      if (enums?.has(name) && !(existing as { enumTypeExplicit?: boolean }).enumTypeExplicit) {
-        (existing as { enumReflectedSubtype?: Type }).enumReflectedSubtype = reflectedTypeForColumn(
-          host,
-          adapter,
-          name,
-          column,
-        );
-      }
+      // Stash the reflected `type_for_column` on the def so phase 1 of
+      // `_defaultAttributes` can seed the override attribute with the real
+      // column `Type::Value` — matching Rails, which seeds
+      // `_default_attributes` from `type_for_column(connection, column)`
+      // (attributes.rb:241-245) and then replays the user's pending
+      // modifications on top. The decorators (enum / serialize / normalizes /
+      // encryption) therefore receive the reflected column type as their
+      // `subtype`; an explicit `attribute(name, type)` still wins because its
+      // PendingType overrides the seed during the phase-2 replay. Computed here
+      // (the adapter is in hand) via the SAME `type_for_column` pipeline the
+      // non-user schema path uses — immutable-string conversion +
+      // `hook_attribute_type` (attributes.rb:301-302, model_schema.rb:622-629).
+      (existing as { reflectedColumnType?: Type }).reflectedColumnType = reflectedTypeForColumn(
+        host,
+        adapter,
+        name,
+        column,
+      );
       continue;
     }
 


### PR DESCRIPTION
## What

Phase 1 of `_defaultAttributes` (`attributes.ts`) seeded a userProvided
override on a real DB column with the override's own type (`def.type`), not the
reflected column type. So the enum / serialize / normalizes / encryption
decorators never received the column's real `Type::Value` as their `subtype` —
and `enum-subtype-from-reflected-column-type` (#4748) had to work around it with
a per-def `enumReflectedSubtype` stash plus an `enumTypeExplicit` gate.

Rails instead seeds `_default_attributes` from `type_for_column(connection,
column)` (attributes.rb:241-245) and replays the user's pending modifications on
top.

## How

- `applyColumnsHash` (model-schema.ts) stashes the reflected `type_for_column`
  (adapter cast type → immutable-string → `hook_attribute_type`) on the def as
  `reflectedColumnType` — unconditionally for any userProvided-on-column def,
  where the adapter is in hand.
- Phase 1 seeds the override attribute with `reflectedColumnType` (falling back
  to `def.type` before reflection). The decorators now receive the reflected
  column type directly.
- Drop the `enumReflectedSubtype` stash and `enumTypeExplicit` gate;
  `enumTypeFrom` mirrors Rails' block verbatim
  (`subtype = subtype.subtype if EnumType === subtype`). An explicit
  `attribute(name, type)` still wins because its phase-2 `PendingType` overrides
  the seed before the enum decorator replays.

## Testing

- enum, serialize/serialized-attribute, normalized-attribute, attributes,
  encryptable-record, encrypted-attribute-type, model-schema suites green
  locally (sqlite).
- MySQL-gated `mysql-enum.test.ts` (explicit integer enum on `TINYINT(1)`)
  exercises the explicit-type-wins path on CI.

Closes-story: converge-attribute-seed-to-reflected-type-for-column