### PR TITLE
fix(preloader): attribute nested-through raw join to its own reflection scope

### DIFF
--- a/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
@@ -50,6 +50,22 @@ type JoinWhere = {
 type HasManyHost = {
   hasMany: (name: string, options: Record<string, unknown>) => void;
 };
+type HasOneHost = {
+  hasOne: (name: string, options: Record<string, unknown>) => void;
+};
+
+// Nested through (through reflection `club` is itself a has_one-through, so
+// `_reflectionScope` is the flattened chain scope) whose has_ONE target's own
+// scope reaches `categorizations` via a RAW string join. Exercises the "join"
+// branch's own-scope raw-join routing for a has_one nested through.
+(Member as unknown as HasOneHost).hasOne("rawCategoryOfClub", {
+  through: "club",
+  source: "category",
+  scope: (rel: JoinWhere) =>
+    rel
+      .joins("INNER JOIN categorizations ON categorizations.category_id = categories.id")
+      .where("categorizations.author_id = 1"),
+});
 
 // Nested through (source `members` on Club is itself a has_many-through) whose
 // OUTER scope reaches `categories` via a RAW string join. The raw join belongs
@@ -109,6 +125,12 @@ describe("Preloader::ThroughAssociation#through_scope nested raw-join attributio
   it("raises when the outer reflection's OWN scope carries a raw join", () => {
     const groucho = members("groucho");
     const loader = throughLoader([groucho], "rawMembersOfClub");
+    expect(() => buildSql(loader)).toThrow(ConfigurationError);
+  });
+
+  it("raises for a has_one nested through whose own scope carries a raw join", () => {
+    const groucho = members("groucho");
+    const loader = throughLoader([groucho], "rawCategoryOfClub");
     expect(() => buildSql(loader)).toThrow(ConfigurationError);
   });
 

--- a/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Preloader::ThroughAssociation#through_scope — raw join attribution for a
+ * NESTED through (source reflection is itself a through).
+ *
+ * Rails' `through_scope` passes the reflection scope's `joins_values` to
+ * `joins!(source_reflection.name => joins)`; a raw SQL string / Arel join node
+ * symbolizes into a bogus association name and `JoinDependency` raises
+ * `ActiveRecord::ConfigurationError`
+ * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb:132-134,
+ * join_dependency.rb:224-226).
+ *
+ * For a nested through, `ThroughReflection#join_scopes` FLATTENS the whole chain
+ * (`source_reflection.join_scopes + super`), so `_reflectionScope` carries the
+ * source SUB-CHAIN's scope too — not just the outer reflection's own. Attributing
+ * that flattened `_joinValues` to the outer through-scope build would raise
+ * `ConfigurationError` for a raw join that belongs to a DEEPER reflection (which
+ * Rails re-derives at its own recursive source-preloader stage, where it raises
+ * there instead — or is valid SQL). So the outer build must read only the outer
+ * reflection's OWN scope (`_ownReflectionScope`, the `super.join_scopes` term):
+ *
+ *   - a raw join in the OUTER reflection's own scope still raises here, and
+ *   - a raw join carried only by the SUB-CHAIN does NOT raise at the outer build.
+ *
+ * No canonical nested-through model scope carries a raw join, so this pins the
+ * behavior by declaring the chain on the canonical Member/Club models.
+ */
+import { describe, it, expect } from "vitest";
+import { registerModel, enableSti } from "../../index.js";
+import { ConfigurationError } from "../../errors.js";
+import { fixtures } from "../../test-helpers/fixtures.js";
+import { Preloader } from "../preloader.js";
+import { ThroughAssociation } from "./through-association.js";
+import { Member } from "../../test-helpers/models/member.js";
+import { Club } from "../../test-helpers/models/club.js";
+import { Membership, CurrentMembership } from "../../test-helpers/models/membership.js";
+import { Category } from "../../test-helpers/models/category.js";
+
+registerModel(Member);
+registerModel(Club);
+enableSti(Membership);
+registerModel(Membership);
+registerModel(CurrentMembership);
+enableSti(Category);
+registerModel(Category);
+
+type JoinWhere = {
+  joins: (sql: string) => JoinWhere;
+  where: (sql: string) => JoinWhere;
+};
+type HasManyHost = {
+  hasMany: (name: string, options: Record<string, unknown>) => void;
+};
+
+// Nested through (source `members` on Club is itself a has_many-through) whose
+// OUTER scope reaches `categories` via a RAW string join. The raw join belongs
+// to the outer reflection's own scope, so — like a non-nested through — Rails
+// raises ConfigurationError at the through-scope build.
+(Member as unknown as HasManyHost).hasMany("rawMembersOfClub", {
+  through: "club",
+  source: "members",
+  scope: (rel: JoinWhere) =>
+    rel
+      .joins("INNER JOIN categories ON categories.id = memberships.club_id")
+      .where("categories.name = 'General'"),
+});
+
+// The SUB-CHAIN building block: Club's own has_many-through whose scope carries
+// a RAW join. Referenced as the `source` of the outer nested through below so
+// its raw join lands in the flattened `_reflectionScope` — but NOT in the outer
+// reflection's own scope.
+(Club as unknown as HasManyHost).hasMany("rawMembers", {
+  through: "memberships",
+  source: "member",
+  scope: (rel: JoinWhere) =>
+    rel
+      .joins("INNER JOIN categories ON categories.id = members.id")
+      .where("categories.name = 'General'"),
+});
+
+// Nested through whose SOURCE (`rawMembers`, a through) carries the raw join, but
+// whose OWN scope is a plain (raw-join-free) predicate. The raw join is the
+// sub-chain's, re-derived at its own recursive stage — so the outer build must
+// NOT raise on it.
+(Member as unknown as HasManyHost).hasMany("membersViaRawClub", {
+  through: "club",
+  source: "rawMembers",
+  scope: (rel: JoinWhere) => rel.where("clubs.name IS NOT NULL"),
+});
+
+describe("Preloader::ThroughAssociation#through_scope nested raw-join attribution", () => {
+  const { members } = fixtures(["memberTypes", "members", "clubs", "memberships", "categories"]);
+
+  function throughLoader(owners: Member[], name: string): ThroughAssociation {
+    const loader = new Preloader({
+      records: owners,
+      associations: [name],
+      associateByDefault: false,
+    }).loaders.find((l) => l instanceof ThroughAssociation);
+    if (!loader) throw new Error("expected a ThroughAssociation loader");
+    return loader;
+  }
+
+  function buildSql(loader: ThroughAssociation): string {
+    return (loader as unknown as { _buildThroughScope: () => { toSql: () => string } })
+      ._buildThroughScope()
+      .toSql();
+  }
+
+  it("raises when the outer reflection's OWN scope carries a raw join", () => {
+    const groucho = members("groucho");
+    const loader = throughLoader([groucho], "rawMembersOfClub");
+    expect(() => buildSql(loader)).toThrow(ConfigurationError);
+  });
+
+  it("does NOT raise when only the source sub-chain carries a raw join", () => {
+    const groucho = members("groucho");
+    const loader = throughLoader([groucho], "membersViaRawClub");
+    // The sub-chain's raw join is flattened into `_reflectionScope`, but reading
+    // the outer reflection's OWN scope keeps it off this build — Rails defers it
+    // to the sub-chain's own recursive source-preloader stage.
+    expect(() => buildSql(loader)).not.toThrow();
+  });
+
+  it("raises on preload when the outer own scope carries a raw join, matching Rails", async () => {
+    const groucho = members("groucho");
+    await expect(Member.where({ id: groucho.id }).preload("rawMembersOfClub")).rejects.toThrow(
+      ConfigurationError,
+    );
+  });
+});

--- a/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-raw-join-scope.test.ts
@@ -1,28 +1,25 @@
 /**
- * Preloader::ThroughAssociation#through_scope — raw join attribution for a
- * NESTED through (source reflection is itself a through).
+ * Preloader::ThroughAssociation#through_scope — raw join handling for a NESTED
+ * through (through/source reflection is itself a through).
  *
- * Rails' `through_scope` passes the reflection scope's `joins_values` to
- * `joins!(source_reflection.name => joins)`; a raw SQL string / Arel join node
- * symbolizes into a bogus association name and `JoinDependency` raises
- * `ActiveRecord::ConfigurationError`
- * (vendor/rails/activerecord/lib/active_record/associations/preloader/through_association.rb:132-134,
- * join_dependency.rb:224-226).
+ * `through_scope` reads `values = reflection_scope.values`, where
+ * `reflection_scope` is the FLATTENED chain scope
+ * (`reflection.join_scopes(...).inject(klass.unscoped, &:merge!)`,
+ * vendor/rails/activerecord/lib/active_record/associations/preloader/association.rb:290)
+ * — source sub-chain + own, merged. Whenever the flattened `where_clause` is
+ * non-empty it nests the whole flattened `values[:joins]` under
+ * `source_reflection.name` via `joins!(source_reflection.name => joins)`
+ * (through_association.rb:117,132-134). A raw SQL string / Arel join symbolizes
+ * into a bogus association name and `JoinDependency` raises
+ * `ActiveRecord::ConfigurationError` (join_dependency.rb:224-226).
  *
- * For a nested through, `ThroughReflection#join_scopes` FLATTENS the whole chain
- * (`source_reflection.join_scopes + super`), so `_reflectionScope` carries the
- * source SUB-CHAIN's scope too — not just the outer reflection's own. Attributing
- * that flattened `_joinValues` to the outer through-scope build would raise
- * `ConfigurationError` for a raw join that belongs to a DEEPER reflection (which
- * Rails re-derives at its own recursive source-preloader stage, where it raises
- * there instead — or is valid SQL). So the outer build must read only the outer
- * reflection's OWN scope (`_ownReflectionScope`, the `super.join_scopes` term):
- *
- *   - a raw join in the OUTER reflection's own scope still raises here, and
- *   - a raw join carried only by the SUB-CHAIN does NOT raise at the outer build.
- *
- * No canonical nested-through model scope carries a raw join, so this pins the
- * behavior by declaring the chain on the canonical Member/Club models.
+ * There is NO "outer-own vs. sub-chain" attribution: a raw join declared on ANY
+ * link of the chain raises at the outer through-scope build, so long as the
+ * flattened `where_clause` is non-empty. Verified against a live vendored-Rails
+ * nested-through repro (raw join on the sub-chain only + a `.where` → raises;
+ * same chain with no `.where` anywhere → the `elsif` is skipped and nothing
+ * raises). No canonical nested-through model scope carries a raw join, so this
+ * pins the behavior by declaring the chain on the canonical Member/Club models.
  */
 import { describe, it, expect } from "vitest";
 import { registerModel, enableSti } from "../../index.js";
@@ -54,23 +51,10 @@ type HasOneHost = {
   hasOne: (name: string, options: Record<string, unknown>) => void;
 };
 
-// Nested through (through reflection `club` is itself a has_one-through, so
-// `_reflectionScope` is the flattened chain scope) whose has_ONE target's own
-// scope reaches `categorizations` via a RAW string join. Exercises the "join"
-// branch's own-scope raw-join routing for a has_one nested through.
-(Member as unknown as HasOneHost).hasOne("rawCategoryOfClub", {
-  through: "club",
-  source: "category",
-  scope: (rel: JoinWhere) =>
-    rel
-      .joins("INNER JOIN categorizations ON categorizations.category_id = categories.id")
-      .where("categorizations.author_id = 1"),
-});
-
-// Nested through (source `members` on Club is itself a has_many-through) whose
-// OUTER scope reaches `categories` via a RAW string join. The raw join belongs
-// to the outer reflection's own scope, so — like a non-nested through — Rails
-// raises ConfigurationError at the through-scope build.
+// Nested through (source `members` on Club is itself a has_many-through, so this
+// takes the "twoStep"/nested branch) whose OUTER scope reaches `categories` via
+// a RAW string join + a `.where`. The flattened where_clause is non-empty, so
+// Rails raises ConfigurationError at the through-scope build.
 (Member as unknown as HasManyHost).hasMany("rawMembersOfClub", {
   through: "club",
   source: "members",
@@ -80,10 +64,11 @@ type HasOneHost = {
       .where("categories.name = 'General'"),
 });
 
-// The SUB-CHAIN building block: Club's own has_many-through whose scope carries
-// a RAW join. Referenced as the `source` of the outer nested through below so
-// its raw join lands in the flattened `_reflectionScope` — but NOT in the outer
-// reflection's own scope.
+// Same nested branch, but the raw join is declared on the SUB-CHAIN only: Club's
+// own has_many-through `rawMembers` carries `.joins(...).where(...)`, and the
+// outer `membersViaRawClub` sources through it with a raw-join-free `.where`.
+// Rails still raises at the OUTER build because the flattened `values[:joins]`
+// includes the sub-chain's raw join and the flattened where_clause is non-empty.
 (Club as unknown as HasManyHost).hasMany("rawMembers", {
   through: "memberships",
   source: "member",
@@ -92,18 +77,38 @@ type HasOneHost = {
       .joins("INNER JOIN categories ON categories.id = members.id")
       .where("categories.name = 'General'"),
 });
-
-// Nested through whose SOURCE (`rawMembers`, a through) carries the raw join, but
-// whose OWN scope is a plain (raw-join-free) predicate. The raw join is the
-// sub-chain's, re-derived at its own recursive stage — so the outer build must
-// NOT raise on it.
 (Member as unknown as HasManyHost).hasMany("membersViaRawClub", {
   through: "club",
   source: "rawMembers",
   scope: (rel: JoinWhere) => rel.where("clubs.name IS NOT NULL"),
 });
 
-describe("Preloader::ThroughAssociation#through_scope nested raw-join attribution", () => {
+// Nested through whose OWN scope carries a raw join but NO `.where` anywhere in
+// the chain. The flattened where_clause is empty, so Rails skips the whole
+// `elsif` branch (through_association.rb:117) and NOTHING raises — the raw join
+// is never nested. Pins that the raise is gated on the where_clause, not on the
+// mere presence of a raw join.
+(Member as unknown as HasManyHost).hasMany("noWhereRawMembersOfClub", {
+  through: "club",
+  source: "members",
+  scope: (rel: JoinWhere) =>
+    rel.joins("INNER JOIN categories ON categories.id = memberships.club_id"),
+});
+
+// Nested through (through reflection `club` is itself a has_one-through, so
+// `_reflectionScope` is the flattened chain scope) whose has_ONE target's own
+// scope reaches `categorizations` via a RAW join + `.where`. Exercises the
+// "join" branch's flattened raw-join handling for a has_one nested through.
+(Member as unknown as HasOneHost).hasOne("rawCategoryOfClub", {
+  through: "club",
+  source: "category",
+  scope: (rel: JoinWhere) =>
+    rel
+      .joins("INNER JOIN categorizations ON categorizations.category_id = categories.id")
+      .where("categorizations.author_id = 1"),
+});
+
+describe("Preloader::ThroughAssociation#through_scope nested raw-join handling", () => {
   const { members } = fixtures(["memberTypes", "members", "clubs", "memberships", "categories"]);
 
   function throughLoader(owners: Member[], name: string): ThroughAssociation {
@@ -122,30 +127,40 @@ describe("Preloader::ThroughAssociation#through_scope nested raw-join attributio
       .toSql();
   }
 
-  it("raises when the outer reflection's OWN scope carries a raw join", () => {
+  it("raises when the outer reflection's own scope carries a raw join", () => {
     const groucho = members("groucho");
-    const loader = throughLoader([groucho], "rawMembersOfClub");
-    expect(() => buildSql(loader)).toThrow(ConfigurationError);
+    expect(() => buildSql(throughLoader([groucho], "rawMembersOfClub"))).toThrow(
+      ConfigurationError,
+    );
   });
 
-  it("raises for a has_one nested through whose own scope carries a raw join", () => {
+  it("raises when only the source sub-chain carries a raw join, matching Rails", () => {
     const groucho = members("groucho");
-    const loader = throughLoader([groucho], "rawCategoryOfClub");
-    expect(() => buildSql(loader)).toThrow(ConfigurationError);
+    // The sub-chain's raw join is flattened into `reflection_scope`; the
+    // flattened where_clause is non-empty, so Rails nests it under the source
+    // reflection at the outer build and raises — it is NOT deferred.
+    expect(() => buildSql(throughLoader([groucho], "membersViaRawClub"))).toThrow(
+      ConfigurationError,
+    );
   });
 
-  it("does NOT raise when only the source sub-chain carries a raw join", () => {
+  it("raises for a has_one nested through whose scope carries a raw join", () => {
     const groucho = members("groucho");
-    const loader = throughLoader([groucho], "membersViaRawClub");
-    // The sub-chain's raw join is flattened into `_reflectionScope`, but reading
-    // the outer reflection's OWN scope keeps it off this build — Rails defers it
-    // to the sub-chain's own recursive source-preloader stage.
-    expect(() => buildSql(loader)).not.toThrow();
+    expect(() => buildSql(throughLoader([groucho], "rawCategoryOfClub"))).toThrow(
+      ConfigurationError,
+    );
   });
 
-  it("raises on preload when the outer own scope carries a raw join, matching Rails", async () => {
+  it("does NOT raise when the chain carries a raw join but an empty where_clause", () => {
     const groucho = members("groucho");
-    await expect(Member.where({ id: groucho.id }).preload("rawMembersOfClub")).rejects.toThrow(
+    // Empty flattened where_clause → Rails skips the `elsif` branch entirely, so
+    // the raw join is never nested and nothing raises.
+    expect(() => buildSql(throughLoader([groucho], "noWhereRawMembersOfClub"))).not.toThrow();
+  });
+
+  it("raises ConfigurationError on preload, matching Rails", async () => {
+    const groucho = members("groucho");
+    await expect(Member.where({ id: groucho.id }).preload("membersViaRawClub")).rejects.toThrow(
       ConfigurationError,
     );
   });

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -571,7 +571,10 @@ export class ThroughAssociation extends Association {
         // `ActiveRecord::ConfigurationError` — real Rails raises on preload here,
         // it does not silently carry the raw join. Nesting it under the source
         // reflection name makes trails' join builder raise the same error.
-        const nestedRawJoinValues: any[] = reflScope?._joinValues ?? [];
+        // Read from the OUTER reflection's OWN scope, not the flattened chain
+        // scope: a nested-through sub-chain's raw join belongs to a deeper
+        // reflection and must NOT raise here (see `_ownReflectionScope`).
+        const nestedRawJoinValues: any[] = this._ownReflectionScope()?._joinValues ?? [];
 
         // Rails `includes!(source_reflection.name => values[:includes])` (bare
         // when the scope has no `.includes`) + `references!(...)` promotes to a
@@ -639,12 +642,59 @@ export class ThroughAssociation extends Association {
         if (throughPreds.length > 0) {
           scope._whereClause = new WhereClause([...scope._whereClause.predicates, ...throughPreds]);
         }
+
+        // A raw string / Arel-node join the OUTER reflection's OWN scope carries
+        // (`.joins("INNER JOIN …")`) raises `ConfigurationError` in Rails
+        // regardless of collection/nested strategy — `through_scope` passes the
+        // whole `joins_values` to `joins!(source_reflection.name => joins)` and
+        // `JoinDependency` rejects the bogus association name. Nest it under the
+        // source reflection name so trails' join builder raises identically.
+        // Sourced from `_ownReflectionScope` (not the flattened chain scope), so
+        // a nested sub-chain's raw join is left to raise at its own recursive
+        // stage — not misattributed to this outer build.
+        const ownRawJoinValues: any[] = this._ownReflectionScope()?._joinValues ?? [];
+        if (ownRawJoinValues.length > 0) {
+          scope = scope.joins({ [sourceRefl.name]: [...ownRawJoinValues] });
+        }
       }
     }
 
     // cascade_strict_loading: a strict-loading preload scope propagates to the
     // through query so intermediate records inherit the constraint (rb:145).
     return this._cascadeStrictLoading(scope);
+  }
+
+  /**
+   * The OUTER reflection's own reflection scope — the merge of its own
+   * `join_scopes` (excluding the source sub-chain), where `_reflectionScope` is
+   * the FLATTENED chain scope (source sub-chain + own, merged by branch.ts).
+   * Used to attribute a raw `_joinValues` join to the reflection that declares
+   * it: for a nested through, a raw join carried only by the sub-chain must NOT
+   * raise at the outer through-scope build (it is deferred to the sub-chain's
+   * own recursive preload stage), while the outer reflection's own raw join
+   * still raises. Returns null when the outer reflection has no own scope, and
+   * falls back to the flattened `_reflectionScope` for a non-through reflection
+   * (a plain has_many/has_one-through's own scope IS the flattened scope, so the
+   * "join" branch is unchanged). Mirrors `super.join_scopes` in
+   * ThroughReflection#join_scopes.
+   * @internal
+   */
+  private _ownReflectionScope(): any {
+    const refl: any = this.reflection;
+    if (typeof refl.ownJoinScopes !== "function") return this._reflectionScope;
+    let klass: typeof Base;
+    try {
+      klass = this.klass;
+    } catch {
+      return this._reflectionScope;
+    }
+    const scopes = refl.ownJoinScopes(
+      (klass as any).arelTable,
+      (klass as any).predicateBuilder,
+      klass,
+    );
+    if (!scopes || scopes.length === 0) return null;
+    return scopes.reduce((acc: any, s: any) => acc.merge(s));
   }
 
   /** @internal */

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -571,10 +571,11 @@ export class ThroughAssociation extends Association {
         // `ActiveRecord::ConfigurationError` — real Rails raises on preload here,
         // it does not silently carry the raw join. Nesting it under the source
         // reflection name makes trails' join builder raise the same error.
-        // Read from the OUTER reflection's OWN scope, not the flattened chain
-        // scope: a nested-through sub-chain's raw join belongs to a deeper
-        // reflection and must NOT raise here (see `_ownReflectionScope`).
-        const nestedRawJoinValues: any[] = this._ownReflectionScope()?._joinValues ?? [];
+        // Read from the FLATTENED `reflection_scope` (`join_scopes.inject(&:merge!)`,
+        // preloader/association.rb:290): Rails nests the whole flattened
+        // `values[:joins]` — sub-chain raw joins included — so a raw join
+        // declared on a deeper link in a nested chain raises here too.
+        const nestedRawJoinValues: any[] = reflScope?._joinValues ?? [];
 
         // Rails `includes!(source_reflection.name => values[:includes])` (bare
         // when the scope has no `.includes`) + `references!(...)` promotes to a
@@ -643,18 +644,21 @@ export class ThroughAssociation extends Association {
           scope._whereClause = new WhereClause([...scope._whereClause.predicates, ...throughPreds]);
         }
 
-        // A raw string / Arel-node join the OUTER reflection's OWN scope carries
-        // (`.joins("INNER JOIN …")`) raises `ConfigurationError` in Rails
-        // regardless of collection/nested strategy — `through_scope` passes the
-        // whole `joins_values` to `joins!(source_reflection.name => joins)` and
-        // `JoinDependency` rejects the bogus association name. Nest it under the
+        // A raw string / Arel-node join anywhere in the FLATTENED chain scope
+        // (`.joins("INNER JOIN …")`, held in `_joinValues`) raises
+        // `ConfigurationError` in Rails regardless of the collection/nested
+        // strategy — `through_scope` passes the whole flattened `values[:joins]`
+        // to `joins!(source_reflection.name => joins)` (rb:132-134) and
+        // `JoinDependency` rejects the bogus association name. This branch is
+        // already gated on the flattened `where_clause` being non-empty (the
+        // same `elsif !reflection_scope.where_clause.empty?` gate, rb:117), so
+        // matching Rails means raising here too — a raw join declared only on a
+        // deeper sub-chain link is NOT deferred to its own recursive stage
+        // (verified against a live Rails nested-through repro). Nest it under the
         // source reflection name so trails' join builder raises identically.
-        // Sourced from `_ownReflectionScope` (not the flattened chain scope), so
-        // a nested sub-chain's raw join is left to raise at its own recursive
-        // stage — not misattributed to this outer build.
-        const ownRawJoinValues: any[] = this._ownReflectionScope()?._joinValues ?? [];
-        if (ownRawJoinValues.length > 0) {
-          scope = scope.joins({ [sourceRefl.name]: [...ownRawJoinValues] });
+        const rawJoinValues: any[] = reflScope?._joinValues ?? [];
+        if (rawJoinValues.length > 0) {
+          scope = scope.joins({ [sourceRefl.name]: [...rawJoinValues] });
         }
       }
     }
@@ -662,39 +666,6 @@ export class ThroughAssociation extends Association {
     // cascade_strict_loading: a strict-loading preload scope propagates to the
     // through query so intermediate records inherit the constraint (rb:145).
     return this._cascadeStrictLoading(scope);
-  }
-
-  /**
-   * The OUTER reflection's own reflection scope — the merge of its own
-   * `join_scopes` (excluding the source sub-chain), where `_reflectionScope` is
-   * the FLATTENED chain scope (source sub-chain + own, merged by branch.ts).
-   * Used to attribute a raw `_joinValues` join to the reflection that declares
-   * it: for a nested through, a raw join carried only by the sub-chain must NOT
-   * raise at the outer through-scope build (it is deferred to the sub-chain's
-   * own recursive preload stage), while the outer reflection's own raw join
-   * still raises. Returns null when the outer reflection has no own scope, and
-   * falls back to the flattened `_reflectionScope` for a non-through reflection
-   * (a plain has_many/has_one-through's own scope IS the flattened scope, so the
-   * "join" branch is unchanged). Mirrors `super.join_scopes` in
-   * ThroughReflection#join_scopes.
-   * @internal
-   */
-  private _ownReflectionScope(): any {
-    const refl: any = this.reflection;
-    if (typeof refl.ownJoinScopes !== "function") return this._reflectionScope;
-    let klass: typeof Base;
-    try {
-      klass = this.klass;
-    } catch {
-      return this._reflectionScope;
-    }
-    const scopes = refl.ownJoinScopes(
-      (klass as any).arelTable,
-      (klass as any).predicateBuilder,
-      klass,
-    );
-    if (!scopes || scopes.length === 0) return null;
-    return scopes.reduce((acc: any, s: any) => acc.merge(s));
   }
 
   /** @internal */

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1689,6 +1689,19 @@ export class ThroughReflection extends AbstractReflection {
     return [...sourceScopes, ...super.joinScopes(table, predicateBuilder, klass, record)];
   }
 
+  /**
+   * This through reflection's OWN join scope — the `super.join_scopes` term of
+   * `join_scopes` above, EXCLUDING the source sub-chain's scopes. `join_scopes`
+   * flattens the whole chain (`source_reflection.join_scopes + super`); the
+   * preloader needs the outer reflection's own scope alone to attribute a raw
+   * `.joins(...)` to the reflection that declares it, rather than to a deeper
+   * sub-chain reflection re-derived at its own recursive stage. Not a new Rails
+   * method — it is the `super` term made addressable.
+   */
+  ownJoinScopes(table: Table, predicateBuilder?: any, klass?: typeof Base, record?: any): any[] {
+    return super.joinScopes(table, predicateBuilder, klass, record);
+  }
+
   collectJoinChain(): AbstractReflection[] {
     return this.collectJoinReflections([this]);
   }

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -1689,19 +1689,6 @@ export class ThroughReflection extends AbstractReflection {
     return [...sourceScopes, ...super.joinScopes(table, predicateBuilder, klass, record)];
   }
 
-  /**
-   * This through reflection's OWN join scope — the `super.join_scopes` term of
-   * `join_scopes` above, EXCLUDING the source sub-chain's scopes. `join_scopes`
-   * flattens the whole chain (`source_reflection.join_scopes + super`); the
-   * preloader needs the outer reflection's own scope alone to attribute a raw
-   * `.joins(...)` to the reflection that declares it, rather than to a deeper
-   * sub-chain reflection re-derived at its own recursive stage. Not a new Rails
-   * method — it is the `super` term made addressable.
-   */
-  ownJoinScopes(table: Table, predicateBuilder?: any, klass?: typeof Base, record?: any): any[] {
-    return super.joinScopes(table, predicateBuilder, klass, record);
-  }
-
   collectJoinChain(): AbstractReflection[] {
     return this.collectJoinReflections([this]);
   }


### PR DESCRIPTION
## What

Converge `Preloader::ThroughAssociation#through_scope` to Rails for **raw
string / Arel joins in a nested through**.

`through_scope` reads `values = reflection_scope.values`, where
`reflection_scope` is the **flattened** chain scope
(`reflection.join_scopes(...).inject(klass.unscoped, &:merge!)`,
`preloader/association.rb:290`) — source sub-chain + own, merged. Whenever the
flattened `where_clause` is non-empty it nests the **whole flattened**
`values[:joins]` under `source_reflection.name`
(`through_association.rb:117,132-134`); a raw join symbolizes into a bogus
association name and `JoinDependency` raises `ConfigurationError`
(`join_dependency.rb:224-226`).

trails' `"join"` branch already did this. The `"twoStep"`/`"nested"` branch did
**not** — a nested/collection-source through with a raw join + non-empty
`where_clause` silently deferred instead of raising. This PR adds the raise to
that branch, reading the same flattened `_reflectionScope._joinValues`.

## Correcting the original premise (thanks to review on this PR)

The story premise — that a raw join carried only by the sub-chain should NOT
raise at the outer build (deferred to a recursive stage) — was **wrong**. There
is no "outer-own vs. sub-chain" attribution anywhere in `through_scope`; the
raise is gated purely on the flattened `where_clause` being non-empty and uses
the flattened `values[:joins]`.

Verified against a live **vendored-Rails** nested-through repro
(`vendor/rails/activerecord`):

- raw join declared **only on the sub-chain** + a `.where` anywhere in the chain
  → `Owner.preload(:leaves)` **raises** `ConfigurationError: Can't join 'Leaf'
  to association named 'INNER JOIN ...'` at the outer stage;
- same chain with **no `.where`** anywhere → flattened `where_clause` is empty,
  the whole `elsif` is skipped, and **nothing** raises.

The earlier `_ownReflectionScope`/`ownJoinScopes` approach is dropped: it had no
Rails counterpart, contradicted the repro, and crashed record-dependent scopes
(`author.ts:651`) by re-invoking `join_scopes` without the `record` (the CI
failure on the prior push).

## Tests

`through-association-nested-raw-join-scope.test.ts`:

- outer reflection's own scope carries a raw join (nested branch) → raises;
- **only the sub-chain** carries a raw join + `.where` → raises (the repro);
- has_one nested through, own raw join (join branch) → raises;
- raw join with an **empty** `where_clause` → does NOT raise (pins the gate);
- preload raises `ConfigurationError`.

No regression: has_many_through (175), has_one_through (53), nested-through
(64/6/6), eager (202), preloader raw-join/nested-join suites all pass.

Closes-story: through-preloader-raw-join-use-own-reflection-scope-nested
