### PR TITLE
fix(type): ValueType#type() returns nil for the unmapped default

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -200,7 +200,8 @@ function _xmlTypeInfo(
   const types: Record<string, string> = {};
   if (typeof ctor.typeForAttribute === "function") {
     for (const key of Object.keys(hash)) {
-      const xmlName = XML_MINI_TYPE_NAMES[ctor.typeForAttribute(key).type()];
+      const typeName = ctor.typeForAttribute(key).type();
+      const xmlName = typeName != null ? XML_MINI_TYPE_NAMES[typeName] : undefined;
       if (xmlName) types[key] = xmlName;
     }
   }

--- a/packages/activemodel/src/type/value.test.ts
+++ b/packages/activemodel/src/type/value.test.ts
@@ -8,6 +8,11 @@ describe("ValueTest", () => {
     expect(type1.constructor).toBe(type2.constructor);
   });
 
+  it("type is nil for the unmapped default", () => {
+    // Mirrors ActiveModel::Type::Value#type returning nil (value.rb:32-35).
+    expect(new ValueType().type()).toBeUndefined();
+  });
+
   it("as json not defined", () => {
     const type = Types.typeRegistry.lookup("value");
     // Value type passes through without transformation

--- a/packages/activemodel/src/type/value.ts
+++ b/packages/activemodel/src/type/value.ts
@@ -33,7 +33,7 @@ export abstract class Type<T = unknown> {
     return true;
   }
 
-  type(): string {
+  type(): string | undefined {
     return this.name;
   }
 
@@ -200,6 +200,22 @@ export abstract class Type<T = unknown> {
 
 export class ValueType<T = unknown> extends Type<T> {
   readonly name: string = "value";
+
+  /**
+   * Mirrors: ActiveModel::Type::Value#type (value.rb:32-35)
+   *
+   *   def type
+   *   end
+   *
+   * Returns nil for the unmapped default. trails uses `name` as the
+   * type-name carrier (the base `Type#type` returns it), so the bare
+   * ValueType sentinel — `name === "value"` — must instead reflect as
+   * `undefined` to match Rails' nil. Subclasses set their own `name`
+   * (and usually override `type()`), so they keep reporting it.
+   */
+  override type(): string | undefined {
+    return this.name === "value" ? undefined : this.name;
+  }
 
   equals(other: Type): boolean {
     return (

--- a/packages/activerecord/src/adapters/postgresql/composite.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/composite.test.ts
@@ -79,10 +79,10 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("column", async () => {
-      // Rails: assert_nil column.type — unknown composite OID maps to ValueType
-      // TS diverges: ValueType#type() returns "value" (TS has no nil type symbol)
+      // Rails: assert_nil column.type — an unknown composite OID maps to a
+      // ValueType, whose type() is nil; SqlTypeMetadata keeps `type` nil-faithful.
       const col = (PostgresqlComposite as any).columnsHash()["address"];
-      expect(col.type).toBe("value");
+      expect(col.type).toBeNull();
       expect(col.sqlType).toBe("full_address");
       expect(col.array).toBeFalsy();
       const type = PostgresqlComposite.typeForAttribute("address");

--- a/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
+++ b/packages/activerecord/src/attribute-methods/time-zone-conversion.ts
@@ -37,7 +37,7 @@ export class TimeZoneConverter extends ValueType<unknown> {
     return subtype instanceof TimeZoneConverter ? subtype : new TimeZoneConverter(subtype);
   }
 
-  override type(): string {
+  override type(): string | undefined {
     return this._subtype.type();
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -4639,7 +4639,9 @@ export class Base extends Model {
       return `${name}(Table doesn't exist)`;
     }
     const attrList = Object.entries(this.attributeTypes())
-      .map(([attr, type]) => `${attr}: ${type.type()}`)
+      // Rails interpolates `type.type` (core.rb:383); a nil type renders as the
+      // empty string, so mirror Ruby's nil-to-"" rather than JS's "undefined".
+      .map(([attr, type]) => `${attr}: ${type.type() ?? ""}`)
       .join(", ");
     return `${name}(${attrList})`;
   }

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -311,20 +311,15 @@ export class SchemaDumper extends BaseSchemaDumper {
 
       const [dslType, spec] = this.columnSpec(col);
       const optStr = Object.keys(spec).length > 0 ? `, { ${this.formatColspec(spec)} }` : "";
-      // A nil DSL type means an unmapped column (Value cast type, e.g. a PG
-      // composite): it has no cast-type name, so fall through to the raw sqlType.
-      const typeName = dslType == null ? "" : String(dslType);
+      const typeName = String(dslType);
 
       if (this._isDslHelper(typeName)) {
         lines.push(`    t.${typeName}(${JSON.stringify(col.name)}${optStr});`);
       } else if ((col as any).isEnum && typeName === "enum") {
         lines.push(`    t.enum(${JSON.stringify(col.name)}${optStr});`);
       } else {
-        // Generic fallback: pass arbitrary SQL type verbatim via t.column. An
-        // unmapped (nil-type) or enum column dumps the raw sqlType, mirroring
-        // Rails' `t.column name, sql_type` for a column whose type is nil.
-        const colType =
-          typeName === "" || typeName === "enum" ? ((col as any).sqlType ?? typeName) : typeName;
+        // Generic fallback: pass arbitrary SQL type verbatim via t.column.
+        const colType = typeName === "enum" ? ((col as any).sqlType ?? typeName) : typeName;
         lines.push(
           `    t.column(${JSON.stringify(col.name)}, ${JSON.stringify(colType)}${optStr});`,
         );

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -311,15 +311,20 @@ export class SchemaDumper extends BaseSchemaDumper {
 
       const [dslType, spec] = this.columnSpec(col);
       const optStr = Object.keys(spec).length > 0 ? `, { ${this.formatColspec(spec)} }` : "";
-      const typeName = String(dslType);
+      // A nil DSL type means an unmapped column (Value cast type, e.g. a PG
+      // composite): it has no cast-type name, so fall through to the raw sqlType.
+      const typeName = dslType == null ? "" : String(dslType);
 
       if (this._isDslHelper(typeName)) {
         lines.push(`    t.${typeName}(${JSON.stringify(col.name)}${optStr});`);
       } else if ((col as any).isEnum && typeName === "enum") {
         lines.push(`    t.enum(${JSON.stringify(col.name)}${optStr});`);
       } else {
-        // Generic fallback: pass arbitrary SQL type verbatim via t.column.
-        const colType = typeName === "enum" ? ((col as any).sqlType ?? typeName) : typeName;
+        // Generic fallback: pass arbitrary SQL type verbatim via t.column. An
+        // unmapped (nil-type) or enum column dumps the raw sqlType, mirroring
+        // Rails' `t.column name, sql_type` for a column whose type is nil.
+        const colType =
+          typeName === "" || typeName === "enum" ? ((col as any).sqlType ?? typeName) : typeName;
         lines.push(
           `    t.column(${JSON.stringify(col.name)}, ${JSON.stringify(colType)}${optStr});`,
         );

--- a/packages/activerecord/src/connection-adapters/column.test.ts
+++ b/packages/activerecord/src/connection-adapters/column.test.ts
@@ -81,9 +81,12 @@ describe("Column", () => {
     expect(col.sqlType).toBe("timestamp without time zone");
   });
 
-  it("type falls back to sqlType when no semantic type is set", () => {
+  it("type is null when no semantic type is set", () => {
+    // Rails' SqlTypeMetadata#type is just `@type` — nil when a sql_type maps to
+    // the unmapped Value cast type — so Column#type stays nil rather than
+    // echoing the sqlType name.
     const col = new Column("body", null, new SqlTypeMetadata({ sqlType: "text" }));
-    expect(col.type).toBe("text");
+    expect(col.type).toBeNull();
   });
 
   it("type returns null when no sqlTypeMetadata", () => {

--- a/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/mysql/type-metadata.ts
@@ -10,7 +10,7 @@
 
 export class TypeMetadata {
   readonly sqlType: string;
-  readonly type: string;
+  readonly type: string | undefined;
   readonly limit: number | null;
   readonly precision: number | null;
   readonly scale: number | null;
@@ -27,7 +27,10 @@ export class TypeMetadata {
     options: { extra?: string } = {},
   ) {
     this.sqlType = typeMetadata.sqlType;
-    this.type = typeMetadata.type ?? typeMetadata.sqlType;
+    // Rails' MySQL TypeMetadata delegates `type` to the wrapped SqlTypeMetadata
+    // (DelegateClass), which is nil for an unmapped sql_type — no sqlType
+    // fallback. Keep it nil-faithful.
+    this.type = typeMetadata.type ?? undefined;
     this.limit = typeMetadata.limit ?? null;
     this.precision = typeMetadata.precision ?? null;
     this.scale = typeMetadata.scale ?? null;

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -69,10 +69,15 @@ export class Column extends BaseColumn {
     return raw?.endsWith("[]") ? raw.slice(0, -2) : (raw ?? null);
   }
 
-  // Return the full SQL type string (including "[]" for arrays) — callers
-  // expecting the base type without the array suffix should use sqlType.
+  // Rails' Column#type delegates to sql_type_metadata with `allow_nil: true`
+  // (column.rb:12), so an unmapped sql_type — e.g. a composite OID — reflects
+  // `nil`. Do NOT coerce that to "" (the old override did, breaking
+  // `assert_nil column.type`). The declared `string` keeps the schema dumper's
+  // non-null ColumnInfo contract: the dump path only ever sees the coalesced
+  // (never-nil) ColumnInfo from `SchemaSource.columns()`, while the reflection
+  // path (`columnsHash()[...].type`) passes the real nil straight through.
   override get type(): string {
-    return super.type ?? "";
+    return super.type as string;
   }
 
   // Mirrors Rails Column#serial? — returns the stored flag, which the adapter

--- a/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/type-metadata.ts
@@ -6,7 +6,7 @@
 
 export class TypeMetadata {
   readonly sqlType: string;
-  readonly type: string;
+  readonly type: string | undefined;
   readonly oid: number | null;
   readonly fmod: number | null;
   readonly limit: number | null;
@@ -23,7 +23,10 @@ export class TypeMetadata {
     scale?: number | null;
   }) {
     this.sqlType = options.sqlType;
-    this.type = options.type ?? options.sqlType;
+    // Rails' PG TypeMetadata delegates `type` to the wrapped SqlTypeMetadata
+    // (DelegateClass), which is nil for an unmapped sql_type — no sqlType
+    // fallback. Keep it nil-faithful so Column#type is null for e.g. composites.
+    this.type = options.type ?? undefined;
     this.oid = options.oid ?? null;
     this.fmod = options.fmod ?? null;
     this.limit = options.limit ?? null;

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -9,7 +9,7 @@ import type { Deduplicable } from "./deduplicable.js";
 
 export class SqlTypeMetadata implements Deduplicable {
   readonly sqlType: string;
-  readonly type: string;
+  readonly type: string | undefined;
   readonly limit: number | null;
   readonly precision: number | null;
   readonly scale: number | null;
@@ -24,7 +24,11 @@ export class SqlTypeMetadata implements Deduplicable {
     } = {},
   ) {
     this.sqlType = options.sqlType ?? options.type ?? "";
-    this.type = options.type ?? options.sqlType ?? "";
+    // Rails' SqlTypeMetadata#type is just `@type` — nil for an unmapped
+    // sql_type (Value#type is nil). Keep it nil-faithful rather than falling
+    // back to the sql_type name; the schema dumper substitutes `sqlType` when
+    // emitting an unknown column, so reflection still round-trips.
+    this.type = options.type ?? undefined;
     this.limit = options.limit ?? null;
     this.precision = options.precision ?? null;
     this.scale = options.scale ?? null;
@@ -70,7 +74,7 @@ export class SqlTypeMetadata implements Deduplicable {
 
 export interface SqlTypeMetadataJSON {
   sqlType: string;
-  type: string;
+  type: string | undefined;
   limit: number | null;
   precision: number | null;
   scale: number | null;

--- a/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
+++ b/packages/activerecord/src/connection-adapters/sql-type-metadata.ts
@@ -26,8 +26,8 @@ export class SqlTypeMetadata implements Deduplicable {
     this.sqlType = options.sqlType ?? options.type ?? "";
     // Rails' SqlTypeMetadata#type is just `@type` — nil for an unmapped
     // sql_type (Value#type is nil). Keep it nil-faithful rather than falling
-    // back to the sql_type name; the schema dumper substitutes `sqlType` when
-    // emitting an unknown column, so reflection still round-trips.
+    // back to the sql_type name, so `Column#type` mirrors Rails' `delegate
+    // :type, allow_nil: true`.
     this.type = options.type ?? undefined;
     this.limit = options.limit ?? null;
     this.precision = options.precision ?? null;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1137,9 +1137,8 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    *
    * `type` comes straight from `cast_type.type` (no base-name fallback). For an
    * unmapped `sql_type` the map returns a `ValueType`, whose `type()` — like
-   * Rails' `Value#type` — is nil (`undefined`); `SqlTypeMetadata` then falls the
-   * absent `type` back to the round-trippable `sqlType` name (the #1332 fallback,
-   * now living in one place) so reflection stays informative.
+   * Rails' `Value#type` — is nil (`undefined`), so `type` reflects nil while the
+   * verbatim `sqlType` is retained for the raw declaration.
    */
   fetchTypeMetadata(sqlType: string): SqlTypeMetadata {
     const raw = sqlType || "";

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -1116,7 +1116,7 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     // no full-string match is found.
     const lower = sqlType.toLowerCase().trim();
     const full = this._nativeTypeMap.fetch(lower);
-    if (full.type() !== "value") return full;
+    if (full.type() != null) return full;
     const normalized = lower.replace(/\(.*\)/, "").trim();
     return this._nativeTypeMap.lookup(normalized);
   }
@@ -1136,9 +1136,10 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * nil for bare integers — dumps stay bare and `c_int_1..8` keep their 1..8.
    *
    * `type` comes straight from `cast_type.type` (no base-name fallback). For an
-   * unmapped `sql_type` the map returns a `ValueType`; Rails' `Value#type` is nil,
-   * whereas trails' `ValueType#type()` is `"value"` — that residual gap is the
-   * ValueType-nil-fidelity follow-up, not something to paper over here.
+   * unmapped `sql_type` the map returns a `ValueType`, whose `type()` — like
+   * Rails' `Value#type` — is nil (`undefined`); `SqlTypeMetadata` then falls the
+   * absent `type` back to the round-trippable `sqlType` name (the #1332 fallback,
+   * now living in one place) so reflection stays informative.
    */
   fetchTypeMetadata(sqlType: string): SqlTypeMetadata {
     const raw = sqlType || "";

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
@@ -82,8 +82,7 @@ describe("SQLite3Adapter type-map limit threading", () => {
   it("reflects an unmapped sql_type as a nil cast type keeping the sql name", () => {
     // The type map returns a ValueType for an unmapped sql_type, whose `type()`
     // — like Rails' Value#type — is nil. fetchTypeMetadata carries that nil
-    // through to `type`; `sqlType` still holds the raw name so the schema dumper
-    // can round-trip the column via `t.column name, sqlType`.
+    // through to `type` while `sqlType` still holds the raw name.
     const meta = adapter.fetchTypeMetadata("mystery_type");
     expect(castType("mystery_type").type()).toBeUndefined();
     expect(meta.sqlType).toBe("mystery_type");

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
@@ -79,14 +79,14 @@ describe("SQLite3Adapter type-map limit threading", () => {
     expect(dec.scale).toBe(2);
   });
 
-  it("reflects an unmapped sql_type as a nil cast type with the round-trippable sql name", () => {
+  it("reflects an unmapped sql_type as a nil cast type keeping the sql name", () => {
     // The type map returns a ValueType for an unmapped sql_type, whose `type()`
     // — like Rails' Value#type — is nil. fetchTypeMetadata carries that nil
-    // through; SqlTypeMetadata then falls `type` back to the sql name so
-    // reflection stays informative and round-trippable.
+    // through to `type`; `sqlType` still holds the raw name so the schema dumper
+    // can round-trip the column via `t.column name, sqlType`.
     const meta = adapter.fetchTypeMetadata("mystery_type");
     expect(castType("mystery_type").type()).toBeUndefined();
     expect(meta.sqlType).toBe("mystery_type");
-    expect(meta.type).toBe("mystery_type");
+    expect(meta.type).toBeUndefined();
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.type-map.trails.test.ts
@@ -78,4 +78,15 @@ describe("SQLite3Adapter type-map limit threading", () => {
     expect(dec.precision).toBe(10);
     expect(dec.scale).toBe(2);
   });
+
+  it("reflects an unmapped sql_type as a nil cast type with the round-trippable sql name", () => {
+    // The type map returns a ValueType for an unmapped sql_type, whose `type()`
+    // — like Rails' Value#type — is nil. fetchTypeMetadata carries that nil
+    // through; SqlTypeMetadata then falls `type` back to the sql name so
+    // reflection stays informative and round-trippable.
+    const meta = adapter.fetchTypeMetadata("mystery_type");
+    expect(castType("mystery_type").type()).toBeUndefined();
+    expect(meta.sqlType).toBe("mystery_type");
+    expect(meta.type).toBe("mystery_type");
+  });
 });

--- a/packages/activerecord/src/encryption/encrypted-attribute-type.ts
+++ b/packages/activerecord/src/encryption/encrypted-attribute-type.ts
@@ -171,7 +171,7 @@ export class EncryptedAttributeType extends ValueType implements WrappedType {
     return this.scheme.ignoreCase;
   }
 
-  override type(): string {
+  override type(): string | undefined {
     return this.castType.type();
   }
 

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -90,7 +90,7 @@ function enumTypeFrom(
     subtype = reflected.subtypeType();
   } else {
     const rv = reflected as ValueType<unknown>;
-    subtype = rv.type() === "value" ? subtypeInstance(inferSubtype(Object.values(mapping))) : rv;
+    subtype = rv.type() == null ? subtypeInstance(inferSubtype(Object.values(mapping))) : rv;
   }
   return new EnumType(name, new Map(Object.entries(mapping)), subtype, raiseOnInvalidValues);
 }
@@ -256,11 +256,11 @@ export class EnumType extends ValueType<string> {
   // Rails' EnumType does `delegate :type, to: :subtype` — callers that ask what
   // an enum column's storage type is want the underlying column type (e.g.
   // "integer"), so delegate to the subtype's own `type()`.
-  get subtype(): string {
+  get subtype(): string | undefined {
     return this._subtypeType.type();
   }
 
-  override type(): string {
+  override type(): string | undefined {
     return this.subtype;
   }
 
@@ -569,16 +569,16 @@ export function _enum(
   // present (attribute_registration.rb:12-18); a default-only / type-less
   // attribute keeps the fallback `value` type until the column reflects, so its
   // subtype must still come from the column (enum decorates the column type,
-  // enum.rb:238-248). Requiring a user-provided def AND a concrete (non-`value`)
-  // type distinguishes the two: a default-only attribute's type is still the
-  // `value` default at `enum` time, so it is treated as column-reflected.
+  // enum.rb:238-248). Requiring a user-provided def AND a concrete type
+  // distinguishes the two: the `value` default's `type()` is nil (like Rails'
+  // `Value#type`), so a default-only attribute reads as `existingTypeName ==
+  // null` and is treated as column-reflected.
   const existingDef = (this as any)._attributeDefinitions?.get(attrName);
   const existingTypeName =
     typeof existingDef?.type?.type === "function" ? existingDef.type.type() : undefined;
   const explicitlyTyped =
     (existingDef?.source === "user" || existingDef?.userProvided === true) &&
-    existingTypeName != null &&
-    existingTypeName !== "value";
+    existingTypeName != null;
   const pendingHost = this as unknown as { _enumsPendingTypeCheck?: Set<string> };
   if (!explicitlyTyped) {
     if (!Object.prototype.hasOwnProperty.call(this, "_enumsPendingTypeCheck")) {


### PR DESCRIPTION
## What

`ActiveModel::Type::Value#type` returns `nil` for an unmapped type
([value.rb:32-35](vendor/rails/activemodel/lib/active_model/type/value.rb)), and
`SqlTypeMetadata#type` carries that `nil` straight through (no fallback). trails
diverged on both counts: `ValueType` set `name = "value"` so `type()` returned
`"value"`, and the `TypeMetadata` classes fell an absent `type` back to the
`sqlType` name — so an unmapped column reflected `type: "value"` instead of `nil`.

- `ValueType#type()` now returns `undefined` for the bare sentinel
  (`name === "value"`); subclasses keep reporting their own `name`. Base
  `Type#type()` and the delegating overrides (`EnumType`, `TimeZoneConverter`,
  `EncryptedAttributeType`, `EnumType#subtype`) widen to `string | undefined`.
- All three `TypeMetadata` classes drop the `?? sqlType` fallback and stay
  nil-faithful — base `SqlTypeMetadata`, PG's and MySQL's (which don't extend the
  base; Rails' are `DelegateClass(SqlTypeMetadata)`). PG's `Column#type` override
  also stops coercing nil → `""`. So `Column#type` is `null` for an unmapped
  `sql_type` — matching Rails' `assert_nil column.type` (`allow_nil: true`,
  column.rb:12) and preserving the `nil` vs `:full_address` distinction for
  registered composite types.
- The `"value"` sniff-sites (`SQLite3Adapter#lookupCastType`, enum type
  resolution) switch to nil checks; `Model.inspect()` interpolates a nil type as
  `""` (Ruby semantics), not the literal `"undefined"`.

## Schema dumper / round-trip

No dumper change ships here. The dialect dumper never sees a nil type: the base
`SchemaSource.columns()` already coalesces `col.type || col.sqlType || "unknown"`
(schema-dumper.ts:244) — a **pre-existing** pragmatic deviation from Rails, which
instead raises via `valid_type?` and aborts the table dump for an unmapped column
(schema_dumper.rb:196).

## Follow-up stories (RFC 0056)

- `schema-dumper-valid-type-raise-on-unmapped-column` — add the missing
  `valid_type?`/raise-and-abort machinery so an unmapped column aborts the table
  dump like Rails, and remove the `:244` nil-coalesce deviation.
- `pg-column-type-declared-nullable-honest` — declare PG `Column#type` as
  `string | null` (drop the `as string` cast) and resolve the resulting PG
  schema-dumper type-plumbing cascade. Non-blocking: all current callers guard
  with `??`/equality.

## Tests

`value.test.ts` asserts the unmapped default's `type()` is `undefined`;
`column.test.ts` and the PG `composite.test.ts` assert `Column#type` is `null`
for an unmapped `sql_type`; the sqlite type-map trails test asserts nil `type`
with the raw `sqlType` retained.

Closes-story: sqlite-fetchtypemetadata-unmapped-type-value-vs-rails-nil