### PR TITLE
refactor(preloader): eager-load source onto through query, collapsing nested-through preload to 2 queries

### DIFF
--- a/packages/activerecord/src/associations/nested-through-associations.test.ts
+++ b/packages/activerecord/src/associations/nested-through-associations.test.ts
@@ -706,14 +706,13 @@ describe("NestedThroughAssociationsTest", () => {
 
   it("nested has many through with conditions on source associations preload", async () => {
     const blue = tags("blue");
-    // Rails asserts 2 queries around `.third` (one author + a preload whose
-    // through query eager-loads the source sub-chain). We load every author via
-    // `.order` (no LIMIT/OFFSET) and, structuring each nested-through reflection
-    // recursively per Rails' `source_preloaders`, fire one query per chain
-    // stage — authors + posts + taggings + tags = 4. Pinning the count guards
-    // the per-reflection scope routing against regressing into an extra fetch.
+    // Matches Rails' `assert_queries_count(2)`: one author query plus one
+    // through query whose eager-load (`includes!(source)` + `references!`) JOINs
+    // the source sub-chain, so the middle records carry the source association
+    // already loaded and the recursive source-preloader stage issues no further
+    // query — authors + posts(⋈ taggings ⋈ tags) = 2.
     let author!: Author;
-    await assertQueriesCount(4, false, async () => {
+    await assertQueriesCount(2, false, async () => {
       [, , author] = await Author.includes("miscPostFirstBlueTags_2").order("authors.id");
     });
     await assertNoQueries(false, async () => {

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -171,7 +171,7 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
     expect(sql).toMatch(new RegExp(`WHERE.*${escapeRegExp(quoteTableName("categories.name"))}`));
   });
 
-  it("routes a has_many-through with a fan-out include+predicate to the two-step", () => {
+  it("nests a has_many-through fan-out include+predicate onto the through query via eager-load", () => {
     const groucho = members("groucho");
     const sql = throughScopeSql([groucho], "categorizedClubs");
     // Rails nests the scope's `values[:includes]` under the source reflection

--- a/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
+++ b/packages/activerecord/src/associations/preloader/through-association-nested-join-scope.test.ts
@@ -90,12 +90,14 @@ type HasManyHost = {
       .where({ categories: { name: "General" } }),
 });
 
-// A has_MANY-through whose scope includes a FAN-OUT path (`categorizations`, a
-// has_many two levels deep) AND predicates on it. Joining it onto the through
-// query would multiply the middle records, so the whole preload falls back to
-// the two-step: the `categorizations` join + predicate ride the source stage,
-// and neither the join nor the predicate is left on the through query (which
-// would be an unjoined-table predicate).
+// A has_MANY-through whose scope includes a two-level nested path
+// (`categorizations`, a has_many via club → category → categorizations) AND
+// predicates on it. Rails' `through_scope` nests `values[:includes]` under the
+// source reflection and eager-loads it, whose JoinDependency instantiates
+// distinct parents by primary key — so the deeper join no longer fans the
+// middle records out. The join and its `categorizations.author_id` predicate
+// are realized on the through query, resolving there instead of leaking onto
+// the source stage.
 (Member as unknown as HasManyHost).hasMany("categorizedClubs", {
   through: "favoriteMemberships",
   source: "club",
@@ -172,11 +174,15 @@ describe("Preloader::ThroughAssociation#through_scope multi-level nested join ca
   it("routes a has_many-through with a fan-out include+predicate to the two-step", () => {
     const groucho = members("groucho");
     const sql = throughScopeSql([groucho], "categorizedClubs");
-    // `categorizations` is a to-many join that would fan the middle records out,
-    // so the whole preload takes the two-step: the through query joins neither
-    // `categorizations` nor carries its predicate (both ride the source stage) —
-    // crucially the predicate is NOT orphaned onto an unjoined table here.
-    expect(sql).not.toContain("categorizations");
+    // Rails nests the scope's `values[:includes]` under the source reflection
+    // and eager-loads it; the JoinDependency dedups the middle records by PK, so
+    // the two-level `categorizations` join is realized on the through query and
+    // the copied `categorizations.author_id` predicate resolves there rather than
+    // being deferred to (and orphaned on) the source stage.
+    expect(sql).toMatch(new RegExp(`JOIN ${escapeRegExp(quoteTableName("categorizations"))}`));
+    expect(sql).toMatch(
+      new RegExp(`WHERE.*${escapeRegExp(quoteTableName("categorizations.author_id"))}`),
+    );
   });
 
   type AssocHost = {

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -662,23 +662,19 @@ export class ThroughAssociation extends Association {
 
         // references!(source.table_name) (rb:127-130): unless the scope already
         // carries explicit references, reference the source table so `includes`
-        // promotes to the eager JOIN. `.klass` can throw for an unresolvable /
-        // polymorphic source reflection (same guard as `_scopeHasFanOutJoin` /
-        // `_includeSpecFansOut`); if it does, skip the reference and let the
-        // `includes` degrade to a plain preload.
+        // promotes to the eager JOIN. Rails reads `source_reflection.table_name`
+        // unguarded here and raises for an unresolvable / polymorphic source
+        // (you can't get a static klass off a polymorphic belongs_to without an
+        // instance) — so this is intentionally NOT wrapped: it must fail loudly
+        // the way Rails does rather than silently degrade to an unreferenced
+        // `includes` (a differently-shaped query). The sibling `.klass` guards in
+        // `_scopeHasFanOutJoin` / `_includeSpecFansOut` are internal routing
+        // heuristics with no Rails counterpart; this branch is a direct port.
         const refs: string[] = reflScope?._referencesValues ?? [];
-        let sourceTableName: string | undefined;
-        if (refs.length === 0) {
-          try {
-            sourceTableName = (sourceRefl as any).klass?.tableName;
-          } catch {
-            sourceTableName = undefined;
-          }
-        }
         if (refs.length > 0) {
           scope = scope.references(...refs);
-        } else if (sourceTableName != null) {
-          scope = scope.references(sourceTableName);
+        } else {
+          scope = scope.references(sourceRefl.klass.tableName);
         }
 
         // joins!(source => joins) / left_outer_joins!(source => …) (rb:132-137).

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -46,11 +46,13 @@ export class ThroughAssociation extends Association {
     // When every owner already carries this association loaded — e.g. an outer
     // through query eager-loaded this source sub-chain via `includes!`/
     // `references!`, so the middle records arrive with their source association
-    // populated — return those targets directly. Skipping the through/source
-    // fetch below is what collapses the deeper stages into the single eager
-    // through query (Rails' `data_available?` short-circuit); the per-owner
-    // `isLoaded` check inside the loop only avoids re-associating, not the
-    // fetch, so it must be hoisted here.
+    // populated — return those targets directly. This is the hoisted
+    // loop-invariant of Rails' `records_by_owner`
+    // (preloader/through_association.rb:11-15): if every owner is loaded, every
+    // iteration takes the early `next`, so `through_records_by_owner` /
+    // `source_records_by_owner` are never forced and no fetch happens. The
+    // per-owner `isLoaded` check inside our loop only avoids re-associating, not
+    // the unconditional fetch above it, so the guard must be hoisted here.
     if (this.owners.length > 0 && this.owners.every((owner) => this.isLoaded(owner))) {
       for (const owner of this.owners) {
         result.set(owner, this.targetFor(owner));
@@ -660,12 +662,23 @@ export class ThroughAssociation extends Association {
 
         // references!(source.table_name) (rb:127-130): unless the scope already
         // carries explicit references, reference the source table so `includes`
-        // promotes to the eager JOIN.
+        // promotes to the eager JOIN. `.klass` can throw for an unresolvable /
+        // polymorphic source reflection (same guard as `_scopeHasFanOutJoin` /
+        // `_includeSpecFansOut`); if it does, skip the reference and let the
+        // `includes` degrade to a plain preload.
         const refs: string[] = reflScope?._referencesValues ?? [];
+        let sourceTableName: string | undefined;
+        if (refs.length === 0) {
+          try {
+            sourceTableName = (sourceRefl as any).klass?.tableName;
+          } catch {
+            sourceTableName = undefined;
+          }
+        }
         if (refs.length > 0) {
           scope = scope.references(...refs);
-        } else {
-          scope = scope.references(sourceRefl.klass.tableName);
+        } else if (sourceTableName != null) {
+          scope = scope.references(sourceTableName);
         }
 
         // joins!(source => joins) / left_outer_joins!(source => …) (rb:132-137).

--- a/packages/activerecord/src/associations/preloader/through-association.ts
+++ b/packages/activerecord/src/associations/preloader/through-association.ts
@@ -42,6 +42,22 @@ export class ThroughAssociation extends Association {
 
   async recordsByOwner(): Promise<Map<Base, Base[]>> {
     const result = new Map<Base, Base[]>();
+
+    // When every owner already carries this association loaded — e.g. an outer
+    // through query eager-loaded this source sub-chain via `includes!`/
+    // `references!`, so the middle records arrive with their source association
+    // populated — return those targets directly. Skipping the through/source
+    // fetch below is what collapses the deeper stages into the single eager
+    // through query (Rails' `data_available?` short-circuit); the per-owner
+    // `isLoaded` check inside the loop only avoids re-associating, not the
+    // fetch, so it must be hoisted here.
+    if (this.owners.length > 0 && this.owners.every((owner) => this.isLoaded(owner))) {
+      for (const owner of this.owners) {
+        result.set(owner, this.targetFor(owner));
+      }
+      return result;
+    }
+
     const throughRecordsByOwner = await this._getThroughRecordsByOwner();
     const sourceRecordsByOwner = await this._getSourceRecordsByOwner();
 
@@ -615,29 +631,61 @@ export class ThroughAssociation extends Association {
         }
       } else if (sourceRefl) {
         // Collection source/target ("twoStep") or nested through source
-        // ("nested"): JOINing the source (or a to-many nested include such as
-        // the canonical `tag` source's own `includes(:tagging)`) onto the
-        // through query would fan the middle records out and duplicate them —
-        // Rails avoids that because its through query is an eager-load whose
-        // JoinDependency instantiates distinct parents by primary key, but
-        // trails' preloader collects raw rows. So the source / sub-chain
-        // predicates, order, and scope includes ride the recursive
-        // source-preloader stage (see `_getSourcePreloaders`) instead. Only a
-        // predicate the reflection scope carries that references the through
-        // table AND no other table (e.g. `miscPostFirstBlueTags_2`'s
-        // `posts.title IN (…)`, whose through reflection is `posts`) is copied
-        // here to constrain which intermediate rows this through query selects —
-        // it is fully resolvable against the through table this query already
-        // selects. A predicate mixing the through table with another table (e.g.
-        // `posts.title = ? OR categorizations.author_id = ?`) is NOT copied: the
-        // through query never joins the other table, so it stays whole on the
-        // source scope (hash/Arel or raw SQL both classified precisely).
-        const throughTable = throughKlass.tableName;
-        const throughPreds = whereClause.predicates.filter((p: any) =>
-          predicateIsThroughOnly(p, throughTable),
-        );
-        if (throughPreds.length > 0) {
-          scope._whereClause = new WhereClause([...scope._whereClause.predicates, ...throughPreds]);
+        // ("nested"): mirror Rails' `through_scope` eager-load branch exactly.
+        // Copy the FULL reflection-scope where_clause and `includes!(source)` +
+        // `references!(source.table_name)`, promoting the source reflection to a
+        // LEFT OUTER JOIN eager-load on this through query. Unlike a bare
+        // `leftOuterJoins`, the eager-load runs through the JoinDependency, which
+        // instantiates distinct parents by primary key — so a to-many source (or
+        // a to-many nested include such as the canonical `tag` source's own
+        // `includes(:tagging)`) no longer fans the middle records out. The
+        // instantiated middle records carry their source association already
+        // loaded, so the recursive `_getSourcePreloaders` stage finds it loaded
+        // and issues no further query — collapsing authors+posts+taggings+tags
+        // to two queries. Every referenced column (through-table, source-table,
+        // or sub-chain intermediate) resolves in this one join, closing the
+        // latent gap where an outer predicate qualified a sub-chain table no
+        // single trails stage joined.
+        scope._whereClause = new WhereClause([
+          ...scope._whereClause.predicates,
+          ...whereClause.predicates,
+        ]);
+        const sourceName = sourceRefl.name;
+        const nestedIncludes: any[] = reflScope?._includesAssociations ?? [];
+        if (nestedIncludes.length > 0) {
+          scope = scope.includes({ [sourceName]: nestedIncludes });
+        } else {
+          scope = scope.includes(sourceName);
+        }
+
+        // references!(source.table_name) (rb:127-130): unless the scope already
+        // carries explicit references, reference the source table so `includes`
+        // promotes to the eager JOIN.
+        const refs: string[] = reflScope?._referencesValues ?? [];
+        if (refs.length > 0) {
+          scope = scope.references(...refs);
+        } else {
+          scope = scope.references(sourceRefl.klass.tableName);
+        }
+
+        // joins!(source => joins) / left_outer_joins!(source => …) (rb:132-137).
+        const nestedRawJoinValues: any[] = reflScope?._joinValues ?? [];
+        const nestedJoins: any[] = reflScope?._namedInnerJoins ?? [];
+        if (nestedRawJoinValues.length > 0 || nestedJoins.length > 0) {
+          scope = scope.joins({ [sourceName]: [...nestedRawJoinValues, ...nestedJoins] });
+        }
+        const nestedLeftOuter: any[] = reflScope?._leftOuterJoinsValues ?? [];
+        if (nestedLeftOuter.length > 0) {
+          scope = scope.leftOuterJoins({ [sourceName]: nestedLeftOuter });
+        }
+
+        // scope.eager_loading? && order (rb:139-141): true here since we always
+        // includes! the source above.
+        const orderClauses: any[] = reflScope?._orderClauses ?? [];
+        const rawOrderClauses: string[] = reflScope?._rawOrderClauses ?? [];
+        if (orderClauses.length > 0 || rawOrderClauses.length > 0) {
+          scope._orderClauses = [...scope._orderClauses, ...orderClauses];
+          scope._rawOrderClauses = [...scope._rawOrderClauses, ...rawOrderClauses];
         }
       }
     }

--- a/packages/activerecord/src/associations/through-association-scope.test.ts
+++ b/packages/activerecord/src/associations/through-association-scope.test.ts
@@ -36,9 +36,11 @@ registerModel(Comment);
 });
 
 // A source-table (`comments.`) condition on a has_many-through (collection
-// source). The single-query JOIN can't cover a collection source (it fans the
-// through rows out), so trails keeps the two-step: the source condition is
-// applied at the source-preloader stage, NOT copied onto the through query.
+// source). Rails' `through_scope` copies the FULL where_clause onto the through
+// query and `includes!(source)` + `references!(source.table_name)`, eager-loading
+// the source via a JOIN whose JoinDependency dedups the middle records by PK — so
+// the source condition IS carried onto the through query (with the source JOIN)
+// rather than deferred to the source-preloader stage.
 (Author as any).hasMany("commentsWithSourceCondition", {
   className: "Comment",
   through: "posts",
@@ -69,10 +71,9 @@ registerModel(Comment);
 });
 
 // A MIXED predicate referencing both the through table (`posts`) and the source
-// table (`comments`) in one node. The two-step through query joins neither the
-// source nor anything else, so this predicate is NOT through-table-only and must
-// stay whole on the source scope — not be split off / copied onto the through
-// query where `comments` is unjoined.
+// table (`comments`) in one node. Rails copies the full where_clause and JOINs
+// the source, so both `posts` and `comments` are available on the through query
+// and the whole predicate resolves there in one query.
 (Author as any).hasMany("commentsWithMixedCondition", {
   className: "Comment",
   through: "posts",
@@ -109,12 +110,14 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
   it("keeps a source-table condition on a collection source at the source stage, not the through query", () => {
     const david = authors("david");
     const loader = throughLoader([david], "commentsWithSourceCondition");
-    // Collection source (has_many comments): the two-step keeps the through
-    // query free of the source condition (it would fan the through rows out).
+    // Rails copies the full where_clause and eager-loads the source (JOIN
+    // comments), whose JoinDependency dedups the middle records by PK — so the
+    // source condition rides the through query with the source JOIN, resolving
+    // in one query rather than being deferred to the source stage.
     const scope = (loader as any)._buildThroughScope();
     const sql = scope.toSql();
-    expect(sql).not.toContain("first comment");
-    expect(sql).not.toMatch(/JOIN/);
+    expect(sql).toContain("first comment");
+    expect(sql).toMatch(/JOIN .*comments/);
   });
 
   it("copies a through-table condition onto the through query for a collection source", () => {
@@ -140,9 +143,12 @@ describe("Preloader::ThroughAssociation#through_scope", () => {
     const loader = throughLoader([david], "commentsWithMixedCondition");
     const scope = (loader as any)._buildThroughScope();
     // The predicate references both `posts` (through) and `comments` (source) in
-    // one node. The through query can't resolve `comments`, so the whole node
-    // stays on the source scope — nothing from it is copied here.
-    expect(scope.toSql()).not.toContain("posts.title");
+    // one node. Rails copies the full where_clause and JOINs the source, so both
+    // tables are available on the through query and the whole predicate resolves
+    // there.
+    const sql = scope.toSql();
+    expect(sql).toContain("posts.title");
+    expect(sql).toMatch(/JOIN .*comments/);
   });
 
   it("cascades strict loading from the preload scope onto the through query", async () => {


### PR DESCRIPTION
## What

Mirrors Rails' `Preloader::ThroughAssociation#through_scope`
(`preloader/through_association.rb:104-146`) for the collection ("twoStep") and
nested-through ("nested") source cases: the through query now copies the full
reflection-scope `where_clause` and `includes!(source_reflection.name)` +
`references!(source_reflection.table_name)`, promoting the source reflection to
a LEFT OUTER JOIN **eager-load** on the through query.

Unlike the previous `leftOuterJoins`/table-name string-match approximation, the
eager-load runs through the `JoinDependency`, which instantiates distinct
parents by primary key — so a to-many source (or a to-many nested include) no
longer fans the middle records out. The instantiated middle records arrive with
their source association already loaded, so the recursive source-preloader stage
finds it loaded and issues no further query.

A `recordsByOwner` short-circuit on `ThroughAssociation` completes the collapse:
when every owner already carries the association loaded (the middle records
eager-loaded by an outer through query), it returns those targets directly
instead of unconditionally fetching the through/source stages — Rails'
`data_available?` short-circuit, hoisted above the fetch.

For `Author.includes(:miscPostFirstBlueTags_2)` the query count drops from
authors + posts + taggings + tags = **4** to authors + posts(⋈ taggings ⋈ tags)
= **2**, matching Rails' `assert_queries_count(2)`
(`nested_through_associations_test.rb:563`). This also closes the latent gap
where an outer predicate qualified a sub-chain intermediate table no single
trails stage joined — the eager JOIN now brings every referenced table into one
query.

## Notes

- The table-name string-matching helpers (`predicateReferencesTable` /
  `predicateReferencesOtherTable` / `predicateIsThroughOnly`) remain: they are
  still live on the **non-eager** two-step fallback in `_getSourcePreloaders`
  (empty-where / `disableJoins` / `sourceType` paths never enter the eager
  branch). They are no longer used in `_buildThroughScope`.
- Two pinned tests that documented the old two-step divergence are updated to
  the new Rails-faithful behavior (fan-out include nested onto the through query,
  deduped by the eager JoinDependency).

## Test plan

- `nested-through-associations.test.ts` (query count now pinned to 2), full file green.
- `associations/preloader/*`, `has-many-through-associations`, `eager`,
  `has-one-through-associations`, `cascaded-eager-loading`,
  `disable-joins-nested-through`, `eager-load-nested-include`,
  `inner-join-association` — all green.
- typecheck + eslint clean.

Closes-story: nested-through-preloader-eager-load-source-collapse
