### PR TITLE
fix(sqlite): bind whole-valued Float/Decimal as SQLITE_FLOAT via cast type

### DIFF
--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
@@ -4,6 +4,8 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
+import { FloatType, DecimalType, IntegerType } from "@blazetrails/activemodel";
+import { BigDecimal } from "@blazetrails/activesupport";
 
 // The better-sqlite3 driver binds every JS number as SQLITE_FLOAT, so an
 // integer-valued bind like `1` would serialize as `real` and `LOWER(?)` would
@@ -39,5 +41,30 @@ describe("SQLite3Adapter integer bind serialization", () => {
     const rows = await adapter.execute("SELECT typeof(?) AS t, LOWER(?) AS l", [true, true]);
     expect(rows[0].t).toBe("integer");
     expect(rows[0].l).toBe("1");
+  });
+
+  // MRI keys the INTEGER/FLOAT choice off the Ruby object class the type-cast
+  // layer produces (Integer vs Float), not the numeric value. A bind carrying a
+  // Float/Decimal cast type therefore binds as SQLITE_FLOAT even when whole —
+  // recovered here from the attribute's `type` since JS has no int/float split.
+  it("binds a whole-valued Float attribute as SQLITE_FLOAT", async () => {
+    const bind = { valueForDatabase: 2, type: new FloatType() };
+    const rows = await adapter.execute("SELECT typeof(?) AS t, LOWER(?) AS l", [bind, bind]);
+    expect(rows[0].t).toBe("real");
+    expect(rows[0].l).toBe("2.0");
+  });
+
+  it("binds a whole-valued Decimal attribute as SQLITE_FLOAT", async () => {
+    const bind = { valueForDatabase: new BigDecimal("2.0"), type: new DecimalType() };
+    const rows = await adapter.execute("SELECT typeof(?) AS t, LOWER(?) AS l", [bind, bind]);
+    expect(rows[0].t).toBe("real");
+    expect(rows[0].l).toBe("2.0");
+  });
+
+  it("binds a whole-valued Integer attribute as SQLITE_INTEGER", async () => {
+    const bind = { valueForDatabase: 2, type: new IntegerType() };
+    const rows = await adapter.execute("SELECT typeof(?) AS t, LOWER(?) AS l", [bind, bind]);
+    expect(rows[0].t).toBe("integer");
+    expect(rows[0].l).toBe("2");
   });
 });

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.integer-bind.test.ts
@@ -5,7 +5,7 @@ import * as path from "node:path";
 import { AbstractSQLite3Adapter } from "./sqlite3-adapter.js";
 import { BetterSQLite3Adapter } from "./better-sqlite3-adapter.js";
 import { FloatType, DecimalType, IntegerType } from "@blazetrails/activemodel";
-import { BigDecimal } from "@blazetrails/activesupport";
+import { QueryAttribute } from "../relation/query-attribute.js";
 
 // The better-sqlite3 driver binds every JS number as SQLITE_FLOAT, so an
 // integer-valued bind like `1` would serialize as `real` and `LOWER(?)` would
@@ -46,23 +46,23 @@ describe("SQLite3Adapter integer bind serialization", () => {
   // MRI keys the INTEGER/FLOAT choice off the Ruby object class the type-cast
   // layer produces (Integer vs Float), not the numeric value. A bind carrying a
   // Float/Decimal cast type therefore binds as SQLITE_FLOAT even when whole —
-  // recovered here from the attribute's `type` since JS has no int/float split.
+  // recovered here from the QueryAttribute's `type` since JS has no int/float split.
   it("binds a whole-valued Float attribute as SQLITE_FLOAT", async () => {
-    const bind = { valueForDatabase: 2, type: new FloatType() };
+    const bind = new QueryAttribute("x", 2, new FloatType());
     const rows = await adapter.execute("SELECT typeof(?) AS t, LOWER(?) AS l", [bind, bind]);
     expect(rows[0].t).toBe("real");
     expect(rows[0].l).toBe("2.0");
   });
 
   it("binds a whole-valued Decimal attribute as SQLITE_FLOAT", async () => {
-    const bind = { valueForDatabase: new BigDecimal("2.0"), type: new DecimalType() };
+    const bind = new QueryAttribute("x", 2, new DecimalType());
     const rows = await adapter.execute("SELECT typeof(?) AS t, LOWER(?) AS l", [bind, bind]);
     expect(rows[0].t).toBe("real");
     expect(rows[0].l).toBe("2.0");
   });
 
   it("binds a whole-valued Integer attribute as SQLITE_INTEGER", async () => {
-    const bind = { valueForDatabase: 2, type: new IntegerType() };
+    const bind = new QueryAttribute("x", 2, new IntegerType());
     const rows = await adapter.execute("SELECT typeof(?) AS t, LOWER(?) AS l", [bind, bind]);
     expect(rows[0].t).toBe("integer");
     expect(rows[0].l).toBe("2");

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -142,13 +142,20 @@ export class SQLiteDateTimeType extends ARDateTimeType {
 // case) pass straight through.
 function _driverBind(this: QuotingDispatchHost, value: unknown): unknown {
   // `valueForDatabase` is a getter on Attribute/QueryAttribute, so reading it
-  // yields the unwrapped DB value directly.
+  // yields the unwrapped DB value directly. The attribute also carries its
+  // cast `type`; thread whether it is a Float/Decimal so typeCast can mirror
+  // MRI's class-based INTEGER/FLOAT dispatch (Ruby Float → SQLITE_FLOAT) rather
+  // than keying purely off the JS value — a whole-valued float like `2.0` must
+  // still bind as `real`, not INTEGER.
+  let bindsAsFloat = false;
   if (value && typeof value === "object" && "valueForDatabase" in value) {
-    value = (value as { valueForDatabase: unknown }).valueForDatabase;
+    const attr = value as { valueForDatabase: unknown; type?: unknown };
+    bindsAsFloat = attr.type instanceof FloatType || attr.type instanceof DecimalType;
+    value = attr.valueForDatabase;
   }
   // `.call(this)` so date/time dispatch lands on the adapter's quotedDate /
   // quotedTime overrides (2000-01-01-prefixed times).
-  return sqliteTypeCast.call(this, value);
+  return sqliteTypeCast.call(this, value, bindsAsFloat);
 }
 
 // A structured column default: an array or a plain object literal (`default: {}`

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -142,15 +142,16 @@ export class SQLiteDateTimeType extends ARDateTimeType {
 // case) pass straight through.
 function _driverBind(this: QuotingDispatchHost, value: unknown): unknown {
   // `valueForDatabase` is a getter on Attribute/QueryAttribute, so reading it
-  // yields the unwrapped DB value directly. The attribute also carries its
-  // cast `type`; thread whether it is a Float/Decimal so typeCast can mirror
-  // MRI's class-based INTEGER/FLOAT dispatch (Ruby Float → SQLITE_FLOAT) rather
-  // than keying purely off the JS value — a whole-valued float like `2.0` must
-  // still bind as `real`, not INTEGER.
+  // yields the unwrapped DB value directly. The attribute also carries its cast
+  // `type`; thread whether it is a Float so typeCast can mirror MRI's
+  // class-based INTEGER/FLOAT dispatch (Ruby Float → SQLITE_FLOAT) rather than
+  // keying purely off the JS value — a whole-valued float like `2.0` must still
+  // bind as `real`, not INTEGER. (Decimal binds reach typeCast as BigDecimal
+  // and take its dedicated float branch, so they need no flag here.)
   let bindsAsFloat = false;
   if (value && typeof value === "object" && "valueForDatabase" in value) {
     const attr = value as { valueForDatabase: unknown; type?: unknown };
-    bindsAsFloat = attr.type instanceof FloatType || attr.type instanceof DecimalType;
+    bindsAsFloat = attr.type instanceof FloatType;
     value = attr.valueForDatabase;
   }
   // `.call(this)` so date/time dispatch lands on the adapter's quotedDate /

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -189,7 +189,7 @@ export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat
     // MRI keys the INTEGER/FLOAT choice off the Ruby object class (Integer vs
     // Float) set by the type-cast layer, whereas both arrive here as an
     // indistinguishable JS number. `_driverBind` recovers the distinction from
-    // the bind's cast type and sets `bindsAsFloat` for Float/Decimal columns, so
+    // the bind's cast type and sets `bindsAsFloat` for Float columns, so
     // a whole-valued float (e.g. `2.0`) stays a JS number and better-sqlite3
     // binds it as SQLITE_FLOAT (`typeof(?) => 'real'`, `LOWER(?) => '2.0'`) —
     // matching MRI's Float → SQLITE_FLOAT dispatch. Absent type info (a bare

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.ts
@@ -166,7 +166,7 @@ export function quoteDefaultExpression(this: QuotingDispatchHost | void, value: 
   return quote.call(this || { quotedDate, quotedTime }, value);
 }
 
-export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
+export function typeCast(this: QuotingDispatchHost, value: unknown, bindsAsFloat = false): unknown {
   if (value === null || value === undefined) return null;
   // Rails routes booleans through `type_cast` to `unquoted_true` /
   // `unquoted_false`, which SQLite defines as the Ruby Integers `1` / `0`
@@ -186,14 +186,16 @@ export function typeCast(this: QuotingDispatchHost, value: unknown): unknown {
     // (e.g. `LOWER(col) = LOWER(?)`) path with Rails. Non-integer numbers keep
     // binding as float.
     //
-    // Fidelity boundary: MRI keys the INTEGER/FLOAT choice off the Ruby object
-    // class (Integer vs Float) set by the type-cast layer, whereas here both
-    // arrive as an indistinguishable JS number, so we key off the value. A
-    // whole-valued Float (e.g. a `2.0` from a float/decimal column) therefore
-    // binds as INTEGER rather than FLOAT — observable only through a
-    // text-forcing function (`LOWER(2.0)` → `'2'` not `'2.0'`), which is not a
-    // path AR generates for numeric columns; numeric comparisons coerce and are
-    // unaffected.
+    // MRI keys the INTEGER/FLOAT choice off the Ruby object class (Integer vs
+    // Float) set by the type-cast layer, whereas both arrive here as an
+    // indistinguishable JS number. `_driverBind` recovers the distinction from
+    // the bind's cast type and sets `bindsAsFloat` for Float/Decimal columns, so
+    // a whole-valued float (e.g. `2.0`) stays a JS number and better-sqlite3
+    // binds it as SQLITE_FLOAT (`typeof(?) => 'real'`, `LOWER(?) => '2.0'`) —
+    // matching MRI's Float → SQLITE_FLOAT dispatch. Absent type info (a bare
+    // number bind), fall back to the value heuristic: whole numbers bind as
+    // SQLITE_INTEGER via BigInt so `LOWER(1)` yields `'1'` like a Ruby Integer.
+    if (bindsAsFloat) return value;
     return Number.isInteger(value) ? BigInt(value) : value;
   }
   if (typeof value === "string" || typeof value === "bigint") return value;


### PR DESCRIPTION
## Summary

PR #4763 fixed integer binds serializing as `SQLITE_FLOAT` by converting
integer-valued JS numbers to `BigInt` in the SQLite type cast. Because JS has
no integer/float distinction, that conversion keyed off the *value*
(`Number.isInteger`), whereas MRI keys the `SQLITE_INTEGER`/`SQLITE_FLOAT`
choice off the Ruby object *class* (`Integer` vs `Float`) set by the type-cast
layer. Consequence: a whole-valued Float bind (e.g. `2.0` from a float column)
bound as `SQLITE_INTEGER` (`LOWER(2.0)` → `'2'`).

This threads the bind attribute's cast type through `_driverBind` into
`typeCast`. A Float/Decimal-typed bind stays a JS number, so better-sqlite3
binds it as `SQLITE_FLOAT` (`typeof(?) => 'real'`, `LOWER(?) => '2.0'`); an
Integer bind still converts to BigInt for `SQLITE_INTEGER`. Bare number binds
with no type info keep the previous value heuristic.

## Testing

- `sqlite3-adapter.integer-bind.test.ts` — added whole-valued Float/Decimal →
  `real`/`'2.0'` and Integer → `integer`/`'2'` cases; all pass.
- `sqlite3/quoting.test.ts`, `numeric-data.test.ts` — no regression.

Closes-story: sqlite-float-bind-value-vs-type-heuristic