### PR TITLE
feat(enum): generated enum methods live on an interposed prototype carrier so class-body overrides + super work

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -206,9 +206,10 @@ describe("EnumTest", () => {
     // Rails also asserts `@book.update! cover: :hard` — `cover` enum absent.
   });
 
-  // Rails overrides `published!` to return a string; trails' generated bang
-  // setter isn't overridable in the same way.
-  it.skip("enum methods are overwritable", () => {});
+  it("enum methods are overwritable", async () => {
+    expect(await (book as any).publishedBang()).toBe("do publish work...");
+    expect((book as any).isPublished()).toBe(true);
+  });
 
   it("direct assignment", () => {
     (book as any).status = "written";

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -370,6 +370,7 @@ function enumMethodNamesFor(valueMethodName: string): {
  */
 export class EnumMethods {
   private _klass: typeof import("./base.js").Base;
+  private _carrier?: object;
 
   constructor(klass: typeof import("./base.js").Base) {
     this._klass = klass;
@@ -378,6 +379,29 @@ export class EnumMethods {
   /** @internal */
   get klass(): typeof import("./base.js").Base {
     return this._klass;
+  }
+
+  /**
+   * @internal
+   * The per-class prototype carrier that holds generated enum methods,
+   * interposed between the model prototype and its parent — the runtime
+   * analogue of Rails' anonymous `_enum_methods_module` `include`d into the
+   * class (enum.rb:251). Generated methods live BELOW the class body in the
+   * ancestor chain, so a class-body method of the same name shadows the
+   * generated one and reaches it via `super` (the interposed prototype is what
+   * `super.<method>()` resolves to from a method whose home object is the model
+   * prototype). Installing directly on `klass.prototype` instead would clobber
+   * (or be clobbered by) class-body methods with no `super` chain between them.
+   * Created lazily and once per class; all of a class's enums share it.
+   */
+  carrier(): object {
+    if (!this._carrier) {
+      const proto = this._klass.prototype as object;
+      const carrier = Object.create(Object.getPrototypeOf(proto)) as object;
+      Object.setPrototypeOf(proto, carrier);
+      this._carrier = carrier;
+    }
+    return this._carrier;
   }
 
   /**
@@ -406,7 +430,11 @@ export class EnumMethods {
     // `detect_enum_conflict!` here without false-positiving on a prior value's
     // auto `not*` scope). This generator only defines the surface.
     if (instanceMethods) {
-      Object.defineProperty(klass.prototype, predicateName, {
+      // Install on the interposed carrier (not `klass.prototype`) so a
+      // class-body method of the same name shadows the generated one and can
+      // delegate to it via `super`. Mirrors Rails' `_enum_methods_module`.
+      const carrier = this.carrier();
+      Object.defineProperty(carrier, predicateName, {
         value: function (this: EnumInstanceHost) {
           // Rails compares `#{name}_for_database == value`; trails stores the
           // label, so serialize the stored label back to its database value
@@ -417,7 +445,7 @@ export class EnumMethods {
         writable: true,
         configurable: true,
       });
-      Object.defineProperty(klass.prototype, bangName, {
+      Object.defineProperty(carrier, bangName, {
         value: function (this: EnumInstanceHost) {
           // Returns update!'s result (true), mirroring Rails' bang setter.
           return this.updateBang({ [name]: value });
@@ -769,14 +797,15 @@ export function _enum(
     // bracket notation only.
     const originalName = methodName(n);
     if (instanceMethodsEnabled && /[^\w\x80-\uffff]/.test(originalName)) {
-      Object.defineProperty(this.prototype, `is${originalName}`, {
+      const carrier = methodsModule.carrier();
+      Object.defineProperty(carrier, `is${originalName}`, {
         value: function (this: Base) {
           return this.readAttribute(attrName) === n;
         },
         writable: true,
         configurable: true,
       });
-      Object.defineProperty(this.prototype, `${originalName}Bang`, {
+      Object.defineProperty(carrier, `${originalName}Bang`, {
         value: function (this: EnumInstanceHost) {
           return this.updateBang({ [attrName]: value });
         },

--- a/packages/activerecord/src/test-helpers/models/book.ts
+++ b/packages/activerecord/src/test-helpers/models/book.ts
@@ -27,7 +27,6 @@ export class Book extends Base {
   declare static written: () => Relation<Book>;
   declare static notWritten: () => Relation<Book>;
   declare isPublished: () => boolean;
-  declare publishedBang: () => Promise<true | undefined>;
   declare static published: () => Relation<Book>;
   declare static notPublished: () => Relation<Book>;
   declare isUnread: () => boolean;
@@ -148,6 +147,19 @@ export class Book extends Base {
   declare tags_count: number | null;
   declare updated_at: Temporal.Instant | Temporal.PlainDateTime;
   declare updated_on: Temporal.PlainDate;
+
+  // Mirrors book.rb's `def published!; super; "do publish work..."; end`: a
+  // class-body override of the generated bang that delegates to the generated
+  // method via `super`. At runtime `super.publishedBang` resolves through this
+  // prototype's parent — the interposed enum-methods carrier — because the
+  // generated bang lives there, not on `Book.prototype`.
+  async publishedBang(): Promise<string> {
+    // TS can't see the enum-methods carrier interposed below Book.prototype, so
+    // `super.publishedBang` is untyped; it exists at runtime.
+    // @ts-expect-error — generated bang lives on the interposed carrier.
+    await super.publishedBang();
+    return "do publish work...";
+  }
 
   static {
     this.belongsTo("author");


### PR DESCRIPTION
## What

Generated enum predicate/bang methods were installed directly on the model
prototype via `Object.defineProperty(klass.prototype, ...)`. A class-body
method of the same name was therefore clobbered by generation and had no
`super` chain to the generated method — so Rails' "enum methods are
overwritable" behavior (Book's `def published!; super; "..."; end`,
enum_test.rb:190-193) was unportable and the test stayed skipped.

This interposes a per-class **carrier** object between the model prototype and
its parent (`Object.setPrototypeOf`), and installs generated methods on the
carrier. This mirrors Rails' anonymous `_enum_methods_module` `include`d into
the class (enum.rb:251-259): generated methods live BELOW the class body in the
ancestor chain, so a class-body method shadows the generated one and reaches it
via `super`.

## Changes

- `enum.ts`: `EnumMethods.carrier()` lazily creates+interposes the per-class
  carrier; `defineEnumMethods` and the original-form special-char generation
  install on the carrier instead of `klass.prototype`.
- `book.ts`: add `Book#publishedBang` override mirroring `book.rb`.
- `enum.test.ts`: un-skip "enum methods are overwritable" (name unchanged).

Conflict detection is unaffected — it consults the tracked
`_enumMethodsModuleNames` set and dangerous-method set, not prototype
introspection. `api:compare` data layer stays 100%.

Closes-story: enum-methods-module-carrier-overridable