### PR TITLE
refactor(mysql): drop redundant columns()-time version warm

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -203,14 +203,6 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
    * (Mysql2Adapter) may still override for performance.
    */
   async columns(tableName: string): Promise<Column[]> {
-    // Warm the server-version/`isMariadb()` flag before reflecting. It's cold on
-    // a freshly leased connection until getFullVersion() runs, and callers gate
-    // engine-specific behavior on `isMariadb()` after reflecting a table's
-    // columns (e.g. version-conditional test skips). The retired information_schema
-    // columns() path warmed it unconditionally for the same reason (PR #4197);
-    // preserve that now that SHOW FULL FIELDS is the sole path. Memoized, so this
-    // is a no-op after the first call.
-    await this.getDatabaseVersion();
     const fields = await this.columnDefinitions(tableName);
     // newColumnFromField's broader function-default detection calls SHOW CREATE TABLE via the
     // sync createTableInfoFn callback. Pre-fetch once iff any field default falls through the


### PR DESCRIPTION
## Summary

Removes the band-aid `await this.getDatabaseVersion()` at the top of
`AbstractMysqlAdapter#columns`.

That warm was added in PR #4718 to re-populate `isMariadb()` / `databaseVersion`
at table-reflection time after the information_schema `columns()` path (which
warmed it as a side effect, PR #4197) was retired for `SHOW FULL FIELDS`.

Since then, **PR #4820** made `Mysql2Adapter#configureConnection` warm the
server version eagerly on the connect-once path and awaits it into the connect
chain (mirroring Rails' `configure_connection` → `check_version` →
`database_version`), so `_databaseVersion` / `_mariadb` are memoized before any
query — including `columns()` — runs. The reflection-time warm is now redundant.

## Scope note

This story (`warm-mysql-version-at-connection-configure`) originally covered the
eager-warm implementation itself. That work, plus the `checkVersion` version-floor
check, landed independently in #4820. This PR delivers the story's remaining
acceptance criterion — removing the now-redundant `columns()` band-aid.

## Testing

- `pnpm --filter @blazetrails/activerecord... build` — clean.
- Connect-time warm + MySQL/MariaDB introspection are covered by the mysql:8 /
  MariaDB CI jobs. No test relied on the `columns()`-time warm (the remaining
  `renameIndex` / `checkConstraints` `getDatabaseVersion()` guards are untouched).

Closes-story: warm-mysql-version-at-connection-configure