### PR TITLE
test(enum): un-skip NULL-from-database casts to nil

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -371,6 +371,8 @@ describe("EnumTest", () => {
   it("NULL values from database should be casted to nil", async () => {
     await Book.where({ id: book.id }).updateAll("status = NULL");
     await book.reload();
+    // Rails asserts only `assert_nil @book.reload.status`; the predicate checks
+    // confirm EnumType#deserialize(null) leaves every state query false.
     expect((book as any).status).toBeNull();
     expect((book as any).isPublished()).toBe(false);
     expect((book as any).isWritten()).toBe(false);

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -368,8 +368,14 @@ describe("EnumTest", () => {
     expect((invalidBook as any).isValid()).toBe(false);
   });
 
-  // Rails: `Book.where(id:).update_all("status = NULL")` (raw SQL fragment).
-  it.skip("NULL values from database should be casted to nil", () => {});
+  it("NULL values from database should be casted to nil", async () => {
+    await Book.where({ id: book.id }).updateAll("status = NULL");
+    await book.reload();
+    expect((book as any).status).toBeNull();
+    expect((book as any).isPublished()).toBe(false);
+    expect((book as any).isWritten()).toBe(false);
+    expect((book as any).isProposed()).toBe(false);
+  });
 
   it("deserialize nil value to enum which defines nil value to hash", () => {
     expect((books("ddd") as any).last_read).toBe("forgotten");


### PR DESCRIPTION
Un-skips the Rails enum test "NULL values from database should be casted to nil" using the raw-fragment `updateAll` form, mirroring the Rails body (`Book.where(id:).update_all("status = NULL")`). `Relation#updateAll` now accepts a raw SQL fragment, so the stated blocker no longer exists; `EnumType#deserialize(null)` returns nil through the reload path.

After reload, `book.status` is null and the predicates (`isPublished()` etc.) return false, matching Rails.

Closes-story: enum-null-db-value-casts-to-nil-unskip