### PR TITLE
test(enum): un-skip find via where with large number

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -19,7 +19,7 @@
  * values).
  */
 import { describe, it, expect, beforeAll, beforeEach, vi } from "vitest";
-import { Base, registerModel } from "./index.js";
+import { Base, registerModel, Range } from "./index.js";
 import { ArgumentError } from "@blazetrails/activemodel";
 import { Book } from "./test-helpers/models/book.js";
 import { fixtures } from "./test-helpers/fixtures.js";
@@ -158,8 +158,21 @@ describe("EnumTest", () => {
     // Pending: `last_read: "forgotten"` and `status: "prohibited"` (nil).
   });
 
-  // Rails uses 64-bit out-of-range labels and beginless/endless ranges.
-  it.skip("find via where with large number", () => {});
+  // Rails passes a 64-bit-out-of-range value (2^63) as an enum array element
+  // and as a Range end bound, plus numeric-string forms. Each element/bound
+  // serializes through EnumType → its integer subtype: the OOR value collapses
+  // via the Unboundable threading (array IN drops it; the Range end bound
+  // becomes unbounded), so every shape still finds the published book.
+  it("find via where with large number", async () => {
+    book = books("awdr");
+    const big = 9223372036854775808n;
+    expect((await Book.where({ status: [2, big] }).first())?.id).toBe(book.id);
+    expect((await Book.where({ status: ["2", "9223372036854775808"] }).first())?.id).toBe(book.id);
+    expect((await Book.where({ status: new Range(2, big) }).first())?.id).toBe(book.id);
+    expect((await Book.where({ status: new Range("2", "9223372036854775808") }).first())?.id).toBe(
+      book.id,
+    );
+  });
 
   it("find via where should be type casted", async () => {
     const created = await (Book as any).enabled().create();


### PR DESCRIPTION
Un-skips the `find via where with large number` case in `enum.test.ts` (faithful port of `enum_test.rb:139-144`), exercising `where` on an enum column with OOR 64-bit values and Ranges.

The enum predicate path already serializes array elements and Range endpoints through `EnumType`:

- **Array IN path** routes via `HomogeneousIn`, whose `castedValues` serializes each element through the column's `EnumType` and drops the out-of-range bignum per the Unboundable threading (#4433).
- **RangeHandler** casts each bound through the resolved `EnumType`, so numeric-string endpoints (`"2".."9223372036854775808"`) serialize to their integer subtype and the OOR upper bound collapses via Unboundable.

All four shapes (OOR bignum in array, numeric-string array, numeric range, numeric-string range) return the Rails result with no implementation change — only the test un-skip.

Closes-story: where-enum-large-number-and-range-values