### PR TITLE
fix(enum): where() serializes null-mapped and unknown enum labels to IS NULL

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -143,8 +143,10 @@ describe("EnumTest", () => {
     expect((await Book.where({ status: ["written", "written"] }).first())?.id).not.toBe(book.id);
     expect((await Book.whereNot({ status: "published" }).first())?.id).not.toBe(book.id);
     expect((await Book.whereNot({ status: "written" }).first())?.id).toBe(book.id);
-    // Pending: `last_read: forgotten`, `status: prohibited` (nil), and `cover`
-    // matches.
+    expect((await Book.where({ last_read: "forgotten" }).first())?.id).toBe(books("ddd").id);
+    expect(await Book.where({ status: "prohibited" }).first()).toBeNull();
+    expect((await Book.where({ cover: "soft" }).first())?.id).toBe(book.id);
+    expect((await Book.whereNot({ cover: "hard" }).first())?.id).toBe(book.id);
   });
 
   it("find via where with strings", async () => {
@@ -155,7 +157,8 @@ describe("EnumTest", () => {
     expect((await Book.where({ status: ["written", "written"] }).first())?.id).not.toBe(book.id);
     expect((await Book.whereNot({ status: "published" }).first())?.id).not.toBe(book.id);
     expect((await Book.whereNot({ status: "written" }).first())?.id).toBe(book.id);
-    // Pending: `last_read: "forgotten"` and `status: "prohibited"` (nil).
+    expect((await Book.where({ last_read: "forgotten" }).first())?.id).toBe(books("ddd").id);
+    expect(await Book.where({ status: "prohibited" }).first()).toBeNull();
   });
 
   // Rails uses 64-bit out-of-range labels and beginless/endless ranges.

--- a/packages/activerecord/src/relation/query-attribute.ts
+++ b/packages/activerecord/src/relation/query-attribute.ts
@@ -8,6 +8,7 @@
  */
 
 import { Attribute, Type, ActiveModelRangeError } from "@blazetrails/activemodel";
+import { Substitute } from "../statement-cache.js";
 
 type CastType = Pick<Type, "cast" | "serialize">;
 
@@ -70,8 +71,19 @@ export class QueryAttribute extends Attribute {
     return this.type.serialize(this.value);
   }
 
+  // Mirrors Rails QueryAttribute#nil? (query_attribute.rb:35-41): a bind is nil
+  // not only when its raw value is nil, but also when the type carries a
+  // `subtype` (enum) or `normalizer` and the value *serializes* to nil — so
+  // `where(last_read: :forgotten)` (a label mapped to null) or an unknown enum
+  // label routes through `IS NULL`. A StatementCache substitute is never nil.
   isNil(): boolean {
-    return this.valueBeforeTypeCast === null || this.valueBeforeTypeCast === undefined;
+    if (this.valueBeforeTypeCast instanceof Substitute) return false;
+    if (this.valueBeforeTypeCast === null || this.valueBeforeTypeCast === undefined) return true;
+    const type = this.type as { subtype?: unknown; normalizer?: unknown };
+    const hasSubtypeOrNormalizer = type.subtype !== undefined || type.normalizer !== undefined;
+    if (!hasSubtypeOrNormalizer || !this.isSerializable()) return false;
+    const forDatabase = this.valueForDatabase;
+    return forDatabase === null || forDatabase === undefined;
   }
 
   isInfinite(): boolean {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -1120,7 +1120,7 @@ export class ToSql extends Visitor {
     if (this.unboundableSign(node.right) !== 0) {
       return collector.append("1=0");
     }
-    if (node.right instanceof Nodes.Quoted && node.right.value === null) {
+    if (this.rightIsNull(node.right)) {
       this.visitNodeOrValue(node.left, collector);
       collector.append(" IS NULL");
       return collector;
@@ -1135,7 +1135,7 @@ export class ToSql extends Visitor {
     node: Nodes.IsNotDistinctFrom,
     collector: SQLString,
   ): SQLString {
-    if (node.right instanceof Nodes.Quoted && node.right.value === null) {
+    if (this.rightIsNull(node.right)) {
       this.visitNodeOrValue(node.left, collector);
       collector.append(" IS NULL");
       return collector;
@@ -1147,7 +1147,7 @@ export class ToSql extends Visitor {
     node: Nodes.IsDistinctFrom,
     collector: SQLString,
   ): SQLString {
-    if (node.right instanceof Nodes.Quoted && node.right.value === null) {
+    if (this.rightIsNull(node.right)) {
       this.visitNodeOrValue(node.left, collector);
       collector.append(" IS NOT NULL");
       return collector;
@@ -1159,7 +1159,7 @@ export class ToSql extends Visitor {
     if (this.unboundableSign(node.right) !== 0) {
       return collector.append("1=1");
     }
-    if (node.right instanceof Nodes.Quoted && node.right.value === null) {
+    if (this.rightIsNull(node.right)) {
       this.visitNodeOrValue(node.left, collector);
       collector.append(" IS NOT NULL");
       return collector;
@@ -2109,5 +2109,21 @@ export class ToSql extends Visitor {
       if ("value" in v) return this.unboundableSign(v.value);
     }
     return 0;
+  }
+
+  /**
+   * Mirrors Rails' `right.nil?` guard in the equality visitors: a nil right
+   * emits `IS NULL` rather than `= ?`. Beyond an explicit `Quoted(null)`, a
+   * bind attribute answers `nil?` true when it *serializes* to nil (a
+   * null-mapped or unknown enum label, or a normalizer that blanks the value),
+   * so honour a duck-typed `isNil()` on the right node too.
+   */
+  protected rightIsNull(right: unknown): boolean {
+    if (right instanceof Nodes.Quoted && right.value === null) return true;
+    // A bound scalar arrives wrapped in a BindParam; peer at the wrapped
+    // attribute so an enum/normalized bind that serializes to nil is caught.
+    const node = right instanceof Nodes.BindParam ? right.value : right;
+    const maybe = node as { isNil?: () => boolean };
+    return typeof maybe?.isNil === "function" && maybe.isNil();
   }
 }


### PR DESCRIPTION
## What

`where({ last_read: "forgotten" })` — where `forgotten` maps to `null` in the
enum declaration — and `where({ status: "prohibited" })` (an unknown label)
previously emitted `col = NULL`, which matches nothing. Rails routes both
through `IS NULL`, so the null-mapped label matches the fixture whose column is
null and the unknown label matches nothing without raising.

## How

Mirror Rails' `QueryAttribute#nil?` (query_attribute.rb:35-41): a bind is nil
not only when its raw value is nil, but also when its type carries a `subtype`
(enum) or `normalizer` and the value *serializes* to nil. The Arel equality
visitors' `right.nil?` guard then emits `IS NULL` — extended here to unwrap a
`BindParam` and honour a duck-typed `isNil()` on the wrapped attribute, matching
Rails' uniform `right.nil?`.

Un-skips the pending `last_read: forgotten` / `status: prohibited` / `cover`
assertions in the `find via where with symbols` / `find via where with strings`
cases of `enum.test.ts`.

Closes-story: where-enum-serializes-null-mapped-and-unknown-labels