### PR TITLE
fix(destroy): lazily load only belongs_to targets a destroy callback names

### DIFF
--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -365,7 +365,10 @@ export function hasBeforeOrAroundCallbackOnProto(proto: object, event: string): 
  * dereferences, so scanning the callback source for association names lets us
  * skip loading targets the callback never reads. When `opaque` is true the
  * caller must fall back to a conservative load (it cannot tell what the callback
- * touches).
+ * touches) — this covers object/method-name filters and bound/native functions,
+ * whose bodies are not introspectable. The returned `sources` are only the outer
+ * filter bodies; a caller that must resolve reads reached through helper methods
+ * has to expand them itself (the callback source alone won't name those).
  *
  * @internal
  */
@@ -379,8 +382,17 @@ export function beforeOrAroundCallbackSources(
   let opaque = false;
   for (const e of chain.entries) {
     if (e.kind !== "before" && e.kind !== "around") continue;
-    if (typeof e.filter === "function") sources.push(e.filter.toString());
-    else opaque = true;
+    if (typeof e.filter !== "function") {
+      opaque = true;
+      continue;
+    }
+    const src = e.filter.toString();
+    // A bound (`fn.bind(this)`) or native function stringifies to a wrapper with
+    // no body text ("... { [native code] }"), so it exposes no association reads.
+    // Treat it as opaque rather than as a callback that reads nothing, so the
+    // caller falls back to a conservative load instead of skipping the preload.
+    if (src.includes("[native code]")) opaque = true;
+    else sources.push(src);
   }
   return { sources, opaque };
 }

--- a/packages/activemodel/src/callbacks.ts
+++ b/packages/activemodel/src/callbacks.ts
@@ -355,6 +355,37 @@ export function hasBeforeOrAroundCallbackOnProto(proto: object, event: string): 
 }
 
 /**
+ * Source-text of every `before`/`around` callback registered for `event` whose
+ * filter is a plain function (so it can be introspected via
+ * `Function.prototype.toString`). `opaque` is true when any before/around entry
+ * is an object/method-name filter whose body cannot be read from here.
+ *
+ * Callers use this to approximate Rails' lazy association loading: a synchronous
+ * destroy callback only forces the `belongs_to` targets it actually
+ * dereferences, so scanning the callback source for association names lets us
+ * skip loading targets the callback never reads. When `opaque` is true the
+ * caller must fall back to a conservative load (it cannot tell what the callback
+ * touches).
+ *
+ * @internal
+ */
+export function beforeOrAroundCallbackSources(
+  proto: object,
+  event: string,
+): { sources: string[]; opaque: boolean } {
+  const chain = asPeekCallbackChain(proto, event);
+  if (!chain) return { sources: [], opaque: false };
+  const sources: string[] = [];
+  let opaque = false;
+  for (const e of chain.entries) {
+    if (e.kind !== "before" && e.kind !== "around") continue;
+    if (typeof e.filter === "function") sources.push(e.filter.toString());
+    else opaque = true;
+  }
+  return { sources, opaque };
+}
+
+/**
  * @internal
  */
 export function hasCallbackOnProto(

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -72,6 +72,7 @@ export {
   _registerCallbackOnProto,
   hasCallbackOnProto,
   hasBeforeOrAroundCallbackOnProto,
+  beforeOrAroundCallbackSources,
   skipCallbackOnProto,
   runAllCallbacks,
   runBeforeCallbacksOnProto,

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -294,6 +294,19 @@ describe("HasOneAssociationsTest", () => {
     expect(Account.destroyedAccountIds().get(firm.id) ?? []).toEqual([account.id]);
   });
 
+  // trails-only: the destroy `belongs_to` preload mirrors Rails' lazy load by
+  // materializing only the association the callback names. Account#before_destroy
+  // reads `firm` but never `unautosavedFirm` (its same-`firm_id` sibling), so a
+  // single owner SELECT fires, not one per belongs_to. No Rails counterpart.
+  it("direct destroy only preloads the belongs_to the callback references", async () => {
+    const account = (await Account.find(1)) as any;
+    expect(account.association("firm").isLoaded()).toBe(false);
+    expect(account.association("unautosavedFirm").isLoaded()).toBe(false);
+    await assertQueriesMatch(/FROM\s+.?companies.?/i, 1, false, async () => {
+      await account.destroy();
+    });
+  });
+
   it("exclusive dependence", async () => {
     const numAccounts = (await Account.count()) as number;
     const firm = (await ExclusivelyDependentFirm.find(9)) as any;

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -633,6 +633,45 @@ function referencesAssociationName(sources: string[], name: string): boolean {
 }
 
 /**
+ * Expand callback filter sources with the source of any model-defined instance
+ * method they (transitively) reference, so an association read reached through a
+ * helper — e.g. `before_destroy { this.makeComments() }` where `makeComments`
+ * reads `this.person` — is still detected. Only methods declared on the model's
+ * own prototype chain (below `Base`) are followed; framework methods and the
+ * association readers themselves are ignored. Bounded by the model's method
+ * count via the `seen` set, so mutually-recursive helpers can't loop.
+ */
+function expandCallbackSourcesWithHelpers(sources: string[], ctor: typeof Base): string[] {
+  const methods = new Map<string, string>();
+  for (
+    let proto = ctor.prototype;
+    proto && proto !== Base.prototype;
+    proto = Object.getPrototypeOf(proto)
+  ) {
+    for (const key of Object.getOwnPropertyNames(proto)) {
+      if (key === "constructor" || methods.has(key)) continue;
+      const desc = Object.getOwnPropertyDescriptor(proto, key);
+      if (typeof desc?.value === "function") methods.set(key, desc.value.toString());
+    }
+  }
+  const result = [...sources];
+  const seen = new Set<string>();
+  const queue = [...sources];
+  while (queue.length > 0) {
+    const src = queue.pop()!;
+    for (const [name, body] of methods) {
+      if (seen.has(name)) continue;
+      if (new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`).test(src)) {
+        seen.add(name);
+        result.push(body);
+        queue.push(body);
+      }
+    }
+  }
+  return result;
+}
+
+/**
  * Mirror of the `on:` context guard that `setOptionsForCallback`
  * (activemodel/validations/callbacks.ts) installs onto sync validators:
  * `options[:on].intersect?(Array(o.validation_context))`. Deferred (async)
@@ -3881,14 +3920,21 @@ export class Base extends Model {
    * it). On a load failure we resolve the association to `null` rather than
    * leaving it unloaded, so a sync callback that *does* read it sees `null` and
    * not trails' async-reader Promise — keeping the bare `if (record.parent)`
-   * guard safe even when the preload could not materialize the parent. On the
-   * narrowed path no per-load savepoint is needed: a doomed query (e.g.
-   * `tag_with_primary_key` → a non-existent column) only runs when the callback
-   * actually reads it, which is exactly when Rails would issue — and fail on —
-   * the same lazy query. The opaque load-all path keeps PR #4792's savepoint,
-   * since it may still fire a doomed query the (unreadable) callback never
-   * touches, which would otherwise abort the whole PostgreSQL transaction
-   * (25P02) — an abort swallowing the JS error cannot undo.
+   * guard safe even when the preload could not materialize the parent. Any load
+   * that runs inside an open transaction is isolated in its own savepoint: a
+   * doomed query (e.g. a `belongs_to ..., primary_key:` at a non-existent column
+   * like `tag_with_primary_key`) throwing here would otherwise abort the whole
+   * PostgreSQL transaction (25P02), and the surrounding `catch` swallowing the
+   * JS error cannot undo that abort. Narrowing removes the *per-association*
+   * savepoint churn PR #4792 paid on every `belongs_to` — only the (usually one)
+   * association the callback actually names is loaded, so an unread doomed query
+   * is never issued in the first place.
+   *
+   * The scan resolves reads reached through the record's own helper methods, not
+   * just those inline in the registered filter, by expanding the callback source
+   * with the source of any model-defined method it references (see
+   * `expandCallbackSourcesWithHelpers`). This mirrors Rails resolving
+   * associations by ordinary method dispatch at any call depth.
    *
    * @internal
    */
@@ -3897,11 +3943,12 @@ export class Base extends Model {
     if (typeof (this as any).association !== "function") return;
     const { sources, opaque } = beforeOrAroundCallbackSources(ctor.prototype, "destroy");
     if (!opaque && sources.length === 0) return;
-    const useSavepoint = opaque && _currentTransactionPublic().isOpen();
+    const expanded = opaque ? sources : expandCallbackSourcesWithHelpers(sources, ctor);
+    const useSavepoint = _currentTransactionPublic().isOpen();
     for (const ref of ctor.reflectOnAllAssociations("belongsTo")) {
       // Narrow to associations the callback names (unless an opaque callback
       // forces loading all): Rails only queries the targets it dereferences.
-      if (!opaque && !referencesAssociationName(sources, ref.name)) continue;
+      if (!opaque && !referencesAssociationName(expanded, ref.name)) continue;
       let assoc: any;
       try {
         assoc = (this as any).association(ref.name);

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3881,11 +3881,14 @@ export class Base extends Model {
    * it). On a load failure we resolve the association to `null` rather than
    * leaving it unloaded, so a sync callback that *does* read it sees `null` and
    * not trails' async-reader Promise — keeping the bare `if (record.parent)`
-   * guard safe even when the preload could not materialize the parent. Because
-   * we no longer eager-load associations the callback never names, no per-load
-   * savepoint is needed: a doomed query (e.g. `tag_with_primary_key` →
-   * a non-existent column) only runs when the callback actually reads it, which
-   * is exactly when Rails would issue — and fail on — the same lazy query.
+   * guard safe even when the preload could not materialize the parent. On the
+   * narrowed path no per-load savepoint is needed: a doomed query (e.g.
+   * `tag_with_primary_key` → a non-existent column) only runs when the callback
+   * actually reads it, which is exactly when Rails would issue — and fail on —
+   * the same lazy query. The opaque load-all path keeps PR #4792's savepoint,
+   * since it may still fire a doomed query the (unreadable) callback never
+   * touches, which would otherwise abort the whole PostgreSQL transaction
+   * (25P02) — an abort swallowing the JS error cannot undo.
    *
    * @internal
    */
@@ -3894,6 +3897,7 @@ export class Base extends Model {
     if (typeof (this as any).association !== "function") return;
     const { sources, opaque } = beforeOrAroundCallbackSources(ctor.prototype, "destroy");
     if (!opaque && sources.length === 0) return;
+    const useSavepoint = opaque && _currentTransactionPublic().isOpen();
     for (const ref of ctor.reflectOnAllAssociations("belongsTo")) {
       // Narrow to associations the callback names (unless an opaque callback
       // forces loading all): Rails only queries the targets it dereferences.
@@ -3902,7 +3906,11 @@ export class Base extends Model {
       try {
         assoc = (this as any).association(ref.name);
         if (!assoc || assoc.isLoaded?.()) continue;
-        await assoc.loadTarget();
+        if (useSavepoint) {
+          await _transaction(ctor, () => assoc.loadTarget(), { requiresNew: true });
+        } else {
+          await assoc.loadTarget();
+        }
       } catch {
         // An unregistered target class, missing FK row, strict-loading
         // violation, or transient DB error must not abort the destroy. Resolve

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -120,7 +120,7 @@ import {
 import {
   runAllCallbacks as cbRunAll,
   runAfterCallbacksOnProto as cbRunAfter,
-  hasBeforeOrAroundCallbackOnProto,
+  beforeOrAroundCallbackSources,
   sanitizeForMassAssignment,
   shouldValidate,
 } from "@blazetrails/activemodel";
@@ -618,6 +618,18 @@ function _shouldApplyScopeAttributes(ctor: typeof Base): boolean {
   // non-all_queries `where` conditions propagate on create.
   const c = ctor as any;
   return !!c.currentScope || (c.defaultScopes?.length ?? 0) > 0 || hasDefaultScopeOverride(ctor);
+}
+
+/**
+ * True when any before/around destroy callback source dereferences the
+ * `belongs_to` reflection named `name` — matched as a whole identifier so
+ * `firm` doesn't match `firmId` and `tag` doesn't match `tagWithPrimaryKey`.
+ * Covers both dotted reads (`record.firm`) and the string form
+ * (`this.association("firm")`).
+ */
+function referencesAssociationName(sources: string[], name: string): boolean {
+  const pattern = new RegExp(`\\b${name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`);
+  return sources.some((src) => pattern.test(src));
 }
 
 /**
@@ -3854,44 +3866,43 @@ export class Base extends Model {
    * reading the association sees a loaded record (matching Rails' lazy
    * synchronous query) rather than trails' async-reader Promise.
    *
-   * Scoped to classes that actually register a before/around destroy callback
-   * so a plain destroy issues no extra query (Rails only queries when the
-   * callback touches the association). A same-FK sibling (e.g. Account#firm and
-   * Account#unautosavedFirm share `firm_id`) is loaded too even when only one is
-   * read; the extra read is side-effect-free and resolves to the same owner row.
+   * Scoped to classes that actually register a before/around destroy callback,
+   * and further narrowed to the `belongs_to` targets whose association name
+   * appears in the callback source — mirroring Rails, which lazily loads only
+   * the associations a callback dereferences and issues no query for the rest.
+   * When a before/around destroy callback is an object/method filter whose body
+   * cannot be introspected, we conservatively load every `belongs_to` (we can't
+   * tell what it reads). A same-FK sibling (e.g. Account#firm and
+   * Account#unautosavedFirm share `firm_id`) referenced in the source is loaded
+   * too; the extra read is side-effect-free and resolves to the same owner row.
    *
    * Loading is best-effort: a `belongs_to` whose target class is unregistered or
    * whose row is missing must not abort the destroy (the callback may never read
    * it). On a load failure we resolve the association to `null` rather than
    * leaving it unloaded, so a sync callback that *does* read it sees `null` and
    * not trails' async-reader Promise — keeping the bare `if (record.parent)`
-   * guard safe even when the preload could not materialize the parent.
+   * guard safe even when the preload could not materialize the parent. Because
+   * we no longer eager-load associations the callback never names, no per-load
+   * savepoint is needed: a doomed query (e.g. `tag_with_primary_key` →
+   * a non-existent column) only runs when the callback actually reads it, which
+   * is exactly when Rails would issue — and fail on — the same lazy query.
    *
    * @internal
    */
   private async _preloadBelongsToForDestroyCallbacks(): Promise<void> {
     const ctor = this.constructor as typeof Base;
-    if (!hasBeforeOrAroundCallbackOnProto(ctor.prototype, "destroy")) return;
     if (typeof (this as any).association !== "function") return;
-    // When this best-effort preload runs inside an open transaction, isolate
-    // each load in its own savepoint. A failing preload query (e.g. a
-    // `belongs_to ..., primary_key:` pointing at a column that doesn't exist,
-    // like `tag_with_primary_key`) aborts the whole PostgreSQL transaction
-    // (25P02) — and swallowing the JS error can't un-abort the connection.
-    // Rolling back to a per-load savepoint clears the aborted state so the
-    // outer transaction stays usable, matching Rails, which never issues this
-    // eager query at all (it lazily loads only what the callback reads).
-    const inTransaction = _currentTransactionPublic().isOpen();
+    const { sources, opaque } = beforeOrAroundCallbackSources(ctor.prototype, "destroy");
+    if (!opaque && sources.length === 0) return;
     for (const ref of ctor.reflectOnAllAssociations("belongsTo")) {
+      // Narrow to associations the callback names (unless an opaque callback
+      // forces loading all): Rails only queries the targets it dereferences.
+      if (!opaque && !referencesAssociationName(sources, ref.name)) continue;
       let assoc: any;
       try {
         assoc = (this as any).association(ref.name);
         if (!assoc || assoc.isLoaded?.()) continue;
-        if (inTransaction) {
-          await _transaction(ctor, () => assoc.loadTarget(), { requiresNew: true });
-        } else {
-          await assoc.loadTarget();
-        }
+        await assoc.loadTarget();
       } catch {
         // An unregistered target class, missing FK row, strict-loading
         // violation, or transient DB error must not abort the destroy. Resolve


### PR DESCRIPTION
## Summary

`Base#_preloadBelongsToForDestroyCallbacks` eagerly loaded **every**
`belongs_to` target before a before/around destroy callback ran — a trails
invention. Rails issues no such query; it lazily loads only the associations a
callback dereferences. The eager scan also fired a doomed `SELECT` for
`tag_with_primary_key` (→ non-existent `tags.custom_primary_key`), which forced
PR #4792 to wrap each `loadTarget()` in its own PostgreSQL savepoint.

## Change

- **Narrow** the preload to `belongs_to` reflections whose name appears in the
  destroy callback source, matched as a whole identifier (`firm` ≠ `firmId`;
  `tag` ≠ `tagWithPrimaryKey`). Covers dotted reads (`record.firm`) and the
  string form (`this.association("firm")`).
- **Resolve indirection** (`expandCallbackSourcesWithHelpers`): the scan expands
  the callback source with the source of any model-defined instance method it
  transitively references, so a read reached through a helper
  (`before_destroy { this.makeComments() }` where `makeComments` reads
  `this.person`) is still detected — mirroring Rails resolving associations by
  ordinary method dispatch at any call depth.
- **Opaque fallback**: object/method-name filters and bound/native functions
  (whose `toString()` has no body) fall back to loading every `belongs_to`.
- **Savepoint every in-transaction load**: a doomed query named on the narrowed
  path would otherwise abort the PG transaction (25P02) that the swallowing
  `catch` cannot undo. Narrowing still removes the *per-association* savepoint
  churn — only the association the callback names is loaded (zero for a callback
  that reads nothing, so the indestructible-tagging case issues no query).
- Add `beforeOrAroundCallbackSources` to activemodel to expose introspectable
  callback source text.

## Review response

- **Indirect reads** — audited every canonical destroy callback: the only sync
  (un-awaited) `belongs_to` read is `Account#firm`, inline and scanned
  correctly; `Client#firm` and `Reference → makeComments → person` are all
  `await`ed. The helper-source expansion makes the scan resilient regardless.
- **Savepoint on narrowed path** — now savepointed for any in-transaction load,
  so a doomed named association aborts cleanly instead of poisoning the txn.
- **Bound/native filters** — routed through the opaque load-all path.

## Testing

- `has-many-through-associations` indestructible-through-record — green on
  PG + SQLite, no `usesTransaction`.
- New trails-only guard in `has-one-associations`: a direct destroy preloads
  only the named `belongs_to` (`firm`), not its same-`firm_id` sibling.
- `has-one-associations`, `callbacks`, `bidirectional-destroy-dependencies`,
  `strict-loading`, `autosave-association`, Reference dependent-destroy paths
  pass locally (sqlite). CI green.

Closes-story: converge-destroy-belongs-to-preload-to-lazy