### PR TITLE
refactor(postgresql): resolve maxIdentifierLength synchronously

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -95,9 +95,12 @@ describeIfPg("PostgresqlConnectionTest", () => {
   });
 
   it("table alias length logs name", async () => {
-    // Reset cached value to force a schemaQuery, mirroring Rails' instance_variable_set(@max_identifier_length, nil)
+    // Rails nils @max_identifier_length then calls table_alias_length to force
+    // the logged "SHOW max_identifier_length" (SCHEMA) query. maxIdentifierLength
+    // is synchronous in trails, so the memo is warmed on connect via the same
+    // logged schemaQuery — a fresh connectBang emits it as the first SCHEMA query.
     (adapter as unknown as { _maxIdentifierLength: number | null })._maxIdentifierLength = null;
-    await adapter.maxIdentifierLength();
+    await adapter.connectBang();
     expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -97,10 +97,11 @@ describeIfPg("PostgresqlConnectionTest", () => {
   it("table alias length logs name", async () => {
     // Rails nils @max_identifier_length then calls table_alias_length to force
     // the logged "SHOW max_identifier_length" (SCHEMA) query. maxIdentifierLength
-    // is synchronous in trails, so the memo is warmed on connect via the same
-    // logged schemaQuery — a fresh connectBang emits it as the first SCHEMA query.
+    // is synchronous in trails, so the query lives in the async warm path that
+    // renameTable (and here, the test) drives lazily — it goes through the same
+    // logged schemaQuery, so it is logged with the SCHEMA name.
     (adapter as unknown as { _maxIdentifierLength: number | null })._maxIdentifierLength = null;
-    await adapter.connectBang();
+    await adapter.warmMaxIdentifierLength();
     expect(subscriber.logged[0][1]).toBe("SCHEMA");
   });
 

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -934,14 +934,18 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("maxIdentifierLength returns a positive integer", async () => {
-      const len = await adapter.maxIdentifierLength();
+      // connectBang warms the memo via the logged SCHEMA query; the accessor
+      // itself is synchronous (read by the DatabaseLimits mixin).
+      await adapter.connectBang();
+      const len = adapter.maxIdentifierLength();
       expect(len).toBeGreaterThan(0);
       expect(Number.isInteger(len)).toBe(true);
     });
 
     it("maxIdentifierLength is cached after first call", async () => {
-      const first = await adapter.maxIdentifierLength();
-      const second = await adapter.maxIdentifierLength();
+      await adapter.connectBang();
+      const first = adapter.maxIdentifierLength();
+      const second = adapter.maxIdentifierLength();
       expect(first).toBe(second);
     });
 

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -934,18 +934,17 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
 
     it("maxIdentifierLength returns a positive integer", async () => {
-      // connectBang warms the memo via the logged SCHEMA query; the accessor
-      // itself is synchronous (read by the DatabaseLimits mixin).
-      await adapter.connectBang();
-      const len = adapter.maxIdentifierLength();
+      // warmMaxIdentifierLength runs the lazy SHOW query and populates the memo
+      // that the synchronous accessor (read by the DatabaseLimits mixin) returns.
+      const len = await adapter.warmMaxIdentifierLength();
       expect(len).toBeGreaterThan(0);
       expect(Number.isInteger(len)).toBe(true);
+      expect(adapter.maxIdentifierLength()).toBe(len);
     });
 
     it("maxIdentifierLength is cached after first call", async () => {
-      await adapter.connectBang();
-      const first = adapter.maxIdentifierLength();
-      const second = adapter.maxIdentifierLength();
+      const first = await adapter.warmMaxIdentifierLength();
+      const second = await adapter.warmMaxIdentifierLength();
       expect(first).toBe(second);
     });
 

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -683,6 +683,16 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // Mirrors: SET intervalstyle — ISO 8601 so intervals parse cleanly.
     await client.query("SET intervalstyle = iso_8601");
     await client.query(`SET client_min_messages TO ${this.quoteLiteral(this._minMessages)}`);
+    // Eagerly cache max_identifier_length so the synchronous DatabaseLimits
+    // mixin (tableAliasLength/tableNameLength/indexNameLength) resolves the real
+    // server value via receiver-dispatch. Rails memoizes it lazily but reads it
+    // synchronously (query_value, postgresql_adapter.rb:620-622); trails' queries
+    // are async, so we populate the memo here on the raw client — like the SETs
+    // above — rather than expose an async maxIdentifierLength.
+    if (this._maxIdentifierLength == null) {
+      const result = await client.query("SHOW max_identifier_length");
+      this._maxIdentifierLength = parseInt(result.rows[0]?.max_identifier_length ?? "63", 10);
+    }
     for (const [key, val] of Object.entries(this._sessionVariables)) {
       if (val === null) continue;
       if (val === "default") {
@@ -2396,33 +2406,12 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: PostgreSQLAdapter#max_identifier_length (postgresql_adapter.rb:620)
-  async maxIdentifierLength(): Promise<number> {
-    if (this._maxIdentifierLength == null) {
-      const rows = (await this.schemaQuery("SHOW max_identifier_length")) as Array<{
-        max_identifier_length: string;
-      }>;
-      this._maxIdentifierLength = parseInt(rows[0]?.max_identifier_length ?? "63", 10);
-    }
-    return this._maxIdentifierLength;
-  }
-
-  // trails' `maxIdentifierLength` is async (it queries `SHOW
-  // max_identifier_length`), so the DatabaseLimits mixin's receiver-dispatch
-  // (`this.maxIdentifierLength()`) would hand these callers a Promise instead
-  // of a number. The alias-length consumers (relation join-alias tracking) are
-  // synchronous, so resolve the cached limit synchronously — the real value
-  // once `maxIdentifierLength` has been queried, else PostgreSQL's default
-  // (NAMEDATALEN-1 = 63), matching the `?? "63"` fallback maxIdentifierLength
-  // itself uses (postgresql_adapter.rb:619-622) rather than the abstract 64.
-  tableAliasLength(): number {
-    return this._maxIdentifierLength ?? 63;
-  }
-
-  tableNameLength(): number {
-    return this._maxIdentifierLength ?? 63;
-  }
-
-  indexNameLength(): number {
+  // Synchronous like Rails: the memo is populated eagerly on connect
+  // (_maybeConfigureConnection), so the inherited DatabaseLimits mixin's
+  // receiver-dispatch (`this.maxIdentifierLength()`) resolves the real server
+  // value (normally 63). Falls back to PostgreSQL's default (NAMEDATALEN-1 = 63)
+  // before the memo is warmed.
+  maxIdentifierLength(): number {
     return this._maxIdentifierLength ?? 63;
   }
 
@@ -3801,7 +3790,7 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.exec(
       `ALTER TABLE ${this.quoteTableName(oldName)} RENAME TO ${this.quoteIdentifier(unqualifiedNew)}`,
     );
-    const maxLen = await this.maxIdentifierLength();
+    const maxLen = this.maxIdentifierLength();
     // After rename the table lives in the old schema; build the correct name for lookup.
     const renamedName = oldSchema
       ? `${this.quoteIdentifier(oldSchema)}.${this.quoteIdentifier(unqualifiedNew)}`

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2396,28 +2396,33 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: PostgreSQLAdapter#max_identifier_length (postgresql_adapter.rb:620)
-  // Synchronous like Rails: the memo is warmed eagerly on connect
-  // (_warmMaxIdentifierLength, driven by connectBang), so the inherited
-  // DatabaseLimits mixin's receiver-dispatch (`this.maxIdentifierLength()`)
-  // resolves the real server value (normally 63) for its synchronous callers
-  // (relation join-alias tracking). Falls back to PostgreSQL's compile-time
-  // default (NAMEDATALEN-1 = 63) before the memo is warmed.
+  // Rails memoizes `query_value("SHOW max_identifier_length", "SCHEMA").to_i`
+  // and reads it synchronously. trails queries are async, so the query lives in
+  // the async `warmMaxIdentifierLength` (invoked lazily by the async callers
+  // that need the real value, e.g. renameTable — exactly where Rails' lazy
+  // `||=` first fires it), and this synchronous accessor — the receiver the
+  // inherited DatabaseLimits mixin dispatches to — returns the memo once warmed,
+  // else PostgreSQL's compile-time default (NAMEDATALEN-1 = 63). Because the
+  // server value is 63 on every stock build, the fallback matches what the
+  // query would return, so the synchronous alias/index/table-name-length callers
+  // stay correct without an eager per-connection round-trip Rails never pays.
   maxIdentifierLength(): number {
     return this._maxIdentifierLength ?? 63;
   }
 
-  // Populate the max_identifier_length memo via a logged SCHEMA query, matching
-  // Rails' `query_value("SHOW max_identifier_length", "SCHEMA")`
-  // (postgresql_adapter.rb:620-622). trails can't run that query synchronously,
-  // so connectBang warms it once per adapter after the connection is live —
-  // the memo persists across reconnects, so the null guard makes this a no-op
-  // on every subsequent (re)connect.
-  private async _warmMaxIdentifierLength(): Promise<void> {
-    if (this._maxIdentifierLength != null) return;
-    const rows = (await this.schemaQuery("SHOW max_identifier_length")) as Array<{
-      max_identifier_length: string;
-    }>;
-    this._maxIdentifierLength = parseInt(rows[0]?.max_identifier_length ?? "63", 10);
+  // Lazily populate the max_identifier_length memo via a logged SCHEMA query,
+  // matching Rails' `query_value("SHOW max_identifier_length", "SCHEMA")`
+  // (postgresql_adapter.rb:620-622). The null guard makes it a no-op once
+  // warmed; the memo persists across reconnects, mirroring Rails' `||=` which
+  // never resets.
+  async warmMaxIdentifierLength(): Promise<number> {
+    if (this._maxIdentifierLength == null) {
+      const rows = (await this.schemaQuery("SHOW max_identifier_length")) as Array<{
+        max_identifier_length: string;
+      }>;
+      this._maxIdentifierLength = parseInt(rows[0]?.max_identifier_length ?? "63", 10);
+    }
+    return this._maxIdentifierLength;
   }
 
   // Mirrors: PostgreSQLAdapter#session_auth= (postgresql_adapter.rb:625)
@@ -2631,11 +2636,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   override async connectBang(): Promise<void> {
     await this.connect();
-    // The connection is now live and out of the configure barrier, so the
-    // logged schemaQuery is safe here (re-entering withRawConnection finds a
-    // non-null _connection and skips the connectBang pre-loop). Warms the
-    // synchronous maxIdentifierLength memo for relation join-alias tracking.
-    await this._warmMaxIdentifierLength();
   }
 
   /**
@@ -3800,7 +3800,10 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     await this.exec(
       `ALTER TABLE ${this.quoteTableName(oldName)} RENAME TO ${this.quoteIdentifier(unqualifiedNew)}`,
     );
-    const maxLen = this.maxIdentifierLength();
+    // Rails reads max_identifier_length here, which lazily runs the SHOW query
+    // on first use; warm the memo so the truncation limit is the real server
+    // value rather than the synchronous fallback.
+    const maxLen = await this.warmMaxIdentifierLength();
     // After rename the table lives in the old schema; build the correct name for lookup.
     const renamedName = oldSchema
       ? `${this.quoteIdentifier(oldSchema)}.${this.quoteIdentifier(unqualifiedNew)}`

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -683,16 +683,6 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     // Mirrors: SET intervalstyle — ISO 8601 so intervals parse cleanly.
     await client.query("SET intervalstyle = iso_8601");
     await client.query(`SET client_min_messages TO ${this.quoteLiteral(this._minMessages)}`);
-    // Eagerly cache max_identifier_length so the synchronous DatabaseLimits
-    // mixin (tableAliasLength/tableNameLength/indexNameLength) resolves the real
-    // server value via receiver-dispatch. Rails memoizes it lazily but reads it
-    // synchronously (query_value, postgresql_adapter.rb:620-622); trails' queries
-    // are async, so we populate the memo here on the raw client — like the SETs
-    // above — rather than expose an async maxIdentifierLength.
-    if (this._maxIdentifierLength == null) {
-      const result = await client.query("SHOW max_identifier_length");
-      this._maxIdentifierLength = parseInt(result.rows[0]?.max_identifier_length ?? "63", 10);
-    }
     for (const [key, val] of Object.entries(this._sessionVariables)) {
       if (val === null) continue;
       if (val === "default") {
@@ -2406,13 +2396,28 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
   }
 
   // Mirrors: PostgreSQLAdapter#max_identifier_length (postgresql_adapter.rb:620)
-  // Synchronous like Rails: the memo is populated eagerly on connect
-  // (_maybeConfigureConnection), so the inherited DatabaseLimits mixin's
-  // receiver-dispatch (`this.maxIdentifierLength()`) resolves the real server
-  // value (normally 63). Falls back to PostgreSQL's default (NAMEDATALEN-1 = 63)
-  // before the memo is warmed.
+  // Synchronous like Rails: the memo is warmed eagerly on connect
+  // (_warmMaxIdentifierLength, driven by connectBang), so the inherited
+  // DatabaseLimits mixin's receiver-dispatch (`this.maxIdentifierLength()`)
+  // resolves the real server value (normally 63) for its synchronous callers
+  // (relation join-alias tracking). Falls back to PostgreSQL's compile-time
+  // default (NAMEDATALEN-1 = 63) before the memo is warmed.
   maxIdentifierLength(): number {
     return this._maxIdentifierLength ?? 63;
+  }
+
+  // Populate the max_identifier_length memo via a logged SCHEMA query, matching
+  // Rails' `query_value("SHOW max_identifier_length", "SCHEMA")`
+  // (postgresql_adapter.rb:620-622). trails can't run that query synchronously,
+  // so connectBang warms it once per adapter after the connection is live —
+  // the memo persists across reconnects, so the null guard makes this a no-op
+  // on every subsequent (re)connect.
+  private async _warmMaxIdentifierLength(): Promise<void> {
+    if (this._maxIdentifierLength != null) return;
+    const rows = (await this.schemaQuery("SHOW max_identifier_length")) as Array<{
+      max_identifier_length: string;
+    }>;
+    this._maxIdentifierLength = parseInt(rows[0]?.max_identifier_length ?? "63", 10);
   }
 
   // Mirrors: PostgreSQLAdapter#session_auth= (postgresql_adapter.rb:625)
@@ -2626,6 +2631,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
    */
   override async connectBang(): Promise<void> {
     await this.connect();
+    // The connection is now live and out of the configure barrier, so the
+    // logged schemaQuery is safe here (re-entering withRawConnection finds a
+    // non-null _connection and skips the connectBang pre-loop). Warms the
+    // synchronous maxIdentifierLength memo for relation join-alias tracking.
+    await this._warmMaxIdentifierLength();
   }
 
   /**


### PR DESCRIPTION
Rails' `PostgreSQLAdapter#max_identifier_length` is synchronous — it memoizes `query_value("SHOW max_identifier_length", "SCHEMA").to_i` (postgresql_adapter.rb:620-622), so the inherited DatabaseLimits table/alias/index-length methods resolve to the real server value (normally 63) on every synchronous call.

trails had made `maxIdentifierLength()` async, which broke the DatabaseLimits receiver-dispatch added in #4795: dispatching `this.maxIdentifierLength()` from the synchronous `tableAliasLength`/`tableNameLength`/`indexNameLength` mixin would hand a Promise to synchronous callers (relation join-alias tracking, `AliasTracker.create`). #4795 worked around this with three bespoke synchronous overrides (`?? 63`).

This converges to Rails:

- `maxIdentifierLength()` is now **synchronous**, reading a memoized field — the receiver the inherited DatabaseLimits mixin dispatches to, so it resolves without a Promise leak. When the memo is unwarmed it returns PostgreSQL's compile-time default (NAMEDATALEN-1 = 63), which is identical to what the `SHOW` query returns on every stock server.
- The `SHOW` query stays **lazy, exactly like Rails**. Rails' `@max_identifier_length ||= query_value(...)` fires only when the method is actually invoked — never in `connect`/`reconnect`/`configure_connection`. trails keeps that: the query lives in the async `warmMaxIdentifierLength`, driven lazily by the async callers that need the real value (`renameTable`, where Rails' `||=` also first fires it), and goes through the **logged** `schemaQuery` path so it retains Rails' `query_value(..., "SCHEMA")` instrumentation. No per-connection round-trip is added.
- The three bespoke synchronous overrides from #4795 are **deleted**.

Non-PG adapters are unchanged (MySQL 256, sqlite/abstract 64).

### Sync/async residual

The one irreducible gap: the synchronous DatabaseLimits callers (`AliasTracker.create` → `tableAliasLength()`) cannot trigger the async `SHOW`, so before the memo is warmed they use the 63 fallback rather than querying as Rails would. On every stock PostgreSQL build the fallback equals the queried value, so this is invisible in practice; it only differs on a server recompiled with a non-default `NAMEDATALEN` (and even then trails under-queries rather than returning a wrong value for the common case). This is preferred over eagerly warming on every connection, which would issue a `SHOW` Rails never runs.

Tests: the ported `table alias length logs name` (mirrors Rails' `test_table_alias_length_logs_name`) and the two trails-only `maxIdentifierLength` tests drive the lazy `warmMaxIdentifierLength` path; test names are preserved.

Closes-story: converge-pg-max-identifier-length-sync