### PR TITLE
refactor(test-helpers): select test backend by ARCONN named connection

### DIFF
--- a/packages/activerecord/src/test-helpers/test-database-config.test.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.test.ts
@@ -17,7 +17,7 @@ describe("buildTestDatabaseConfig", () => {
     expect(configs.findDbConfig("test")).toBeDefined();
   });
 
-  it("defaults to sqlite when no URL env vars are set", async () => {
+  it("selects the sqlite3 connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "sqlite3");
     vi.stubEnv("PG_TEST_URL", "");
     vi.stubEnv("MYSQL_TEST_URL", "");
@@ -25,6 +25,14 @@ describe("buildTestDatabaseConfig", () => {
     expect(adapter).toBe("sqlite");
     expect(envConfig.adapter).toMatch(/sqlite/i);
     expect(DatabaseTasks.resolveTask("sqlite3")).toBeDefined();
+  });
+
+  it("falls back to the default_connection (sqlite3) when ARCONN is unset", async () => {
+    vi.stubEnv("ARCONN", "");
+    vi.stubEnv("PG_TEST_URL", "");
+    vi.stubEnv("MYSQL_TEST_URL", "");
+    const { adapter } = await buildTestDatabaseConfig();
+    expect(adapter).toBe("sqlite");
   });
 
   it("inherits Rails' default pool size (5) on the file-backed lane", async () => {
@@ -36,22 +44,24 @@ describe("buildTestDatabaseConfig", () => {
     expect(envConfig.pool).toBe(5);
   });
 
-  it("pins pool 1 on a bare :memory: primary", async () => {
-    vi.stubEnv("ARCONN", "sqlite3");
+  it("pins pool 1 on the sqlite3_mem :memory: connection", async () => {
+    vi.stubEnv("ARCONN", "sqlite3_mem");
     vi.stubEnv("PG_TEST_URL", "");
     vi.stubEnv("MYSQL_TEST_URL", "");
     vi.stubEnv("AR_TEST_WORKER_DB", "");
-    const { envConfig } = await buildTestDatabaseConfig();
+    const { adapter, envConfig } = await buildTestDatabaseConfig();
+    expect(adapter).toBe("sqlite");
     expect(envConfig.pool).toBe(1);
   });
 
-  it("picks postgres when PG_TEST_URL is set", async () => {
+  it("selects the postgresql connection named by ARCONN", async () => {
+    vi.stubEnv("ARCONN", "postgresql");
     vi.stubEnv("PG_TEST_URL", "postgresql://localhost/trails_test");
     const { adapter } = await buildTestDatabaseConfig();
     expect(adapter).toBe("postgres");
   });
 
-  it("picks mysql when MYSQL_TEST_URL is set and PG_TEST_URL is absent", async () => {
+  it("selects the mysql2 connection named by ARCONN", async () => {
     vi.stubEnv("ARCONN", "mysql2");
     vi.stubEnv("PG_TEST_URL", "");
     vi.stubEnv("MYSQL_TEST_URL", "mysql2://localhost/trails_test");
@@ -59,32 +69,26 @@ describe("buildTestDatabaseConfig", () => {
     expect(adapter).toBe("mysql");
   });
 
-  it("throws when ARCONN=postgresql but PG_TEST_URL is absent", async () => {
+  it("fails loudly when ARCONN names an unconfigured connection", async () => {
+    vi.stubEnv("ARCONN", "oracle");
+    await expect(buildTestDatabaseConfig()).rejects.toThrow(/Connection "oracle" not found/);
+  });
+
+  it("raises on an ARCONN / resolved-adapter mismatch (postgresql without PG_TEST_URL)", async () => {
     vi.stubEnv("ARCONN", "postgresql");
     vi.stubEnv("PG_TEST_URL", "");
     vi.stubEnv("MYSQL_TEST_URL", "");
-    await expect(buildTestDatabaseConfig()).rejects.toThrow(/ARCONN=postgresql but PG_TEST_URL/);
+    await expect(buildTestDatabaseConfig()).rejects.toThrow(
+      /connection name did not match the adapter name/,
+    );
   });
 
-  it("throws when ARCONN=mysql2 but MYSQL_TEST_URL is absent", async () => {
+  it("raises on an ARCONN / resolved-adapter mismatch (mysql2 without MYSQL_TEST_URL)", async () => {
     vi.stubEnv("ARCONN", "mysql2");
     vi.stubEnv("PG_TEST_URL", "");
     vi.stubEnv("MYSQL_TEST_URL", "");
-    await expect(buildTestDatabaseConfig()).rejects.toThrow(/ARCONN=mysql2 but MYSQL_TEST_URL/);
-  });
-
-  it("does not throw when ARCONN=postgresql and PG_TEST_URL is set", async () => {
-    vi.stubEnv("ARCONN", "postgresql");
-    vi.stubEnv("PG_TEST_URL", "postgresql://localhost/trails_test");
-    const { adapter } = await buildTestDatabaseConfig();
-    expect(adapter).toBe("postgres");
-  });
-
-  it("does not throw when ARCONN=sqlite3 and no URL env vars are set", async () => {
-    vi.stubEnv("ARCONN", "sqlite3");
-    vi.stubEnv("PG_TEST_URL", "");
-    vi.stubEnv("MYSQL_TEST_URL", "");
-    const { adapter } = await buildTestDatabaseConfig();
-    expect(adapter).toBe("sqlite");
+    await expect(buildTestDatabaseConfig()).rejects.toThrow(
+      /connection name did not match the adapter name/,
+    );
   });
 });

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -26,6 +26,7 @@
  */
 
 import { getEnv } from "@blazetrails/activesupport";
+import { ArgumentError } from "@blazetrails/activemodel";
 import { Base } from "../base.js";
 import { DatabaseConfigurations } from "../database-configurations.js";
 import { DatabaseTasks } from "../tasks/database-tasks.js";
@@ -128,14 +129,14 @@ function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfi
   // Rails: `unless connection_name.include?(arunit_adapter) raise ArgumentError`
   // (connection.rb:35-37). A live-backend `ARCONN` whose connection details are
   // absent would silently fall back to SQLite — folding in PR #4768's guard, we
-  // raise instead of resolving the wrong backend.
+  // raise instead of resolving the wrong backend. The `arunit_adapter` proxy is
+  // the fallback lane (`sqlite3`); the message mirrors Rails' wording verbatim
+  // (single-quoted interpolations included) — only the trigger (missing env var
+  // vs. a genuine post-connect adapter mismatch) is necessarily trails-specific.
   if (envConfig === null) {
-    // eslint-disable-next-line blazetrails/rails-error-parity
-    throw new Error(
+    throw new ArgumentError(
       `The connection name did not match the adapter name. Connection name is ` +
-        `"${connectionName}" (adapter "${connection.adapter}"), but its connection ` +
-        `details (PG_TEST_URL / MYSQL_TEST_URL) are not set, so the run would ` +
-        `silently fall back to SQLite.`,
+        `'${connectionName}' and the adapter name is '${DEFAULT_CONNECTION}'.`,
     );
   }
 

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -1,8 +1,24 @@
 /**
- * Builds the test-environment `DatabaseConfigurations` from the standard
- * env-var signals (`PG_TEST_URL` / `MYSQL_TEST_URL` / sqlite fallback) and
- * wires it into `DatabaseTasks`, routing schema load through the real
- * Rails-mirrored path (`loadSchema` / `reconstructFromSchema`).
+ * Builds the test-environment `DatabaseConfigurations` from a Rails-faithful
+ * named-connections map (the `config.yml`-analogue) selected purely by
+ * `ARCONN`, and wires it into `DatabaseTasks`, routing schema load through the
+ * real Rails-mirrored path (`loadSchema` / `reconstructFromSchema`).
+ *
+ * Mirrors `vendor/rails/activerecord/test/support/connection.rb`:
+ *   - `connection_name = ENV["ARCONN"] || config["default_connection"]`
+ *     (`connection.rb:10`),
+ *   - `config.fetch("connections").fetch(connection_name) { ... exit 1 }`
+ *     (`connection.rb:14-19`) — a hard failure when `ARCONN` names an
+ *     unconfigured connection,
+ *   - `unless connection_name.include?(arunit_adapter) raise ArgumentError`
+ *     (`connection.rb:35-37`) — a loud raise when `ARCONN` and the resolved
+ *     adapter diverge. PR #4768's `*_TEST_URL`-presence guard folds into this:
+ *     a live-backend `ARCONN` whose connection details are absent resolves to
+ *     SQLite, whose adapter (`sqlite3`) is not a substring of the connection
+ *     name (`postgresql` / `mysql2`), so the mismatch check raises.
+ *
+ * As in `config.example.yml`, `ENV` only feeds connection *sub-settings*
+ * (host/port/socket/credentials); it never selects the backend.
  *
  * Phase 1 of RFC 0002 — new file, no consumer changes.
  * Phase 2 of RFC 0002 — adds `establishFromTestConfig` for setupHandlerSuite.
@@ -28,50 +44,83 @@ export interface TestDatabaseConfig {
 }
 
 /**
- * Guard against a silent SQLite fallback when `ARCONN` selects a live backend.
- *
- * `ARCONN` only drives which tests vitest includes (`vitest.config.ts`); the
- * backend is chosen here from `PG_TEST_URL` / `MYSQL_TEST_URL`. When `ARCONN`
- * is `postgresql`/`mysql2` but the matching `*_TEST_URL` is absent, the SELECTs
- * would run against SQLite while the run pretends to be the PG/MySQL job — a
- * false green that hides adapter-specific divergences. Fail loudly instead.
+ * The named connections available to the test harness, mirroring the
+ * `connections:` hash of `vendor/rails/activerecord/test/config.example.yml`.
+ * `ARCONN` selects one of these keys; `DEFAULT_CONNECTION` is Rails'
+ * `config["default_connection"]` fallback.
  */
-function assertTestUrlPresentForArconn(pgUrl?: string, mysqlUrl?: string): void {
-  const arconn = getEnv("ARCONN");
-  if (arconn === "postgresql" && !pgUrl) {
-    // Test-helper invariant with no Rails error counterpart — a bare Error is intentional.
-    // eslint-disable-next-line blazetrails/rails-error-parity
-    throw new Error(
-      "ARCONN=postgresql but PG_TEST_URL is not set: the test backend would " +
-        "silently fall back to SQLite, running against the wrong database. " +
-        "Set PG_TEST_URL to a live PostgreSQL, or unset ARCONN to run on SQLite.",
-    );
-  }
-  if (arconn === "mysql2" && !mysqlUrl) {
-    // Test-helper invariant with no Rails error counterpart — a bare Error is intentional.
-    // eslint-disable-next-line blazetrails/rails-error-parity
-    throw new Error(
-      "ARCONN=mysql2 but MYSQL_TEST_URL is not set: the test backend would " +
-        "silently fall back to SQLite, running against the wrong database. " +
-        "Set MYSQL_TEST_URL to a live MySQL, or unset ARCONN to run on SQLite.",
-    );
-  }
+type ConnectionName = "sqlite3" | "sqlite3_mem" | "postgresql" | "mysql2";
+
+const DEFAULT_CONNECTION: ConnectionName = "sqlite3";
+
+/**
+ * Each named connection builds its primary "test" env config from
+ * Rails-mirrored sub-setting env vars (never a URL that also *selects* the
+ * backend). The live-backend builders return a SQLite fallback when their
+ * connection details are absent; the adapter-mismatch check downstream turns
+ * that into Rails' `ArgumentError`.
+ */
+const CONNECTIONS: Record<ConnectionName, () => HashConfig | UrlConfig> = {
+  sqlite3: () => new HashConfig("test", "primary", sqliteHash()),
+  sqlite3_mem: () =>
+    new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:", pool: 1 }),
+  postgresql: () => {
+    const pgUrl = getEnv("PG_TEST_URL");
+    if (pgUrl) return new UrlConfig("test", "primary", pgUrl);
+    return new HashConfig("test", "primary", sqliteHash());
+  },
+  mysql2: () => {
+    const mysqlUrl = getEnv("MYSQL_TEST_URL");
+    if (mysqlUrl) return new UrlConfig("test", "primary", mysqlUrl);
+    return new HashConfig("test", "primary", sqliteHash());
+  },
+};
+
+/** Map a resolved `envConfig.adapter` to the public {@link TestAdapterName}. */
+function adapterName(config: HashConfig | UrlConfig): TestAdapterName {
+  const adapter = config.adapter ?? "";
+  if (adapter.includes("postgres")) return "postgres";
+  if (adapter.includes("mysql")) return "mysql";
+  return "sqlite";
 }
 
+/**
+ * Resolve the named connection selected by `ARCONN` into an adapter + config.
+ *
+ * Mirrors `ARTest.connection_name` / `test_configuration_hashes` / the
+ * adapter-name guard in `connection.rb`.
+ */
 function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfig } {
-  const pgUrl = getEnv("PG_TEST_URL");
-  const mysqlUrl = getEnv("MYSQL_TEST_URL");
-  assertTestUrlPresentForArconn(pgUrl, mysqlUrl);
-  if (pgUrl) {
-    return { adapter: "postgres", envConfig: new UrlConfig("test", "primary", pgUrl) };
+  const connectionName = (getEnv("ARCONN") || DEFAULT_CONNECTION) as ConnectionName;
+  const builder = CONNECTIONS[connectionName];
+  if (!builder) {
+    // Rails prints "Connection ... not found" and `exit 1`; we have no
+    // `process.exit`, so the loud failure is a throw with the same message.
+    // Test-helper invariant with no Rails error counterpart — a bare Error is intentional.
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(
+      `Connection "${connectionName}" not found. Available connections: ` +
+        `${Object.keys(CONNECTIONS).join(", ")}`,
+    );
   }
-  if (mysqlUrl) {
-    return { adapter: "mysql", envConfig: new UrlConfig("test", "primary", mysqlUrl) };
+
+  const envConfig = builder();
+  const arunitAdapter = envConfig.adapter ?? "";
+  // Rails: `unless connection_name.include?(arunit_adapter) raise ArgumentError`
+  // (connection.rb:35-37). A live-backend `ARCONN` whose connection details are
+  // absent resolves to SQLite here, whose adapter is not a substring of the
+  // connection name, so this fires — folding in PR #4768's silent-fallback guard.
+  if (!connectionName.includes(arunitAdapter)) {
+    // eslint-disable-next-line blazetrails/rails-error-parity
+    throw new Error(
+      `The connection name did not match the adapter name. Connection name is ` +
+        `"${connectionName}" and the adapter name is "${arunitAdapter}". ` +
+        `The ${connectionName} backend's connection details (e.g. PG_TEST_URL / ` +
+        `MYSQL_TEST_URL) are not set, so the run would silently fall back to SQLite.`,
+    );
   }
-  return {
-    adapter: "sqlite",
-    envConfig: new HashConfig("test", "primary", sqliteHash()),
-  };
+
+  return { adapter: adapterName(envConfig), envConfig };
 }
 
 /**
@@ -124,7 +173,7 @@ export async function buildTestDatabaseConfig(): Promise<TestDatabaseConfig> {
 }
 
 /**
- * Re-establish `Base`'s connection handler from the env-var config if not
+ * Re-establish `Base`'s connection handler from the resolved test config if not
  * already connected. Called by `setupHandlerSuite` so handler-path test files
  * get a live pool without knowing which adapter the worker is using.
  * Idempotent — a no-op when already connected.
@@ -136,16 +185,10 @@ export async function buildTestDatabaseConfig(): Promise<TestDatabaseConfig> {
  */
 export async function establishFromTestConfig(): Promise<void> {
   if (Base.isConnectedQ()) return;
-  const pgUrl = getEnv("PG_TEST_URL");
-  const mysqlUrl = getEnv("MYSQL_TEST_URL");
-  assertTestUrlPresentForArconn(pgUrl, mysqlUrl);
-  if (pgUrl) {
-    await Base.establishConnection(pgUrl);
+  const { envConfig } = resolve();
+  if (envConfig instanceof UrlConfig) {
+    await Base.establishConnection(envConfig.url);
     return;
   }
-  if (mysqlUrl) {
-    await Base.establishConnection(mysqlUrl);
-    return;
-  }
-  await Base.establishConnection(sqliteHash());
+  await Base.establishConnection(envConfig.configurationHash);
 }

--- a/packages/activerecord/src/test-helpers/test-database-config.ts
+++ b/packages/activerecord/src/test-helpers/test-database-config.ts
@@ -44,45 +44,65 @@ export interface TestDatabaseConfig {
 }
 
 /**
+ * A named connection in the `connections:` hash of
+ * `vendor/rails/activerecord/test/config.example.yml`: its `arunit` adapter
+ * name plus a builder for the primary "test" env config.
+ *
+ * `build()` returns `null` when the backend's connection details are absent
+ * (the live-backend analogue of a `config.yml` entry with no reachable server);
+ * `resolve()` turns that into Rails' loud adapter-mismatch failure rather than
+ * silently falling back to SQLite.
+ */
+interface NamedConnection {
+  /** The `arunit` adapter name Rails checks against (`connection.rb:35`). */
+  adapter: string;
+  /** The public {@link TestAdapterName} lane this connection drives. */
+  lane: TestAdapterName;
+  build(): HashConfig | UrlConfig | null;
+}
+
+/**
  * The named connections available to the test harness, mirroring the
- * `connections:` hash of `vendor/rails/activerecord/test/config.example.yml`.
- * `ARCONN` selects one of these keys; `DEFAULT_CONNECTION` is Rails'
- * `config["default_connection"]` fallback.
+ * `connections:` hash of `config.example.yml`. `ARCONN` selects one of these
+ * keys; `DEFAULT_CONNECTION` is Rails' `config["default_connection"]` fallback.
+ *
+ * Connection details for the live backends still come from `PG_TEST_URL` /
+ * `MYSQL_TEST_URL` in this foundation PR; migrating those onto Rails' discrete
+ * sub-setting env vars is tracked as a follow-up story.
  */
 type ConnectionName = "sqlite3" | "sqlite3_mem" | "postgresql" | "mysql2";
 
 const DEFAULT_CONNECTION: ConnectionName = "sqlite3";
 
-/**
- * Each named connection builds its primary "test" env config from
- * Rails-mirrored sub-setting env vars (never a URL that also *selects* the
- * backend). The live-backend builders return a SQLite fallback when their
- * connection details are absent; the adapter-mismatch check downstream turns
- * that into Rails' `ArgumentError`.
- */
-const CONNECTIONS: Record<ConnectionName, () => HashConfig | UrlConfig> = {
-  sqlite3: () => new HashConfig("test", "primary", sqliteHash()),
-  sqlite3_mem: () =>
-    new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:", pool: 1 }),
-  postgresql: () => {
-    const pgUrl = getEnv("PG_TEST_URL");
-    if (pgUrl) return new UrlConfig("test", "primary", pgUrl);
-    return new HashConfig("test", "primary", sqliteHash());
+const CONNECTIONS: Record<ConnectionName, NamedConnection> = {
+  sqlite3: {
+    adapter: "sqlite3",
+    lane: "sqlite",
+    build: () => new HashConfig("test", "primary", sqliteHash()),
   },
-  mysql2: () => {
-    const mysqlUrl = getEnv("MYSQL_TEST_URL");
-    if (mysqlUrl) return new UrlConfig("test", "primary", mysqlUrl);
-    return new HashConfig("test", "primary", sqliteHash());
+  sqlite3_mem: {
+    adapter: "sqlite3",
+    lane: "sqlite",
+    build: () =>
+      new HashConfig("test", "primary", { adapter: "sqlite3", database: ":memory:", pool: 1 }),
+  },
+  postgresql: {
+    adapter: "postgresql",
+    lane: "postgres",
+    build: () => {
+      const pgUrl = getEnv("PG_TEST_URL");
+      return pgUrl ? new UrlConfig("test", "primary", pgUrl) : null;
+    },
+  },
+  mysql2: {
+    adapter: "mysql2",
+    lane: "mysql",
+    build: () => {
+      const mysqlUrl = getEnv("MYSQL_TEST_URL");
+      return mysqlUrl ? new UrlConfig("test", "primary", mysqlUrl) : null;
+    },
   },
 };
-
-/** Map a resolved `envConfig.adapter` to the public {@link TestAdapterName}. */
-function adapterName(config: HashConfig | UrlConfig): TestAdapterName {
-  const adapter = config.adapter ?? "";
-  if (adapter.includes("postgres")) return "postgres";
-  if (adapter.includes("mysql")) return "mysql";
-  return "sqlite";
-}
 
 /**
  * Resolve the named connection selected by `ARCONN` into an adapter + config.
@@ -92,8 +112,8 @@ function adapterName(config: HashConfig | UrlConfig): TestAdapterName {
  */
 function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfig } {
   const connectionName = (getEnv("ARCONN") || DEFAULT_CONNECTION) as ConnectionName;
-  const builder = CONNECTIONS[connectionName];
-  if (!builder) {
+  const connection = CONNECTIONS[connectionName];
+  if (!connection) {
     // Rails prints "Connection ... not found" and `exit 1`; we have no
     // `process.exit`, so the loud failure is a throw with the same message.
     // Test-helper invariant with no Rails error counterpart — a bare Error is intentional.
@@ -104,23 +124,22 @@ function resolve(): { adapter: TestAdapterName; envConfig: HashConfig | UrlConfi
     );
   }
 
-  const envConfig = builder();
-  const arunitAdapter = envConfig.adapter ?? "";
+  const envConfig = connection.build();
   // Rails: `unless connection_name.include?(arunit_adapter) raise ArgumentError`
   // (connection.rb:35-37). A live-backend `ARCONN` whose connection details are
-  // absent resolves to SQLite here, whose adapter is not a substring of the
-  // connection name, so this fires — folding in PR #4768's silent-fallback guard.
-  if (!connectionName.includes(arunitAdapter)) {
+  // absent would silently fall back to SQLite — folding in PR #4768's guard, we
+  // raise instead of resolving the wrong backend.
+  if (envConfig === null) {
     // eslint-disable-next-line blazetrails/rails-error-parity
     throw new Error(
       `The connection name did not match the adapter name. Connection name is ` +
-        `"${connectionName}" and the adapter name is "${arunitAdapter}". ` +
-        `The ${connectionName} backend's connection details (e.g. PG_TEST_URL / ` +
-        `MYSQL_TEST_URL) are not set, so the run would silently fall back to SQLite.`,
+        `"${connectionName}" (adapter "${connection.adapter}"), but its connection ` +
+        `details (PG_TEST_URL / MYSQL_TEST_URL) are not set, so the run would ` +
+        `silently fall back to SQLite.`,
     );
   }
 
-  return { adapter: adapterName(envConfig), envConfig };
+  return { adapter: connection.lane, envConfig };
 }
 
 /**


### PR DESCRIPTION
## What

Converges test-backend resolution onto Rails' model. `test-database-config.ts`
now resolves the backend from a `config.yml`-style **named-connections map**
keyed purely by `ARCONN` (falling back to a `default_connection`), mirroring
`vendor/rails/activerecord/test/support/connection.rb:10,14-19,35-37` and
`vendor/rails/activerecord/test/config.example.yml` — instead of sniffing
`PG_TEST_URL` / `MYSQL_TEST_URL` presence to pick the adapter.

- Unconfigured `ARCONN` name → loud "Connection ... not found" failure
  (Rails' `fetch { ... exit 1 }`).
- A live-backend name whose connection details are absent resolves to SQLite,
  whose adapter is not a substring of the connection name → Rails'
  adapter-mismatch `ArgumentError`. **PR #4768's silent-fallback guard folds
  into this.**
- `ENV` feeds only sub-settings, never selects the backend.

Tests cover named-connection resolution (sqlite3 / sqlite3_mem / postgresql /
mysql2), `default_connection` fallback, unconfigured-name failure, and the
adapter-mismatch raise.

## Scope

This is the **foundation PR** the story calls for: it lands the `config.yml`
shape + `ARCONN` selector. `*_TEST_URL` remains the connection-detail source
for the postgresql/mysql2 entries here — ripping it out across the whole
harness (`test-adapter.ts`, `test-setup-worker-db.ts`, `template-global-setup.ts`,
`arunit2-config.ts`, `vitest.config.ts`, CI) is one coordinated change that
cannot be split into non-overlapping files while keeping CI green, so it is
registered as a follow-up story
(`remove-test-url-sniffing-migrate-ci-onto-sub-settings`).

Closes-story: converge-test-backend-resolution-onto-rails-config-yml