### PR TITLE
refactor(attributes): resolve type_for_attribute through attribute_types

### DIFF
--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -101,7 +101,6 @@ import {
   decorateAttributes,
   pendingAttributeModifications as _pendingAttributeModificationsHelper,
   resetDefaultAttributesBang as _resetDefaultAttributesBangHelper,
-  resetDefaultAttributes as _resetDefaultAttributesHelper,
   resolveAttributeName as _resolveAttributeNameHelper,
   resolveTypeName as _resolveTypeNameHelper,
   hookAttributeType as _hookAttributeTypeHelper,
@@ -405,8 +404,10 @@ export class Model {
       this.decorateAttributes([attr], this._normalizationDecorator(attr));
     }
     // AR reflects columns after the class body runs, so at declaration time the
-    // decorate above no-ops on a not-yet-reflected column. `applyPendingNormalizations`
-    // re-runs once the column appears (wired next to `applyPendingEncryptions`).
+    // immediate `_attributeDefinitions` apply above no-ops on a not-yet-reflected
+    // column — but `decorateAttributes` also pushed a durable pending decorator
+    // that replays on every `_defaultAttributes` rebuild, so the reflected column
+    // is decorated in the default attribute set that `type_for_attribute` reads.
 
     // Rails' ActiveRecord::Normalization registers
     // `before_validation :normalize_changed_in_place_attributes` at include
@@ -460,9 +461,9 @@ export class Model {
   }
 
   /**
-   * Build the idempotent NormalizedValueType decorator for `name`. Reused by
-   * `normalizes` (immediate apply + pending replay) and `applyPendingNormalizations`
-   * (post-reflection). The `_normalizations` entry object is the identity token:
+   * Build the idempotent NormalizedValueType decorator for `name`, used by
+   * `normalizes` (immediate apply + durable pending replay via `decorateAttributes`).
+   * The `_normalizations` entry object is the identity token:
    * a decorator returns `null` (no change) when the cast type is already wrapped
    * with the SAME entry, and unwraps+rewraps when a different/older one is found
    * (so subclass stacking replaces the parent's wrap with the fuller combined set).
@@ -485,45 +486,6 @@ export class Model {
       };
       return normalizedValueType(base, normalizer, entry.applyToNil, entry);
     };
-  }
-
-  /**
-   * Re-apply normalization decorators onto `_attributeDefinitions` once columns
-   * are reflected — the query-side lookup (`type_for_attribute`, `TypeCaster::Map`)
-   * reads that store. Mirrors AR's `applyPendingEncryptions` replay.
-   *
-   * Unlike `normalizes` this mutates `_attributeDefinitions` DIRECTLY rather than
-   * routing through `decorateAttributes`: the durable `PendingDecorator` that
-   * `normalizes` already pushed replays on every `_defaultAttributes` rebuild, so
-   * pushing another one here would grow `_pendingAttributeModifications` without
-   * bound each time a schema reload resets a column's type back to raw. The
-   * `_normalizationDecorator` token guard keeps this idempotent and no-op once the
-   * stored type already carries the decoration.
-   *
-   * @internal
-   */
-  static applyPendingNormalizations(): void {
-    if (!this._normalizations || this._normalizations.size === 0) return;
-    const defs = this._attributeDefinitions;
-    if (!defs) return;
-    let mutated = false;
-    for (const [name, entry] of this._normalizations) {
-      const def = defs.get(name);
-      if (!def) continue; // column not reflected yet; re-invoked once it appears
-      if (normalizedValueToken(def.type) === entry) continue; // already applied
-      const newType = this._normalizationDecorator(name)(name, def.type);
-      if (!newType) continue; // decorator declined (already decorated by this entry)
-      if (!Object.prototype.hasOwnProperty.call(this, "_attributeDefinitions")) {
-        this._attributeDefinitions = new Map(defs);
-      }
-      this._attributeDefinitions.set(name, { ...def, type: newType });
-      mutated = true;
-    }
-    // Invalidate the cached default AttributeSet (and subclasses') so the next
-    // rebuild seeds from the freshly-decorated `_attributeDefinitions`.
-    if (mutated) {
-      _resetDefaultAttributesHelper(this as unknown as AttributeHostInternals);
-    }
   }
 
   /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -330,10 +330,7 @@ import {
   writeStoreAttributeMethod as _writeStoreAttributeMethod,
   storeAccessorForMethod as _storeAccessorForMethod,
 } from "./store.js";
-import {
-  serialize as _serializeAttribute,
-  applyPendingSerializations as _applyPendingSerializations,
-} from "./serialize.js";
+import { serialize as _serializeAttribute } from "./serialize.js";
 import { YAMLColumn as _YAMLColumn } from "./coders/yaml-column.js";
 
 // Break store→serialize→json→store circular dep by injecting serialize into store at init.
@@ -1183,9 +1180,15 @@ export class Base extends Model {
     if (name === "id" && Object.prototype.hasOwnProperty.call(this.prototype, "id")) {
       delete (this.prototype as any).id;
     }
+    // Encryption still needs a post-reflection pass: `registerEncryptedType`
+    // defers pushing its `decorateAttributes` decorator until the column is
+    // reflected (it threads the column default into the EncryptedAttributeType),
+    // and this hook also installs the frozen-encryption validator / column-size
+    // checks. `normalizes` / `serialize` push their durable decorator eagerly at
+    // declaration, so — now that `type_for_attribute` / `TypeCaster::Map` resolve
+    // through `attribute_types` (the decorated default attribute set) — they need
+    // no per-feature `_attributeDefinitions` replay here.
     encryptionHooks.applyPendingEncryptions(this);
-    this.applyPendingNormalizations();
-    _applyPendingSerializations(this as unknown as typeof Base);
   }
 
   /**
@@ -1219,7 +1222,12 @@ export class Base extends Model {
     // Rails raises inside enum's `decorate_attributes` block for an enum backed
     // by neither a DB column nor an explicit `attribute` type.
     _EnumModule.assertEnumTypeDeclared(this as unknown as typeof Base, resolved);
-    return (this._attributeDefinitions as any)?.get(resolved)?.type ?? typeRegistry.lookup("value");
+    // Resolve through the decorated default attribute set (`attribute_types`),
+    // mirroring Rails `type_for_attribute` (attribute_registration.rb:43-50).
+    // The set replays every pending decorator (serialize/normalizes/encrypts)
+    // onto the reflected column type, so query-side decorations are honored
+    // without a per-feature post-reflection replay onto `_attributeDefinitions`.
+    return this.attributeTypes()[resolved] ?? typeRegistry.lookup("value");
   }
 
   /**

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -31,7 +31,6 @@ import {
   Model,
   MissingAttributeError,
   Type,
-  typeRegistry,
   pushPendingDecorator,
   type AttributeOptions,
   type TransactionalCallbackConditions,
@@ -1222,12 +1221,16 @@ export class Base extends Model {
     // Rails raises inside enum's `decorate_attributes` block for an enum backed
     // by neither a DB column nor an explicit `attribute` type.
     _EnumModule.assertEnumTypeDeclared(this as unknown as typeof Base, resolved);
-    // Resolve through the decorated default attribute set (`attribute_types`),
-    // mirroring Rails `type_for_attribute` (attribute_registration.rb:43-50).
-    // The set replays every pending decorator (serialize/normalizes/encrypts)
-    // onto the reflected column type, so query-side decorations are honored
-    // without a per-feature post-reflection replay onto `_attributeDefinitions`.
-    return this.attributeTypes()[resolved] ?? typeRegistry.lookup("value");
+    // Resolve through the decorated default attribute set — Rails'
+    // `attribute_types[name]` is `_default_attributes.cast_types[name]` with a
+    // `Type.default_value` hash default (attribute_registration.rb:43-50). The set
+    // replays every pending decorator (serialize/normalizes/encrypts) onto the
+    // reflected column type, so query-side decorations are honored without a
+    // per-feature post-reflection replay onto `_attributeDefinitions`. Read the
+    // single attribute (O(1), and `getAttribute` returns a `value`-typed Null for
+    // an unknown name) rather than `attributeTypes()`, which rebuilds the whole
+    // cast-types record + Proxy on every call — this is a hot per-bind path.
+    return this._defaultAttributes().getAttribute(resolved).type;
   }
 
   /**

--- a/packages/activerecord/src/model-schema.ts
+++ b/packages/activerecord/src/model-schema.ts
@@ -24,7 +24,6 @@ import { modelRegistry } from "./associations.js";
 import { realPool } from "./connection-adapters/abstract/connection-pool.js";
 import { TableNotSpecified } from "./errors.js";
 import { encryptionHooks } from "./encryption-hooks.js";
-import { applyPendingSerializations } from "./serialize.js";
 import { isWrappedType } from "./encryption/wrapped-type.js";
 import { FakePool, SchemaReflection } from "./connection-adapters/schema-cache.js";
 import { threadedConnectionFor, connectionPool } from "./connection-handling.js";
@@ -1147,12 +1146,12 @@ function applyColumnsHash(
   invalidate(host, { deleteOwn: false });
   if (originatingHost && originatingHost !== host) invalidate(originatingHost, { deleteOwn: true });
 
+  // Encryption still needs a post-reflection pass (`registerEncryptedType`
+  // defers pushing its decorator until the column reflects, to thread the column
+  // default). `normalizes` / `serialize` push their durable decorator eagerly, so
+  // — now that `type_for_attribute` / `TypeCaster::Map` resolve through
+  // `attribute_types` — no per-feature `_attributeDefinitions` replay is needed.
   encryptionHooks.applyPendingEncryptions(host);
-  // Re-apply normalization decorators now that columns are reflected, so the
-  // query-side type lookup (`type_for_attribute` / `TypeCaster::Map`) sees the
-  // decorated cast type. Mirrors the `applyPendingEncryptions` replay above.
-  (host as { applyPendingNormalizations?(): void }).applyPendingNormalizations?.();
-  applyPendingSerializations(host as unknown as typeof Base);
 
   // Now the DB column set is authoritative: re-run the ignoreCase
   // `original_<name>` requirement so a genuinely absent column raises even when
@@ -1189,8 +1188,6 @@ function applyColumnsHash(
     }
     originatingHost._attributeDefinitions = baseDefs;
     encryptionHooks.applyPendingEncryptions(originatingHost);
-    (originatingHost as { applyPendingNormalizations?(): void }).applyPendingNormalizations?.();
-    applyPendingSerializations(originatingHost as unknown as typeof Base);
     // Recompute the reflected column set against the subclass's own
     // `ignoredColumns` — an STI subclass may ignore a different set than its
     // base, so reusing the base's `reflectedColumnNames` could check against the

--- a/packages/activerecord/src/serialize.ts
+++ b/packages/activerecord/src/serialize.ts
@@ -1,5 +1,5 @@
 import type { Base } from "./base.js";
-import { type Type, ArgumentError, resetDefaultAttributes } from "@blazetrails/activemodel";
+import { type Type, ArgumentError } from "@blazetrails/activemodel";
 import { Json } from "./type/json.js";
 import { Serialized, type Coder } from "./type/serialized.js";
 import {
@@ -164,81 +164,10 @@ export function serialize(
     return new Serialized(subtype, coder);
   };
 
-  // Track the coder so `applyPendingSerializations` can re-wrap the reflected DB
-  // type once columns load: `decorateAttributes` replays into the default
-  // attribute set, but the raw `_attributeDefinitions` store that
-  // `type_for_attribute` / `TypeCaster::Map` read is only decorated for columns
-  // already reflected at declaration time. Without the replay a `serialize`d
-  // column resolves to its bare DB type on the query side, so `where` binds the
-  // un-encoded value instead of the coder's payload. Mirrors AR's
-  // `applyPendingNormalizations` / `applyPendingEncryptions` post-reflection hooks.
-  registerColumnSerializer(modelClass, attribute, coder, decorator);
-
+  // `decorateAttributes` pushes a durable pending decorator that replays on every
+  // `_defaultAttributes` rebuild, so the query-side lookup (`type_for_attribute` /
+  // `TypeCaster::Map`), which now resolves through `attribute_types` (the decorated
+  // default attribute set), sees the `Serialized` cast type once columns reflect —
+  // no per-feature `_attributeDefinitions` replay needed.
   modelClass.decorateAttributes([attribute], decorator);
-}
-
-interface SerializerEntry {
-  coder: Coder;
-  decorator: (name: string, castType: Type) => Type;
-}
-
-function columnSerializers(modelClass: typeof Base): Map<string, SerializerEntry> {
-  const cls = modelClass as unknown as { _columnSerializers?: Map<string, SerializerEntry> };
-  // Fork per-class (copying the parent's entries) so a subclass `serialize` never
-  // mutates the shared base map — mirrors `_normalizations`' own-property guard.
-  if (!Object.prototype.hasOwnProperty.call(modelClass, "_columnSerializers")) {
-    const parent = Object.getPrototypeOf(modelClass) as {
-      _columnSerializers?: Map<string, SerializerEntry>;
-    };
-    cls._columnSerializers = new Map(parent?._columnSerializers ?? undefined);
-  }
-  return cls._columnSerializers!;
-}
-
-function registerColumnSerializer(
-  modelClass: typeof Base,
-  attribute: string,
-  coder: Coder,
-  decorator: (name: string, castType: Type) => Type,
-): void {
-  columnSerializers(modelClass).set(attribute, { coder, decorator });
-}
-
-/**
- * Re-apply serialize decorators onto `_attributeDefinitions` once columns are
- * reflected, so the query-side lookup (`type_for_attribute`, `TypeCaster::Map`)
- * sees the `Serialized` cast type. Mirrors AR's `applyPendingNormalizations`
- * replay — mutates `_attributeDefinitions` directly rather than routing through
- * `decorateAttributes` (whose durable pending decorator already replays on every
- * `_defaultAttributes` rebuild). The coder-identity guard keeps it idempotent.
- *
- * @internal
- */
-export function applyPendingSerializations(modelClass: typeof Base): void {
-  const cls = modelClass as unknown as {
-    _columnSerializers?: Map<string, SerializerEntry>;
-    _attributeDefinitions?: Map<string, { name: string; type: Type }>;
-  };
-  const serializers = cls._columnSerializers;
-  if (!serializers || serializers.size === 0) return;
-  const defs = cls._attributeDefinitions;
-  if (!defs) return;
-  let mutated = false;
-  for (const [name, entry] of serializers) {
-    const def = defs.get(name);
-    if (!def) continue; // column not reflected yet; re-invoked once it appears
-    // The decorator returns the same type reference when it's already wrapped by
-    // this coder (idempotency guard), so this both no-ops the applied case and
-    // re-wraps a freshly-reflected raw column.
-    const newType = entry.decorator(name, def.type);
-    if (newType === def.type) continue;
-    if (!Object.prototype.hasOwnProperty.call(modelClass, "_attributeDefinitions")) {
-      cls._attributeDefinitions = new Map(defs);
-    }
-    cls._attributeDefinitions!.set(name, { ...def, type: newType });
-    mutated = true;
-  }
-  if (mutated) {
-    resetDefaultAttributes(modelClass as any);
-  }
 }

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -39,20 +39,16 @@ export class Map {
   private _baseTypeForAttribute(name: string): Type {
     const klass = this._klass;
 
-    // Resolve through the decorated default attribute set (`attribute_types`),
-    // mirroring Rails `type_for_attribute` (attribute_registration.rb:43-50): it
-    // replays every pending decorator (serialize/normalizes/encrypts) onto the
-    // reflected column type, so query-side decorations are honored without a
-    // per-feature post-reflection replay onto `_attributeDefinitions`.
+    // Resolve through the decorated default attribute set — Rails'
+    // `attribute_types[name]` (attribute_registration.rb:43-50) — so pending
+    // decorators (serialize/normalizes/encrypts) are honored on the query side
+    // without a per-feature post-reflection replay onto `_attributeDefinitions`.
+    // Read the single attribute (O(1), `getAttribute` returns a `value`-typed Null
+    // for an unknown name) rather than the whole `attributeTypes()` record + Proxy
+    // — this runs once per predicate-builder bind.
     const resolved = klass._attributeAliases?.[name] ?? name;
-    const attributeTypes =
-      typeof klass.attributeTypes === "function" ? klass.attributeTypes() : klass.attributeTypes;
-    if (attributeTypes) {
-      const type =
-        attributeTypes instanceof globalThis.Map
-          ? attributeTypes.get(resolved)
-          : attributeTypes[resolved];
-      if (type) return type as Type;
+    if (typeof klass._defaultAttributes === "function") {
+      return klass._defaultAttributes().getAttribute(resolved).type as Type;
     }
 
     return new ValueType();

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -30,25 +30,25 @@ export class Map {
   }
 
   typeForAttribute(name: string): Type {
-    // The resolved type already carries any NormalizedValueType decoration:
-    // `normalizes` decorates the attribute's cast type in `_attributeDefinitions`
-    // (single read+write decoration path), so no query-side re-wrap is needed.
+    // The resolved type already carries every decoration (NormalizedValueType,
+    // Serialized, EncryptedAttributeType): `_baseTypeForAttribute` delegates to
+    // `klass.typeForAttribute`, which resolves through the decorated default
+    // attribute set, so no query-side re-wrap is needed.
     return this._baseTypeForAttribute(name);
   }
 
   private _baseTypeForAttribute(name: string): Type {
     const klass = this._klass;
 
-    // Resolve through the decorated default attribute set — Rails'
-    // `attribute_types[name]` (attribute_registration.rb:43-50) — so pending
-    // decorators (serialize/normalizes/encrypts) are honored on the query side
-    // without a per-feature post-reflection replay onto `_attributeDefinitions`.
-    // Read the single attribute (O(1), `getAttribute` returns a `value`-typed Null
-    // for an unknown name) rather than the whole `attributeTypes()` record + Proxy
-    // — this runs once per predicate-builder bind.
-    const resolved = klass._attributeAliases?.[name] ?? name;
-    if (typeof klass._defaultAttributes === "function") {
-      return klass._defaultAttributes().getAttribute(resolved).type as Type;
+    // Rails' `TypeCaster::Map#type_for_attribute` is a one-line delegation to
+    // `klass.type_for_attribute(name)` (type_caster/map.rb:15-16). Delegating gets
+    // alias resolution, the enum `assertEnumTypeDeclared` guard, and the decorated
+    // default attribute set (`attribute_types`) for free — so pending decorators
+    // (serialize/normalizes/encrypts) are honored on the query side without a
+    // per-feature post-reflection replay onto `_attributeDefinitions`. `ValueType`
+    // is the fallback for non-model `klass` shapes lacking `typeForAttribute`.
+    if (typeof klass.typeForAttribute === "function") {
+      return klass.typeForAttribute(name) as Type;
     }
 
     return new ValueType();

--- a/packages/activerecord/src/type-caster/map.ts
+++ b/packages/activerecord/src/type-caster/map.ts
@@ -39,34 +39,20 @@ export class Map {
   private _baseTypeForAttribute(name: string): Type {
     const klass = this._klass;
 
-    // Prefer O(1) lookup via _attributeDefinitions (avoids building full attributeTypes object)
-    const attributeDefinitions = klass._attributeDefinitions;
-    if (attributeDefinitions) {
-      const definition =
-        attributeDefinitions instanceof globalThis.Map
-          ? attributeDefinitions.get(name)
-          : attributeDefinitions?.[name];
-      if (definition) {
-        const type =
-          typeof definition === "object" && definition !== null && "type" in definition
-            ? definition.type
-            : definition;
-        if (type) return type as Type;
-      }
-    }
-
-    // Fallback to attributeTypes (builds full object, O(n))
+    // Resolve through the decorated default attribute set (`attribute_types`),
+    // mirroring Rails `type_for_attribute` (attribute_registration.rb:43-50): it
+    // replays every pending decorator (serialize/normalizes/encrypts) onto the
+    // reflected column type, so query-side decorations are honored without a
+    // per-feature post-reflection replay onto `_attributeDefinitions`.
+    const resolved = klass._attributeAliases?.[name] ?? name;
     const attributeTypes =
       typeof klass.attributeTypes === "function" ? klass.attributeTypes() : klass.attributeTypes;
     if (attributeTypes) {
       const type =
-        attributeTypes instanceof globalThis.Map ? attributeTypes.get(name) : attributeTypes[name];
+        attributeTypes instanceof globalThis.Map
+          ? attributeTypes.get(resolved)
+          : attributeTypes[resolved];
       if (type) return type as Type;
-    }
-
-    // Instance-level lookup fallback
-    if (typeof klass.typeForAttribute === "function") {
-      return klass.typeForAttribute(name);
     }
 
     return new ValueType();


### PR DESCRIPTION
## What

Route `Base.typeForAttribute` and `TypeCaster::Map` through the decorated
default attribute set (`attribute_types`), mirroring Rails' `type_for_attribute`
(`activemodel/lib/active_model/attribute_registration.rb:43-50`). Because the
attribute set replays every pending `decorateAttributes` decorator onto the
reflected column type, `serialize` / `normalizes` decorations are honored on the
query side without a per-feature post-reflection replay onto
`_attributeDefinitions`.

## Changes

- `Base.typeForAttribute` / `TypeCaster::Map._baseTypeForAttribute` resolve
  `attribute_types[name]` instead of reading the raw `_attributeDefinitions`
  store.
- Retire `applyPendingNormalizations` and `applyPendingSerializations` (plus the
  `_columnSerializers` tracking that only fed the serialize replay) and their
  reflection-site call sites in `base.ts` / `model-schema.ts`.
- `normalizes` / `serialize` push their durable pending decorator eagerly at
  declaration, so the reflected column is decorated in the default attribute set
  with no extra replay.

## Kept

Encryption retains its `applyPendingEncryptions` post-reflection pass:
`registerEncryptedType` deliberately defers pushing its `decorateAttributes`
decorator until the column is reflected (it threads the true column default into
the `EncryptedAttributeType`), and the hook also installs the frozen-encryption
validator / column-size checks — so it does more than a query-side replay.

## Enum

Enum where/create round-tripping is preserved: the reflected `EnumType` lives in
the attribute set and serves both the cast and serialize paths, so the
`Map`/`Connection` split (`type-caster/map.ts:17-35`) is unaffected.

## Tests

enum, enum.trails, serialized-attribute, normalized-attribute, encryption
(encryptable-record, extended-deterministic-queries, schemes, unencrypted,
hooks), type-caster/connection, attribute-registration, attributes,
attribute-methods, relation/where — all green locally. Full suite runs in CI.

Closes-story: converge-type-for-attribute-through-attribute-types
