### PR TITLE
fix(enum): resolve inherited enum predicate against the record's runtime class

### DIFF
--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -805,6 +805,10 @@ describe("EnumTest", () => {
   // the replayed superclass decorator resolves against the subclass's own
   // columns (books.nullable_status), so no false raise and — crucially — no
   // `TableNotSpecified` from routing the predicate through the abstract parent.
+  // The generated `is{Value}()` predicate must serialize through the *record's*
+  // class, not the abstract parent it was declared on (which has no table): this
+  // is the `Lion < abstract Cat` case, exercised here with a canonical books
+  // column since `lions` has no registered fixture set.
   it("enum on abstract parent materializes green against a backing subclass column", () => {
     class AbstractParent extends Base {
       static {
@@ -819,8 +823,13 @@ describe("EnumTest", () => {
 
     expect(() => (Backed as any)._defaultAttributes()).not.toThrow();
     const record = new (Backed as any)({ nullable_status: "married" });
+    // The predicate (`castEnumValue` on the record's own class) must not route
+    // through the abstract parent's tableless schema. Pre-fix this raised
+    // `TableNotSpecified: AbstractParent has no table configured`.
+    expect(() => record.isMarried()).not.toThrow();
     expect(record.isMarried()).toBe(true);
     expect(record.isSingle()).toBe(false);
+    expect(record.nullable_status).toBe("married");
   });
 
   it("query state by predicate with prefix", () => {

--- a/packages/activerecord/src/enum.test.ts
+++ b/packages/activerecord/src/enum.test.ts
@@ -774,6 +774,55 @@ describe("EnumTest", () => {
     );
   });
 
+  // The inherited-enum raise must also fire through the create/materialization
+  // path — not only `type_for_attribute`. Rails replays a superclass's pending
+  // `decorate_attributes` block into the concrete subclass's attribute set
+  // (attribute_registration.rb:81-87), so the enum block runs and raises
+  // `Undeclared attribute type for enum` while `_default_attributes`
+  // materializes. Constructing a record (or bare `_defaultAttributes()`) is
+  // enough; no prior `type_for_attribute` lookup is required.
+  it("enum on abstract parent raises through subclass materialization", () => {
+    class AbstractParent extends Base {
+      static {
+        this._abstractClass = true;
+        this.enum("typeless_genre", ["adventure", "comic"] as any);
+      }
+    }
+    class Concrete extends AbstractParent {
+      static _tableName = "books"; // books has no `typeless_genre` column
+    }
+    registerModel(Concrete);
+
+    expect(() => (Concrete as any)._defaultAttributes()).toThrow(
+      /Undeclared attribute type for enum 'typeless_genre' in Concrete/,
+    );
+    expect(() => new (Concrete as any)({})).toThrow(
+      /Undeclared attribute type for enum 'typeless_genre' in Concrete/,
+    );
+  });
+
+  // A concrete subclass that DOES back the inherited enum materializes cleanly:
+  // the replayed superclass decorator resolves against the subclass's own
+  // columns (books.nullable_status), so no false raise and — crucially — no
+  // `TableNotSpecified` from routing the predicate through the abstract parent.
+  it("enum on abstract parent materializes green against a backing subclass column", () => {
+    class AbstractParent extends Base {
+      static {
+        this._abstractClass = true;
+        this.enum("nullable_status", ["single", "married"] as any);
+      }
+    }
+    class Backed extends AbstractParent {
+      static _tableName = "books"; // books.nullable_status is an integer column
+    }
+    registerModel(Backed);
+
+    expect(() => (Backed as any)._defaultAttributes()).not.toThrow();
+    const record = new (Backed as any)({ nullable_status: "married" });
+    expect(record.isMarried()).toBe(true);
+    expect(record.isSingle()).toBe(false);
+  });
+
   it("query state by predicate with prefix", () => {
     expect((book as any).isAuthorVisibilityVisible()).toBe(true);
     expect((book as any).isAuthorVisibilityInvisible()).toBe(false);

--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -440,7 +440,15 @@ export class EnumMethods {
           // label, so serialize the stored label back to its database value
           // (via castEnumValue) and compare. Robust on fresh/unsaved records
           // where the raw `valueForDatabase` attribute path isn't wired yet.
-          return castEnumValue(klass, name, this.readAttribute(name)) === value;
+          //
+          // Resolve against the record's runtime class, not the captured
+          // declaring `klass`: an enum declared on an abstract parent (e.g.
+          // `Cat.enum :gender`) must serialize against the concrete subclass's
+          // columns (`Lion`), mirroring Rails' `type_for_attribute` on the
+          // record's own class. Keying off `klass` would send an abstract
+          // parent through `columnForAttribute`, raising `TableNotSpecified`.
+          const recordClass = (this as unknown as { constructor: typeof Base }).constructor;
+          return castEnumValue(recordClass, name, this.readAttribute(name)) === value;
         },
         writable: true,
         configurable: true,


### PR DESCRIPTION
## Summary

An enum declared on an abstract parent (e.g. `Cat.enum :gender`) captured the **declaring** class in its generated `is{Value}()` predicate. A concrete subclass's `isFemale()` therefore serialized through the tableless abstract parent's `columnForAttribute`, raising `TableNotSpecified`. The fix resolves `castEnumValue` against the **record's own runtime class** instead — mirroring Rails, which replays the superclass `decorate_attributes` block into the subclass attribute set (attribute_registration.rb:81-87) so the subclass's columns back the enum. `readEnumValue` already resolved via `record.constructor`; the predicate now matches.

## Materialization-path coverage

The inherited-enum raise already fires through `_default_attributes` on `main`, but was only tested via `type_for_attribute`. Added regression tests exercising the create/materialization path directly:

- A concrete subclass whose abstract parent declares a **typeless** enum raises `Undeclared attribute type for enum` on `_defaultAttributes()` / `new` — no prior `type_for_attribute` lookup required.
- A concrete subclass that **backs** the inherited enum (books.nullable_status) materializes green — no false raise, no `TableNotSpecified` (this is the case the predicate fix repairs).

## Test plan

- `pnpm vitest run packages/activerecord/src/enum.test.ts packages/activerecord/src/enum.trails.test.ts` — 131 passed
- `pnpm vitest run packages/activerecord/src/scoping/default-scoping.test.ts` — 97 passed (Lion enum predicates unaffected)

Closes-story: inherited-enum-decorator-replays-into-subclass-materialization