### PR TITLE
refactor(delegation): model-agnostic delegator + STI carrier module inheritance

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -3314,7 +3314,7 @@ function wrapCollectionProxy<T extends Base = Base>(
       const modelClass = target.model;
       const classMethod = modelClass[prop];
       if (typeof classMethod === "function") {
-        const delegator = classMethodDelegator(modelClass, prop, classMethod);
+        const delegator = classMethodDelegator(prop);
         if (!uncacheableMethods().has(prop)) {
           generateRelationMethod(modelClass, prop, delegator);
         }

--- a/packages/activerecord/src/relation/delegation.trails.test.ts
+++ b/packages/activerecord/src/relation/delegation.trails.test.ts
@@ -19,6 +19,7 @@ import {
 } from "./delegation.js";
 import { Post } from "../test-helpers/models/post.js";
 import { Comment } from "../test-helpers/models/comment.js";
+import { Company, Firm } from "../test-helpers/models/company.js";
 // Loading these registers each delegate class with the relation family so the
 // carrier resolvers find their base ctor and `uncacheableMethods()` sees the
 // subclass-only methods (`target`, …).
@@ -126,6 +127,28 @@ describe("generated relation methods — remaining delegate-class carriers", () 
       "DisableJoinsAssociationRelation",
     );
     expect(collectionProxyClassFor(Post as never).name).toBe("CollectionProxy");
+  });
+
+  it("inherits an STI base model's generated module onto the child carrier (include_relation_methods recursion)", () => {
+    // Rails' `include_relation_methods` recurses up the STI chain
+    // (`superclass.include_relation_methods(delegate) unless base_class?`,
+    // delegation.rb:57-60): a method generated on the base model (`Company`)
+    // must be a real method on the child (`Firm`) carrier's prototype — resolved
+    // by ordinary prototype lookup, not re-derived via the Proxy miss path.
+    // `Firm extends Company`; `Company` is the STI base_class.
+    generateRelationMethod(Company as never, "stiBaseGenerated", () => "base");
+    const firmCarrier = relationClassFor(Firm as never).prototype as Record<string, unknown>;
+    expect(Object.prototype.hasOwnProperty.call(firmCarrier, "stiBaseGenerated")).toBe(true);
+    expect((firmCarrier.stiBaseGenerated as () => string)()).toBe("base");
+  });
+
+  it("lets a child model's own generated method win over an inherited one", () => {
+    // Rails includes super first, own last, so an own generated method shadows
+    // an inherited one of the same name (`stiCarrierChain` returns base-first).
+    generateRelationMethod(Company as never, "stiOverridden", () => "base");
+    generateRelationMethod(Firm as never, "stiOverridden", () => "child");
+    const firmCarrier = relationClassFor(Firm as never).prototype as Record<string, unknown>;
+    expect((firmCarrier.stiOverridden as () => string)()).toBe("child");
   });
 
   it("gives distinct models distinct carriers per delegate class (no cross-model leakage)", () => {

--- a/packages/activerecord/src/relation/delegation.trails.test.ts
+++ b/packages/activerecord/src/relation/delegation.trails.test.ts
@@ -143,12 +143,18 @@ describe("generated relation methods — remaining delegate-class carriers", () 
   });
 
   it("lets a child model's own generated method win over an inherited one", () => {
-    // Rails includes super first, own last, so an own generated method shadows
-    // an inherited one of the same name (`stiCarrierChain` returns base-first).
-    generateRelationMethod(Company as never, "stiOverridden", () => "base");
+    // Rails' ancestor-chain MRO puts the child module before the ancestor, so an
+    // own generated method shadows an inherited one of the same name. The win is
+    // *structural* (per-carrier module priority), NOT temporal: generate the
+    // child's fn FIRST, then the ancestor's — the reverse order that a naive
+    // last-write-wins carrier would get wrong — and the child must still win.
     generateRelationMethod(Firm as never, "stiOverridden", () => "child");
+    generateRelationMethod(Company as never, "stiOverridden", () => "base");
     const firmCarrier = relationClassFor(Firm as never).prototype as Record<string, unknown>;
     expect((firmCarrier.stiOverridden as () => string)()).toBe("child");
+    // The base carrier (Company) only sees its own module, so it resolves "base".
+    const companyCarrier = relationClassFor(Company as never).prototype as Record<string, unknown>;
+    expect((companyCarrier.stiOverridden as () => string)()).toBe("base");
   });
 
   it("gives distinct models distinct carriers per delegate class (no cross-model leakage)", () => {

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -372,23 +372,44 @@ function perModelCarrier(
       configurable: true,
     });
     cache.set(modelClass, subclass);
-    // Only the model's OWN generated module is included — deliberately NOT the
-    // Rails `include_relation_methods` superclass recursion
+    // Mirror Rails' `include_relation_methods` superclass recursion
     // (`superclass.include_relation_methods(delegate) unless base_class?`,
-    // delegation.rb:57-60). Rails can safely inherit an ancestor's generated
-    // module because its generated body is model-agnostic — `def m(...); scoping
-    // { model.m(...) }; end` reads `self.model` dynamically (delegation.rb:76-88).
-    // trails' delegator instead CAPTURES a specific `modelClass` + bound class
-    // method and scopes/guards that captured model (`classMethodDelegator`), so
-    // installing a parent model's delegator onto an STI child carrier would
-    // dispatch to the parent model — wrong scope and wrong STI type-condition.
-    // The child instead re-derives a correctly-bound delegator onto its own
-    // module via the `Proxy` miss path (keyed by the relation's real
-    // `_modelClass`), yielding identical observable behavior to Rails at the cost
-    // of one extra miss-path pass per (subclass, method).
-    includeRelationMethods(subclass.prototype, generatedRelationMethods(modelClass));
+    // delegation.rb:57-60): include each STI ancestor model's generated module
+    // (from `base_class` down) and finally the model's OWN module. Rails walks
+    // super first, then includes own last, so an own generated method wins over
+    // an inherited one; `stiCarrierChain` returns the chain base_class-first to
+    // preserve that order. This is safe because the generated delegator is now
+    // model-agnostic (`classMethodDelegator` reads the relation's live
+    // `_modelClass` at call time), so an ancestor's module installed onto an STI
+    // child carrier still dispatches to the child (child scope + child STI
+    // type-condition) — inherited generated methods resolve by ordinary
+    // prototype lookup instead of re-entering the `Proxy` miss path per
+    // subclass.
+    for (const ancestor of stiCarrierChain(modelClass)) {
+      includeRelationMethods(subclass.prototype, generatedRelationMethods(ancestor));
+    }
   }
   return subclass;
+}
+
+/**
+ * The STI ancestor chain of generated-module owners for a model, ordered
+ * `base_class`-first through the model itself. Mirrors the recursion in Rails'
+ * `DelegateCache#include_relation_methods` (delegation.rb:57-60), which walks
+ * Ruby superclasses up to (and stopping at) `base_class`. Each element's
+ * `generatedRelationMethods` module is `include`d into a child carrier so an
+ * STI child inherits every ancestor's generated relation methods.
+ */
+function stiCarrierChain(modelClass: typeof Base): (typeof Base)[] {
+  const chain: (typeof Base)[] = [];
+  let current: typeof Base | null = modelClass;
+  while (current) {
+    chain.push(current);
+    if (current.isBaseClass()) break;
+    const parent = Object.getPrototypeOf(current) as unknown;
+    current = typeof parent === "function" ? (parent as typeof Base) : null;
+  }
+  return chain.reverse();
 }
 
 /**
@@ -467,22 +488,30 @@ export function generateRelationMethod(
 /**
  * Build the function that delegates a model class method through a relation /
  * collection-proxy scope — Rails' `ClassSpecificRelation#method_missing`
- * `scoping { @klass.public_send(method, ...) }` (delegation.rb:118-131). The
+ * `scoping { model.public_send(method, ...) }` (delegation.rb:118-131). The
  * `this` it's invoked with becomes the current scope for the call's duration:
  * sync results (a Relation) restore the prior scope immediately so the result
  * is directly chainable; async results (a Promise) defer restoration until the
  * promise settles, mirroring Rails' synchronous block-scoping across the body.
  *
+ * The delegator is **model-agnostic** (Rails' generated body is
+ * `def m(...); scoping { model.m(...) }; end`, delegation.rb:76-88): it reads
+ * the live model off the relation it's invoked on (`this._modelClass`) rather
+ * than capturing a specific `modelClass`, resolving and scoping that model's
+ * class method at call time. This is what lets a single delegator be correct on
+ * any model in an STI hierarchy — a parent model's generated module can be
+ * inherited down onto an STI child carrier and still dispatch to the child
+ * (child scope + child STI type-condition), matching Rails'
+ * `include_relation_methods` superclass recursion.
+ *
  * This is also what `generateRelationMethod` caches (delegation.rb:127-129) so
  * subsequent calls skip the proxy miss path.
  */
-export function classMethodDelegator(
-  modelClass: typeof Base,
-  prop: string,
-  classMethod: AnyCallable,
-): AnyCallable {
+export function classMethodDelegator(prop: string): AnyCallable {
   return function (this: any, ...args: any[]) {
+    const modelClass = this._modelClass as typeof Base;
     guardBaseMethodDelegation(modelClass, prop);
+    const classMethod = (modelClass as any)[prop] as AnyCallable;
     const prev = ScopeRegistry.currentScope(modelClass);
     ScopeRegistry.setCurrentScope(modelClass, this);
     let result: unknown;
@@ -709,7 +738,7 @@ export function wrapWithScopeProxy<T extends object>(rel: T): T {
       // mirroring Rails' synchronous block-scoping across the full body.
       const classMethod = (modelClass as any)[prop];
       if (typeof classMethod === "function") {
-        const delegator = classMethodDelegator(modelClass, prop, classMethod);
+        const delegator = classMethodDelegator(prop);
         // Cache the delegation so subsequent calls resolve through the
         // generated method above rather than re-running this proxy miss path
         // (delegation.rb:127-129) — except uncacheable methods (to_a/records/

--- a/packages/activerecord/src/relation/delegation.ts
+++ b/packages/activerecord/src/relation/delegation.ts
@@ -69,28 +69,61 @@ export interface ClassSpecificRelation {}
  *
  * Mirrors: ActiveRecord::Delegation::GeneratedRelationMethods
  */
+/**
+ * Per-carrier record of the highest module *priority* that has installed each
+ * method name, so a more-derived module's method structurally wins over a less-
+ * derived one regardless of `generate()` call order — mirroring Ruby's ancestor-
+ * chain MRO, where `Firm::GeneratedRelationMethods` precedes
+ * `Company::GeneratedRelationMethods` in `FirmDelegate.ancestors` independent of
+ * definition order. Without this, a late `generate()` on an ancestor module
+ * would silently clobber a child module's already-installed method on the shared
+ * carrier prototype (last-write-wins by time). Keyed by carrier prototype.
+ */
+const _carrierNamePriority = new WeakMap<object, Map<string, number>>();
+
+/**
+ * Install `fn` for `name` onto `carrier` only if `priority` is at least the
+ * priority of whatever module last claimed that name on this carrier. Higher
+ * priority = more-derived module (own wins over inherited); equal priority is a
+ * same-module re-`generate()` (latest fn wins). Lower priority (an ancestor
+ * writing after a child already claimed the name) is skipped.
+ */
+function installOnCarrier(carrier: object, name: string, fn: AnyCallable, priority: number): void {
+  let priorities = _carrierNamePriority.get(carrier);
+  if (!priorities) {
+    priorities = new Map();
+    _carrierNamePriority.set(carrier, priorities);
+  }
+  const existing = priorities.get(name);
+  if (existing !== undefined && priority < existing) return;
+  (carrier as Record<string, AnyCallable>)[name] = fn;
+  priorities.set(name, priority);
+}
+
 export class GeneratedRelationMethods {
   private _methods: Map<string, AnyCallable> = new Map();
-  private _carriers: object[] = [];
+  private _carriers: { carrier: object; priority: number }[] = [];
 
   generate(name: string, fn: AnyCallable): void {
     this._methods.set(name, fn);
-    for (const carrier of this._carriers) {
-      (carrier as Record<string, AnyCallable>)[name] = fn;
+    for (const { carrier, priority } of this._carriers) {
+      installOnCarrier(carrier, name, fn, priority);
     }
   }
 
   /**
-   * `include` this module into a delegate prototype carrier — install every
-   * already-generated method as a real own property and register the carrier so
-   * future {@link generate}s propagate to it. Mirrors Rails'
-   * `DelegateCache#include_relation_methods` (delegation.rb:57-60).
+   * `include` this module into a delegate prototype carrier at `priority` (its
+   * position in the carrier's STI module chain — higher = more derived): install
+   * every already-generated method as a real own property, respecting per-name
+   * priority, and register the carrier so future {@link generate}s propagate to
+   * it. Mirrors Rails' `DelegateCache#include_relation_methods`
+   * (delegation.rb:57-60).
    */
-  includeInto(carrier: object): void {
-    if (this._carriers.includes(carrier)) return;
-    this._carriers.push(carrier);
+  includeInto(carrier: object, priority: number): void {
+    if (this._carriers.some((entry) => entry.carrier === carrier)) return;
+    this._carriers.push({ carrier, priority });
     for (const [name, fn] of this._methods) {
-      (carrier as Record<string, AnyCallable>)[name] = fn;
+      installOnCarrier(carrier, name, fn, priority);
     }
   }
 
@@ -316,8 +349,12 @@ export function generatedRelationMethods(modelClass: typeof Base): GeneratedRela
  * `delegate.include generated_relation_methods` installs the per-model module's
  * generated methods as real methods on a delegate prototype carrier.
  */
-export function includeRelationMethods(carrier: object, methods: GeneratedRelationMethods): void {
-  methods.includeInto(carrier);
+export function includeRelationMethods(
+  carrier: object,
+  methods: GeneratedRelationMethods,
+  priority: number,
+): void {
+  methods.includeInto(carrier, priority);
 }
 
 /**
@@ -384,10 +421,14 @@ function perModelCarrier(
     // child carrier still dispatches to the child (child scope + child STI
     // type-condition) — inherited generated methods resolve by ordinary
     // prototype lookup instead of re-entering the `Proxy` miss path per
-    // subclass.
-    for (const ancestor of stiCarrierChain(modelClass)) {
-      includeRelationMethods(subclass.prototype, generatedRelationMethods(ancestor));
-    }
+    // subclass. The chain index is the module's priority (base_class = 0, own =
+    // highest), so `includeRelationMethods` structurally lets an own method win
+    // over an inherited one of the same name regardless of `generate()` order,
+    // mirroring Ruby's ancestor-chain MRO.
+    const carrierProto = subclass.prototype;
+    stiCarrierChain(modelClass).forEach((ancestor, priority) => {
+      includeRelationMethods(carrierProto, generatedRelationMethods(ancestor), priority);
+    });
   }
   return subclass;
 }


### PR DESCRIPTION
## What

Two coupled changes in `relation/delegation.ts` (RFC 0058, closing the divergence flagged on PR #4793):

1. **Model-agnostic generated delegator.** `classMethodDelegator` no longer captures a specific `modelClass` + bound class method. It reads the live model off the relation it's invoked on (`this._modelClass`), then resolves and scopes *that* model's class method at call time — mirroring Rails' generated body `def m(...); scoping { model.m(...) }; end` (delegation.rb:76-88). A single delegator is therefore correct on any model in an STI hierarchy.

2. **STI carrier module inheritance.** With a model-agnostic delegator it is now safe to mirror Rails' `include_relation_methods` superclass recursion (delegation.rb:57-60). `perModelCarrier` includes each STI ancestor model's generated module (`base_class`-first via the new `stiCarrierChain`) plus the model's own module last — so an own generated method wins over an inherited one, and inherited generated methods resolve by ordinary prototype lookup instead of re-entering the `Proxy` miss path per subclass.

## Behavior

No observable behavior change. STI correctness is preserved: a child relation's delegated class method still scopes the child model and applies the child's STI type-condition. The only delta is fewer miss-path passes for STI subclasses.

## Tests

- `delegation.test.ts` (78) + `DelegationCachingTest` — unchanged, pass.
- `delegation.trails.test.ts` — added two STI mechanism tests: ancestor module inherited onto child carrier, and own-method-wins ordering.
- inheritance / named-scoping / relation-scoping / default-scoping suites pass.

Closes-story: delegation-model-agnostic-delegator-sti-carrier-inheritance