### PR TITLE
refactor(module-carrier): unify per-class prototype-carrier interposition

### DIFF
--- a/packages/activerecord/src/enum.ts
+++ b/packages/activerecord/src/enum.ts
@@ -9,6 +9,7 @@ import {
   isDecoratorReplay,
 } from "@blazetrails/activemodel";
 import { dangerousAttributeMethods } from "./attribute-methods.js";
+import { getOrCreateModuleCarrier } from "./module-carrier.js";
 import { isDangerousClassMethod, isRelationInstanceMethod } from "./scoping/named.js";
 // The synchronous schema reflector (warm-cache path), NOT the async
 // `Base.loadSchema()` — mirrors what `Base.typeForAttribute` calls.
@@ -368,9 +369,14 @@ function enumMethodNamesFor(valueMethodName: string): {
  *
  * Mirrors: ActiveRecord::Enum::EnumMethods
  */
+/**
+ * Per-class memo of the interposed enum carrier, keyed independently of the
+ * store carrier so the two mechanisms stack rather than share.
+ */
+const _enumCarriers = new WeakMap<typeof import("./base.js").Base, object>();
+
 export class EnumMethods {
   private _klass: typeof import("./base.js").Base;
-  private _carrier?: object;
 
   constructor(klass: typeof import("./base.js").Base) {
     this._klass = klass;
@@ -395,13 +401,7 @@ export class EnumMethods {
    * Created lazily and once per class; all of a class's enums share it.
    */
   carrier(): object {
-    if (!this._carrier) {
-      const proto = this._klass.prototype as object;
-      const carrier = Object.create(Object.getPrototypeOf(proto)) as object;
-      Object.setPrototypeOf(proto, carrier);
-      this._carrier = carrier;
-    }
-    return this._carrier;
+    return getOrCreateModuleCarrier(this._klass, _enumCarriers);
   }
 
   /**

--- a/packages/activerecord/src/module-carrier.ts
+++ b/packages/activerecord/src/module-carrier.ts
@@ -1,0 +1,33 @@
+import type { Base } from "./base.js";
+
+/**
+ * Interpose a per-class prototype carrier directly below `modelClass.prototype`,
+ * memoized per (class, purpose). This is the shared implementation of the RFC
+ * 0058 module-carrier mechanism — the runtime analogue of a Ruby `include` of an
+ * anonymous module into a class. `store()` and `enum` each drive one instance of
+ * it (each keyed by its own `cache`), so an override on `modelClass.prototype`
+ * can reach the generated method via `super`.
+ *
+ * On first call for a `modelClass` the carrier is spliced into the chain between
+ * `modelClass.prototype` and its current parent. The current parent is captured
+ * at call time, so carriers from different purposes stack in `include` order
+ * (last-interposed nearest to the prototype — Ruby's last-included-module-wins).
+ *
+ * The `cache` doubles as the per-purpose key: pass a distinct
+ * `WeakMap<typeof Base, object>` per mechanism so their carriers memoize
+ * independently.
+ *
+ * @internal
+ */
+export function getOrCreateModuleCarrier(
+  modelClass: typeof Base,
+  cache: WeakMap<typeof Base, object>,
+): object {
+  const existing = cache.get(modelClass);
+  if (existing) return existing;
+  const proto = modelClass.prototype as object;
+  const carrier = Object.create(Object.getPrototypeOf(proto)) as object;
+  Object.setPrototypeOf(proto, carrier);
+  cache.set(modelClass, carrier);
+  return carrier;
+}

--- a/packages/activerecord/src/store.ts
+++ b/packages/activerecord/src/store.ts
@@ -2,6 +2,7 @@ import { ConfigurationError } from "./errors.js";
 import type { Base } from "./base.js";
 import { HashWithIndifferentAccess } from "@blazetrails/activesupport";
 import { buildColumnSerializer } from "./attribute-methods/serialization.js";
+import { getOrCreateModuleCarrier } from "./module-carrier.js";
 
 // Injected by base.ts to break the store→serialize→json→store circular dep.
 // store() calls this when wiring IndifferentCoder for plain text/string columns.
@@ -125,12 +126,7 @@ const _storeModuleProtos = new WeakMap<typeof Base, object>();
  * @internal
  */
 function getOrCreateStoreModuleProto(modelClass: typeof Base): object {
-  if (_storeModuleProtos.has(modelClass)) return _storeModuleProtos.get(modelClass)!;
-  const currentParent = Object.getPrototypeOf(modelClass.prototype) as object;
-  const storeModule = Object.create(currentParent);
-  Object.setPrototypeOf(modelClass.prototype, storeModule);
-  _storeModuleProtos.set(modelClass, storeModule);
-  return storeModule;
+  return getOrCreateModuleCarrier(modelClass, _storeModuleProtos);
 }
 
 /**


### PR DESCRIPTION
## What

Extract a single shared `getOrCreateModuleCarrier(modelClass, cache)` helper
(`packages/activerecord/src/module-carrier.ts`) implementing the RFC 0058
module-carrier mechanism — interposing a per-class prototype carrier directly
below `Model.prototype`, memoized per (class, purpose) via a per-purpose
`WeakMap<typeof Base, object>` passed as `cache`. It captures the current
parent at call time, so carriers from different purposes stack in `include`
order (last-interposed nearest — Ruby's last-included-module-wins).

Route the two sites that independently implemented this identical mechanism
through it:

- `store.ts` — `getOrCreateStoreModuleProto` (was its own
  `Object.create` + `setPrototypeOf`, WeakMap `_storeModuleProtos`).
- `enum.ts` — `EnumMethods.carrier()` (was an instance-cached carrier);
  now memoized in a module-level `_enumCarriers` WeakMap keyed by class,
  identity-equivalent to the old per-class `EnumMethods` cache.

## Scope note — delegation carrier

The third site named in the story context
(`delegation-generated-methods-per-model-prototype-carrier`) is structurally
different: it is a **per-model subclass prototype** (`class extends baseCtor {}`,
`perModelCarrier` in `relation/delegation.ts`), not a `setPrototypeOf`
interposition below `Model.prototype`. The only two `Object.setPrototypeOf`
sites in the source are store and enum. Routing the subclass carrier through a
below-prototype helper would change behavior, which the "no behavior change"
acceptance forbids — so it is intentionally left as-is.

## Verification

- `enum.test.ts`, `enum.trails.test.ts`, `store.test.ts` — 179 passed / 14 skipped.
- Carrier stacking order (last-interposed nearest) preserved; pure consolidation.
- `tsc --build` + typecheck clean.

Closes-story: unify-prototype-carrier-interposition-helper
