### PR TITLE
fix(associations): thread connection tableAliasLength into tracker construction

### DIFF
--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -276,15 +276,10 @@ export class AssociationScope {
     // joins to the same table get unique aliases.
     // Rails builds the tracker with the connection (association_scope.rb:26),
     // so its alias cap is the connection's `table_alias_length` (256 on MySQL,
-    // 63 on PG). Pass the connection — `create` reads its `tableAliasLength` —
-    // rather than `null`, which would fall back to the 64 default.
-    const tracker = AliasTracker.create(
-      klass.connection,
-      klass.arelTable.name,
-      [],
-      undefined,
-      quoter,
-    );
+    // 63 on PG). Pass the connection (`quoter` is `klass.connection`) — `create`
+    // reads its `tableAliasLength` — rather than `null`, which would fall back
+    // to the 64 default.
+    const tracker = AliasTracker.create(quoter, klass.arelTable.name, [], undefined, quoter);
     const chain = this.getChain(reflection, tracker);
     // Rails: `scope.extending! reflection.extensions` (association_scope.rb:28).
     // Mix any `extend:`-declared modules onto the relation so extension

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -8,6 +8,7 @@ import { CompositePrimaryKeyMismatchError } from "./errors.js";
 import { routeThroughCheckValidity } from "./validate-through-reflection.js";
 import type { Quoting } from "../connection-adapters/abstract/quoting-interface.js";
 import { constructJoinDependency, structuralUnionEq } from "../relation/query-methods.js";
+import { threadedConnectionFor } from "../connection-handling.js";
 
 /**
  * Lambda applied to each FK/type bind value before it reaches the
@@ -260,7 +261,12 @@ export class AssociationScope {
    */
   scope(association: AssociationScopeable): unknown {
     const { owner, reflection, klass } = association;
-    const quoter = klass.connection as unknown as Quoting;
+    // Prefer the connection threaded by the enclosing `withConnection` wrap over
+    // the deprecated `.connection` getter (which flips the lease permanent under
+    // `permanent_connection_checkout = :deprecated|:disallowed`), matching the
+    // resolution in join-dependency.ts and merged-join-alias-tracker.ts.
+    const connection = threadedConnectionFor(klass) ?? klass.connection;
+    const quoter = connection as unknown as Quoting;
     // Rails: `klass.unscoped` (association_scope.rb:23). Rails' unscoped
     // bypasses default_scope but STILL applies the STI `type_condition`
     // because `relation()` adds it for `finder_needs_type_condition?`
@@ -276,9 +282,9 @@ export class AssociationScope {
     // joins to the same table get unique aliases.
     // Rails builds the tracker with the connection (association_scope.rb:26),
     // so its alias cap is the connection's `table_alias_length` (256 on MySQL,
-    // 63 on PG). Pass the connection (`quoter` is `klass.connection`) — `create`
-    // reads its `tableAliasLength` — rather than `null`, which would fall back
-    // to the 64 default.
+    // 63 on PG). Pass the resolved connection — `create` reads its
+    // `tableAliasLength` — rather than `null`, which would fall back to the 64
+    // default.
     const tracker = AliasTracker.create(quoter, klass.arelTable.name, [], undefined, quoter);
     const chain = this.getChain(reflection, tracker);
     // Rails: `scope.extending! reflection.extensions` (association_scope.rb:28).

--- a/packages/activerecord/src/associations/association-scope.ts
+++ b/packages/activerecord/src/associations/association-scope.ts
@@ -274,7 +274,17 @@ export class AssociationScope {
     // default seeding with `klass.arel_table`). The tracker is
     // shared across the chain walk within this call so repeated
     // joins to the same table get unique aliases.
-    const tracker = AliasTracker.create(null, klass.arelTable.name, [], undefined, quoter);
+    // Rails builds the tracker with the connection (association_scope.rb:26),
+    // so its alias cap is the connection's `table_alias_length` (256 on MySQL,
+    // 63 on PG). Pass the connection — `create` reads its `tableAliasLength` —
+    // rather than `null`, which would fall back to the 64 default.
+    const tracker = AliasTracker.create(
+      klass.connection,
+      klass.arelTable.name,
+      [],
+      undefined,
+      quoter,
+    );
     const chain = this.getChain(reflection, tracker);
     // Rails: `scope.extending! reflection.extensions` (association_scope.rb:28).
     // Mix any `extend:`-declared modules onto the relation so extension

--- a/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
@@ -41,6 +41,16 @@ describe("JoinDependency AliasTracker seeding", () => {
     expect(tracker.aliasNameFor("a".repeat(200))).toBe("a".repeat(63));
   });
 
+  it("threads the connection length through the suffix-truncation branch (256 - 2)", () => {
+    const jd = new JoinDependency(stubBaseModel(256));
+    const tracker = trackerOf(jd);
+    const candidate = "a".repeat(300);
+    // First claim keeps the full 256-slice; the repeat aliases through
+    // `truncate` (slice to tableAliasLength - 2) with a `_2` suffix.
+    expect(tracker.aliasNameFor(candidate)).toBe("a".repeat(256));
+    expect(tracker.aliasNameFor(candidate)).toBe(`${"a".repeat(254)}_2`);
+  });
+
   it("falls back to the default cap when the base connection getter throws", () => {
     const noConnModel = {
       tableName: "posts",

--- a/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
@@ -1,0 +1,43 @@
+/**
+ * JoinDependency seeds its AliasTracker with the base model's connection
+ * `table_alias_length`, so a MySQL join chain caps aliases at 256 (not the
+ * hardcoded 64 default). Rails builds the tracker inside `pool.with_connection`
+ * (alias_tracker.rb:24), so the cap is always the connection's value.
+ *
+ * trails-specific: exercises the sync connection-length threading with a stub
+ * connection, which has no Rails analog.
+ */
+import { describe, it, expect } from "vitest";
+import { Table } from "@blazetrails/arel";
+import { JoinDependency } from "./join-dependency.js";
+import { AliasTracker } from "./alias-tracker.js";
+
+type BaseModelArg = ConstructorParameters<typeof JoinDependency>[0];
+
+function stubBaseModel(tableAliasLength: number): BaseModelArg {
+  return {
+    tableName: "posts",
+    arelTable: new Table("posts"),
+    connection: { tableAliasLength: () => tableAliasLength },
+  } as unknown as BaseModelArg;
+}
+
+function trackerOf(jd: JoinDependency): AliasTracker {
+  return (jd as unknown as { _aliasTracker: AliasTracker })._aliasTracker;
+}
+
+describe("JoinDependency AliasTracker seeding", () => {
+  it("caps aliases at the base connection's tableAliasLength (256 on MySQL)", () => {
+    const jd = new JoinDependency(stubBaseModel(256));
+    const tracker = trackerOf(jd);
+    tracker.aliasNameFor("posts"); // claim once so a repeat aliases + truncates
+    expect(tracker.aliasNameFor("a".repeat(300))).toBe("a".repeat(256));
+  });
+
+  it("caps aliases at the base connection's tableAliasLength (63 on PostgreSQL)", () => {
+    const jd = new JoinDependency(stubBaseModel(63));
+    const tracker = trackerOf(jd);
+    tracker.aliasNameFor("posts");
+    expect(tracker.aliasNameFor("a".repeat(200))).toBe("a".repeat(63));
+  });
+});

--- a/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
@@ -40,4 +40,18 @@ describe("JoinDependency AliasTracker seeding", () => {
     tracker.aliasNameFor("posts");
     expect(tracker.aliasNameFor("a".repeat(200))).toBe("a".repeat(63));
   });
+
+  it("falls back to the default cap when the base connection getter throws", () => {
+    const noConnModel = {
+      tableName: "posts",
+      arelTable: new Table("posts"),
+      get connection(): never {
+        throw new Error("no connection established");
+      },
+    } as unknown as BaseModelArg;
+    const jd = new JoinDependency(noConnModel);
+    const tracker = trackerOf(jd);
+    // maxIdentifierLength default is 64.
+    expect(tracker.aliasNameFor("a".repeat(200))).toBe("a".repeat(64));
+  });
 });

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -27,6 +27,7 @@ import { JoinPart } from "./join-dependency/join-part.js";
 import { AssociationNotFoundError, EagerLoadPolymorphicError } from "./errors.js";
 import { ConfigurationError } from "../errors.js";
 import { AliasTracker } from "./alias-tracker.js";
+import { threadedConnectionFor } from "../connection-handling.js";
 
 /**
  * Identity-cache key for a no-primary-key node. Rails uses `id = keys.map { nil }`
@@ -179,10 +180,32 @@ export class JoinDependency {
   constructor(baseModel: typeof Base, joinType?: typeof Nodes.InnerJoin | typeof Nodes.OuterJoin) {
     this._baseModel = baseModel;
     this._baseAlias = (baseModel as any).tableName;
-    this._aliasTracker = new AliasTracker(undefined, new Map([[this._baseAlias, 1]]));
+    this._aliasTracker = new AliasTracker(
+      this._baseTableAliasLength(),
+      new Map([[this._baseAlias, 1]]),
+    );
     const baseTable = (baseModel as any).arelTable;
     this._joinRoot = new JoinBase(baseModel, baseTable);
     this._joinType = joinType ?? Nodes.OuterJoin;
+  }
+
+  /**
+   * The base model's connection `table_alias_length`, used to cap alias
+   * truncation. Rails always builds the tracker inside `pool.with_connection`
+   * (alias_tracker.rb:24), so the cap is the connection's value — 256 on MySQL,
+   * 63 on PostgreSQL, 64 (default) on SQLite. Prefer the connection threaded by
+   * the enclosing `withConnection` wrap over the deprecated `.connection`
+   * getter (which flips the lease permanent under a restricted checkout mode);
+   * returns `undefined` when no connection resolves, letting the tracker fall
+   * back to its default.
+   * @internal
+   */
+  private _baseTableAliasLength(): number | undefined {
+    const connection =
+      threadedConnectionFor(this._baseModel) ?? (this._baseModel as any).connection;
+    return typeof connection?.tableAliasLength === "function"
+      ? connection.tableAliasLength()
+      : undefined;
   }
 
   /**
@@ -666,7 +689,10 @@ export class JoinDependency {
     if (aliasTracker) {
       this._aliasTracker = aliasTracker;
     } else {
-      this._aliasTracker = new AliasTracker(undefined, new Map([[this._baseAlias, 1]]));
+      this._aliasTracker = new AliasTracker(
+        this._baseTableAliasLength(),
+        new Map([[this._baseAlias, 1]]),
+      );
     }
     // Clear each through-group's resolved flag so this fresh emit re-resolves
     // aliases from scratch. Cover the `joinsToAdd` (stashed/merged) roots too:

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -196,16 +196,21 @@ export class JoinDependency {
    * 63 on PostgreSQL, 64 (default) on SQLite. Prefer the connection threaded by
    * the enclosing `withConnection` wrap over the deprecated `.connection`
    * getter (which flips the lease permanent under a restricted checkout mode);
-   * returns `undefined` when no connection resolves, letting the tracker fall
-   * back to its default.
+   * returns `undefined` when no connection resolves (or the `.connection` getter
+   * throws because none is established), letting the tracker fall back to its
+   * default so construction never fails on account of alias sizing.
    * @internal
    */
   private _baseTableAliasLength(): number | undefined {
-    const connection =
-      threadedConnectionFor(this._baseModel) ?? (this._baseModel as any).connection;
-    return typeof connection?.tableAliasLength === "function"
-      ? connection.tableAliasLength()
-      : undefined;
+    try {
+      const connection =
+        threadedConnectionFor(this._baseModel) ?? (this._baseModel as any).connection;
+      return typeof connection?.tableAliasLength === "function"
+        ? connection.tableAliasLength()
+        : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   /**


### PR DESCRIPTION
## What

Rails always builds an `AliasTracker` inside `pool.with_connection`
(`alias_tracker.rb:24`), so the tracker's alias cap is the **connection's**
`table_alias_length` — 256 on MySQL, 63 on PostgreSQL, 64 (default) on SQLite.
PR #4795 made `AliasTracker.create` honor a connection-like arg's
`tableAliasLength`, but two construction sites still hardcoded the 64 default.

- **`JoinDependency`** (constructor + `joinConstraints` fresh-tracker branch)
  built the tracker with `new AliasTracker(undefined, ...)`, always yielding 64.
  It now seeds from the base model's connection `tableAliasLength()` via a new
  `_baseTableAliasLength` helper that prefers the connection threaded by the
  enclosing `withConnection` wrap over the deprecated `.connection` getter
  (mirroring `buildMergedJoinAliasTracker`), so a MySQL join chain caps at 256.
- **`AssociationScope#scope`** passed `null` to `AliasTracker.create`; it now
  passes `klass.connection` so `create` reads its `tableAliasLength`.

Non-MySQL adapters keep their real cap (PG 63, SQLite 64). The length is
resolved synchronously up front — no async ripple into the sync tracker-construction callers.

## Tests

- `join-dependency-alias-length.trails.test.ts`: MySQL(-stub, 256) and PG(-stub, 63)
  connections cap alias truncation at their respective lengths.

Closes-story: thread-connection-table-alias-length-into-tracker-construction