### PR TITLE
fix(mysql): checkVersion enforces the 5.6.4 version floor

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.test.ts
@@ -791,3 +791,31 @@ describe("AbstractMysqlAdapter#tableAliasLength", () => {
     expect(adapter.tableAliasFor(long)).toBe("a".repeat(256));
   });
 });
+
+describe("AbstractMysqlAdapter#checkVersion", () => {
+  it("raises DatabaseVersionError when the warmed version is too old", async () => {
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    const { Version } = await import("./abstract-adapter.js");
+    const { DatabaseVersionError } = await import("../errors.js");
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as InstanceType<
+      typeof AbstractMysqlAdapter
+    >;
+    (adapter as unknown as { _databaseVersion: InstanceType<typeof Version> })._databaseVersion =
+      new Version("5.6.3");
+    expect(() => adapter.checkVersion()).toThrow(DatabaseVersionError);
+    expect(() => adapter.checkVersion()).toThrow(
+      "Your version of MySQL (5.6.3) is too old. Active Record supports MySQL >= 5.6.4.",
+    );
+  });
+
+  it("does not raise when the warmed version is supported", async () => {
+    const { AbstractMysqlAdapter } = await import("./abstract-mysql-adapter.js");
+    const { Version } = await import("./abstract-adapter.js");
+    const adapter = Object.create(AbstractMysqlAdapter.prototype) as InstanceType<
+      typeof AbstractMysqlAdapter
+    >;
+    (adapter as unknown as { _databaseVersion: InstanceType<typeof Version> })._databaseVersion =
+      new Version("5.6.4");
+    expect(() => adapter.checkVersion()).not.toThrow();
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-mysql-adapter.ts
@@ -1296,7 +1296,21 @@ export class AbstractMysqlAdapter extends AbstractAdapter {
     return sql;
   }
 
-  checkVersion(): void {}
+  // Mirrors: ActiveRecord::ConnectionAdapters::AbstractMysqlAdapter#check_version.
+  // Rails reads `database_version` (a synchronous accessor over the already-
+  // established connection); in trails the version is warmed asynchronously into
+  // `_databaseVersion` (getFullVersion) before checkVersion runs at connect time,
+  // so we read that cached value rather than issue a round-trip. When the version
+  // has not been warmed yet (`_databaseVersion` is null) we skip the floor check
+  // rather than raise a false positive — a query-issuing sync port isn't possible.
+  override checkVersion(): void {
+    const version = this._databaseVersion;
+    if (version && version.lt("5.6.4")) {
+      throw new DatabaseVersionError(
+        `Your version of MySQL (${version}) is too old. Active Record supports MySQL >= 5.6.4.`,
+      );
+    }
+  }
 
   /**
    * Escape-only string quoting per the Quoting interface contract

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.base-connection-field.trails.test.ts
@@ -18,7 +18,9 @@ describe("Mysql2Adapter base _connection field", () => {
 
   function stubNewClient(): { end: ReturnType<typeof vi.fn> } {
     const end = vi.fn(() => Promise.resolve());
-    const fakeConn = { end, query: () => Promise.resolve() };
+    // The connect-once configure warms the server version (getFullVersion issues
+    // SELECT VERSION() before checkVersion); hand it a row so the warm resolves.
+    const fakeConn = { end, query: () => Promise.resolve([[{ v: "8.0.28" }]]) };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
     return { end };
   }

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
@@ -19,8 +19,14 @@ describe("Mysql2Adapter configure-on-fresh-connect", () => {
     vi.restoreAllMocks();
   });
 
-  function stubNewClient(): void {
-    const fakeConn = { end: () => Promise.resolve(), query: () => Promise.resolve() };
+  function stubNewClient(version = "8.0.28"): void {
+    const fakeConn = {
+      end: () => Promise.resolve(),
+      // getFullVersion() (run by the connect-once configure to warm the version
+      // before checkVersion) issues SELECT VERSION(); hand it a row so the warm
+      // resolves offline.
+      query: () => Promise.resolve([[{ v: version }]]),
+    };
     vi.spyOn(Mysql2Adapter, "newClient").mockResolvedValue(fakeConn as never);
   }
 
@@ -51,6 +57,17 @@ describe("Mysql2Adapter configure-on-fresh-connect", () => {
 
     expect(checkVersionSpy).toHaveBeenCalledTimes(1);
     expect(timezoneSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects the connect when the server version is below the 5.6.4 floor", async () => {
+    const { DatabaseVersionError } = await import("../errors.js");
+    stubNewClient("5.6.3");
+    const adapter = new Mysql2Adapter({ host: "localhost" });
+
+    // The connect-once configure warms the version, then checkVersion enforces
+    // the floor — a too-old server rejects the connect end-to-end (mirrors Rails'
+    // configure_connection → check_version raising during connect).
+    await expect(adapter.connectBang()).rejects.toThrow(DatabaseVersionError);
   });
 
   it("re-runs the connect-once configure for the next connection after a disconnect resets the gate", async () => {

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1735,7 +1735,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // attemptConfigureConnection. Mirrors PostgreSQLAdapter's
     // _maybeConfigureConnection gate. Reset to false on raw-handle teardown so
     // the next connect re-runs it.
-    if (this._connectionConfigured) return;
+    // Only the connect-once warm+check needs a live socket. Rails'
+    // configure_connection always runs with @raw_connection set (called from
+    // connect!/reconnect! once the driver connection exists); a standalone
+    // configureConnection() on a not-yet-connected adapter (the timezone-seed
+    // reseed path) must not flip the gate or bootstrap an unawaited connect via
+    // getDatabaseVersion — so bail before the gate when there's no `_client`.
+    if (this._connectionConfigured || !this._client) return;
     this._connectionConfigured = true;
     // Warm the server version before checkVersion runs. Rails' check_version
     // reads database_version, a synchronous accessor that itself triggers the

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -718,7 +718,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
       ...this._poolConfig,
       initSql: this._buildInitSql(),
     }).then(
-      (conn): mysql.Connection | Promise<mysql.Connection> => {
+      async (conn): Promise<mysql.Connection> => {
         if (this._connectGeneration !== gen) {
           // disconnectBang()/close() happened while we were connecting. Clear
           // the promise ref then end the socket as part of this chain so
@@ -758,7 +758,10 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
         // so without this the eager query-loop connect would never configure
         // its first connection. Gated by _connectionConfigured so a following
         // verifyBang/reconnectBang can't double-configure.
-        this.configureConnection();
+        // Await so the connect-once warm + checkVersion complete before the
+        // socket is handed out — a too-old server rejects the connect (Rails'
+        // configure_connection → check_version raises during connect).
+        await this.configureConnection();
         return conn;
       },
       (err) => {
@@ -1713,7 +1716,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
   }
 
   /** @internal */
-  override configureConnection(): void {
+  override async configureConnection(): Promise<void> {
     // In Rails this sets @raw_connection.query_options[:as] = :array and
     // database_timezone on the single raw connection. We have a single
     // persistent connection here too; mysql2's typeCast handles temporal
@@ -1734,6 +1737,13 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // the next connect re-runs it.
     if (this._connectionConfigured) return;
     this._connectionConfigured = true;
+    // Warm the server version before checkVersion runs. Rails' check_version
+    // reads database_version, a synchronous accessor that itself triggers the
+    // round-trip (get_database_version) when unmemoized — so Rails guarantees the
+    // version is fetched before the floor check. checkVersion() is sync in trails
+    // and can't issue the query itself, so we await the warm here (getDatabaseVersion
+    // memoizes into _databaseVersion) before super.configureConnection() invokes it.
+    await this.getDatabaseVersion();
     super.configureConnection();
   }
 


### PR DESCRIPTION
Ports Rails' `AbstractMysqlAdapter#check_version` (abstract_mysql_adapter.rb:684). `checkVersion` was a no-op stub; it now raises `DatabaseVersionError` with the verbatim Rails message when the server version is below `5.6.4`.

**Connect-path wiring.** Rails' `check_version` reads `database_version`, a synchronous accessor that triggers the round-trip itself when unmemoized — so Rails guarantees the version is fetched before the floor check. `checkVersion()` is sync in trails and can't issue the query, so `Mysql2Adapter#configureConnection` now awaits `getDatabaseVersion()` (memoizing into `_databaseVersion`) before `super.configureConnection()` invokes `checkVersion()`. The connect site (`_ensureClient`) awaits `configureConnection`, so a too-old server rejects the connect end-to-end — matching Rails' `configure_connection → check_version` raising during connect. `checkVersion` reads the warmed `_databaseVersion` (no extra round-trip).

**Tests:**
- `abstract-mysql-adapter.test.ts`: too-old version raises with the verbatim message; supported version does not.
- `mysql2-adapter.configure-on-connect.trails.test.ts`: a 5.6.3 server **rejects the real `connectBang()` connect path** (catches the regression where the warm never fired before the check).

Closes-story: mysql-checkversion-enforce-version-floor