### PR TITLE
refactor(pg): PostgreSQL Column#type declares string | null honestly

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -146,7 +146,12 @@ export class SchemaDumper extends BaseSchemaDumper {
   /** @internal */
   protected schemaType(column: Column): string {
     if (this.isBigint(column)) return "bigint";
-    return column.type;
+    // Column#type is nil for an unmapped sql_type (e.g. a composite OID),
+    // mirroring Rails' `allow_nil: true`. Fall back to the raw sql_type so the
+    // dump still round-trips (RFC 0056) rather than masking the nil as "". The
+    // coalesced `AdapterSchemaSource.columns()` shape is never-nil at runtime,
+    // so this guard only fires for a raw adapter dumped directly as SchemaSource.
+    return column.type ?? column.sqlType ?? "unknown";
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql/column.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/column.ts
@@ -72,12 +72,13 @@ export class Column extends BaseColumn {
   // Rails' Column#type delegates to sql_type_metadata with `allow_nil: true`
   // (column.rb:12), so an unmapped sql_type — e.g. a composite OID — reflects
   // `nil`. Do NOT coerce that to "" (the old override did, breaking
-  // `assert_nil column.type`). The declared `string` keeps the schema dumper's
-  // non-null ColumnInfo contract: the dump path only ever sees the coalesced
-  // (never-nil) ColumnInfo from `SchemaSource.columns()`, while the reflection
-  // path (`columnsHash()[...].type`) passes the real nil straight through.
-  override get type(): string {
-    return super.type as string;
+  // `assert_nil column.type`). The declared `string | null` tells the truth
+  // rather than casting the runtime nil away, so callers must null-guard. The
+  // schema dumper never sees this nil at runtime: the dump path only reads the
+  // coalesced (never-nil) ColumnInfo from `SchemaSource.columns()`, while the
+  // reflection path (`columnsHash()[...].type`) passes the real nil through.
+  override get type(): string | null {
+    return super.type;
   }
 
   // Mirrors Rails Column#serial? — returns the stored flag, which the adapter

--- a/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql/schema-dumper.ts
@@ -9,8 +9,7 @@ import type {
   ExclusionConstraintDefinition,
   UniqueConstraintDefinition,
 } from "./schema-definitions.js";
-import type { Column } from "./column.js";
-import type { IndexInfo } from "../../schema-dumper.js";
+import type { ColumnInfo, IndexInfo } from "../../schema-dumper.js";
 
 export class SchemaDumper extends AbstractSchemaDumper {
   // Per-table constraint cache populated by filterIndexesForDump and consumed
@@ -19,7 +18,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
   private _cachedExclConstraints: ExclusionConstraintDefinition[] | undefined;
   private _cachedUniqConstraints: UniqueConstraintDefinition[] | undefined;
   /** @internal */
-  protected override prepareColumnOptions(column: Column): Record<string, unknown> {
+  protected override prepareColumnOptions(column: ColumnInfo): Record<string, unknown> {
     const spec = super.prepareColumnOptions(column as any);
     if (column.array) spec["array"] = true;
 
@@ -42,7 +41,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /** @internal */
-  protected override isDefaultPrimaryKey(column: Column): boolean {
+  protected override isDefaultPrimaryKey(column: ColumnInfo): boolean {
     // Mirrors Rails `schema_type(column) == :bigserial`. createTable now emits
     // BIGSERIAL for the default PK, so only bigserial is the default; a `serial`
     // PK is non-default and keeps its explicit `id: "serial"` option in dumps.
@@ -56,7 +55,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
    * `column.limit` is absent.
    * @internal
    */
-  protected override schemaLimit(column: Column): string | undefined {
+  protected override schemaLimit(column: ColumnInfo): string | undefined {
     // int4's limit (4) is the native default, so Rails `schema_limit` omits it
     // (`limit != native_database_types[:integer][:limit]`; typeToSql("integer", {limit: 4})
     // === "integer"). Without this an explicit `id: :integer` PK would dump
@@ -82,7 +81,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
    * from the element type's SQL type string (e.g. `"numeric(10,2)"`).
    * @internal
    */
-  protected override schemaPrecision(column: Column): string | undefined {
+  protected override schemaPrecision(column: ColumnInfo): string | undefined {
     const base = super.schemaPrecision(column);
     if (base !== undefined) return base;
     const sqlType = (column.sqlType ?? "").toLowerCase();
@@ -95,7 +94,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
    * the element type's SQL type string (e.g. `"numeric(10,2)"`).
    * @internal
    */
-  protected override schemaScale(column: Column): string | undefined {
+  protected override schemaScale(column: ColumnInfo): string | undefined {
     const base = super.schemaScale(column);
     if (base !== undefined) return base;
     const sqlType = (column.sqlType ?? "").toLowerCase();
@@ -104,12 +103,12 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /** @internal */
-  protected isExplicitPrimaryKeyDefault(column: Column): boolean {
+  protected isExplicitPrimaryKeyDefault(column: ColumnInfo): boolean {
     return column.type === "uuid" || (column.type === "integer" && !column.isSerial);
   }
 
   /** @internal */
-  protected override schemaType(column: Column): string {
+  protected override schemaType(column: ColumnInfo): string {
     // Use sqlType to detect bigint (works with both real Column objects and
     // plain ColumnInfo from AdapterSchemaSource, which has no isBigint() method).
     const isBigSql = /^bigint\b/i.test(column.sqlType ?? "");
@@ -124,7 +123,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /** @internal */
-  protected override schemaTypeWithVirtual(column: Column): string {
+  protected override schemaTypeWithVirtual(column: ColumnInfo): string {
     if (this._isVirtual(column)) return "virtual";
     return this.schemaType(column);
   }
@@ -133,7 +132,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
    * Handles both real PG Column objects (which expose `isVirtual()`) and plain
    * `ColumnInfo` objects from `AdapterSchemaSource` (which expose `virtual`).
    */
-  private _isVirtual(column: Column): boolean {
+  private _isVirtual(column: ColumnInfo): boolean {
     return typeof (column as any).isVirtual === "function"
       ? (column as any).isVirtual()
       : !!(column as any).virtual;
@@ -151,7 +150,7 @@ export class SchemaDumper extends AbstractSchemaDumper {
    * (e.g. `t`/`f` → `true`/`false`, `1.5` → quoted decimal, `4` → bare integer).
    * @internal
    */
-  protected override schemaDefault(column: Column): string | undefined {
+  protected override schemaDefault(column: ColumnInfo): string | undefined {
     if (column.array && typeof column.default === "string" && /^\{.*\}$/.test(column.default)) {
       const elements = parsePgArrayLiteral(column.default);
       if (elements.length === 0) return "[]";
@@ -171,13 +170,13 @@ export class SchemaDumper extends AbstractSchemaDumper {
   }
 
   /** @internal */
-  protected override schemaExpression(column: Column): string | undefined {
+  protected override schemaExpression(column: ColumnInfo): string | undefined {
     if (column.isSerial) return undefined;
     return super.schemaExpression(column as any);
   }
 
   /** @internal */
-  protected extractExpressionForVirtualColumn(column: Column): string {
+  protected extractExpressionForVirtualColumn(column: ColumnInfo): string {
     return JSON.stringify(column.defaultFunction);
   }
 

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -34,8 +34,12 @@ async function loadSchemaIntrospection(): Promise<typeof SchemaIntrospectionModu
 
 export interface ColumnInfo {
   name: string;
-  /** DSL cast type (`"string"`, `"integer"`, `"datetime"` …) — what `schemaType` reads. */
-  type: string;
+  /**
+   * DSL cast type (`"string"`, `"integer"`, `"datetime"` …) — what `schemaType`
+   * reads. Nil for an unmapped `sql_type` (e.g. a composite OID), mirroring
+   * Rails' `Column#type` `allow_nil: true`; `schemaType` coalesces it.
+   */
+  type: string | null;
   /**
    * Raw SQL type from the adapter (`"varchar(255)"`, `"timestamp"`, `"enum('a','b')"` …).
    * Carried separately from {@link type} so dialect dumpers (`schemaType`/`schemaLimit`/


### PR DESCRIPTION
## What

`postgresql/column.ts` `get type()` returned `super.type as string`, casting away the genuine runtime `null` (composite/unmapped OID, matching Rails' `delegate :type, allow_nil: true`, `column.rb:12`). PR #4801 kept the cast to avoid a ~13-error cascade in `postgresql/schema-dumper.ts`.

This drops the cast and declares `get type(): string | null`, so callers must null-guard and the compiler enforces it.

## How the cascade is resolved honestly (no `?? ""` mask)

- **PG dumper param types decoupled from the raw `Column` class** — the override methods (`schemaType`, `schemaLimit`, `prepareColumnOptions`, …) now take the base dumper's coalesced `ColumnInfo` shape instead of the raw PG `Column`, so widening `Column.type` no longer breaks their structural match with the base overrides.
- **`ColumnInfo.type` widened to `string | null`** — the raw-adapter-as-`SchemaSource` path (`PostgreSQLAdapter.columns()` returns real PG `Column[]`) can carry the nil, so the interface tells the truth.
- **Base `schemaType` coalesces** — falls back to the raw `sql_type` (RFC 0056 round-trip direction), then to the same `"unknown"` sentinel `AdapterSchemaSource.columns()` already uses (`schema-dumper.ts:248`) for the impossible both-nil case, instead of masking nil as `""`.

## No behavior change

`AdapterSchemaSource.columns()` still coalesces `type` to a never-nil value at runtime (`schema-dumper.ts:248`), so schema dumps are unchanged. The reflection path (`columnsHash()[...].type`) keeps returning nil for an unmapped `sql_type`.

## Verification

- `node scripts/typecheck.mjs` clean (full `tsc --build`).
- Suites green: `abstract/schema-dumper`, `postgresql/schema-dumper`, `schema-dumper`, `schema-dumper.trails`, `postgresql/quoting`, `postgresql/schema-statements-class`.
- **test:compare non-negative** — this PR touches only source files (no test added/removed/renamed), so the TS test-name set is unchanged and the delta is 0 by construction.

Closes-story: pg-column-type-declared-nullable-honest