### PR TITLE
fix(schema-dumper): raise on unmapped column type via validType

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/range.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/range.test.ts
@@ -298,14 +298,19 @@ describeIfPg("PostgreSQLAdapter", () => {
       expect(result.excludeEnd).toBe(true);
     });
     it("range schema dump", async () => {
+      // postgresql_ranges carries the user-defined `floatrange`/`stringrange`
+      // domains, whose DSL type is unmapped (not in native_database_types). Rails
+      // reflects them as OID::Range(:floatrange) and `valid_type?(:floatrange)` is
+      // false, so SchemaDumper#table raises and discards the whole create_table
+      // body in favor of the "Could not dump table" comment (schema_dumper.rb:196,
+      // 220-224) rather than fabricating a `t.column "float_range", "floatrange"`.
       const output = await SchemaDumper.dumpTableSchema(adapter, "postgresql_ranges");
-      expect(output).toContain('t.int4range("int4_range"');
-      expect(output).toContain('t.int8range("int8_range"');
-      expect(output).toContain('t.numrange("num_range"');
-      expect(output).toContain('t.daterange("date_range"');
-      expect(output).toContain('t.tsrange("ts_range"');
-      expect(output).toContain('t.tstzrange("tstz_range"');
-      expect(output).not.toContain('t.column("int4_range"');
+      expect(output).toContain(
+        '# Could not dump table "postgresql_ranges" because of following StandardError',
+      );
+      expect(output).toContain("#   Unknown type 'floatrange' for column 'float_range'");
+      expect(output).not.toContain('t.column("float_range"');
+      expect(output).not.toContain('t.int4range("int4_range"');
     });
     it("range migration", async () => {
       await adapter.exec(`DROP TABLE IF EXISTS range_migration_test`);

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1270,7 +1270,16 @@ export class AbstractAdapter implements Quoting {
   // --- Capability introspection ---
 
   isValidType(type: string | null | undefined): boolean {
-    return type != null && this.nativeDatabaseTypes()[type] != null;
+    if (type == null) return false;
+    const types = this.nativeDatabaseTypes();
+    if (types[type] != null) return true;
+    // Rails keys `native_database_types` by the same snake_case symbol that
+    // `Column#type` returns, so membership is a direct hit. trails instead keys
+    // by its camelCase DSL name (e.g. `bitVarying`) while `Column#type` stays
+    // Rails-snake (`bit_varying`); bridge the two spellings so a legit native
+    // type isn't misread as unmapped by `valid_type?` (schema dumper gate).
+    const camel = type.replace(/_([a-z])/g, (_m, c: string) => c.toUpperCase());
+    return camel !== type && types[camel] != null;
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
@@ -153,4 +153,22 @@ describe("SchemaDumper raises on a column whose type is not a valid native type"
     expect(output).not.toContain("createTable");
     expect(output).not.toContain('t.column("kind"');
   });
+
+  it("still dumps the table normally when every column type is a valid native type", async () => {
+    // The valid_type? gate must not over-reject: a table whose columns all map
+    // to native types dumps its create_table body unchanged.
+    const validSource = {
+      tables: () => ["widgets"],
+      columns: (_t: string) => [
+        { name: "id", type: "integer", sqlType: "integer", primaryKey: true },
+        { name: "name", type: "string", sqlType: "varchar(255)", limit: 255 },
+      ],
+      indexes: (_t: string) => [],
+      isValidType: (type: string | null | undefined) => type === "integer" || type === "string",
+    };
+    const output = await SchemaDumper.dump(validSource as any);
+    expect(output).not.toContain("# Could not dump table");
+    expect(output).toContain(`await ctx.createTable("widgets"`);
+    expect(output).toContain(`t.string("name"`);
+  });
 });

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.test.ts
@@ -130,3 +130,27 @@ describe("SchemaDumper columnSpec emits TS-DSL-emittable text", () => {
     expect(text).not.toContain("-> {");
   });
 });
+
+describe("SchemaDumper raises on a column whose type is not a valid native type", () => {
+  // Mirrors Rails' SchemaDumper#table (schema_dumper.rb:196,220-224): an
+  // unmapped/composite column reflects a nil DSL type, so `valid_type?` is
+  // false, the per-column raise fires, and the whole create_table body is
+  // discarded in favor of the "Could not dump table" comment.
+  const source = {
+    tables: () => ["widgets"],
+    columns: (_t: string) => [
+      { name: "id", type: "integer", sqlType: "integer", primaryKey: true },
+      { name: "kind", type: null, sqlType: "composite_type" },
+    ],
+    indexes: (_t: string) => [],
+    isValidType: (type: string | null | undefined) => type === "integer",
+  };
+
+  it("emits the Could-not-dump comment instead of a fabricated t.column line", async () => {
+    const output = await SchemaDumper.dump(source as any);
+    expect(output).toContain(`# Could not dump table "widgets" because of following StandardError`);
+    expect(output).toContain(`#   Unknown type 'composite_type' for column 'kind'`);
+    expect(output).not.toContain("createTable");
+    expect(output).not.toContain('t.column("kind"');
+  });
+});

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -146,12 +146,9 @@ export class SchemaDumper extends BaseSchemaDumper {
   /** @internal */
   protected schemaType(column: Column): string {
     if (this.isBigint(column)) return "bigint";
-    // Column#type is nil for an unmapped sql_type (e.g. a composite OID),
-    // mirroring Rails' `allow_nil: true`. Fall back to the raw sql_type so the
-    // dump still round-trips (RFC 0056) rather than masking the nil as "". The
-    // coalesced `AdapterSchemaSource.columns()` shape is never-nil at runtime,
-    // so this guard only fires for a raw adapter dumped directly as SchemaSource.
-    return column.type ?? column.sqlType ?? "unknown";
+    // `column.type` is non-null here: `emitTable` runs `validType?` over every
+    // column first and raises on a nil type, so a null never reaches schemaType.
+    return column.type ?? "";
   }
 
   /**
@@ -255,6 +252,59 @@ export class SchemaDumper extends BaseSchemaDumper {
    * @internal
    */
   protected override emitTable(
+    lines: string[],
+    tableName: string,
+    columns: ColumnInfo[],
+    indexes: IndexInfo[],
+    adapterTableOpts: Record<string, unknown> = {},
+    inlineConstraints: string[] = [],
+  ): void {
+    // Build into a local buffer so a raise mid-table discards the partial
+    // `create_table` body (Rails writes into its own `tbl` StringIO and only
+    // prints it on success — schema_dumper.rb:220-224). On any error we emit
+    // the "Could not dump table" comment instead of the table.
+    const body: string[] = [];
+    try {
+      // Rails validates every column's type before emitting the body
+      // (schema_dumper.rb:196), raising on an unmapped/composite type whose
+      // DSL type is nil so `valid_type?` is false. This includes the PK column.
+      for (const col of columns) {
+        if (!this.validType((col as Column).type)) {
+          const err = new Error(
+            `Unknown type '${(col as Column).sqlType ?? ""}' for column '${col.name}'`,
+          );
+          // Rails raises a StandardError; surface that class in the comment.
+          err.name = "StandardError";
+          throw err;
+        }
+      }
+      this.emitTableBody(body, tableName, columns, indexes, adapterTableOpts, inlineConstraints);
+    } catch (e) {
+      const cls = e instanceof Error ? e.name : "StandardError";
+      const message = e instanceof Error ? e.message : String(e);
+      lines.push(`# Could not dump table ${JSON.stringify(tableName)} because of following ${cls}`);
+      lines.push(`#   ${message}`);
+      return;
+    }
+    for (const line of body) lines.push(line);
+  }
+
+  /**
+   * Mirrors `abstract_adapter.rb:262` `valid_type?` — `!native_database_types[type]`.
+   * Delegates to the backing adapter's `isValidType`; raw/mock sources without an
+   * adapter can't validate a type map, so they accept (the pre-raise behavior).
+   * @internal
+   */
+  protected validType(type: string | null | undefined): boolean {
+    const adapter = this._adapter();
+    if (adapter && typeof adapter.isValidType === "function") {
+      return adapter.isValidType(type);
+    }
+    return true;
+  }
+
+  /** @internal */
+  protected emitTableBody(
     lines: string[],
     tableName: string,
     columns: ColumnInfo[],

--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -269,10 +269,8 @@ export class SchemaDumper extends BaseSchemaDumper {
       // (schema_dumper.rb:196), raising on an unmapped/composite type whose
       // DSL type is nil so `valid_type?` is false. This includes the PK column.
       for (const col of columns) {
-        if (!this.validType((col as Column).type)) {
-          const err = new Error(
-            `Unknown type '${(col as Column).sqlType ?? ""}' for column '${col.name}'`,
-          );
+        if (!this.validType(col.type)) {
+          const err = new Error(`Unknown type '${col.sqlType ?? ""}' for column '${col.name}'`);
           // Rails raises a StandardError; surface that class in the comment.
           err.name = "StandardError";
           throw err;

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -35,9 +35,10 @@ async function loadSchemaIntrospection(): Promise<typeof SchemaIntrospectionModu
 export interface ColumnInfo {
   name: string;
   /**
-   * DSL cast type (`"string"`, `"integer"`, `"datetime"` …) — what `schemaType`
-   * reads. Nil for an unmapped `sql_type` (e.g. a composite OID), mirroring
-   * Rails' `Column#type` `allow_nil: true`; `schemaType` coalesces it.
+   * DSL cast type (`"string"`, `"integer"`, `"datetime"` …) — what `schemaType` reads.
+   * `null` for an unmapped/composite `sqlType` (Rails' `SqlTypeMetadata#type` is nil);
+   * the dumper rejects such a column via `validType?` and emits the "Could not dump
+   * table" comment rather than fabricating a type.
    */
   type: string | null;
   /**
@@ -244,8 +245,11 @@ class AdapterSchemaSource implements SchemaSource {
         name: col.name,
         // Carry the dsl cast type in `type` and the raw SQL type in `sqlType`.
         // schemaType/schemaLimit/schemaPrecision read the dsl type off `type`
-        // and inspect the raw declaration off `sqlType`.
-        type: col.type || col.sqlType || "unknown",
+        // and inspect the raw declaration off `sqlType`. A nil dsl type
+        // (unmapped/composite sqlType) flows through as null so the dumper's
+        // `validType?` check rejects it — mirroring Rails, which raises rather
+        // than coalescing to the raw sqlType name.
+        type: col.type ?? null,
         sqlType: col.sqlType ?? undefined,
         primaryKey: col.primaryKey,
         null: col.null,

--- a/packages/trailties/src/schema-source.ts
+++ b/packages/trailties/src/schema-source.ts
@@ -15,58 +15,6 @@ function detectAdapter(adapter: DatabaseAdapter): "sqlite" | "postgres" | "mysql
 }
 
 /**
- * Normalize a SQLite default value expression.
- * PRAGMA table_info returns SQL expressions like 'foo', 0, NULL, CURRENT_TIMESTAMP.
- */
-function normalizeSqliteDefault(raw: unknown): unknown {
-  if (raw === null || raw === undefined) return undefined;
-  const str = String(raw);
-
-  // String literal: 'value' or 'it''s'
-  const strMatch = str.match(/^'((?:[^']|'')*)'$/);
-  if (strMatch) {
-    return strMatch[1].replace(/''/g, "'");
-  }
-
-  if (str === "NULL") return undefined;
-  if (str === "TRUE" || str === "true") return true;
-  if (str === "FALSE" || str === "false") return false;
-  if (/^-?\d+(\.\d+)?$/.test(str)) return Number(str);
-
-  // Expression defaults (CURRENT_TIMESTAMP, etc.) — omit to avoid mis-quoting on reload
-  return undefined;
-}
-
-/**
- * Normalize a Postgres default value expression.
- * Only emit literal defaults; omit expression defaults (nextval, now(), etc.)
- * to avoid semantic changes on schema round-trip.
- */
-function normalizePgDefault(raw: unknown): unknown {
-  if (raw === null || raw === undefined) return undefined;
-  const str = String(raw);
-
-  // String literal with type cast: 'value'::type
-  const strMatch = str.match(/^'((?:[^']|'')*)'(?:::[\w\s."[\](),]+)*$/);
-  if (strMatch) {
-    return strMatch[1].replace(/''/g, "'");
-  }
-
-  // Numeric literal with optional cast: 42::integer, (3.14)::numeric
-  const numMatch = str.match(/^\(?(-?\d+(?:\.\d+)?)\)?(?:::[\w\s."[\](),]+)*$/);
-  if (numMatch) {
-    return Number(numMatch[1]);
-  }
-
-  if (str === "true") return true;
-  if (str === "false") return false;
-  if (str === "NULL::*" || str === "NULL") return undefined;
-
-  // Expression defaults (nextval(...), now(), gen_random_uuid(), etc.) — omit
-  return undefined;
-}
-
-/**
  * Adapter-backed SchemaSource for use with SchemaDumper.
  * Queries the actual database for table, column, and index info.
  * Supports SQLite and Postgres.
@@ -109,51 +57,26 @@ export class AdapterSchemaSource implements SchemaSource {
     if (t === "mysql") {
       throw new Error("MySQL schema introspection is not yet supported by AdapterSchemaSource.");
     }
-
-    if (t === "postgres") {
-      // Use format_type for precise types (handles enums, domains, arrays)
-      const rows = await this.adapter.execute(
-        `SELECT a.attname AS column_name,
-                pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
-                NOT a.attnotnull AS is_nullable,
-                pg_get_expr(d.adbin, d.adrelid) AS column_default,
-                CASE WHEN a.atttypid = 1043 AND a.atttypmod > 0 THEN a.atttypmod - 4 ELSE NULL END AS character_maximum_length,
-                CASE WHEN a.atttypid IN (1700) AND a.atttypmod > 0 THEN ((a.atttypmod - 4) >> 16) & 65535 ELSE NULL END AS numeric_precision,
-                CASE WHEN a.atttypid IN (1700) AND a.atttypmod > 0 THEN (a.atttypmod - 4) & 65535 ELSE NULL END AS numeric_scale
-         FROM pg_attribute a
-         LEFT JOIN pg_attrdef d ON a.attrelid = d.adrelid AND a.attnum = d.adnum
-         WHERE a.attrelid = ?::regclass AND a.attnum > 0 AND NOT a.attisdropped
-         ORDER BY a.attnum`,
-        [tableName],
-      );
-      const pkRows = await this.adapter.execute(
-        `SELECT a.attname FROM pg_index i
-         JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
-         WHERE i.indrelid = ?::regclass AND i.indisprimary`,
-        [tableName],
-      );
-      const pkCols = new Set((pkRows as any[]).map((r: any) => r.attname));
-
-      return (rows as any[]).map((r: any) => ({
-        name: r.column_name,
-        type: r.data_type,
-        primaryKey: pkCols.has(r.column_name),
-        null: !!r.is_nullable,
-        default: normalizePgDefault(r.column_default),
-        limit: r.character_maximum_length != null ? Number(r.character_maximum_length) : undefined,
-        precision: r.numeric_precision != null ? Number(r.numeric_precision) : undefined,
-        scale: r.numeric_scale != null ? Number(r.numeric_scale) : undefined,
-      }));
-    }
-
-    // SQLite (PRAGMA doesn't support bind params, so escape the identifier)
-    const rows = await this.adapter.execute(`PRAGMA table_info(${sqliteId(tableName)})`);
-    return (rows as any[]).map((r: any) => ({
-      name: r.name,
-      type: r.type,
-      primaryKey: r.pk > 0,
-      null: r.notnull === 0,
-      default: normalizeSqliteDefault(r.dflt_value),
+    // Delegate to the adapter's own reflection so `type` carries the resolved
+    // DSL cast type (`"integer"`, `"bit_varying"`, …) — not the raw SQL type
+    // string. The dumper's `valid_type?` gate rejects unmapped types, and its
+    // `schema_type`/`schema_default` helpers key off the DSL type, so a raw
+    // `"INTEGER"`/`"character varying"` here would be misread as unmapped and
+    // dumped (or dropped) incorrectly. Mirrors the activerecord
+    // AdapterSchemaSource, which already reflects through `adapter.columns()`.
+    const cols = (await this.adapter.columns(tableName)) as any[];
+    return cols.map((c) => ({
+      name: c.name,
+      type: c.type,
+      sqlType: c.sqlType ?? undefined,
+      primaryKey: c.primaryKey,
+      null: c.null,
+      default: c.default,
+      defaultFunction: c.defaultFunction ?? undefined,
+      limit: c.limit ?? undefined,
+      precision: c.precision === undefined ? undefined : c.precision,
+      scale: c.scale ?? undefined,
+      collation: c.collation ?? undefined,
     }));
   }
 


### PR DESCRIPTION
## Summary

Ports Rails' `SchemaDumper#table` validity gate. PR #4801 made `Column#type`
nil-faithful for an unmapped `sql_type`; this exposed that trails had no
`valid_type?`/raise-and-abort machinery in the dumper and instead silently
coalesced a nil type to the raw `sqlType` name.

- The connection-adapters `emitTable` now runs `validType?` over every column
  first (`schema_dumper.rb:196`), delegating to the adapter's `isValidType`
  (`valid_type?` = `!native_database_types[type]`, `abstract_adapter.rb:262`).
- The table body is built into a local buffer, so on a raise the partial
  `create_table` is discarded and the
  `# Could not dump table … because of following StandardError` comment block
  is emitted instead (`schema_dumper.rb:220-224`).
- Removed the `col.type || col.sqlType || "unknown"` nil-coalesce deviation at
  `AdapterSchemaSource.columns` so a nil DSL type reaches the dumper as `null`.

## Fidelity gaps the gate surfaced (fixed here)

Enabling the gate exposed three upstream type-reflection divergences that had to
converge, not be ratified:

- **`isValidType` keying** — trails keyed `native_database_types` by its
  camelCase DSL name (`bitVarying`) while `Column#type` is Rails snake_case
  (`bit_varying`), so legit multi-word native types were misread as unmapped.
  Now bridges snake → camel in the lookup.
- **trailties `AdapterSchemaSource`** — it put the raw SQL type (`"INTEGER"`)
  in `ColumnInfo.type` instead of the resolved DSL cast type, so every column
  read as unmapped. Now delegates to `adapter.columns()`, mirroring the
  activerecord `AdapterSchemaSource`, so it reflects DSL types + `sqlType`.
- **PG `range schema dump` test** — `postgresql_ranges` carries user-defined
  `floatrange`/`stringrange` domains whose DSL type is unmapped; Rails raises
  and discards the whole table. Converged the test to assert the
  "Could not dump table" outcome instead of a fabricated `t.column`.

## Tests

- Unmapped/composite column → "Could not dump" comment, not a fabricated
  `t.column`; plus a happy-path regression that a fully-valid table still dumps.
- Range/bit-string PG adapter tests converge to Rails-faithful behavior.
- Full trailties `db` suite green after the source converges to DSL types.

Closes-story: schema-dumper-valid-type-raise-on-unmapped-column
