### PR TITLE
fix(arel): BindParam#isNil delegates to wrapped value

### DIFF
--- a/packages/arel/src/nodes/bind-param.test.ts
+++ b/packages/arel/src/nodes/bind-param.test.ts
@@ -50,6 +50,30 @@ describe("BindParam", () => {
     });
   });
 
+  describe("isNil", () => {
+    it("is true when wrapping a bare null", () => {
+      expect(new Nodes.BindParam(null).isNil()).toBe(true);
+    });
+
+    it("is false for a valueless positional-bind placeholder", () => {
+      expect(new Nodes.BindParam().isNil()).toBe(false);
+    });
+
+    it("is false when wrapping a non-nil scalar", () => {
+      expect(new Nodes.BindParam(42).isNil()).toBe(false);
+    });
+
+    it("delegates to value.isNil when present — true", () => {
+      const bp = new Nodes.BindParam({ isNil: () => true });
+      expect(bp.isNil()).toBe(true);
+    });
+
+    it("delegates to value.isNil when present — false", () => {
+      const bp = new Nodes.BindParam({ isNil: () => false });
+      expect(bp.isNil()).toBe(false);
+    });
+  });
+
   describe("isInfinite", () => {
     it("returns null when value has no isInfinite", () => {
       const bp = new Nodes.BindParam(42);

--- a/packages/arel/src/nodes/bind-param.ts
+++ b/packages/arel/src/nodes/bind-param.ts
@@ -27,6 +27,21 @@ export class BindParam extends Node {
     return typeof v?.valueBeforeTypeCast === "function" ? v.valueBeforeTypeCast() : this.value;
   }
 
+  /**
+   * Mirrors `Arel::Nodes::BindParam#nil?` (bind_param.rb:23-25), which
+   * delegates to `value.nil?`. A bare raw `null` value is nil; a wrapped
+   * attribute (e.g. a QueryAttribute that serializes an enum/normalized value
+   * to nil) answers via its own `isNil()`. So a `BindParam` around a nil right
+   * reports nil and the equality visitors emit `IS NULL`. A valueless
+   * placeholder (`undefined`) is a trails positional-bind marker, not a Rails
+   * value, so it stays a `?` bind rather than collapsing to `IS NULL`.
+   */
+  isNil(): boolean {
+    if (this.value === null) return true;
+    const v = this.value as { isNil?: () => boolean } | undefined;
+    return typeof v?.isNil === "function" && v.isNil();
+  }
+
   isInfinite(): number | null {
     const v = this.value as { isInfinite?: () => number | null } | null | undefined;
     return typeof v?.isInfinite === "function" ? v.isInfinite() : null;

--- a/packages/arel/src/visitors/to-sql.test.ts
+++ b/packages/arel/src/visitors/to-sql.test.ts
@@ -602,6 +602,16 @@ describe("the to_sql visitor", () => {
       const node = users.get("id").eq(null);
       expect(new Visitors.ToSql().compile(node)).toContain("IS NULL");
     });
+
+    it("emits IS NULL for a BindParam wrapping a bare null", () => {
+      const node = new Nodes.Equality(users.get("id"), new Nodes.BindParam(null));
+      expect(new Visitors.ToSql().compile(node)).toContain("IS NULL");
+    });
+
+    it("emits IS NOT NULL for a NotEqual BindParam wrapping a bare null", () => {
+      const node = new Nodes.NotEqual(users.get("id"), new Nodes.BindParam(null));
+      expect(new Visitors.ToSql().compile(node)).toContain("IS NOT NULL");
+    });
   });
 
   describe("Nodes::InfixOperation", () => {

--- a/packages/arel/src/visitors/to-sql.ts
+++ b/packages/arel/src/visitors/to-sql.ts
@@ -2120,10 +2120,10 @@ export class ToSql extends Visitor {
    */
   protected rightIsNull(right: unknown): boolean {
     if (right instanceof Nodes.Quoted && right.value === null) return true;
-    // A bound scalar arrives wrapped in a BindParam; peer at the wrapped
-    // attribute so an enum/normalized bind that serializes to nil is caught.
-    const node = right instanceof Nodes.BindParam ? right.value : right;
-    const maybe = node as { isNil?: () => boolean };
+    // A bound scalar arrives wrapped in a BindParam whose `isNil()` delegates
+    // to its wrapped value (bind_param.rb:23-25) — so a raw-null bind or an
+    // enum/normalized bind that serializes to nil is caught.
+    const maybe = right as { isNil?: () => boolean };
     return typeof maybe?.isNil === "function" && maybe.isNil();
   }
 }


### PR DESCRIPTION
## What

Rails' `Arel::Nodes::BindParam#nil?` (bind_param.rb:23-25) always delegates to `value.nil?`, so a `BindParam` wrapping a nil right — including one built around a bare raw `null` (a non-Attribute value) — reports nil and the equality visitors emit `IS NULL`.

trails' `BindParam` had no `isNil()` of its own. `ToSql#rightIsNull` worked around this by unwrapping the `BindParam` and calling `isNil()` on the wrapped attribute — covering the QueryAttribute case (enum/normalized serialize-to-nil) but NOT a `BindParam` constructed around a raw non-Attribute `null`.

## Changes

- `BindParam#isNil()` — Rails-faithful, delegates to its wrapped value's nil-ness (bind_param.rb:23-25). A bare `null` is nil; a wrapped attribute answers via its own `isNil()`. A valueless positional-bind placeholder (`undefined`) stays a `?` bind rather than collapsing to `IS NULL`.
- `ToSql#rightIsNull` now goes through that delegation instead of special-casing the `BindParam` unwrap inline.
- Tests: `BindParam#isNil` unit coverage; `Equality`/`NotEqual` over a `BindParam(null)` emit `IS NULL` / `IS NOT NULL`.

Existing enum where IS NULL behavior (PR #4808) still passes.

Closes-story: bindparam-nil-delegates-to-wrapped-value