### PR TITLE
refactor(schema-dumper): single dumper class, synchronous bare-base construction

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/schema-dumper.ts
@@ -1,16 +1,38 @@
 /**
- * Connection-adapters-layer SchemaDumper. Mirrors Rails'
+ * Connection-adapters-layer SchemaDumper column-spec helpers. Mirrors Rails'
  * `ActiveRecord::ConnectionAdapters::SchemaDumper < SchemaDumper`
- * (connection_adapters/abstract/schema_dumper.rb) — the adapter
- * subclass of the base dumper that adds column-spec helpers used by
- * `schema_type`, `schema_limit`, `schema_default`, etc.
+ * (connection_adapters/abstract/schema_dumper.rb) — the adapter subclass of the
+ * base dumper that adds the column-spec helpers driving `schema_type`,
+ * `schema_limit`, `schema_default`, etc.
+ *
+ * Rails mixes these into the dumper via subclassing; the base `SchemaDumper#table`
+ * calls the unqualified (private) `column_spec` that only the adapter subclass
+ * defines. TypeScript can't statically `extends` the base from here without an
+ * ESM temporal-dead-zone cycle (base ↔ subclass), so instead of a subclass we
+ * ship these as `this`-typed functions ("Module mixins" in CLAUDE.md). The base
+ * class (`../../schema-dumper.ts`) assigns them onto its own prototype via thin
+ * `protected` wrappers, so there is a single dumper class with no cyclic
+ * `extends` — a bare-base construction needs no other module to have loaded the
+ * adapter layer. Keeping the bodies here preserves the api:compare file mapping
+ * (`column_spec`/`schema_default`/`schema_expression` live in this file).
+ *
+ * `SchemaDumper` is re-exported from the base module so existing deep imports
+ * (`connection-adapters/abstract/schema-dumper.js`) and the public `index.ts`
+ * export keep resolving to the single class.
  */
 
-import type { SchemaSource, ColumnInfo, IndexInfo } from "../../schema-dumper.js";
-import { SchemaDumper as BaseSchemaDumper } from "../../schema-dumper.js";
+import type { ColumnInfo, IndexInfo } from "../../schema-dumper.js";
+export { SchemaDumper } from "../../schema-dumper.js";
 
-/** Column-shaped interface this dumper depends on. */
-interface Column extends ColumnInfo {
+/**
+ * Mirrors the abstract subclass's `DEFAULT_DATETIME_PRECISION = 6` (Rails
+ * redeclares the constant on `ConnectionAdapters::SchemaDumper`). Kept local so
+ * `schemaPrecision` doesn't reach back into the base class value at module eval.
+ */
+export const DEFAULT_DATETIME_PRECISION = 6;
+
+/** Column-shaped interface these helpers depend on. */
+export interface Column extends ColumnInfo {
   bigint?: boolean;
   virtual?: boolean;
   hasDefault?: boolean;
@@ -20,327 +42,291 @@ interface Column extends ColumnInfo {
   sqlType?: string | null;
 }
 
-export class SchemaDumper extends BaseSchemaDumper {
-  /**
-   * Per-table primary-key column order from `@connection.primary_key(table)`.
-   * Populated by `table()` before column iteration so `emitTable` can render
-   * `primaryKey: [...]` (and pick the single-PK column) in PK definition order
-   * rather than introspection/declaration order. Mirrors Rails' reliance on
-   * `@connection.primary_key(table)`, which already returns columns in key order.
-   * @internal
-   */
-  protected primaryKeyOrderCache: Record<string, string[] | undefined> = Object.create(null);
-
-  static override create<T extends typeof BaseSchemaDumper>(
-    this: T,
-    source: SchemaSource,
-    options: Record<string, unknown> = {},
-  ): InstanceType<T> {
-    return new this(source, options) as InstanceType<T>;
-  }
-
-  /** @internal */
-  override async table(tableName: string, lines: string[]): Promise<void> {
-    const adapter = this._adapter();
-    if (adapter && typeof adapter.primaryKeys === "function") {
-      try {
-        this.primaryKeyOrderCache[tableName] = await adapter.primaryKeys(tableName);
-      } catch {
-        // Live introspection is best-effort; fall through to declaration order.
-      }
-    }
-    await super.table(tableName, lines);
-  }
-
-  /**
-   * The table's primary-key columns, in key order. Defaults to the columns
-   * carrying the per-column `primaryKey` flag (reordered by the live PK order).
-   * Dialects whose per-column flag can over-report (e.g. MySQL's `column_key`
-   * promotes a UNIQUE NOT NULL index to `PRI` when there is no PRIMARY KEY)
-   * override this to consult the authoritative primary key instead.
-   * @internal
-   */
-  protected resolvePrimaryKeyColumns(tableName: string, columns: ColumnInfo[]): ColumnInfo[] {
-    return this.orderPrimaryKeyColumns(
-      tableName,
-      columns.filter((c) => c.primaryKey),
-    );
-  }
-
-  /** @internal */
-  protected override orderPrimaryKeyColumns(
-    tableName: string,
-    pkColumns: ColumnInfo[],
-  ): ColumnInfo[] {
-    const order = this.primaryKeyOrderCache[tableName];
-    if (!order || order.length === 0) return pkColumns;
-    const byName = new Map(pkColumns.map((c) => [c.name, c]));
-    const reordered: ColumnInfo[] = [];
-    for (const name of order) {
-      const col = byName.get(name);
-      if (col) {
-        reordered.push(col);
-        byName.delete(name);
-      }
-    }
-    for (const col of byName.values()) reordered.push(col);
-    return reordered;
-  }
-
-  /** @internal */
-  protected columnSpec(column: Column): [symbol | string, Record<string, unknown>] {
-    return [this.schemaTypeWithVirtual(column), this.prepareColumnOptions(column)];
-  }
-
-  /** @internal */
-  protected columnSpecForPrimaryKey(column: Column): Record<string, unknown> {
-    const spec: Record<string, unknown> = {};
-    if (!this.isDefaultPrimaryKey(column)) {
-      // Pre-format the id value as a TS-DSL string literal for formatColspec.
-      spec["id"] = JSON.stringify(this.schemaType(column));
-    }
-    const colOpts = this.prepareColumnOptions(column);
-    delete colOpts["null"];
-    Object.assign(spec, colOpts);
-    if (this.isExplicitPrimaryKeyDefault(column)) {
-      // "null" (not Ruby "nil") — emitted verbatim by formatColspec as `default: null`.
-      spec["default"] ??= "null";
-    }
-    return spec;
-  }
-
-  /** @internal */
-  protected prepareColumnOptions(column: Column): Record<string, unknown> {
-    const spec: Record<string, unknown> = {};
-    const limit = this.schemaLimit(column);
-    if (limit !== undefined) spec["limit"] = limit;
-    const precision = this.schemaPrecision(column);
-    if (precision !== undefined) spec["precision"] = precision;
-    const scale = this.schemaScale(column);
-    if (scale !== undefined) spec["scale"] = scale;
-    const def = this.schemaDefault(column);
-    if (def !== undefined) spec["default"] = def;
-    if (column.null === false) spec["null"] = "false";
-    const collation = this.schemaCollation(column);
-    if (collation !== undefined) spec["collation"] = collation;
-    if (column.comment) spec["comment"] = JSON.stringify(column.comment);
-    return spec;
-  }
-
-  /** @internal */
-  protected isDefaultPrimaryKey(column: Column): boolean {
-    return this.schemaType(column) === "bigint";
-  }
-
-  /** @internal */
-  protected isExplicitPrimaryKeyDefault(_column: Column): boolean {
-    return false;
-  }
-
-  /** @internal */
-  protected schemaTypeWithVirtual(column: Column): string {
-    if (column.virtual) return "virtual";
-    return this.schemaType(column);
-  }
-
-  /** @internal */
-  protected schemaType(column: Column): string {
-    if (this.isBigint(column)) return "bigint";
-    // Column#type is nil for an unmapped sql_type (e.g. a composite OID),
-    // mirroring Rails' `allow_nil: true`. Fall back to the raw sql_type so the
-    // dump still round-trips (RFC 0056) rather than masking the nil as "". The
-    // coalesced `AdapterSchemaSource.columns()` shape is never-nil at runtime,
-    // so this guard only fires for a raw adapter dumped directly as SchemaSource.
-    return column.type ?? column.sqlType ?? "unknown";
-  }
-
-  /**
-   * Mirrors `ConnectionAdapters::Column#bigint?` (`/\Abigint\b/.match?(sql_type)`),
-   * which the abstract `schema_type` consults. A live column reflects a `bigint`
-   * declaration as sqlType `"bigint"`/`"BIGINT"` with dsl type `"integer"`, so
-   * detect it off sqlType; the `bigint` flag / `type === "bigint"` arms keep mock
-   * sources that set them directly working.
-   * @internal
-   */
-  protected isBigint(column: Column): boolean {
-    return !!column.bigint || column.type === "bigint" || /^bigint\b/i.test(column.sqlType ?? "");
-  }
-
-  /** @internal */
-  protected schemaLimit(column: Column): string | undefined {
-    // Mirrors Rails `schema_limit`: `limit = column.limit unless column.bigint?` — same
-    // predicate `schema_type` uses, so a column whose bigint-ness is only visible through
-    // sqlType is limit-suppressed too.
-    if (this.isBigint(column)) return undefined;
-    // Rails suppresses the serial/bigserial limit because it matches the native
-    // database type's default (int4 limit = 4, int8 limit = 8). We don't have
-    // the native_database_types comparison available here, so we guard explicitly
-    // on isSerial — functionally equivalent to the Rails approach.
-    if (column.isSerial) return undefined;
-    const limit = column.limit;
-    if (limit == null) return undefined;
-    return String(limit);
-  }
-
-  /** @internal */
-  protected schemaPrecision(column: Column): string | undefined {
-    if (column.type === "datetime") {
-      // TS-DSL literal `null` (Rails dumps the Ruby `nil`); the value is emitted
-      // verbatim by formatColspec, so it must already read as valid TS.
-      if (column.precision == null) return "null";
-      if (column.precision === BaseSchemaDumper.DEFAULT_DATETIME_PRECISION) return undefined;
-      return String(column.precision);
-    }
-    if (column.precision != null) return String(column.precision);
-    return undefined;
-  }
-
-  /** @internal */
-  protected schemaScale(column: Column): string | undefined {
-    if (column.scale != null) return String(column.scale);
-    return undefined;
-  }
-
-  // Rails `schema_default` / `schema_expression` live in
-  // `connection_adapters/abstract/schema_dumper.rb`, so the ports stay in this
-  // file (the api:compare-mapped location) — the sole definitions, consumed by
-  // this class's single `emitTable`/`columnSpec` dispatch. `_adapter` is a
-  // trails-only helper on the base (it reaches base-private `_source`).
-
-  /** @internal */
-  protected schemaDefault(column: Column): string | undefined {
-    if (!column.hasDefault && column.default === undefined) return undefined;
-    if (column.default == null) return this.schemaExpression(column);
-    const adapter = this._adapter();
-    if (adapter?.lookupCastTypeFromColumn) {
-      const type = adapter.lookupCastTypeFromColumn(column);
-      if (type != null && typeof type.deserialize === "function") {
-        const deserialized = type.deserialize(column.default);
-        if (deserialized == null) {
-          // column.default is already non-null (the `== null` guard above
-          // returned early). It may be a pre-deserialized JS value (e.g. []
-          // for a PG OID::Array column) that the scalar element type cannot
-          // deserialize. Apply typeCastForSchema directly on the original.
-          return type.typeCastForSchema(column.default);
-        }
-        return type.typeCastForSchema(deserialized);
-      }
-    }
-    if (typeof column.default === "string") return JSON.stringify(column.default);
-    return String(column.default);
-  }
-
-  /** @internal */
-  protected schemaExpression(column: Column): string | undefined {
-    // TS-DSL arrow form (Rails dumps the Ruby lambda `-> { … }`); emitted verbatim
-    // by formatColspec and consumed by the DSL as `default: () => "fn()"`.
-    if (column.defaultFunction) return `() => ${JSON.stringify(column.defaultFunction)}`;
-    return undefined;
-  }
-
-  /** @internal */
-  protected schemaCollation(column: Column): string | undefined {
-    if (column.collation) return JSON.stringify(column.collation);
-    return undefined;
-  }
-
-  /**
-   * The single `emitTable`, routed through `columnSpec` so per-dialect
-   * `prepareColumnOptions` overrides (schemaType, schemaLimit, schemaPrecision,
-   * schemaDefault, etc.) take effect. Mirrors the column-emission half of Rails'
-   * `SchemaDumper#table`, whose `@connection.column_spec` is the adapter's
-   * mixed-in method. Every dump reaches it — the bare base redirects
-   * construction here (see `SchemaDumper.connectionAdaptersDumper`), including
-   * the in-memory MigrationContext and mock-source paths.
-   * @internal
-   */
-  protected override emitTable(
-    lines: string[],
-    tableName: string,
-    columns: ColumnInfo[],
-    indexes: IndexInfo[],
-    adapterTableOpts: Record<string, unknown> = {},
-    inlineConstraints: string[] = [],
-  ): void {
-    const pkColumns = this.resolvePrimaryKeyColumns(tableName, columns);
-    const hasCompositePk = pkColumns.length > 1;
-    const pkColumn = pkColumns[0];
-    // The single-PK column name Rails skips in the column loop (`next if column.name == pk`).
-    // Composite PKs (Rails Array case) and PK-less tables never skip a column.
-    const singlePkName = !hasCompositePk && pkColumn ? pkColumn.name : undefined;
-    const stripped = this.removePrefixAndSuffix(tableName);
-
-    // All values in tableOpts are pre-formatted TS-DSL text for formatColspec.
-    const tableOpts: Record<string, unknown> = {};
-    if (hasCompositePk) {
-      // Rails (Array case) emits only `primary_key: [...]`; the TS DSL also needs
-      // `id: false` so createTable doesn't auto-add an `id` column on round-trip.
-      tableOpts["primaryKey"] = JSON.stringify(pkColumns.map((c) => c.name));
-      tableOpts["id"] = "false";
-    } else if (!pkColumn) {
-      tableOpts["id"] = "false";
-    } else {
-      // Rails (String case): print `primary_key: <name>` for a non-"id" key, then the
-      // column spec unless empty. Mirrors schema_dumper.rb:170-179.
-      if (pkColumn.name !== "id") tableOpts["primaryKey"] = JSON.stringify(pkColumn.name);
-      // columnSpecForPrimaryKey returns a FLAT spec (dialect overrides post-process it,
-      // e.g. MySQL deletes auto_increment); wrap into `id: { ... }` here at the call site,
-      // after those overrides, so the PK's own `comment:` doesn't collide with the
-      // table-level `comment:`.
-      const pkSpec = this.columnSpecForPrimaryKey(pkColumn);
-      if (Object.keys(pkSpec).length > 0) {
-        if (Object.keys(pkSpec).every((k) => k === "id" || k === "default")) {
-          Object.assign(tableOpts, pkSpec);
-        } else {
-          const { id: idType, ...rest } = pkSpec as { id?: unknown } & Record<string, unknown>;
-          tableOpts["id"] = { ...(idType != null ? { type: idType } : {}), ...rest };
-        }
-      }
-    }
-    if (typeof adapterTableOpts.charset === "string")
-      tableOpts["charset"] = JSON.stringify(adapterTableOpts.charset);
-    if (typeof adapterTableOpts.collation === "string")
-      tableOpts["collation"] = JSON.stringify(adapterTableOpts.collation);
-    if (typeof adapterTableOpts.options === "string")
-      tableOpts["options"] = JSON.stringify(adapterTableOpts.options);
-    if (typeof adapterTableOpts.comment === "string" && adapterTableOpts.comment.trim().length > 0)
-      tableOpts["comment"] = JSON.stringify(adapterTableOpts.comment);
-    tableOpts["force"] = '"cascade"';
-
-    lines.push(
-      `  await ctx.createTable(${JSON.stringify(stripped)}, { ${this.formatColspec(tableOpts)} }, (t) => {`,
-    );
-
-    for (const col of columns) {
-      if (col.name === singlePkName) continue;
-
-      const [dslType, spec] = this.columnSpec(col);
-      const optStr = Object.keys(spec).length > 0 ? `, { ${this.formatColspec(spec)} }` : "";
-      const typeName = String(dslType);
-
-      if (this._isDslHelper(typeName)) {
-        lines.push(`    t.${typeName}(${JSON.stringify(col.name)}${optStr});`);
-      } else if ((col as any).isEnum && typeName === "enum") {
-        lines.push(`    t.enum(${JSON.stringify(col.name)}${optStr});`);
-      } else {
-        // Generic fallback: pass arbitrary SQL type verbatim via t.column.
-        const colType = typeName === "enum" ? ((col as any).sqlType ?? typeName) : typeName;
-        lines.push(
-          `    t.column(${JSON.stringify(col.name)}, ${JSON.stringify(colType)}${optStr});`,
-        );
-      }
-    }
-
-    for (const line of inlineConstraints) lines.push(line);
-    lines.push("  });");
-    this.indexesInCreate(tableName, lines, indexes);
-  }
+/**
+ * Public view of the dumper members these `this`-typed helpers reach. The base
+ * `SchemaDumper` declares most of these `protected`; a free function can't touch
+ * protected members through `this`, so the base wraps each helper and passes
+ * `this` cast to this host interface. Dialect subclass overrides of the mixin
+ * methods (schemaType, schemaLimit, …) still dispatch dynamically through `this`.
+ * @internal
+ */
+export interface SchemaDumperMixinHost {
+  readonly tableName: string | undefined;
+  _adapter(): any;
+  resolvePrimaryKeyColumns(tableName: string, columns: ColumnInfo[]): ColumnInfo[];
+  removePrefixAndSuffix(table: string): string;
+  formatColspec(colspec: Record<string, unknown>): string;
+  indexesInCreate(tableName: string, lines: string[], indexes?: IndexInfo[]): void;
+  _isDslHelper(dslType: string): boolean;
+  columnSpec(column: Column): [string, Record<string, unknown>];
+  columnSpecForPrimaryKey(column: Column): Record<string, unknown>;
+  prepareColumnOptions(column: Column): Record<string, unknown>;
+  isDefaultPrimaryKey(column: Column): boolean;
+  isExplicitPrimaryKeyDefault(column: Column): boolean;
+  schemaTypeWithVirtual(column: Column): string;
+  schemaType(column: Column): string;
+  isBigint(column: Column): boolean;
+  schemaLimit(column: Column): string | undefined;
+  schemaPrecision(column: Column): string | undefined;
+  schemaScale(column: Column): string | undefined;
+  schemaDefault(column: Column): string | undefined;
+  schemaExpression(column: Column): string | undefined;
+  schemaCollation(column: Column): string | undefined;
 }
 
-// Register this ConnectionAdapters subclass so `BaseSchemaDumper.create`/`dump`
-// with a plain (non-adapter) SchemaSource transparently constructs it — the
-// single `emitTable`/`columnSpec` dispatch, mirroring Rails' adapter-mixed-in
-// `column_spec`. Every file that can reach a bare-base dump also loads this
-// module (the public `SchemaDumper` export is this class), so the slot is set
-// before any redirect resolves.
-BaseSchemaDumper.connectionAdaptersDumper = SchemaDumper;
+/** @internal */
+export function columnSpec(
+  this: SchemaDumperMixinHost,
+  column: Column,
+): [string, Record<string, unknown>] {
+  return [this.schemaTypeWithVirtual(column), this.prepareColumnOptions(column)];
+}
+
+/** @internal */
+export function columnSpecForPrimaryKey(
+  this: SchemaDumperMixinHost,
+  column: Column,
+): Record<string, unknown> {
+  const spec: Record<string, unknown> = {};
+  if (!this.isDefaultPrimaryKey(column)) {
+    // Pre-format the id value as a TS-DSL string literal for formatColspec.
+    spec["id"] = JSON.stringify(this.schemaType(column));
+  }
+  const colOpts = this.prepareColumnOptions(column);
+  delete colOpts["null"];
+  Object.assign(spec, colOpts);
+  if (this.isExplicitPrimaryKeyDefault(column)) {
+    // "null" (not Ruby "nil") — emitted verbatim by formatColspec as `default: null`.
+    spec["default"] ??= "null";
+  }
+  return spec;
+}
+
+/** @internal */
+export function prepareColumnOptions(
+  this: SchemaDumperMixinHost,
+  column: Column,
+): Record<string, unknown> {
+  const spec: Record<string, unknown> = {};
+  const limit = this.schemaLimit(column);
+  if (limit !== undefined) spec["limit"] = limit;
+  const precision = this.schemaPrecision(column);
+  if (precision !== undefined) spec["precision"] = precision;
+  const scale = this.schemaScale(column);
+  if (scale !== undefined) spec["scale"] = scale;
+  const def = this.schemaDefault(column);
+  if (def !== undefined) spec["default"] = def;
+  if (column.null === false) spec["null"] = "false";
+  const collation = this.schemaCollation(column);
+  if (collation !== undefined) spec["collation"] = collation;
+  if (column.comment) spec["comment"] = JSON.stringify(column.comment);
+  return spec;
+}
+
+/** @internal */
+export function isDefaultPrimaryKey(this: SchemaDumperMixinHost, column: Column): boolean {
+  return this.schemaType(column) === "bigint";
+}
+
+/** @internal */
+export function isExplicitPrimaryKeyDefault(this: SchemaDumperMixinHost, _column: Column): boolean {
+  return false;
+}
+
+/** @internal */
+export function schemaTypeWithVirtual(this: SchemaDumperMixinHost, column: Column): string {
+  if (column.virtual) return "virtual";
+  return this.schemaType(column);
+}
+
+/** @internal */
+export function schemaType(this: SchemaDumperMixinHost, column: Column): string {
+  if (this.isBigint(column)) return "bigint";
+  // Column#type is nil for an unmapped sql_type (e.g. a composite OID),
+  // mirroring Rails' `allow_nil: true`. Fall back to the raw sql_type so the
+  // dump still round-trips (RFC 0056) rather than masking the nil as "". The
+  // coalesced `AdapterSchemaSource.columns()` shape is never-nil at runtime,
+  // so this guard only fires for a raw adapter dumped directly as SchemaSource.
+  return column.type ?? column.sqlType ?? "unknown";
+}
+
+/**
+ * Mirrors `ConnectionAdapters::Column#bigint?` (`/\Abigint\b/.match?(sql_type)`),
+ * which the abstract `schema_type` consults. A live column reflects a `bigint`
+ * declaration as sqlType `"bigint"`/`"BIGINT"` with dsl type `"integer"`, so
+ * detect it off sqlType; the `bigint` flag / `type === "bigint"` arms keep mock
+ * sources that set them directly working.
+ * @internal
+ */
+export function isBigint(this: SchemaDumperMixinHost, column: Column): boolean {
+  return !!column.bigint || column.type === "bigint" || /^bigint\b/i.test(column.sqlType ?? "");
+}
+
+/** @internal */
+export function schemaLimit(this: SchemaDumperMixinHost, column: Column): string | undefined {
+  // Mirrors Rails `schema_limit`: `limit = column.limit unless column.bigint?` — same
+  // predicate `schema_type` uses, so a column whose bigint-ness is only visible through
+  // sqlType is limit-suppressed too.
+  if (this.isBigint(column)) return undefined;
+  // Rails suppresses the serial/bigserial limit because it matches the native
+  // database type's default (int4 limit = 4, int8 limit = 8). We don't have
+  // the native_database_types comparison available here, so we guard explicitly
+  // on isSerial — functionally equivalent to the Rails approach.
+  if (column.isSerial) return undefined;
+  const limit = column.limit;
+  if (limit == null) return undefined;
+  return String(limit);
+}
+
+/** @internal */
+export function schemaPrecision(this: SchemaDumperMixinHost, column: Column): string | undefined {
+  if (column.type === "datetime") {
+    // TS-DSL literal `null` (Rails dumps the Ruby `nil`); the value is emitted
+    // verbatim by formatColspec, so it must already read as valid TS.
+    if (column.precision == null) return "null";
+    if (column.precision === DEFAULT_DATETIME_PRECISION) return undefined;
+    return String(column.precision);
+  }
+  if (column.precision != null) return String(column.precision);
+  return undefined;
+}
+
+/** @internal */
+export function schemaScale(this: SchemaDumperMixinHost, column: Column): string | undefined {
+  if (column.scale != null) return String(column.scale);
+  return undefined;
+}
+
+// Rails `schema_default` / `schema_expression` live in
+// `connection_adapters/abstract/schema_dumper.rb`, so the ports stay in this
+// file (the api:compare-mapped location) — the sole definitions, consumed by
+// the single `emitTable`/`columnSpec` dispatch. `_adapter` is a trails-only
+// helper on the base (it reaches base-private `_source`).
+
+/** @internal */
+export function schemaDefault(this: SchemaDumperMixinHost, column: Column): string | undefined {
+  if (!column.hasDefault && column.default === undefined) return undefined;
+  if (column.default == null) return this.schemaExpression(column);
+  const adapter = this._adapter();
+  if (adapter?.lookupCastTypeFromColumn) {
+    const type = adapter.lookupCastTypeFromColumn(column);
+    if (type != null && typeof type.deserialize === "function") {
+      const deserialized = type.deserialize(column.default);
+      if (deserialized == null) {
+        // column.default is already non-null (the `== null` guard above
+        // returned early). It may be a pre-deserialized JS value (e.g. []
+        // for a PG OID::Array column) that the scalar element type cannot
+        // deserialize. Apply typeCastForSchema directly on the original.
+        return type.typeCastForSchema(column.default);
+      }
+      return type.typeCastForSchema(deserialized);
+    }
+  }
+  if (typeof column.default === "string") return JSON.stringify(column.default);
+  return String(column.default);
+}
+
+/** @internal */
+export function schemaExpression(this: SchemaDumperMixinHost, column: Column): string | undefined {
+  // TS-DSL arrow form (Rails dumps the Ruby lambda `-> { … }`); emitted verbatim
+  // by formatColspec and consumed by the DSL as `default: () => "fn()"`.
+  if (column.defaultFunction) return `() => ${JSON.stringify(column.defaultFunction)}`;
+  return undefined;
+}
+
+/** @internal */
+export function schemaCollation(this: SchemaDumperMixinHost, column: Column): string | undefined {
+  if (column.collation) return JSON.stringify(column.collation);
+  return undefined;
+}
+
+/**
+ * The single `emitTable`, routed through `columnSpec` so per-dialect
+ * `prepareColumnOptions` overrides (schemaType, schemaLimit, schemaPrecision,
+ * schemaDefault, etc.) take effect. Mirrors the column-emission half of Rails'
+ * `SchemaDumper#table`, whose `@connection.column_spec` is the adapter's
+ * mixed-in method. Every dump reaches it — the single dumper class assigns this
+ * onto its prototype, including the in-memory MigrationContext and mock-source
+ * paths.
+ * @internal
+ */
+export function emitTable(
+  this: SchemaDumperMixinHost,
+  lines: string[],
+  tableName: string,
+  columns: ColumnInfo[],
+  indexes: IndexInfo[],
+  adapterTableOpts: Record<string, unknown> = {},
+  inlineConstraints: string[] = [],
+): void {
+  const pkColumns = this.resolvePrimaryKeyColumns(tableName, columns);
+  const hasCompositePk = pkColumns.length > 1;
+  const pkColumn = pkColumns[0];
+  // The single-PK column name Rails skips in the column loop (`next if column.name == pk`).
+  // Composite PKs (Rails Array case) and PK-less tables never skip a column.
+  const singlePkName = !hasCompositePk && pkColumn ? pkColumn.name : undefined;
+  const stripped = this.removePrefixAndSuffix(tableName);
+
+  // All values in tableOpts are pre-formatted TS-DSL text for formatColspec.
+  const tableOpts: Record<string, unknown> = {};
+  if (hasCompositePk) {
+    // Rails (Array case) emits only `primary_key: [...]`; the TS DSL also needs
+    // `id: false` so createTable doesn't auto-add an `id` column on round-trip.
+    tableOpts["primaryKey"] = JSON.stringify(pkColumns.map((c) => c.name));
+    tableOpts["id"] = "false";
+  } else if (!pkColumn) {
+    tableOpts["id"] = "false";
+  } else {
+    // Rails (String case): print `primary_key: <name>` for a non-"id" key, then the
+    // column spec unless empty. Mirrors schema_dumper.rb:170-179.
+    if (pkColumn.name !== "id") tableOpts["primaryKey"] = JSON.stringify(pkColumn.name);
+    // columnSpecForPrimaryKey returns a FLAT spec (dialect overrides post-process it,
+    // e.g. MySQL deletes auto_increment); wrap into `id: { ... }` here at the call site,
+    // after those overrides, so the PK's own `comment:` doesn't collide with the
+    // table-level `comment:`.
+    const pkSpec = this.columnSpecForPrimaryKey(pkColumn);
+    if (Object.keys(pkSpec).length > 0) {
+      if (Object.keys(pkSpec).every((k) => k === "id" || k === "default")) {
+        Object.assign(tableOpts, pkSpec);
+      } else {
+        const { id: idType, ...rest } = pkSpec as { id?: unknown } & Record<string, unknown>;
+        tableOpts["id"] = { ...(idType != null ? { type: idType } : {}), ...rest };
+      }
+    }
+  }
+  if (typeof adapterTableOpts.charset === "string")
+    tableOpts["charset"] = JSON.stringify(adapterTableOpts.charset);
+  if (typeof adapterTableOpts.collation === "string")
+    tableOpts["collation"] = JSON.stringify(adapterTableOpts.collation);
+  if (typeof adapterTableOpts.options === "string")
+    tableOpts["options"] = JSON.stringify(adapterTableOpts.options);
+  if (typeof adapterTableOpts.comment === "string" && adapterTableOpts.comment.trim().length > 0)
+    tableOpts["comment"] = JSON.stringify(adapterTableOpts.comment);
+  tableOpts["force"] = '"cascade"';
+
+  lines.push(
+    `  await ctx.createTable(${JSON.stringify(stripped)}, { ${this.formatColspec(tableOpts)} }, (t) => {`,
+  );
+
+  for (const col of columns) {
+    if (col.name === singlePkName) continue;
+
+    const [dslType, spec] = this.columnSpec(col);
+    const optStr = Object.keys(spec).length > 0 ? `, { ${this.formatColspec(spec)} }` : "";
+    const typeName = String(dslType);
+
+    if (this._isDslHelper(typeName)) {
+      lines.push(`    t.${typeName}(${JSON.stringify(col.name)}${optStr});`);
+    } else if ((col as any).isEnum && typeName === "enum") {
+      lines.push(`    t.enum(${JSON.stringify(col.name)}${optStr});`);
+    } else {
+      // Generic fallback: pass arbitrary SQL type verbatim via t.column.
+      const colType = typeName === "enum" ? ((col as any).sqlType ?? typeName) : typeName;
+      lines.push(`    t.column(${JSON.stringify(col.name)}, ${JSON.stringify(colType)}${optStr});`);
+    }
+  }
+
+  for (const line of inlineConstraints) lines.push(line);
+  lines.push("  });");
+  this.indexesInCreate(tableName, lines, indexes);
+}

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -10,15 +10,24 @@
  * same logic across two classes — the base here in schema_dumper.rb
  * and a `ConnectionAdapters::SchemaDumper` subclass at
  * connection_adapters/abstract/schema_dumper.rb that adds adapter-
- * specific column-spec helpers. We keep the same file layout and
- * `inner extends outer` relationship; the inner lives at
- * connection-adapters/abstract/schema-dumper.ts.
+ * specific column-spec helpers. TypeScript can't `extends` the subclass
+ * back onto this base without an ESM temporal-dead-zone cycle, so we
+ * keep a single dumper class here and mix the subclass's column-spec
+ * helpers in as `this`-typed functions (CLAUDE.md "Module mixins"),
+ * whose bodies live at connection-adapters/abstract/schema-dumper.ts
+ * to preserve the api:compare file layout. Construction is fully
+ * synchronous and needs no other module to have loaded the adapter layer.
  */
 
 import type { AbstractAdapter as DatabaseAdapter } from "./connection-adapters/abstract-adapter.js";
 import type { SchemaStatements } from "./connection-adapters/abstract/schema-statements.js";
 import { assertSchemaAdapter } from "./connection-adapters/abstract/assert-schema-adapter.js";
 import type * as SchemaIntrospectionModule from "./schema-introspection.js";
+import * as adapterDumper from "./connection-adapters/abstract/schema-dumper.js";
+import type {
+  SchemaDumperMixinHost,
+  Column,
+} from "./connection-adapters/abstract/schema-dumper.js";
 import { SchemaMigration } from "./schema-migration.js";
 import { Base } from "./base.js";
 
@@ -335,19 +344,14 @@ export class SchemaDumper {
   static uniqueIgnorePattern: RegExp = /^uniq_rails_[0-9a-f]{10}$/;
 
   /**
-   * The `ConnectionAdapters::SchemaDumper` subclass, registered by that module
-   * at load. Rails has a single dumper: `SchemaDumper#table` drives columns
-   * through the unqualified `column_spec` (schema_dumper.rb:199), a private
-   * method defined only on the adapter subclass (abstract/schema_dumper.rb:13),
-   * so Rails always instantiates that subclass via `connection.create_schema_dumper`
-   * — a bare `ActiveRecord::SchemaDumper` would `NameError` on `column_spec`. TS
-   * can't mix a module into a class, so the emitter lives on the subclass and the
-   * base factory (`create`/`dump`/`dumpTableSchema`) redirects to it for
-   * non-adapter sources. Dialect subclasses set `this` to themselves and are
-   * never redirected.
+   * Per-table primary-key column order from `@connection.primary_key(table)`.
+   * Populated by `table()` before column iteration so `emitTable` can render
+   * `primaryKey: [...]` (and pick the single-PK column) in PK definition order
+   * rather than introspection/declaration order. Mirrors Rails' reliance on
+   * `@connection.primary_key(table)`, which already returns columns in key order.
    * @internal
    */
-  static connectionAdaptersDumper?: typeof SchemaDumper;
+  protected primaryKeyOrderCache: Record<string, string[] | undefined> = Object.create(null);
 
   private _source: SchemaSource;
   protected _options: Record<string, unknown>;
@@ -418,27 +422,11 @@ export class SchemaDumper {
     source: SchemaSource,
     options: Record<string, unknown> = {},
   ): InstanceType<T> {
-    // Redirect the bare base to the ConnectionAdapters subclass so the single
-    // `emitTable`/`columnSpec` dispatch (which lives there, mirroring Rails'
-    // adapter-mixed-in column_spec) serves every source. Dialect subclasses
-    // pass `this !== SchemaDumper` and construct themselves unchanged.
-    if (this !== SchemaDumper) return new this(source, options) as InstanceType<T>;
-    const Sub = SchemaDumper.connectionAdaptersDumper;
-    if (!Sub) {
-      // Like Rails, a bare base has no `column_spec` — `SchemaDumper#table`
-      // (schema_dumper.rb:199) calls the unqualified `column_spec`, private to
-      // the adapter subclass (abstract/schema_dumper.rb:13), so Rails always
-      // builds it via `connection.create_schema_dumper`. The public
-      // `SchemaDumper` export IS that subclass; this throw only fires for a deep
-      // import of the internal base module without the connection-adapters layer
-      // loaded. Deterministic (never a silent async/broken dump), not
-      // timing-dependent.
-      throw new Error(
-        "SchemaDumper has no column_spec on the base class; obtain the dumper via " +
-          "an adapter's createSchemaDumper() or the ConnectionAdapters SchemaDumper.",
-      );
-    }
-    return new Sub(source, options) as InstanceType<T>;
+    // Single dumper class: the `emitTable`/`columnSpec` dispatch is mixed onto
+    // this prototype (see the wrappers below), so a bare-base construction is
+    // fully self-contained. `this` is the concrete subclass, so calling
+    // `.create(...)` on a dialect subclass returns that subclass.
+    return new this(source, options) as InstanceType<T>;
   }
 
   /**
@@ -713,6 +701,17 @@ export class SchemaDumper {
 
   /** @internal */
   async table(tableName: string, lines: string[]): Promise<void> {
+    // Mirrors Rails' reliance on `@connection.primary_key(table)`: capture the
+    // authoritative PK column order before iterating columns so `emitTable` /
+    // `resolvePrimaryKeyColumns` render composite/promoted keys in key order.
+    const adapter = this._adapter();
+    if (adapter && typeof adapter.primaryKeys === "function") {
+      try {
+        this.primaryKeyOrderCache[tableName] = await adapter.primaryKeys(tableName);
+      } catch {
+        // Live introspection is best-effort; fall through to declaration order.
+      }
+    }
     this.tableName = tableName;
     try {
       const columns = await this._source.columns(tableName);
@@ -804,38 +803,149 @@ export class SchemaDumper {
   }
 
   /**
-   * Hook for adapter subclasses to reorder the primary-key column list emitted
-   * inside `tableOpts.primaryKey` for composite PKs. Default: identity
-   * (preserve `SHOW COLUMNS` declaration order). MySQL overrides this to
-   * mirror Rails' `@connection.primary_key(table)`, which returns columns in
-   * `seq_in_index` order.
+   * The table's primary-key columns, in key order. Defaults to the columns
+   * carrying the per-column `primaryKey` flag (reordered by the live PK order).
+   * Dialects whose per-column flag can over-report (e.g. MySQL's `column_key`
+   * promotes a UNIQUE NOT NULL index to `PRI` when there is no PRIMARY KEY)
+   * override this to consult the authoritative primary key instead.
    * @internal
    */
-  protected orderPrimaryKeyColumns(_tableName: string, pkColumns: ColumnInfo[]): ColumnInfo[] {
-    return pkColumns;
+  protected resolvePrimaryKeyColumns(tableName: string, columns: ColumnInfo[]): ColumnInfo[] {
+    return this.orderPrimaryKeyColumns(
+      tableName,
+      columns.filter((c) => c.primaryKey),
+    );
   }
 
   /**
-   * Emit a single `create_table` block. Mirrors the column-emission half of
-   * Rails' `SchemaDumper#table`, whose `@connection.column_spec(column)` call
-   * is provided by the adapter's mixed-in `ConnectionAdapters::SchemaDumper`.
-   * TS has no module mixin, so the implementation lives on that subclass
-   * (`connection-adapters/abstract/schema-dumper.ts`) and every dump reaches it
-   * via {@link create}'s redirect — the bare base is never the emitter.
+   * Reorder the primary-key column list to match the live PK order captured in
+   * `primaryKeyOrderCache` (`@connection.primary_key(table)`); falls back to the
+   * given order when no live order is known (in-memory / mock sources).
    * @internal
    */
+  protected orderPrimaryKeyColumns(tableName: string, pkColumns: ColumnInfo[]): ColumnInfo[] {
+    const order = this.primaryKeyOrderCache[tableName];
+    if (!order || order.length === 0) return pkColumns;
+    const byName = new Map(pkColumns.map((c) => [c.name, c]));
+    const reordered: ColumnInfo[] = [];
+    for (const name of order) {
+      const col = byName.get(name);
+      if (col) {
+        reordered.push(col);
+        byName.delete(name);
+      }
+    }
+    for (const col of byName.values()) reordered.push(col);
+    return reordered;
+  }
+
+  // Column-spec dispatch mixed in from the `ConnectionAdapters::SchemaDumper`
+  // layer (connection-adapters/abstract/schema-dumper.ts). The bodies live there
+  // to keep the api:compare file mapping; these thin `protected` wrappers put
+  // them on this single class's prototype (so dialect subclasses' `super`/
+  // `override` resolve normally) without a cyclic `extends`. `this` is cast to
+  // the public host view because the wrapped helpers reach protected members.
+
+  /** @internal */
   protected emitTable(
-    _lines: string[],
-    _tableName: string,
-    _columns: ColumnInfo[],
-    _indexes: IndexInfo[],
-    _adapterTableOpts: Record<string, unknown> = {},
-    _inlineConstraints: string[] = [],
+    lines: string[],
+    tableName: string,
+    columns: ColumnInfo[],
+    indexes: IndexInfo[],
+    adapterTableOpts: Record<string, unknown> = {},
+    inlineConstraints: string[] = [],
   ): void {
-    throw new Error(
-      "SchemaDumper.emitTable must run on the ConnectionAdapters subclass; " +
-        "construct via SchemaDumper.create/dump so the column_spec dispatch is available.",
+    return adapterDumper.emitTable.call(
+      this as unknown as SchemaDumperMixinHost,
+      lines,
+      tableName,
+      columns,
+      indexes,
+      adapterTableOpts,
+      inlineConstraints,
     );
+  }
+
+  /** @internal */
+  protected columnSpec(column: Column): [string, Record<string, unknown>] {
+    return adapterDumper.columnSpec.call(this as unknown as SchemaDumperMixinHost, column);
+  }
+
+  /** @internal */
+  protected columnSpecForPrimaryKey(column: Column): Record<string, unknown> {
+    return adapterDumper.columnSpecForPrimaryKey.call(
+      this as unknown as SchemaDumperMixinHost,
+      column,
+    );
+  }
+
+  /** @internal */
+  protected prepareColumnOptions(column: Column): Record<string, unknown> {
+    return adapterDumper.prepareColumnOptions.call(
+      this as unknown as SchemaDumperMixinHost,
+      column,
+    );
+  }
+
+  /** @internal */
+  protected isDefaultPrimaryKey(column: Column): boolean {
+    return adapterDumper.isDefaultPrimaryKey.call(this as unknown as SchemaDumperMixinHost, column);
+  }
+
+  /** @internal */
+  protected isExplicitPrimaryKeyDefault(column: Column): boolean {
+    return adapterDumper.isExplicitPrimaryKeyDefault.call(
+      this as unknown as SchemaDumperMixinHost,
+      column,
+    );
+  }
+
+  /** @internal */
+  protected schemaTypeWithVirtual(column: Column): string {
+    return adapterDumper.schemaTypeWithVirtual.call(
+      this as unknown as SchemaDumperMixinHost,
+      column,
+    );
+  }
+
+  /** @internal */
+  protected schemaType(column: Column): string {
+    return adapterDumper.schemaType.call(this as unknown as SchemaDumperMixinHost, column);
+  }
+
+  /** @internal */
+  protected isBigint(column: Column): boolean {
+    return adapterDumper.isBigint.call(this as unknown as SchemaDumperMixinHost, column);
+  }
+
+  /** @internal */
+  protected schemaLimit(column: Column): string | undefined {
+    return adapterDumper.schemaLimit.call(this as unknown as SchemaDumperMixinHost, column);
+  }
+
+  /** @internal */
+  protected schemaPrecision(column: Column): string | undefined {
+    return adapterDumper.schemaPrecision.call(this as unknown as SchemaDumperMixinHost, column);
+  }
+
+  /** @internal */
+  protected schemaScale(column: Column): string | undefined {
+    return adapterDumper.schemaScale.call(this as unknown as SchemaDumperMixinHost, column);
+  }
+
+  /** @internal */
+  protected schemaDefault(column: Column): string | undefined {
+    return adapterDumper.schemaDefault.call(this as unknown as SchemaDumperMixinHost, column);
+  }
+
+  /** @internal */
+  protected schemaExpression(column: Column): string | undefined {
+    return adapterDumper.schemaExpression.call(this as unknown as SchemaDumperMixinHost, column);
+  }
+
+  /** @internal */
+  protected schemaCollation(column: Column): string | undefined {
+    return adapterDumper.schemaCollation.call(this as unknown as SchemaDumperMixinHost, column);
   }
 
   /** @internal */

--- a/packages/activerecord/src/schema-dumper.ts
+++ b/packages/activerecord/src/schema-dumper.ts
@@ -843,8 +843,19 @@ export class SchemaDumper {
   // layer (connection-adapters/abstract/schema-dumper.ts). The bodies live there
   // to keep the api:compare file mapping; these thin `protected` wrappers put
   // them on this single class's prototype (so dialect subclasses' `super`/
-  // `override` resolve normally) without a cyclic `extends`. `this` is cast to
-  // the public host view because the wrapped helpers reach protected members.
+  // `override` resolve normally) without a cyclic `extends`. Each wrapper passes
+  // `this` through `_mixinHost` because the mixed-in helpers reach members this
+  // class declares `protected` (a free function can't see those through `this`).
+
+  /**
+   * The same instance, typed as the public host view the mixin helpers expect.
+   * Only a type reinterpretation — dynamic dispatch through `this` (dialect
+   * overrides of schemaType, schemaLimit, …) is preserved.
+   * @internal
+   */
+  private get _mixinHost(): SchemaDumperMixinHost {
+    return this as unknown as SchemaDumperMixinHost;
+  }
 
   /** @internal */
   protected emitTable(
@@ -856,7 +867,7 @@ export class SchemaDumper {
     inlineConstraints: string[] = [],
   ): void {
     return adapterDumper.emitTable.call(
-      this as unknown as SchemaDumperMixinHost,
+      this._mixinHost,
       lines,
       tableName,
       columns,
@@ -868,84 +879,72 @@ export class SchemaDumper {
 
   /** @internal */
   protected columnSpec(column: Column): [string, Record<string, unknown>] {
-    return adapterDumper.columnSpec.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.columnSpec.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected columnSpecForPrimaryKey(column: Column): Record<string, unknown> {
-    return adapterDumper.columnSpecForPrimaryKey.call(
-      this as unknown as SchemaDumperMixinHost,
-      column,
-    );
+    return adapterDumper.columnSpecForPrimaryKey.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected prepareColumnOptions(column: Column): Record<string, unknown> {
-    return adapterDumper.prepareColumnOptions.call(
-      this as unknown as SchemaDumperMixinHost,
-      column,
-    );
+    return adapterDumper.prepareColumnOptions.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected isDefaultPrimaryKey(column: Column): boolean {
-    return adapterDumper.isDefaultPrimaryKey.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.isDefaultPrimaryKey.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected isExplicitPrimaryKeyDefault(column: Column): boolean {
-    return adapterDumper.isExplicitPrimaryKeyDefault.call(
-      this as unknown as SchemaDumperMixinHost,
-      column,
-    );
+    return adapterDumper.isExplicitPrimaryKeyDefault.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected schemaTypeWithVirtual(column: Column): string {
-    return adapterDumper.schemaTypeWithVirtual.call(
-      this as unknown as SchemaDumperMixinHost,
-      column,
-    );
+    return adapterDumper.schemaTypeWithVirtual.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected schemaType(column: Column): string {
-    return adapterDumper.schemaType.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.schemaType.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected isBigint(column: Column): boolean {
-    return adapterDumper.isBigint.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.isBigint.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected schemaLimit(column: Column): string | undefined {
-    return adapterDumper.schemaLimit.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.schemaLimit.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected schemaPrecision(column: Column): string | undefined {
-    return adapterDumper.schemaPrecision.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.schemaPrecision.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected schemaScale(column: Column): string | undefined {
-    return adapterDumper.schemaScale.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.schemaScale.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected schemaDefault(column: Column): string | undefined {
-    return adapterDumper.schemaDefault.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.schemaDefault.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected schemaExpression(column: Column): string | undefined {
-    return adapterDumper.schemaExpression.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.schemaExpression.call(this._mixinHost, column);
   }
 
   /** @internal */
   protected schemaCollation(column: Column): string | undefined {
-    return adapterDumper.schemaCollation.call(this as unknown as SchemaDumperMixinHost, column);
+    return adapterDumper.schemaCollation.call(this._mixinHost, column);
   }
 
   /** @internal */


### PR DESCRIPTION
## What

Makes the bare-base `SchemaDumper` (`schema_dumper.rb` → `schema-dumper.ts`) construct its column-spec emitter **synchronously**, with no dependency on some other module having loaded the adapter layer and no timing-dependent throw.

Previously the base class had no emitter: `SchemaDumper.create` redirected to the `ConnectionAdapters::SchemaDumper` subclass through a class slot (`connectionAdaptersDumper`) registered at the subclass module's load, and threw when a deep import of the base module ran without the adapter layer loaded. A Codex reviewer flagged this across several rounds.

## Approach

Chose acceptance-criteria option **(a)**: flatten the base/subclass onto the repo's `this`-typed function-mixin pattern (CLAUDE.md "Module mixins"), so a single dumper class exists with no cyclic `extends`.

- The adapter-layer emitter helpers (`column_spec`, `column_spec_for_primary_key`, `prepare_column_options`, `schema_type`/`schema_limit`/`schema_precision`/`schema_scale`/`schema_default`/`schema_expression`/`schema_collation`, `schema_type_with_virtual`, `emit_table`, …) become exported `this`-typed **functions** in `connection-adapters/abstract/schema-dumper.ts` — keeping the api:compare file mapping intact (`column_spec`/`schema_default`/`schema_expression` remain there).
- The single base class in `schema-dumper.ts` imports those functions and assigns them onto its own prototype via thin `protected` wrappers (each passes `this` through a `_mixinHost` view because the helpers reach `protected` members). It also absorbs the trails-only `resolvePrimaryKeyColumns`/`orderPrimaryKeyColumns`/`primaryKeyOrderCache` + PK-order population. `create` is now a plain synchronous `new this(...)`.
- The abstract module **re-exports** the base class, so existing deep imports and the public `index.ts` export keep resolving to the one class.
- Dialect subclasses (PG/MySQL/SQLite) are **unchanged**: they extend the re-exported base and their `super`/`override` calls resolve to the mixed-in wrappers.

Because `schema-dumper.ts` now statically imports the (lightweight) adapter-layer helper module itself, the emitter is present on the class the moment the base module is evaluated — no registration slot, no redirect, no ordering assumption.

## Verification

- `pnpm api:compare` green: `schema_dumper.rb`, `connection_adapters/abstract/schema_dumper.rb`, and the three dialect dumper files all map **100%**. Narrow + wide call-mismatch ratchets, body-pins, conventions-doc, and lint-deps all pass with **no baseline reseed** (bodies moved verbatim).
- Bare in-memory dump returns a `string` synchronously (no `Promise`), with no adapter instance and no throw.
- 182 dumper/PK tests pass (base/abstract/dialect `schema-dumper.test.ts`, `schema-dumper.trails`, `schema-dumping-helper`, `primary-keys`, `defaults`, `date-time-precision`). No dump-output change.

## Scope note

The `create`-time throw and the slot race are gone. A separate, pre-existing module-graph hazard is out of scope: importing the raw internal `schema-dumper.ts` in isolation still eagerly pulls `Base`'s connection-adapter graph, which loads the dialect dumpers — and any module that `extends` the base while the base module is mid-initialization hits an ESM temporal-dead-zone. This reproduces identically on `main` (there the TDZ surfaces in the old `abstract` subclass instead of a dialect) and is rooted in `Base`'s adapter graph, not the dumper hierarchy; the normal entry points (`index.ts`, any adapter, `schema-dumping-helper`) are unaffected.

## Note on size

The diff is large in raw line count but is almost entirely mechanical **code motion** (abstract class methods → exported functions, verbatim bodies) plus the delegating wrappers; the net new logic is small and matches the ~250-LOC estimate. Kept as a single PR because the two files are one cohesive refactor.

Closes-story: synchronous-bare-base-dumper-construction

## Reviewer note — `columnSpec` return type

Flagged: the first tuple element narrowed from `[symbol | string, …]` to `[string, …]`. This is a deliberate type-accuracy fix, not a behavior change, and the bodies are otherwise verbatim:

- Rails' `schema_type` returns a Ruby **symbol** (`:bigint`, `:virtual`, `column.type`), which is why an early port typed the union with `symbol`. Our TS port never produces a `symbol`: `schemaType` and `schemaTypeWithVirtual` (base + every PG/MySQL/SQLite override) are all annotated `: string` and return string literals/expressions (`"virtual"`, `"bigint"`, `"bigserial"`, `column.type`).
- Dialect overrides also *consume* the result as a string (`this.schemaType(column) === "bigint"` / `"bigserial"` / `"integer"`), and `emitTable` does `String(dslType)` — so no current or override code path relies on a `symbol` sentinel. Grepped: no `Symbol(` in any dumper.
- If a future Rails-parity port ever needs a symbol-style sentinel, it would be introduced as a string constant here (consistent with the rest of the TS DSL), not a JS `symbol`.
