### PR TITLE
fix(associations): infer composite-PK "id" for owner-side has_many/has_one

### DIFF
--- a/packages/activerecord/src/associations.ts
+++ b/packages/activerecord/src/associations.ts
@@ -2280,18 +2280,26 @@ export function computeHasManyWhere(
     return conditions;
   }
 
-  // Scalar FK: a composite PK here is a mismatch too.
+  // Scalar FK against a composite-PK owner collapses to the "id" component,
+  // matching `reflection.active_record_primary_key` (reflection.rb) — the same
+  // resolver loadHasMany's AssociationScope path uses. A composite PK lacking
+  // "id" can't map to a scalar FK, so that remains a mismatch.
   if (Array.isArray(primaryKey)) {
-    // Route through the reflection's canonical checkValidityBang (Rails'
-    // single raise site) so the error carries the Rails-faithful message.
-    routeThroughCheckValidity(ctor, assocName);
-    // No reflection resolvable — minimal trails-only fallback guard.
-    throw new CompositePrimaryKeyMismatchError({
-      activeRecord: ctor.name,
-      name: assocName,
-      primaryKey,
-      foreignKey,
-    });
+    const inferred = reflection?.activeRecordPrimaryKey;
+    if (typeof inferred === "string") {
+      primaryKey = inferred;
+    } else {
+      // Route through the reflection's canonical checkValidityBang (Rails'
+      // single raise site) so the error carries the Rails-faithful message.
+      routeThroughCheckValidity(ctor, assocName);
+      // No reflection resolvable — minimal trails-only fallback guard.
+      throw new CompositePrimaryKeyMismatchError({
+        activeRecord: ctor.name,
+        name: assocName,
+        primaryKey,
+        foreignKey,
+      });
+    }
   }
   const pkValue = record._readAttribute(primaryKey);
   if (pkValue === null || pkValue === undefined) return null;

--- a/packages/activerecord/src/test-helpers/models/cpk.ts
+++ b/packages/activerecord/src/test-helpers/models/cpk.ts
@@ -218,14 +218,12 @@ export class CpkOrder extends Base {
     this.hasMany("orderAgreements", {
       className: "CpkOrderAgreement",
       foreignKey: "order_id",
-      primaryKey: "id",
     });
     this.hasMany("books", { className: "CpkBook", foreignKey: ["shop_id", "order_id"] });
     this.hasOne("book", { className: "CpkBook", foreignKey: ["shop_id", "order_id"] });
     this.hasMany("orderTags", {
       className: "CpkOrderTag",
       foreignKey: "order_id",
-      primaryKey: "id",
     });
     this.hasMany("tags", { className: "CpkTag", through: "orderTags" });
   }
@@ -283,7 +281,7 @@ export class CpkOrderWithPrimaryKeyAssociatedBook extends CpkOrder {
 
   static _demodulizedName = "OrderWithPrimaryKeyAssociatedBook";
   static {
-    this.hasOne("book", { className: "CpkBook", foreignKey: "order_id", primaryKey: "id" });
+    this.hasOne("book", { className: "CpkBook", foreignKey: "order_id" });
   }
 }
 


### PR DESCRIPTION
Drop the trails-only `primaryKey: "id"` annotations from `CpkOrder`'s
`orderAgreements`/`orderTags` has_many and
`CpkOrderWithPrimaryKeyAssociatedBook`'s `book` has_one so the canonical
models match Rails verbatim. Rails' `cpk/order.rb` omits `primary_key:` on
all three (`has_many :order_agreements`, `has_many :order_tags`, and
`OrderWithPrimaryKeyAssociatedBook has_one :book, foreign_key: :order_id`).
This follows PR #4747, which removed the sibling belongs_to annotations.

The owner-side has_many/has_one key inference resolves the composite-PK
`"id"` component on its own: `computeHasManyWhere`'s scalar-FK branch now
collapses a composite-PK owner to its `"id"` component via
`reflection.activeRecordPrimaryKey` (reflection.rb `active_record_primary_key`),
the same resolver `loadHasMany`'s AssociationScope path already uses.
Previously it threw `CompositePrimaryKeyMismatchError`, which the explicit
annotations papered over. The has_one path already routes through
AssociationScope, so it needed no change.

Verified across the cpk-referencing suites (associations, has-many/has-one
and their -through variants, eager, autosave, persistence, batches,
update-all/delete-all, primary-keys, and the cpk relation trails suites) —
all green, no test renames.

Closes-story: cpk-canonical-models-drop-owner-side-primarykey-id