### PR TITLE
fix(associations): has_one find_target honors new-record owner primary key

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -5,7 +5,8 @@ import { DeleteRestrictionError } from "./errors.js";
 import { RecordNotSaved } from "../errors.js";
 import { underscore } from "@blazetrails/activesupport";
 import { reflectOnAllAssociations } from "../reflection.js";
-import { ForeignAssociation } from "./foreign-association.js";
+import { ForeignAssociation, foreignKeyPresentFor } from "./foreign-association.js";
+import type { AssociationReflection } from "../reflection.js";
 import { SingularAssociation } from "./singular-association.js";
 import { polymorphicName } from "../inheritance.js";
 
@@ -189,6 +190,25 @@ export class HasOneAssociation extends SingularAssociation {
     } finally {
       this.target = currentTarget;
     }
+  }
+
+  /**
+   * Whether the target can be fetched for a new-record owner. A vanilla has_one
+   * requires the owner's `active_record_primary_key` to be present
+   * (`ForeignAssociation#foreign_key_present?`, foreign_association.rb:5), so a
+   * new-record owner with its PK assigned (e.g. `Author.new(id: 42)`) can still
+   * load its child. Mirrors `CollectionAssociation#foreignKeyPresent` — the
+   * rich reflection is resolved so a custom-PK owner isn't misreported.
+   *
+   * @internal
+   */
+  protected override foreignKeyPresent(): boolean {
+    const ctor = this.owner.constructor as typeof Base & {
+      _reflectOnAssociation?: (n: string) => unknown;
+    };
+    const reflection = (ctor._reflectOnAssociation?.(this.reflection.name) ??
+      this.reflection) as unknown as AssociationReflection;
+    return foreignKeyPresentFor(reflection, this.owner);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -7,7 +7,7 @@
  * `Account` models and the `companies`/`accounts` fixtures. No `defineSchema`.
  */
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
-import { ArgumentError } from "@blazetrails/activemodel";
+import { ArgumentError, UnknownAttributeError } from "@blazetrails/activemodel";
 import { throwAbort } from "@blazetrails/activesupport";
 import {
   Base,
@@ -451,9 +451,11 @@ describe("HasOneAssociationsTest", () => {
     expect((await readHasOne(firm, "account")).id).toBe(account.id);
   });
 
-  it.skip("create with inexistent foreign key failing", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): building an Account through `account_with_inexistent_foreign_key`
-    // does not raise UnknownAttributeError for the bad foreign key column.
+  it("create with inexistent foreign key failing", async () => {
+    const firm = await Firm.create({ name: "GlobalMegaCorp" });
+    await expect((firm as any).createAccountWithInexistentForeignKey()).rejects.toThrow(
+      UnknownAttributeError,
+    );
   });
 
   it("reload association", async () => {
@@ -742,13 +744,22 @@ describe("HasOneAssociationsTest", () => {
     expect((await (pirate.association("ship") as any).forceReloadReader()).name).toBe("new name");
   });
 
-  it.skip("has one autosave with primary key manually set", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): manual-PK autosave on Author/Post — gap.
+  it("has one loading for new record", async () => {
+    const post = await Post.createBang({ author_id: 42, title: "foo", body: "bar" });
+    const author = new Author({ id: 42 });
+    expect((await readHasOne(author, "post")).id).toBe(post.id);
   });
 
-  it.skip("has one loading for new record", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): a new (unsaved) Author with a manually-set id does not load its
-    // has_one post — has_one read on a new record short-circuits to null.
+  it("has one autosave with primary key manually set", async () => {
+    const post = await Post.create({ id: 1234, title: "Some title", body: "Some content" });
+    const author = new Author({ id: 33, name: "Hank Moody" });
+
+    (author as any).post = post;
+    await (author as any).save();
+    await author.reload();
+
+    expect(await readHasOne(author, "post")).not.toBeNull();
+    expect((await readHasOne(author, "post")).id).toBe(post.id);
   });
 
   it("has one relationship cannot have a counter cache", () => {

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -13007,6 +13007,27 @@
   },
   {
     "package": "activerecord",
+    "tsFile": "associations/has-one-association.ts",
+    "rubyName": "foreign_key_present?",
+    "call": "attribute_present?",
+    "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which calls owner.attributePresent — same delegation as CollectionAssociation#foreignKeyPresent."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-association.ts",
+    "rubyName": "foreign_key_present?",
+    "call": "klass",
+    "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which reads reflection.klass — same delegation as CollectionAssociation#foreignKeyPresent."
+  },
+  {
+    "package": "activerecord",
+    "tsFile": "associations/has-one-association.ts",
+    "rubyName": "foreign_key_present?",
+    "call": "primary_key",
+    "reason": "Satisfied via the extracted foreignKeyPresentFor helper (foreign-association.ts), which reads klass.primaryKey — same delegation as CollectionAssociation#foreignKeyPresent."
+  },
+  {
+    "package": "activerecord",
     "tsFile": "associations/belongs-to-association.ts",
     "rubyName": "foreign_key_present?",
     "call": "all?",


### PR DESCRIPTION
## What

Mirror Rails `ForeignAssociation#foreign_key_present?` on `HasOneAssociation`
(foreign_association.rb:5) so a new-record owner with its primary key assigned
(e.g. `Author.new(id: 42)`) can still load its has_one child. Previously the
base `foreignKeyPresent()` returned `false`, so `find_target?` refused to query
and the reader nil-ed out for new-record owners.

The `has_one :through` subclass keeps its own `foreignKeyPresent` override
(mirroring `ThroughAssociation#foreign_key_present?`), so it is unaffected.

## Tests un-skipped (verbatim Rails names)

- `has one loading for new record`
- `has one autosave with primary key manually set`
- `create with inexistent foreign key failing` (pure body-fill — model already existed)

## Remaining gaps split into new stories

The larger has_one gap clusters are registered under RFC 0005 as their own
stories so they get scheduled/owned separately:
`d2-has-one-touch-option`, `d2-has-one-replacement-failure`,
`d2-has-one-poly-cpk-shapes`, `d2-has-one-assoc-enum`, `d2-has-one-misc-gaps`.

Closes-story: d2-has-one-remaining-gaps