### PR TITLE
feat(associations): un-skip four misc has_one gap singles

### DIFF
--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -158,7 +158,15 @@ export class Association {
     }
   }
 
-  async reload(): Promise<this> {
+  async reload(force = false): Promise<this> {
+    // Mirrors Rails `Association#reload` (association.rb:72-78): a *forced*
+    // reload (the generated `reload_<name>` reader) clears the query cache
+    // first, so the re-fetch bypasses any cached SELECT for this record.
+    if (force) {
+      const klass = this.klass as (typeof Base & { connectionPool?: () => unknown }) | undefined;
+      const pool = klass?.connectionPool?.() as { clearQueryCache?: () => void } | undefined;
+      pool?.clearQueryCache?.();
+    }
     this.reset();
     this.resetScope();
     await this.loadTarget();

--- a/packages/activerecord/src/associations/association.ts
+++ b/packages/activerecord/src/associations/association.ts
@@ -163,9 +163,7 @@ export class Association {
     // reload (the generated `reload_<name>` reader) clears the query cache
     // first, so the re-fetch bypasses any cached SELECT for this record.
     if (force) {
-      const klass = this.klass as (typeof Base & { connectionPool?: () => unknown }) | undefined;
-      const pool = klass?.connectionPool?.() as { clearQueryCache?: () => void } | undefined;
-      pool?.clearQueryCache?.();
+      this.klass.connectionPool().clearQueryCache();
     }
     this.reset();
     this.resetScope();

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -7,7 +7,7 @@
  * `Account` models and the `companies`/`accounts` fixtures. No `defineSchema`.
  */
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
-import { ArgumentError, UnknownAttributeError } from "@blazetrails/activemodel";
+import { ArgumentError, I18n, UnknownAttributeError } from "@blazetrails/activemodel";
 import { throwAbort } from "@blazetrails/activesupport";
 import {
   Base,
@@ -39,7 +39,7 @@ import { Pirate } from "../test-helpers/models/pirate.js";
 import { Ship } from "../test-helpers/models/ship.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
-import { Developer } from "../test-helpers/models/developer.js";
+import { Developer, AuditLog } from "../test-helpers/models/developer.js";
 import { Room } from "../test-helpers/models/room.js";
 import { User } from "../test-helpers/models/user.js";
 import { fixtures } from "../test-helpers/fixtures.js";
@@ -98,6 +98,7 @@ describe("HasOneAssociationsTest", () => {
     registerModel(Author);
     registerModel(Post);
     registerModel(Developer);
+    registerModel(AuditLog);
     registerModel(Room);
     registerModel(User);
     await Company.loadSchema();
@@ -219,9 +220,12 @@ describe("HasOneAssociationsTest", () => {
     // (employable) — polymorphic has_one feature gap.
   });
 
-  it.skip("nullification on destroyed association", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): Developer.create triggers a before_create that builds an
-    // `auditLogs` association whose `AuditLog` model is not ported/registered.
+  it("nullification on destroyed association", async () => {
+    const developer = await Developer.create({ name: "Someone" });
+    const ship = await Ship.create({ name: "Planet Caravan", developer });
+    await ship.destroy();
+    expect(ship.isPersisted()).toBe(false);
+    expect(developer.isPersisted()).toBe(false);
   });
 
   it.skip("nullification on cpk association", () => {
@@ -345,8 +349,24 @@ describe("HasOneAssociationsTest", () => {
     expect(await readHasOne(firm, "account")).not.toBeNull();
   });
 
-  it.skip("restrict with error with locale", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): requires I18n backend translation lookup.
+  it("restrict with error with locale", async () => {
+    I18n.storeTranslations("en", {
+      activerecord: { attributes: { restricted_with_error_firm: { account: "firm account" } } },
+    });
+    try {
+      const firm = (await RestrictedWithErrorFirm.create({ name: "restrict" })) as any;
+      await firm.createAccount({ credit_limit: 10 });
+      expect(await readHasOne(firm, "account")).not.toBeNull();
+      await firm.destroy();
+      expect(firm.errors.where("base").length).toBeGreaterThan(0);
+      expect(firm.errors.messagesFor("base")[0]).toBe(
+        "Cannot delete record because a dependent firm account exists",
+      );
+      expect(await RestrictedWithErrorFirm.exists({ name: "restrict" })).toBe(true);
+      expect(await readHasOne(firm, "account")).not.toBeNull();
+    } finally {
+      I18n.reset();
+    }
   });
 
   it("successful build association", async () => {
@@ -428,9 +448,17 @@ describe("HasOneAssociationsTest", () => {
     expect((error as RecordNotSaved).record).toBe(firm);
   });
 
-  it.skip("clearing an association clears the associations inverse", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): `post.update({ author: null })` does not nullify the belongs_to
-    // foreign key — belongs_to association assignment via update is a gap.
+  it("clearing an association clears the associations inverse", async () => {
+    const author = (await Author.create({ name: "Jimmy Tolkien" })) as any;
+    const post = await author.createPost({ title: "The silly medallion", body: "" });
+    expect((await readHasOne(author, "post")).id).toBe(post.id);
+    expect((await post.association("author").loadTarget()).id).toBe(author.id);
+
+    await post.update({ author: null });
+    expect(await post.association("author").loadTarget()).toBeNull();
+
+    await author.update({ name: "J.R.R. Tolkien" });
+    expect(await post.association("author").loadTarget()).toBeNull();
   });
 
   it("create association with bang", async () => {
@@ -474,8 +502,30 @@ describe("HasOneAssociationsTest", () => {
     expect((await readHasOne(odegy, "account")).credit_limit).toBe(80);
   });
 
-  it.skip("reload association with query cache", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): requires connection query cache (enable_query_cache!).
+  it("reload association with query cache", async () => {
+    const odegyId = (companies("odegy") as any).id;
+
+    const connection = (await Base.leaseConnection()) as any;
+    connection.enableQueryCacheBang();
+    connection.clearQueryCache();
+
+    // Populate the cache with a query
+    const odegy = (await Company.find(odegyId)) as any;
+    // Populate the cache with a second query
+    await readHasOne(odegy, "account");
+
+    expect(connection.queryCache!.size).toBe(2);
+
+    // Clear the cache and fetch the account again, populating the cache with a query
+    await assertQueriesCount(1, false, async () => {
+      await odegy.reloadAccount();
+    });
+
+    // This query is not cached anymore, so it should make a real SQL query
+    await assertQueriesCount(1, false, async () => {
+      await Company.find(odegyId);
+    });
+    connection.disableQueryCacheBang();
   });
 
   it("reset association", async () => {
@@ -546,9 +596,10 @@ describe("HasOneAssociationsTest", () => {
   });
 
   it.skip("assignment before child saved", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): trails defers has_one writer persistence to the owner's save,
-    // so `firm.account = Account.new(...)` does not immediately persist the
-    // child (Rails persists on assignment to a saved owner).
+    // BLOCKED (tracked: d2-has-one-assignment-before-child-saved): trails defers has_one
+    // writer persistence to the owner's save, so `firm.account = Account.new(...)` does
+    // not immediately persist the child (Rails persists on assignment to a saved owner).
+    // The JS property setter cannot `await` the immediate-persist path.
   });
 
   it("save still works after accessing nil has one", async () => {

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -508,24 +508,26 @@ describe("HasOneAssociationsTest", () => {
     const connection = (await Base.leaseConnection()) as any;
     connection.enableQueryCacheBang();
     connection.clearQueryCache();
+    try {
+      // Populate the cache with a query
+      const odegy = (await Company.find(odegyId)) as any;
+      // Populate the cache with a second query
+      await readHasOne(odegy, "account");
 
-    // Populate the cache with a query
-    const odegy = (await Company.find(odegyId)) as any;
-    // Populate the cache with a second query
-    await readHasOne(odegy, "account");
+      expect(connection.queryCache!.size).toBe(2);
 
-    expect(connection.queryCache!.size).toBe(2);
+      // Clear the cache and fetch the account again, populating the cache with a query
+      await assertQueriesCount(1, false, async () => {
+        await odegy.reloadAccount();
+      });
 
-    // Clear the cache and fetch the account again, populating the cache with a query
-    await assertQueriesCount(1, false, async () => {
-      await odegy.reloadAccount();
-    });
-
-    // This query is not cached anymore, so it should make a real SQL query
-    await assertQueriesCount(1, false, async () => {
-      await Company.find(odegyId);
-    });
-    connection.disableQueryCacheBang();
+      // This query is not cached anymore, so it should make a real SQL query
+      await assertQueriesCount(1, false, async () => {
+        await Company.find(odegyId);
+      });
+    } finally {
+      connection.disableQueryCacheBang();
+    }
   });
 
   it("reset association", async () => {

--- a/packages/activerecord/src/associations/singular-association.ts
+++ b/packages/activerecord/src/associations/singular-association.ts
@@ -40,7 +40,7 @@ export class SingularAssociation extends Association {
   }
 
   async forceReloadReader(): Promise<Base | null> {
-    await this.reload();
+    await this.reload(true);
     return this.target;
   }
 

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -12910,27 +12910,6 @@
   {
     "package": "activerecord",
     "tsFile": "associations/association.ts",
-    "rubyName": "reload",
-    "call": "clear_query_cache",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "reload",
-    "call": "connection_pool",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
-    "rubyName": "reload",
-    "call": "klass",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/association.ts",
     "rubyName": "scope",
     "call": "create",
     "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."


### PR DESCRIPTION
Un-skips four of the five misc has_one feature-gap singles in `has-one-associations.test.ts`, each now backed by existing infrastructure.

- **nullification on destroyed association** — register `AuditLog` in the test so `Developer`'s `before_create` audit-log build resolves; `Ship.belongs_to :developer, dependent: :destroy` cascade already works.
- **restrict with error with locale** — the `restrict_with_error` message already derives the dependent name via `humanAttributeName`, which consults I18n. Store the `activerecord.attributes.restricted_with_error_firm.account` translation and assert the localized message.
- **reload association with query cache** — thread a `force` flag through `Association#reload` (and `forceReloadReader`) that clears the connection's query cache before re-fetching, mirroring Rails `reload(force=true)` (`association.rb:72-78`).
- **clearing an association clears the associations inverse** — already worked; just un-skipped.

The fifth single, **assignment before child saved**, is re-split into its own story (`d2-has-one-assignment-before-child-saved`): it requires immediate persistence on `firm.account = a`, which the JS property setter cannot `await`.

Test names match Rails verbatim.

Closes-story: d2-has-one-misc-gaps