### PR TITLE
fix(has_one): immediate-persist writer loads existing target before replace

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -103,6 +103,9 @@ export class HasOneAssociation extends SingularAssociation {
    * defers to the owner's next save (`autosaveHasOne`).
    */
   override writer(record: Base | null): void | Promise<void> {
+    // Delegate to an async helper rather than making `writer` itself `async`, so
+    // the base `void | Promise<void>` signature (shared with the through
+    // override, which can return synchronously) is preserved.
     return this.writeImmediate(record);
   }
 

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -103,6 +103,14 @@ export class HasOneAssociation extends SingularAssociation {
    * defers to the owner's next save (`autosaveHasOne`).
    */
   override writer(record: Base | null): void | Promise<void> {
+    return this.writeImmediate(record);
+  }
+
+  private async writeImmediate(record: Base | null): Promise<void> {
+    // Mirror Rails `replace`'s leading `load_target`: materialize the currently
+    // associated record (possibly a DB row on a freshly-found owner) so it can
+    // be nullified/removed, rather than silently orphaning it.
+    if (!this.loaded) await this.loadTarget();
     const displaced = this.target;
     // Mirror Rails `replace`'s `assigning_another_record || has_changes_to_save?`
     // gate: only touch the DB when the assignment actually changes something, so

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -543,10 +543,20 @@ describe("HasOneAssociationsTest", () => {
     expect(found.rating).toBe(10);
   });
 
-  it.skip("assignment before child saved", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): trails defers has_one writer persistence to the owner's save,
-    // so `firm.account = Account.new(...)` does not immediately persist the
-    // child (Rails persists on assignment to a saved owner).
+  it("assignment before child saved", async () => {
+    // Rails persists the child synchronously on `firm.account = a`. The JS
+    // property setter cannot `await`, so the Rails-faithful immediate-persist
+    // path is reached through the awaitable writer
+    // (`association(name).writer(value)` → `persistImmediate`); the bare `=`
+    // setter defers to the owner's next save. Assigning through the writer
+    // therefore stands in for `firm.account = a` here.
+    const firm = (await Firm.find(1)) as any;
+    const a = new Account({ credit_limit: 1000 });
+    await firm.association("account").writer(a);
+    expect(a.isPersisted()).toBe(true);
+    expect((await readHasOne(firm, "account")).id).toBe(a.id);
+    await firm.association("account").reload();
+    expect((await readHasOne(firm, "account")).id).toBe(a.id);
   });
 
   it("save still works after accessing nil has one", async () => {


### PR DESCRIPTION
## What

Fixes the has_one immediate-persist writer so it loads the currently-associated
target before replacing it, mirroring Rails' `HasOneAssociation#replace`.

## Why

Rails' `replace` (`activerecord/lib/active_record/associations/has_one_association.rb:59-85`)
begins with `load_target` — `return target unless load_target || record` — so the
displaced record is always computed from a *materialized* target. Trails' writer
computed `displaced` from `this.target` directly. On a freshly-found owner whose
target was never loaded, `this.target` was `null`, so an existing DB row was
silently orphaned instead of being nullified/removed.

## Change

- `writer` now delegates to a private `writeImmediate` async helper rather than
  becoming `async` itself, preserving the base `void | Promise<void>` signature
  shared with the through override (which returns synchronously).
- `writeImmediate` calls `await this.loadTarget()` when the target isn't loaded,
  before computing `displaced` — matching Rails' leading `load_target`.
- Un-skips the `assignment before child saved` test, driven through
  `firm.association("account").writer(a)` (the awaitable path) since the bare
  property setter can't `await`.

## Notes

- `loadTarget` only queries when not loaded/stale, so it won't clobber an
  unsaved in-memory build made before the call.
