### PR TITLE
fix(has_one): restore prior target on failed replacement/creation

### DIFF
--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -123,6 +123,12 @@ export class HasOneAssociation extends SingularAssociation {
   }
 
   private async writeImmediate(record: Base | null): Promise<void> {
+    // Rails' `replace` raises on a class mismatch as its very first statement,
+    // before `load_target` (has_one_association.rb:60). The persist path below no
+    // longer routes through `replace` up front (the target is committed only
+    // after the transaction succeeds), so hoist the check here — a saved owner
+    // must reject `writer(someOtherModel)` before any DB I/O.
+    if (record) (this as any).raiseOnTypeMismatchBang(record);
     // Mirror Rails `replace`'s leading `load_target`: materialize the currently
     // associated record (possibly a DB row on a freshly-found owner) so it can
     // be nullified/removed, rather than silently orphaning it.
@@ -137,7 +143,6 @@ export class HasOneAssociation extends SingularAssociation {
     // and this short-circuits to undefined, which is falsy — exactly where
     // Rails would have returned.
     const changed = !sameRecord(displaced, record) || record?.hasChangesToSave === true;
-    this.replace(record);
     if (changed) {
       // Rails: `save &&= owner.persisted?` (:66) — a new owner does not gate the
       // block itself, only `transaction_if` (:68) and `record.save` (:75).
@@ -146,15 +151,22 @@ export class HasOneAssociation extends SingularAssociation {
       const save = (this.owner as { isPersisted?: () => boolean }).isPersisted?.() === true;
       return this.persistImmediate(record, displaced, save);
     }
+    this.replace(record);
   }
 
   /**
    * The awaitable immediate-persist body for `HasOneAssociation#replace`'s
-   * transaction (has_one_association.rb:68-81): remove the displaced record
-   * (:69), then re-derive the foreign key and save the new record (:71-80).
-   * `replace` has already set the in-memory target/inverse. `save` is Rails'
-   * post-`&&=` flag (:66): false for a non-persisted owner, which both skips
-   * the transaction (:68) and gates the new record's save (:75).
+   * transaction (has_one_association.rb:68-84): remove the displaced record
+   * (:69), then re-derive the foreign key and save the new record (:71-80), and
+   * promote the new target only after the transaction commits. `save` is Rails'
+   * post-`&&=` flag (:66): false for a non-persisted owner, which both skips the
+   * transaction (:68) and gates the new record's save (:75).
+   *
+   * `this.target` is left as `displaced` throughout — writeImmediate has not
+   * called `replace` — so a throw anywhere in the block (a failed `remove_target!`
+   * nullify, or the `RecordNotSaved` on a failed save) leaves the OLD record
+   * cached, exactly as Rails reaches `self.target = record` (:84) only after the
+   * block. Same target-on-failure invariant as `detachDisplacedTarget`.
    */
   private async persistImmediate(
     record: Base | null,
@@ -162,14 +174,9 @@ export class HasOneAssociation extends SingularAssociation {
     save: boolean,
   ): Promise<void> {
     await transactionIf(this, save, async () => {
+      // `this.target` is still `displaced`, so `removeTargetBang` removes it.
       if (displaced && !(displaced as any).isDestroyed?.() && !sameRecord(displaced, record)) {
-        const currentTarget = this.target;
-        this.target = displaced;
-        try {
-          await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
-        } finally {
-          this.target = currentTarget;
-        }
+        await removeTargetBang(this, (this.reflection.options.dependent as string) ?? "");
       }
       if (record) {
         this.setOwnerAttributes(record);
@@ -184,6 +191,11 @@ export class HasOneAssociation extends SingularAssociation {
         }
       }
     });
+    // Transaction committed: promote the new record to the target (Rails'
+    // `self.target = record`, :84). `replace` re-applies the FK/inverse (a no-op
+    // repeat of the in-transaction work) and, for `record === null`, clears the
+    // inverse on the now-removed displaced record.
+    this.replace(record);
   }
 
   /**

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -42,7 +42,7 @@ import {
   DrinkDesignerWithPolymorphicTouchChef,
   DrinkDesignerWithPolymorphicDependentNullifyChef,
 } from "../test-helpers/models/drink-designer.js";
-import { Pirate } from "../test-helpers/models/pirate.js";
+import { Pirate, DestructivePirate } from "../test-helpers/models/pirate.js";
 import { Ship } from "../test-helpers/models/ship.js";
 import { Author } from "../test-helpers/models/author.js";
 import { Post } from "../test-helpers/models/post.js";
@@ -144,7 +144,7 @@ class SpecialBulb extends Base {
 // HasOneAssociationsTest — mirrors has_one_associations_test.rb
 // ==========================================================================
 describe("HasOneAssociationsTest", () => {
-  const { companies, accounts, pirates } = fixtures([
+  const { companies, accounts, pirates, ships } = fixtures([
     "companies",
     "accounts",
     "developers",
@@ -161,6 +161,7 @@ describe("HasOneAssociationsTest", () => {
     registerModel(Car);
     registerModel(Bulb);
     registerModel(Pirate);
+    registerModel(DestructivePirate);
     registerModel(Ship);
     registerModel(Author);
     registerModel(Post);
@@ -820,26 +821,91 @@ describe("HasOneAssociationsTest", () => {
     expect(newAccount.firm_name).toBe("Account");
   });
 
-  it.skip("creation failure replaces existing without dependent option", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): pirate.create_ship validation-failure replacement — gap.
+  it("creation failure replaces existing without dependent option", async () => {
+    const pirate = pirates("blackbeard") as any;
+    const origShip = await readHasOne(pirate, "ship");
+
+    expect(origShip.isEqual(ships("black_pearl"))).toBe(true);
+    const newShip = await pirate.createShip();
+    expect(newShip.isEqual(ships("black_pearl"))).toBe(false);
+    expect((await readHasOne(pirate, "ship")).isEqual(newShip)).toBe(true);
+    expect(newShip.isNewRecord()).toBe(true);
+    expect(newShip.isInvalid()).toBe(true);
+    expect(origShip.pirate_id).toBeNull();
+    expect(origShip.changed).toBe(false); // check it was saved
   });
 
-  it.skip("creation failure replaces existing with dependent option", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): becomes(DestructivePirate) + dependent replacement — gap.
+  it("creation failure replaces existing with dependent option", async () => {
+    const pirate = (pirates("blackbeard") as any).becomes(DestructivePirate);
+    const origShip = await readHasOne(pirate, "dependentShip");
+
+    const newShip = await pirate.createDependentShip();
+    expect(newShip.isNewRecord()).toBe(true);
+    expect(newShip.isInvalid()).toBe(true);
+    expect(origShip.isDestroyed()).toBe(true);
   });
 
-  it.skip("creation failure due to new record should raise error", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): the RecordNotSaved is raised correctly, but the failed has_one
-    // assignment leaves the invalid Ship cached as the target instead of
-    // resetting `pirate.ship` to nil — post-failure target reset is a gap.
+  it("creation failure due to new record should raise error", async () => {
+    const pirate = pirates("redbeard") as any;
+    const newShip = new Ship();
+
+    // Rails: `pirate.ship = new_ship`. The JS property setter cannot `await` a
+    // persist, so the Rails-faithful immediate-persist path is reached through
+    // the awaitable writer (see "assignment before child saved").
+    let error: any;
+    try {
+      await pirate.association("ship").writer(newShip);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(RecordNotSaved);
+    expect(error.message).toBe("Failed to save the new associated ship.");
+    expect(error.record).toBe(newShip);
+    expect(await readHasOne(pirate, "ship")).toBeNull();
+    expect(newShip.pirate_id).toBeNull();
   });
 
-  it.skip("replacement failure due to existing record should raise error", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): replacement-failure error path on existing record — gap.
+  it("replacement failure due to existing record should raise error", async () => {
+    const pirate = pirates("blackbeard") as any;
+    const currentShip = await readHasOne(pirate, "ship");
+    currentShip.name = null;
+
+    expect(currentShip.isValid()).toBe(false);
+    let error: any;
+    try {
+      await pirate.association("ship").writer(ships("interceptor"));
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(RecordNotSaved);
+
+    expect((await readHasOne(pirate, "ship")).isEqual(ships("black_pearl"))).toBe(true);
+    expect((await readHasOne(pirate, "ship")).pirate_id).toBe(pirate.id);
+    expect(error.message).toBe(
+      "Failed to remove the existing associated ship. " +
+        "The record failed to save after its foreign key was set to nil.",
+    );
+    expect(error.record).toBe(currentShip);
   });
 
-  it.skip("replacement failure due to new record should raise error", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): replacement-failure error path on new record — gap.
+  it("replacement failure due to new record should raise error", async () => {
+    const pirate = pirates("blackbeard") as any;
+    const newShip = new Ship();
+
+    let error: any;
+    try {
+      await pirate.association("ship").writer(newShip);
+    } catch (e) {
+      error = e;
+    }
+    expect(error).toBeInstanceOf(RecordNotSaved);
+
+    expect(error.message).toBe("Failed to save the new associated ship.");
+    expect(error.record).toBe(newShip);
+    expect((await readHasOne(pirate, "ship")).isEqual(ships("black_pearl"))).toBe(true);
+    expect((await readHasOne(pirate, "ship")).pirate_id).toBe(pirate.id);
+    expect((await ships("black_pearl").reload()).pirate_id).toBe(pirate.id);
+    expect(newShip.pirate_id).toBeNull();
   });
 
   it("association keys bypass attribute protection", async () => {


### PR DESCRIPTION
## Summary

Failed `has_one` replacement/creation through the immediate writer path now
restores the previously associated record and raises the Rails `RecordNotSaved`,
matching `HasOneAssociation#replace` (`has_one_association.rb:59-84`).

`writeImmediate` → `persistImmediate` previously pre-committed the new record as
the target (`replace`-first), so a failed replacement/creation left the
invalid/rejected record cached instead of the prior one. Rails reaches
`self.target = record` (`:84`) only *after* the transaction block, so:

- `this.target` is kept as the displaced record throughout `persistImmediate`;
  the new target is promoted only after the transaction commits.
- A failed `remove_target!` nullify (existing invalid record) or the
  `RecordNotSaved` on a failed save (new invalid record) therefore leaves the
  OLD target attached, and the transaction rolls back the DB row.
- `raiseOnTypeMismatchBang` is hoisted into `writeImmediate` since the persist
  path no longer routes through `replace` up front.

This is the same target-on-failure invariant #4904 gave the create path via
`detachDisplacedTarget`; the create-over-loaded-target replacement (the two
`creation failure replaces existing …` cases) is already handled there and just
needed un-skipping. The non-persisted-owner `remove_target!` behavior landed
separately in #4898 (`save` flag), preserved here.

## Tests

Un-skips the five `has_one_associations_test` failure/replacement cases with
verbatim Rails names:

- `creation failure replaces existing without dependent option`
- `creation failure replaces existing with dependent option`
- `creation failure due to new record should raise error`
- `replacement failure due to existing record should raise error`
- `replacement failure due to new record should raise error`

The writer-path tests drive assignment through `association("ship").writer(...)`
(the awaitable immediate-persist path), consistent with the rest of this file
(e.g. `assignment before child saved`), since the sync `pirate.ship =` setter
cannot `await`.

Closes-story: d2-has-one-replacement-failure
