### PR TITLE
feat(has_one): honor touch: option through autosave/touch propagation

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -108,14 +108,18 @@ export class HasOne extends SingularAssociation {
   static override defineCallbacks(model: any, reflection: any): void {
     super.defineCallbacks(model, reflection);
     const options = reflection.options ?? {};
-    if (options.touch) {
-      this.addTouchCallbacks(model, reflection);
-    }
     // Mirrors Rails AutosaveAssociation::AssociationBuilderExtension.build —
     // registered for every has_one regardless of the `autosave:` option.
     // The save callbacks gate on `options.autosave` internally; the validate
     // callback gates on `reflection.validate?` (true for `validate: true`).
+    // Registered BEFORE the touch callbacks so the child is autosaved (and thus
+    // persisted) before the after_create/after_update touch fires — mirrors
+    // Rails, where has_one.rb's `define_callbacks` runs `super` (which wires
+    // autosave) before `add_touch_callbacks`.
     addAutosaveAssociationCallbacks(model, reflection);
+    if (options.touch) {
+      this.addTouchCallbacks(model, reflection);
+    }
   }
 
   static override addDestroyCallbacks(model: any, reflection: any): void {
@@ -163,8 +167,13 @@ export class HasOne extends SingularAssociation {
       await HasOne.touchRecord(record, name, touch);
     };
 
-    afterCreate(model, callback);
-    afterUpdate(model, callback);
+    // Mirrors Rails `HasOne.add_touch_callbacks`: the create/update touch fires
+    // only when the owner actually saved changes (`if: :saved_changes?`), so a
+    // no-op `save` on an unchanged owner does not re-touch the child.
+    const savedChangesQ = (record: any) => Object.keys(record.savedChanges ?? {}).length > 0;
+
+    afterCreate(model, callback, { if: savedChangesQ });
+    afterUpdate(model, callback, { if: savedChangesQ });
     afterDestroy(model, async (record: any) => {
       if (typeof record.isNewRecord !== "function" || !record.isNewRecord()) {
         await HasOne.touchRecord(record, name, touch);

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -1,6 +1,7 @@
 import { ArgumentError } from "@blazetrails/activemodel";
 import { SingularAssociation } from "./singular-association.js";
 import { afterCreate, afterUpdate, afterDestroy } from "../../callbacks.js";
+import { afterCreateCommit } from "../../transactions.js";
 import { addAutosaveAssociationCallbacks } from "../../autosave-association.js";
 
 /**
@@ -168,11 +169,19 @@ export class HasOne extends SingularAssociation {
     };
 
     // Mirrors Rails `HasOne.add_touch_callbacks`: the create/update touch fires
-    // only when the owner actually saved changes (`if: :saved_changes?`), so a
-    // no-op `save` on an unchanged owner does not re-touch the child.
-    const savedChangesQ = (record: any) => Object.keys(record.savedChanges ?? {}).length > 0;
+    // only when the owner actually saved changes (`if: :saved_changes?`). Reuse
+    // the existing `isSavedChanges` predicate (matches belongs-to.ts's touch
+    // callback) so a no-op `save` on an unchanged owner does not re-touch.
+    const savedChangesQ = (record: any) =>
+      typeof record.isSavedChanges === "function" && record.isSavedChanges();
 
     afterCreate(model, callback, { if: savedChangesQ });
+    // Mirrors Rails `after_create_commit { association(name).reset_negative_cache }`:
+    // once the create transaction commits, drop the negative (nil) target cache
+    // so a subsequent read re-queries and sees the freshly persisted child.
+    afterCreateCommit(model, async (record: any) => {
+      record.association(name).resetNegativeCache();
+    });
     afterUpdate(model, callback, { if: savedChangesQ });
     afterDestroy(model, async (record: any) => {
       if (typeof record.isNewRecord !== "function" || !record.isNewRecord()) {

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -35,6 +35,13 @@ import {
 import { Account } from "../test-helpers/models/account.js";
 import { Car } from "../test-helpers/models/car.js";
 import { Bulb } from "../test-helpers/models/bulb.js";
+import { Club } from "../test-helpers/models/club.js";
+import { Membership } from "../test-helpers/models/membership.js";
+import { Chef } from "../test-helpers/models/chef.js";
+import {
+  DrinkDesignerWithPolymorphicTouchChef,
+  DrinkDesignerWithPolymorphicDependentNullifyChef,
+} from "../test-helpers/models/drink-designer.js";
 import { Pirate } from "../test-helpers/models/pirate.js";
 import { Ship } from "../test-helpers/models/ship.js";
 import { Author } from "../test-helpers/models/author.js";
@@ -44,8 +51,6 @@ import { Room } from "../test-helpers/models/room.js";
 import { User } from "../test-helpers/models/user.js";
 import { Image } from "../test-helpers/models/image.js";
 import { Department } from "../test-helpers/models/department.js";
-import { Chef } from "../test-helpers/models/chef.js";
-import { DrinkDesignerWithPolymorphicDependentNullifyChef } from "../test-helpers/models/drink-designer.js";
 import {
   CpkBook,
   CpkOrder,
@@ -178,6 +183,9 @@ describe("HasOneAssociationsTest", () => {
     registerModel(CpkNonCpkBook);
     registerModel("SpecialCar", SpecialCar);
     registerModel("SpecialBulb", SpecialBulb);
+    registerModel(Club);
+    registerModel(Membership);
+    registerModel(DrinkDesignerWithPolymorphicTouchChef);
     await Company.loadSchema();
     await Account.loadSchema();
     await Car.loadSchema();
@@ -188,6 +196,9 @@ describe("HasOneAssociationsTest", () => {
     await DrinkDesignerWithPolymorphicDependentNullifyChef.loadSchema();
     await CpkBook.loadSchema();
     await CpkOrderWithNullifiedBook.loadSchema();
+    await Club.loadSchema();
+    await Membership.loadSchema();
+    await DrinkDesignerWithPolymorphicTouchChef.loadSchema();
   });
 
   beforeEach(() => {
@@ -960,32 +971,63 @@ describe("HasOneAssociationsTest", () => {
     }
   });
 
-  it.skip("has one with touch option on create", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): Club/Membership touch via nested attributes — query-count gap.
+  it("has one with touch option on create", async () => {
+    await assertQueriesCount(5, false, async () => {
+      await Club.create({ name: "1000 Oaks", membershipAttributes: { favorite: true } });
+    });
   });
 
   it.skip("polymorphic has one with touch option on create wont cache association so fetching after transaction commit works", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): polymorphic touch + transaction commit — gap.
+    // BLOCKED (tracked: d2-has-one-touch-polymorphic-inverse-cache): touch: is
+    // honored, but the parent's after_create touch loads its child through the
+    // polymorphic association rather than the cached in-memory inverse, adding
+    // one extra SELECT (7 vs Rails' 6). Needs polymorphic inverse-set on assign
+    // plus after_create_commit reset_negative_cache.
   });
 
-  it.skip("polymorphic has one with touch option on update will touch record by fetching from database if needed", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): polymorphic touch on update — gap.
+  it("polymorphic has one with touch option on update will touch record by fetching from database if needed", async () => {
+    await DrinkDesignerWithPolymorphicTouchChef.create({ chef: new Chef() });
+    const designer = (await DrinkDesignerWithPolymorphicTouchChef.last()) as any;
+
+    await assertQueriesCount(5, false, async () => {
+      await designer.update({ name: "foo" });
+    });
   });
 
-  it.skip("has one with touch option on update", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): Club/Membership touch — query-count gap.
+  it("has one with touch option on update", async () => {
+    const newClub = (await Club.create({ name: "1000 Oaks" })) as any;
+    await newClub.createMembership();
+
+    await assertQueriesCount(4, false, async () => {
+      await newClub.update({ name: "Effingut" });
+    });
   });
 
-  it.skip("has one with touch option on touch", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): touch propagation chain — gap.
+  it("has one with touch option on touch", async () => {
+    const newClub = (await Club.create({ name: "1000 Oaks" })) as any;
+    await newClub.createMembership();
+
+    await assertQueriesCount(3, false, async () => {
+      await newClub.touch();
+    });
   });
 
-  it.skip("has one with touch option on destroy", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): Club/Membership touch on destroy — query-count gap.
+  it("has one with touch option on destroy", async () => {
+    const newClub = (await Club.create({ name: "1000 Oaks" })) as any;
+    await newClub.createMembership();
+
+    await assertQueriesCount(4, false, async () => {
+      await newClub.destroy();
+    });
   });
 
-  it.skip("has one with touch option on empty update", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): no-op save detection — gap.
+  it("has one with touch option on empty update", async () => {
+    const newClub = (await Club.create({ name: "1000 Oaks" })) as any;
+    await newClub.createMembership();
+
+    await assertNoQueries(false, async () => {
+      await newClub.save();
+    });
   });
 
   it("has one with touch option on nonpersisted built associations doesnt update parent", async () => {

--- a/packages/activerecord/src/test-helpers/models/club.ts
+++ b/packages/activerecord/src/test-helpers/models/club.ts
@@ -7,6 +7,7 @@ import type { Sponsor } from "./sponsor.js";
 import type { SuperMembership } from "./membership.js";
 // vendor/rails/activerecord/test/models/club.rb
 import { Base } from "../../base.js";
+import { acceptsNestedAttributesFor } from "../../nested-attributes.js";
 
 export class Club extends Base {
   declare membership: Membership | null;
@@ -59,6 +60,8 @@ export class Club extends Base {
     );
   }
 }
+
+acceptsNestedAttributesFor(Club, "membership");
 
 export class SuperClub extends Base {
   declare memberships: AssociationProxy<SuperMembership>;

--- a/packages/activerecord/src/timestamp.ts
+++ b/packages/activerecord/src/timestamp.ts
@@ -82,11 +82,6 @@ export async function touch(
   const touchColSet = new Set<string>([...updateTimestampAttrs, ...resolvedNames]);
   const touchCols = Array.from(touchColSet);
 
-  // Mirrors Rails Persistence#touch (persistence.rb:805-810): when there are no
-  // timestamp columns and no caller-supplied names, the `else true end` branch
-  // returns true — touch is a successful no-op, not a failure.
-  if (touchCols.length === 0) return true;
-
   // Mirrors Rails: ActiveRecord::Transactions#touch wraps the persistence-layer
   // touch in `with_transaction_returning_status`, so the record is enrolled in
   // the current transaction and its `after_update_commit` /
@@ -117,6 +112,16 @@ function raiseRecordNotTouchedError(): never {
  */
 async function touchRow(this: Base, touchCols: string[], now: Temporal.Instant): Promise<boolean> {
   const ctor = this.constructor as typeof Base;
+
+  // Mirrors Rails Callbacks#touch (`_run_touch_callbacks { super }`): the
+  // after_touch callbacks fire around the whole touch, even when the model has
+  // no timestamp columns and no caller-supplied names (persistence.rb:805-810's
+  // `else true end` no-op). This is how a `has_one ..., touch: true` on a model
+  // that itself has no timestamps still propagates the touch to its child.
+  if (touchCols.length === 0) {
+    await runAfterCallbacksOnProto(ctor.prototype, "touch", this);
+    return true;
+  }
 
   // Write new values via writeAttribute so changesApplied() populates previousChanges.
   for (const col of touchCols) {

--- a/scripts/api-compare/call-mismatches-wide-exclude.json
+++ b/scripts/api-compare/call-mismatches-wide-exclude.json
@@ -13532,20 +13532,6 @@
   },
   {
     "package": "activerecord",
-    "tsFile": "associations/builder/has-one.ts",
-    "rubyName": "add_touch_callbacks",
-    "call": "after_create_commit",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
-    "tsFile": "associations/builder/has-one.ts",
-    "rubyName": "add_touch_callbacks",
-    "call": "association",
-    "reason": "Baseline (RFC 0047): wide call-set flag seeded when the wide ratchet landed; bucket (b) equivalent or (c) noise pending per-cluster burndown review."
-  },
-  {
-    "package": "activerecord",
     "tsFile": "associations/builder/singular-association.ts",
     "rubyName": "define_accessors",
     "call": "generated_association_methods",


### PR DESCRIPTION
Wires the `has_one ..., touch: true` cluster so a parent's `updated_at` is
bumped on child create/update/touch/destroy per Rails, and un-skips six of the
eight touch tests in `has-one-associations.test.ts` with verbatim Rails names.

## Changes

- **`builder/has-one.ts`**: register the autosave callbacks *before* the touch
  callbacks so the child is persisted before the `after_create`/`after_update`
  touch fires (mirrors Rails `has_one.rb` `define_callbacks`, which runs `super`
  before `add_touch_callbacks`), and gate the create/update touch on
  `saved_changes?` so a no-op `save` on an unchanged owner does not re-touch the
  child.
- **`timestamp.ts`**: run `after_touch` callbacks even when the model has no
  timestamp columns and no supplied names, mirroring Rails `Callbacks#touch`
  (`_run_touch_callbacks { super }`). This is how a `has_one ..., touch: true`
  on a timestamp-less parent (e.g. `Club`) still propagates the touch to its
  child.
- **`test-helpers/models/club.ts`**: `accepts_nested_attributes_for :membership`.

## Un-skipped (6)

create, update, touch, destroy, empty update, and the polymorphic-on-update
touch tests.

## Deferred (2, tracked)

- `polymorphic ... wont cache association ...` — needs polymorphic inverse-set
  on assign + `after_create_commit` reset_negative_cache (one extra SELECT).
  → story `d2-has-one-touch-polymorphic-inverse-cache`.
- `nonpersisted built associations doesnt update parent` — touch correctly does
  not fire, but Rails' synchronous `has_one` build runs one `load_target` SELECT
  that trails' necessarily-sync build cannot.
  → story `d2-has-one-touch-nonpersisted-build-load`.

Closes-story: d2-has-one-touch-option