### PR TITLE
fix(destroy): preload scan resolves belongs_to reads through arrow-field helpers

### DIFF
--- a/packages/activerecord/src/associations/destroy-preload-arrow-field-helper.trails.test.ts
+++ b/packages/activerecord/src/associations/destroy-preload-arrow-field-helper.trails.test.ts
@@ -1,0 +1,88 @@
+/**
+ * trails-only regression (no Rails counterpart).
+ *
+ * The destroy `belongs_to` preload scan (`_preloadBelongsToForDestroyCallbacks`
+ * / `expandCallbackSourcesWithHelpers`) resolves association reads reached
+ * through a model-defined helper so a synchronous, un-awaited `belongs_to` read
+ * inside that helper is preloaded before the sync reader runs. PR #4809 walked
+ * only the prototype chain, so an **arrow-function class field**
+ * (`makeReport = () => { ... this.firm }`) — which lives on the *instance*, not
+ * the prototype — was invisible to the scan. This exercises that gap: a destroy
+ * callback that dereferences `firm` through an arrow-field helper must see the
+ * loaded `Company`, not the async reader's Promise.
+ */
+import { describe, it, expect, beforeAll } from "vitest";
+import { Base, registerModel, enableSti, registerSubclass } from "../index.js";
+import {
+  Company,
+  Firm,
+  DependentFirm,
+  ExclusivelyDependentFirm,
+  RestrictedWithExceptionFirm,
+  RestrictedWithErrorFirm,
+  Client,
+} from "../test-helpers/models/company.js";
+import { fixtures } from "../test-helpers/fixtures.js";
+
+// Rides the canonical `accounts` table (no bespoke schema). The arrow-field
+// helper `recordFirm` reads `this.firm` synchronously and captures whether the
+// value was the loaded record or trails' async-reader thenable.
+class ArrowFieldAccount extends Base {
+  static _tableName = "accounts";
+  declare firm: Company | null;
+  declare firm_id: number;
+
+  static _seenFirmIsThenable: boolean | null = null;
+  static _seenFirmId: number | undefined = undefined;
+
+  recordFirm = (): void => {
+    const firm = this.firm as { then?: unknown; id?: number } | null;
+    ArrowFieldAccount._seenFirmIsThenable = typeof firm?.then === "function";
+    ArrowFieldAccount._seenFirmId = firm?.id;
+  };
+
+  static {
+    this.belongsTo("firm", { className: "Company" });
+    this.beforeDestroy(function (this: ArrowFieldAccount, record?: ArrowFieldAccount) {
+      (record ?? this).recordFirm();
+    });
+  }
+}
+
+describe("destroy belongs_to preload through arrow-field helper", () => {
+  const { accounts } = fixtures(["companies", "accounts"]);
+
+  beforeAll(async () => {
+    registerModel(Company);
+    registerModel(Firm);
+    registerModel(DependentFirm);
+    registerModel(ExclusivelyDependentFirm);
+    registerModel(RestrictedWithExceptionFirm);
+    registerModel(RestrictedWithErrorFirm);
+    registerModel(Client);
+    enableSti(Company);
+    registerSubclass(Firm);
+    registerSubclass(DependentFirm);
+    registerSubclass(ExclusivelyDependentFirm);
+    registerSubclass(RestrictedWithExceptionFirm);
+    registerSubclass(RestrictedWithErrorFirm);
+    registerSubclass(Client);
+    registerModel("ArrowFieldAccount", ArrowFieldAccount);
+    await Company.loadSchema();
+    await ArrowFieldAccount.loadSchema();
+  });
+
+  it("preloads the belongs_to a destroy callback reads through an arrow-field helper", async () => {
+    ArrowFieldAccount._seenFirmIsThenable = null;
+    ArrowFieldAccount._seenFirmId = undefined;
+    const account = await ArrowFieldAccount.find((accounts("signals37") as { id: number }).id);
+    expect(account.association("firm").isLoaded()).toBe(false);
+
+    await account.destroy();
+
+    // The sync reader inside the arrow field saw the loaded Company, not the
+    // async reader's Promise.
+    expect(ArrowFieldAccount._seenFirmIsThenable).toBe(false);
+    expect(ArrowFieldAccount._seenFirmId).toBe(account.firm_id);
+  });
+});

--- a/packages/activerecord/src/associations/destroy-preload-arrow-field-helper.trails.test.ts
+++ b/packages/activerecord/src/associations/destroy-preload-arrow-field-helper.trails.test.ts
@@ -35,6 +35,9 @@ class ArrowFieldAccount extends Base {
   static _seenFirmIsThenable: boolean | null = null;
   static _seenFirmId: number | undefined = undefined;
 
+  // Arrow-function class field — lives on the instance, not the prototype. The
+  // `this.firm` read must be lexical here (not delegated to a free function) so
+  // the callback-source scan can see the association name.
   recordFirm = (): void => {
     const firm = this.firm as { then?: unknown; id?: number } | null;
     ArrowFieldAccount._seenFirmIsThenable = typeof firm?.then === "function";
@@ -44,6 +47,30 @@ class ArrowFieldAccount extends Base {
   static {
     this.belongsTo("firm", { className: "Company" });
     this.beforeDestroy(function (this: ArrowFieldAccount, record?: ArrowFieldAccount) {
+      (record ?? this).recordFirm();
+    });
+  }
+}
+
+// Prototype-method helper (the PR #4809 path) — asserts that resolution through
+// an ordinary prototype method is unchanged by the arrow-field expansion.
+class ProtoHelperAccount extends Base {
+  static _tableName = "accounts";
+  declare firm: Company | null;
+  declare firm_id: number;
+
+  static _seenFirmIsThenable: boolean | null = null;
+  static _seenFirmId: number | undefined = undefined;
+
+  recordFirm(): void {
+    const firm = this.firm as { then?: unknown; id?: number } | null;
+    ProtoHelperAccount._seenFirmIsThenable = typeof firm?.then === "function";
+    ProtoHelperAccount._seenFirmId = firm?.id;
+  }
+
+  static {
+    this.belongsTo("firm", { className: "Company" });
+    this.beforeDestroy(function (this: ProtoHelperAccount, record?: ProtoHelperAccount) {
       (record ?? this).recordFirm();
     });
   }
@@ -68,8 +95,10 @@ describe("destroy belongs_to preload through arrow-field helper", () => {
     registerSubclass(RestrictedWithErrorFirm);
     registerSubclass(Client);
     registerModel("ArrowFieldAccount", ArrowFieldAccount);
+    registerModel("ProtoHelperAccount", ProtoHelperAccount);
     await Company.loadSchema();
     await ArrowFieldAccount.loadSchema();
+    await ProtoHelperAccount.loadSchema();
   });
 
   it("preloads the belongs_to a destroy callback reads through an arrow-field helper", async () => {
@@ -84,5 +113,17 @@ describe("destroy belongs_to preload through arrow-field helper", () => {
     // async reader's Promise.
     expect(ArrowFieldAccount._seenFirmIsThenable).toBe(false);
     expect(ArrowFieldAccount._seenFirmId).toBe(account.firm_id);
+  });
+
+  it("still preloads the belongs_to a destroy callback reads through a prototype helper", async () => {
+    ProtoHelperAccount._seenFirmIsThenable = null;
+    ProtoHelperAccount._seenFirmId = undefined;
+    const account = await ProtoHelperAccount.find((accounts("signals37") as { id: number }).id);
+    expect(account.association("firm").isLoaded()).toBe(false);
+
+    await account.destroy();
+
+    expect(ProtoHelperAccount._seenFirmIsThenable).toBe(false);
+    expect(ProtoHelperAccount._seenFirmId).toBe(account.firm_id);
   });
 });

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -646,6 +646,17 @@ function expandCallbackSourcesWithHelpers(
   record?: InstanceType<typeof Base>,
 ): string[] {
   const methods = new Map<string, string>();
+  // Instance-own function properties (arrow-field methods) first: they win
+  // method dispatch over a same-named prototype method, so their source is the
+  // one actually run — record them before the prototype walk, whose
+  // `methods.has(key)` guard then leaves them in place.
+  if (record) {
+    for (const key of Object.getOwnPropertyNames(record)) {
+      if (key === "constructor" || methods.has(key)) continue;
+      const desc = Object.getOwnPropertyDescriptor(record, key);
+      if (typeof desc?.value === "function") methods.set(key, desc.value.toString());
+    }
+  }
   for (
     let proto = ctor.prototype;
     proto && proto !== Base.prototype;
@@ -654,13 +665,6 @@ function expandCallbackSourcesWithHelpers(
     for (const key of Object.getOwnPropertyNames(proto)) {
       if (key === "constructor" || methods.has(key)) continue;
       const desc = Object.getOwnPropertyDescriptor(proto, key);
-      if (typeof desc?.value === "function") methods.set(key, desc.value.toString());
-    }
-  }
-  if (record) {
-    for (const key of Object.getOwnPropertyNames(record)) {
-      if (key === "constructor" || methods.has(key)) continue;
-      const desc = Object.getOwnPropertyDescriptor(record, key);
       if (typeof desc?.value === "function") methods.set(key, desc.value.toString());
     }
   }

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -632,12 +632,19 @@ function referencesAssociationName(sources: string[], name: string): boolean {
  * Expand callback filter sources with the source of any model-defined instance
  * method they (transitively) reference, so an association read reached through a
  * helper — e.g. `before_destroy { this.makeComments() }` where `makeComments`
- * reads `this.person` — is still detected. Only methods declared on the model's
- * own prototype chain (below `Base`) are followed; framework methods and the
- * association readers themselves are ignored. Bounded by the model's method
- * count via the `seen` set, so mutually-recursive helpers can't loop.
+ * reads `this.person` — is still detected. Methods declared on the model's own
+ * prototype chain (below `Base`) are followed, as are instance-own
+ * function-valued properties — arrow-function class fields
+ * (`makeComments = async () => { ... this.person }`) live on the instance, not
+ * the prototype, so the prototype walk alone would miss them. Framework methods
+ * and the association readers themselves are ignored. Bounded by the model's
+ * method count via the `seen` set, so mutually-recursive helpers can't loop.
  */
-function expandCallbackSourcesWithHelpers(sources: string[], ctor: typeof Base): string[] {
+function expandCallbackSourcesWithHelpers(
+  sources: string[],
+  ctor: typeof Base,
+  record?: InstanceType<typeof Base>,
+): string[] {
   const methods = new Map<string, string>();
   for (
     let proto = ctor.prototype;
@@ -647,6 +654,13 @@ function expandCallbackSourcesWithHelpers(sources: string[], ctor: typeof Base):
     for (const key of Object.getOwnPropertyNames(proto)) {
       if (key === "constructor" || methods.has(key)) continue;
       const desc = Object.getOwnPropertyDescriptor(proto, key);
+      if (typeof desc?.value === "function") methods.set(key, desc.value.toString());
+    }
+  }
+  if (record) {
+    for (const key of Object.getOwnPropertyNames(record)) {
+      if (key === "constructor" || methods.has(key)) continue;
+      const desc = Object.getOwnPropertyDescriptor(record, key);
       if (typeof desc?.value === "function") methods.set(key, desc.value.toString());
     }
   }
@@ -3954,7 +3968,7 @@ export class Base extends Model {
     if (typeof (this as any).association !== "function") return;
     const { sources, opaque } = beforeOrAroundCallbackSources(ctor.prototype, "destroy");
     if (!opaque && sources.length === 0) return;
-    const expanded = opaque ? sources : expandCallbackSourcesWithHelpers(sources, ctor);
+    const expanded = opaque ? sources : expandCallbackSourcesWithHelpers(sources, ctor, this);
     const useSavepoint = _currentTransactionPublic().isOpen();
     for (const ref of ctor.reflectOnAllAssociations("belongsTo")) {
       // Narrow to associations the callback names (unless an opaque callback


### PR DESCRIPTION
## Summary

`expandCallbackSourcesWithHelpers` (`packages/activerecord/src/base.ts`, PR #4809) makes the destroy-callback `belongs_to` preload scan resilient to association reads reached through a helper method, but it only walked `Object.getOwnPropertyNames(proto)` up the prototype chain. An **arrow-function class field** (`makeReport = () => { ... this.firm }`) lives on the *instance*, not the prototype, so it was invisible to the scan. A synchronous, un-awaited `belongs_to` read inside such a field — referenced from a `before_destroy`/`around_destroy` callback — would not be preloaded, and the sync reader would then surface trails' unresolved async-reader Promise (the exact bug the preload prevents).

## Change

- `expandCallbackSourcesWithHelpers` now also folds in the source of the record's instance-own function-valued properties (arrow-field methods), not just prototype methods. Prototype-method resolution is unchanged.
- Regression test (trails-only, no Rails counterpart): a model riding the canonical `accounts` table whose `before_destroy` reads `firm` synchronously through an arrow-function class field asserts the sync reader sees the loaded `Company` (not a thenable). Verified it fails without the fix and passes with it.

Closes-story: destroy-preload-scan-resolves-arrow-field-helpers