### PR TITLE
fix(has_one): build accessor loads existing target before replace

### DIFF
--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -56,9 +56,13 @@ export class HasOne extends SingularAssociation {
         const assoc = this.association(name);
         // Only take the async load path when a query would actually run: a
         // persisted / FK-present owner whose target isn't loaded. New-record
-        // owners build synchronously (no query), so their `build#{name}` still
-        // returns the record — and any synchronous error (e.g. an invalid STI
-        // type) still throws synchronously rather than rejecting a Promise.
+        // owners build synchronously (no query), so their `build#{name}` returns
+        // the record directly and a synchronous build error (e.g. an invalid STI
+        // type from `build_record`) still throws synchronously — the shape the
+        // building-with-invalid-type tests assert. On the load path the same
+        // error surfaces as a rejected Promise instead, an unavoidable
+        // consequence of awaiting `load_target` in JS (Rails' `replace` is
+        // fully synchronous, so it raises inline regardless of persistence).
         if (
           typeof assoc.needsTargetLoadForBuild === "function" &&
           assoc.needsTargetLoadForBuild()

--- a/packages/activerecord/src/associations/builder/has-one.ts
+++ b/packages/activerecord/src/associations/builder/has-one.ts
@@ -40,6 +40,38 @@ export class HasOne extends SingularAssociation {
     return super.build(model, name, scope, options);
   }
 
+  static override defineConstructors(mixin: any, name: string): void {
+    super.defineConstructors(mixin, name);
+    if (!mixin || typeof mixin !== "object") return;
+    const cap = name.charAt(0).toUpperCase() + name.slice(1);
+    // Redefine the `build#{name}` accessor to mirror Rails' synchronous
+    // `set_new_record` → `replace` → `load_target`: materialize the current
+    // target before the built record displaces it. The accessor returns a
+    // Promise (the sync `build` / nested-attributes paths can't await), so a
+    // second build sees the loaded target and issues no query — one
+    // `load_target` SELECT across repeated builds. `association.build` itself
+    // stays synchronous for the in-memory internal paths.
+    Object.defineProperty(mixin, `build${cap}`, {
+      value: function (this: { association(n: string): any }, ...args: unknown[]) {
+        const assoc = this.association(name);
+        // Only take the async load path when a query would actually run: a
+        // persisted / FK-present owner whose target isn't loaded. New-record
+        // owners build synchronously (no query), so their `build#{name}` still
+        // returns the record — and any synchronous error (e.g. an invalid STI
+        // type) still throws synchronously rather than rejecting a Promise.
+        if (
+          typeof assoc.needsTargetLoadForBuild === "function" &&
+          assoc.needsTargetLoadForBuild()
+        ) {
+          return assoc.loadTarget().then(() => assoc.build(...args));
+        }
+        return assoc.build(...args);
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
+
   static override defineWriters(mixin: object, name: string): void {
     if (!mixin || typeof mixin !== "object") return;
     const existing = Object.getOwnPropertyDescriptor(mixin, name);

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -320,11 +320,13 @@ export class HasOneAssociation extends SingularAssociation {
    * paths can't await, so the awaitable accessor (builder/has-one.ts) consults
    * this and issues the SELECT only when a query would actually run
    * (`find_target?`): a persisted / FK-present owner whose target isn't loaded.
+   * `findTargetNeeded()` already returns false when the target is loaded
+   * (association.ts, `if (this.loaded) return false`), so it is the whole gate.
    *
    * @internal
    */
   needsTargetLoadForBuild(): boolean {
-    return !this.loaded && this.findTargetNeeded();
+    return this.findTargetNeeded();
   }
 
   protected override replace(record: Base | null, _save = true): void {

--- a/packages/activerecord/src/associations/has-one-association.ts
+++ b/packages/activerecord/src/associations/has-one-association.ts
@@ -311,6 +311,22 @@ export class HasOneAssociation extends SingularAssociation {
     // raise FrozenError.
   }
 
+  /**
+   * Whether a `build#{name}` accessor call must first run Rails'
+   * `load_target` — mirrors `HasOneAssociation#set_new_record` →
+   * `replace(record, false)`, whose leading `load_target`
+   * (has_one_association.rb:59) materializes the current target before the
+   * freshly-built record displaces it. The sync `build` / nested-attributes
+   * paths can't await, so the awaitable accessor (builder/has-one.ts) consults
+   * this and issues the SELECT only when a query would actually run
+   * (`find_target?`): a persisted / FK-present owner whose target isn't loaded.
+   *
+   * @internal
+   */
+  needsTargetLoadForBuild(): boolean {
+    return !this.loaded && this.findTargetNeeded();
+  }
+
   protected override replace(record: Base | null, _save = true): void {
     if (record) (this as any).raiseOnTypeMismatchBang(record);
     const assigningAnother = !sameRecord(this.target, record);

--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -113,6 +113,28 @@ class SpecialSubscription extends Base {
   }
 }
 
+// Mirrors the SpecialCar/SpecialBulb models defined inline in
+// has_one_associations_test.rb (:929) — a has_one whose child belongs_to the
+// owner with `touch: true`, used to prove that building a nonpersisted child
+// does not touch the parent.
+class SpecialCar extends Base {
+  static {
+    this._tableName = "cars";
+    this.hasOne("specialBulb", {
+      inverseOf: "car",
+      dependent: "destroy",
+      className: "SpecialBulb",
+      foreignKey: "car_id",
+    });
+  }
+}
+class SpecialBulb extends Base {
+  static {
+    this._tableName = "bulbs";
+    this.belongsTo("car", { inverseOf: "specialBulb", touch: true, className: "SpecialCar" });
+  }
+}
+
 // ==========================================================================
 // HasOneAssociationsTest — mirrors has_one_associations_test.rb
 // ==========================================================================
@@ -154,6 +176,8 @@ describe("HasOneAssociationsTest", () => {
     registerModel(CpkBrokenOrder);
     registerModel(CpkBrokenOrderWithNonCpkBooks);
     registerModel(CpkNonCpkBook);
+    registerModel("SpecialCar", SpecialCar);
+    registerModel("SpecialBulb", SpecialBulb);
     await Company.loadSchema();
     await Account.loadSchema();
     await Car.loadSchema();
@@ -452,7 +476,7 @@ describe("HasOneAssociationsTest", () => {
   it("successful build association", async () => {
     const firm = new Firm({ name: "GlobalMegaCorp" });
     await (firm as any).save();
-    const account = (firm as any).buildAccount({ credit_limit: 1000 });
+    const account = await (firm as any).buildAccount({ credit_limit: 1000 });
     expect(await account.save()).toBeTruthy();
     expect((await readHasOne(firm, "account")).id).toBe(account.id);
   });
@@ -496,7 +520,7 @@ describe("HasOneAssociationsTest", () => {
     const pirate = pirates("blackbeard") as any;
     const scope = pirate.association("fooBulb").scope().whereValuesHash();
 
-    let bulb = pirate.buildFooBulb();
+    let bulb = await pirate.buildFooBulb();
     expect(bulb.scopeAfterInitialize.whereValuesHash()).not.toEqual(scope);
 
     bulb = await pirate.createFooBulb();
@@ -724,7 +748,7 @@ describe("HasOneAssociationsTest", () => {
 
   it("build respects hash condition", async () => {
     const firm = companies("first_firm") as any;
-    const account = firm.buildAccountLimit500WithHashConditions();
+    const account = await firm.buildAccountLimit500WithHashConditions();
     expect(await account.save()).toBeTruthy();
     expect(account.credit_limit).toBe(500);
   });
@@ -737,7 +761,9 @@ describe("HasOneAssociationsTest", () => {
   });
 
   it("attributes are being set when initialized from has one association with where clause", async () => {
-    const newAccount = (companies("first_firm") as any).buildAccount({ firm_name: "Account" });
+    const newAccount = await (companies("first_firm") as any).buildAccount({
+      firm_name: "Account",
+    });
     expect(newAccount.firm_name).toBe("Account");
   });
 
@@ -796,7 +822,7 @@ describe("HasOneAssociationsTest", () => {
 
   it("build with block", async () => {
     const car = (await Car.create({ name: "honda" })) as any;
-    const bulb = car.buildBulb(undefined, (b: any) => {
+    const bulb = await car.buildBulb(undefined, (b: any) => {
       b.color = "Red";
     });
     expect(bulb.color).toBe("RED!");
@@ -962,9 +988,17 @@ describe("HasOneAssociationsTest", () => {
     // BLOCKED (tracked: d2-has-one-remaining-gaps): no-op save detection — gap.
   });
 
-  it.skip("has one with touch option on nonpersisted built associations doesnt update parent", () => {
-    // BLOCKED (tracked: d2-has-one-remaining-gaps): SpecialCar/SpecialBulb touch on unpersisted built association —
-    // query-count gap.
+  it("has one with touch option on nonpersisted built associations doesnt update parent", async () => {
+    const car = await (SpecialCar as any).create({ name: "honda" });
+    // Rails' synchronous `build_special_bulb` runs one `load_target` SELECT
+    // inside `replace`; the JS accessor can't await, so the awaitable
+    // has_one build path is driven directly. The second build sees the loaded
+    // target and issues no query — 1 query total, and the built (nonpersisted)
+    // child never fires the `touch: true` callback, so the parent is untouched.
+    await assertQueriesCount(1, false, async () => {
+      await car.buildSpecialBulb();
+      await car.buildSpecialBulb();
+    });
   });
 
   it("has one double belongs to destroys both from either end", async () => {

--- a/packages/activerecord/src/associations/inverse-associations.test.ts
+++ b/packages/activerecord/src/associations/inverse-associations.test.ts
@@ -434,7 +434,7 @@ describe("InverseHasOneTests", () => {
 
   it("parent instance should be shared with newly built child", async () => {
     const human = (await Human.first())!;
-    const face = (human as any).buildFace({ description: "haunted" });
+    const face = await (human as any).buildFace({ description: "haunted" });
     expect(face.human).not.toBeNull();
     expect(face.human.name).toBe((human as any).name);
     (human as any).name = "Bongo";


### PR DESCRIPTION
## What

Makes the has_one `build#{name}` accessor mirror Rails' synchronous
`HasOneAssociation#set_new_record` → `replace(record, false)`, whose leading
`load_target` (has_one_association.rb:59) materializes the currently-associated
record before the freshly-built one displaces it.

## Why

`car.build_special_bulb; car.build_special_bulb` emits **1 query** in Rails —
the first build runs `load_target` (one SELECT), the second sees the loaded
target and issues none. trails' synchronous build ran **0 queries**, so the
`test_has_one_with_touch_option_on_nonpersisted_built_associations_doesnt_update_parent`
query-count assertion stayed skipped.

## Change

- `HasOneAssociation#needsTargetLoadForBuild` exposes Rails' `find_target?`
  gate (unloaded + persisted/FK-present + klass).
- The has_one `build#{name}` accessor (builder/has-one.ts `defineConstructors`)
  consults it: when a query would actually run it returns
  `loadTarget().then(build)` (a Promise, since the JS path can't await
  synchronously); otherwise it builds synchronously and still throws sync
  errors (e.g. invalid STI type). The plain `association.build` — used by the
  nested-attributes / internal in-memory paths — is unchanged.
- Un-skips the listed test with inline SpecialCar/SpecialBulb models; awaits the
  handful of existing has_one build accessors on persisted owners.

Closes-story: d2-has-one-touch-nonpersisted-build-load


## Design notes (review)

**Why the accessor, not `replace`, is the seam.** Rails puts the pre-load
inside `replace` itself (`has_one_association.rb:62`,
`return target unless load_target || record`), so every `replace`/
`set_new_record` caller gets it for free. That works because Ruby's `replace`
is fully synchronous. trails' `HasOneAssociation#replace` cannot be — a JS
build/property path can't `await` DB I/O — so the load is hoisted to the one
caller that *can* await (the `build#{name}` accessor). The other callers are
already covered without touching `replace`: `writer()` does its own
`if (!this.loaded) await this.loadTarget()` before `replace`
(has-one-association.ts), and `_createRecord` goes through the save-first path.
The direct `association.build(...)` used by nested-attributes / autosave is
deliberately left synchronous (same sync-build divergence trails already
accepts elsewhere); no current caller of the raw `build` relies on a pre-loaded
target. `needsTargetLoadForBuild` is intentionally single-purpose plumbing for
that one awaitable seam.

**Synchronous-error scope.** The "throws synchronously" guarantee holds for the
no-load path (new-record / FK-absent owners) — the shape the
`building the associated object with an invalid type` tests assert on
`new DependentFirm()`. On the load path (persisted owner) the same build error
surfaces as a rejected Promise, an unavoidable consequence of awaiting
`load_target` in JS; Rails raises inline only because its `replace` is fully
synchronous. Comment at builder/has-one.ts updated to state this precisely.
