### PR TITLE
fix(has_one): reset negative cache on after_create_commit for touched has_one

### DIFF
--- a/packages/activerecord/src/associations/has-one-associations.test.ts
+++ b/packages/activerecord/src/associations/has-one-associations.test.ts
@@ -977,12 +977,12 @@ describe("HasOneAssociationsTest", () => {
     });
   });
 
-  it.skip("polymorphic has one with touch option on create wont cache association so fetching after transaction commit works", () => {
-    // BLOCKED (tracked: d2-has-one-touch-polymorphic-inverse-cache): touch: is
-    // honored, but the parent's after_create touch loads its child through the
-    // polymorphic association rather than the cached in-memory inverse, adding
-    // one extra SELECT (7 vs Rails' 6). Needs polymorphic inverse-set on assign
-    // plus after_create_commit reset_negative_cache.
+  it("polymorphic has one with touch option on create wont cache association so fetching after transaction commit works", async () => {
+    await assertQueriesCount(6, false, async () => {
+      const chef = await Chef.create({ employable: new DrinkDesignerWithPolymorphicTouchChef() });
+      const employable = await chef.association("employable").loadTarget();
+      expect((await readHasOne(employable, "chef")).id).toBe(chef.id);
+    });
   });
 
   it("polymorphic has one with touch option on update will touch record by fetching from database if needed", async () => {


### PR DESCRIPTION
## Summary

Un-skips the verbatim Rails test
`polymorphic has one with touch option on create wont cache association so
fetching after transaction commit works`
(vendor/rails/activerecord/test/cases/associations/has_one_associations_test.rb:765),
query count **6**.

The underlying fix — Rails' `Builder::HasOne.add_touch_callbacks` wiring
`after_create_commit { association(name).reset_negative_cache }`
(builder/has_one.rb:52) — landed in `main` independently via a sibling touch
story after this branch opened. After rebasing, this PR is reduced to just
enabling the test.

## Verified query-for-query against a real Rails run

Ran the actual Rails test under `vendor/rails/activerecord` (sqlite3) with an
`sql.active_record` subscriber. Rails emits exactly these 6 (SCHEMA excluded,
matching `assert_queries_count`'s `SQLCounter#log`):

```
1. SAVEPOINT active_record_1
2. INSERT INTO "drink_designers" ...
3. SELECT "chefs".* FROM "chefs" WHERE employable_id = ? AND employable_type = ? LIMIT ?
4. INSERT INTO "chefs" ...
5. RELEASE SAVEPOINT active_record_1
6. SELECT "chefs".* FROM "chefs" WHERE employable_id = ? AND employable_type = ? LIMIT ?
```

Trails emits the identical sequence (same statements, same order). So this is an
exact match, not a coincidentally-equal count.

## Why 6, not 5 (and why the story's inverse criterion is wrong)

Query **3** is the create-time `SELECT chefs`: the parent
`DrinkDesignerWithPolymorphicTouchChef` (has_one owner) autosaves before `Chef`,
so its `after_create` touch loads `chef` while the row doesn't exist yet →
negative-caches `nil`. `after_create_commit` resets that so the post-commit read
(query 6) re-queries and finds the persisted chef.

Plain `Chef` has `belongs_to :employable, polymorphic: true` with **no**
`inverse_of`, so `polymorphic_inverse_of` is nil and no in-memory inverse
short-circuits the touch — the `SELECT chefs` fires in Rails too. The story's
acceptance criterion #1 ("polymorphic inverse is set on assignment so the touch
finds the cached child, no extra SELECT") is factually incorrect: implementing
it would drop the count to **5** and diverge from Rails' **6**. The real Rails
run above confirms 6 with the SELECT present.

`chef.association("employable").loadTarget()` mirrors Rails' cached
`chef.employable`; `readHasOne(employable, "chef")` mirrors `employable.chef`.

Closes-story: d2-has-one-touch-polymorphic-inverse-cache