### PR TITLE
fix(log): translate driver errors with sql+binds like Rails' log

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { Temporal } from "@blazetrails/activesupport/temporal";
-import { Rollback } from "../../errors.js";
+import { Rollback, StatementInvalid } from "../../errors.js";
 import {
   buildFixtureSql,
   buildFixtureStatements,
@@ -240,6 +240,42 @@ describe("DatabaseStatements", () => {
       } as unknown as DatabaseStatementsHost;
       const result = await internalExecQuery.call(host, "SELECT 1", "SQL");
       expect((result as any).rows).toEqual([[1]]);
+    });
+
+    it("attaches sql and binds to a translated StatementInvalid via set_query", async () => {
+      const { internalExecQuery } = await import("./database-statements.js");
+      // Mirror with_raw_connection: internalExecute rejects with an already
+      // translated StatementInvalid carrying no statement context.
+      const host = {
+        internalExecute: async () => {
+          throw new StatementInvalid("duplicate key value violates unique constraint");
+        },
+      } as unknown as DatabaseStatementsHost;
+      const binds = [1, "x"];
+      const err = await internalExecQuery
+        .call(host, "INSERT INTO t (id, name) VALUES ($1, $2)", "SQL", binds)
+        .then(
+          () => null,
+          (e) => e,
+        );
+      expect(err).toBeInstanceOf(StatementInvalid);
+      expect(err.sql).toBe("INSERT INTO t (id, name) VALUES ($1, $2)");
+      expect(err.binds).toEqual(binds);
+    });
+
+    it("does not overwrite sql and binds already set on a StatementInvalid", async () => {
+      const { internalExecQuery } = await import("./database-statements.js");
+      const host = {
+        internalExecute: async () => {
+          throw new StatementInvalid("boom", { sql: "ORIGINAL", binds: [99] });
+        },
+      } as unknown as DatabaseStatementsHost;
+      const err = await internalExecQuery.call(host, "OUTER SQL", "SQL", [1]).then(
+        () => null,
+        (e) => e,
+      );
+      expect(err.sql).toBe("ORIGINAL");
+      expect(err.binds).toEqual([99]);
     });
 
     it("normalizes execute fallback result", async () => {

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -23,6 +23,7 @@ import {
   TransactionIsolationError,
   NotImplementedError,
   RangeError as ARRangeError,
+  StatementInvalid,
 } from "../../errors.js";
 import {
   formatInstantForSql,
@@ -1383,6 +1384,11 @@ async function logSql<T>(
       // so subscribers (e.g. ExplainSubscriber) can detect failed queries.
       payload.exception = e;
       payload.exception_object = e;
+      // Mirrors AbstractAdapter#log's rescue: the driver error has already been
+      // translated to a StatementInvalid by with_raw_connection (with sql:/binds:
+      // nil), so we only attach the statement context here — set_query is a no-op
+      // when sql was already supplied, so this never double-translates.
+      if (e instanceof StatementInvalid) throw e.setQuery(sql, binds ?? []);
       throw e;
     }
   }) as Promise<T>;

--- a/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/database-statements.ts
@@ -1388,7 +1388,7 @@ async function logSql<T>(
       // translated to a StatementInvalid by with_raw_connection (with sql:/binds:
       // nil), so we only attach the statement context here — set_query is a no-op
       // when sql was already supplied, so this never double-translates.
-      if (e instanceof StatementInvalid) throw e.setQuery(sql, binds ?? []);
+      if (e instanceof StatementInvalid) throw e.setQuery(sql, bindArray);
       throw e;
     }
   }) as Promise<T>;

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -2157,17 +2157,14 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
             payload.row_count = count;
             return runResult;
           } catch (e: any) {
-            // A bound query is the exec_insert RETURNING read-back: translate with
-            // sql + binds here (mirroring _instrumentedQueryOnClient) so a
-            // constraint violation surfaces as RecordNotUnique/InvalidForeignKey
-            // carrying statement context. withRawConnection re-catches this AR
-            // error and passes it through unchanged; its own translate would
-            // otherwise re-wrap with null sql / empty binds. Transaction-control
-            // SQL (no binds) keeps the raw rethrow, matching pre-PR behavior.
-            const translated = hasBinds ? this._translateException(e, runSql, bindArray) : e;
-            payload.exception = translated;
-            payload.exception_object = translated;
-            throw translated;
+            // Rethrow raw: withRawConnection translates the driver error to an
+            // ActiveRecordError (with sql: null / binds: []), and the shared logSql
+            // rescue then attaches sql + binds via set_query — mirroring Rails'
+            // AbstractAdapter#log. Translating here would duplicate that and, on an
+            // already-translated error, re-wrap it as StatementInvalid.
+            payload.exception = e;
+            payload.exception_object = e;
+            throw e;
           }
         }),
       );


### PR DESCRIPTION
## Summary

Rails' `AbstractAdapter#log` rescue attaches statement context to a translated
driver error: `rescue ActiveRecord::StatementInvalid => ex; raise ex.set_query(sql, binds)`.
trails' `logSql` did not — it only set `payload.exception`/`payload.exception_object`
and rethrew, so translated errors surfaced from `internalExecQuery`/`rawExecQuery`
with `sql = null` / `binds = []` (`with_raw_connection` translates with null context).

This makes `logSql` mirror Rails: in its rescue, if the error is a
`StatementInvalid`, call `setQuery(sql, binds)`. Because `set_query` is a no-op
when `sql` is already present, an already-contextualized error is never
re-translated or overwritten.

## Changes

- `logSql` (`abstract/database-statements.ts`): attach `sql` + `binds` to a
  translated `StatementInvalid` via `setQuery`, mirroring `AbstractAdapter#log`.
- `postgresql-adapter.ts` `internalExecute`: remove the bound-path
  `_translateException` workaround added in PR #4684. It now rethrows the raw
  driver error and lets `with_raw_connection` translate + `logSql` attach
  context. Avoids the double-translation the workaround guarded against.
- Unit tests: `internalExecQuery` fills in `sql`/`binds` on a translated
  `StatementInvalid`, and does not overwrite context already set.

## Acceptance criteria

- [x] `logSql` translates driver errors with `sql` + `binds` (Rails `log` parity).
- [x] No double-translation of an already-translated `ActiveRecordError`
      (`set_query` no-op guard).
- [x] PG `internalExecute` bound-path workaround removed.
- [x] Constraint-violation class + `sql`/`binds` verified: SQLite local
      (`adapter.test.ts`, `insert-all.test.ts`); PG/MySQL via CI adapter jobs.

Closes-story: logsql-translate-exception-with-sql-binds-parity
