### PR TITLE
fix(mass-assignment): empty-bag guard delegates to wrapper empty?

### DIFF
--- a/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
+++ b/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { Model } from "@blazetrails/activemodel";
+import { Parameters } from "../../metal/strong-parameters.js";
+
+// A real ActionController::Parameters stores its data in a private field and
+// delegates `empty?` to it — so counting the wrapper's own `Object.keys` reads
+// its instance fields, not its parameter count. The mass-assignment empty-bag
+// guard must delegate to the wrapper's emptiness (Rails
+// `return if new_attributes.empty?`), so an EMPTY wrapper is a construction
+// no-op rather than proceeding into sanitize_for_mass_assignment.
+class Account extends Model {
+  static {
+    this.attribute("name", "string");
+  }
+}
+
+describe("MassAssignmentEmptyParametersTest", () => {
+  it("empty Parameters is a no-op at construction", () => {
+    const params = new Parameters({});
+    let record: Account | undefined;
+    expect(() => {
+      record = new Account(params as unknown as Record<string, unknown>);
+    }).not.toThrow();
+    expect(record!.readAttribute("name")).toBeNull();
+  });
+
+  it("non-empty Parameters is treated as non-empty (empty? delegation)", () => {
+    // The guard must NOT count the wrapper's own instance fields: a non-empty
+    // Parameters reports `empty === false`, so the guard proceeds past the
+    // empty-bag short-circuit rather than being wrongly skipped.
+    const params = new Parameters({ name: "Bob" });
+    expect(params.empty).toBe(false);
+  });
+});

--- a/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
+++ b/packages/actionpack/src/action-controller/controller/parameters/mass-assignment-empty.test.ts
@@ -24,11 +24,21 @@ describe("MassAssignmentEmptyParametersTest", () => {
     expect(record!.readAttribute("name")).toBeNull();
   });
 
-  it("non-empty Parameters is treated as non-empty (empty? delegation)", () => {
+  it("non-empty Parameters proceeds past the empty-bag guard at construction", () => {
     // The guard must NOT count the wrapper's own instance fields: a non-empty
-    // Parameters reports `empty === false`, so the guard proceeds past the
-    // empty-bag short-circuit rather than being wrongly skipped.
-    const params = new Parameters({ name: "Bob" });
-    expect(params.empty).toBe(false);
+    // Parameters reports `empty === false`, so construction proceeds past the
+    // empty-bag short-circuit into sanitize_for_mass_assignment (contrast the
+    // empty no-op above). We assert only that it does NOT silently no-op — it
+    // throws — not the specific error class: an unpermitted Parameters SHOULD
+    // raise ForbiddenAttributesError, but real Parameters exposes `permitted`
+    // as a boolean getter (not a method), so sanitize currently misreads it as
+    // a plain hash and raises on its private fields instead. That
+    // permitted-getter divergence is tracked separately in
+    // `sanitize-mass-assignment-permitted-getter`; either way the guard is
+    // proven to proceed rather than skip.
+    expect(new Parameters({ name: "Bob" }).empty).toBe(false);
+    expect(
+      () => new Account(new Parameters({ name: "Bob" }) as unknown as Record<string, unknown>),
+    ).toThrow();
   });
 });

--- a/packages/activemodel/src/attribute-assignment.test.ts
+++ b/packages/activemodel/src/attribute-assignment.test.ts
@@ -22,6 +22,13 @@ class ProtectedParams {
     return this;
   }
 
+  // Rails ProtectedParams: `delegate :empty?, to: :@parameters`. The wrapper's
+  // own instance fields (`parameters`, `_permitted`) are NOT its contents, so
+  // emptiness must delegate to the private parameter store.
+  get empty(): boolean {
+    return Object.keys(this.parameters).length === 0;
+  }
+
   toH(): Record<string, unknown> {
     return this.parameters;
   }
@@ -278,6 +285,50 @@ describe("AttributeAssignmentTest", () => {
     p.assignAttributes({ name: "Dave", role: "admin" });
     expect(p.readAttribute("name")).toBe("Dave");
     expect(p.readAttribute("role")).toBeNull();
+  });
+
+  it("empty params wrapper is a no-op on assignAttributes (empty? delegation)", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const p = new Person({});
+    // Empty AND unpermitted: Rails `assign_attributes` returns before
+    // sanitizing (`return if new_attributes.empty?`), so no
+    // ForbiddenAttributesError despite the wrapper being unpermitted.
+    const params = new ProtectedParams({});
+    expect(() => p.assignAttributes(params as unknown as Record<string, unknown>)).not.toThrow();
+    expect(p.readAttribute("name")).toBeNull();
+  });
+
+  it("empty params wrapper is a no-op at construction (empty? delegation)", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const params = new ProtectedParams({});
+    let record: Person | undefined;
+    expect(() => {
+      record = new Person(params as unknown as Record<string, unknown>);
+    }).not.toThrow();
+    expect(record!.readAttribute("name")).toBeNull();
+  });
+
+  it("non-empty unpermitted params wrapper still raises (empty? delegation)", () => {
+    class Person extends Model {
+      static {
+        this.attribute("name", "string");
+      }
+    }
+    const p = new Person({});
+    // Non-empty (per empty? delegation, not the wrapper's Object.keys) → the
+    // guard proceeds into sanitize_for_mass_assignment, which forbids it.
+    const params = new ProtectedParams({ name: "Bob" });
+    expect(() => p.assignAttributes(params as unknown as Record<string, unknown>)).toThrow(
+      ForbiddenAttributesError,
+    );
   });
 
   it("subclass override of _assignAttribute is called by _assignAttributes", () => {

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -44,10 +44,18 @@ export function isMassAssignmentEmpty(attrs: object): boolean {
 }
 
 /**
- * A non-plain object duck-typing the `ActionController::Parameters` surface
- * (`permitted`/`toH`) — distinct from a plain hash, whose own keys ARE its
- * contents. Only such a wrapper's `empty` should be consulted, so a plain hash
- * that happens to carry an `empty: <boolean>` attribute is unaffected.
+ * A non-plain object duck-typing the `ActionController::Parameters` surface —
+ * the trails analogue of Rails' params wrapper, distinct from a plain hash whose
+ * own keys ARE its contents. Single source of truth for wrapper recognition on
+ * the mass-assignment path: `isHashLike` admits it as hash-like, and
+ * `isMassAssignmentEmpty` consults its `empty` (so a plain hash that happens to
+ * carry an `empty: <boolean>` attribute is unaffected).
+ *
+ * For the real ActionController::Parameters, `permitted` is a boolean getter
+ * (strong-parameters.ts:113), not a method, so `toH` is the load-bearing check
+ * that admits it here; the `permitted` function-probe covers other duck-typed
+ * wrappers. (sanitizeForMassAssignment has the same permitted-as-function
+ * assumption — tracked in `sanitize-mass-assignment-permitted-getter`.)
  */
 function isParamsLikeWrapper(attrs: object): boolean {
   const proto = Object.getPrototypeOf(attrs);
@@ -165,13 +173,7 @@ export function assertHashAttributes(attrs: unknown): asserts attrs is Record<st
 function isHashLike(attrs: object): boolean {
   const proto = Object.getPrototypeOf(attrs);
   if (proto === Object.prototype || proto === null) return true;
-  const wrapper = attrs as PermittedAttributes;
-  // For the real ActionController::Parameters, `permitted` is a boolean getter
-  // (strong-parameters.ts:113), not a method, so `toH` is the load-bearing check
-  // that admits it here; the `permitted` function-probe covers other duck-typed
-  // wrappers. (sanitizeForMassAssignment has the same permitted-as-function
-  // assumption — tracked in `sanitize-mass-assignment-permitted-getter`.)
-  return typeof wrapper.permitted === "function" || typeof wrapper.toH === "function";
+  return isParamsLikeWrapper(attrs);
 }
 
 function typeNameForError(value: unknown): string {

--- a/packages/activemodel/src/attribute-assignment.ts
+++ b/packages/activemodel/src/attribute-assignment.ts
@@ -11,10 +11,49 @@ export function assignAttributes(model: AttributeAssignment, newAttributes: unkn
   assertHashAttributes(newAttributes);
 
   const attrs = newAttributes;
-  if (Object.keys(attrs).length === 0) return;
+  if (isMassAssignmentEmpty(attrs)) return;
 
   const sanitized = sanitizeForMassAssignment(attrs);
   _assignAttributes(model, sanitized);
+}
+
+/**
+ * The mass-assignment empty-bag guard shared by every entry point that runs
+ * `sanitize_for_mass_assignment` before per-key dispatch (the `Model`
+ * constructor, `Model#assignAttributes`, and the ActiveRecord `Base`
+ * constructor).
+ *
+ * Mirrors ActiveModel::AttributeAssignment#assign_attributes'
+ * `return if new_attributes.empty?` (attribute_assignment.rb:32). A params-like
+ * wrapper (the `ActionController::Parameters` analogue) delegates `empty?` to
+ * its private parameter store (strong_parameters.rb:250) — so counting the
+ * wrapper's own `Object.keys` reads its instance fields (`parameters`,
+ * `_permitted`), NOT its parameter count, and an EMPTY unpermitted wrapper
+ * would wrongly read as non-empty and proceed into sanitization instead of
+ * being a no-op. Consult the wrapper's `empty` when present; a plain hash has
+ * no such delegate, so it falls through to the key count.
+ *
+ * @internal Rails-private helper.
+ */
+export function isMassAssignmentEmpty(attrs: object): boolean {
+  if (isParamsLikeWrapper(attrs)) {
+    const empty = (attrs as { empty?: unknown }).empty;
+    if (typeof empty === "boolean") return empty;
+  }
+  return Object.keys(attrs).length === 0;
+}
+
+/**
+ * A non-plain object duck-typing the `ActionController::Parameters` surface
+ * (`permitted`/`toH`) — distinct from a plain hash, whose own keys ARE its
+ * contents. Only such a wrapper's `empty` should be consulted, so a plain hash
+ * that happens to carry an `empty: <boolean>` attribute is unaffected.
+ */
+function isParamsLikeWrapper(attrs: object): boolean {
+  const proto = Object.getPrototypeOf(attrs);
+  if (proto === Object.prototype || proto === null) return false;
+  const wrapper = attrs as PermittedAttributes;
+  return typeof wrapper.permitted === "function" || typeof wrapper.toH === "function";
 }
 
 export interface AttributeAssignment {

--- a/packages/activemodel/src/index.ts
+++ b/packages/activemodel/src/index.ts
@@ -25,6 +25,7 @@ export {
   assertHashAttributes,
   attributeWriterMissing,
   sanitizeForMassAssignment,
+  isMassAssignmentEmpty,
   ArgumentError,
 } from "./attribute-assignment.js";
 export type { AttributeAssignment } from "./attribute-assignment.js";

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -81,6 +81,7 @@ import {
   sanitizeForMassAssignment as attrSanitize,
   attributeWriterMissing as defaultAttributeWriterMissing,
   assertHashAttributes,
+  isMassAssignmentEmpty,
   ArgumentError,
 } from "./attribute-assignment.js";
 import { PresenceValidator } from "./validations/presence.js";
@@ -1620,7 +1621,7 @@ export class Model {
     // sanitize on the AR path no-ops rather than double-checking.
     this._initializingAttributes = true;
     try {
-      if (Object.keys(attrs).length > 0) {
+      if (!isMassAssignmentEmpty(attrs)) {
         this._assignAttributes(this.sanitizeForMassAssignment(attrs));
       }
     } finally {
@@ -2395,7 +2396,7 @@ export class Model {
   assignAttributes(newAttributes: unknown): void {
     assertHashAttributes(newAttributes);
     const attrs = newAttributes;
-    if (Object.keys(attrs).length === 0) return;
+    if (isMassAssignmentEmpty(attrs)) return;
     this._assignAttributes(this.sanitizeForMassAssignment(attrs));
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -121,6 +121,7 @@ import {
   runAfterCallbacksOnProto as cbRunAfter,
   beforeOrAroundCallbackSources,
   sanitizeForMassAssignment,
+  isMassAssignmentEmpty,
   shouldValidate,
 } from "@blazetrails/activemodel";
 import { SignedGlobalID as _SignedGlobalIDCtor } from "@blazetrails/globalid/signed-global-id";
@@ -3138,7 +3139,7 @@ export class Base extends Model {
     // un-permitted) params object neither raises nor sanitizes. Only a
     // non-empty bag is checked.
     attrs ??= {};
-    if (Object.keys(attrs).length > 0) {
+    if (!isMassAssignmentEmpty(attrs)) {
       attrs = sanitizeForMassAssignment(attrs);
     }
     // STI dispatch at `new`: when the inheritance column names a subclass in


### PR DESCRIPTION
## Summary

The mass-assignment empty-bag guard gated on the wrapper's own `Object.keys(attrs).length` rather than delegating to a params-like wrapper's `empty?`. For a real `ActionController::Parameters` (or any params-like object storing data in private fields), `Object.keys` returns the wrapper's own instance fields (`parameters`, `_permitted`), NOT its parameter count — so an EMPTY unpermitted `Parameters` read as non-empty and proceeded into `sanitizeForMassAssignment` (raising `ForbiddenAttributesError`) instead of being a no-op.

Rails `assign_attributes` does `return if new_attributes.empty?` (`attribute_assignment.rb:32`), and `ActionController::Parameters` delegates `empty?` to its private `@parameters` (`strong_parameters.rb:250`).

## Change

- New shared `isMassAssignmentEmpty(attrs)` helper in `attribute-assignment.ts`: consults a params-like wrapper's `empty` when present (non-plain object duck-typing `permitted`/`toH`), otherwise falls back to a plain hash's key count. A plain hash carrying an `empty: <boolean>` attribute is unaffected.
- Wired into all three shared entry points (one helper, not three divergent checks): the `Model` constructor, `Model#assignAttributes`, and the AR `Base` constructor — plus the standalone `assignAttributes` helper.

## Tests

- `attribute-assignment.test.ts`: `ProtectedParams` stub gains an `empty` getter (mirrors Rails' `delegate :empty?`); empty unpermitted wrapper is a no-op at construction and via `assignAttributes`; non-empty unpermitted wrapper still raises.
- `mass-assignment-empty.test.ts` (actionpack): real `Parameters` — empty is a construction no-op; non-empty reports `empty === false`.
- Plain-hash behavior unchanged.

Closes-story: mass-assignment-empty-bag-delegates-to-wrapper-empty