### PR TITLE
lint(activerecord,activemodel): enable no-floating-promises + full no-misused-promises

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -632,32 +632,27 @@ export default defineConfig(
     },
   },
 
-  // ── no-misused-promises: boolean-position guard (RFC 0063 async-validation) ──
-  // Before `isValid()`/`validate()` flip to returning `Promise<boolean>`, lint
-  // must catch a forgotten `await`: `if (record.isValid())` on an un-awaited
-  // Promise is always truthy and fails silently. `checksConditionals` (default
-  // on) makes a Promise used in a boolean position — condition, `!`, `&&`, `||`,
-  // ternary — a hard error, which is exactly the flip's footgun. Scoped to the
-  // two packages the flip touches (src + tests). The rule needs type info — the
-  // projectService block above supplies it.
+  // ── dropped-Promise guards (RFC 0063 async-validation) ──
+  // As `isValid()`/`validate()` flip to returning `Promise<boolean>`, lint must
+  // catch a forgotten `await`. Two rules cover the footguns over the two
+  // packages the flip touches (src + tests); both need type info, supplied by
+  // the projectService block above.
   //
-  // The other two sub-checks are turned OFF, each for cause:
-  //  - checksVoidReturn: 12 pre-existing sites pass an async callback / override
-  //    an adapter method typed to return void. Those are legitimate patterns
-  //    unrelated to the validation flip, and fixing them means runtime changes
-  //    this story forbids. Follow-up: lint-guard-misused-promises-void-return.
-  //  - checksSpreads: 1 pre-existing site (collection-proxy.test.ts) spreads a
-  //    Promise into an object. Same follow-up burden; off for now.
-  // A `no-floating-promises` companion (177 dropped-Promise sites, ~170 in
-  // tests) is deferred to its own burndown story — enabling it would require
-  // the runtime `await`/`void` edits this story forbids.
+  //  - no-misused-promises (all three sub-checks on): `checksConditionals`
+  //    catches a Promise in a boolean position (`if (record.isValid())` is
+  //    always truthy); `checksVoidReturn` catches an async callback / adapter
+  //    override passed where a void return is expected; `checksSpreads` catches
+  //    a Promise spread into an object.
+  //  - no-floating-promises: catches a dropped Promise statement — a bare
+  //    `record.save()` whose result nobody awaits.
   {
     files: ["packages/activemodel/src/**/*.ts", "packages/activerecord/src/**/*.ts"],
     rules: {
       "@typescript-eslint/no-misused-promises": [
         "error",
-        { checksConditionals: true, checksVoidReturn: false, checksSpreads: false },
+        { checksConditionals: true, checksVoidReturn: true, checksSpreads: true },
       ],
+      "@typescript-eslint/no-floating-promises": "error",
     },
   },
 );

--- a/packages/activemodel/src/callbacks.test.ts
+++ b/packages/activemodel/src/callbacks.test.ts
@@ -10,7 +10,7 @@ import {
 } from "./callbacks.js";
 
 describe("CallbacksTest", () => {
-  it("after callbacks are not executed if the block returns false", () => {
+  it("after callbacks are not executed if the block returns false", async () => {
     // Faithful port of Rails ModelCallbacks (callbacks_test.rb:6-87): an
     // around_create returning false, an after_create returning false, and a
     // final after_create, with `create` running run_callbacks(:create) whose
@@ -55,7 +55,7 @@ describe("CallbacksTest", () => {
       }
     }
     const model = new ModelCallbacks({ valid: false });
-    model.create();
+    await model.create();
     expect(model.callbacks).toEqual([
       "before_create",
       "before_around_create",
@@ -93,7 +93,7 @@ describe("CallbacksTest", () => {
     expect(p.isValid()).toBe(true);
   });
 
-  it("after_create callbacks with both callbacks declared in different lines", () => {
+  it("after_create callbacks with both callbacks declared in different lines", async () => {
     const log: string[] = [];
     class Person extends Model {
       static {
@@ -107,20 +107,20 @@ describe("CallbacksTest", () => {
       }
     }
     const p = new Person({ name: "test" });
-    runAfterCallbacksOnProto((p.constructor as typeof Model).prototype, "create", p);
+    await runAfterCallbacksOnProto((p.constructor as typeof Model).prototype, "create", p);
     expect(log).toEqual(["first", "second"]);
   });
 
-  it("complete callback chain", () => {
+  it("complete callback chain", async () => {
     const order: string[] = [];
     class Person extends Model {
       static {
         this.beforeSave(() => {
           order.push("before_save");
         });
-        this.aroundSave((_r, proceed) => {
+        this.aroundSave(async (_r, proceed) => {
           order.push("around_before");
-          proceed();
+          await proceed();
           order.push("around_after");
         });
         this.afterSave(() => {
@@ -128,7 +128,7 @@ describe("CallbacksTest", () => {
         });
       }
     }
-    new Person().runCallbacks("save", () => {
+    await new Person().runCallbacks("save", () => {
       order.push("save");
     });
     expect(order).toEqual(["before_save", "around_before", "save", "around_after", "after_save"]);
@@ -163,7 +163,7 @@ describe("CallbacksTest", () => {
     expect(order).not.toContain("after");
   });
 
-  it("only selects which types of callbacks should be created", () => {
+  it("only selects which types of callbacks should be created", async () => {
     // Test that before/after/around create callbacks exist
     const order: string[] = [];
     class Person extends Model {
@@ -176,13 +176,13 @@ describe("CallbacksTest", () => {
         });
       }
     }
-    new Person().runCallbacks("create", () => {
+    await new Person().runCallbacks("create", () => {
       order.push("create");
     });
     expect(order).toEqual(["before_create", "create", "after_create"]);
   });
 
-  it("after_create callbacks with both callbacks declared in one line", () => {
+  it("after_create callbacks with both callbacks declared in one line", async () => {
     const order: string[] = [];
     class Person extends Model {
       static {
@@ -194,7 +194,7 @@ describe("CallbacksTest", () => {
         });
       }
     }
-    new Person().runCallbacks("create", () => {
+    await new Person().runCallbacks("create", () => {
       order.push("create");
     });
     expect(order).toEqual(["create", "first_after", "second_after"]);
@@ -309,7 +309,7 @@ describe("CallbacksTest", () => {
     expect(log).toContain("camelCase called");
   });
 
-  it("class-based around callback object with proceed", () => {
+  it("class-based around callback object with proceed", async () => {
     const log: string[] = [];
     const wrapper = {
       aroundSave(record: any, proceed: () => void) {
@@ -325,13 +325,13 @@ describe("CallbacksTest", () => {
       }
     }
     const p = new Person({ name: "test" });
-    p.runCallbacks("save", () => {
+    await p.runCallbacks("save", () => {
       log.push("save");
     });
     expect(log).toEqual(["around_before", "save", "around_after"]);
   });
 
-  it("class-based callback via defineModelCallbacks-generated methods", () => {
+  it("class-based callback via defineModelCallbacks-generated methods", async () => {
     const log: string[] = [];
     const observer = {
       beforeProcess(record: any) {
@@ -346,7 +346,7 @@ describe("CallbacksTest", () => {
       }
     }
     const j = new Job({ name: "import" });
-    j.runCallbacks("process", () => {
+    await j.runCallbacks("process", () => {
       log.push("executed");
     });
     expect(log).toEqual(["processing import", "executed"]);
@@ -354,20 +354,20 @@ describe("CallbacksTest", () => {
 });
 
 describe("CallbackChain.run", () => {
-  it("runs after callbacks only after the block completes", () => {
+  it("runs after callbacks only after the block completes", async () => {
     const proto = Object.create(null);
     const log: string[] = [];
     _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    runAllCallbacks(proto, "save", {}, () => {
+    await runAllCallbacks(proto, "save", {}, () => {
       log.push("block:start");
       log.push("block:end");
     });
     expect(log).toEqual(["block:start", "block:end", "after"]);
   });
 
-  it("around callbacks wrap the block", () => {
+  it("around callbacks wrap the block", async () => {
     const proto = Object.create(null);
     const log: string[] = [];
     _registerCallbackOnProto(proto, "around", "save", (_record: any, proceed: () => void) => {
@@ -378,13 +378,13 @@ describe("CallbackChain.run", () => {
     _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after");
     });
-    runAllCallbacks(proto, "save", {}, () => {
+    await runAllCallbacks(proto, "save", {}, () => {
       log.push("block");
     });
     expect(log).toEqual(["around:before", "block", "around:after", "after"]);
   });
 
-  it("after callbacks run in registration order", () => {
+  it("after callbacks run in registration order", async () => {
     const proto = Object.create(null);
     const log: string[] = [];
     _registerCallbackOnProto(proto, "after", "save", () => {
@@ -393,7 +393,7 @@ describe("CallbackChain.run", () => {
     _registerCallbackOnProto(proto, "after", "save", () => {
       log.push("after2");
     });
-    runAllCallbacks(proto, "save", {}, () => {
+    await runAllCallbacks(proto, "save", {}, () => {
       log.push("block");
     });
     expect(log).toEqual(["block", "after1", "after2"]);
@@ -404,16 +404,16 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
   // Rails `set_callback(name, type, filter, options)` /
   // `skip_callback(...)` / `reset_callbacks(name)` from
   // `ActiveSupport::Callbacks::ClassMethods`.
-  it("setCallback registers a function for arbitrary event + timing", () => {
+  it("setCallback registers a function for arbitrary event + timing", async () => {
     const log: string[] = [];
     class Thing extends Model {}
     Thing.setCallback("save", "before", () => log.push("before"));
     Thing.setCallback("save", "after", () => log.push("after"));
-    new Thing().runCallbacks("save", () => log.push("block"));
+    await new Thing().runCallbacks("save", () => log.push("block"));
     expect(log).toEqual(["before", "block", "after"]);
   });
 
-  it("skipCallback removes a previously registered callback by reference", () => {
+  it("skipCallback removes a previously registered callback by reference", async () => {
     const log: string[] = [];
     class Thing extends Model {}
     const cb = () => log.push("skipped-callback");
@@ -421,7 +421,7 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
     Thing.setCallback("save", "before", () => log.push("kept"));
 
     expect(Thing.skipCallback("save", "before", cb)).toBe(true);
-    new Thing().runCallbacks("save", () => log.push("block"));
+    await new Thing().runCallbacks("save", () => log.push("block"));
     expect(log).toEqual(["kept", "block"]);
   });
 
@@ -430,7 +430,7 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
     expect(Thing.skipCallback("save", "before", () => undefined)).toBe(false);
   });
 
-  it("resetCallbacks clears all callbacks for an event", () => {
+  it("resetCallbacks clears all callbacks for an event", async () => {
     const log: string[] = [];
     class Thing extends Model {}
     Thing.setCallback("save", "before", () => log.push("before"));
@@ -438,23 +438,23 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
     Thing.setCallback("update", "before", () => log.push("update-before"));
 
     Thing.resetCallbacks("save");
-    new Thing().runCallbacks("save", () => log.push("save-block"));
-    new Thing().runCallbacks("update", () => log.push("update-block"));
+    await new Thing().runCallbacks("save", () => log.push("save-block"));
+    await new Thing().runCallbacks("update", () => log.push("update-block"));
     expect(log).toEqual(["save-block", "update-before", "update-block"]);
   });
 
-  it("setCallback on subclass does not leak up to parent (copy-on-first-write)", () => {
+  it("setCallback on subclass does not leak up to parent (copy-on-first-write)", async () => {
     const log: string[] = [];
     class Parent extends Model {}
     class Child extends Parent {}
     Child.setCallback("save", "before", () => log.push("child"));
-    new Parent().runCallbacks("save", () => log.push("parent-block"));
+    await new Parent().runCallbacks("save", () => log.push("parent-block"));
     expect(log).toEqual(["parent-block"]);
-    new Child().runCallbacks("save", () => log.push("child-block"));
+    await new Child().runCallbacks("save", () => log.push("child-block"));
     expect(log).toEqual(["parent-block", "child", "child-block"]);
   });
 
-  it("skipCallback miss does NOT isolate subclass from future parent callbacks", () => {
+  it("skipCallback miss does NOT isolate subclass from future parent callbacks", async () => {
     // A miss must preserve copy-on-first-write inheritance so a
     // subclass that later has callbacks added to its parent still sees
     // them via the prototype chain.
@@ -464,11 +464,11 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
     expect(Child.skipCallback("save", "before", () => undefined)).toBe(false);
     // Now register on Parent — Child should still see it.
     Parent.setCallback("save", "before", () => log.push("from-parent"));
-    new Child().runCallbacks("save", () => log.push("child-block"));
+    await new Child().runCallbacks("save", () => log.push("child-block"));
     expect(log).toEqual(["from-parent", "child-block"]);
   });
 
-  it("skipCallback removes a CallbackObject registered by reference", () => {
+  it("skipCallback removes a CallbackObject registered by reference", async () => {
     // Rails `set_callback(:save, :before, CallbackObject.new)` looks up
     // `before_save` (or our camelCase `beforeSave`) on the object. The
     // same reference must identify it for `skip_callback` — even though
@@ -485,11 +485,11 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
     Thing.setCallback("save", "before", () => log.push("fn-kept"));
 
     expect(Thing.skipCallback("save", "before", obj)).toBe(true);
-    new Thing().runCallbacks("save", () => log.push("block"));
+    await new Thing().runCallbacks("save", () => log.push("block"));
     expect(log).toEqual(["fn-kept", "block"]);
   });
 
-  it("skipCallback removes a CallbackObject registered via beforeX/afterX helpers", () => {
+  it("skipCallback removes a CallbackObject registered via beforeX/afterX helpers", async () => {
     // The generated `beforeX`/`afterX`/`aroundX` helpers from
     // `defineModelCallbacks` pass the original filter straight to
     // `register` so skipCallback(event, timing, originalObject) can
@@ -509,7 +509,7 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
     (Thing as unknown as { beforeShip: (fn: () => void) => void }).beforeShip(() => log.push("fn"));
 
     expect(Thing.skipCallback("ship", "before", obj)).toBe(true);
-    new Thing().runCallbacks("ship", () => log.push("block"));
+    await new Thing().runCallbacks("ship", () => log.push("block"));
     expect(log).toEqual(["fn", "block"]);
   });
 
@@ -533,7 +533,7 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
     ).not.toThrow();
   });
 
-  it("resetCallbacks clears CallbackObject-registered callbacks too", () => {
+  it("resetCallbacks clears CallbackObject-registered callbacks too", async () => {
     // Companion to the skipCallback-with-object case: resetCallbacks
     // must sweep the event bucket regardless of whether its entries
     // came from functions or CallbackObjects.
@@ -548,16 +548,16 @@ describe("Generic Model.setCallback / skipCallback / resetCallbacks (Rails fidel
     Thing.setCallback("save", "before", () => log.push("fn"));
 
     Thing.resetCallbacks("save");
-    new Thing().runCallbacks("save", () => log.push("block-after-reset"));
+    await new Thing().runCallbacks("save", () => log.push("block-after-reset"));
     expect(log).toEqual(["block-after-reset"]);
   });
 
-  it("setCallback respects prepend: true (runs before earlier-registered)", () => {
+  it("setCallback respects prepend: true (runs before earlier-registered)", async () => {
     const log: string[] = [];
     class Thing extends Model {}
     Thing.setCallback("save", "before", () => log.push("registered-first"));
     Thing.setCallback("save", "before", () => log.push("prepended"), { prepend: true });
-    new Thing().runCallbacks("save", () => log.push("block"));
+    await new Thing().runCallbacks("save", () => log.push("block"));
     expect(log).toEqual(["prepended", "registered-first", "block"]);
   });
 });
@@ -697,7 +697,7 @@ describe("unified sync/async runner", () => {
   });
 });
 describe("Callbacks", () => {
-  it("before/after callbacks run in order", () => {
+  it("before/after callbacks run in order", async () => {
     const order: string[] = [];
     class Ordered extends Model {
       static {
@@ -711,26 +711,26 @@ describe("Callbacks", () => {
       }
     }
     const o = new Ordered();
-    o.runCallbacks("save", () => {
+    await o.runCallbacks("save", () => {
       order.push("action");
     });
     expect(order).toEqual(["before", "action", "after"]);
   });
 
-  it("around callbacks wrap the action", () => {
+  it("around callbacks wrap the action", async () => {
     const order: string[] = [];
     class Around extends Model {
       static {
         this.attribute("name", "string");
-        this.aroundSave((_record, proceed) => {
+        this.aroundSave(async (_record, proceed) => {
           order.push("around_before");
-          proceed();
+          await proceed();
           order.push("around_after");
         });
       }
     }
     const a = new Around();
-    a.runCallbacks("save", () => {
+    await a.runCallbacks("save", () => {
       order.push("action");
     });
     expect(order).toEqual(["around_before", "action", "around_after"]);
@@ -773,16 +773,16 @@ describe("Callbacks", () => {
     expect(n.errors.count).toBe(0); // validations never ran
   });
 
-  it("complete callback chain", () => {
+  it("complete callback chain", async () => {
     const order: string[] = [];
     class Full extends Model {
       static {
         this.beforeSave(() => {
           order.push("before_save");
         });
-        this.aroundSave((_r, proceed) => {
+        this.aroundSave(async (_r, proceed) => {
           order.push("around_before");
-          proceed();
+          await proceed();
           order.push("around_after");
         });
         this.afterSave(() => {
@@ -790,7 +790,7 @@ describe("Callbacks", () => {
         });
       }
     }
-    new Full().runCallbacks("save", () => {
+    await new Full().runCallbacks("save", () => {
       order.push("save");
     });
     expect(order).toEqual(["before_save", "around_before", "save", "around_after", "after_save"]);
@@ -830,7 +830,7 @@ describe("Callbacks (extended)", () => {
     expect(order).toContain("after_validation");
   });
 
-  it("callback inheritance — child inherits parent callbacks", () => {
+  it("callback inheritance — child inherits parent callbacks", async () => {
     const order: string[] = [];
     class Parent extends Model {
       static {
@@ -848,7 +848,7 @@ describe("Callbacks (extended)", () => {
       }
     }
     const c = new Child();
-    c.runCallbacks("save", () => {
+    await c.runCallbacks("save", () => {
       order.push("action");
     });
     expect(order).toContain("parent_before");
@@ -856,7 +856,7 @@ describe("Callbacks (extended)", () => {
     expect(order.indexOf("parent_before")).toBeLessThan(order.indexOf("child_before"));
   });
 
-  it("child callbacks do not affect parent", () => {
+  it("child callbacks do not affect parent", async () => {
     const parentOrder: string[] = [];
     const childOrder: string[] = [];
     class Parent extends Model {
@@ -875,7 +875,7 @@ describe("Callbacks (extended)", () => {
         });
       }
     }
-    new Parent().runCallbacks("save", () => {
+    await new Parent().runCallbacks("save", () => {
       parentOrder.push("action");
     });
     expect(parentOrder).not.toContain("child");
@@ -923,7 +923,7 @@ describe("afterCommit / afterRollback callbacks", () => {
   });
 });
 describe("defineModelCallbacks()", () => {
-  it("creates before/after/around methods for custom events", () => {
+  it("creates before/after/around methods for custom events", async () => {
     class Payment extends Model {
       static {
         this.attribute("amount", "integer");
@@ -941,8 +941,8 @@ describe("defineModelCallbacks()", () => {
 
     const p = new Payment({ amount: 100 });
     // Run callbacks manually
-    runBeforeCallbacksOnProto(Payment.prototype, "process", p);
-    runAfterCallbacksOnProto(Payment.prototype, "process", p);
+    await runBeforeCallbacksOnProto(Payment.prototype, "process", p);
+    await runAfterCallbacksOnProto(Payment.prototype, "process", p);
     expect(log).toEqual(["before_process", "after_process"]);
   });
 
@@ -959,7 +959,7 @@ describe("defineModelCallbacks()", () => {
 });
 
 describe("callbacks with prepend option", () => {
-  it("prepend: true puts callback first in the chain", () => {
+  it("prepend: true puts callback first in the chain", async () => {
     class User extends Model {
       static {
         this.attribute("name", "string");
@@ -977,7 +977,7 @@ describe("callbacks with prepend option", () => {
     );
 
     const u = new User({ name: "Alice" });
-    runBeforeCallbacksOnProto(User.prototype, "save", u);
+    await runBeforeCallbacksOnProto(User.prototype, "save", u);
     expect(order).toEqual(["prepended", "first"]);
   });
 });
@@ -1007,7 +1007,7 @@ describe("withOptions()", () => {
 });
 
 describe("skipCallbackOnProto with CallbackObject (mixin-level)", () => {
-  it("removes a CallbackObject from the chain by reference", () => {
+  it("removes a CallbackObject from the chain by reference", async () => {
     const log: string[] = [];
     const proto = Object.create(null);
     const obj = {
@@ -1018,7 +1018,7 @@ describe("skipCallbackOnProto with CallbackObject (mixin-level)", () => {
     _registerCallbackOnProto(proto, "before", "save", obj);
     _registerCallbackOnProto(proto, "before", "save", () => log.push("fn"));
     expect(skipCallbackOnProto(proto, "save", "before", obj)).toBe(true);
-    runBeforeCallbacksOnProto(proto, "save", {});
+    await runBeforeCallbacksOnProto(proto, "save", {});
     expect(log).toEqual(["fn"]);
   });
 });

--- a/packages/activemodel/src/model.ts
+++ b/packages/activemodel/src/model.ts
@@ -1636,7 +1636,9 @@ export class Model {
     // then fire after_initialize in Rails-compatible order.
     const callbackSuppressor = ctor as typeof ctor & { _suppressInitializeCallback?: boolean };
     if (callbackSuppressor._suppressInitializeCallback !== true) {
-      runAfterCallbacksOnProto(ctor.prototype, "initialize", this, { strict: "sync" });
+      // strict:"sync" guarantees synchronous completion (async callbacks throw),
+      // so the returned Promise is already settled — void the sync-strict result.
+      void runAfterCallbacksOnProto(ctor.prototype, "initialize", this, { strict: "sync" });
     }
   }
 
@@ -1875,7 +1877,9 @@ export class Model {
   /** @internal */
   _runValidateCallbacks(): void {
     const ctor = this.constructor as typeof Model;
-    runBeforeCallbacksOnProto(ctor.prototype, "validate", this, { strict: "sync" });
+    // strict:"sync" guarantees synchronous completion (async callbacks throw),
+    // so the returned Promise is already settled — void the sync-strict result.
+    void runBeforeCallbacksOnProto(ctor.prototype, "validate", this, { strict: "sync" });
   }
 
   /**

--- a/packages/activerecord/src/adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapter-prevent-writes.test.ts
@@ -11,14 +11,16 @@ import { PostgreSQLAdapter, PG_TEST_URL } from "./adapters/postgresql/test-helpe
 
 let adapter: AbstractSQLite3Adapter;
 
-beforeEach(() => {
+beforeEach(async () => {
   adapter = new BetterSQLite3Adapter(":memory:");
-  adapter.exec(`CREATE TABLE "subscribers" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "nick" TEXT)`);
+  await adapter.exec(
+    `CREATE TABLE "subscribers" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "nick" TEXT)`,
+  );
 });
 
 afterEach(async () => {
   await adapter.exec(`DROP TABLE IF EXISTS "subscribers"`).catch(() => undefined);
-  adapter.close();
+  await adapter.close();
 });
 
 describe("AdapterPreventWritesTest", () => {

--- a/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/mysql2/mysql2-adapter.trails.test.ts
@@ -302,12 +302,12 @@ describeIfMysql("Mysql2Adapter (trails extensions)", () => {
     // up front. Asserts the seed lands immediately — the per-query re-sync
     // is covered by the mirror's timezone test.
     adapter.databaseTimezone = "utc";
-    await withTimezoneConfig({ default: "local" }, () => {
-      adapter.configureConnection();
+    await withTimezoneConfig({ default: "local" }, async () => {
+      await adapter.configureConnection();
       expect(adapter.databaseTimezone).toBe("local");
     });
-    await withTimezoneConfig({ default: "utc" }, () => {
-      adapter.configureConnection();
+    await withTimezoneConfig({ default: "utc" }, async () => {
+      await adapter.configureConnection();
       expect(adapter.databaseTimezone).toBe("utc");
     });
   });

--- a/packages/activerecord/src/adapters/postgresql/connection.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/connection.test.ts
@@ -306,7 +306,7 @@ describeIfPg("PostgresqlConnectionTest", () => {
   it("reconnect resets connection so queries work again", async () => {
     const a = new PostgreSQLAdapter(PG_TEST_URL);
     try {
-      a.reconnect();
+      await a.reconnect();
       expect(a.active).toBe(true);
       const rows = await a.execute("SELECT 1 AS n");
       expect(rows[0]?.n).toBe(1);
@@ -320,7 +320,7 @@ describeIfPg("PostgresqlConnectionTest", () => {
     try {
       a.disconnectBang();
       expect(a.active).toBe(false);
-      a.reconnect();
+      await a.reconnect();
       expect(a.active).toBe(true);
       const rows = await a.execute("SELECT 2 AS n");
       expect(rows[0]?.n).toBe(2);

--- a/packages/activerecord/src/adapters/postgresql/enum.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/enum.test.ts
@@ -341,8 +341,8 @@ describeIfPg("PostgreSQLAdapter", () => {
               await schema.createTable(
                 "postgresql_enums_in_test_schema",
                 { force: "cascade" },
-                async (t) => {
-                  await t.enum("current_mood", { enum_type: "mood_in_test_schema" });
+                (t) => {
+                  t.enum("current_mood", { enum_type: "mood_in_test_schema" });
                 },
               );
             });

--- a/packages/activerecord/src/adapters/postgresql/schema.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/schema.test.ts
@@ -915,7 +915,7 @@ describeIfPg("PostgreSQLAdapter", () => {
 
     it("Active Record basics", async () => {
       await adapter.setSchemaSearchPath('"my.schema"');
-      await adapter.createTable("articles", async (t) => {
+      await adapter.createTable("articles", (t) => {
         t.string("title");
       });
       class Article extends Base {

--- a/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/statement-pool.test.ts
@@ -244,7 +244,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       await adapter.beginDbTransaction();
       await adapter.execute("SELECT $1::int", [1]);
       await adapter.rollback();
-      adapter.reconnect();
+      await adapter.reconnect();
       // Re-pop a statement into the pool's history, then tear down
       // the live connection and trigger the reset-branch of
       // clearCacheBang so the drain flag is set.
@@ -266,6 +266,10 @@ describeIfPg("PostgreSQLAdapter", () => {
       const observed: string[] = [];
       const live = conn!;
       const origQuery = live.query.bind(live);
+      // pg's `query` is overloaded with a void-returning callback form, so the
+      // mock's Promise return trips checksVoidReturn; the Promise form is the one
+      // exercised here (execute awaits it), so the return is intentional.
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       vi.spyOn(live, "query").mockImplementation(((sql: unknown, ...rest: unknown[]) => {
         if (typeof sql === "string") observed.push(sql);
         return (origQuery as (...a: unknown[]) => unknown)(sql, ...rest);

--- a/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/timestamp.test.ts
@@ -139,7 +139,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       );
       try {
         await withTimezoneConfig({ default: "utc", awareAttributes: true }, async () => {
-          adapter.reconnect();
+          await adapter.reconnect();
           class PostgresqlTimestampWithZone extends Base {
             static _tableName = "postgresql_timestamp_with_zones";
           }
@@ -155,7 +155,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           );
         });
       } finally {
-        adapter.reconnect();
+        await adapter.reconnect();
         await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
       }
     });
@@ -170,7 +170,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       );
       try {
         await withTimezoneConfig({ default: "local", awareAttributes: false }, async () => {
-          adapter.reconnect();
+          await adapter.reconnect();
           // make sure to use a non-UTC time zone
           await adapter.execute(`SET time zone 'America/Jamaica'`);
           class PostgresqlTimestampWithZone extends Base {
@@ -186,7 +186,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           );
         });
       } finally {
-        adapter.reconnect();
+        await adapter.reconnect();
         await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
       }
     });
@@ -210,7 +210,7 @@ describeIfPg("PostgreSQLAdapter", () => {
             awareTypes: ["timestamptz", "datetime", "time"],
           },
           async () => {
-            adapter.reconnect();
+            await adapter.reconnect();
             class PostgresqlTimestampWithZone extends Base {
               static _tableName = "postgresql_timestamp_with_zones";
             }
@@ -227,7 +227,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           },
         );
       } finally {
-        adapter.reconnect();
+        await adapter.reconnect();
         await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
       }
     });
@@ -251,7 +251,7 @@ describeIfPg("PostgreSQLAdapter", () => {
               awareTypes: ["timestamptz", "datetime", "time"],
             },
             async () => {
-              adapter.reconnect();
+              await adapter.reconnect();
               class PostgresqlTimestampWithZone extends Base {
                 static _tableName = "postgresql_timestamp_with_zones";
               }
@@ -269,7 +269,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           );
         });
       } finally {
-        adapter.reconnect();
+        await adapter.reconnect();
         await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
       }
     });
@@ -291,7 +291,7 @@ describeIfPg("PostgreSQLAdapter", () => {
               awareTypes: ["timestamptz", "datetime", "time"],
             },
             async () => {
-              adapter.reconnect();
+              await adapter.reconnect();
               class PostgresqlTimestampWithZone extends Base {
                 static _tableName = "postgresql_timestamp_with_zones";
               }
@@ -307,7 +307,7 @@ describeIfPg("PostgreSQLAdapter", () => {
           );
         });
       } finally {
-        adapter.reconnect();
+        await adapter.reconnect();
         await adapter.exec(`DROP TABLE IF EXISTS postgresql_timestamp_with_zones`);
       }
     });

--- a/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3-adapter.test.ts
@@ -22,13 +22,13 @@ describe("SqliteAdapter", () => {
         )
         .catch(() => undefined);
     }
-    adapter.close();
+    await adapter.close();
   });
 
   // -- Basic adapter operations --
   describe("raw SQL execution", () => {
     it("creates tables and inserts data", async () => {
-      adapter.exec(`CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+      await adapter.exec(`CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
       await adapter.executeMutation(`INSERT INTO "users" ("name") VALUES ('Alice')`);
       const rows = await adapter.execute(`SELECT * FROM "users"`);
       expect(rows).toHaveLength(1);
@@ -36,7 +36,7 @@ describe("SqliteAdapter", () => {
     });
 
     it("returns last insert rowid for INSERT", async () => {
-      adapter.exec(`CREATE TABLE "items" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+      await adapter.exec(`CREATE TABLE "items" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
       const id1 = await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('A')`);
       const id2 = await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('B')`);
       expect(id1).toBe(1);
@@ -44,7 +44,7 @@ describe("SqliteAdapter", () => {
     });
 
     it("returns affected rows for UPDATE", async () => {
-      adapter.exec(
+      await adapter.exec(
         `CREATE TABLE "items" ("id" INTEGER PRIMARY KEY, "name" TEXT, "active" INTEGER DEFAULT 1)`,
       );
       await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('A')`);
@@ -54,7 +54,7 @@ describe("SqliteAdapter", () => {
     });
 
     it("returns affected rows for DELETE", async () => {
-      adapter.exec(`CREATE TABLE "items" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+      await adapter.exec(`CREATE TABLE "items" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
       await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('A')`);
       await adapter.executeMutation(`INSERT INTO "items" ("name") VALUES ('B')`);
       const deleted = await adapter.executeMutation(`DELETE FROM "items" WHERE "name" = 'A'`);
@@ -64,8 +64,8 @@ describe("SqliteAdapter", () => {
 
   // -- Transactions --
   describe("transactions", () => {
-    beforeEach(() => {
-      adapter.exec(
+    beforeEach(async () => {
+      await adapter.exec(
         `CREATE TABLE "accounts" ("id" INTEGER PRIMARY KEY, "name" TEXT, "balance" INTEGER)`,
       );
     });
@@ -159,7 +159,7 @@ describe("SqliteAdapter", () => {
     });
 
     it("adds columns with migrations", async () => {
-      adapter.exec(`CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+      await adapter.exec(`CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
 
       class AddEmailToUsers extends Migration {
         async up() {
@@ -182,7 +182,7 @@ describe("SqliteAdapter", () => {
     });
 
     it("creates indexes", async () => {
-      adapter.exec(`CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "email" TEXT)`);
+      await adapter.exec(`CREATE TABLE "users" ("id" INTEGER PRIMARY KEY, "email" TEXT)`);
 
       class AddEmailIndex extends Migration {
         async up() {
@@ -274,8 +274,8 @@ describe("SQLite3Adapter._isMemoryFilename", () => {
 describe("SQLite3Adapter pragmas option", () => {
   let adapter: AbstractSQLite3Adapter | undefined;
 
-  afterEach(() => {
-    adapter?.close();
+  afterEach(async () => {
+    await adapter?.close();
     vi.restoreAllMocks();
   });
 

--- a/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bigint-roundtrip.test.ts
@@ -9,9 +9,9 @@ const bigType = new BigIntegerType();
 const intType = new IntegerType();
 const boolType = new BooleanType();
 
-beforeEach(() => {
+beforeEach(async () => {
   adapter = new BetterSQLite3Adapter(":memory:");
-  adapter.exec(`
+  await adapter.exec(`
     CREATE TABLE "big_items" (
       "id"     INTEGER PRIMARY KEY AUTOINCREMENT,
       "score"  BIGINT NOT NULL,
@@ -23,7 +23,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   await adapter.exec(`DROP TABLE IF EXISTS "big_items"`).catch(() => undefined);
-  adapter.close();
+  await adapter.close();
 });
 
 describeIfSqlite("SQLite3 bigint round-trip", () => {

--- a/packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/bind-parameter.test.ts
@@ -14,12 +14,14 @@ beforeEach(() => {
 
 afterEach(async () => {
   await adapter.exec(`DROP TABLE IF EXISTS "topics"`).catch(() => undefined);
-  adapter.close();
+  await adapter.close();
 });
 
 describeIfSqlite("SQLite3Adapter", () => {
-  beforeEach(() => {
-    adapter.exec(`CREATE TABLE "topics" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "title" TEXT)`);
+  beforeEach(async () => {
+    await adapter.exec(
+      `CREATE TABLE "topics" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "title" TEXT)`,
+    );
   });
 
   describe("BindParameterTest", () => {

--- a/packages/activerecord/src/adapters/sqlite3/collation.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/collation.test.ts
@@ -9,9 +9,9 @@ import { SchemaDumper } from "../../schema-dumper.js";
 
 let adapter: AbstractSQLite3Adapter;
 
-beforeEach(() => {
+beforeEach(async () => {
   adapter = new BetterSQLite3Adapter(":memory:");
-  adapter.exec(`CREATE TABLE "collation_table_sqlite3" (
+  await adapter.exec(`CREATE TABLE "collation_table_sqlite3" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "string_nocase" VARCHAR(255) COLLATE "NOCASE",
     "text_rtrim" TEXT COLLATE "RTRIM",
@@ -22,7 +22,7 @@ beforeEach(() => {
 
 afterEach(async () => {
   await adapter.exec(`DROP TABLE IF EXISTS "collation_table_sqlite3"`).catch(() => undefined);
-  adapter.close();
+  await adapter.close();
 });
 
 describeIfSqlite("SQLite3CollationTest", () => {

--- a/packages/activerecord/src/adapters/sqlite3/json.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/json.test.ts
@@ -31,7 +31,7 @@ beforeEach(async () => {
 afterEach(async () => {
   // Mirrors Rails JSONSharedTestCases#teardown: drop_table :json_data_type.
   await adapter.dropTable("json_data_type", { ifExists: true });
-  adapter.close();
+  await adapter.close();
 });
 
 describeIfSqlite("SQLite3JSONTest", () => {

--- a/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/quoting.test.ts
@@ -20,33 +20,33 @@ afterEach(async () => {
       `DROP TABLE IF EXISTS quote_test; DROP TABLE IF EXISTS q; DROP TABLE IF EXISTS my; DROP TABLE IF EXISTS bin_enc; DROP TABLE IF EXISTS bool_test; DROP TABLE IF EXISTS bool_test2; DROP TABLE IF EXISTS bd_test; DROP TABLE IF EXISTS bin_quote; DROP TABLE IF EXISTS time_test; DROP TABLE IF EXISTS time_norm; DROP TABLE IF EXISTS time_utc; DROP TABLE IF EXISTS time_local; DROP TABLE IF EXISTS inf_test; DROP TABLE IF EXISTS nan_test`,
     )
     .catch(() => undefined);
-  adapter.close();
+  await adapter.close();
 });
 
 // -- Rails test class: quoting_test.rb --
 describeIfSqlite("SQLite3QuotingTest", () => {
   it("quote string", async () => {
-    adapter.exec(`CREATE TABLE "quote_test" ("id" INTEGER PRIMARY KEY, "val" TEXT)`);
+    await adapter.exec(`CREATE TABLE "quote_test" ("id" INTEGER PRIMARY KEY, "val" TEXT)`);
     await adapter.executeMutation(`INSERT INTO "quote_test" ("val") VALUES ('it''s')`);
     const rows = await adapter.execute(`SELECT "val" FROM "quote_test"`);
     expect(rows[0].val).toBe("it's");
   });
 
   it("quote column name", async () => {
-    adapter.exec(`CREATE TABLE "q" ("weird col" TEXT)`);
+    await adapter.exec(`CREATE TABLE "q" ("weird col" TEXT)`);
     await adapter.executeMutation(`INSERT INTO "q" ("weird col") VALUES ('val')`);
     const rows = await adapter.execute(`SELECT "weird col" FROM "q"`);
     expect(rows[0]["weird col"]).toBe("val");
   });
 
   it("quote table name", async () => {
-    adapter.exec(`CREATE TABLE "my table" ("id" INTEGER PRIMARY KEY)`);
+    await adapter.exec(`CREATE TABLE "my table" ("id" INTEGER PRIMARY KEY)`);
     const rows = await adapter.execute(`SELECT * FROM "my table"`);
     expect(rows).toHaveLength(0);
   });
 
   it("type cast binary encoding without logger", async () => {
-    adapter.exec(`CREATE TABLE "bin_enc" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
+    await adapter.exec(`CREATE TABLE "bin_enc" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
     const buf = Buffer.from([0xde, 0xad, 0xbe, 0xef]);
     await adapter.executeMutation(`INSERT INTO "bin_enc" ("data") VALUES (?)`, [buf]);
     const rows = await adapter.execute(`SELECT "data" FROM "bin_enc"`);
@@ -54,14 +54,14 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("type cast true", async () => {
-    adapter.exec(`CREATE TABLE "bool_test" ("id" INTEGER PRIMARY KEY, "flag" INTEGER)`);
+    await adapter.exec(`CREATE TABLE "bool_test" ("id" INTEGER PRIMARY KEY, "flag" INTEGER)`);
     await adapter.executeMutation(`INSERT INTO "bool_test" ("flag") VALUES (1)`);
     const rows = await adapter.execute(`SELECT "flag" FROM "bool_test"`);
     expect(rows[0].flag).toBe(1);
   });
 
   it("type cast false", async () => {
-    adapter.exec(`CREATE TABLE "bool_test2" ("id" INTEGER PRIMARY KEY, "flag" INTEGER)`);
+    await adapter.exec(`CREATE TABLE "bool_test2" ("id" INTEGER PRIMARY KEY, "flag" INTEGER)`);
     await adapter.executeMutation(`INSERT INTO "bool_test2" ("flag") VALUES (0)`);
     const rows = await adapter.execute(`SELECT "flag" FROM "bool_test2"`);
     expect(rows[0].flag).toBe(0);
@@ -69,21 +69,21 @@ describeIfSqlite("SQLite3QuotingTest", () => {
 
   it("type cast bigdecimal", async () => {
     // SQLite stores large decimals as REAL; we verify round-trip fidelity
-    adapter.exec(`CREATE TABLE "bd_test" ("id" INTEGER PRIMARY KEY, "amount" REAL)`);
+    await adapter.exec(`CREATE TABLE "bd_test" ("id" INTEGER PRIMARY KEY, "amount" REAL)`);
     await adapter.executeMutation(`INSERT INTO "bd_test" ("amount") VALUES (?)`, [123456.789]);
     const rows = await adapter.execute(`SELECT "amount" FROM "bd_test"`);
     expect(rows[0].amount).toBeCloseTo(123456.789, 3);
   });
 
   it("quoting binary strings", async () => {
-    adapter.exec(`CREATE TABLE "bin_quote" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
+    await adapter.exec(`CREATE TABLE "bin_quote" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
     await adapter.executeMutation(`INSERT INTO "bin_quote" ("data") VALUES (X'48656C6C6F')`);
     const rows = await adapter.execute(`SELECT * FROM "bin_quote"`);
     expect(rows).toHaveLength(1);
   });
 
   it("quoted time returns date qualified time", async () => {
-    adapter.exec(`CREATE TABLE "time_test" ("id" INTEGER PRIMARY KEY, "created_at" TEXT)`);
+    await adapter.exec(`CREATE TABLE "time_test" ("id" INTEGER PRIMARY KEY, "created_at" TEXT)`);
     const ts = "2024-01-15 10:30:00";
     await adapter.executeMutation(`INSERT INTO "time_test" ("created_at") VALUES (?)`, [ts]);
     const rows = await adapter.execute(`SELECT "created_at" FROM "time_test"`);
@@ -91,7 +91,7 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("quoted time normalizes date qualified time", async () => {
-    adapter.exec(`CREATE TABLE "time_norm" ("id" INTEGER PRIMARY KEY, "ts" TEXT)`);
+    await adapter.exec(`CREATE TABLE "time_norm" ("id" INTEGER PRIMARY KEY, "ts" TEXT)`);
     const ts = "2024-06-15 08:00:00";
     await adapter.executeMutation(`INSERT INTO "time_norm" ("ts") VALUES (?)`, [ts]);
     const rows = await adapter.execute(`SELECT "ts" FROM "time_norm"`);
@@ -99,7 +99,7 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("quoted time dst utc", async () => {
-    adapter.exec(`CREATE TABLE "time_utc" ("id" INTEGER PRIMARY KEY, "ts" TEXT)`);
+    await adapter.exec(`CREATE TABLE "time_utc" ("id" INTEGER PRIMARY KEY, "ts" TEXT)`);
     const ts = "2024-03-10 07:00:00";
     await adapter.executeMutation(`INSERT INTO "time_utc" ("ts") VALUES (?)`, [ts]);
     const rows = await adapter.execute(`SELECT "ts" FROM "time_utc"`);
@@ -107,7 +107,7 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("quoted time dst local", async () => {
-    adapter.exec(`CREATE TABLE "time_local" ("id" INTEGER PRIMARY KEY, "ts" TEXT)`);
+    await adapter.exec(`CREATE TABLE "time_local" ("id" INTEGER PRIMARY KEY, "ts" TEXT)`);
     const ts = "2024-11-03 01:30:00";
     await adapter.executeMutation(`INSERT INTO "time_local" ("ts") VALUES (?)`, [ts]);
     const rows = await adapter.execute(`SELECT "ts" FROM "time_local"`);
@@ -115,7 +115,7 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("quote numeric infinity", async () => {
-    adapter.exec(`CREATE TABLE "inf_test" ("id" INTEGER PRIMARY KEY, "val" REAL)`);
+    await adapter.exec(`CREATE TABLE "inf_test" ("id" INTEGER PRIMARY KEY, "val" REAL)`);
     // Mirrors Rails SQLite3::Quoting#type_cast: Float::INFINITY → nil.
     // Binds pass through sqliteTypeCast before driver hand-off, so Infinity → null.
     await adapter.executeMutation(`INSERT INTO "inf_test" ("val") VALUES (?)`, [Infinity]);
@@ -124,7 +124,7 @@ describeIfSqlite("SQLite3QuotingTest", () => {
   });
 
   it("quote float nan", async () => {
-    adapter.exec(`CREATE TABLE "nan_test" ("id" INTEGER PRIMARY KEY, "val" REAL)`);
+    await adapter.exec(`CREATE TABLE "nan_test" ("id" INTEGER PRIMARY KEY, "val" REAL)`);
     // SQLite stores NaN as NULL when passed through binds
     await adapter.executeMutation(`INSERT INTO "nan_test" ("val") VALUES (?)`, [NaN]);
     const rows = await adapter.execute(`SELECT "val" FROM "nan_test"`);

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter-prevent-writes.test.ts
@@ -21,13 +21,13 @@ afterEach(async () => {
       `DROP TABLE IF EXISTS pw; DROP TABLE IF EXISTS pw2; DROP TABLE IF EXISTS pw3; DROP TABLE IF EXISTS pw4; DROP TABLE IF EXISTS pw5`,
     )
     .catch(() => undefined);
-  adapter.close();
+  await adapter.close();
 });
 
 // -- Rails test class: sqlite3_adapter_prevent_writes_test.rb --
 describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
   it("errors when an insert query is called while preventing writes", async () => {
-    adapter.exec(`CREATE TABLE "pw" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`CREATE TABLE "pw" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
     await adapter.withPreventedWrites(async () => {
       await expect(
         adapter.executeMutation(`INSERT INTO "pw" ("name") VALUES ('x')`),
@@ -36,7 +36,7 @@ describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
   });
 
   it("errors when an update query is called while preventing writes", async () => {
-    adapter.exec(`CREATE TABLE "pw2" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`CREATE TABLE "pw2" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
     await adapter.executeMutation(`INSERT INTO "pw2" ("name") VALUES ('x')`);
     await adapter.withPreventedWrites(async () => {
       await expect(adapter.executeMutation(`UPDATE "pw2" SET "name" = 'y'`)).rejects.toThrow(
@@ -46,7 +46,7 @@ describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
   });
 
   it("errors when a delete query is called while preventing writes", async () => {
-    adapter.exec(`CREATE TABLE "pw3" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`CREATE TABLE "pw3" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
     await adapter.executeMutation(`INSERT INTO "pw3" ("name") VALUES ('x')`);
     await adapter.withPreventedWrites(async () => {
       await expect(adapter.executeMutation(`DELETE FROM "pw3"`)).rejects.toThrow(ReadOnlyError);
@@ -54,7 +54,7 @@ describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
   });
 
   it("errors when a replace query is called while preventing writes", async () => {
-    adapter.exec(`CREATE TABLE "pw4" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`CREATE TABLE "pw4" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
     await adapter.withPreventedWrites(async () => {
       await expect(
         adapter.executeMutation(`REPLACE INTO "pw4" ("id", "name") VALUES (1, 'x')`),
@@ -63,7 +63,7 @@ describeIfSqlite("SQLite3AdapterPreventWritesTest", () => {
   });
 
   it("doesnt error when a select query is called while preventing writes", async () => {
-    adapter.exec(`CREATE TABLE "pw5" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`CREATE TABLE "pw5" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
     await adapter.withPreventedWrites(async () => {
       const rows = await adapter.execute(`SELECT * FROM "pw5"`);
       expect(rows).toHaveLength(0);

--- a/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/sqlite3-adapter.test.ts
@@ -34,8 +34,8 @@ afterEach(async () => {
 });
 
 describeIfSqlite("SQLite3AdapterTest", () => {
-  beforeEach(() => {
-    adapter.exec(
+  beforeEach(async () => {
+    await adapter.exec(
       `CREATE TABLE "items" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT, "price" INTEGER, "active" INTEGER DEFAULT 1)`,
     );
   });
@@ -79,7 +79,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("column types", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "typed" ("id" INTEGER PRIMARY KEY, "name" TEXT, "age" INTEGER, "score" REAL, "data" BLOB)`,
     );
     const cols = await adapter.execute(`PRAGMA table_info("typed")`);
@@ -95,7 +95,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   // `{}` on every DEFAULT-emitting path, not just addColumn. Mirrors Rails'
   // quote_default_expression serializing through the column's cast type.
   it("change column default serializes a structured json default", async () => {
-    adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" json)`);
+    await adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" json)`);
     await adapter.changeColumnDefault("json_defs", "options", {});
     const col = (await adapter.columns("json_defs")).find((c) => c.name === "options");
     expect(col?.default).toEqual("{}");
@@ -105,14 +105,14 @@ describeIfSqlite("SQLite3AdapterTest", () => {
     // Rails' extract_new_default_value only unwraps a Hash carrying BOTH :from
     // and :to; `{ to: 1 }` without :from is the literal default, not a changes
     // hash (schema_statements.rb:1820).
-    adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" json)`);
+    await adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" json)`);
     await adapter.changeColumnDefault("json_defs", "options", { to: 1 });
     const col = (await adapter.columns("json_defs")).find((c) => c.name === "options");
     expect(col?.default).toEqual('{"to":1}');
   });
 
   it("change column serializes a structured json default", async () => {
-    adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" TEXT)`);
+    await adapter.exec(`CREATE TABLE "json_defs" ("id" INTEGER PRIMARY KEY, "options" TEXT)`);
     await adapter.changeColumn("json_defs", "options", "json", { default: {} });
     const col = (await adapter.columns("json_defs")).find((c) => c.name === "options");
     expect(col?.default).toEqual("{}");
@@ -133,7 +133,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("primary key returns nil for no pk", async () => {
-    adapter.exec(`CREATE TABLE "no_pk" ("name" TEXT, "value" TEXT)`);
+    await adapter.exec(`CREATE TABLE "no_pk" ("name" TEXT, "value" TEXT)`);
     const cols = await adapter.execute(`PRAGMA table_info("no_pk")`);
     const pkCols = cols.filter((c: any) => c.pk > 0);
     expect(pkCols).toHaveLength(0);
@@ -267,7 +267,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("quote binary column escapes it", async () => {
-    adapter.exec(`CREATE TABLE "bin_esc" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
+    await adapter.exec(`CREATE TABLE "bin_esc" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
     const buf = Buffer.from([0x00, 0x01, 0x02, 0xff]);
     await adapter.executeMutation(`INSERT INTO "bin_esc" ("data") VALUES (?)`, [buf]);
     const rows = await adapter.execute(`SELECT "data" FROM "bin_esc"`);
@@ -275,7 +275,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("type cast should not mutate encoding", async () => {
-    adapter.exec(`CREATE TABLE "enc_test" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
+    await adapter.exec(`CREATE TABLE "enc_test" ("id" INTEGER PRIMARY KEY, "data" BLOB)`);
     const original = Buffer.from("hello world");
     const copy = Buffer.from(original);
     await adapter.executeMutation(`INSERT INTO "enc_test" ("data") VALUES (?)`, [copy]);
@@ -311,7 +311,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("exec insert default values with returning disabled", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "def_vals" ("id" INTEGER PRIMARY KEY, "name" TEXT DEFAULT 'default')`,
     );
     const id = await adapter.executeMutation(`INSERT INTO "def_vals" DEFAULT VALUES`);
@@ -374,14 +374,18 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("columns with not null", async () => {
-    adapter.exec(`CREATE TABLE "strict_items" ("id" INTEGER PRIMARY KEY, "name" TEXT NOT NULL)`);
+    await adapter.exec(
+      `CREATE TABLE "strict_items" ("id" INTEGER PRIMARY KEY, "name" TEXT NOT NULL)`,
+    );
     const cols = await adapter.execute(`PRAGMA table_info("strict_items")`);
     const nameCol = cols.find((c: any) => c.name === "name");
     expect(nameCol!.notnull).toBe(1);
   });
 
   it("add column with not null", async () => {
-    adapter.exec(`ALTER TABLE "items" ADD COLUMN "required" TEXT NOT NULL DEFAULT 'default_val'`);
+    await adapter.exec(
+      `ALTER TABLE "items" ADD COLUMN "required" TEXT NOT NULL DEFAULT 'default_val'`,
+    );
     const cols = await adapter.execute(`PRAGMA table_info("items")`);
     const reqCol = cols.find((c: any) => c.name === "required");
     expect(reqCol!.notnull).toBe(1);
@@ -406,7 +410,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("index", async () => {
-    adapter.exec(`CREATE UNIQUE INDEX "fun" ON "items" ("id")`);
+    await adapter.exec(`CREATE UNIQUE INDEX "fun" ON "items" ("id")`);
     const indexes = (await adapter.indexes("items")) as any[];
     const index = indexes.find((idx) => idx.name === "fun");
     expect(index.table).toBe("items");
@@ -415,29 +419,29 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("index with if not exists", async () => {
-    adapter.exec(`CREATE INDEX IF NOT EXISTS "idx_items_name" ON "items" ("name")`);
-    adapter.exec(`CREATE INDEX IF NOT EXISTS "idx_items_name" ON "items" ("name")`);
+    await adapter.exec(`CREATE INDEX IF NOT EXISTS "idx_items_name" ON "items" ("name")`);
+    await adapter.exec(`CREATE INDEX IF NOT EXISTS "idx_items_name" ON "items" ("name")`);
     const rows = await adapter.execute(`PRAGMA index_list("items")`);
     const matching = rows.filter((r: any) => r.name === "idx_items_name");
     expect(matching).toHaveLength(1);
   });
 
   it("non unique index", async () => {
-    adapter.exec(`CREATE INDEX "fun" ON "items" ("id")`);
+    await adapter.exec(`CREATE INDEX "fun" ON "items" ("id")`);
     const indexes = (await adapter.indexes("items")) as any[];
     const index = indexes.find((idx) => idx.name === "fun");
     expect(index.unique).toBe(false);
   });
 
   it("compound index", async () => {
-    adapter.exec(`CREATE INDEX "fun" ON "items" ("id", "price")`);
+    await adapter.exec(`CREATE INDEX "fun" ON "items" ("id", "price")`);
     const indexes = (await adapter.indexes("items")) as any[];
     const index = indexes.find((idx) => idx.name === "fun");
     expect([...index.columns].sort()).toEqual(["id", "price"].sort());
   });
 
   it("partial index with comment", async () => {
-    adapter.exec(`CREATE INDEX "fun" ON "items" ("id") WHERE price > 0 /*tag:test*/`);
+    await adapter.exec(`CREATE INDEX "fun" ON "items" ("id") WHERE price > 0 /*tag:test*/`);
     const indexes = (await adapter.indexes("items")) as any[];
     const index = indexes.find((idx) => idx.name === "fun");
     expect(index.columns).toEqual(["id"]);
@@ -445,21 +449,23 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   itIfSupports("expression_index", "expression index", async () => {
-    adapter.exec(`CREATE INDEX "expression" ON "items" (max(id, price))`);
+    await adapter.exec(`CREATE INDEX "expression" ON "items" (max(id, price))`);
     const indexes = (await adapter.indexes("items")) as any[];
     const index = indexes.find((idx) => idx.name === "expression");
     expect(index.columns).toBe("max(id, price)");
   });
 
   itIfSupports("expression_index", "expression index with trailing comment", async () => {
-    adapter.exec(`CREATE INDEX expression on items (price % 10) /* comment */`);
+    await adapter.exec(`CREATE INDEX expression on items (price % 10) /* comment */`);
     const indexes = (await adapter.indexes("items")) as any[];
     const index = indexes.find((idx) => idx.name === "expression");
     expect(index.columns).toBe("price % 10");
   });
 
   itIfSupports("expression_index", "expression index with where", async () => {
-    adapter.exec(`CREATE INDEX "expression" ON "items" (id % 10, max(id, price)) WHERE id > 1000`);
+    await adapter.exec(
+      `CREATE INDEX "expression" ON "items" (id % 10, max(id, price)) WHERE id > 1000`,
+    );
     const indexes = (await adapter.indexes("items")) as any[];
     const index = indexes.find((idx) => idx.name === "expression");
     expect(index.columns).toBe("id % 10, max(id, price)");
@@ -467,7 +473,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   itIfSupports("expression_index", "complicated expression", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE INDEX expression ON items (id % 10, (CASE WHEN price > 0 THEN max(id, price) END))WHERE(id > 1000)`,
     );
     const indexes = (await adapter.indexes("items")) as any[];
@@ -477,7 +483,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   itIfSupports("expression_index", "not everything an expression", async () => {
-    adapter.exec(`CREATE INDEX "expression" ON "items" (id, max(id, price))`);
+    await adapter.exec(`CREATE INDEX "expression" ON "items" (id, max(id, price))`);
     const indexes = (await adapter.indexes("items")) as any[];
     const index = indexes.find((idx) => idx.name === "expression");
     expect(index.columns).toBe("id, max(id, price)");
@@ -490,42 +496,44 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("no primary key", async () => {
-    adapter.exec(`CREATE TABLE "no_pk" ("a" TEXT, "b" TEXT)`);
+    await adapter.exec(`CREATE TABLE "no_pk" ("a" TEXT, "b" TEXT)`);
     const cols = await adapter.execute(`PRAGMA table_info("no_pk")`);
     const pkCols = cols.filter((c: any) => c.pk > 0);
     expect(pkCols).toHaveLength(0);
   });
 
   it("copy table with existing records have custom primary key", async () => {
-    adapter.exec(`CREATE TABLE "custom_pk_src" ("custom_id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(
+      `CREATE TABLE "custom_pk_src" ("custom_id" INTEGER PRIMARY KEY, "name" TEXT)`,
+    );
     await adapter.executeMutation(`INSERT INTO "custom_pk_src" ("name") VALUES ('Alice')`);
-    adapter.exec(`CREATE TABLE "custom_pk_dest" AS SELECT * FROM "custom_pk_src"`);
+    await adapter.exec(`CREATE TABLE "custom_pk_dest" AS SELECT * FROM "custom_pk_src"`);
     const rows = await adapter.execute(`SELECT * FROM "custom_pk_dest"`);
     expect(rows).toHaveLength(1);
     expect(rows[0].custom_id).toBe(1);
   });
 
   it("copy table with composite primary keys", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "cpk_src" ("a" INTEGER, "b" INTEGER, "val" TEXT, PRIMARY KEY ("a", "b"))`,
     );
     await adapter.executeMutation(`INSERT INTO "cpk_src" ("a", "b", "val") VALUES (1, 2, 'x')`);
-    adapter.exec(`CREATE TABLE "cpk_dest" AS SELECT * FROM "cpk_src"`);
+    await adapter.exec(`CREATE TABLE "cpk_dest" AS SELECT * FROM "cpk_src"`);
     const rows = await adapter.execute(`SELECT * FROM "cpk_dest"`);
     expect(rows).toHaveLength(1);
     expect(rows[0].val).toBe("x");
   });
 
   it("custom primary key in create table", async () => {
-    adapter.exec(`CREATE TABLE "custom_pk" ("custom_id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`CREATE TABLE "custom_pk" ("custom_id" INTEGER PRIMARY KEY, "name" TEXT)`);
     const cols = await adapter.execute(`PRAGMA table_info("custom_pk")`);
     const pkCol = cols.find((c: any) => c.pk === 1);
     expect(pkCol!.name).toBe("custom_id");
   });
 
   it("custom primary key in change table", async () => {
-    adapter.exec(`CREATE TABLE "change_pk" ("custom_id" INTEGER PRIMARY KEY, "name" TEXT)`);
-    adapter.exec(`ALTER TABLE "change_pk" ADD COLUMN "age" INTEGER DEFAULT 0`);
+    await adapter.exec(`CREATE TABLE "change_pk" ("custom_id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`ALTER TABLE "change_pk" ADD COLUMN "age" INTEGER DEFAULT 0`);
     const cols = await adapter.execute(`PRAGMA table_info("change_pk")`);
     expect(cols.find((c: any) => c.name === "age")).toBeDefined();
     const pkCol = cols.find((c: any) => c.pk === 1);
@@ -533,8 +541,8 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("add column with custom primary key", async () => {
-    adapter.exec(`CREATE TABLE "add_col_pk" ("custom_id" INTEGER PRIMARY KEY, "name" TEXT)`);
-    adapter.exec(`ALTER TABLE "add_col_pk" ADD COLUMN "age" INTEGER`);
+    await adapter.exec(`CREATE TABLE "add_col_pk" ("custom_id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`ALTER TABLE "add_col_pk" ADD COLUMN "age" INTEGER`);
     const cols = await adapter.execute(`PRAGMA table_info("add_col_pk")`);
     expect(cols.some((c: any) => c.name === "age")).toBe(true);
     const pkCol = cols.find((c: any) => c.pk === 1);
@@ -542,12 +550,12 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("remove column preserves index options", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "barcodes" ("id" INTEGER PRIMARY KEY, "code" TEXT, "region" TEXT, "bool_attr" INTEGER)`,
     );
-    adapter.exec(`CREATE UNIQUE INDEX "unique" ON "barcodes" ("code")`);
-    adapter.exec(`CREATE INDEX "partial" ON "barcodes" ("code") WHERE bool_attr`);
-    adapter.exec(`CREATE INDEX "ordered" ON "barcodes" ("code" DESC)`);
+    await adapter.exec(`CREATE UNIQUE INDEX "unique" ON "barcodes" ("code")`);
+    await adapter.exec(`CREATE INDEX "partial" ON "barcodes" ("code") WHERE bool_attr`);
+    await adapter.exec(`CREATE INDEX "ordered" ON "barcodes" ("code" DESC)`);
     await adapter.removeColumn("barcodes", "region");
 
     const indexes = (await adapter.indexes("barcodes")) as any[];
@@ -773,7 +781,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("rowid column", async () => {
-    adapter.exec(`CREATE TABLE "rowid_test" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`CREATE TABLE "rowid_test" ("id" INTEGER PRIMARY KEY, "name" TEXT)`);
     const cols = await adapter.execute(`PRAGMA table_info("rowid_test")`);
     const idCol = cols.find((c: any) => c.name === "id");
     expect(idCol!.type).toBe("INTEGER");
@@ -781,21 +789,21 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("lowercase rowid column", async () => {
-    adapter.exec(`CREATE TABLE "rowid_lower" ("id" integer PRIMARY KEY, "name" text)`);
+    await adapter.exec(`CREATE TABLE "rowid_lower" ("id" integer PRIMARY KEY, "name" text)`);
     const cols = await adapter.execute(`PRAGMA table_info("rowid_lower")`);
     const idCol = cols.find((c: any) => c.name === "id");
     expect(idCol!.pk).toBe(1);
   });
 
   it("non integer column returns false for rowid", async () => {
-    adapter.exec(`CREATE TABLE "text_pk" ("id" TEXT PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`CREATE TABLE "text_pk" ("id" TEXT PRIMARY KEY, "name" TEXT)`);
     const cols = await adapter.execute(`PRAGMA table_info("text_pk")`);
     const idCol = cols.find((c: any) => c.name === "id");
     expect(idCol!.type).toBe("TEXT");
   });
 
   it("mixed case integer colum returns true for rowid", async () => {
-    adapter.exec(`CREATE TABLE "mixed_case" ("id" Integer PRIMARY KEY, "name" TEXT)`);
+    await adapter.exec(`CREATE TABLE "mixed_case" ("id" Integer PRIMARY KEY, "name" TEXT)`);
     const cols = await adapter.execute(`PRAGMA table_info("mixed_case")`);
     const idCol = cols.find((c: any) => c.name === "id");
     // SQLite normalizes type names to uppercase
@@ -804,7 +812,9 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("rowid column with autoincrement returns true for rowid", async () => {
-    adapter.exec(`CREATE TABLE "auto_inc" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)`);
+    await adapter.exec(
+      `CREATE TABLE "auto_inc" ("id" INTEGER PRIMARY KEY AUTOINCREMENT, "name" TEXT)`,
+    );
     const cols = await adapter.execute(`PRAGMA table_info("auto_inc")`);
     const idCol = cols.find((c: any) => c.name === "id");
     expect(idCol!.type).toBe("INTEGER");
@@ -812,7 +822,7 @@ describeIfSqlite("SQLite3AdapterTest", () => {
   });
 
   it("integer cpk column returns false for rowid", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "cpk" ("id1" INTEGER, "id2" INTEGER, "name" TEXT, PRIMARY KEY ("id1", "id2"))`,
     );
     const cols = await adapter.execute(`PRAGMA table_info("cpk")`);

--- a/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/statement-pool.trails.test.ts
@@ -53,7 +53,7 @@ describeIfSqlite("SQLite3StatementPoolTest", () => {
 
   it("clearCacheBang clears the pool without throwing on next query", async () => {
     const adapter = track(new BetterSQLite3Adapter(":memory:"));
-    adapter.exec(`CREATE TABLE t (id INTEGER)`);
+    await adapter.exec(`CREATE TABLE t (id INTEGER)`);
     await adapter.execute("SELECT * FROM t WHERE id = ?", [1]);
     adapter.clearCacheBang();
     await adapter.execute("SELECT * FROM t WHERE id = ?", [2]);

--- a/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/transaction.test.ts
@@ -23,7 +23,7 @@ const openAdapters: AbstractSQLite3Adapter[] = [];
 afterEach(async () => {
   while (openAdapters.length) {
     try {
-      openAdapters.pop()!.close();
+      await openAdapters.pop()!.close();
     } catch {
       // best-effort
     }
@@ -80,7 +80,7 @@ describeIfSqlite("SQLite3TransactionTest", () => {
   it.skip("opens a `read_uncommitted` transaction", async () => {
     // PERMANENT-SKIP: driver-limit (see scripts/api-compare/unported-files.ts) — single-process-sqlite
     const conn1 = withConn({ sharedCache: true });
-    conn1.exec(`CREATE TABLE IF NOT EXISTS "zines" ("id" INTEGER PRIMARY KEY, "title" TEXT)`);
+    await conn1.exec(`CREATE TABLE IF NOT EXISTS "zines" ("id" INTEGER PRIMARY KEY, "title" TEXT)`);
     await conn1.beginDbTransaction();
     await conn1.executeMutation(`INSERT INTO "zines" ("title") VALUES ('foo')`);
 

--- a/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-column.test.ts
@@ -21,13 +21,13 @@ afterEach(async () => {
       `DROP TABLE IF EXISTS stored_gen; DROP TABLE IF EXISTS virt_gen; DROP TABLE IF EXISTS impl_virt; DROP TABLE IF EXISTS virt_comma; DROP TABLE IF EXISTS chg_stored; DROP TABLE IF EXISTS chg_virt; DROP TABLE IF EXISTS chg_impl`,
     )
     .catch(() => undefined);
-  adapter.close();
+  await adapter.close();
 });
 
 // -- Rails test class: virtual_column_test.rb --
 describeIfSqlite("SQLite3VirtualColumnTest", () => {
   itIfSupports("virtual_columns", "stored column", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "stored_gen" ("id" INTEGER PRIMARY KEY, "price" INTEGER, "tax" INTEGER, "total" INTEGER GENERATED ALWAYS AS ("price" + "tax") STORED)`,
     );
     await adapter.executeMutation(`INSERT INTO "stored_gen" ("price", "tax") VALUES (100, 10)`);
@@ -36,7 +36,7 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
   });
 
   itIfSupports("virtual_columns", "explicit virtual column", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "virt_gen" ("id" INTEGER PRIMARY KEY, "first" TEXT, "last" TEXT, "full" TEXT GENERATED ALWAYS AS ("first" || ' ' || "last") VIRTUAL)`,
     );
     await adapter.executeMutation(
@@ -48,7 +48,7 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
 
   itIfSupports("virtual_columns", "implicit virtual column", async () => {
     // Without STORED keyword, generated columns are virtual by default
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "impl_virt" ("id" INTEGER PRIMARY KEY, "a" INTEGER, "b" INTEGER, "c" INTEGER GENERATED ALWAYS AS ("a" + "b"))`,
     );
     await adapter.executeMutation(`INSERT INTO "impl_virt" ("a", "b") VALUES (3, 4)`);
@@ -57,7 +57,7 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
   });
 
   itIfSupports("virtual_columns", "virtual column with comma in definition", async () => {
-    adapter.exec(
+    await adapter.exec(
       `CREATE TABLE "virt_comma" ("id" INTEGER PRIMARY KEY, "x" INTEGER, "y" INTEGER, "label" TEXT GENERATED ALWAYS AS (CAST("x" AS TEXT) || ',' || CAST("y" AS TEXT)) VIRTUAL)`,
     );
     await adapter.executeMutation(`INSERT INTO "virt_comma" ("x", "y") VALUES (1, 2)`);
@@ -66,9 +66,11 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
   });
 
   itIfSupports("virtual_columns", "change table with stored generated column", async () => {
-    adapter.exec(`CREATE TABLE "chg_stored" ("id" INTEGER PRIMARY KEY, "x" INTEGER, "y" INTEGER)`);
+    await adapter.exec(
+      `CREATE TABLE "chg_stored" ("id" INTEGER PRIMARY KEY, "x" INTEGER, "y" INTEGER)`,
+    );
     // SQLite 3.31+ supports ADD COLUMN with generated
-    adapter.exec(
+    await adapter.exec(
       `ALTER TABLE "chg_stored" ADD COLUMN "total" INTEGER GENERATED ALWAYS AS ("x" + "y") STORED`,
     );
     await adapter.executeMutation(`INSERT INTO "chg_stored" ("x", "y") VALUES (5, 3)`);
@@ -80,8 +82,10 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
     "virtual_columns",
     "change table with explicit virtual generated column",
     async () => {
-      adapter.exec(`CREATE TABLE "chg_virt" ("id" INTEGER PRIMARY KEY, "first" TEXT, "last" TEXT)`);
-      adapter.exec(
+      await adapter.exec(
+        `CREATE TABLE "chg_virt" ("id" INTEGER PRIMARY KEY, "first" TEXT, "last" TEXT)`,
+      );
+      await adapter.exec(
         `ALTER TABLE "chg_virt" ADD COLUMN "full" TEXT GENERATED ALWAYS AS ("first" || ' ' || "last") VIRTUAL`,
       );
       await adapter.executeMutation(
@@ -96,8 +100,12 @@ describeIfSqlite("SQLite3VirtualColumnTest", () => {
     "virtual_columns",
     "change table with implicit virtual generated column",
     async () => {
-      adapter.exec(`CREATE TABLE "chg_impl" ("id" INTEGER PRIMARY KEY, "a" INTEGER, "b" INTEGER)`);
-      adapter.exec(`ALTER TABLE "chg_impl" ADD COLUMN "c" INTEGER GENERATED ALWAYS AS ("a" * "b")`);
+      await adapter.exec(
+        `CREATE TABLE "chg_impl" ("id" INTEGER PRIMARY KEY, "a" INTEGER, "b" INTEGER)`,
+      );
+      await adapter.exec(
+        `ALTER TABLE "chg_impl" ADD COLUMN "c" INTEGER GENERATED ALWAYS AS ("a" * "b")`,
+      );
       await adapter.executeMutation(`INSERT INTO "chg_impl" ("a", "b") VALUES (4, 5)`);
       const rows = await adapter.execute(`SELECT "c" FROM "chg_impl"`);
       expect(rows[0].c).toBe(20);

--- a/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
+++ b/packages/activerecord/src/adapters/sqlite3/virtual-table.test.ts
@@ -18,8 +18,8 @@ beforeEach(async () => {
   ]);
 });
 
-afterEach(() => {
-  adapter.close();
+afterEach(async () => {
+  await adapter.close();
 });
 
 describeIfSqlite("SQLite3VirtualTableTest", () => {
@@ -43,6 +43,6 @@ describeIfSqlite("SQLite3VirtualTableTest", () => {
     const adapter2 = new BetterSQLite3Adapter(":memory:");
     await adapter2.createVirtualTable("emails", "fts5", ["content", "meta UNINDEXED"]);
     expect(await adapter2.virtualTableExists("emails")).toBe(true);
-    adapter2.close();
+    await adapter2.close();
   });
 });

--- a/packages/activerecord/src/associations/belongs-to-association.ts
+++ b/packages/activerecord/src/associations/belongs-to-association.ts
@@ -74,7 +74,7 @@ export class BelongsToAssociation extends SingularAssociation {
     if ((await this.reader) == null) {
       const value = await block(this.owner);
       if (value != null) {
-        this.writer(value);
+        await this.writer(value);
       }
     }
   }

--- a/packages/activerecord/src/associations/collection-proxy.test.ts
+++ b/packages/activerecord/src/associations/collection-proxy.test.ts
@@ -188,7 +188,9 @@ describe("CollectionProxy — array-likeness (Phase R.1)", () => {
   it("array spread reads the loaded target", async () => {
     const author = await authorWithPosts();
     const proxy = association<Post>(author, "posts");
-    const titles = [...proxy].map((p) => p.title);
+    // proxy is a thenable Relation; spread it via its iterator contract so the
+    // lint sees an Iterable, not a Promise being spread.
+    const titles = [...(proxy as Iterable<Post>)].map((p) => p.title);
     expect(titles).toEqual(["a", "b", "c"]);
   });
 

--- a/packages/activerecord/src/associations/collection-proxy.ts
+++ b/packages/activerecord/src/associations/collection-proxy.ts
@@ -4108,7 +4108,11 @@ export class CollectionProxy<T extends Base = Base> extends Relation<T> {
       get loaded() {
         return proxy._targetLoaded;
       },
-      reset: () => this.reset(),
+      // reset() returns `this` (a thenable Relation); the contract here is a
+      // plain void reset, so discard the proxy return rather than leak it.
+      reset: () => {
+        this.reset();
+      },
     };
   }
 

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -3020,8 +3020,9 @@ export class Base extends Model {
     // (e.g. association inverse wiring) BEFORE running the find/initialize
     // callbacks, so an `after_find` hook already sees the inverse set.
     block?.(record);
-    cbRunAfter(this.prototype, "find", record, { strict: "sync" });
-    cbRunAfter(this.prototype, "initialize", record, { strict: "sync" });
+    // strict:"sync" guarantees synchronous completion — void the settled result.
+    void cbRunAfter(this.prototype, "find", record, { strict: "sync" });
+    void cbRunAfter(this.prototype, "initialize", record, { strict: "sync" });
     return record;
   }
 
@@ -3235,7 +3236,8 @@ export class Base extends Model {
         // before after_initialize — used by association `build_record` to run
         // `initialize_attributes` (scope FK + set_inverse_instance) first.
         initBlock?.(this as unknown as Base);
-        cbRunAfter(ctor.prototype, "initialize", this, { strict: "sync" });
+        // strict:"sync" guarantees synchronous completion -- void the settled result.
+        void cbRunAfter(ctor.prototype, "initialize", this, { strict: "sync" });
       }
     } else {
       // For the regular (non-multiparameter) path, mirror the multiparameter
@@ -3331,7 +3333,8 @@ export class Base extends Model {
         // before after_initialize — used by association `build_record` to run
         // `initialize_attributes` (scope FK + set_inverse_instance) first.
         initBlock?.(this as unknown as Base);
-        cbRunAfter(ctor2.prototype, "initialize", this, { strict: "sync" });
+        // strict:"sync" guarantees synchronous completion -- void the settled result.
+        void cbRunAfter(ctor2.prototype, "initialize", this, { strict: "sync" });
       }
     }
     // Suppressed-callback fallback: parent caller fires after_initialize, so

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.lifecycle.test.ts
@@ -76,11 +76,11 @@ describe("AbstractAdapter connection lifecycle privates", () => {
     );
   });
 
-  it("configureConnection invokes checkVersion", () => {
+  it("configureConnection invokes checkVersion", async () => {
     const a = new AbstractAdapter();
     let called = 0;
     a.checkVersion = () => void (called += 1);
-    a.configureConnection();
+    await a.configureConnection();
     expect(called).toBe(1);
   });
 });

--- a/packages/activerecord/src/connection-adapters/abstract-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/abstract-adapter.ts
@@ -1597,7 +1597,7 @@ export class AbstractAdapter implements Quoting {
     return dbStatementsTransaction.call(this as any, block, opts) as Promise<T | undefined>;
   }
 
-  close(): void {
+  close(): void | Promise<void> {
     // Mirrors Rails' `close` (abstract_adapter.rb:830): `pool.checkin self`.
     // Rails adapters always carry a pool (NullPool by default), whose
     // `checkin` is a no-op; trails leaves `pool` null for standalone adapters,

--- a/packages/activerecord/src/connection-adapters/adapter-leasing.test.ts
+++ b/packages/activerecord/src/connection-adapters/adapter-leasing.test.ts
@@ -50,7 +50,7 @@ describe("AdapterLeasingTest", () => {
     expect(adapter.inUse).toBe(true);
 
     // Close should put the adapter back in the pool
-    adapter.close();
+    await adapter.close();
     expect(adapter.inUse).toBe(false);
 
     expect(await pool.leaseConnection()).toBe(adapter);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.configure-on-connect.trails.test.ts
@@ -53,7 +53,7 @@ describe("Mysql2Adapter configure-on-fresh-connect", () => {
     // reconnectBang's attemptConfigureConnection issues configureConnection()
     // argless after the raw connect — the gate must make the connect-once work
     // a no-op, but the (idempotent) timezone reseed still runs.
-    adapter.configureConnection();
+    await adapter.configureConnection();
 
     expect(checkVersionSpy).toHaveBeenCalledTimes(1);
     expect(timezoneSpy).toHaveBeenCalledTimes(2);

--- a/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/mysql2-adapter.ts
@@ -1750,7 +1750,7 @@ export class Mysql2Adapter extends AbstractMysqlAdapter implements DatabaseAdapt
     // and can't issue the query itself, so we await the warm here (getDatabaseVersion
     // memoizes into _databaseVersion) before super.configureConnection() invokes it.
     await this.getDatabaseVersion();
-    super.configureConnection();
+    await super.configureConnection();
   }
 
   /**

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -345,9 +345,11 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // constructor needing a non-Rails-shaped extra argument. Mirrors Rails,
       // where StatementPool#dealloc reaches @connection.@raw_connection to issue
       // the DEALLOCATE under the connection's control (postgresql_adapter.rb:307).
-      pgDeallocSerializers.set(value, (deallocSql) =>
-        this._enqueueMaintenance(() => value.query(deallocSql)),
-      );
+      pgDeallocSerializers.set(value, (deallocSql) => {
+        // Fire-and-forget by contract (serializer is typed void; callers ignore
+        // the result). The maintenance queue owns error handling and ordering.
+        void this._enqueueMaintenance(() => value.query(deallocSql));
+      });
     }
   }
   private _pgClientOptions: pg.ClientConfig | null = null;

--- a/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3-adapter.ts
@@ -390,7 +390,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
     this.connect();
     // Async-only drivers (e.g. expo-sqlite) can't open in a sync constructor;
     // connect() flags them for the async path instead. See completeAsyncConnect.
-    if (!this._asyncConnectPending) this.configureConnection();
+    // Sync-driver path resolves synchronously; the async path is flagged out
+    // above and configured later via completeAsyncConnect. Fire-and-forget here.
+    if (!this._asyncConnectPending) void this.configureConnection();
     this._nativeTypeMap = AbstractSQLite3Adapter._buildTypeMap();
   }
 
@@ -2957,7 +2959,9 @@ export class AbstractSQLite3Adapter extends AbstractAdapter implements DatabaseA
    * @internal
    */
   override configureConnection(): void | Promise<void> {
-    super.configureConnection();
+    // Base only runs the sync version check; SQLite's PRAGMAs are the async
+    // work, awaited by the driver-async branch below. Void the base call.
+    void super.configureConnection();
     const stmts = this.configurePragmas();
     const warn = (label: string, e: unknown) =>
       console.warn(`${label} failed: ${e instanceof Error ? e.message : String(e)}`);

--- a/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
+++ b/packages/activerecord/src/connection-adapters/sqlite3/quoting.test.ts
@@ -306,9 +306,9 @@ describe("SQLite3::Quoting", () => {
   describe("SQLite microsecond round-trip — integration", () => {
     let adapter: AbstractSQLite3Adapter;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       adapter = new BetterSQLite3Adapter(":memory:");
-      adapter.exec(`CREATE TABLE "events" (
+      await adapter.exec(`CREATE TABLE "events" (
         "id" INTEGER PRIMARY KEY AUTOINCREMENT,
         "ts"  DATETIME,
         "dt"  DATETIME,
@@ -319,7 +319,7 @@ describe("SQLite3::Quoting", () => {
 
     afterEach(async () => {
       await adapter.exec(`DROP TABLE IF EXISTS "events"`).catch(() => undefined);
-      adapter.close();
+      await adapter.close();
     });
 
     it("Temporal.Instant with microsecond precision survives INSERT → SELECT as Instant", async () => {

--- a/packages/activerecord/src/connection-adapters/type-lookup.test.ts
+++ b/packages/activerecord/src/connection-adapters/type-lookup.test.ts
@@ -13,8 +13,8 @@ beforeEach(() => {
   adapter = new BetterSQLite3Adapter(":memory:");
 });
 
-afterEach(() => {
-  adapter.close();
+afterEach(async () => {
+  await adapter.close();
 });
 
 function assertLookupType(expected: string, sqlType: string) {

--- a/packages/activerecord/src/establish-connection.test.ts
+++ b/packages/activerecord/src/establish-connection.test.ts
@@ -8,9 +8,9 @@ import { writeFileSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
-function resetConnection() {
+async function resetConnection() {
   Base._adapter = null;
-  Base._connectionHandler.clearAllConnections();
+  await Base._connectionHandler.clearAllConnections();
   Base._connectionHandler = new ConnectionHandler();
 }
 
@@ -103,13 +103,13 @@ describe("Base.establishConnection with config file", () => {
   const tempDir = join(tmpdir(), `trails-test-${process.pid}`);
   const configPath = join(tempDir, "database.json");
 
-  beforeEach(() => {
-    resetConnection();
+  beforeEach(async () => {
+    await resetConnection();
     mkdirSync(tempDir, { recursive: true });
     Base._configPath = configPath;
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (originalEnv === undefined) {
       delete process.env.DATABASE_URL;
     } else {
@@ -121,7 +121,7 @@ describe("Base.establishConnection with config file", () => {
       process.env.NODE_ENV = originalNodeEnv;
     }
     Base._configPath = null;
-    resetConnection();
+    await resetConnection();
     try {
       rmSync(tempDir, { recursive: true });
     } catch {}
@@ -208,13 +208,13 @@ describe("Base.establishConnection with JS config file", () => {
   const tempDir = join(tmpdir(), `trails-jsconfig-${process.pid}`);
   const configDir = join(tempDir, "config");
 
-  beforeEach(() => {
-    resetConnection();
+  beforeEach(async () => {
+    await resetConnection();
     mkdirSync(configDir, { recursive: true });
     process.chdir(tempDir);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     if (originalEnv === undefined) {
       delete process.env.DATABASE_URL;
     } else {
@@ -227,7 +227,7 @@ describe("Base.establishConnection with JS config file", () => {
     }
     process.chdir(originalCwd);
     Base._configPath = null;
-    resetConnection();
+    await resetConnection();
     try {
       rmSync(tempDir, { recursive: true });
     } catch {}

--- a/packages/activerecord/src/inheritance.ts
+++ b/packages/activerecord/src/inheritance.ts
@@ -661,8 +661,9 @@ function directInstantiate(
   // Rails' init_with_attributes yields to the loader block (inverse wiring)
   // before firing after_find then after_initialize.
   block?.(record);
-  runAfterCallbacksOnProto((klass as any).prototype, "find", record, { strict: "sync" });
-  runAfterCallbacksOnProto((klass as any).prototype, "initialize", record, { strict: "sync" });
+  // strict:"sync" guarantees synchronous completion — void the settled result.
+  void runAfterCallbacksOnProto((klass as any).prototype, "find", record, { strict: "sync" });
+  void runAfterCallbacksOnProto((klass as any).prototype, "initialize", record, { strict: "sync" });
   return record;
 }
 

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -682,9 +682,12 @@ export async function updateBang<T extends UpdateRecord>(
     // See update(): raw loop preserves original error classes (matches Rails,
     // avoids Base#assignAttributes's AttributeAssignmentError wrap); nested
     // attribute writers still route through their setter.
+    const pending: Promise<void>[] = [];
     for (const [key, value] of Object.entries(attrs)) {
-      assignUpdateAttribute(self, key, value);
+      const p = assignUpdateAttribute(self, key, value);
+      if (p) pending.push(p);
     }
+    if (pending.length) await Promise.all(pending);
     return self.saveBang() as Promise<true | undefined>;
   }) as Promise<true | undefined>;
 }
@@ -1564,7 +1567,8 @@ export function dup<T extends DupRecord>(this: T): T {
   // NOT re-run `initialize_internals_callback`/`ensure_proper_type` (that lives
   // in Core#initialize), so the STI type column is carried solely by the
   // deep-dup'd `@attributes`, not re-asserted here.
-  runAfterCallbacksOnProto(ctor.prototype, "initialize", duped, { strict: "sync" });
+  // strict:"sync" guarantees synchronous completion — void the settled result.
+  void runAfterCallbacksOnProto(ctor.prototype, "initialize", duped, { strict: "sync" });
   // The Timestamp/Locking `initialize_dup` clears run AFTER the callbacks in
   // Rails: their modules `super` into `Core#initialize_dup` (which fires the
   // hook) and clear only as the stack unwinds. So the hook above observes the

--- a/packages/activerecord/src/transaction.test.ts
+++ b/packages/activerecord/src/transaction.test.ts
@@ -17,10 +17,10 @@ describe("Transaction (public wrapper, Rails ActiveRecord::Transaction)", () => 
     expect(t.uuid()).toBeNull();
   });
 
-  it("afterCommit on a null transaction runs the block immediately", () => {
+  it("afterCommit on a null transaction runs the block immediately", async () => {
     const t = Transaction.NULL_TRANSACTION;
     let ran = false;
-    t.afterCommit(() => {
+    await t.afterCommit(() => {
       ran = true;
     });
     expect(ran).toBe(true);

--- a/packages/activerecord/src/transactions.test.ts
+++ b/packages/activerecord/src/transactions.test.ts
@@ -119,19 +119,19 @@ describe("TransactionTest", () => {
 
   it("after all transactions commit", async () => {
     let called = 0;
-    afterAllTransactionsCommit(() => {
+    await afterAllTransactionsCommit(() => {
       called += 1;
     });
     expect(called).toBe(1);
 
-    afterAllTransactionsCommit(() => {
+    await afterAllTransactionsCommit(() => {
       called += 1;
     });
     expect(called).toBe(2);
 
     called = 0;
     await Topic.transaction(async () => {
-      afterAllTransactionsCommit(() => {
+      await afterAllTransactionsCommit(() => {
         called += 1;
       });
       expect(called).toBe(0);
@@ -142,7 +142,7 @@ describe("TransactionTest", () => {
     await Topic.transaction(async () => {
       await Topic.transaction(
         async () => {
-          afterAllTransactionsCommit(() => {
+          await afterAllTransactionsCommit(() => {
             called += 1;
           });
           expect(called).toBe(0);
@@ -155,7 +155,7 @@ describe("TransactionTest", () => {
 
     called = 0;
     await Topic.transaction(async () => {
-      afterAllTransactionsCommit(() => {
+      await afterAllTransactionsCommit(() => {
         called += 1;
       });
       expect(called).toBe(0);
@@ -169,7 +169,7 @@ describe("TransactionTest", () => {
     called = 0;
     await Topic.transaction(async (tx) => {
       tx._internalTransaction.invalidateBang();
-      afterAllTransactionsCommit(() => {
+      await afterAllTransactionsCommit(() => {
         called += 1;
       });
       expect(called).toBe(1);
@@ -186,19 +186,19 @@ describe("TransactionTest", () => {
     // Rails' multidb (ARUnit2Model) sub-case is omitted: there is no secondary
     // DB in the single-database test env.
     let called = 0;
-    Topic.currentTransaction().afterCommit(() => {
+    await Topic.currentTransaction().afterCommit(() => {
       called += 1;
     });
     expect(called).toBe(1);
 
-    Topic.currentTransaction().afterCommit(() => {
+    await Topic.currentTransaction().afterCommit(() => {
       called += 1;
     });
     expect(called).toBe(2);
 
     called = 0;
     await Topic.transaction(async () => {
-      Topic.currentTransaction().afterCommit(() => {
+      await Topic.currentTransaction().afterCommit(() => {
         called += 1;
       });
       expect(called).toBe(0);
@@ -209,7 +209,7 @@ describe("TransactionTest", () => {
     await Topic.transaction(async () => {
       await Topic.transaction(
         async () => {
-          Topic.currentTransaction().afterCommit(() => {
+          await Topic.currentTransaction().afterCommit(() => {
             called += 1;
           });
           expect(called).toBe(0);
@@ -222,7 +222,7 @@ describe("TransactionTest", () => {
 
     called = 0;
     await Topic.transaction(async () => {
-      Topic.currentTransaction().afterCommit(() => {
+      await Topic.currentTransaction().afterCommit(() => {
         called += 1;
       });
       expect(called).toBe(0);

--- a/packages/activerecord/src/transactions.trails.test.ts
+++ b/packages/activerecord/src/transactions.trails.test.ts
@@ -43,10 +43,10 @@ interface AdapterTxView {
 
 const openAdapters: AbstractSQLite3Adapter[] = [];
 
-function makeSQLiteTopic() {
+async function makeSQLiteTopic() {
   const adp = new BetterSQLite3Adapter(":memory:");
   openAdapters.push(adp);
-  adp.exec(
+  await adp.exec(
     "CREATE TABLE topics (id INTEGER PRIMARY KEY AUTOINCREMENT, title TEXT, approved INTEGER DEFAULT 0)",
   );
   class Topic extends Base {
@@ -67,7 +67,7 @@ afterEach(async () => {
     } catch {
       /* adapter may already be closed */
     }
-    a.close();
+    await a.close();
   }
 });
 
@@ -112,7 +112,7 @@ describe("TransactionTest", () => {
     const log: string[] = [];
 
     await transaction(CanonicalTopic, async (tx) => {
-      tx.afterCommit(() => {
+      await tx.afterCommit(() => {
         log.push("committed");
       });
       await CanonicalTopic.create({ title: "Alice" });
@@ -247,7 +247,7 @@ describe("savepoint statements dirty the current transaction (trails ensure relo
   });
 
   it("createSavepoint dirties the current (parent) transaction frame", async () => {
-    const { adapter } = makeSQLiteTopic();
+    const { adapter } = await makeSQLiteTopic();
     const tm = adapter.transactionManager;
     await tm.withinNewTransaction({}, async () => {
       // BEGIN is emitted with materializeTransactions:false, so the frame is
@@ -260,7 +260,7 @@ describe("savepoint statements dirty the current transaction (trails ensure relo
   });
 
   it("a savepoint statement failing mid-flight still dirties the parent (ensure fires on the error path)", async () => {
-    const { adapter } = makeSQLiteTopic();
+    const { adapter } = await makeSQLiteTopic();
     const tm = adapter.transactionManager;
     await tm.withinNewTransaction({}, async () => {
       await tm.materializeTransactions();
@@ -282,7 +282,7 @@ describe("savepoint statements dirty the current transaction (trails ensure relo
 describe("rememberTransactionRecordState / restoreTransactionRecordState (Story K)", () => {
   it("rememberTransactionRecordState populates _startTransactionState with level and attributes", async () => {
     const { rememberTransactionRecordState } = await import("./transactions.js");
-    const { Topic } = makeSQLiteTopic();
+    const { Topic } = await makeSQLiteTopic();
     const topic = new Topic({ title: "before" });
     const internals = topic as unknown as TxRecordInternals;
     internals._newRecord = false;
@@ -300,7 +300,7 @@ describe("rememberTransactionRecordState / restoreTransactionRecordState (Story 
 
   it("rolledbackBang restores identity and clears mutation tracking", async () => {
     const { rolledbackBang, rememberTransactionRecordState } = await import("./transactions.js");
-    const { Topic } = makeSQLiteTopic();
+    const { Topic } = await makeSQLiteTopic();
     const topic = new Topic({ title: "original" });
     const internals = topic as unknown as TxRecordInternals;
     internals._newRecord = false;
@@ -334,7 +334,7 @@ describe("rememberTransactionRecordState / restoreTransactionRecordState (Story 
 describe("DirtyTracker.redetectChanges after rollback (Story K-followup)", () => {
   it("rollback preserves in-TX user edits as dirty", async () => {
     const { rememberTransactionRecordState, rolledbackBang } = await import("./transactions.js");
-    const { Topic } = makeSQLiteTopic();
+    const { Topic } = await makeSQLiteTopic();
     const topic = new Topic({ title: "original" });
     const internals = topic as unknown as TxRecordInternals;
     internals._newRecord = false;
@@ -360,7 +360,7 @@ describe("DirtyTracker.redetectChanges after rollback (Story K-followup)", () =>
 
   it("rollback leaves clean attributes unchanged (no spurious dirty)", async () => {
     const { rememberTransactionRecordState, rolledbackBang } = await import("./transactions.js");
-    const { Topic } = makeSQLiteTopic();
+    const { Topic } = await makeSQLiteTopic();
     const topic = new Topic({ title: "original" });
     const internals = topic as unknown as TxRecordInternals;
     internals._newRecord = false;


### PR DESCRIPTION
## Summary

Completes the RFC 0063 async-validation lint guard (follow-up to
`lint-guard-unawaited-isvalid`). Enables `@typescript-eslint/no-floating-promises`
and re-enables the `checksVoidReturn` / `checksSpreads` sub-checks of
`no-misused-promises` over `packages/activemodel` and `packages/activerecord`
(src + tests), then clears every flagged site.

## Runtime (src) fixes

- **Sync-strict callback runners** (`model.ts`, `base.ts`, `inheritance.ts`,
  `persistence.ts`): `void` the settled Promise — `strict:"sync"` guarantees
  synchronous completion (async callbacks throw), so nothing is lost.
- **`belongs-to-association.ts`**: `await` the default writer.
- **`persistence.ts` updateBang**: drain `assignUpdateAttribute` promises
  (mirrors the existing `update` path).
- **`mysql2-adapter.ts`**: `await super.configureConnection()`.
- **`abstract-adapter.ts`**: widen `close()` to `void | Promise<void>` so the
  async adapter overrides no longer misuse a void-returning contract.
- **`postgresql-adapter.ts`**: `void` the dealloc serializer (fire-and-forget
  by contract; the maintenance queue owns ordering/errors).
- **`collection-proxy.ts`**: `proxyAssociation.reset` discards the thenable
  Relation return.

## Test fixes

`await` previously-dropped promises; mark enclosing callbacks `async` where
needed; make two `createTable` blocks synchronous (the block is never awaited
and does no async work); spread the collection proxy via its `Iterable`
contract; one targeted `eslint-disable` for a pg `query` mock whose overloaded
void-callback form trips `checksVoidReturn`.

## Notes

- **LOC**: ~549 (add+del). Over the 500 default because this is an atomic
  lint-flip burndown — the config flip and ~200 mechanical `await`/`async`
  fixes must land together or lint breaks; it can't be split into sibling PRs.
  The bulk is 1-for-1 line rewrites (`x()` → `await x()`).
- `pnpm lint` passes for all promise rules. (A pre-existing, unrelated
  `blazetrails/expected-fixtures` error in `encrypted-fixtures.test.ts`
  reproduces on clean `main` locally due to a missing local `rails-api.json`
  manifest; CI regenerates it.)

Closes-story: lint-guard-floating-promises-burndown