### PR TITLE
fix(join-dependency): narrow alias-length catch to no-connection only

### DIFF
--- a/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
@@ -11,7 +11,7 @@ import { describe, it, expect } from "vitest";
 import { Table } from "@blazetrails/arel";
 import { JoinDependency } from "./join-dependency.js";
 import { AliasTracker } from "./alias-tracker.js";
-import { ConnectionNotDefined } from "../errors.js";
+import { ConnectionNotDefined, ConnectionTimeoutError } from "../errors.js";
 
 type BaseModelArg = ConstructorParameters<typeof JoinDependency>[0];
 
@@ -75,5 +75,19 @@ describe("JoinDependency AliasTracker seeding", () => {
       },
     } as unknown as BaseModelArg;
     expect(() => new JoinDependency(brokenModel)).toThrow("adapter blew up");
+  });
+
+  it("propagates a connection error that is not a no-connection error", () => {
+    // ConnectionTimeoutError is a ConnectionNotEstablished but not a
+    // ConnectionNotDefined, so it is a genuine failure that must not be
+    // swallowed into the default alias cap.
+    const timingOutModel = {
+      tableName: "posts",
+      arelTable: new Table("posts"),
+      get connection(): never {
+        throw new ConnectionTimeoutError("could not obtain a connection");
+      },
+    } as unknown as BaseModelArg;
+    expect(() => new JoinDependency(timingOutModel)).toThrow(ConnectionTimeoutError);
   });
 });

--- a/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
+++ b/packages/activerecord/src/associations/join-dependency-alias-length.trails.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from "vitest";
 import { Table } from "@blazetrails/arel";
 import { JoinDependency } from "./join-dependency.js";
 import { AliasTracker } from "./alias-tracker.js";
+import { ConnectionNotDefined } from "../errors.js";
 
 type BaseModelArg = ConstructorParameters<typeof JoinDependency>[0];
 
@@ -56,12 +57,23 @@ describe("JoinDependency AliasTracker seeding", () => {
       tableName: "posts",
       arelTable: new Table("posts"),
       get connection(): never {
-        throw new Error("no connection established");
+        throw new ConnectionNotDefined("No connection pool for posts");
       },
     } as unknown as BaseModelArg;
     const jd = new JoinDependency(noConnModel);
     const tracker = trackerOf(jd);
     // maxIdentifierLength default is 64.
     expect(tracker.aliasNameFor("a".repeat(200))).toBe("a".repeat(64));
+  });
+
+  it("propagates a genuine connection error instead of swallowing it", () => {
+    const brokenModel = {
+      tableName: "posts",
+      arelTable: new Table("posts"),
+      get connection(): never {
+        throw new Error("adapter blew up");
+      },
+    } as unknown as BaseModelArg;
+    expect(() => new JoinDependency(brokenModel)).toThrow("adapter blew up");
   });
 });

--- a/packages/activerecord/src/associations/join-dependency.ts
+++ b/packages/activerecord/src/associations/join-dependency.ts
@@ -25,7 +25,7 @@ import { JoinBase } from "./join-dependency/join-base.js";
 import { JoinAssociation } from "./join-dependency/join-association.js";
 import { JoinPart } from "./join-dependency/join-part.js";
 import { AssociationNotFoundError, EagerLoadPolymorphicError } from "./errors.js";
-import { ConfigurationError } from "../errors.js";
+import { ConfigurationError, ConnectionNotDefined } from "../errors.js";
 import { AliasTracker } from "./alias-tracker.js";
 import { threadedConnectionFor } from "../connection-handling.js";
 
@@ -196,21 +196,24 @@ export class JoinDependency {
    * 63 on PostgreSQL, 64 (default) on SQLite. Prefer the connection threaded by
    * the enclosing `withConnection` wrap over the deprecated `.connection`
    * getter (which flips the lease permanent under a restricted checkout mode);
-   * returns `undefined` when no connection resolves (or the `.connection` getter
-   * throws because none is established), letting the tracker fall back to its
-   * default so construction never fails on account of alias sizing.
+   * returns `undefined` only when no connection is established (the `.connection`
+   * getter throws `ConnectionNotDefined`), letting the tracker fall back to its
+   * default so construction never fails on account of alias sizing in
+   * connectionless contexts. A genuine connection/adapter error propagates,
+   * matching Rails' `pool.with_connection` raise semantics.
    * @internal
    */
   private _baseTableAliasLength(): number | undefined {
+    let connection;
     try {
-      const connection =
-        threadedConnectionFor(this._baseModel) ?? (this._baseModel as any).connection;
-      return typeof connection?.tableAliasLength === "function"
-        ? connection.tableAliasLength()
-        : undefined;
-    } catch {
-      return undefined;
+      connection = threadedConnectionFor(this._baseModel) ?? (this._baseModel as any).connection;
+    } catch (error) {
+      if (error instanceof ConnectionNotDefined) return undefined;
+      throw error;
     }
+    return typeof connection?.tableAliasLength === "function"
+      ? connection.tableAliasLength()
+      : undefined;
   }
 
   /**


### PR DESCRIPTION
## Summary

`JoinDependency#_baseTableAliasLength` wrapped connection resolution in a blanket `try/catch` that swallowed **all** errors and fell back to the default alias cap (64). Rails builds the tracker inside `pool.with_connection` (`alias_tracker.rb:24`), which **raises** when no connection resolves — it never silently falls back on a genuine connection error.

This narrows the catch to `ConnectionNotDefined` (the "no connection established" case), so connectionless test contexts still fall back to the default cap while a real connection/adapter error propagates — matching Rails' raise semantics.

Codex flagged this on #4819 as a non-blocking looser-than-Rails fallback.

## Tests

- Established stub connection still threads 256 (existing tests).
- Fallback test now throws `ConnectionNotDefined` → default cap.
- New test: a genuine adapter error surfaces instead of being swallowed.

Closes-story: narrow-alias-tracker-connection-length-fallback-catch