### PR TITLE
fix(pg): disconnect!/close bump acquire generation so a racing reconnect can't adopt the orphaned connect

### DIFF
--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1066,6 +1066,47 @@ describeIfPg("PostgreSQLAdapter", () => {
         await orphan.end().catch(() => {});
       }
     });
+
+    it("orphaned acquire still fails when the racing reconnect publishes first", async () => {
+      // The reconnect wins the open race and publishes _rawConnection BEFORE the
+      // orphaned pre-disconnect connect resolves. A stale-generation acquire
+      // must fail uniformly here too — it must NOT fall through to adopt the
+      // now-valid post-disconnect connection (the pre-#4842 _rawConnection != null
+      // fallback would have). Locks in the deliberate "orphaned acquire never
+      // succeeds" semantics rather than a race-timing-dependent outcome.
+      const a = new PostgreSQLAdapter(PG_TEST_URL);
+      const orphan = await PostgreSQLAdapter.newClient({ connectionString: PG_TEST_URL });
+      const reconnected = await PostgreSQLAdapter.newClient({ connectionString: PG_TEST_URL });
+      const endSpy = vi.spyOn(orphan, "end");
+      const first = defer();
+      const spy = vi
+        .spyOn(PostgreSQLAdapter, "newClient")
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(() => Promise.resolve(reconnected));
+      try {
+        const firstAcquire = a.connect();
+        await waitForNewClientCalls(spy, 1);
+
+        a.disconnectBang();
+
+        // Reconnect resolves fully first: _rawConnection is now `reconnected`.
+        await a.reconnect();
+        expect(a._rawConnectionForTest()).toBe(reconnected);
+
+        // Only now does the orphaned pre-disconnect connect resolve.
+        first.resolve(orphan);
+        await expect(firstAcquire).rejects.toBeTruthy();
+
+        // It tore down its own client and left the valid reconnect untouched —
+        // it did NOT overwrite or adopt `reconnected`.
+        expect(endSpy).toHaveBeenCalled();
+        expect(a._rawConnectionForTest()).toBe(reconnected);
+      } finally {
+        spy.mockRestore();
+        await a.close();
+        await orphan.end().catch(() => {});
+      }
+    });
   });
 
   describe("lock sharing", () => {

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -1010,6 +1010,16 @@ describeIfPg("PostgreSQLAdapter", () => {
       const promise = new Promise<pg.Client>((r) => (resolve = r));
       return { promise, resolve };
     };
+    // Wait until `newClient` has been called at least `n` times — the acquire
+    // reaches the connect only after the _inFlightReset / _maintenanceTail
+    // awaits, so poll on the call count rather than a fixed microtask count.
+    const waitForNewClientCalls = async (
+      spy: { mock: { calls: unknown[] } },
+      n: number,
+    ): Promise<void> => {
+      for (let i = 0; i < 1000 && spy.mock.calls.length < n; i++) await Promise.resolve();
+      if (spy.mock.calls.length < n) throw new Error(`newClient not called ${n} time(s)`);
+    };
 
     it("disconnectBang orphans an in-flight acquire so it is not adopted by a racing reconnect", async () => {
       const a = new PostgreSQLAdapter(PG_TEST_URL);
@@ -1025,7 +1035,7 @@ describeIfPg("PostgreSQLAdapter", () => {
       try {
         // First acquire suspends at `await newClient(...)` (generation 0).
         const firstAcquire = a.connect();
-        await Promise.resolve();
+        await waitForNewClientCalls(spy, 1);
 
         // disconnect while the connect is in flight: bumps the generation.
         a.disconnectBang();
@@ -1033,16 +1043,18 @@ describeIfPg("PostgreSQLAdapter", () => {
         // A checkout reconnect clears _closed and _rawConnection, then opens a
         // fresh connect (generation 1) which also suspends.
         const reconnect = a.reconnect();
-        await Promise.resolve();
+        await waitForNewClientCalls(spy, 2);
 
         // The pre-disconnect connect resolves NOW, while _rawConnection is null
         // and _closed is false — the exact window the adoption race exploits.
         first.resolve(orphan);
         await expect(firstAcquire).rejects.toBeTruthy();
 
-        // The stale acquire tore its client down instead of adopting it.
+        // The stale acquire tore its client down instead of adopting it: it
+        // did NOT publish onto _rawConnection (still null — the reconnect's own
+        // connect has not resolved yet) and end()ed the socket.
         expect(endSpy).toHaveBeenCalled();
-        expect(a._rawConnectionForTest()).not.toBe(orphan);
+        expect(a._rawConnectionForTest()).toBeNull();
 
         // The fresh reconnect publishes its own client and works.
         second.resolve(reconnected);

--- a/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
+++ b/packages/activerecord/src/adapters/postgresql/postgresql-adapter.trails.test.ts
@@ -997,6 +997,65 @@ describeIfPg("PostgreSQLAdapter", () => {
     });
   });
 
+  describe("in-flight acquire adoption race", () => {
+    // A disconnectBang()/close() that races an in-flight _doAcquire() (suspended
+    // at `await newClient(...)`) must not let that stale acquire adopt/publish
+    // its pre-disconnect client after a checkout verify → reconnect clears
+    // _closed. disconnectBang/close bump _acquireGeneration; the resolving
+    // connect sees a stale generation and end()s its socket instead of adopting
+    // it. The disconnect/close analogue of the discard fix in PR #4303.
+    type Deferred = { promise: Promise<pg.Client>; resolve: (c: pg.Client) => void };
+    const defer = (): Deferred => {
+      let resolve!: (c: pg.Client) => void;
+      const promise = new Promise<pg.Client>((r) => (resolve = r));
+      return { promise, resolve };
+    };
+
+    it("disconnectBang orphans an in-flight acquire so it is not adopted by a racing reconnect", async () => {
+      const a = new PostgreSQLAdapter(PG_TEST_URL);
+      const orphan = await PostgreSQLAdapter.newClient({ connectionString: PG_TEST_URL });
+      const reconnected = await PostgreSQLAdapter.newClient({ connectionString: PG_TEST_URL });
+      const endSpy = vi.spyOn(orphan, "end");
+      const first = defer();
+      const second = defer();
+      const spy = vi
+        .spyOn(PostgreSQLAdapter, "newClient")
+        .mockImplementationOnce(() => first.promise)
+        .mockImplementationOnce(() => second.promise);
+      try {
+        // First acquire suspends at `await newClient(...)` (generation 0).
+        const firstAcquire = a.connect();
+        await Promise.resolve();
+
+        // disconnect while the connect is in flight: bumps the generation.
+        a.disconnectBang();
+
+        // A checkout reconnect clears _closed and _rawConnection, then opens a
+        // fresh connect (generation 1) which also suspends.
+        const reconnect = a.reconnect();
+        await Promise.resolve();
+
+        // The pre-disconnect connect resolves NOW, while _rawConnection is null
+        // and _closed is false — the exact window the adoption race exploits.
+        first.resolve(orphan);
+        await expect(firstAcquire).rejects.toBeTruthy();
+
+        // The stale acquire tore its client down instead of adopting it.
+        expect(endSpy).toHaveBeenCalled();
+        expect(a._rawConnectionForTest()).not.toBe(orphan);
+
+        // The fresh reconnect publishes its own client and works.
+        second.resolve(reconnected);
+        await reconnect;
+        expect(a._rawConnectionForTest()).toBe(reconnected);
+      } finally {
+        spy.mockRestore();
+        await a.close();
+        await orphan.end().catch(() => {});
+      }
+    });
+  });
+
   describe("lock sharing", () => {
     // Regression: withRawConnection and the transaction manager must share one
     // reentrant lock (Rails' single @lock). With separate locks a transaction

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1207,14 +1207,22 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
       // publish `newClient` — tear it down instead so we don't leak
       // a live socket onto a closed adapter.
       const racedDiscard = this._discardedAcquireGenerations.has(acquireGen);
+      // A disconnectBang/close/discardBang bumps _acquireGeneration when this
+      // acquire is in flight, so a mismatch means this acquire was orphaned by
+      // one of them. Checking the captured generation (not the mutable _closed
+      // flag) keeps the decision correct even when a racing reconnect clears
+      // _closed before the connect resolves — otherwise the stale acquire would
+      // adopt/publish its pre-disconnect newClient onto the reconnected adapter.
+      const staleGeneration = acquireGen !== this._acquireGeneration;
       if (
         this._closed ||
         this._pgClientOptions == null ||
         this._rawConnection != null ||
-        racedDiscard
+        racedDiscard ||
+        staleGeneration
       ) {
         this._teardownRacedClient(newClient, acquireGen);
-        if (this._closed || this._pgClientOptions == null || racedDiscard) {
+        if (this._closed || this._pgClientOptions == null || racedDiscard || staleGeneration) {
           throw new Error("PostgreSQLAdapter: connection is closed");
         }
         // Another caller raced ahead and already published a
@@ -2603,6 +2611,9 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     this._connectionConfigured = false;
     this._typeMapEagerLoaded = false;
     this._closed = true;
+    // Bump the in-flight acquire's generation (see disconnectBang) so a stale
+    // connect end()s its socket instead of adopting it onto a racing reconnect.
+    if (this._acquiring) this._acquireGeneration++;
     const conn = this._rawConnection;
     this._rawConnection = null;
     this._pgClientOptions = null;
@@ -2857,6 +2868,13 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
     this._needsDeallocateAll = false;
     this._inTransaction = false;
     this._closed = true;
+    // If a connect is in flight, bump its generation so it tears down (end()s,
+    // not adopts) its socket when it resolves — even if a racing reconnect
+    // clears _closed first — and so a later reconnect opens a fresh acquire
+    // instead of reusing the orphaned one. Unlike discardBang, this generation
+    // is NOT recorded in _discardedAcquireGenerations, so _teardownRacedClient
+    // end()s the socket (matching Rails' disconnect!) rather than abandoning it.
+    if (this._acquiring) this._acquireGeneration++;
     conn?.end().catch(() => {});
     // Rails' disconnect! calls reset_transaction; super.disconnectBang() does not.
     this.resetTransaction();

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -1222,6 +1222,15 @@ export class PostgreSQLAdapter extends AbstractAdapter implements DatabaseAdapte
         staleGeneration
       ) {
         this._teardownRacedClient(newClient, acquireGen);
+        // A stale-generation acquire ALWAYS fails, uniformly — even in the
+        // narrow sub-case where a racing reconnect has already published a
+        // valid _rawConnection (i.e. we'd otherwise fall through to adopt it
+        // below). This is a deliberate behavior change: an acquire orphaned by
+        // disconnect!/close/discard! belongs to a connection epoch that was
+        // explicitly torn down, so adopting a POST-teardown connection would
+        // silently paper over the disconnect (the mirror of the adoption bug
+        // this guard fixes). Only same-generation callers that merely lost a
+        // benign open race are allowed to adopt the winner's connection below.
         if (this._closed || this._pgClientOptions == null || racedDiscard || staleGeneration) {
           throw new Error("PostgreSQLAdapter: connection is closed");
         }


### PR DESCRIPTION
## Summary

PR #4303 hardened the PG adapter against a connect/teardown adoption race for
`discardBang()` only, using a per-acquire generation token. The same race
existed for `disconnectBang()` and `close()`, which set `_closed = true` but did
NOT bump `_acquireGeneration`.

If an in-flight `_doAcquire()` is suspended at `await newClient(...)` when
`disconnectBang()`/`close()` runs, and a checkout `verifyBang()` →
`reconnectBang()` → `reconnect()` → `_discardRawConnection()` clears `_closed`
before the connect resolves, the stale `_doAcquire` reached its teardown guard
with `_closed === false` and adopted (published) the pre-disconnect `newClient`
onto the reconnected adapter instead of tearing it down.

Rails serializes `disconnect!`/`reconnect!` under `@lock.synchronize`, so the
interleave can't occur there; trails' async model allows it.

## Changes

- `disconnectBang()` / `close()` now bump `_acquireGeneration` when a connect is
  in flight (like `discardBang`), so a later reconnect opens a fresh acquire
  rather than reusing the orphaned one.
- `_doAcquire`'s teardown guard adds a `staleGeneration` check (captured
  generation vs. current) instead of relying on the mutable `_closed` flag, so a
  stale acquire tears its socket down even after a racing reconnect clears
  `_closed`.
- The bumped generation is NOT recorded in `_discardedAcquireGenerations`, so
  `_teardownRacedClient` `end()`s the socket (matching Rails' `disconnect!`)
  rather than abandoning it — the discard path's abandon-vs-end decision is
  untouched.
- Regression test in `postgresql-adapter.trails.test.ts` exercising the exact
  window (orphaned connect resolves while `_rawConnection` is null and `_closed`
  is false). Verified to fail without the fix.

No `node:*` / `process.*`; async-only; no new deps.

Closes-story: pg-disconnect-close-inflight-acquire-adoption-race

## Testing note

The regression test drives the `disconnectBang()` path because it is the
reachable race: `disconnectBang` leaves `_pgClientOptions` intact, so a checkout
`verifyBang()` → `reconnect()` genuinely clears `_closed` and re-opens. `close()`
additionally nulls `_pgClientOptions` (making the adapter terminally unusable —
`verifyBang` refuses to reconnect), so its guard already rejected adoption; the
generation bump there is defensive parity exercising the same `staleGeneration`
guard. Both share the single guarded code path the test covers.

Verified the test fails against `origin/main` (adopts the orphan / `firstAcquire`
resolves instead of rejecting) and passes with the fix.


## Design note: stale-generation acquires fail uniformly

`staleGeneration` is added to the *unconditional-throw* guard as well as the
teardown guard (postgresql-adapter.ts:1225), so an orphaned acquire **always**
fails once its generation is superseded — including the sub-case where a racing
reconnect has already published its own valid `_rawConnection` before the
orphaned connect resolves. Pre-#4842 that sub-case fell through the
`_rawConnection != null` branch and adopted the newly-published connection.

This is deliberate: an acquire orphaned by `disconnect!`/`close`/`discard!`
belongs to a connection epoch that was explicitly torn down. Letting it adopt a
*post*-teardown connection is the same class of bug this PR fixes (just the
mirror sub-case), and making the caller's outcome depend on which of the two
connects wins the race would be non-deterministic. A uniform "orphaned acquire
never succeeds" is the cleaner invariant; the caller (`connectBang`/`reconnect`/
the pool's `verifyBang` retry loop) re-acquires on the current generation. Both
race orderings (orphan-first and reconnect-first) are covered by tests.
