### PR TITLE
fix(pg): execInsert dirties query cache on multi-column RETURNING read-back

### DIFF
--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.exec-query.test.ts
@@ -12,6 +12,7 @@ import { Notifications } from "@blazetrails/activesupport";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Result } from "../result.js";
+import { Store } from "./abstract/query-cache.js";
 import { Uuid } from "./postgresql/oid/uuid.js";
 import { PostgreSQLAdapter, type StatementPool } from "./postgresql-adapter.js";
 
@@ -372,5 +373,42 @@ describe("PostgreSQLAdapter#executeMutation", () => {
       secondCallRan = true;
     });
     expect(secondCallRan).toBe(true);
+  });
+});
+
+describe("PostgreSQLAdapter#execInsert query cache", () => {
+  let adapter: PostgreSQLAdapter;
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    if (adapter) await adapter.close().catch(() => undefined);
+  });
+
+  // The multi-column RETURNING read-back runs through internalExecQuery, not
+  // executeMutation, so only `dirtiesQueryCache(PostgreSQLAdapter, "execInsert")`
+  // clears the cache on that path — matching MySQL/SQLite. Rails dirties the
+  // query cache on every write; without the execInsert registration a cached
+  // SELECT after such an INSERT would be served stale.
+  it("clears the query cache on a multi-column RETURNING insert", async () => {
+    adapter = new PostgreSQLAdapter({ host: "localhost", port: 1 });
+    const qc = new Store();
+    qc.enabled = true;
+    qc.dirties = true;
+    await qc.computeIfAbsent("SELECT * FROM posts", async () => [{ id: 1 }]);
+    expect(qc.empty).toBe(false);
+    (adapter as unknown as { _queryCache: Store })._queryCache = qc;
+    (adapter as unknown as { _useInsertReturning: boolean })._useInsertReturning = true;
+
+    // The dirtiesQueryCache wrapper clears before delegating to the original
+    // execInsert; the delegated read-back has no live connection and rejects,
+    // but the cache is already cleared by then.
+    await adapter
+      .execInsert("INSERT INTO posts (title) VALUES ('t')", "SQL", [], "id", null, [
+        "id",
+        "created_at",
+      ])
+      .catch(() => undefined);
+
+    expect(qc.empty).toBe(true);
   });
 });

--- a/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
+++ b/packages/activerecord/src/connection-adapters/postgresql-adapter.ts
@@ -5207,6 +5207,12 @@ const FORMAT_TYPE_ALIASES: Record<string, string> = {
 // schema changes — the trails analogue of Rails' `dirties_query_cache base,
 // :execute` for the write side.
 dirtiesQueryCache(PostgreSQLAdapter, "executeMutation");
+// `execInsert`'s multi-column RETURNING read-back runs through `internalExecQuery`
+// rather than `executeMutation`, so dirty it too — otherwise a subsequent read
+// could be served stale from the query cache after such an INSERT. (The
+// single-column path delegates to `executeMutation`, which is already dirtied;
+// the double-clear there is a harmless no-op.)
+dirtiesQueryCache(PostgreSQLAdapter, "execInsert");
 
 // Mirrors `ActiveSupport.run_load_hooks(:active_record_postgresqladapter, self)`
 // at the bottom of Rails' postgresql_adapter.rb — lets railtie initializers


### PR DESCRIPTION
## Summary

PostgreSQL's `execInsert` multi-column RETURNING read-back
(`execInsertReturningReadback`) runs through `internalExecQuery`, bypassing
`executeMutation`. The adapter registered only
`dirtiesQueryCache(PostgreSQLAdapter, "executeMutation")`, so a bound
multi-column `INSERT ... RETURNING` inside an open query-cache scope did **not**
clear the SELECT query cache — where Rails dirties the cache on every write.
MySQL and SQLite already register `execInsert` with the dirtier; PG did not.

This registers `dirtiesQueryCache(PostgreSQLAdapter, "execInsert")`, matching
MySQL/SQLite and Rails. The single-column fast path still delegates to
`executeMutation` (already dirtied); the resulting double-clear is a harmless
no-op.

## Test

Adds a regression test in `postgresql-adapter.exec-query.test.ts`: a populated,
enabled query cache is cleared by a multi-column RETURNING `execInsert`.
Verified it fails without the registration and passes with it.

Closes-story: pg-execinsert-dirties-query-cache-on-returning-readback