### PR TITLE
feat(autosave): reset marked_for_destruction on reload

### DIFF
--- a/packages/activerecord/src/aggregations.test.ts
+++ b/packages/activerecord/src/aggregations.test.ts
@@ -303,8 +303,11 @@ describe("lazy composed_of inclusion", () => {
     class Plain extends Base {}
     expect(own(Plain, "reload")).toBe(false);
     expect(own(Plain, "initializeDup")).toBe(false);
-    // Its reload is Persistence#reload verbatim, not an aggregation-cache wrapper.
-    expect(Plain.prototype.reload).toBe(persistenceReload);
+    // Its reload is the inherited AutosaveAssociation#reload wrapper (which
+    // delegates to Persistence#reload), not an aggregation-cache wrapper. The
+    // aggregation wrapper is only mixed in by composed_of.
+    expect(Plain.prototype.reload).toBe(Base.prototype.reload);
+    expect(Plain.prototype.reload).not.toBe(persistenceReload);
   });
 
   it("mixes Aggregations onto a model that declares composed_of", () => {

--- a/packages/activerecord/src/autosave-association.test.ts
+++ b/packages/activerecord/src/autosave-association.test.ts
@@ -70,12 +70,16 @@ describe("TestDestroyAsPartOfAutosaveAssociation", () => {
   }
 
   it("a marked for destruction record should not be be marked after reload", async () => {
-    const { Pirate } = makePirateShip();
-    const pirate = await Pirate.create({ catchphrase: "Yarr" });
+    const { Pirate, Ship } = makePirateShip();
+    const pirate = await Pirate.create({ catchphrase: "Don' botharrr talkin' like one, savvy?" });
+    const ship = await Ship.create({ name: "Nights Dirty Lightning", pirate_id: pirate.id });
+    cacheAssoc(pirate, "ship", ship);
+
     markForDestruction(pirate);
-    expect(isMarkedForDestruction(pirate)).toBe(true);
-    const reloaded = await Pirate.find(pirate.id!);
-    expect(isMarkedForDestruction(reloaded)).toBe(false);
+    markForDestruction(ship);
+
+    expect(isMarkedForDestruction(await pirate.reload())).toBe(false);
+    expect(isMarkedForDestruction(await ship.reload())).toBe(false);
   });
 
   it("should destroy a child association as part of the save transaction if it was marked for destruction", async () => {

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -189,8 +189,9 @@ type ReloadFn<T extends Base> = (this: T, options?: ReloadOptions) => Promise<T>
  */
 export function reload<T extends Base>(inheritedReload: ReloadFn<T>): ReloadFn<T> {
   return function (this: T, options?: ReloadOptions): Promise<T> {
-    (this as unknown as AutosaveAssociationHost)[MARKED_FOR_DESTRUCTION] = false;
-    (this as unknown as AutosaveAssociationHost).destroyedByAssociation = null;
+    const record = this as unknown as AutosaveAssociationHost;
+    record[MARKED_FOR_DESTRUCTION] = false;
+    record.destroyedByAssociation = null;
     return inheritedReload.call(this, options);
   };
 }

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -175,6 +175,26 @@ interface AutosaveAssociationHost {
 // Module object — included into Base via include(Base, AutosaveAssociation)
 // ---------------------------------------------------------------------------
 
+type ReloadOptions = { lock?: boolean | string; unscoped?: boolean };
+type ReloadFn<T extends Base> = (this: T, options?: ReloadOptions) => Promise<T>;
+
+/**
+ * Reset the in-memory autosave flags before reloading from the database, then
+ * delegate to the inherited `reload` (Ruby `super`). `inheritedReload` is the
+ * reload method that sat on the prototype when AutosaveAssociation was mixed in,
+ * captured at include time so the delegation walks the real ancestry
+ * (AutosaveAssociation → Persistence) rather than hardcoding a jump.
+ *
+ * Mirrors: ActiveRecord::AutosaveAssociation#reload
+ */
+export function reload<T extends Base>(inheritedReload: ReloadFn<T>): ReloadFn<T> {
+  return function (this: T, options?: ReloadOptions): Promise<T> {
+    (this as unknown as AutosaveAssociationHost)[MARKED_FOR_DESTRUCTION] = false;
+    (this as unknown as AutosaveAssociationHost).destroyedByAssociation = null;
+    return inheritedReload.call(this, options);
+  };
+}
+
 export const AutosaveAssociation = {
   markForDestruction(this: AutosaveAssociationHost): void {
     this[MARKED_FOR_DESTRUCTION] = true;

--- a/packages/activerecord/src/autosave-association.ts
+++ b/packages/activerecord/src/autosave-association.ts
@@ -329,14 +329,6 @@ export async function flushPendingReplaces(record: Base): Promise<void> {
   }
 }
 
-export function clearAutosaveState(record: Base): void {
-  const r = record as any;
-  r[MARKED_FOR_DESTRUCTION] = false;
-  r.destroyedByAssociation = null;
-  delete r[VALIDATING_BELONGS_TO_FOR];
-  delete r[AUTOSAVING_BELONGS_TO_FOR];
-}
-
 // ---------------------------------------------------------------------------
 // Validate & autosave (called from Base.isValid and Base.save)
 // ---------------------------------------------------------------------------

--- a/packages/activerecord/src/base.ts
+++ b/packages/activerecord/src/base.ts
@@ -75,6 +75,7 @@ import {
 import { NotImplementedError, RecordNotFound, StaleObjectError } from "./errors.js";
 import {
   AutosaveAssociation,
+  reload as _autosaveReload,
   flushPendingReplaces,
   computePrimaryKey as _computePrimaryKey,
   _ensureNoDuplicateErrors as _autosaveEnsureNoDuplicateErrors,
@@ -5072,6 +5073,22 @@ include(Base, TouchLater.InstanceMethods);
 };
 include(Base, _AttributeAssignment.InstanceMethods);
 include(Base, AutosaveAssociation);
+// AutosaveAssociation#reload resets marked-for-destruction / destroyed-by-
+// association state, then calls super. Capture the inherited reload (Persistence)
+// at wire time and slot it BELOW Aggregations' lazy wrap, so the MRO is
+// Aggregations → AutosaveAssociation → Persistence. Mirrors Ruby's module super
+// chain; trails has no super across mixins, so wire it explicitly.
+{
+  const inheritedReload = (Base.prototype as any).reload as (
+    this: Base,
+    options?: { lock?: boolean | string; unscoped?: boolean },
+  ) => Promise<Base>;
+  Object.defineProperty(Base.prototype, "reload", {
+    value: _autosaveReload(inheritedReload),
+    writable: true,
+    configurable: true,
+  });
+}
 include(Base, _NestedAttributes.InstanceMethods);
 include(Base, _AssocInstance.InstanceMethods);
 include(Base, {

--- a/packages/activerecord/src/persistence.ts
+++ b/packages/activerecord/src/persistence.ts
@@ -30,7 +30,6 @@ import {
 } from "./multiparameter-attribute-assignment.js";
 import { assignAssociationIfMatch } from "./attribute-assignment.js";
 import { threadedConnectionFor } from "./connection-handling.js";
-import { clearAutosaveState } from "./autosave-association.js";
 import {
   getStiBase,
   getInheritanceColumn,
@@ -1434,7 +1433,6 @@ export async function reload<T extends ReloadRecord>(
   for (const proxy of this._collectionProxies.values()) {
     (proxy as { owner: unknown }).owner = this;
   }
-  clearAutosaveState(this as unknown as Parameters<typeof clearAutosaveState>[0]);
   return this;
 }
 


### PR DESCRIPTION
Port `ActiveRecord::AutosaveAssociation#reload` (autosave_association.rb:237-242):
on reload, reset the in-memory `markedForDestruction` and `destroyedByAssociation`
state before delegating to the inherited (Persistence) reload.

## Changes
- `autosave-association.ts`: add a `reload(inheritedReload)` factory that clears
  the marked-for-destruction symbol + `destroyedByAssociation`, then calls the
  captured inherited reload (Ruby `super`).
- `base.ts`: wire the wrapper onto `Base.prototype` right after
  `include(Base, AutosaveAssociation)`, capturing the inherited Persistence
  reload. It sits below Aggregations' lazy `composed_of` wrap, giving MRO
  Aggregations → AutosaveAssociation → Persistence (PR #4527 set this up).
- `persistence.ts`: remove the `clearAutosaveState(this)` call (and the now-unused
  helper). Rails' `Persistence#reload` (persistence.rb:742-756) does NOT touch
  `marked_for_destruction` / `destroyed_by_association` — that reset belongs
  solely to `AutosaveAssociation#reload` via `super`. The call was a pre-existing
  stand-in (PR #685) for the missing override; now that the override is ported it
  was a duplicate at the wrong layer. The validating/autosaving belongs-to guards
  it also cleared are always reset in their own `finally` blocks, so no behavior
  is lost.
- `autosave-association.test.ts`: `test_a_marked_for_destruction_record_should_not_be_be_marked_after_reload`
  now exercises real `reload()` on both pirate and ship (was a `find` workaround).
- `aggregations.test.ts`: plain-model reload is now the inherited
  AutosaveAssociation wrapper (delegating to Persistence), not persistenceReload
  verbatim.

Closes-story: port-autosave-association-reload-reset-marked-for-destruction
