### PR TITLE
fix(counter-cache): resolve aliased column in hasCachedCounter

### DIFF
--- a/packages/activerecord/src/associations/has-many-associations.test.ts
+++ b/packages/activerecord/src/associations/has-many-associations.test.ts
@@ -7121,7 +7121,7 @@ describe("HasManyAssociationsTest", () => {
 });
 
 describe("HasManyAssociationsTest", () => {
-  const { cars } = fixtures(["cars", "topics", "ships", "treasures"]);
+  const { cars, posts } = fixtures(["cars", "topics", "ships", "treasures", "posts", "comments"]);
 
   beforeAll(() => {
     registerModel(HmCar);
@@ -7130,6 +7130,8 @@ describe("HasManyAssociationsTest", () => {
     registerModel(HmTreasure);
     registerModel(HmTopic);
     registerModel(HmReply);
+    registerModel(HmPost);
+    registerModel(Comment);
     enableSti(HmTopic);
     registerSubclass(HmReply);
   });
@@ -7209,15 +7211,13 @@ describe("HasManyAssociationsTest", () => {
     expect(reloaded.replies_count).toBe(1);
   });
 
-  // Rails uses posts(:welcome).comments; trails' posts table has `legacy_comments_count`
-  // (not `comments_count`), so hasCachedCounter? is false for post.comments and
-  // assertNoQueries would fail. Car/Engine (engines_count) tests the same path faithfully.
   it("calling empty with counter cache", async () => {
-    const car = cars("honda") as any;
-    await car.engines.create({});
-    const fresh = (await HmCar.find(car.id)) as any;
+    // Post.comments derives counter column `comments_count`, aliased to the
+    // canonical `legacy_comments_count` — hasCachedCounter? resolves the alias
+    // so isEmpty() reads the cache instead of querying (reflection.ts).
+    const post = posts("welcome") as any;
     await assertNoQueries(false, async () => {
-      expect(await fresh.engines.isEmpty()).toBe(false);
+      expect(await post.comments.isEmpty()).toBe(false);
     });
   });
 });

--- a/packages/activerecord/src/reflection.ts
+++ b/packages/activerecord/src/reflection.ts
@@ -490,7 +490,15 @@ export class AbstractReflection {
     const iwucc = this.inverseWhichUpdatesCounterCache();
     if (iwucc && asConcrete(iwucc).options?.counterCache) {
       const col = this.counterCacheColumn();
-      if (col && (this._concrete().activeRecord as any)?.hasAttribute?.(col)) return true;
+      // Rails' class-level `has_attribute?` resolves attribute aliases
+      // (attribute_methods.rb:256) before checking `attribute_types`. Trails'
+      // static `hasAttribute` does not, so resolve the derived counter column
+      // (e.g. comments_count) through the owner's aliases first — the canonical
+      // posts table stores it as `legacy_comments_count`
+      // (aliasAttribute("commentsCount", "legacy_comments_count")).
+      const owner = this._concrete().activeRecord as any;
+      const resolved = col ? resolveAliasedColumn(owner, col) : col;
+      if (resolved && owner?.hasAttribute?.(resolved)) return true;
     }
     return false;
   }


### PR DESCRIPTION
## Summary

`Post.reflectOnAssociation("comments").hasCachedCounter()` returned `false`
because the derived counter column `comments_count` was checked against
`Post.hasAttribute(...)` without resolving attribute aliases. The canonical
posts table stores it as `legacy_comments_count`
(`aliasAttribute("commentsCount", "legacy_comments_count")`), so
`post.comments.isEmpty()` fell through to a DB query, deviating from Rails'
`assert_no_queries { post.comments.empty? }`.

Rails' class-level `has_attribute?` resolves attribute aliases before checking
`attribute_types` (attribute_methods.rb:256). This mirrors that behavior in
`hasCachedCounter` by resolving the derived counter column through the owner's
aliases (`resolveAliasedColumn`).

## Changes

- `reflection.ts`: resolve the counter column through the owner's aliases in `hasCachedCounter`.
- `has-many-associations.test.ts`: re-port "calling empty with counter cache" against `posts("welcome")` with `assertNoQueries` (removing the Car/Engine workaround), matching Rails' `test_calling_empty_with_counter_cache`.

## Testing

- `calling empty with counter cache` passes with `assertNoQueries`.
- Full `has-many-associations.test.ts` and `reflection.trails.test.ts` pass — no regressions.

Closes-story: post-comments-counter-cache-column-alias