### PR TITLE
fix(core): back Base.predicateBuilder with TableMetadata like Rails

### DIFF
--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -664,11 +664,17 @@ export function filterAttributes(
  * keys and association-key expansion flow through the associated_table
  * fallback — `buildFromHash({"schema.table.column": v})` expands to
  * `"schema.table"."column" = ?` without a hand-built TableMetadata.
+ *
+ * Memoize as an OWN property (not a prototype-chain read): the builder's
+ * TableMetadata is bound to `this`, so an STI subclass (same table_name) must
+ * not inherit the parent's builder — that would resolve associations/
+ * aggregates against the wrong klass. Rails gets this from `inherited`
+ * resetting `@predicate_builder = nil` in the subclass (core.rb:422-425).
  */
-export function predicateBuilder(this: CoreHost): any {
-  if (this._predicateBuilder) return this._predicateBuilder;
+export function predicateBuilder(this: CoreHost): PredicateBuilder {
+  if (Object.prototype.hasOwnProperty.call(this, "_predicateBuilder") && this._predicateBuilder)
+    return this._predicateBuilder;
   const table = this.arelTable;
-  if (!table) return null;
   const metadata = new TableMetadata(this as any, table);
   const pb = new PredicateBuilder(table);
   pb.setTableContext(metadata);

--- a/packages/activerecord/src/core.ts
+++ b/packages/activerecord/src/core.ts
@@ -22,6 +22,7 @@ import {
 } from "./reflection.js";
 import { compactUniqIds, compactUniqTuples } from "./relation/compact-uniq-ids.js";
 import { PredicateBuilder } from "./relation/predicate-builder.js";
+import { TableMetadata } from "./table-metadata.js";
 import { argumentError } from "./relation/query-methods.js";
 import { formatForInspect } from "./attribute-inspection.js";
 import type { PrettyPrinter } from "./pretty-print.js";
@@ -659,15 +660,19 @@ export function filterAttributes(
  * Rails: PredicateBuilder.new(TableMetadata.new(self, arel_table))
  * Memoized per class.
  *
- * Note: Rails passes a TableMetadata to PredicateBuilder. Our PredicateBuilder
- * currently takes a Table directly. TableMetadata.predicateBuilder handles the
- * full Rails flow when accessed from that path.
+ * Backed by a TableMetadata (like Rails) so dot-notation / schema-qualified
+ * keys and association-key expansion flow through the associated_table
+ * fallback — `buildFromHash({"schema.table.column": v})` expands to
+ * `"schema.table"."column" = ?` without a hand-built TableMetadata.
  */
 export function predicateBuilder(this: CoreHost): any {
   if (this._predicateBuilder) return this._predicateBuilder;
   const table = this.arelTable;
   if (!table) return null;
-  this._predicateBuilder = new PredicateBuilder(table);
+  const metadata = new TableMetadata(this as any, table);
+  const pb = new PredicateBuilder(table);
+  pb.setTableContext(metadata);
+  this._predicateBuilder = pb;
   return this._predicateBuilder;
 }
 

--- a/packages/activerecord/src/relation/predicate-builder.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.test.ts
@@ -110,10 +110,9 @@ describe("PredicateBuilderTest", () => {
     // TableMetadata.associated_table("schema.table") falls back to a bare
     // Arel::Table("schema.table"), so expand_from_hash produces:
     //   "schema.table"."column" = 'value'
-    // Rails' Topic.predicate_builder is always TableMetadata-backed; trails'
-    // Base.predicateBuilder is Table-backed, so we build the TableMetadata-backed
-    // PB explicitly to exercise the associated_table fallback expansion.
-    const [node] = new TableMetadata(Topic as any, Topic.arelTable).predicateBuilder.buildFromHash({
+    // Topic.predicateBuilder is TableMetadata-backed (like Rails), so the
+    // associated_table fallback expansion happens without a hand-built PB.
+    const [node] = Topic.predicateBuilder.buildFromHash({
       "schema.table.column": "value",
     });
     const sql = new Visitors.ToSql().compile(node);

--- a/packages/activerecord/src/relation/predicate-builder.trails.test.ts
+++ b/packages/activerecord/src/relation/predicate-builder.trails.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from "vitest";
+import { Company, Firm } from "../test-helpers/models/company.js";
+
+// trails-specific regression guard (no Rails counterpart): Base.predicateBuilder
+// is now TableMetadata-backed, and that metadata is bound to the class. The memo
+// must be an OWN property so an STI subclass (same table_name) does not inherit
+// the parent's builder via the prototype chain — that would resolve
+// associations/aggregates against the parent klass. Rails avoids this
+// structurally by resetting @predicate_builder in `inherited` (core.rb:422-425).
+describe("Base.predicateBuilder STI memoization", () => {
+  it("does not leak the parent's builder to an STI subclass", () => {
+    // Warm the parent first: with a prototype-chain memo, this instance would
+    // then be returned for the subclass too.
+    const companyPb = Company.predicateBuilder;
+    const firmPb = Firm.predicateBuilder;
+    expect(firmPb).not.toBe(companyPb);
+    // Idempotent per class.
+    expect(Company.predicateBuilder).toBe(companyPb);
+    expect(Firm.predicateBuilder).toBe(firmPb);
+  });
+});


### PR DESCRIPTION
## Summary

Rails' `Model.predicate_builder` is always `PredicateBuilder.new(table_metadata)`, so schema-qualified / dot-notation keys and association-key expansion flow through the `associated_table` fallback automatically. trails constructed `Base.predicateBuilder` (`core.ts` `predicateBuilder()`) from a bare Arel `Table`, so `Model.predicateBuilder.buildFromHash({"schema.table.column": v})` did not expand to `"schema.table"."column" = ?` without a hand-built `TableMetadata`.

This sets a `TableMetadata` context on the memoized `Base.predicateBuilder` (matching Rails and the existing Relation-level builder) and updates the predicate-builder `build from hash with schema` test to call `Topic.predicateBuilder.buildFromHash(...)` directly.

- trails: `packages/activerecord/src/core.ts` `predicateBuilder()`
- Rails: `activerecord/lib/active_record/core.rb` `predicate_builder` / `table_metadata`

## Tests

- `predicate-builder.test.ts`, `core.test.ts`, `inheritance.test.ts`, `finder.test.ts` pass locally.

Closes-story: predicate-builder-base-not-tablemetadata-backed