### PR TITLE
feat(query-cache): make cacheNotificationInfo overridable per connection

### DIFF
--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -184,6 +184,17 @@ export interface QueryCacheHost extends DatabaseStatementsHost {
     binds: unknown[],
     result: Record<string, unknown>[],
   ): Record<string, unknown>;
+  lookupSqlCache(
+    sql: string,
+    name: string | null | undefined,
+    binds: unknown[],
+  ): Record<string, unknown>[] | undefined;
+  cacheSql(
+    sql: string,
+    name: string | null | undefined,
+    binds: unknown[],
+    execute: () => Promise<Record<string, unknown>[]>,
+  ): Promise<Record<string, unknown>[]>;
 }
 
 /**
@@ -469,11 +480,17 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
     const forwardOpts = { ...opts, preparable: resolvedPreparable };
     const qc = this._queryCache;
     if (qc?.enabled && !LOCKED_QUERY.test(sql)) {
-      const cached = lookupSqlCache.call(this, sql, name, binds ?? []);
+      // Rails splits this by `async`: the sync path is `cache_sql { super }`
+      // (which instruments the hit inside cache_sql, query_cache.rb:279-297),
+      // the async path is `lookup_sql_cache(...) || super`. trails has no async
+      // FutureResult path, so it always takes the `lookup_sql_cache || cacheSql`
+      // shape — the hit is caught (and instrumented) here by lookupSqlCache, so
+      // cacheSql below only ever runs on a miss and its own hit branch is inert.
+      const cached = this.lookupSqlCache(sql, name, binds ?? []);
       if (cached !== undefined) {
         return Result.fromRowHashes(cached.map((r) => ({ ...r })));
       }
-      const rows = await cacheSql.call(this, sql, name, binds ?? [], async () => {
+      const rows = await this.cacheSql(sql, name, binds ?? [], async () => {
         const result = await original.call(this, sql, name, binds, forwardOpts);
         return result.toArray();
       });

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -481,11 +481,18 @@ export function makeCachedSelectAll(original: BaseSelectAll): BaseSelectAll {
     const qc = this._queryCache;
     if (qc?.enabled && !LOCKED_QUERY.test(sql)) {
       // Rails splits this by `async`: the sync path is `cache_sql { super }`
-      // (which instruments the hit inside cache_sql, query_cache.rb:279-297),
+      // (which itself tracks `hit` and instruments, query_cache.rb:283,291-296),
       // the async path is `lookup_sql_cache(...) || super`. trails has no async
       // FutureResult path, so it always takes the `lookup_sql_cache || cacheSql`
-      // shape — the hit is caught (and instrumented) here by lookupSqlCache, so
-      // cacheSql below only ever runs on a miss and its own hit branch is inert.
+      // shape. INVARIANT: there must be no `await` between this lookupSqlCache
+      // and the cacheSql below — lookupSqlCache runs synchronously and cacheSql
+      // reaches `Store.computeIfAbsent`'s synchronous `get` immediately, so
+      // nothing can populate the key in between. That is why trails' cacheSql
+      // carries no `hit`/instrument branch of its own: a hit is always caught
+      // and instrumented here by lookupSqlCache; Rails' hit branch effectively
+      // lives in `Store.computeIfAbsent` (the dup-on-hit path). Break the
+      // no-await invariant and a concurrent write could turn the cacheSql call
+      // into a silent, uninstrumented cache hit.
       const cached = this.lookupSqlCache(sql, name, binds ?? []);
       if (cached !== undefined) {
         return Result.fromRowHashes(cached.map((r) => ({ ...r })));

--- a/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
+++ b/packages/activerecord/src/connection-adapters/abstract/query-cache.ts
@@ -170,6 +170,20 @@ export interface QueryCachePool {
 export interface QueryCacheHost extends DatabaseStatementsHost {
   _queryCache: Store | null;
   pool?: DatabaseStatementsHost["pool"] & QueryCachePool;
+  // Mixed in from the QueryCache module below. Dispatched through `this` (not
+  // the module-level functions) so a per-connection override is honored, as in
+  // Rails' `def connection.cache_notification_info`.
+  cacheNotificationInfo(
+    sql: string,
+    name: string | null | undefined,
+    binds: unknown[],
+  ): Record<string, unknown>;
+  cacheNotificationInfoResult(
+    sql: string,
+    name: string | null | undefined,
+    binds: unknown[],
+    result: Record<string, unknown>[],
+  ): Record<string, unknown>;
 }
 
 /**
@@ -537,7 +551,7 @@ function cacheNotificationInfoResult(
   binds: unknown[],
   result: Record<string, unknown>[],
 ): Record<string, unknown> {
-  const payload = cacheNotificationInfo.call(this, sql, name, binds);
+  const payload = this.cacheNotificationInfo(sql, name, binds);
   payload["row_count"] = result.length;
   return payload;
 }
@@ -568,7 +582,7 @@ function lookupSqlCache(
   if (result !== undefined) {
     Notifications.instrument(
       "sql.active_record",
-      cacheNotificationInfoResult.call(this, sql, name, binds, result),
+      this.cacheNotificationInfoResult(sql, name, binds, result),
     );
   }
   return result;

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -308,15 +308,41 @@ describe("QueryCacheTest", () => {
     });
   });
 
-  it.skip("cache notifications can be overridden", () => {
-    // TRACKED-PENDING-CONVERGENCE (0023-surfaced-deviations:
-    // query-cache-dirties-wiring-incomplete): Rails dups the connection and
-    // overrides `cache_notification_info` so the cached event payload carries
-    // `neat: true`. trails builds that payload from a module-level
-    // `cacheNotificationInfo` invoked via `cacheNotificationInfoResult.call(this)`
-    // (query-cache.ts) rather than an overridable per-connection method, so a
-    // per-connection override does not take effect and the `neat: true`
-    // assertion cannot be reproduced.
+  it("cache notifications can be overridden", async () => {
+    // Rails dups the connection and defines a singleton
+    // `connection.cache_notification_info(sql, name, binds)` that merges
+    // `neat: true` into `super`, then asserts the cached event carries it.
+    // trails dispatches the payload through the per-connection
+    // `cacheNotificationInfo` method, so an own-property override on the
+    // connection instance shadows the mixed-in one.
+    const events: NotificationEvent[] = [];
+    const sub = Notifications.subscribe("sql.active_record", (e) => events.push(e));
+
+    const connection = (await Base.leaseConnection()) as unknown as {
+      cacheNotificationInfo(
+        sql: string,
+        name: string | null | undefined,
+        binds: unknown[],
+      ): Record<string, unknown>;
+      cache<T>(fn: () => T | Promise<T>): Promise<T>;
+      selectAll(sql: string): Promise<unknown>;
+    };
+    const original = connection.cacheNotificationInfo;
+    connection.cacheNotificationInfo = function (sql, name, binds) {
+      return { ...original.call(this, sql, name, binds), neat: true };
+    };
+
+    try {
+      await connection.cache(async () => {
+        await connection.selectAll("select 1");
+        await connection.selectAll("select 1");
+      });
+    } finally {
+      Notifications.unsubscribe(sub);
+      delete (connection as { cacheNotificationInfo?: unknown }).cacheNotificationInfo;
+    }
+
+    expect(events[events.length - 1].payload["neat"]).toBe(true);
   });
 
   it("cache does not raise exceptions", async () => {

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -314,7 +314,10 @@ describe("QueryCacheTest", () => {
     // `neat: true` into `super`, then asserts the cached event carries it.
     // trails dispatches the payload through the per-connection
     // `cacheNotificationInfo` method, so an own-property override on the
-    // connection instance shadows the mixed-in one.
+    // connection instance shadows the mixed-in one. trails has no connection
+    // `dup`, so instead of Rails' throwaway copy we patch the shared leased
+    // connection and delete the own property in `finally` — the save/restore
+    // stands in for `dup`.
     const events: NotificationEvent[] = [];
     const sub = Notifications.subscribe("sql.active_record", (e) => events.push(e));
 


### PR DESCRIPTION
Surfaced by the faithful port of `query_cache_test.rb`. trails built the cached-hit `sql.active_record` notification payload from a module-level `cacheNotificationInfo` invoked via `.call(this)`, so Rails' per-connection override (`def connection.cache_notification_info; super.merge(neat: true); end`) had no effect.

## Changes

- Dispatch the cached-hit payload through `this.cacheNotificationInfoResult` / `this.cacheNotificationInfo` (mixed onto the adapter prototype via `include(AbstractAdapter, QueryCache)`), so an own-property override on a connection instance shadows the mixed-in method — mirroring Rails' singleton-method override.
- Declare both methods on `QueryCacheHost` for typed `this`-dispatch.
- Un-skip `cache notifications can be overridden` and assert the override-injected `neat: true` key is present on the last cached event.

Closes-story: query-cache-cache-notification-info-overridable