### PR TITLE
fix(predicate-builder): blank hash and un-castable where values

### DIFF
--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -541,12 +541,16 @@ export class Relation<T extends Base> {
     ...rest: unknown[]
   ): Relation<T> | WhereChain<Relation<T>> {
     if (conditionsOrSql === undefined) return new WhereChain<Relation<T>>(this._clone());
-    // Rails: `where([])` is blank (`args.length == 1 && args.first.blank?`,
-    // query_methods.rb:1036) and returns the relation unchanged, like
-    // `where({})` / `where(null)` / `where("")`. This applies ONLY to the
-    // single-argument call — `where([], tuples)` (a 2-arg composite) must fall
-    // through so the empty column list raises rather than silently no-opping.
-    if (Array.isArray(conditionsOrSql) && conditionsOrSql.length === 0 && rest.length === 0) {
+    // Rails: a single blank-ish argument (`args.length == 1 && args.first.blank?`,
+    // query_methods.rb:1036) makes `where` a no-op returning the relation
+    // unchanged — `where({})` / `where([])` / `where(null)` / `where("")` all
+    // match every row. This applies ONLY to the single-argument call:
+    // `where([], tuples)` (a 2-arg composite) must fall through so the empty
+    // column list raises rather than silently no-opping. Short-circuiting the
+    // empty top-level hash here (rather than in the predicate builder) is what
+    // lets a NESTED empty hash (`where(posts: {})`) still expand to the `1=0`
+    // contradiction Rails' `expand_from_hash` returns.
+    if (rest.length === 0 && _qm.isBlankArgument(conditionsOrSql)) {
       return this._clone();
     }
     // Composite-key form: array of column names + array of tuples. It is
@@ -5740,7 +5744,19 @@ export class Relation<T extends Base> {
       if (type?.isForceEquality?.(value)) return value;
       return value.map((v) => this._modelClass._castAttributeValue(attrKey, v));
     }
-    return this._modelClass._castAttributeValue(attrKey, value);
+    const cast = this._modelClass._castAttributeValue(attrKey, value);
+    // Rails never pre-casts scalar `where` values to nil: an un-castable string
+    // (`where(parent_id: "not-a-number")`, `where(written_on: "")`) keeps its raw
+    // value, and the QueryAttribute bind serializes to NULL at compile time —
+    // yielding `col = NULL` (matches nothing), not `col IS NULL` (matches nulls).
+    // Collapsing to nil here would reroute the predicate builder onto the
+    // explicit-nil `IS NULL` path. Preserve the raw value so the bind, not this
+    // pre-cast, decides nullness (mirrors PredicateBuilder building a bind whose
+    // `nil?`/`unboundable?` is evaluated by the visitor).
+    if ((cast === null || cast === undefined) && value !== null && value !== undefined) {
+      return value;
+    }
+    return cast;
   }
 
   private _qualifiedCol(table: Table, key: string): { tbl: string; col: string } {

--- a/packages/activerecord/src/relation.ts
+++ b/packages/activerecord/src/relation.ts
@@ -5742,17 +5742,29 @@ export class Relation<T extends Base> {
         | { isForceEquality?(v: unknown): boolean }
         | undefined;
       if (type?.isForceEquality?.(value)) return value;
-      return value.map((v) => this._modelClass._castAttributeValue(attrKey, v));
+      return value.map((v) => this._castPreservingUncastable(attrKey, v));
     }
+    return this._castPreservingUncastable(attrKey, value);
+  }
+
+  /**
+   * Cast a scalar `where` value through its column type, but preserve the raw
+   * value when the cast collapses a non-null input to `null`.
+   *
+   * Rails never pre-casts a `where` value to nil: an un-castable string
+   * (`where(parent_id: "not-a-number")`, `where(written_on: "")`, or such an
+   * element inside `where(parent_id: ["not-a-number"])`) keeps its raw value and
+   * the QueryAttribute bind serializes to NULL at compile time — yielding
+   * `col = NULL` / `col IN (NULL)` (matches nothing), not the `IS NULL` path
+   * (matches nulls). Collapsing to nil here would misroute BOTH the scalar
+   * (Equality → `rightIsNull`) and array (ArrayHandler's `values.compact!`
+   * nil-partition, array_handler.rb:16) paths onto explicit-nil handling. So the
+   * bind — evaluated by the visitor via `nil?`/`unboundable?` — decides
+   * nullness, not this pre-cast. A genuinely null input stays null (routes to
+   * `IS NULL`), matching Rails treating only real `nil` as null.
+   */
+  private _castPreservingUncastable(attrKey: string, value: unknown): unknown {
     const cast = this._modelClass._castAttributeValue(attrKey, value);
-    // Rails never pre-casts scalar `where` values to nil: an un-castable string
-    // (`where(parent_id: "not-a-number")`, `where(written_on: "")`) keeps its raw
-    // value, and the QueryAttribute bind serializes to NULL at compile time —
-    // yielding `col = NULL` (matches nothing), not `col IS NULL` (matches nulls).
-    // Collapsing to nil here would reroute the predicate builder onto the
-    // explicit-nil `IS NULL` path. Preserve the raw value so the bind, not this
-    // pre-cast, decides nullness (mirrors PredicateBuilder building a bind whose
-    // `nil?`/`unboundable?` is evaluated by the visitor).
     if ((cast === null || cast === undefined) && value !== null && value !== undefined) {
       return value;
     }

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -149,8 +149,13 @@ export class PredicateBuilder {
     // `where({})` never reaches here — it short-circuits as a blank argument in
     // `Relation#where` (like Rails' `args.first.blank?`), so this fires only for
     // the nested/associated recursion.
+    //
+    // Under negation (`where.not(sink: {})`) trails threads `negated` into the
+    // recursion (Rails builds positively then inverts the WhereClause), so the
+    // contradiction inverts to the `1=1` tautology — `NOT (1=0)` matches every
+    // row, mirroring `WhereClause#invert` over Rails' `["1=0"]`.
     if (Object.keys(conditions).length === 0) {
-      return [arelSql("1=0")];
+      return [arelSql(negated ? "1=1" : "1=0")];
     }
     const nodes: Nodes.Node[] = [];
     for (const [key, value] of Object.entries(conditions)) {

--- a/packages/activerecord/src/relation/predicate-builder.ts
+++ b/packages/activerecord/src/relation/predicate-builder.ts
@@ -142,6 +142,16 @@ export class PredicateBuilder {
     negated: boolean,
     block?: (tableName: string) => unknown,
   ): Nodes.Node[] {
+    // Mirrors Rails PredicateBuilder#expand_from_hash: `return ["1=0"] if
+    // attributes.empty?` (predicate_builder.rb:85). An empty hash is a
+    // contradiction, so `where(posts: {})` (nested empty hash) and
+    // `where(sink: {})` (empty hash, no foreign key) match nothing. Top-level
+    // `where({})` never reaches here — it short-circuits as a blank argument in
+    // `Relation#where` (like Rails' `args.first.blank?`), so this fires only for
+    // the nested/associated recursion.
+    if (Object.keys(conditions).length === 0) {
+      return [arelSql("1=0")];
+    }
     const nodes: Nodes.Node[] = [];
     for (const [key, value] of Object.entries(conditions)) {
       if (

--- a/packages/activerecord/src/relation/query-methods.ts
+++ b/packages/activerecord/src/relation/query-methods.ts
@@ -1306,7 +1306,12 @@ function havingBang(
   opts: string | Record<string, unknown> | Nodes.Node,
   ...rest: unknown[]
 ): any {
-  if (opts == null || (typeof opts === "string" && opts.trim() === "")) return this;
+  // Rails' `having` no-ops on a blank condition (`opts.blank? ? self : …`,
+  // query_methods.rb:1198) — including an empty hash. Guard it here (mirroring
+  // the same check `where` applies) so `having({})` stays a no-op rather than
+  // routing an empty hash through PredicateBuilder, which now expands it to the
+  // `1=0` contradiction.
+  if (opts == null || isBlankArgument(opts)) return this;
 
   if (typeof opts === "string") {
     const sql = rest.length > 0 ? this._modelClass.sanitizeSqlArray(opts, ...rest) : opts;

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -138,6 +138,7 @@ describe("WhereTest", () => {
     const first = topics("first") as any;
     await first.update({ parent_id: 0, written_on: null, bonus_time: null, last_read: null });
     expect(await Topic.where({ parent_id: "not-a-number" })).toHaveLength(0);
+    expect(await Topic.where({ parent_id: ["not-a-number"] })).toHaveLength(0);
     expect(await Topic.where({ written_on: "" })).toHaveLength(0);
     expect(await Topic.where({ bonus_time: "" })).toHaveLength(0);
     expect(await Topic.where({ last_read: "" })).toHaveLength(0);

--- a/packages/activerecord/src/relation/where.test.ts
+++ b/packages/activerecord/src/relation/where.test.ts
@@ -134,14 +134,7 @@ describe("WhereTest", () => {
     expect(ids(chefs)).toStrictEqual([(chef as any).id]);
   });
 
-  it.skip("where with invalid value", async () => {
-    // BLOCKED: predicate-builder — an un-castable query value (non-numeric string
-    // for an integer column, "" for date/time) casts to `null` and emits `IS NULL`,
-    // so the query matches NULL rows instead of nothing.
-    // ROOT-CAUSE: relation/predicate-builder.ts not implementing Rails'
-    // QueryAttribute#boundable? contradiction (`1=0`) for un-boundable values.
-    // SCOPE: convergence tracked by RFC 0023
-    // predicate-builder-blank-and-unboundable-contradiction.
+  it("where with invalid value", async () => {
     const first = topics("first") as any;
     await first.update({ parent_id: 0, written_on: null, bonus_time: null, last_read: null });
     expect(await Topic.where({ parent_id: "not-a-number" })).toHaveLength(0);
@@ -485,13 +478,7 @@ describe("WhereTest", () => {
     expect((found as any).id).toBe((post as any).id);
   });
 
-  it.skip("where with table name and empty hash", async () => {
-    // BLOCKED: predicate-builder — `where(posts: {})` should match nothing.
-    // ROOT-CAUSE: relation/predicate-builder.ts buildFromHashInternal expands an
-    // empty nested hash to zero predicate nodes (condition dropped → all rows),
-    // vs Rails expand_from_hash returning `["1=0"]` (predicate_builder.rb:85).
-    // SCOPE: convergence tracked by RFC 0023
-    // predicate-builder-blank-and-unboundable-contradiction.
+  it("where with table name and empty hash", async () => {
     expect(await Post.where({ posts: {} }).count()).toBe(0);
   });
 
@@ -499,13 +486,7 @@ describe("WhereTest", () => {
     expect(await Post.where({ id: [] }).count()).toBe(0);
   });
 
-  it.skip("where with empty hash and no foreign key", async () => {
-    // BLOCKED: predicate-builder — `where(sink: {})` should match nothing.
-    // ROOT-CAUSE: same empty-nested-hash gap as "where with table name and empty
-    // hash"; relation/predicate-builder.ts drops the empty hash instead of
-    // emitting Rails' `["1=0"]`.
-    // SCOPE: convergence tracked by RFC 0023
-    // predicate-builder-blank-and-unboundable-contradiction.
+  it("where with empty hash and no foreign key", async () => {
     expect(await Edge.where({ sink: {} }).count()).toBe(0);
   });
 

--- a/packages/activerecord/src/relations.test.ts
+++ b/packages/activerecord/src/relations.test.ts
@@ -1915,8 +1915,13 @@ describe("RelationTest", () => {
   });
 
   it("doesnt add having values if options are blank", () => {
-    const sql = Post.group("title").toSql();
-    expect(sql).not.toContain("HAVING");
+    // Mirrors Rails: a blank `having` argument is a no-op leaving the having
+    // clause empty (relations_test.rb:1806). trails routes `{}` through the
+    // same `opts.blank?` guard as `""` / `[]`, so the empty hash never reaches
+    // PredicateBuilder's empty-hash `1=0` expansion.
+    expect(Post.having("").havingClause.isEmpty()).toBe(true);
+    expect(Post.having([] as any).havingClause.isEmpty()).toBe(true);
+    expect(Post.having({}).havingClause.isEmpty()).toBe(true);
   });
 
   it("having with binds for both where and having", async () => {


### PR DESCRIPTION
Three Rails-fidelity gaps around blank / un-boundable WHERE values, surfaced converting `where.test.ts` onto the canonical schema + fixtures (RFC 0019).

## Changes

- **Empty nested/associated hash → `1=0`.** `PredicateBuilder.buildFromHashInternal` now mirrors Rails `expand_from_hash`'s empty-hash branch (`predicate_builder.rb:85`), emitting a `1=0` contradiction so `where(posts: {})` and `where(sink: {})` match nothing. A blank *top-level* argument (`{}` / `[]` / `null` / `""`) short-circuits in `Relation#where` (Rails `args.first.blank?`), so only the nested recursion produces the contradiction.
- **Un-castable scalar string keeps its raw value.** `_castWhereValue` no longer pre-casts an un-castable string (`where(parent_id: "not-a-number")`, `where(written_on: "")`) to `nil`. The `QueryAttribute` bind serializes to NULL at compile time — yielding `col = NULL` (matches nothing), like Rails, instead of routing onto the explicit-nil `IS NULL` path (which matched NULL rows).

## Tests

Un-skips `where with invalid value`, `where with table name and empty hash`, and `where with empty hash and no foreign key`. `where with blank conditions` was already passing.

The two `large number` ports stay skipped under a **distinct** out-of-range gap (the OOR bind raises `ActiveModelRangeError` on cast for MariaDB/PG), now tracked separately by `predicate-builder-out-of-range-bind-raises-on-cast`.

Closes-story: predicate-builder-blank-and-unboundable-contradiction