### PR TITLE
test(query-cache): port multi-role connected_to tests

### DIFF
--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -193,11 +193,14 @@ describe("QueryCacheTest", () => {
   it("query cache is applied to all connections", async () => {
     const dbConfig = Base.connectionPool().dbConfig;
     await Base.connectedTo({ role: "reading" }, async () => {
-      Base.connectionHandler.establishConnection(dbConfig, { owner: "Base", role: "reading" });
+      await Base.establishConnection(dbConfig);
     });
 
     const mw = middleware(async () => {
       for (const pool of Base.connectionHandler.connectionPoolList("all")) {
+        // Rails checks `pool.lease_connection.query_cache_enabled`; trails
+        // holds the cache flag on the pool, so lease (to match Rails) then
+        // assert the pool-level flag.
         await pool.leaseConnection();
         expect(pool.queryCacheEnabled).toBe(true);
       }
@@ -209,10 +212,7 @@ describe("QueryCacheTest", () => {
   it("cache is not applied when config is false", async () => {
     const dbConfig = Base.connectionPool().dbConfig;
     await Base.connectedTo({ role: "reading" }, async () => {
-      Base.connectionHandler.establishConnection(
-        { ...dbConfig.configurationHash, queryCache: false },
-        { owner: "Base", role: "reading" },
-      );
+      await Base.establishConnection({ ...dbConfig.configurationHash, queryCache: false });
     });
 
     const mw = middleware(async () => {
@@ -228,10 +228,7 @@ describe("QueryCacheTest", () => {
   it("cache is applied when config is string", async () => {
     const dbConfig = Base.connectionPool().dbConfig;
     await Base.connectedTo({ role: "reading" }, async () => {
-      Base.connectionHandler.establishConnection(
-        { ...dbConfig.configurationHash, queryCache: "unlimited" },
-        { owner: "Base", role: "reading" },
-      );
+      await Base.establishConnection({ ...dbConfig.configurationHash, queryCache: "unlimited" });
     });
 
     const mw = middleware(async () => {
@@ -249,10 +246,7 @@ describe("QueryCacheTest", () => {
   it("cache is applied when config is integer", async () => {
     const dbConfig = Base.connectionPool().dbConfig;
     await Base.connectedTo({ role: "reading" }, async () => {
-      Base.connectionHandler.establishConnection(
-        { ...dbConfig.configurationHash, queryCache: 42 },
-        { owner: "Base", role: "reading" },
-      );
+      await Base.establishConnection({ ...dbConfig.configurationHash, queryCache: 42 });
     });
 
     const mw = middleware(async () => {
@@ -268,10 +262,7 @@ describe("QueryCacheTest", () => {
   it("cache is applied when config is nil", async () => {
     const dbConfig = Base.connectionPool().dbConfig;
     await Base.connectedTo({ role: "reading" }, async () => {
-      Base.connectionHandler.establishConnection(
-        { ...dbConfig.configurationHash, queryCache: null },
-        { owner: "Base", role: "reading" },
-      );
+      await Base.establishConnection({ ...dbConfig.configurationHash, queryCache: null });
     });
 
     const mw = middleware(async () => {
@@ -623,7 +614,7 @@ describe("QueryCacheTest", () => {
   it("clear query cache is called on all connections", async () => {
     const dbConfig = Base.connectionPool().dbConfig;
     await Base.connectedTo({ role: "reading" }, async () => {
-      Base.connectionHandler.establishConnection(dbConfig, { owner: "Base", role: "reading" });
+      await Base.establishConnection(dbConfig);
     });
     setupSharedConnectionPool();
 

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -25,7 +25,12 @@ for (const m of [Task, Topic, Category, Post]) registerModel(m as never);
 // disabling + clearing it afterward.
 function middleware(app: () => unknown | Promise<unknown>): () => Promise<void> {
   let hook: { run(): void; complete(): void } | null = null;
-  QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h) }, [Base.connectionPool()]);
+  // Resolve the pool list lazily on each run/complete so pools established
+  // after the middleware is built (the multi-role `connected_to(role: :reading)`
+  // tests) are included, mirroring Rails' `connection_pool_list(:all)`.
+  QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h) }, () =>
+    Base.connectionHandler.connectionPoolList("all"),
+  );
   return async () => {
     hook!.run();
     try {
@@ -59,12 +64,69 @@ function assertCache(
   }
 }
 
+// Reads the pool-level query-cache max size — the trails analogue of Rails'
+// `pool.query_cache.instance_variable_get(:@max_size)`. Rails reads it off the
+// per-connection `Store`; trails' `Store` coalesces a disabled pool's `nil`
+// size to `0`, so the faithful value lives on the pool's cache config
+// (`@query_cache_max_size` in Rails). `false`/`0` → `null`, an Integer → that
+// integer, `nil` → the default size (100). trails represents Rails' "unbounded"
+// `nil` (the fall-through for a raw string like "unlimited") as `Infinity`.
+function poolQueryCacheMaxSize(pool: ConnectionPool): number | null {
+  return (pool as unknown as { _cacheConfig: { _queryCacheMaxSize: number | null } })._cacheConfig
+    ._queryCacheMaxSize;
+}
+
+// Mirrors ActiveRecord::TestCase#clean_up_connection_handler: drop every
+// non-default (e.g. :reading) role a test established, leaving the writing pool.
+function cleanUpConnectionHandler(): void {
+  const managers: Map<string, { roleNames: string[]; removeRole(role: string): boolean }> = (
+    Base.connectionHandler as unknown as {
+      _connectionNameToPoolManager: Map<string, never>;
+    }
+  )._connectionNameToPoolManager as never;
+  for (const [, poolManager] of managers) {
+    for (const role of [...poolManager.roleNames]) {
+      if (role !== Base.defaultRole) poolManager.removeRole(role);
+    }
+  }
+}
+
+// Mirrors ActiveRecord::TestFixtures#setup_shared_connection_pool: point every
+// role's pool config at the writing pool config so a freshly-established
+// :reading pool shares the fixture-pinned connection (and therefore sees the
+// same rows), the same mechanism Rails uses to keep roles coherent under tests.
+function setupSharedConnectionPool(): void {
+  const writingRole = Base.writingRole;
+  const managers: Map<
+    string,
+    {
+      shardNames: string[];
+      roleNames: string[];
+      getPoolConfig(role: string, shard: string): unknown;
+      setPoolConfig(role: string, shard: string, config: unknown): void;
+    }
+  > = (Base.connectionHandler as unknown as { _connectionNameToPoolManager: Map<string, never> })
+    ._connectionNameToPoolManager as never;
+  for (const [, poolManager] of managers) {
+    for (const shard of [...poolManager.shardNames]) {
+      const writingPoolConfig = poolManager.getPoolConfig(writingRole, shard);
+      if (!writingPoolConfig) continue;
+      for (const role of [...poolManager.roleNames]) {
+        const poolConfig = poolManager.getPoolConfig(role, shard);
+        if (!poolConfig || poolConfig === writingPoolConfig) continue;
+        poolManager.setPoolConfig(role, shard, writingPoolConfig);
+      }
+    }
+  }
+}
+
 describe("QueryCacheTest", () => {
   fixtures(["tasks", "topics", "categories", "posts", "categoriesPosts"]);
 
   afterEach(async () => {
     Task.connectionPool().clearQueryCache();
     Base.connectionPool().disableQueryCacheBang();
+    cleanUpConnectionHandler();
   });
 
   it.skip("execute clear cache", () => {
@@ -128,22 +190,99 @@ describe("QueryCacheTest", () => {
     assertCache("off");
   });
 
-  it.skip("query cache is applied to all connections", () => {
-    // BLOCKED: multi-role connection handler (connected_to role: :reading) — not
-    // supported by trails' single-pool handler.
+  it("query cache is applied to all connections", async () => {
+    const dbConfig = Base.connectionPool().dbConfig;
+    await Base.connectedTo({ role: "reading" }, async () => {
+      Base.connectionHandler.establishConnection(dbConfig, { owner: "Base", role: "reading" });
+    });
+
+    const mw = middleware(async () => {
+      for (const pool of Base.connectionHandler.connectionPoolList("all")) {
+        await pool.leaseConnection();
+        expect(pool.queryCacheEnabled).toBe(true);
+      }
+    });
+
+    await mw();
   });
 
-  it.skip("cache is not applied when config is false", () => {
-    // BLOCKED: multi-role connection handler (connected_to role: :reading).
+  it("cache is not applied when config is false", async () => {
+    const dbConfig = Base.connectionPool().dbConfig;
+    await Base.connectedTo({ role: "reading" }, async () => {
+      Base.connectionHandler.establishConnection(
+        { ...dbConfig.configurationHash, queryCache: false },
+        { owner: "Base", role: "reading" },
+      );
+    });
+
+    const mw = middleware(async () => {
+      await Base.connectedTo({ role: "reading" }, async () => {
+        assertCache("off");
+        expect(poolQueryCacheMaxSize(Base.connectionPool())).toBeNull();
+      });
+    });
+
+    await mw();
   });
-  it.skip("cache is applied when config is string", () => {
-    // BLOCKED: multi-role connection handler (connected_to role: :reading).
+
+  it("cache is applied when config is string", async () => {
+    const dbConfig = Base.connectionPool().dbConfig;
+    await Base.connectedTo({ role: "reading" }, async () => {
+      Base.connectionHandler.establishConnection(
+        { ...dbConfig.configurationHash, queryCache: "unlimited" },
+        { owner: "Base", role: "reading" },
+      );
+    });
+
+    const mw = middleware(async () => {
+      await Base.connectedTo({ role: "reading" }, async () => {
+        assertCache("clean");
+        // Rails leaves `@max_size` nil (unbounded) for a raw string config;
+        // trails represents that unbounded size as `Infinity`.
+        expect(poolQueryCacheMaxSize(Base.connectionPool())).toBe(Number.POSITIVE_INFINITY);
+      });
+    });
+
+    await mw();
   });
-  it.skip("cache is applied when config is integer", () => {
-    // BLOCKED: multi-role connection handler (connected_to role: :reading).
+
+  it("cache is applied when config is integer", async () => {
+    const dbConfig = Base.connectionPool().dbConfig;
+    await Base.connectedTo({ role: "reading" }, async () => {
+      Base.connectionHandler.establishConnection(
+        { ...dbConfig.configurationHash, queryCache: 42 },
+        { owner: "Base", role: "reading" },
+      );
+    });
+
+    const mw = middleware(async () => {
+      await Base.connectedTo({ role: "reading" }, async () => {
+        assertCache("clean");
+        expect(poolQueryCacheMaxSize(Base.connectionPool())).toBe(42);
+      });
+    });
+
+    await mw();
   });
-  it.skip("cache is applied when config is nil", () => {
-    // BLOCKED: multi-role connection handler (connected_to role: :reading).
+
+  it("cache is applied when config is nil", async () => {
+    const dbConfig = Base.connectionPool().dbConfig;
+    await Base.connectedTo({ role: "reading" }, async () => {
+      Base.connectionHandler.establishConnection(
+        { ...dbConfig.configurationHash, queryCache: null },
+        { owner: "Base", role: "reading" },
+      );
+    });
+
+    const mw = middleware(async () => {
+      await Base.connectedTo({ role: "reading" }, async () => {
+        assertCache("clean");
+        // Rails ConnectionAdapters::QueryCache::DEFAULT_SIZE.
+        expect(poolQueryCacheMaxSize(Base.connectionPool())).toBe(100);
+      });
+    });
+
+    await mw();
   });
 
   it.skip("query cache with forked processes", () => {
@@ -477,8 +616,39 @@ describe("QueryCacheTest", () => {
     await mw();
   });
 
-  it.skip("clear query cache is called on all connections", () => {
-    // BLOCKED: multi-role connection handler (connected_to role: :reading).
+  // Rails guards this with `unless in_memory_db?` (a :memory: reading role
+  // can't see the writing role's database). trails' worker DB is file-backed
+  // and, via setupSharedConnectionPool, the reading role shares the
+  // fixture-pinned writing connection, so the guard doesn't apply.
+  it("clear query cache is called on all connections", async () => {
+    const dbConfig = Base.connectionPool().dbConfig;
+    await Base.connectedTo({ role: "reading" }, async () => {
+      Base.connectionHandler.establishConnection(dbConfig, { owner: "Base", role: "reading" });
+    });
+    setupSharedConnectionPool();
+
+    let topic: Topic | null = null;
+    const mw = middleware(async () => {
+      await Base.connectedTo({ role: "reading" }, async () => {
+        topic = await Topic.first();
+      });
+
+      expect(topic).toBeTruthy();
+
+      await Base.connectedTo({ role: "writing" }, async () => {
+        topic!.title = "Topic title";
+        await topic!.saveBang();
+      });
+
+      expect(topic!.title).toBe("Topic title");
+
+      await Base.connectedTo({ role: "reading" }, async () => {
+        topic = await Topic.first();
+        expect(topic!.title).toBe("Topic title");
+      });
+    });
+
+    await mw();
   });
 
   it.skip("query cache is enabled in threads with shared connection", () => {

--- a/packages/activerecord/src/query-cache.test.ts
+++ b/packages/activerecord/src/query-cache.test.ts
@@ -28,6 +28,9 @@ function middleware(app: () => unknown | Promise<unknown>): () => Promise<void> 
   // Resolve the pool list lazily on each run/complete so pools established
   // after the middleware is built (the multi-role `connected_to(role: :reading)`
   // tests) are included, mirroring Rails' `connection_pool_list(:all)`.
+  // (Rails threads run's enabled-pool result into complete so a disabled pool
+  // is never touched on complete; trails re-resolves the full list — tracked by
+  // 0023-surfaced-deviations: query-cache-run-returns-enabled-pools-for-complete.)
   QueryCache.installExecutorHooks({ registerHook: (h) => (hook = h) }, () =>
     Base.connectionHandler.connectionPoolList("all"),
   );
@@ -91,37 +94,16 @@ function cleanUpConnectionHandler(): void {
   }
 }
 
-// Mirrors ActiveRecord::TestFixtures#setup_shared_connection_pool: point every
-// role's pool config at the writing pool config so a freshly-established
-// :reading pool shares the fixture-pinned connection (and therefore sees the
-// same rows), the same mechanism Rails uses to keep roles coherent under tests.
-function setupSharedConnectionPool(): void {
-  const writingRole = Base.writingRole;
-  const managers: Map<
-    string,
-    {
-      shardNames: string[];
-      roleNames: string[];
-      getPoolConfig(role: string, shard: string): unknown;
-      setPoolConfig(role: string, shard: string, config: unknown): void;
-    }
-  > = (Base.connectionHandler as unknown as { _connectionNameToPoolManager: Map<string, never> })
-    ._connectionNameToPoolManager as never;
-  for (const [, poolManager] of managers) {
-    for (const shard of [...poolManager.shardNames]) {
-      const writingPoolConfig = poolManager.getPoolConfig(writingRole, shard);
-      if (!writingPoolConfig) continue;
-      for (const role of [...poolManager.roleNames]) {
-        const poolConfig = poolManager.getPoolConfig(role, shard);
-        if (!poolConfig || poolConfig === writingPoolConfig) continue;
-        poolManager.setPoolConfig(role, shard, writingPoolConfig);
-      }
-    }
-  }
-}
-
 describe("QueryCacheTest", () => {
-  fixtures(["tasks", "topics", "categories", "posts", "categoriesPosts"]);
+  // Rails sets `self.use_transactional_tests = false` for this whole file
+  // (query_cache_test.rb:11) so the multi-role tests keep genuinely separate
+  // :reading/:writing pools against committed fixture rows — a transactional
+  // (savepoint-pinned) run would swap the reading pool onto the writing config
+  // (test_fixtures.rb:183-199) and break both the `@max_size` assertions and
+  // the "cleared on all connections" guarantee.
+  fixtures(["tasks", "topics", "categories", "posts", "categoriesPosts"], {
+    useTransactionalTests: false,
+  });
 
   afterEach(async () => {
     Task.connectionPool().clearQueryCache();
@@ -198,11 +180,10 @@ describe("QueryCacheTest", () => {
 
     const mw = middleware(async () => {
       for (const pool of Base.connectionHandler.connectionPoolList("all")) {
-        // Rails checks `pool.lease_connection.query_cache_enabled`; trails
-        // holds the cache flag on the pool, so lease (to match Rails) then
-        // assert the pool-level flag.
-        await pool.leaseConnection();
-        expect(pool.queryCacheEnabled).toBe(true);
+        // Mirrors `assert_predicate pool.lease_connection, :query_cache_enabled`:
+        // the connection-level flag (proving checkout_and_verify wired the Store
+        // onto the connection), not the pool-level flag.
+        expect((await pool.leaseConnection()).queryCacheEnabled).toBe(true);
       }
     });
 
@@ -235,7 +216,10 @@ describe("QueryCacheTest", () => {
       await Base.connectedTo({ role: "reading" }, async () => {
         assertCache("clean");
         // Rails leaves `@max_size` nil (unbounded) for a raw string config;
-        // trails represents that unbounded size as `Infinity`.
+        // trails overloads null as "disabled" so represents unbounded as
+        // `Infinity` (converged by 0023-surfaced-deviations:
+        // query-cache-disabled-gate-on-config-not-maxsize, which will flip this
+        // assertion to null).
         expect(poolQueryCacheMaxSize(Base.connectionPool())).toBe(Number.POSITIVE_INFINITY);
       });
     });
@@ -607,39 +591,16 @@ describe("QueryCacheTest", () => {
     await mw();
   });
 
-  // Rails guards this with `unless in_memory_db?` (a :memory: reading role
-  // can't see the writing role's database). trails' worker DB is file-backed
-  // and, via setupSharedConnectionPool, the reading role shares the
-  // fixture-pinned writing connection, so the guard doesn't apply.
-  it("clear query cache is called on all connections", async () => {
-    const dbConfig = Base.connectionPool().dbConfig;
-    await Base.connectedTo({ role: "reading" }, async () => {
-      await Base.establishConnection(dbConfig);
-    });
-    setupSharedConnectionPool();
-
-    let topic: Topic | null = null;
-    const mw = middleware(async () => {
-      await Base.connectedTo({ role: "reading" }, async () => {
-        topic = await Topic.first();
-      });
-
-      expect(topic).toBeTruthy();
-
-      await Base.connectedTo({ role: "writing" }, async () => {
-        topic!.title = "Topic title";
-        await topic!.saveBang();
-      });
-
-      expect(topic!.title).toBe("Topic title");
-
-      await Base.connectedTo({ role: "reading" }, async () => {
-        topic = await Topic.first();
-        expect(topic!.title).toBe("Topic title");
-      });
-    });
-
-    await mw();
+  it.skip("clear query cache is called on all connections", () => {
+    // TRACKED-PENDING-CONVERGENCE (0023-surfaced-deviations:
+    // query-cache-dirties-wiring-incomplete): a write under the :writing role
+    // must clear the query cache on ALL of the current thread's pools (Rails'
+    // `dirties_query_cache` decorator calls
+    // `ActiveRecord::Base.clear_query_caches_for_current_thread`,
+    // query_cache.rb:24). trails' decorator (abstract/query-cache.ts) clears
+    // only the writing connection's own Store, so the :reading pool's cache
+    // stays stale and the re-read returns the pre-write title. Un-skips once
+    // that story wires clearing across connections.
   });
 
   it.skip("query cache is enabled in threads with shared connection", () => {


### PR DESCRIPTION
Ports the six query-cache multi-role `connected_to` tests that were left
`it.skip` ("BLOCKED: multi-role connection handler") in
`query-cache.test.ts`, now that trails supports `connected_to(role:)` /
role-scoped `establish_connection` / `connection_pool_list(:all)`.

Ported faithfully from
`vendor/rails/activerecord/test/cases/query_cache_test.rb`. Five are un-skipped
and green; the sixth is honestly tracked-skipped (see review response below):

- `query cache is applied to all connections` (`:127`)
- `cache is not applied when config is false` (`:144`)
- `cache is applied when config is string` (`:162`)
- `cache is applied when config is integer` (`:180`)
- `cache is applied when config is nil` (`:198`)
- `clear query cache is called on all connections` (`:695`) — tracked-skip

The file now runs **non-transactionally** (`useTransactionalTests: false`),
mirroring Rails' `self.use_transactional_tests = false` (query_cache_test.rb:11)
so the `:reading`/`:writing` roles keep genuinely separate pools against
committed fixtures.

Test-only helpers: `middleware` resolves `connection_pool_list(:all)` lazily
(mirrors `QueryCache.run`); `poolQueryCacheMaxSize` reads the pool cache
config's max size (analogue of `pool.query_cache.@max_size`);
`cleanUpConnectionHandler` mirrors `TestCase#clean_up_connection_handler`.

No production code changed; test file only.

## Review response (Claude review, 5 findings)

1. **Non-transactional + drop `setupSharedConnectionPool` — taken.** Correct
   catch: Rails sets `use_transactional_tests = false` here precisely so the
   reading role keeps its own pool config. Flipped the file to
   `useTransactionalTests: false` and removed the shared-pool workaround.
2. **Connection-level assertion — fixed.** Now
   `expect((await pool.leaseConnection()).queryCacheEnabled).toBe(true)`,
   mirroring `assert_predicate pool.lease_connection, :query_cache_enabled`;
   removed the inaccurate "flag on the pool" comment.
3. **run→complete threading — out of scope, story registered.** Pre-existing in
   `installExecutorHooks`; registered
   `query-cache-run-returns-enabled-pools-for-complete`
   (0023-surfaced-deviations) and referenced it in the `middleware` comment.
4. **`queryCacheDisabled` / `"unlimited"` → nil — story registered.** Genuine
   convergence: registered
   `query-cache-disabled-gate-on-config-not-maxsize` (0023-surfaced-deviations)
   to gate `queryCacheDisabled` on `db_config.query_cache === false` and map
   `"unlimited"` to a null/unbounded size, which will flip the string/false
   assertions to null (Rails-verbatim). Referenced from the test comment.
5. **`teardown_shared_connection_pool` asymmetry — resolved by #1.** The shared
   pool is gone, so there is nothing to restore.

**Sixth test tracked-skip.** Taking #1 (separate committed pools) exposed a real
production gap the shared-pool version was masking: a `:writing` write must
clear the query cache on ALL of the current thread's pools (Rails'
`dirties_query_cache` → `clear_query_caches_for_current_thread`,
query_cache.rb:24), but trails' write decorator
(`connection-adapters/abstract/query-cache.ts`) clears only the writing
connection's own Store, so the `:reading` cache stays stale and the re-read
returns the pre-write title. This is the cross-connection facet of the already
claimed `query-cache-dirties-wiring-incomplete` story, which owns un-skipping
the write-path cache-clearing cases. Skipped with a `TRACKED-PENDING-CONVERGENCE`
reference rather than shipping a false green or making a core write-path change
under a test-porting story — consistent with the sibling `execute clear cache` /
`exec query clear cache` skips.

Minor (`cleanUpConnectionHandler` owner allowlist, undisconnected reading pools):
acknowledged; equivalent here as noted in the review.

Closes-story: query-cache-multi-role-connected-to-tests

## Second review round (2 non-blocking notes)

1. **Fix pointer added to the tracking story.** Appended the cross-connection
   diagnosis + one-line pointer (decorator should call
   `clearQueryCachesForCurrentThread`, which already exists) to
   `query-cache-dirties-wiring-incomplete`, and listed
   `clear query cache is called on all connections` among its un-skip cases,
   so the story owner doesn't re-derive.
2. **`assertCache` pool-level is equivalent — no change.** In trails the query
   cache lives on the pool's thread-keyed `Store`, and `checkoutAndVerify`
   wires `connection._queryCache = this.queryCache` (abstract/query-cache.ts:207)
   — the *same object*. So `pool.queryCacheEnabled` and
   `connection.queryCacheEnabled` read the identical `enabled`/`empty` flags
   within an execution context; pool-level also lets `assertCache` work without
   leasing a connection. Rails' connection-vs-pool distinction doesn't bite
   here, so no story — converging the ~40-test shared helper would be a no-op
   rename.
